### PR TITLE
Add PR review webhook routing and rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,12 @@ WEBHOOK_PORT=8080
 # HMAC secret for verifying incoming webhook payloads
 WEBHOOK_SECRET=your-webhook-secret
 
+# PR Review Agent (auto-review PRs when GitHub webhooks fire)
+# Opt-in: disabled by default. Enable to have Kai post code reviews on PRs.
+# Cooldown prevents review spam from rapid force-pushes to the same PR.
+#PR_REVIEW_ENABLED=true
+#PR_REVIEW_COOLDOWN=300
+
 # Telegram webhook URL - where Telegram pushes updates
 # If set, uses webhook mode (requires a tunnel/proxy). If unset, falls back to polling.
 #TELEGRAM_WEBHOOK_URL=https://your-host/webhook/telegram

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -131,6 +131,13 @@ class Config:
     # When unset, Claude runs as the same user as the bot (development default).
     claude_user: str | None = None
 
+    # PR review agent: automatically review PRs when GitHub webhooks fire.
+    # Disabled by default so existing users are not surprised by automatic reviews.
+    pr_review_enabled: bool = False
+    # Minimum seconds between reviews of the same PR. Absorbs force-push bursts
+    # so rapid pushes to an open PR don't trigger a review for each one.
+    pr_review_cooldown: int = 300
+
     # TOTP two-factor authentication timing (only relevant when TOTP is enabled)
     totp_session_minutes: int = 30
     totp_challenge_seconds: int = 120
@@ -284,6 +291,14 @@ def load_config() -> Config:
         webhook_port = int(os.environ.get("WEBHOOK_PORT", "8080"))
     except ValueError:
         raise SystemExit("WEBHOOK_PORT must be an integer") from None
+
+    # PR review agent config
+    pr_review_enabled = os.environ.get("PR_REVIEW_ENABLED", "").lower() in ("1", "true", "yes")
+    try:
+        pr_review_cooldown = int(os.environ.get("PR_REVIEW_COOLDOWN", "300"))
+    except ValueError:
+        raise SystemExit("PR_REVIEW_COOLDOWN must be an integer") from None
+
     try:
         totp_session_minutes = int(os.environ.get("TOTP_SESSION_MINUTES", "30"))
     except ValueError:
@@ -317,6 +332,8 @@ def load_config() -> Config:
         workspace_base=workspace_base,
         allowed_workspaces=allowed_workspaces,
         claude_user=os.environ.get("CLAUDE_USER") or None,
+        pr_review_enabled=pr_review_enabled,
+        pr_review_cooldown=pr_review_cooldown,
         totp_session_minutes=totp_session_minutes,
         totp_challenge_seconds=totp_challenge_seconds,
         totp_lockout_attempts=totp_lockout_attempts,

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -44,6 +44,7 @@ import hmac
 import json
 import logging
 import re
+import time
 from pathlib import Path
 
 from aiohttp import web
@@ -80,6 +81,47 @@ _HEALTH_CHECK_INTERVAL = 300  # 5 minutes
 # Slightly longer than the check interval so a single transient error
 # in the previous cycle triggers a re-registration on the next check.
 _ERROR_RECENCY_THRESHOLD = 600  # 10 minutes
+
+
+# ── PR review rate limiting ─────────────────────────────────────────
+# In-memory cooldown dict: (repo_full_name, pr_number) -> last_review_timestamp.
+# Resets on restart, which is acceptable - worst case is one extra review
+# after a restart. No database table needed for stateless reviews.
+_review_cooldowns: dict[tuple[str, int], float] = {}
+
+
+def _should_skip_review(repo: str, pr_number: int, cooldown: int) -> bool:
+    """
+    Check if a PR was reviewed recently enough to skip this event.
+
+    Uses the in-memory cooldown dict to absorb force-push bursts.
+    Returns True if the PR should NOT be reviewed (still in cooldown).
+
+    Args:
+        repo: GitHub repo full name (e.g., "dcellison/kai").
+        pr_number: The PR number.
+        cooldown: Minimum seconds between reviews of the same PR.
+    """
+    key = (repo, pr_number)
+    last_review = _review_cooldowns.get(key)
+    if last_review is None:
+        return False
+    return (time.time() - last_review) < cooldown
+
+
+def _record_review(repo: str, pr_number: int) -> None:
+    """
+    Record that a PR review was just initiated, updating the cooldown timestamp.
+
+    Called after a review is successfully launched (not after it completes,
+    since the review runs as a background task and we want to prevent
+    duplicate launches, not duplicate completions).
+
+    Args:
+        repo: GitHub repo full name (e.g., "dcellison/kai").
+        pr_number: The PR number.
+    """
+    _review_cooldowns[(repo, pr_number)] = time.time()
 
 
 def _strip_markdown(text: str) -> str:
@@ -336,6 +378,34 @@ async def _handle_github(request: web.Request) -> web.Response:
     except json.JSONDecodeError:
         return web.Response(status=400, text="Invalid JSON")
 
+    # ── PR review routing ────────────────────────────────────────
+    # When PR review is enabled, reviewable PR events (opened, reopened,
+    # synchronize) are routed to the review pipeline instead of the
+    # notification formatter. Non-reviewable actions (closed, merged)
+    # still get the standard Telegram notification.
+    pr_review_enabled = request.app.get("pr_review_enabled", False)
+    if pr_review_enabled and event_type == "pull_request":
+        action = payload.get("action", "")
+        if action in ("opened", "reopened", "synchronize"):
+            pr = payload.get("pull_request", {})
+            pr_number = pr.get("number", 0)
+            repo = payload.get("repository", {}).get("full_name", "")
+            cooldown = request.app.get("pr_review_cooldown", 300)
+
+            if _should_skip_review(repo, pr_number, cooldown):
+                log.info("Skipping review of %s PR #%d (cooldown)", repo, pr_number)
+                return web.json_response({"msg": "review_cooldown"})
+
+            _record_review(repo, pr_number)
+
+            # Launch the review as a background task. The actual review
+            # logic is in review.py (issue #55/#56). For now, just log.
+            # This will be wired up in issue #56.
+            log.info("PR review triggered for %s PR #%d (%s)", repo, pr_number, action)
+            # TODO(#56): launch review background task here
+            return web.json_response({"status": "review_triggered"})
+
+    # ── Standard notification path ───────────────────────────────
     # Look up the formatter for this event type
     formatter = _GITHUB_FORMATTERS.get(event_type)
     if not formatter:
@@ -827,8 +897,6 @@ async def _webhook_health_loop(bot, webhook_url: str, webhook_secret: str) -> No
     Condition 3 requires two consecutive checks to avoid false positives
     from normal message bursts (a single check catching in-flight updates).
     """
-    import time
-
     await asyncio.sleep(_HEALTH_CHECK_INTERVAL)  # skip the first check (just registered)
 
     # Track pending updates across consecutive checks. A single non-zero
@@ -921,6 +989,10 @@ async def start(telegram_app, config) -> None:
 
     # Store workspace path for send-file path confinement
     _app["workspace"] = str(config.claude_workspace)
+
+    # PR review agent config - stored in app for access by _handle_github()
+    _app["pr_review_enabled"] = config.pr_review_enabled
+    _app["pr_review_cooldown"] = config.pr_review_cooldown
 
     _app.router.add_get("/health", _handle_health)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,8 @@ _CONFIG_ENV_VARS = [
     "WORKSPACE_BASE",
     "ALLOWED_WORKSPACES",
     "CLAUDE_USER",
+    "PR_REVIEW_ENABLED",
+    "PR_REVIEW_COOLDOWN",
     "KAI_DATA_DIR",
     "KAI_INSTALL_DIR",
 ]
@@ -444,3 +446,31 @@ class TestDualModeLoading:
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "from-env")
         config = load_config()
         assert config.telegram_bot_token == "from-env"
+
+
+# ── PR review config ─────────────────────────────────────────────
+
+
+class TestPRReviewConfig:
+    def test_defaults(self, monkeypatch):
+        """PR review is disabled by default with a 5-minute cooldown."""
+        _set_required(monkeypatch)
+        config = load_config()
+        assert config.pr_review_enabled is False
+        assert config.pr_review_cooldown == 300
+
+    def test_enabled_with_custom_cooldown(self, monkeypatch):
+        """PR_REVIEW_ENABLED and PR_REVIEW_COOLDOWN are picked up from env."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("PR_REVIEW_ENABLED", "true")
+        monkeypatch.setenv("PR_REVIEW_COOLDOWN", "60")
+        config = load_config()
+        assert config.pr_review_enabled is True
+        assert config.pr_review_cooldown == 60
+
+    def test_cooldown_invalid_raises(self, monkeypatch):
+        """Non-numeric PR_REVIEW_COOLDOWN raises SystemExit."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("PR_REVIEW_COOLDOWN", "not_a_number")
+        with pytest.raises(SystemExit, match="PR_REVIEW_COOLDOWN"):
+            load_config()

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2,6 +2,12 @@
 
 import hashlib
 import hmac
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
 
 from kai.webhook import (
     _fmt_issue_comment,
@@ -9,6 +15,10 @@ from kai.webhook import (
     _fmt_pull_request,
     _fmt_pull_request_review,
     _fmt_push,
+    _handle_github,
+    _record_review,
+    _review_cooldowns,
+    _should_skip_review,
     _strip_markdown,
     _verify_github_signature,
 )
@@ -233,3 +243,257 @@ class TestFmtPullRequestReview:
 
     def test_non_submitted_action_returns_none(self):
         assert _fmt_pull_request_review(_review_payload("edited", "approved")) is None
+
+
+# ── _should_skip_review / _record_review ────────────────────────────
+
+
+class TestReviewCooldown:
+    def setup_method(self):
+        """Clear the cooldown dict before each test."""
+        _review_cooldowns.clear()
+
+    def test_first_review_not_skipped(self):
+        """A PR that has never been reviewed should not be skipped."""
+        assert _should_skip_review("owner/repo", 1, 300) is False
+
+    def test_recent_review_skipped(self):
+        """A PR reviewed within the cooldown window should be skipped."""
+        _record_review("owner/repo", 1)
+        assert _should_skip_review("owner/repo", 1, 300) is True
+
+    def test_different_pr_not_skipped(self):
+        """Cooldown is per-PR, so a different PR number is not skipped."""
+        _record_review("owner/repo", 1)
+        assert _should_skip_review("owner/repo", 2, 300) is False
+
+    def test_different_repo_not_skipped(self):
+        """Cooldown is per-repo+PR, so a different repo is not skipped."""
+        _record_review("owner/repo", 1)
+        assert _should_skip_review("other/repo", 1, 300) is False
+
+    def test_expired_cooldown_not_skipped(self):
+        """After cooldown expires, the PR can be reviewed again."""
+        from unittest.mock import patch
+
+        _record_review("owner/repo", 1)
+        # Advance time past the cooldown
+        import time
+
+        future = time.time() + 301
+        with patch("kai.webhook.time.time", return_value=future):
+            assert _should_skip_review("owner/repo", 1, 300) is False
+
+
+# ── PR review routing (integration tests) ──────────────────────────
+
+
+# Shared secret used to sign GitHub webhook payloads in tests
+_TEST_SECRET = "test-webhook-secret"
+
+
+def _sign_payload(payload: dict) -> str:
+    """Compute HMAC-SHA256 signature for a GitHub webhook payload."""
+    body = json.dumps(payload).encode()
+    digest = hmac.new(_TEST_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _make_pr_payload(action: str, pr_number: int = 42, merged: bool = False) -> dict:
+    """Build a minimal pull_request webhook payload."""
+    return {
+        "action": action,
+        "pull_request": {
+            "title": "Test PR",
+            "number": pr_number,
+            "user": {"login": "testuser"},
+            "html_url": f"https://github.com/owner/repo/pull/{pr_number}",
+            "merged": merged,
+        },
+        "repository": {"full_name": "owner/repo"},
+    }
+
+
+def _build_test_app(pr_review_enabled: bool = True, cooldown: int = 300) -> web.Application:
+    """Build a minimal aiohttp app with _handle_github wired up."""
+    app = web.Application()
+    app["webhook_secret"] = _TEST_SECRET
+    app["pr_review_enabled"] = pr_review_enabled
+    app["pr_review_cooldown"] = cooldown
+    # Mock bot that records sent messages
+    mock_bot = AsyncMock()
+    app["telegram_bot"] = mock_bot
+    app["chat_id"] = 12345
+    app.router.add_post("/webhook/github", _handle_github)
+    return app
+
+
+@pytest.fixture
+def _clear_cooldowns():
+    """Clear the review cooldown dict before each routing test."""
+    _review_cooldowns.clear()
+    yield
+    _review_cooldowns.clear()
+
+
+class TestPRReviewRouting:
+    """Integration tests for PR review routing in _handle_github."""
+
+    @pytest.mark.asyncio
+    async def test_routes_opened_when_enabled(self, _clear_cooldowns):
+        """Reviewable PR events are routed to review pipeline, not Telegram."""
+        app = _build_test_app(pr_review_enabled=True)
+        payload = _make_pr_payload("opened")
+        body = json.dumps(payload).encode()
+        sig = _sign_payload(payload)
+
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/webhook/github",
+                data=body,
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-Hub-Signature-256": sig,
+                },
+            )
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["status"] == "review_triggered"
+            # Should NOT have sent a Telegram notification
+            app["telegram_bot"].send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_through_when_disabled(self, _clear_cooldowns):
+        """With PR review disabled, opened events go to the notification formatter."""
+        app = _build_test_app(pr_review_enabled=False)
+        payload = _make_pr_payload("opened")
+        body = json.dumps(payload).encode()
+        sig = _sign_payload(payload)
+
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/webhook/github",
+                data=body,
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-Hub-Signature-256": sig,
+                },
+            )
+            data = await resp.json()
+            assert resp.status == 200
+            # Falls through to _fmt_pull_request, which formats a notification
+            assert data.get("status") == "ok"
+            app["telegram_bot"].send_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cooldown_skips_recent(self, _clear_cooldowns):
+        """Second event for the same PR within cooldown returns review_cooldown."""
+        app = _build_test_app(pr_review_enabled=True, cooldown=300)
+        payload = _make_pr_payload("synchronize", pr_number=10)
+        body = json.dumps(payload).encode()
+        sig = _sign_payload(payload)
+
+        async with TestClient(TestServer(app)) as client:
+            # First request triggers a review
+            resp1 = await client.post(
+                "/webhook/github",
+                data=body,
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-Hub-Signature-256": sig,
+                },
+            )
+            data1 = await resp1.json()
+            assert data1["status"] == "review_triggered"
+
+            # Second request hits cooldown
+            resp2 = await client.post(
+                "/webhook/github",
+                data=body,
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-Hub-Signature-256": sig,
+                },
+            )
+            data2 = await resp2.json()
+            assert data2["msg"] == "review_cooldown"
+
+    @pytest.mark.asyncio
+    async def test_cooldown_allows_after_expiry(self, _clear_cooldowns):
+        """After cooldown expires, the same PR can be reviewed again."""
+        from unittest.mock import patch
+
+        app = _build_test_app(pr_review_enabled=True, cooldown=60)
+        payload = _make_pr_payload("synchronize", pr_number=10)
+        body = json.dumps(payload).encode()
+        sig = _sign_payload(payload)
+
+        async with TestClient(TestServer(app)) as client:
+            # First request
+            resp1 = await client.post(
+                "/webhook/github",
+                data=body,
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-Hub-Signature-256": sig,
+                },
+            )
+            assert (await resp1.json())["status"] == "review_triggered"
+
+            # Advance time past the cooldown
+            import time
+
+            future = time.time() + 61
+            with patch("kai.webhook.time.time", return_value=future):
+                resp2 = await client.post(
+                    "/webhook/github",
+                    data=body,
+                    headers={
+                        "X-GitHub-Event": "pull_request",
+                        "X-Hub-Signature-256": sig,
+                    },
+                )
+                assert (await resp2.json())["status"] == "review_triggered"
+
+    @pytest.mark.asyncio
+    async def test_closed_still_notifies(self, _clear_cooldowns):
+        """Closed PRs go through the standard notification path, not the review pipeline."""
+        app = _build_test_app(pr_review_enabled=True)
+        payload = _make_pr_payload("closed", merged=False)
+        body = json.dumps(payload).encode()
+        sig = _sign_payload(payload)
+
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/webhook/github",
+                data=body,
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-Hub-Signature-256": sig,
+                },
+            )
+            data = await resp.json()
+            assert resp.status == 200
+            # Should fall through to _fmt_pull_request for the "closed" notification
+            assert data.get("status") == "ok"
+            app["telegram_bot"].send_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_synchronize_routed(self, _clear_cooldowns):
+        """synchronize events (new push to existing PR) are routed to review."""
+        app = _build_test_app(pr_review_enabled=True)
+        payload = _make_pr_payload("synchronize", pr_number=99)
+        body = json.dumps(payload).encode()
+        sig = _sign_payload(payload)
+
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/webhook/github",
+                data=body,
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-Hub-Signature-256": sig,
+                },
+            )
+            data = await resp.json()
+            assert data["status"] == "review_triggered"


### PR DESCRIPTION
## Summary

Part 1 of 6 for the PR review agent (ref #50).

- Add `PR_REVIEW_ENABLED` and `PR_REVIEW_COOLDOWN` config fields with env var parsing
- Route reviewable `pull_request` events (`opened`, `reopened`, `synchronize`) to the review pipeline when enabled; non-reviewable actions (`closed`, `merged`) still get standard Telegram notifications
- In-memory per-PR cooldown dict absorbs force-push bursts (default 5 min between reviews of the same PR)
- Review pipeline is a placeholder `TODO(#56)` - routing and rate limiting are functional, actual review logic comes in issues #55/#56

spec: workspace/specs/issue-54-pr-review-routing.md

## Test plan

- [x] Config defaults: `pr_review_enabled=False`, `pr_review_cooldown=300`
- [x] Config parsing from env vars (`PR_REVIEW_ENABLED=true`, `PR_REVIEW_COOLDOWN=60`)
- [x] Invalid `PR_REVIEW_COOLDOWN` raises `SystemExit`
- [x] Cooldown unit tests: first review not skipped, recent review skipped, different PR/repo not skipped, expired cooldown not skipped
- [x] Integration: `opened` event routed to review when enabled
- [x] Integration: `opened` event falls through to Telegram notification when disabled
- [x] Integration: cooldown skips second event for same PR
- [x] Integration: cooldown allows review after expiry
- [x] Integration: `closed` action still sends Telegram notification even with review enabled
- [x] Integration: `synchronize` action routed to review (previously silently ignored)
- [x] Full test suite passes (694 tests, 0 failures)
