### PR TITLE
Fix change_workspace() orphaning claude process during streaming

### DIFF
--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -632,11 +632,20 @@ class PersistentClaude:
         Kill the subprocess immediately and clean up resources.
 
         Sends SIGKILL, waits up to 5 seconds for exit, then clears all
-        process state. The timeout prevents hanging on zombie processes
-        (the previous bare wait() had no timeout). Idempotent - safe to
-        call even if the process has already exited.
+        process state. After clearing, sends one final SIGKILL to the
+        saved process group to catch any orphaned children that survived
+        the initial signal (e.g., claude reparented to init after sudo
+        died). The timeout prevents hanging on zombie processes.
+        Idempotent - safe to call even if the process has already exited.
         """
         if self._proc:
+            # Save pgid before clearing - the EOF handler in _send_locked()
+            # may call _kill() again after we clear self._pgid, but we need
+            # to ensure the process group gets signaled at least once more
+            # after the wait completes (belt-and-suspenders for the race
+            # where sudo dies but claude survives the initial SIGKILL).
+            saved_pgid = self._pgid
+
             self._send_signal(signal.SIGKILL)
             try:
                 await asyncio.wait_for(self._proc.wait(), timeout=5)
@@ -646,6 +655,17 @@ class PersistentClaude:
             self._pgid = None
             self._session_id = None
             self._session_started_at = None
+
+            # Final cleanup: signal the saved process group one more time.
+            # If claude was reparented to init during the wait, this catches
+            # it. If everything is already dead, killpg raises OSError which
+            # we ignore. Only applies to claude_user mode (pgid is None
+            # otherwise).
+            if saved_pgid is not None:
+                try:
+                    os.killpg(saved_pgid, signal.SIGKILL)
+                except OSError:
+                    pass
         if self._stderr_task:
             self._stderr_task.cancel()
             self._stderr_task = None
@@ -665,6 +685,8 @@ class PersistentClaude:
         _send_signal() handles already-dead processes via OSError instead.
         """
         if self._proc:
+            saved_pgid = self._pgid
+
             self._send_signal(signal.SIGTERM)
             try:
                 await asyncio.wait_for(self._proc.wait(), timeout=5)
@@ -674,6 +696,9 @@ class PersistentClaude:
                     await asyncio.wait_for(self._proc.wait(), timeout=5)
                 except TimeoutError:
                     log.warning("Process did not exit after SIGKILL; abandoning")
+        else:
+            saved_pgid = None
+
         # Clean up state regardless of how (or whether) the process exited
         self._proc = None
         self._pgid = None
@@ -681,3 +706,11 @@ class PersistentClaude:
         if self._stderr_task:
             self._stderr_task.cancel()
             self._stderr_task = None
+
+        # Final cleanup: signal the saved process group one more time
+        # to catch any orphaned children that survived the initial signals.
+        if saved_pgid is not None:
+            try:
+                os.killpg(saved_pgid, signal.SIGKILL)
+            except OSError:
+                pass

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1206,6 +1206,83 @@ class TestKill:
         assert claude._proc is None
         assert claude._session_id is None
 
+    @pytest.mark.asyncio
+    async def test_kill_signals_saved_pgid_after_clearing(self):
+        """_kill sends a final SIGKILL to the saved pgid after clearing state.
+
+        This is the core fix for the orphan race: even after self._pgid is
+        cleared (making subsequent _kill() calls no-ops), the saved pgid
+        gets one final signal to catch any claude process that survived
+        the initial SIGKILL (e.g., reparented to init after sudo died).
+        """
+        claude = _make_claude(claude_user="daniel")
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        mock_proc.wait = AsyncMock()
+        claude._proc = mock_proc
+        claude._pgid = 12345
+
+        with patch("os.killpg") as mock_killpg:
+            await claude._kill()
+
+        # killpg called at least twice: once from _send_signal (initial SIGKILL)
+        # and once from the final cleanup after state is cleared
+        killpg_calls = [call.args for call in mock_killpg.call_args_list]
+        assert len(killpg_calls) >= 2
+        assert (12345, signal.SIGKILL) in killpg_calls
+
+    @pytest.mark.asyncio
+    async def test_kill_no_final_signal_without_pgid(self):
+        """Final cleanup is skipped when _pgid is None (non-claude_user mode).
+
+        Without claude_user, _proc IS the claude process and send_signal()
+        on the proc is sufficient. No process group signal needed.
+        """
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        mock_proc.send_signal = MagicMock()
+        mock_proc.wait = AsyncMock()
+        claude._proc = mock_proc
+        # _pgid is None (no claude_user)
+
+        with patch("os.killpg") as mock_killpg:
+            await claude._kill()
+
+        # killpg should never be called in non-claude_user mode
+        mock_killpg.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_second_kill_is_noop_but_orphan_already_handled(self):
+        """Simulates the race: first _kill() handles the orphan, second is a no-op.
+
+        change_workspace() calls _kill() while the streaming loop is active.
+        The streaming loop sees EOF and calls _kill() again. The second call
+        is a no-op (self._proc is None), but the first call already sent the
+        final signal to the saved pgid, so the orphan is handled.
+        """
+        claude = _make_claude(claude_user="daniel")
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        mock_proc.wait = AsyncMock()
+        claude._proc = mock_proc
+        claude._pgid = 12345
+
+        with patch("os.killpg") as mock_killpg:
+            # First call: from change_workspace() - signals and clears state
+            await claude._kill()
+            first_call_count = mock_killpg.call_count
+
+            # Verify state is cleared
+            assert claude._proc is None
+            assert claude._pgid is None
+
+            # Second call: from EOF handler - no-op since _proc is None
+            await claude._kill()
+
+            # No additional killpg calls from the second _kill()
+            assert mock_killpg.call_count == first_call_count
+
 
 # ── shutdown ─────────────────────────────────────────────────────────
 
@@ -1362,6 +1439,31 @@ class TestShutdown:
 
         assert "did not exit" in caplog.text.lower()
         assert claude._proc is None
+
+    @pytest.mark.asyncio
+    async def test_shutdown_signals_saved_pgid_after_clearing(self):
+        """shutdown sends a final SIGKILL to the saved pgid after state cleanup.
+
+        Same belt-and-suspenders pattern as _kill(): saves the pgid before
+        clearing state, then signals the process group one final time to
+        catch any orphaned claude process that survived the initial signals.
+        """
+        claude = _make_claude(claude_user="daniel")
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        mock_proc.wait = AsyncMock()
+        claude._proc = mock_proc
+        claude._pgid = 12345
+
+        with patch("os.killpg") as mock_killpg:
+            await claude.shutdown()
+
+        # Final killpg call should be SIGKILL to the saved pgid
+        killpg_calls = [call.args for call in mock_killpg.call_args_list]
+        # At least: SIGTERM from _send_signal, and final SIGKILL cleanup
+        assert (12345, signal.SIGKILL) in killpg_calls
+        assert claude._proc is None
+        assert claude._pgid is None
 
 
 # ── change_workspace ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- When `change_workspace()`, `/stop`, or `/new` call `_kill()` while `_send_locked()` is actively streaming, the old claude process can become orphaned (PPID=1). The race: `_kill()` sends SIGKILL and clears `self._pgid`, then the streaming loop sees EOF and calls `_kill()` again, but the pgid is gone so it cannot reach a claude process that survived the initial signal (e.g., reparented to init after sudo died).
- Fix: save the pgid before clearing state, then send a final SIGKILL to the saved process group after `_proc.wait()` completes. If everything is already dead, the signal harmlessly raises OSError.
- Applied the same pattern to `shutdown()` for consistency.
- 4 new tests covering the saved-pgid behavior, the no-pgid skip, and the double-kill race simulation.

## Test plan

- [x] 677 tests pass (`make test`)
- [x] Ruff check + format clean
- [ ] Verify in production: `/workspace` during active response no longer leaves orphaned claude processes (`ps aux | grep claude`)

Fixes #51
