### PR TITLE
Add optional user separation for Claude subprocess

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,3 +84,18 @@ TTS_ENABLED=false
 #TOTP_LOCKOUT_ATTEMPTS=3
 # Duration of lockout in minutes after the threshold is exceeded (default 15)
 #TOTP_LOCKOUT_MINUTES=15
+
+# ── User Separation (optional) ──────────────────────────────────
+
+# Run the inner Claude process as a different OS user for security isolation.
+# The bot spawns Claude via 'sudo -u <user> claude ...', creating a hard
+# OS-level boundary between the bot and the AI subprocess.
+#
+# Requirements:
+#   - The user must exist on the system
+#   - The user must NOT be an admin (no sudo privileges)
+#   - A sudoers rule must allow kai to run claude as this user (see README)
+#   - Claude Code must be installed and accessible to this user
+#
+# When unset, Claude runs as the same user as the bot (no isolation).
+#CLAUDE_USER=daniel

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -1693,6 +1693,7 @@ def create_bot(config: Config, *, use_webhook: bool = True) -> Application:
         max_budget_usd=config.claude_max_budget_usd,
         timeout_seconds=config.claude_timeout_seconds,
         services_info=services.get_available_services(),
+        claude_user=config.claude_user,
     )
 
     # Command handlers (alphabetical registration, but order doesn't matter for commands)

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -29,6 +29,8 @@ Context injection on first message of each session:
 import asyncio
 import json
 import logging
+import os
+import signal
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -102,6 +104,7 @@ class PersistentClaude:
         max_budget_usd: float = 1.0,
         timeout_seconds: int = 120,
         services_info: list[dict] | None = None,
+        claude_user: str | None = None,
     ):
         self.model = model
         self.workspace = workspace
@@ -111,6 +114,7 @@ class PersistentClaude:
         self.max_budget_usd = max_budget_usd
         self.timeout_seconds = timeout_seconds
         self.services_info = services_info or []
+        self.claude_user = claude_user
         self._proc: asyncio.subprocess.Process | None = None
         self._lock = asyncio.Lock()  # Serializes all message sends
         self._session_id: str | None = None
@@ -135,13 +139,19 @@ class PersistentClaude:
         for headless operation), and the configured model and budget. The process
         runs in the current workspace directory and persists across messages.
 
+        When claude_user is set, the process is spawned via sudo -u to run as
+        a different OS user. The subprocess is started in its own process group
+        (start_new_session=True) so the entire tree (sudo + claude) can be
+        killed reliably via os.killpg().
+
         The stdout buffer limit is raised to 1 MiB (from the default 64 KiB)
         because large tool results from Claude can exceed the default.
         """
         if self.is_alive:
             return
 
-        cmd = [
+        # Build the Claude command arguments.
+        claude_cmd = [
             "claude",
             "--input-format",
             "stream-json",
@@ -155,7 +165,20 @@ class PersistentClaude:
             "--max-budget-usd",
             str(self.max_budget_usd),
         ]
-        log.info("Starting persistent Claude process (model=%s)", self.model)
+
+        # When running as a different user, spawn via sudo -u.
+        # The subprocess runs with the target user's UID, home directory,
+        # and environment - completely isolated from the bot user.
+        if self.claude_user:
+            cmd = ["sudo", "-u", self.claude_user, "--"] + claude_cmd
+        else:
+            cmd = claude_cmd
+
+        log.info(
+            "Starting persistent Claude process (model=%s, user=%s)",
+            self.model,
+            self.claude_user or "(same as bot)",
+        )
 
         self._proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -164,6 +187,10 @@ class PersistentClaude:
             stderr=asyncio.subprocess.PIPE,
             cwd=str(self.workspace),
             limit=1024 * 1024,  # 1 MiB; default 64 KiB too small for large tool results
+            # When spawned via sudo, start in a new process group so we can
+            # kill the entire tree (sudo + claude) via os.killpg(). Without
+            # this, killing sudo may orphan the claude process.
+            start_new_session=bool(self.claude_user),
         )
         self._session_id = None
         self._fresh_session = True
@@ -188,6 +215,27 @@ class PersistentClaude:
                     log.debug("Claude stderr: %s", text[:200])
             except Exception:
                 break
+
+    def _kill_proc(self, sig: int = signal.SIGKILL) -> None:
+        """
+        Send a signal to the Claude subprocess.
+
+        When claude_user is set, the process runs in its own process group
+        (via start_new_session=True). We must kill the entire group to
+        ensure the actual claude process dies, not just the sudo wrapper.
+
+        Args:
+            sig: Signal to send. Defaults to SIGKILL.
+        """
+        if not self._proc or self._proc.returncode is not None:
+            return
+        try:
+            if self.claude_user:
+                os.killpg(os.getpgid(self._proc.pid), sig)
+            else:
+                self._proc.send_signal(sig)
+        except (ProcessLookupError, PermissionError):
+            pass
 
     async def send(self, prompt: str | list) -> AsyncIterator[StreamEvent]:
         """
@@ -479,11 +527,7 @@ class PersistentClaude:
         existing error-handling path. Does not await process termination
         (that happens in the streaming loop).
         """
-        if self._proc and self._proc.returncode is None:
-            try:
-                self._proc.kill()
-            except ProcessLookupError:
-                pass
+        self._kill_proc(signal.SIGKILL)
 
     async def change_workspace(self, new_workspace: Path) -> None:
         """
@@ -510,14 +554,11 @@ class PersistentClaude:
         Kill the subprocess and clean up resources.
 
         Sends SIGKILL, waits for the process to exit, clears the session ID,
-        and cancels the stderr drain task. Idempotent — safe to call even if
+        and cancels the stderr drain task. Idempotent - safe to call even if
         the process has already exited.
         """
         if self._proc:
-            try:
-                self._proc.kill()
-            except ProcessLookupError:
-                pass
+            self._kill_proc(signal.SIGKILL)
             try:
                 await self._proc.wait()
             except Exception:
@@ -537,11 +578,18 @@ class PersistentClaude:
         Called during bot shutdown from main.py.
         """
         if self._proc and self._proc.returncode is None:
-            self._proc.terminate()
+            self._kill_proc(signal.SIGTERM)
             try:
+                # Note: when claude_user is set, self._proc is the sudo process.
+                # SIGTERM is sent to the entire process group (sudo + claude), but
+                # sudo may exit before claude finishes handling the signal. This
+                # wait() returns when sudo exits, not necessarily when claude does.
+                # In practice claude exits near-instantly after SIGTERM, but if
+                # orphaned claude processes are ever observed after graceful
+                # shutdown, this is the place to investigate.
                 await asyncio.wait_for(self._proc.wait(), timeout=5)
             except TimeoutError:
-                self._proc.kill()
+                self._kill_proc(signal.SIGKILL)
                 await self._proc.wait()
         self._proc = None
         if self._stderr_task:

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -56,6 +56,9 @@ class Config:
         allowed_workspaces: Additional workspace directories accessible by name, from config only.
             These appear as pinned workspaces in /workspaces and are reachable via /workspace <name>
             without being under WORKSPACE_BASE. Non-existent paths are skipped at startup.
+        claude_user: OS user for the inner Claude process. When set, Claude is spawned
+            via 'sudo -u <user>' for OS-level isolation. Must be a non-admin user.
+            When None, Claude runs as the same user as the bot (development default).
     """
 
     # Required fields - no defaults, must be provided
@@ -92,6 +95,12 @@ class Config:
     # Workspace switching
     workspace_base: Path | None = None
     allowed_workspaces: list[Path] = field(default_factory=list)
+
+    # User separation: run Claude as a different OS user for process isolation.
+    # When set, the bot spawns Claude via 'sudo -u <user> claude ...'.
+    # The user must exist on the system and must NOT have admin/sudo privileges.
+    # When unset, Claude runs as the same user as the bot (development default).
+    claude_user: str | None = None
 
 
 def load_config() -> Config:
@@ -195,4 +204,5 @@ def load_config() -> Config:
         tts_enabled=os.environ.get("TTS_ENABLED", "").lower() in ("1", "true", "yes"),
         workspace_base=workspace_base,
         allowed_workspaces=allowed_workspaces,
+        claude_user=os.environ.get("CLAUDE_USER") or None,
     )

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1,0 +1,158 @@
+"""Tests for claude.py user separation (sudo spawning and process group signals)."""
+
+import signal
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kai.claude import PersistentClaude
+
+
+def _make_claude(**kwargs) -> PersistentClaude:
+    """Create a PersistentClaude with sensible defaults for testing."""
+    defaults = {
+        "model": "sonnet",
+        "workspace": Path("/tmp/test-workspace"),
+        "max_budget_usd": 1.0,
+        "timeout_seconds": 30,
+    }
+    defaults.update(kwargs)
+    return PersistentClaude(**defaults)
+
+
+# ── Command construction ─────────────────────────────────────────────
+
+
+class TestCommandConstruction:
+    """Verify _ensure_started() builds the right command depending on claude_user."""
+
+    @pytest.mark.asyncio
+    async def test_cmd_without_claude_user(self):
+        """Without claude_user, command starts with 'claude' directly."""
+        claude = _make_claude()
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = AsyncMock()
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+            args = mock_exec.call_args
+            cmd = args[0]
+            assert cmd[0] == "claude"
+            assert "sudo" not in cmd
+            # Should NOT use start_new_session when running as same user
+            assert args[1].get("start_new_session") is False
+
+    @pytest.mark.asyncio
+    async def test_cmd_with_claude_user(self):
+        """With claude_user set, command is prefixed with 'sudo -u <user> --'."""
+        claude = _make_claude(claude_user="daniel")
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = AsyncMock()
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+            args = mock_exec.call_args
+            cmd = args[0]
+            assert cmd[0] == "sudo"
+            assert cmd[1] == "-u"
+            assert cmd[2] == "daniel"
+            assert cmd[3] == "--"
+            assert cmd[4] == "claude"
+
+    @pytest.mark.asyncio
+    async def test_start_new_session_true_with_claude_user(self):
+        """start_new_session=True when claude_user is set (process group isolation)."""
+        claude = _make_claude(claude_user="daniel")
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = AsyncMock()
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+            args = mock_exec.call_args
+            assert args[1].get("start_new_session") is True
+
+
+# ── Process signal handling ──────────────────────────────────────────
+
+
+class TestProcessSignals:
+    """Verify _kill_proc() and force_kill() use the right signal strategy."""
+
+    def test_force_kill_same_user(self):
+        """Without claude_user, force_kill sends SIGKILL via proc.send_signal()."""
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        mock_proc.pid = 12345
+        claude._proc = mock_proc
+
+        claude.force_kill()
+
+        mock_proc.send_signal.assert_called_once_with(signal.SIGKILL)
+
+    def test_force_kill_different_user(self):
+        """With claude_user, force_kill sends SIGKILL to the entire process group."""
+        claude = _make_claude(claude_user="daniel")
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        mock_proc.pid = 12345
+        claude._proc = mock_proc
+
+        with patch("os.getpgid", return_value=12345) as mock_getpgid, patch("os.killpg") as mock_killpg:
+            claude.force_kill()
+
+            mock_getpgid.assert_called_once_with(12345)
+            mock_killpg.assert_called_once_with(12345, signal.SIGKILL)
+
+    def test_kill_proc_noop_when_no_process(self):
+        """_kill_proc() is a no-op when there's no subprocess."""
+        claude = _make_claude()
+        # _proc is None by default; should not raise
+        claude._kill_proc(signal.SIGKILL)
+
+    def test_kill_proc_noop_when_already_exited(self):
+        """_kill_proc() is a no-op when the process has already exited."""
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0  # Already exited
+        claude._proc = mock_proc
+
+        claude._kill_proc(signal.SIGKILL)
+
+        mock_proc.send_signal.assert_not_called()
+
+    def test_kill_proc_handles_process_lookup_error(self):
+        """_kill_proc() swallows ProcessLookupError (race between check and kill)."""
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        mock_proc.send_signal.side_effect = ProcessLookupError
+        claude._proc = mock_proc
+
+        # Should not raise
+        claude._kill_proc(signal.SIGKILL)
+
+    def test_kill_proc_handles_permission_error(self):
+        """_kill_proc() swallows PermissionError (process owned by another user)."""
+        claude = _make_claude(claude_user="daniel")
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        mock_proc.pid = 12345
+        claude._proc = mock_proc
+
+        with patch("os.getpgid", return_value=12345), patch("os.killpg", side_effect=PermissionError):
+            # Should not raise
+            claude._kill_proc(signal.SIGKILL)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,6 +19,7 @@ _CONFIG_ENV_VARS = [
     "TTS_ENABLED",
     "WORKSPACE_BASE",
     "ALLOWED_WORKSPACES",
+    "CLAUDE_USER",
 ]
 
 
@@ -175,6 +176,21 @@ class TestLoadConfigOptional:
         monkeypatch.setenv("ALLOWED_WORKSPACES", f"{dir_a},{non_canonical}")
         config = load_config()
         assert len(config.allowed_workspaces) == 1
+
+    def test_claude_user_default_none(self, monkeypatch):
+        _set_required(monkeypatch)
+        assert load_config().claude_user is None
+
+    def test_claude_user_from_env(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("CLAUDE_USER", "daniel")
+        assert load_config().claude_user == "daniel"
+
+    def test_claude_user_empty_string_becomes_none(self, monkeypatch):
+        # Empty CLAUDE_USER is treated as unset (the `or None` coercion)
+        _set_required(monkeypatch)
+        monkeypatch.setenv("CLAUDE_USER", "")
+        assert load_config().claude_user is None
 
 
 # ── Telegram webhook config ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `CLAUDE_USER` config option to run the inner Claude process as a different OS user via `sudo -u`
- Closes the TOTP sudoers hole identified by mmx003 on #23: Claude can no longer access `/etc/kai/totp.secret` because the configured user has no sudoers rules
- When `CLAUDE_USER` is unset, behavior is identical to current - zero impact on existing installs

## What changed

- `config.py`: new `claude_user` field, loaded from `CLAUDE_USER` env var
- `claude.py`: subprocess spawned via `sudo -u <user> --` when configured; new `_kill_proc()` helper centralizes signal dispatch with process group support (`os.killpg`) for reliable `/stop` across the sudo boundary
- `bot.py`: passes `claude_user` through to `PersistentClaude`
- `.env.example`: documents the new option with requirements
- New test file `tests/test_claude.py` (158 lines) covering command construction, process group signals, edge cases
- New config tests for `CLAUDE_USER` parsing

## How it works

When `CLAUDE_USER=daniel`, the process tree becomes:

    kai (bot) -> sudo -u daniel -- claude ...

The subprocess starts in its own process group (`start_new_session=True`) so `/stop` can kill the entire tree via `os.killpg()`, not just the sudo wrapper.

## Test plan

- [x] All 243 tests pass (no regressions)
- [x] Ruff clean
- [ ] Manual: verify Claude spawns as configured user (`ps aux | grep claude`)
- [ ] Manual: verify `/stop` kills the process reliably
- [ ] Manual: verify `sudo cat /etc/kai/totp.secret` fails from Claude's session

Addresses #23
