### PR TITLE
Increase PR review timeout to 900s for extended thinking

### DIFF
--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -54,9 +54,11 @@ _REVIEW_MODEL = "sonnet"
 # Sonnet reviews of typical PRs cost well under $0.50.
 _REVIEW_BUDGET_USD = 1.0
 
-# Timeout for the Claude subprocess in seconds. Large diffs may take a
-# while to analyze, but anything beyond 5 minutes is likely stuck.
-_REVIEW_TIMEOUT = 300
+# Timeout for the Claude subprocess in seconds. Sonnet 4.6+ uses extended
+# thinking, which can take significantly longer on large diffs with prior
+# review context. 15 minutes accommodates thinking-heavy reviews while
+# still catching genuinely stuck processes.
+_REVIEW_TIMEOUT = 900
 
 # Header prepended to every review comment on GitHub. Distinguishes
 # automated reviews from human comments. Per design decision #11.


### PR DESCRIPTION
## Summary

- Increase `_REVIEW_TIMEOUT` from 300s to 900s in `review.py`
- Sonnet 4.6+ uses extended thinking, which pushed large reviews past the 5-minute timeout (PR #216 reviews 4 and 5 both timed out at exactly 300s)
- The `--max-budget-usd 1.0` cap is the real safety net against runaway cost; the timeout just needs to accommodate thinking-heavy reviews

## Test plan

- [x] `make check` passes (lint + format)
- [x] No test changes needed (timeout constant is internal)
- [ ] Verify next PR review completes without timeout
