### PR TITLE
Move TOTP subprocess calls off the event loop

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -1576,7 +1576,7 @@ async def _check_totp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> boo
     Informational commands (/stats, /help, /jobs, etc.) do NOT need
     this gate since they don't invoke Claude with user content.
     """
-    if not is_totp_configured():
+    if not await asyncio.to_thread(is_totp_configured):
         return True
 
     assert context.user_data is not None
@@ -1624,7 +1624,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     # which only handles the first two steps. We keep the expiry check
     # inline here because _check_totp sets totp_pending as a side effect,
     # and we need to read the pending state before that happens.
-    if is_totp_configured():
+    if await asyncio.to_thread(is_totp_configured):
         assert context.user_data is not None
         assert update.effective_chat is not None
 
@@ -1666,7 +1666,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                 pass
 
             # Check global lockout before calling verify_code()
-            lockout_remaining = get_lockout_remaining()
+            lockout_remaining = await asyncio.to_thread(get_lockout_remaining)
             if lockout_remaining > 0:
                 minutes = math.ceil(lockout_remaining / 60)
                 await update.effective_chat.send_message(
@@ -1677,21 +1677,21 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             lockout_attempts = totp_cfg.totp_lockout_attempts
             lockout_minutes = totp_cfg.totp_lockout_minutes
 
-            if verify_code(code, lockout_attempts, lockout_minutes):
+            if await asyncio.to_thread(verify_code, code, lockout_attempts, lockout_minutes):
                 del context.user_data["totp_pending"]
                 context.user_data["totp_authenticated_at"] = time.time()
                 await update.effective_chat.send_message("Authenticated.")
                 return
 
             # Verification failed
-            lockout_remaining = get_lockout_remaining()
+            lockout_remaining = await asyncio.to_thread(get_lockout_remaining)
             if lockout_remaining > 0:
                 del context.user_data["totp_pending"]
                 await update.effective_chat.send_message(
                     f"Too many failed attempts. Locked out for {lockout_minutes} minutes."
                 )
             else:
-                remaining = lockout_attempts - get_failure_count()
+                remaining = lockout_attempts - await asyncio.to_thread(get_failure_count)
                 await update.effective_chat.send_message(f"Invalid code. {remaining} attempt(s) remaining.")
             return
 


### PR DESCRIPTION
## Summary

- Wrap all six `totp.py` call sites in `bot.py` with `asyncio.to_thread()` so synchronous `subprocess.run()` calls run in the thread pool instead of blocking the event loop
- A single `verify_code()` invocation can block for up to 15 seconds (three `sudo` calls with 5-second timeouts each), freezing message processing for all users
- `totp.py` itself is unchanged - it stays synchronous, which is correct for its CLI usage (`python -m kai totp setup/status/reset`)

## Call sites wrapped

| # | Function | Location |
|---|----------|----------|
| 1 | `is_totp_configured()` | `_check_totp` |
| 2 | `is_totp_configured()` | `handle_message` |
| 3 | `get_lockout_remaining()` | `handle_message` (pre-verify) |
| 4 | `verify_code()` | `handle_message` |
| 5 | `get_lockout_remaining()` | `handle_message` (post-verify failure) |
| 6 | `get_failure_count()` | `handle_message` |

## Test plan

- [x] All 1038 existing tests pass unchanged (mocks work with `to_thread` - it calls `mock()` in the thread pool, returning `mock.return_value`)
- [x] `make check` clean (ruff lint + format)
- [x] `grep -c "to_thread" src/kai/bot.py` returns 6
- [x] No direct calls remain: `grep "verify_code\|get_lockout_remaining\|get_failure_count\|is_totp_configured" src/kai/bot.py | grep -v "to_thread\|import\|def \|#"` returns empty

Fixes #123
