### PR TITLE
Add mem0ai and sentence-transformers for semantic memory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,6 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "aiohttp>=3.9.0",
     "pyyaml>=6.0",
-    "mem0ai>=0.1.0",
-    "sentence-transformers>=3.0.0",
 ]
 
 [project.scripts]
@@ -26,6 +24,10 @@ dev = [
     "ruff>=0.9.0",
     "pytest>=8.0",
     "pytest-asyncio>=0.24.0",
+]
+memory = [
+    "mem0ai>=2.0.0",
+    "sentence-transformers>=3.0.0",
 ]
 tts = [
     "piper-tts>=1.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "aiohttp>=3.9.0",
     "pyyaml>=6.0",
+    "mem0ai>=0.1.0",
+    "sentence-transformers>=3.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- Add `mem0ai` and `sentence-transformers` as optional dependencies (`[memory]` extra) in preparation for the semantic memory system

## Why

Kai's current memory is a flat MEMORY.md file - useful for explicit saves, but with no way to search or retrieve memories by meaning. The upcoming memory system update adds vector-based semantic memory using:

- **mem0ai** - memory layer that handles storage, retrieval, and deduplication of memories using vector similarity search. Uses Qdrant as the local vector store (pulled transitively).
- **sentence-transformers** - provides the `all-MiniLM-L6-v2` embedding model for converting text into vectors locally. Pulls PyTorch transitively.

These are heavyweight dependencies (PyTorch alone is ~2GB), so they are gated behind an optional `[memory]` extra rather than added to the base install. They run entirely local - no API calls, no external services. The embedding model is pre-downloaded to `~/.cache/huggingface/` (~80MB) and the vector store uses a local Qdrant directory.

This PR adds only the dependencies. The memory system implementation will follow in a separate PR.

## Test plan

- [x] `pip install -e ".[dev,memory]"` succeeds
- [x] `from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')` loads without error
- [x] `make test` still passes (no import-time side effects)
