### PR TITLE
Add comprehensive test coverage across all source modules

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,19 +1,65 @@
-"""Tests for bot.py pure functions."""
+"""
+Tests for bot.py - pure functions and handler coverage.
 
+The first section tests pure/synchronous helpers (resolve_workspace_path,
+chunk_text, etc.) with no mocking needed. The second section tests command
+handlers, callback handlers, media handlers, and the streaming response
+handler using mock Telegram Update/Context objects.
+"""
+
+import asyncio
+import json
+import logging
+from contextlib import asynccontextmanager
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from telegram.error import BadRequest
 
 from kai.bot import (
     _chunk_text,
+    _clear_responding,
+    _edit_message_safe,
+    _is_authorized,
     _is_workspace_allowed,
+    _models_keyboard,
+    _reply_safe,
+    _require_auth,
     _resolve_workspace_path,
     _save_to_workspace,
+    _set_responding,
     _short_workspace_name,
     _truncate_for_telegram,
+    _voices_keyboard,
     _workspaces_keyboard,
     create_bot,
+    handle_canceljob,
+    handle_document,
+    handle_help,
+    handle_jobs,
+    handle_message,
+    handle_model,
+    handle_model_callback,
+    handle_models,
+    handle_new,
+    handle_photo,
+    handle_start,
+    handle_stats,
+    handle_stop,
+    handle_unknown_command,
+    handle_voice,
+    handle_voice_callback,
+    handle_voice_command,
+    handle_voices,
+    handle_webhooks,
+    handle_workspace,
+    handle_workspace_callback,
+    handle_workspaces,
 )
+from kai.claude import ClaudeResponse, StreamEvent
+from kai.config import Config
+from kai.tts import DEFAULT_VOICE, VOICES
 
 # ── _resolve_workspace_path ──────────────────────────────────────────
 
@@ -244,17 +290,27 @@ class TestWorkspacesKeyboard:
 # ── _is_workspace_allowed ────────────────────────────────────────────
 
 
-from kai.config import Config  # noqa: E402 — after fixtures, before tests
+def _make_config(**overrides) -> Config:
+    """
+    Create a Config for tests with sensible defaults.
 
-
-def _make_config(workspace_base=None, allowed_workspaces=None) -> Config:
-    """Minimal Config for testing _is_workspace_allowed."""
-    return Config(
-        telegram_bot_token="test",
-        allowed_user_ids={1},
-        workspace_base=workspace_base,
-        allowed_workspaces=allowed_workspaces or [],
-    )
+    Accepts any Config field as a keyword override. Used by both the pure
+    function tests (workspace_base, allowed_workspaces) and the handler
+    tests (tts_enabled, voice_enabled, webhook_secret, etc.).
+    """
+    defaults: dict = {
+        "telegram_bot_token": "test-token",
+        "allowed_user_ids": {1},
+        "claude_workspace": Path("/home/workspace"),
+        "workspace_base": None,
+        "allowed_workspaces": [],
+        "webhook_secret": "test-secret",
+        "webhook_port": 8080,
+        "tts_enabled": False,
+        "voice_enabled": False,
+    }
+    defaults.update(overrides)
+    return Config(**defaults)
 
 
 class TestIsWorkspaceAllowed:
@@ -334,3 +390,1770 @@ class TestCreateBotTransportMode:
         config = _make_config()
         app = create_bot(config, use_webhook=False)
         assert app.updater is not None
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Handler tests - mock Telegram Update/Context objects
+# ══════════════════════════════════════════════════════════════════════
+
+
+# ── Test helpers ─────────────────────────────────────────────────────
+
+
+def _make_update(text="hello", chat_id=12345, user_id=1):
+    """Create a mock Telegram Update for handler tests."""
+    update = MagicMock()
+    update.message.text = text
+    update.message.reply_text = AsyncMock()
+    update.message.delete = AsyncMock()
+    update.message.caption = None
+    update.message.photo = None
+    update.message.document = None
+    update.message.voice = None
+    update.effective_chat.id = chat_id
+    update.effective_chat.send_message = AsyncMock()
+    update.effective_user.id = user_id
+    return update
+
+
+def _make_callback_update(data="model:opus", chat_id=12345, user_id=1):
+    """Create a mock Update for callback query handlers."""
+    update = MagicMock()
+    update.callback_query.data = data
+    update.callback_query.answer = AsyncMock()
+    update.callback_query.edit_message_text = AsyncMock()
+    update.callback_query.edit_message_reply_markup = AsyncMock()
+    update.effective_chat.id = chat_id
+    update.effective_user.id = user_id
+    return update
+
+
+def _make_mock_claude(model="sonnet", workspace=None, is_alive=True):
+    """Create a mock PersistentClaude."""
+    claude = MagicMock()
+    claude.model = model
+    claude.is_alive = is_alive
+    claude.workspace = workspace or Path("/home/workspace")
+    claude.restart = AsyncMock()
+    claude.change_workspace = AsyncMock()
+    claude.force_kill = MagicMock()
+    claude.send = MagicMock()  # configured per test
+    return claude
+
+
+def _make_context(config=None, claude=None, args=None, user_data=None, job_queue=None):
+    """Create a mock PTB context with bot_data, args, and user_data."""
+    ctx = MagicMock()
+    ctx.bot_data = {
+        "config": config or _make_config(),
+        "claude": claude or _make_mock_claude(),
+    }
+    ctx.args = args or []
+    ctx.user_data = user_data if user_data is not None else {}
+    ctx.bot.send_chat_action = AsyncMock()
+    ctx.bot.get_file = AsyncMock()
+    ctx.bot.send_voice = AsyncMock()
+    if job_queue is not None:
+        ctx.application.job_queue = job_queue
+    return ctx
+
+
+@asynccontextmanager
+async def _fake_lock(*_args, **_kwargs):
+    """Async context manager stand-in for the per-chat asyncio.Lock."""
+    yield
+
+
+def _text_event(text: str) -> StreamEvent:
+    """Non-final streaming event with accumulated text."""
+    return StreamEvent(text_so_far=text, done=False, response=None)
+
+
+def _done_event(text="Final response", cost=0.01, session_id="sess-1", success=True, error=None) -> StreamEvent:
+    """Final streaming event with a ClaudeResponse."""
+    return StreamEvent(
+        text_so_far=text,
+        done=True,
+        response=ClaudeResponse(
+            text=text,
+            success=success,
+            error=error,
+            cost_usd=cost,
+            duration_ms=1000,
+            session_id=session_id,
+        ),
+    )
+
+
+async def _fake_stream(*events):
+    """Async generator that yields StreamEvents."""
+    for e in events:
+        yield e
+
+
+# ── Crash recovery flag ──────────────────────────────────────────────
+
+
+class TestCrashRecoveryFlag:
+    def test_set_responding_writes_chat_id(self, tmp_path):
+        """Flag file contains the chat ID as text."""
+        flag = tmp_path / ".responding_to"
+        with patch("kai.bot._RESPONDING_FLAG", flag):
+            _set_responding(12345)
+        assert flag.read_text() == "12345"
+
+    def test_clear_responding_removes_flag(self, tmp_path):
+        """Flag file is deleted after clearing."""
+        flag = tmp_path / ".responding_to"
+        flag.write_text("12345")
+        with patch("kai.bot._RESPONDING_FLAG", flag):
+            _clear_responding()
+        assert not flag.exists()
+
+    def test_clear_responding_noop_if_missing(self, tmp_path):
+        """No error when flag file doesn't exist."""
+        flag = tmp_path / ".responding_to"
+        with patch("kai.bot._RESPONDING_FLAG", flag):
+            _clear_responding()  # should not raise
+
+
+# ── Authorization ────────────────────────────────────────────────────
+
+
+class TestAuthorization:
+    def test_authorized_user(self):
+        config = _make_config(allowed_user_ids={1, 2})
+        assert _is_authorized(config, 1) is True
+
+    def test_unauthorized_user(self):
+        config = _make_config(allowed_user_ids={1})
+        assert _is_authorized(config, 99) is False
+
+    @pytest.mark.asyncio
+    async def test_require_auth_calls_wrapped(self):
+        """Authorized user: the wrapped function is called."""
+        inner = AsyncMock()
+        wrapped = _require_auth(inner)
+        update = _make_update(user_id=1)
+        ctx = _make_context(config=_make_config(allowed_user_ids={1}))
+        await wrapped(update, ctx)
+        inner.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_require_auth_blocks_unauthorized(self):
+        """Unauthorized user: the wrapped function is NOT called."""
+        inner = AsyncMock()
+        wrapped = _require_auth(inner)
+        update = _make_update(user_id=99)
+        ctx = _make_context(config=_make_config(allowed_user_ids={1}))
+        await wrapped(update, ctx)
+        inner.assert_not_called()
+
+
+# ── _reply_safe ──────────────────────────────────────────────────────
+
+
+class TestReplySafe:
+    @pytest.mark.asyncio
+    async def test_markdown_success(self):
+        """Successful Markdown send returns the message."""
+        msg = MagicMock()
+        msg.reply_text = AsyncMock(return_value="sent")
+        result = await _reply_safe(msg, "hello")
+        assert result == "sent"
+
+    @pytest.mark.asyncio
+    async def test_markdown_fails_retries_plain(self):
+        """Markdown failure falls back to plain text."""
+        msg = MagicMock()
+        msg.reply_text = AsyncMock(side_effect=[BadRequest("bad markup"), "sent-plain"])
+        result = await _reply_safe(msg, "*bad*")
+        assert result == "sent-plain"
+        assert msg.reply_text.call_count == 2
+
+
+# ── _edit_message_safe ───────────────────────────────────────────────
+
+
+class TestEditMessageSafe:
+    @pytest.mark.asyncio
+    async def test_markdown_edit_success(self):
+        msg = MagicMock()
+        msg.edit_text = AsyncMock()
+        await _edit_message_safe(msg, "hello")
+        msg.edit_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_markdown_fails_retries_plain(self):
+        """BadRequest on Markdown triggers plain text retry."""
+        msg = MagicMock()
+        msg.edit_text = AsyncMock(side_effect=[BadRequest("bad"), None])
+        await _edit_message_safe(msg, "text")
+        assert msg.edit_text.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_both_fail_no_exception(self, caplog):
+        """Both Markdown and plain text fail: logs debug, no exception raised."""
+        msg = MagicMock()
+        msg.edit_text = AsyncMock(side_effect=[BadRequest("bad"), RuntimeError("fail")])
+        with caplog.at_level(logging.DEBUG, logger="kai.bot"):
+            await _edit_message_safe(msg, "text")
+        assert "Failed to edit message" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_non_badrequest_exception(self, caplog):
+        """Non-BadRequest exception is caught and logged."""
+        msg = MagicMock()
+        msg.edit_text = AsyncMock(side_effect=RuntimeError("network"))
+        with caplog.at_level(logging.DEBUG, logger="kai.bot"):
+            await _edit_message_safe(msg, "text")
+        assert "Failed to edit message" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_long_text_truncated(self):
+        """Text exceeding 4096 chars is truncated before editing."""
+        msg = MagicMock()
+        msg.edit_text = AsyncMock()
+        await _edit_message_safe(msg, "a" * 5000)
+        sent = msg.edit_text.call_args[0][0]
+        assert len(sent) <= 4096
+
+
+# ── _models_keyboard ─────────────────────────────────────────────────
+
+
+class TestModelsKeyboard:
+    def test_current_model_gets_green_dot(self):
+        kb = _models_keyboard("sonnet")
+        labels = _button_labels(kb)
+        assert any("\U0001f7e2" in lbl and "Sonnet" in lbl for lbl in labels)
+
+    def test_all_models_present(self):
+        kb = _models_keyboard("sonnet")
+        callbacks = _button_callbacks(kb)
+        assert "model:opus" in callbacks
+        assert "model:sonnet" in callbacks
+        assert "model:haiku" in callbacks
+
+    def test_callback_data_format(self):
+        kb = _models_keyboard("opus")
+        callbacks = _button_callbacks(kb)
+        assert all(c.startswith("model:") for c in callbacks)
+
+
+# ── _voices_keyboard ─────────────────────────────────────────────────
+
+
+class TestVoicesKeyboard:
+    def test_current_voice_gets_green_dot(self):
+        kb = _voices_keyboard(DEFAULT_VOICE)
+        labels = _button_labels(kb)
+        assert any("\U0001f7e2" in lbl for lbl in labels)
+
+    def test_all_voices_present(self):
+        kb = _voices_keyboard(DEFAULT_VOICE)
+        callbacks = _button_callbacks(kb)
+        for key in VOICES:
+            assert f"voice:{key}" in callbacks
+
+    def test_callback_data_format(self):
+        kb = _voices_keyboard("jenny")
+        callbacks = _button_callbacks(kb)
+        assert all(c.startswith("voice:") for c in callbacks)
+
+
+# ── Simple command handlers ──────────────────────────────────────────
+
+
+class TestHandleStart:
+    @pytest.mark.asyncio
+    async def test_sends_greeting(self):
+        update = _make_update()
+        ctx = _make_context()
+        await handle_start(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "ready" in reply.lower()
+
+
+class TestHandleNew:
+    @pytest.mark.asyncio
+    async def test_clears_session_and_restarts(self):
+        claude = _make_mock_claude()
+        update = _make_update()
+        ctx = _make_context(claude=claude)
+        with patch("kai.bot.sessions.clear_session", new_callable=AsyncMock) as mock_clear:
+            await handle_new(update, ctx)
+        claude.restart.assert_called_once()
+        mock_clear.assert_called_once_with(12345)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "cleared" in reply.lower()
+
+
+class TestHandleHelp:
+    @pytest.mark.asyncio
+    async def test_sends_help_text(self):
+        update = _make_update()
+        ctx = _make_context()
+        await handle_help(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "/stop" in reply
+        assert "/new" in reply
+        assert "/workspace" in reply
+
+
+class TestHandleUnknownCommand:
+    @pytest.mark.asyncio
+    async def test_echoes_unknown_command(self):
+        update = _make_update(text="/foo")
+        ctx = _make_context()
+        await handle_unknown_command(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "/foo" in reply
+        assert "Unknown command" in reply
+
+
+class TestHandleStop:
+    @pytest.mark.asyncio
+    async def test_sets_stop_event_and_kills(self):
+        """Sets the stop event, kills Claude, and sends confirmation."""
+        claude = _make_mock_claude()
+        update = _make_update()
+        ctx = _make_context(claude=claude)
+        stop_event = asyncio.Event()
+        with patch("kai.bot.get_stop_event", return_value=stop_event):
+            await handle_stop(update, ctx)
+        assert stop_event.is_set()
+        claude.force_kill.assert_called_once()
+        reply = update.message.reply_text.call_args[0][0]
+        assert "stopping" in reply.lower()
+
+
+# ── handle_stats ─────────────────────────────────────────────────────
+
+
+class TestHandleStats:
+    @pytest.mark.asyncio
+    async def test_no_active_session(self):
+        update = _make_update()
+        ctx = _make_context()
+        with patch("kai.bot.sessions.get_stats", new_callable=AsyncMock, return_value=None):
+            await handle_stats(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "No active session" in reply
+
+    @pytest.mark.asyncio
+    async def test_active_session(self):
+        update = _make_update()
+        ctx = _make_context()
+        stats = {
+            "session_id": "abcd1234efgh",
+            "model": "sonnet",
+            "created_at": "2026-01-01",
+            "last_used_at": "2026-01-02",
+            "total_cost_usd": 0.1234,
+        }
+        with patch("kai.bot.sessions.get_stats", new_callable=AsyncMock, return_value=stats):
+            await handle_stats(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "abcd1234" in reply
+        assert "sonnet" in reply
+        assert "0.1234" in reply
+
+
+# ── handle_jobs ──────────────────────────────────────────────────────
+
+
+class TestHandleJobs:
+    @pytest.mark.asyncio
+    async def test_no_jobs(self):
+        update = _make_update()
+        ctx = _make_context()
+        with patch("kai.bot.sessions.get_jobs", new_callable=AsyncMock, return_value=[]):
+            await handle_jobs(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "No active" in reply
+
+    @pytest.mark.asyncio
+    async def test_formats_interval_hours(self):
+        """Interval >= 3600s displays as hours."""
+        update = _make_update()
+        ctx = _make_context()
+        jobs = [
+            {
+                "id": 1,
+                "name": "Check",
+                "job_type": "claude",
+                "schedule_type": "interval",
+                "schedule_data": json.dumps({"seconds": 7200}),
+            }
+        ]
+        with patch("kai.bot.sessions.get_jobs", new_callable=AsyncMock, return_value=jobs):
+            await handle_jobs(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "2h" in reply
+        assert "\U0001f916" in reply  # robot emoji for claude type
+
+    @pytest.mark.asyncio
+    async def test_formats_interval_minutes(self):
+        """Interval >= 60s but < 3600s displays as minutes."""
+        update = _make_update()
+        ctx = _make_context()
+        jobs = [
+            {
+                "id": 2,
+                "name": "Ping",
+                "job_type": "reminder",
+                "schedule_type": "interval",
+                "schedule_data": json.dumps({"seconds": 300}),
+            }
+        ]
+        with patch("kai.bot.sessions.get_jobs", new_callable=AsyncMock, return_value=jobs):
+            await handle_jobs(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "5m" in reply
+        assert "\U0001f514" in reply  # bell emoji for reminder type
+
+    @pytest.mark.asyncio
+    async def test_formats_daily(self):
+        update = _make_update()
+        ctx = _make_context()
+        jobs = [
+            {
+                "id": 3,
+                "name": "Standup",
+                "job_type": "reminder",
+                "schedule_type": "daily",
+                "schedule_data": json.dumps({"times": ["14:00"]}),
+            }
+        ]
+        with patch("kai.bot.sessions.get_jobs", new_callable=AsyncMock, return_value=jobs):
+            await handle_jobs(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "14:00" in reply
+
+
+# ── handle_canceljob ─────────────────────────────────────────────────
+
+
+class TestHandleCancelJob:
+    @pytest.mark.asyncio
+    async def test_no_args(self):
+        update = _make_update()
+        ctx = _make_context()
+        await handle_canceljob(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "Usage" in reply
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_arg(self):
+        update = _make_update()
+        ctx = _make_context(args=["abc"])
+        await handle_canceljob(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "number" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_job_not_found(self):
+        update = _make_update()
+        ctx = _make_context(args=["99"])
+        with patch("kai.bot.sessions.delete_job", new_callable=AsyncMock, return_value=False):
+            await handle_canceljob(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "not found" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_successful_deletion(self):
+        """Deletes from DB and removes APScheduler jobs."""
+        update = _make_update()
+        # Mock the job queue with matching jobs
+        mock_job = MagicMock()
+        mock_job.name = "cron_5"
+        mock_job.schedule_removal = MagicMock()
+        jq = MagicMock()
+        jq.jobs.return_value = [mock_job]
+        ctx = _make_context(args=["5"], job_queue=jq)
+        with patch("kai.bot.sessions.delete_job", new_callable=AsyncMock, return_value=True):
+            await handle_canceljob(update, ctx)
+        mock_job.schedule_removal.assert_called_once()
+        reply = update.message.reply_text.call_args[0][0]
+        assert "cancelled" in reply.lower()
+
+
+# ── handle_models ────────────────────────────────────────────────────
+
+
+class TestHandleModels:
+    @pytest.mark.asyncio
+    async def test_sends_keyboard(self):
+        update = _make_update()
+        ctx = _make_context()
+        await handle_models(update, ctx)
+        call = update.message.reply_text.call_args
+        assert "Choose a model" in call[0][0]
+        assert call[1]["reply_markup"] is not None
+
+
+# ── handle_model ─────────────────────────────────────────────────────
+
+
+class TestHandleModel:
+    @pytest.mark.asyncio
+    async def test_no_args(self):
+        update = _make_update()
+        ctx = _make_context()
+        await handle_model(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "Usage" in reply
+
+    @pytest.mark.asyncio
+    async def test_invalid_model(self):
+        update = _make_update()
+        ctx = _make_context(args=["gpt4"])
+        await handle_model(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "opus" in reply.lower() or "sonnet" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_valid_model(self):
+        claude = _make_mock_claude(model="sonnet")
+        update = _make_update()
+        ctx = _make_context(claude=claude, args=["opus"])
+        with patch("kai.bot.sessions.clear_session", new_callable=AsyncMock):
+            await handle_model(update, ctx)
+        assert claude.model == "opus"
+        claude.restart.assert_called_once()
+
+
+# ── handle_model_callback ────────────────────────────────────────────
+
+
+class TestHandleModelCallback:
+    @pytest.mark.asyncio
+    async def test_unauthorized(self):
+        update = _make_callback_update(data="model:opus", user_id=99)
+        ctx = _make_context(config=_make_config(allowed_user_ids={1}))
+        await handle_model_callback(update, ctx)
+        update.callback_query.answer.assert_called_once_with("Not authorized.")
+
+    @pytest.mark.asyncio
+    async def test_invalid_model(self):
+        update = _make_callback_update(data="model:gpt4")
+        ctx = _make_context()
+        await handle_model_callback(update, ctx)
+        update.callback_query.answer.assert_called_once_with("Invalid model.")
+
+    @pytest.mark.asyncio
+    async def test_same_model_no_change(self):
+        """Selecting the current model shows 'No change.'"""
+        claude = _make_mock_claude(model="opus")
+        update = _make_callback_update(data="model:opus")
+        ctx = _make_context(claude=claude)
+        await handle_model_callback(update, ctx)
+        edit_text = update.callback_query.edit_message_text.call_args[0][0]
+        assert "No change" in edit_text
+
+    @pytest.mark.asyncio
+    async def test_switch_model(self):
+        claude = _make_mock_claude(model="sonnet")
+        update = _make_callback_update(data="model:opus")
+        ctx = _make_context(claude=claude)
+        with patch("kai.bot.sessions.clear_session", new_callable=AsyncMock):
+            await handle_model_callback(update, ctx)
+        assert claude.model == "opus"
+        edit_text = update.callback_query.edit_message_text.call_args[0][0]
+        assert "Switched" in edit_text
+
+
+# ── handle_voice_command ─────────────────────────────────────────────
+
+
+class TestHandleVoiceCommand:
+    @pytest.mark.asyncio
+    async def test_tts_disabled(self):
+        update = _make_update()
+        ctx = _make_context(config=_make_config(tts_enabled=False))
+        await handle_voice_command(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "not enabled" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_toggle_off_to_only(self):
+        """No args when mode is off: toggles to 'only'."""
+        update = _make_update()
+        ctx = _make_context(config=_make_config(tts_enabled=True))
+        with (
+            patch("kai.bot.sessions.get_setting", new_callable=AsyncMock, return_value=None),
+            patch("kai.bot.sessions.set_setting", new_callable=AsyncMock) as mock_set,
+        ):
+            await handle_voice_command(update, ctx)
+        # Should set to "only" (toggling from default "off")
+        mock_set.assert_called_once_with("voice_mode:12345", "only")
+
+    @pytest.mark.asyncio
+    async def test_toggle_only_to_off(self):
+        """No args when mode is 'only': toggles to 'off'."""
+        update = _make_update()
+        ctx = _make_context(config=_make_config(tts_enabled=True))
+
+        async def _get(key):
+            if "voice_mode" in key:
+                return "only"
+            return None
+
+        with (
+            patch("kai.bot.sessions.get_setting", side_effect=_get),
+            patch("kai.bot.sessions.set_setting", new_callable=AsyncMock) as mock_set,
+        ):
+            await handle_voice_command(update, ctx)
+        mock_set.assert_called_once_with("voice_mode:12345", "off")
+
+    @pytest.mark.asyncio
+    async def test_set_mode_on(self):
+        update = _make_update()
+        ctx = _make_context(config=_make_config(tts_enabled=True), args=["on"])
+        with (
+            patch("kai.bot.sessions.get_setting", new_callable=AsyncMock, return_value=None),
+            patch("kai.bot.sessions.set_setting", new_callable=AsyncMock) as mock_set,
+        ):
+            await handle_voice_command(update, ctx)
+        mock_set.assert_called_once_with("voice_mode:12345", "on")
+
+    @pytest.mark.asyncio
+    async def test_set_voice_name_enables_if_off(self):
+        """Setting a voice name auto-enables voice mode when off."""
+        update = _make_update()
+        # Use a real voice key from the VOICES dict
+        voice_key = next(iter(VOICES.keys()))
+        ctx = _make_context(config=_make_config(tts_enabled=True), args=[voice_key])
+
+        async def _get(key):
+            if "voice_mode" in key:
+                return "off"
+            return DEFAULT_VOICE
+
+        with (
+            patch("kai.bot.sessions.get_setting", side_effect=_get),
+            patch("kai.bot.sessions.set_setting", new_callable=AsyncMock) as mock_set,
+        ):
+            await handle_voice_command(update, ctx)
+        # Should set both voice name and mode
+        calls = {c[0] for c in mock_set.call_args_list}
+        assert ("voice_name:12345", voice_key) in calls
+        assert ("voice_mode:12345", "only") in calls
+
+    @pytest.mark.asyncio
+    async def test_invalid_voice_name(self):
+        update = _make_update()
+        ctx = _make_context(config=_make_config(tts_enabled=True), args=["badname"])
+        with patch("kai.bot.sessions.get_setting", new_callable=AsyncMock, return_value=None):
+            await handle_voice_command(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "Unknown" in reply or "Usage" in reply
+
+
+# ── handle_voices ────────────────────────────────────────────────────
+
+
+class TestHandleVoices:
+    @pytest.mark.asyncio
+    async def test_tts_disabled(self):
+        update = _make_update()
+        ctx = _make_context(config=_make_config(tts_enabled=False))
+        await handle_voices(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "not enabled" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_sends_keyboard(self):
+        update = _make_update()
+        ctx = _make_context(config=_make_config(tts_enabled=True))
+        with patch("kai.bot.sessions.get_setting", new_callable=AsyncMock, return_value=None):
+            await handle_voices(update, ctx)
+        call = update.message.reply_text.call_args
+        assert call[1]["reply_markup"] is not None
+
+
+# ── handle_voice_callback ────────────────────────────────────────────
+
+
+class TestHandleVoiceCallback:
+    @pytest.mark.asyncio
+    async def test_unauthorized(self):
+        update = _make_callback_update(data="voice:jenny", user_id=99)
+        ctx = _make_context(config=_make_config(allowed_user_ids={1}))
+        await handle_voice_callback(update, ctx)
+        update.callback_query.answer.assert_called_once_with("Not authorized.")
+
+    @pytest.mark.asyncio
+    async def test_invalid_voice(self):
+        update = _make_callback_update(data="voice:nonexistent")
+        ctx = _make_context()
+        await handle_voice_callback(update, ctx)
+        update.callback_query.answer.assert_called_once_with("Invalid voice.")
+
+    @pytest.mark.asyncio
+    async def test_same_voice_no_change(self):
+        update = _make_callback_update(data=f"voice:{DEFAULT_VOICE}")
+        ctx = _make_context()
+        with patch("kai.bot.sessions.get_setting", new_callable=AsyncMock, return_value=None):
+            await handle_voice_callback(update, ctx)
+        edit_text = update.callback_query.edit_message_text.call_args[0][0]
+        assert "No change" in edit_text
+
+    @pytest.mark.asyncio
+    async def test_switch_voice(self):
+        """Switching voice sets the new name and confirms."""
+        new_voice = "jenny" if DEFAULT_VOICE != "jenny" else "alan"
+        update = _make_callback_update(data=f"voice:{new_voice}")
+        ctx = _make_context()
+        with (
+            patch("kai.bot.sessions.get_setting", new_callable=AsyncMock, return_value=None),
+            patch("kai.bot.sessions.set_setting", new_callable=AsyncMock),
+        ):
+            await handle_voice_callback(update, ctx)
+        edit_text = update.callback_query.edit_message_text.call_args[0][0]
+        assert VOICES[new_voice] in edit_text
+
+    @pytest.mark.asyncio
+    async def test_auto_enables_when_off(self):
+        """Switching voice auto-enables mode to 'only' when off."""
+        new_voice = "jenny" if DEFAULT_VOICE != "jenny" else "alan"
+        update = _make_callback_update(data=f"voice:{new_voice}")
+        ctx = _make_context()
+
+        async def _get(key):
+            if "voice_mode" in key:
+                return "off"
+            return None  # default voice
+
+        with (
+            patch("kai.bot.sessions.get_setting", side_effect=_get),
+            patch("kai.bot.sessions.set_setting", new_callable=AsyncMock) as mock_set,
+        ):
+            await handle_voice_callback(update, ctx)
+        calls = {c[0] for c in mock_set.call_args_list}
+        assert ("voice_mode:12345", "only") in calls
+
+
+# ── handle_webhooks ──────────────────────────────────────────────────
+
+
+class TestHandleWebhooks:
+    @pytest.mark.asyncio
+    async def test_running_with_secret(self):
+        update = _make_update()
+        ctx = _make_context(config=_make_config(webhook_secret="s3cret"))
+        with patch("kai.bot.webhook.is_running", return_value=True):
+            await handle_webhooks(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "running" in reply
+        assert "GitHub setup" in reply
+
+    @pytest.mark.asyncio
+    async def test_not_running(self):
+        update = _make_update()
+        ctx = _make_context(config=_make_config(webhook_secret="s3cret"))
+        with patch("kai.bot.webhook.is_running", return_value=False):
+            await handle_webhooks(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "not running" in reply
+
+    @pytest.mark.asyncio
+    async def test_no_secret(self):
+        update = _make_update()
+        ctx = _make_context(config=_make_config(webhook_secret=""))
+        with patch("kai.bot.webhook.is_running", return_value=True):
+            await handle_webhooks(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "WEBHOOK_SECRET not set" in reply
+
+
+# ── handle_workspace ─────────────────────────────────────────────────
+
+
+class TestHandleWorkspace:
+    @pytest.mark.asyncio
+    async def test_no_args_shows_current(self):
+        """No args: shows the current workspace."""
+        claude = _make_mock_claude(workspace=Path("/home/workspace"))
+        update = _make_update()
+        ctx = _make_context(claude=claude)
+        await handle_workspace(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "Home" in reply or "workspace" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_home_switches(self):
+        """'home' keyword switches to home workspace."""
+        claude = _make_mock_claude(workspace=Path("/other"))
+        config = _make_config(claude_workspace=Path("/home/workspace"))
+        update = _make_update()
+        ctx = _make_context(claude=claude, config=config, args=["home"])
+        with (
+            patch("kai.bot.sessions.clear_session", new_callable=AsyncMock),
+            patch("kai.bot.sessions.delete_setting", new_callable=AsyncMock),
+            patch("kai.bot.webhook.update_workspace"),
+        ):
+            await handle_workspace(update, ctx)
+        claude.change_workspace.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_absolute_path_rejected(self):
+        update = _make_update()
+        ctx = _make_context(args=["/tmp/evil"])
+        await handle_workspace(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "Absolute paths" in reply
+
+    @pytest.mark.asyncio
+    async def test_tilde_path_rejected(self):
+        update = _make_update()
+        ctx = _make_context(args=["~/foo"])
+        await handle_workspace(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "Absolute paths" in reply
+
+    @pytest.mark.asyncio
+    async def test_new_without_name(self):
+        update = _make_update()
+        ctx = _make_context(args=["new"])
+        await handle_workspace(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "Usage" in reply
+
+    @pytest.mark.asyncio
+    async def test_new_without_base(self):
+        update = _make_update()
+        ctx = _make_context(config=_make_config(workspace_base=None), args=["new", "myproj"])
+        await handle_workspace(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "WORKSPACE_BASE" in reply
+
+    @pytest.mark.asyncio
+    async def test_new_already_exists(self, tmp_path):
+        existing = tmp_path / "myproj"
+        existing.mkdir()
+        update = _make_update()
+        ctx = _make_context(
+            config=_make_config(workspace_base=tmp_path, claude_workspace=Path("/home")),
+            args=["new", "myproj"],
+        )
+        await handle_workspace(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "Already exists" in reply
+
+    @pytest.mark.asyncio
+    async def test_new_creates_and_switches(self, tmp_path):
+        """'new <name>' creates the directory, runs git init, and switches."""
+        update = _make_update()
+        claude = _make_mock_claude(workspace=Path("/home"))
+        config = _make_config(workspace_base=tmp_path, claude_workspace=Path("/home"))
+        ctx = _make_context(config=config, claude=claude, args=["new", "fresh"])
+        mock_proc = MagicMock()
+        mock_proc.wait = AsyncMock()
+        with (
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc),
+            patch("kai.bot.sessions.clear_session", new_callable=AsyncMock),
+            patch("kai.bot.sessions.set_setting", new_callable=AsyncMock),
+            patch("kai.bot.sessions.upsert_workspace_history", new_callable=AsyncMock),
+            patch("kai.bot.webhook.update_workspace"),
+        ):
+            await handle_workspace(update, ctx)
+        # Directory should have been created
+        assert (tmp_path / "fresh").is_dir()
+        claude.change_workspace.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_name_found_in_base(self, tmp_path):
+        """Name resolved via WORKSPACE_BASE."""
+        project = tmp_path / "myproj"
+        project.mkdir()
+        claude = _make_mock_claude(workspace=Path("/other"))
+        config = _make_config(workspace_base=tmp_path, claude_workspace=Path("/home"))
+        update = _make_update()
+        ctx = _make_context(config=config, claude=claude, args=["myproj"])
+        with (
+            patch("kai.bot.sessions.clear_session", new_callable=AsyncMock),
+            patch("kai.bot.sessions.set_setting", new_callable=AsyncMock),
+            patch("kai.bot.sessions.upsert_workspace_history", new_callable=AsyncMock),
+            patch("kai.bot.webhook.update_workspace"),
+        ):
+            await handle_workspace(update, ctx)
+        claude.change_workspace.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_name_found_in_allowed(self, tmp_path):
+        """Name resolved via ALLOWED_WORKSPACES directory name match."""
+        project = tmp_path / "myproj"
+        project.mkdir()
+        claude = _make_mock_claude(workspace=Path("/other"))
+        config = _make_config(
+            allowed_workspaces=[project],
+            claude_workspace=Path("/home"),
+        )
+        update = _make_update()
+        ctx = _make_context(config=config, claude=claude, args=["myproj"])
+        with (
+            patch("kai.bot.sessions.clear_session", new_callable=AsyncMock),
+            patch("kai.bot.sessions.set_setting", new_callable=AsyncMock),
+            patch("kai.bot.sessions.upsert_workspace_history", new_callable=AsyncMock),
+            patch("kai.bot.webhook.update_workspace"),
+        ):
+            await handle_workspace(update, ctx)
+        claude.change_workspace.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_multiple_matches_in_allowed(self, tmp_path):
+        """Multiple ALLOWED_WORKSPACES with the same name: shows disambiguation message."""
+        proj_a = tmp_path / "a" / "proj"
+        proj_b = tmp_path / "b" / "proj"
+        proj_a.mkdir(parents=True)
+        proj_b.mkdir(parents=True)
+        config = _make_config(allowed_workspaces=[proj_a, proj_b], claude_workspace=Path("/home"))
+        update = _make_update()
+        ctx = _make_context(config=config, args=["proj"])
+        await handle_workspace(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "Multiple workspaces" in reply
+
+    @pytest.mark.asyncio
+    async def test_not_found_with_sources(self, tmp_path):
+        config = _make_config(workspace_base=tmp_path, claude_workspace=Path("/home"))
+        update = _make_update()
+        ctx = _make_context(config=config, args=["nonexistent"])
+        await handle_workspace(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "not found" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_not_found_no_sources(self):
+        config = _make_config(workspace_base=None, allowed_workspaces=[], claude_workspace=Path("/home"))
+        update = _make_update()
+        ctx = _make_context(config=config, args=["anything"])
+        await handle_workspace(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "WORKSPACE_BASE" in reply
+
+
+# ── handle_workspaces ────────────────────────────────────────────────
+
+
+class TestHandleWorkspaces:
+    @pytest.mark.asyncio
+    async def test_no_history_at_home(self):
+        update = _make_update()
+        claude = _make_mock_claude(workspace=Path("/home/workspace"))
+        config = _make_config(claude_workspace=Path("/home/workspace"))
+        ctx = _make_context(config=config, claude=claude)
+        with patch("kai.bot.sessions.get_workspace_history", new_callable=AsyncMock, return_value=[]):
+            await handle_workspaces(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "No workspace history" in reply
+
+    @pytest.mark.asyncio
+    async def test_has_history_shows_keyboard(self):
+        update = _make_update()
+        claude = _make_mock_claude(workspace=Path("/home/workspace"))
+        config = _make_config(claude_workspace=Path("/home/workspace"))
+        ctx = _make_context(config=config, claude=claude)
+        history = [{"path": "/some/project"}]
+        with patch("kai.bot.sessions.get_workspace_history", new_callable=AsyncMock, return_value=history):
+            await handle_workspaces(update, ctx)
+        call = update.message.reply_text.call_args
+        assert call[1]["reply_markup"] is not None
+
+
+# ── handle_workspace_callback ────────────────────────────────────────
+
+
+class TestHandleWorkspaceCallback:
+    @pytest.mark.asyncio
+    async def test_unauthorized(self):
+        update = _make_callback_update(data="ws:home", user_id=99)
+        ctx = _make_context(config=_make_config(allowed_user_ids={1}))
+        await handle_workspace_callback(update, ctx)
+        update.callback_query.answer.assert_called_once_with("Not authorized.")
+
+    @pytest.mark.asyncio
+    async def test_home(self):
+        """ws:home switches to home workspace."""
+        claude = _make_mock_claude(workspace=Path("/other"))
+        config = _make_config(claude_workspace=Path("/home/workspace"))
+        update = _make_callback_update(data="ws:home")
+        ctx = _make_context(config=config, claude=claude)
+        with (
+            patch("kai.bot.sessions.clear_session", new_callable=AsyncMock),
+            patch("kai.bot.sessions.delete_setting", new_callable=AsyncMock),
+            patch("kai.bot.webhook.update_workspace"),
+        ):
+            await handle_workspace_callback(update, ctx)
+        claude.change_workspace.assert_called_once()
+        edit_text = update.callback_query.edit_message_text.call_args[0][0]
+        assert "Home" in edit_text
+
+    @pytest.mark.asyncio
+    async def test_allowed_workspace(self, tmp_path):
+        """ws:allowed:<idx> switches to the indexed allowed workspace."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        claude = _make_mock_claude(workspace=Path("/other"))
+        config = _make_config(
+            allowed_workspaces=[project],
+            claude_workspace=Path("/home/workspace"),
+        )
+        update = _make_callback_update(data="ws:allowed:0")
+        ctx = _make_context(config=config, claude=claude)
+        with (
+            patch("kai.bot.sessions.clear_session", new_callable=AsyncMock),
+            patch("kai.bot.sessions.set_setting", new_callable=AsyncMock),
+            patch("kai.bot.sessions.upsert_workspace_history", new_callable=AsyncMock),
+            patch("kai.bot.webhook.update_workspace"),
+        ):
+            await handle_workspace_callback(update, ctx)
+        claude.change_workspace.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_allowed_nonexistent_dir(self, tmp_path):
+        """ws:allowed:<idx> where directory was deleted."""
+        gone = tmp_path / "gone"  # not created
+        config = _make_config(allowed_workspaces=[gone], claude_workspace=Path("/home"))
+        update = _make_callback_update(data="ws:allowed:0")
+        ctx = _make_context(config=config)
+        await handle_workspace_callback(update, ctx)
+        update.callback_query.answer.assert_called_once_with("That workspace no longer exists.")
+
+    @pytest.mark.asyncio
+    async def test_allowed_bad_index(self):
+        update = _make_callback_update(data="ws:allowed:bad")
+        ctx = _make_context()
+        await handle_workspace_callback(update, ctx)
+        update.callback_query.answer.assert_called_once_with("Invalid selection.")
+
+    @pytest.mark.asyncio
+    async def test_allowed_out_of_range(self):
+        config = _make_config(allowed_workspaces=[], claude_workspace=Path("/home"))
+        update = _make_callback_update(data="ws:allowed:99")
+        ctx = _make_context(config=config)
+        await handle_workspace_callback(update, ctx)
+        update.callback_query.answer.assert_called_once_with("Workspace no longer available.")
+
+    @pytest.mark.asyncio
+    async def test_history_entry(self, tmp_path):
+        """ws:<idx> switches to a history entry."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        claude = _make_mock_claude(workspace=Path("/other"))
+        config = _make_config(claude_workspace=Path("/home/workspace"))
+        update = _make_callback_update(data="ws:0")
+        ctx = _make_context(config=config, claude=claude)
+        history = [{"path": str(project)}]
+        with (
+            patch("kai.bot.sessions.get_workspace_history", new_callable=AsyncMock, return_value=history),
+            patch("kai.bot.sessions.clear_session", new_callable=AsyncMock),
+            patch("kai.bot.sessions.set_setting", new_callable=AsyncMock),
+            patch("kai.bot.sessions.upsert_workspace_history", new_callable=AsyncMock),
+            patch("kai.bot.webhook.update_workspace"),
+        ):
+            await handle_workspace_callback(update, ctx)
+        claude.change_workspace.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_history_no_longer_allowed(self, tmp_path):
+        """History entry disallowed: deleted from history, keyboard refreshed."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        # Configure with a base that doesn't contain the project
+        other_base = tmp_path / "base"
+        other_base.mkdir()
+        config = _make_config(
+            workspace_base=other_base,
+            claude_workspace=Path("/home/workspace"),
+        )
+        claude = _make_mock_claude(workspace=Path("/home/workspace"))
+        update = _make_callback_update(data="ws:0")
+        ctx = _make_context(config=config, claude=claude)
+        history = [{"path": str(project)}]
+        with (
+            patch("kai.bot.sessions.get_workspace_history", new_callable=AsyncMock, return_value=history),
+            patch("kai.bot.sessions.delete_workspace_history", new_callable=AsyncMock) as mock_del,
+        ):
+            await handle_workspace_callback(update, ctx)
+        mock_del.assert_called_once_with(str(project))
+        update.callback_query.answer.assert_called_once_with("That workspace is no longer allowed.")
+
+    @pytest.mark.asyncio
+    async def test_history_dir_deleted(self, tmp_path):
+        """History entry whose directory no longer exists: removed from history."""
+        gone = tmp_path / "gone"  # not created
+        config = _make_config(claude_workspace=Path("/home/workspace"))
+        claude = _make_mock_claude(workspace=Path("/home/workspace"))
+        update = _make_callback_update(data="ws:0")
+        ctx = _make_context(config=config, claude=claude)
+        history = [{"path": str(gone)}]
+        with (
+            patch("kai.bot.sessions.get_workspace_history", new_callable=AsyncMock, return_value=history),
+            patch("kai.bot.sessions.delete_workspace_history", new_callable=AsyncMock) as mock_del,
+        ):
+            await handle_workspace_callback(update, ctx)
+        mock_del.assert_called_once_with(str(gone))
+
+    @pytest.mark.asyncio
+    async def test_already_in_workspace(self, tmp_path):
+        """Selecting the current workspace shows 'No change.'"""
+        home = Path("/home/workspace")
+        claude = _make_mock_claude(workspace=home)
+        config = _make_config(claude_workspace=home)
+        update = _make_callback_update(data="ws:home")
+        ctx = _make_context(config=config, claude=claude)
+        await handle_workspace_callback(update, ctx)
+        edit_text = update.callback_query.edit_message_text.call_args[0][0]
+        assert "No change" in edit_text
+
+
+# ── handle_message (non-TOTP) ────────────────────────────────────────
+
+
+class TestHandleMessage:
+    @pytest.mark.asyncio
+    async def test_normal_message(self):
+        """Normal message: logs, acquires lock, calls _handle_response."""
+        update = _make_update(text="hello world")
+        ctx = _make_context()
+        with (
+            patch("kai.bot.is_totp_configured", return_value=False),
+            patch("kai.bot._handle_response", new_callable=AsyncMock) as mock_resp,
+            patch("kai.bot.log_message") as mock_log,
+            patch("kai.bot._set_responding"),
+            patch("kai.bot._clear_responding"),
+            patch("kai.bot.get_lock", return_value=_fake_lock()),
+        ):
+            await handle_message(update, ctx)
+        mock_resp.assert_called_once()
+        mock_log.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_message(self):
+        """Empty text: returns early without processing."""
+        update = _make_update()
+        update.message.text = None
+        ctx = _make_context()
+        with (
+            patch("kai.bot.is_totp_configured", return_value=False),
+            patch("kai.bot._handle_response", new_callable=AsyncMock) as mock_resp,
+        ):
+            await handle_message(update, ctx)
+        mock_resp.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_and_clear_responding(self):
+        """_set_responding called before and _clear_responding after, even on error."""
+        update = _make_update()
+        ctx = _make_context()
+        with (
+            patch("kai.bot.is_totp_configured", return_value=False),
+            patch("kai.bot._handle_response", new_callable=AsyncMock, side_effect=RuntimeError("boom")),
+            patch("kai.bot.log_message"),
+            patch("kai.bot._set_responding") as mock_set,
+            patch("kai.bot._clear_responding") as mock_clear,
+            patch("kai.bot.get_lock", return_value=_fake_lock()),
+            pytest.raises(RuntimeError),
+        ):
+            await handle_message(update, ctx)
+        mock_set.assert_called_once()
+        mock_clear.assert_called_once()
+
+
+# ── handle_photo ─────────────────────────────────────────────────────
+
+
+class TestHandlePhoto:
+    @pytest.mark.asyncio
+    async def test_downloads_and_sends_multimodal(self, tmp_path):
+        """Downloads photo, base64-encodes, and calls _handle_response with list content."""
+        update = _make_update()
+        photo = MagicMock()
+        photo.file_id = "file123"
+        photo.file_unique_id = "uniq123"
+        update.message.photo = [MagicMock(), photo]  # last is highest res
+
+        mock_file = MagicMock()
+        mock_file.download_as_bytearray = AsyncMock(return_value=bytearray(b"image-data"))
+        claude = _make_mock_claude(workspace=tmp_path)
+        ctx = _make_context(claude=claude)
+        ctx.bot.get_file = AsyncMock(return_value=mock_file)
+
+        with (
+            patch("kai.bot._handle_response", new_callable=AsyncMock) as mock_resp,
+            patch("kai.bot.log_message"),
+            patch("kai.bot._set_responding"),
+            patch("kai.bot._clear_responding"),
+            patch("kai.bot.get_lock", return_value=_fake_lock()),
+        ):
+            await handle_photo(update, ctx)
+        # The content arg should be a list (multi-modal)
+        content = mock_resp.call_args[0][3]
+        assert isinstance(content, list)
+        assert content[1]["type"] == "image"
+
+    @pytest.mark.asyncio
+    async def test_uses_caption(self, tmp_path):
+        """Uses caption if provided instead of default question."""
+        update = _make_update()
+        photo = MagicMock()
+        photo.file_id = "file123"
+        photo.file_unique_id = "uniq123"
+        update.message.photo = [photo]
+        update.message.caption = "Describe this logo"
+
+        mock_file = MagicMock()
+        mock_file.download_as_bytearray = AsyncMock(return_value=bytearray(b"img"))
+        claude = _make_mock_claude(workspace=tmp_path)
+        ctx = _make_context(claude=claude)
+        ctx.bot.get_file = AsyncMock(return_value=mock_file)
+
+        with (
+            patch("kai.bot._handle_response", new_callable=AsyncMock) as mock_resp,
+            patch("kai.bot.log_message"),
+            patch("kai.bot._set_responding"),
+            patch("kai.bot._clear_responding"),
+            patch("kai.bot.get_lock", return_value=_fake_lock()),
+        ):
+            await handle_photo(update, ctx)
+        content = mock_resp.call_args[0][3]
+        assert "Describe this logo" in content[0]["text"]
+
+
+# ── handle_document ──────────────────────────────────────────────────
+
+
+class TestHandleDocument:
+    def _setup_doc(self, update, file_name, mime_type=None, data=b"content"):
+        """Attach a mock document to the update."""
+        update.message.document = MagicMock()
+        update.message.document.file_name = file_name
+        update.message.document.file_id = "doc_file_id"
+        update.message.document.mime_type = mime_type
+        return data
+
+    @pytest.mark.asyncio
+    async def test_image_document(self, tmp_path):
+        """Image file extension: sent as multi-modal content."""
+        update = _make_update()
+        self._setup_doc(update, "logo.png", "image/png")
+        mock_file = MagicMock()
+        mock_file.download_as_bytearray = AsyncMock(return_value=bytearray(b"png-data"))
+        claude = _make_mock_claude(workspace=tmp_path)
+        ctx = _make_context(claude=claude)
+        ctx.bot.get_file = AsyncMock(return_value=mock_file)
+
+        with (
+            patch("kai.bot._handle_response", new_callable=AsyncMock) as mock_resp,
+            patch("kai.bot.log_message"),
+            patch("kai.bot._set_responding"),
+            patch("kai.bot._clear_responding"),
+            patch("kai.bot.get_lock", return_value=_fake_lock()),
+        ):
+            await handle_document(update, ctx)
+        content = mock_resp.call_args[0][3]
+        assert isinstance(content, list)
+        assert content[1]["type"] == "image"
+
+    @pytest.mark.asyncio
+    async def test_text_document(self, tmp_path):
+        """Text file: decoded as UTF-8 and sent as code block string."""
+        update = _make_update()
+        self._setup_doc(update, "script.py", "text/python")
+        mock_file = MagicMock()
+        mock_file.download_as_bytearray = AsyncMock(return_value=bytearray(b"print('hi')"))
+        claude = _make_mock_claude(workspace=tmp_path)
+        ctx = _make_context(claude=claude)
+        ctx.bot.get_file = AsyncMock(return_value=mock_file)
+
+        with (
+            patch("kai.bot._handle_response", new_callable=AsyncMock) as mock_resp,
+            patch("kai.bot.log_message"),
+            patch("kai.bot._set_responding"),
+            patch("kai.bot._clear_responding"),
+            patch("kai.bot.get_lock", return_value=_fake_lock()),
+        ):
+            await handle_document(update, ctx)
+        content = mock_resp.call_args[0][3]
+        assert isinstance(content, str)
+        assert "```" in content
+
+    @pytest.mark.asyncio
+    async def test_text_decode_error(self, tmp_path):
+        """UTF-8 decode failure: sends error reply, no _handle_response call."""
+        update = _make_update()
+        self._setup_doc(update, "data.txt", "text/plain")
+        mock_file = MagicMock()
+        # Invalid UTF-8 bytes
+        mock_file.download_as_bytearray = AsyncMock(return_value=bytearray(b"\xff\xfe"))
+        claude = _make_mock_claude(workspace=tmp_path)
+        ctx = _make_context(claude=claude)
+        ctx.bot.get_file = AsyncMock(return_value=mock_file)
+
+        with (
+            patch("kai.bot._handle_response", new_callable=AsyncMock) as mock_resp,
+            patch("kai.bot.log_message"),
+            patch("kai.bot._set_responding"),
+            patch("kai.bot._clear_responding"),
+            patch("kai.bot.get_lock", return_value=_fake_lock()),
+        ):
+            await handle_document(update, ctx)
+        mock_resp.assert_not_called()
+        reply = update.message.reply_text.call_args[0][0]
+        assert "decode" in reply.lower() or "text" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_other_file_type(self, tmp_path):
+        """Non-image, non-text file: saved to disk, path sent in prompt."""
+        update = _make_update()
+        self._setup_doc(update, "archive.zip", "application/zip")
+        mock_file = MagicMock()
+        mock_file.download_as_bytearray = AsyncMock(return_value=bytearray(b"PK..."))
+        claude = _make_mock_claude(workspace=tmp_path)
+        ctx = _make_context(claude=claude)
+        ctx.bot.get_file = AsyncMock(return_value=mock_file)
+
+        with (
+            patch("kai.bot._handle_response", new_callable=AsyncMock) as mock_resp,
+            patch("kai.bot.log_message"),
+            patch("kai.bot._set_responding"),
+            patch("kai.bot._clear_responding"),
+            patch("kai.bot.get_lock", return_value=_fake_lock()),
+        ):
+            await handle_document(update, ctx)
+        content = mock_resp.call_args[0][3]
+        assert isinstance(content, str)
+        assert "archive.zip" in content
+
+
+# ── handle_voice ─────────────────────────────────────────────────────
+
+
+class TestHandleVoice:
+    @pytest.mark.asyncio
+    async def test_voice_not_enabled(self):
+        update = _make_update()
+        update.message.voice = MagicMock()
+        ctx = _make_context(config=_make_config(voice_enabled=False))
+        await handle_voice(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "not enabled" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_dependencies(self, tmp_path):
+        """Lists missing deps when ffmpeg/whisper/model aren't available."""
+        update = _make_update()
+        update.message.voice = MagicMock()
+        config = _make_config(voice_enabled=True, whisper_model_path=tmp_path / "nomodel")
+        ctx = _make_context(config=config)
+        with patch("shutil.which", return_value=None):
+            await handle_voice(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "ffmpeg" in reply
+
+    @pytest.mark.asyncio
+    async def test_transcription_error(self, tmp_path):
+        """TranscriptionError: sends error reply."""
+        from kai.transcribe import TranscriptionError
+
+        model_file = tmp_path / "model.bin"
+        model_file.touch()
+        update = _make_update()
+        voice_msg = MagicMock()
+        voice_msg.file_id = "v1"
+        voice_msg.duration = 5
+        update.message.voice = voice_msg
+        mock_file = MagicMock()
+        mock_file.download_as_bytearray = AsyncMock(return_value=bytearray(b"audio"))
+        config = _make_config(voice_enabled=True, whisper_model_path=model_file)
+        ctx = _make_context(config=config)
+        ctx.bot.get_file = AsyncMock(return_value=mock_file)
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("kai.bot.transcribe_voice", new_callable=AsyncMock, side_effect=TranscriptionError("fail")),
+            patch("kai.bot.log_message"),
+        ):
+            await handle_voice(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "Transcription failed" in reply
+
+    @pytest.mark.asyncio
+    async def test_empty_transcript(self, tmp_path):
+        model_file = tmp_path / "model.bin"
+        model_file.touch()
+        update = _make_update()
+        voice_msg = MagicMock()
+        voice_msg.file_id = "v1"
+        voice_msg.duration = 5
+        update.message.voice = voice_msg
+        mock_file = MagicMock()
+        mock_file.download_as_bytearray = AsyncMock(return_value=bytearray(b"audio"))
+        config = _make_config(voice_enabled=True, whisper_model_path=model_file)
+        ctx = _make_context(config=config)
+        ctx.bot.get_file = AsyncMock(return_value=mock_file)
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("kai.bot.transcribe_voice", new_callable=AsyncMock, return_value=""),
+            patch("kai.bot.log_message"),
+        ):
+            await handle_voice(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert "speech" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_successful_transcription(self, tmp_path):
+        """Echoes transcript, then sends to Claude."""
+        model_file = tmp_path / "model.bin"
+        model_file.touch()
+        update = _make_update()
+        voice_msg = MagicMock()
+        voice_msg.file_id = "v1"
+        voice_msg.duration = 5
+        update.message.voice = voice_msg
+        mock_file = MagicMock()
+        mock_file.download_as_bytearray = AsyncMock(return_value=bytearray(b"audio"))
+        claude = _make_mock_claude(workspace=tmp_path)
+        config = _make_config(voice_enabled=True, whisper_model_path=model_file)
+        ctx = _make_context(config=config, claude=claude)
+        ctx.bot.get_file = AsyncMock(return_value=mock_file)
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("kai.bot.transcribe_voice", new_callable=AsyncMock, return_value="Hello there"),
+            patch("kai.bot.log_message"),
+            patch("kai.bot._handle_response", new_callable=AsyncMock) as mock_resp,
+            patch("kai.bot._set_responding"),
+            patch("kai.bot._clear_responding"),
+            patch("kai.bot.get_lock", return_value=_fake_lock()),
+        ):
+            await handle_voice(update, ctx)
+        # Echo the transcript
+        echo_call = update.message.reply_text.call_args
+        assert "Hello there" in echo_call[0][0]
+        # Then send to Claude
+        prompt = mock_resp.call_args[0][3]
+        assert "Hello there" in prompt
+
+
+# ── _handle_response ─────────────────────────────────────────────────
+
+
+class TestHandleResponse:
+    """Tests for the streaming response handler."""
+
+    def _base_patches(self):
+        """
+        Common patches for _handle_response tests.
+
+        Returns a dict suitable for patch.multiple("kai.bot", ...).
+        Voice mode defaults to "off" (normal text mode).
+        """
+        return {
+            "sessions": MagicMock(
+                get_setting=AsyncMock(return_value="off"),
+                save_session=AsyncMock(),
+            ),
+            "log_message": MagicMock(),
+        }
+
+    @pytest.mark.asyncio
+    async def test_normal_flow(self):
+        """Streams text, creates live message, delivers final text."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        claude = _make_mock_claude()
+        claude.send = MagicMock(return_value=_fake_stream(_text_event("Hello"), _done_event("Hello world")))
+        ctx = _make_context(claude=claude)
+
+        with patch.multiple("kai.bot", **self._base_patches()):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        # Live message should have been created via reply_text
+        assert update.message.reply_text.called
+
+    @pytest.mark.asyncio
+    async def test_final_matches_last_edit_no_redundant(self):
+        """When final text matches last edit, no extra edit is made."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        # The live message mock - track edit_text calls
+        live_msg = MagicMock()
+        live_msg.edit_text = AsyncMock()
+        update.message.reply_text = AsyncMock(return_value=live_msg)
+
+        claude = _make_mock_claude()
+        claude.send = MagicMock(return_value=_fake_stream(_text_event("Done"), _done_event("Done")))
+        ctx = _make_context(claude=claude)
+
+        with patch.multiple("kai.bot", **self._base_patches()):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        # The important thing is no exception was raised and
+        # the response completed successfully
+
+    @pytest.mark.asyncio
+    async def test_stop_interruption(self):
+        """Stop event during streaming: edits '(stopped)', returns without error."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        live_msg = MagicMock()
+        live_msg.edit_text = AsyncMock()
+        update.message.reply_text = AsyncMock(return_value=live_msg)
+
+        stop_event = asyncio.Event()
+
+        async def _streaming(*args):
+            yield _text_event("Partial")
+            # Simulate /stop during streaming
+            stop_event.set()
+            yield _text_event("More text")
+            yield _done_event("Should not reach")
+
+        claude = _make_mock_claude()
+        claude.send = MagicMock(return_value=_streaming())
+        ctx = _make_context(claude=claude)
+
+        with (
+            patch.multiple("kai.bot", **self._base_patches()),
+            patch("kai.bot.get_stop_event", return_value=stop_event),
+        ):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        # Should NOT send the "No response" error
+        replies = [c[0][0] for c in update.message.reply_text.call_args_list]
+        assert not any("Error" in r for r in replies)
+
+    @pytest.mark.asyncio
+    async def test_no_done_event_error(self):
+        """No done event: sends 'No response from Claude' error."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        claude = _make_mock_claude()
+        # Stream that ends without a done event
+        claude.send = MagicMock(return_value=_fake_stream(_text_event("Partial")))
+        ctx = _make_context(claude=claude)
+
+        with patch.multiple("kai.bot", **self._base_patches()):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        replies = [c[0][0] for c in update.message.reply_text.call_args_list]
+        assert any("No response from Claude" in r for r in replies)
+
+    @pytest.mark.asyncio
+    async def test_error_response_with_live_msg(self):
+        """success=False with existing live message: edits error into live message."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        live_msg = MagicMock()
+        live_msg.edit_text = AsyncMock()
+        update.message.reply_text = AsyncMock(return_value=live_msg)
+
+        claude = _make_mock_claude()
+        claude.send = MagicMock(
+            return_value=_fake_stream(
+                _text_event("Partial"),
+                _done_event("Something broke", success=False, error="Something broke"),
+            )
+        )
+        ctx = _make_context(claude=claude)
+
+        with patch.multiple("kai.bot", **self._base_patches()):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        # Error should be edited into the live message
+        last_edit = live_msg.edit_text.call_args_list[-1]
+        assert "Error" in last_edit[0][0]
+
+    @pytest.mark.asyncio
+    async def test_error_response_no_live_msg(self):
+        """success=False with no live message: sends error as new reply."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        claude = _make_mock_claude()
+        # Done event immediately (no text events to create a live message)
+        claude.send = MagicMock(
+            return_value=_fake_stream(
+                _done_event("Broke", success=False, error="Broke"),
+            )
+        )
+        ctx = _make_context(claude=claude)
+
+        with patch.multiple("kai.bot", **self._base_patches()):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        replies = [c[0][0] for c in update.message.reply_text.call_args_list]
+        assert any("Error" in r for r in replies)
+
+    @pytest.mark.asyncio
+    async def test_long_response_chunked(self):
+        """Response > 4096 chars: first chunk edits live message, rest sent as new messages."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        live_msg = MagicMock()
+        live_msg.edit_text = AsyncMock()
+        update.message.reply_text = AsyncMock(return_value=live_msg)
+
+        long_text = "a" * 5000
+        claude = _make_mock_claude()
+        claude.send = MagicMock(return_value=_fake_stream(_text_event("start"), _done_event(long_text)))
+        ctx = _make_context(claude=claude)
+
+        with patch.multiple("kai.bot", **self._base_patches()):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        # Multiple messages should have been sent (chunked)
+        assert update.message.reply_text.call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_session_saved_with_id(self):
+        """Saves session when session_id is present."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        claude = _make_mock_claude()
+        claude.send = MagicMock(return_value=_fake_stream(_done_event("Ok", session_id="sess-abc")))
+        ctx = _make_context(claude=claude)
+        mock_sessions = MagicMock(
+            get_setting=AsyncMock(return_value="off"),
+            save_session=AsyncMock(),
+        )
+
+        with patch("kai.bot.sessions", mock_sessions), patch("kai.bot.log_message"):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        mock_sessions.save_session.assert_called_once()
+        args = mock_sessions.save_session.call_args[0]
+        assert args[0] == 12345
+        assert args[1] == "sess-abc"
+
+    @pytest.mark.asyncio
+    async def test_session_not_saved_without_id(self):
+        """Does NOT save session when session_id is None."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        claude = _make_mock_claude()
+        claude.send = MagicMock(return_value=_fake_stream(_done_event("Ok", session_id=None)))
+        ctx = _make_context(claude=claude)
+        mock_sessions = MagicMock(
+            get_setting=AsyncMock(return_value="off"),
+            save_session=AsyncMock(),
+        )
+
+        with patch("kai.bot.sessions", mock_sessions), patch("kai.bot.log_message"):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        mock_sessions.save_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_voice_only_mode(self):
+        """Voice-only: no live text message, synthesizes and sends voice."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        claude = _make_mock_claude()
+        claude.send = MagicMock(return_value=_fake_stream(_done_event("Hello voice")))
+        config = _make_config(tts_enabled=True, piper_model_dir=Path("/models"))
+        ctx = _make_context(config=config, claude=claude)
+        mock_sessions = MagicMock(
+            get_setting=AsyncMock(return_value="only"),
+            save_session=AsyncMock(),
+        )
+
+        with (
+            patch("kai.bot.sessions", mock_sessions),
+            patch("kai.bot.log_message"),
+            patch("kai.bot.synthesize_speech", new_callable=AsyncMock, return_value=b"audio-bytes"),
+        ):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        ctx.bot.send_voice.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_voice_only_tts_failure_falls_back(self):
+        """Voice-only TTS failure: falls back to text delivery."""
+        from kai.bot import _handle_response
+        from kai.tts import TTSError
+
+        update = _make_update()
+        claude = _make_mock_claude()
+        claude.send = MagicMock(return_value=_fake_stream(_done_event("Fallback text")))
+        config = _make_config(tts_enabled=True, piper_model_dir=Path("/models"))
+        ctx = _make_context(config=config, claude=claude)
+        mock_sessions = MagicMock(
+            get_setting=AsyncMock(return_value="only"),
+            save_session=AsyncMock(),
+        )
+
+        with (
+            patch("kai.bot.sessions", mock_sessions),
+            patch("kai.bot.log_message"),
+            patch("kai.bot.synthesize_speech", new_callable=AsyncMock, side_effect=TTSError("fail")),
+        ):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        # Should fall back to text
+        assert update.message.reply_text.called
+
+    @pytest.mark.asyncio
+    async def test_text_plus_voice_mode(self):
+        """Text+voice mode: sends text normally, then sends voice note."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        live_msg = MagicMock()
+        live_msg.edit_text = AsyncMock()
+        update.message.reply_text = AsyncMock(return_value=live_msg)
+
+        claude = _make_mock_claude()
+        claude.send = MagicMock(return_value=_fake_stream(_text_event("Hi"), _done_event("Hi there")))
+        config = _make_config(tts_enabled=True, piper_model_dir=Path("/models"))
+        ctx = _make_context(config=config, claude=claude)
+
+        async def _get_setting(key):
+            if "voice_mode" in key:
+                return "on"
+            return DEFAULT_VOICE
+
+        mock_sessions = MagicMock(
+            get_setting=AsyncMock(side_effect=_get_setting),
+            save_session=AsyncMock(),
+        )
+
+        with (
+            patch("kai.bot.sessions", mock_sessions),
+            patch("kai.bot.log_message"),
+            patch("kai.bot.synthesize_speech", new_callable=AsyncMock, return_value=b"audio"),
+        ):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        # Both text (reply_text) and voice (send_voice) should be sent
+        assert update.message.reply_text.called
+        ctx.bot.send_voice.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_typing_task_cancelled(self):
+        """Typing indicator task is cancelled in finally block."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        claude = _make_mock_claude()
+        claude.send = MagicMock(return_value=_fake_stream(_done_event("Ok")))
+        ctx = _make_context(claude=claude)
+
+        with patch.multiple("kai.bot", **self._base_patches()):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        # If we got here without hanging, the typing task was properly cancelled

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1,12 +1,28 @@
-"""Tests for claude.py user separation (sudo spawning and process group signals)."""
+"""
+Tests for claude.py persistent subprocess manager.
 
+Covers:
+1. Command construction and sudo wrapping (existing tests)
+2. Signal handling and process group dispatch (existing tests)
+3. Properties: is_alive, session_id
+4. _ensure_started() subprocess launch
+5. _drain_stderr() background reader
+6. _send_locked() stream parsing, error handling, context injection
+7. send() lock acquisition
+8. _kill(), shutdown(), change_workspace(), restart()
+"""
+
+import asyncio
+import json
 import signal
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kai.claude import PersistentClaude
+from kai.claude import PersistentClaude, StreamEvent
+
+# ── Shared helpers ───────────────────────────────────────────────────
 
 
 def _make_claude(**kwargs) -> PersistentClaude:
@@ -19,6 +35,75 @@ def _make_claude(**kwargs) -> PersistentClaude:
     }
     defaults.update(kwargs)
     return PersistentClaude(**defaults)
+
+
+def _json_line(obj: dict) -> bytes:
+    """Encode a dict as a JSON line (bytes with trailing newline)."""
+    return json.dumps(obj).encode() + b"\n"
+
+
+def _make_mock_proc(stdout_lines: list[bytes]) -> MagicMock:
+    """
+    Build a mock subprocess that yields predefined stdout lines.
+
+    stdout_lines should be a list of bytes, each ending with b"\\n".
+    The final entry should be b"" to signal EOF.
+    """
+    proc = MagicMock()
+    proc.returncode = None
+    proc.stdin = MagicMock()
+    proc.stdin.write = MagicMock()
+    proc.stdin.drain = AsyncMock()
+    proc.stdout = MagicMock()
+    proc.stdout.readline = AsyncMock(side_effect=stdout_lines)
+    proc.stderr = MagicMock()
+    proc.stderr.readline = AsyncMock(return_value=b"")
+    proc.wait = AsyncMock()
+    proc.send_signal = MagicMock()
+    return proc
+
+
+async def _collect_events(claude: PersistentClaude, prompt: str | list = "test") -> list[StreamEvent]:
+    """Send a prompt and collect all yielded StreamEvents."""
+    events = []
+    async for event in claude._send_locked(prompt):
+        events.append(event)
+    return events
+
+
+def _system_event(session_id: str = "sess-123") -> bytes:
+    """Build a system event JSON line."""
+    return _json_line({"type": "system", "session_id": session_id})
+
+
+def _assistant_event(text: str) -> bytes:
+    """Build an assistant event JSON line with a single text block."""
+    return _json_line(
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": text}]},
+        }
+    )
+
+
+def _result_event(
+    text: str = "Final",
+    is_error: bool = False,
+    session_id: str = "sess-123",
+    cost: float = 0.05,
+    duration: int = 1500,
+) -> bytes:
+    """Build a result event JSON line."""
+    return _json_line(
+        {
+            "type": "result",
+            "result": text,
+            "is_error": is_error,
+            "session_id": session_id,
+            "total_cost_usd": cost,
+            "duration_ms": duration,
+        }
+    )
 
 
 # ── Command construction ─────────────────────────────────────────────
@@ -156,3 +241,959 @@ class TestProcessSignals:
         with patch("os.getpgid", return_value=12345), patch("os.killpg", side_effect=PermissionError):
             # Should not raise
             claude._kill_proc(signal.SIGKILL)
+
+
+# ── Properties ───────────────────────────────────────────────────────
+
+
+class TestProperties:
+    def test_is_alive_no_process(self):
+        """is_alive returns False when _proc is None (initial state)."""
+        claude = _make_claude()
+        assert claude.is_alive is False
+
+    def test_is_alive_running(self):
+        """is_alive returns True when process exists and returncode is None."""
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        claude._proc = mock_proc
+        assert claude.is_alive is True
+
+    def test_is_alive_exited(self):
+        """is_alive returns False when process has exited (returncode set)."""
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        claude._proc = mock_proc
+        assert claude.is_alive is False
+
+    def test_session_id_initial(self):
+        """session_id returns None before any interaction."""
+        claude = _make_claude()
+        assert claude.session_id is None
+
+    def test_session_id_after_set(self):
+        """session_id returns the value after it's been set."""
+        claude = _make_claude()
+        claude._session_id = "sess-abc"
+        assert claude.session_id == "sess-abc"
+
+
+# ── _ensure_started ──────────────────────────────────────────────────
+
+
+class TestEnsureStarted:
+    @pytest.mark.asyncio
+    async def test_noop_when_alive(self):
+        """No-op when process is already alive."""
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        claude._proc = mock_proc
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            await claude._ensure_started()
+        mock_exec.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_passes_webhook_secret_in_env(self):
+        """Webhook secret is passed via KAI_WEBHOOK_SECRET env var."""
+        claude = _make_claude(webhook_secret="my-secret")
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = AsyncMock()
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+            call_kwargs = mock_exec.call_args[1]
+            assert call_kwargs["env"]["KAI_WEBHOOK_SECRET"] == "my-secret"
+
+    @pytest.mark.asyncio
+    async def test_sets_fresh_session(self):
+        """_fresh_session is True after starting a new process."""
+        claude = _make_claude()
+        claude._fresh_session = False  # Simulate a prior session
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = AsyncMock()
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+        assert claude._fresh_session is True
+
+    @pytest.mark.asyncio
+    async def test_starts_stderr_drain(self):
+        """_ensure_started creates a background task for stderr draining."""
+        claude = _make_claude()
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+        assert claude._stderr_task is not None
+
+
+# ── _drain_stderr ────────────────────────────────────────────────────
+
+
+class TestDrainStderr:
+    @pytest.mark.asyncio
+    async def test_logs_stderr_at_debug(self, caplog):
+        """Stderr lines are logged at DEBUG level."""
+        caplog.set_level("DEBUG", logger="kai.claude")
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.stderr = MagicMock()
+        mock_proc.stderr.readline = AsyncMock(side_effect=[b"some warning\n", b""])
+        claude._proc = mock_proc
+
+        await claude._drain_stderr()
+
+        assert "some warning" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_truncates_long_lines(self, caplog):
+        """Long stderr lines are truncated to 200 chars in the log."""
+        caplog.set_level("DEBUG", logger="kai.claude")
+        claude = _make_claude()
+        long_line = "x" * 300 + "\n"
+        mock_proc = MagicMock()
+        mock_proc.stderr = MagicMock()
+        mock_proc.stderr.readline = AsyncMock(side_effect=[long_line.encode(), b""])
+        claude._proc = mock_proc
+
+        await claude._drain_stderr()
+
+        # The log message should contain the truncated text (200 chars max)
+        for record in caplog.records:
+            if "stderr" in record.message.lower():
+                # %s formatting inserts the truncated value
+                assert len(record.args[0]) <= 200
+
+    @pytest.mark.asyncio
+    async def test_stops_on_eof(self):
+        """Stops reading when readline returns empty bytes (EOF)."""
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.stderr = MagicMock()
+        mock_proc.stderr.readline = AsyncMock(side_effect=[b"line1\n", b""])
+        claude._proc = mock_proc
+
+        await claude._drain_stderr()
+
+        # readline should have been called exactly twice (one line + EOF)
+        assert mock_proc.stderr.readline.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_breaks_on_exception(self):
+        """Catches exceptions and stops rather than crashing."""
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.stderr = MagicMock()
+        mock_proc.stderr.readline = AsyncMock(side_effect=RuntimeError("pipe broken"))
+        claude._proc = mock_proc
+
+        # Should not raise
+        await claude._drain_stderr()
+
+
+# ── _send_locked: basic stream parsing ───────────────────────────────
+
+
+class TestSendLockedBasic:
+    """Tests for _send_locked stream parsing and event dispatch."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_kill(self, monkeypatch):
+        """Prevent _kill from interacting with mock processes after test scenarios."""
+        monkeypatch.setattr(PersistentClaude, "_kill", AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_writes_json_to_stdin(self):
+        """Sends a JSON-formatted message to the process stdin."""
+        proc = _make_mock_proc([_system_event(), _result_event(), b""])
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        await _collect_events(claude)
+
+        # Verify stdin.write was called with valid JSON
+        written = proc.stdin.write.call_args[0][0]
+        msg = json.loads(written.decode())
+        assert msg["type"] == "user"
+        assert msg["message"]["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_yields_text_from_assistant_events(self):
+        """Assistant events yield StreamEvents with accumulated text."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _assistant_event("Hello"),
+                _result_event("Hello"),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        # Should have at least a text event and a done event
+        text_events = [e for e in events if not e.done]
+        assert len(text_events) >= 1
+        assert text_events[0].text_so_far == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_final_event_has_claude_response(self):
+        """Final event has done=True with a complete ClaudeResponse."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _assistant_event("Hello"),
+                _result_event("Hello", cost=0.05, duration=1500),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        done_event = events[-1]
+        assert done_event.done is True
+        assert done_event.response is not None
+        assert done_event.response.success is True
+        assert done_event.response.cost_usd == 0.05
+        assert done_event.response.duration_ms == 1500
+        assert done_event.response.session_id == "sess-123"
+
+    @pytest.mark.asyncio
+    async def test_system_event_sets_session_id(self):
+        """System events update the instance's session_id."""
+        proc = _make_mock_proc(
+            [
+                _system_event("new-session-42"),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        await _collect_events(claude)
+
+        assert claude._session_id == "new-session-42"
+
+    @pytest.mark.asyncio
+    async def test_multiple_assistant_events_accumulate(self):
+        """Multiple assistant events accumulate text with \\n\\n separator."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _assistant_event("First"),
+                _assistant_event("Second"),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        # The last text event before done should have both chunks
+        text_events = [e for e in events if not e.done]
+        last_text = text_events[-1].text_so_far
+        assert "First" in last_text
+        assert "Second" in last_text
+        assert "\n\n" in last_text
+
+    @pytest.mark.asyncio
+    async def test_non_text_content_blocks_ignored(self):
+        """Content blocks that aren't type=text are skipped."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _json_line(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [
+                                {"type": "tool_use", "id": "tool-1"},
+                                {"type": "text", "text": "Result"},
+                            ]
+                        },
+                    }
+                ),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        text_events = [e for e in events if not e.done]
+        assert len(text_events) == 1
+        assert text_events[0].text_so_far == "Result"
+
+    @pytest.mark.asyncio
+    async def test_non_json_lines_skipped(self):
+        """Non-JSON stdout lines are skipped without breaking the stream."""
+        proc = _make_mock_proc(
+            [
+                b"Some startup banner\n",
+                _system_event(),
+                _result_event(text="Done"),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        done_event = events[-1]
+        assert done_event.done is True
+        assert done_event.response.success is True
+
+
+# ── _send_locked: error handling ─────────────────────────────────────
+
+
+class TestSendLockedErrors:
+    @pytest.fixture(autouse=True)
+    def _patch_kill(self, monkeypatch):
+        """Prevent _kill from interacting with mock processes after test scenarios."""
+        monkeypatch.setattr(PersistentClaude, "_kill", AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_cli_not_found(self):
+        """FileNotFoundError from _ensure_started yields a done event with error."""
+        claude = _make_claude()
+        claude._proc = None
+        claude._fresh_session = False
+
+        with patch.object(claude, "_ensure_started", side_effect=FileNotFoundError):
+            events = await _collect_events(claude)
+
+        assert len(events) == 1
+        assert events[0].done is True
+        assert "not found" in events[0].response.error
+
+    @pytest.mark.asyncio
+    async def test_stdin_write_failure(self):
+        """OSError on stdin.write kills the process and yields an error event."""
+        proc = _make_mock_proc([])
+        proc.stdin.write = MagicMock(side_effect=OSError("broken pipe"))
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        assert len(events) == 1
+        assert events[0].done is True
+        assert events[0].response.success is False
+        assert "died" in events[0].response.error
+
+    @pytest.mark.asyncio
+    async def test_timeout(self):
+        """Timeout on stdout.readline yields a 'timed out' error event."""
+        proc = _make_mock_proc([])
+        # Override readline to simulate timeout
+        proc.stdout.readline = AsyncMock(side_effect=asyncio.TimeoutError)
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        # Patch wait_for to propagate the TimeoutError
+        with patch("asyncio.wait_for", side_effect=TimeoutError):
+            events = await _collect_events(claude)
+
+        assert events[-1].done is True
+        assert "timed out" in events[-1].response.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_eof_with_text(self):
+        """EOF with accumulated text yields success=True, error=None."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _assistant_event("Partial response"),
+                b"",  # EOF
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        done_event = events[-1]
+        assert done_event.done is True
+        assert done_event.response.success is True
+        assert done_event.response.error is None
+        assert "Partial response" in done_event.response.text
+
+    @pytest.mark.asyncio
+    async def test_eof_without_text(self):
+        """EOF without accumulated text yields success=False with error."""
+        proc = _make_mock_proc([b""])  # Immediate EOF
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        done_event = events[-1]
+        assert done_event.done is True
+        assert done_event.response.success is False
+        assert done_event.response.error is not None
+
+
+# ── _send_locked: result event parsing ───────────────────────────────
+
+
+class TestSendLockedResult:
+    @pytest.fixture(autouse=True)
+    def _patch_kill(self, monkeypatch):
+        monkeypatch.setattr(PersistentClaude, "_kill", AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_is_error_sets_failure(self):
+        """is_error=True in result event sets success=False and error to result text."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _result_event(text="Something went wrong", is_error=True),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        done = events[-1]
+        assert done.response.success is False
+        assert done.response.error == "Something went wrong"
+
+    @pytest.mark.asyncio
+    async def test_accumulated_text_preferred_over_result(self):
+        """When text has been accumulated, it's used instead of result event text."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _assistant_event("Accumulated text here"),
+                _result_event(text="Result text"),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        done = events[-1]
+        assert done.response.text == "Accumulated text here"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_result_text(self):
+        """When no text accumulated, falls back to result event text."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _result_event(text="Only in result"),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        done = events[-1]
+        assert done.response.text == "Only in result"
+
+
+# ── _send_locked: context injection ──────────────────────────────────
+
+
+class TestContextInjection:
+    """Tests for first-message context injection in _send_locked."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_kill(self, monkeypatch):
+        monkeypatch.setattr(PersistentClaude, "_kill", AsyncMock())
+
+    @pytest.fixture()
+    def home_workspace(self, tmp_path):
+        """Create a home workspace with identity and memory files."""
+        home = tmp_path / "home"
+        claude_dir = home / ".claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "CLAUDE.md").write_text("You are Kai.")
+        (claude_dir / "MEMORY.md").write_text("User likes concise responses.")
+        return home
+
+    @pytest.fixture()
+    def foreign_workspace(self, tmp_path):
+        """Create a foreign workspace (different from home)."""
+        foreign = tmp_path / "foreign"
+        claude_dir = foreign / ".claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "MEMORY.md").write_text("Foreign workspace memory.")
+        return foreign
+
+    def _extract_prompt(self, proc: MagicMock) -> str:
+        """Extract the prompt text from what was written to stdin."""
+        written = proc.stdin.write.call_args[0][0]
+        msg = json.loads(written.decode())
+        content = msg["message"]["content"]
+        # Content is a list of blocks; concatenate all text blocks
+        return "\n".join(block["text"] for block in content if block.get("type") == "text")
+
+    @pytest.mark.asyncio
+    async def test_first_message_injects_context(self, home_workspace):
+        """First message in a session prepends identity, memory, and history."""
+        proc = _make_mock_proc([_system_event(), _result_event(), b""])
+        claude = _make_claude(
+            workspace=home_workspace,
+            home_workspace=home_workspace,
+            webhook_secret="secret",
+        )
+        claude._proc = proc
+        claude._fresh_session = True
+
+        with patch("kai.claude.get_recent_history", return_value="User: hello\nKai: hi"):
+            await _collect_events(claude, "What's up?")
+
+        prompt = self._extract_prompt(proc)
+        # Memory should be injected (home workspace memory)
+        assert "User likes concise responses" in prompt
+        # History should be injected
+        assert "Recent conversations" in prompt
+        # The actual user prompt should be at the end
+        assert "What's up?" in prompt
+
+    @pytest.mark.asyncio
+    async def test_second_message_no_injection(self, home_workspace):
+        """Second message does NOT re-inject context (fresh_session is False)."""
+        proc = _make_mock_proc([_system_event(), _result_event(), b""])
+        claude = _make_claude(workspace=home_workspace, home_workspace=home_workspace)
+        claude._proc = proc
+        claude._fresh_session = False
+
+        await _collect_events(claude, "Follow-up question")
+
+        prompt = self._extract_prompt(proc)
+        # Should just be the raw prompt, no injected sections
+        assert "persistent memory" not in prompt.lower()
+        assert "Follow-up question" in prompt
+
+    @pytest.mark.asyncio
+    async def test_foreign_workspace_injects_identity(self, home_workspace, foreign_workspace):
+        """Foreign workspace injects identity from home and per-message reminder."""
+        proc = _make_mock_proc([_system_event(), _result_event(), b""])
+        claude = _make_claude(
+            workspace=foreign_workspace,
+            home_workspace=home_workspace,
+        )
+        claude._proc = proc
+        claude._fresh_session = True
+
+        with patch("kai.claude.get_recent_history", return_value=""):
+            await _collect_events(claude, "Help me")
+
+        prompt = self._extract_prompt(proc)
+        # Identity from home workspace should be injected
+        assert "You are Kai" in prompt
+        # Foreign workspace memory should be injected
+        assert "Foreign workspace memory" in prompt
+        # Per-message reminder should be present
+        assert "IMPORTANT" in prompt
+        assert "Respond ONLY" in prompt
+
+    @pytest.mark.asyncio
+    async def test_home_workspace_no_identity_injection(self, home_workspace):
+        """Home workspace does NOT inject identity (Claude Code reads it natively)."""
+        proc = _make_mock_proc([_system_event(), _result_event(), b""])
+        claude = _make_claude(
+            workspace=home_workspace,
+            home_workspace=home_workspace,
+        )
+        claude._proc = proc
+        claude._fresh_session = True
+
+        with patch("kai.claude.get_recent_history", return_value=""):
+            await _collect_events(claude, "Test")
+
+        prompt = self._extract_prompt(proc)
+        # Identity text should NOT be injected when in home workspace
+        assert "core identity" not in prompt.lower()
+        # No per-message reminder either
+        assert "Respond ONLY" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_webhook_secret_injects_api_info(self, home_workspace):
+        """When webhook secret is set, scheduling and file API info are injected."""
+        proc = _make_mock_proc([_system_event(), _result_event(), b""])
+        claude = _make_claude(
+            workspace=home_workspace,
+            home_workspace=home_workspace,
+            webhook_secret="my-secret",
+            webhook_port=8080,
+        )
+        claude._proc = proc
+        claude._fresh_session = True
+
+        with patch("kai.claude.get_recent_history", return_value=""):
+            await _collect_events(claude, "Test")
+
+        prompt = self._extract_prompt(proc)
+        assert "Scheduling API" in prompt
+        assert "File API" in prompt
+        assert "8080" in prompt
+
+    @pytest.mark.asyncio
+    async def test_no_webhook_secret_no_api_info(self, home_workspace):
+        """Without webhook secret, no API info is injected."""
+        proc = _make_mock_proc([_system_event(), _result_event(), b""])
+        claude = _make_claude(
+            workspace=home_workspace,
+            home_workspace=home_workspace,
+            webhook_secret="",
+        )
+        claude._proc = proc
+        claude._fresh_session = True
+
+        with patch("kai.claude.get_recent_history", return_value=""):
+            await _collect_events(claude, "Test")
+
+        prompt = self._extract_prompt(proc)
+        assert "Scheduling API" not in prompt
+        assert "File API" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_services_info_injected(self, home_workspace):
+        """Available services info is injected when services are configured."""
+        proc = _make_mock_proc([_system_event(), _result_event(), b""])
+        claude = _make_claude(
+            workspace=home_workspace,
+            home_workspace=home_workspace,
+            webhook_secret="secret",
+            services_info=[
+                {
+                    "name": "perplexity",
+                    "method": "POST",
+                    "description": "Web search",
+                    "notes": "Use sonar model",
+                }
+            ],
+        )
+        claude._proc = proc
+        claude._fresh_session = True
+
+        with patch("kai.claude.get_recent_history", return_value=""):
+            await _collect_events(claude, "Test")
+
+        prompt = self._extract_prompt(proc)
+        assert "perplexity" in prompt
+        assert "Web search" in prompt
+        assert "sonar" in prompt
+
+
+# ── _send_locked: multi-modal prompt ─────────────────────────────────
+
+
+class TestMultiModalPrompt:
+    @pytest.fixture(autouse=True)
+    def _patch_kill(self, monkeypatch):
+        monkeypatch.setattr(PersistentClaude, "_kill", AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_list_prompt_with_context_injection(self, tmp_path):
+        """List prompts get context prepended as text blocks, content sent as-is."""
+        home = tmp_path / "home"
+        claude_dir = home / ".claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "MEMORY.md").write_text("Some memory")
+
+        proc = _make_mock_proc([_system_event(), _result_event(), b""])
+        claude = _make_claude(
+            workspace=home,
+            home_workspace=home,
+            webhook_secret="secret",
+        )
+        claude._proc = proc
+        claude._fresh_session = True
+
+        # Multi-modal prompt (e.g., image + text)
+        prompt_list = [
+            {"type": "image", "source": {"data": "base64data"}},
+            {"type": "text", "text": "What's in this image?"},
+        ]
+
+        with patch("kai.claude.get_recent_history", return_value=""):
+            await _collect_events(claude, prompt_list)
+
+        written = proc.stdin.write.call_args[0][0]
+        msg = json.loads(written.decode())
+        content = msg["message"]["content"]
+
+        # First block should be injected context (text type)
+        assert content[0]["type"] == "text"
+        assert "Some memory" in content[0]["text"]
+
+        # Original content blocks should follow
+        assert content[-1]["type"] == "text"
+        assert content[-1]["text"] == "What's in this image?"
+
+
+# ── send() lock acquisition ──────────────────────────────────────────
+
+
+class TestSendLock:
+    @pytest.mark.asyncio
+    async def test_acquires_lock(self):
+        """send() acquires the internal lock before calling _send_locked."""
+        proc = _make_mock_proc([_system_event(), _result_event(), b""])
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        # Patch _kill to prevent cleanup issues
+        with patch.object(claude, "_kill", new_callable=AsyncMock):
+            lock_was_held = False
+
+            # Wrap _send_locked to check if the lock is held when it runs
+            original = claude._send_locked
+
+            async def checking_send(prompt):
+                nonlocal lock_was_held
+                lock_was_held = claude._lock.locked()
+                async for event in original(prompt):
+                    yield event
+
+            with patch.object(claude, "_send_locked", checking_send):
+                async for _ in claude.send("test"):
+                    pass
+
+            assert lock_was_held is True
+
+
+# ── _kill ────────────────────────────────────────────────────────────
+
+
+class TestKill:
+    @pytest.mark.asyncio
+    async def test_kills_and_clears_state(self):
+        """_kill sends SIGKILL, waits, and clears _proc and _session_id."""
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        mock_proc.send_signal = MagicMock()
+        mock_proc.wait = AsyncMock()
+        claude._proc = mock_proc
+        claude._session_id = "sess-123"
+
+        await claude._kill()
+
+        mock_proc.send_signal.assert_called_with(signal.SIGKILL)
+        assert claude._proc is None
+        assert claude._session_id is None
+
+    @pytest.mark.asyncio
+    async def test_cancels_stderr_task(self):
+        """_kill cancels the stderr drain task."""
+        claude = _make_claude()
+        mock_task = MagicMock()
+        claude._stderr_task = mock_task
+        claude._proc = None  # No process to kill
+
+        await claude._kill()
+
+        mock_task.cancel.assert_called_once()
+        assert claude._stderr_task is None
+
+    @pytest.mark.asyncio
+    async def test_idempotent_no_process(self):
+        """_kill is idempotent when _proc is already None."""
+        claude = _make_claude()
+        # Should not raise
+        await claude._kill()
+
+    @pytest.mark.asyncio
+    async def test_handles_wait_exception(self):
+        """_kill handles exceptions from _proc.wait() without crashing."""
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        mock_proc.send_signal = MagicMock()
+        mock_proc.wait = AsyncMock(side_effect=ProcessLookupError)
+        claude._proc = mock_proc
+
+        # Should not raise
+        await claude._kill()
+        assert claude._proc is None
+
+
+# ── shutdown ─────────────────────────────────────────────────────────
+
+
+class TestShutdown:
+    @pytest.mark.asyncio
+    async def test_sigterm_then_wait(self):
+        """shutdown sends SIGTERM first and waits for clean exit."""
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        mock_proc.send_signal = MagicMock()
+        mock_proc.wait = AsyncMock()
+        claude._proc = mock_proc
+
+        await claude.shutdown()
+
+        mock_proc.send_signal.assert_called_with(signal.SIGTERM)
+        assert claude._proc is None
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_sigkill_on_timeout(self):
+        """When SIGTERM times out, falls back to SIGKILL."""
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        mock_proc.send_signal = MagicMock()
+        # First wait (SIGTERM) times out, second wait (SIGKILL) succeeds
+        mock_proc.wait = AsyncMock()
+        claude._proc = mock_proc
+
+        # Simulate SIGTERM timeout on the first wait_for call, success on second
+        call_count = 0
+        original_wait_for = asyncio.wait_for
+
+        async def mock_wait_for(coro, timeout):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Cancel the coroutine to avoid "was never awaited" warning
+                coro.close()
+                raise TimeoutError
+            return await original_wait_for(coro, timeout=timeout)
+
+        with patch("asyncio.wait_for", side_effect=mock_wait_for):
+            await claude.shutdown()
+
+        # Should have sent SIGTERM then SIGKILL
+        signals_sent = [call.args[0] for call in mock_proc.send_signal.call_args_list]
+        assert signal.SIGTERM in signals_sent
+        assert signal.SIGKILL in signals_sent
+        assert claude._proc is None
+
+    @pytest.mark.asyncio
+    async def test_noop_when_already_exited(self):
+        """No-op when process has already exited (returncode is set)."""
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0  # Already exited
+        claude._proc = mock_proc
+
+        await claude.shutdown()
+
+        mock_proc.send_signal.assert_not_called()
+        # Should still clear state
+        assert claude._proc is None
+
+    @pytest.mark.asyncio
+    async def test_clears_stderr_task(self):
+        """shutdown cancels the stderr drain task."""
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        claude._proc = mock_proc
+        mock_task = MagicMock()
+        claude._stderr_task = mock_task
+
+        await claude.shutdown()
+
+        mock_task.cancel.assert_called_once()
+        assert claude._stderr_task is None
+
+    @pytest.mark.asyncio
+    async def test_zombie_process_logs_warning(self, caplog):
+        """When both SIGTERM and SIGKILL timeout, logs a warning and clears state."""
+        caplog.set_level("WARNING", logger="kai.claude")
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        mock_proc.send_signal = MagicMock()
+        mock_proc.wait = AsyncMock()
+        claude._proc = mock_proc
+
+        # Both wait_for calls time out
+        async def always_timeout(coro, timeout):
+            coro.close()
+            raise TimeoutError
+
+        with patch("asyncio.wait_for", side_effect=always_timeout):
+            await claude.shutdown()
+
+        assert "did not exit" in caplog.text.lower()
+        assert claude._proc is None
+
+
+# ── change_workspace ─────────────────────────────────────────────────
+
+
+class TestChangeWorkspace:
+    @pytest.mark.asyncio
+    async def test_updates_workspace_and_kills(self):
+        """change_workspace updates the path and kills the current process."""
+        claude = _make_claude()
+        new_path = Path("/tmp/other-workspace")
+
+        with patch.object(claude, "_kill", new_callable=AsyncMock) as mock_kill:
+            await claude.change_workspace(new_path)
+
+        assert claude.workspace == new_path
+        mock_kill.assert_called_once()
+
+
+# ── restart ──────────────────────────────────────────────────────────
+
+
+class TestRestart:
+    @pytest.mark.asyncio
+    async def test_calls_kill(self):
+        """restart() kills the current process so the next send() starts fresh."""
+        claude = _make_claude()
+
+        with patch.object(claude, "_kill", new_callable=AsyncMock) as mock_kill:
+            await claude.restart()
+
+        mock_kill.assert_called_once()

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -1,8 +1,127 @@
-"""Tests for cron.py pure functions."""
+"""
+Tests for cron.py scheduled job registration and execution.
 
+Covers:
+1. _ensure_utc() - timezone normalization (existing tests)
+2. _register_job() - APScheduler trigger dispatch
+3. register_job_by_id() - DB lookup + registration
+4. _register_new_jobs() - startup bulk registration
+5. init_jobs() - entry point delegation
+6. _job_callback() - reminder and Claude job execution branches
+"""
+
+import json
 from datetime import UTC, datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from kai.cron import _ensure_utc
+import pytest
+from telegram.error import Forbidden
+
+from kai.cron import (
+    _ensure_utc,
+    _job_callback,
+    _register_job,
+    _register_new_jobs,
+    init_jobs,
+    register_job_by_id,
+)
+
+# ── Shared fixtures ─────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def mock_lock(monkeypatch):
+    """Stub out the async lock so Claude job tests don't need real asyncio locks."""
+    lock = AsyncMock()
+    lock.__aenter__ = AsyncMock()
+    lock.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr("kai.cron.get_lock", lambda _: lock)
+
+
+@pytest.fixture()
+def mock_app():
+    """Build a mock Telegram Application with a stubbed JobQueue."""
+    app = MagicMock()
+    app.job_queue = MagicMock()
+    app.job_queue.jobs.return_value = []
+    app.job_queue.run_once = MagicMock()
+    app.job_queue.run_daily = MagicMock()
+    app.job_queue.run_repeating = MagicMock()
+    return app
+
+
+def _make_job(
+    *,
+    job_id=1,
+    chat_id=12345,
+    name="Test Job",
+    job_type="reminder",
+    prompt="Test prompt",
+    auto_remove=False,
+    schedule_type="daily",
+    schedule_data='{"times": ["09:00"]}',
+    notify_on_check=False,
+):
+    """Build a job dict matching the shape returned by sessions.get_job_by_id."""
+    return {
+        "id": job_id,
+        "chat_id": chat_id,
+        "name": name,
+        "job_type": job_type,
+        "prompt": prompt,
+        "auto_remove": auto_remove,
+        "schedule_type": schedule_type,
+        "schedule_data": schedule_data,
+        "notify_on_check": notify_on_check,
+    }
+
+
+@pytest.fixture()
+def mock_context():
+    """Build a mock Telegram callback context with job data for _job_callback."""
+    ctx = AsyncMock()
+    ctx.bot = AsyncMock()
+    ctx.bot.send_message = AsyncMock()
+    ctx.bot.send_chat_action = AsyncMock()
+    ctx.job = MagicMock()
+    ctx.job.data = {
+        "job_id": 1,
+        "chat_id": 12345,
+        "job_type": "reminder",
+        "prompt": "Test prompt",
+        "auto_remove": False,
+        "name": "Test Job",
+        "schedule_type": "daily",
+    }
+    ctx.job.schedule_removal = MagicMock()
+    # Default: no Claude process (reminder tests don't need it)
+    ctx.bot_data = {}
+    return ctx
+
+
+def _make_claude_mock(text="The response", success=True, error=None):
+    """
+    Build a mock Claude process whose send() yields a single done event.
+
+    The async generator protocol matches what _job_callback expects:
+    iterate events until event.done is True, then read event.response.
+    """
+    mock_claude = MagicMock()
+
+    async def fake_send(prompt):
+        event = MagicMock()
+        event.done = True
+        event.response = MagicMock()
+        event.response.success = success
+        event.response.text = text
+        event.response.error = error
+        yield event
+
+    mock_claude.send = fake_send
+    return mock_claude
+
+
+# ── _ensure_utc ──────────────────────────────────────────────────────
 
 
 class TestEnsureUtc:
@@ -25,3 +144,500 @@ class TestEnsureUtc:
         result = _ensure_utc(dt)
         assert result is dt
         assert result.tzinfo is eastern
+
+
+# ── _register_job ────────────────────────────────────────────────────
+
+
+class TestRegisterJob:
+    def test_once_schedule(self, mock_app):
+        """run_once is called with the parsed run_at datetime."""
+        job = _make_job(
+            schedule_type="once",
+            schedule_data='{"run_at": "2026-06-01T12:00:00+00:00"}',
+        )
+        _register_job(mock_app, job)
+        mock_app.job_queue.run_once.assert_called_once()
+        call_kwargs = mock_app.job_queue.run_once.call_args
+        assert call_kwargs.kwargs["name"] == "cron_1"
+        assert call_kwargs.kwargs["when"].hour == 12
+
+    def test_interval_schedule(self, mock_app):
+        """run_repeating is called with the interval in seconds."""
+        job = _make_job(
+            schedule_type="interval",
+            schedule_data='{"seconds": 3600}',
+        )
+        _register_job(mock_app, job)
+        mock_app.job_queue.run_repeating.assert_called_once()
+        call_kwargs = mock_app.job_queue.run_repeating.call_args
+        assert call_kwargs.kwargs["interval"] == 3600
+        assert call_kwargs.kwargs["name"] == "cron_1"
+
+    def test_daily_single_time(self, mock_app):
+        """Single-time daily job uses unsuffixed name (cron_1, not cron_1_0)."""
+        job = _make_job(schedule_data='{"times": ["14:30"]}')
+        _register_job(mock_app, job)
+        mock_app.job_queue.run_daily.assert_called_once()
+        call_kwargs = mock_app.job_queue.run_daily.call_args
+        assert call_kwargs.kwargs["name"] == "cron_1"
+        # Verify the parsed time
+        t = call_kwargs.kwargs["time"]
+        assert t.hour == 14
+        assert t.minute == 30
+
+    def test_daily_multiple_times(self, mock_app):
+        """Multi-time daily jobs get suffixed names to avoid APScheduler collisions."""
+        job = _make_job(schedule_data='{"times": ["08:00", "20:00"]}')
+        _register_job(mock_app, job)
+        assert mock_app.job_queue.run_daily.call_count == 2
+        names = [c.kwargs["name"] for c in mock_app.job_queue.run_daily.call_args_list]
+        assert names == ["cron_1_0", "cron_1_1"]
+
+    def test_daily_invalid_time_string_skipped(self, mock_app, caplog):
+        """Unparseable time strings are skipped with an error log."""
+        job = _make_job(schedule_data='{"times": ["abc"]}')
+        _register_job(mock_app, job)
+        mock_app.job_queue.run_daily.assert_not_called()
+        assert "Invalid time" in caplog.text
+
+    def test_daily_out_of_range_skipped(self, mock_app, caplog):
+        """Out-of-range hour/minute values (e.g. 25:00) are skipped."""
+        job = _make_job(schedule_data='{"times": ["25:00"]}')
+        _register_job(mock_app, job)
+        mock_app.job_queue.run_daily.assert_not_called()
+        assert "Invalid time" in caplog.text
+
+    def test_unknown_schedule_type_logs_warning(self, mock_app, caplog):
+        """Unknown schedule types are ignored with a warning."""
+        job = _make_job(schedule_type="weekly", schedule_data="{}")
+        _register_job(mock_app, job)
+        assert "Unknown schedule type" in caplog.text
+        # Nothing was scheduled
+        mock_app.job_queue.run_once.assert_not_called()
+        mock_app.job_queue.run_daily.assert_not_called()
+        mock_app.job_queue.run_repeating.assert_not_called()
+
+
+# ── register_job_by_id ───────────────────────────────────────────────
+
+
+class TestRegisterJobById:
+    @pytest.mark.asyncio()
+    async def test_job_exists(self, mock_app):
+        """Loads the job from the DB and delegates to _register_job."""
+        job = _make_job()
+        with (
+            patch("kai.cron.sessions.get_job_by_id", new_callable=AsyncMock, return_value=job),
+            patch("kai.cron._register_job") as mock_register,
+        ):
+            result = await register_job_by_id(mock_app, 1)
+        assert result is True
+        mock_register.assert_called_once_with(mock_app, job)
+
+    @pytest.mark.asyncio()
+    async def test_job_not_found(self, mock_app, caplog):
+        """Returns False and logs an error when the job ID doesn't exist."""
+        with patch("kai.cron.sessions.get_job_by_id", new_callable=AsyncMock, return_value=None):
+            result = await register_job_by_id(mock_app, 999)
+        assert result is False
+        assert "not found" in caplog.text
+
+
+# ── _register_new_jobs ───────────────────────────────────────────────
+
+
+class TestRegisterNewJobs:
+    @pytest.mark.asyncio()
+    async def test_registers_unregistered_jobs(self, mock_app):
+        """Active jobs not in the scheduler get registered."""
+        jobs = [_make_job(job_id=1), _make_job(job_id=2)]
+        with (
+            patch("kai.cron.sessions.get_all_active_jobs", new_callable=AsyncMock, return_value=jobs),
+            patch("kai.cron._register_job") as mock_register,
+        ):
+            count = await _register_new_jobs(mock_app)
+        assert count == 2
+        assert mock_register.call_count == 2
+
+    @pytest.mark.asyncio()
+    async def test_skips_already_registered(self, mock_app):
+        """Jobs whose name is already in the scheduler are skipped."""
+        jobs = [_make_job(job_id=5)]
+        # Simulate cron_5 already in the job queue
+        existing_job = MagicMock()
+        existing_job.name = "cron_5"
+        mock_app.job_queue.jobs.return_value = [existing_job]
+        with (
+            patch("kai.cron.sessions.get_all_active_jobs", new_callable=AsyncMock, return_value=jobs),
+            patch("kai.cron._register_job") as mock_register,
+        ):
+            count = await _register_new_jobs(mock_app)
+        assert count == 0
+        mock_register.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_skips_already_registered_daily_multi_time(self, mock_app):
+        """Daily multi-time jobs with suffixed names (cron_5_0) are recognized as registered."""
+        jobs = [_make_job(job_id=5)]
+        existing_job = MagicMock()
+        existing_job.name = "cron_5_0"
+        mock_app.job_queue.jobs.return_value = [existing_job]
+        with (
+            patch("kai.cron.sessions.get_all_active_jobs", new_callable=AsyncMock, return_value=jobs),
+            patch("kai.cron._register_job") as mock_register,
+        ):
+            count = await _register_new_jobs(mock_app)
+        assert count == 0
+        mock_register.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_deactivates_expired_one_shot(self, mock_app, caplog):
+        """One-shot jobs with run_at in the past get deactivated instead of registered."""
+        caplog.set_level("INFO", logger="kai.cron")
+        past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        jobs = [_make_job(job_id=3, schedule_type="once", schedule_data=json.dumps({"run_at": past}))]
+        with (
+            patch("kai.cron.sessions.get_all_active_jobs", new_callable=AsyncMock, return_value=jobs),
+            patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock) as mock_deactivate,
+            patch("kai.cron._register_job") as mock_register,
+        ):
+            count = await _register_new_jobs(mock_app)
+        assert count == 0
+        mock_deactivate.assert_called_once_with(3)
+        mock_register.assert_not_called()
+        assert "expired" in caplog.text.lower()
+
+    @pytest.mark.asyncio()
+    async def test_returns_correct_count(self, mock_app):
+        """Count reflects only newly registered jobs, not skipped ones."""
+        jobs = [_make_job(job_id=1), _make_job(job_id=2), _make_job(job_id=3)]
+        # Job 2 is already registered
+        existing = MagicMock()
+        existing.name = "cron_2"
+        mock_app.job_queue.jobs.return_value = [existing]
+        with (
+            patch("kai.cron.sessions.get_all_active_jobs", new_callable=AsyncMock, return_value=jobs),
+            patch("kai.cron._register_job"),
+        ):
+            count = await _register_new_jobs(mock_app)
+        assert count == 2
+
+
+# ── init_jobs ────────────────────────────────────────────────────────
+
+
+class TestInitJobs:
+    @pytest.mark.asyncio()
+    async def test_delegates_to_register_new_jobs(self, mock_app):
+        """init_jobs is a thin wrapper that calls _register_new_jobs."""
+        with patch("kai.cron._register_new_jobs", new_callable=AsyncMock) as mock_register:
+            await init_jobs(mock_app)
+        mock_register.assert_called_once_with(mock_app)
+
+
+# ── _job_callback: reminder jobs ─────────────────────────────────────
+
+
+class TestJobCallbackReminder:
+    @pytest.mark.asyncio()
+    async def test_sends_prompt_to_telegram(self, mock_context):
+        """Reminder jobs send the prompt text as a Telegram message."""
+        await _job_callback(mock_context)
+        mock_context.bot.send_message.assert_called_once_with(chat_id=12345, text="Test prompt")
+
+    @pytest.mark.asyncio()
+    async def test_strips_backslash_escapes(self, mock_context):
+        """Stray backslash escapes from bash double-quoting in curl are cleaned."""
+        mock_context.job.data["prompt"] = "Don\\!t forget\\. Really\\?"
+        await _job_callback(mock_context)
+        mock_context.bot.send_message.assert_called_once_with(chat_id=12345, text="Don!t forget. Really?")
+
+    @pytest.mark.asyncio()
+    async def test_logs_message_to_history(self, mock_context):
+        """Reminder delivery is recorded in message history."""
+        with patch("kai.cron.log_message") as mock_log:
+            await _job_callback(mock_context)
+        mock_log.assert_called_once()
+        call_kwargs = mock_log.call_args.kwargs
+        assert call_kwargs["direction"] == "assistant"
+        assert call_kwargs["chat_id"] == 12345
+
+    @pytest.mark.asyncio()
+    async def test_forbidden_deactivates_and_removes(self, mock_context):
+        """When the chat is gone (Forbidden), the job is deactivated and removed."""
+        mock_context.bot.send_message.side_effect = Forbidden("bot was blocked")
+        with patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock) as mock_deactivate:
+            await _job_callback(mock_context)
+        mock_deactivate.assert_called_once_with(1)
+        mock_context.job.schedule_removal.assert_called_once()
+
+    @pytest.mark.asyncio()
+    async def test_other_exception_does_not_deactivate(self, mock_context):
+        """Non-Forbidden exceptions log the error but don't deactivate the job."""
+        mock_context.bot.send_message.side_effect = RuntimeError("network error")
+        with patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock) as mock_deactivate:
+            await _job_callback(mock_context)
+        mock_deactivate.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_one_shot_deactivates_after_sending(self, mock_context):
+        """One-shot reminders (schedule_type=once) auto-deactivate after delivery."""
+        mock_context.job.data["schedule_type"] = "once"
+        with patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock) as mock_deactivate:
+            await _job_callback(mock_context)
+        mock_deactivate.assert_called_once_with(1)
+        # schedule_removal is NOT called - APScheduler handles that for run_once
+        mock_context.job.schedule_removal.assert_not_called()
+
+
+# ── _job_callback: Claude jobs (no auto-remove) ─────────────────────
+
+
+class TestJobCallbackClaude:
+    @pytest.fixture(autouse=True)
+    def _setup_claude_context(self, mock_context):
+        """Configure mock_context for Claude job tests."""
+        mock_context.job.data["job_type"] = "claude"
+        self.ctx = mock_context
+
+    @pytest.mark.asyncio()
+    async def test_sends_claude_response_to_telegram(self):
+        """Claude response is delivered with a [Job: name] prefix."""
+        self.ctx.bot_data = {"claude": _make_claude_mock("Hello world")}
+        with patch("kai.cron.log_message"):
+            await _job_callback(self.ctx)
+        self.ctx.bot.send_message.assert_called_once_with(chat_id=12345, text="[Job: Test Job]\nHello world")
+
+    @pytest.mark.asyncio()
+    async def test_shows_typing_indicator(self):
+        """A typing indicator is sent before the Claude request."""
+        self.ctx.bot_data = {"claude": _make_claude_mock()}
+        with patch("kai.cron.log_message"):
+            await _job_callback(self.ctx)
+        self.ctx.bot.send_chat_action.assert_called_once()
+
+    @pytest.mark.asyncio()
+    async def test_no_claude_process_returns_early(self, caplog):
+        """When claude isn't in bot_data, logs error and returns without crashing."""
+        self.ctx.bot_data = {}
+        await _job_callback(self.ctx)
+        assert "No Claude process" in caplog.text
+        self.ctx.bot.send_message.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_claude_stream_exception_returns_early(self, caplog):
+        """Exceptions during Claude interaction are caught and logged."""
+        mock_claude = MagicMock()
+
+        async def exploding_send(prompt):
+            raise RuntimeError("process died")
+            yield
+
+        mock_claude.send = exploding_send
+        self.ctx.bot_data = {"claude": mock_claude}
+        await _job_callback(self.ctx)
+        assert "crashed" in caplog.text
+        self.ctx.bot.send_message.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_no_done_event_returns_early(self, caplog):
+        """When the stream ends without a done event, logs warning and returns."""
+        mock_claude = MagicMock()
+
+        async def empty_send(prompt):
+            # Yield a non-done event, then end
+            event = MagicMock()
+            event.done = False
+            yield event
+
+        mock_claude.send = empty_send
+        self.ctx.bot_data = {"claude": mock_claude}
+        await _job_callback(self.ctx)
+        assert "without a done event" in caplog.text
+        self.ctx.bot.send_message.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_claude_error_response_returns_early(self, caplog):
+        """When Claude returns success=False, logs the error and returns."""
+        self.ctx.bot_data = {"claude": _make_claude_mock(success=False, error="rate limited")}
+        await _job_callback(self.ctx)
+        assert "rate limited" in caplog.text
+        self.ctx.bot.send_message.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_forbidden_on_send_deactivates(self):
+        """Forbidden when sending the result deactivates and removes the job."""
+        self.ctx.bot_data = {"claude": _make_claude_mock()}
+        self.ctx.bot.send_message.side_effect = Forbidden("blocked")
+        with (
+            patch("kai.cron.log_message"),
+            patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock) as mock_deactivate,
+        ):
+            await _job_callback(self.ctx)
+        mock_deactivate.assert_called_once_with(1)
+        self.ctx.job.schedule_removal.assert_called_once()
+
+    @pytest.mark.asyncio()
+    async def test_other_send_exception_does_not_deactivate(self):
+        """Non-Forbidden send exceptions log the error but keep the job active."""
+        self.ctx.bot_data = {"claude": _make_claude_mock()}
+        self.ctx.bot.send_message.side_effect = RuntimeError("timeout")
+        with (
+            patch("kai.cron.log_message"),
+            patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock) as mock_deactivate,
+        ):
+            await _job_callback(self.ctx)
+        mock_deactivate.assert_not_called()
+
+
+# ── _job_callback: CONDITION_MET ─────────────────────────────────────
+
+
+class TestJobCallbackConditionMet:
+    @pytest.fixture(autouse=True)
+    def _setup_auto_remove_context(self, mock_context):
+        """Configure mock_context for auto-remove Claude job tests."""
+        mock_context.job.data["job_type"] = "claude"
+        mock_context.job.data["auto_remove"] = True
+        self.ctx = mock_context
+
+    @pytest.mark.asyncio()
+    async def test_detects_condition_met_prefix(self):
+        """Case-insensitive CONDITION_MET: prefix triggers the met branch."""
+        self.ctx.bot_data = {"claude": _make_claude_mock("condition_met: Package arrived!")}
+        with (
+            patch("kai.cron.log_message"),
+            patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock) as mock_deactivate,
+        ):
+            await _job_callback(self.ctx)
+        # Job was deactivated and removed
+        mock_deactivate.assert_called_once_with(1)
+        self.ctx.job.schedule_removal.assert_called_once()
+
+    @pytest.mark.asyncio()
+    async def test_extracts_message_after_marker(self):
+        """The message text after CONDITION_MET: is delivered to the user."""
+        self.ctx.bot_data = {"claude": _make_claude_mock("CONDITION_MET: Package arrived!")}
+        with (
+            patch("kai.cron.log_message"),
+            patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock),
+        ):
+            await _job_callback(self.ctx)
+        sent_text = self.ctx.bot.send_message.call_args.kwargs["text"]
+        assert sent_text == "[Job: Test Job]\nPackage arrived!"
+
+    @pytest.mark.asyncio()
+    async def test_multi_line_response(self):
+        """Text on lines after the marker line is included in the message."""
+        self.ctx.bot_data = {"claude": _make_claude_mock("CONDITION_MET: Done\nHere are details.")}
+        with (
+            patch("kai.cron.log_message"),
+            patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock),
+        ):
+            await _job_callback(self.ctx)
+        sent_text = self.ctx.bot.send_message.call_args.kwargs["text"]
+        assert "Done" in sent_text
+        assert "Here are details." in sent_text
+
+    @pytest.mark.asyncio()
+    async def test_no_message_after_marker(self):
+        """When nothing follows CONDITION_MET:, a default message is sent."""
+        self.ctx.bot_data = {"claude": _make_claude_mock("CONDITION_MET:")}
+        with (
+            patch("kai.cron.log_message"),
+            patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock),
+        ):
+            await _job_callback(self.ctx)
+        sent_text = self.ctx.bot.send_message.call_args.kwargs["text"]
+        assert sent_text == "[Job: Test Job] Condition met."
+
+    @pytest.mark.asyncio()
+    async def test_forbidden_still_deactivates(self):
+        """Even if the chat is gone (Forbidden), the job is still deactivated."""
+        self.ctx.bot_data = {"claude": _make_claude_mock("CONDITION_MET: done")}
+        self.ctx.bot.send_message.side_effect = Forbidden("blocked")
+        with (
+            patch("kai.cron.log_message"),
+            patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock) as mock_deactivate,
+        ):
+            await _job_callback(self.ctx)
+        mock_deactivate.assert_called_once_with(1)
+        self.ctx.job.schedule_removal.assert_called_once()
+
+
+# ── _job_callback: CONDITION_NOT_MET ─────────────────────────────────
+
+
+class TestJobCallbackConditionNotMet:
+    @pytest.fixture(autouse=True)
+    def _setup_auto_remove_context(self, mock_context):
+        """Configure mock_context for auto-remove Claude job tests."""
+        mock_context.job.data["job_type"] = "claude"
+        mock_context.job.data["auto_remove"] = True
+        mock_context.job.data["notify_on_check"] = False
+        self.ctx = mock_context
+
+    @pytest.mark.asyncio()
+    async def test_detects_condition_not_met(self):
+        """CONDITION_NOT_MET is recognized (case-insensitive, no colon required)."""
+        self.ctx.bot_data = {"claude": _make_claude_mock("CONDITION_NOT_MET")}
+        with patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock) as mock_deactivate:
+            await _job_callback(self.ctx)
+        # Job stays active - not deactivated
+        mock_deactivate.assert_not_called()
+        self.ctx.job.schedule_removal.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_silent_when_notify_disabled(self):
+        """With notify_on_check=False, no message is sent to the user."""
+        self.ctx.bot_data = {"claude": _make_claude_mock("CONDITION_NOT_MET: still waiting")}
+        await _job_callback(self.ctx)
+        self.ctx.bot.send_message.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_sends_message_when_notify_enabled(self):
+        """With notify_on_check=True, the status message is sent to the user."""
+        self.ctx.job.data["notify_on_check"] = True
+        self.ctx.bot_data = {"claude": _make_claude_mock("CONDITION_NOT_MET: Package in transit")}
+        with patch("kai.cron.log_message"):
+            await _job_callback(self.ctx)
+        sent_text = self.ctx.bot.send_message.call_args.kwargs["text"]
+        assert sent_text == "[Job: Test Job]\nPackage in transit"
+
+    @pytest.mark.asyncio()
+    async def test_handles_optional_colon(self):
+        """Both 'CONDITION_NOT_MET: msg' and 'CONDITION_NOT_MET msg' work."""
+        self.ctx.job.data["notify_on_check"] = True
+        # Without colon
+        self.ctx.bot_data = {"claude": _make_claude_mock("CONDITION_NOT_MET Still checking")}
+        with patch("kai.cron.log_message"):
+            await _job_callback(self.ctx)
+        # The lstrip(":") handles the optional colon; without it, the space
+        # separates "CONDITION_NOT_MET" from "Still checking"
+        sent_text = self.ctx.bot.send_message.call_args.kwargs["text"]
+        assert "Still checking" in sent_text
+
+    @pytest.mark.asyncio()
+    async def test_no_message_after_marker_with_notify(self):
+        """When nothing follows CONDITION_NOT_MET with notify=True, sends default text."""
+        self.ctx.job.data["notify_on_check"] = True
+        self.ctx.bot_data = {"claude": _make_claude_mock("CONDITION_NOT_MET")}
+        with patch("kai.cron.log_message"):
+            await _job_callback(self.ctx)
+        sent_text = self.ctx.bot.send_message.call_args.kwargs["text"]
+        assert sent_text == "[Job: Test Job] Still checking..."
+
+    @pytest.mark.asyncio()
+    async def test_forbidden_with_notify_deactivates(self):
+        """Forbidden when sending a notify update deactivates and removes the job."""
+        self.ctx.job.data["notify_on_check"] = True
+        self.ctx.bot_data = {"claude": _make_claude_mock("CONDITION_NOT_MET: status")}
+        self.ctx.bot.send_message.side_effect = Forbidden("blocked")
+        with (
+            patch("kai.cron.log_message"),
+            patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock) as mock_deactivate,
+        ):
+            await _job_callback(self.ctx)
+        mock_deactivate.assert_called_once_with(1)
+        self.ctx.job.schedule_removal.assert_called_once()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -12,6 +13,11 @@ from kai.install import (
     _LAUNCHD_LABEL,
     _apply_directories,
     _apply_migrate,
+    _apply_models,
+    _apply_secrets,
+    _apply_service,
+    _apply_source,
+    _apply_sudoers,
     _apply_venv,
     _check_path,
     _check_service_status,
@@ -19,13 +25,17 @@ from kai.install import (
     _cmd_apply,
     _cmd_config,
     _cmd_status,
+    _copy_tree,
     _file_checksum,
     _generate_env_file,
     _generate_launchd_plist,
+    _generate_launcher_script,
     _generate_sudoers,
     _generate_systemd_unit,
+    _set_ownership,
     _start_service,
     _stop_service,
+    _user_home,
     _validate_port,
     _validate_positive_float,
     _validate_positive_int,
@@ -936,3 +946,235 @@ class TestCli:
         monkeypatch.setattr("kai.install._cmd_apply", mock_apply)
         cli(["apply", "--dry-run"])
         assert captured_env.get("DRY_RUN") == "1"
+
+
+# ── _set_ownership ───────────────────────────────────────────────────
+
+
+class TestSetOwnership:
+    def test_single_file(self, tmp_path):
+        """Sets ownership on a single file."""
+        f = tmp_path / "file.txt"
+        f.touch()
+        with patch("os.chown") as mock_chown:
+            _set_ownership(f, 1000, 1000)
+        mock_chown.assert_called_once_with(f, 1000, 1000)
+
+    def test_recursive(self, tmp_path):
+        """Recursive: sets ownership on directory and all children."""
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "a.txt").touch()
+        (sub / "b.txt").touch()
+        with patch("os.chown") as mock_chown:
+            _set_ownership(tmp_path, 0, 0, recursive=True)
+        # Should chown the root, sub dir, and both files
+        chowned_paths = {call[0][0] for call in mock_chown.call_args_list}
+        assert tmp_path in chowned_paths
+        assert sub in chowned_paths
+        assert sub / "a.txt" in chowned_paths
+        assert sub / "b.txt" in chowned_paths
+
+
+# ── _copy_tree ───────────────────────────────────────────────────────
+
+
+class TestCopyTree:
+    def test_copies_tree(self, tmp_path):
+        """Copies source tree to destination."""
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "file.py").write_text("code")
+        dst = tmp_path / "dst"
+        _copy_tree(src, dst)
+        assert (dst / "file.py").read_text() == "code"
+
+    def test_excludes_patterns(self, tmp_path):
+        """Excluded patterns are not copied."""
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "file.py").write_text("code")
+        cache = src / "__pycache__"
+        cache.mkdir()
+        (cache / "file.pyc").write_bytes(b"\x00")
+        dst = tmp_path / "dst"
+        _copy_tree(src, dst, excludes={"__pycache__"})
+        assert (dst / "file.py").exists()
+        assert not (dst / "__pycache__").exists()
+
+    def test_overwrites_existing(self, tmp_path):
+        """Existing destination is removed before copy."""
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "new.py").write_text("new")
+        dst = tmp_path / "dst"
+        dst.mkdir()
+        (dst / "old.py").write_text("old")
+        _copy_tree(src, dst)
+        assert (dst / "new.py").exists()
+        assert not (dst / "old.py").exists()
+
+
+# ── _user_home ───────────────────────────────────────────────────────
+
+
+class TestUserHome:
+    def test_known_user(self):
+        """Known user returns their actual home dir from pwd."""
+        import getpass
+
+        current = getpass.getuser()
+        result = _user_home(current)
+        assert Path(result).is_dir()
+
+    def test_unknown_user_darwin(self, monkeypatch):
+        """Unknown user on Darwin: returns /Users/<username>."""
+        monkeypatch.setattr("kai.install.pwd.getpwnam", MagicMock(side_effect=KeyError))
+        monkeypatch.setattr("kai.install.sys.platform", "darwin")
+        assert _user_home("testuser") == "/Users/testuser"
+
+    def test_unknown_user_linux(self, monkeypatch):
+        """Unknown user on Linux: returns /home/<username>."""
+        monkeypatch.setattr("kai.install.pwd.getpwnam", MagicMock(side_effect=KeyError))
+        monkeypatch.setattr("kai.install.sys.platform", "linux")
+        assert _user_home("testuser") == "/home/testuser"
+
+
+# ── _generate_launcher_script ────────────────────────────────────────
+
+
+class TestGenerateLauncherScript:
+    def test_contains_install_dir(self):
+        script = _generate_launcher_script("/opt/kai")
+        assert "/opt/kai" in script
+
+    def test_contains_webhook_port(self):
+        script = _generate_launcher_script("/opt/kai", webhook_port=9090)
+        assert "9090" in script
+
+    def test_starts_with_shebang(self):
+        script = _generate_launcher_script("/opt/kai")
+        assert script.startswith("#!/bin/bash")
+
+    def test_contains_signal_forwarding(self):
+        script = _generate_launcher_script("/opt/kai")
+        assert "trap" in script
+        assert "TERM" in script
+
+
+# ── _apply_source ────────────────────────────────────────────────────
+
+
+class TestApplySource:
+    def test_dry_run(self, tmp_path, capsys):
+        """Dry run: prints messages, doesn't copy."""
+        with patch("kai.install.PROJECT_ROOT", tmp_path):
+            _apply_source(tmp_path / "install", dry_run=True)
+        output = capsys.readouterr().out
+        assert "DRY RUN" in output
+        assert "Would copy" in output
+
+    def test_actual(self, tmp_path):
+        """Actual: calls _copy_tree, _set_ownership, and copies pyproject.toml."""
+        # Set up source structure
+        src = tmp_path / "source"
+        (src / "src").mkdir(parents=True)
+        (src / "src" / "module.py").write_text("code")
+        (src / "pyproject.toml").write_text("[project]")
+        install = tmp_path / "install"
+        install.mkdir()
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install._copy_tree") as mock_copy,
+            patch("kai.install._set_ownership") as mock_own,
+            patch("shutil.copy2") as mock_cp,
+            patch("os.chown"),
+        ):
+            _apply_source(install, dry_run=False)
+        mock_copy.assert_called_once()
+        mock_own.assert_called_once()
+        mock_cp.assert_called_once()
+
+
+# ── _apply_models ────────────────────────────────────────────────────
+
+
+class TestApplyModels:
+    def test_no_models_dir(self, tmp_path):
+        """No models directory: returns early."""
+        with patch("kai.install.PROJECT_ROOT", tmp_path):
+            _apply_models(tmp_path / "install", dry_run=False)
+        # No exception, no output
+
+    def test_empty_models_dir(self, tmp_path):
+        """Empty models directory: returns early."""
+        (tmp_path / "models").mkdir()
+        with patch("kai.install.PROJECT_ROOT", tmp_path):
+            _apply_models(tmp_path / "install", dry_run=False)
+
+    def test_dry_run(self, tmp_path, capsys):
+        """Dry run with models: prints message."""
+        models = tmp_path / "models"
+        models.mkdir()
+        (models / "model.bin").touch()
+        with patch("kai.install.PROJECT_ROOT", tmp_path):
+            _apply_models(tmp_path / "install", dry_run=True)
+        assert "DRY RUN" in capsys.readouterr().out
+
+    def test_actual(self, tmp_path):
+        """Actual: calls _copy_tree and _set_ownership."""
+        models = tmp_path / "models"
+        models.mkdir()
+        (models / "model.bin").touch()
+        with (
+            patch("kai.install.PROJECT_ROOT", tmp_path),
+            patch("kai.install._copy_tree") as mock_copy,
+            patch("kai.install._set_ownership") as mock_own,
+        ):
+            _apply_models(tmp_path / "install", dry_run=False)
+        mock_copy.assert_called_once()
+        mock_own.assert_called_once()
+
+
+# ── _apply_secrets dry run ───────────────────────────────────────────
+
+
+class TestApplySecretsDryRun:
+    def test_dry_run(self, capsys):
+        """Dry run: prints message, doesn't write files."""
+        _apply_secrets({"TELEGRAM_BOT_TOKEN": "test"}, dry_run=True)
+        output = capsys.readouterr().out
+        assert "DRY RUN" in output
+        assert "env" in output
+
+
+# ── _apply_sudoers dry run ───────────────────────────────────────────
+
+
+class TestApplySudoersDryRun:
+    def test_dry_run(self, capsys):
+        """Dry run: prints expected messages."""
+        _apply_sudoers("kai", dry_run=True)
+        output = capsys.readouterr().out
+        assert "DRY RUN" in output
+        assert "sudoers" in output.lower() or "visudo" in output.lower()
+
+
+# ── _apply_service dry run ───────────────────────────────────────────
+
+
+class TestApplyServiceDryRun:
+    def test_dry_run_darwin(self, capsys):
+        """Dry run on Darwin: prints launcher and plist messages."""
+        _apply_service("/opt/kai", "/var/lib/kai", "kai", "darwin", dry_run=True)
+        output = capsys.readouterr().out
+        assert "DRY RUN" in output
+        assert "launcher" in output.lower() or "run.sh" in output.lower()
+        assert "plist" in output.lower() or "LaunchDaemon" in output
+
+    def test_dry_run_linux(self, capsys):
+        """Dry run on Linux: prints unit file message."""
+        _apply_service("/opt/kai", "/var/lib/kai", "kai", "linux", dry_run=True)
+        output = capsys.readouterr().out
+        assert "DRY RUN" in output

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,83 @@
+"""
+Tests for main.py - setup_logging() configuration.
+
+The main() and _init_and_run() functions orchestrate the full application
+lifecycle and are impractical to unit test. setup_logging() is testable
+in isolation since it just configures the root logger.
+"""
+
+import logging
+from logging.handlers import TimedRotatingFileHandler
+from unittest.mock import patch
+
+import pytest
+
+from kai.main import setup_logging
+
+# ── setup_logging() ──────────────────────────────────────────────────
+
+
+class TestSetupLogging:
+    @pytest.fixture(autouse=True)
+    def _restore_root_logger(self):
+        """
+        Restore root logger state after each test.
+
+        setup_logging() modifies the global root logger by adding handlers
+        and setting levels. Without cleanup, handlers accumulate across
+        tests and can cause file handle leaks.
+        """
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        original_level = root.level
+        yield
+        # Close any file handlers we added (prevents open file warnings)
+        for h in root.handlers:
+            if h not in original_handlers and hasattr(h, "close"):
+                h.close()
+        root.handlers = original_handlers
+        root.level = original_level
+
+    def test_creates_log_directory(self, tmp_path):
+        """Creates the logs/ directory under DATA_DIR."""
+        with patch("kai.main.DATA_DIR", tmp_path):
+            setup_logging()
+        assert (tmp_path / "logs").is_dir()
+
+    def test_adds_file_handler(self, tmp_path):
+        """Adds a TimedRotatingFileHandler to the root logger."""
+        with patch("kai.main.DATA_DIR", tmp_path):
+            setup_logging()
+        root = logging.getLogger()
+        file_handlers = [h for h in root.handlers if isinstance(h, TimedRotatingFileHandler)]
+        assert len(file_handlers) >= 1
+
+    def test_adds_stream_handler(self, tmp_path):
+        """Adds a StreamHandler to the root logger."""
+        with patch("kai.main.DATA_DIR", tmp_path):
+            setup_logging()
+        root = logging.getLogger()
+        stream_handlers = [
+            h
+            for h in root.handlers
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, TimedRotatingFileHandler)
+        ]
+        assert len(stream_handlers) >= 1
+
+    def test_root_level_info(self, tmp_path):
+        """Sets root logger to INFO level."""
+        with patch("kai.main.DATA_DIR", tmp_path):
+            setup_logging()
+        assert logging.getLogger().level == logging.INFO
+
+    def test_httpx_level_warning(self, tmp_path):
+        """Sets httpx logger to WARNING to silence per-request HTTP logs."""
+        with patch("kai.main.DATA_DIR", tmp_path):
+            setup_logging()
+        assert logging.getLogger("httpx").level == logging.WARNING
+
+    def test_apscheduler_level_warning(self, tmp_path):
+        """Sets apscheduler logger to WARNING to silence tick logs."""
+        with patch("kai.main.DATA_DIR", tmp_path):
+            setup_logging()
+        assert logging.getLogger("apscheduler.executors.default").level == logging.WARNING

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,0 +1,171 @@
+"""
+Tests for transcribe.py - voice message transcription via ffmpeg + whisper-cli.
+
+Tests the _run() subprocess helper (success, missing binary, non-zero exit,
+timeout, stderr truncation) and the transcribe_voice() pipeline (model
+validation, full pipeline with mocked subprocesses).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kai.transcribe import TranscriptionError, _run, transcribe_voice
+
+# ── Test helpers ─────────────────────────────────────────────────────
+
+
+def _make_proc(stdout=b"", stderr=b"", returncode=0):
+    """Create a mock subprocess with controllable communicate() output."""
+    proc = MagicMock()
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.returncode = returncode
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+    return proc
+
+
+# ── _run() ───────────────────────────────────────────────────────────
+
+
+class TestRun:
+    @pytest.mark.asyncio
+    async def test_success(self):
+        """Returns decoded stdout on success."""
+        proc = _make_proc(stdout=b"hello world\n", returncode=0)
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc):
+            result = await _run("echo", "hi", label="echo")
+        assert result == "hello world\n"
+
+    @pytest.mark.asyncio
+    async def test_binary_not_found(self):
+        """FileNotFoundError raises TranscriptionError with install hint."""
+        with (
+            patch(
+                "asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                side_effect=FileNotFoundError,
+            ),
+            pytest.raises(TranscriptionError, match="not found"),
+        ):
+            await _run("whisper-cli", label="whisper-cli")
+
+    @pytest.mark.asyncio
+    async def test_non_zero_exit(self):
+        """Non-zero exit code raises TranscriptionError with stderr snippet."""
+        proc = _make_proc(stderr=b"bad input format", returncode=1)
+        with (
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc),
+            pytest.raises(TranscriptionError, match=r"failed.*exit 1.*bad input"),
+        ):
+            await _run("ffmpeg", label="ffmpeg")
+
+    @pytest.mark.asyncio
+    async def test_timeout(self):
+        """Timeout kills process and raises TranscriptionError."""
+        proc = _make_proc()
+        with (
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc),
+            patch("asyncio.wait_for", side_effect=TimeoutError),
+            pytest.raises(TranscriptionError, match="timed out"),
+        ):
+            await _run("ffmpeg", label="ffmpeg")
+        proc.kill.assert_called_once()
+        proc.wait.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stderr_truncated(self):
+        """Long stderr is truncated to 200 chars in error message."""
+        long_err = b"x" * 500
+        proc = _make_proc(stderr=long_err, returncode=1)
+        with (
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc),
+            pytest.raises(TranscriptionError) as exc_info,
+        ):
+            await _run("ffmpeg", label="ffmpeg")
+        # The stderr portion of the error message should be at most 200 chars
+        msg = str(exc_info.value)
+        # Extract the part after the colon (the stderr snippet)
+        snippet = msg.split(": ", 1)[1] if ": " in msg else msg
+        assert len(snippet) <= 200
+
+
+# ── transcribe_voice() ───────────────────────────────────────────────
+
+
+class TestTranscribeVoice:
+    @pytest.mark.asyncio
+    async def test_model_missing(self, tmp_path):
+        """Raises TranscriptionError when model file doesn't exist."""
+        missing = tmp_path / "no_model.bin"
+        with pytest.raises(TranscriptionError, match="not found"):
+            await transcribe_voice(b"audio", missing)
+
+    @pytest.mark.asyncio
+    async def test_full_pipeline(self, tmp_path):
+        """Full pipeline: writes ogg, calls ffmpeg then whisper-cli, returns text."""
+        model = tmp_path / "model.bin"
+        model.touch()
+
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # ffmpeg call - succeeds
+                return _make_proc(returncode=0)
+            else:
+                # whisper-cli call - returns transcript
+                return _make_proc(stdout=b"  Hello world  \n", returncode=0)
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await transcribe_voice(b"fake-audio", model)
+
+        assert result == "Hello world"
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_ffmpeg_args(self, tmp_path):
+        """Verifies ffmpeg is called with 16kHz mono WAV args."""
+        model = tmp_path / "model.bin"
+        model.touch()
+
+        captured_args = []
+
+        async def _mock_exec(*args, **kwargs):
+            captured_args.append(args)
+            return _make_proc(stdout=b"text", returncode=0)
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            await transcribe_voice(b"audio", model)
+
+        # First call is ffmpeg
+        ffmpeg_args = captured_args[0]
+        assert ffmpeg_args[0] == "ffmpeg"
+        assert "-ar" in ffmpeg_args
+        assert "16000" in ffmpeg_args
+        assert "-ac" in ffmpeg_args
+        assert "1" in ffmpeg_args
+
+    @pytest.mark.asyncio
+    async def test_whisper_args(self, tmp_path):
+        """Verifies whisper-cli is called with model path and --no-timestamps."""
+        model = tmp_path / "model.bin"
+        model.touch()
+
+        captured_args = []
+
+        async def _mock_exec(*args, **kwargs):
+            captured_args.append(args)
+            return _make_proc(stdout=b"text", returncode=0)
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            await transcribe_voice(b"audio", model)
+
+        # Second call is whisper-cli
+        whisper_args = captured_args[1]
+        assert whisper_args[0] == "whisper-cli"
+        assert "--model" in whisper_args
+        assert str(model) in whisper_args
+        assert "--no-timestamps" in whisper_args

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -1,0 +1,315 @@
+"""
+Tests for tts.py - text-to-speech synthesis via Piper TTS + ffmpeg.
+
+Tests validation paths (empty text, unknown voice, missing model), piper
+subprocess errors, ffmpeg subprocess errors, and the full pipeline success
+path. All subprocess calls are mocked via asyncio.create_subprocess_exec.
+"""
+
+import asyncio
+import sys
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kai.tts import _VOICE_MODELS, DEFAULT_VOICE, TTSError, synthesize_speech
+
+# ── Test helpers ─────────────────────────────────────────────────────
+
+
+def _make_proc(stdout=b"", stderr=b"", returncode=0):
+    """Create a mock subprocess with controllable communicate() output."""
+    proc = MagicMock()
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.returncode = returncode
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+    return proc
+
+
+def _model_path(tmp_path, voice=DEFAULT_VOICE):
+    """Create the expected .onnx model file and return the model dir."""
+    model_name = _VOICE_MODELS[voice]
+    model_file = tmp_path / f"{model_name}.onnx"
+    model_file.touch()
+    return tmp_path
+
+
+@pytest.fixture
+def tts_tmpdir(tmp_path, monkeypatch):
+    """
+    Redirect TTS temp directory to a known location.
+
+    synthesize_speech() uses tempfile.TemporaryDirectory() internally;
+    this fixture patches it to return tmp_path so tests can predict
+    and create the intermediate WAV/OGG file paths.
+    """
+
+    @contextmanager
+    def _fake_tmpdir():
+        yield str(tmp_path)
+
+    monkeypatch.setattr("kai.tts.tempfile.TemporaryDirectory", _fake_tmpdir)
+    return tmp_path
+
+
+# ── Validation (no subprocess needed) ────────────────────────────────
+
+
+class TestSynthesizeValidation:
+    @pytest.mark.asyncio
+    async def test_empty_text(self, tmp_path):
+        with pytest.raises(TTSError, match="No text"):
+            await synthesize_speech("   ", tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_unknown_voice(self, tmp_path):
+        with pytest.raises(TTSError, match="Unknown voice"):
+            await synthesize_speech("hello", tmp_path, voice="nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_model_missing(self, tmp_path):
+        """Missing .onnx file raises TTSError with download hint."""
+        with pytest.raises(TTSError, match="not found"):
+            await synthesize_speech("hello", tmp_path, voice=DEFAULT_VOICE)
+
+
+# ── Piper subprocess errors ──────────────────────────────────────────
+
+
+class TestSynthesizePiper:
+    @pytest.mark.asyncio
+    async def test_piper_not_found(self, tmp_path, tts_tmpdir):
+        model_dir = _model_path(tmp_path)
+        with (
+            patch(
+                "asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                side_effect=FileNotFoundError,
+            ),
+            pytest.raises(TTSError, match="piper-tts not found"),
+        ):
+            await synthesize_speech("hello", model_dir)
+
+    @pytest.mark.asyncio
+    async def test_piper_timeout(self, tmp_path, tts_tmpdir):
+        model_dir = _model_path(tmp_path)
+        proc = _make_proc()
+        with (
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc),
+            patch("asyncio.wait_for", side_effect=TimeoutError),
+            pytest.raises(TTSError, match="timed out"),
+        ):
+            await synthesize_speech("hello", model_dir)
+        proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_piper_non_zero_exit(self, tmp_path, tts_tmpdir):
+        model_dir = _model_path(tmp_path)
+        proc = _make_proc(stderr=b"segfault", returncode=139)
+        with (
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc),
+            pytest.raises(TTSError, match=r"Piper failed.*exit 139"),
+        ):
+            await synthesize_speech("hello", model_dir)
+
+
+# ── ffmpeg subprocess errors ─────────────────────────────────────────
+
+
+class TestSynthesizeFfmpeg:
+    def _piper_then_ffmpeg_error(self, tts_tmpdir, ffmpeg_side_effect):
+        """
+        Helper: piper succeeds (first call), ffmpeg fails (second call).
+
+        Creates the intermediate WAV file (as piper would) so the test
+        reaches the ffmpeg step. Returns a side_effect function for
+        create_subprocess_exec.
+        """
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Piper succeeds - create the WAV file it would produce
+                wav = tts_tmpdir / "speech.wav"
+                wav.write_bytes(b"RIFF-fake-wav")
+                return _make_proc(returncode=0)
+            else:
+                raise ffmpeg_side_effect
+
+        return _mock_exec
+
+    @pytest.mark.asyncio
+    async def test_ffmpeg_not_found(self, tmp_path, tts_tmpdir):
+        model_dir = _model_path(tmp_path)
+        mock_exec = self._piper_then_ffmpeg_error(tts_tmpdir, FileNotFoundError())
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=mock_exec),
+            pytest.raises(TTSError, match="ffmpeg not found"),
+        ):
+            await synthesize_speech("hello", model_dir)
+
+    @pytest.mark.asyncio
+    async def test_ffmpeg_timeout(self, tmp_path, tts_tmpdir):
+        model_dir = _model_path(tmp_path)
+        wait_for_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            if args[0] != "ffmpeg":
+                # Piper call - write WAV file
+                wav = tts_tmpdir / "speech.wav"
+                wav.write_bytes(b"RIFF-fake-wav")
+                return _make_proc(returncode=0)
+            # ffmpeg call - return proc that will be timed out
+            return _make_proc()
+
+        original_wait_for = asyncio.wait_for
+
+        async def _wait_for_side_effect(coro, timeout):
+            nonlocal wait_for_count
+            wait_for_count += 1
+            if wait_for_count == 1:
+                # Piper's communicate - let it through
+                return await original_wait_for(coro, timeout=timeout)
+            # ffmpeg's communicate - timeout
+            raise TimeoutError
+
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=_mock_exec),
+            patch("kai.tts.asyncio.wait_for", side_effect=_wait_for_side_effect),
+            pytest.raises(TTSError, match="ffmpeg timed out"),
+        ):
+            await synthesize_speech("hello", model_dir)
+
+    @pytest.mark.asyncio
+    async def test_ffmpeg_non_zero_exit(self, tmp_path, tts_tmpdir):
+        model_dir = _model_path(tmp_path)
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                wav = tts_tmpdir / "speech.wav"
+                wav.write_bytes(b"RIFF-fake-wav")
+                return _make_proc(returncode=0)
+            return _make_proc(stderr=b"codec error", returncode=1)
+
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=_mock_exec),
+            pytest.raises(TTSError, match=r"ffmpeg failed.*exit 1"),
+        ):
+            await synthesize_speech("hello", model_dir)
+
+
+# ── Full success path ────────────────────────────────────────────────
+
+
+class TestSynthesizeSuccess:
+    @pytest.mark.asyncio
+    async def test_full_pipeline(self, tmp_path, tts_tmpdir):
+        """Full pipeline: piper writes WAV, ffmpeg converts to OGG, returns bytes."""
+        model_dir = _model_path(tmp_path)
+        call_count = 0
+        captured_args = []
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            captured_args.append(args)
+            if call_count == 1:
+                # Piper step - create the WAV file
+                wav = tts_tmpdir / "speech.wav"
+                wav.write_bytes(b"RIFF-fake-wav-data")
+                return _make_proc(returncode=0)
+            else:
+                # ffmpeg step - create the OGG file
+                ogg = tts_tmpdir / "speech.ogg"
+                ogg.write_bytes(b"OggS-fake-audio")
+                return _make_proc(returncode=0)
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await synthesize_speech("Hello world", model_dir)
+
+        assert result == b"OggS-fake-audio"
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_piper_called_with_correct_args(self, tmp_path, tts_tmpdir):
+        """Piper is called via sys.executable -m piper with model path."""
+        model_dir = _model_path(tmp_path)
+        captured_args = []
+        captured_kwargs = []
+
+        async def _mock_exec(*args, **kwargs):
+            captured_args.append(args)
+            captured_kwargs.append(kwargs)
+            if len(captured_args) == 1:
+                (tts_tmpdir / "speech.wav").write_bytes(b"wav")
+            else:
+                (tts_tmpdir / "speech.ogg").write_bytes(b"ogg")
+            return _make_proc(returncode=0)
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            await synthesize_speech("Test text", model_dir)
+
+        # First call is piper
+        piper_args = captured_args[0]
+        assert piper_args[0] == sys.executable
+        assert "-m" in piper_args
+        assert "piper" in piper_args
+        assert "--model" in piper_args
+        assert "--output_file" in piper_args
+
+    @pytest.mark.asyncio
+    async def test_piper_receives_text_via_stdin(self, tmp_path, tts_tmpdir):
+        """Piper's communicate() is called with text.encode() as input."""
+        model_dir = _model_path(tmp_path)
+        piper_proc = _make_proc(returncode=0)
+
+        async def _mock_exec(*args, **kwargs):
+            if len(_mock_exec.calls) == 0:
+                _mock_exec.calls.append(1)
+                (tts_tmpdir / "speech.wav").write_bytes(b"wav")
+                return piper_proc
+            _mock_exec.calls.append(1)
+            (tts_tmpdir / "speech.ogg").write_bytes(b"ogg")
+            return _make_proc(returncode=0)
+
+        _mock_exec.calls = []
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            await synthesize_speech("Say this", model_dir)
+
+        # Piper's communicate should have been called with the text as bytes
+        piper_proc.communicate.assert_called_once()
+        call_kwargs = piper_proc.communicate.call_args
+        # communicate() may receive text as positional or keyword arg
+        input_bytes = call_kwargs[1].get("input") or (call_kwargs[0][0] if call_kwargs[0] else None)
+        assert input_bytes == b"Say this"
+
+    @pytest.mark.asyncio
+    async def test_ffmpeg_called_with_opus(self, tmp_path, tts_tmpdir):
+        """ffmpeg is called with libopus codec and ogg format."""
+        model_dir = _model_path(tmp_path)
+        captured_args = []
+
+        async def _mock_exec(*args, **kwargs):
+            captured_args.append(args)
+            if len(captured_args) == 1:
+                (tts_tmpdir / "speech.wav").write_bytes(b"wav")
+            else:
+                (tts_tmpdir / "speech.ogg").write_bytes(b"ogg")
+            return _make_proc(returncode=0)
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            await synthesize_speech("Test", model_dir)
+
+        # Second call is ffmpeg
+        ffmpeg_args = captured_args[1]
+        assert ffmpeg_args[0] == "ffmpeg"
+        assert "libopus" in ffmpeg_args
+        assert "ogg" in ffmpeg_args

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -1,18 +1,26 @@
 """Integration tests for webhook HTTP API endpoints (jobs CRUD, file exchange)."""
 
 import asyncio
+import hashlib
+import hmac as hmac_mod
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
 
 import kai.webhook as webhook_mod
 from kai import sessions
+from kai.services import ServiceResponse
 from kai.webhook import (
     _handle_delete_job,
+    _handle_generic,
+    _handle_get_job,
+    _handle_get_jobs,
+    _handle_github,
     _handle_schedule,
     _handle_send_file,
+    _handle_service_call,
     _handle_telegram_update,
     _handle_update_job,
     update_workspace,
@@ -481,3 +489,614 @@ class TestTelegramUpdate:
 
         assert resp.status == 200
         telegram_request.app["telegram_app"].process_update.assert_not_called()
+
+
+# ── GitHub webhook helpers ─────────────────────────────────────────
+
+
+def _sign_body(secret: str, body: bytes) -> str:
+    """Compute a valid GitHub HMAC-SHA256 signature for test payloads."""
+    digest = hmac_mod.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+@pytest.fixture()
+def github_request():
+    """Create a mock request for the GitHub webhook endpoint."""
+    request = MagicMock(spec=web.Request)
+    request.app = {
+        "webhook_secret": "test-secret",
+        "telegram_bot": AsyncMock(),
+        "chat_id": 12345,
+    }
+    request.headers = {}
+    return request
+
+
+def _github_push_payload() -> dict:
+    """Minimal GitHub push event payload for testing."""
+    return {
+        "pusher": {"name": "testuser"},
+        "ref": "refs/heads/main",
+        "commits": [{"id": "abc1234def5678", "message": "Fix bug"}],
+        "repository": {"full_name": "testuser/repo"},
+        "compare": "https://github.com/testuser/repo/compare/abc...def",
+    }
+
+
+# ── POST /webhook/github ──────────────────────────────────────────
+
+
+class TestGitHubWebhook:
+    async def test_valid_push_sends_markdown(self, github_request):
+        """Valid signature + push event sends a Markdown-formatted message."""
+        payload = _github_push_payload()
+        body = json.dumps(payload).encode()
+        github_request.read = AsyncMock(return_value=body)
+        github_request.headers = {
+            "X-Hub-Signature-256": _sign_body("test-secret", body),
+            "X-GitHub-Event": "push",
+        }
+
+        resp = await _handle_github(github_request)
+
+        assert resp.status == 200
+        bot = github_request.app["telegram_bot"]
+        bot.send_message.assert_called_once()
+        call_kwargs = bot.send_message.call_args
+        assert call_kwargs.kwargs.get("parse_mode") == "Markdown" or call_kwargs[2] == "Markdown"
+
+    async def test_markdown_failure_falls_back_to_plain(self, github_request):
+        """When Markdown parse fails, resends as stripped plain text."""
+        payload = _github_push_payload()
+        body = json.dumps(payload).encode()
+        github_request.read = AsyncMock(return_value=body)
+        github_request.headers = {
+            "X-Hub-Signature-256": _sign_body("test-secret", body),
+            "X-GitHub-Event": "push",
+        }
+        bot = github_request.app["telegram_bot"]
+        # First call (Markdown) fails, second call (plain) succeeds
+        bot.send_message = AsyncMock(side_effect=[Exception("parse error"), None])
+
+        resp = await _handle_github(github_request)
+
+        assert resp.status == 200
+        assert bot.send_message.call_count == 2
+
+    async def test_both_sends_fail_returns_error(self, github_request):
+        """When both Markdown and plain text fail, returns error response."""
+        payload = _github_push_payload()
+        body = json.dumps(payload).encode()
+        github_request.read = AsyncMock(return_value=body)
+        github_request.headers = {
+            "X-Hub-Signature-256": _sign_body("test-secret", body),
+            "X-GitHub-Event": "push",
+        }
+        bot = github_request.app["telegram_bot"]
+        bot.send_message = AsyncMock(side_effect=Exception("always fails"))
+
+        resp = await _handle_github(github_request)
+
+        body_json = json.loads(resp.body.decode())
+        assert body_json["msg"] == "error"
+
+    async def test_invalid_signature_returns_401(self, github_request):
+        """Requests with an invalid HMAC signature are rejected."""
+        body = b'{"any": "payload"}'
+        github_request.read = AsyncMock(return_value=body)
+        github_request.headers = {
+            "X-Hub-Signature-256": "sha256=invalid",
+            "X-GitHub-Event": "push",
+        }
+
+        resp = await _handle_github(github_request)
+
+        assert resp.status == 401
+        github_request.app["telegram_bot"].send_message.assert_not_called()
+
+    async def test_ping_event_returns_pong(self, github_request):
+        """GitHub ping events are acknowledged without sending to Telegram."""
+        body = b'{"zen": "testing"}'
+        github_request.read = AsyncMock(return_value=body)
+        github_request.headers = {
+            "X-Hub-Signature-256": _sign_body("test-secret", body),
+            "X-GitHub-Event": "ping",
+        }
+
+        resp = await _handle_github(github_request)
+
+        body_json = json.loads(resp.body.decode())
+        assert body_json["msg"] == "pong"
+        github_request.app["telegram_bot"].send_message.assert_not_called()
+
+    async def test_unknown_event_type_ignored(self, github_request):
+        """Unsupported event types (e.g. 'star') are silently ignored."""
+        payload = {"action": "created"}
+        body = json.dumps(payload).encode()
+        github_request.read = AsyncMock(return_value=body)
+        github_request.headers = {
+            "X-Hub-Signature-256": _sign_body("test-secret", body),
+            "X-GitHub-Event": "star",
+        }
+
+        resp = await _handle_github(github_request)
+
+        body_json = json.loads(resp.body.decode())
+        assert body_json["msg"] == "ignored"
+
+    async def test_filtered_action_ignored(self, github_request):
+        """Known event type with filtered action (e.g. PR 'edited') is ignored."""
+        # PR "edited" is not in the formatter's accepted actions
+        payload = {"action": "edited", "pull_request": {"title": "test"}}
+        body = json.dumps(payload).encode()
+        github_request.read = AsyncMock(return_value=body)
+        github_request.headers = {
+            "X-Hub-Signature-256": _sign_body("test-secret", body),
+            "X-GitHub-Event": "pull_request",
+        }
+
+        resp = await _handle_github(github_request)
+
+        body_json = json.loads(resp.body.decode())
+        assert body_json["msg"] == "ignored"
+
+    async def test_invalid_json_after_valid_signature_returns_400(self, github_request):
+        """Valid signature over malformed JSON body returns 400."""
+        body = b"not valid json"
+        github_request.read = AsyncMock(return_value=body)
+        github_request.headers = {
+            "X-Hub-Signature-256": _sign_body("test-secret", body),
+            # Use a known event type so JSON parsing is attempted
+            "X-GitHub-Event": "push",
+        }
+
+        resp = await _handle_github(github_request)
+
+        assert resp.status == 400
+
+
+# ── POST /webhook (generic) ───────────────────────────────────────
+
+
+@pytest.fixture()
+def generic_request():
+    """Create a mock request for the generic webhook endpoint."""
+    request = MagicMock(spec=web.Request)
+    request.app = {
+        "webhook_secret": "test-secret",
+        "telegram_bot": AsyncMock(),
+        "chat_id": 12345,
+    }
+    request.headers = {"X-Webhook-Secret": "test-secret"}
+    return request
+
+
+class TestGenericWebhook:
+    async def test_sends_message_field(self, generic_request):
+        """Payload with a 'message' field sends that string to Telegram."""
+        generic_request.json = AsyncMock(return_value={"message": "Alert: disk full"})
+
+        resp = await _handle_generic(generic_request)
+
+        assert resp.status == 200
+        generic_request.app["telegram_bot"].send_message.assert_called_once_with(12345, "Alert: disk full")
+
+    async def test_dumps_full_payload_when_no_message(self, generic_request):
+        """Payload without 'message' sends the full JSON dump to Telegram."""
+        payload = {"key": "value", "count": 42}
+        generic_request.json = AsyncMock(return_value=payload)
+
+        resp = await _handle_generic(generic_request)
+
+        assert resp.status == 200
+        sent_text = generic_request.app["telegram_bot"].send_message.call_args[0][1]
+        # Should be a pretty-printed JSON dump
+        assert '"key": "value"' in sent_text
+        assert '"count": 42' in sent_text
+
+    async def test_empty_message_field_sends_empty_string(self, generic_request):
+        """Empty string 'message' is sent as-is (not treated as missing)."""
+        generic_request.json = AsyncMock(return_value={"message": ""})
+
+        resp = await _handle_generic(generic_request)
+
+        assert resp.status == 200
+        sent_text = generic_request.app["telegram_bot"].send_message.call_args[0][1]
+        assert sent_text == ""
+
+    async def test_long_message_truncated(self, generic_request):
+        """Messages over 4096 chars are truncated with '...' suffix."""
+        long_msg = "x" * 5000
+        generic_request.json = AsyncMock(return_value={"message": long_msg})
+
+        resp = await _handle_generic(generic_request)
+
+        assert resp.status == 200
+        sent_text = generic_request.app["telegram_bot"].send_message.call_args[0][1]
+        assert len(sent_text) == 4096
+        assert sent_text.endswith("...")
+
+    async def test_invalid_json_returns_400(self, generic_request):
+        """Malformed JSON body returns 400."""
+        generic_request.json = AsyncMock(side_effect=json.JSONDecodeError("test", "doc", 0))
+
+        resp = await _handle_generic(generic_request)
+
+        assert resp.status == 400
+
+    async def test_send_failure_still_returns_ok(self, generic_request):
+        """Telegram send failures are logged but the response is still 200/ok."""
+        generic_request.json = AsyncMock(return_value={"message": "test"})
+        generic_request.app["telegram_bot"].send_message = AsyncMock(side_effect=RuntimeError("network error"))
+
+        resp = await _handle_generic(generic_request)
+
+        assert resp.status == 200
+        body_json = json.loads(resp.body.decode())
+        assert body_json["status"] == "ok"
+
+    async def test_missing_secret_returns_401(self, generic_request):
+        """Missing webhook secret header returns 401."""
+        generic_request.headers = {}
+        generic_request.json = AsyncMock(return_value={"message": "test"})
+
+        resp = await _handle_generic(generic_request)
+
+        assert resp.status == 401
+
+
+# ── GET /api/jobs ──────────────────────────────────────────────────
+
+
+class TestGetJobs:
+    async def test_returns_active_jobs(self, db, mock_request):
+        """Returns a list of active jobs for the configured chat."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app["chat_id"] = 123
+
+        await sessions.create_job(
+            chat_id=123,
+            name="Job A",
+            job_type="reminder",
+            prompt="hello",
+            schedule_type="daily",
+            schedule_data='{"times": ["09:00"]}',
+        )
+        await sessions.create_job(
+            chat_id=123,
+            name="Job B",
+            job_type="claude",
+            prompt="check",
+            schedule_type="interval",
+            schedule_data='{"seconds": 3600}',
+        )
+
+        resp = await _handle_get_jobs(mock_request)
+
+        assert resp.status == 200
+        body = json.loads(resp.body.decode())
+        assert len(body) == 2
+        names = {j["name"] for j in body}
+        assert names == {"Job A", "Job B"}
+
+    async def test_returns_empty_list_when_no_jobs(self, db, mock_request):
+        """Returns an empty list when no jobs exist."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app["chat_id"] = 123
+
+        resp = await _handle_get_jobs(mock_request)
+
+        assert resp.status == 200
+        body = json.loads(resp.body.decode())
+        assert body == []
+
+    async def test_missing_secret_returns_401(self, db, mock_request):
+        """Missing webhook secret returns 401."""
+        mock_request.headers = {}
+        mock_request.app["chat_id"] = 123
+
+        resp = await _handle_get_jobs(mock_request)
+
+        assert resp.status == 401
+
+
+# ── GET /api/jobs/{id} ─────────────────────────────────────────────
+
+
+class TestGetJob:
+    async def test_returns_existing_job(self, db, mock_request):
+        """Returns the full job record for a valid ID."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        job_id = await sessions.create_job(
+            chat_id=123,
+            name="My Job",
+            job_type="reminder",
+            prompt="test prompt",
+            schedule_type="once",
+            schedule_data='{"run_at": "2026-06-01T12:00:00+00:00"}',
+        )
+        mock_request.match_info = {"id": str(job_id)}
+
+        resp = await _handle_get_job(mock_request)
+
+        assert resp.status == 200
+        body = json.loads(resp.body.decode())
+        assert body["name"] == "My Job"
+        assert body["id"] == job_id
+
+    async def test_nonexistent_job_returns_404(self, db, mock_request):
+        """Returns 404 for a job ID that doesn't exist."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.match_info = {"id": "999"}
+
+        resp = await _handle_get_job(mock_request)
+
+        assert resp.status == 404
+
+    async def test_invalid_id_returns_400(self, db, mock_request):
+        """Returns 400 for a non-numeric job ID."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.match_info = {"id": "abc"}
+
+        resp = await _handle_get_job(mock_request)
+
+        assert resp.status == 400
+        body = json.loads(resp.body.decode())
+        assert "invalid" in body["error"].lower()
+
+    async def test_missing_secret_returns_401(self, db, mock_request):
+        """Missing webhook secret returns 401."""
+        mock_request.headers = {}
+        mock_request.match_info = {"id": "1"}
+
+        resp = await _handle_get_job(mock_request)
+
+        assert resp.status == 401
+
+
+# ── POST /api/schedule (additional coverage) ───────────────────────
+
+
+class TestScheduleValidation:
+    async def test_missing_required_fields_returns_400(self, db, mock_request):
+        """Returns 400 when required fields are missing."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app["chat_id"] = 123
+        # Missing prompt, schedule_type, and schedule_data
+        mock_request.json = AsyncMock(return_value={"name": "incomplete"})
+
+        resp = await _handle_schedule(mock_request)
+
+        assert resp.status == 400
+        body = json.loads(resp.body.decode())
+        assert "required" in body["error"].lower()
+
+    async def test_invalid_schedule_type_returns_400(self, db, mock_request):
+        """Returns 400 for unrecognized schedule_type."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app["chat_id"] = 123
+        mock_request.json = AsyncMock(
+            return_value={
+                "name": "test",
+                "prompt": "test",
+                "schedule_type": "weekly",
+                "schedule_data": {},
+            }
+        )
+
+        resp = await _handle_schedule(mock_request)
+
+        assert resp.status == 400
+        body = json.loads(resp.body.decode())
+        assert "schedule_type" in body["error"]
+
+    async def test_dict_schedule_data_serialized_to_json(self, db, mock_request):
+        """schedule_data as a dict is serialized to a JSON string for DB storage."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app["chat_id"] = 123
+        mock_request.json = AsyncMock(
+            return_value={
+                "name": "dict test",
+                "prompt": "test",
+                "schedule_type": "interval",
+                "schedule_data": {"seconds": 600},
+            }
+        )
+        with patch("kai.cron.register_job_by_id", new_callable=AsyncMock):
+            resp = await _handle_schedule(mock_request)
+
+        assert resp.status == 200
+        body = json.loads(resp.body.decode())
+        # Verify the stored data is valid JSON
+        job = await sessions.get_job_by_id(body["job_id"])
+        assert job is not None
+        stored = json.loads(job["schedule_data"])
+        assert stored["seconds"] == 600
+
+    async def test_string_schedule_data_passed_through(self, db, mock_request):
+        """schedule_data as a pre-serialized string is stored as-is."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app["chat_id"] = 123
+        mock_request.json = AsyncMock(
+            return_value={
+                "name": "string test",
+                "prompt": "test",
+                "schedule_type": "interval",
+                "schedule_data": '{"seconds": 900}',
+            }
+        )
+        with patch("kai.cron.register_job_by_id", new_callable=AsyncMock):
+            resp = await _handle_schedule(mock_request)
+
+        assert resp.status == 200
+        body = json.loads(resp.body.decode())
+        job = await sessions.get_job_by_id(body["job_id"])
+        assert job is not None
+        assert job["schedule_data"] == '{"seconds": 900}'
+
+    async def test_defaults_for_optional_fields(self, db, mock_request):
+        """auto_remove defaults to False when omitted. job_type defaults to 'reminder'."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app["chat_id"] = 123
+        mock_request.json = AsyncMock(
+            return_value={
+                "name": "defaults test",
+                "prompt": "test",
+                "schedule_type": "once",
+                "schedule_data": {"run_at": "2026-06-01T12:00:00+00:00"},
+            }
+        )
+        with patch("kai.cron.register_job_by_id", new_callable=AsyncMock):
+            resp = await _handle_schedule(mock_request)
+
+        assert resp.status == 200
+        body = json.loads(resp.body.decode())
+        job = await sessions.get_job_by_id(body["job_id"])
+        assert job is not None
+        assert job["auto_remove"] is False
+        assert job["job_type"] == "reminder"
+
+    async def test_db_failure_returns_500(self, db, mock_request):
+        """Database create failure returns 500 with an error message."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app["chat_id"] = 123
+        mock_request.json = AsyncMock(
+            return_value={
+                "name": "fail test",
+                "prompt": "test",
+                "schedule_type": "daily",
+                "schedule_data": {"times": ["09:00"]},
+            }
+        )
+        with patch(
+            "kai.webhook.sessions.create_job",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB locked"),
+        ):
+            resp = await _handle_schedule(mock_request)
+
+        assert resp.status == 500
+        body = json.loads(resp.body.decode())
+        assert "error" in body
+
+    async def test_successful_creation_registers_with_scheduler(self, db, mock_request):
+        """Successful job creation calls register_job_by_id with the new ID."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app["chat_id"] = 123
+        mock_request.json = AsyncMock(
+            return_value={
+                "name": "scheduler test",
+                "prompt": "test",
+                "schedule_type": "interval",
+                "schedule_data": {"seconds": 300},
+            }
+        )
+        with patch("kai.cron.register_job_by_id", new_callable=AsyncMock) as mock_register:
+            resp = await _handle_schedule(mock_request)
+
+        assert resp.status == 200
+        body = json.loads(resp.body.decode())
+        mock_register.assert_called_once_with(mock_request.app["telegram_app"], body["job_id"])
+
+    async def test_invalid_json_returns_400(self, db, mock_request):
+        """Malformed JSON body returns 400."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app["chat_id"] = 123
+        mock_request.json = AsyncMock(side_effect=json.JSONDecodeError("test", "doc", 0))
+
+        resp = await _handle_schedule(mock_request)
+
+        assert resp.status == 400
+
+
+# ── POST /api/services/{name} ─────────────────────────────────────
+
+
+@pytest.fixture()
+def service_request():
+    """Create a mock request for the service proxy endpoint."""
+    request = MagicMock(spec=web.Request)
+    request.app = {
+        "webhook_secret": "test-secret",
+    }
+    request.headers = {"X-Webhook-Secret": "test-secret"}
+    request.match_info = {"name": "perplexity"}
+    return request
+
+
+class TestServiceCall:
+    async def test_successful_call_returns_status_and_body(self, service_request):
+        """Successful service call returns the status code and response body."""
+        service_request.json = AsyncMock(return_value={"body": {"model": "sonar", "messages": []}})
+        mock_result = ServiceResponse(success=True, status=200, body='{"answer": "42"}')
+        with patch("kai.services.call_service", new_callable=AsyncMock, return_value=mock_result):
+            resp = await _handle_service_call(service_request)
+
+        assert resp.status == 200
+        body = json.loads(resp.body.decode())
+        assert body["status"] == 200
+        assert body["body"] == '{"answer": "42"}'
+
+    async def test_failed_call_returns_502(self, service_request):
+        """Failed service call (success=False) returns 502 with error message."""
+        service_request.json = AsyncMock(return_value={"body": {}})
+        mock_result = ServiceResponse(success=False, error="Connection refused")
+        with patch("kai.services.call_service", new_callable=AsyncMock, return_value=mock_result):
+            resp = await _handle_service_call(service_request)
+
+        assert resp.status == 502
+        body = json.loads(resp.body.decode())
+        assert "Connection refused" in body["error"]
+
+    async def test_forwards_body_params_and_path_suffix(self, service_request):
+        """All request fields (body, params, path_suffix) are forwarded to call_service."""
+        service_request.json = AsyncMock(
+            return_value={
+                "body": {"query": "test"},
+                "params": {"limit": "10"},
+                "path_suffix": "/search",
+            }
+        )
+        mock_result = ServiceResponse(success=True, status=200, body="ok")
+        with patch("kai.services.call_service", new_callable=AsyncMock, return_value=mock_result) as mock_call:
+            await _handle_service_call(service_request)
+
+        mock_call.assert_called_once_with(
+            "perplexity",
+            body={"query": "test"},
+            params={"limit": "10"},
+            path_suffix="/search",
+        )
+
+    async def test_no_json_body_passes_defaults(self, service_request):
+        """Request with no JSON body passes None/defaults to call_service."""
+        service_request.json = AsyncMock(side_effect=json.JSONDecodeError("test", "doc", 0))
+        mock_result = ServiceResponse(success=True, status=200, body="ok")
+        with patch("kai.services.call_service", new_callable=AsyncMock, return_value=mock_result) as mock_call:
+            await _handle_service_call(service_request)
+
+        mock_call.assert_called_once_with(
+            "perplexity",
+            body=None,
+            params=None,
+            path_suffix="",
+        )
+
+    async def test_invalid_json_treated_as_no_body(self, service_request):
+        """Invalid JSON is silently ignored (all fields are optional)."""
+        service_request.json = AsyncMock(side_effect=json.JSONDecodeError("test", "doc", 0))
+        mock_result = ServiceResponse(success=True, status=200, body="ok")
+        with patch("kai.services.call_service", new_callable=AsyncMock, return_value=mock_result):
+            resp = await _handle_service_call(service_request)
+
+        # Should NOT return 400 - invalid JSON is fine for this endpoint
+        assert resp.status == 200
+
+    async def test_missing_secret_returns_401(self, service_request):
+        """Missing webhook secret returns 401."""
+        service_request.headers = {}
+
+        resp = await _handle_service_call(service_request)
+
+        assert resp.status == 401


### PR DESCRIPTION
## Summary

Takes the test suite from 183 tests to 636 tests (3.5x increase), covering every source module in the project. This was the test coverage phase of the code review, organized into 5 parts by module priority.

## What changed

**8 test files modified or created** - no production code was changed.

### Part 1: cron.py (3 -> 43 tests)
- `_ensure_utc` timezone normalization
- `_register_job` schedule type dispatch (once/daily/interval)
- `register_job_by_id` database-to-scheduler bridge
- `_register_new_jobs` batch registration with deduplication
- `init_jobs` startup job loading
- `_job_callback` execution: reminder delivery, Claude job dispatch, conditional auto-remove protocol (CONDITION_MET/CONDITION_NOT_MET parsing), notification modes

### Part 2: webhook.py route handlers (30 -> 64 tests)
- `_handle_github`: HMAC signature validation, event dispatch to formatters, Markdown-with-fallback delivery, ping/unknown/filtered events
- `_handle_generic`: message extraction, payload truncation, secret validation
- `_handle_get_jobs` / `_handle_get_job`: job listing and retrieval with real DB
- `_handle_schedule`: field validation, schedule_data serialization, defaults, DB failure handling
- `_handle_service_call`: service proxy forwarding, error responses, auth

### Part 3: claude.py async lifecycle (9 -> 57 tests)
- `is_alive` / `session_id` properties
- `_ensure_started`: subprocess spawning, webhook secret env var, fresh session flag, stderr drain task
- `_drain_stderr`: line reading, truncation, EOF, exception handling
- `_send_locked`: the core stream parser covering basic message flow, CLI-not-found, stdin failure, timeout, EOF (with/without text), non-JSON lines, system events, assistant text accumulation, result event construction, context injection (first message, foreign workspace, home workspace, API info, services), multi-modal prompts
- `send()`: lock acquisition
- `_kill`: SIGKILL + wait + state cleanup, stderr task cancellation, idempotency, exception resilience
- `shutdown`: SIGTERM-then-SIGKILL sequence, timeout fallback, zombie handling
- `change_workspace` / `restart`

### Part 4: bot.py handlers (39 -> 150 tests)
- Crash recovery flag (`_set_responding` / `_clear_responding`)
- Authorization (`_is_authorized`, `_require_auth` decorator)
- Message utilities (`_reply_safe`, `_edit_message_safe` with Markdown fallback chains)
- Keyboard builders (`_models_keyboard`, `_voices_keyboard`)
- All command handlers: `/start`, `/new`, `/help`, `/stop`, `/stats`, `/jobs`, `/canceljob`, `/models`, `/model`, `/workspace` (14 tests covering all subcommands), `/workspaces`, `/webhooks`
- All callback handlers: model selection, voice selection, workspace selection (with auth, invalid, same-value, stale entry, disallowed history paths)
- Voice command handlers: mode toggling, voice switching, TTS-disabled guard
- Media handlers: `handle_message` (non-TOTP path), `handle_photo`, `handle_document` (image/text/other branches), `handle_voice` (dependency checks, transcription errors, success)
- `_handle_response` streaming: normal flow, stop interruption, error paths (no response, failure), long response chunking, session saving, voice-only mode (with TTS fallback), text+voice mode, typing task cancellation

### Part 5: new test files + install gaps (3 new files, 50 tests added)
- **test_transcribe.py** (new, 9 tests): `_run()` subprocess helper (success, missing binary, non-zero exit, timeout, stderr truncation) + `transcribe_voice()` pipeline (model validation, full ffmpeg+whisper flow)
- **test_tts.py** (new, 13 tests): input validation (empty text, unknown voice, missing model), piper subprocess errors (not found, timeout, failure), ffmpeg subprocess errors (not found, timeout, failure), full success pipeline with temp directory redirection
- **test_main.py** (new, 6 tests): `setup_logging()` handler configuration, log levels, directory creation
- **test_install.py** (+22 tests): `_set_ownership` (single/recursive), `_copy_tree` (basic/excludes/overwrite), `_user_home` (known/unknown user, platform branching), `_generate_launcher_script`, `_apply_source`, `_apply_models`, dry-run paths for `_apply_secrets`/`_apply_sudoers`/`_apply_service`

## Test plan

- [x] `make test` passes (636 passed, 0 failed)
- [x] `make lint` clean
- [x] `make fmt` clean
- [x] No production code modified
- [x] CI should pass (test-only changes)