### PR TITLE
Deactivate one-shot Claude jobs after firing

### DIFF
--- a/src/kai/cron.py
+++ b/src/kai/cron.py
@@ -359,6 +359,8 @@ async def _job_callback(context: ContextTypes.DEFAULT_TYPE) -> None:
 
             # One-shot jobs will never fire again; deactivate the DB row.
             # APScheduler's run_once already removed it from the queue.
+            # Runs even if delivery failed above - the job can't retry
+            # regardless, so deactivating prevents a stale active=1 row.
             if data["schedule_type"] == "once":
                 await sessions.deactivate_job(job_id)
 
@@ -377,5 +379,7 @@ async def _job_callback(context: ContextTypes.DEFAULT_TYPE) -> None:
 
             # One-shot jobs will never fire again; deactivate the DB row.
             # APScheduler's run_once already removed it from the queue.
+            # Runs even if delivery failed above - the job can't retry
+            # regardless, so deactivating prevents a stale active=1 row.
             if data["schedule_type"] == "once":
                 await sessions.deactivate_job(job_id)

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -512,7 +512,9 @@ class TestJobCallbackClaude:
         ):
             await _job_callback(self.ctx)
         mock_deactivate.assert_called_once_with(1)
-        # APScheduler handles queue removal for run_once; no schedule_removal needed
+        # APScheduler handles queue removal for run_once jobs automatically.
+        # schedule_removal() is only needed for recurring jobs being manually
+        # removed (e.g., in the Forbidden handler). One-shot jobs never need it.
         self.ctx.job.schedule_removal.assert_not_called()
 
     @pytest.mark.asyncio()


### PR DESCRIPTION
## Summary

One-shot Claude jobs (`schedule_type == "once"`, `job_type == "claude"`) were never deactivated in the database after firing. APScheduler's `run_once` removed them from the in-memory scheduler queue, but the DB row stayed `active=1` until the next restart when `_register_new_jobs` caught it as an "expired one-shot."

The reminder path had the correct check since the beginning (`if data["schedule_type"] == "once": await sessions.deactivate_job(job_id)`). The Claude job path was missing it in two of its three branches.

### What changed

Added the one-shot deactivation check to two branches in `_job_callback`:

1. **CONDITION_NOT_MET path** - A one-shot auto-remove job whose condition is not met on its single firing will never fire again. Now correctly deactivated.

2. **Non-conditional else path** - A plain one-shot Claude job (no auto_remove) fires, delivers its response, and now correctly deactivates. This was the main bug.

The **CONDITION_MET path** already deactivates unconditionally via auto_remove logic - no change needed.

### What did NOT change

- No `schedule_removal()` calls added - APScheduler handles that for `run_once` jobs
- No changes to the reminder path (already correct)
- No changes to the try/except blocks (purely additive)
- No changes to the CONDITION_MET path (already deactivates)

Fixes #112

## Test plan

- [x] `test_one_shot_claude_deactivates_after_sending` - one-shot Claude job deactivates after delivery, no schedule_removal called
- [x] `test_recurring_claude_does_not_deactivate` - daily/interval jobs NOT deactivated (regression guard)
- [x] `test_one_shot_condition_not_met_deactivates` - one-shot auto-remove job deactivates even when condition not met
- [x] All 1018 tests pass (3 new)
