### PR TITLE
Kill subprocess before mutating state in change_workspace()

### DIFF
--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -723,9 +723,14 @@ class PersistentClaude:
             workspace_config: Per-workspace config for the target, or
                 None to use global defaults.
         """
-        # No lock needed: _kill() terminates the process, and the next send()
-        # call will start fresh in the new workspace via _ensure_started().
-        # Any in-flight send() will see EOF on stdout and clean up.
+        # Kill first, then mutate. An in-flight _send_locked() reads
+        # self.workspace, self.timeout_seconds, and self.workspace_config
+        # at various await points during streaming. If we mutate before
+        # killing, the stream sees new config values while still running
+        # the old workspace's process. Killing first ensures the stream
+        # hits EOF and exits before any state changes.
+        await self._kill()
+
         self.workspace = new_workspace
         self.workspace_config = workspace_config
 
@@ -745,8 +750,6 @@ class PersistentClaude:
                 self.max_budget_usd = workspace_config.budget
             if workspace_config.timeout is not None:
                 self.timeout_seconds = workspace_config.timeout
-
-        await self._kill()
 
     async def restart(self) -> None:
         """

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1540,6 +1540,25 @@ class TestChangeWorkspace:
         assert claude.workspace == new_path
         mock_kill.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_kill_before_state_mutation(self):
+        """_kill() runs before attributes are mutated, not after."""
+        claude = _make_claude()
+        original_workspace = claude.workspace
+        kill_order: list[tuple[str, Path]] = []
+
+        async def tracking_kill():
+            # Record what workspace was set when _kill was called
+            kill_order.append(("kill", claude.workspace))
+
+        with patch.object(claude, "_kill", side_effect=tracking_kill):
+            await claude.change_workspace(Path("/tmp/new-workspace"))
+
+        # _kill should have seen the ORIGINAL workspace, not the new one
+        assert kill_order == [("kill", original_workspace)]
+        # Final state should still be the new workspace
+        assert claude.workspace == Path("/tmp/new-workspace")
+
 
 # ── restart ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Move `await self._kill()` above attribute mutations in `change_workspace()` to fix a race condition
- An in-flight `_send_locked()` reads `self.workspace`, `self.timeout_seconds`, and `self.workspace_config` at multiple `await` points during streaming
- With the old ordering (mutate then kill), the stream could see new config values while still running the old workspace process - e.g., applying workspace B timeout to workspace A subprocess
- Killing first ensures the stream hits EOF and exits before any state changes take effect

The attribute mutation block itself is unchanged. This is purely a reordering of `_kill()` relative to the mutations.

## The race

```
                         Old ordering                    New ordering
                         ───────────                     ───────────
_send_locked() running   self.workspace = B              await self._kill()
  on workspace A...      self.model = B_model              stream sees EOF, exits
                         self.timeout = B_timeout
                         await self._kill()              self.workspace = B
                           stream sees B timeout           self.model = B_model
                           while still on A                self.timeout = B_timeout
```

## Test plan

- [x] New ordering test: patches `_kill` with a side-effect that records `self.workspace` at call time, asserts it sees the original workspace (not the new one)
- [x] All 1034 existing tests pass (existing `TestChangeWorkspace` and `TestWorkspaceConfig` tests verify final attribute values, which are unchanged)
- [x] `make lint` clean
- [x] Visual verification: `await self._kill()` appears before any `self.workspace =` or `self.model =` assignments

Fixes #121
