### PR TITLE
Filter non-code messages in TOTP gate

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -1648,12 +1648,14 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
             code = update.message.text.strip() if update.message.text else ""
 
-            # Only treat 6-digit strings as code attempts. Other messages
-            # (e.g., normal chat that arrived concurrently with the challenge)
-            # are dropped with a brief reminder instead of being fed to
-            # verify_code(). This prevents message deletion, spurious
+            # Only treat 6-digit ASCII strings as code attempts. Other
+            # messages (e.g., normal chat that arrived concurrently with the
+            # challenge) are dropped with a brief reminder instead of being
+            # fed to verify_code(). This prevents message deletion, spurious
             # "Invalid code" responses, and unnecessary sudo calls.
-            if not code.isdigit() or len(code) != 6:
+            # Note: isascii() guard is needed because isdigit() accepts
+            # non-ASCII digit characters (superscripts, Arabic-Indic, etc.).
+            if not (code.isascii() and code.isdigit() and len(code) == 6):
                 await update.effective_chat.send_message("Authentication required. Enter your 6-digit code.")
                 return
 

--- a/tests/test_bot_totp.py
+++ b/tests/test_bot_totp.py
@@ -355,7 +355,7 @@ async def test_non_code_message_not_deleted():
     mock_verify.assert_not_called()
     # User should see a reminder
     sent = update.effective_chat.send_message.call_args[0][0]
-    assert "6-digit" in sent.lower() or "code" in sent.lower()
+    assert "6-digit" in sent
 
 
 async def test_six_digit_code_still_verified():


### PR DESCRIPTION
## Summary

- Add a format check (exactly 6 digits) before the TOTP verification path in `handle_message()`
- With `concurrent_updates=True`, messages arriving while a TOTP challenge is pending were unconditionally treated as code attempts
- This caused three problems for non-code messages: (1) message deletion, (2) spurious "Invalid code" responses, (3) unnecessary `sudo` calls via `get_lockout_remaining()`/`get_failure_count()`
- Non-code messages now get a brief "Enter your 6-digit code" reminder and return without touching the verification machinery
- `verify_code()` in `totp.py` already has the same format guard (line 171) as defense-in-depth, but the handler needs to distinguish non-codes before reaching the delete/lockout/verify path

## What changed

Single `if` block added between `code = ...` and the message deletion block in `handle_message()`. Everything downstream (delete, lockout check, verify_code, failure handling) is untouched.

## Test plan

- [x] `test_non_code_message_not_deleted` - normal text not deleted, verify_code not called, reminder sent
- [x] `test_six_digit_code_still_verified` - 6-digit strings still reach verify_code and get deleted
- [x] `test_non_code_no_sudo_calls` - no sudo-backed functions called for non-code text
- [x] `test_partial_digit_string_not_treated_as_code` - edge cases: 5 digits, 7 digits, mixed alphanumeric, prefixed digits
- [x] Existing `test_code_message_deleted_after_verification` (uses "123456") still passes
- [x] Existing `test_invalid_code_shows_remaining_attempts` (uses "000000") still passes
- [x] 1038 tests pass, `make check` clean

Fixes #122
