### PR TITLE
Rename CLAUDE_MAX_BUDGET_USD to BUDGET_CEILING, separate ceiling from default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,9 +40,9 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 # users.yaml or use /settings timeout via Telegram.
 #CLAUDE_TIMEOUT_SECONDS=120
 
-# DEPRECATED when users.yaml exists - set per-user 'max_budget' in
-# users.yaml or use /settings budget via Telegram.
-#CLAUDE_MAX_BUDGET_USD=10.0
+# Global budget ceiling in USD. Users cannot exceed this via /settings.
+# Per-user defaults are set via 'max_budget' in users.yaml.
+#BUDGET_CEILING=10.0
 
 # Maximum session age in hours before recycling (0 = no limit).
 # Prevents unbounded memory growth in the inner Claude process.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ users:
     github: alice-dev     # routes GitHub events to this user
     os_user: alice        # subprocess runs as this OS account
     home_workspace: /home/alice/workspace
-    max_budget: 15.0      # ceiling for /settings budget (CLAUDE_MAX_BUDGET_USD is the default)
+    max_budget: 15.0      # default budget for this user (BUDGET_CEILING is the global ceiling)
 ```
 
 Each user gets:
@@ -194,7 +194,7 @@ cp .env.example .env
 | `ALLOWED_USER_IDS` | Deprecated* | | Comma-separated Telegram user IDs. Superseded by `users.yaml`; use `make config` instead. (*Still works if `users.yaml` absent.) |
 | `CLAUDE_MODEL` | Deprecated* | `sonnet` | Default model. Set per-user in `users.yaml` or via `/settings model`. |
 | `CLAUDE_TIMEOUT_SECONDS` | Deprecated* | `120` | Per-message timeout. Set per-user in `users.yaml` or via `/settings timeout`. |
-| `CLAUDE_MAX_BUDGET_USD` | Deprecated* | `10.0` | Session budget cap. Set per-user in `users.yaml` or via `/settings budget`. |
+| `BUDGET_CEILING` | No | `10.0` | Global budget ceiling in USD. Users cannot exceed this via `/settings budget`. Per-user defaults are set via `max_budget` in `users.yaml`. |
 | `CLAUDE_MAX_CONTEXT_WINDOW` | Deprecated* | `0` | Context window size in tokens (0 = backend default). Set per-user in `users.yaml` or via `/settings context`. |
 | `CLAUDE_AUTOCOMPACT_PCT` | No | `80` | Context compression threshold %, Claude Code only. When usage hits this, Claude compresses history. Can only lower the default (~83%), not raise it. |
 | `CLAUDE_MAX_SESSION_HOURS` | No | `0` | Maximum session age in hours before recycling the subprocess (0 = no limit). Recommended: 4-8 on memory-constrained machines. |
@@ -221,7 +221,7 @@ cp .env.example .env
 
 *Deprecated vars still work for backward compatibility when `users.yaml` is absent. When `users.yaml` is present, `users.yaml` wins and a warning is logged. Run `make config` to migrate.
 
-`CLAUDE_MAX_BUDGET_USD` limits spending in a single session. For Claude Code, this maps to the `--max-budget-usd` CLI flag (on Pro/Max plans, purely a runaway prevention mechanism). Goose does not currently enforce this limit. The session resets on `/new`, model switch, or workspace switch.
+`BUDGET_CEILING` limits spending in a single session. For Claude Code, this maps to the `--max-budget-usd` CLI flag (on Pro/Max plans, purely a runaway prevention mechanism). Goose does not currently enforce this limit. The session resets on `/new`, model switch, or workspace switch.
 
 ## Running
 

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -599,15 +599,9 @@ async def handle_settings(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         except ValueError:
             await update.message.reply_text("Budget must be a positive number.")
             return
-        # Enforce ceiling: users.yaml max_budget or global default.
-        # 0 means "no admin ceiling" (e.g., CLAUDE_MAX_BUDGET_USD unset
-        # or explicitly 0). Only enforce when a positive ceiling exists.
-        user_config = config.get_user_config(chat_id)
-        ceiling = (
-            user_config.max_budget
-            if user_config and user_config.max_budget is not None
-            else config.claude_max_budget_usd
-        )
+        # Enforce ceiling: always from global config, never per-user.
+        # 0 means "no ceiling" (skip enforcement).
+        ceiling = config.budget_ceiling
         if ceiling and budget > ceiling:
             await update.message.reply_text(f"Budget cannot exceed ${ceiling:.2f} (admin limit).")
             return
@@ -710,11 +704,12 @@ async def _show_settings(update: Update, context: ContextTypes.DEFAULT_TYPE, cha
 
     # Budget - 0 means "unlimited" (consistent with the ceiling check
     # in the budget handler, where 0 = no ceiling).
+    # budget_ceiling doubles as the fallback default for unconfigured users
     yaml_budget = user_config.max_budget if user_config else None
     budget, budget_src = _resolve(
         "budget",
         yaml_budget,
-        config.claude_max_budget_usd,
+        config.budget_ceiling,
         lambda v: "unlimited" if float(v) == 0 else f"${float(v):.2f}",
     )
 
@@ -751,16 +746,6 @@ async def _show_settings(update: Update, context: ContextTypes.DEFAULT_TYPE, cha
         ctx_src = "global default"
     ctx_label = f"{ctx_val:,} tokens" if ctx_val > 0 else "not set (model default)"
 
-    # Budget ceiling - show when a positive ceiling exists so the user
-    # knows their limit before hitting it. Falls through to the global
-    # default when no users.yaml entry exists. 0 = no limit, suppress.
-    ceiling = (
-        user_config.max_budget
-        if user_config and user_config.max_budget is not None
-        else config.claude_max_budget_usd or None  # 0 means no limit
-    )
-    ceiling_line = f"\n\nBudget ceiling: ${ceiling:.2f} (admin)" if ceiling else ""
-
     # Provider info - always show so users know their configuration.
     # Uses the shared helper that checks the running instance first,
     # falling back to config cascade so new users see their provider
@@ -776,7 +761,6 @@ async def _show_settings(update: Update, context: ContextTypes.DEFAULT_TYPE, cha
         f"  Budget: {budget} ({budget_src})\n"
         f"  Timeout: {timeout} ({timeout_src})\n"
         f"  Context: {ctx_label} ({ctx_src})"
-        f"{ceiling_line}"
     )
 
 
@@ -817,9 +801,8 @@ def _revert_instance_field(pool: SubprocessPool, chat_id: int, field: str, confi
                     fallback = config.default_model
                 instance.model = fallback
     elif field == "budget":
-        instance.max_budget_usd = (
-            user.max_budget if user and user.max_budget is not None else config.claude_max_budget_usd
-        )
+        # budget_ceiling doubles as the fallback default for unconfigured users
+        instance.max_budget_usd = user.max_budget if user and user.max_budget is not None else config.budget_ceiling
     elif field == "timeout":
         instance.timeout_seconds = user.timeout if user and user.timeout is not None else config.claude_timeout_seconds
     elif field == "context_window":
@@ -1443,14 +1426,9 @@ async def _handle_workspace_config(
         except ValueError:
             await update.message.reply_text("Budget must be a positive number.")
             return
-        # Enforce ceiling: per-user max_budget from users.yaml, or the
-        # global claude_max_budget_usd as fallback. 0 = no ceiling.
-        user_config = config.get_user_config(chat_id)
-        ceiling = (
-            user_config.max_budget
-            if user_config and user_config.max_budget is not None
-            else config.claude_max_budget_usd
-        )
+        # Enforce ceiling: always from global config, never per-user.
+        # 0 means "no ceiling" (skip enforcement).
+        ceiling = config.budget_ceiling
         if ceiling and budget > ceiling:
             await update.message.reply_text(f"Budget cannot exceed ${ceiling:.2f} (admin limit).")
             return
@@ -1541,7 +1519,8 @@ async def _show_workspace_config(
         elif user_config and user_config.max_budget is not None:
             budget, budget_src = user_config.max_budget, "users.yaml"
         else:
-            budget, budget_src = config.claude_max_budget_usd, "global default"
+            # budget_ceiling doubles as the fallback default for unconfigured users
+            budget, budget_src = config.budget_ceiling, "global default"
         lines.append(f"  Budget: ${budget:.2f} ({budget_src})")
     except (ValueError, TypeError):
         lines.append("  Budget: (corrupted - reset with /workspace config reset budget)")

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -240,9 +240,10 @@ class UserConfig:
         github: GitHub username for webhook actor routing.
         os_user: OS username for subprocess isolation (Phase 3).
         home_workspace: Per-user home workspace directory.
-        max_budget: Budget ceiling in USD. Serves double duty as both
-            the admin ceiling (user cannot exceed via /settings budget)
-            and the baseline default (used if user hasn't set their own).
+        max_budget: Default budget in USD for this user. Used as the
+            baseline when the user has not set their own via /settings
+            budget. Does NOT serve as a ceiling - the ceiling is
+            BUDGET_CEILING (global env var).
         model: Default model name (e.g., "opus", "sonnet", "haiku").
         timeout: Default timeout in seconds for Claude responses.
         context_window: Default context window size in tokens (0 = default).
@@ -297,7 +298,9 @@ class Config:
         allowed_user_ids: Set of Telegram user IDs permitted to interact with the bot (required)
         default_model: Default model name, provider-dependent (e.g. sonnet, gpt-5.4, gemini-3-flash)
         claude_timeout_seconds: Seconds before a Claude response is considered timed out
-        claude_max_budget_usd: Per-session spending cap in USD
+        budget_ceiling: Global budget ceiling in USD. Users cannot exceed
+            this via /settings budget. Also serves as the fallback default
+            for users without a per-user max_budget in users.yaml.
         claude_max_session_hours: Hours before the inner Claude process is recycled. Prevents
             unbounded V8 memory growth that can trigger macOS Jetsam kernel panics. 0 = no limit.
         claude_workspace: Working directory for the inner Claude Code process
@@ -330,7 +333,7 @@ class Config:
     # Claude Code process configuration
     default_model: str = "sonnet"
     claude_timeout_seconds: int = 120
-    claude_max_budget_usd: float = 10.0
+    budget_ceiling: float = 10.0
     claude_max_session_hours: float = 0  # 0 = no limit
     claude_idle_timeout: int = 1800  # seconds before idle subprocess eviction; 0 = no eviction
     claude_workspace: Path = field(default_factory=lambda: PROJECT_ROOT / "home")
@@ -1208,10 +1211,17 @@ def load_config() -> Config:
         claude_timeout_seconds = int(os.environ.get("CLAUDE_TIMEOUT_SECONDS", "120"))
     except ValueError:
         raise SystemExit("CLAUDE_TIMEOUT_SECONDS must be an integer") from None
+    # Budget ceiling: new var takes precedence, fall back to old var
+    # for backward compat on upgrade (existing .env has old key name).
+    raw_ceiling = os.environ.get("BUDGET_CEILING", "").strip()
+    if not raw_ceiling:
+        raw_ceiling = os.environ.get("CLAUDE_MAX_BUDGET_USD", "").strip()
+    if not raw_ceiling:
+        raw_ceiling = "10.0"
     try:
-        claude_max_budget_usd = float(os.environ.get("CLAUDE_MAX_BUDGET_USD", "10.0"))
+        budget_ceiling = float(raw_ceiling)
     except ValueError:
-        raise SystemExit("CLAUDE_MAX_BUDGET_USD must be a number") from None
+        raise SystemExit("BUDGET_CEILING must be a number") from None
     try:
         claude_max_session_hours = float(os.environ.get("CLAUDE_MAX_SESSION_HOURS", "0"))
     except ValueError:
@@ -1350,7 +1360,7 @@ def load_config() -> Config:
     if user_configs is not None:
         _deprecated_env_vars = {
             "CLAUDE_MODEL": "Renamed to DEFAULT_MODEL. Set per-user 'model' in users.yaml or use /settings model",
-            "CLAUDE_MAX_BUDGET_USD": "Set per-user 'max_budget' in users.yaml or use /settings budget",
+            "CLAUDE_MAX_BUDGET_USD": "Renamed to BUDGET_CEILING. Set per-user 'max_budget' in users.yaml or use /settings budget",
             "CLAUDE_TIMEOUT_SECONDS": "Set per-user 'timeout' in users.yaml or use /settings timeout",
             "CLAUDE_MAX_CONTEXT_WINDOW": "Set per-user 'context_window' in users.yaml or use /settings context",
             "CLAUDE_USER": "Set per-user 'os_user' in users.yaml",
@@ -1423,7 +1433,7 @@ def load_config() -> Config:
         allowed_user_ids=allowed_ids,
         default_model=default_model,
         claude_timeout_seconds=claude_timeout_seconds,
-        claude_max_budget_usd=claude_max_budget_usd,
+        budget_ceiling=budget_ceiling,
         claude_max_session_hours=claude_max_session_hours,
         claude_idle_timeout=claude_idle_timeout,
         claude_max_context_window=claude_max_context_window,

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1360,7 +1360,7 @@ def load_config() -> Config:
     if user_configs is not None:
         _deprecated_env_vars = {
             "CLAUDE_MODEL": "Renamed to DEFAULT_MODEL. Set per-user 'model' in users.yaml or use /settings model",
-            "CLAUDE_MAX_BUDGET_USD": "Renamed to BUDGET_CEILING. Set per-user 'max_budget' in users.yaml or use /settings budget",
+            "CLAUDE_MAX_BUDGET_USD": "Renamed to BUDGET_CEILING (global ceiling). Per-user defaults go in users.yaml 'max_budget'",
             "CLAUDE_TIMEOUT_SECONDS": "Set per-user 'timeout' in users.yaml or use /settings timeout",
             "CLAUDE_MAX_CONTEXT_WINDOW": "Set per-user 'context_window' in users.yaml or use /settings context",
             "CLAUDE_USER": "Set per-user 'os_user' in users.yaml",

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -464,7 +464,7 @@ def _cmd_config() -> None:
         # Read DEFAULT_MODEL, falling back to CLAUDE_MODEL for backward compat
         model = existing_env.get("DEFAULT_MODEL", existing_env.get("CLAUDE_MODEL", ""))
         timeout = existing_env.get("CLAUDE_TIMEOUT_SECONDS", "")
-        budget = existing_env.get("CLAUDE_MAX_BUDGET_USD", "")
+        budget = existing_env.get("BUDGET_CEILING", existing_env.get("CLAUDE_MAX_BUDGET_USD", ""))
         max_context_window = existing_env.get("CLAUDE_MAX_CONTEXT_WINDOW", "")
     else:
         print("-- Claude --")
@@ -500,7 +500,7 @@ def _cmd_config() -> None:
         while True:
             budget = _prompt(
                 "Claude budget (USD)",
-                existing_env.get("CLAUDE_MAX_BUDGET_USD", "10.0"),
+                existing_env.get("BUDGET_CEILING", existing_env.get("CLAUDE_MAX_BUDGET_USD", "10.0")),
             )
             if _validate_positive_float(budget):
                 break
@@ -702,14 +702,15 @@ def _cmd_config() -> None:
 
     # Deprecated per-user vars: only include without users.yaml
     # (legacy single-user mode). With users.yaml, these are noise.
-    # Remove stale CLAUDE_MODEL if present - it was renamed to
-    # DEFAULT_MODEL and leaving both keys causes silent confusion
-    # (the deprecation warning is suppressed when DEFAULT_MODEL exists).
+    # Remove stale renamed keys if present - leaving both the old and
+    # new key causes silent confusion (the deprecation warning is
+    # suppressed when the new key exists).
     env.pop("CLAUDE_MODEL", None)
+    env.pop("CLAUDE_MAX_BUDGET_USD", None)
     if not users_yaml_exists:
         env["DEFAULT_MODEL"] = model
         env["CLAUDE_TIMEOUT_SECONDS"] = timeout
-        env["CLAUDE_MAX_BUDGET_USD"] = budget
+        env["BUDGET_CEILING"] = budget
 
     # Context window tuning - only include if non-default.
     # Compare as int to handle inputs like "000" that pass validation.

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -700,17 +700,21 @@ def _cmd_config() -> None:
     if llm_api_key_var and llm_api_key:
         env[llm_api_key_var] = llm_api_key
 
-    # Deprecated per-user vars: only include without users.yaml
-    # (legacy single-user mode). With users.yaml, these are noise.
     # Remove stale renamed keys if present - leaving both the old and
     # new key causes silent confusion (the deprecation warning is
     # suppressed when the new key exists).
     env.pop("CLAUDE_MODEL", None)
     env.pop("CLAUDE_MAX_BUDGET_USD", None)
+
+    # BUDGET_CEILING is global (not per-user), so always write it
+    # regardless of whether users.yaml exists.
+    env["BUDGET_CEILING"] = budget
+
+    # Deprecated per-user vars: only include without users.yaml
+    # (legacy single-user mode). With users.yaml, these are noise.
     if not users_yaml_exists:
         env["DEFAULT_MODEL"] = model
         env["CLAUDE_TIMEOUT_SECONDS"] = timeout
-        env["BUDGET_CEILING"] = budget
 
     # Context window tuning - only include if non-default.
     # Compare as int to handle inputs like "000" that pass validation.

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -155,7 +155,8 @@ class SubprocessPool:
                 )
                 model = self._config.default_model
 
-        budget = user.max_budget if user and user.max_budget is not None else self._config.claude_max_budget_usd
+        # budget_ceiling doubles as the fallback default for unconfigured users
+        budget = user.max_budget if user and user.max_budget is not None else self._config.budget_ceiling
         timeout = user.timeout if user and user.timeout is not None else self._config.claude_timeout_seconds
         context_window = (
             user.context_window if user and user.context_window is not None else self._config.claude_max_context_window

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -713,11 +713,9 @@ async def resolve_user_defaults(
     yaml_model = raw_yaml_model.strip() if raw_yaml_model is not None else None
     model = db_model if db_model else yaml_model if yaml_model else config.default_model
 
-    # Budget: DB > users.yaml max_budget (as default, not ceiling) > env.
-    # max_budget in users.yaml serves double duty - it's both the admin
-    # ceiling AND the baseline default. If a user has max_budget=20 and
-    # hasn't set a /settings budget, they get $20. If they set /settings
-    # budget 15, they get $15. They cannot set above $20.
+    # Budget: DB > users.yaml max_budget (as default only) > global ceiling.
+    # max_budget in users.yaml is the admin-set baseline default, NOT a
+    # ceiling. The ceiling comes solely from BUDGET_CEILING (config.budget_ceiling).
     # Defensive try/except matches _restore_workspace and _show_settings.
     yaml_budget = user_config.max_budget if user_config and user_config.max_budget is not None else None
     try:
@@ -725,7 +723,8 @@ async def resolve_user_defaults(
     except (ValueError, TypeError):
         budget = None
     if budget is None:
-        budget = yaml_budget if yaml_budget is not None else config.claude_max_budget_usd
+        # budget_ceiling doubles as the fallback default for unconfigured users
+        budget = yaml_budget if yaml_budget is not None else config.budget_ceiling
 
     # Timeout: DB > users.yaml > env > 120
     yaml_timeout = user_config.timeout if user_config and user_config.timeout is not None else None

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -73,7 +73,7 @@ from kai.bot import (
     handle_workspace_callback,
     handle_workspaces,
 )
-from kai.config import PROVIDER_MODELS, Config
+from kai.config import PROVIDER_MODELS, Config, UserConfig
 from kai.tts import DEFAULT_VOICE, VOICES
 from kai.workspace_utils import is_workspace_allowed
 
@@ -3372,12 +3372,13 @@ class TestHandleWorkspaceConfig:
     # ── Budget ceiling enforcement ──────────────────────────────────
 
     @pytest.mark.asyncio
-    async def test_budget_ceiling_from_user_config(self):
-        """Budget exceeding per-user max_budget is rejected."""
-        from kai.config import UserConfig
-
+    async def test_budget_ceiling_from_global_config(self):
+        """Budget exceeding global budget_ceiling is rejected."""
+        # Ceiling comes from config.budget_ceiling, not per-user max_budget.
+        # User has max_budget=5 but global ceiling is 8; requesting 10
+        # should be rejected because 10 > 8 (global ceiling).
         user = UserConfig(telegram_id=12345, name="test", max_budget=5.0)
-        config = _make_config(user_configs={12345: user})
+        config = _make_config(budget_ceiling=8.0, user_configs={12345: user})
         update = _make_update(text="/workspace config budget 10")
         pool = _make_mock_claude()
         ctx = _make_context(config=config, pool=pool)
@@ -3386,11 +3387,28 @@ class TestHandleWorkspaceConfig:
         with self._patches(mock_sessions):
             await _handle_workspace_config(update, ctx, "config budget 10")
 
-        # Should reject - 10 exceeds per-user ceiling of 5
+        # Should reject - 10 exceeds global ceiling of 8
         mock_sessions.set_workspace_config_setting.assert_not_called()
         reply = update.message.reply_text.call_args[0][0]
-        assert "$5.00" in reply
+        assert "$8.00" in reply
         assert "admin limit" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_budget_above_yaml_default_but_under_ceiling_allowed(self):
+        """Budget above per-user max_budget but under global ceiling succeeds."""
+        # User has max_budget=5 in users.yaml, but global ceiling is 20.
+        # Setting budget to 10 should succeed (above yaml default, under ceiling).
+        user = UserConfig(telegram_id=12345, name="test", max_budget=5.0)
+        config = _make_config(budget_ceiling=20.0, user_configs={12345: user})
+        update = _make_update(text="/workspace config budget 10")
+        pool = _make_mock_claude()
+        ctx = _make_context(config=config, pool=pool)
+        mock_sessions = self._mock_sessions()
+
+        with self._patches(mock_sessions):
+            await _handle_workspace_config(update, ctx, "config budget 10")
+
+        mock_sessions.set_workspace_config_setting.assert_called_once()
 
     # ── Invalid model rejected ──────────────────────────────────────
 
@@ -3519,11 +3537,9 @@ class TestHandleSettings:
 
     @pytest.mark.asyncio
     async def test_budget_exceeds_ceiling(self):
-        """/settings budget 999 is rejected when ceiling is lower."""
-        from kai.config import UserConfig
-
-        user = UserConfig(telegram_id=12345, name="test", max_budget=5.0)
-        config = _make_config(user_configs={12345: user})
+        """/settings budget 999 is rejected when global ceiling is lower."""
+        # Ceiling comes from config.budget_ceiling (global), not per-user
+        config = _make_config(budget_ceiling=25.0)
         update = _make_update(text="/settings budget 999")
         ctx = _make_context(config=config, args=["budget", "999"])
         mock_sessions = self._mock_sessions()
@@ -3533,7 +3549,7 @@ class TestHandleSettings:
 
         mock_sessions.set_user_setting.assert_not_called()
         reply = update.message.reply_text.call_args[0][0]
-        assert "$5.00" in reply
+        assert "$25.00" in reply
         assert "admin limit" in reply.lower()
 
     # ── 5b. Budget allowed when ceiling is zero (no limit) ──────────
@@ -3541,9 +3557,9 @@ class TestHandleSettings:
     @pytest.mark.asyncio
     async def test_budget_allowed_when_ceiling_zero(self):
         """/settings budget 50 succeeds when global ceiling is 0 (no limit)."""
-        # If CLAUDE_MAX_BUDGET_USD=0 and no users.yaml entry, 0 means
+        # If BUDGET_CEILING=0 and no users.yaml entry, 0 means
         # "no admin ceiling" - budget should be allowed, not rejected.
-        config = _make_config(claude_max_budget_usd=0.0)
+        config = _make_config(budget_ceiling=0.0)
         update = _make_update(text="/settings budget 50")
         pool = _make_mock_claude()
         pool.get_if_exists = MagicMock(return_value=MagicMock())
@@ -3793,7 +3809,7 @@ class TestHandleSettings:
             await handle_settings(update, ctx)
 
         assert instance.model == config.default_model
-        assert instance.max_budget_usd == config.claude_max_budget_usd
+        assert instance.max_budget_usd == config.budget_ceiling
         assert instance.timeout_seconds == config.claude_timeout_seconds
         assert instance.max_context_window == config.claude_max_context_window
 
@@ -3803,7 +3819,7 @@ class TestHandleSettings:
     async def test_show_settings_budget_zero_displays_unlimited(self):
         """Budget of $0.00 displays as 'unlimited', not '$0.00'."""
         update = _make_update(text="/settings")
-        config = _make_config(claude_max_budget_usd=0.0)
+        config = _make_config(budget_ceiling=0.0)
         ctx = _make_context(config=config)
         mock_sessions = self._mock_sessions()
 
@@ -3814,23 +3830,26 @@ class TestHandleSettings:
         assert "unlimited" in reply.lower()
         assert "$0.00" not in reply
 
-    # ── 20. Global budget ceiling visible in /settings ────────────
+    # ── 20. Ceiling enforced from global config, not per-user ────
 
     @pytest.mark.asyncio
-    async def test_show_settings_global_ceiling_visible(self):
-        """Users without a yaml entry see the global ceiling in /settings."""
-        update = _make_update(text="/settings")
-        # No user_configs - ceiling should fall through to global default
-        config = _make_config(claude_max_budget_usd=10.0)
-        ctx = _make_context(config=config)
+    async def test_ceiling_enforced_from_global_config(self):
+        """Ceiling comes from config.budget_ceiling, not per-user max_budget."""
+        # User has max_budget=15 in users.yaml, but global ceiling is 50.
+        # User should be able to set budget up to $50, not just $15.
+        user = UserConfig(telegram_id=12345, name="testuser", max_budget=15.0)
+        config = _make_config(budget_ceiling=50.0, user_configs={12345: user})
+        update = _make_update(text="/settings budget 40")
+        pool = _make_mock_claude()
+        pool.get_if_exists = MagicMock(return_value=MagicMock())
+        ctx = _make_context(config=config, pool=pool, args=["budget", "40"])
         mock_sessions = self._mock_sessions()
 
         with self._patches(mock_sessions):
-            await _show_settings(update, ctx, 12345, config)
+            await handle_settings(update, ctx)
 
-        reply = update.message.reply_text.call_args[0][0]
-        assert "$10.00" in reply
-        assert "ceiling" in reply.lower()
+        # Budget of $40 should succeed (under $50 ceiling, above $15 yaml default)
+        mock_sessions.set_user_setting.assert_called_once_with(12345, "budget", "40.0")
 
 
 # ── /github command ─────────────────────────────────────────────────

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,7 +20,8 @@ _CONFIG_ENV_VARS = [
     "DEFAULT_MODEL",
     "CLAUDE_MODEL",
     "CLAUDE_TIMEOUT_SECONDS",
-    "CLAUDE_MAX_BUDGET_USD",
+    "BUDGET_CEILING",
+    "CLAUDE_MAX_BUDGET_USD",  # backward compat (renamed to BUDGET_CEILING)
     "CLAUDE_MAX_SESSION_HOURS",
     "CLAUDE_IDLE_TIMEOUT",
     "WEBHOOK_PORT",
@@ -85,7 +86,7 @@ class TestLoadConfigDefaults:
         config = load_config()
         assert config.default_model == "sonnet"
         assert config.claude_timeout_seconds == 120
-        assert config.claude_max_budget_usd == 10.0
+        assert config.budget_ceiling == 10.0
         assert config.claude_max_session_hours == 0
         assert config.webhook_port == 8080
         # Without TELEGRAM_WEBHOOK_URL, defaults to polling mode
@@ -730,7 +731,7 @@ def _mock_user_configs(monkeypatch):
 # for path vars because it always exists on both macOS and Linux.
 _DEPRECATED_VARS_WITH_VALUES = {
     "CLAUDE_MODEL": "sonnet",
-    "CLAUDE_MAX_BUDGET_USD": "10.0",
+    "CLAUDE_MAX_BUDGET_USD": "10.0",  # old name, still tested for deprecation warning
     "CLAUDE_TIMEOUT_SECONDS": "120",
     "CLAUDE_MAX_CONTEXT_WINDOW": "200000",
     "CLAUDE_USER": "kai",
@@ -916,7 +917,7 @@ class TestMinimalEnvWithUsersYaml:
         # Uses dataclass defaults when no env var is set
         assert config.default_model == "sonnet"
         assert config.claude_timeout_seconds == 120
-        assert config.claude_max_budget_usd == 10.0
+        assert config.budget_ceiling == 10.0
         assert config.claude_max_context_window == 0
         assert config.claude_user is None
         assert config.workspace_base is None
@@ -945,7 +946,7 @@ class TestMinimalEnvWithUsersYaml:
         assert config.user_configs[123].model == "opus"
 
     def test_per_user_budget_without_env(self, monkeypatch):
-        """Per-user budget from users.yaml works when CLAUDE_MAX_BUDGET_USD is unset."""
+        """Per-user budget from users.yaml works when BUDGET_CEILING is unset."""
         for var, val in _MINIMAL_GLOBAL_ENV.items():
             monkeypatch.setenv(var, val)
         user = UserConfig(telegram_id=123, name="testuser", max_budget=25.0)
@@ -954,7 +955,7 @@ class TestMinimalEnvWithUsersYaml:
             lambda *_a: {123: user},
         )
         config = load_config()
-        assert config.claude_max_budget_usd == 10.0  # dataclass default
+        assert config.budget_ceiling == 10.0  # dataclass default
         assert config.user_configs is not None
         assert config.user_configs[123].max_budget == 25.0
 
@@ -1099,13 +1100,28 @@ class TestLegacyEnvOnlyMode:
         """Full config from env vars works when users.yaml is absent."""
         _set_required(monkeypatch)
         monkeypatch.setenv("CLAUDE_MODEL", "opus")
-        monkeypatch.setenv("CLAUDE_MAX_BUDGET_USD", "25.0")
+        monkeypatch.setenv("BUDGET_CEILING", "25.0")
         monkeypatch.setenv("CLAUDE_TIMEOUT_SECONDS", "300")
         config = load_config()
         assert config.default_model == "opus"
-        assert config.claude_max_budget_usd == 25.0
+        assert config.budget_ceiling == 25.0
         assert config.claude_timeout_seconds == 300
         assert config.user_configs is None
+
+    def test_old_budget_env_var_backward_compat(self, monkeypatch):
+        """CLAUDE_MAX_BUDGET_USD still works as fallback when BUDGET_CEILING is not set."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("CLAUDE_MAX_BUDGET_USD", "42.0")
+        config = load_config()
+        assert config.budget_ceiling == 42.0
+
+    def test_new_budget_env_var_takes_precedence(self, monkeypatch):
+        """BUDGET_CEILING wins over CLAUDE_MAX_BUDGET_USD when both are set."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("BUDGET_CEILING", "50.0")
+        monkeypatch.setenv("CLAUDE_MAX_BUDGET_USD", "25.0")
+        config = load_config()
+        assert config.budget_ceiling == 50.0
 
     def test_no_deprecation_warnings(self, monkeypatch, caplog):
         """No users.yaml deprecation warnings when users.yaml is absent."""

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -30,7 +30,7 @@ def _make_config(**overrides) -> Config:
         "allowed_user_ids": {111, 222},
         "default_model": "sonnet",
         "claude_timeout_seconds": 30,
-        "claude_max_budget_usd": 1.0,
+        "budget_ceiling": 1.0,
         "claude_max_session_hours": 0,
         "claude_idle_timeout": 1800,
         "claude_workspace": Path("/home/workspace"),
@@ -110,7 +110,7 @@ class TestInstanceCreation:
         config = _make_config(
             user_configs={111: user},
             default_model="haiku",
-            claude_max_budget_usd=5.0,
+            budget_ceiling=5.0,
             claude_timeout_seconds=60,
             claude_max_context_window=100_000,
         )

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -540,7 +540,7 @@ class TestResolveUserDefaults:
             "telegram_bot_token": "test",
             "allowed_user_ids": {111},
             "default_model": "sonnet",
-            "claude_max_budget_usd": 10.0,
+            "budget_ceiling": 10.0,
             "claude_timeout_seconds": 120,
             "claude_max_context_window": 0,
         }


### PR DESCRIPTION
## Summary

- Rename `CLAUDE_MAX_BUDGET_USD` to `BUDGET_CEILING` across config, bot, pool, sessions, install, docs, and tests
- Separate ceiling enforcement from per-user defaults: the ceiling always comes from the global `BUDGET_CEILING` env var, while `max_budget` in users.yaml is only a default
- Remove the "Budget ceiling" line from `/settings` output
- Add backward-compat parsing so existing `.env` files with the old key name still work on upgrade

## Details

Previously, `CLAUDE_MAX_BUDGET_USD` did double duty as both the global default budget and the ceiling. Per-user `max_budget` in users.yaml also conflated default and ceiling. When a user changed their `max_budget`, the displayed ceiling changed with it, defeating the purpose.

Now the ceiling is always `config.budget_ceiling` (the global env var). Per-user `max_budget` is only a baseline default. A user with `max_budget: 15` in users.yaml can `/settings budget 40` if the global ceiling is $50.

Backward compat: `BUDGET_CEILING` > `CLAUDE_MAX_BUDGET_USD` > `10.0`. `install.py` reads from either key on upgrade, writes the new key, and removes the old one.

## Test plan

- [x] All 1686 tests pass
- [x] Ruff lint and format clean
- [x] Backward compat tests: old env var still works, new var takes precedence when both are set
- [x] New test: budget above yaml default but under global ceiling succeeds
- [x] Ceiling enforcement tests updated for global-only behavior

Fixes #304
