### PR TITLE
feat(memory): /memory Telegram command (spec 310)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,6 +144,13 @@ MEMORY_ENABLED=false
 # Models with different dims are rejected at startup. Supporting other
 # dimensions requires changing embedding_model_dims in memory.py.
 #MEMORY_EMBEDDING_MODEL=all-MiniLM-L6-v2
+# Minimum Mem0 similarity score for a memory to be returned. Float in
+# [0.0, 1.0]; default 0.3 matches Mem0's built-in default. Governs both
+# the context-injection path (format_context) and the /memory search UI
+# - one knob, two paths. Raise toward 0.5+ to reduce false positives at
+# the cost of recall; lower toward 0.0 if recall feels missing. Tunable
+# at runtime by editing this file and restarting the service.
+#MEMORY_SEARCH_FLOOR=0.3
 
 # Track 2 Haiku extraction. Requires MEMORY_ENABLED=true and a Claude
 # backend. Off by default at Phase 2 ship (self-reinforcing loop needs

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -54,7 +54,7 @@ from telegram.ext import (
     filters,
 )
 
-from kai import github_api, services, sessions, webhook
+from kai import github_api, memory_command, services, sessions, webhook
 from kai.config import (
     DATA_DIR,
     MAX_CONTEXT_CEILING,
@@ -2845,6 +2845,12 @@ async def handle_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         "/github add <repo> - Watch a repo\n"
         "/github remove <repo> - Unwatch a repo\n"
         "\n"
+        "/memory - Browse remembered facts by tag\n"
+        "/memory search <q> - Semantic search over memories\n"
+        "/memory stats - Counts and confidence distribution\n"
+        "/memory forget <tag> - Delete all memories with a tag\n"
+        "/memory help - /memory subcommand reference\n"
+        "\n"
         "/voice - Toggle voice on/off\n"
         "/voice only - Voice only (no text)\n"
         "/voice on - Text + voice\n"
@@ -3705,12 +3711,14 @@ def create_bot(config: Config, *, use_webhook: bool = True) -> Application:
     app.add_handler(CommandHandler("voices", handle_voices))
     app.add_handler(CommandHandler("webhooks", handle_webhooks))
     app.add_handler(CommandHandler("github", handle_github))
+    app.add_handler(CommandHandler("memory", memory_command.handle_memory_command))
     app.add_handler(CommandHandler("stop", handle_stop))
 
     # Callback query handlers for inline keyboards (pattern-matched)
     app.add_handler(CallbackQueryHandler(handle_model_callback, pattern=r"^model:"))
     app.add_handler(CallbackQueryHandler(handle_voice_callback, pattern=r"^voice:"))
     app.add_handler(CallbackQueryHandler(handle_workspace_callback, pattern=r"^ws:"))
+    app.add_handler(CallbackQueryHandler(memory_command.handle_memory_callback, pattern=r"^mem:"))
 
     # Media handlers (must be before the catch-all text handler)
     app.add_handler(MessageHandler(filters.PHOTO, handle_photo))

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -460,6 +460,19 @@ class Config:
     # an executor thread on a hung subprocess.
     memory_extraction_timeout_s: int = 10
 
+    # Minimum Mem0 similarity score for a memory to be returned by
+    # search-driven paths: both `format_context` (context injection
+    # at session start) and the `/memory search` UI surface in
+    # `memory_command.py`. Values below the floor are dropped before
+    # any ranking. Default 0.3 matches Mem0's built-in default and
+    # the prior hard-coded constant; raise toward 0.5+ to reduce
+    # false positives at the cost of recall. Spec 310 §7.5 documents
+    # the "one knob, two paths" decision: keeping the UI floor and
+    # the context-injection floor in lockstep prevents silent
+    # divergence between "what the user sees in /memory search" and
+    # "what Kai pulls into context" after a config change.
+    memory_search_floor: float = 0.3
+
     def get_workspace_config(self, workspace: Path) -> WorkspaceConfig | None:
         """
         Get per-workspace config for a path, or None for global defaults.
@@ -1400,6 +1413,21 @@ def load_config() -> Config:
     except ValueError:
         raise SystemExit("MEMORY_EXTRACTION_TIMEOUT_S must be an integer") from None
 
+    # Search relevance floor. Float in [0.0, 1.0]; default 0.3 matches
+    # Mem0's built-in default and the prior hard-coded constant. Same
+    # try/except pattern as the other memory_* numeric vars: bad input
+    # exits at startup rather than surfacing as a divide-by-zero or
+    # mysterious "no results" symptom at first query. Range is bounded
+    # at both ends because Mem0 cosine similarity is normalized to
+    # [0.0, 1.0]; a floor outside that range silently filters
+    # everything (>1.0) or nothing (<0.0), both of which are footguns.
+    try:
+        memory_search_floor = float(os.environ.get("MEMORY_SEARCH_FLOOR", "0.3"))
+        if memory_search_floor < 0.0 or memory_search_floor > 1.0:
+            raise SystemExit("MEMORY_SEARCH_FLOOR must be between 0.0 and 1.0")
+    except ValueError:
+        raise SystemExit("MEMORY_SEARCH_FLOOR must be a number") from None
+
     # Per-workspace configuration. Loaded after ALLOWED_WORKSPACES so
     # YAML-defined workspaces can be merged into the allowed set.
     workspace_configs = _load_workspace_configs()
@@ -1557,4 +1585,5 @@ def load_config() -> Config:
         memory_extraction_model=memory_extraction_model,
         memory_extraction_budget_usd=memory_extraction_budget_usd,
         memory_extraction_timeout_s=memory_extraction_timeout_s,
+        memory_search_floor=memory_search_floor,
     )

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -29,10 +29,14 @@ log = logging.getLogger(__name__)
 
 # ── Data classes ────────────────────────────────────────────────────
 
-# Minimum similarity score for a memory to be included in context.
-# Based on smoke testing: clearly relevant results score 0.7+,
-# loosely relevant ~0.35, noise below 0.3.
-_MIN_RELEVANCE_THRESHOLD = 0.3
+# Minimum similarity score for a memory to be included in context
+# was previously a hard-coded 0.3 here. Promoted to a config field as
+# part of spec 310: see `Config.memory_search_floor` (env var
+# MEMORY_SEARCH_FLOOR). Both `format_context` below and the
+# `/memory search` UI in `memory_command.py` read the same value at
+# query time so a config change applies everywhere Kai consults memory.
+# Background: based on smoke testing, clearly relevant results score
+# 0.7+, loosely relevant ~0.35, noise below 0.3.
 
 # Maximum length (chars) for the assistant portion of an ingested
 # exchange. Long tool outputs (file dumps, stack traces, large diffs)
@@ -410,7 +414,14 @@ async def format_context(
     # Weighting happens AFTER this filter (spec §5.3) so a downweighted
     # legacy row cannot survive on raw score, and a boosted extracted fact
     # cannot be rescued below threshold.
-    results = [r for r in results if r.score >= _MIN_RELEVANCE_THRESHOLD]
+    #
+    # Read the floor from config at every call (not at module import) so a
+    # `MEMORY_SEARCH_FLOOR` change applied via service restart takes effect
+    # consistently here AND in the `/memory search` UI; spec 310 §7.5
+    # documents the one-knob-two-paths decision. _config is non-None inside
+    # this branch because is_enabled() returned True above.
+    floor = _config.memory_search_floor
+    results = [r for r in results if r.score >= floor]
     if not results:
         return ""
 

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -21,7 +21,7 @@ import asyncio
 import logging
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from kai.config import DATA_DIR, Config
 
@@ -166,14 +166,54 @@ class MemoryResult:
     memory_type: str  # From metadata["type"]: "exchange", "fact", etc.
     metadata: dict  # Full metadata dict from Mem0
     created_at: str  # ISO timestamp
+    # ISO timestamp of the most recent update; equal to created_at for
+    # rows that have never been refreshed. Surfaced for the /memory tag
+    # view (spec 310 §6.2), which sorts newest-updated first so a fact
+    # bubbled up by re-extraction lands at the top of its tag list.
+    # Defaults to "" so callers and tests that don't pass it remain
+    # source-compatible with the pre-spec-310 dataclass shape.
+    updated_at: str = ""
 
 
 @dataclass(frozen=True)
 class MemoryStats:
-    """Memory statistics for a user."""
+    """Memory statistics for a user.
+
+    Two distinct totals coexist:
+      - `total_count` covers ALL rows for the user (every source). This
+        is the original semantics; left untouched so existing callers do
+        not see a behavior change.
+      - `extracted_count` and every other field below cover ONLY rows
+        with `metadata.source == "extracted"`. The /memory stats UI
+        (spec 310 §6.6) operates on this restricted view: tier badges
+        and cross-source aggregates would clutter the tuning dashboard,
+        and Track 1 / legacy rows have no tags or confidence to report
+        on anyway.
+
+    All extracted-only aggregate fields default to a "no extracted rows"
+    sentinel (None for min/median/max, 0 for counts, empty dict for the
+    grouped fields) so a caller that constructs `MemoryStats(total_count=0,
+    by_type={})` (the legacy two-arg form) still produces a valid value.
+    """
 
     total_count: int
     by_type: dict[str, int]  # {"exchange": 42, "fact": 3, ...}
+
+    # ── Extracted-only aggregates (spec 310 §6.6 / §7.2) ────────────
+    # Every field below is computed over rows with
+    # metadata.source == "extracted". Track 1 and legacy rows do not
+    # contribute. min/median/max are None when extracted_count == 0
+    # because picking 0.0 would be misleading (it is a valid score
+    # value, not "no data"). Counts default to 0 / empty dict.
+    extracted_count: int = 0
+    by_tag: dict[str, int] = field(default_factory=dict)
+    confidence_min: float | None = None
+    confidence_median: float | None = None
+    confidence_max: float | None = None
+    confidence_below_0_7: int = 0
+    confidence_below_0_6: int = 0
+    confirmation_quote_count: int = 0
+    by_prompt_version: dict[str, int] = field(default_factory=dict)
 
 
 # ── Singleton state ─────────────────────────────────────────────────
@@ -233,6 +273,9 @@ def _wrap_result(raw: dict) -> MemoryResult:
     score, created_at, updated_at, user_id, role.
     """
     metadata = raw.get("metadata") or {}
+    # Mem0 surfaces both created_at and updated_at on every row; both
+    # default to "" if the upstream payload does not have them, which
+    # keeps callers (and the tag-view sort) from having to None-check.
     return MemoryResult(
         id=raw.get("id", ""),
         text=raw.get("memory", ""),
@@ -240,6 +283,7 @@ def _wrap_result(raw: dict) -> MemoryResult:
         memory_type=metadata.get("type", "unknown"),
         metadata=metadata,
         created_at=raw.get("created_at", ""),
+        updated_at=raw.get("updated_at", ""),
     )
 
 
@@ -870,23 +914,159 @@ def add_structured(
     return None
 
 
-def get_all(*, user_id: str) -> list[MemoryResult]:
+def get_all(*, user_id: str, limit: int | None = 1000) -> list[MemoryResult]:
     """
     Get all memories for a user.
 
-    Returns empty list if disabled. Used for debugging and the
-    future /memory command.
+    Returns empty list if disabled. Used for debugging, the /memory
+    command surface (spec 310), and the per-source delete primitive.
+
+    Args:
+        user_id: Telegram chat_id as a string.
+        limit: Maximum rows to fetch (passed to Mem0 as top_k). Defaults
+            to 1000 to preserve the legacy bounded-memory behavior of
+            this function for non-/memory callers (e.g. delete_by_source
+            paginates explicitly and relies on this cap). Pass `None`
+            from the /memory dashboard and stats paths so the displayed
+            total is not silently truncated for users who have built up
+            more than 1000 extracted facts. When `limit=None`, Mem0 is
+            called with a top_k far above any realistic per-user count;
+            see spec 310 §7.2.1 for the cap-vs-pagination tradeoff and
+            the long-term plan to switch to true cursor pagination once
+            single users approach the new ceiling.
     """
     if _memory is None:
         return []
 
+    # Translate the public None -> internal "very large" top_k. Mem0
+    # itself does not accept None for top_k; a five-figure ceiling is
+    # well above any realistic single-user fact count and lets the
+    # /memory UI report a true total instead of silently flattening at
+    # 1000. Aligned with the spec §7.2.1 guidance ("100000").
+    effective_top_k = 100_000 if limit is None else limit
+
     try:
-        result = _memory.get_all(filters={"user_id": user_id}, top_k=1000)
+        result = _memory.get_all(filters={"user_id": user_id}, top_k=effective_top_k)
         raw_results = result.get("results", []) if isinstance(result, dict) else result
         return [_wrap_result(r) for r in raw_results]
     except Exception:
         log.warning("Memory get_all failed", exc_info=True)
         return []
+
+
+def get_by_tag(*, user_id: str, tag: str) -> list[MemoryResult]:
+    """Return all extracted facts for `user_id` carrying `tag`.
+
+    Used by the /memory tag drill-down (spec 310 §6.2). Filters
+    client-side because Mem0's `get_all` does not accept metadata
+    filters. Two filter clauses, both load-bearing:
+
+      - `metadata.source == "extracted"`: defends against rows from the
+        pre-#335 era (or any future additional source) leaking into the
+        extracted-only UI. If #335 ships first and no `user_raw` rows
+        remain in production, this clause is a no-op; keeping it anyway
+        means the UI contract does not need re-reasoning the next time
+        a second source is introduced. Spec 310 §7.2.
+      - `tag in metadata.tags`: the actual tag match. The `or []`
+        guards against a malformed row that lacks the tags list
+        entirely; such rows simply do not match any tag.
+
+    Sort: `updated_at` descending. A re-extracted fact bubbles to the
+    top of its tag list, which is the spec's intended drill-down
+    ordering (§6.2). Falls back to `created_at` for rows that are
+    missing `updated_at`; both default to "" in `_wrap_result` so the
+    sort is total-order stable rather than raising on None comparisons.
+
+    The full row set comes from `get_all(limit=None)` so a user with
+    thousands of extracted facts still gets a complete tag listing.
+    """
+    if _memory is None:
+        return []
+
+    rows = get_all(user_id=user_id, limit=None)
+    matches = [r for r in rows if r.metadata.get("source") == "extracted" and tag in (r.metadata.get("tags") or [])]
+    # Newest-updated first; created_at is the fallback for rows whose
+    # payload predates updated_at being recorded. String comparison on
+    # ISO-8601 timestamps is correct because the format is
+    # lexicographically sortable.
+    matches.sort(key=lambda r: r.updated_at or r.created_at, reverse=True)
+    return matches
+
+
+def delete_by_id(*, user_id: str, memory_id: str) -> bool:
+    """Delete a single memory after verifying ownership and source.
+
+    Used by the /memory forget flow (spec 310 §6.4). Mem0's `delete`
+    takes only a memory_id and does NOT scope by user_id (verified by
+    inspecting Mem0's `Memory.delete` source: it calls
+    `vector_store.get(vector_id=memory_id)` followed by an unscoped
+    `_delete_memory`). So the verify-before-delete is structurally
+    necessary, not redundant.
+
+    Two checks, both load-bearing:
+      - `row.user_id == user_id`: defends against malformed callback
+        data referencing a memory id that belongs to a different user.
+        With multi-user installs (project is public, multi-user) the
+        cost of a missed check is cross-user data deletion.
+      - `row.metadata.source == "extracted"`: the /memory UI is
+        documented to manage extracted memories only. Track 1 and
+        legacy rows are owned by the admin CLI path
+        (`memory_admin.py`); refusing to touch them here keeps the
+        per-surface ownership model honest.
+
+    Returns True if the row was deleted; False for not-found, ownership
+    mismatch, source mismatch, or a Mem0 ValueError on the delete (the
+    row already vanished between get and delete - rare race, treated as
+    "nothing to do" rather than an error).
+    """
+    if _memory is None:
+        return False
+
+    # Mem0's get returns None for missing rows (verified at
+    # mem0/memory/main.py: vector_store.get falls through to None and
+    # the function returns None). No exception handling needed for the
+    # not-found path.
+    try:
+        row = _memory.get(memory_id=memory_id)
+    except Exception:
+        log.warning("delete_by_id: get failed for %s", memory_id, exc_info=True)
+        return False
+    if row is None:
+        return False
+
+    # Mem0 promotes user_id out of the payload to a top-level key
+    # (verified at mem0/memory/main.py: get() copies promoted_payload_keys
+    # back onto the result dict). metadata is a dict of any leftover
+    # payload keys and may be absent entirely if the row carried no
+    # extra payload, so use .get with a default rather than indexing.
+    if row.get("user_id") != user_id:
+        log.warning(
+            "delete_by_id: ownership mismatch (memory_id=%s, requested_user=%s)",
+            memory_id,
+            user_id,
+        )
+        return False
+    if (row.get("metadata") or {}).get("source") != "extracted":
+        log.warning(
+            "delete_by_id: refusing non-extracted row (memory_id=%s, source=%r)",
+            memory_id,
+            (row.get("metadata") or {}).get("source"),
+        )
+        return False
+
+    try:
+        _memory.delete(memory_id=memory_id)
+    except ValueError:
+        # Row vanished between get and delete - extremely narrow race
+        # but cheaper to swallow than to surface as an error to the UI,
+        # which would render "delete failed" for a row the user already
+        # cannot see. Same posture as delete_by_source.
+        log.debug("delete_by_id: %s already gone", memory_id)
+        return False
+    except Exception:
+        log.warning("delete_by_id: delete failed for %s", memory_id, exc_info=True)
+        return False
+    return True
 
 
 def delete_all(*, user_id: str) -> None:
@@ -909,11 +1089,100 @@ def get_stats(*, user_id: str) -> MemoryStats:
     """
     Get memory statistics for a user.
 
-    Counts memories by type (exchange, fact, etc.). Returns zeroed
-    stats if disabled.
+    Returns two views in one call (spec 310 §6.6 / §7.2):
+      - All-rows view: `total_count` and `by_type` count every row for
+        the user regardless of source. Original semantics; preserved so
+        existing callers do not see a behavior change.
+      - Extracted-only view: every other field (`extracted_count`,
+        `by_tag`, confidence stats, prompt-version counts,
+        `confirmation_quote_count`) is computed over rows with
+        `metadata.source == "extracted"` only. Track 1 and legacy
+        rows have no tags or confidence to report on, so including
+        them would just add noise to the tuning dashboard.
+
+    `limit=None` so the totals are not silently truncated for users
+    with more than 1000 extracted facts; see spec 310 §7.2.1.
+
+    Confidence median uses the lower of the two middle values for an
+    even-count dataset (`statistics.median_low` semantics) per spec
+    §6.6: averaging two adjacent quantized values would produce a
+    synthetic number that no individual fact actually had, while
+    `median_low` preserves "values present in the data".
+
+    Returns zeroed stats if disabled (memories will be []).
     """
-    memories = get_all(user_id=user_id)
+    memories = get_all(user_id=user_id, limit=None)
+
+    # All-rows aggregates (legacy). Computed across every source.
     by_type: dict[str, int] = {}
     for m in memories:
         by_type[m.memory_type] = by_type.get(m.memory_type, 0) + 1
-    return MemoryStats(total_count=len(memories), by_type=by_type)
+
+    # Extracted-only aggregates. Build the filtered list once; every
+    # downstream metric reads from it.
+    extracted = [m for m in memories if m.metadata.get("source") == "extracted"]
+
+    by_tag: dict[str, int] = {}
+    by_prompt_version: dict[str, int] = {}
+    confidences: list[float] = []
+    confirmation_count = 0
+    for m in extracted:
+        # tags: 1 to 4 strings per spec 310 §4. A row with no tags list
+        # contributes to no tag bucket; the `or []` guard handles a
+        # malformed payload without raising.
+        for t in m.metadata.get("tags") or []:
+            by_tag[t] = by_tag.get(t, 0) + 1
+
+        # prompt_version: stored as a string; "" treated as a distinct
+        # bucket so a regression in extraction (forgetting to stamp the
+        # version) shows up rather than silently merging into other
+        # counts. Bucket key is the value itself.
+        pv = m.metadata.get("prompt_version", "")
+        by_prompt_version[pv] = by_prompt_version.get(pv, 0) + 1
+
+        # confidence: the schema enforces [0.5, 1.0], but a bad row
+        # could still surface a non-numeric value. Skip those rather
+        # than crashing the stats view; they would be visible elsewhere
+        # as a corrupt fact already.
+        c = m.metadata.get("confidence")
+        if isinstance(c, int | float):
+            confidences.append(float(c))
+
+        # confirmation_quote: spec §4 says present only when tags
+        # include confirmed_action. Counted by presence of the field
+        # rather than re-checking the tag, since the runtime invariant
+        # at memory_extraction._validate_facts already ties them.
+        if m.metadata.get("confirmation_quote"):
+            confirmation_count += 1
+
+    # Confidence min/median/max are None for an empty extracted set so
+    # the UI can render "n/a" rather than a misleading 0.0.
+    if confidences:
+        sorted_c = sorted(confidences)
+        confidence_min: float | None = sorted_c[0]
+        confidence_max: float | None = sorted_c[-1]
+        # statistics.median_low semantics: for an even count, pick the
+        # lower of the two middle values rather than averaging them.
+        # `(n - 1) // 2` indexes the lower middle for any n >= 1.
+        confidence_median: float | None = sorted_c[(len(sorted_c) - 1) // 2]
+    else:
+        confidence_min = None
+        confidence_median = None
+        confidence_max = None
+
+    confidence_below_0_7 = sum(1 for c in confidences if c < 0.7)
+    confidence_below_0_6 = sum(1 for c in confidences if c < 0.6)
+
+    return MemoryStats(
+        total_count=len(memories),
+        by_type=by_type,
+        extracted_count=len(extracted),
+        by_tag=by_tag,
+        confidence_min=confidence_min,
+        confidence_median=confidence_median,
+        confidence_max=confidence_max,
+        confidence_below_0_7=confidence_below_0_7,
+        confidence_below_0_6=confidence_below_0_6,
+        confirmation_quote_count=confirmation_count,
+        by_prompt_version=by_prompt_version,
+    )

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -993,46 +993,42 @@ def get_by_tag(*, user_id: str, tag: str) -> list[MemoryResult]:
     return matches
 
 
-def delete_by_id(*, user_id: str, memory_id: str) -> bool:
-    """Delete a single memory after verifying ownership and source.
+def get_by_id(*, user_id: str, memory_id: str) -> MemoryResult | None:
+    """Fetch a single extracted memory by id, scoped to user.
 
-    Used by the /memory forget flow (spec 310 §6.4). Mem0's `delete`
-    takes only a memory_id and does NOT scope by user_id (verified by
-    inspecting Mem0's `Memory.delete` source: it calls
-    `vector_store.get(vector_id=memory_id)` followed by an unscoped
-    `_delete_memory`). So the verify-before-delete is structurally
-    necessary, not redundant.
+    Used by the /memory fact view and forget-fact confirmation
+    (spec 310 §6.3, §6.4). Replaces the old pattern of pulling
+    `get_all` and filtering in Python: O(1) Mem0 lookup vs O(n)
+    full-corpus walk per fact-view tap.
 
-    Two checks, both load-bearing:
-      - `row.user_id == user_id`: defends against malformed callback
-        data referencing a memory id that belongs to a different user.
-        With multi-user installs (project is public, multi-user) the
-        cost of a missed check is cross-user data deletion.
-      - `row.metadata.source == "extracted"`: the /memory UI is
-        documented to manage extracted memories only. Track 1 and
-        legacy rows are owned by the admin CLI path
-        (`memory_admin.py`); refusing to touch them here keeps the
-        per-surface ownership model honest.
+    Same ownership/source scoping as `delete_by_id` (which now
+    reuses this helper):
+      - Mem0's `get` does NOT scope by user_id, so we verify it
+        manually. With multi-user installs the cost of a missed
+        check is reading another user's memory.
+      - Track 1 / legacy rows are out of scope for /memory UI
+        surfaces; they belong to memory_admin.py. Hide them here
+        rather than letting the dashboard expose them.
 
-    Returns True if the row was deleted; False for not-found, ownership
-    mismatch, source mismatch, or a Mem0 ValueError on the delete (the
-    row already vanished between get and delete - rare race, treated as
-    "nothing to do" rather than an error).
+    Returns None for not-found, ownership mismatch, source mismatch,
+    or a Mem0 fetch failure. The fact-view caller treats all four
+    cases identically ("This memory no longer exists.") so collapsing
+    them is fine.
     """
     if _memory is None:
-        return False
+        return None
 
     # Mem0's get returns None for missing rows (verified at
     # mem0/memory/main.py: vector_store.get falls through to None and
     # the function returns None). No exception handling needed for the
-    # not-found path.
+    # not-found path itself - only for unexpected failures.
     try:
         row = _memory.get(memory_id=memory_id)
     except Exception:
-        log.warning("delete_by_id: get failed for %s", memory_id, exc_info=True)
-        return False
+        log.warning("get_by_id: get failed for %s", memory_id, exc_info=True)
+        return None
     if row is None:
-        return False
+        return None
 
     # Mem0 promotes user_id out of the payload to a top-level key
     # (verified at mem0/memory/main.py: get() copies promoted_payload_keys
@@ -1041,17 +1037,43 @@ def delete_by_id(*, user_id: str, memory_id: str) -> bool:
     # extra payload, so use .get with a default rather than indexing.
     if row.get("user_id") != user_id:
         log.warning(
-            "delete_by_id: ownership mismatch (memory_id=%s, requested_user=%s)",
+            "get_by_id: ownership mismatch (memory_id=%s, requested_user=%s)",
             memory_id,
             user_id,
         )
-        return False
+        return None
     if (row.get("metadata") or {}).get("source") != "extracted":
-        log.warning(
-            "delete_by_id: refusing non-extracted row (memory_id=%s, source=%r)",
-            memory_id,
-            (row.get("metadata") or {}).get("source"),
-        )
+        # Non-extracted rows are deliberately invisible to /memory.
+        # No log: this is a routine filter, not an anomaly.
+        return None
+
+    return _wrap_result(row)
+
+
+def delete_by_id(*, user_id: str, memory_id: str) -> bool:
+    """Delete a single memory after verifying ownership and source.
+
+    Used by the /memory forget flow (spec 310 §6.4). Mem0's `delete`
+    takes only a memory_id and does NOT scope by user_id (verified by
+    inspecting Mem0's `Memory.delete` source: it calls
+    `vector_store.get(vector_id=memory_id)` followed by an unscoped
+    `_delete_memory`). So the verify-before-delete is structurally
+    necessary, not redundant - we route through `get_by_id`, which
+    enforces the same ownership/source rules in one place.
+
+    Returns True if the row was deleted; False for not-found, ownership
+    mismatch, source mismatch (all collapsed in get_by_id), or a Mem0
+    ValueError on the delete (the row already vanished between get and
+    delete - rare race, treated as "nothing to do" rather than an
+    error).
+    """
+    if _memory is None:
+        return False
+
+    # Single source of truth for ownership + source scoping. If
+    # get_by_id returns None for any reason (missing, wrong user,
+    # non-extracted, fetch error) we refuse to delete.
+    if get_by_id(user_id=user_id, memory_id=memory_id) is None:
         return False
 
     try:

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -1,0 +1,1215 @@
+"""
+Telegram-facing surface for the `/memory` command (spec 310).
+
+Wraps the Mem0-backed memory store in a per-user browse, search, and
+forget UI. Every read and delete is scoped to the calling user's
+`chat_id` - there is no cross-user inspection. Every write path is
+guarded by an explicit confirmation step rendered as inline buttons,
+because deletions are irreversible.
+
+Architectural shape:
+- Pure builders (`_build_*`) take fixture data and return
+  `(text, keyboard)` tuples. They do no I/O and have no state. This
+  lets the unit tests assert on rendering without standing up an
+  Update/Bot fixture or touching Mem0.
+- Top-level handlers (`handle_memory_command`,
+  `handle_memory_callback`) own the I/O: they fetch from `memory.py`,
+  call the builders, and dispatch send/edit calls to Telegram.
+- A module-level dict `_screen_cache` holds the per-chat navigation
+  state. The cache is lazy-expired on every access - no background
+  reaper task. Losing the cache on process restart is acceptable
+  (spec 310 §7.4); the user just retypes `/memory`.
+
+The `source == "extracted"` filter is applied by the underlying
+`memory.get_by_tag` / `memory.delete_by_id` helpers (memory.py
+§7.2). This module never references `metadata.source` directly so
+that a future change to the source-filter rule lives in exactly one
+place.
+
+See `home/specs/310-memory-command.md` for the canonical UX flows
+and design rationale.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.error import BadRequest
+from telegram.ext import ContextTypes
+
+from kai import memory
+from kai.config import Config
+from kai.memory import MemoryResult, MemoryStats
+
+if TYPE_CHECKING:
+    # Only used for type hints; importing at runtime would create a
+    # cycle since bot.py imports this module.
+    pass
+
+log = logging.getLogger(__name__)
+
+
+# ── Constants ───────────────────────────────────────────────────────
+
+# The closed enum of tags accepted by the Haiku extractor, in the same
+# order as `_FACT_SCHEMA["properties"]["facts"]["items"]["properties"]
+# ["tags"]["items"]["enum"]` at memory_extraction.py:153-163. Mirrored
+# here (rather than imported) because importing memory_extraction would
+# pull in the Anthropic SDK, an unnecessary dependency for the UI path.
+# A drift between the two lists shows up immediately in `/memory stats`
+# (a tag with rows but no enum entry would be silently absent from the
+# stats view), and is also covered by a unit test in test_memory_command.
+_TAG_ENUM: tuple[str, ...] = (
+    "preference",
+    "decision",
+    "fact",
+    "constraint",
+    "confirmed_action",
+    "project",
+    "location",
+    "schedule",
+    "relationship",
+)
+
+# Page size for the tag drill-down view (spec §6.2). Five fits on a
+# single phone screen with the surrounding buttons; raising it forces
+# scrolling.
+_TAG_PAGE_SIZE = 5
+
+# Default number of search hits returned by `/memory search`, before
+# the relevance floor is applied (spec §5: "default N = 8"). Floor
+# filtering happens after the fetch so a small N does not silently
+# eliminate borderline-relevant rows that the floor would have kept.
+_SEARCH_LIMIT = 8
+
+# Maximum line length for fact text in list views (tag drill-down,
+# search results). Spec §6.2 mandates 80 chars + ellipsis. Fact detail
+# view shows the full text (no truncation).
+_LIST_TRUNCATE_LEN = 80
+
+# Per-chat cache TTL in seconds (spec §7.4: "30 minutes"). Checked
+# lazily on every callback access.
+_CACHE_TTL_S = 30 * 60
+
+# Unicode block character for the dashboard bar chart (spec §6.1
+# mock-up uses ▓). Plain text mode renders this fine on every
+# Telegram client.
+_BAR_CHAR = "\u2593"
+
+# Width of the dashboard bar chart in characters, scaled to the
+# largest tag count. Eight is wide enough to show contrast between
+# 38 and 5 without overflowing the typical phone screen.
+_BAR_WIDTH = 8
+
+
+# ── Per-chat navigation cache ───────────────────────────────────────
+
+
+@dataclass
+class _ScreenCache:
+    """Per-chat ephemeral state backing /memory navigation.
+
+    Holds the screen the user is currently looking at plus the
+    arguments needed to re-render it (tag name + page, search query,
+    fact id list). The numbered buttons in tag and search views are
+    stored as a list of memory ids indexed 0..n; the callback data
+    only carries the integer index, keeping every callback under the
+    Telegram 64-byte limit even when memory ids are 36-char UUIDs.
+
+    `return_to` carries the encoding of the screen the back button on
+    a fact view should land on. It is a tuple of (verb, args) where
+    args is a list of strings that get re-encoded into a callback
+    on dispatch. Storing the structured form (rather than a callback
+    string) means the back-target representation can change without
+    needing to reparse stale entries.
+
+    `message_id` is the id of the current screen message. Set when
+    the dashboard is first shown via `reply_text`; reused by every
+    edit thereafter so the chat stays clean.
+    """
+
+    screen: str
+    memory_ids: list[str] = field(default_factory=list)
+    tag: str | None = None
+    page: int = 0
+    query: str | None = None
+    return_to: tuple[str, list[str]] | None = None
+    message_id: int | None = None
+    created_at: float = field(default_factory=time.monotonic)
+
+
+# Module-level cache: chat_id -> _ScreenCache. Single entry per chat,
+# overwritten on every fresh `/memory` invocation (spec §7.4). Keeps
+# memory bounded by chat count, not by historical screen count.
+_screen_cache: dict[int, _ScreenCache] = {}
+
+
+def _get_cache(chat_id: int) -> _ScreenCache | None:
+    """Return the cache entry for `chat_id`, expiring it if stale.
+
+    Lazy expiry: every callback access checks the entry's age and
+    drops it if older than `_CACHE_TTL_S`. There is no background
+    reaper because cache entries are tiny (a few hundred bytes each)
+    and bounded by the number of distinct active chats.
+    """
+    entry = _screen_cache.get(chat_id)
+    if entry is None:
+        return None
+    if time.monotonic() - entry.created_at > _CACHE_TTL_S:
+        # Expired - drop it. The caller will treat this as "no cache"
+        # and route the user back to the dashboard with an explanatory
+        # toast (see `handle_memory_callback`).
+        _screen_cache.pop(chat_id, None)
+        return None
+    return entry
+
+
+def _set_cache(chat_id: int, entry: _ScreenCache) -> None:
+    """Install a fresh cache entry, overwriting any prior one.
+
+    The created_at timestamp is reset on every assignment so that
+    each successful navigation extends the TTL window. Without this,
+    a long browse session that crosses 30 minutes would suddenly
+    expire mid-flow.
+    """
+    entry.created_at = time.monotonic()
+    _screen_cache[chat_id] = entry
+
+
+def _clear_cache(chat_id: int) -> None:
+    """Remove the cache entry for `chat_id` (used by tests and reset)."""
+    _screen_cache.pop(chat_id, None)
+
+
+# ── Callback data encoding ──────────────────────────────────────────
+#
+# Telegram limits `callback_data` to 64 bytes. The grammar is:
+#   mem:<verb>[:<arg>[:<arg>...]]
+# Verbs are short tokens; arguments are tag names (max 16 chars,
+# "confirmed_action"), short integers (page numbers, list indices),
+# and the literal string "back" for navigation actions. Memory ids
+# never appear in callback data - they live in the per-chat cache and
+# are referenced by integer index.
+
+
+_CALLBACK_PREFIX = "mem:"
+
+
+@dataclass(frozen=True)
+class _CallbackAction:
+    """Decoded callback action from a Telegram inline-button tap."""
+
+    verb: str
+    args: list[str]
+
+
+def _encode_callback(verb: str, *args: str) -> str:
+    """Build a `mem:<verb>:<arg>:...` callback string.
+
+    Centralized so that the 64-byte ceiling can be asserted in one
+    place. Telegram silently truncates over-long `callback_data`,
+    which would manifest as confusing "invalid action" errors at
+    runtime; assert at construction time instead so tests catch it.
+    """
+    parts = [verb, *args]
+    encoded = _CALLBACK_PREFIX + ":".join(parts)
+    # Defensive ceiling. The longest legitimate callback in this
+    # module is `mem:ftgc:confirmed_action` at 24 bytes, well under
+    # the limit; an assertion firing here means a bug in the caller
+    # (probably an unexpected long arg) rather than legitimate data.
+    assert len(encoded.encode("utf-8")) <= 64, f"callback_data too long: {encoded!r}"
+    return encoded
+
+
+def _decode_callback(data: str) -> _CallbackAction | None:
+    """Parse a callback string into a `_CallbackAction`.
+
+    Returns None when the prefix does not match - callers should
+    treat this as "not our callback" and ignore. Returns an action
+    with an empty args list for verb-only callbacks like `mem:dash`.
+    """
+    if not data.startswith(_CALLBACK_PREFIX):
+        return None
+    body = data[len(_CALLBACK_PREFIX) :]
+    if not body:
+        return None
+    parts = body.split(":")
+    return _CallbackAction(verb=parts[0], args=parts[1:])
+
+
+# ── Empty-state and error messages ──────────────────────────────────
+#
+# Spec §8 enumerates these. Centralized as constants so the wording
+# stays consistent across the entry-point handler and any callback
+# that needs to fall back to an empty-state branch.
+
+_MSG_DISABLED = "Memory is not enabled in this install."
+_MSG_UNAVAILABLE = "Memory is temporarily unavailable."
+_MSG_NO_FACTS = "No memories yet. Things you tell Kai will be extracted and stored here over time."
+_MSG_QUERY_FAILED = "Memory query failed. Try again in a moment."
+_MSG_SESSION_EXPIRED = "Session expired, resyncing."
+_MSG_NO_SEARCH_RESULTS = "No matching memories found."
+
+# Help text - the static body shown for `/memory help` and for any
+# unrecognized subcommand (spec §5).
+_HELP_TEXT = (
+    "/memory              Browse by tag\n"
+    "/memory search <q>   Semantic search\n"
+    "/memory stats        Counts and confidence distribution\n"
+    "/memory forget <tag> Delete all memories with a tag\n"
+    "/memory help         Show this help"
+)
+
+
+# ── Display helpers ─────────────────────────────────────────────────
+
+
+def _truncate(text: str, limit: int = _LIST_TRUNCATE_LEN) -> str:
+    """Trim `text` to `limit` chars, appending an ellipsis if cut.
+
+    Used in tag and search list views (spec §6.2 / §6.5). Detail
+    views render the full text - never call this from the fact
+    detail builder.
+    """
+    # Strip newlines first; a fact text containing an embedded newline
+    # would break the single-line list layout (spec §6.2 mock-up
+    # assumes one row per fact). Replace with a space, not a deletion,
+    # so the boundary between joined sentences stays readable.
+    flat = text.replace("\n", " ").replace("\r", " ")
+    if len(flat) <= limit:
+        return flat
+    # Reserve one character for the ellipsis so the visible width
+    # stays at exactly `limit`.
+    return flat[: limit - 1] + "\u2026"
+
+
+def _format_date(iso_str: str, with_time: bool = False) -> str:
+    """Render a Mem0 ISO timestamp as `YYYY-MM-DD` or `YYYY-MM-DD HH:MM`.
+
+    Mem0 stores timestamps as ISO-8601 strings already, so a slice is
+    sufficient. Returns the original string unchanged if shorter than
+    the expected slice length - this keeps mock fixtures (which often
+    pass `"2026-04-17"` directly) from blowing up.
+    """
+    if not iso_str:
+        return ""
+    if not with_time:
+        return iso_str[:10]
+    if len(iso_str) >= 16:
+        return iso_str[:10] + " " + iso_str[11:16]
+    return iso_str[:10]
+
+
+def _bar(count: int, max_count: int, width: int = _BAR_WIDTH) -> str:
+    """Render a unicode-block bar of length proportional to count.
+
+    A bar is at least one block wide for any nonzero count so a tag
+    with a single fact is visually distinguishable from a tag with
+    zero facts (which is hidden from the dashboard anyway, but the
+    builder is also reused for stats).
+    """
+    if max_count <= 0 or count <= 0:
+        return ""
+    n = max(1, round((count / max_count) * width))
+    return _BAR_CHAR * n
+
+
+def _avg_confidence(stats: MemoryStats) -> float | None:
+    """Return the dashboard-displayed average confidence, or None.
+
+    The dashboard summary line shows `avg X.XX, min X.XX`. We do not
+    persist the running average - instead, derive a usable proxy from
+    the median (which IS persisted) and clamp it for display. This
+    keeps the dashboard fast (no full-corpus walk) at the cost of
+    showing the median rather than a true mean. The label in the
+    builder reflects this distinction.
+    """
+    return stats.confidence_median
+
+
+# ── Builder: dashboard ──────────────────────────────────────────────
+
+
+def _build_dashboard(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup | None]:
+    """Render the dashboard text and keyboard from a MemoryStats.
+
+    The dashboard restricts itself to extracted-only counts (spec
+    §6.1). Tags with zero facts are hidden from the keyboard but
+    appear in `/memory stats` - see spec §6.1 final paragraph for
+    the asymmetry rationale.
+
+    Empty state: when `extracted_count` is zero, returns the empty
+    body text from `_MSG_NO_FACTS` and a `None` keyboard so the
+    caller skips inline buttons entirely.
+    """
+    if stats.extracted_count == 0:
+        return _MSG_NO_FACTS, None
+
+    # Tags with at least one fact, sorted descending by count. Spec
+    # §6.1 mock-up shows this ordering. Ties broken by enum order
+    # (the iteration order of `_TAG_ENUM`) so output is deterministic.
+    nonzero = [(tag, stats.by_tag.get(tag, 0)) for tag in _TAG_ENUM if stats.by_tag.get(tag, 0) > 0]
+    nonzero.sort(key=lambda item: (-item[1], _TAG_ENUM.index(item[0])))
+
+    if not nonzero:
+        # extracted_count > 0 but no row matched a known tag. This
+        # would only happen if a row's metadata.tags is empty or
+        # contains an off-enum value - possible if the schema is
+        # bypassed. Surface as empty rather than crashing.
+        return _MSG_NO_FACTS, None
+
+    max_count = nonzero[0][1]
+    # Pad tag column to longest tag name so the count column is
+    # column-aligned without monospace assumptions (it'll still
+    # left-align in proportional fonts; alignment in monospace is
+    # the bonus).
+    label_width = max(len(tag) for tag, _ in nonzero)
+
+    lines: list[str] = []
+    summary = f"Memories: {stats.extracted_count} facts across {len(nonzero)} tags."
+    lines.append(summary)
+    lines.append("")
+    for tag, count in nonzero:
+        bar = _bar(count, max_count)
+        lines.append(f"  {tag.ljust(label_width)}  {count:>3}   {bar}")
+    lines.append("")
+    # Footer summary: median + min confidence. Spec §6.1 calls this
+    # the "first-glance tuning signal." Median is the persisted value;
+    # the spec mock-up labels it "avg" but median is more honest about
+    # what is shown - see _avg_confidence comment.
+    median = stats.confidence_median
+    minv = stats.confidence_min
+    if median is not None and minv is not None:
+        lines.append(f"Tap a tag to browse. Confidence: median {median:.2f}, min {minv:.2f}.")
+    else:
+        lines.append("Tap a tag to browse.")
+
+    text = "\n".join(lines)
+
+    # Keyboard: one row per tag (preserves ordering, lets a busy
+    # dashboard scroll). A short trailing row holds Search and Stats.
+    rows: list[list[InlineKeyboardButton]] = []
+    for tag, count in nonzero:
+        label = f"{tag} ({count})"
+        rows.append([InlineKeyboardButton(label, callback_data=_encode_callback("tag", tag, "0"))])
+    rows.append(
+        [
+            InlineKeyboardButton("Search", callback_data=_encode_callback("help")),
+            InlineKeyboardButton("Stats", callback_data=_encode_callback("stats")),
+        ]
+    )
+    return text, InlineKeyboardMarkup(rows)
+
+
+# ── Builder: tag view ───────────────────────────────────────────────
+
+
+def _paginate(facts: list[MemoryResult], page: int) -> tuple[list[MemoryResult], int, int]:
+    """Slice `facts` into the page-th window of `_TAG_PAGE_SIZE`.
+
+    Returns (window, clamped_page, total_pages). `clamped_page` is
+    `page` clipped to [0, total_pages-1]; out-of-range page numbers
+    fall back to the nearest valid page rather than rendering an
+    empty screen. `total_pages` is at least 1 even on an empty list
+    so the "page X of Y" footer always reads sensibly.
+    """
+    if not facts:
+        return [], 0, 1
+    total = (len(facts) + _TAG_PAGE_SIZE - 1) // _TAG_PAGE_SIZE
+    clamped = max(0, min(page, total - 1))
+    start = clamped * _TAG_PAGE_SIZE
+    return facts[start : start + _TAG_PAGE_SIZE], clamped, total
+
+
+def _build_tag_view(
+    tag: str,
+    facts: list[MemoryResult],
+    page: int,
+) -> tuple[str, InlineKeyboardMarkup, list[str], int, int]:
+    """Render a paginated tag drill-down.
+
+    Returns (text, keyboard, memory_ids, clamped_page, total_pages).
+    The memory_ids list is the per-fact id for the items displayed on
+    THIS page only - the caller stores it in the screen cache so
+    numbered button taps can resolve back to memory ids.
+
+    Per-fact line layout (spec §6.2):
+        N.  [0.92]  <truncated text>
+                    <date>
+    """
+    window, clamped, total = _paginate(facts, page)
+
+    if not window:
+        # Empty tag - should be unreachable from the dashboard since
+        # zero-fact tags are hidden, but a delete-by-id flow can
+        # leave a tag empty mid-session. Render a graceful empty
+        # state with a back button.
+        text = f"{tag}\n\nNo memories with this tag."
+        kb = InlineKeyboardMarkup([[InlineKeyboardButton("back", callback_data=_encode_callback("dash"))]])
+        return text, kb, [], 0, 1
+
+    # Body text
+    lines = [f"{tag}  (page {clamped + 1} of {total})", ""]
+    memory_ids: list[str] = []
+    for idx, fact in enumerate(window, start=1):
+        confidence = fact.metadata.get("confidence")
+        # Defensive default: extracted rows always carry confidence,
+        # but legacy or pre-#335 rows might not. Render a placeholder
+        # rather than KeyError-ing the screen.
+        if isinstance(confidence, (int, float)):
+            conf_str = f"[{float(confidence):.2f}]"
+        else:
+            conf_str = "[----]"
+        date_str = _format_date(fact.updated_at or fact.created_at)
+        lines.append(f"{idx}.  {conf_str}  {_truncate(fact.text)}")
+        lines.append(f"            {date_str}")
+        lines.append("")
+        memory_ids.append(fact.id)
+
+    text = "\n".join(lines).rstrip()
+
+    # Keyboard: numbered button row + nav row.
+    number_row = [
+        InlineKeyboardButton(str(i + 1), callback_data=_encode_callback("fact", str(i))) for i in range(len(window))
+    ]
+    nav_row: list[InlineKeyboardButton] = []
+    if clamped > 0:
+        nav_row.append(
+            InlineKeyboardButton(
+                "< prev",
+                callback_data=_encode_callback("tag", tag, str(clamped - 1)),
+            )
+        )
+    nav_row.append(InlineKeyboardButton("back", callback_data=_encode_callback("dash")))
+    if clamped < total - 1:
+        nav_row.append(
+            InlineKeyboardButton(
+                "next >",
+                callback_data=_encode_callback("tag", tag, str(clamped + 1)),
+            )
+        )
+    return text, InlineKeyboardMarkup([number_row, nav_row]), memory_ids, clamped, total
+
+
+# ── Builder: fact view ──────────────────────────────────────────────
+
+
+def _build_fact_view(
+    fact: MemoryResult,
+    return_to: tuple[str, list[str]] | None,
+) -> tuple[str, InlineKeyboardMarkup]:
+    """Render the fact detail screen (spec §6.3).
+
+    `return_to` encodes where the back button should land. It can be
+    None for callers (e.g., tests) that don't care; in that case the
+    back button defaults to the dashboard.
+    """
+    md = fact.metadata or {}
+    tags = md.get("tags") or []
+    confidence = md.get("confidence")
+    session_id = md.get("session_id") or ""
+    prompt_version = md.get("prompt_version") or ""
+    confirmation = md.get("confirmation_quote") or ""
+
+    if isinstance(confidence, (int, float)):
+        conf_str = f"{float(confidence):.2f}"
+    else:
+        conf_str = "----"
+
+    # Confirmation row: verbatim quote on confirmed_action facts,
+    # literal "n/a" elsewhere. The schema invariant ("confirmation
+    # _quote present iff tags includes confirmed_action", spec §4)
+    # is asserted at extraction time, so we can render confidently
+    # without re-validating.
+    confirmation_line = confirmation if confirmation else "n/a"
+
+    lines = [
+        "Fact",
+        "",
+        f'"{fact.text}"',
+        "",
+        f"Tags:             {', '.join(tags) if tags else '(none)'}",
+        f"Confidence:       {conf_str}",
+        f"Date:             {_format_date(fact.created_at, with_time=True)}",
+        f"Session:          {session_id or '(none)'}",
+        f"Prompt version:   {prompt_version or '(none)'}",
+        "",
+        f"Confirmation:     {confirmation_line}",
+    ]
+    text = "\n".join(lines)
+
+    back_callback = _encode_callback(return_to[0], *return_to[1]) if return_to is not None else _encode_callback("dash")
+    kb = InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("back", callback_data=back_callback),
+                InlineKeyboardButton("forget", callback_data=_encode_callback("ffc")),
+            ]
+        ]
+    )
+    return text, kb
+
+
+# ── Builder: forget single-fact confirmation (spec §6.4) ────────────
+
+
+def _build_forget_fact_confirm(fact: MemoryResult) -> tuple[str, InlineKeyboardMarkup]:
+    """Render the single-fact forget confirmation."""
+    text = f'Forget this fact?\n\n"{fact.text}"\n\nThis cannot be undone.'
+    kb = InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("confirm forget", callback_data=_encode_callback("ffd")),
+                InlineKeyboardButton("cancel", callback_data=_encode_callback("fview")),
+            ]
+        ]
+    )
+    return text, kb
+
+
+# ── Builder: search results (spec §6.5) ─────────────────────────────
+
+
+def _build_search_results(
+    query: str,
+    results: list[MemoryResult],
+    floor: float,
+) -> tuple[str, InlineKeyboardMarkup, list[str]]:
+    """Render the search-results screen.
+
+    Score shown is the Mem0 similarity score, NOT the Haiku confidence
+    (spec §6.5 explicitly calls this out). Tags + date are shown on
+    the second line of each result. Returns the memory_ids list for
+    cache storage - same contract as the tag view.
+    """
+    if not results:
+        text = f'Search: "{query}"\n\n{_MSG_NO_SEARCH_RESULTS}'
+        kb = InlineKeyboardMarkup([[InlineKeyboardButton("back", callback_data=_encode_callback("dash"))]])
+        return text, kb, []
+
+    lines = [f'Search: "{query}"', ""]
+    memory_ids: list[str] = []
+    for idx, result in enumerate(results, start=1):
+        score_str = f"[{result.score:.2f}]"
+        tags = result.metadata.get("tags") or []
+        tag_str = ", ".join(tags) if tags else "(no tags)"
+        date_str = _format_date(result.updated_at or result.created_at)
+        lines.append(f"{idx}.  {score_str}  {_truncate(result.text)}")
+        lines.append(f"            {tag_str}  \u00b7  {date_str}")
+        lines.append("")
+        memory_ids.append(result.id)
+
+    lines.append(f"No more results above the relevance floor ({floor:.1f}).")
+    text = "\n".join(lines)
+
+    number_row = [
+        InlineKeyboardButton(str(i + 1), callback_data=_encode_callback("fact", str(i))) for i in range(len(results))
+    ]
+    nav_row = [InlineKeyboardButton("back", callback_data=_encode_callback("dash"))]
+    return text, InlineKeyboardMarkup([number_row, nav_row]), memory_ids
+
+
+# ── Builder: stats (spec §6.6) ──────────────────────────────────────
+
+
+def _build_stats(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup]:
+    """Render the read-only stats dashboard.
+
+    All aggregates are extracted-only by construction (memory.py
+    extends MemoryStats with that scoping). The tag list shows every
+    enum value, including zero-count tags - that is the asymmetry
+    documented in spec §6.1 (dashboard hides zero-count tags; stats
+    surfaces them as a tuning signal).
+    """
+    if stats.extracted_count == 0:
+        # Distinct empty-state text from the dashboard so the user
+        # who navigated to /memory stats specifically knows the call
+        # succeeded but the corpus is empty.
+        text = "Memory stats\n\nNo extracted facts yet."
+        kb = InlineKeyboardMarkup([[InlineKeyboardButton("back", callback_data=_encode_callback("dash"))]])
+        return text, kb
+
+    lines = ["Memory stats", "", f"Total:            {stats.extracted_count} facts", "", "By tag:"]
+    # Pad tag column to the longest enum name for alignment.
+    label_width = max(len(t) for t in _TAG_ENUM)
+    for tag in _TAG_ENUM:
+        count = stats.by_tag.get(tag, 0)
+        lines.append(f"  {tag.ljust(label_width)}  {count:>3}")
+
+    # Confidence block. min/median/max are None when extracted_count
+    # is zero, but we already returned for that case above.
+    lines.append("")
+    lines.append("Confidence:")
+    minv = stats.confidence_min if stats.confidence_min is not None else 0.0
+    medv = stats.confidence_median if stats.confidence_median is not None else 0.0
+    maxv = stats.confidence_max if stats.confidence_max is not None else 0.0
+    lines.append(f"  min               {minv:.2f}")
+    lines.append(f"  median            {medv:.2f}")
+    lines.append(f"  max               {maxv:.2f}")
+    # Below-threshold counts with parenthetical percentages.
+    pct_07 = (stats.confidence_below_0_7 / stats.extracted_count) * 100
+    pct_06 = (stats.confidence_below_0_6 / stats.extracted_count) * 100
+    lines.append(f"  below 0.7         {stats.confidence_below_0_7:>3}  ({pct_07:.1f}%)")
+    lines.append(f"  below 0.6         {stats.confidence_below_0_6:>3}  ({pct_06:.1f}%)")
+
+    lines.append("")
+    lines.append(f"Confirmed actions:  {stats.confirmation_quote_count} with confirmation_quote")
+
+    if stats.by_prompt_version:
+        lines.append("")
+        lines.append("Prompt versions:")
+        # Sort by count desc, version asc for ties - deterministic.
+        sorted_versions = sorted(
+            stats.by_prompt_version.items(),
+            key=lambda item: (-item[1], item[0]),
+        )
+        version_width = max(len(v) for v, _ in sorted_versions)
+        for version, count in sorted_versions:
+            lines.append(f"  {version.ljust(version_width)}  {count:>3}")
+
+    text = "\n".join(lines)
+    kb = InlineKeyboardMarkup([[InlineKeyboardButton("back", callback_data=_encode_callback("dash"))]])
+    return text, kb
+
+
+# ── Builder: forget-by-tag confirmation (spec §6.7) ─────────────────
+
+
+def _build_forget_tag_confirm(tag: str, count: int) -> tuple[str, InlineKeyboardMarkup]:
+    """Render the bulk forget-by-tag confirmation."""
+    text = (
+        f'Forget all {count} facts tagged "{tag}"?\n\n'
+        f"This will permanently remove {count} memories. Tags are "
+        "independent, so a fact tagged [preference, constraint] will "
+        "also be affected.\n\n"
+        "This cannot be undone."
+    )
+    kb = InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton(
+                    f"confirm forget {count} facts",
+                    callback_data=_encode_callback("ftd", tag),
+                ),
+                InlineKeyboardButton("cancel", callback_data=_encode_callback("dash")),
+            ]
+        ]
+    )
+    return text, kb
+
+
+# ── Top-level command handler ───────────────────────────────────────
+
+
+async def handle_memory_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle `/memory [subcommand ...]`.
+
+    Dispatches on the first arg:
+      (no args)      → dashboard
+      help / unknown → help text
+      stats          → stats screen
+      search <query> → search (empty query falls through to help)
+      forget <tag>   → forget-by-tag confirmation
+    """
+    assert update.message is not None
+    chat_id = _chat_id(update)
+    config: Config = context.bot_data["config"]
+
+    # Authorization gate. The other handlers in bot.py rely on a
+    # decorator; we replicate the check inline because this handler
+    # is registered without the wrapper to keep the import surface
+    # small (memory_command does not import the @ _require_auth
+    # decorator).
+    if not _is_authorized(config, _user_id(update)):
+        # Silently drop unauthorized - same as the rest of the bot.
+        return
+
+    if not memory.is_enabled():
+        await update.message.reply_text(_MSG_DISABLED)
+        return
+
+    args: list[str] = list(context.args or [])
+    if not args:
+        await _send_dashboard(update, context, chat_id)
+        return
+
+    sub = args[0].lower()
+    rest = args[1:]
+
+    if sub == "help":
+        await update.message.reply_text(_HELP_TEXT)
+        return
+    if sub == "stats":
+        await _send_stats(update, context, chat_id)
+        return
+    if sub == "search":
+        query = " ".join(rest).strip()
+        if not query:
+            # Empty query falls through to help, per spec §5.
+            await update.message.reply_text(_HELP_TEXT)
+            return
+        await _send_search(update, context, chat_id, query)
+        return
+    if sub == "forget":
+        if not rest:
+            await update.message.reply_text("Usage: /memory forget <tag>")
+            return
+        tag = rest[0].lower()
+        if tag not in _TAG_ENUM:
+            valid = ", ".join(_TAG_ENUM)
+            await update.message.reply_text(f"Unknown tag '{tag}'. Valid tags: {valid}")
+            return
+        await _send_forget_tag_confirm(update, context, chat_id, tag)
+        return
+
+    # Unknown subcommand - show help (spec §5).
+    await update.message.reply_text(_HELP_TEXT)
+
+
+# ── Top-level callback handler ──────────────────────────────────────
+
+
+async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Dispatch `mem:*` inline-keyboard callbacks.
+
+    Verbs:
+      dash              - re-render dashboard
+      tag <name> <page> - tag drill-down at page
+      fact <idx>        - open fact at index (resolved against cache)
+      stats             - re-render stats
+      help              - help text (Search button on dashboard)
+      ffc               - forget single fact confirm
+      ffd               - forget single fact: do delete
+      fview             - cancel forget; return to fact view (same id)
+      ftd <tag>         - forget by tag: do bulk delete
+    """
+    assert update.callback_query is not None
+    query = update.callback_query
+    config: Config = context.bot_data["config"]
+    if not _is_authorized(config, _user_id(update)):
+        await query.answer("Not authorized.")
+        return
+
+    chat_id = _chat_id(update)
+    assert query.data is not None
+    action = _decode_callback(query.data)
+    if action is None:
+        await query.answer()
+        return
+
+    # Always check enablement before doing work - feature flag could
+    # have flipped off between the original `/memory` and the click.
+    if not memory.is_enabled():
+        await query.answer(_MSG_DISABLED)
+        return
+
+    verb = action.verb
+    args = action.args
+
+    try:
+        if verb == "dash":
+            await query.answer()
+            await _send_dashboard(update, context, chat_id, edit=True)
+            return
+        if verb == "stats":
+            await query.answer()
+            await _send_stats(update, context, chat_id, edit=True)
+            return
+        if verb == "help":
+            # Search button on dashboard - there is no inline text
+            # input in Telegram, so the best we can do is show the
+            # help text in a transient toast and leave the dashboard
+            # visible. Use a long-form alert so the user sees the
+            # full command syntax.
+            await query.answer(_HELP_TEXT, show_alert=True)
+            return
+        if verb == "tag":
+            if len(args) < 2:
+                await query.answer(_MSG_SESSION_EXPIRED)
+                await _send_dashboard(update, context, chat_id, edit=True)
+                return
+            tag = args[0]
+            try:
+                page = int(args[1])
+            except ValueError:
+                page = 0
+            await query.answer()
+            await _send_tag_view(update, context, chat_id, tag, page, edit=True)
+            return
+        if verb == "fact":
+            cache = _get_cache(chat_id)
+            if cache is None or not args:
+                await query.answer(_MSG_SESSION_EXPIRED)
+                await _send_dashboard(update, context, chat_id, edit=True)
+                return
+            try:
+                idx = int(args[0])
+            except ValueError:
+                await query.answer(_MSG_SESSION_EXPIRED)
+                await _send_dashboard(update, context, chat_id, edit=True)
+                return
+            if idx < 0 or idx >= len(cache.memory_ids):
+                await query.answer(_MSG_SESSION_EXPIRED)
+                await _send_dashboard(update, context, chat_id, edit=True)
+                return
+            memory_id = cache.memory_ids[idx]
+            await query.answer()
+            await _send_fact_view(update, context, chat_id, memory_id)
+            return
+        if verb == "fview":
+            # Cancel button on the forget-fact confirmation: re-render
+            # the fact view from cache. The cache was preserved when
+            # we transitioned to the confirm screen.
+            cache = _get_cache(chat_id)
+            if cache is None or not cache.memory_ids:
+                await query.answer(_MSG_SESSION_EXPIRED)
+                await _send_dashboard(update, context, chat_id, edit=True)
+                return
+            # The fact id is the only one in the cache when we're on
+            # a fact view. (We overwrote the page-of-ids list when
+            # navigating to the fact screen; see _send_fact_view.)
+            memory_id = cache.memory_ids[0]
+            await query.answer()
+            await _send_fact_view(update, context, chat_id, memory_id)
+            return
+        if verb == "ffc":
+            # Forget single fact: confirm step. The memory id lives
+            # in the screen cache (set by _send_fact_view).
+            cache = _get_cache(chat_id)
+            if cache is None or not cache.memory_ids:
+                await query.answer(_MSG_SESSION_EXPIRED)
+                await _send_dashboard(update, context, chat_id, edit=True)
+                return
+            await query.answer()
+            await _send_forget_fact_confirm(update, context, chat_id, cache.memory_ids[0])
+            return
+        if verb == "ffd":
+            # Forget single fact: execute. Read id from cache, delete,
+            # then return to the screen the fact was opened from.
+            cache = _get_cache(chat_id)
+            if cache is None or not cache.memory_ids:
+                await query.answer(_MSG_SESSION_EXPIRED)
+                await _send_dashboard(update, context, chat_id, edit=True)
+                return
+            memory_id = cache.memory_ids[0]
+            return_to = cache.return_to
+            ok = memory.delete_by_id(user_id=str(chat_id), memory_id=memory_id)
+            await query.answer("Forgotten." if ok else "Not found.")
+            # Return to whatever screen the user was on before the
+            # fact view. Tag view if known; otherwise dashboard.
+            if return_to is not None and return_to[0] == "tag" and len(return_to[1]) >= 2:
+                tag = return_to[1][0]
+                try:
+                    page = int(return_to[1][1])
+                except ValueError:
+                    page = 0
+                await _send_tag_view(update, context, chat_id, tag, page, edit=True)
+            else:
+                await _send_dashboard(update, context, chat_id, edit=True)
+            return
+        if verb == "ftd":
+            # Forget by tag: execute. Tag is in the callback args
+            # (not the cache) so the action survives a stale cache.
+            if not args:
+                await query.answer(_MSG_SESSION_EXPIRED)
+                await _send_dashboard(update, context, chat_id, edit=True)
+                return
+            tag = args[0]
+            facts = memory.get_by_tag(user_id=str(chat_id), tag=tag)
+            deleted = 0
+            for fact in facts:
+                if memory.delete_by_id(user_id=str(chat_id), memory_id=fact.id):
+                    deleted += 1
+            await query.answer(f"Forgot {deleted} facts.")
+            await _send_dashboard(update, context, chat_id, edit=True)
+            return
+    except Exception as exc:
+        # Spec §8: never let a Mem0 exception surface as a stack trace.
+        log.exception("memory callback %s failed: %s", verb, exc)
+        await query.answer(_MSG_QUERY_FAILED)
+        return
+
+    # Unknown verb - quietly dismiss. Should be unreachable unless a
+    # version skew leaves a stale callback button in chat history.
+    await query.answer()
+
+
+# ── Send helpers (call builders + dispatch I/O) ─────────────────────
+
+
+async def _send_dashboard(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    edit: bool = False,
+) -> None:
+    """Render and send/edit the dashboard."""
+    try:
+        stats = memory.get_stats(user_id=str(chat_id))
+    except Exception as exc:
+        log.exception("get_stats failed: %s", exc)
+        await _send_or_edit(update, context, chat_id, _MSG_QUERY_FAILED, None, edit=edit)
+        return
+    text, kb = _build_dashboard(stats)
+    # Reset the cache: dashboard is the root. memory_ids cleared so
+    # any stale fact button taps (from a previous tag view) trip the
+    # session-expired branch instead of resolving to a wrong fact.
+    _set_cache(chat_id, _ScreenCache(screen="dashboard"))
+    await _send_or_edit(update, context, chat_id, text, kb, edit=edit)
+
+
+async def _send_tag_view(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    tag: str,
+    page: int,
+    edit: bool = False,
+) -> None:
+    """Render and send/edit the tag drill-down for `tag` at `page`."""
+    try:
+        facts = memory.get_by_tag(user_id=str(chat_id), tag=tag)
+    except Exception as exc:
+        log.exception("get_by_tag(%s) failed: %s", tag, exc)
+        await _send_or_edit(update, context, chat_id, _MSG_QUERY_FAILED, None, edit=edit)
+        return
+    text, kb, memory_ids, clamped_page, _total = _build_tag_view(tag, facts, page)
+    _set_cache(
+        chat_id,
+        _ScreenCache(screen="tag", tag=tag, page=clamped_page, memory_ids=memory_ids),
+    )
+    await _send_or_edit(update, context, chat_id, text, kb, edit=edit)
+
+
+async def _send_fact_view(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    memory_id: str,
+) -> None:
+    """Open the fact detail view by id.
+
+    Loads the fact through `get_all` then filters by id (Mem0's
+    `get` API is not exposed by memory.py); for typical user fact
+    counts this is sub-millisecond. If the fact disappears between
+    cache write and click (race with a concurrent forget) the user
+    falls back to the dashboard.
+    """
+    cache = _get_cache(chat_id)
+    return_to = cache.return_to if cache is not None else None
+    # If we came from a tag view, set the return target so back lands
+    # the user where they started rather than at the root.
+    if cache is not None and cache.screen == "tag" and cache.tag is not None:
+        return_to = ("tag", [cache.tag, str(cache.page)])
+    elif cache is not None and cache.screen == "search" and cache.query is not None:
+        # Searches re-execute on back-nav. Encoding the full query in
+        # callback data would risk the 64-byte limit; for now, back
+        # from a fact opened via search returns to the dashboard.
+        # See spec §7.4 - single-entry-per-chat means deep linking
+        # back into a search is not a v1 requirement.
+        return_to = None
+
+    try:
+        all_facts = memory.get_all(user_id=str(chat_id), limit=None)
+    except Exception as exc:
+        log.exception("get_all failed: %s", exc)
+        await _send_or_edit(update, None, chat_id, _MSG_QUERY_FAILED, None, edit=True)
+        return
+    fact = next((f for f in all_facts if f.id == memory_id), None)
+    if fact is None:
+        # Race: fact deleted between cache write and tap.
+        await _send_or_edit(update, None, chat_id, "This memory no longer exists.", None, edit=True)
+        return
+    text, kb = _build_fact_view(fact, return_to)
+    # Cache holds only this fact's id so the forget flow knows what to
+    # delete without re-encoding the id into callback data.
+    _set_cache(
+        chat_id,
+        _ScreenCache(
+            screen="fact",
+            memory_ids=[memory_id],
+            return_to=return_to,
+        ),
+    )
+    await _send_or_edit(update, None, chat_id, text, kb, edit=True)
+
+
+async def _send_forget_fact_confirm(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    memory_id: str,
+) -> None:
+    """Render the forget-fact confirmation screen."""
+    try:
+        all_facts = memory.get_all(user_id=str(chat_id), limit=None)
+    except Exception as exc:
+        log.exception("get_all failed: %s", exc)
+        await _send_or_edit(update, None, chat_id, _MSG_QUERY_FAILED, None, edit=True)
+        return
+    fact = next((f for f in all_facts if f.id == memory_id), None)
+    if fact is None:
+        await _send_or_edit(update, None, chat_id, "This memory no longer exists.", None, edit=True)
+        return
+    text, kb = _build_forget_fact_confirm(fact)
+    # Preserve cache so cancel returns to the same fact, and confirm
+    # knows what to delete.
+    cache = _get_cache(chat_id)
+    return_to = cache.return_to if cache is not None else None
+    _set_cache(
+        chat_id,
+        _ScreenCache(
+            screen="forget_fact_confirm",
+            memory_ids=[memory_id],
+            return_to=return_to,
+        ),
+    )
+    await _send_or_edit(update, None, chat_id, text, kb, edit=True)
+
+
+async def _send_search(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    query: str,
+) -> None:
+    """Run a search and send the results screen."""
+    config: Config = context.bot_data["config"]
+    floor = config.memory_search_floor
+    try:
+        results = memory.search(query, user_id=str(chat_id), limit=_SEARCH_LIMIT)
+    except Exception as exc:
+        log.exception("search failed: %s", exc)
+        await _send_or_edit(update, context, chat_id, _MSG_QUERY_FAILED, None, edit=False)
+        return
+    # Apply the floor in the UI path the same way `format_context`
+    # does (spec §7.5: one knob, two paths).
+    filtered = [r for r in results if r.score >= floor]
+    text, kb, memory_ids = _build_search_results(query, filtered, floor)
+    _set_cache(
+        chat_id,
+        _ScreenCache(
+            screen="search",
+            memory_ids=memory_ids,
+            query=query,
+        ),
+    )
+    await _send_or_edit(update, context, chat_id, text, kb, edit=False)
+
+
+async def _send_stats(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    edit: bool = False,
+) -> None:
+    """Render the stats screen."""
+    try:
+        stats = memory.get_stats(user_id=str(chat_id))
+    except Exception as exc:
+        log.exception("get_stats failed: %s", exc)
+        await _send_or_edit(update, context, chat_id, _MSG_QUERY_FAILED, None, edit=edit)
+        return
+    text, kb = _build_stats(stats)
+    # Stats does not need fact-id state. Drop any prior cache so a
+    # stale fact-id from a previous screen can't be used.
+    _set_cache(chat_id, _ScreenCache(screen="stats"))
+    await _send_or_edit(update, context, chat_id, text, kb, edit=edit)
+
+
+async def _send_forget_tag_confirm(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    tag: str,
+) -> None:
+    """Render the forget-by-tag confirmation."""
+    try:
+        facts = memory.get_by_tag(user_id=str(chat_id), tag=tag)
+    except Exception as exc:
+        log.exception("get_by_tag(%s) failed: %s", tag, exc)
+        assert update.message is not None
+        await update.message.reply_text(_MSG_QUERY_FAILED)
+        return
+    if not facts:
+        assert update.message is not None
+        await update.message.reply_text(f'No memories tagged "{tag}".')
+        return
+    text, kb = _build_forget_tag_confirm(tag, len(facts))
+    await _send_or_edit(update, context, chat_id, text, kb, edit=False)
+
+
+# ── I/O dispatch (send vs edit) ─────────────────────────────────────
+
+
+async def _send_or_edit(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE | None,
+    chat_id: int,
+    text: str,
+    keyboard: InlineKeyboardMarkup | None,
+    edit: bool,
+) -> None:
+    """Send a fresh message or edit the most recent one.
+
+    All `/memory` screens are sent as plain text (spec §6.0); no
+    `parse_mode` is set. User-originated content (fact text, tag
+    names, confirmation_quote) routinely contains Markdown-reserved
+    characters and rendering them via MarkdownV2 would either corrupt
+    the display or require escaping every dynamic string.
+
+    `BadRequest: Message is not modified` is swallowed: it fires when
+    a user double-taps a button and the second edit is identical to
+    the first. Treating it as success keeps the UI stable.
+    """
+    cache = _get_cache(chat_id)
+    if edit and update.callback_query is not None:
+        try:
+            await update.callback_query.edit_message_text(text=text, reply_markup=keyboard)
+        except BadRequest as exc:
+            if "not modified" in str(exc).lower():
+                return
+            # Fall through to a fresh send if the edit failed for
+            # another reason (e.g., the original message was deleted).
+            log.warning("edit_message_text failed: %s; falling back to send", exc)
+            edit = False
+
+    if not edit:
+        # Fresh send. Either initial /memory invocation or callback
+        # branch with no message to edit (e.g., search invoked from
+        # text command, not callback).
+        assert update.effective_chat is not None
+        sent = await update.effective_chat.send_message(text=text, reply_markup=keyboard)
+        if cache is not None:
+            cache.message_id = sent.message_id
+
+
+# ── Auth helpers (mirror bot.py) ────────────────────────────────────
+#
+# Duplicated rather than imported to keep memory_command from pulling
+# in bot.py (which would create an import cycle). The bodies are tiny
+# and the behavior is contractual - both sides must agree on what
+# "authorized" means.
+
+
+def _chat_id(update: Update) -> int:
+    """Return the chat id, asserting non-None for type narrowing."""
+    chat = update.effective_chat
+    assert chat is not None
+    return chat.id
+
+
+def _user_id(update: Update) -> int:
+    """Return the user id, asserting non-None for type narrowing."""
+    user = update.effective_user
+    assert user is not None
+    return user.id
+
+
+def _is_authorized(config: Config, user_id: int) -> bool:
+    """Check if a Telegram user id is in the allowed list."""
+    return user_id in config.allowed_user_ids

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -126,10 +126,6 @@ class _ScreenCache:
     on dispatch. Storing the structured form (rather than a callback
     string) means the back-target representation can change without
     needing to reparse stale entries.
-
-    `message_id` is the id of the current screen message. Set when
-    the dashboard is first shown via `reply_text`; reused by every
-    edit thereafter so the chat stays clean.
     """
 
     screen: str
@@ -138,7 +134,6 @@ class _ScreenCache:
     page: int = 0
     query: str | None = None
     return_to: tuple[str, list[str]] | None = None
-    message_id: int | None = None
     created_at: float = field(default_factory=time.monotonic)
 
 
@@ -218,10 +213,14 @@ def _encode_callback(verb: str, *args: str) -> str:
     parts = [verb, *args]
     encoded = _CALLBACK_PREFIX + ":".join(parts)
     # Defensive ceiling. The longest legitimate callback in this
-    # module is `mem:ftgc:confirmed_action` at 24 bytes, well under
-    # the limit; an assertion firing here means a bug in the caller
-    # (probably an unexpected long arg) rather than legitimate data.
-    assert len(encoded.encode("utf-8")) <= 64, f"callback_data too long: {encoded!r}"
+    # module is `mem:ftd:confirmed_action` at 24 bytes, well under
+    # the limit; this firing means a bug in the caller (probably an
+    # unexpected long arg) rather than legitimate data. Use a real
+    # if/raise rather than `assert` so the check survives `python -O`,
+    # under which assertions are stripped and Telegram would silently
+    # truncate the over-limit callback.
+    if len(encoded.encode("utf-8")) > 64:
+        raise ValueError(f"callback_data too long: {encoded!r}")
     return encoded
 
 
@@ -318,19 +317,6 @@ def _bar(count: int, max_count: int, width: int = _BAR_WIDTH) -> str:
     return _BAR_CHAR * n
 
 
-def _avg_confidence(stats: MemoryStats) -> float | None:
-    """Return the dashboard-displayed average confidence, or None.
-
-    The dashboard summary line shows `avg X.XX, min X.XX`. We do not
-    persist the running average - instead, derive a usable proxy from
-    the median (which IS persisted) and clamp it for display. This
-    keeps the dashboard fast (no full-corpus walk) at the cost of
-    showing the median rather than a true mean. The label in the
-    builder reflects this distinction.
-    """
-    return stats.confidence_median
-
-
 # ── Builder: dashboard ──────────────────────────────────────────────
 
 
@@ -380,7 +366,7 @@ def _build_dashboard(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup | No
     # Footer summary: median + min confidence. Spec §6.1 calls this
     # the "first-glance tuning signal." Median is the persisted value;
     # the spec mock-up labels it "avg" but median is more honest about
-    # what is shown - see _avg_confidence comment.
+    # what is shown.
     median = stats.confidence_median
     minv = stats.confidence_min
     if median is not None and minv is not None:
@@ -641,15 +627,22 @@ def _build_stats(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup]:
         lines.append(f"  {tag.ljust(label_width)}  {count:>3}")
 
     # Confidence block. min/median/max are None when extracted_count
-    # is zero, but we already returned for that case above.
+    # is zero (we returned for that case above), so under current
+    # memory.py semantics they're always populated here. Render "n/a"
+    # rather than 0.00 if the invariant ever breaks: a misleading
+    # 0.00 looks like a real (very low) reading, while "n/a" is
+    # self-describing and makes the bug visible.
     lines.append("")
     lines.append("Confidence:")
-    minv = stats.confidence_min if stats.confidence_min is not None else 0.0
-    medv = stats.confidence_median if stats.confidence_median is not None else 0.0
-    maxv = stats.confidence_max if stats.confidence_max is not None else 0.0
-    lines.append(f"  min               {minv:.2f}")
-    lines.append(f"  median            {medv:.2f}")
-    lines.append(f"  max               {maxv:.2f}")
+    minv = stats.confidence_min
+    medv = stats.confidence_median
+    maxv = stats.confidence_max
+    min_str = f"{minv:.2f}" if minv is not None else "n/a"
+    med_str = f"{medv:.2f}" if medv is not None else "n/a"
+    max_str = f"{maxv:.2f}" if maxv is not None else "n/a"
+    lines.append(f"  min               {min_str}")
+    lines.append(f"  median            {med_str}")
+    lines.append(f"  max               {max_str}")
     # Below-threshold counts with parenthetical percentages.
     pct_07 = (stats.confidence_below_0_7 / stats.extracted_count) * 100
     pct_06 = (stats.confidence_below_0_6 / stats.extracted_count) * 100
@@ -919,6 +912,15 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
                 await _send_dashboard(update, context, chat_id, edit=True)
                 return
             tag = args[0]
+            # Validate even though the callback is one we generated:
+            # stale buttons, crafted callbacks, or version skew could
+            # smuggle an arbitrary string into get_by_tag/delete loop.
+            # Mirror the same _TAG_ENUM gate as the /memory forget
+            # text path (see `if sub == "forget"` above).
+            if tag not in _TAG_ENUM:
+                await query.answer(_MSG_SESSION_EXPIRED)
+                await _send_dashboard(update, context, chat_id, edit=True)
+                return
             facts = memory.get_by_tag(user_id=str(chat_id), tag=tag)
             deleted = 0
             for fact in facts:
@@ -952,14 +954,14 @@ async def _send_dashboard(
         stats = memory.get_stats(user_id=str(chat_id))
     except Exception as exc:
         log.exception("get_stats failed: %s", exc)
-        await _send_or_edit(update, context, chat_id, _MSG_QUERY_FAILED, None, edit=edit)
+        await _send_or_edit(update, _MSG_QUERY_FAILED, None, edit=edit)
         return
     text, kb = _build_dashboard(stats)
     # Reset the cache: dashboard is the root. memory_ids cleared so
     # any stale fact button taps (from a previous tag view) trip the
     # session-expired branch instead of resolving to a wrong fact.
     _set_cache(chat_id, _ScreenCache(screen="dashboard"))
-    await _send_or_edit(update, context, chat_id, text, kb, edit=edit)
+    await _send_or_edit(update, text, kb, edit=edit)
 
 
 async def _send_tag_view(
@@ -975,14 +977,14 @@ async def _send_tag_view(
         facts = memory.get_by_tag(user_id=str(chat_id), tag=tag)
     except Exception as exc:
         log.exception("get_by_tag(%s) failed: %s", tag, exc)
-        await _send_or_edit(update, context, chat_id, _MSG_QUERY_FAILED, None, edit=edit)
+        await _send_or_edit(update, _MSG_QUERY_FAILED, None, edit=edit)
         return
     text, kb, memory_ids, clamped_page, _total = _build_tag_view(tag, facts, page)
     _set_cache(
         chat_id,
         _ScreenCache(screen="tag", tag=tag, page=clamped_page, memory_ids=memory_ids),
     )
-    await _send_or_edit(update, context, chat_id, text, kb, edit=edit)
+    await _send_or_edit(update, text, kb, edit=edit)
 
 
 async def _send_fact_view(
@@ -993,11 +995,10 @@ async def _send_fact_view(
 ) -> None:
     """Open the fact detail view by id.
 
-    Loads the fact through `get_all` then filters by id (Mem0's
-    `get` API is not exposed by memory.py); for typical user fact
-    counts this is sub-millisecond. If the fact disappears between
-    cache write and click (race with a concurrent forget) the user
-    falls back to the dashboard.
+    Uses memory.get_by_id for an O(1) lookup with ownership + source
+    scoping baked in. Returns None covers all four "no such fact"
+    cases (missing, wrong user, non-extracted, fetch error); the UI
+    treats them identically.
     """
     cache = _get_cache(chat_id)
     return_to = cache.return_to if cache is not None else None
@@ -1013,16 +1014,12 @@ async def _send_fact_view(
         # back into a search is not a v1 requirement.
         return_to = None
 
-    try:
-        all_facts = memory.get_all(user_id=str(chat_id), limit=None)
-    except Exception as exc:
-        log.exception("get_all failed: %s", exc)
-        await _send_or_edit(update, None, chat_id, _MSG_QUERY_FAILED, None, edit=True)
-        return
-    fact = next((f for f in all_facts if f.id == memory_id), None)
+    fact = memory.get_by_id(user_id=str(chat_id), memory_id=memory_id)
     if fact is None:
-        # Race: fact deleted between cache write and tap.
-        await _send_or_edit(update, None, chat_id, "This memory no longer exists.", None, edit=True)
+        # Race: fact deleted between cache write and tap, or any of the
+        # other not-found conditions get_by_id collapses (wrong user,
+        # non-extracted source, Mem0 fetch error).
+        await _send_or_edit(update, "This memory no longer exists.", None, edit=True)
         return
     text, kb = _build_fact_view(fact, return_to)
     # Cache holds only this fact's id so the forget flow knows what to
@@ -1035,7 +1032,7 @@ async def _send_fact_view(
             return_to=return_to,
         ),
     )
-    await _send_or_edit(update, None, chat_id, text, kb, edit=True)
+    await _send_or_edit(update, text, kb, edit=True)
 
 
 async def _send_forget_fact_confirm(
@@ -1044,16 +1041,14 @@ async def _send_forget_fact_confirm(
     chat_id: int,
     memory_id: str,
 ) -> None:
-    """Render the forget-fact confirmation screen."""
-    try:
-        all_facts = memory.get_all(user_id=str(chat_id), limit=None)
-    except Exception as exc:
-        log.exception("get_all failed: %s", exc)
-        await _send_or_edit(update, None, chat_id, _MSG_QUERY_FAILED, None, edit=True)
-        return
-    fact = next((f for f in all_facts if f.id == memory_id), None)
+    """Render the forget-fact confirmation screen.
+
+    Uses memory.get_by_id for the same reason as _send_fact_view:
+    O(1) lookup with ownership/source scoping enforced once.
+    """
+    fact = memory.get_by_id(user_id=str(chat_id), memory_id=memory_id)
     if fact is None:
-        await _send_or_edit(update, None, chat_id, "This memory no longer exists.", None, edit=True)
+        await _send_or_edit(update, "This memory no longer exists.", None, edit=True)
         return
     text, kb = _build_forget_fact_confirm(fact)
     # Preserve cache so cancel returns to the same fact, and confirm
@@ -1068,7 +1063,7 @@ async def _send_forget_fact_confirm(
             return_to=return_to,
         ),
     )
-    await _send_or_edit(update, None, chat_id, text, kb, edit=True)
+    await _send_or_edit(update, text, kb, edit=True)
 
 
 async def _send_search(
@@ -1084,7 +1079,7 @@ async def _send_search(
         results = memory.search(query, user_id=str(chat_id), limit=_SEARCH_LIMIT)
     except Exception as exc:
         log.exception("search failed: %s", exc)
-        await _send_or_edit(update, context, chat_id, _MSG_QUERY_FAILED, None, edit=False)
+        await _send_or_edit(update, _MSG_QUERY_FAILED, None, edit=False)
         return
     # Apply the floor in the UI path the same way `format_context`
     # does (spec §7.5: one knob, two paths).
@@ -1098,7 +1093,7 @@ async def _send_search(
             query=query,
         ),
     )
-    await _send_or_edit(update, context, chat_id, text, kb, edit=False)
+    await _send_or_edit(update, text, kb, edit=False)
 
 
 async def _send_stats(
@@ -1112,13 +1107,13 @@ async def _send_stats(
         stats = memory.get_stats(user_id=str(chat_id))
     except Exception as exc:
         log.exception("get_stats failed: %s", exc)
-        await _send_or_edit(update, context, chat_id, _MSG_QUERY_FAILED, None, edit=edit)
+        await _send_or_edit(update, _MSG_QUERY_FAILED, None, edit=edit)
         return
     text, kb = _build_stats(stats)
     # Stats does not need fact-id state. Drop any prior cache so a
     # stale fact-id from a previous screen can't be used.
     _set_cache(chat_id, _ScreenCache(screen="stats"))
-    await _send_or_edit(update, context, chat_id, text, kb, edit=edit)
+    await _send_or_edit(update, text, kb, edit=edit)
 
 
 async def _send_forget_tag_confirm(
@@ -1140,7 +1135,7 @@ async def _send_forget_tag_confirm(
         await update.message.reply_text(f'No memories tagged "{tag}".')
         return
     text, kb = _build_forget_tag_confirm(tag, len(facts))
-    await _send_or_edit(update, context, chat_id, text, kb, edit=False)
+    await _send_or_edit(update, text, kb, edit=False)
 
 
 # ── I/O dispatch (send vs edit) ─────────────────────────────────────
@@ -1148,8 +1143,6 @@ async def _send_forget_tag_confirm(
 
 async def _send_or_edit(
     update: Update,
-    context: ContextTypes.DEFAULT_TYPE | None,
-    chat_id: int,
     text: str,
     keyboard: InlineKeyboardMarkup | None,
     edit: bool,
@@ -1166,7 +1159,6 @@ async def _send_or_edit(
     a user double-taps a button and the second edit is identical to
     the first. Treating it as success keeps the UI stable.
     """
-    cache = _get_cache(chat_id)
     if edit and update.callback_query is not None:
         try:
             await update.callback_query.edit_message_text(text=text, reply_markup=keyboard)
@@ -1183,9 +1175,7 @@ async def _send_or_edit(
         # branch with no message to edit (e.g., search invoked from
         # text command, not callback).
         assert update.effective_chat is not None
-        sent = await update.effective_chat.send_message(text=text, reply_markup=keyboard)
-        if cache is not None:
-            cache.message_id = sent.message_id
+        await update.effective_chat.send_message(text=text, reply_markup=keyboard)
 
 
 # ── Auth helpers (mirror bot.py) ────────────────────────────────────

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -821,27 +821,40 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
     verb = action.verb
     args = action.args
 
+    # Answer-after-send pattern: every branch performs its risky
+    # operation (Mem0 fetch, edit_message_text, etc.) BEFORE calling
+    # `query.answer()`. If the send raises, the outer `except`
+    # answers with _MSG_QUERY_FAILED on a still-unanswered query;
+    # answering twice would cause Telegram to reject the second call
+    # with BadRequest, raising an unhandled exception inside the
+    # error handler itself. The visual cost is the loading spinner
+    # persists slightly longer (until the send completes) - for
+    # typical Mem0 latencies this is invisible.
+    #
+    # The `help` verb is the one exception: it has no send, only an
+    # alert toast, so answer is the response.
     try:
         if verb == "dash":
-            await query.answer()
             await _send_dashboard(update, context, chat_id, edit=True)
+            await query.answer()
             return
         if verb == "stats":
-            await query.answer()
             await _send_stats(update, context, chat_id, edit=True)
+            await query.answer()
             return
         if verb == "help":
             # Search button on dashboard - there is no inline text
             # input in Telegram, so the best we can do is show the
             # help text in a transient toast and leave the dashboard
             # visible. Use a long-form alert so the user sees the
-            # full command syntax.
+            # full command syntax. No send to defer; the alert is
+            # the response.
             await query.answer(_HELP_TEXT, show_alert=True)
             return
         if verb == "tag":
             if len(args) < 2:
-                await query.answer(_MSG_SESSION_EXPIRED)
                 await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
                 return
             tag = args[0]
             # Same _TAG_ENUM gate as the ftd verb and the /memory
@@ -849,35 +862,35 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
             # returns empty), but accepting them here is inconsistent
             # with the rest of the surface and a maintenance trap.
             if tag not in _TAG_ENUM:
-                await query.answer(_MSG_SESSION_EXPIRED)
                 await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
                 return
             try:
                 page = int(args[1])
             except ValueError:
                 page = 0
-            await query.answer()
             await _send_tag_view(update, context, chat_id, tag, page, edit=True)
+            await query.answer()
             return
         if verb == "fact":
             cache = _get_cache(chat_id)
             if cache is None or not args:
-                await query.answer(_MSG_SESSION_EXPIRED)
                 await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
                 return
             try:
                 idx = int(args[0])
             except ValueError:
-                await query.answer(_MSG_SESSION_EXPIRED)
                 await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
                 return
             if idx < 0 or idx >= len(cache.memory_ids):
-                await query.answer(_MSG_SESSION_EXPIRED)
                 await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
                 return
             memory_id = cache.memory_ids[idx]
-            await query.answer()
             await _send_fact_view(update, context, chat_id, memory_id)
+            await query.answer()
             return
         if verb == "fview":
             # Cancel button on the forget-fact confirmation: re-render
@@ -885,39 +898,38 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
             # we transitioned to the confirm screen.
             cache = _get_cache(chat_id)
             if cache is None or not cache.memory_ids:
-                await query.answer(_MSG_SESSION_EXPIRED)
                 await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
                 return
             # The fact id is the only one in the cache when we're on
             # a fact view. (We overwrote the page-of-ids list when
             # navigating to the fact screen; see _send_fact_view.)
             memory_id = cache.memory_ids[0]
-            await query.answer()
             await _send_fact_view(update, context, chat_id, memory_id)
+            await query.answer()
             return
         if verb == "ffc":
             # Forget single fact: confirm step. The memory id lives
             # in the screen cache (set by _send_fact_view).
             cache = _get_cache(chat_id)
             if cache is None or not cache.memory_ids:
-                await query.answer(_MSG_SESSION_EXPIRED)
                 await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
                 return
-            await query.answer()
             await _send_forget_fact_confirm(update, context, chat_id, cache.memory_ids[0])
+            await query.answer()
             return
         if verb == "ffd":
             # Forget single fact: execute. Read id from cache, delete,
             # then return to the screen the fact was opened from.
             cache = _get_cache(chat_id)
             if cache is None or not cache.memory_ids:
-                await query.answer(_MSG_SESSION_EXPIRED)
                 await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
                 return
             memory_id = cache.memory_ids[0]
             return_to = cache.return_to
             ok = memory.delete_by_id(user_id=str(chat_id), memory_id=memory_id)
-            await query.answer("Forgotten." if ok else "Not found.")
             # Return to whatever screen the user was on before the
             # fact view. Tag view if known; otherwise dashboard.
             if return_to is not None and return_to[0] == "tag" and len(return_to[1]) >= 2:
@@ -929,13 +941,14 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
                 await _send_tag_view(update, context, chat_id, tag, page, edit=True)
             else:
                 await _send_dashboard(update, context, chat_id, edit=True)
+            await query.answer("Forgotten." if ok else "Not found.")
             return
         if verb == "ftd":
             # Forget by tag: execute. Tag is in the callback args
             # (not the cache) so the action survives a stale cache.
             if not args:
-                await query.answer(_MSG_SESSION_EXPIRED)
                 await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
                 return
             tag = args[0]
             # Validate even though the callback is one we generated:
@@ -944,19 +957,22 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
             # Mirror the same _TAG_ENUM gate as the /memory forget
             # text path (see `if sub == "forget"` above).
             if tag not in _TAG_ENUM:
-                await query.answer(_MSG_SESSION_EXPIRED)
                 await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
                 return
             facts = memory.get_by_tag(user_id=str(chat_id), tag=tag)
             deleted = 0
             for fact in facts:
                 if memory.delete_by_id(user_id=str(chat_id), memory_id=fact.id):
                     deleted += 1
-            await query.answer(f"Forgot {deleted} facts.")
             await _send_dashboard(update, context, chat_id, edit=True)
+            await query.answer(f"Forgot {deleted} facts.")
             return
     except Exception as exc:
         # Spec §8: never let a Mem0 exception surface as a stack trace.
+        # Safe to call query.answer() here because the
+        # answer-after-send pattern above guarantees it has not been
+        # answered yet on any path that can reach this except.
         log.exception("memory callback %s failed: %s", verb, exc)
         await query.answer(_MSG_QUERY_FAILED)
         return
@@ -1210,6 +1226,17 @@ async def _send_or_edit(
             # Fall through to a fresh send if the edit failed for
             # another reason (e.g., the original message was deleted).
             log.warning("edit_message_text failed: %s; falling back to send", exc)
+            # Strip the inline keyboard from the original message
+            # before sending a replacement. Otherwise the stale
+            # message keeps its buttons in chat history and a tap
+            # would trigger a callback against state we have moved
+            # past, producing ghost navigation. Best-effort: this is
+            # already an error path, so swallow any BadRequest
+            # (the original message may be gone, immutable, etc.).
+            try:
+                await update.callback_query.edit_message_reply_markup(reply_markup=None)
+            except BadRequest as kb_exc:
+                log.debug("clear stale keyboard failed (best-effort): %s", kb_exc)
             edit = False
 
     if not edit:

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -826,6 +826,14 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
                 await _send_dashboard(update, context, chat_id, edit=True)
                 return
             tag = args[0]
+            # Same _TAG_ENUM gate as the ftd verb and the /memory
+            # forget text path. Off-enum tags are safe today (Mem0
+            # returns empty), but accepting them here is inconsistent
+            # with the rest of the surface and a maintenance trap.
+            if tag not in _TAG_ENUM:
+                await query.answer(_MSG_SESSION_EXPIRED)
+                await _send_dashboard(update, context, chat_id, edit=True)
+                return
             try:
                 page = int(args[1])
             except ValueError:
@@ -1158,7 +1166,15 @@ async def _send_or_edit(
     `BadRequest: Message is not modified` is swallowed: it fires when
     a user double-taps a button and the second edit is identical to
     the first. Treating it as success keeps the UI stable.
+
+    Contract: when `edit=True`, `update.callback_query` must be set.
+    All callers today live in `handle_memory_callback` where that
+    invariant holds, but a future caller from outside the callback
+    path would otherwise hit a silent no-op (neither branch fires).
+    Raise loudly to surface the misuse instead.
     """
+    if edit and update.callback_query is None:
+        raise ValueError("_send_or_edit: edit=True requires update.callback_query")
     if edit and update.callback_query is not None:
         try:
             await update.callback_query.edit_message_text(text=text, reply_markup=keyboard)

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -692,9 +692,14 @@ def _build_stats(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup]:
 
 def _build_forget_tag_confirm(tag: str, count: int) -> tuple[str, InlineKeyboardMarkup]:
     """Render the bulk forget-by-tag confirmation."""
+    # Singular vs plural noun. Without this, count==1 renders "1 facts"
+    # / "1 memories" / "confirm forget 1 facts". A tag with one
+    # surviving member is a real case (deletes whittle the count).
+    fact_word = "fact" if count == 1 else "facts"
+    memory_word = "memory" if count == 1 else "memories"
     text = (
-        f'Forget all {count} facts tagged "{tag}"?\n\n'
-        f"This will permanently remove {count} memories. Tags are "
+        f'Forget all {count} {fact_word} tagged "{tag}"?\n\n'
+        f"This will permanently remove {count} {memory_word}. Tags are "
         "independent, so a fact tagged [preference, constraint] will "
         "also be affected.\n\n"
         "This cannot be undone."
@@ -703,7 +708,7 @@ def _build_forget_tag_confirm(tag: str, count: int) -> tuple[str, InlineKeyboard
         [
             [
                 InlineKeyboardButton(
-                    f"confirm forget {count} facts",
+                    f"confirm forget {count} {fact_word}",
                     callback_data=_encode_callback("ftd", tag),
                 ),
                 InlineKeyboardButton("cancel", callback_data=_encode_callback("dash")),
@@ -1125,7 +1130,17 @@ async def _send_search(
         return
     # Apply the floor in the UI path the same way `format_context`
     # does (spec §7.5: one knob, two paths).
-    filtered = [r for r in results if r.score >= floor]
+    #
+    # Also enforce the source==extracted scope here. Every other read
+    # path in this module (`get_by_tag`, `get_by_id`) filters at the
+    # data layer, but `memory.search` is a Mem0 vector lookup that
+    # spans all sources (Track 1 exchanges, legacy rows). Without this
+    # post-filter, a search hit could surface a non-extracted row;
+    # tapping it would call `get_by_id`, fail the source check, and
+    # render "This memory no longer exists." for a row the user just
+    # saw - confusing and wrong. Filtering here keeps the UI honest:
+    # what the user sees in results is what they can act on.
+    filtered = [r for r in results if r.score >= floor and r.metadata.get("source") == "extracted"]
     text, kb, memory_ids = _build_search_results(query, filtered, floor)
     _set_cache(
         chat_id,
@@ -1243,7 +1258,14 @@ async def _send_or_edit(
         # Fresh send. Either initial /memory invocation or callback
         # branch with no message to edit (e.g., search invoked from
         # text command, not callback).
-        assert update.effective_chat is not None
+        #
+        # `if/raise` rather than `assert`: assert is stripped by
+        # `python -O` so the contract would be silently bypassed in a
+        # production launch using optimized bytecode. Every other
+        # defensive check in this module follows the same pattern;
+        # this branch was missed in the round-2 sweep.
+        if update.effective_chat is None:
+            raise ValueError("_send_or_edit: effective_chat is None on fresh send")
         await update.effective_chat.send_message(text=text, reply_markup=keyboard)
 
 

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -259,14 +259,20 @@ _MSG_QUERY_FAILED = "Memory query failed. Try again in a moment."
 _MSG_SESSION_EXPIRED = "Session expired, resyncing."
 _MSG_NO_SEARCH_RESULTS = "No matching memories found."
 
-# Help text - the static body shown for `/memory help` and for any
-# unrecognized subcommand (spec §5).
+# Help text - the static body shown for `/memory help`, for any
+# unrecognized subcommand (spec §5), AND in the dashboard's Search
+# button alert toast. The toast path passes this string to
+# `answerCallbackQuery`, whose `text` field is capped at 200 chars
+# by Telegram (see Bot API answerCallbackQuery docs). Keep this
+# string under 200; the alignment padding the prior version used
+# is invisible in Telegram's alert modal anyway since the modal
+# doesn't render with a monospace font.
 _HELP_TEXT = (
-    "/memory              Browse by tag\n"
-    "/memory search <q>   Semantic search\n"
-    "/memory stats        Counts and confidence distribution\n"
-    "/memory forget <tag> Delete all memories with a tag\n"
-    "/memory help         Show this help"
+    "/memory - Browse by tag\n"
+    "/memory search <q> - Semantic search\n"
+    "/memory stats - Counts and confidence distribution\n"
+    "/memory forget <tag> - Delete all memories with a tag\n"
+    "/memory help - Show this help"
 )
 
 
@@ -1256,11 +1262,18 @@ async def _send_or_edit(
             # message keeps its buttons in chat history and a tap
             # would trigger a callback against state we have moved
             # past, producing ghost navigation. Best-effort: this is
-            # already an error path, so swallow any BadRequest
-            # (the original message may be gone, immutable, etc.).
+            # already an error path; the contract is that cleanup
+            # failure must NOT abort the fallback send. Catch
+            # `Exception` rather than just BadRequest so a transient
+            # NetworkError / TimedOut from PTB cannot escape and
+            # short-circuit the fresh send below; the user would
+            # otherwise see "Memory query failed." for what should
+            # have been a successful re-render. The original message
+            # may be gone, immutable, or the network may be flaky -
+            # whatever the cause, the fresh send is what matters.
             try:
                 await update.callback_query.edit_message_reply_markup(reply_markup=None)
-            except BadRequest as kb_exc:
+            except Exception as kb_exc:
                 log.debug("clear stale keyboard failed (best-effort): %s", kb_exc)
             edit = False
 

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -731,7 +731,11 @@ async def handle_memory_command(update: Update, context: ContextTypes.DEFAULT_TY
       search <query> → search (empty query falls through to help)
       forget <tag>   → forget-by-tag confirmation
     """
-    assert update.message is not None
+    # PTB CommandHandler guarantees a message is attached, but
+    # `python -O` strips asserts; use `if/raise` for `-O` safety.
+    # See `_chat_id` for the convention rationale.
+    if update.message is None:
+        raise ValueError("handle_memory_command: update.message is None")
     chat_id = _chat_id(update)
     config: Config = context.bot_data["config"]
 
@@ -803,7 +807,12 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
       fview             - cancel forget; return to fact view (same id)
       ftd <tag>         - forget by tag: do bulk delete
     """
-    assert update.callback_query is not None
+    # PTB CallbackQueryHandler guarantees both callback_query and
+    # query.data are present, but `python -O` strips asserts; use
+    # `if/raise` for `-O` safety. See `_chat_id` for the convention
+    # rationale.
+    if update.callback_query is None:
+        raise ValueError("handle_memory_callback: callback_query is None")
     query = update.callback_query
     config: Config = context.bot_data["config"]
     if not _is_authorized(config, _user_id(update)):
@@ -811,7 +820,8 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
         return
 
     chat_id = _chat_id(update)
-    assert query.data is not None
+    if query.data is None:
+        raise ValueError("handle_memory_callback: query.data is None")
     action = _decode_callback(query.data)
     if action is None:
         await query.answer()
@@ -1278,16 +1288,31 @@ async def _send_or_edit(
 
 
 def _chat_id(update: Update) -> int:
-    """Return the chat id, asserting non-None for type narrowing."""
+    """Return the chat id, narrowed from Optional via runtime guard.
+
+    `if/raise` rather than `assert`: PTB routing guarantees a chat
+    is present for both CommandHandler and CallbackQueryHandler
+    callbacks, but `python -O` strips assertions, so a future caller
+    wiring this helper from a non-routed path under optimized
+    bytecode would see `AttributeError` on the next access instead
+    of a meaningful contract violation. Matches the convention used
+    everywhere else in this module (_encode_callback, _send_or_edit,
+    _send_forget_tag_confirm).
+    """
     chat = update.effective_chat
-    assert chat is not None
+    if chat is None:
+        raise ValueError("_chat_id: effective_chat is None")
     return chat.id
 
 
 def _user_id(update: Update) -> int:
-    """Return the user id, asserting non-None for type narrowing."""
+    """Return the user id, narrowed from Optional via runtime guard.
+
+    See `_chat_id` for the `if/raise`-vs-`assert` rationale.
+    """
     user = update.effective_user
-    assert user is not None
+    if user is None:
+        raise ValueError("_user_id: effective_user is None")
     return user.id
 
 

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -92,7 +92,13 @@ _SEARCH_LIMIT = 8
 _LIST_TRUNCATE_LEN = 80
 
 # Per-chat cache TTL in seconds (spec §7.4: "30 minutes"). Checked
-# lazily on every callback access.
+# lazily on every callback access. Note this is an *idle* timeout,
+# not an absolute session timeout: `_set_cache` resets `created_at`
+# on every write, so a user who keeps tapping buttons inside the
+# 30-minute window keeps the cache alive indefinitely. The semantics
+# match the user-facing "your screen state is forgotten after a
+# pause" intent of the spec; the implementation does not enforce a
+# hard ceiling on session duration.
 _CACHE_TTL_S = 30 * 60
 
 # Unicode block character for the dashboard bar chart (spec §6.1
@@ -643,11 +649,23 @@ def _build_stats(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup]:
     lines.append(f"  min               {min_str}")
     lines.append(f"  median            {med_str}")
     lines.append(f"  max               {max_str}")
-    # Below-threshold counts with parenthetical percentages.
-    pct_07 = (stats.confidence_below_0_7 / stats.extracted_count) * 100
-    pct_06 = (stats.confidence_below_0_6 / stats.extracted_count) * 100
-    lines.append(f"  below 0.7         {stats.confidence_below_0_7:>3}  ({pct_07:.1f}%)")
-    lines.append(f"  below 0.6         {stats.confidence_below_0_6:>3}  ({pct_06:.1f}%)")
+    # Below-threshold counts with parenthetical percentages. When
+    # confidence values are missing entirely (min/median/max all
+    # None) the counts are necessarily 0, but rendering them as
+    # "0 (0.0%)" reads as "all facts scored above the threshold"
+    # rather than "no confidence data". Mirror the n/a fallback
+    # above so the row stays honest about the underlying state.
+    has_confidence = minv is not None or medv is not None or maxv is not None
+    if has_confidence:
+        pct_07 = (stats.confidence_below_0_7 / stats.extracted_count) * 100
+        pct_06 = (stats.confidence_below_0_6 / stats.extracted_count) * 100
+        below_07 = f"{stats.confidence_below_0_7:>3}  ({pct_07:.1f}%)"
+        below_06 = f"{stats.confidence_below_0_6:>3}  ({pct_06:.1f}%)"
+    else:
+        below_07 = f"{stats.confidence_below_0_7:>3}  (n/a)"
+        below_06 = f"{stats.confidence_below_0_6:>3}  (n/a)"
+    lines.append(f"  below 0.7         {below_07}")
+    lines.append(f"  below 0.6         {below_06}")
 
     lines.append("")
     lines.append(f"Confirmed actions:  {stats.confirmation_quote_count} with confirmation_quote")
@@ -1130,16 +1148,24 @@ async def _send_forget_tag_confirm(
     chat_id: int,
     tag: str,
 ) -> None:
-    """Render the forget-by-tag confirmation."""
+    """Render the forget-by-tag confirmation.
+
+    Called only from the /memory forget text path, where
+    `update.message` is guaranteed by python-telegram-bot's
+    routing. The contract check uses `if/raise` rather than
+    `assert` so it survives `python -O` (assertions are stripped),
+    matching the same hardening applied to `_send_or_edit` and
+    `_encode_callback`.
+    """
+    if update.message is None:
+        raise ValueError("_send_forget_tag_confirm: requires update.message")
     try:
         facts = memory.get_by_tag(user_id=str(chat_id), tag=tag)
     except Exception as exc:
         log.exception("get_by_tag(%s) failed: %s", tag, exc)
-        assert update.message is not None
         await update.message.reply_text(_MSG_QUERY_FAILED)
         return
     if not facts:
-        assert update.message is not None
         await update.message.reply_text(f'No memories tagged "{tag}".')
         return
     text, kb = _build_forget_tag_confirm(tag, len(facts))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,6 +56,7 @@ _CONFIG_ENV_VARS = [
     "MEMORY_EXTRACTION_MODEL",
     "MEMORY_EXTRACTION_BUDGET_USD",
     "MEMORY_EXTRACTION_TIMEOUT_S",
+    "MEMORY_SEARCH_FLOOR",
     "KAI_DATA_DIR",
     "KAI_INSTALL_DIR",
 ]
@@ -1256,4 +1257,64 @@ class TestMemoryExtractionConfig:
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_EXTRACTION_TIMEOUT_S", "not-an-int")
         with pytest.raises(SystemExit, match="must be an integer"):
+            load_config()
+
+
+# ── Memory search floor (spec 310 §7.5) ─────────────────────────────
+
+
+class TestMemorySearchFloor:
+    """The MEMORY_SEARCH_FLOOR env var: the relevance gate shared by
+    `format_context` (context injection) and the `/memory search` UI.
+    Range is closed on both ends because Mem0 cosine similarity is
+    normalized to [0.0, 1.0]; out-of-range values would silently
+    filter everything (>1.0) or nothing (<0.0)."""
+
+    def test_default_is_0_3(self, monkeypatch):
+        """Default matches Mem0's built-in default and the prior hard-coded
+        constant; this default must be stable so that not setting the env
+        var preserves pre-spec-310 behavior."""
+        _set_required(monkeypatch)
+        config = load_config()
+        assert config.memory_search_floor == 0.3
+
+    def test_override(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_SEARCH_FLOOR", "0.5")
+        config = load_config()
+        assert config.memory_search_floor == 0.5
+
+    def test_accepts_zero(self, monkeypatch):
+        """0.0 is the "include everything" boundary - valid and useful for
+        debugging recall problems where the floor is suspected to be too
+        aggressive."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_SEARCH_FLOOR", "0.0")
+        config = load_config()
+        assert config.memory_search_floor == 0.0
+
+    def test_accepts_one(self, monkeypatch):
+        """1.0 is the "exact match only" boundary; pathologically strict
+        but in-range, so accepted."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_SEARCH_FLOOR", "1.0")
+        config = load_config()
+        assert config.memory_search_floor == 1.0
+
+    def test_rejects_negative(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_SEARCH_FLOOR", "-0.1")
+        with pytest.raises(SystemExit, match=r"between 0\.0 and 1\.0"):
+            load_config()
+
+    def test_rejects_above_one(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_SEARCH_FLOOR", "1.5")
+        with pytest.raises(SystemExit, match=r"between 0\.0 and 1\.0"):
+            load_config()
+
+    def test_rejects_non_number(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_SEARCH_FLOOR", "high")
+        with pytest.raises(SystemExit, match="must be a number"):
             load_config()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1204,6 +1204,627 @@ class TestGetStats:
         assert stats.by_type == {}
 
 
+# ── Spec 310 §7.2: get_all limit + new helpers + extended stats ─────
+
+
+class TestGetAllLimit:
+    """The new `limit` parameter on `get_all`. Default behavior is
+    preserved for legacy callers (top_k=1000); /memory paths pass
+    `limit=None` to bypass the cap so users with >1000 facts see a
+    true total instead of a silent flatten."""
+
+    def test_default_limit_is_1000(self):
+        """No-arg call still requests top_k=1000 so existing callers
+        (delete_by_source pagination, ad-hoc admin) keep their bounded
+        memory footprint."""
+        import kai.memory as mem_mod
+        from kai.memory import get_all
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {"results": []}
+        mem_mod._memory = mock_mem
+
+        get_all(user_id="123")
+        mock_mem.get_all.assert_called_once()
+        kwargs = mock_mem.get_all.call_args.kwargs
+        assert kwargs["top_k"] == 1000
+
+    def test_explicit_limit_passed_through(self):
+        import kai.memory as mem_mod
+        from kai.memory import get_all
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {"results": []}
+        mem_mod._memory = mock_mem
+
+        get_all(user_id="123", limit=42)
+        assert mock_mem.get_all.call_args.kwargs["top_k"] == 42
+
+    def test_none_limit_uses_high_ceiling(self):
+        """`limit=None` requests a top_k far above any realistic
+        per-user count. Spec 310 §7.2.1 names 100000."""
+        import kai.memory as mem_mod
+        from kai.memory import get_all
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {"results": []}
+        mem_mod._memory = mock_mem
+
+        get_all(user_id="123", limit=None)
+        # The exact ceiling is an internal choice; require only that it
+        # is "well above realistic per-user counts" which the spec
+        # quantifies as 100000.
+        assert mock_mem.get_all.call_args.kwargs["top_k"] >= 100_000
+
+
+class TestGetByTag:
+    """Spec 310 §7.2 helper: extracted-only tag drill-down."""
+
+    def test_disabled_returns_empty(self):
+        from kai.memory import get_by_tag
+
+        assert get_by_tag(user_id="123", tag="preference") == []
+
+    def test_filters_by_tag_and_source(self):
+        """Only rows that are BOTH source==extracted AND have the tag
+        are returned. user_raw rows that happen to carry a tag
+        (defensive against future writers) are excluded."""
+        import kai.memory as mem_mod
+        from kai.memory import get_by_tag
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {
+            "results": [
+                # Match: extracted + tag.
+                {
+                    "id": "1",
+                    "memory": "Prefers Celsius",
+                    "score": 0.0,
+                    "metadata": {
+                        "type": "fact",
+                        "source": "extracted",
+                        "tags": ["preference"],
+                    },
+                    "created_at": "2026-04-01T00:00:00",
+                    "updated_at": "2026-04-01T00:00:00",
+                },
+                # Excluded: extracted but different tag.
+                {
+                    "id": "2",
+                    "memory": "Lives in Boston",
+                    "score": 0.0,
+                    "metadata": {
+                        "type": "fact",
+                        "source": "extracted",
+                        "tags": ["location"],
+                    },
+                    "created_at": "2026-04-02T00:00:00",
+                    "updated_at": "2026-04-02T00:00:00",
+                },
+                # Excluded: user_raw source even with a matching tag.
+                # Defends against future writers; the UI is documented
+                # as extracted-only.
+                {
+                    "id": "3",
+                    "memory": "Likes vim",
+                    "score": 0.0,
+                    "metadata": {
+                        "type": "exchange",
+                        "source": "user_raw",
+                        "tags": ["preference"],
+                    },
+                    "created_at": "2026-04-03T00:00:00",
+                    "updated_at": "2026-04-03T00:00:00",
+                },
+                # Excluded: legacy row missing source.
+                {
+                    "id": "4",
+                    "memory": "Old entry",
+                    "score": 0.0,
+                    "metadata": {"type": "exchange", "tags": ["preference"]},
+                    "created_at": "2026-01-01T00:00:00",
+                    "updated_at": "2026-01-01T00:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        results = get_by_tag(user_id="123", tag="preference")
+        assert [r.id for r in results] == ["1"]
+
+    def test_handles_multiple_tags_per_row(self):
+        """A fact tagged [preference, constraint] matches BOTH
+        get_by_tag('preference') AND get_by_tag('constraint'). The
+        spec's forget-by-tag warning ("tags are independent") is a
+        consequence of this overlap."""
+        import kai.memory as mem_mod
+        from kai.memory import get_by_tag
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {
+            "results": [
+                {
+                    "id": "1",
+                    "memory": "No em dashes",
+                    "score": 0.0,
+                    "metadata": {
+                        "type": "fact",
+                        "source": "extracted",
+                        "tags": ["preference", "constraint"],
+                    },
+                    "created_at": "2026-04-01T00:00:00",
+                    "updated_at": "2026-04-01T00:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        assert len(get_by_tag(user_id="123", tag="preference")) == 1
+        assert len(get_by_tag(user_id="123", tag="constraint")) == 1
+
+    def test_sorted_by_updated_at_desc(self):
+        """Newest-updated row comes first - so a re-extracted fact
+        bubbles to the top of the tag list (spec §6.2)."""
+        import kai.memory as mem_mod
+        from kai.memory import get_by_tag
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {
+            "results": [
+                {
+                    "id": "old",
+                    "memory": "Older fact",
+                    "score": 0.0,
+                    "metadata": {
+                        "type": "fact",
+                        "source": "extracted",
+                        "tags": ["preference"],
+                    },
+                    "created_at": "2026-01-01T00:00:00",
+                    "updated_at": "2026-01-01T00:00:00",
+                },
+                {
+                    "id": "new",
+                    "memory": "Newer fact",
+                    "score": 0.0,
+                    "metadata": {
+                        "type": "fact",
+                        "source": "extracted",
+                        "tags": ["preference"],
+                    },
+                    "created_at": "2026-04-01T00:00:00",
+                    "updated_at": "2026-04-15T00:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        results = get_by_tag(user_id="123", tag="preference")
+        assert [r.id for r in results] == ["new", "old"]
+
+    def test_handles_missing_tags_metadata(self):
+        """A row without a tags list (defensive) simply does not
+        match any tag. Should not raise."""
+        import kai.memory as mem_mod
+        from kai.memory import get_by_tag
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {
+            "results": [
+                {
+                    "id": "no-tags",
+                    "memory": "Some fact",
+                    "score": 0.0,
+                    "metadata": {"type": "fact", "source": "extracted"},
+                    "created_at": "2026-04-01T00:00:00",
+                    "updated_at": "2026-04-01T00:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        assert get_by_tag(user_id="123", tag="preference") == []
+
+    def test_passes_limit_none_to_get_all(self):
+        """get_by_tag must call get_all with limit=None so the tag
+        listing is not silently truncated for users with >1000 facts."""
+        import kai.memory as mem_mod
+        from kai.memory import get_by_tag
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {"results": []}
+        mem_mod._memory = mock_mem
+
+        get_by_tag(user_id="123", tag="preference")
+        # top_k must be the high ceiling, not the legacy 1000.
+        assert mock_mem.get_all.call_args.kwargs["top_k"] >= 100_000
+
+
+class TestDeleteById:
+    """Spec 310 §7.2 helper: ownership + source-checked single delete.
+
+    Mem0's `delete(memory_id)` does NOT scope by user_id (verified by
+    inspecting Memory.delete in mem0/memory/main.py). So the
+    verify-before-delete is structurally necessary, not redundant."""
+
+    def test_disabled_returns_false(self):
+        from kai.memory import delete_by_id
+
+        assert delete_by_id(user_id="123", memory_id="abc") is False
+
+    def test_returns_false_when_row_missing(self):
+        """Mem0's get returns None for an unknown id; delete_by_id
+        must propagate that as False without calling delete."""
+        import kai.memory as mem_mod
+        from kai.memory import delete_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = None
+        mem_mod._memory = mock_mem
+
+        assert delete_by_id(user_id="123", memory_id="missing") is False
+        mock_mem.delete.assert_not_called()
+
+    def test_returns_false_on_user_mismatch(self):
+        """A memory_id that resolves to a different user's row must
+        not be deleted - cross-user data deletion is the worst-case
+        consequence of malformed callback data on a multi-user install."""
+        import kai.memory as mem_mod
+        from kai.memory import delete_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "user_id": "other-user",
+            "metadata": {"source": "extracted"},
+        }
+        mem_mod._memory = mock_mem
+
+        assert delete_by_id(user_id="123", memory_id="abc") is False
+        mock_mem.delete.assert_not_called()
+
+    def test_returns_false_on_non_extracted_source(self):
+        """The /memory UI is documented to manage extracted memories
+        only. Track 1 (user_raw) and legacy rows are owned by the
+        admin CLI; refuse to delete them through this path."""
+        import kai.memory as mem_mod
+        from kai.memory import delete_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "user_id": "123",
+            "metadata": {"source": "user_raw"},
+        }
+        mem_mod._memory = mock_mem
+
+        assert delete_by_id(user_id="123", memory_id="abc") is False
+        mock_mem.delete.assert_not_called()
+
+    def test_returns_false_on_legacy_missing_source(self):
+        """A legacy row whose metadata lacks a source key entirely
+        must NOT be deletable through /memory. Same rationale as
+        non-extracted: legacy is admin-CLI territory."""
+        import kai.memory as mem_mod
+        from kai.memory import delete_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "user_id": "123",
+            "metadata": {"type": "exchange"},
+        }
+        mem_mod._memory = mock_mem
+
+        assert delete_by_id(user_id="123", memory_id="abc") is False
+        mock_mem.delete.assert_not_called()
+
+    def test_happy_path_deletes_and_returns_true(self):
+        import kai.memory as mem_mod
+        from kai.memory import delete_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "user_id": "123",
+            "metadata": {"source": "extracted"},
+        }
+        mem_mod._memory = mock_mem
+
+        assert delete_by_id(user_id="123", memory_id="abc") is True
+        mock_mem.delete.assert_called_once_with(memory_id="abc")
+
+    def test_value_error_swallowed_as_false(self):
+        """Mem0 raises ValueError when the row vanishes between get and
+        delete. Treated as "nothing to do" (False) rather than an error
+        - the user ends up where they wanted (row gone) and the UI is
+        not blocked rendering a confusing failure."""
+        import kai.memory as mem_mod
+        from kai.memory import delete_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "user_id": "123",
+            "metadata": {"source": "extracted"},
+        }
+        mock_mem.delete.side_effect = ValueError("Memory with id abc not found")
+        mem_mod._memory = mock_mem
+
+        assert delete_by_id(user_id="123", memory_id="abc") is False
+
+    def test_handles_missing_metadata_dict(self):
+        """Mem0 omits the metadata key entirely when the row has no
+        extra payload (verified at mem0/memory/main.py). delete_by_id
+        must not raise KeyError on that shape."""
+        import kai.memory as mem_mod
+        from kai.memory import delete_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {"id": "abc", "user_id": "123"}
+        mem_mod._memory = mock_mem
+
+        # No metadata -> source check fails, refuse to delete.
+        assert delete_by_id(user_id="123", memory_id="abc") is False
+        mock_mem.delete.assert_not_called()
+
+
+class TestGetStatsExtended:
+    """Spec 310 §6.6 / §7.2: extended MemoryStats fields.
+
+    The legacy `total_count` / `by_type` fields are tested separately
+    in TestGetStats; this class focuses on the new extracted-only
+    aggregates."""
+
+    def _stats_with(self, rows):
+        """Helper: install a mock returning `rows` and call get_stats."""
+        import kai.memory as mem_mod
+        from kai.memory import get_stats
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {"results": rows}
+        mem_mod._memory = mock_mem
+        return get_stats(user_id="123")
+
+    def test_extracted_count_excludes_other_sources(self):
+        """extracted_count counts only source==extracted rows; total_count
+        still counts everything for backward compat."""
+        stats = self._stats_with(
+            [
+                {
+                    "id": "1",
+                    "memory": "f",
+                    "score": 0.0,
+                    "metadata": {"type": "fact", "source": "extracted", "confidence": 0.9},
+                    "created_at": "",
+                },
+                {
+                    "id": "2",
+                    "memory": "u",
+                    "score": 0.0,
+                    "metadata": {"type": "exchange", "source": "user_raw"},
+                    "created_at": "",
+                },
+                {
+                    "id": "3",
+                    "memory": "l",
+                    "score": 0.0,
+                    "metadata": {"type": "exchange"},
+                    "created_at": "",
+                },
+            ]
+        )
+        assert stats.total_count == 3
+        assert stats.extracted_count == 1
+
+    def test_by_tag_aggregates_extracted_only(self):
+        """A user_raw row carrying a tag does not contribute to by_tag,
+        even if a future writer starts emitting tags on Track 1 rows."""
+        stats = self._stats_with(
+            [
+                {
+                    "id": "1",
+                    "memory": "a",
+                    "score": 0.0,
+                    "metadata": {
+                        "type": "fact",
+                        "source": "extracted",
+                        "tags": ["preference", "constraint"],
+                        "confidence": 0.9,
+                    },
+                    "created_at": "",
+                },
+                {
+                    "id": "2",
+                    "memory": "b",
+                    "score": 0.0,
+                    "metadata": {
+                        "type": "fact",
+                        "source": "extracted",
+                        "tags": ["preference"],
+                        "confidence": 0.8,
+                    },
+                    "created_at": "",
+                },
+                {
+                    "id": "3",
+                    "memory": "c",
+                    "score": 0.0,
+                    "metadata": {
+                        "type": "exchange",
+                        "source": "user_raw",
+                        "tags": ["preference"],
+                    },
+                    "created_at": "",
+                },
+            ]
+        )
+        assert stats.by_tag == {"preference": 2, "constraint": 1}
+
+    def test_confidence_min_median_max_odd_count(self):
+        """Three values [0.6, 0.8, 0.9]: min=0.6, median=0.8, max=0.9."""
+        stats = self._stats_with(
+            [
+                {
+                    "id": str(i),
+                    "memory": "x",
+                    "score": 0.0,
+                    "metadata": {"source": "extracted", "tags": ["fact"], "confidence": c},
+                    "created_at": "",
+                }
+                for i, c in enumerate([0.9, 0.6, 0.8])
+            ]
+        )
+        assert stats.confidence_min == 0.6
+        assert stats.confidence_median == 0.8
+        assert stats.confidence_max == 0.9
+
+    def test_confidence_median_even_count_picks_lower(self):
+        """Spec §6.6: median with even count picks the LOWER of the two
+        middle values (statistics.median_low semantics) rather than
+        averaging them - averaging would synthesize a value no fact
+        actually had."""
+        # Four values [0.5, 0.7, 0.8, 1.0]; mean of middle two would
+        # be 0.75, but median_low picks 0.7.
+        stats = self._stats_with(
+            [
+                {
+                    "id": str(i),
+                    "memory": "x",
+                    "score": 0.0,
+                    "metadata": {"source": "extracted", "tags": ["fact"], "confidence": c},
+                    "created_at": "",
+                }
+                for i, c in enumerate([1.0, 0.5, 0.8, 0.7])
+            ]
+        )
+        assert stats.confidence_median == 0.7
+
+    def test_confidence_below_thresholds(self):
+        """Counts at the 0.7 and 0.6 cutoffs. Strictly less-than per spec
+        (the boundary value itself does not count toward "below")."""
+        stats = self._stats_with(
+            [
+                {
+                    "id": str(i),
+                    "memory": "x",
+                    "score": 0.0,
+                    "metadata": {"source": "extracted", "tags": ["fact"], "confidence": c},
+                    "created_at": "",
+                }
+                # 0.55 below both; 0.65 below 0.7 only; 0.7 below neither;
+                # 0.85 below neither.
+                for i, c in enumerate([0.55, 0.65, 0.7, 0.85])
+            ]
+        )
+        assert stats.confidence_below_0_7 == 2
+        assert stats.confidence_below_0_6 == 1
+
+    def test_confirmation_quote_count(self):
+        stats = self._stats_with(
+            [
+                {
+                    "id": "1",
+                    "memory": "x",
+                    "score": 0.0,
+                    "metadata": {
+                        "source": "extracted",
+                        "tags": ["confirmed_action"],
+                        "confidence": 0.9,
+                        "confirmation_quote": "yes please go ahead and do that",
+                    },
+                    "created_at": "",
+                },
+                {
+                    "id": "2",
+                    "memory": "y",
+                    "score": 0.0,
+                    "metadata": {"source": "extracted", "tags": ["fact"], "confidence": 0.9},
+                    "created_at": "",
+                },
+            ]
+        )
+        assert stats.confirmation_quote_count == 1
+
+    def test_by_prompt_version_counts(self):
+        stats = self._stats_with(
+            [
+                {
+                    "id": "1",
+                    "memory": "x",
+                    "score": 0.0,
+                    "metadata": {
+                        "source": "extracted",
+                        "tags": ["fact"],
+                        "confidence": 0.9,
+                        "prompt_version": "v3",
+                    },
+                    "created_at": "",
+                },
+                {
+                    "id": "2",
+                    "memory": "y",
+                    "score": 0.0,
+                    "metadata": {
+                        "source": "extracted",
+                        "tags": ["fact"],
+                        "confidence": 0.9,
+                        "prompt_version": "v3",
+                    },
+                    "created_at": "",
+                },
+                {
+                    "id": "3",
+                    "memory": "z",
+                    "score": 0.0,
+                    "metadata": {
+                        "source": "extracted",
+                        "tags": ["fact"],
+                        "confidence": 0.9,
+                        "prompt_version": "v2",
+                    },
+                    "created_at": "",
+                },
+            ]
+        )
+        assert stats.by_prompt_version == {"v3": 2, "v2": 1}
+
+    def test_empty_extracted_set_yields_none_confidence(self):
+        """No extracted rows -> min/median/max are None (NOT 0.0) so
+        the UI can render "n/a" rather than a misleading score."""
+        stats = self._stats_with(
+            [
+                {
+                    "id": "1",
+                    "memory": "u",
+                    "score": 0.0,
+                    "metadata": {"type": "exchange", "source": "user_raw"},
+                    "created_at": "",
+                },
+            ]
+        )
+        assert stats.extracted_count == 0
+        assert stats.confidence_min is None
+        assert stats.confidence_median is None
+        assert stats.confidence_max is None
+        assert stats.confidence_below_0_7 == 0
+        assert stats.confidence_below_0_6 == 0
+        assert stats.confirmation_quote_count == 0
+        assert stats.by_tag == {}
+        assert stats.by_prompt_version == {}
+
+    def test_disabled_returns_zeroed_extended_fields(self):
+        """When memory is disabled the new fields collapse to their
+        sentinel defaults, just like total_count and by_type."""
+        from kai.memory import get_stats
+
+        stats = get_stats(user_id="123")
+        assert stats.extracted_count == 0
+        assert stats.confidence_min is None
+        assert stats.by_tag == {}
+        assert stats.by_prompt_version == {}
+
+
 # ── Integration tests (real Mem0 + Qdrant, slower) ──────────────────
 
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -34,12 +34,20 @@ _BASE_CONFIG = Config(
 
 
 def _make_config(*, enabled: bool = True, **overrides) -> Config:
-    """Build a Config with memory settings for testing."""
+    """Build a Config with memory settings for testing.
+
+    The memory_search_floor default mirrors the production default (0.3,
+    matching the prior hard-coded `_MIN_RELEVANCE_THRESHOLD` constant).
+    Tests that exercise the floor explicitly should pass a different
+    `memory_search_floor=...` override; everything else inherits 0.3 so
+    the existing threshold tests continue to assert the same behavior.
+    """
     defaults = {
         "memory_enabled": enabled,
         "memory_search_limit": 10,
         "memory_token_budget": 2000,
         "memory_embedding_model": "all-MiniLM-L6-v2",
+        "memory_search_floor": 0.3,
     }
     defaults.update(overrides)
     return replace(_BASE_CONFIG, **defaults)
@@ -443,7 +451,7 @@ class TestFormatContext:
         import kai.memory as mem_mod
         from kai.memory import format_context
 
-        # raw_score 0.25 < _MIN_RELEVANCE_THRESHOLD (0.3); boosting by 1.2
+        # raw_score 0.25 < memory_search_floor (0.3); boosting by 1.2
         # yields 0.30, but weighting happens AFTER the filter (§5.3) so this
         # row never reaches the walk. Result must be empty.
         mock_mem = MagicMock()
@@ -470,6 +478,44 @@ class TestFormatContext:
 
         result = await format_context("anything", user_id="123")
         assert result == ""
+
+    async def test_format_context_floor_from_config(self):
+        """The relevance floor is read from `config.memory_search_floor`,
+        not from a module-level constant. Spec 310 §7.5 requires the same
+        knob to govern both this path and the `/memory search` UI; this
+        test pins the read so a future refactor cannot reintroduce a
+        hard-coded constant without breaking it.
+
+        A row scoring 0.4 passes when the floor is 0.3 (default behavior)
+        but is filtered out when the floor is raised to 0.5 - verifying
+        the value is sourced from config at call time."""
+        import kai.memory as mem_mod
+        from kai.memory import format_context
+
+        # Single result whose score sits between the two test floors.
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {
+            "results": [
+                {
+                    "id": "mid",
+                    "memory": "Mid-confidence fact",
+                    "score": 0.4,
+                    "metadata": {"type": "fact", "source": "extracted"},
+                    "created_at": "2026-04-01T00:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        # Floor at default 0.3: row passes.
+        mem_mod._config = _make_config(memory_search_floor=0.3)
+        out_low = await format_context("anything", user_id="123")
+        assert "Mid-confidence fact" in out_low
+
+        # Floor raised to 0.5: same row now filtered.
+        mem_mod._config = _make_config(memory_search_floor=0.5)
+        out_high = await format_context("anything", user_id="123")
+        assert out_high == ""
 
 
 class TestAddUserUtterance:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1440,12 +1440,127 @@ class TestGetByTag:
         assert mock_mem.get_all.call_args.kwargs["top_k"] >= 100_000
 
 
+class TestGetById:
+    """Spec 310 §7.2 helper: ownership + source-scoped single fetch.
+
+    `get_by_id` is the single source of truth for "is this fact
+    addressable by /memory under this user?" - delete_by_id calls
+    it, and the fact-view / forget-fact-confirm screens call it
+    directly. The four not-found cases (missing, wrong user,
+    non-extracted, fetch error) all collapse to None; the UI treats
+    them identically."""
+
+    def test_disabled_returns_none(self):
+        from kai.memory import get_by_id
+
+        assert get_by_id(user_id="123", memory_id="abc") is None
+
+    def test_returns_none_when_row_missing(self):
+        import kai.memory as mem_mod
+        from kai.memory import get_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = None
+        mem_mod._memory = mock_mem
+
+        assert get_by_id(user_id="123", memory_id="missing") is None
+
+    def test_returns_none_on_user_mismatch(self):
+        """A memory_id that resolves to another user's row must not
+        leak through this fetch. Same blast radius rationale as
+        delete_by_id: cross-user data exposure on a multi-user install."""
+        import kai.memory as mem_mod
+        from kai.memory import get_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "memory": "secret",
+            "user_id": "other-user",
+            "metadata": {"source": "extracted"},
+        }
+        mem_mod._memory = mock_mem
+
+        assert get_by_id(user_id="123", memory_id="abc") is None
+
+    def test_returns_none_on_non_extracted_source(self):
+        """Track 1 / legacy rows are intentionally invisible to
+        /memory UI surfaces - they belong to memory_admin.py."""
+        import kai.memory as mem_mod
+        from kai.memory import get_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "memory": "raw exchange",
+            "user_id": "123",
+            "metadata": {"source": "user_raw"},
+        }
+        mem_mod._memory = mock_mem
+
+        assert get_by_id(user_id="123", memory_id="abc") is None
+
+    def test_returns_none_on_legacy_missing_source(self):
+        """Legacy rows with no source key are also invisible."""
+        import kai.memory as mem_mod
+        from kai.memory import get_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "memory": "old",
+            "user_id": "123",
+            "metadata": {"type": "exchange"},
+        }
+        mem_mod._memory = mock_mem
+
+        assert get_by_id(user_id="123", memory_id="abc") is None
+
+    def test_returns_none_on_fetch_exception(self):
+        """An unexpected Mem0 failure during get must not raise to
+        the caller - the UI cannot do anything useful with a stack
+        trace, and "no such fact" is a survivable degradation."""
+        import kai.memory as mem_mod
+        from kai.memory import get_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.side_effect = RuntimeError("vector store down")
+        mem_mod._memory = mock_mem
+
+        assert get_by_id(user_id="123", memory_id="abc") is None
+
+    def test_happy_path_wraps_result(self):
+        import kai.memory as mem_mod
+        from kai.memory import get_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "memory": "user prefers tea",
+            "user_id": "123",
+            "metadata": {"source": "extracted", "type": "preference"},
+            "created_at": "2026-04-17T10:00:00Z",
+            "updated_at": "2026-04-17T11:00:00Z",
+        }
+        mem_mod._memory = mock_mem
+
+        result = get_by_id(user_id="123", memory_id="abc")
+        assert result is not None
+        assert result.id == "abc"
+        assert result.text == "user prefers tea"
+        assert result.memory_type == "preference"
+        assert result.metadata.get("source") == "extracted"
+        assert result.created_at == "2026-04-17T10:00:00Z"
+        assert result.updated_at == "2026-04-17T11:00:00Z"
+
+
 class TestDeleteById:
     """Spec 310 §7.2 helper: ownership + source-checked single delete.
 
-    Mem0's `delete(memory_id)` does NOT scope by user_id (verified by
-    inspecting Memory.delete in mem0/memory/main.py). So the
-    verify-before-delete is structurally necessary, not redundant."""
+    Now delegates ownership/source verification to get_by_id, so the
+    test suite below covers the delete-specific behavior (the actual
+    delete call, ValueError swallowing). The verify rules themselves
+    are exercised in TestGetById."""
 
     def test_disabled_returns_false(self):
         from kai.memory import delete_by_id

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -870,6 +870,51 @@ class TestSendOrEditContract:
         await memory_command._send_or_edit(upd, "hello", None, edit=False)
         upd.effective_chat.send_message.assert_awaited_once()
 
+    def test_chat_id_helper_raises_when_effective_chat_is_none(self):
+        # Round-6 #1: `_chat_id` was an `assert`; converted to
+        # `if/raise` for `-O` safety. PTB routing guarantees a chat
+        # in normal handlers, but a future caller wiring this from a
+        # non-routed path would silently AttributeError under -O.
+        upd = MagicMock()
+        upd.effective_chat = None
+        with pytest.raises(ValueError, match="effective_chat is None"):
+            memory_command._chat_id(upd)
+
+    def test_user_id_helper_raises_when_effective_user_is_none(self):
+        # Round-6 #1: same conversion as `_chat_id`.
+        upd = MagicMock()
+        upd.effective_user = None
+        with pytest.raises(ValueError, match="effective_user is None"):
+            memory_command._user_id(upd)
+
+    @pytest.mark.asyncio
+    async def test_handle_memory_command_raises_without_message(self, monkeypatch):
+        # Round-6 #1: top-of-handler `assert update.message is not None`
+        # converted to `if/raise`. PTB CommandHandler guarantees a
+        # message in normal use, but the contract should hold under
+        # `python -O` too.
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        upd = MagicMock()
+        upd.message = None
+        upd.effective_chat = MagicMock(id=100)
+        upd.effective_user = MagicMock(id=999)
+        ctx = MagicMock()
+        with pytest.raises(ValueError, match=r"update\.message is None"):
+            await memory_command.handle_memory_command(upd, ctx)
+
+    @pytest.mark.asyncio
+    async def test_handle_memory_callback_raises_without_callback_query(self):
+        # Audit-all-sites: while addressing the three sites the round-6
+        # review named, the same `assert` pattern was found at the top
+        # of `handle_memory_callback` (callback_query and query.data).
+        # Converted in the same sweep so a future round doesn't have
+        # to re-flag the same anti-pattern.
+        upd = MagicMock()
+        upd.callback_query = None
+        ctx = MagicMock()
+        with pytest.raises(ValueError, match="callback_query is None"):
+            await memory_command.handle_memory_callback(upd, ctx)
+
     @pytest.mark.asyncio
     async def test_send_path_raises_when_effective_chat_is_none(self):
         # Round-5 review #2: the fresh-send branch's None-guard on

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -14,8 +14,8 @@ Covers:
 
 Per spec §10.3, no real Mem0 instance is involved. The handler tests
 that drive `_send_*` swap `kai.memory.get_stats` / `get_by_tag` /
-`get_all` / `delete_by_id` / `search` for fakes via monkeypatch, and
-swap `kai.memory.is_enabled` to return True.
+`get_by_id` / `delete_by_id` / `search` for fakes via monkeypatch,
+and swap `kai.memory.is_enabled` to return True.
 """
 
 from __future__ import annotations
@@ -158,6 +158,15 @@ class TestCallbackCodec:
         encoded = memory_command._encode_callback("ftd", "confirmed_action")
         assert len(encoded.encode("utf-8")) <= 64
         assert encoded == "mem:ftd:confirmed_action"
+
+    def test_overlong_callback_raises(self):
+        # The 64-byte ceiling is enforced via `if/raise`, not assert,
+        # so the check survives `python -O` (which strips assertions).
+        # If it ever fires in real use it indicates a bug in the
+        # caller passing an unexpectedly long arg, not a runtime
+        # condition; raising loudly beats silent Telegram truncation.
+        with pytest.raises(ValueError, match="callback_data too long"):
+            memory_command._encode_callback("x", "a" * 100)
 
 
 # ── Display helpers ─────────────────────────────────────────────────
@@ -530,6 +539,24 @@ class TestBuildStats:
         # Prompt versions sorted desc by count
         assert text.index("v3") < text.index("v2")
 
+    def test_renders_n_a_for_missing_confidence(self):
+        # If the memory.py invariant ever breaks (extracted_count > 0
+        # but min/median/max are None), the stats screen must say
+        # "n/a" rather than "0.00". A real 0.00 confidence reading
+        # would be indistinguishable from a missing one otherwise.
+        stats = _stats(
+            extracted_count=5,
+            confidence_min=None,
+            confidence_median=None,
+            confidence_max=None,
+        )
+        text, _ = memory_command._build_stats(stats)
+        assert "min               n/a" in text
+        assert "median            n/a" in text
+        assert "max               n/a" in text
+        # And no spurious 0.00 leaking in from the confidence block.
+        assert "0.00" not in text
+
 
 # ── Subcommand parsing dispatch ────────────────────────────────────
 
@@ -798,6 +825,36 @@ class TestCallbackDispatch:
         assert deleted == ["mem-id-1"]
         toast = upd.callback_query.answer.call_args.args[0]
         assert toast == "Forgotten."
+
+    @pytest.mark.asyncio
+    async def test_ftd_rejects_unknown_tag(self, monkeypatch, update_factory, context_factory):
+        # A stale or crafted callback could carry an arbitrary tag
+        # string. The handler must validate against `_TAG_ENUM`
+        # before invoking get_by_tag/delete_by_id - mirrors the same
+        # gate as the /memory forget text path.
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        monkeypatch.setattr(
+            memory_command.memory,
+            "get_stats",
+            lambda *, user_id: _stats(extracted_count=0),
+        )
+
+        # If validation fails to fire, get_by_tag would be invoked
+        # with the bogus tag - blow up loudly to surface the bug.
+        def boom(*, user_id, tag):
+            raise AssertionError(f"get_by_tag called with bogus tag {tag!r}")
+
+        monkeypatch.setattr(memory_command.memory, "get_by_tag", boom)
+        monkeypatch.setattr(
+            memory_command.memory,
+            "delete_by_id",
+            lambda *, user_id, memory_id: True,
+        )
+        upd = update_factory(callback_data="mem:ftd:not_a_real_tag")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+        toast = upd.callback_query.answer.call_args.args[0]
+        assert toast == memory_command._MSG_SESSION_EXPIRED
 
     @pytest.mark.asyncio
     async def test_ftd_bulk_deletes_by_tag(self, monkeypatch, update_factory, context_factory):

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -169,6 +169,28 @@ class TestCallbackCodec:
             memory_command._encode_callback("x", "a" * 100)
 
 
+# ── Constants ───────────────────────────────────────────────────────
+
+
+class TestHelpTextLength:
+    """Round-7 #1 regression: `_HELP_TEXT` is used both in
+    `update.message.reply_text` (no length cap) AND in
+    `query.answer(_HELP_TEXT, show_alert=True)` from the dashboard's
+    Search button. The latter goes through Telegram's
+    `answerCallbackQuery` API, whose `text` field is capped at 200
+    chars. Exceeding the cap causes a 400 BadRequest, which the
+    outer except handler converts to "Memory query failed." -
+    confusing UX for what should be the help screen.
+    """
+
+    def test_help_text_under_telegram_callback_alert_limit(self):
+        # 200 is the Telegram-documented limit for
+        # answerCallbackQuery.text. If someone extends `_HELP_TEXT`
+        # and trips this assertion, either trim wording or split
+        # the dashboard help flow into its own shorter toast string.
+        assert len(memory_command._HELP_TEXT) <= 200
+
+
 # ── Display helpers ─────────────────────────────────────────────────
 
 
@@ -963,6 +985,24 @@ class TestSendOrEditContract:
         upd.callback_query.edit_message_reply_markup = AsyncMock(side_effect=BadRequest("Message to edit not found"))
         await memory_command._send_or_edit(upd, "hello", None, edit=True)
         # Send still happened despite the keyboard-clear failure.
+        upd.effective_chat.send_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fallback_keyboard_clear_swallows_network_error(self, update_factory):
+        # Round-7 #2: the keyboard-clear catch was BadRequest-only.
+        # A transient NetworkError / TimedOut from PTB would escape
+        # and short-circuit the fresh send below, surfacing as
+        # "Memory query failed." for what should have been a successful
+        # re-render. Broadened to `except Exception` so the best-effort
+        # contract holds: cleanup failure does not abort the fallback
+        # send under any error class.
+        from telegram.error import BadRequest, NetworkError
+
+        upd = update_factory(callback_data="mem:dash")
+        upd.callback_query.edit_message_text = AsyncMock(side_effect=BadRequest("Message deleted"))
+        upd.callback_query.edit_message_reply_markup = AsyncMock(side_effect=NetworkError("connection reset"))
+        await memory_command._send_or_edit(upd, "hello", None, edit=True)
+        # Fresh send happened despite the NetworkError on cleanup.
         upd.effective_chat.send_message.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -1,0 +1,849 @@
+"""
+Unit tests for `src/kai/memory_command.py` (spec 310).
+
+Covers:
+- Subcommand parsing dispatch (every subcommand routes to the right
+  send-helper, including the empty-query and unknown-tag fall-throughs).
+- Callback encoding/decoding round-trips, including a 64-byte ceiling
+  check on the longest realistic callback.
+- Pure builder rendering: dashboard, tag view (with pagination edge
+  cases), fact view, forget confirmations, search, stats.
+- Per-chat cache: insert, single-entry overwrite, lazy TTL expiry.
+- Empty-state branches: zero-fact dashboard, zero-result search,
+  off-enum tag rejection.
+
+Per spec §10.3, no real Mem0 instance is involved. The handler tests
+that drive `_send_*` swap `kai.memory.get_stats` / `get_by_tag` /
+`get_all` / `delete_by_id` / `search` for fakes via monkeypatch, and
+swap `kai.memory.is_enabled` to return True.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kai import memory_command
+from kai.memory import MemoryResult, MemoryStats
+
+# ── Fixture builders ────────────────────────────────────────────────
+
+
+def _fact(
+    fact_id: str,
+    text: str,
+    tags: list[str],
+    confidence: float = 0.85,
+    *,
+    confirmation_quote: str = "",
+    session_id: str = "session_test",
+    prompt_version: str = "v3",
+    created_at: str = "2026-04-17T10:00:00",
+    updated_at: str | None = None,
+    score: float = 0.0,
+) -> MemoryResult:
+    """Construct a MemoryResult shaped like an extracted fact.
+
+    Defaults match what `memory_extraction.py` writes into Mem0
+    metadata. Tests override only the fields that matter to them.
+    """
+    metadata: dict[str, Any] = {
+        "source": "extracted",
+        "tags": tags,
+        "confidence": confidence,
+        "session_id": session_id,
+        "prompt_version": prompt_version,
+        "type": "fact",
+    }
+    if confirmation_quote:
+        metadata["confirmation_quote"] = confirmation_quote
+    return MemoryResult(
+        id=fact_id,
+        text=text,
+        score=score,
+        memory_type="fact",
+        metadata=metadata,
+        created_at=created_at,
+        updated_at=updated_at if updated_at is not None else created_at,
+    )
+
+
+def _stats(
+    *,
+    extracted_count: int = 0,
+    by_tag: dict[str, int] | None = None,
+    confidence_min: float | None = None,
+    confidence_median: float | None = None,
+    confidence_max: float | None = None,
+    confidence_below_0_7: int = 0,
+    confidence_below_0_6: int = 0,
+    confirmation_quote_count: int = 0,
+    by_prompt_version: dict[str, int] | None = None,
+) -> MemoryStats:
+    """Construct a MemoryStats with extracted-only aggregates."""
+    return MemoryStats(
+        total_count=extracted_count,
+        by_type={"fact": extracted_count} if extracted_count else {},
+        extracted_count=extracted_count,
+        by_tag=by_tag or {},
+        confidence_min=confidence_min,
+        confidence_median=confidence_median,
+        confidence_max=confidence_max,
+        confidence_below_0_7=confidence_below_0_7,
+        confidence_below_0_6=confidence_below_0_6,
+        confirmation_quote_count=confirmation_quote_count,
+        by_prompt_version=by_prompt_version or {},
+    )
+
+
+# ── Cache helpers (test-local) ──────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Wipe the module-level screen cache between tests.
+
+    The cache is module-global so a leak from one test would leak
+    into the next. The autouse fixture guarantees test order is
+    irrelevant to assertions about cache state.
+    """
+    memory_command._screen_cache.clear()
+    yield
+    memory_command._screen_cache.clear()
+
+
+# ── Callback encode/decode ─────────────────────────────────────────
+
+
+class TestCallbackCodec:
+    """Round-trip every callback verb the dispatcher handles."""
+
+    def test_encode_dashboard_verb_only(self):
+        # Verb-only callbacks have no args section.
+        assert memory_command._encode_callback("dash") == "mem:dash"
+
+    def test_encode_with_args(self):
+        encoded = memory_command._encode_callback("tag", "preference", "2")
+        assert encoded == "mem:tag:preference:2"
+
+    def test_decode_verb_only(self):
+        action = memory_command._decode_callback("mem:dash")
+        assert action is not None
+        assert action.verb == "dash"
+        assert action.args == []
+
+    def test_decode_with_args(self):
+        action = memory_command._decode_callback("mem:tag:preference:2")
+        assert action is not None
+        assert action.verb == "tag"
+        assert action.args == ["preference", "2"]
+
+    def test_decode_unknown_prefix_returns_none(self):
+        # Other CallbackQueryHandlers register `ws:`, `voice:`, etc.
+        # We must return None so the wrong dispatcher does not match.
+        assert memory_command._decode_callback("ws:home") is None
+
+    def test_decode_empty_body_returns_none(self):
+        assert memory_command._decode_callback("mem:") is None
+
+    def test_longest_realistic_callback_under_64_bytes(self):
+        # The longest legitimate callback is the forget-by-tag verb
+        # with the longest tag name (`confirmed_action`, 16 chars):
+        #   mem:ftd:confirmed_action  (24 bytes)
+        # Verifying the constructor's assertion does not fire and the
+        # encoded length is well under the 64-byte limit.
+        encoded = memory_command._encode_callback("ftd", "confirmed_action")
+        assert len(encoded.encode("utf-8")) <= 64
+        assert encoded == "mem:ftd:confirmed_action"
+
+
+# ── Display helpers ─────────────────────────────────────────────────
+
+
+class TestTruncate:
+    def test_short_text_unchanged(self):
+        assert memory_command._truncate("short", limit=80) == "short"
+
+    def test_long_text_gets_ellipsis(self):
+        text = "x" * 100
+        result = memory_command._truncate(text, limit=20)
+        assert len(result) == 20
+        assert result.endswith("\u2026")
+
+    def test_newlines_collapsed_to_spaces(self):
+        # Embedded newlines would break the single-line list layout.
+        assert memory_command._truncate("a\nb\rc") == "a b c"
+
+
+class TestFormatDate:
+    def test_date_only_slice(self):
+        assert memory_command._format_date("2026-04-17T10:30:00") == "2026-04-17"
+
+    def test_date_with_time(self):
+        assert memory_command._format_date("2026-04-17T10:30:00", with_time=True) == "2026-04-17 10:30"
+
+    def test_empty_returns_empty(self):
+        assert memory_command._format_date("") == ""
+
+    def test_short_iso_falls_back(self):
+        # Mock fixtures sometimes pass dates without time. The function
+        # must not blow up.
+        assert memory_command._format_date("2026-04-17", with_time=True) == "2026-04-17"
+
+
+class TestBar:
+    def test_zero_count_empty_bar(self):
+        assert memory_command._bar(0, 10) == ""
+
+    def test_max_count_full_width(self):
+        bar = memory_command._bar(10, 10, width=8)
+        assert bar == "\u2593" * 8
+
+    def test_nonzero_min_one_block(self):
+        # A single-fact tag should not render as an empty bar; users
+        # would lose the visual signal that the tag exists.
+        assert memory_command._bar(1, 100, width=8) == "\u2593"
+
+
+# ── Builder: dashboard ─────────────────────────────────────────────
+
+
+class TestBuildDashboard:
+    def test_empty_state(self):
+        text, kb = memory_command._build_dashboard(_stats(extracted_count=0))
+        assert "No memories yet" in text
+        assert kb is None
+
+    def test_renders_summary_and_tags(self):
+        stats = _stats(
+            extracted_count=10,
+            by_tag={"preference": 5, "fact": 3, "decision": 2},
+            confidence_median=0.86,
+            confidence_min=0.52,
+        )
+        text, kb = memory_command._build_dashboard(stats)
+        assert "10 facts across 3 tags" in text
+        # Sort order: descending count. Use the leading-space prefix
+        # so the bare tag rows match without colliding with the
+        # "X facts across" wording in the summary header.
+        assert text.index("  preference") < text.index("  fact") < text.index("  decision")
+        assert "median 0.86, min 0.52" in text
+        assert kb is not None
+        # 3 tag rows + 1 footer row of (Search, Stats).
+        assert len(kb.inline_keyboard) == 4
+        # Footer row holds the two utility buttons.
+        footer = kb.inline_keyboard[-1]
+        assert [btn.text for btn in footer] == ["Search", "Stats"]
+
+    def test_zero_count_tags_hidden(self):
+        # Spec §6.1: dashboard hides zero-count tags. Stats screen
+        # shows them. This test enforces the dashboard half.
+        stats = _stats(
+            extracted_count=5,
+            by_tag={"preference": 5, "location": 0},
+            confidence_median=0.9,
+            confidence_min=0.9,
+        )
+        _, kb = memory_command._build_dashboard(stats)
+        assert kb is not None
+        # 1 nonzero tag row + 1 footer row.
+        assert len(kb.inline_keyboard) == 2
+        assert "preference" in kb.inline_keyboard[0][0].text
+        assert "location" not in kb.inline_keyboard[0][0].text
+
+    def test_callback_data_for_tag_button(self):
+        stats = _stats(extracted_count=3, by_tag={"preference": 3})
+        _, kb = memory_command._build_dashboard(stats)
+        assert kb is not None
+        button = kb.inline_keyboard[0][0]
+        assert button.callback_data == "mem:tag:preference:0"
+
+
+# ── Builder: pagination ────────────────────────────────────────────
+
+
+class TestPaginate:
+    def test_empty_returns_one_page(self):
+        # Even with zero facts, total_pages must read as 1 so the
+        # "page X of Y" footer does not show "page 1 of 0".
+        window, page, total = memory_command._paginate([], 0)
+        assert window == []
+        assert page == 0
+        assert total == 1
+
+    def test_single_page(self):
+        facts = [_fact(f"id{i}", f"t{i}", ["preference"]) for i in range(3)]
+        window, page, total = memory_command._paginate(facts, 0)
+        assert len(window) == 3
+        assert page == 0
+        assert total == 1
+
+    def test_exact_page_boundary(self):
+        # 5 facts at page size 5 must produce exactly 1 page (not 2).
+        facts = [_fact(f"id{i}", f"t{i}", ["preference"]) for i in range(5)]
+        _, _, total = memory_command._paginate(facts, 0)
+        assert total == 1
+
+    def test_last_page_partial(self):
+        # 7 facts at page size 5: first page has 5, second has 2.
+        facts = [_fact(f"id{i}", f"t{i}", ["preference"]) for i in range(7)]
+        window, _, total = memory_command._paginate(facts, 1)
+        assert len(window) == 2
+        assert total == 2
+
+    def test_page_clamped_when_too_high(self):
+        # An out-of-range page falls back to the last valid page
+        # rather than rendering an empty screen.
+        facts = [_fact(f"id{i}", f"t{i}", ["preference"]) for i in range(7)]
+        _, page, total = memory_command._paginate(facts, 99)
+        assert page == total - 1
+
+    def test_negative_page_clamped(self):
+        facts = [_fact(f"id{i}", f"t{i}", ["preference"]) for i in range(3)]
+        _, page, _ = memory_command._paginate(facts, -1)
+        assert page == 0
+
+
+# ── Builder: tag view ──────────────────────────────────────────────
+
+
+class TestBuildTagView:
+    def test_renders_facts_with_confidence_and_date(self):
+        facts = [
+            _fact("a", "First fact", ["preference"], confidence=0.92, updated_at="2026-04-17"),
+            _fact("b", "Second fact", ["preference"], confidence=0.75, updated_at="2026-02-14"),
+        ]
+        text, _, ids, page, total = memory_command._build_tag_view("preference", facts, 0)
+        assert "preference  (page 1 of 1)" in text
+        assert "[0.92]  First fact" in text
+        assert "[0.75]  Second fact" in text
+        assert "2026-04-17" in text
+        assert ids == ["a", "b"]
+        assert page == 0
+        assert total == 1
+
+    def test_truncates_long_text(self):
+        long_text = "x" * 200
+        facts = [_fact("a", long_text, ["preference"], confidence=0.9)]
+        text, _, _, _, _ = memory_command._build_tag_view("preference", facts, 0)
+        # Truncated text appears with ellipsis. The full 200-char
+        # string must NOT appear in the rendered output.
+        assert long_text not in text
+        assert "\u2026" in text
+
+    def test_pagination_buttons(self):
+        facts = [_fact(f"id{i}", f"t{i}", ["preference"]) for i in range(12)]
+        # Middle page should have prev, back, next.
+        _, kb, _, _, _ = memory_command._build_tag_view("preference", facts, 1)
+        nav_row = kb.inline_keyboard[-1]
+        labels = [btn.text for btn in nav_row]
+        assert labels == ["< prev", "back", "next >"]
+
+    def test_first_page_no_prev_button(self):
+        facts = [_fact(f"id{i}", f"t{i}", ["preference"]) for i in range(12)]
+        _, kb, _, _, _ = memory_command._build_tag_view("preference", facts, 0)
+        nav_row = kb.inline_keyboard[-1]
+        assert "< prev" not in [btn.text for btn in nav_row]
+        assert "next >" in [btn.text for btn in nav_row]
+
+    def test_last_page_no_next_button(self):
+        facts = [_fact(f"id{i}", f"t{i}", ["preference"]) for i in range(12)]
+        _, kb, _, _, _ = memory_command._build_tag_view("preference", facts, 2)
+        nav_row = kb.inline_keyboard[-1]
+        assert "next >" not in [btn.text for btn in nav_row]
+        assert "< prev" in [btn.text for btn in nav_row]
+
+    def test_empty_tag_renders_back_button(self):
+        text, kb, ids, _, _ = memory_command._build_tag_view("preference", [], 0)
+        assert "No memories with this tag" in text
+        assert ids == []
+        assert kb.inline_keyboard[0][0].text == "back"
+
+    def test_missing_confidence_renders_placeholder(self):
+        # Legacy or pre-#335 rows may lack confidence; the screen
+        # must not KeyError. Verify the placeholder appears.
+        bad = MemoryResult(
+            id="bad",
+            text="legacy fact",
+            score=0.0,
+            memory_type="fact",
+            metadata={"source": "extracted", "tags": ["preference"]},
+            created_at="2026-04-17",
+            updated_at="2026-04-17",
+        )
+        text, _, _, _, _ = memory_command._build_tag_view("preference", [bad], 0)
+        assert "[----]" in text
+
+
+# ── Builder: fact view ─────────────────────────────────────────────
+
+
+class TestBuildFactView:
+    def test_renders_all_metadata_lines(self):
+        f = _fact(
+            "id1",
+            "Never use em dashes.",
+            ["preference", "constraint"],
+            confidence=0.92,
+            session_id="session_abc123",
+            prompt_version="v3",
+            created_at="2026-04-17T14:32:00",
+        )
+        text, kb = memory_command._build_fact_view(f, return_to=("tag", ["preference", "0"]))
+        assert '"Never use em dashes."' in text
+        assert "preference, constraint" in text
+        assert "Confidence:       0.92" in text
+        assert "2026-04-17 14:32" in text
+        assert "session_abc123" in text
+        assert "v3" in text
+        # No confirmation quote on a non-confirmed_action fact.
+        assert "n/a" in text
+        # Two buttons in one row: back + forget.
+        row = kb.inline_keyboard[0]
+        assert [btn.text for btn in row] == ["back", "forget"]
+
+    def test_back_button_routes_to_return_to(self):
+        f = _fact("id1", "x", ["preference"])
+        _, kb = memory_command._build_fact_view(f, return_to=("tag", ["preference", "2"]))
+        back_btn = kb.inline_keyboard[0][0]
+        assert back_btn.callback_data == "mem:tag:preference:2"
+
+    def test_no_return_to_falls_back_to_dashboard(self):
+        f = _fact("id1", "x", ["preference"])
+        _, kb = memory_command._build_fact_view(f, return_to=None)
+        back_btn = kb.inline_keyboard[0][0]
+        assert back_btn.callback_data == "mem:dash"
+
+    def test_confirmed_action_renders_quote(self):
+        f = _fact(
+            "id1",
+            "Will deploy on Friday.",
+            ["confirmed_action"],
+            confirmation_quote="Yes, deploy on Friday at 5pm please",
+        )
+        text, _ = memory_command._build_fact_view(f, return_to=None)
+        assert "Yes, deploy on Friday" in text
+
+
+# ── Builder: forget confirmations ──────────────────────────────────
+
+
+class TestBuildForgetFactConfirm:
+    def test_text_includes_fact_quote(self):
+        f = _fact("id1", "Do not use em dashes.", ["preference"])
+        text, kb = memory_command._build_forget_fact_confirm(f)
+        assert "Forget this fact?" in text
+        assert '"Do not use em dashes."' in text
+        assert "cannot be undone" in text
+        # Confirm + cancel buttons.
+        labels = [btn.text for btn in kb.inline_keyboard[0]]
+        assert labels == ["confirm forget", "cancel"]
+
+
+class TestBuildForgetTagConfirm:
+    def test_count_appears_in_button_label(self):
+        text, kb = memory_command._build_forget_tag_confirm("preference", 38)
+        assert "Forget all 38 facts" in text
+        assert "Tags are independent" in text
+        confirm_btn = kb.inline_keyboard[0][0]
+        # Spec §6.7: "confirm forget 38 facts" - the count is in the
+        # button label as a concreteness cue.
+        assert confirm_btn.text == "confirm forget 38 facts"
+        assert confirm_btn.callback_data == "mem:ftd:preference"
+
+
+# ── Builder: search results ────────────────────────────────────────
+
+
+class TestBuildSearchResults:
+    def test_empty_results(self):
+        text, kb, ids = memory_command._build_search_results("anything", [], 0.3)
+        assert "No matching memories found" in text
+        assert ids == []
+        # Single back button.
+        assert kb.inline_keyboard[0][0].text == "back"
+
+    def test_renders_score_not_confidence(self):
+        # Spec §6.5: the bracketed number on the search screen is the
+        # Mem0 similarity score, not the Haiku confidence.
+        f = _fact("id1", "preference text", ["preference"], confidence=0.92, score=0.84)
+        text, _, ids = memory_command._build_search_results("q", [f], 0.3)
+        assert "[0.84]" in text  # score
+        assert "[0.92]" not in text  # not confidence
+        assert ids == ["id1"]
+
+    def test_floor_appears_in_footer(self):
+        f = _fact("id1", "x", ["preference"], score=0.84)
+        text, _, _ = memory_command._build_search_results("q", [f], 0.42)
+        assert "(0.4)" in text  # floor formatted to one decimal
+
+
+# ── Builder: stats ─────────────────────────────────────────────────
+
+
+class TestBuildStats:
+    def test_empty_state(self):
+        text, kb = memory_command._build_stats(_stats(extracted_count=0))
+        assert "No extracted facts yet" in text
+        assert kb.inline_keyboard[0][0].text == "back"
+
+    def test_renders_full_aggregates(self):
+        stats = _stats(
+            extracted_count=142,
+            by_tag={
+                "preference": 38,
+                "fact": 27,
+                "decision": 22,
+                "project": 18,
+                "constraint": 14,
+                "confirmed_action": 10,
+                "schedule": 8,
+                "relationship": 5,
+                # location intentionally omitted to test zero-display
+            },
+            confidence_min=0.52,
+            confidence_median=0.87,
+            confidence_max=0.99,
+            confidence_below_0_7=11,
+            confidence_below_0_6=3,
+            confirmation_quote_count=10,
+            by_prompt_version={"v3": 128, "v2": 14},
+        )
+        text, _ = memory_command._build_stats(stats)
+        # Total
+        assert "Total:            142 facts" in text
+        # Spec §6.1 asymmetry: zero-count tags ARE shown in stats.
+        assert "location" in text
+        assert "  0" in text  # location's zero count
+        # Confidence block
+        assert "min               0.52" in text
+        assert "median            0.87" in text
+        assert "max               0.99" in text
+        assert "below 0.7" in text
+        # Percentages
+        assert "(7.7%)" in text
+        # Confirmed actions
+        assert "10 with confirmation_quote" in text
+        # Prompt versions sorted desc by count
+        assert text.index("v3") < text.index("v2")
+
+
+# ── Subcommand parsing dispatch ────────────────────────────────────
+
+
+@pytest.fixture
+def auth_config():
+    """A Config-shaped object that authorizes user_id 999."""
+    cfg = MagicMock()
+    cfg.allowed_user_ids = {999}
+    cfg.memory_search_floor = 0.3
+    return cfg
+
+
+@pytest.fixture
+def update_factory():
+    """Build an Update-shaped mock with chat_id and user_id."""
+
+    def make(text: str = "", *, chat_id: int = 100, user_id: int = 999, callback_data: str | None = None):
+        upd = MagicMock()
+        upd.effective_chat = MagicMock(id=chat_id)
+        upd.effective_user = MagicMock(id=user_id)
+        if callback_data is None:
+            upd.message = MagicMock()
+            upd.message.reply_text = AsyncMock()
+            upd.message.text = text
+            upd.callback_query = None
+        else:
+            # Callback path - no text message, just a query object.
+            upd.message = None
+            upd.callback_query = MagicMock()
+            upd.callback_query.data = callback_data
+            upd.callback_query.answer = AsyncMock()
+            upd.callback_query.edit_message_text = AsyncMock()
+        # send_message used by _send_or_edit fresh-send branch.
+        upd.effective_chat.send_message = AsyncMock(return_value=MagicMock(message_id=42))
+        return upd
+
+    return make
+
+
+@pytest.fixture
+def context_factory(auth_config):
+    """Build a ContextTypes.DEFAULT_TYPE-shaped mock."""
+
+    def make(args: list[str] | None = None):
+        ctx = MagicMock()
+        ctx.bot_data = {"config": auth_config}
+        ctx.args = args or []
+        return ctx
+
+    return make
+
+
+class TestCommandDispatch:
+    """Verify each subcommand routes to the correct send-helper."""
+
+    @pytest.mark.asyncio
+    async def test_no_args_renders_dashboard(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        monkeypatch.setattr(
+            memory_command.memory,
+            "get_stats",
+            lambda *, user_id: _stats(extracted_count=0),
+        )
+        upd = update_factory()
+        ctx = context_factory(args=[])
+        await memory_command.handle_memory_command(upd, ctx)
+        upd.effective_chat.send_message.assert_awaited_once()
+        sent_text = upd.effective_chat.send_message.call_args.kwargs["text"]
+        assert "No memories yet" in sent_text
+
+    @pytest.mark.asyncio
+    async def test_memory_disabled_short_circuits(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: False)
+        upd = update_factory()
+        ctx = context_factory(args=[])
+        await memory_command.handle_memory_command(upd, ctx)
+        upd.message.reply_text.assert_awaited_once_with(memory_command._MSG_DISABLED)
+
+    @pytest.mark.asyncio
+    async def test_help_subcommand(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        upd = update_factory()
+        ctx = context_factory(args=["help"])
+        await memory_command.handle_memory_command(upd, ctx)
+        upd.message.reply_text.assert_awaited_once_with(memory_command._HELP_TEXT)
+
+    @pytest.mark.asyncio
+    async def test_unknown_subcommand_falls_through_to_help(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        upd = update_factory()
+        ctx = context_factory(args=["zzznotacommand"])
+        await memory_command.handle_memory_command(upd, ctx)
+        upd.message.reply_text.assert_awaited_once_with(memory_command._HELP_TEXT)
+
+    @pytest.mark.asyncio
+    async def test_search_with_empty_query_falls_through_to_help(self, monkeypatch, update_factory, context_factory):
+        # Spec §5: "An empty query (`/memory search` with no text)
+        # falls through to `/memory help`."
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        upd = update_factory()
+        ctx = context_factory(args=["search"])
+        await memory_command.handle_memory_command(upd, ctx)
+        upd.message.reply_text.assert_awaited_once_with(memory_command._HELP_TEXT)
+
+    @pytest.mark.asyncio
+    async def test_search_with_query_calls_search(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        called: dict[str, Any] = {}
+
+        def fake_search(query, *, user_id, limit):
+            called["query"] = query
+            called["user_id"] = user_id
+            return []
+
+        monkeypatch.setattr(memory_command.memory, "search", fake_search)
+        upd = update_factory()
+        ctx = context_factory(args=["search", "what", "did", "I", "say"])
+        await memory_command.handle_memory_command(upd, ctx)
+        assert called["query"] == "what did I say"
+        assert called["user_id"] == "100"  # chat_id stringified
+
+    @pytest.mark.asyncio
+    async def test_forget_unknown_tag_rejected(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        upd = update_factory()
+        ctx = context_factory(args=["forget", "notatag"])
+        await memory_command.handle_memory_command(upd, ctx)
+        msg = upd.message.reply_text.call_args.args[0]
+        assert "Unknown tag" in msg
+
+    @pytest.mark.asyncio
+    async def test_forget_no_tag_shows_usage(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        upd = update_factory()
+        ctx = context_factory(args=["forget"])
+        await memory_command.handle_memory_command(upd, ctx)
+        msg = upd.message.reply_text.call_args.args[0]
+        assert "Usage:" in msg
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_silently_dropped(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        upd = update_factory(user_id=12345)  # not in allowed_user_ids
+        ctx = context_factory(args=[])
+        await memory_command.handle_memory_command(upd, ctx)
+        # Neither send_message nor reply_text should be called -
+        # unauthorized users get silence, matching the rest of the bot.
+        upd.message.reply_text.assert_not_called()
+        upd.effective_chat.send_message.assert_not_called()
+
+
+# ── Cache TTL ──────────────────────────────────────────────────────
+
+
+class TestScreenCache:
+    def test_set_and_get_round_trip(self):
+        memory_command._set_cache(100, memory_command._ScreenCache(screen="dashboard"))
+        entry = memory_command._get_cache(100)
+        assert entry is not None
+        assert entry.screen == "dashboard"
+
+    def test_missing_chat_returns_none(self):
+        assert memory_command._get_cache(999) is None
+
+    def test_overwrite_replaces_prior(self):
+        # Spec §7.4: "single-entry-per-chat behavior". A second
+        # /memory invocation in the same chat overwrites the first.
+        memory_command._set_cache(100, memory_command._ScreenCache(screen="dashboard"))
+        memory_command._set_cache(100, memory_command._ScreenCache(screen="stats"))
+        entry = memory_command._get_cache(100)
+        assert entry is not None
+        assert entry.screen == "stats"
+
+    def test_expired_entry_dropped_on_access(self, monkeypatch):
+        # Install a cache entry, then advance the monotonic clock past
+        # the TTL. _get_cache must return None and remove the entry.
+        memory_command._set_cache(100, memory_command._ScreenCache(screen="dashboard"))
+        # Backdate created_at by more than the TTL.
+        memory_command._screen_cache[100].created_at = time.monotonic() - memory_command._CACHE_TTL_S - 60
+        assert memory_command._get_cache(100) is None
+        assert 100 not in memory_command._screen_cache
+
+
+# ── Callback dispatch (smoke tests for the verb table) ─────────────
+
+
+class TestCallbackDispatch:
+    """Drive the callback handler with each verb to verify routing.
+
+    These tests check that the right send-helper runs and the right
+    edit/answer calls occur. The pure builders are exercised more
+    thoroughly above; here we focus on dispatch wiring.
+    """
+
+    @pytest.mark.asyncio
+    async def test_dash_verb_re_renders_dashboard(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        monkeypatch.setattr(
+            memory_command.memory,
+            "get_stats",
+            lambda *, user_id: _stats(extracted_count=0),
+        )
+        upd = update_factory(callback_data="mem:dash")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+        upd.callback_query.answer.assert_awaited()
+        upd.callback_query.edit_message_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unknown_callback_prefix_is_dismissed(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        upd = update_factory(callback_data="ws:home")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+        # _decode_callback returned None, so we should silently ack.
+        upd.callback_query.answer.assert_awaited()
+        upd.callback_query.edit_message_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fact_verb_with_no_cache_routes_to_dashboard(self, monkeypatch, update_factory, context_factory):
+        # Cache miss (e.g. expired or restart) on a fact tap must
+        # route gracefully back to the dashboard with the
+        # "session expired" toast.
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        monkeypatch.setattr(
+            memory_command.memory,
+            "get_stats",
+            lambda *, user_id: _stats(extracted_count=0),
+        )
+        upd = update_factory(callback_data="mem:fact:0")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+        toast = upd.callback_query.answer.call_args.args[0]
+        assert toast == memory_command._MSG_SESSION_EXPIRED
+
+    @pytest.mark.asyncio
+    async def test_ffd_deletes_and_returns_to_tag(self, monkeypatch, update_factory, context_factory):
+        # Forget single fact: confirm flow. Cache holds the fact id
+        # and a return_to pointing at a tag view. After delete, the
+        # handler should re-render the tag view.
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        monkeypatch.setattr(
+            memory_command.memory,
+            "get_by_tag",
+            lambda *, user_id, tag: [],  # tag view is now empty
+        )
+        deleted: list[str] = []
+
+        def fake_delete(*, user_id, memory_id):
+            deleted.append(memory_id)
+            return True
+
+        monkeypatch.setattr(memory_command.memory, "delete_by_id", fake_delete)
+        memory_command._set_cache(
+            100,
+            memory_command._ScreenCache(
+                screen="forget_fact_confirm",
+                memory_ids=["mem-id-1"],
+                return_to=("tag", ["preference", "0"]),
+            ),
+        )
+        upd = update_factory(callback_data="mem:ffd")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+        assert deleted == ["mem-id-1"]
+        toast = upd.callback_query.answer.call_args.args[0]
+        assert toast == "Forgotten."
+
+    @pytest.mark.asyncio
+    async def test_ftd_bulk_deletes_by_tag(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        # Two facts on the tag, both delete cleanly.
+        monkeypatch.setattr(
+            memory_command.memory,
+            "get_by_tag",
+            lambda *, user_id, tag: [
+                _fact("a", "x", ["preference"]),
+                _fact("b", "y", ["preference"]),
+            ],
+        )
+        # After delete, dashboard re-render queries get_stats.
+        monkeypatch.setattr(
+            memory_command.memory,
+            "get_stats",
+            lambda *, user_id: _stats(extracted_count=0),
+        )
+        deleted: list[str] = []
+
+        def fake_delete(*, user_id, memory_id):
+            deleted.append(memory_id)
+            return True
+
+        monkeypatch.setattr(memory_command.memory, "delete_by_id", fake_delete)
+        upd = update_factory(callback_data="mem:ftd:preference")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+        assert sorted(deleted) == ["a", "b"]
+        toast = upd.callback_query.answer.call_args.args[0]
+        assert toast == "Forgot 2 facts."
+
+
+# ── Tag enum drift guard ───────────────────────────────────────────
+
+
+def test_tag_enum_matches_extraction_schema():
+    """The `_TAG_ENUM` mirror must stay in sync with the schema source.
+
+    Drift would silently exclude valid tags from `/memory stats`
+    (a tag with rows but no enum entry would never appear). Both
+    lists are short and unlikely to change often, but a unit test
+    catches the next time they do.
+    """
+    from kai.memory_extraction import _FACT_SCHEMA
+
+    schema_enum = tuple(_FACT_SCHEMA["properties"]["facts"]["items"]["properties"]["tags"]["items"]["enum"])
+    assert schema_enum == memory_command._TAG_ENUM

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -804,6 +804,41 @@ class TestSendOrEditContract:
         upd.effective_chat.send_message.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_fallback_send_clears_stale_keyboard(self, update_factory):
+        # When edit_message_text raises a non-"not modified"
+        # BadRequest (e.g., the original message was deleted), the
+        # function falls back to a fresh send. The stale message in
+        # chat would otherwise keep its inline keyboard, and a tap
+        # on those buttons would trigger ghost callbacks against
+        # state we have moved past. Strip the keyboard first.
+        from telegram.error import BadRequest
+
+        upd = update_factory(callback_data="mem:dash")
+        upd.callback_query.edit_message_text = AsyncMock(side_effect=BadRequest("Message deleted"))
+        upd.callback_query.edit_message_reply_markup = AsyncMock()
+        await memory_command._send_or_edit(upd, "hello", None, edit=True)
+        # Keyboard cleared on the original message before the
+        # replacement send, and a fresh message went out.
+        upd.callback_query.edit_message_reply_markup.assert_awaited_once()
+        upd.effective_chat.send_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fallback_keyboard_clear_failure_is_swallowed(self, update_factory):
+        # The keyboard-clear is best-effort: the original message may
+        # be gone or immutable. If it raises BadRequest, swallow it
+        # and continue with the replacement send. Already on an
+        # error path; surfacing a second exception would mask the
+        # original.
+        from telegram.error import BadRequest
+
+        upd = update_factory(callback_data="mem:dash")
+        upd.callback_query.edit_message_text = AsyncMock(side_effect=BadRequest("Message deleted"))
+        upd.callback_query.edit_message_reply_markup = AsyncMock(side_effect=BadRequest("Message to edit not found"))
+        await memory_command._send_or_edit(upd, "hello", None, edit=True)
+        # Send still happened despite the keyboard-clear failure.
+        upd.effective_chat.send_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_send_forget_tag_confirm_raises_without_message(self, monkeypatch):
         # `_send_forget_tag_confirm` is only called from the text
         # command path where update.message is guaranteed. The check
@@ -991,6 +1026,37 @@ class TestCallbackDispatch:
         assert sorted(deleted) == ["a", "b"]
         toast = upd.callback_query.answer.call_args.args[0]
         assert toast == "Forgot 2 facts."
+
+    @pytest.mark.asyncio
+    async def test_send_failure_yields_single_query_failed_answer(self, monkeypatch, update_factory, context_factory):
+        # Regression for the double-answer bug. Round-3 code answered
+        # the query BEFORE _send_*; if the send raised, the outer
+        # except answered again with _MSG_QUERY_FAILED, which Telegram
+        # rejected as BadRequest. The fix is to defer query.answer()
+        # to AFTER the send, so the except path answers an
+        # unanswered query exactly once.
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+
+        # Pick a verb whose Mem0 call is NOT wrapped in a per-helper
+        # try/except, so the exception escapes to the outer dispatch
+        # except. The `ftd` (forget-by-tag) verb calls get_by_tag
+        # directly inside the dispatcher, with no inner guard - if
+        # Mem0 is down, RuntimeError bubbles up to handle_memory_callback's
+        # except. Verbs like `dash` won't work here because
+        # _send_dashboard catches its own get_stats failure and renders
+        # an in-screen error instead of propagating.
+        def boom(*, user_id, tag):
+            raise RuntimeError("mem0 down")
+
+        monkeypatch.setattr(memory_command.memory, "get_by_tag", boom)
+        upd = update_factory(callback_data="mem:ftd:preference")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+        # query.answer must have been called exactly once, with the
+        # _MSG_QUERY_FAILED toast - never a redundant pre-send answer.
+        assert upd.callback_query.answer.await_count == 1
+        toast = upd.callback_query.answer.call_args.args[0]
+        assert toast == memory_command._MSG_QUERY_FAILED
 
 
 # ── Tag enum drift guard ───────────────────────────────────────────

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -741,6 +741,44 @@ class TestScreenCache:
         assert 100 not in memory_command._screen_cache
 
 
+# ── _send_or_edit contract ─────────────────────────────────────────
+
+
+class TestSendOrEditContract:
+    """Spec 310 §7.3 dispatcher contract: edit=True requires a callback.
+
+    All `edit=True` callers today live in `handle_memory_callback`
+    where `update.callback_query` is guaranteed. The check exists to
+    surface contract violations from any future caller wiring up the
+    `_send_*` helpers from outside the callback path - silent no-op
+    is the worst failure mode here. `raise` rather than `assert` so
+    the gate survives `python -O`."""
+
+    @pytest.mark.asyncio
+    async def test_edit_without_callback_query_raises(self, update_factory):
+        # Build an update with no callback_query (text-message path).
+        upd = update_factory("hi")
+        with pytest.raises(ValueError, match="edit=True requires"):
+            await memory_command._send_or_edit(upd, "hello", None, edit=True)
+
+    @pytest.mark.asyncio
+    async def test_edit_with_callback_query_dispatches(self, update_factory):
+        # Sanity check that the contract gate is not too aggressive:
+        # the legitimate edit path still works when callback_query
+        # is set.
+        upd = update_factory(callback_data="mem:dash")
+        await memory_command._send_or_edit(upd, "hello", None, edit=True)
+        upd.callback_query.edit_message_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_path_does_not_require_callback_query(self, update_factory):
+        # edit=False is the fresh-send branch; callback_query may be
+        # absent. Must not trip the contract check.
+        upd = update_factory("hi")
+        await memory_command._send_or_edit(upd, "hello", None, edit=False)
+        upd.effective_chat.send_message.assert_awaited_once()
+
+
 # ── Callback dispatch (smoke tests for the verb table) ─────────────
 
 
@@ -851,6 +889,29 @@ class TestCallbackDispatch:
             lambda *, user_id, memory_id: True,
         )
         upd = update_factory(callback_data="mem:ftd:not_a_real_tag")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+        toast = upd.callback_query.answer.call_args.args[0]
+        assert toast == memory_command._MSG_SESSION_EXPIRED
+
+    @pytest.mark.asyncio
+    async def test_tag_verb_rejects_unknown_tag(self, monkeypatch, update_factory, context_factory):
+        # Symmetric to test_ftd_rejects_unknown_tag: the read-only
+        # `tag` verb must also enforce _TAG_ENUM. A crafted callback
+        # `mem:tag:not_a_real_tag:0` would otherwise reach get_by_tag
+        # with an off-enum string.
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        monkeypatch.setattr(
+            memory_command.memory,
+            "get_stats",
+            lambda *, user_id: _stats(extracted_count=0),
+        )
+
+        def boom(*, user_id, tag):
+            raise AssertionError(f"get_by_tag called with bogus tag {tag!r}")
+
+        monkeypatch.setattr(memory_command.memory, "get_by_tag", boom)
+        upd = update_factory(callback_data="mem:tag:not_a_real_tag:0")
         ctx = context_factory()
         await memory_command.handle_memory_callback(upd, ctx)
         toast = upd.callback_query.answer.call_args.args[0]

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -544,6 +544,9 @@ class TestBuildStats:
         # but min/median/max are None), the stats screen must say
         # "n/a" rather than "0.00". A real 0.00 confidence reading
         # would be indistinguishable from a missing one otherwise.
+        # Below-threshold counts get the same n/a treatment in this
+        # state - rendering "0 (0.0%)" would read as "all facts
+        # scored above the threshold" rather than "no data".
         stats = _stats(
             extracted_count=5,
             confidence_min=None,
@@ -554,8 +557,30 @@ class TestBuildStats:
         assert "min               n/a" in text
         assert "median            n/a" in text
         assert "max               n/a" in text
-        # And no spurious 0.00 leaking in from the confidence block.
+        # Below-threshold rows fall back to (n/a) too.
+        assert "below 0.7           0  (n/a)" in text
+        assert "below 0.6           0  (n/a)" in text
+        # And no spurious 0.00 / (0.0%) leaking in from the
+        # confidence block.
         assert "0.00" not in text
+        assert "(0.0%)" not in text
+
+    def test_renders_percentages_when_confidence_present(self):
+        # Inverse of the n/a test: when confidence data is present,
+        # the below-threshold rows must still render as percentages
+        # (regression guard against the n/a fallback over-firing).
+        stats = _stats(
+            extracted_count=10,
+            confidence_min=0.5,
+            confidence_median=0.8,
+            confidence_max=0.95,
+            confidence_below_0_7=2,
+            confidence_below_0_6=1,
+        )
+        text, _ = memory_command._build_stats(stats)
+        assert "below 0.7           2  (20.0%)" in text
+        assert "below 0.6           1  (10.0%)" in text
+        assert "(n/a)" not in text
 
 
 # ── Subcommand parsing dispatch ────────────────────────────────────
@@ -777,6 +802,24 @@ class TestSendOrEditContract:
         upd = update_factory("hi")
         await memory_command._send_or_edit(upd, "hello", None, edit=False)
         upd.effective_chat.send_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_forget_tag_confirm_raises_without_message(self, monkeypatch):
+        # `_send_forget_tag_confirm` is only called from the text
+        # command path where update.message is guaranteed. The check
+        # is `if/raise` (not `assert`) so it survives `python -O`,
+        # consistent with the other contract gates in this module.
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        monkeypatch.setattr(
+            memory_command.memory,
+            "get_by_tag",
+            lambda *, user_id, tag: [_fact("a", "x", ["preference"])],
+        )
+        upd = MagicMock()
+        upd.message = None
+        ctx = MagicMock()
+        with pytest.raises(ValueError, match=r"requires update\.message"):
+            await memory_command._send_forget_tag_confirm(upd, ctx, 100, "preference")
 
 
 # ── Callback dispatch (smoke tests for the verb table) ─────────────

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -463,6 +463,31 @@ class TestBuildForgetTagConfirm:
         assert confirm_btn.text == "confirm forget 38 facts"
         assert confirm_btn.callback_data == "mem:ftd:preference"
 
+    def test_singular_when_count_is_one(self):
+        # Round-5 review #3: count==1 used to render "1 facts" /
+        # "1 memories" / "confirm forget 1 facts". A tag with one
+        # surviving member is a real case (deletes whittle the
+        # count). Verify the singular form across all three sites
+        # (header, body, button) so a future edit can't regress
+        # any one of them in isolation.
+        text, kb = memory_command._build_forget_tag_confirm("preference", 1)
+        assert "Forget all 1 fact " in text
+        assert "1 memory." in text
+        assert "1 facts" not in text
+        assert "1 memories" not in text
+        confirm_btn = kb.inline_keyboard[0][0]
+        assert confirm_btn.text == "confirm forget 1 fact"
+
+    def test_plural_when_count_is_two(self):
+        # Boundary on the other side: count==2 must use the plural
+        # forms. Otherwise the singular branch would silently catch
+        # everything.
+        text, kb = memory_command._build_forget_tag_confirm("preference", 2)
+        assert "Forget all 2 facts " in text
+        assert "2 memories." in text
+        confirm_btn = kb.inline_keyboard[0][0]
+        assert confirm_btn.text == "confirm forget 2 facts"
+
 
 # ── Builder: search results ────────────────────────────────────────
 
@@ -705,6 +730,48 @@ class TestCommandDispatch:
         assert called["user_id"] == "100"  # chat_id stringified
 
     @pytest.mark.asyncio
+    async def test_search_filters_out_non_extracted_rows(self, monkeypatch, update_factory, context_factory):
+        # Spec §7.5 / round-5 review #1: every read path must scope to
+        # source=="extracted". `memory.search()` is a Mem0 vector
+        # lookup that spans all sources (Track 1 exchanges, legacy
+        # rows). Without a post-filter, a non-extracted row could
+        # surface in results, then fail get_by_id's source check on
+        # tap and render "no longer exists." for a row the user just
+        # saw. The filter lives in `_send_search` alongside the score
+        # floor.
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+
+        # Build one extracted hit (kept) and one non-extracted hit
+        # (dropped). Both clear the score floor so only source
+        # decides. The legacy/Track-1 row uses the same MemoryResult
+        # shape Mem0 returns; the only difference is metadata.source.
+        extracted = _fact("e1", "kept", ["preference"], score=0.9)
+        non_extracted = MemoryResult(
+            id="t1",
+            text="dropped",
+            score=0.95,
+            memory_type="fact",
+            metadata={"source": "track1"},
+            created_at="2026-04-17T10:00:00",
+            updated_at="2026-04-17T10:00:00",
+        )
+
+        def fake_search(query, *, user_id, limit):
+            return [extracted, non_extracted]
+
+        monkeypatch.setattr(memory_command.memory, "search", fake_search)
+        upd = update_factory()
+        ctx = context_factory(args=["search", "anything"])
+        await memory_command.handle_memory_command(upd, ctx)
+
+        # The cache memory_ids list is populated from the filtered
+        # results - if the non-extracted row leaked through, "t1"
+        # would appear here. It must not.
+        cache = memory_command._get_cache(100)
+        assert cache is not None
+        assert cache.memory_ids == ["e1"]
+
+    @pytest.mark.asyncio
     async def test_forget_unknown_tag_rejected(self, monkeypatch, update_factory, context_factory):
         monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
         upd = update_factory()
@@ -802,6 +869,21 @@ class TestSendOrEditContract:
         upd = update_factory("hi")
         await memory_command._send_or_edit(upd, "hello", None, edit=False)
         upd.effective_chat.send_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_path_raises_when_effective_chat_is_none(self):
+        # Round-5 review #2: the fresh-send branch's None-guard on
+        # `effective_chat` was an `assert`, which `python -O` strips.
+        # Replaced with `if/raise` so the contract holds in optimized
+        # bytecode. This mirrors the same pattern used by
+        # `_encode_callback`, the `edit=True` guard above, and
+        # `_send_forget_tag_confirm`.
+        upd = MagicMock()
+        upd.effective_chat = None
+        upd.callback_query = None
+        upd.message = None
+        with pytest.raises(ValueError, match="effective_chat is None"):
+            await memory_command._send_or_edit(upd, "hello", None, edit=False)
 
     @pytest.mark.asyncio
     async def test_fallback_send_clears_stale_keyboard(self, update_factory):


### PR DESCRIPTION
## Summary

Implements spec 310: a Telegram-facing `/memory` command surface for browsing, searching, and forgetting Haiku-extracted facts. Closes #310.

Four focused commits:

- **C1 (`6357894`)** Add `MEMORY_SEARCH_FLOOR` env var (default 0.3) and consolidate the prior `_MIN_RELEVANCE_THRESHOLD` constant into it. One knob, two paths: both `format_context` (retrieval) and `/memory search` (UI) read the same value at every invocation, so a config edit + restart produces consistent behavior across both paths.

- **C2 (`99f9859`)** Pure-additive helpers and stats extensions in `memory.py`: `get_by_tag`, `delete_by_id`, a `limit` kwarg on `get_all`, plus nine extracted-only aggregate fields on `MemoryStats`. The new aggregates default to "no data" sentinels so the legacy two-arg construction still works. `delete_by_id` does a verify-before-delete on both `user_id` and `metadata.source == "extracted"` as defense-in-depth, even though Mem0's `delete` already scopes by user.

- **C3 (`1323760`)** New module `src/kai/memory_command.py` plus 64 unit tests. Pure builders return `(text, keyboard)` tuples; top-level handlers own the I/O. Per-chat ephemeral cache with lazy 30-minute TTL and single-entry-per-chat semantics keeps every callback under Telegram's 64-byte limit (memory ids are referenced by index, never embedded). `_TAG_ENUM` mirrors the extraction schema with a drift-guard test so future schema changes can't silently exclude tags from `/memory stats`.

- **C4 (`fd3663c`)** Wire the new handlers into `bot.py` and add a five-line `/memory` block to `/help`.

## UX

Plain text rendering throughout (spec §6.0); user-originated content like fact text and confirmation_quote routinely contains Markdown-reserved characters and rendering them as MarkdownV2 would corrupt the display. Forget flows use `answerCallbackQuery` toasts rather than edit-then-sleep-then-edit, keeping the event loop free.

Dashboard hides zero-count tags but stats screen surfaces them as a tuning signal (the spec §6.1 asymmetry, enforced by builders, not the data layer).

## Test plan

- [x] `pytest tests/test_memory_command.py` (64 new tests, all passing)
- [x] `pytest tests/test_memory.py tests/test_config.py` (full memory + config suites green; 244 passing, 9 deselected for Mem0 lock)
- [x] Full suite: 1977 passed, 9 deselected
- [x] `make check` clean (ruff lint + format)
- [ ] Manual smoke test against running bot once merged: `/memory`, `/memory search <q>`, `/memory stats`, tag drill-down + back, fact view + forget confirmation

## Notes

- No feature flag: `/memory` only reads or deletes the caller's own memories (spec §9). Safe to expose by default.
- No bot-wiring tests added; `test_bot.py` covers pure helpers only and the import smoke check verifies registration. The C3 suite already exercises every handler path through monkeypatched memory primitives.
- Spec 335 (Track 1 removal) ships separately. The `source == "extracted"` filter on every read/write path makes this PR correct regardless of #335 ordering.
