### PR TITLE
Fix env file quote stripping for mixed-quote values

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -318,6 +318,19 @@ def _read_protected_yaml(filename: str) -> dict | object | None:
         return _YAML_MALFORMED
 
 
+def _strip_quotes(value: str) -> str:
+    """
+    Remove matched surrounding quotes from a value string.
+
+    Only strips when the first and last characters are the same quote
+    type (' or "). This avoids corrupting values that contain the
+    opposite quote type internally (e.g., 'he said "hello"').
+    """
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+        return value[1:-1]
+    return value
+
+
 def parse_env_file(path: Path) -> dict[str, str]:
     """
     Parse a KEY=VALUE file into a dict.
@@ -326,8 +339,8 @@ def parse_env_file(path: Path) -> dict[str, str]:
     - Lines with KEY=VALUE or KEY="VALUE" or KEY='VALUE'
     - Lines starting with 'export ' (stripped)
     - Comments (lines starting with #) and blank lines (skipped)
-    - Surrounding quotes on values (stripped via str.strip, not matched
-      pairs - same limitation as the main .env parser in load_config)
+    - Surrounding quotes on values (stripped as matched pairs only -
+      inner quotes of the opposite type are preserved)
 
     Same parsing logic as _read_protected_file() uses for /etc/kai/env.
     Re-reads the file each time to pick up changes without restart.
@@ -348,7 +361,7 @@ def parse_env_file(path: Path) -> dict[str, str]:
         # Handle `export KEY=VALUE` lines (common in shell-sourced env files)
         line = line.removeprefix("export ")
         key, _, value = line.partition("=")
-        env[key.strip()] = value.strip().strip("\"'")
+        env[key.strip()] = _strip_quotes(value.strip())
     return env
 
 
@@ -707,7 +720,7 @@ def load_config() -> Config:
                 # Handle `export KEY=VALUE` lines (common in shell-sourced env files)
                 line = line.removeprefix("export ")
                 key, _, value = line.partition("=")
-                os.environ.setdefault(key.strip(), value.strip().strip("\"'"))
+                os.environ.setdefault(key.strip(), _strip_quotes(value.strip()))
     else:
         load_dotenv(PROJECT_ROOT / ".env")
 

--- a/tests/test_workspace_config.py
+++ b/tests/test_workspace_config.py
@@ -20,6 +20,7 @@ from kai.config import (
     WorkspaceConfig,
     _load_workspace_configs,
     _read_protected_yaml,
+    _strip_quotes,
     parse_env_file,
 )
 
@@ -113,6 +114,70 @@ class TestParseEnvFile:
         env_file.write_text("URL=postgres://host/db?opt=1\n")
         result = parse_env_file(env_file)
         assert result == {"URL": "postgres://host/db?opt=1"}
+
+    def test_single_quotes_containing_double(self, tmp_path):
+        """Single-quoted values preserve internal double quotes."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("""KEY='he said "hello"'\n""")
+        result = parse_env_file(env_file)
+        assert result == {"KEY": 'he said "hello"'}
+
+    def test_double_quotes_containing_single(self, tmp_path):
+        """Double-quoted values preserve internal single quotes."""
+        env_file = tmp_path / ".env"
+        env_file.write_text('KEY="it\'s fine"\n')
+        result = parse_env_file(env_file)
+        assert result == {"KEY": "it's fine"}
+
+    def test_mismatched_quotes_not_stripped(self, tmp_path):
+        """Mismatched outer quotes are left as-is."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("""KEY='value"\n""")
+        result = parse_env_file(env_file)
+        assert result == {"KEY": "'value\""}
+
+    def test_unquoted_value_unchanged(self, tmp_path):
+        """Values without surrounding quotes pass through unchanged."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY=no_quotes_here\n")
+        result = parse_env_file(env_file)
+        assert result == {"KEY": "no_quotes_here"}
+
+    def test_single_quote_char_unchanged(self, tmp_path):
+        """A value that is just a single quote character is not corrupted."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY='\n")
+        result = parse_env_file(env_file)
+        assert result == {"KEY": "'"}
+
+
+# ── _strip_quotes ──────────────────────────────────────────────────
+
+
+class TestStripQuotes:
+    def test_double_quoted(self):
+        assert _strip_quotes('"hello"') == "hello"
+
+    def test_single_quoted(self):
+        assert _strip_quotes("'hello'") == "hello"
+
+    def test_mismatched(self):
+        assert _strip_quotes("'hello\"") == "'hello\""
+
+    def test_no_quotes(self):
+        assert _strip_quotes("hello") == "hello"
+
+    def test_empty_string(self):
+        assert _strip_quotes("") == ""
+
+    def test_single_char_quote(self):
+        assert _strip_quotes("'") == "'"
+
+    def test_empty_quoted_string(self):
+        assert _strip_quotes('""') == ""
+
+    def test_inner_quotes_preserved(self):
+        assert _strip_quotes("""'he said "hello"'""") == 'he said "hello"'
 
 
 # ── _read_protected_yaml ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace `.strip("\"'")` with matched-pair quote detection in both env file parsing paths
- `str.strip(chars)` treats its argument as a set of characters, removing any from both ends independently - so `KEY='he said "hello"'` loses the trailing `"` because it is in the strip set, yielding a corrupted value
- New `_strip_quotes()` helper only strips when the first and last characters are the same quote type
- Applied to both `parse_env_file()` and the protected env parser in `load_config()`
- The `python-dotenv` code path already handles this correctly; only the manual fallback parsers were affected

## Test plan

- [x] `_strip_quotes` unit tests: matched double, matched single, mismatched, no quotes, empty string, single char quote, empty quoted string, inner quotes preserved (8 tests)
- [x] `parse_env_file` integration tests: single quotes containing double, double containing single, mismatched not stripped, unquoted unchanged, single quote char unchanged (5 tests)
- [x] Existing `test_quoted_values` (simple `"hello"` and `'world'`) still passes
- [x] All 1062 tests pass, `make check` clean

Fixes #131
