### PR TITLE
Fix send-file path confinement not tracking workspace switches

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -648,6 +648,9 @@ async def _do_switch_workspace(context: ContextTypes.DEFAULT_TYPE, chat_id: int,
     home = config.claude_workspace
 
     await claude.change_workspace(path)
+    # Keep the webhook server's confinement path in sync so send-file accepts
+    # files from the new workspace rather than rejecting them with 403.
+    webhook.update_workspace(str(path))
     await sessions.clear_session(chat_id)
 
     if path == home:

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -297,7 +297,7 @@ class PersistentClaude:
                     f"[File API: To send a file to the user, POST JSON to "
                     f"http://localhost:{self.webhook_port}/api/send-file "
                     f"with header 'X-Webhook-Secret: {self.webhook_secret}'. "
-                    f'Required: "path" (absolute file path within the workspace). '
+                    f'Required: "path" (absolute file path within the current workspace {self.workspace}). '
                     f'Optional: "caption". Images are sent as photos, '
                     f"everything else as documents.\n"
                     f"Incoming files from the user are auto-saved to "

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -174,6 +174,12 @@ def main() -> None:
 
             # Start webhook and scheduling API server
             await webhook.start(app, config)
+            # webhook.start() initializes the confinement path from config (home workspace).
+            # If a non-default workspace was restored above, sync it now so send-file
+            # accepts files from the restored workspace. Must come after start() because
+            # start() would overwrite any earlier update_workspace() call.
+            if app.bot_data["claude"].workspace != config.claude_workspace:
+                webhook.update_workspace(str(app.bot_data["claude"].workspace))
 
             # Check if a previous response was interrupted by a crash/restart.
             # bot.py writes this flag file when it starts processing a message

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -753,3 +753,24 @@ async def stop() -> None:
 def is_running() -> bool:
     """True if the webhook server is currently running."""
     return _runner is not None
+
+
+def update_workspace(workspace: str) -> None:
+    """
+    Update the workspace path used by the send-file endpoint's confinement check.
+
+    Called by _do_switch_workspace in bot.py whenever the user switches workspaces,
+    and by main.py after startup if a non-default workspace was restored from the
+    settings table. Without this, the confinement check keeps using the initial
+    home workspace path set at startup, causing send-file to return 403 for any
+    file in the current (switched) workspace.
+
+    The server must already be running when this is called - callers in main.py
+    should invoke this after webhook.start(), not before, since start() sets the
+    path from config and would overwrite an earlier call.
+
+    Args:
+        workspace: Absolute path string of the new current workspace.
+    """
+    if _app is not None:
+        _app["workspace"] = workspace

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -6,8 +6,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aiohttp import web
 
+import kai.webhook as webhook_mod
 from kai import sessions
-from kai.webhook import _handle_delete_job, _handle_schedule, _handle_send_file, _handle_update_job
+from kai.webhook import _handle_delete_job, _handle_schedule, _handle_send_file, _handle_update_job, update_workspace
 
 
 @pytest.fixture
@@ -380,3 +381,25 @@ class TestSendFile:
         send_file_request.json = AsyncMock(return_value={"path": "/any"})
         resp = await _handle_send_file(send_file_request)
         assert resp.status == 401
+
+
+# ── update_workspace() ──────────────────────────────────────────────
+
+
+class TestUpdateWorkspace:
+    def test_updates_app_workspace(self, monkeypatch):
+        """update_workspace() changes the path stored in the live aiohttp app dict."""
+        # Simulate a running server by setting _app to a real Application instance
+        app = web.Application()
+        app["workspace"] = "/original/workspace"
+        monkeypatch.setattr(webhook_mod, "_app", app)
+
+        update_workspace("/switched/workspace")
+
+        assert app["workspace"] == "/switched/workspace"
+
+    def test_no_op_when_server_not_running(self, monkeypatch):
+        """update_workspace() is a no-op (no exception) when the server hasn't started."""
+        monkeypatch.setattr(webhook_mod, "_app", None)
+        # Should not raise
+        update_workspace("/any/path")


### PR DESCRIPTION
## Summary

- `POST /api/send-file` confined paths to the workspace set at startup and never updated when the user switched via `/workspace`, causing 403 errors for files in the current workspace
- Add `update_workspace()` to `webhook.py` to update `_app["workspace"]` in place
- Call it from `_do_switch_workspace` in `bot.py` on every workspace change
- Call it from `main.py` after `webhook.start()` if a non-default workspace was restored at startup (must come after `start()` since `start()` sets the initial path from config)
- Update the File API prompt in `claude.py` to include the current workspace path so Claude knows where files must live
- Add two tests for `update_workspace()` in `test_webhook_api.py`

## Test plan

- [x] `make check` passes
- [x] `make test` passes (185 tests)
- [x] Switch to a foreign workspace via `/workspace`, ask Kai to generate and send a file - should succeed (previously failed with "Path outside workspace")
- [x] Switch back to home workspace, send a file - still works
- [x] Restart Kai with a non-default workspace active, send a file - works without needing to switch again