### PR TITLE
Notify user when message queues behind busy lock

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -107,6 +107,57 @@ def _clear_responding() -> None:
     _RESPONDING_FLAG.unlink(missing_ok=True)
 
 
+async def _notify_if_queued(update: Update, chat_id: int) -> bool:
+    """Send a notification if the user's message will queue behind the lock.
+
+    Called immediately before acquiring the per-chat lock. If the lock is
+    already held (Kai is mid-response), sends a one-line Telegram message
+    so the user knows their message was received. The notification goes
+    directly to Telegram via _reply_safe - Claude never sees it. Do NOT
+    add a log_message call here; the notification is purely for the user.
+
+    Returns True if the message is queuing (lock was held), False otherwise.
+    The caller uses this to decide whether to prepend a context-switch
+    marker to the prompt via _prepend_queue_marker().
+
+    There is a harmless TOCTOU gap: if the lock holder releases between
+    the locked() check and the subsequent acquire, the user sees "finishing
+    something up" followed by an instant response, and Claude gets a
+    context-switch marker for a task that already finished. Both are
+    harmless and not worth fixing.
+    """
+    if get_lock(chat_id).locked():
+        assert update.message is not None
+        await _reply_safe(
+            update.message,
+            "Got your message - finishing something up. /stop to interrupt.",
+        )
+        return True
+    return False
+
+
+# Prepended to prompts that waited behind the lock, so Claude focuses on the
+# new message instead of continuing from the previous task's tool output.
+_QUEUED_MESSAGE_MARKER = (
+    "[The user sent this while you were working on something else. "
+    "Their previous task is done. Focus on this new message.]\n\n"
+)
+
+
+def _prepend_queue_marker(prompt: str | list[dict[str, str]]) -> str | list[dict[str, str]]:
+    """Prepend context-switch marker to a prompt that waited behind the lock.
+
+    Handles both plain string prompts (text, document, voice) and multimodal
+    content lists (photo). For lists, prepends to the first text block's text
+    field and passes subsequent blocks (e.g., base64 image) through unchanged.
+    """
+    if isinstance(prompt, list):
+        # Multimodal content (photo): prepend to the first text block
+        first = prompt[0]
+        return [{"type": "text", "text": _QUEUED_MESSAGE_MARKER + first["text"]}] + prompt[1:]
+    return _QUEUED_MESSAGE_MARKER + prompt
+
+
 # ── Update property helpers (Pyright can't narrow @property returns) ─
 
 
@@ -1152,10 +1203,18 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": b64}},
     ]
 
+    was_queued = await _notify_if_queued(update, chat_id)
     async with get_lock(chat_id):
         _set_responding(chat_id)
         try:
-            await _handle_response(update, context, chat_id, content, claude, model)
+            await _handle_response(
+                update,
+                context,
+                chat_id,
+                _prepend_queue_marker(content) if was_queued else content,
+                claude,
+                model,
+            )
         finally:
             _clear_responding()
 
@@ -1308,10 +1367,18 @@ async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         )
         content = (caption or f"File received: {file_name}") + f"\n[File saved to: {saved}]"
 
+    was_queued = await _notify_if_queued(update, chat_id)
     async with get_lock(chat_id):
         _set_responding(chat_id)
         try:
-            await _handle_response(update, context, chat_id, content, claude, model)
+            await _handle_response(
+                update,
+                context,
+                chat_id,
+                _prepend_queue_marker(content) if was_queued else content,
+                claude,
+                model,
+            )
         finally:
             _clear_responding()
 
@@ -1380,10 +1447,18 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     prompt = f"[Voice message transcription]: {transcript}"
     model = claude.model
 
+    was_queued = await _notify_if_queued(update, chat_id)
     async with get_lock(chat_id):
         _set_responding(chat_id)
         try:
-            await _handle_response(update, context, chat_id, prompt, claude, model)
+            await _handle_response(
+                update,
+                context,
+                chat_id,
+                _prepend_queue_marker(prompt) if was_queued else prompt,
+                claude,
+                model,
+            )
         finally:
             _clear_responding()
 
@@ -1495,10 +1570,18 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     claude = _get_claude(context)
     model = claude.model
 
+    was_queued = await _notify_if_queued(update, chat_id)
     async with get_lock(chat_id):
         _set_responding(chat_id)
         try:
-            await _handle_response(update, context, chat_id, prompt, claude, model)
+            await _handle_response(
+                update,
+                context,
+                chat_id,
+                _prepend_queue_marker(prompt) if was_queued else prompt,
+                claude,
+                model,
+            )
         finally:
             _clear_responding()
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -10,7 +10,6 @@ handler using mock Telegram Update/Context objects.
 import asyncio
 import json
 import logging
-from contextlib import asynccontextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -18,12 +17,15 @@ import pytest
 from telegram.error import BadRequest
 
 from kai.bot import (
+    _QUEUED_MESSAGE_MARKER,
     _chunk_text,
     _clear_responding,
     _edit_message_safe,
     _is_authorized,
     _is_workspace_allowed,
     _models_keyboard,
+    _notify_if_queued,
+    _prepend_queue_marker,
     _reply_safe,
     _require_auth,
     _resolve_workspace_path,
@@ -458,10 +460,14 @@ def _make_context(config=None, claude=None, args=None, user_data=None, job_queue
     return ctx
 
 
-@asynccontextmanager
-async def _fake_lock(*_args, **_kwargs):
-    """Async context manager stand-in for the per-chat asyncio.Lock."""
-    yield
+def _fake_lock(*_args, **_kwargs):
+    """Return a real asyncio.Lock to stand in for the per-chat lock.
+
+    Uses a real Lock instead of a bare async context manager so that both
+    async-with and .locked() work (the latter is needed by _notify_if_queued).
+    The lock starts unlocked, so _notify_if_queued correctly skips notification.
+    """
+    return asyncio.Lock()
 
 
 def _text_event(text: str) -> StreamEvent:
@@ -2157,3 +2163,151 @@ class TestHandleResponse:
             await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
 
         # If we got here without hanging, the typing task was properly cancelled
+
+
+# ── _notify_if_queued ────────────────────────────────────────────────
+
+
+class TestNotifyIfQueued:
+    """Tests for the pre-lock queue notification and context-switch marker."""
+
+    @pytest.mark.asyncio
+    async def test_sends_when_locked(self):
+        """Sends a notification and returns True when the lock is already held."""
+        update = _make_update()
+        chat_id = 12345
+
+        # Acquire the lock to simulate Kai being busy
+        from kai.locks import get_lock
+
+        lock = get_lock(chat_id)
+        await lock.acquire()
+        try:
+            result = await _notify_if_queued(update, chat_id)
+            assert result is True
+            # The notification goes via reply_text (called by _reply_safe)
+            update.message.reply_text.assert_called()
+            call_text = update.message.reply_text.call_args[0][0]
+            assert "Got your message" in call_text
+            assert "/stop" in call_text
+        finally:
+            lock.release()
+
+    @pytest.mark.asyncio
+    async def test_silent_when_unlocked(self):
+        """Does nothing and returns False when the lock is free."""
+        update = _make_update()
+        # Use a unique chat_id to avoid lock state from other tests
+        chat_id = 99999
+
+        result = await _notify_if_queued(update, chat_id)
+
+        assert result is False
+        update.message.reply_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_notification_not_sent_to_claude(self):
+        """The notification goes directly to Telegram, not through Claude."""
+        update = _make_update()
+        chat_id = 12345
+
+        from kai.locks import get_lock
+
+        lock = get_lock(chat_id)
+        await lock.acquire()
+        try:
+            # Mock Claude's send to verify it's never called
+            mock_claude = _make_mock_claude()
+            mock_claude.send = MagicMock()
+
+            await _notify_if_queued(update, chat_id)
+
+            # Claude.send was never called; the notification uses reply_text
+            mock_claude.send.assert_not_called()
+            update.message.reply_text.assert_called()
+        finally:
+            lock.release()
+
+    @pytest.mark.asyncio
+    async def test_queued_message_gets_notification_then_processes(self):
+        """Integration test: message B gets a notification while A holds the lock.
+
+        Simulates two concurrent messages: A acquires the lock and processes,
+        B arrives while A is busy, gets a notification, then processes after
+        A releases. Proves the full flow works end to end.
+        """
+        update_b = _make_update(text="second message")
+        chat_id = 77777
+
+        from kai.locks import get_lock
+
+        lock = get_lock(chat_id)
+
+        # Track ordering of events
+        events: list[str] = []
+
+        async def handler_a():
+            """Simulate message A holding the lock."""
+            async with lock:
+                events.append("a_acquired")
+                # Simulate processing time so B's handler runs
+                await asyncio.sleep(0.05)
+                events.append("a_released")
+
+        async def handler_b():
+            """Simulate message B arriving while A is busy."""
+            # Small delay so A grabs the lock first
+            await asyncio.sleep(0.01)
+            # This is the pre-lock notification
+            result = await _notify_if_queued(update_b, chat_id)
+            assert result is True
+            events.append("b_notified")
+            async with lock:
+                events.append("b_acquired")
+
+        await asyncio.gather(handler_a(), handler_b())
+
+        # B's notification happened while A held the lock
+        assert events.index("b_notified") > events.index("a_acquired")
+        assert events.index("b_notified") < events.index("a_released")
+        # B acquired the lock after A released
+        assert events.index("b_acquired") > events.index("a_released")
+        # B got the notification
+        update_b.message.reply_text.assert_called()
+        call_text = update_b.message.reply_text.call_args[0][0]
+        assert "Got your message" in call_text
+
+
+class TestPrependQueueMarker:
+    """Tests for _prepend_queue_marker(), the context-switch prompt helper."""
+
+    def test_string_prompt(self):
+        """Prepends marker to a plain string prompt."""
+        result = _prepend_queue_marker("hello world")
+        assert result.startswith(_QUEUED_MESSAGE_MARKER)
+        assert result.endswith("hello world")
+
+    def test_multimodal_prompt(self):
+        """Prepends marker to the first text block of a multimodal list."""
+        content = [
+            {"type": "text", "text": "Photo caption"},
+            {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "abc"}},
+        ]
+        result = _prepend_queue_marker(content)
+        assert isinstance(result, list)
+        assert len(result) == 2
+        # First block has marker prepended
+        assert result[0]["text"].startswith(_QUEUED_MESSAGE_MARKER)
+        assert result[0]["text"].endswith("Photo caption")
+        # Second block (image) is unchanged
+        assert result[1] == content[1]
+
+    def test_does_not_mutate_original(self):
+        """Returns a new list; does not mutate the original content."""
+        content = [
+            {"type": "text", "text": "original"},
+            {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "abc"}},
+        ]
+        _prepend_queue_marker(content)
+        # Original is untouched
+        assert content[0]["text"] == "original"

--- a/tests/test_bot_totp.py
+++ b/tests/test_bot_totp.py
@@ -14,8 +14,8 @@ wrapped by @_require_auth which silently drops updates from unauthorized users
 access control, we bypass the auth check in all cases.
 """
 
+import asyncio
 import time
-from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from kai.bot import handle_message
@@ -53,10 +53,13 @@ def _make_context(user_data: dict | None = None) -> MagicMock:
     return ctx
 
 
-@asynccontextmanager
-async def _fake_lock(*_args, **_kwargs):
-    """Async context manager stand-in for the per-chat asyncio.Lock."""
-    yield
+def _fake_lock(*_args, **_kwargs):
+    """Return a real asyncio.Lock to stand in for the per-chat lock.
+
+    Uses a real Lock instead of a bare async context manager so that both
+    async-with and .locked() work (the latter is needed by _notify_if_queued).
+    """
+    return asyncio.Lock()
 
 
 def _downstream_patches() -> dict:


### PR DESCRIPTION
## Summary

- When Kai is mid-response (per-chat lock held), incoming messages silently wait with no feedback. From the user perspective, Kai is ignoring them. When the lock releases, Claude's context is dominated by the previous task's tool output, so the queued message gets buried or receives a confused response.
- Adds `_notify_if_queued()` - checks `lock.locked()` before acquiring. If held, sends "Got your message - finishing something up. /stop to interrupt." directly to Telegram. Claude never sees the notification.
- Adds `_prepend_queue_marker()` - when a message waited behind the lock, prepends a context-switch marker to the prompt so Claude focuses on the new message instead of continuing from previous output. Handles both string and multimodal (photo) prompts.
- Applied to all four message handlers (text, photo, document, voice).
- Avoids the race condition that killed the previous attempt (Feb 2026, commit 3122dcd): that used an asyncio.Task during the locked section, which raced with the streaming loop. This approach sends the notification entirely before entering the lock.
- Updated `_fake_lock` in test helpers to use a real `asyncio.Lock()` so both `.locked()` and `async with` work correctly.

## Test plan

- [x] 680 tests pass (`make test`)
- [x] Ruff check + format clean
- [ ] Send a message while Kai is mid-response, verify notification appears
- [ ] Verify Claude responds to the queued message (not the previous task)
- [ ] Send a message when Kai is idle, verify no notification and no marker
- [ ] Verify /stop works from the notification context
