### PR TITLE
Fix CONTRIBUTING.md intro to not assume PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to Kai
 
 Thanks for your interest in contributing to Kai. This document covers
-what you need to know before opening a pull request.
+how the project accepts contributions and what to expect.
 
 ## How to Contribute
 


### PR DESCRIPTION
The opening line said "what you need to know before opening a pull request" - directly contradicting the section below it that says PRs are restricted to collaborators. Updated to neutral language that matches the document's actual message.