### PR TITLE
Replace GITHUB_REPO with workspace-aware repo resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,8 +49,9 @@ WEBHOOK_SECRET=your-webhook-secret
 #PR_REVIEW_ENABLED=true
 #PR_REVIEW_COOLDOWN=300
 
-# GitHub repo name for review agent spec/convention resolution (e.g., "kai").
-# Must match the repo part of the full GitHub name (e.g., "kai" for dcellison/kai).
+# Deprecated: review agent now resolves repos via workspace config
+# (WORKSPACE_BASE, ALLOWED_WORKSPACES, workspace history). Kept for
+# backwards compatibility; the value is parsed but no longer used.
 #GITHUB_REPO=
 
 # Directory for spec files, relative to repo root (default: specs)

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -137,8 +137,9 @@ class Config:
     # Minimum seconds between reviews of the same PR. Absorbs force-push bursts
     # so rapid pushes to an open PR don't trigger a review for each one.
     pr_review_cooldown: int = 300
-    # GitHub repository name (just the repo part, not owner/repo). Used by the
-    # review agent to identify the local repo path for spec and convention resolution.
+    # Deprecated: review agent now resolves repos via workspace config.
+    # Kept for backwards compatibility with existing .env files; the value
+    # is parsed but no longer used by webhook.py.
     github_repo: str = ""
     # Directory (relative to repo root) where spec files live for
     # branch-name matching. Does not affect body marker resolution,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -333,6 +333,10 @@ def _cmd_config() -> None:
         "Allowed workspaces (comma-separated paths, optional)",
         existing_env.get("ALLOWED_WORKSPACES", ""),
     )
+    spec_dir = _prompt(
+        "Spec directory relative to repo root (for PR review agent)",
+        existing_env.get("SPEC_DIR", "specs"),
+    )
     print()
 
     # -- Optional features --
@@ -388,6 +392,9 @@ def _cmd_config() -> None:
         env["CLAUDE_USER"] = claude_user
     if perplexity_key:
         env["PERPLEXITY_API_KEY"] = perplexity_key
+    if spec_dir != "specs":
+        # Only write if non-default; config.py defaults to "specs"
+        env["SPEC_DIR"] = spec_dir
 
     # Build and write install.conf
     conf = {

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -124,6 +124,59 @@ def _record_review(repo: str, pr_number: int) -> None:
     _review_cooldowns[(repo, pr_number)] = time.time()
 
 
+async def _resolve_local_repo(repo_full_name: str, app: web.Application) -> str | None:
+    """
+    Resolve a GitHub repo name to a local filesystem path.
+
+    Matches the repo part of the full name (e.g., "kai" from "dcellison/kai")
+    against known workspace locations. Checks in priority order:
+
+    1. Home workspace (derived from app["workspace"] parent)
+    2. WORKSPACE_BASE children
+    3. ALLOWED_WORKSPACES entries
+    4. workspace_history entries from the database
+
+    Args:
+        repo_full_name: Full GitHub repo name (e.g., "dcellison/kai").
+        app: The aiohttp application with workspace config.
+
+    Returns:
+        Absolute path to the local repo checkout, or None if not found.
+    """
+    # Extract just the repo name from "owner/repo"
+    repo_name = repo_full_name.split("/")[-1]
+
+    # 1. Home workspace - the workspace parent is the repo root.
+    # app["workspace"] is the workspace subdirectory (e.g., /opt/kai/workspace),
+    # so .parent gives the repo root (e.g., /opt/kai/).
+    workspace = app.get("workspace")
+    if workspace:
+        home_path = Path(workspace).parent
+        if home_path.name == repo_name and home_path.is_dir():
+            return str(home_path)
+
+    # 2. WORKSPACE_BASE - scan immediate children for matching dir name
+    workspace_base = app.get("workspace_base")
+    if workspace_base:
+        candidate = Path(workspace_base) / repo_name
+        if candidate.is_dir():
+            return str(candidate)
+
+    # 3. ALLOWED_WORKSPACES - check each entry's directory name
+    for allowed in app.get("allowed_workspaces", []):
+        if Path(allowed).name == repo_name and Path(allowed).is_dir():
+            return str(allowed)
+
+    # 4. workspace_history - check each entry's directory name
+    history = await sessions.get_workspace_history(limit=50)
+    for entry in history:
+        path = Path(entry["path"])
+        if path.name == repo_name and path.is_dir():
+            return str(path)
+
+    return None
+
+
 def _strip_markdown(text: str) -> str:
     """
     Remove markdown syntax so text reads cleanly as plain Telegram text.
@@ -399,15 +452,9 @@ async def _handle_github(request: web.Request) -> web.Response:
             _record_review(repo, pr_number)
 
             # Resolve a local repo path for spec/convention loading.
-            # If the webhook event is for the home repo, derive the repo
-            # root from the workspace path. app["workspace"] stores the
-            # workspace subdirectory (e.g., /opt/kai/workspace), but spec
-            # paths are relative to the repo root, so we need the parent.
-            local_repo_path = None
-            workspace = request.app.get("workspace")
-            home_repo = request.app.get("home_repo_name")
-            if home_repo and workspace and repo.endswith(f"/{home_repo}"):
-                local_repo_path = str(Path(workspace).parent)
+            # Checks home workspace, WORKSPACE_BASE, ALLOWED_WORKSPACES,
+            # and workspace history for a directory matching the repo name.
+            local_repo_path = await _resolve_local_repo(repo, request.app)
 
             # Launch the review as a fire-and-forget background task.
             # Same pattern as Telegram update processing: create_task +
@@ -1021,10 +1068,11 @@ async def start(telegram_app, config) -> None:
     _app["webhook_port"] = config.webhook_port
     _app["claude_user"] = config.claude_user
 
-    # The GitHub repo name for the home workspace (e.g., "kai").
-    # Configured via GITHUB_REPO env var. Used to resolve local repo
-    # paths for spec compliance checking (#57) and conventions (#58).
-    _app["home_repo_name"] = config.github_repo
+    # Workspace config for review agent repo resolution. These let
+    # _resolve_local_repo() match incoming PR webhook repos against
+    # local checkouts without a hardcoded GITHUB_REPO setting.
+    _app["workspace_base"] = str(config.workspace_base) if config.workspace_base else None
+    _app["allowed_workspaces"] = [str(p) for p in config.allowed_workspaces]
     _app["spec_dir"] = config.spec_dir
 
     _app.router.add_get("/health", _handle_health)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -287,6 +287,7 @@ class TestCmdConfig:
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces (empty)
+                "specs",  # spec dir (default)
                 "false",  # voice
                 "false",  # tts
                 "",  # claude user (empty)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -17,6 +17,7 @@ from kai.webhook import (
     _fmt_push,
     _handle_github,
     _record_review,
+    _resolve_local_repo,
     _review_cooldowns,
     _should_skip_review,
     _strip_markdown,
@@ -323,10 +324,12 @@ def _build_test_app(pr_review_enabled: bool = True, cooldown: int = 300) -> web.
     # Config needed by review background tasks
     app["webhook_port"] = 8080
     app["claude_user"] = None
-    # Spec/convention resolution config: workspace path, repo name, and
-    # spec directory for launching review background tasks.
-    app["workspace"] = "/home/user/workspace"
-    app["home_repo_name"] = "repo"
+    # Workspace config for review agent repo resolution. The workspace
+    # path parent name ("repo") matches the test payload repo name so
+    # _resolve_local_repo() finds it via the home workspace check.
+    app["workspace"] = "/home/user/repo/workspace"
+    app["workspace_base"] = None
+    app["allowed_workspaces"] = []
     app["spec_dir"] = "specs"
     # Mock bot that records sent messages
     mock_bot = AsyncMock()
@@ -344,11 +347,18 @@ def _clear_cooldowns():
     _review_cooldowns.clear()
 
 
+@pytest.fixture(autouse=False)
+def _mock_resolve_repo():
+    """Mock _resolve_local_repo so routing tests skip filesystem/DB checks."""
+    with patch("kai.webhook._resolve_local_repo", new_callable=AsyncMock, return_value=None):
+        yield
+
+
 class TestPRReviewRouting:
     """Integration tests for PR review routing in _handle_github."""
 
     @pytest.mark.asyncio
-    async def test_routes_opened_when_enabled(self, _clear_cooldowns):
+    async def test_routes_opened_when_enabled(self, _clear_cooldowns, _mock_resolve_repo):
         """Reviewable PR events are routed to review pipeline, not Telegram."""
         app = _build_test_app(pr_review_enabled=True)
         payload = _make_pr_payload("opened")
@@ -394,7 +404,7 @@ class TestPRReviewRouting:
             app["telegram_bot"].send_message.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_cooldown_skips_recent(self, _clear_cooldowns):
+    async def test_cooldown_skips_recent(self, _clear_cooldowns, _mock_resolve_repo):
         """Second event for the same PR within cooldown returns review_cooldown."""
         app = _build_test_app(pr_review_enabled=True, cooldown=300)
         payload = _make_pr_payload("synchronize", pr_number=10)
@@ -427,7 +437,7 @@ class TestPRReviewRouting:
             assert data2["msg"] == "review_cooldown"
 
     @pytest.mark.asyncio
-    async def test_cooldown_allows_after_expiry(self, _clear_cooldowns):
+    async def test_cooldown_allows_after_expiry(self, _clear_cooldowns, _mock_resolve_repo):
         """After cooldown expires, the same PR can be reviewed again."""
         from unittest.mock import patch
 
@@ -487,7 +497,7 @@ class TestPRReviewRouting:
             app["telegram_bot"].send_message.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_synchronize_routed(self, _clear_cooldowns):
+    async def test_synchronize_routed(self, _clear_cooldowns, _mock_resolve_repo):
         """synchronize events (new push to existing PR) are routed to review."""
         app = _build_test_app(pr_review_enabled=True)
         payload = _make_pr_payload("synchronize", pr_number=99)
@@ -507,7 +517,7 @@ class TestPRReviewRouting:
             assert data["status"] == "review_triggered"
 
     @pytest.mark.asyncio
-    async def test_launches_background_task(self, _clear_cooldowns):
+    async def test_launches_background_task(self, _clear_cooldowns, _mock_resolve_repo):
         """Reviewable PR events launch review.review_pr as a background task."""
         app = _build_test_app(pr_review_enabled=True)
         payload = _make_pr_payload("opened")
@@ -537,7 +547,166 @@ class TestPRReviewRouting:
             assert call_kwargs[0][0] == payload
             assert call_kwargs[1]["webhook_port"] == 8080
             assert call_kwargs[1]["webhook_secret"] == _TEST_SECRET
-            # local_repo_path should be the parent of workspace (repo root,
-            # not the workspace subdirectory) since the payload repo matches
-            # home_repo_name.
-            assert call_kwargs[1]["local_repo_path"] == "/home/user"
+            # _resolve_local_repo is mocked to return None here;
+            # dedicated tests for resolution logic are in TestResolveLocalRepo.
+            assert call_kwargs[1]["local_repo_path"] is None
+
+
+# ── _resolve_local_repo ─────────────────────────────────────────────
+
+
+class TestResolveLocalRepo:
+    """Tests for workspace-aware repo resolution."""
+
+    @pytest.mark.asyncio
+    async def test_home_workspace(self, tmp_path):
+        """Resolves via home workspace when parent dir name matches repo."""
+        # Create a directory structure like /tmp/.../kai/workspace
+        repo_dir = tmp_path / "kai"
+        repo_dir.mkdir()
+        workspace_dir = repo_dir / "workspace"
+        workspace_dir.mkdir()
+
+        app = web.Application()
+        app["workspace"] = str(workspace_dir)
+        app["workspace_base"] = None
+        app["allowed_workspaces"] = []
+
+        result = await _resolve_local_repo("dcellison/kai", app)
+        assert result == str(repo_dir)
+
+    @pytest.mark.asyncio
+    async def test_workspace_base(self, tmp_path):
+        """Resolves via WORKSPACE_BASE when a child dir matches repo name."""
+        # Create ~/Projects/anvil/ structure
+        anvil_dir = tmp_path / "anvil"
+        anvil_dir.mkdir()
+
+        app = web.Application()
+        app["workspace"] = "/nonexistent/workspace"
+        app["workspace_base"] = str(tmp_path)
+        app["allowed_workspaces"] = []
+
+        result = await _resolve_local_repo("dcellison/anvil", app)
+        assert result == str(anvil_dir)
+
+    @pytest.mark.asyncio
+    async def test_allowed_workspaces(self, tmp_path):
+        """Resolves via ALLOWED_WORKSPACES when dir name matches."""
+        myrepo = tmp_path / "myrepo"
+        myrepo.mkdir()
+
+        app = web.Application()
+        app["workspace"] = "/nonexistent/workspace"
+        app["workspace_base"] = None
+        app["allowed_workspaces"] = [str(myrepo)]
+
+        result = await _resolve_local_repo("owner/myrepo", app)
+        assert result == str(myrepo)
+
+    @pytest.mark.asyncio
+    async def test_workspace_history(self, tmp_path):
+        """Resolves via workspace_history entries from the database."""
+        history_repo = tmp_path / "historic"
+        history_repo.mkdir()
+
+        app = web.Application()
+        app["workspace"] = "/nonexistent/workspace"
+        app["workspace_base"] = None
+        app["allowed_workspaces"] = []
+
+        with patch(
+            "kai.webhook.sessions.get_workspace_history",
+            new_callable=AsyncMock,
+            return_value=[{"path": str(history_repo)}],
+        ):
+            result = await _resolve_local_repo("owner/historic", app)
+        assert result == str(history_repo)
+
+    @pytest.mark.asyncio
+    async def test_priority_order(self, tmp_path):
+        """Home workspace wins over workspace_base."""
+        # Both home and base have a matching "kai" directory
+        home_repo = tmp_path / "home" / "kai"
+        home_repo.mkdir(parents=True)
+        home_workspace = home_repo / "workspace"
+        home_workspace.mkdir()
+
+        base_dir = tmp_path / "base"
+        base_kai = base_dir / "kai"
+        base_kai.mkdir(parents=True)
+
+        app = web.Application()
+        app["workspace"] = str(home_workspace)
+        app["workspace_base"] = str(base_dir)
+        app["allowed_workspaces"] = []
+
+        result = await _resolve_local_repo("dcellison/kai", app)
+        # Home workspace should win
+        assert result == str(home_repo)
+
+    @pytest.mark.asyncio
+    async def test_no_match(self, tmp_path):
+        """Returns None when no workspace matches the repo."""
+        app = web.Application()
+        app["workspace"] = str(tmp_path / "unrelated" / "workspace")
+        app["workspace_base"] = str(tmp_path)
+        app["allowed_workspaces"] = []
+
+        with patch(
+            "kai.webhook.sessions.get_workspace_history",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await _resolve_local_repo("owner/nonexistent", app)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_dir_skipped(self, tmp_path):
+        """History entries pointing to deleted directories are skipped."""
+        app = web.Application()
+        app["workspace"] = "/nonexistent/workspace"
+        app["workspace_base"] = None
+        app["allowed_workspaces"] = []
+
+        with patch(
+            "kai.webhook.sessions.get_workspace_history",
+            new_callable=AsyncMock,
+            return_value=[{"path": "/gone/deleted-repo"}],
+        ):
+            result = await _resolve_local_repo("owner/deleted-repo", app)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_handler_uses_resolve(self, _clear_cooldowns):
+        """_handle_github calls _resolve_local_repo instead of old home_repo_name logic."""
+        app = _build_test_app(pr_review_enabled=True)
+        payload = _make_pr_payload("opened")
+        body = json.dumps(payload).encode()
+        sig = _sign_payload(payload)
+
+        with (
+            patch(
+                "kai.webhook._resolve_local_repo",
+                new_callable=AsyncMock,
+                return_value="/resolved/path",
+            ) as mock_resolve,
+            patch("kai.webhook.review.review_pr", new_callable=AsyncMock),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/webhook/github",
+                    data=body,
+                    headers={
+                        "X-GitHub-Event": "pull_request",
+                        "X-Hub-Signature-256": sig,
+                    },
+                )
+                assert (await resp.json())["status"] == "review_triggered"
+
+            import asyncio
+
+            await asyncio.sleep(0.01)
+
+            # Verify _resolve_local_repo was called with the repo name
+            mock_resolve.assert_called_once_with("owner/repo", app)


### PR DESCRIPTION
## Summary

Fixes #67

- Replace `GITHUB_REPO` config with workspace-aware repo resolution for the PR review agent
- New `_resolve_local_repo()` checks home workspace, `WORKSPACE_BASE`, `ALLOWED_WORKSPACES`, and workspace history to match incoming PR webhooks to local repo checkouts
- Specs and CLAUDE.md conventions now load automatically for any repo Kai knows about, not just a single hardcoded one
- `GITHUB_REPO` deprecated (still parsed, no longer used)
- Add `SPEC_DIR` prompt to install config under Workspaces section

## Test plan

- [x] 766 tests pass (8 new)
- [x] `make check` clean (ruff + pyright)
- [x] `_resolve_local_repo` tested: home workspace, workspace_base, allowed_workspaces, workspace history, priority order, no match, nonexistent dir skipped
- [x] Handler integration test verifies `_resolve_local_repo` is called
- [x] Install config test updated for new `SPEC_DIR` prompt
- [ ] After merge and deploy, verify multi-repo PR reviews resolve correctly
