### PR TITLE
Update plist example to use simple KeepAlive

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,7 @@ Create `~/Library/LaunchAgents/com.kai.bot.plist`:
     <true/>
 
     <key>KeepAlive</key>
-    <dict>
-        <key>NetworkState</key>
-        <true/>
-    </dict>
+    <true/>
 
     <key>ProcessType</key>
     <string>Background</string>


### PR DESCRIPTION
## Summary
- Update the launchd plist example in README to match the local plist: replace `KeepAlive` `NetworkState` dict with plain `<true/>` for unconditional restart.