### PR TITLE
Fix TOTP comment style and add README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ Three layers of persistent context:
 
 Foreign workspaces also get their own `.claude/MEMORY.md` injected alongside home memory. See [System Architecture](https://github.com/dcellison/kai/wiki/System-Architecture).
 
+### TOTP authentication
+
+Optional two-factor authentication using time-based one-time passwords. When enabled, the bot requires a 6-digit authenticator code before processing messages after a configurable session timeout. The TOTP secret is stored in a root-owned file (`/etc/kai/totp.secret`, mode 0600) that is inaccessible to the bot user and any subprocesses it spawns. The bot reads the secret via narrowly-scoped sudoers rules at verification time only.
+
+Setup requires the optional dependency group and root access:
+
+```bash
+pip install -e '.[totp]'             # adds pyotp and qrcode
+sudo python -m kai totp setup        # generate secret, display QR code, confirm
+python -m kai totp status            # check configuration state
+sudo python -m kai totp reset        # remove secret and attempts files
+```
+
+Rate limiting locks the account after consecutive failed attempts (configurable, default 3). Lockout state is persisted to disk so it survives restarts. Code messages are deleted from Telegram immediately after verification. All settings are configurable via environment variables (see below).
+
 ### Crash recovery
 
 If interrupted mid-response, Kai notifies you on restart and asks you to resend your last message.
@@ -121,6 +136,10 @@ cp .env.example .env
 | `TELEGRAM_WEBHOOK_SECRET` | No | | Separate secret for Telegram webhook auth (defaults to `WEBHOOK_SECRET`) |
 | `VOICE_ENABLED` | No | `false` | Enable voice message transcription |
 | `TTS_ENABLED` | No | `false` | Enable text-to-speech voice responses |
+| `TOTP_SESSION_MINUTES` | No | `30` | Minutes before TOTP re-authentication is required |
+| `TOTP_CHALLENGE_SECONDS` | No | `120` | Seconds the code entry window stays open |
+| `TOTP_LOCKOUT_ATTEMPTS` | No | `3` | Failed TOTP attempts before temporary lockout |
+| `TOTP_LOCKOUT_MINUTES` | No | `15` | TOTP lockout duration in minutes |
 
 `CLAUDE_MAX_BUDGET_USD` limits how much work Claude can do in a single session via Claude Code's `--max-budget-usd` flag. On Pro/Max plans this is purely a runaway prevention mechanism (no per-token charges). The session resets on `/new`, model switch, or workspace switch.
 
@@ -243,6 +262,7 @@ kai/
 │   ├── webhook.py        # HTTP server: GitHub/generic webhooks, scheduling API
 │   ├── history.py        # Conversation history (read/write JSONL logs)
 │   ├── locks.py          # Per-chat async locks and stop events
+│   ├── totp.py           # TOTP verification, rate limiting, and CLI
 │   ├── transcribe.py     # Voice message transcription (ffmpeg + whisper-cpp)
 │   └── tts.py            # Text-to-speech synthesis (Piper TTS + ffmpeg)
 ├── tests/                # Test suite

--- a/src/kai/totp.py
+++ b/src/kai/totp.py
@@ -166,7 +166,6 @@ def verify_code(code: str, lockout_attempts: int = 3, lockout_minutes: int = 15)
     if state.get("lockout_until", 0) > time.time():
         return False
 
-    # Read the secret and verify the code.
     secret = _read_secret()
     if not secret:
         return False
@@ -191,9 +190,7 @@ def verify_code(code: str, lockout_attempts: int = 3, lockout_minutes: int = 15)
     return False
 
 
-# ---------------------------------------------------------------------------
-# CLI entry point (python -m kai totp <subcommand>)
-# ---------------------------------------------------------------------------
+# ── CLI entry point (python -m kai totp <subcommand>) ────────────────
 
 # Platform-specific binary paths for the sudoers rule.
 # macOS ships cat at /bin/cat; most Linux distros put it at /usr/bin/cat.

--- a/tests/test_totp.py
+++ b/tests/test_totp.py
@@ -24,7 +24,8 @@ from kai.totp import (
 
 @pytest.fixture(autouse=True)
 def _reset_totp_cache():
-    """Reset the is_totp_configured module-level cache before and after each test.
+    """
+    Reset the is_totp_configured module-level cache before and after each test.
 
     Without this, a test that calls is_totp_configured() and gets True would
     pollute the cache for subsequent tests in the same process run.
@@ -70,9 +71,7 @@ def _tee_proc() -> MagicMock:
     return m
 
 
-# ---------------------------------------------------------------------------
-# verify_code: valid and invalid codes
-# ---------------------------------------------------------------------------
+# ── verify_code: valid and invalid codes ─────────────────────────────
 
 
 def test_verify_code_rejects_malformed_input():
@@ -114,9 +113,7 @@ def test_verify_code_invalid():
     assert result is False
 
 
-# ---------------------------------------------------------------------------
-# Rate limiting: failure counter
-# ---------------------------------------------------------------------------
+# ── Rate limiting: failure counter ───────────────────────────────────
 
 
 def test_failure_counter_increments():
@@ -194,9 +191,7 @@ def test_successful_code_resets_failure_counter():
     assert written["lockout_until"] == 0
 
 
-# ---------------------------------------------------------------------------
-# is_totp_configured
-# ---------------------------------------------------------------------------
+# ── is_totp_configured ───────────────────────────────────────────────
 
 
 def test_is_totp_configured_true_when_readable():
@@ -211,9 +206,7 @@ def test_is_totp_configured_false_when_file_missing():
         assert is_totp_configured() is False
 
 
-# ---------------------------------------------------------------------------
-# get_lockout_remaining
-# ---------------------------------------------------------------------------
+# ── get_lockout_remaining ────────────────────────────────────────────
 
 
 def test_get_lockout_remaining_zero_when_not_locked():
@@ -232,9 +225,7 @@ def test_get_lockout_remaining_positive_when_locked():
     assert 295 <= remaining <= 300
 
 
-# ---------------------------------------------------------------------------
-# get_failure_count
-# ---------------------------------------------------------------------------
+# ── get_failure_count ────────────────────────────────────────────────
 
 
 def test_get_failure_count_returns_failures_from_disk():

--- a/tests/test_totp_cli.py
+++ b/tests/test_totp_cli.py
@@ -37,9 +37,7 @@ def _reset_totp_cache():
     kai.totp._totp_is_configured = False
 
 
-# ---------------------------------------------------------------------------
-# _cmd_status
-# ---------------------------------------------------------------------------
+# ── _cmd_status ──────────────────────────────────────────────────────
 
 
 def test_cmd_status_prints_configured(capsys):
@@ -61,9 +59,7 @@ def test_cmd_status_prints_not_configured(capsys):
     assert "not configured" in out.lower()
 
 
-# ---------------------------------------------------------------------------
-# _cmd_reset
-# ---------------------------------------------------------------------------
+# ── _cmd_reset ───────────────────────────────────────────────────────
 
 
 def test_cmd_reset_exits_if_not_root():
@@ -124,9 +120,7 @@ def test_cmd_reset_handles_partially_missing_files(capsys):
     assert TOTP_SECRET_PATH in out
 
 
-# ---------------------------------------------------------------------------
-# _cmd_setup root guard
-# ---------------------------------------------------------------------------
+# ── _cmd_setup root guard ────────────────────────────────────────────
 
 
 def test_cmd_setup_exits_if_not_root():
@@ -140,9 +134,7 @@ def test_cmd_setup_exits_if_not_root():
     assert exc.value.code == 1
 
 
-# ---------------------------------------------------------------------------
-# cli() dispatch
-# ---------------------------------------------------------------------------
+# ── cli() dispatch ───────────────────────────────────────────────────
 
 
 def test_cli_exits_on_unknown_subcommand():


### PR DESCRIPTION
## Summary

- Fix section separators in `totp.py`, `test_totp.py`, and `test_totp_cli.py` to use the project's single-line `# ──` convention instead of three-line `# -----` blocks
- Fix multi-line docstring format in `test_totp.py` (opening `"""` on its own line per style guide)
- Remove redundant "what" comment in `verify_code()`
- Add TOTP authentication section to README (feature description, setup commands, rate limiting)
- Add TOTP env vars to the environment variables table
- Add `totp.py` to the project structure tree

## Test plan

- [x] 231 tests pass (`make test`)
- [x] Lint and format clean (`make check`)
- [x] Verify README renders correctly on GitHub
