### PR TITLE
Validate brace-extracted JSON in triage parser

### DIFF
--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -428,12 +428,26 @@ def _parse_triage_json(raw: str) -> dict:
     text = text.strip()
 
     # If Claude added preamble text before the JSON (e.g., "Here's the
-    # analysis:\n{...}"), try to extract the outermost JSON object.
+    # analysis:\n{...}"), try to extract a valid JSON object. The naive
+    # first-{-to-last-} approach can grab the wrong span when the preamble
+    # contains braces, so we validate each candidate by trying json.loads
+    # on each { position until one succeeds.
     if text and not text.startswith("{"):
-        brace_start = text.find("{")
         brace_end = text.rfind("}")
-        if brace_start != -1 and brace_end > brace_start:
-            text = text[brace_start : brace_end + 1]
+        if brace_end != -1:
+            pos = 0
+            while pos <= brace_end:
+                brace_start = text.find("{", pos)
+                if brace_start == -1 or brace_start > brace_end:
+                    break
+                candidate = text[brace_start : brace_end + 1]
+                try:
+                    json.loads(candidate)
+                    text = candidate
+                    break
+                except json.JSONDecodeError:
+                    # This { didn't produce valid JSON; try the next one
+                    pos = brace_start + 1
 
     try:
         result = json.loads(text)

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -404,6 +404,24 @@ class TestParseTriageJson:
         result = _parse_triage_json(raw)
         assert result == {"labels": ["bug"], "priority": "high"}
 
+    def test_preamble_with_braces(self):
+        """Preamble containing braces doesn't confuse the extractor."""
+        raw = 'Here\'s the {"quick": "note"} before the real response:\n{"labels": ["bug"], "priority": "high"}'
+        result = _parse_triage_json(raw)
+        assert result == {"labels": ["bug"], "priority": "high"}
+
+    def test_preamble_with_multiple_brace_groups(self):
+        """Multiple brace groups in preamble are skipped to find valid JSON."""
+        raw = 'See {x} and {y: z} for context.\n{"labels": ["enhancement"]}'
+        result = _parse_triage_json(raw)
+        assert result == {"labels": ["enhancement"]}
+
+    def test_no_valid_json_raises(self):
+        """Text with braces but no valid JSON still raises ValueError."""
+        raw = "Here is {some broken and {nested stuff}"
+        with pytest.raises(ValueError, match="non-JSON"):
+            _parse_triage_json(raw)
+
 
 # ── _sanitize_search_query ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Replace the naive first-`{`-to-last-`}` JSON extraction in `_parse_triage_json()` with a scan-forward approach that validates each candidate with `json.loads`. The old approach could grab the wrong span when Claude's preamble text contained braces (code examples, inline JSON, template literals).

### Before
```
find("{") -> first brace (might be in preamble)
rfind("}") -> last brace
extract everything between -> might be invalid JSON
```

### After
```
for each { position:
    candidate = text[{pos : last-}+1]
    if json.loads(candidate) succeeds: use it
    else: try the next {
```

## Test plan

- [x] `test_preamble_with_braces` - preamble containing `{...}` before real JSON
- [x] `test_preamble_with_multiple_brace_groups` - multiple brace groups in preamble
- [x] `test_no_valid_json_raises` - braces but no valid JSON still raises ValueError
- [x] Existing tests (clean JSON, fenced JSON, simple preamble) all pass unchanged
- [x] All 1132 tests pass, `make check` clean

Fixes #163
