### PR TITLE
Document file exchange feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Switch between Opus, Sonnet, and Haiku via `/models` (interactive picker) or `/m
 
 Point Claude at any project with `/workspace <name>`. Names resolve relative to `WORKSPACE_BASE` (set in `.env`). Identity and memory from the home workspace carry over. Create new workspaces with `/workspace new <name>`. Absolute paths are not accepted — all workspaces must live under the configured base directory.
 
-### Image and file support
+### File exchange
 
-Send photos or documents directly in chat. Supports images (JPEG, PNG, GIF, WebP) and text files (Python, JS, JSON, Markdown, and many more).
+Send any file type directly in chat -- photos, documents, PDFs, archives, anything. Files are saved to `workspace/files/` with timestamped names, and Claude gets the path so it can work with them via shell tools. Claude can also send files back to you through the internal API. Images render inline; everything else arrives as a document attachment.
 
 ### Voice input
 

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -7,6 +7,7 @@ Provides functionality to:
 3. Expose a scheduling API for creating cron-style jobs via HTTP
 4. Expose a jobs query API for listing and fetching scheduled jobs
 5. Proxy authenticated requests to external services (service layer)
+6. Send files from the workspace to the Telegram chat (file exchange API)
 
 The server runs on aiohttp alongside the Telegram bot in the same event loop.
 Routes are organized into five groups:


### PR DESCRIPTION
## Summary

- **README.md** -- renamed "Image and file support" to "File exchange" and expanded to describe bidirectional file transfer, universal file type support, and workspace file saving
- **webhook.py** -- added file exchange API to the module docstring functionality list

Wiki was updated directly (not part of this PR):
- **System Architecture** -- added send-file endpoint to the endpoints table, file exchange section after service proxy, file API info to the context injection list, and the PATCH/DELETE jobs endpoints that were missing since PR #5

## Test plan

- [x] No code changes, docs only
- [x] Wiki changes pushed and live