### PR TITLE
Include memory extra in production install

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1839,7 +1839,7 @@ def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:
     # Uses a non-editable install (not -e) so the venv is self-contained
     # and doesn't depend on the source directory being writable.
     pip = str(venv_path / "bin" / "pip")
-    extras = "totp,tts"
+    extras = "memory,totp,tts"
     install_spec = f"{install_path}[{extras}]"
     subprocess.run(
         [pip, "install", install_spec],


### PR DESCRIPTION
## Summary

- Add `memory` to the extras string in `install.py` so `make install` pulls mem0ai and sentence-transformers into the production venv.
- Without this, `MEMORY_ENABLED=true` at runtime hits a ModuleNotFoundError and falls back to file-only memory.
- Follows the same pattern as `totp` and `tts`: always installed, gated by an env var at runtime.

Fixes the gap between PR #313 (added the pyproject extra) and PR #314 (added the runtime code).

## Test plan

- [ ] `sudo make install` completes without error
- [ ] `/opt/kai/venv/bin/pip list | grep -iE "(mem0|qdrant|sentence)"` shows all three packages
- [ ] Restart service with `MEMORY_ENABLED=true`; confirm no ImportError in logs
