### PR TITLE
Hide agent backend prompt until GooseBackend exists

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -409,16 +409,22 @@ def _cmd_config() -> None:
     print()
 
     # -- Agent backend --
-    print("-- Agent backend --")
-    agent_backend = _prompt_choice(
-        "Agent backend",
-        sorted(VALID_BACKENDS),
-        existing_env.get("AGENT_BACKEND", "claude"),
-    )
-    if agent_backend == "goose":
-        print("  Note: Goose requires a provider API key (e.g. ANTHROPIC_API_KEY)")
-        print("  in the environment. Add it to /etc/kai/env after installation.")
-    print()
+    # The prompt is gated behind an existing AGENT_BACKEND value so
+    # users who haven't opted into Goose never see the choice. Once
+    # GooseBackend ships (#262), remove the gate and always prompt.
+    if existing_env.get("AGENT_BACKEND", "claude") != "claude":
+        print("-- Agent backend --")
+        agent_backend = _prompt_choice(
+            "Agent backend",
+            sorted(VALID_BACKENDS),
+            existing_env.get("AGENT_BACKEND", "claude"),
+        )
+        if agent_backend == "goose":
+            print("  Note: Goose requires a provider API key (e.g. ANTHROPIC_API_KEY)")
+            print("  in the environment. Add it to /etc/kai/env after installation.")
+        print()
+    else:
+        agent_backend = "claude"
 
     # -- Claude --
     # When users.yaml exists, model/timeout/budget/context are per-user

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -440,7 +440,7 @@ class TestCmdConfig:
                 "admin",  # admin display name
                 "false",  # advanced user options
                 "polling",  # transport
-                "claude",  # agent backend
+                # agent backend prompt not shown (gated behind existing non-claude value)
                 "sonnet",  # model
                 "120",  # timeout
                 "10.0",  # budget
@@ -502,7 +502,7 @@ class TestCmdConfig:
                 "testuser",  # os_user
                 str(tmp_path),  # home_workspace
                 "polling",  # transport
-                "claude",  # agent backend
+                # agent backend prompt not shown (gated behind existing non-claude value)
                 "sonnet",  # model
                 "120",  # timeout
                 "10.0",  # budget
@@ -540,9 +540,15 @@ class TestCmdConfig:
     def test_goose_backend_writes_env(self, tmp_path, monkeypatch):
         """Selecting goose backend writes AGENT_BACKEND to env."""
         monkeypatch.chdir(tmp_path)
-        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        conf_path = tmp_path / "install.conf"
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+
+        # Pre-seed existing config with goose backend so the prompt
+        # appears (it is gated behind an existing non-claude value).
+        existing = {"version": 1, "env": {"AGENT_BACKEND": "goose"}}
+        conf_path.write_text(json.dumps(existing))
 
         inputs = iter(
             [
@@ -555,7 +561,7 @@ class TestCmdConfig:
                 "admin",  # admin display name
                 "false",  # advanced user options
                 "polling",  # transport
-                "goose",  # agent backend
+                "goose",  # agent backend (prompt shown because existing config has goose)
                 "sonnet",  # model
                 "120",  # timeout
                 "10.0",  # budget


### PR DESCRIPTION
## Summary

- Gate the agent backend prompt in `make config` behind an existing non-claude `AGENT_BACKEND` value
- Fresh installs and existing claude installs skip the prompt entirely (defaults to "claude")
- Only users who have already configured goose see the choice
- Remove the gate when #262 ships GooseBackend

Fixes a UX issue from #264 where the wizard presented a non-functional option.

## Test plan

- [x] `make check` passes
- [x] `make test` passes (1568 tests)
- [x] Fresh install test (no existing config) skips backend prompt
- [x] Goose backend test (pre-seeded config) still shows prompt and writes env
