### PR TITLE
fix(install): emit sudoers rule per users.yaml os_user

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -34,6 +34,7 @@ import sys
 import tempfile
 import textwrap
 import time
+from collections.abc import Iterable
 from pathlib import Path
 
 import yaml
@@ -997,7 +998,73 @@ def _generate_users_yaml(
     return "\n".join(lines)
 
 
-def _generate_sudoers(service_user: str, claude_user: str | None = None) -> str:
+def _collect_os_users_from_yaml(users_yaml_path: str | Path) -> list[str]:
+    """
+    Read users.yaml and return distinct, non-empty os_user values.
+
+    The runtime (pool.py / claude.py) spawns the inner Claude as each user's
+    `os_user` via `sudo -u`. That requires a matching sudoers rule for every
+    distinct os_user. Without this loader, only the legacy single CLAUDE_USER
+    env var got a rule, and additional users had to be hand-added with visudo
+    only to be wiped by the next `make install`.
+
+    The reader is intentionally lightweight: it does not validate roles,
+    models, or providers (config._load_user_configs already does that at
+    runtime). Install only needs the os_user strings.
+
+    Behavior:
+        - Missing file → []   (first install: users.yaml may not exist yet)
+        - Empty / non-dict / no `users:` key → []
+        - Malformed YAML → raises (yaml.YAMLError); install should fail loudly
+          rather than silently emit no per-user rules
+        - Non-string / empty / whitespace-only os_user values are skipped
+        - Duplicate os_user values are deduplicated, preserving first-seen order
+
+    Args:
+        users_yaml_path: Path to users.yaml (typically /etc/kai/users.yaml).
+
+    Returns:
+        Ordered list of unique non-empty os_user strings.
+    """
+    path = Path(users_yaml_path)
+    if not path.exists():
+        return []
+
+    text = path.read_text(encoding="utf-8")
+    if not text.strip():
+        return []
+
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        return []
+
+    users = data.get("users")
+    if not isinstance(users, list):
+        return []
+
+    seen: set[str] = set()
+    result: list[str] = []
+    for entry in users:
+        if not isinstance(entry, dict):
+            continue
+        os_user = entry.get("os_user")
+        # PyYAML may parse "yes"/"no"/numeric os_user values as bool/int;
+        # only strings are valid OS usernames here.
+        if not isinstance(os_user, str):
+            continue
+        normalized = os_user.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def _generate_sudoers(
+    service_user: str,
+    claude_user: str | None = None,
+    os_users: Iterable[str] = (),
+) -> str:
     """
     Generate sudoers rules for the service user to read protected config files.
 
@@ -1009,12 +1076,17 @@ def _generate_sudoers(service_user: str, claude_user: str | None = None) -> str:
     Falls back to /bin/cat and /usr/bin/tee if the binaries aren't found
     in the current PATH (e.g., when running in a minimal environment).
 
-    When claude_user is set, an additional rule allows the service user to
-    run the claude binary as that user (for process isolation via sudo -u).
+    Per-user `(target_user) SETENV: NOPASSWD:` rules for the claude binary are
+    emitted for every distinct user in `os_users` and `claude_user` combined.
+    Users matching `service_user` are skipped (the runtime detects self-sudo
+    via resolve_claude_user() and spawns claude directly without sudo).
 
     Args:
         service_user: The OS username that runs the Kai service.
-        claude_user: Optional OS username for the inner Claude process.
+        claude_user: Optional OS username for the inner Claude process
+            (legacy single CLAUDE_USER env var path; kept for backwards compat).
+        os_users: Distinct os_user values from users.yaml. Combined with
+            claude_user; duplicates and self-sudo entries are dropped.
 
     Returns:
         The sudoers file contents as a string.
@@ -1036,17 +1108,30 @@ def _generate_sudoers(service_user: str, claude_user: str | None = None) -> str:
         {service_user} ALL=(root) NOPASSWD: {tee_path} /etc/kai/totp.attempts
     """)
 
-    # Allow running the claude binary as the CLAUDE_USER for process isolation.
-    # Resolve the actual binary location; fall back to the native installer's
-    # default path under the service user's home if claude is not on PATH
-    # (e.g., when running under sudo with a stripped environment).
-    if claude_user:
+    # Merge legacy claude_user with yaml-derived os_users. Order: legacy first
+    # so behavior is stable when only claude_user is set (existing installs).
+    # Drop self-sudo entries — pool.py uses resolve_claude_user() to skip the
+    # sudo wrapper entirely when the target matches the service user, so a
+    # rule would be dead code (and slightly misleading to future readers).
+    target_users: list[str] = []
+    seen: set[str] = set()
+    for candidate in (claude_user, *os_users):
+        if not candidate or candidate == service_user or candidate in seen:
+            continue
+        seen.add(candidate)
+        target_users.append(candidate)
+
+    if target_users:
+        # Resolve the actual binary location; fall back to the native installer's
+        # default path under the service user's home if claude is not on PATH
+        # (e.g., when running under sudo with a stripped environment).
         svc_home = _user_home(service_user)
         claude_bin = shutil.which("claude") or f"{svc_home}/.local/bin/claude"
         # SETENV: allows the service user to pass env vars (e.g.,
         # KAI_WEBHOOK_SECRET) through sudo to the claude process.
-        # Scoped to this rule only; cat/tee rules remain locked down.
-        rules += f"{service_user} ALL=({claude_user}) SETENV: NOPASSWD: {claude_bin}\n"
+        # Scoped to per-user rules only; cat/tee rules remain locked down.
+        for target in target_users:
+            rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {claude_bin}\n"
 
     return rules
 
@@ -2013,10 +2098,23 @@ def _apply_goose_config(
     print(f"  Deployed Goose config to {dst}")
 
 
-def _apply_sudoers(service_user: str, dry_run: bool, claude_user: str | None = None) -> None:
-    """Write sudoers rules for the service user to read protected config."""
+def _apply_sudoers(
+    service_user: str,
+    dry_run: bool,
+    claude_user: str | None = None,
+    users_yaml_path: str | Path = "/etc/kai/users.yaml",
+) -> None:
+    """
+    Write sudoers rules for the service user to read protected config.
+
+    Loads `users_yaml_path` (default /etc/kai/users.yaml) to discover every
+    distinct `os_user` the runtime may target via `sudo -u`, so each gets a
+    matching SETENV: NOPASSWD: rule. Without this, hand-added per-user rules
+    were silently wiped on every `sudo make install`. See issue #341.
+    """
     sudoers_path = Path("/etc/sudoers.d/kai")
-    sudoers_content = _generate_sudoers(service_user, claude_user)
+    os_users = _collect_os_users_from_yaml(users_yaml_path)
+    sudoers_content = _generate_sudoers(service_user, claude_user, os_users)
 
     if dry_run:
         print(f"[DRY RUN] Would write: {sudoers_path} (mode 0440)")

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1000,7 +1000,7 @@ def _generate_users_yaml(
 
 def _collect_os_users_from_yaml(users_yaml_path: str | Path) -> list[str]:
     """
-    Read users.yaml and return distinct, non-empty os_user values.
+    Read users.yaml and return distinct, validated os_user values.
 
     The runtime (pool.py / claude.py) spawns the inner Claude as each user's
     `os_user` via `sudo -u`. That requires a matching sudoers rule for every
@@ -1018,19 +1018,35 @@ def _collect_os_users_from_yaml(users_yaml_path: str | Path) -> list[str]:
         - Malformed YAML → raises (yaml.YAMLError); install should fail loudly
           rather than silently emit no per-user rules
         - Non-string / empty / whitespace-only os_user values are skipped
+        - Non-empty values that fail _validate_os_user (e.g. contain `)`,
+          newline, whitespace) raise ValueError. Without this check, a
+          crafted users.yaml could inject arbitrary sudoers directives —
+          /etc/sudoers.d files are loaded directly and visudo only validates
+          syntax, not authorial intent. Hard fail rather than silent skip
+          so the operator sees the bad entry rather than getting a
+          half-functional install.
         - Duplicate os_user values are deduplicated, preserving first-seen order
 
     Args:
         users_yaml_path: Path to users.yaml (typically /etc/kai/users.yaml).
 
     Returns:
-        Ordered list of unique non-empty os_user strings.
+        Ordered list of unique, validated os_user strings.
+
+    Raises:
+        ValueError: If any non-empty os_user value fails username validation.
+        yaml.YAMLError: If the file exists but cannot be parsed.
     """
     path = Path(users_yaml_path)
-    if not path.exists():
+
+    # try/except instead of exists() + read_text() avoids a TOCTOU race:
+    # the file could be deleted between the two calls. Functionally
+    # identical here (root-only install path), but the idiom is cleaner.
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
         return []
 
-    text = path.read_text(encoding="utf-8")
     if not text.strip():
         return []
 
@@ -1053,7 +1069,15 @@ def _collect_os_users_from_yaml(users_yaml_path: str | Path) -> list[str]:
         if not isinstance(os_user, str):
             continue
         normalized = os_user.strip()
-        if not normalized or normalized in seen:
+        # Empty / whitespace-only is treated as "no os_user set" (legitimate;
+        # that user runs as the service user). Skip without raising.
+        if not normalized:
+            continue
+        # Anything else must be a valid username before we let it near the
+        # sudoers writer. See the docstring above for the security rationale.
+        if not _validate_os_user(normalized):
+            raise ValueError(f"Invalid os_user {normalized!r} in {path}: must match {_OS_USER_RE.pattern}")
+        if normalized in seen:
             continue
         seen.add(normalized)
         result.append(normalized)
@@ -1113,11 +1137,20 @@ def _generate_sudoers(
     # Drop self-sudo entries — pool.py uses resolve_claude_user() to skip the
     # sudo wrapper entirely when the target matches the service user, so a
     # rule would be dead code (and slightly misleading to future readers).
+    #
+    # Defense-in-depth: validate every candidate before interpolating into
+    # the sudoers template. _collect_os_users_from_yaml already validates,
+    # but claude_user can come straight from the legacy CLAUDE_USER env var
+    # without going through that path. A `)` or newline in an unvalidated
+    # username would let an attacker with control of that env var inject
+    # arbitrary sudoers directives.
     target_users: list[str] = []
     seen: set[str] = set()
     for candidate in (claude_user, *os_users):
         if not candidate or candidate == service_user or candidate in seen:
             continue
+        if not _validate_os_user(candidate):
+            raise ValueError(f"Invalid sudoers target user {candidate!r}: must match {_OS_USER_RE.pattern}")
         seen.add(candidate)
         target_users.append(candidate)
 
@@ -2113,6 +2146,10 @@ def _apply_sudoers(
     were silently wiped on every `sudo make install`. See issue #341.
     """
     sudoers_path = Path("/etc/sudoers.d/kai")
+    # Load and validate users.yaml *before* the dry_run gate. Intentional:
+    # a malformed YAML file or invalid os_user value should abort even a
+    # dry run, since the operator's next step is `sudo make install` which
+    # would hit the same error with worse blast radius (partial install).
     os_users = _collect_os_users_from_yaml(users_yaml_path)
     sudoers_content = _generate_sudoers(service_user, claude_user, os_users)
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -591,14 +591,6 @@ class TestGenerateSudoersValidation:
         with pytest.raises(ValueError, match="Invalid sudoers target user"):
             _generate_sudoers("kai", claude_user="alice\nroot ALL")
 
-    def test_self_sudo_skip_runs_before_validation(self):
-        """service_user match short-circuits before validation (no rule emitted)."""
-        # If we passed the service_user as os_user with bad chars, the skip
-        # would happen first; but service_user itself is always trusted, so
-        # this test just verifies "kai" with a clean value doesn't blow up.
-        result = _generate_sudoers("kai", os_users=["kai"])
-        assert "kai ALL=(kai)" not in result
-
 
 class TestGenerateLaunchdPlist:
     def test_contains_label(self):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -543,6 +543,62 @@ class TestCollectOsUsersFromYaml:
         with pytest.raises(yaml.YAMLError):
             _collect_os_users_from_yaml(path)
 
+    # -- Security: validate os_user before sudoers write (PR #342 review) -
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "alice) NOPASSWD: ALL",  # closing-paren injection
+            "alice\nroot ALL=(ALL) NOPASSWD: ALL",  # newline injection
+            "alice ALL",  # whitespace
+            "alice;bob",  # semicolon
+            "alice=bob",  # equals
+            "alice/bob",  # slash
+            "alice@host",  # at-sign
+        ],
+    )
+    def test_invalid_os_user_raises(self, tmp_path, bad_value):
+        """Crafted os_user values that could inject sudoers directives must raise."""
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            yaml.safe_dump({"users": [{"telegram_id": 1, "os_user": bad_value}]}),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="Invalid os_user"):
+            _collect_os_users_from_yaml(path)
+
+    def test_invalid_os_user_error_names_path(self, tmp_path):
+        """ValueError message includes the offending path so the operator can fix it."""
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            yaml.safe_dump({"users": [{"telegram_id": 1, "os_user": "bad)user"}]}),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match=str(path)):
+            _collect_os_users_from_yaml(path)
+
+
+class TestGenerateSudoersValidation:
+    """Defense-in-depth: _generate_sudoers itself must reject bad targets."""
+
+    def test_invalid_os_user_in_os_users_raises(self):
+        """Bad os_users values must raise even if they bypass the loader."""
+        with pytest.raises(ValueError, match="Invalid sudoers target user"):
+            _generate_sudoers("kai", os_users=["alice) NOPASSWD: ALL"])
+
+    def test_invalid_claude_user_raises(self):
+        """Legacy CLAUDE_USER env var path must also be validated."""
+        with pytest.raises(ValueError, match="Invalid sudoers target user"):
+            _generate_sudoers("kai", claude_user="alice\nroot ALL")
+
+    def test_self_sudo_skip_runs_before_validation(self):
+        """service_user match short-circuits before validation (no rule emitted)."""
+        # If we passed the service_user as os_user with bad chars, the skip
+        # would happen first; but service_user itself is always trusted, so
+        # this test just verifies "kai" with a clean value doesn't blow up.
+        result = _generate_sudoers("kai", os_users=["kai"])
+        assert "kai ALL=(kai)" not in result
+
 
 class TestGenerateLaunchdPlist:
     def test_contains_label(self):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -27,6 +27,7 @@ from kai.install import (
     _cmd_apply,
     _cmd_config,
     _cmd_status,
+    _collect_os_users_from_yaml,
     _copy_tree,
     _file_checksum,
     _generate_env_file,
@@ -357,6 +358,190 @@ class TestGenerateSudoers:
         monkeypatch.setattr(shutil, "which", lambda n: None if n == "claude" else real_which(n))
         result = _generate_sudoers("kai", claude_user="alice")
         assert "kai ALL=(alice) SETENV: NOPASSWD: /home/kai/.local/bin/claude" in result
+
+    # -- Issue #341: per-user rules from users.yaml -----------------------
+
+    def test_no_per_user_rule_when_os_users_empty(self, monkeypatch):
+        """Acceptance (a): zero os_user entries → no per-user rules emitted."""
+        monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
+        result = _generate_sudoers("kai", os_users=[])
+        assert "SETENV: NOPASSWD" not in result
+        assert "claude" not in result
+
+    def test_one_os_user_emits_one_rule(self, monkeypatch):
+        """Acceptance (b): one os_user → one matching rule."""
+        monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
+        real_which = shutil.which
+        monkeypatch.setattr(shutil, "which", lambda n: "/usr/bin/claude" if n == "claude" else real_which(n))
+        result = _generate_sudoers("kai", os_users=["sellison"])
+        assert result.count("SETENV: NOPASSWD: /usr/bin/claude") == 1
+        assert "kai ALL=(sellison) SETENV: NOPASSWD: /usr/bin/claude" in result
+
+    def test_multiple_os_users_emit_one_rule_each(self, monkeypatch):
+        """Acceptance (c): multiple distinct os_users → one rule each."""
+        monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
+        real_which = shutil.which
+        monkeypatch.setattr(shutil, "which", lambda n: "/usr/bin/claude" if n == "claude" else real_which(n))
+        result = _generate_sudoers("kai", os_users=["sellison", "bob", "carol"])
+        assert "kai ALL=(sellison) SETENV: NOPASSWD: /usr/bin/claude" in result
+        assert "kai ALL=(bob) SETENV: NOPASSWD: /usr/bin/claude" in result
+        assert "kai ALL=(carol) SETENV: NOPASSWD: /usr/bin/claude" in result
+        assert result.count("SETENV: NOPASSWD: /usr/bin/claude") == 3
+
+    def test_duplicate_os_users_deduped(self, monkeypatch):
+        """Acceptance (c, dedupe): repeated os_user values produce one rule."""
+        monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
+        real_which = shutil.which
+        monkeypatch.setattr(shutil, "which", lambda n: "/usr/bin/claude" if n == "claude" else real_which(n))
+        result = _generate_sudoers("kai", os_users=["sellison", "sellison", "bob"])
+        assert result.count("(sellison)") == 1
+        assert result.count("(bob)") == 1
+
+    def test_os_user_matching_service_user_skipped(self, monkeypatch):
+        """Acceptance (d): os_user == service_user → no rule (self-sudo path)."""
+        monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
+        real_which = shutil.which
+        monkeypatch.setattr(shutil, "which", lambda n: "/usr/bin/claude" if n == "claude" else real_which(n))
+        result = _generate_sudoers("kai", os_users=["kai", "sellison"])
+        # No self-sudo rule: kai ALL=(kai) would be a dead rule, since
+        # resolve_claude_user() short-circuits the sudo wrapper at runtime.
+        assert "kai ALL=(kai)" not in result
+        assert "kai ALL=(sellison) SETENV: NOPASSWD: /usr/bin/claude" in result
+        assert result.count("SETENV: NOPASSWD: /usr/bin/claude") == 1
+
+    def test_legacy_claude_user_combined_with_os_users(self, monkeypatch):
+        """Legacy CLAUDE_USER and yaml os_users coexist; deduped."""
+        monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
+        real_which = shutil.which
+        monkeypatch.setattr(shutil, "which", lambda n: "/usr/bin/claude" if n == "claude" else real_which(n))
+        # claude_user and os_users overlap on "alice"; should produce one rule.
+        result = _generate_sudoers("kai", claude_user="alice", os_users=["alice", "bob"])
+        assert result.count("(alice)") == 1
+        assert result.count("(bob)") == 1
+
+
+class TestCollectOsUsersFromYaml:
+    """Loader for issue #341 — extract distinct os_user values from users.yaml."""
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        """First-install path: users.yaml does not exist yet."""
+        result = _collect_os_users_from_yaml(tmp_path / "nope.yaml")
+        assert result == []
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        path = tmp_path / "users.yaml"
+        path.write_text("", encoding="utf-8")
+        assert _collect_os_users_from_yaml(path) == []
+
+    def test_whitespace_only_returns_empty(self, tmp_path):
+        path = tmp_path / "users.yaml"
+        path.write_text("   \n\t\n", encoding="utf-8")
+        assert _collect_os_users_from_yaml(path) == []
+
+    def test_no_users_key_returns_empty(self, tmp_path):
+        path = tmp_path / "users.yaml"
+        path.write_text("other_key: 1\n", encoding="utf-8")
+        assert _collect_os_users_from_yaml(path) == []
+
+    def test_users_not_list_returns_empty(self, tmp_path):
+        path = tmp_path / "users.yaml"
+        path.write_text("users: not_a_list\n", encoding="utf-8")
+        assert _collect_os_users_from_yaml(path) == []
+
+    def test_no_os_user_field_returns_empty(self, tmp_path):
+        """Users without os_user (the default — bot's service user) are skipped."""
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            yaml.safe_dump({"users": [{"telegram_id": 1, "name": "alice"}]}),
+            encoding="utf-8",
+        )
+        assert _collect_os_users_from_yaml(path) == []
+
+    def test_one_os_user_returned(self, tmp_path):
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            yaml.safe_dump({"users": [{"telegram_id": 1, "os_user": "sellison"}]}),
+            encoding="utf-8",
+        )
+        assert _collect_os_users_from_yaml(path) == ["sellison"]
+
+    def test_multiple_distinct_os_users_returned(self, tmp_path):
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "users": [
+                        {"telegram_id": 1, "os_user": "sellison"},
+                        {"telegram_id": 2, "os_user": "bob"},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert _collect_os_users_from_yaml(path) == ["sellison", "bob"]
+
+    def test_duplicates_deduped_preserving_first_seen_order(self, tmp_path):
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "users": [
+                        {"telegram_id": 1, "os_user": "sellison"},
+                        {"telegram_id": 2, "os_user": "bob"},
+                        {"telegram_id": 3, "os_user": "sellison"},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert _collect_os_users_from_yaml(path) == ["sellison", "bob"]
+
+    def test_empty_string_os_user_skipped(self, tmp_path):
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "users": [
+                        {"telegram_id": 1, "os_user": ""},
+                        {"telegram_id": 2, "os_user": "  "},
+                        {"telegram_id": 3, "os_user": "sellison"},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert _collect_os_users_from_yaml(path) == ["sellison"]
+
+    def test_non_string_os_user_skipped(self, tmp_path):
+        """PyYAML may parse "yes"/"no"/numbers as bool/int; filter those out."""
+        path = tmp_path / "users.yaml"
+        # Hand-craft YAML to force bool/int values for os_user.
+        path.write_text(
+            "users:\n"
+            "  - telegram_id: 1\n"
+            "    os_user: true\n"
+            "  - telegram_id: 2\n"
+            "    os_user: 42\n"
+            "  - telegram_id: 3\n"
+            "    os_user: sellison\n",
+            encoding="utf-8",
+        )
+        assert _collect_os_users_from_yaml(path) == ["sellison"]
+
+    def test_os_user_is_stripped(self, tmp_path):
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            yaml.safe_dump({"users": [{"telegram_id": 1, "os_user": "  sellison  "}]}),
+            encoding="utf-8",
+        )
+        assert _collect_os_users_from_yaml(path) == ["sellison"]
+
+    def test_malformed_yaml_raises(self, tmp_path):
+        """Corrupt YAML must surface so install fails loudly, not silently."""
+        path = tmp_path / "users.yaml"
+        path.write_text("users:\n  - [unclosed\n", encoding="utf-8")
+        with pytest.raises(yaml.YAMLError):
+            _collect_os_users_from_yaml(path)
 
 
 class TestGenerateLaunchdPlist:


### PR DESCRIPTION
Fixes #341.

## Problem

`_apply_sudoers` only emitted a per-user sudo rule for the legacy single `CLAUDE_USER` env var. Per-user `os_user` values from `users.yaml` were ignored, so every `sudo make install` truncated `/etc/sudoers.d/kai` and wiped any hand-added rules. The runtime spawn for those users then failed silently with `Sorry, user kai is not allowed to execute ... as <os_user>`, surfacing in the daemon log only as `Claude process EOF` ~50 ms after spawn.

## Changes

- `_collect_os_users_from_yaml(path)` — lightweight reader returning distinct, non-empty `os_user` strings. Missing file returns `[]` (first install). Malformed YAML raises so install fails loudly rather than silently emitting no rules. Non-string values (PyYAML can parse `yes`/`no`/numerics as bool/int) are skipped.
- `_generate_sudoers(service_user, claude_user=None, os_users=())` — emits one `(target) SETENV: NOPASSWD: <claude_bin>` rule per distinct user across `claude_user` and `os_users`, dropping any that match `service_user` (those go through `resolve_claude_user()`'s self-sudo skip path at runtime).
- `_apply_sudoers` — loads `/etc/kai/users.yaml` by default; path parameterized for testability. Caller in `_cmd_apply` is unchanged.

## Acceptance coverage

Tests in `tests/test_install.py`:

- `test_no_per_user_rule_when_os_users_empty` — case (a)
- `test_one_os_user_emits_one_rule` — case (b)
- `test_multiple_os_users_emit_one_rule_each` — case (c)
- `test_duplicate_os_users_deduped` — case (c, dedupe)
- `test_os_user_matching_service_user_skipped` — case (d)
- `test_legacy_claude_user_combined_with_os_users` — backwards-compat dedupe

Plus a `TestCollectOsUsersFromYaml` class covering missing file, empty file, no `users:` key, non-list `users`, no `os_user` field, dedupe order, whitespace stripping, non-string values, and malformed YAML.

## Test plan

- [x] `make check` passes
- [x] `make test` passes (2034 tests, +23 new)
- [ ] `sudo make install` on the Mac mini and verify `/etc/sudoers.d/kai` contains one `kai ALL=(<os_user>) SETENV: NOPASSWD: <claude_bin>` line per distinct `os_user` in `users.yaml`
- [ ] Telegram message from the second user (sellison) processes without `Claude process EOF`

## Out of scope

Memory env vars missing from the install wizard (separate future issue).
