### PR TITLE
Rewrite CONTRIBUTING.md for current contribution policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,13 +5,27 @@ how the project accepts contributions and what to expect.
 
 ## How to Contribute
 
-**Pull requests are currently restricted to collaborators.** Kai's architecture is evolving quickly and all implementation is handled internally to keep the codebase coherent. This isn't permanent, but it's the right call for where the project is right now.
+**Pull requests are currently restricted to collaborators.** Kai's
+architecture is evolving quickly and all implementation is handled
+internally to keep the codebase coherent. This will open up as the
+project stabilizes - check back or watch the repo for updates.
 
-**The best way to contribute is through issues.** Bug reports, feature ideas, and design feedback are all welcome. For non-trivial proposals, include a spec: describe the problem, the proposed solution, what changes are needed, and what's explicitly out of scope. A well-written spec is more valuable than a surprise PR - it lets us discuss the approach before anyone writes code.
+**The best way to contribute right now is through issues.** Bug reports,
+feature ideas, and design feedback are all welcome. For non-trivial
+proposals, include a spec: describe the problem, the proposed solution,
+what changes are needed, and what's explicitly out of scope. A
+well-written spec is more valuable than a surprise PR - it lets us
+discuss the approach before anyone writes code.
 
-**Open an issue first.** Even if you're a collaborator, open an issue before starting work on anything non-trivial. This keeps the "why" (issue) separate from the "how" (PR) and gives the triage agent something to work with.
+**Open an issue first.** Even if you're a collaborator, open an issue
+before starting work on anything non-trivial. This keeps the "why"
+(issue) separate from the "how" (PR) and gives the triage agent
+something to work with.
 
 ## Development Setup
+
+If you want to run Kai locally (for testing, exploring, or preparing a
+future contribution):
 
 ```bash
 # Clone and install in a virtual environment
@@ -30,14 +44,14 @@ Requires **Python 3.13+**. See the
 [Getting Started](https://github.com/dcellison/kai/wiki/Getting-Started)
 wiki page for full setup instructions including `.env` configuration.
 
-**Development vs. production:** `make setup` installs in editable mode with dev
-dependencies for local development. For a protected deployment to `/opt/kai/`,
-use `python -m kai install config` followed by `sudo python -m kai install apply`
-instead. See the README for details.
-
 ## Branch and PR Workflow (Collaborators)
 
-Direct pushes to `main` are blocked. All changes go through pull requests with required CI checks.
+This section is for project collaborators with push access. If you're
+contributing through issues, you can skip this - but the standards below
+are useful context for writing specs.
+
+Direct pushes to `main` are blocked. All changes go through pull
+requests with required CI checks.
 
 1. **Create a branch** from `main` with a descriptive prefix:
    - `feature/` -- new functionality
@@ -49,13 +63,13 @@ Direct pushes to `main` are blocked. All changes go through pull requests with r
 
    Use kebab-case for the rest: `feature/file-exchange`, `fix/path-traversal`.
 
-2. **Keep PRs focused.** One feature or fix per PR. Don't bundle unrelated
-   changes -- if you notice something else worth fixing, open a separate PR.
+2. **Keep PRs focused.** One feature or fix per PR. If you notice
+   something else worth fixing, open a separate issue.
 
-3. **Review your own diff before submitting.** Every file in the diff should
-   be there intentionally. Unrelated deletions, reformatting of untouched
-   code, or tooling artifacts (`.idea/`, `.vscode/`, etc.) will get your
-   PR sent back.
+3. **Review your own diff before submitting.** Every file in the diff
+   should be there intentionally. Unrelated deletions, reformatting of
+   untouched code, or tooling artifacts (`.idea/`, `.vscode/`, etc.)
+   will get the PR sent back.
 
 4. **CI must pass.** The pipeline runs ruff (lint + format) and pytest.
    Check locally first:
@@ -63,20 +77,32 @@ Direct pushes to `main` are blocked. All changes go through pull requests with r
    make check && make test
    ```
 
-5. **Expect an automated review.** Kai runs a PR Review Agent that posts a code review comment on every push. It checks for bugs, security issues, missing error handling, and style violations. If you reference a spec file (add `spec: path/to/spec.md` in the PR body), it also checks your implementation against the spec. Treat its feedback like any other review - address what's valid, explain what's intentional.
+5. **Expect an automated review.** Kai runs a PR Review Agent that
+   posts a code review comment on every push. It checks for bugs,
+   security issues, missing error handling, and style violations. If
+   you reference a spec file (add `spec: path/to/spec.md` in the PR
+   body), it also checks your implementation against the spec. Treat
+   its feedback like any other review - address what's valid, explain
+   what's intentional.
 
-## Code Style
+## Project Standards
 
-### Python
+The following sections describe the standards the codebase follows.
+These apply to all code changes and are useful context for anyone
+proposing features or reviewing the architecture.
 
-- **Ruff** handles linting and formatting. The full rule configuration is in
-  `pyproject.toml`. Run `make format` to auto-format before committing.
+### Code Style
+
+- **Ruff** handles linting and formatting. The full rule configuration
+  is in `pyproject.toml`.
 - **Line length:** 120 characters max.
-- **Imports:** sorted by ruff's isort rules (stdlib, third-party, first-party).
+- **Imports:** sorted by ruff's isort rules (stdlib, third-party,
+  first-party).
 
 ### Comments and Docstrings
 
-Kai's codebase is thoroughly commented. New code must match this standard:
+The codebase is thoroughly commented. All code changes are expected to
+match this standard:
 
 - **Every function and class** gets a docstring. Single-line for simple
   helpers, multi-line with `Args:` / `Returns:` for anything non-trivial.
@@ -108,29 +134,30 @@ async def save_session(chat_id: int, session_id: str, model: str, cost_usd: floa
 
 ### Type Safety
 
-The codebase passes Pyright in strict mode. New code should maintain this:
+The codebase passes Pyright in strict mode. All code changes are
+expected to maintain this:
 
-- Use type annotations on all function signatures.
-- Use `assert` for narrowing `Optional` types from external libraries.
-- Extract `@property` returns to local variables before narrowing (Pyright
-  limitation).
+- Type annotations on all function signatures.
+- `assert` for narrowing `Optional` types from external libraries.
+- Extract `@property` returns to local variables before narrowing
+  (Pyright limitation).
 
-## Security
+### Security
 
-Kai exposes a webhook server and API endpoints. If your change touches
-networking, file I/O, or process execution:
+Kai exposes a webhook server and API endpoints. Changes that touch
+networking, file I/O, or process execution follow these rules:
 
-- **Path confinement:** Use `Path.relative_to()` for directory containment
+- **Path confinement:** `Path.relative_to()` for directory containment
   checks, not string prefix matching (which is bypassable via symlinks).
 - **Input validation:** Validate at system boundaries (user input, API
-  payloads, external data). Don't trust anything from the network.
+  payloads, external data). Nothing from the network is trusted.
 - **No new attack surface without discussion.** New endpoints, file
-  operations, or shell commands should be discussed in the issue first.
+  operations, or shell commands get discussed in an issue first.
 
-## Tests
+### Tests
 
 - Tests live in `tests/` and use **pytest** with **pytest-asyncio**.
-- New features need tests. Bug fixes should include a regression test where
+- New features need tests. Bug fixes include a regression test where
   practical.
 - Test the function directly when possible (unit tests over integration
   tests). Mock external dependencies (Telegram API, filesystem for
@@ -143,13 +170,15 @@ make test
 
 ## What Not to Include
 
+These should never appear in a pull request:
+
 - **Secrets or credentials** -- `.env` files, API keys, tokens. The
-  `.gitignore` already covers these, but double-check your diff.
+  `.gitignore` already covers these, but always verify before pushing.
 - **Generated files** -- IDE configs, OS metadata (`.DS_Store`), build
   artifacts, tool caches.
-- **Unrelated changes** -- reformatting files you didn't modify, deleting
-  files outside the scope of your feature, adding ignore rules for your
-  personal tooling.
+- **Unrelated changes** -- reformatting files that weren't otherwise
+  modified, deleting files outside the scope of the work, adding ignore
+  rules for personal tooling.
 
 ## License
 


### PR DESCRIPTION
## Summary

The previous CONTRIBUTING.md was written when PRs were open to everyone. When we restricted PRs to collaborators (PR #84), the policy section was added on top but the rest of the document still addressed the reader as a PR-submitting code contributor. This rewrite brings the entire document in line with the current policy.

PRs will be accepted from external contributors again once the architecture stabilizes. The document now says this explicitly and frames the project standards as useful context for anyone - including those contributing through issues and specs today.

### Changes

- Reframed "How to Contribute" to emphasize the temporary nature of PR restrictions and that they will open up
- Added context to Development Setup (useful for anyone, not just PR authors)
- Added a preamble to the collaborator workflow section so non-collaborators know they can skip it
- Consolidated Code Style, Type Safety, Security, and Tests under a new "Project Standards" heading with a framing paragraph
- Removed production deployment instructions (internal ops, not contribution guidance)
- Neutralized "your PR" / "your diff" / "your feature" language throughout
- Changed "open a separate PR" to "open a separate issue" to match issue-first workflow
