### PR TITLE
Avoid leaking exception details to Telegram in triage error notifications

### DIFF
--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -834,7 +834,7 @@ async def triage_issue(
             return
         await _send_error_notification(
             metadata,
-            str(exc),
+            type(exc).__name__,
             webhook_port,
             webhook_secret,
             notify_chat_id,

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1007,3 +1007,42 @@ class TestApplyTriageNotifyChatId:
         assert len(summary_call) >= 1
         body = summary_call[0][1]["json"]
         assert body["chat_id"] == -100999
+
+
+# ── Triage error notification content ────────────────────────────────
+
+
+class TestTriageErrorContent:
+    @pytest.mark.asyncio
+    async def test_error_sends_exception_type_not_message(self):
+        """Triage failure notification contains only the exception type name,
+        not the full message (which may leak internal paths)."""
+        metadata = IssueMetadata(
+            repo="owner/repo",
+            number=42,
+            title="Test issue",
+            body="body",
+            author="user",
+            url="https://github.com/owner/repo/issues/42",
+            labels=[],
+        )
+
+        sensitive_path = "/opt/kai/home/.claude/CLAUDE.md"
+        error = FileNotFoundError(f"[Errno 2] No such file or directory: '{sensitive_path}'")
+
+        with (
+            patch("kai.triage.extract_issue_metadata", return_value=metadata),
+            patch("kai.triage.search_related_issues", side_effect=error),
+            patch("kai.triage._send_error_notification", new_callable=AsyncMock) as mock_notify,
+        ):
+            await triage_issue(
+                {"issue": {}, "repository": {}},
+                webhook_port=8080,
+                webhook_secret="secret",
+            )
+
+        # The error_detail argument should be just the type name
+        mock_notify.assert_called_once()
+        error_detail = mock_notify.call_args[0][1]
+        assert error_detail == "FileNotFoundError"
+        assert sensitive_path not in error_detail


### PR DESCRIPTION
## Summary

Replace `str(exc)` with `type(exc).__name__` in the `triage_issue()` exception handler to avoid leaking internal details (filesystem paths, URLs, subprocess arguments) to Telegram notifications.

### Before
```
Issue triage failed for owner/repo#42: [Errno 2] No such file or directory: '/opt/kai/home/.claude/CLAUDE.md'
```

### After
```
Issue triage failed for owner/repo#42: FileNotFoundError
```

The full traceback stays in `log.exception()` where operators can find it.

## Changes

One line in `src/kai/triage.py`: `str(exc)` becomes `type(exc).__name__`.

## Test plan

- [x] `test_error_sends_exception_type_not_message` - verifies only the type name is sent, sensitive paths are not leaked
- [x] All 1162 tests pass, `make check` clean

Fixes #186
