### PR TITLE
Add declarative HTTP service layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,13 @@ VOICE_ENABLED=false
 # Requires: pip install -e '.[tts]', plus Piper voice models
 # Download models: make tts-model
 TTS_ENABLED=false
+
+# ── External Services (optional) ──────────────────────────────
+
+# API keys for external services defined in services.yaml.
+# Copy services.example.yaml to services.yaml and uncomment the
+# services you want, then set the corresponding keys here.
+
+# Perplexity AI — web search and synthesis (recommended)
+# Get a key at https://www.perplexity.ai/
+#PERPLEXITY_API_KEY=your-perplexity-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .env
 .venv/
 
+# Service config (user-specific, contains service selections)
+services.yaml
+
 # Python
 __pycache__/
 *.pyc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "aiosqlite>=0.19.0",
     "python-dotenv>=1.0.0",
     "aiohttp>=3.9.0",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/services.example.yaml
+++ b/services.example.yaml
@@ -1,0 +1,89 @@
+# ── External Services ────────────────────────────────────────────────
+#
+# Declarative HTTP service definitions for Kai. Each entry describes an
+# external API that inner Claude can call via the local proxy endpoint.
+#
+# Setup:
+#   1. Copy this file: cp services.example.yaml services.yaml
+#   2. Uncomment the services you want to use
+#   3. Set the corresponding API key(s) in .env
+#   4. Restart Kai
+#
+# Kai injects authentication from .env at call time — API keys never
+# enter Claude's context. See workspace/.claude/CLAUDE.md for usage docs.
+#
+# Auth types:
+#   bearer  — Authorization: Bearer $KEY
+#   header  — Custom header {name}: $KEY
+#   query   — Query param {name}=$KEY
+#   none    — No authentication
+# ─────────────────────────────────────────────────────────────────────
+
+services:
+
+  # ── Perplexity (recommended for web search) ─────────────────────
+  # Sign up at https://www.perplexity.ai/ and generate an API key.
+  # Set PERPLEXITY_API_KEY in .env to activate.
+  perplexity:
+    url: https://api.perplexity.ai/chat/completions
+    method: POST
+    auth:
+      type: bearer
+      env: PERPLEXITY_API_KEY
+    headers:
+      Content-Type: application/json
+    description: "Web search and AI synthesis via Perplexity Sonar API"
+    notes: >
+      Send JSON body with "model" (use "sonar" for web search) and "messages"
+      array. Example: {"model": "sonar", "messages": [{"role": "user",
+      "content": "What happened today?"}]}. Response includes citations in
+      the "citations" array.
+
+  # ── Brave Search ────────────────────────────────────────────────
+  # Uncomment to enable. Get an API key at https://brave.com/search/api/
+  # Set BRAVE_API_KEY in .env to activate.
+  #
+  # brave_search:
+  #   url: https://api.search.brave.com/res/v1/web/search
+  #   method: GET
+  #   auth:
+  #     type: header
+  #     name: X-Subscription-Token
+  #     env: BRAVE_API_KEY
+  #   description: "Web search via Brave Search API"
+  #   notes: >
+  #     Pass search query as "q" param. Example params: {"q": "your query"}.
+  #     Returns JSON with "web.results" array containing title, url, description.
+
+  # ── Jina Reader ─────────────────────────────────────────────────
+  # Uncomment to enable. Works without a key (rate-limited), or get
+  # a key at https://jina.ai/reader/ for higher limits.
+  # Set JINA_API_KEY in .env (optional) to activate with auth.
+  #
+  # jina_reader:
+  #   url: https://r.jina.ai/
+  #   method: GET
+  #   auth:
+  #     type: bearer
+  #     env: JINA_API_KEY
+  #     optional: true
+  #   description: "Convert URLs to clean markdown text"
+  #   notes: >
+  #     Append the target URL as path_suffix. Example: set path_suffix
+  #     to "https://example.com" to fetch and convert that page.
+
+  # ── SearXNG (self-hosted) ──────────────────────────────────────
+  # Uncomment if you run a local SearXNG instance.
+  # No API key needed — just set the correct URL.
+  #
+  # searxng:
+  #   url: http://localhost:8888/search
+  #   method: GET
+  #   auth:
+  #     type: none
+  #   params:
+  #     format: json
+  #   description: "Self-hosted metasearch via local SearXNG instance"
+  #   notes: >
+  #     Pass search query as "q" param. Example params: {"q": "your query"}.
+  #     Returns JSON with "results" array.

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -49,7 +49,7 @@ from telegram.ext import (
     filters,
 )
 
-from kai import sessions, webhook
+from kai import services, sessions, webhook
 from kai.claude import PersistentClaude
 from kai.config import PROJECT_ROOT, Config
 from kai.history import log_message
@@ -891,6 +891,7 @@ async def handle_webhooks(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             "  POST /webhook/github  (GitHub events)",
             "  POST /webhook         (generic)",
             "  POST /api/schedule    (scheduling API)",
+            "  POST /api/services/*  (external service proxy)",
         ]
     else:
         lines += [
@@ -1424,6 +1425,7 @@ def create_bot(config: Config) -> Application:
         webhook_secret=config.webhook_secret,
         max_budget_usd=config.claude_max_budget_usd,
         timeout_seconds=config.claude_timeout_seconds,
+        services_info=services.get_available_services(),
     )
 
     # Command handlers (alphabetical registration, but order doesn't matter for commands)

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from telegram import BotCommand
 from telegram.error import NetworkError
 
-from kai import cron, sessions, webhook
+from kai import cron, services, sessions, webhook
 from kai.bot import create_bot
 from kai.config import PROJECT_ROOT, load_config
 
@@ -93,6 +93,12 @@ def main() -> None:
 
     config = load_config()
     logging.info("Kai starting (model=%s, users=%s)", config.claude_model, config.allowed_user_ids)
+
+    # Load external service definitions from services.yaml (missing file is fine — graceful degradation)
+    loaded = services.load_services(PROJECT_ROOT / "services.yaml")
+    if loaded:
+        names = ", ".join(loaded.keys())
+        logging.info("Loaded %d service(s): %s", len(loaded), names)
 
     async def _init_and_run() -> None:
         """

--- a/src/kai/services.py
+++ b/src/kai/services.py
@@ -1,0 +1,354 @@
+"""
+Declarative HTTP service layer for external API integrations.
+
+Provides functionality to:
+1. Load service definitions from a YAML config file (services.yaml)
+2. Validate service configs and check that required env vars are set
+3. Inject authentication (bearer, header, query param) into outbound requests
+4. Proxy HTTP calls to external APIs on behalf of the inner Claude process
+
+Services are defined as inert data — URL, method, auth type, headers. No code
+execution, no plugins, no middleware. Kai's own process makes the HTTP call
+directly and returns the result. API keys live in .env and are never exposed
+to the inner Claude process or included in conversation context.
+
+The proxy flow:
+    Inner Claude  --curl-->  localhost:8080/api/services/{name}  --HTTP-->  External API
+                             (webhook.py injects auth from .env)
+
+This follows the same local-proxy pattern as the scheduling API — inner Claude
+already uses curl to hit local endpoints. The service layer extends this pattern
+to external API calls with authentication injection.
+
+Auth injection by type:
+    bearer  ->  Authorization: Bearer $KEY
+    header  ->  {auth.name}: $KEY
+    query   ->  ?{auth.name}=$KEY
+    none    ->  no auth
+"""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import aiohttp
+import yaml
+
+log = logging.getLogger(__name__)
+
+# Valid authentication types for service definitions
+_VALID_AUTH_TYPES = {"bearer", "header", "query", "none"}
+
+# Module-level service registry, populated by load_services() at startup
+_services: dict[str, "ServiceDef"] | None = None
+
+
+# ── Data classes ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class AuthConfig:
+    """
+    Authentication configuration for an external service.
+
+    Attributes:
+        type: Auth injection method — "bearer", "header", "query", or "none".
+        env: Environment variable name containing the API key (e.g., "PERPLEXITY_API_KEY").
+        name: Header or query parameter name for "header"/"query" types (e.g., "X-Subscription-Token").
+        optional: If True, the service remains available even when the env var is unset.
+    """
+
+    type: str
+    env: str = ""
+    name: str = ""
+    optional: bool = False
+
+
+@dataclass(frozen=True)
+class ServiceDef:
+    """
+    A complete external service definition loaded from services.yaml.
+
+    Each service describes a single HTTP endpoint with its URL, method,
+    authentication, and optional static headers/params. The description
+    and notes fields are injected into inner Claude's context so it knows
+    how to use the service.
+
+    Attributes:
+        name: Unique identifier used in the proxy URL (e.g., "perplexity").
+        url: Base URL for the API endpoint.
+        method: HTTP method — "GET" or "POST".
+        auth: Authentication configuration.
+        headers: Static headers to include on every request.
+        params: Static query parameters to include on every request.
+        description: Human-readable description of what the service does.
+        notes: Usage hints for inner Claude (e.g., expected request body format).
+    """
+
+    name: str
+    url: str
+    method: str
+    auth: AuthConfig
+    headers: dict[str, str] = field(default_factory=dict)
+    params: dict[str, str] = field(default_factory=dict)
+    description: str = ""
+    notes: str = ""
+
+
+@dataclass
+class ServiceResponse:
+    """
+    Result from calling an external service.
+
+    Attributes:
+        success: True if the HTTP call completed (even with non-2xx status).
+        status: HTTP status code from the external API.
+        body: Response body as a string.
+        error: Error message if the call failed entirely (timeout, connection error, etc.).
+    """
+
+    success: bool
+    status: int = 0
+    body: str = ""
+    error: str = ""
+
+
+# ── Service loading and validation ──────────────────────────────────
+
+
+def load_services(config_path: Path) -> dict[str, ServiceDef]:
+    """
+    Parse a services.yaml file, validate each entry, and populate the module registry.
+
+    Missing file is not an error — returns an empty dict (graceful degradation).
+    Invalid YAML syntax is a fatal error — raises SystemExit to prevent startup
+    with a silently broken config.
+
+    For each service entry:
+    - Validates URL is present and auth type is recognized
+    - Checks that the referenced env var is set (skips the service with a warning
+      if missing, unless auth.optional is True)
+    - Normalizes the HTTP method to uppercase
+
+    Args:
+        config_path: Path to the services.yaml file.
+
+    Returns:
+        Dict mapping service names to their validated ServiceDef objects.
+
+    Raises:
+        SystemExit: If the YAML file exists but contains invalid syntax.
+    """
+    global _services
+
+    if not config_path.exists():
+        log.info("No services config at %s — external services disabled", config_path)
+        _services = {}
+        return _services
+
+    try:
+        raw = yaml.safe_load(config_path.read_text())
+    except yaml.YAMLError as e:
+        log.critical("Invalid YAML in %s: %s", config_path, e)
+        raise SystemExit(1) from e
+
+    # Handle empty file or non-dict top level
+    if not isinstance(raw, dict):
+        log.warning("Services config is not a YAML mapping — ignoring")
+        _services = {}
+        return _services
+
+    services_raw = raw.get("services", {})
+    if not isinstance(services_raw, dict):
+        log.warning("'services' key is not a mapping — ignoring")
+        _services = {}
+        return _services
+
+    result: dict[str, ServiceDef] = {}
+
+    for name, entry in services_raw.items():
+        if not isinstance(entry, dict):
+            log.warning("Service '%s': entry is not a mapping — skipping", name)
+            continue
+
+        # URL is required
+        url = entry.get("url")
+        if not url:
+            log.warning("Service '%s': missing 'url' — skipping", name)
+            continue
+
+        # Parse and validate auth config
+        auth_raw = entry.get("auth", {})
+        if not isinstance(auth_raw, dict):
+            log.warning("Service '%s': 'auth' is not a mapping — skipping", name)
+            continue
+
+        auth_type = auth_raw.get("type", "none")
+        if auth_type not in _VALID_AUTH_TYPES:
+            log.warning("Service '%s': invalid auth type '%s' — skipping", name, auth_type)
+            continue
+
+        auth = AuthConfig(
+            type=auth_type,
+            env=auth_raw.get("env", ""),
+            name=auth_raw.get("name", ""),
+            optional=bool(auth_raw.get("optional", False)),
+        )
+
+        # Check that the referenced env var is actually set
+        if auth.type != "none" and auth.env and not os.environ.get(auth.env):
+            if auth.optional:
+                log.info("Service '%s': env var %s not set (optional) — available without auth", name, auth.env)
+            else:
+                log.warning("Service '%s': env var %s not set — skipping", name, auth.env)
+                continue
+
+        # Parse static headers and params
+        headers = entry.get("headers", {})
+        if not isinstance(headers, dict):
+            headers = {}
+
+        params = entry.get("params", {})
+        if not isinstance(params, dict):
+            params = {}
+
+        method = str(entry.get("method", "GET")).upper()
+
+        result[name] = ServiceDef(
+            name=name,
+            url=url,
+            method=method,
+            auth=auth,
+            headers={str(k): str(v) for k, v in headers.items()},
+            params={str(k): str(v) for k, v in params.items()},
+            description=entry.get("description", ""),
+            notes=entry.get("notes", ""),
+        )
+
+    _services = result
+    return _services
+
+
+# ── Module-level accessors ──────────────────────────────────────────
+
+
+def get_services() -> dict[str, ServiceDef]:
+    """Return the loaded service registry, raising if load_services() hasn't been called."""
+    assert _services is not None, "Services not loaded — call load_services() first"
+    return _services
+
+
+def get_available_services() -> list[dict]:
+    """
+    Return metadata for all loaded services (for context injection).
+
+    Returns a list of dicts with name, description, method, and notes —
+    the information inner Claude needs to know what services are available
+    and how to use them. No auth details are included.
+    """
+    assert _services is not None, "Services not loaded — call load_services() first"
+    return [
+        {
+            "name": s.name,
+            "description": s.description,
+            "method": s.method,
+            "notes": s.notes,
+        }
+        for s in _services.values()
+    ]
+
+
+# ── HTTP proxy call ─────────────────────────────────────────────────
+
+
+async def call_service(
+    name: str,
+    *,
+    body: dict | None = None,
+    params: dict[str, str] | None = None,
+    path_suffix: str = "",
+) -> ServiceResponse:
+    """
+    Call an external service by name, injecting authentication from env vars.
+
+    Constructs the HTTP request from the service definition, resolves the API
+    key from the environment at call time (not at load time — supports key
+    rotation without restart), and makes the request via aiohttp.
+
+    A new ClientSession is created per call. This is simple and adequate for
+    the expected call frequency (a few per conversation, not hundreds per second).
+
+    Args:
+        name: Service name as defined in services.yaml.
+        body: Optional JSON body for POST requests.
+        params: Optional query parameters (merged with static params from config).
+        path_suffix: Optional path appended to the base URL (e.g., for Jina Reader URLs).
+
+    Returns:
+        ServiceResponse with success status, HTTP status code, and response body.
+    """
+    services = get_services()
+
+    if name not in services:
+        return ServiceResponse(success=False, error=f"Unknown service: {name}")
+
+    svc = services[name]
+
+    # Resolve the API key from env at call time (supports rotation without restart)
+    api_key = ""
+    if svc.auth.type != "none" and svc.auth.env:
+        api_key = os.environ.get(svc.auth.env, "")
+        if not api_key and not svc.auth.optional:
+            return ServiceResponse(success=False, error=f"Env var {svc.auth.env} not set")
+
+    # Build request headers — start with static headers from config
+    headers = dict(svc.headers)
+
+    # Inject auth into headers based on type
+    if api_key:
+        if svc.auth.type == "bearer":
+            headers["Authorization"] = f"Bearer {api_key}"
+        elif svc.auth.type == "header" and svc.auth.name:
+            headers[svc.auth.name] = api_key
+
+    # Build query params — merge static config params with caller-provided params
+    merged_params = dict(svc.params)
+    if params:
+        merged_params.update(params)
+
+    # Inject auth into query params if applicable
+    if api_key and svc.auth.type == "query" and svc.auth.name:
+        merged_params[svc.auth.name] = api_key
+
+    # Construct the full URL (base + optional path suffix)
+    url = svc.url + path_suffix
+
+    log.info("Calling service '%s': %s %s", name, svc.method, url)
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            # 30-second timeout — generous enough for slow APIs, short enough
+            # to avoid blocking the proxy endpoint indefinitely
+            timeout = aiohttp.ClientTimeout(total=30)
+            async with session.request(
+                method=svc.method,
+                url=url,
+                headers=headers,
+                params=merged_params if merged_params else None,
+                json=body if body else None,
+                timeout=timeout,
+            ) as resp:
+                response_body = await resp.text()
+                log.info("Service '%s' responded: %d (%d bytes)", name, resp.status, len(response_body))
+                return ServiceResponse(
+                    success=True,
+                    status=resp.status,
+                    body=response_body,
+                )
+    except TimeoutError:
+        log.warning("Service '%s' timed out", name)
+        return ServiceResponse(success=False, error="Request timed out (30s)")
+    except aiohttp.ClientError as e:
+        log.warning("Service '%s' connection error: %s", name, e)
+        return ServiceResponse(success=False, error=f"Connection error: {e}")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,649 @@
+"""Tests for the declarative HTTP service layer (services.py)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import kai.services as services
+from kai.services import (
+    call_service,
+    get_available_services,
+    load_services,
+)
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_services():
+    """Reset the module-level service registry between tests."""
+    services._services = None
+    yield
+    services._services = None
+
+
+def _write_yaml(tmp_path, content: str):
+    """Helper to write a YAML config file and return its path."""
+    p = tmp_path / "services.yaml"
+    p.write_text(content)
+    return p
+
+
+# ── TestLoadServices ────────────────────────────────────────────────
+
+
+class TestLoadServices:
+    def test_missing_file_returns_empty(self, tmp_path):
+        """Missing config file is not an error — graceful degradation."""
+        result = load_services(tmp_path / "nonexistent.yaml")
+        assert result == {}
+
+    def test_valid_bearer_auth(self, tmp_path, monkeypatch):
+        """Bearer auth service loads when env var is set."""
+        monkeypatch.setenv("TEST_KEY", "secret123")
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  testapi:
+    url: https://api.example.com/v1
+    method: POST
+    auth:
+      type: bearer
+      env: TEST_KEY
+    description: Test API
+""",
+        )
+        result = load_services(path)
+        assert "testapi" in result
+        assert result["testapi"].url == "https://api.example.com/v1"
+        assert result["testapi"].method == "POST"
+        assert result["testapi"].auth.type == "bearer"
+        assert result["testapi"].auth.env == "TEST_KEY"
+        assert result["testapi"].description == "Test API"
+
+    def test_valid_header_auth(self, tmp_path, monkeypatch):
+        """Header auth service loads with custom header name."""
+        monkeypatch.setenv("BRAVE_KEY", "bravesecret")
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  brave:
+    url: https://api.search.brave.com/res/v1/web/search
+    method: GET
+    auth:
+      type: header
+      name: X-Subscription-Token
+      env: BRAVE_KEY
+    description: Brave Search
+""",
+        )
+        result = load_services(path)
+        assert "brave" in result
+        assert result["brave"].auth.type == "header"
+        assert result["brave"].auth.name == "X-Subscription-Token"
+
+    def test_valid_query_auth(self, tmp_path, monkeypatch):
+        """Query param auth service loads correctly."""
+        monkeypatch.setenv("GOOGLE_KEY", "googlekey")
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  google:
+    url: https://customsearch.googleapis.com/customsearch/v1
+    method: GET
+    auth:
+      type: query
+      name: key
+      env: GOOGLE_KEY
+    description: Google Custom Search
+""",
+        )
+        result = load_services(path)
+        assert "google" in result
+        assert result["google"].auth.type == "query"
+        assert result["google"].auth.name == "key"
+
+    def test_valid_none_auth(self, tmp_path):
+        """No-auth services don't require env vars."""
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  local:
+    url: http://localhost:8888/search
+    method: GET
+    auth:
+      type: none
+    description: Local SearXNG
+""",
+        )
+        result = load_services(path)
+        assert "local" in result
+        assert result["local"].auth.type == "none"
+
+    def test_missing_env_var_skips_service(self, tmp_path, monkeypatch):
+        """Service is skipped when its required env var is not set."""
+        monkeypatch.delenv("MISSING_KEY", raising=False)
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  broken:
+    url: https://api.example.com
+    method: GET
+    auth:
+      type: bearer
+      env: MISSING_KEY
+    description: Will be skipped
+""",
+        )
+        result = load_services(path)
+        assert "broken" not in result
+
+    def test_optional_auth_keeps_service(self, tmp_path, monkeypatch):
+        """Services with optional auth remain available when env var is unset."""
+        monkeypatch.delenv("OPTIONAL_KEY", raising=False)
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  jina:
+    url: https://r.jina.ai/
+    method: GET
+    auth:
+      type: bearer
+      env: OPTIONAL_KEY
+      optional: true
+    description: Jina Reader
+""",
+        )
+        result = load_services(path)
+        assert "jina" in result
+        assert result["jina"].auth.optional is True
+
+    def test_invalid_auth_type_skips(self, tmp_path):
+        """Services with unrecognized auth types are skipped."""
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  bad:
+    url: https://api.example.com
+    method: POST
+    auth:
+      type: oauth2
+    description: Invalid auth type
+""",
+        )
+        result = load_services(path)
+        assert "bad" not in result
+
+    def test_missing_url_skips(self, tmp_path):
+        """Services without a URL are skipped."""
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  nourl:
+    method: GET
+    auth:
+      type: none
+    description: No URL
+""",
+        )
+        result = load_services(path)
+        assert "nourl" not in result
+
+    def test_invalid_yaml_raises_system_exit(self, tmp_path):
+        """Malformed YAML causes SystemExit (fail fast on broken config)."""
+        path = _write_yaml(tmp_path, "services:\n  bad: [unbalanced: {")
+        with pytest.raises(SystemExit):
+            load_services(path)
+
+    def test_static_headers_and_params(self, tmp_path):
+        """Static headers and params from config are preserved."""
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  local:
+    url: http://localhost:8888/search
+    method: GET
+    auth:
+      type: none
+    headers:
+      Accept: application/json
+    params:
+      format: json
+      language: en
+    description: Local search
+""",
+        )
+        result = load_services(path)
+        assert result["local"].headers == {"Accept": "application/json"}
+        assert result["local"].params == {"format": "json", "language": "en"}
+
+    def test_notes_field(self, tmp_path, monkeypatch):
+        """The notes field is loaded for context injection."""
+        monkeypatch.setenv("TEST_KEY", "key")
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  testapi:
+    url: https://api.example.com
+    method: POST
+    auth:
+      type: bearer
+      env: TEST_KEY
+    description: Test
+    notes: Send JSON body with "query" field
+""",
+        )
+        result = load_services(path)
+        assert result["testapi"].notes == 'Send JSON body with "query" field'
+
+    def test_mixed_valid_and_invalid(self, tmp_path, monkeypatch):
+        """Valid services load even when other entries are invalid."""
+        monkeypatch.setenv("GOOD_KEY", "value")
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  good:
+    url: https://api.example.com
+    method: GET
+    auth:
+      type: bearer
+      env: GOOD_KEY
+    description: Good service
+  bad_no_url:
+    method: GET
+    auth:
+      type: none
+  bad_auth:
+    url: https://api.example.com
+    auth:
+      type: magic
+""",
+        )
+        result = load_services(path)
+        assert "good" in result
+        assert "bad_no_url" not in result
+        assert "bad_auth" not in result
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        """An empty YAML file returns an empty registry."""
+        path = _write_yaml(tmp_path, "")
+        result = load_services(path)
+        assert result == {}
+
+    def test_no_services_key_returns_empty(self, tmp_path):
+        """A YAML file without a 'services' key returns an empty registry."""
+        path = _write_yaml(tmp_path, "other_key: value\n")
+        result = load_services(path)
+        assert result == {}
+
+    def test_method_defaults_to_get(self, tmp_path):
+        """Method defaults to GET when not specified."""
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  simple:
+    url: http://localhost/api
+    auth:
+      type: none
+""",
+        )
+        result = load_services(path)
+        assert result["simple"].method == "GET"
+
+    def test_method_normalized_to_uppercase(self, tmp_path, monkeypatch):
+        """Method is normalized to uppercase."""
+        monkeypatch.setenv("K", "v")
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  api:
+    url: https://api.example.com
+    method: post
+    auth:
+      type: bearer
+      env: K
+""",
+        )
+        result = load_services(path)
+        assert result["api"].method == "POST"
+
+
+# ── TestGetAvailableServices ────────────────────────────────────────
+
+
+class TestGetAvailableServices:
+    def test_returns_metadata(self, tmp_path, monkeypatch):
+        """Returns name, description, method, and notes for each service."""
+        monkeypatch.setenv("KEY", "val")
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  myapi:
+    url: https://api.example.com
+    method: POST
+    auth:
+      type: bearer
+      env: KEY
+    description: My API
+    notes: Use JSON body
+""",
+        )
+        load_services(path)
+        available = get_available_services()
+        assert len(available) == 1
+        assert available[0]["name"] == "myapi"
+        assert available[0]["description"] == "My API"
+        assert available[0]["method"] == "POST"
+        assert available[0]["notes"] == "Use JSON body"
+
+    def test_empty_when_no_services(self, tmp_path):
+        """Returns empty list when no services are configured."""
+        load_services(tmp_path / "nonexistent.yaml")
+        assert get_available_services() == []
+
+
+# ── TestCallService ─────────────────────────────────────────────────
+
+
+class TestCallService:
+    async def test_unknown_service_error(self, tmp_path):
+        """Calling a non-existent service returns an error response."""
+        load_services(tmp_path / "nonexistent.yaml")
+        result = await call_service("nonexistent")
+        assert result.success is False
+        assert "Unknown service" in result.error
+
+    async def test_bearer_auth_injected(self, tmp_path, monkeypatch):
+        """Bearer token is injected into the Authorization header."""
+        monkeypatch.setenv("API_KEY", "mytoken123")
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  testapi:
+    url: https://api.example.com/v1
+    method: POST
+    auth:
+      type: bearer
+      env: API_KEY
+    headers:
+      Content-Type: application/json
+""",
+        )
+        load_services(path)
+
+        # Mock aiohttp.ClientSession to capture the request
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.text = AsyncMock(return_value='{"result": "ok"}')
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("kai.services.aiohttp.ClientSession", return_value=mock_session):
+            result = await call_service("testapi", body={"query": "test"})
+
+        assert result.success is True
+        assert result.status == 200
+        assert result.body == '{"result": "ok"}'
+
+        # Verify the Authorization header was injected
+        call_kwargs = mock_session.request.call_args
+        headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers", {})
+        assert headers["Authorization"] == "Bearer mytoken123"
+        assert headers["Content-Type"] == "application/json"
+
+    async def test_header_auth_injected(self, tmp_path, monkeypatch):
+        """Custom header auth is injected with the correct header name."""
+        monkeypatch.setenv("BRAVE_KEY", "bravetoken")
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  brave:
+    url: https://api.search.brave.com/res/v1/web/search
+    method: GET
+    auth:
+      type: header
+      name: X-Subscription-Token
+      env: BRAVE_KEY
+""",
+        )
+        load_services(path)
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.text = AsyncMock(return_value="[]")
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("kai.services.aiohttp.ClientSession", return_value=mock_session):
+            result = await call_service("brave", params={"q": "test"})
+
+        assert result.success is True
+        call_kwargs = mock_session.request.call_args
+        headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers", {})
+        assert headers["X-Subscription-Token"] == "bravetoken"
+
+    async def test_query_auth_injected(self, tmp_path, monkeypatch):
+        """Query param auth is injected into the params dict."""
+        monkeypatch.setenv("GOOGLE_KEY", "googlekey")
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  google:
+    url: https://customsearch.googleapis.com/customsearch/v1
+    method: GET
+    auth:
+      type: query
+      name: key
+      env: GOOGLE_KEY
+""",
+        )
+        load_services(path)
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.text = AsyncMock(return_value="{}")
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("kai.services.aiohttp.ClientSession", return_value=mock_session):
+            result = await call_service("google", params={"q": "test"})
+
+        assert result.success is True
+        call_kwargs = mock_session.request.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params", {})
+        assert params["key"] == "googlekey"
+        assert params["q"] == "test"
+
+    async def test_path_suffix_appended(self, tmp_path, monkeypatch):
+        """Path suffix is appended to the base URL."""
+        monkeypatch.setenv("JINA_KEY", "jinakey")
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  jina:
+    url: https://r.jina.ai/
+    method: GET
+    auth:
+      type: bearer
+      env: JINA_KEY
+""",
+        )
+        load_services(path)
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.text = AsyncMock(return_value="# Page content")
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("kai.services.aiohttp.ClientSession", return_value=mock_session):
+            result = await call_service("jina", path_suffix="https://example.com")
+
+        assert result.success is True
+        call_kwargs = mock_session.request.call_args
+        url = call_kwargs.kwargs.get("url") or call_kwargs[1].get("url")
+        assert url == "https://r.jina.ai/https://example.com"
+
+    async def test_env_var_disappears_after_load(self, tmp_path, monkeypatch):
+        """If an env var is unset after load, call_service returns an error."""
+        monkeypatch.setenv("TEMP_KEY", "tempvalue")
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  tempapi:
+    url: https://api.example.com
+    method: GET
+    auth:
+      type: bearer
+      env: TEMP_KEY
+""",
+        )
+        load_services(path)
+        assert "tempapi" in services.get_services()
+
+        # Remove the env var after loading
+        monkeypatch.delenv("TEMP_KEY")
+        result = await call_service("tempapi")
+        assert result.success is False
+        assert "not set" in result.error
+
+    async def test_static_params_merged(self, tmp_path):
+        """Static params from config are merged with caller-provided params."""
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  local:
+    url: http://localhost:8888/search
+    method: GET
+    auth:
+      type: none
+    params:
+      format: json
+""",
+        )
+        load_services(path)
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.text = AsyncMock(return_value="[]")
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("kai.services.aiohttp.ClientSession", return_value=mock_session):
+            result = await call_service("local", params={"q": "test"})
+
+        assert result.success is True
+        call_kwargs = mock_session.request.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params", {})
+        # Both static and caller params should be present
+        assert params["format"] == "json"
+        assert params["q"] == "test"
+
+    async def test_connection_error_handled(self, tmp_path):
+        """Connection errors return a ServiceResponse with error details."""
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  failing:
+    url: http://localhost:99999/api
+    method: GET
+    auth:
+      type: none
+""",
+        )
+        load_services(path)
+
+        import aiohttp as _aiohttp
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(side_effect=_aiohttp.ClientError("Connection refused"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("kai.services.aiohttp.ClientSession", return_value=mock_session):
+            result = await call_service("failing")
+
+        assert result.success is False
+        assert "Connection error" in result.error
+
+    async def test_non_2xx_still_succeeds(self, tmp_path, monkeypatch):
+        """Non-2xx status codes are still returned as success (HTTP completed)."""
+        monkeypatch.setenv("KEY", "val")
+        path = _write_yaml(
+            tmp_path,
+            """
+services:
+  api:
+    url: https://api.example.com
+    method: POST
+    auth:
+      type: bearer
+      env: KEY
+""",
+        )
+        load_services(path)
+
+        mock_response = AsyncMock()
+        mock_response.status = 429
+        mock_response.text = AsyncMock(return_value='{"error": "rate limited"}')
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("kai.services.aiohttp.ClientSession", return_value=mock_session):
+            result = await call_service("api", body={"query": "test"})
+
+        # HTTP completed, even though status is 429 — that's still success=True
+        assert result.success is True
+        assert result.status == 429
+        assert "rate limited" in result.body

--- a/workspace/.claude/CLAUDE.md
+++ b/workspace/.claude/CLAUDE.md
@@ -105,3 +105,29 @@ For auto-remove jobs, start your response with `CONDITION_MET: <message>` when t
   - `interval`: `{"seconds": N}`
 - `job_type` — `reminder` (default) or `claude`
 - `auto_remove` — boolean, deactivate when condition met (claude jobs only)
+
+## External Services
+
+Use the service proxy to call external APIs without handling API keys directly. The proxy endpoint, secret, and available services are provided in your session context. Use `SECRET` as a placeholder below — replace with the actual value from your context.
+
+### Calling a service:
+```bash
+curl -s -X POST http://localhost:8080/api/services/perplexity \
+  -H 'Content-Type: application/json' \
+  -H 'X-Webhook-Secret: SECRET' \
+  -d '{"body": {"model": "sonar", "messages": [{"role": "user", "content": "What happened today in tech news?"}]}}'
+```
+
+### Request JSON fields (all optional):
+- `body` — dict, forwarded as JSON body to the external API
+- `params` — dict, query parameters (merged with any static params in the service config)
+- `path_suffix` — string, appended to the service's base URL (useful for Jina Reader: set to the target URL)
+
+### Response format:
+- Success: `{"status": 200, "body": "..."}`
+- Failure: `{"error": "..."}`
+
+### When to use services vs built-in tools:
+- **Prefer external services** (like Perplexity) when available — they provide better, more current results than built-in WebSearch/WebFetch
+- **Fall back to WebSearch/WebFetch** if no services are configured or if a service call fails
+- Check your session context for the list of available services and their usage notes


### PR DESCRIPTION
## Summary

Adds a YAML-based external service integration layer, starting with Perplexity for web search.

- **New module** (`services.py`): Loads service definitions from `services.yaml`, validates config, executes HTTP calls with automatic auth injection (bearer, header, query, none)
- **Proxy endpoint** (`POST /api/services/{name}`): Inner Claude calls this via curl -- auth is injected server-side, so API keys never enter Claude context
- **Context injection** (`claude.py`): Available services are listed in session context with descriptions, notes, and curl examples
- **28 new tests** covering config loading, validation, all auth types, HTTP call mocking, and error handling (126 total, all passing)

### Security model

Five hard constraints: REST only, auth from `.env` only, no code execution, outbound only, no third-party runtime. Service definitions are inert YAML data, not executable code.

### Files changed

| File | Change |
|------|--------|
| `src/kai/services.py` | **New** -- service layer core |
| `tests/test_services.py` | **New** -- 28 tests |
| `services.example.yaml` | **New** -- example config with Perplexity + commented alternatives |
| `src/kai/webhook.py` | Add `/api/services/{name}` proxy route |
| `src/kai/claude.py` | Add `services_info` param + context injection |
| `src/kai/bot.py` | Wire services into PersistentClaude, update `/webhooks` |
| `src/kai/main.py` | Load services at startup |
| `workspace/.claude/CLAUDE.md` | Add service usage instructions |
| `pyproject.toml` | Add PyYAML dependency |
| `.env.example` | Add `PERPLEXITY_API_KEY` section |
| `.gitignore` | Add `services.yaml` |

## Test plan

- [x] `make check` -- lint + format clean
- [x] `make test` -- 126 tests passing (28 new)
- [x] Live test: Kai successfully used Perplexity for web search via the proxy endpoint
- [x] Graceful degradation: starts fine without `services.yaml`