### PR TITLE
Log raw result event when is_error has no result field

### DIFF
--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -543,6 +543,17 @@ class ClaudeCodeBackend(AgentBackend):
                     # when nothing was accumulated (e.g., system-only responses).
                     result_text = event.get("result", "")
                     text = accumulated_text if accumulated_text else result_text
+                    # When the CLI signals an error but does not populate the
+                    # result field, the user sees the literal string "Error:
+                    # None" with no clue about the error class. Log the raw
+                    # event so the payload is captured for diagnosis (see
+                    # issue #326). The event is small (no model output, just
+                    # metadata) so logging it fully is cheap.
+                    if event.get("is_error") and not result_text:
+                        log.warning(
+                            "Result event with is_error=true has no result field; raw event: %s",
+                            event,
+                        )
                     response = AgentResponse(
                         success=not event.get("is_error", False),
                         text=text,

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -545,14 +545,24 @@ class ClaudeCodeBackend(AgentBackend):
                     text = accumulated_text if accumulated_text else result_text
                     # When the CLI signals an error but does not populate the
                     # result field, the user sees the literal string "Error:
-                    # None" with no clue about the error class. Log the raw
-                    # event so the payload is captured for diagnosis (see
-                    # issue #326). The event is small (no model output, just
-                    # metadata) so logging it fully is cheap.
-                    if event.get("is_error") and not result_text:
+                    # None" with no clue about the error class. Log the known
+                    # safe metadata fields individually so diagnosis does not
+                    # depend on assumptions about the CLI's event schema: the
+                    # event could in principle gain new fields that contain
+                    # model output or user content, and logging the full dict
+                    # would silently leak them. Log `sorted(event.keys())`
+                    # rather than the full dict so that a schema addition is
+                    # visible (key name only, not value), and a follow-up can
+                    # opt-in to logging the new field once its shape is known.
+                    # See issue #326 for the paired UX fix.
+                    if event.get("is_error", False) and not result_text:
                         log.warning(
-                            "Result event with is_error=true has no result field; raw event: %s",
-                            event,
+                            "Result event with is_error=true has no result field; "
+                            "session=%s cost_usd=%s duration_ms=%s keys=%s",
+                            event.get("session_id"),
+                            event.get("total_cost_usd"),
+                            event.get("duration_ms"),
+                            sorted(event.keys()),
                         )
                     response = AgentResponse(
                         success=not event.get("is_error", False),


### PR DESCRIPTION
## Summary

When the Claude CLI emits a result event with `is_error: true` but no populated `result` field, the user sees the literal string `Error: None` with no diagnostic context. The main log also captures nothing for the failure, so the error class (rate limit, context exhaustion, auth, etc.) cannot currently be identified.

This PR adds one `log.warning` call in `src/kai/claude.py` (in the `result` event branch of the stream-json reader) that logs the full raw event whenever `is_error` is set and the `result` field is empty. The event carries only metadata (session_id, cost, duration, flags), so logging it in full is cheap and contains no model output or user content.

Paired with issue #326, which tracks the user-facing UX fix (live-message wipe on error).

## Test plan

- [x] `make check` passes (ruff check + format)
- [x] `pytest tests/test_claude.py` passes (117 tests)
- [ ] Next time the condition reproduces in production, a WARNING line appears in `kai.log` containing the raw event payload. The payload will identify the error class so #326 can map it to a useful user-facing message.
