### PR TITLE
Warn when goose binary is missing during install

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1848,18 +1848,20 @@ def _apply_goose_config(
     if not src.exists():
         raise SystemExit(f"Goose config template not found at {src}")
 
-    # Warn if the goose binary isn't on PATH. Not fatal because the
-    # user may install it after running make install, but a clear
-    # message now saves debugging an opaque runtime error later.
-    if not shutil.which("goose"):
-        print("  WARNING: 'goose' binary not found on PATH.")
-        print("  Kai will fail to start the Goose backend until goose is installed.")
-        print("  See https://github.com/block/goose for installation instructions.")
-
     if dry_run:
         print(f"[DRY RUN] Would create: {goose_dir}")
         print(f"[DRY RUN] Would copy: {src} -> {dst}")
         return
+
+    # Warn if the goose binary isn't on PATH. Not fatal because the
+    # user may install it after running make install, but a clear
+    # message now saves debugging an opaque runtime error later.
+    # Placed after the dry-run guard so dry runs don't warn about
+    # runtime dependencies.
+    if not shutil.which("goose"):
+        print("  WARNING: 'goose' binary not found on PATH.")
+        print("  Kai will fail to start the Goose backend until goose is installed.")
+        print("  See https://github.com/block/goose for installation instructions.")
 
     # Track whether we're creating .config for the first time so we
     # can set ownership on it below. mkdir(parents=True) creates both

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2123,6 +2123,22 @@ class TestApplyGooseConfig:
         assert "WARNING" in output
         assert "goose" in output.lower()
 
+    def test_no_warning_in_dry_run(self, tmp_path, capsys, monkeypatch):
+        """Dry run does not warn about missing goose binary."""
+        install_path = self._setup(tmp_path)
+        svc_home = tmp_path / "home" / "kai"
+        svc_home.mkdir(parents=True)
+        monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        monkeypatch.setattr("shutil.which", lambda cmd: None)
+
+        uid = os.getuid()
+        gid = os.getgid()
+        _apply_goose_config("kai", install_path, uid, gid, dry_run=True)
+
+        output = capsys.readouterr().out
+        assert "WARNING" not in output
+        assert "DRY RUN" in output
+
     def test_no_warning_when_goose_on_path(self, tmp_path, capsys, monkeypatch):
         """No warning printed when goose binary exists on PATH."""
         install_path = self._setup(tmp_path)


### PR DESCRIPTION
## Summary

- Add `shutil.which("goose")` check in `_apply_goose_config()` that warns when the goose binary is not on PATH during `make install`
- Non-fatal (install continues) since goose may be installed afterward, but gives a clear message instead of an opaque runtime error
- Closes the last gap in the Goose backend parent issue (#260)

Fixes #260

## Test plan

- [x] `make check` passes
- [x] `make test` passes (1613 tests)
- [x] New tests verify warning appears when goose is missing and is absent when goose is found
