### PR TITLE
Add ALLOWED_WORKSPACES config for pinned workspace access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ CLAUDE_MAX_BUDGET_USD=10.0
 # Must be an existing directory. If unset, only /workspace home works.
 WORKSPACE_BASE=
 
+# Additional workspaces accessible by name, outside WORKSPACE_BASE.
+# Comma-separated absolute paths. Non-existent paths are skipped at startup.
+# Example: ALLOWED_WORKSPACES=/home/user/project-a,/home/user/project-b
+ALLOWED_WORKSPACES=
+
 # ── Webhook & Scheduling API ─────────────────────────────────────
 
 # Port for the local webhook/API server (receives GitHub events, scheduling API)

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -668,30 +668,51 @@ async def _workspaces_keyboard(
     current_path: str,
     home_path: str,
     base: Path | None,
+    allowed_workspaces: list[Path],
 ) -> InlineKeyboardMarkup:
     """
     Build an inline keyboard for workspace switching.
 
-    Shows a Home button at the top, followed by recent workspace history.
-    The current workspace is marked with a green dot. Each button's callback
-    data is "ws:home" or "ws:<index>" where index maps to the history list.
+    Layout (top to bottom):
+    1. Home button (always first)
+    2. Allowed (pinned) workspaces from ALLOWED_WORKSPACES config, in order
+    3. Recent workspace history, deduplicated against allowed workspaces and home
+
+    The current workspace is marked with a green dot. Callback data:
+    - "ws:home" for the home button
+    - "ws:allowed:<index>" for pinned workspaces (index into allowed_workspaces)
+    - "ws:<index>" for history entries (index into the history list)
     """
     buttons = []
+
+    # Collect allowed paths as strings for deduplication checks below
+    allowed_path_strs = {str(p) for p in allowed_workspaces}
+
     # Home button (always first)
     home_label = "\U0001f3e0 Home"
     if current_path == home_path:
         home_label += " \U0001f7e2"
     buttons.append([InlineKeyboardButton(home_label, callback_data="ws:home")])
-    # History entries (skip home, already shown above)
+
+    # Pinned workspaces from ALLOWED_WORKSPACES (shown above history)
+    for i, p in enumerate(allowed_workspaces):
+        short = _short_workspace_name(str(p), base)
+        label = short
+        if str(p) == current_path:
+            label += " \U0001f7e2"
+        buttons.append([InlineKeyboardButton(label, callback_data=f"ws:allowed:{i}")])
+
+    # History entries — skip home and any path already shown in the allowed section
     for i, entry in enumerate(history):
         p = entry["path"]
-        if p == home_path:
+        if p == home_path or p in allowed_path_strs:
             continue
         short = _short_workspace_name(p, base)
         label = short
         if p == current_path:
             label += " \U0001f7e2"
         buttons.append([InlineKeyboardButton(label, callback_data=f"ws:{i}")])
+
     return InlineKeyboardMarkup(buttons)
 
 
@@ -705,11 +726,11 @@ async def handle_workspaces(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     current = str(claude.workspace)
     home = str(config.claude_workspace)
 
-    if not history and current == home:
+    if not history and not config.allowed_workspaces and current == home:
         await update.message.reply_text("No workspace history yet.\nUse /workspace new <name> to create one.")
         return
 
-    keyboard = await _workspaces_keyboard(history, current, home, config.workspace_base)
+    keyboard = await _workspaces_keyboard(history, current, home, config.workspace_base, config.allowed_workspaces)
     await update.message.reply_text("Workspaces:", reply_markup=keyboard)
 
 
@@ -738,6 +759,25 @@ async def handle_workspace_callback(update: Update, context: ContextTypes.DEFAUL
     if data == "home":
         path = home
         label = "Home"
+    elif data.startswith("allowed:"):
+        # Pinned workspace from ALLOWED_WORKSPACES config
+        try:
+            idx = int(data.removeprefix("allowed:"))
+        except ValueError:
+            await query.answer("Invalid selection.")
+            await query.edit_message_text("No change.", reply_markup=InlineKeyboardMarkup([]))
+            return
+        allowed = config.allowed_workspaces
+        if idx < 0 or idx >= len(allowed):
+            await query.answer("Workspace no longer available.")
+            await query.edit_message_text("No change.", reply_markup=InlineKeyboardMarkup([]))
+            return
+        path = allowed[idx]
+        if not path.is_dir():
+            await query.answer("That workspace no longer exists.")
+            await query.edit_message_text("No change.", reply_markup=InlineKeyboardMarkup([]))
+            return
+        label = _short_workspace_name(str(path), base)
     else:
         try:
             idx = int(data)
@@ -756,7 +796,9 @@ async def handle_workspace_callback(update: Update, context: ContextTypes.DEFAUL
             await sessions.delete_workspace_history(str(path))
             await query.answer("That workspace no longer exists.")
             history = await sessions.get_workspace_history()
-            keyboard = await _workspaces_keyboard(history, str(claude.workspace), str(home), base)
+            keyboard = await _workspaces_keyboard(
+                history, str(claude.workspace), str(home), base, config.allowed_workspaces
+            )
             await query.edit_message_reply_markup(reply_markup=keyboard)
             return
         label = _short_workspace_name(str(path), base)
@@ -787,11 +829,11 @@ async def handle_workspace(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     Subcommands:
         /workspace              — show current workspace
         /workspace home         — switch to home workspace
-        /workspace <name>       — switch to a workspace by name (resolved under WORKSPACE_BASE)
+        /workspace <name>       — switch to a workspace by name (WORKSPACE_BASE, then ALLOWED_WORKSPACES)
         /workspace new <name>   — create a new workspace with git init and switch to it
 
-    Absolute paths and ~ expansion are rejected for security. All workspace
-    names are resolved relative to WORKSPACE_BASE with traversal prevention.
+    Absolute paths and ~ expansion are rejected for security. Name resolution
+    checks WORKSPACE_BASE first, then ALLOWED_WORKSPACES (by directory name).
     """
     assert update.message is not None
     claude = _get_claude(context)
@@ -849,21 +891,25 @@ async def handle_workspace(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         await _switch_workspace(update, context, resolved)
         return
 
-    # Resolve workspace name via base directory
-    if not base:
-        await update.message.reply_text(_NO_BASE_MSG)
-        return
+    # Try WORKSPACE_BASE first (WORKSPACE_BASE wins on name collision per spec)
+    resolved: Path | None = None
+    base_candidate = _resolve_workspace_path(target, base)
+    if base_candidate is not None and base_candidate.is_dir():
+        resolved = base_candidate
 
-    resolved = _resolve_workspace_path(target, base)
+    # Fall back to allowed workspaces — match by directory name
     if resolved is None:
-        await update.message.reply_text("Invalid workspace name.")
-        return
+        resolved = next(
+            (p for p in config.allowed_workspaces if p.name == target),
+            None,
+        )
 
-    if not resolved.exists():
-        await update.message.reply_text(f"Path does not exist:\n{resolved}")
-        return
-    if not resolved.is_dir():
-        await update.message.reply_text(f"Not a directory:\n{resolved}")
+    if resolved is None:
+        # Give a helpful message if neither source is configured
+        if not base and not config.allowed_workspaces:
+            await update.message.reply_text(_NO_BASE_MSG)
+        else:
+            await update.message.reply_text(f"Workspace '{target}' not found.")
         return
 
     await _switch_workspace(update, context, resolved)

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -12,6 +12,7 @@ All paths are resolved relative to PROJECT_ROOT (the repository root), which is
 derived from this file's location in the source tree: src/kai/config.py -> project root.
 """
 
+import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -46,6 +47,9 @@ class Config:
         tts_enabled: Whether to enable Piper text-to-speech for voice responses
         piper_model_dir: Directory containing Piper voice model files
         workspace_base: Base directory for workspace name resolution (/workspace <name>)
+        allowed_workspaces: Additional workspace directories accessible by name, from config only.
+            These appear as pinned workspaces in /workspaces and are reachable via /workspace <name>
+            without being under WORKSPACE_BASE. Non-existent paths are skipped at startup.
     """
 
     # Required fields — no defaults, must be provided
@@ -75,6 +79,7 @@ class Config:
 
     # Workspace switching
     workspace_base: Path | None = None
+    allowed_workspaces: list[Path] = field(default_factory=list)
 
 
 def load_config() -> Config:
@@ -119,6 +124,19 @@ def load_config() -> Config:
         if not workspace_base.is_dir():
             raise SystemExit(f"WORKSPACE_BASE is not an existing directory: {workspace_base}")
 
+    # Parse optional: allowed workspaces (comma-separated absolute paths).
+    # Non-existent paths are skipped with a warning rather than crashing, so
+    # a stale entry (e.g. an unmounted external drive) doesn't block startup.
+    allowed_workspaces: list[Path] = []
+    raw_allowed = os.environ.get("ALLOWED_WORKSPACES", "").strip()
+    if raw_allowed:
+        for raw_path in raw_allowed.split(","):
+            p = Path(raw_path.strip()).expanduser().resolve()
+            if p.is_dir():
+                allowed_workspaces.append(p)
+            else:
+                logging.warning("ALLOWED_WORKSPACES: skipping non-existent path: %s", p)
+
     return Config(
         telegram_bot_token=token,
         allowed_user_ids=allowed_ids,
@@ -130,4 +148,5 @@ def load_config() -> Config:
         voice_enabled=os.environ.get("VOICE_ENABLED", "").lower() in ("1", "true", "yes"),
         tts_enabled=os.environ.get("TTS_ENABLED", "").lower() in ("1", "true", "yes"),
         workspace_base=workspace_base,
+        allowed_workspaces=allowed_workspaces,
     )

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2,12 +2,15 @@
 
 from pathlib import Path
 
+import pytest
+
 from kai.bot import (
     _chunk_text,
     _resolve_workspace_path,
     _save_to_workspace,
     _short_workspace_name,
     _truncate_for_telegram,
+    _workspaces_keyboard,
 )
 
 # ── _resolve_workspace_path ──────────────────────────────────────────
@@ -135,3 +138,76 @@ class TestSaveToWorkspace:
         result = _save_to_workspace(b"x", "test.txt", tmp_path)
         assert result.is_absolute()
         assert result.is_file()
+
+
+# ── _workspaces_keyboard ────────────────────────────────────────────
+
+
+def _button_labels(markup) -> list[str]:
+    """Flatten InlineKeyboardMarkup into a list of button labels."""
+    return [btn.text for row in markup.inline_keyboard for btn in row]
+
+
+def _button_callbacks(markup) -> list[str]:
+    """Flatten InlineKeyboardMarkup into a list of callback data strings."""
+    return [btn.callback_data for row in markup.inline_keyboard for btn in row]
+
+
+class TestWorkspacesKeyboard:
+    @pytest.mark.asyncio
+    async def test_home_always_first(self, tmp_path):
+        """Home button appears first regardless of history or allowed workspaces."""
+        markup = await _workspaces_keyboard([], "/home", "/home", None, [])
+        assert _button_labels(markup)[0] == "\U0001f3e0 Home \U0001f7e2"
+
+    @pytest.mark.asyncio
+    async def test_allowed_workspaces_appear_before_history(self, tmp_path):
+        """Pinned workspaces appear between Home and history entries."""
+        pinned = tmp_path / "pinned"
+        pinned.mkdir()
+        history = [{"path": "/other/project"}]
+        markup = await _workspaces_keyboard(history, "/other/project", "/home", None, [pinned])
+        labels = _button_labels(markup)
+        # Home, then pinned, then history
+        assert labels[0].startswith("\U0001f3e0 Home")
+        assert labels[1] == "pinned"
+        assert labels[2].endswith("\U0001f7e2")  # history entry marked as current
+
+    @pytest.mark.asyncio
+    async def test_allowed_workspace_callback_data(self, tmp_path):
+        """Pinned workspaces use ws:allowed:<index> callback data."""
+        pinned = tmp_path / "project-a"
+        pinned.mkdir()
+        markup = await _workspaces_keyboard([], "/home", "/home", None, [pinned])
+        callbacks = _button_callbacks(markup)
+        assert "ws:allowed:0" in callbacks
+
+    @pytest.mark.asyncio
+    async def test_history_deduplicated_against_allowed(self, tmp_path):
+        """A path in both allowed and history appears only once (in allowed section)."""
+        pinned = tmp_path / "shared"
+        pinned.mkdir()
+        history = [{"path": str(pinned)}]
+        markup = await _workspaces_keyboard(history, "/home", "/home", None, [pinned])
+        labels = _button_labels(markup)
+        # Should be: Home + one "shared" entry — not two "shared" entries
+        assert labels.count("shared") == 1
+        callbacks = _button_callbacks(markup)
+        # The single entry should be the allowed version, not a bare history index
+        assert "ws:allowed:0" in callbacks
+        assert not any(c == "ws:0" for c in callbacks)
+
+    @pytest.mark.asyncio
+    async def test_current_workspace_marked_in_allowed(self, tmp_path):
+        """Green dot appears on the pinned workspace button when it is current."""
+        pinned = tmp_path / "active"
+        pinned.mkdir()
+        markup = await _workspaces_keyboard([], str(pinned), "/home", None, [pinned])
+        labels = _button_labels(markup)
+        assert any("active" in lbl and "\U0001f7e2" in lbl for lbl in labels)
+
+    @pytest.mark.asyncio
+    async def test_no_allowed_no_history_shows_only_home(self):
+        """With no allowed workspaces and no history, only the Home button appears."""
+        markup = await _workspaces_keyboard([], "/home", "/home", None, [])
+        assert len(_button_labels(markup)) == 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,7 @@ _CONFIG_ENV_VARS = [
     "VOICE_ENABLED",
     "TTS_ENABLED",
     "WORKSPACE_BASE",
+    "ALLOWED_WORKSPACES",
 ]
 
 
@@ -110,3 +111,38 @@ class TestLoadConfigOptional:
         _set_required(monkeypatch)
         monkeypatch.setenv("WEBHOOK_SECRET", "s3cret")
         assert load_config().webhook_secret == "s3cret"
+
+    def test_allowed_workspaces_default_empty(self, monkeypatch):
+        _set_required(monkeypatch)
+        assert load_config().allowed_workspaces == []
+
+    def test_allowed_workspaces_single(self, monkeypatch, tmp_path):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("ALLOWED_WORKSPACES", str(tmp_path))
+        config = load_config()
+        assert config.allowed_workspaces == [tmp_path]
+
+    def test_allowed_workspaces_multiple(self, monkeypatch, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        _set_required(monkeypatch)
+        monkeypatch.setenv("ALLOWED_WORKSPACES", f"{dir_a},{dir_b}")
+        config = load_config()
+        assert config.allowed_workspaces == [dir_a, dir_b]
+
+    def test_allowed_workspaces_skips_nonexistent(self, monkeypatch, tmp_path):
+        # Non-existent paths are skipped with a warning, not a crash
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        fake_dir = tmp_path / "nope"
+        _set_required(monkeypatch)
+        monkeypatch.setenv("ALLOWED_WORKSPACES", f"{real_dir},{fake_dir}")
+        config = load_config()
+        assert config.allowed_workspaces == [real_dir]
+
+    def test_allowed_workspaces_all_nonexistent_returns_empty(self, monkeypatch, tmp_path):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("ALLOWED_WORKSPACES", str(tmp_path / "nope"))
+        assert load_config().allowed_workspaces == []


### PR DESCRIPTION
## Summary

Adds `ALLOWED_WORKSPACES` config to make specific workspace directories accessible by name without requiring them to be under `WORKSPACE_BASE`. This is useful for working with existing projects that live outside the workspace base directory.

- `ALLOWED_WORKSPACES=/path/a,/path/b` in `.env` — comma-separated absolute paths
- Non-existent paths are skipped at startup with a warning, not a crash
- `/workspace <name>` checks `WORKSPACE_BASE` first, then falls through to `ALLOWED_WORKSPACES` by directory name
- `WORKSPACE_BASE` wins on name collision (per spec)
- `/workspaces` keyboard shows allowed workspaces as a pinned section above history
- History deduplicates against allowed workspaces — paths shown in pinned section do not repeat in history
- Callback data scheme: `ws:allowed:<index>` for pinned buttons alongside existing `ws:home` and `ws:<index>`

## Test plan

- [x] All tests pass (`make test`) — 172 total, 11 new
- [x] Ruff lint and format clean (`make check`)
- [ ] Manual: add `ALLOWED_WORKSPACES=/path/to/project` to `.env`, restart, verify `/workspace project-name` switches correctly
- [ ] Manual: verify `/workspaces` keyboard shows pinned section above history
- [ ] Manual: verify a path in both allowed and history appears only once (pinned section)
