### PR TITLE
Fix duplicate messages on network errors during Markdown fallback

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -42,6 +42,7 @@ from pathlib import Path
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
 from telegram.constants import ChatAction, ParseMode
+from telegram.error import BadRequest
 from telegram.ext import (
     Application,
     CallbackQueryHandler,
@@ -165,11 +166,13 @@ async def _reply_safe(msg: Message, text: str) -> Message:
 
     Telegram's Markdown parser is strict about balanced formatting characters.
     Rather than trying to escape everything, we just retry without parse_mode
-    if the first attempt fails.
+    if the first attempt fails. Only catches BadRequest (Telegram rejecting the
+    markup) - network errors and timeouts propagate normally to avoid sending
+    duplicate messages.
     """
     try:
         return await msg.reply_text(text, parse_mode=ParseMode.MARKDOWN)
-    except Exception:
+    except BadRequest:
         return await msg.reply_text(text)
 
 
@@ -177,18 +180,21 @@ async def _edit_message_safe(msg: Message, text: str) -> None:
     """
     Edit an existing message with Markdown, falling back to plain text.
 
-    Used during streaming to update the live response message. Silently
-    ignores errors from the final fallback (e.g., message not modified,
-    message deleted by user).
+    Used during streaming to update the live response message. On BadRequest
+    (Telegram rejecting the markup), retries without parse_mode. All other
+    errors are silently ignored since edits are best-effort during streaming
+    (e.g., message not modified, message deleted by user, network blip).
     """
     truncated = _truncate_for_telegram(text)
     try:
         await msg.edit_text(truncated, parse_mode=ParseMode.MARKDOWN)
-    except Exception:
+    except BadRequest:
         try:
             await msg.edit_text(truncated)
         except Exception:
             pass
+    except Exception:
+        pass
 
 
 def _chunk_text(text: str, max_len: int = 4096) -> list[str]:


### PR DESCRIPTION
## Summary

- Narrowed `_reply_safe()` to catch only `BadRequest` instead of `Exception` when retrying without Markdown
- Restructured `_edit_message_safe()` so `BadRequest` triggers plain-text retry, while other exceptions (network errors, "message not modified") are silently ignored
- Added `BadRequest` import from `telegram.error`

Previously, if Telegram accepted and delivered a Markdown message but the HTTP response back to the bot failed (timeout, network blip), the broad `except Exception` fired the plain-text retry, sending the same content twice.

## Test plan

- [x] `make check` passes (lint + format)
- [x] `make test` passes (243 tests)
- [ ] Verify in Telegram: messages with Markdown render correctly
- [ ] Verify in Telegram: malformed Markdown falls back to plain text (single message, not duplicated)