### PR TITLE
Update inner Claude CLAUDE.md for multi-user and missing docs

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -145,7 +145,7 @@ curl -s -X POST http://localhost:8080/api/send-file \
 - `chat_id` - integer; required for routing
 - `path` - required; absolute path within the current workspace
 - `caption` - string; optional
-- Images (png, jpg, gif, webp) are sent as photos (rendered inline). Everything else is sent as a document attachment.
+- Images (png, jpg, webp) are sent as photos (rendered inline). Everything else is sent as a document attachment.
 
 ## Issue-First Workflow
 


### PR DESCRIPTION
## Summary

Updates the inner Claude CLAUDE.md (`home/.claude/CLAUDE.md`) with documentation improvements and missing endpoint coverage.

- **Memory and Chat History** sections now reference the exact injection labels from `claude.py` instead of vague "provided in your session context" wording
- **Scheduling Jobs**: timezone conversion guidance ("convert to UTC, confirm in reply") and `chat_id` in all curl examples for correct multi-user routing
- **Sending Messages**: `chat_id` added to example
- **Sending Files**: new section documenting the `/api/send-file` endpoint (was entirely missing)
- **GitHub Project Board**: replaced 25-line unreliable `gh project item-edit` block with 3 lines (`fixes #N` handles the important transition; `gh project` commands silently fail)
- **External Services**: fixed response body type from string to object

## Test plan

- [x] Docs-only change, no code affected
- [x] Verified injection labels match `claude.py` source (lines 435, 457, 460)
- [x] Verified Sending Files fields match `_handle_send_file` in `webhook.py`

Fixes #249
