### PR TITLE
Add consecutive failure tracking and notification to health monitor

### DIFF
--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -1370,10 +1370,12 @@ async def _webhook_health_loop(bot, webhook_url: str, webhook_secret: str, chat_
                         chat_id,
                         "Webhook health monitor has failed 3 consecutive checks. Self-healing may be degraded.",
                     )
-                    failure_notified = True
                 except Exception:
                     # If we can't even reach Telegram, just log it.
                     log.warning("Could not send health monitor failure notification")
+                # Set regardless of whether the send succeeded. We tried
+                # once per failure sequence - don't retry every 5 minutes.
+                failure_notified = True
 
         await asyncio.sleep(_HEALTH_CHECK_INTERVAL)
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1107,5 +1107,5 @@ class TestWebhookHealthMonitor:
             except asyncio.CancelledError:
                 pass
 
-        # send_message was attempted but failed - loop didn't crash
-        bot.send_message.assert_called()
+        # send_message was attempted exactly once (not retried after failure)
+        bot.send_message.assert_called_once()


### PR DESCRIPTION
## Summary

Add consecutive failure tracking and admin notification to the webhook health monitor. Previously, persistent health check failures logged exceptions every 5 minutes silently forever. Now the admin is notified via Telegram after 3 consecutive failures (15 minutes of degraded self-healing).

## Changes

| Change | Detail |
|--------|--------|
| `consecutive_failures` counter | Increments on exception, resets on success |
| `failure_notified` flag | Prevents notification spam (one per failure sequence) |
| Admin notification | `bot.send_message()` after 3 failures, with inner try/except for Telegram-down case |
| `chat_id` parameter | Passed from `start()` via `_app["chat_id"]` |

## Why `bot.send_message()` instead of the HTTP API

The health loop runs alongside the aiohttp server. If the server is unhealthy, an HTTP self-request to `/api/send-message` would fail. `bot.send_message()` only depends on Telegram being reachable.

## Test plan

- [x] `test_failure_counter_increments` - 2 failures, no notification (threshold is 3)
- [x] `test_notification_after_three_failures` - notification fires exactly once after 3 failures
- [x] `test_counter_resets_on_success` - 2 failures then success, no notification
- [x] `test_failed_notification_does_not_crash` - Telegram unreachable, loop continues
- [x] All 1126 tests pass, `make check` clean

Fixes #161
