### PR TITLE
Add post-apply reminder about install.conf secrets

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1153,6 +1153,15 @@ def _cmd_apply() -> None:
         print(f"  Data:    {data_dir}")
         print("  Secrets: /etc/kai/env")
         print(f"  User:    {service_user}")
+        # Remind the user that install.conf contains secrets and can be
+        # cleaned up. Don't auto-delete - the user may want to re-run
+        # apply or adjust config.
+        if INSTALL_CONF.exists():
+            print(
+                f"\nNote: {INSTALL_CONF} contains secrets (bot token, webhook secret)."
+                "\nYou can safely delete it now that secrets are in /etc/kai/env."
+                "\nTo reconfigure later, re-run: python -m kai install config"
+            )
 
 
 def _apply_directories(

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -413,6 +413,8 @@ class TestCmdApply:
         assert "[DRY RUN]" in output
         # Verify nothing was actually created
         assert not (tmp_path / "opt" / "kai").exists()
+        # Secrets reminder should NOT appear during dry run
+        assert "contains secrets" not in output
 
     def test_generates_env_file_content(self):
         """The generated env file contains all provided values."""


### PR DESCRIPTION
## Summary

Add a reminder after successful `make install` that `install.conf` contains secrets and can be safely deleted now that they are in `/etc/kai/env`.

The file is already 0600 and gitignored, so the risk is low. But keeping unnecessary copies of secrets is bad hygiene, and the user may not realize `install.conf` still contains them. The reminder is informational only - no auto-deletion.

## Changes

| Change | Detail |
|--------|--------|
| Post-apply message | Prints note about `install.conf` secrets with deletion guidance |
| `INSTALL_CONF.exists()` guard | Only prints if the file exists |
| Dry run excluded | Reminder is in the non-dry-run branch |
| Test assertion | Dry run test verifies "contains secrets" does NOT appear |

## Test plan

- [x] Dry run test confirms reminder does not print
- [x] All 1135 tests pass, `make check` clean
- [ ] Manual: run `sudo make install` and verify the reminder appears

Fixes #165
