### PR TITLE
Rename goose_provider to llm_provider for backend-agnostic provider resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,14 +14,14 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 # "claude" uses Claude Code CLI, "goose" uses Goose ACP protocol.
 #AGENT_BACKEND=claude
 
-# Goose LLM provider. Required when AGENT_BACKEND=goose.
-# Set during `make config`; valid values: anthropic, openai, google,
-# openrouter, ollama. Goose reads this from the environment at runtime.
-#GOOSE_PROVIDER=anthropic
+# LLM provider. Required when AGENT_BACKEND is a non-Claude backend.
+# Valid values depend on the backend:
+#   goose: anthropic, openai, google, openrouter, ollama
+#LLM_PROVIDER=anthropic
 
-# Provider API key for the Goose backend. Set the one matching your
-# GOOSE_PROVIDER above. Ollama does not require an API key (local
-# inference). These are Goose env vars, not Kai config fields - Kai
+# Provider API key. Set the one matching your LLM_PROVIDER.
+# Ollama does not require an API key (local inference).
+# These are backend env vars, not Kai config fields - Kai
 # passes them through to the subprocess environment.
 #ANTHROPIC_API_KEY=sk-ant-...
 #OPENAI_API_KEY=sk-...

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -112,9 +112,8 @@ class AgentBackend(ABC):
 
     Backend-specific attributes (NOT on the ABC) stay on the concrete
     class. For ClaudeCodeBackend these include: claude_user,
-    max_session_hours, autocompact_pct. For GooseBackend: goose_provider.
-    The pool never touches these directly; they are set at construction
-    by _create_instance().
+    max_session_hours, autocompact_pct. The pool never touches these
+    directly; they are set at construction by _create_instance().
     """
 
     # These are plain instance attributes, not abstract properties,

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -368,7 +368,7 @@ def _get_user_provider(pool: SubprocessPool, chat_id: int, config: Config) -> st
     # No running instance - derive from config cascade (same as _create_instance)
     user_config = config.get_user_config(chat_id)
     uc_backend = user_config.agent_backend if user_config and user_config.agent_backend else config.agent_backend
-    uc_provider = user_config.goose_provider if user_config and user_config.goose_provider else config.goose_provider
+    uc_provider = user_config.llm_provider if user_config and user_config.llm_provider else config.llm_provider
     return get_effective_provider(uc_backend, uc_provider)
 
 
@@ -801,7 +801,7 @@ def _revert_instance_field(pool: SubprocessPool, chat_id: int, field: str, confi
             # If the user's provider differs from the global provider, the
             # global default_model may be invalid for their provider.
             provider = instance.provider
-            effective_global = get_effective_provider(config.agent_backend, config.goose_provider)
+            effective_global = get_effective_provider(config.agent_backend, config.llm_provider)
             if provider == effective_global:
                 instance.model = config.default_model
             else:

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -43,13 +43,18 @@ DATA_DIR = Path(os.environ.get("KAI_DATA_DIR") or str(PROJECT_ROOT))
 # "goose" uses Goose ACP. Shared between load_config() and install.py.
 VALID_BACKENDS = {"claude", "goose"}
 
-# Valid Goose LLM providers. Shared between load_config() and install.py.
-VALID_GOOSE_PROVIDERS = {"anthropic", "openai", "google", "openrouter", "ollama"}
+# Valid LLM providers per backend. Claude always uses Anthropic
+# (hardcoded in get_effective_provider), so it has no entry here.
+# Backends that don't appear in this dict accept no provider config.
+VALID_PROVIDERS: dict[str, frozenset[str]] = {
+    "goose": frozenset({"anthropic", "openai", "google", "openrouter", "ollama"}),
+}
 
-# Maps each Goose provider to its API key environment variable name.
-# Used by install.py for prompting the correct API key env var.
+# Maps LLM provider to its API key environment variable name.
+# Backend-agnostic - the API key for Anthropic is the same env var
+# regardless of which backend is using it.
 # Ollama is absent because it requires no API key (local inference).
-GOOSE_PROVIDER_KEY_VARS: dict[str, str] = {
+PROVIDER_KEY_VARS: dict[str, str] = {
     "anthropic": "ANTHROPIC_API_KEY",
     "openai": "OPENAI_API_KEY",
     "google": "GOOGLE_API_KEY",
@@ -100,15 +105,15 @@ OPEN_ENDED_PROVIDERS: frozenset[str] = frozenset({"openrouter", "ollama"})
 _ALL_CURATED_MODELS: frozenset[str] = frozenset(model for models in PROVIDER_MODELS.values() for model in models)
 
 
-def get_effective_provider(backend: str, goose_provider: str) -> str:
-    """Derive the effective provider from backend + goose_provider.
+def get_effective_provider(backend: str, llm_provider: str) -> str:
+    """Derive the effective provider from backend + llm_provider.
 
-    The Claude backend always uses Anthropic models. The Goose backend
-    uses whatever provider is configured.
+    The Claude backend always uses Anthropic models. All other
+    backends use whatever provider is configured.
     """
     if backend == "claude":
         return "anthropic"
-    return goose_provider
+    return llm_provider
 
 
 def validate_model_for_provider(model: str, provider: str) -> bool:
@@ -117,14 +122,14 @@ def validate_model_for_provider(model: str, provider: str) -> bool:
     Returns True if the provider is open-ended (accepts any model)
     or if the model is in the provider's curated list. Unknown providers
     (not in PROVIDER_MODELS or OPEN_ENDED_PROVIDERS) are accepted with
-    a warning - this catches the case where VALID_GOOSE_PROVIDERS gains
+    a warning - this catches the case where VALID_PROVIDERS gains
     a new entry but PROVIDER_MODELS was not updated to match.
     """
     if provider in OPEN_ENDED_PROVIDERS:
         return True
     models = PROVIDER_MODELS.get(provider)
     if models is None:
-        # Provider is valid (passed VALID_GOOSE_PROVIDERS check) but has
+        # Provider is valid (passed VALID_PROVIDERS check) but has
         # no curated model list and is not explicitly open-ended. This
         # is a programming oversight - log it so it's visible.
         if provider:
@@ -257,7 +262,7 @@ class UserConfig:
     # Per-user backend/provider override. Admin-controlled via users.yaml,
     # not user-configurable via /settings. None = use global config.
     agent_backend: str | None = None
-    goose_provider: str | None = None
+    llm_provider: str | None = None
     # GitHub notification routing fields. github_repos controls which
     # repos route webhook events to this user. pr_review and issue_triage
     # are tri-state: None = use global default, True/False = admin override.
@@ -406,10 +411,11 @@ class Config:
     # "goose" uses Goose ACP (Agent Client Protocol) as the agent harness.
     agent_backend: str = "claude"
 
-    # Goose LLM provider (only relevant when agent_backend="goose").
-    # Determines which API key env var Goose expects and whether Kai's
+    # LLM provider for non-Claude backends (e.g. Goose). Determines
+    # which API key env var the backend expects and whether Kai's
     # logical model names ("sonnet", "opus") are translated to Anthropic IDs.
-    goose_provider: str = ""
+    # Ignored when agent_backend="claude".
+    llm_provider: str = ""
 
     def get_workspace_config(self, workspace: Path) -> WorkspaceConfig | None:
         """
@@ -726,7 +732,7 @@ _VALID_ROLES = {"admin", "user"}
 
 def _load_user_configs(
     global_backend: str,
-    global_provider: str,
+    global_llm_provider: str,
 ) -> dict[int, UserConfig] | None:
     """
     Load per-user configs from users.yaml.
@@ -737,7 +743,7 @@ def _load_user_configs(
 
     Args:
         global_backend: The global agent_backend from env config.
-        global_provider: The global goose_provider from env config.
+        global_llm_provider: The global llm_provider from env config.
             Both are needed to cascade per-user model validation:
             a user's effective provider determines which models are valid.
 
@@ -882,31 +888,36 @@ def _load_user_configs(
                 )
             user_backend = backend_str
 
-        # Validate optional goose_provider (must be valid if set)
+        # Validate optional llm_provider (must be valid for the user's backend)
         user_provider: str | None = None
-        raw_provider = entry.get("goose_provider")
+        raw_provider = entry.get("llm_provider")
         if raw_provider is not None:
             provider_str = str(raw_provider).strip().lower()
-            if provider_str not in VALID_GOOSE_PROVIDERS:
+            # Validate against the user's effective backend. If the user
+            # has no explicit backend, validate against the global one.
+            eff_backend_for_val = user_backend or global_backend
+            valid = VALID_PROVIDERS.get(eff_backend_for_val)
+            if valid is not None and provider_str not in valid:
                 raise SystemExit(
-                    f"users.yaml: user '{name}' has invalid goose_provider '{provider_str}' "
-                    f"(must be one of: {', '.join(sorted(VALID_GOOSE_PROVIDERS))})"
+                    f"users.yaml: user '{name}' has invalid llm_provider "
+                    f"'{provider_str}' for backend '{eff_backend_for_val}' "
+                    f"(must be one of: {', '.join(sorted(valid))})"
                 )
             user_provider = provider_str
 
         # Resolve effective backend and provider for this user.
-        # Used for both the goose-without-provider check and model validation.
+        # Used for both the provider-required check and model validation.
         eff_backend = user_backend or global_backend
-        eff_provider_str = user_provider or global_provider
+        eff_provider_str = user_provider or global_llm_provider
         eff_provider = get_effective_provider(eff_backend, eff_provider_str)
 
-        # If user has goose backend but no provider can be resolved
-        # (neither user-level nor global), that's a fatal config error.
-        if eff_backend == "goose" and not eff_provider_str:
+        # If user's effective backend requires a provider but none can be
+        # resolved (neither user-level nor global), that's a fatal config error.
+        if eff_backend in VALID_PROVIDERS and not eff_provider_str:
             raise SystemExit(
-                f"users.yaml: user '{name}' has agent_backend='goose' but no "
-                f"goose_provider is configured (set it in users.yaml or as "
-                f"GOOSE_PROVIDER env var)"
+                f"users.yaml: user '{name}' has agent_backend='{eff_backend}' but no "
+                f"llm_provider is configured (set it in users.yaml or as "
+                f"LLM_PROVIDER env var)"
             )
 
         # Warn if user is on an open-ended provider with no model set.
@@ -1063,7 +1074,7 @@ def _load_user_configs(
             context_window=user_context_window,
             workspace_base=user_workspace_base,
             agent_backend=user_backend,
-            goose_provider=user_provider,
+            llm_provider=user_provider,
             github_repos=github_repos,
             github_notify_chat_id=github_notify_chat_id,
             pr_review=pr_review,
@@ -1277,15 +1288,17 @@ def load_config() -> Config:
             f"AGENT_BACKEND '{agent_backend}' is not valid (must be one of: {', '.join(sorted(VALID_BACKENDS))})"
         )
 
-    # Goose provider - only validated when agent_backend=goose.
-    # When backend is claude, the field stays empty (unused).
-    goose_provider = ""
-    if agent_backend == "goose":
-        goose_provider = os.environ.get("GOOSE_PROVIDER", "").strip().lower()
-        if goose_provider not in VALID_GOOSE_PROVIDERS:
+    # LLM provider - validated against the backend's supported set.
+    # Only required for non-Claude backends.
+    llm_provider = ""
+    valid_providers = VALID_PROVIDERS.get(agent_backend)
+    if valid_providers is not None:
+        llm_provider = os.environ.get("LLM_PROVIDER", "").strip().lower()
+        if llm_provider not in valid_providers:
             raise SystemExit(
-                f"GOOSE_PROVIDER '{goose_provider}' is not valid "
-                f"(must be one of: {', '.join(sorted(VALID_GOOSE_PROVIDERS))})"
+                f"LLM_PROVIDER '{llm_provider}' is not valid for backend "
+                f"'{agent_backend}' (must be one of: "
+                f"{', '.join(sorted(valid_providers))})"
             )
 
     # Per-workspace configuration. Loaded after ALLOWED_WORKSPACES so
@@ -1302,7 +1315,7 @@ def load_config() -> Config:
     # Per-user configuration. If users.yaml exists, it is authoritative;
     # ALLOWED_USER_IDS is ignored. If users.yaml does not exist,
     # ALLOWED_USER_IDS works as before (backward-compatible).
-    user_configs = _load_user_configs(agent_backend, goose_provider)
+    user_configs = _load_user_configs(agent_backend, llm_provider)
     if user_configs is not None:
         if raw_ids:
             log.warning("ALLOWED_USER_IDS is set but users.yaml exists; using users.yaml")
@@ -1393,7 +1406,7 @@ def load_config() -> Config:
     # Validate DEFAULT_MODEL against the effective global provider.
     # Catches typos at startup instead of letting them propagate to
     # a confusing runtime failure.
-    global_provider = get_effective_provider(agent_backend, goose_provider)
+    global_provider = get_effective_provider(agent_backend, llm_provider)
     if not validate_model_for_provider(default_model, global_provider):
         valid = sorted(PROVIDER_MODELS.get(global_provider, {}).keys())
         raise SystemExit(
@@ -1434,5 +1447,5 @@ def load_config() -> Config:
         totp_lockout_attempts=totp_lockout_attempts,
         totp_lockout_minutes=totp_lockout_minutes,
         agent_backend=agent_backend,
-        goose_provider=goose_provider,
+        llm_provider=llm_provider,
     )

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -46,6 +46,8 @@ VALID_BACKENDS = {"claude", "goose"}
 # Valid LLM providers per backend. Claude always uses Anthropic
 # (hardcoded in get_effective_provider), so it has no entry here.
 # Backends that don't appear in this dict accept no provider config.
+# NOTE: Non-Claude entries in VALID_BACKENDS should have a matching
+# key here. Missing entries silently skip provider validation.
 VALID_PROVIDERS: dict[str, frozenset[str]] = {
     "goose": frozenset({"anthropic", "openai", "google", "openrouter", "ollama"}),
 }

--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -83,7 +83,7 @@ class GooseBackend(AgentBackend):
         services_info: list[dict] | None = None,
         workspace_config: WorkspaceConfig | None = None,
         max_context_window: int = 0,
-        goose_provider: str = "",
+        provider: str = "",
     ):
         # ABC-required attributes (pool.py reads/writes these)
         self.model = model
@@ -93,8 +93,7 @@ class GooseBackend(AgentBackend):
         self.timeout_seconds = timeout_seconds
         self.workspace_config = workspace_config
         self.max_context_window = max_context_window
-        self.provider = goose_provider  # ABC-mandated; bot.py reads this
-        self.goose_provider = goose_provider
+        self.provider = provider  # ABC-mandated; bot.py reads this
 
         # API context for session injection (passed to build_session_context)
         self._api_context = ApiContext(
@@ -162,7 +161,7 @@ class GooseBackend(AgentBackend):
         # Kai's logical model names ("sonnet", "opus", "haiku") only apply
         # to the Anthropic provider. Other providers require full model IDs
         # set via user config (users.yaml or /settings). Pass through unchanged.
-        if self.goose_provider == "anthropic":
+        if self.provider == "anthropic":
             mapped = _ANTHROPIC_MODEL_MAP.get(self.model, self.model)
         else:
             mapped = self.model

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -39,14 +39,14 @@ from pathlib import Path
 import yaml
 
 from kai.config import (
-    GOOSE_PROVIDER_KEY_VARS,
     MAX_CONTEXT_CEILING,
     OPEN_ENDED_PROVIDERS,
     PROJECT_ROOT,
     PROVIDER_DEFAULTS,
+    PROVIDER_KEY_VARS,
     PROVIDER_MODELS,
     VALID_BACKENDS,
-    VALID_GOOSE_PROVIDERS,
+    VALID_PROVIDERS,
 )
 
 # Config file written by `config`, read by `apply`.
@@ -425,27 +425,28 @@ def _cmd_config() -> None:
         existing_env.get("AGENT_BACKEND", "claude"),
     )
 
-    # Goose-specific: provider and API key. The provider choice
+    # Non-Claude backends: provider and API key. The provider choice
     # determines which env var to prompt for (or none for ollama).
-    goose_provider = ""
-    goose_api_key_var = ""
-    goose_api_key = ""
-    if agent_backend == "goose":
-        goose_provider = _prompt_choice(
-            "Goose LLM provider",
-            sorted(VALID_GOOSE_PROVIDERS),
-            existing_env.get("GOOSE_PROVIDER", ""),
+    llm_provider = ""
+    llm_api_key_var = ""
+    llm_api_key = ""
+    valid_providers = VALID_PROVIDERS.get(agent_backend)
+    if valid_providers is not None:
+        llm_provider = _prompt_choice(
+            "LLM provider",
+            sorted(valid_providers),
+            existing_env.get("LLM_PROVIDER", ""),
         )
-        goose_api_key_var = GOOSE_PROVIDER_KEY_VARS.get(goose_provider, "")
-        if goose_api_key_var:
-            goose_api_key = _prompt(
-                goose_api_key_var,
-                existing_env.get(goose_api_key_var, ""),
+        llm_api_key_var = PROVIDER_KEY_VARS.get(llm_provider, "")
+        if llm_api_key_var:
+            llm_api_key = _prompt(
+                llm_api_key_var,
+                existing_env.get(llm_api_key_var, ""),
                 required=True,
             )
         else:
-            # Ollama: no API key needed (local inference)
-            print(f"  {goose_provider} does not require an API key.")
+            # Ollama, Copilot, etc.: no API key needed
+            print(f"  {llm_provider} does not require an API key.")
     print()
 
     # -- Claude --
@@ -454,7 +455,7 @@ def _cmd_config() -> None:
     # Only prompt for truly global Claude settings (autocompact).
     # Determine the effective provider for model choices. Claude
     # backend always uses Anthropic; Goose uses the selected provider.
-    eff_provider = "anthropic" if agent_backend == "claude" else goose_provider
+    eff_provider = "anthropic" if agent_backend == "claude" else llm_provider
 
     if users_yaml_exists:
         print("-- Claude --")
@@ -692,12 +693,12 @@ def _cmd_config() -> None:
     if agent_backend != "claude":
         env["AGENT_BACKEND"] = agent_backend
 
-    # Goose provider and API key. Written alongside the backend choice
+    # LLM provider and API key. Written alongside the backend choice
     # so they survive into /etc/kai/env and are not wiped on reinstall.
-    if goose_provider:
-        env["GOOSE_PROVIDER"] = goose_provider
-    if goose_api_key_var and goose_api_key:
-        env[goose_api_key_var] = goose_api_key
+    if llm_provider:
+        env["LLM_PROVIDER"] = llm_provider
+    if llm_api_key_var and llm_api_key:
+        env[llm_api_key_var] = llm_api_key
 
     # Deprecated per-user vars: only include without users.yaml
     # (legacy single-user mode). With users.yaml, these are noise.

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -100,7 +100,7 @@ class SubprocessPool:
 
         Resolution order for each setting:
         1. UserConfig from users.yaml (os_user, home_workspace, model,
-           budget, timeout, context_window, agent_backend, goose_provider)
+           budget, timeout, context_window, agent_backend, llm_provider)
         2. Global config defaults (from .env)
 
         Per-user DB overrides (set via /settings or /model) are applied
@@ -117,13 +117,13 @@ class SubprocessPool:
 
         # Per-user backend and provider, falling back to global config.
         backend = user.agent_backend if user and user.agent_backend else self._config.agent_backend
-        provider = user.goose_provider if user and user.goose_provider else self._config.goose_provider
+        provider = user.llm_provider if user and user.llm_provider else self._config.llm_provider
 
         # Per-user model. When the user's effective provider differs from
         # the global provider, the global default_model may not be valid.
         # Fall back to the provider's default model instead.
         effective_provider = get_effective_provider(backend, provider)
-        global_provider = get_effective_provider(self._config.agent_backend, self._config.goose_provider)
+        global_provider = get_effective_provider(self._config.agent_backend, self._config.llm_provider)
         if user and user.model:
             model = user.model
         elif effective_provider == global_provider:
@@ -176,7 +176,7 @@ class SubprocessPool:
                 services_info=self._services_info,
                 workspace_config=ws_config,
                 max_context_window=context_window,
-                goose_provider=provider,
+                provider=provider,
             )
 
         # os_user for sudo -u isolation. None = run as bot user.

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -66,7 +66,7 @@ _REVIEW_TIMEOUT = 900
 # burn frontier-tier tokens. Full provider-native model IDs are required
 # because `goose run --model` uses provider naming, not Claude aliases.
 #
-# NOTE: Kai stores Google's provider as "google" in VALID_GOOSE_PROVIDERS,
+# NOTE: Kai stores Google's provider as "google" in VALID_PROVIDERS,
 # but Goose's --help lists it as "gemini-cli". This dict keys on Kai's
 # stored value ("google"). If Goose requires "gemini-cli", that is a
 # pre-existing config.py naming issue, not introduced by this change.
@@ -77,7 +77,7 @@ _GOOSE_AGENT_MODELS: dict[str, str] = {
 }
 
 
-def _resolve_goose_model(goose_provider: str) -> str:
+def _resolve_goose_model(provider: str) -> str:
     """Pick the review model for a Goose provider.
 
     Curated providers get a hardcoded mid-tier model (cost-effective
@@ -88,7 +88,7 @@ def _resolve_goose_model(goose_provider: str) -> str:
     Raises RuntimeError if no model can be resolved (open-ended
     provider with no GOOSE_MODEL set).
     """
-    model = _GOOSE_AGENT_MODELS.get(goose_provider)
+    model = _GOOSE_AGENT_MODELS.get(provider)
     if model:
         return model
     # Open-ended provider: use whatever the user configured.
@@ -96,7 +96,7 @@ def _resolve_goose_model(goose_provider: str) -> str:
     model = os.environ.get("GOOSE_MODEL", "")
     if not model:
         raise RuntimeError(
-            f"No model configured for Goose provider '{goose_provider}'. "
+            f"No model configured for Goose provider '{provider}'. "
             f"Set GOOSE_MODEL in the environment or DEFAULT_MODEL in .env."
         )
     return model
@@ -655,7 +655,7 @@ async def run_review(
     prompt: str,
     claude_user: str | None = None,
     agent_backend: str = "claude",
-    goose_provider: str = "",
+    provider: str = "",
 ) -> str:
     """
     Spawn a one-shot LLM subprocess to perform the review.
@@ -676,7 +676,7 @@ async def run_review(
         claude_user: Optional OS user to run Claude as (via sudo -u).
             Ignored when agent_backend is "goose".
         agent_backend: Which LLM backend to use ("claude" or "goose").
-        goose_provider: Goose provider name (e.g. "anthropic", "openai").
+        provider: LLM provider name (e.g. "anthropic", "openai").
             Only used when agent_backend is "goose".
 
     Returns:
@@ -686,22 +686,22 @@ async def run_review(
         RuntimeError: If the subprocess fails or times out.
     """
     if agent_backend == "goose":
-        if not goose_provider:
+        if not provider:
             raise ValueError(
-                "agent_backend is 'goose' but goose_provider is empty. Set GOOSE_PROVIDER in .env or per-user config."
+                "agent_backend is 'goose' but provider is empty. Set LLM_PROVIDER in .env or per-user config."
             )
         # Goose one-shot mode: read prompt from stdin, write response
         # to stdout. -q suppresses non-response output, --no-session
         # avoids creating session files, --no-profile skips user
         # config, --max-turns 1 prevents runaway tool loops.
-        model = _resolve_goose_model(goose_provider)
+        model = _resolve_goose_model(provider)
         cmd = [
             "goose",
             "run",
             "-i",
             "-",
             "--provider",
-            goose_provider,
+            provider,
             "--model",
             model,
             "-q",
@@ -888,7 +888,7 @@ async def review_pr(
     spec_dir: str = "specs",
     notify_chat_id: int | None = None,
     agent_backend: str = "claude",
-    goose_provider: str = "",
+    provider: str = "",
 ) -> None:
     """
     Full review pipeline: fetch diff, build prompt, run review, post results.
@@ -953,7 +953,7 @@ async def review_pr(
             prompt,
             claude_user=claude_user,
             agent_backend=agent_backend,
-            goose_provider=goose_provider,
+            provider=provider,
         )
 
         if not review_text.strip():

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -56,7 +56,7 @@ _TRIAGE_TIMEOUT = 300
 # burn frontier-tier tokens. Full provider-native model IDs are required
 # because `goose run --model` uses provider naming, not Claude aliases.
 #
-# NOTE: Kai stores Google's provider as "google" in VALID_GOOSE_PROVIDERS,
+# NOTE: Kai stores Google's provider as "google" in VALID_PROVIDERS,
 # but Goose's --help lists it as "gemini-cli". This dict keys on Kai's
 # stored value ("google"). If Goose requires "gemini-cli", that is a
 # pre-existing config.py naming issue, not introduced by this change.
@@ -67,7 +67,7 @@ _GOOSE_AGENT_MODELS: dict[str, str] = {
 }
 
 
-def _resolve_goose_model(goose_provider: str) -> str:
+def _resolve_goose_model(provider: str) -> str:
     """Pick the triage model for a Goose provider.
 
     Curated providers get a hardcoded mid-tier model (cost-effective
@@ -78,7 +78,7 @@ def _resolve_goose_model(goose_provider: str) -> str:
     Raises RuntimeError if no model can be resolved (open-ended
     provider with no GOOSE_MODEL set).
     """
-    model = _GOOSE_AGENT_MODELS.get(goose_provider)
+    model = _GOOSE_AGENT_MODELS.get(provider)
     if model:
         return model
     # Open-ended provider: use whatever the user configured.
@@ -86,7 +86,7 @@ def _resolve_goose_model(goose_provider: str) -> str:
     model = os.environ.get("GOOSE_MODEL", "")
     if not model:
         raise RuntimeError(
-            f"No model configured for Goose provider '{goose_provider}'. "
+            f"No model configured for Goose provider '{provider}'. "
             f"Set GOOSE_MODEL in the environment or DEFAULT_MODEL in .env."
         )
     return model
@@ -387,7 +387,7 @@ async def run_triage(
     prompt: str,
     claude_user: str | None = None,
     agent_backend: str = "claude",
-    goose_provider: str = "",
+    provider: str = "",
 ) -> str:
     """
     Spawn a one-shot LLM subprocess to perform the triage analysis.
@@ -402,7 +402,7 @@ async def run_triage(
         claude_user: Optional OS user to run Claude as (via sudo -u).
             Ignored when agent_backend is "goose".
         agent_backend: Which LLM backend to use ("claude" or "goose").
-        goose_provider: Goose provider name (e.g. "anthropic", "openai").
+        provider: LLM provider name (e.g. "anthropic", "openai").
             Only used when agent_backend is "goose".
 
     Returns:
@@ -412,22 +412,22 @@ async def run_triage(
         RuntimeError: If the subprocess fails or times out.
     """
     if agent_backend == "goose":
-        if not goose_provider:
+        if not provider:
             raise ValueError(
-                "agent_backend is 'goose' but goose_provider is empty. Set GOOSE_PROVIDER in .env or per-user config."
+                "agent_backend is 'goose' but provider is empty. Set LLM_PROVIDER in .env or per-user config."
             )
         # Goose one-shot mode: read prompt from stdin, write response
         # to stdout. -q suppresses non-response output, --no-session
         # avoids creating session files, --no-profile skips user
         # config, --max-turns 1 prevents runaway tool loops.
-        model = _resolve_goose_model(goose_provider)
+        model = _resolve_goose_model(provider)
         cmd = [
             "goose",
             "run",
             "-i",
             "-",
             "--provider",
-            goose_provider,
+            provider,
             "--model",
             model,
             "-q",
@@ -867,7 +867,7 @@ async def triage_issue(
     claude_user: str | None = None,
     notify_chat_id: int | None = None,
     agent_backend: str = "claude",
-    goose_provider: str = "",
+    provider: str = "",
 ) -> None:
     """
     Full triage pipeline: analyze issue, apply labels, post results.
@@ -908,7 +908,7 @@ async def triage_issue(
             prompt,
             claude_user=claude_user,
             agent_backend=agent_backend,
-            goose_provider=goose_provider,
+            provider=provider,
         )
 
         if not raw_response.strip():

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -725,10 +725,10 @@ async def _process_github_event_for_user(
     else:
         agent_backend = config.agent_backend
 
-    if user_config and user_config.goose_provider:
-        goose_provider = user_config.goose_provider
+    if user_config and user_config.llm_provider:
+        provider = user_config.llm_provider
     else:
-        goose_provider = config.goose_provider
+        provider = config.llm_provider
 
     # ── PR review routing ────────────────────────────────────────
     # When PR review is enabled for this user, reviewable PR events
@@ -776,7 +776,7 @@ async def _process_github_event_for_user(
                     spec_dir=request.app.get("spec_dir", "specs"),
                     notify_chat_id=target_chat_id,
                     agent_backend=agent_backend,
-                    goose_provider=goose_provider,
+                    goose_provider=provider,
                 )
             )
             _background_tasks.add(task)
@@ -822,7 +822,7 @@ async def _process_github_event_for_user(
                     claude_user=claude_user,
                     notify_chat_id=target_chat_id,
                     agent_backend=agent_backend,
-                    goose_provider=goose_provider,
+                    goose_provider=provider,
                 )
             )
             _background_tasks.add(task)

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -776,7 +776,7 @@ async def _process_github_event_for_user(
                     spec_dir=request.app.get("spec_dir", "specs"),
                     notify_chat_id=target_chat_id,
                     agent_backend=agent_backend,
-                    goose_provider=provider,
+                    goose_provider=provider,  # TODO(#278): rename param to provider
                 )
             )
             _background_tasks.add(task)
@@ -822,7 +822,7 @@ async def _process_github_event_for_user(
                     claude_user=claude_user,
                     notify_chat_id=target_chat_id,
                     agent_backend=agent_backend,
-                    goose_provider=provider,
+                    goose_provider=provider,  # TODO(#278): rename param to provider
                 )
             )
             _background_tasks.add(task)

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -776,7 +776,7 @@ async def _process_github_event_for_user(
                     spec_dir=request.app.get("spec_dir", "specs"),
                     notify_chat_id=target_chat_id,
                     agent_backend=agent_backend,
-                    goose_provider=provider,  # TODO(#278): rename param to provider
+                    provider=provider,
                 )
             )
             _background_tasks.add(task)
@@ -822,7 +822,7 @@ async def _process_github_event_for_user(
                     claude_user=claude_user,
                     notify_chat_id=target_chat_id,
                     agent_backend=agent_backend,
-                    goose_provider=provider,  # TODO(#278): rename param to provider
+                    provider=provider,
                 )
             )
             _background_tasks.add(task)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,7 +44,7 @@ _CONFIG_ENV_VARS = [
     "TOTP_LOCKOUT_ATTEMPTS",
     "TOTP_LOCKOUT_MINUTES",
     "AGENT_BACKEND",
-    "GOOSE_PROVIDER",
+    "LLM_PROVIDER",
     "KAI_DATA_DIR",
     "KAI_INSTALL_DIR",
 ]
@@ -190,50 +190,50 @@ class TestLoadConfigErrors:
         with pytest.raises(SystemExit, match="AGENT_BACKEND"):
             load_config()
 
-    def test_invalid_goose_provider(self, monkeypatch):
-        """GOOSE_PROVIDER with an unrecognized value raises SystemExit."""
+    def test_invalid_llm_provider(self, monkeypatch):
+        """LLM_PROVIDER with an unrecognized value raises SystemExit."""
         _set_required(monkeypatch)
         monkeypatch.setenv("AGENT_BACKEND", "goose")
-        monkeypatch.setenv("GOOSE_PROVIDER", "invalid")
-        with pytest.raises(SystemExit, match="GOOSE_PROVIDER"):
+        monkeypatch.setenv("LLM_PROVIDER", "invalid")
+        with pytest.raises(SystemExit, match="LLM_PROVIDER"):
             load_config()
 
-    def test_missing_goose_provider(self, monkeypatch):
-        """GOOSE_PROVIDER missing when backend=goose raises SystemExit."""
+    def test_missing_llm_provider(self, monkeypatch):
+        """LLM_PROVIDER missing when backend=goose raises SystemExit."""
         _set_required(monkeypatch)
         monkeypatch.setenv("AGENT_BACKEND", "goose")
-        with pytest.raises(SystemExit, match="GOOSE_PROVIDER"):
+        with pytest.raises(SystemExit, match="LLM_PROVIDER"):
             load_config()
 
-    def test_goose_provider_ignored_for_claude(self, monkeypatch):
-        """GOOSE_PROVIDER is not validated when backend=claude."""
+    def test_llm_provider_ignored_for_claude(self, monkeypatch):
+        """LLM_PROVIDER is not validated when backend=claude."""
         _set_required(monkeypatch)
         cfg = load_config()
-        assert cfg.goose_provider == ""
+        assert cfg.llm_provider == ""
 
-    def test_invalid_goose_provider_ignored_for_claude(self, monkeypatch):
-        """Even an invalid GOOSE_PROVIDER is ignored when backend=claude."""
+    def test_invalid_llm_provider_ignored_for_claude(self, monkeypatch):
+        """Even an invalid LLM_PROVIDER is ignored when backend=claude."""
         _set_required(monkeypatch)
-        monkeypatch.setenv("GOOSE_PROVIDER", "completelywrong")
+        monkeypatch.setenv("LLM_PROVIDER", "completelywrong")
         cfg = load_config()
-        assert cfg.goose_provider == ""
+        assert cfg.llm_provider == ""
 
-    def test_valid_goose_provider(self, monkeypatch):
-        """Valid GOOSE_PROVIDER is accepted and stored."""
+    def test_valid_llm_provider(self, monkeypatch):
+        """Valid LLM_PROVIDER is accepted and stored."""
         _set_required(monkeypatch)
         monkeypatch.setenv("AGENT_BACKEND", "goose")
-        monkeypatch.setenv("GOOSE_PROVIDER", "openai")
+        monkeypatch.setenv("LLM_PROVIDER", "openai")
         # DEFAULT_MODEL must be valid for the openai provider
         monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4")
         cfg = load_config()
-        assert cfg.goose_provider == "openai"
+        assert cfg.llm_provider == "openai"
 
     def test_goose_without_provider_exits(self, monkeypatch):
-        """AGENT_BACKEND=goose without GOOSE_PROVIDER fails at startup."""
+        """AGENT_BACKEND=goose without LLM_PROVIDER fails at startup."""
         _set_required(monkeypatch)
         monkeypatch.setenv("AGENT_BACKEND", "goose")
-        # GOOSE_PROVIDER not set - empty string is not in VALID_GOOSE_PROVIDERS
-        with pytest.raises(SystemExit, match=r"GOOSE_PROVIDER.*not valid"):
+        # LLM_PROVIDER not set - empty string is not in VALID_PROVIDERS["goose"]
+        with pytest.raises(SystemExit, match=r"LLM_PROVIDER.*not valid"):
             load_config()
 
 

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -345,7 +345,7 @@ class TestHandshake:
     @pytest.mark.asyncio
     async def test_model_env_var_set(self):
         """GOOSE_MODEL env var is set during startup."""
-        g = _make_goose(model="opus", goose_provider="anthropic")
+        g = _make_goose(model="opus", provider="anthropic")
         proc = _make_mock_proc(_handshake_lines())
 
         with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
@@ -357,7 +357,7 @@ class TestHandshake:
     @pytest.mark.asyncio
     async def test_model_passthrough_for_non_anthropic(self):
         """Non-Anthropic providers pass model value through unchanged."""
-        g = _make_goose(model="sonnet", goose_provider="openai")
+        g = _make_goose(model="sonnet", provider="openai")
         proc = _make_mock_proc(_handshake_lines())
 
         with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -589,7 +589,7 @@ class TestCmdConfig:
 
         conf = json.loads((tmp_path / "install.conf").read_text())
         assert conf["env"]["AGENT_BACKEND"] == "goose"
-        assert conf["env"]["GOOSE_PROVIDER"] == "anthropic"
+        assert conf["env"]["LLM_PROVIDER"] == "anthropic"
         assert conf["env"]["ANTHROPIC_API_KEY"] == "sk-ant-test-key"
 
     def test_goose_ollama_no_api_key(self, tmp_path, monkeypatch):
@@ -640,7 +640,7 @@ class TestCmdConfig:
         _cmd_config()
 
         conf = json.loads((tmp_path / "install.conf").read_text())
-        assert conf["env"]["GOOSE_PROVIDER"] == "ollama"
+        assert conf["env"]["LLM_PROVIDER"] == "ollama"
         # Ollama is local inference - no API key should be present
         for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "OPENROUTER_API_KEY"):
             assert key not in conf["env"]

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -132,7 +132,7 @@ class TestPerUserBackendRouting:
             telegram_id=111,
             name="alice",
             agent_backend="goose",
-            goose_provider="openai",
+            llm_provider="openai",
             model="gpt-5.4",
         )
         config = _make_config(user_configs={111: user})
@@ -153,17 +153,17 @@ class TestPerUserBackendRouting:
         assert instance.provider == "anthropic"
 
     def test_user_provider_overrides_global(self):
-        """User with goose_provider gets GooseBackend with that provider."""
+        """User with llm_provider gets GooseBackend with that provider."""
         user = UserConfig(
             telegram_id=111,
             name="alice",
             agent_backend="goose",
-            goose_provider="google",
+            llm_provider="google",
             model="gemini-3-flash",
         )
         config = _make_config(
             agent_backend="goose",
-            goose_provider="openai",
+            llm_provider="openai",
             default_model="gpt-5.4",
             user_configs={111: user},
         )
@@ -180,7 +180,7 @@ class TestPerUserBackendRouting:
             telegram_id=111,
             name="alice",
             agent_backend="goose",
-            goose_provider="openai",
+            llm_provider="openai",
             # No model set - should get openai default, not global "sonnet"
         )
         config = _make_config(user_configs={111: user})
@@ -196,7 +196,7 @@ class TestPerUserBackendRouting:
             telegram_id=111,
             name="alice",
             agent_backend="goose",
-            goose_provider="openai",
+            llm_provider="openai",
             model="gpt-5.4",
         )
         config = _make_config(user_configs={111: user})

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -694,7 +694,7 @@ class TestRunReviewGoose:
             result = await run_review(
                 "review prompt",
                 agent_backend="goose",
-                goose_provider="openai",
+                provider="openai",
             )
 
         assert result == "review output"
@@ -723,7 +723,7 @@ class TestRunReviewGoose:
         mock_proc = _mock_process(stdout=b"output")
 
         with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_review("prompt", agent_backend="goose", goose_provider="anthropic")
+            await run_review("prompt", agent_backend="goose", provider="anthropic")
 
         cmd = mock_exec.call_args[0]
         assert "--model" in cmd
@@ -736,7 +736,7 @@ class TestRunReviewGoose:
         mock_proc = _mock_process(stdout=b"  review text with whitespace  \n")
 
         with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await run_review("prompt", agent_backend="goose", goose_provider="anthropic")
+            result = await run_review("prompt", agent_backend="goose", provider="anthropic")
 
         assert result == "review text with whitespace"
 
@@ -754,7 +754,7 @@ class TestRunReviewGoose:
             patch("kai.review.os.killpg") as mock_killpg,
             pytest.raises(RuntimeError, match="timed out"),
         ):
-            await run_review("prompt", agent_backend="goose", goose_provider="openai")
+            await run_review("prompt", agent_backend="goose", provider="openai")
 
         mock_proc.kill.assert_called_once()
         mock_killpg.assert_not_called()
@@ -768,7 +768,7 @@ class TestRunReviewGoose:
             patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc),
             pytest.raises(RuntimeError, match=r"Review subprocess failed.*provider error"),
         ):
-            await run_review("prompt", agent_backend="goose", goose_provider="openai")
+            await run_review("prompt", agent_backend="goose", provider="openai")
 
     @pytest.mark.asyncio
     async def test_no_sudo_even_with_claude_user(self):
@@ -780,7 +780,7 @@ class TestRunReviewGoose:
                 "prompt",
                 claude_user="kai",
                 agent_backend="goose",
-                goose_provider="anthropic",
+                provider="anthropic",
             )
 
         cmd = mock_exec.call_args[0]
@@ -796,7 +796,7 @@ class TestRunReviewGoose:
             patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
             patch.dict(os.environ, {"GOOSE_MODEL": "llama3.3:70b"}),
         ):
-            await run_review("prompt", agent_backend="goose", goose_provider="ollama")
+            await run_review("prompt", agent_backend="goose", provider="ollama")
 
         cmd = mock_exec.call_args[0]
         model_idx = cmd.index("--model")
@@ -811,7 +811,7 @@ class TestRunReviewGoose:
         ):
             # Remove GOOSE_MODEL if it happens to be set in the test env
             os.environ.pop("GOOSE_MODEL", None)
-            await run_review("prompt", agent_backend="goose", goose_provider="ollama")
+            await run_review("prompt", agent_backend="goose", provider="ollama")
 
     @pytest.mark.asyncio
     async def test_default_backend_is_claude(self):
@@ -826,10 +826,10 @@ class TestRunReviewGoose:
         assert "--print" in cmd
 
     @pytest.mark.asyncio
-    async def test_empty_goose_provider_raises(self):
+    async def test_empty_provider_raises(self):
         """Goose backend with empty provider raises ValueError early."""
-        with pytest.raises(ValueError, match="goose_provider is empty"):
-            await run_review("prompt", agent_backend="goose", goose_provider="")
+        with pytest.raises(ValueError, match="provider is empty"):
+            await run_review("prompt", agent_backend="goose", provider="")
 
 
 class TestResolveGooseModelReview:

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -459,7 +459,7 @@ class TestRunTriageGoose:
             result = await run_triage(
                 "triage prompt",
                 agent_backend="goose",
-                goose_provider="openai",
+                provider="openai",
             )
 
         assert result == '{"labels": ["bug"]}'
@@ -488,7 +488,7 @@ class TestRunTriageGoose:
         mock_proc = _mock_subprocess(stdout='{"labels": []}')
 
         with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage("prompt", agent_backend="goose", goose_provider="anthropic")
+            await run_triage("prompt", agent_backend="goose", provider="anthropic")
 
         cmd = mock_exec.call_args[0]
         assert "--model" in cmd
@@ -501,7 +501,7 @@ class TestRunTriageGoose:
         mock_proc = _mock_subprocess(stdout='  {"labels": ["feature"]}  \n')
 
         with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await run_triage("prompt", agent_backend="goose", goose_provider="anthropic")
+            result = await run_triage("prompt", agent_backend="goose", provider="anthropic")
 
         assert result == '{"labels": ["feature"]}'
 
@@ -519,7 +519,7 @@ class TestRunTriageGoose:
             patch("kai.triage.os.killpg") as mock_killpg,
             pytest.raises(RuntimeError, match="timed out"),
         ):
-            await run_triage("prompt", agent_backend="goose", goose_provider="openai")
+            await run_triage("prompt", agent_backend="goose", provider="openai")
 
         mock_proc.kill.assert_called_once()
         mock_killpg.assert_not_called()
@@ -533,7 +533,7 @@ class TestRunTriageGoose:
             patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc),
             pytest.raises(RuntimeError, match=r"Triage subprocess failed.*provider error"),
         ):
-            await run_triage("prompt", agent_backend="goose", goose_provider="openai")
+            await run_triage("prompt", agent_backend="goose", provider="openai")
 
     @pytest.mark.asyncio
     async def test_no_sudo_even_with_claude_user(self):
@@ -545,7 +545,7 @@ class TestRunTriageGoose:
                 "prompt",
                 claude_user="kai",
                 agent_backend="goose",
-                goose_provider="anthropic",
+                provider="anthropic",
             )
 
         cmd = mock_exec.call_args[0]
@@ -561,7 +561,7 @@ class TestRunTriageGoose:
             patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
             patch.dict(os.environ, {"GOOSE_MODEL": "llama3.3:70b"}),
         ):
-            await run_triage("prompt", agent_backend="goose", goose_provider="ollama")
+            await run_triage("prompt", agent_backend="goose", provider="ollama")
 
         cmd = mock_exec.call_args[0]
         model_idx = cmd.index("--model")
@@ -575,7 +575,7 @@ class TestRunTriageGoose:
             pytest.raises(RuntimeError, match="No model configured"),
         ):
             os.environ.pop("GOOSE_MODEL", None)
-            await run_triage("prompt", agent_backend="goose", goose_provider="ollama")
+            await run_triage("prompt", agent_backend="goose", provider="ollama")
 
     @pytest.mark.asyncio
     async def test_default_backend_is_claude(self):
@@ -590,10 +590,10 @@ class TestRunTriageGoose:
         assert "--print" in cmd
 
     @pytest.mark.asyncio
-    async def test_empty_goose_provider_raises(self):
+    async def test_empty_provider_raises(self):
         """Goose backend with empty provider raises ValueError early."""
-        with pytest.raises(ValueError, match="goose_provider is empty"):
-            await run_triage("prompt", agent_backend="goose", goose_provider="")
+        with pytest.raises(ValueError, match="provider is empty"):
+            await run_triage("prompt", agent_backend="goose", provider="")
 
 
 class TestResolveGooseModelTriage:

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -45,7 +45,7 @@ class TestUserConfig:
         assert uc.pr_review is None
         assert uc.issue_triage is None
         assert uc.agent_backend is None
-        assert uc.goose_provider is None
+        assert uc.llm_provider is None
 
     def test_all_fields(self):
         """Full config with every field populated."""
@@ -66,7 +66,7 @@ class TestUserConfig:
             pr_review=True,
             issue_triage=False,
             agent_backend="goose",
-            goose_provider="openai",
+            llm_provider="openai",
         )
         assert uc.role == "admin"
         assert uc.github == "alice-dev"
@@ -81,7 +81,7 @@ class TestUserConfig:
         assert uc.pr_review is True
         assert uc.issue_triage is False
         assert uc.agent_backend == "goose"
-        assert uc.goose_provider == "openai"
+        assert uc.llm_provider == "openai"
 
     def test_frozen(self):
         """UserConfig is immutable."""
@@ -913,7 +913,7 @@ class TestLoadUserConfigs:
               - telegram_id: 111
                 name: alice
                 agent_backend: goose
-                goose_provider: openai
+                llm_provider: openai
                 model: gpt-5.4
             """,
         )
@@ -924,7 +924,7 @@ class TestLoadUserConfigs:
             configs = _load_user_configs("claude", "")
         assert configs is not None
         assert configs[111].agent_backend == "goose"
-        assert configs[111].goose_provider == "openai"
+        assert configs[111].llm_provider == "openai"
         assert configs[111].model == "gpt-5.4"
 
     def test_invalid_agent_backend_exits(self, tmp_path):
@@ -945,21 +945,22 @@ class TestLoadUserConfigs:
         ):
             _load_user_configs("claude", "")
 
-    def test_invalid_goose_provider_exits(self, tmp_path):
-        """Invalid goose_provider causes SystemExit."""
+    def test_invalid_llm_provider_exits(self, tmp_path):
+        """Invalid llm_provider for the user's backend causes SystemExit."""
         self._write_yaml(
             tmp_path,
             """\
             users:
               - telegram_id: 111
                 name: alice
-                goose_provider: badprovider
+                agent_backend: goose
+                llm_provider: badprovider
             """,
         )
         with (
             patch("kai.config._read_protected_yaml", return_value=None),
             patch("kai.config.PROJECT_ROOT", tmp_path),
-            pytest.raises(SystemExit, match="invalid goose_provider"),
+            pytest.raises(SystemExit, match="invalid llm_provider"),
         ):
             _load_user_configs("claude", "")
 
@@ -978,12 +979,12 @@ class TestLoadUserConfigs:
             patch("kai.config._read_protected_yaml", return_value=None),
             patch("kai.config.PROJECT_ROOT", tmp_path),
             # Global provider is "" (empty), user has none set
-            pytest.raises(SystemExit, match="no goose_provider"),
+            pytest.raises(SystemExit, match="no llm_provider"),
         ):
             _load_user_configs("claude", "")
 
     def test_goose_backend_inherits_global_provider(self, tmp_path):
-        """User with goose backend inherits global goose_provider."""
+        """User with goose backend inherits global llm_provider."""
         self._write_yaml(
             tmp_path,
             """\
@@ -1003,7 +1004,7 @@ class TestLoadUserConfigs:
         assert configs is not None
         # User inherits global provider, no per-user override stored
         assert configs[111].agent_backend == "goose"
-        assert configs[111].goose_provider is None
+        assert configs[111].llm_provider is None
 
     def test_model_validated_against_user_provider(self, tmp_path):
         """Model invalid for user's effective provider is rejected."""
@@ -1014,7 +1015,7 @@ class TestLoadUserConfigs:
               - telegram_id: 111
                 name: alice
                 agent_backend: goose
-                goose_provider: openai
+                llm_provider: openai
                 model: opus
             """,
         )
@@ -1036,7 +1037,7 @@ class TestLoadUserConfigs:
               - telegram_id: 111
                 name: alice
                 agent_backend: goose
-                goose_provider: ollama
+                llm_provider: ollama
             """,
         )
         import logging

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2065,14 +2065,14 @@ class TestPerUserRouting:
 
     @pytest.mark.asyncio
     async def test_review_receives_user_backend(self, _clear_cooldowns, _mock_resolve_repo):
-        """Per-user agent_backend/goose_provider are passed to review_pr."""
+        """Per-user agent_backend/llm_provider are passed to review_pr."""
         base = self._make_user_config(111, repos=["owner/repo"])
         # Frozen dataclass - use replace to set per-user backend override
-        user = dataclasses.replace(base, agent_backend="goose", goose_provider="openai")
+        user = dataclasses.replace(base, agent_backend="goose", llm_provider="openai")
         config = self._make_config_with_users([user])
         # Global defaults (should be overridden by per-user values)
         config.agent_backend = "claude"
-        config.goose_provider = ""
+        config.llm_provider = ""
         app = _build_test_app(config=config)
         payload = _make_pr_payload("opened")
         body = json.dumps(payload).encode()
@@ -2100,12 +2100,12 @@ class TestPerUserRouting:
 
     @pytest.mark.asyncio
     async def test_triage_receives_user_backend(self, _clear_cooldowns):
-        """Per-user agent_backend/goose_provider are passed to triage_issue."""
+        """Per-user agent_backend/llm_provider are passed to triage_issue."""
         base = self._make_user_config(111, repos=["owner/repo"])
-        user = dataclasses.replace(base, agent_backend="goose", goose_provider="anthropic")
+        user = dataclasses.replace(base, agent_backend="goose", llm_provider="anthropic")
         config = self._make_config_with_users([user])
         config.agent_backend = "claude"
-        config.goose_provider = ""
+        config.llm_provider = ""
         app = _build_test_app(config=config)
         payload = _make_issue_payload("opened")
         body = json.dumps(payload).encode()
@@ -2135,10 +2135,10 @@ class TestPerUserRouting:
     async def test_review_uses_global_backend_when_no_user_override(self, _clear_cooldowns, _mock_resolve_repo):
         """Without per-user override, review_pr gets the global backend."""
         user = self._make_user_config(111, repos=["owner/repo"])
-        # No agent_backend/goose_provider set on user - defaults are None
+        # No agent_backend/llm_provider set on user - defaults are None
         config = self._make_config_with_users([user])
         config.agent_backend = "goose"
-        config.goose_provider = "google"
+        config.llm_provider = "google"
         app = _build_test_app(config=config)
         payload = _make_pr_payload("opened")
         body = json.dumps(payload).encode()

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2096,7 +2096,7 @@ class TestPerUserRouting:
             await asyncio.sleep(0.01)
             mock_review.assert_called_once()
             assert mock_review.call_args[1]["agent_backend"] == "goose"
-            assert mock_review.call_args[1]["goose_provider"] == "openai"
+            assert mock_review.call_args[1]["provider"] == "openai"
 
     @pytest.mark.asyncio
     async def test_triage_receives_user_backend(self, _clear_cooldowns):
@@ -2129,7 +2129,7 @@ class TestPerUserRouting:
             await asyncio.sleep(0.01)
             mock_triage.assert_called_once()
             assert mock_triage.call_args[1]["agent_backend"] == "goose"
-            assert mock_triage.call_args[1]["goose_provider"] == "anthropic"
+            assert mock_triage.call_args[1]["provider"] == "anthropic"
 
     @pytest.mark.asyncio
     async def test_review_uses_global_backend_when_no_user_override(self, _clear_cooldowns, _mock_resolve_repo):
@@ -2163,7 +2163,7 @@ class TestPerUserRouting:
             mock_review.assert_called_once()
             # Falls back to global config values
             assert mock_review.call_args[1]["agent_backend"] == "goose"
-            assert mock_review.call_args[1]["goose_provider"] == "google"
+            assert mock_review.call_args[1]["provider"] == "google"
 
 
 # ── add_allowed_chat_id / remove_allowed_chat_id ────────────────────

--- a/users.example.yaml
+++ b/users.example.yaml
@@ -36,9 +36,9 @@ users:
 
     # Agent backend. Overrides the global AGENT_BACKEND from .env for
     # this user only. Default is "claude" (Claude Code CLI). Set to
-    # "goose" to use Goose ACP with the specified provider.
+    # "goose" to use Goose ACP with the specified LLM provider.
     # agent_backend: goose
-    # goose_provider: openai    # required when agent_backend is goose
+    # llm_provider: openai    # required for non-Claude backends
 
     # GitHub notification settings. github_repos controls which repos
     # route events to this user. pr_review and issue_triage toggle


### PR DESCRIPTION
## Summary

Renames `goose_provider` to `llm_provider` / `provider` across the entire codebase so provider resolution is backend-agnostic. Prepares for additional backends (OpenCode, #296) by eliminating per-backend if/elif/else branches at every provider resolution point.

- `VALID_GOOSE_PROVIDERS` flat set replaced with `VALID_PROVIDERS` dict keyed by backend name
- `GOOSE_PROVIDER_KEY_VARS` renamed to `PROVIDER_KEY_VARS` (backend-agnostic)
- `Config.goose_provider` / `UserConfig.goose_provider` renamed to `llm_provider`
- `GOOSE_PROVIDER` env var renamed to `LLM_PROVIDER`
- `GooseBackend(goose_provider=)` constructor param renamed to `provider=`; redundant `self.goose_provider` attribute removed
- All call sites updated: pool.py, bot.py, webhook.py, install.py
- `run_review()`, `review_pr()`, `run_triage()`, `triage_issue()` parameter renamed from `goose_provider` to `provider`, along with internal usages, error messages, and docstrings
- `_resolve_goose_model()` parameter renamed to `provider` (function name kept as-is since it is Goose-specific)
- No production users of `GOOSE_PROVIDER` exist, so no deprecation path needed

Fixes #297

## Test plan

- [x] All 1683 tests pass
- [x] Ruff lint + format clean
- [x] Zero remaining `goose_provider` / `GOOSE_PROVIDER` / `VALID_GOOSE_PROVIDERS` references in src/ or tests/
