### PR TITLE
Fix webhook handlers using stale chat_id for file and message delivery

### DIFF
--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -58,17 +58,23 @@ log = logging.getLogger(__name__)
 _RESPONDING_FLAG = DATA_DIR / ".responding_to"
 
 
-def _active_chat_id(app: web.Application) -> int:
+async def _active_chat_id(app: web.Application) -> int:
     """Return the chat ID of the user currently being served.
 
     While *bot.py* is processing a message it writes the requester's
     chat ID to a flag file.  Prefer that value so webhook responses
     (files, notifications) reach the correct user.  Fall back to the
     app-level default when the flag is absent.
+
+    Note: this assumes only one user is being served at a time.  If two
+    users are processed concurrently, bot.py's _set_responding() calls
+    will race on the same flag file.  A proper fix requires passing
+    chat_id through the MCP tool call.
     """
     try:
-        return int(_RESPONDING_FLAG.read_text().strip())
-    except (FileNotFoundError, ValueError):
+        text = await asyncio.to_thread(_RESPONDING_FLAG.read_text)
+        return int(text.strip())
+    except (OSError, ValueError):
         return app["chat_id"]
 
 
@@ -472,7 +478,7 @@ async def _handle_github(request: web.Request) -> web.Response:
     """
     secret = request.app["webhook_secret"]
     bot = request.app["telegram_bot"]
-    chat_id = _active_chat_id(request.app)
+    chat_id = request.app["chat_id"]
 
     body = await request.read()
 
@@ -612,7 +618,7 @@ async def _handle_generic(request: web.Request) -> web.Response:
     4096-char limit.
     """
     bot = request.app["telegram_bot"]
-    chat_id = _active_chat_id(request.app)
+    chat_id = request.app["chat_id"]
 
     try:
         payload = await request.json()
@@ -695,7 +701,7 @@ async def _handle_schedule(request: web.Request) -> web.Response:
         )
     auto_remove = payload.get("auto_remove", False)
     notify_on_check = payload.get("notify_on_check", False)
-    chat_id = _active_chat_id(request.app)
+    chat_id = await _active_chat_id(request.app)
 
     # schedule_data can arrive as a JSON object or a pre-serialized string
     if isinstance(schedule_data, dict):
@@ -739,7 +745,7 @@ async def _handle_get_jobs(request: web.Request) -> web.Response:
     without needing to parse Telegram bot command output.
     """
 
-    chat_id = _active_chat_id(request.app)
+    chat_id = await _active_chat_id(request.app)
     jobs = await sessions.get_jobs(chat_id)
     return web.json_response(jobs)
 
@@ -945,7 +951,7 @@ async def _handle_send_message(request: web.Request) -> web.Response:
         return web.json_response({"error": "Missing required field: text"}, status=400)
 
     bot = request.app["telegram_bot"]
-    chat_id = _active_chat_id(request.app)
+    chat_id = await _active_chat_id(request.app)
 
     try:
         # Telegram limits messages to 4096 characters. Split long messages
@@ -1025,7 +1031,7 @@ async def _handle_send_file(request: web.Request) -> web.Response:
         return web.json_response({"error": f"File not found: {file_path}"}, status=404)
 
     bot = request.app["telegram_bot"]
-    chat_id = _active_chat_id(request.app)
+    chat_id = await _active_chat_id(request.app)
     caption = payload.get("caption", "")
 
     # Send images as photos (Telegram renders them inline) and everything


### PR DESCRIPTION
## Summary

Webhook handlers (`_handle_send_file`, `_handle_send_message`, and 4 others) resolve `chat_id` from `request.app["chat_id"]` - a value set once at startup to `next(iter(allowed_user_ids))`. When multiple users are configured, every file, photo, and notification is delivered to whichever user happens to be first in the set, regardless of who is actually being served.

`bot.py` already writes the active requester's `chat_id` to a `.responding_to` flag file (via `_set_responding()`) before each `_handle_response()` call and removes it afterward. This PR makes webhook handlers read that flag file, falling back to the app-level default when it's absent.

## Problem

```mermaid
sequenceDiagram
    participant User_A as User A (chat 454579837)
    participant Bot as bot.py
    participant Claude as Claude subprocess
    participant WH as webhook.py

    Note over WH: app["chat_id"] = 960257093<br/>(first in allowed_user_ids, set at startup)

    User_A->>Bot: Send me a chart
    Bot->>Bot: _set_responding(454579837)
    Bot->>Claude: process prompt
    Claude->>WH: POST /api/send-file {path: "chart.png"}
    WH->>WH: chat_id = app["chat_id"] -> 960257093 ❌
    WH-->>User_A: ✗ File goes to User 960257093 instead
```

## Fix

```mermaid
sequenceDiagram
    participant User_A as User A (chat 454579837)
    participant Bot as bot.py
    participant Flag as .responding_to
    participant Claude as Claude subprocess
    participant WH as webhook.py

    User_A->>Bot: Send me a chart
    Bot->>Flag: write 454579837
    Bot->>Claude: process prompt
    Claude->>WH: POST /api/send-file {path: "chart.png"}
    WH->>Flag: read -> 454579837
    WH->>WH: chat_id = 454579837 ✅
    WH-->>User_A: ✓ File delivered to correct user
    Bot->>Flag: unlink (clear)
```

## Changes

File: `src/kai/webhook.py` (only file modified)

1. Import `DATA_DIR` from `kai.config`
2. Add `_RESPONDING_FLAG` constant (mirrors `bot.py:94`)
3. Add `_active_chat_id(app)` helper - reads the flag file, falls back to `app["chat_id"]`
4. Replace all 6 occurrences of `chat_id = request.app["chat_id"]` with `chat_id = _active_chat_id(request.app)`

Affected handlers:
| Handler | Purpose |
|---------|---------|
| `_handle_github` | GitHub webhook notifications |
| `_handle_generic` | Generic webhook notifications |
| `_handle_schedule` | Job scheduling |
| `_handle_get_jobs` | Job listing |
| `_handle_send_message` | Send text to Telegram |
| `_handle_send_file` | Send file/photo to Telegram |

## Why this is safe

- No new infrastructure - `bot.py` already writes/clears `.responding_to` around every `_handle_response()` call
- Graceful fallback - if the flag file is missing or contains invalid data, behavior is identical to before (uses app-level `chat_id`)
- External webhooks unaffected - GitHub/generic webhooks fire when no message is being processed, so `.responding_to` won't exist and the fallback kicks in
- Single-user setups unchanged - with one `allowed_user_id`, the flag file value and the app default are the same

## Test plan

- [ ] `ruff check src/kai/webhook.py` passes
- [ ] `ruff format --check src/kai/webhook.py` passes
- [ ] With 2+ users in `allowed_user_ids`: User A requests a file -> file is delivered to User A, not User B
- [ ] With 1 user: behavior unchanged
- [ ] GitHub webhook notification still delivered correctly (fallback path)