### PR TITLE
Fix workspace/.claude/ directory ownership for service user

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -959,7 +959,7 @@ def _cmd_apply() -> None:
             print(f"  WARNING: {warning}")
 
     # -- Step 2: Copy source --
-    _apply_source(install_path, dry_run)
+    _apply_source(install_path, svc_uid, svc_gid, dry_run)
 
     # -- Step 3: Create/update venv --
     _apply_venv(install_path, is_update, dry_run)
@@ -1052,7 +1052,7 @@ def _apply_directories(
             print(f"  Created {path}")
 
 
-def _apply_source(install_path: Path, dry_run: bool) -> None:
+def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool) -> None:
     """Copy source tree and workspace config from PROJECT_ROOT to the install location."""
     src_src = PROJECT_ROOT / "src"
     src_dst = install_path / "src"
@@ -1079,10 +1079,14 @@ def _apply_source(install_path: Path, dry_run: bool) -> None:
     # Copy workspace/.claude/ (bot identity, memory template) excluding
     # runtime data. Without CLAUDE.md, the bot has no identity in the home
     # workspace and nothing to inject into foreign workspace sessions.
+    # Files inside are root-owned (read-only config), but the directory
+    # itself is service-user-owned so history.py can create history/ at
+    # runtime.
     if ws_claude_src.is_dir():
         ws_claude_dst.parent.mkdir(parents=True, exist_ok=True)
         _copy_tree(ws_claude_src, ws_claude_dst, _WORKSPACE_CLAUDE_EXCLUDES)
         _set_ownership(ws_claude_dst, 0, 0, recursive=True)
+        os.chown(ws_claude_dst, svc_uid, svc_gid)
         print(f"  Copied workspace config to {ws_claude_dst}")
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1073,7 +1073,7 @@ class TestApplySource:
         ws_claude.mkdir(parents=True)
         (ws_claude / "CLAUDE.md").write_text("identity")
         with patch("kai.install.PROJECT_ROOT", tmp_path):
-            _apply_source(tmp_path / "install", dry_run=True)
+            _apply_source(tmp_path / "install", svc_uid=1000, svc_gid=1000, dry_run=True)
         output = capsys.readouterr().out
         assert "DRY RUN" in output
         assert "Would copy" in output
@@ -1083,7 +1083,7 @@ class TestApplySource:
     def test_dry_run_no_workspace_claude(self, tmp_path, capsys):
         """Dry run without workspace/.claude/: no workspace copy message."""
         with patch("kai.install.PROJECT_ROOT", tmp_path):
-            _apply_source(tmp_path / "install", dry_run=True)
+            _apply_source(tmp_path / "install", svc_uid=1000, svc_gid=1000, dry_run=True)
         output = capsys.readouterr().out
         assert "DRY RUN" in output
         assert "workspace" not in output.lower() or "workspace config" not in output
@@ -1106,14 +1106,21 @@ class TestApplySource:
             patch("kai.install._copy_tree") as mock_copy,
             patch("kai.install._set_ownership") as mock_own,
             patch("shutil.copy2") as mock_cp,
-            patch("os.chown"),
+            patch("os.chown") as mock_chown,
         ):
-            _apply_source(install, dry_run=False)
+            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
         # Should call _copy_tree twice: once for src/, once for workspace/.claude/
         assert mock_copy.call_count == 2
         # Should call _set_ownership twice: once for src/, once for workspace/.claude/
         assert mock_own.call_count == 2
         mock_cp.assert_called_once()
+        # os.chown called twice: once for pyproject.toml (root), once for
+        # the .claude/ directory itself (service user)
+        ws_claude_dst = install / "workspace" / ".claude"
+        chown_calls = mock_chown.call_args_list
+        assert any(c.args == (ws_claude_dst, 1000, 1000) for c in chown_calls), (
+            f"Expected os.chown({ws_claude_dst}, 1000, 1000) in {chown_calls}"
+        )
 
     def test_actual_no_workspace_claude(self, tmp_path):
         """Actual without workspace/.claude/: copies source only, no error."""
@@ -1131,7 +1138,7 @@ class TestApplySource:
             patch("shutil.copy2") as mock_cp,
             patch("os.chown"),
         ):
-            _apply_source(install, dry_run=False)
+            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
         # Only one _copy_tree call (src/), no workspace/.claude/ copy
         mock_copy.assert_called_once()
         mock_own.assert_called_once()
@@ -1158,7 +1165,7 @@ class TestApplySource:
             patch("shutil.copy2"),
             patch("os.chown"),
         ):
-            _apply_source(install, dry_run=False)
+            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
 
         # Second _copy_tree call is for workspace/.claude/
         ws_call = mock_copy.call_args_list[1]


### PR DESCRIPTION
## Summary

- Fix `.claude/` directory ownership in `_apply_source()` so the service user can create `history/` at runtime
- Files inside (CLAUDE.md, MEMORY.md.example) stay root-owned and read-only
- The directory itself is set to service-user ownership after the recursive root chown
- Without this fix, `history.py` crashes with `PermissionError` when writing conversation logs

Follow-up to PR #41 which introduced the workspace/.claude/ copy.

## Test plan

- [x] `test_actual` verifies `os.chown(ws_claude_dst, svc_uid, svc_gid)` is called
- [x] All existing tests updated with new `svc_uid`/`svc_gid` parameters
- [x] Full test suite: 648 tests pass, ruff clean
