### PR TITLE
Validate CLAUDE_MODEL env var against VALID_MODELS at startup

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -866,12 +866,21 @@ def load_config() -> Config:
         # No users.yaml and no ALLOWED_USER_IDS - can't start
         raise SystemExit("ALLOWED_USER_IDS is required in .env (or create users.yaml)")
 
+    # Validate CLAUDE_MODEL against the same VALID_MODELS set used
+    # for workspace config. Catches typos at startup instead of
+    # letting them propagate to a confusing runtime failure.
+    claude_model = os.environ.get("CLAUDE_MODEL", "sonnet")
+    if claude_model not in VALID_MODELS:
+        raise SystemExit(
+            f"CLAUDE_MODEL '{claude_model}' is not valid (must be one of: {', '.join(sorted(VALID_MODELS))})"
+        )
+
     return Config(
         telegram_bot_token=token,
         telegram_webhook_url=telegram_webhook_url,
         telegram_webhook_secret=telegram_webhook_secret,
         allowed_user_ids=allowed_ids,
-        claude_model=os.environ.get("CLAUDE_MODEL", "sonnet"),
+        claude_model=claude_model,
         claude_timeout_seconds=claude_timeout_seconds,
         claude_max_budget_usd=claude_max_budget_usd,
         claude_max_session_hours=claude_max_session_hours,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -119,11 +119,24 @@ class TestLoadConfigErrors:
         config = load_config()
         assert config.claude_max_session_hours == 4.5
 
+    def test_invalid_claude_model(self, monkeypatch):
+        """CLAUDE_MODEL with an unrecognized value raises SystemExit."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("CLAUDE_MODEL", "sonet")
+        with pytest.raises(SystemExit, match="CLAUDE_MODEL"):
+            load_config()
+
 
 # ── Optional fields ──────────────────────────────────────────────────
 
 
 class TestLoadConfigOptional:
+    def test_claude_model_from_env(self, monkeypatch):
+        """CLAUDE_MODEL is read from environment when set."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("CLAUDE_MODEL", "opus")
+        assert load_config().claude_model == "opus"
+
     def test_voice_enabled_true(self, monkeypatch):
         _set_required(monkeypatch)
         monkeypatch.setenv("VOICE_ENABLED", "true")


### PR DESCRIPTION
## Summary

- Validate `CLAUDE_MODEL` env var against `VALID_MODELS` at startup in `load_config()`
- A typo like `CLAUDE_MODEL=sonet` now raises `SystemExit` with a clear message instead of silently passing through to a confusing runtime failure
- Matches the validation already in place for workspace config models (`config.py:431-440`)
- Uses `SystemExit` consistent with other fatal config errors (missing token, bad user IDs, etc.)

## Test plan

- [x] `test_invalid_claude_model` - typo raises `SystemExit` matching "CLAUDE_MODEL"
- [x] `test_claude_model_from_env` - valid model ("opus") is read correctly
- [x] All 1049 tests pass, `make check` clean

Fixes #130
