### PR TITLE
Clean up workspace CLAUDE.md

### DIFF
--- a/workspace/.claude/CLAUDE.md
+++ b/workspace/.claude/CLAUDE.md
@@ -151,10 +151,15 @@ ISSUE_NUM=77           # the issue number to update
 ITEM_ID=$(gh project item-list $PROJECT_NUM --owner dcellison --format json \
   | jq -r ".items[] | select(.content.number == $ISSUE_NUM) | .id")
 
-# Look up the project ID, Status field ID, and option IDs
-gh project field-list $PROJECT_NUM --owner dcellison --format json
+# Look up the project node ID
+PROJECT_ID=$(gh project list --owner dcellison --format json \
+  | jq -r ".projects[] | select(.number == $PROJECT_NUM) | .id")
 
-# Update the status (use field/option IDs from the command above)
+# Look up the Status field ID and option IDs
+gh project field-list $PROJECT_NUM --owner dcellison --format json
+# Set FIELD_ID and OPTION_ID from the output above
+
+# Update the status
 gh project item-edit --project-id "$PROJECT_ID" --id "$ITEM_ID" \
   --field-id "$FIELD_ID" --single-select-option-id "$OPTION_ID"
 ```


### PR DESCRIPTION
## Summary

- Replace all em dashes with hyphens throughout the file
- Trim the scheduling API section from ~88 lines to ~55 by consolidating examples into a single code block and compacting the CRUD reference
- Standardize on `$KAI_WEBHOOK_SECRET` environment variable instead of the vague "SECRET" placeholder
- Add send-message API documentation (was missing despite being available to inner Claude)
- Generalize the GitHub Project Board section to use dynamic ID lookup via `gh project` commands instead of hardcoded issue numbers (#54-59) and project/field/option IDs

## Test plan

- [ ] Verify the file renders correctly on GitHub
- [ ] Confirm inner Claude can still use the scheduling API curl examples (double-quoted headers for variable expansion)
- [ ] Check that the `gh project` commands in the Project Board section work with real project data

Fixes #77
