### PR TITLE
Harden webhook server: bind localhost, validate job_type

### DIFF
--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -295,6 +295,9 @@ async def _handle_generic(request: web.Request) -> web.Response:
 # Valid schedule types accepted by the scheduling API
 _VALID_SCHEDULE_TYPES = ("once", "daily", "interval")
 
+# Valid job types accepted by the scheduling API
+_VALID_JOB_TYPES = ("reminder", "claude")
+
 
 async def _handle_schedule(request: web.Request) -> web.Response:
     """
@@ -343,8 +346,13 @@ async def _handle_schedule(request: web.Request) -> web.Response:
             status=400,
         )
 
-    # Optional fields with defaults
+    # Optional fields with defaults — validate job_type the same way as schedule_type
     job_type = payload.get("job_type", "reminder")
+    if job_type not in _VALID_JOB_TYPES:
+        return web.json_response(
+            {"error": f"job_type must be one of: {', '.join(_VALID_JOB_TYPES)}"},
+            status=400,
+        )
     auto_remove = payload.get("auto_remove", False)
     notify_on_check = payload.get("notify_on_check", False)
     chat_id = request.app["chat_id"]
@@ -638,7 +646,9 @@ async def start(telegram_app, config) -> None:
 
     _runner = web.AppRunner(_app, access_log=None)
     await _runner.setup()
-    site = web.TCPSite(_runner, "0.0.0.0", config.webhook_port)
+    # Bind to localhost only — all external access routes through Cloudflare Tunnel,
+    # so there's no reason to expose the server on the LAN.
+    site = web.TCPSite(_runner, "127.0.0.1", config.webhook_port)
     await site.start()
     log.info("Webhook server listening on port %d", config.webhook_port)
 

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -7,7 +7,7 @@ import pytest
 from aiohttp import web
 
 from kai import sessions
-from kai.webhook import _handle_delete_job, _handle_update_job
+from kai.webhook import _handle_delete_job, _handle_schedule, _handle_update_job
 
 
 @pytest.fixture
@@ -33,6 +33,59 @@ def mock_request():
     request.headers = {}
     request.match_info = {}
     return request
+
+
+# ── POST /api/schedule ────────────────────────────────────────────────
+
+
+class TestScheduleJobType:
+    async def test_invalid_job_type_returns_400(self, db, mock_request):
+        """Schedule endpoint rejects unrecognized job_type values."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app["chat_id"] = 123
+        mock_request.json = AsyncMock(
+            return_value={
+                "name": "test",
+                "prompt": "test",
+                "schedule_type": "once",
+                "schedule_data": {"run_at": "2026-02-20T10:00:00+00:00"},
+                "job_type": "invalid",
+            }
+        )
+
+        resp = await _handle_schedule(mock_request)
+
+        assert resp.status == 400
+        body = json.loads(resp.body.decode())
+        assert "error" in body
+        assert "job_type" in body["error"]
+
+    async def test_valid_job_type_accepted(self, db, mock_request):
+        """Schedule endpoint accepts valid job_type values without error."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app["chat_id"] = 123
+        mock_request.app["telegram_app"].job_queue = MagicMock()
+
+        # Mock register_job_by_id so we don't need a full APScheduler setup
+        import kai.cron as cron_mod
+
+        cron_mod.register_job_by_id = AsyncMock()
+
+        mock_request.json = AsyncMock(
+            return_value={
+                "name": "test claude job",
+                "prompt": "test",
+                "schedule_type": "once",
+                "schedule_data": {"run_at": "2026-02-20T10:00:00+00:00"},
+                "job_type": "claude",
+            }
+        )
+
+        resp = await _handle_schedule(mock_request)
+
+        assert resp.status == 200
+        body = json.loads(resp.body.decode())
+        assert "job_id" in body
 
 
 # ── DELETE /api/jobs/{id} ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Bind aiohttp server to `127.0.0.1` instead of `0.0.0.0` -- all external access routes through Cloudflare Tunnel, so there's no reason to expose the API on the LAN
- Validate `job_type` in the schedule endpoint -- reject anything that isn't `"reminder"` or `"claude"` with a 400 response, matching the existing `schedule_type` validation pattern
- Add tests for both valid and invalid `job_type` values

Inspired by community PR #7 (closed). These two improvements were the good parts, extracted and done properly.

## Test plan

- [x] Existing 40 webhook tests pass
- [x] New `TestScheduleJobType` tests cover invalid rejection (400) and valid acceptance (200)
- [x] Ruff lint clean