### PR TITLE
Add prior-comment awareness to PR review agent

### DIFF
--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -291,6 +291,8 @@ async def fetch_prior_comments(repo: str, pr_number: int) -> str | None:
             "api",
             f"repos/{repo}/issues/{pr_number}/comments",
             "--paginate",
+            "--jq",
+            ".[]",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -306,7 +308,13 @@ async def fetch_prior_comments(repo: str, pr_number: int) -> str | None:
             )
             return None
 
-        comments = json.loads(stdout.decode())
+        # --jq '.[]' flattens paginated arrays into newline-delimited JSON
+        # objects. Without this, --paginate concatenates JSON arrays
+        # ("[...][...]") which json.loads() cannot parse.
+        raw = stdout.decode().strip()
+        if not raw:
+            return None
+        comments = [json.loads(line) for line in raw.splitlines() if line.strip()]
     except Exception:
         log.warning(
             "Failed to fetch prior comments for %s#%d",
@@ -330,8 +338,10 @@ async def fetch_prior_comments(repo: str, pr_number: int) -> str | None:
         author = comment.get("user", {}).get("login", "unknown")
         timestamp = comment.get("created_at", "")
 
-        # Check if this comment is a review by Kai
-        is_review = body.startswith(_REVIEW_HEADER) or body.startswith(_REVIEW_HEADER.rstrip())
+        # Check if this comment is a review by Kai. Use the stripped
+        # header ("## Review by Kai") to match regardless of trailing
+        # newlines in the actual comment body.
+        is_review = body.startswith(_REVIEW_HEADER.rstrip())
 
         if is_review:
             # Start a new thread segment. Save the previous one if it exists.
@@ -364,9 +374,12 @@ async def fetch_prior_comments(repo: str, pr_number: int) -> str | None:
             if len(full_text) <= _MAX_PRIOR_COMMENTS_CHARS:
                 break
 
-        # If a single thread still exceeds the cap, truncate from the start
+        # If a single thread still exceeds the cap, truncate from the
+        # start and prepend a marker so Claude knows the context is partial.
         if len(full_text) > _MAX_PRIOR_COMMENTS_CHARS:
-            full_text = full_text[-_MAX_PRIOR_COMMENTS_CHARS:]
+            truncation_marker = "[... earlier comments truncated ...]\n"
+            available = _MAX_PRIOR_COMMENTS_CHARS - len(truncation_marker)
+            full_text = truncation_marker + full_text[-available:]
 
     return full_text
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -90,6 +90,11 @@ def _gh_comment(
     }
 
 
+def _ndjson(comments: list[dict]) -> bytes:
+    """Encode comments as newline-delimited JSON (gh api --jq '.[]' output)."""
+    return "\n".join(json.dumps(c) for c in comments).encode()
+
+
 # ── extract_pr_metadata ────────────────────────────────────────────
 
 
@@ -254,7 +259,7 @@ class TestFetchPriorComments:
             _gh_comment("Just a regular comment.", login="alice"),
             _gh_comment("Another comment.", login="bob"),
         ]
-        mock_proc = _mock_process(stdout=json.dumps(comments).encode())
+        mock_proc = _mock_process(stdout=_ndjson(comments))
 
         with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await fetch_prior_comments("owner/repo", 42)
@@ -271,7 +276,7 @@ class TestFetchPriorComments:
                 created_at="2026-03-12T14:00:00Z",
             ),
         ]
-        mock_proc = _mock_process(stdout=json.dumps(comments).encode())
+        mock_proc = _mock_process(stdout=_ndjson(comments))
 
         with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await fetch_prior_comments("owner/repo", 42)
@@ -301,7 +306,7 @@ class TestFetchPriorComments:
                 created_at="2026-03-12T16:00:00Z",
             ),
         ]
-        mock_proc = _mock_process(stdout=json.dumps(comments).encode())
+        mock_proc = _mock_process(stdout=_ndjson(comments))
 
         with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await fetch_prior_comments("owner/repo", 42)
@@ -327,7 +332,7 @@ class TestFetchPriorComments:
                 created_at="2026-03-12T14:00:00Z",
             ),
         ]
-        mock_proc = _mock_process(stdout=json.dumps(comments).encode())
+        mock_proc = _mock_process(stdout=_ndjson(comments))
 
         with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await fetch_prior_comments("owner/repo", 42)
@@ -347,7 +352,7 @@ class TestFetchPriorComments:
             _gh_comment(big_body, login="kai-bot", created_at="2026-03-12T14:00:00Z"),
             _gh_comment(small_body, login="kai-bot", created_at="2026-03-12T16:00:00Z"),
         ]
-        mock_proc = _mock_process(stdout=json.dumps(comments).encode())
+        mock_proc = _mock_process(stdout=_ndjson(comments))
 
         with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await fetch_prior_comments("owner/repo", 42)
@@ -356,6 +361,22 @@ class TestFetchPriorComments:
         # The recent review should survive; the old one should be dropped
         assert "Recent review is small." in result
         assert len(result) <= _MAX_PRIOR_COMMENTS_CHARS
+
+    @pytest.mark.asyncio
+    async def test_single_thread_truncation_adds_marker(self):
+        """When a single thread exceeds the cap, it is truncated with a marker."""
+        big_body = f"{_REVIEW_HEADER}{'z' * (_MAX_PRIOR_COMMENTS_CHARS + 5000)}"
+        comments = [
+            _gh_comment(big_body, login="kai-bot", created_at="2026-03-12T14:00:00Z"),
+        ]
+        mock_proc = _mock_process(stdout=_ndjson(comments))
+
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await fetch_prior_comments("owner/repo", 42)
+
+        assert result is not None
+        assert len(result) <= _MAX_PRIOR_COMMENTS_CHARS
+        assert result.startswith("[... earlier comments truncated ...]")
 
     @pytest.mark.asyncio
     async def test_api_failure_returns_none(self):
@@ -380,8 +401,8 @@ class TestFetchPriorComments:
 
     @pytest.mark.asyncio
     async def test_empty_comments_returns_none(self):
-        """Empty comment list returns None."""
-        mock_proc = _mock_process(stdout=b"[]")
+        """Empty comment list returns None (--jq '.[]' produces empty output)."""
+        mock_proc = _mock_process(stdout=b"")
 
         with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await fetch_prior_comments("owner/repo", 42)
@@ -400,7 +421,7 @@ class TestFetchPriorComments:
                 created_at="2026-03-12T14:00:00Z",
             ),
         ]
-        mock_proc = _mock_process(stdout=json.dumps(comments).encode())
+        mock_proc = _mock_process(stdout=_ndjson(comments))
 
         with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await fetch_prior_comments("owner/repo", 42)


### PR DESCRIPTION
## Summary

- Adds prior-comment awareness to the PR review agent so it stops re-flagging dismissed issues across review rounds
- `fetch_prior_comments()` retrieves the PR comment thread via `gh api`, filters for "Review by Kai" threads plus replies, and caps at 50K chars (oldest-first truncation)
- Prior comments are rendered as an XML-delimited `<prior-review-thread>` block in the review prompt, positioned between conventions and diff
- Graceful degradation: if the API call fails, the review proceeds without context rather than failing entirely

spec: workspace/specs/context-aware-pr-reviews.md

## Test plan

- [x] 10 new tests for `fetch_prior_comments` (no reviews, single, multiple, pre-review exclusion, truncation, API failure, exception, empty list, header variants)
- [x] 3 new tests for `build_review_prompt` with `prior_comments` (no tags when None, tags when present, ordering between sections)
- [x] 2 new integration tests for `review_pr` pipeline (prior comments injected, graceful degradation)
- [x] All existing tests updated for new `fetch_prior_comments` mock
- [x] Full suite: 826 tests pass, ruff clean
