### PR TITLE
Fix webhook timeout causing duplicate messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Voice notes are transcribed locally using [whisper.cpp](https://github.com/ggerg
 
 Text-to-speech via [Piper TTS](https://github.com/rhasspy/piper). Three modes: `/voice only` (voice note, no text), `/voice on` (text + voice), `/voice off` (text only, default). Eight curated English voices. Requires `pip install -e '.[tts]'` and `TTS_ENABLED=true`. See [Voice Setup](https://github.com/dcellison/kai/wiki/Voice-Setup).
 
+### Dual-mode Telegram transport
+
+Kai supports two ways of receiving Telegram updates: **long polling** (default) and **webhooks**. Polling works out of the box behind NAT with zero infrastructure. Set `TELEGRAM_WEBHOOK_URL` in `.env` to switch to webhook mode for lower latency - this requires a tunnel or reverse proxy (see [Exposing Kai to the Internet](https://github.com/dcellison/kai/wiki/Exposing-Kai-to-the-Internet)).
+
 ### Webhooks
 
 An HTTP server receives GitHub webhook events (pushes, PRs, issues, comments, reviews) and forwards them to Telegram. Signatures are validated via HMAC-SHA256. A generic webhook endpoint (`POST /webhook`) accepts JSON from any service. See [Exposing Kai to the Internet](https://github.com/dcellison/kai/wiki/Exposing-Kai-to-the-Internet).
@@ -113,6 +117,8 @@ cp .env.example .env
 | `WORKSPACE_BASE` | No | | Base directory for workspace name resolution |
 | `WEBHOOK_PORT` | No | `8080` | HTTP server port for webhooks and scheduling API |
 | `WEBHOOK_SECRET` | No | | Secret for webhook validation and scheduling API auth |
+| `TELEGRAM_WEBHOOK_URL` | No | | Telegram webhook URL (enables webhook mode; omit for polling) |
+| `TELEGRAM_WEBHOOK_SECRET` | No | | Separate secret for Telegram webhook auth (defaults to `WEBHOOK_SECRET`) |
 | `VOICE_ENABLED` | No | `false` | Enable voice message transcription |
 | `TTS_ENABLED` | No | `false` | Enable text-to-speech voice responses |
 

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -35,6 +35,7 @@ to the configured Telegram chat. The formatter pattern (dispatch dict mapping
 event type to formatter function) makes it easy to add new event types.
 """
 
+import asyncio
 import hashlib
 import hmac
 import json
@@ -55,6 +56,12 @@ _runner: web.AppRunner | None = None
 # Tracks whether we registered a Telegram webhook with the API, so stop()
 # knows whether to call delete_webhook(). Only True in webhook mode.
 _webhook_registered: bool = False
+
+# Background tasks for processing Telegram updates. Tasks are kept in this set
+# to prevent garbage collection (Python only weakly references fire-and-forget
+# tasks, so an unreferenced task can be silently collected mid-execution).
+# Each task removes itself from the set via a done callback.
+_background_tasks: set[asyncio.Task] = set()
 
 
 def _strip_markdown(text: str) -> str:
@@ -219,6 +226,14 @@ async def _handle_telegram_update(request: web.Request) -> web.Response:
     secret, deserializes the JSON body into a python-telegram-bot Update object,
     and dispatches it to the existing handler system via process_update().
 
+    IMPORTANT: process_update() is launched as a background task, not awaited.
+    Claude responses can take 30+ seconds, and Telegram's webhook client times
+    out after ~30-35s. If we awaited process_update(), Telegram would assume
+    delivery failed and retry the same message, causing duplicate responses.
+    By returning 200 immediately and processing in the background, we acknowledge
+    receipt before Telegram's timeout. The per-chat lock in bot.py serializes
+    concurrent messages, so ordering is preserved.
+
     Always returns 200 on valid-secret requests, even on errors. Telegram retries
     on non-200 responses, so surfacing internal errors as HTTP errors would cause
     an infinite retry loop. Errors are logged instead.
@@ -241,7 +256,12 @@ async def _handle_telegram_update(request: web.Request) -> web.Response:
     try:
         update = Update.de_json(data, bot)
         if update:
-            await telegram_app.process_update(update)
+            # Fire-and-forget: return 200 to Telegram immediately while
+            # processing continues in the background. Without this, Claude's
+            # response time would exceed Telegram's webhook timeout.
+            task = asyncio.create_task(telegram_app.process_update(update))
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
     except Exception:
         log.exception("Error processing Telegram update")
 

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -1,5 +1,6 @@
 """Integration tests for webhook HTTP API endpoints (jobs CRUD, file exchange)."""
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
 
@@ -439,6 +440,10 @@ class TestTelegramUpdate:
         resp = await _handle_telegram_update(telegram_request)
 
         assert resp.status == 200
+        # process_update runs as a background task (fire-and-forget to avoid
+        # Telegram's webhook timeout). Yield to the event loop so the task
+        # actually executes before we assert.
+        await asyncio.sleep(0)
         telegram_request.app["telegram_app"].process_update.assert_called_once_with(fake_update)
 
     async def test_wrong_secret_returns_401(self, telegram_request):


### PR DESCRIPTION
## Summary

- Fix duplicate message delivery in webhook mode caused by awaiting `process_update()` in the HTTP handler
- Telegram times out after ~30-35s and retries when the handler blocks on Claude responses
- Dispatch `process_update()` as a background task and return 200 immediately
- Add dual-mode transport section and env vars to README (missed in #18)

## Changes

| File | Change |
|------|--------|
| `webhook.py` | `asyncio.create_task()` instead of `await` for `process_update()`; `_background_tasks` set prevents GC of in-flight tasks |
| `test_webhook_api.py` | Add `await asyncio.sleep(0)` to yield to event loop before asserting on background task |
| `README.md` | Add dual-mode transport section and `TELEGRAM_WEBHOOK_URL`/`TELEGRAM_WEBHOOK_SECRET` to env vars table |

## Test plan

- [x] `make check` passes (ruff lint + format)
- [x] `make test` passes (198 tests)
- [ ] Verify no duplicate messages in webhook mode with slow Claude responses
