### PR TITLE
Fix memory directory ownership in install flow

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1448,11 +1448,11 @@ def _apply_migrate(data_path: Path, install_path: Path, svc_uid: int, svc_gid: i
     # or a prior install left stale ownership, those directories would be
     # root-owned and the service user could not write to them.
     memory_tree = data_path / "memory"
-    if memory_tree.is_dir() and not dry_run:
-        for root, _subdirs, fnames in os.walk(memory_tree):
-            os.chown(root, svc_uid, svc_gid)
-            for fname in fnames:
-                os.chown(os.path.join(root, fname), svc_uid, svc_gid)
+    if memory_tree.is_dir():
+        if dry_run:
+            print(f"[DRY RUN] Would set ownership on {memory_tree} ({svc_uid}:{svc_gid})")
+        else:
+            _set_ownership(memory_tree, svc_uid, svc_gid, recursive=True)
 
 
 def _cmd_apply() -> None:

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1441,6 +1441,19 @@ def _apply_migrate(data_path: Path, install_path: Path, svc_uid: int, svc_gid: i
         elif not copied and not dry_run:
             print("  Uploaded files already migrated or no files to copy")
 
+    # -- Memory directory ownership --
+    # Ensure the entire memory/ tree is owned by the service user.
+    # Subdirectories like qdrant/ are created at runtime by init_memory(),
+    # but if the service was ever started as root (e.g., a manual test run)
+    # or a prior install left stale ownership, those directories would be
+    # root-owned and the service user could not write to them.
+    memory_tree = data_path / "memory"
+    if memory_tree.is_dir() and not dry_run:
+        for root, _subdirs, fnames in os.walk(memory_tree):
+            os.chown(root, svc_uid, svc_gid)
+            for fname in fnames:
+                os.chown(os.path.join(root, fname), svc_uid, svc_gid)
+
 
 def _cmd_apply() -> None:
     """

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1463,6 +1463,9 @@ class TestApplyMigrate:
         memory_dir.mkdir()
         (memory_dir / "MEMORY.md").write_text("existing personalized content")
 
+        # Mock chown - the ownership fix walks the memory tree unconditionally
+        monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
+
         _apply_migrate(data_path, tmp_path / "install", svc_uid=501, svc_gid=20, dry_run=False)
 
         assert (memory_dir / "MEMORY.md").read_text() == "existing personalized content"
@@ -1537,6 +1540,41 @@ class TestApplyMigrate:
         assert "Would migrate 1 uploaded file(s)" in output
         # Nothing should have been copied
         assert not (data_path / "files" / "photo.jpg").exists()
+
+    def test_memory_tree_ownership(self, tmp_path, monkeypatch):
+        """Chowns the entire memory/ tree so runtime-created subdirs get fixed."""
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path / "src")
+        (tmp_path / "src").mkdir()
+
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        (data_path / "logs").mkdir()
+
+        # Simulate a memory tree with a qdrant subdirectory and files
+        # (as would exist after init_memory() has run at least once).
+        memory_dir = data_path / "memory"
+        memory_dir.mkdir()
+        qdrant_dir = memory_dir / "qdrant"
+        qdrant_dir.mkdir()
+        (qdrant_dir / "meta.json").write_text("{}")
+        (memory_dir / "MEMORY.md").write_text("# Memory")
+
+        chowned: list[tuple[str, int, int]] = []
+        monkeypatch.setattr(
+            "kai.install.os.chown",
+            lambda path, uid, gid: chowned.append((str(path), uid, gid)),
+        )
+
+        _apply_migrate(data_path, tmp_path / "install", svc_uid=501, svc_gid=20, dry_run=False)
+
+        # Every directory and file in the memory tree should be chowned.
+        chowned_paths = {entry[0] for entry in chowned}
+        assert str(memory_dir) in chowned_paths
+        assert str(qdrant_dir) in chowned_paths
+        assert str(qdrant_dir / "meta.json") in chowned_paths
+        assert str(memory_dir / "MEMORY.md") in chowned_paths
+        # All entries should use the service user's uid/gid.
+        assert all(uid == 501 and gid == 20 for _, uid, gid in chowned)
 
 
 # ── Service lifecycle ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Recursively chown `DATA_DIR/memory/` to the service user during `make install`.
- Subdirectories like `qdrant/` are created at runtime by `init_memory()`, but if
  the directory tree was ever touched by root (manual test, prior install artifact),
  the service user cannot write to them. This caused a `PermissionError` on
  `qdrant/meta.json` at startup.
- Follows the same pattern as the uploaded files migration, which already does a
  recursive chown on `DATA_DIR/files/`.
- Adds a test verifying every directory and file in the memory tree gets chowned.
- Fixes the existing `test_memory_skips_existing` test which now needs a chown mock.

Follow-up to PR #315 (which added the memory extra to the install).

## Test plan

- [ ] `make test` passes (177/177 install tests)
- [ ] `sudo make install` completes; `ls -laR /var/lib/kai/memory/` shows all entries owned by `kai`
- [ ] Restart service; no PermissionError in logs
