### PR TITLE
Harden workspace validation after ALLOWED_WORKSPACES audit

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -597,6 +597,31 @@ def _resolve_workspace_path(target: str, base: Path | None) -> Path | None:
     return resolved
 
 
+def _is_workspace_allowed(path: Path, config: "Config") -> bool:
+    """
+    Return True if path is covered by a configured workspace source.
+
+    Accepts paths that are under WORKSPACE_BASE or present in ALLOWED_WORKSPACES.
+    If neither source is configured, all paths are accepted (permissive mode for
+    installs that don't restrict workspace access).
+
+    Args:
+        path: The workspace path to validate (need not exist).
+        config: The application config.
+
+    Returns:
+        True if the path is allowed, False if it should be rejected.
+    """
+    base = config.workspace_base
+    if not base and not config.allowed_workspaces:
+        # No restrictions configured — open access
+        return True
+    resolved = path.resolve()
+    in_base = base and (str(resolved).startswith(str(base) + "/") or resolved == base)
+    in_allowed = resolved in config.allowed_workspaces
+    return bool(in_base or in_allowed)
+
+
 def _short_workspace_name(path: str, base: Path | None) -> str:
     """
     Shorten a workspace path for display in Telegram messages and keyboards.
@@ -694,9 +719,20 @@ async def _workspaces_keyboard(
         home_label += " \U0001f7e2"
     buttons.append([InlineKeyboardButton(home_label, callback_data="ws:home")])
 
+    # Detect name collisions within the allowed list so labels can be disambiguated.
+    # If two entries share the same directory name, show "parent/name" instead of "name".
+    name_counts: dict[str, int] = {}
+    for p in allowed_workspaces:
+        name_counts[p.name] = name_counts.get(p.name, 0) + 1
+    duplicate_names = {name for name, count in name_counts.items() if count > 1}
+
     # Pinned workspaces from ALLOWED_WORKSPACES (shown above history)
     for i, p in enumerate(allowed_workspaces):
-        short = _short_workspace_name(str(p), base)
+        if p.name in duplicate_names:
+            # Include parent directory name to make the button unambiguous
+            short = f"{p.parent.name}/{p.name}"
+        else:
+            short = _short_workspace_name(str(p), base)
         label = short
         if str(p) == current_path:
             label += " \U0001f7e2"
@@ -791,6 +827,18 @@ async def handle_workspace_callback(update: Update, context: ContextTypes.DEFAUL
             await query.edit_message_text("No change.", reply_markup=InlineKeyboardMarkup([]))
             return
         path = Path(history[idx]["path"])
+        # Reject history entries that are no longer in an allowed workspace source.
+        # This handles the case where a path was removed from ALLOWED_WORKSPACES
+        # after the user visited it — the history entry persists but access is revoked.
+        if not _is_workspace_allowed(path, config):
+            await sessions.delete_workspace_history(str(path))
+            await query.answer("That workspace is no longer allowed.")
+            history = await sessions.get_workspace_history()
+            keyboard = await _workspaces_keyboard(
+                history, str(claude.workspace), str(home), base, config.allowed_workspaces
+            )
+            await query.edit_message_reply_markup(reply_markup=keyboard)
+            return
         # Remove stale entries where the directory no longer exists
         if not path.is_dir():
             await sessions.delete_workspace_history(str(path))
@@ -897,12 +945,17 @@ async def handle_workspace(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     if base_candidate is not None and base_candidate.is_dir():
         resolved = base_candidate
 
-    # Fall back to allowed workspaces — match by directory name
+    # Fall back to allowed workspaces — match by directory name.
+    # Multiple matches means the user needs to pick via /workspaces.
     if resolved is None:
-        resolved = next(
-            (p for p in config.allowed_workspaces if p.name == target),
-            None,
-        )
+        matches = [p for p in config.allowed_workspaces if p.name == target]
+        if len(matches) > 1:
+            paths = "\n".join(f"  {p}" for p in matches)
+            await update.message.reply_text(
+                f"Multiple workspaces named '{target}':\n{paths}\nUse /workspaces to pick one."
+            )
+            return
+        resolved = matches[0] if matches else None
 
     if resolved is None:
         # Give a helpful message if neither source is configured

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -125,13 +125,18 @@ def load_config() -> Config:
             raise SystemExit(f"WORKSPACE_BASE is not an existing directory: {workspace_base}")
 
     # Parse optional: allowed workspaces (comma-separated absolute paths).
-    # Non-existent paths are skipped with a warning rather than crashing, so
-    # a stale entry (e.g. an unmounted external drive) doesn't block startup.
+    # Paths are resolved to canonical form so /a/b and /a/../a/b deduplicate
+    # to one entry. Non-existent paths are skipped with a warning rather than
+    # crashing, so a stale entry (e.g. an unmounted drive) doesn't block startup.
     allowed_workspaces: list[Path] = []
+    seen_allowed: set[Path] = set()
     raw_allowed = os.environ.get("ALLOWED_WORKSPACES", "").strip()
     if raw_allowed:
         for raw_path in raw_allowed.split(","):
             p = Path(raw_path.strip()).expanduser().resolve()
+            if p in seen_allowed:
+                continue
+            seen_allowed.add(p)
             if p.is_dir():
                 allowed_workspaces.append(p)
             else:

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -35,7 +35,7 @@ from telegram import BotCommand
 from telegram.error import NetworkError
 
 from kai import cron, services, sessions, webhook
-from kai.bot import create_bot
+from kai.bot import _is_workspace_allowed, create_bot
 from kai.config import PROJECT_ROOT, load_config
 
 
@@ -115,14 +115,7 @@ def main() -> None:
         saved_workspace = await sessions.get_setting("workspace")
         if saved_workspace:
             ws_path = Path(saved_workspace)
-            base = config.workspace_base
-            resolved = ws_path.resolve()
-            # Security check: if workspace sources are configured, reject any saved workspace
-            # that isn't covered by WORKSPACE_BASE or ALLOWED_WORKSPACES. Without any source
-            # configured, the saved path is trusted as-is (single-user local install).
-            in_base = base and (str(resolved).startswith(str(base) + "/") or resolved == base)
-            in_allowed = resolved in config.allowed_workspaces
-            if (base or config.allowed_workspaces) and not in_base and not in_allowed:
+            if not _is_workspace_allowed(ws_path, config):
                 logging.warning(
                     "Saved workspace %s is not under WORKSPACE_BASE or ALLOWED_WORKSPACES, ignoring",
                     saved_workspace,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -6,6 +6,7 @@ import pytest
 
 from kai.bot import (
     _chunk_text,
+    _is_workspace_allowed,
     _resolve_workspace_path,
     _save_to_workspace,
     _short_workspace_name,
@@ -211,3 +212,95 @@ class TestWorkspacesKeyboard:
         """With no allowed workspaces and no history, only the Home button appears."""
         markup = await _workspaces_keyboard([], "/home", "/home", None, [])
         assert len(_button_labels(markup)) == 1
+
+    @pytest.mark.asyncio
+    async def test_disambiguates_duplicate_names(self, tmp_path):
+        """Two allowed workspaces with the same directory name get parent/name labels."""
+        foo_a = tmp_path / "projects" / "foo"
+        foo_b = tmp_path / "clients" / "foo"
+        foo_a.mkdir(parents=True)
+        foo_b.mkdir(parents=True)
+        markup = await _workspaces_keyboard([], "/home", "/home", None, [foo_a, foo_b])
+        labels = _button_labels(markup)
+        assert "projects/foo" in labels
+        assert "clients/foo" in labels
+        # Neither bare "foo" label should appear
+        assert "foo" not in labels
+
+    @pytest.mark.asyncio
+    async def test_unique_names_not_disambiguated(self, tmp_path):
+        """Allowed workspaces with unique names keep their short labels."""
+        bar = tmp_path / "bar"
+        baz = tmp_path / "baz"
+        bar.mkdir()
+        baz.mkdir()
+        markup = await _workspaces_keyboard([], "/home", "/home", None, [bar, baz])
+        labels = _button_labels(markup)
+        assert "bar" in labels
+        assert "baz" in labels
+
+
+# ── _is_workspace_allowed ────────────────────────────────────────────
+
+
+from kai.config import Config  # noqa: E402 — after fixtures, before tests
+
+
+def _make_config(workspace_base=None, allowed_workspaces=None) -> Config:
+    """Minimal Config for testing _is_workspace_allowed."""
+    return Config(
+        telegram_bot_token="test",
+        allowed_user_ids={1},
+        workspace_base=workspace_base,
+        allowed_workspaces=allowed_workspaces or [],
+    )
+
+
+class TestIsWorkspaceAllowed:
+    def test_no_sources_allows_anything(self, tmp_path):
+        """With no WORKSPACE_BASE and no ALLOWED_WORKSPACES, all paths are allowed."""
+        config = _make_config()
+        assert _is_workspace_allowed(tmp_path / "anything", config) is True
+
+    def test_path_under_base_is_allowed(self, tmp_path):
+        """Paths under WORKSPACE_BASE are allowed."""
+        config = _make_config(workspace_base=tmp_path)
+        assert _is_workspace_allowed(tmp_path / "myproject", config) is True
+
+    def test_path_in_allowed_workspaces_is_allowed(self, tmp_path):
+        """Paths listed in ALLOWED_WORKSPACES are allowed."""
+        project = tmp_path / "project"
+        project.mkdir()
+        config = _make_config(allowed_workspaces=[project])
+        assert _is_workspace_allowed(project, config) is True
+
+    def test_path_outside_both_is_rejected(self, tmp_path):
+        """Paths not in WORKSPACE_BASE or ALLOWED_WORKSPACES are rejected."""
+        base = tmp_path / "base"
+        base.mkdir()
+        outside = tmp_path / "outside"
+        config = _make_config(workspace_base=base)
+        assert _is_workspace_allowed(outside, config) is False
+
+    def test_base_set_allowed_workspaces_empty_rejects_outside(self, tmp_path):
+        """With WORKSPACE_BASE set but no allowed workspaces, outside paths are rejected."""
+        base = tmp_path / "base"
+        base.mkdir()
+        config = _make_config(workspace_base=base, allowed_workspaces=[])
+        assert _is_workspace_allowed(tmp_path / "other", config) is False
+
+    def test_only_allowed_workspaces_set_rejects_unlisted(self, tmp_path):
+        """With only ALLOWED_WORKSPACES set, unlisted paths are rejected."""
+        allowed = tmp_path / "allowed"
+        allowed.mkdir()
+        unlisted = tmp_path / "unlisted"
+        config = _make_config(allowed_workspaces=[allowed])
+        assert _is_workspace_allowed(unlisted, config) is False
+
+    def test_resolves_symlinks_for_comparison(self, tmp_path):
+        """Path resolution handles non-canonical paths correctly."""
+        project = tmp_path / "project"
+        project.mkdir()
+        config = _make_config(allowed_workspaces=[project])
+        # Pass the resolved canonical path — should still match
+        assert _is_workspace_allowed(project.resolve(), config) is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -146,3 +146,23 @@ class TestLoadConfigOptional:
         _set_required(monkeypatch)
         monkeypatch.setenv("ALLOWED_WORKSPACES", str(tmp_path / "nope"))
         assert load_config().allowed_workspaces == []
+
+    def test_allowed_workspaces_deduplicates(self, monkeypatch, tmp_path):
+        # Same path listed twice should appear only once
+        dir_a = tmp_path / "a"
+        dir_a.mkdir()
+        _set_required(monkeypatch)
+        monkeypatch.setenv("ALLOWED_WORKSPACES", f"{dir_a},{dir_a}")
+        config = load_config()
+        assert len(config.allowed_workspaces) == 1
+        assert config.allowed_workspaces[0] == dir_a
+
+    def test_allowed_workspaces_deduplicates_canonical_paths(self, monkeypatch, tmp_path):
+        # /a/b and /a/../a/b resolve to the same path — only one entry
+        dir_a = tmp_path / "a"
+        dir_a.mkdir()
+        non_canonical = tmp_path / "." / "a"
+        _set_required(monkeypatch)
+        monkeypatch.setenv("ALLOWED_WORKSPACES", f"{dir_a},{non_canonical}")
+        config = load_config()
+        assert len(config.allowed_workspaces) == 1


### PR DESCRIPTION
Three edge cases found during audit of PR #12:

**1. History entries bypassed validation (medium)**
Clicking a history entry in `/workspaces` never validated the path against `WORKSPACE_BASE` or `ALLOWED_WORKSPACES`. A path removed from config remained clickable until restart. Added `_is_workspace_allowed()` check in the history branch of `handle_workspace_callback()`.

**2. Ambiguous names in ALLOWED_WORKSPACES (minor)**
Two entries sharing the same directory name produced duplicate keyboard labels and silent first-match in `/workspace <name>`. `_workspaces_keyboard` now detects collisions and shows `parent/name` labels. `handle_workspace` now shows a disambiguation message when multiple entries match.

**3. Duplicate paths at config load (minor)**
The same canonical path listed twice (via symlinks or `./foo`) produced duplicate entries. Config parsing now deduplicates with a `seen` set before checking existence.

Also extracts `_is_workspace_allowed()` as a shared helper used by both `bot.py` and `main.py`, replacing the inline logic from PR #13.

## Test plan

- [x] All 183 tests pass
- [x] Lint clean
- [ ] Manual: remove a path from ALLOWED_WORKSPACES, restart, verify its history entry is rejected when clicked
- [ ] Manual: add two paths with the same directory name, verify keyboard shows `parent/name` labels
- [ ] Manual: list the same path twice in ALLOWED_WORKSPACES, verify it appears once in `/workspaces`
