### PR TITLE
Fix concurrent stdout read in shutdown() during active stream

### DIFF
--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -780,6 +780,11 @@ class ClaudeCodeBackend(AgentBackend):
             # call without awaiting, and avoids the deadlock that would
             # occur if we tried to acquire (since _kill() is also called
             # from within _send_locked on error paths).
+            #
+            # Note: there is a theoretical TOCTOU window between the
+            # check and _save_prompt()'s first await (drain at stdin
+            # write). In practice this is negligible because shutdown()
+            # runs during cleanup when new send() calls are not arriving.
             if not self._lock.locked():
                 await self._save_prompt()
             else:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -2271,8 +2271,11 @@ class TestSavePrompt:
                     pass
 
             stream_task = asyncio.create_task(do_stream())
-            # Yield so the stream task acquires the lock and blocks on readline
-            await asyncio.sleep(0)
+            # Yield enough times for send() to advance through
+            # _ensure_started (AsyncMock - needs its own tick) and
+            # then acquire the lock.
+            for _ in range(5):
+                await asyncio.sleep(0)
 
             # Verify the lock is actually held before we call shutdown
             assert claude._lock.locked(), "Lock should be held by the stream task"
@@ -2283,10 +2286,8 @@ class TestSavePrompt:
             # The stream task should finish cleanly (EOF from signal)
             try:
                 await asyncio.wait_for(stream_task, timeout=2)
-            except (TimeoutError, Exception):
-                # Stream task may raise from mock limitations; the key
-                # assertion is that no readuntil error occurred
-                pass
+            except TimeoutError:
+                stream_task.cancel()
 
         # _save_prompt must have been skipped (lock was held)
         mock_save.assert_not_called()


### PR DESCRIPTION
## Summary

- Guard `_save_prompt()` in `shutdown()` with `_lock.locked()` to skip the save when a streaming interaction is in flight, preventing concurrent stdout reads on the same asyncio StreamReader
- Add three tests: lock-held skips save, lock-free still saves, concurrent stream+shutdown integration

Fixes #280.

## Test plan

- [x] `test_shutdown_skips_save_prompt_when_lock_held` - verifies save is skipped when lock is held
- [x] `test_shutdown_calls_save_prompt_when_lock_free` - regression test for normal idle shutdown
- [x] `test_shutdown_during_active_stream` - concurrent send()+shutdown() with mock subprocess
- [x] Full test suite passes (1673 tests)
- [ ] Manual: send a long message, kill the service mid-stream, verify no `readuntil` traceback in logs
