### PR TITLE
Parameterize PR review subprocess timeout + budget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,18 @@ WEBHOOK_SECRET=your-webhook-secret
 # Not deprecated - this is a machine-wide resource limit.
 #PR_REVIEW_COOLDOWN=300
 
+# Subprocess timeout for a single PR review, in seconds. Sonnet with
+# extended thinking on a large diff and prior review context can take
+# several minutes. Raise if reviews are being killed mid-run; lower if
+# stuck processes should be reaped faster. Must be a positive integer.
+#PR_REVIEW_TIMEOUT_S=900
+
+# Hard USD ceiling for one PR review subprocess (passed to
+# claude --max-budget-usd). Not a typical-run estimate - Sonnet reviews
+# of normal PRs cost well under this. Treat as a safety limit, not a
+# target. Must be a positive number.
+#PR_REVIEW_BUDGET_USD=1.0
+
 # Deprecated: review agent now resolves repos via workspace config
 # (WORKSPACE_BASE, ALLOWED_WORKSPACES, workspace history). Kept for
 # backwards compatibility; the value is parsed but no longer used.

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -379,6 +379,16 @@ class Config:
     # Minimum seconds between reviews of the same PR. Absorbs force-push bursts
     # so rapid pushes to an open PR don't trigger a review for each one.
     pr_review_cooldown: int = 300
+    # Subprocess timeout for a single PR review, in seconds. Sonnet with
+    # extended thinking on a large diff with prior review context can take
+    # a long time; the default gives thinking-heavy reviews room while
+    # still terminating genuinely stuck processes.
+    pr_review_timeout_s: int = 900
+    # Hard USD ceiling for one PR review subprocess. Passed through to
+    # claude --max-budget-usd. Not a typical-run estimate - Sonnet reviews
+    # of normal PRs cost well under this. The ceiling is a safety limit
+    # against runaway invocations, not a cost target.
+    pr_review_budget_usd: float = 1.0
     # Deprecated: review agent now resolves repos via workspace config.
     # Kept for backwards compatibility with existing .env files; the value
     # is parsed but no longer used by webhook.py.
@@ -1267,6 +1277,18 @@ def load_config() -> Config:
         pr_review_cooldown = int(os.environ.get("PR_REVIEW_COOLDOWN", "300"))
     except ValueError:
         raise SystemExit("PR_REVIEW_COOLDOWN must be an integer") from None
+    try:
+        pr_review_timeout_s = int(os.environ.get("PR_REVIEW_TIMEOUT_S", "900"))
+        if pr_review_timeout_s <= 0:
+            raise SystemExit("PR_REVIEW_TIMEOUT_S must be a positive integer")
+    except ValueError:
+        raise SystemExit("PR_REVIEW_TIMEOUT_S must be an integer") from None
+    try:
+        pr_review_budget_usd = float(os.environ.get("PR_REVIEW_BUDGET_USD", "1.0"))
+        if pr_review_budget_usd <= 0:
+            raise SystemExit("PR_REVIEW_BUDGET_USD must be a positive number")
+    except ValueError:
+        raise SystemExit("PR_REVIEW_BUDGET_USD must be a number") from None
 
     # Issue triage agent config
     issue_triage_enabled = os.environ.get("ISSUE_TRIAGE_ENABLED", "").lower() in ("1", "true", "yes")
@@ -1473,6 +1495,8 @@ def load_config() -> Config:
         claude_user=os.environ.get("CLAUDE_USER") or None,
         pr_review_enabled=pr_review_enabled,
         pr_review_cooldown=pr_review_cooldown,
+        pr_review_timeout_s=pr_review_timeout_s,
+        pr_review_budget_usd=pr_review_budget_usd,
         github_repo=os.getenv("GITHUB_REPO", ""),
         spec_dir=os.getenv("SPEC_DIR", "specs"),
         issue_triage_enabled=issue_triage_enabled,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -585,8 +585,11 @@ def _cmd_config() -> None:
 
     # -- PR review agent --
     # pr_review_timeout_s and pr_review_budget_usd are global resource limits
-    # for the review subprocess, not per-user preferences - collect them even
-    # when users.yaml exists, same as PR_REVIEW_COOLDOWN.
+    # for the review subprocess, not per-user preferences. They are prompted
+    # unconditionally below (unlike pr_review_cooldown, which is only
+    # prompted when users.yaml is absent and pr_review is enabled) because
+    # any review can time out or hit budget regardless of how users are
+    # configured.
     if users_yaml_exists:
         print("-- PR review agent --")
         print("  PR review is now per-user. Set 'pr_review' in users.yaml")

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -584,6 +584,9 @@ def _cmd_config() -> None:
     print()
 
     # -- PR review agent --
+    # pr_review_timeout_s and pr_review_budget_usd are global resource limits
+    # for the review subprocess, not per-user preferences - collect them even
+    # when users.yaml exists, same as PR_REVIEW_COOLDOWN.
     if users_yaml_exists:
         print("-- PR review agent --")
         print("  PR review is now per-user. Set 'pr_review' in users.yaml")
@@ -606,6 +609,25 @@ def _cmd_config() -> None:
                 if _validate_positive_int(pr_review_cooldown):
                     break
                 print("  Must be a positive integer.")
+
+    # Timeout + budget for the review subprocess. Always collectable: they
+    # apply to any review whether or not the global env flag is set.
+    while True:
+        pr_review_timeout_s = _prompt(
+            "Review subprocess timeout in seconds",
+            existing_env.get("PR_REVIEW_TIMEOUT_S", "900"),
+        )
+        if _validate_positive_int(pr_review_timeout_s):
+            break
+        print("  Must be a positive integer.")
+    while True:
+        pr_review_budget_usd = _prompt(
+            "Review subprocess USD budget ceiling",
+            existing_env.get("PR_REVIEW_BUDGET_USD", "1.0"),
+        )
+        if _validate_positive_float(pr_review_budget_usd):
+            break
+        print("  Must be a positive number.")
     print()
 
     # -- Issue triage agent --
@@ -757,6 +779,13 @@ def _cmd_config() -> None:
         # via users.yaml even when the global env var is unset.
         if pr_review_cooldown != "300":
             env["PR_REVIEW_COOLDOWN"] = pr_review_cooldown
+
+    # Review subprocess resource limits. Written in both branches because
+    # they apply globally to any review, regardless of users.yaml presence.
+    if pr_review_timeout_s != "900":
+        env["PR_REVIEW_TIMEOUT_S"] = pr_review_timeout_s
+    if pr_review_budget_usd != "1.0":
+        env["PR_REVIEW_BUDGET_USD"] = pr_review_budget_usd
 
     # Build and write install.conf
     conf = {

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -737,13 +737,17 @@ async def run_review(
             raise RuntimeError(f"Review subprocess timed out after {timeout_s}s") from None
     else:
         # Claude one-shot mode: --print reads from stdin, writes to stdout.
+        # Format budget as fixed-point (f-string :.4f) rather than str() so
+        # very small values never render in scientific notation like
+        # "1e-05", which the Claude CLI's numeric parser may reject. Four
+        # fractional digits cover any realistic per-review ceiling.
         cmd = [
             "claude",
             "--print",
             "--model",
             _REVIEW_MODEL,
             "--max-budget-usd",
-            str(budget_usd),
+            f"{budget_usd:.4f}",
         ]
 
         # Resolve self-sudo: skip sudo when claude_user matches the bot

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -51,14 +51,18 @@ _MAX_DIFF_CHARS = 100_000
 # Opus tokens. Sonnet is more than capable for code review.
 _REVIEW_MODEL = "sonnet"
 
-# Per-review budget cap in USD. A single review should never exceed this.
-# Sonnet reviews of typical PRs cost well under $0.50.
+# Default per-review budget cap in USD. Overridable via PR_REVIEW_BUDGET_USD
+# in config; the Config field is the runtime source of truth. Kept here as a
+# fallback default for direct run_review() callers (tests, scripts) that do
+# not thread config through. Sonnet reviews of typical PRs cost well under
+# $0.50, so 1.0 is a headroom ceiling rather than a typical cost.
 _REVIEW_BUDGET_USD = 1.0
 
-# Timeout for the review subprocess in seconds. Sonnet 4.6+ uses extended
-# thinking, which can take significantly longer on large diffs with prior
-# review context. 15 minutes accommodates thinking-heavy reviews while
-# still catching genuinely stuck processes.
+# Default subprocess timeout for a single review, in seconds. Overridable
+# via PR_REVIEW_TIMEOUT_S in config; same fallback rationale as the budget
+# default above. Sonnet 4.6+ uses extended thinking, which can take a long
+# time on large diffs with prior review context - 15 minutes accommodates
+# thinking-heavy reviews while still terminating genuinely stuck processes.
 _REVIEW_TIMEOUT = 900
 
 # Mid-tier model per provider for Goose background agent tasks. Matches
@@ -656,6 +660,8 @@ async def run_review(
     claude_user: str | None = None,
     agent_backend: str = "claude",
     provider: str = "",
+    timeout_s: int = _REVIEW_TIMEOUT,
+    budget_usd: float = _REVIEW_BUDGET_USD,
 ) -> str:
     """
     Spawn a one-shot LLM subprocess to perform the review.
@@ -723,12 +729,12 @@ async def run_review(
         try:
             stdout, stderr = await asyncio.wait_for(
                 proc.communicate(input=prompt.encode()),
-                timeout=_REVIEW_TIMEOUT,
+                timeout=timeout_s,
             )
         except TimeoutError:
             proc.kill()
             await proc.wait()
-            raise RuntimeError(f"Review subprocess timed out after {_REVIEW_TIMEOUT}s") from None
+            raise RuntimeError(f"Review subprocess timed out after {timeout_s}s") from None
     else:
         # Claude one-shot mode: --print reads from stdin, writes to stdout.
         cmd = [
@@ -737,7 +743,7 @@ async def run_review(
             "--model",
             _REVIEW_MODEL,
             "--max-budget-usd",
-            str(_REVIEW_BUDGET_USD),
+            str(budget_usd),
         ]
 
         # Resolve self-sudo: skip sudo when claude_user matches the bot
@@ -762,7 +768,7 @@ async def run_review(
         try:
             stdout, stderr = await asyncio.wait_for(
                 proc.communicate(input=prompt.encode()),
-                timeout=_REVIEW_TIMEOUT,
+                timeout=timeout_s,
             )
         except TimeoutError:
             # Kill the subprocess tree if it exceeds the timeout.
@@ -777,7 +783,7 @@ async def run_review(
             else:
                 proc.kill()
             await proc.wait()
-            raise RuntimeError(f"Review subprocess timed out after {_REVIEW_TIMEOUT}s") from None
+            raise RuntimeError(f"Review subprocess timed out after {timeout_s}s") from None
 
     if proc.returncode != 0:
         error = stderr.decode().strip()
@@ -889,6 +895,8 @@ async def review_pr(
     notify_chat_id: int | None = None,
     agent_backend: str = "claude",
     provider: str = "",
+    timeout_s: int = _REVIEW_TIMEOUT,
+    budget_usd: float = _REVIEW_BUDGET_USD,
 ) -> None:
     """
     Full review pipeline: fetch diff, build prompt, run review, post results.
@@ -954,6 +962,8 @@ async def review_pr(
             claude_user=claude_user,
             agent_backend=agent_backend,
             provider=provider,
+            timeout_s=timeout_s,
+            budget_usd=budget_usd,
         )
 
         if not review_text.strip():

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -777,6 +777,8 @@ async def _process_github_event_for_user(
                     notify_chat_id=target_chat_id,
                     agent_backend=agent_backend,
                     provider=provider,
+                    timeout_s=request.app["pr_review_timeout_s"],
+                    budget_usd=request.app["pr_review_budget_usd"],
                 )
             )
             _background_tasks.add(task)
@@ -1637,6 +1639,8 @@ async def start(telegram_app, config) -> None:
     # feature flags (pr_review, issue_triage) are resolved at event time
     # via sessions.resolve_github_settings(), not stored here.
     _app["pr_review_cooldown"] = config.pr_review_cooldown
+    _app["pr_review_timeout_s"] = config.pr_review_timeout_s
+    _app["pr_review_budget_usd"] = config.pr_review_budget_usd
     _app["webhook_port"] = config.webhook_port
     _app["claude_user"] = config.claude_user
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,6 +34,8 @@ _CONFIG_ENV_VARS = [
     "FILE_RETENTION_DAYS",
     "PR_REVIEW_ENABLED",
     "PR_REVIEW_COOLDOWN",
+    "PR_REVIEW_TIMEOUT_S",
+    "PR_REVIEW_BUDGET_USD",
     "GITHUB_REPO",
     "SPEC_DIR",
     "ISSUE_TRIAGE_ENABLED",
@@ -595,6 +597,8 @@ class TestPRReviewConfig:
         config = load_config()
         assert config.pr_review_enabled is False
         assert config.pr_review_cooldown == 300
+        assert config.pr_review_timeout_s == 900
+        assert config.pr_review_budget_usd == 1.0
 
     def test_enabled_with_custom_cooldown(self, monkeypatch):
         """PR_REVIEW_ENABLED and PR_REVIEW_COOLDOWN are picked up from env."""
@@ -610,6 +614,48 @@ class TestPRReviewConfig:
         _set_required(monkeypatch)
         monkeypatch.setenv("PR_REVIEW_COOLDOWN", "not_a_number")
         with pytest.raises(SystemExit, match="PR_REVIEW_COOLDOWN"):
+            load_config()
+
+    def test_timeout_override(self, monkeypatch):
+        """PR_REVIEW_TIMEOUT_S parses to an int and reaches the Config."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("PR_REVIEW_TIMEOUT_S", "1800")
+        config = load_config()
+        assert config.pr_review_timeout_s == 1800
+
+    def test_timeout_rejects_non_integer(self, monkeypatch):
+        """Non-numeric PR_REVIEW_TIMEOUT_S raises SystemExit."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("PR_REVIEW_TIMEOUT_S", "twenty")
+        with pytest.raises(SystemExit, match="PR_REVIEW_TIMEOUT_S"):
+            load_config()
+
+    def test_timeout_rejects_non_positive(self, monkeypatch):
+        """Zero or negative PR_REVIEW_TIMEOUT_S raises SystemExit."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("PR_REVIEW_TIMEOUT_S", "0")
+        with pytest.raises(SystemExit, match="PR_REVIEW_TIMEOUT_S"):
+            load_config()
+
+    def test_budget_override(self, monkeypatch):
+        """PR_REVIEW_BUDGET_USD parses to a float and reaches the Config."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("PR_REVIEW_BUDGET_USD", "2.5")
+        config = load_config()
+        assert config.pr_review_budget_usd == 2.5
+
+    def test_budget_rejects_non_number(self, monkeypatch):
+        """Non-numeric PR_REVIEW_BUDGET_USD raises SystemExit."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("PR_REVIEW_BUDGET_USD", "cheap")
+        with pytest.raises(SystemExit, match="PR_REVIEW_BUDGET_USD"):
+            load_config()
+
+    def test_budget_rejects_non_positive(self, monkeypatch):
+        """Zero or negative PR_REVIEW_BUDGET_USD raises SystemExit."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("PR_REVIEW_BUDGET_USD", "-1.0")
+        with pytest.raises(SystemExit, match="PR_REVIEW_BUDGET_USD"):
             load_config()
 
     def test_github_repo_from_env(self, monkeypatch):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -452,6 +452,8 @@ class TestCmdConfig:
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces (empty)
                 "false",  # pr review enabled
+                "900",  # pr review timeout (seconds)
+                "1.0",  # pr review budget (USD)
                 "false",  # issue triage enabled
                 "",  # github notify chat id (empty)
                 "false",  # voice
@@ -514,6 +516,8 @@ class TestCmdConfig:
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces (empty)
                 "false",  # pr review enabled
+                "900",  # pr review timeout (seconds)
+                "1.0",  # pr review budget (USD)
                 "false",  # issue triage enabled
                 "",  # github notify chat id (empty)
                 "false",  # voice
@@ -575,6 +579,8 @@ class TestCmdConfig:
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces (empty)
                 "false",  # pr review enabled
+                "900",  # pr review timeout (seconds)
+                "1.0",  # pr review budget (USD)
                 "false",  # issue triage enabled
                 "",  # github notify chat id (empty)
                 "false",  # voice
@@ -627,6 +633,8 @@ class TestCmdConfig:
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces (empty)
                 "false",  # pr review enabled
+                "900",  # pr review timeout (seconds)
+                "1.0",  # pr review budget (USD)
                 "false",  # issue triage enabled
                 "",  # github notify chat id (empty)
                 "false",  # voice

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -518,6 +518,24 @@ class TestRunReview:
         assert "sonnet" in cmd
 
     @pytest.mark.asyncio
+    async def test_budget_argv_uses_fixed_point_for_small_values(self):
+        """
+        --max-budget-usd must be rendered as fixed-point, not scientific
+        notation. str(1e-5) yields '1e-05', which some numeric parsers
+        reject; using f'{budget:.4f}' keeps the argv stable.
+        """
+        mock_proc = _mock_process(stdout=b"ok")
+
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_review("prompt", budget_usd=1e-4)
+
+        cmd = mock_exec.call_args[0]
+        budget_idx = cmd.index("--max-budget-usd")
+        budget_value = cmd[budget_idx + 1]
+        assert "e" not in budget_value.lower()
+        assert budget_value == "0.0001"
+
+    @pytest.mark.asyncio
     async def test_failure_raises(self):
         """Non-zero exit from Claude subprocess raises RuntimeError."""
         mock_proc = _mock_process(stderr=b"model not found", returncode=1)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -406,6 +406,9 @@ def _build_test_app(
     app = web.Application()
     app["webhook_secret"] = _TEST_SECRET
     app["pr_review_cooldown"] = cooldown
+    # Review subprocess resource limits (defaults match config.py).
+    app["pr_review_timeout_s"] = 900
+    app["pr_review_budget_usd"] = 1.0
     # Config needed by review background tasks
     app["webhook_port"] = 8080
     app["claude_user"] = None


### PR DESCRIPTION
## Motivation

PR #333 failed review with `RuntimeError: Review subprocess timed out after 900s`. The timeout is a hardcoded module constant, so the only way to raise it was a code edit and redeploy - painful for the exact moment you need to review a PR. Both `_REVIEW_TIMEOUT` and `_REVIEW_BUDGET_USD` now come from config, which means bumping them is a `.env` change plus a service restart.

The two ceilings travel together because they are the two dials an operator reaches for when a review times out or gets killed by the budget cap. Separating them into two PRs would be pure churn.

## Changes

- **config.py**: `pr_review_timeout_s: int = 900` and `pr_review_budget_usd: float = 1.0`. `load_config()` parses `PR_REVIEW_TIMEOUT_S` as positive int and `PR_REVIEW_BUDGET_USD` as positive float, `SystemExit` on invalid input.
- **review.py**: `run_review()` and `review_pr()` gain `timeout_s` and `budget_usd` parameters. Defaults come from the existing module constants so every direct caller (22 sites in `test_review.py`) keeps working unchanged.
- **webhook.py**: stashes both values on the app dict from config and forwards them into `review.review_pr()` at the background-task call site.
- **install.py**: two new prompts in `_cmd_config()` using `_validate_positive_int` / `_validate_positive_float` loops; values write to env only when non-default.
- **.env.example**: `PR_REVIEW_TIMEOUT_S` and `PR_REVIEW_BUDGET_USD` documented under the existing `PR_REVIEW_COOLDOWN` section.

## Tests

- `tests/test_config.py`: both vars added to `_CONFIG_ENV_VARS`; `TestPRReviewConfig` gains six tests (defaults, override parse, non-integer / non-number reject, non-positive reject).
- `tests/test_webhook.py`: `_build_webhook_app()` seeds both keys so the review path has them available.
- `tests/test_install.py`: prompt sequences for four `_cmd_config` scenarios gain the two new responses.

`make check` clean; full suite 1732 passed.

## Test plan

- [x] `make check` clean
- [x] Full test suite passes (1732)
- [ ] After merge + `sudo make install`, verify `PR_REVIEW_TIMEOUT_S=1800` in `.env` flows through to the subprocess (confirm via successful re-review of PR #333 with any follow-up push)
