### PR TITLE
fix(install): prompt for memory env vars in wizard (#343)

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -696,6 +696,49 @@ def _cmd_config() -> None:
         )
     print()
 
+    # -- Semantic memory --
+    # MEMORY_ENABLED is a single global toggle for Mem0 + Qdrant. Per-user
+    # partitioning happens at runtime via user_id = telegram_chat_id, so
+    # there is no users.yaml branching here. Without these prompts the
+    # wizard silently drops memory config on every reinstall (see #343).
+    print("-- Semantic memory --")
+    memory_enabled = _prompt_bool(
+        "Enable semantic memory (Mem0 + Qdrant)",
+        existing_env.get("MEMORY_ENABLED", "false").lower() in ("1", "true", "yes"),
+    )
+    # Defaults match the dataclass values in config.py. Only non-defaults
+    # (or memory_enabled=true itself) are written to the env dict below.
+    memory_extraction_enabled = False
+    memory_extraction_budget_usd = "0.01"
+    memory_token_budget = "2000"
+    if memory_enabled:
+        # Haiku extraction requires a Claude backend (config.py refuses
+        # to enable it otherwise). Skip the prompt for non-claude backends
+        # rather than offering an option the operator can't use.
+        if agent_backend == "claude":
+            memory_extraction_enabled = _prompt_bool(
+                "Enable Haiku extraction (proactive memory writes)",
+                existing_env.get("MEMORY_EXTRACTION_ENABLED", "false").lower() in ("1", "true", "yes"),
+            )
+            if memory_extraction_enabled:
+                while True:
+                    memory_extraction_budget_usd = _prompt(
+                        "Per-extraction USD budget (suggest 0.05 or higher)",
+                        existing_env.get("MEMORY_EXTRACTION_BUDGET_USD", "0.01"),
+                    )
+                    if _validate_positive_float(memory_extraction_budget_usd):
+                        break
+                    print("  Must be a positive number.")
+        while True:
+            memory_token_budget = _prompt(
+                "Memory context token budget per turn",
+                existing_env.get("MEMORY_TOKEN_BUDGET", "2000"),
+            )
+            if _validate_positive_int(memory_token_budget):
+                break
+            print("  Must be a positive integer.")
+    print()
+
     # -- External services --
     print("-- External services --")
     perplexity_key = _prompt(
@@ -790,6 +833,18 @@ def _cmd_config() -> None:
         env["PR_REVIEW_TIMEOUT_S"] = pr_review_timeout_s
     if pr_review_budget_usd != "1.0":
         env["PR_REVIEW_BUDGET_USD"] = pr_review_budget_usd
+
+    # Semantic memory: global env vars (per-user partitioning is runtime).
+    # Toggling memory_enabled from true back to false correctly drops
+    # MEMORY_* keys here, so the next /etc/kai/env reflects the new state.
+    if memory_enabled:
+        env["MEMORY_ENABLED"] = "true"
+        if memory_extraction_enabled:
+            env["MEMORY_EXTRACTION_ENABLED"] = "true"
+        if memory_extraction_budget_usd != "0.01":
+            env["MEMORY_EXTRACTION_BUDGET_USD"] = memory_extraction_budget_usd
+        if int(memory_token_budget) != 2000:
+            env["MEMORY_TOKEN_BUDGET"] = memory_token_budget
 
     # Build and write install.conf
     conf = {

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -712,9 +712,10 @@ def _cmd_config() -> None:
     memory_extraction_budget_usd = "0.01"
     memory_token_budget = "2000"
     if memory_enabled:
-        # Haiku extraction requires a Claude backend (config.py refuses
-        # to enable it otherwise). Skip the prompt for non-claude backends
-        # rather than offering an option the operator can't use.
+        # Haiku extraction only fires when the active backend is Claude
+        # (bot.py:3609 silently skips it otherwise - no startup error,
+        # no log line). Skip the prompt for non-claude backends rather
+        # than offer an option whose effect is invisible at runtime.
         if agent_backend == "claude":
             memory_extraction_enabled = _prompt_bool(
                 "Enable Haiku extraction (proactive memory writes)",
@@ -847,6 +848,15 @@ def _cmd_config() -> None:
                 env["MEMORY_EXTRACTION_BUDGET_USD"] = memory_extraction_budget_usd
         if int(memory_token_budget) != 2000:
             env["MEMORY_TOKEN_BUDGET"] = memory_token_budget
+
+    # Drop stale extraction keys when the backend isn't Claude. Mirrors
+    # the CLAUDE_MODEL/CLAUDE_MAX_BUDGET_USD cleanup above: bot.py:3609
+    # silently ignores these on non-claude backends, so leaving them in
+    # /etc/kai/env is misleading without effect. A user who flips backend
+    # from claude to goose should not see lingering extraction config.
+    if agent_backend != "claude":
+        env.pop("MEMORY_EXTRACTION_ENABLED", None)
+        env.pop("MEMORY_EXTRACTION_BUDGET_USD", None)
 
     # Build and write install.conf
     conf = {

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -837,12 +837,14 @@ def _cmd_config() -> None:
     # Semantic memory: global env vars (per-user partitioning is runtime).
     # Toggling memory_enabled from true back to false correctly drops
     # MEMORY_* keys here, so the next /etc/kai/env reflects the new state.
+    # Numeric comparisons (not string) so "0.010" or "2000.0" are not
+    # treated as non-default and spuriously written.
     if memory_enabled:
         env["MEMORY_ENABLED"] = "true"
         if memory_extraction_enabled:
             env["MEMORY_EXTRACTION_ENABLED"] = "true"
-        if memory_extraction_budget_usd != "0.01":
-            env["MEMORY_EXTRACTION_BUDGET_USD"] = memory_extraction_budget_usd
+            if float(memory_extraction_budget_usd) != 0.01:
+                env["MEMORY_EXTRACTION_BUDGET_USD"] = memory_extraction_budget_usd
         if int(memory_token_budget) != 2000:
             env["MEMORY_TOKEN_BUDGET"] = memory_token_budget
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1037,9 +1037,6 @@ class TestCmdConfig:
         _cmd_config()
 
         conf = json.loads((tmp_path / "install.conf").read_text())
-        # _generate_env_file is what _apply_secrets calls to render
-        # /etc/kai/env from the env dict. Round-tripping here proves the
-        # values reach the file the daemon actually reads at startup.
         rendered = _generate_env_file(conf["env"])
         assert 'MEMORY_ENABLED="true"' in rendered
         assert 'MEMORY_EXTRACTION_ENABLED="true"' in rendered

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1051,14 +1051,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
 
-        # Pre-seed install.conf with required fields plus memory tunables,
-        # then press Enter at every prompt so the wizard accepts each
-        # default. Required prompts without a default (bot token, webhook
-        # secret) would otherwise re-prompt forever against "" input.
-        # AGENT_BACKEND is seeded explicitly: the extraction-keys cleanup
-        # block pops MEMORY_EXTRACTION_* on non-claude backends, so this
-        # test would silently fail if the wizard's backend default ever
-        # changed away from "claude".
+        # AGENT_BACKEND seeded explicitly so the extraction-keys cleanup (non-claude pops them) doesn't depend on the wizard's implicit default.
         existing = {
             "version": 1,
             "install_dir": "/opt/kai",
@@ -1098,10 +1091,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
 
-        # Prior install had memory on with custom tunables. The wizard
-        # run below answers "false" to MEMORY_ENABLED. The output env
-        # must not retain any MEMORY_* keys - if it did, the daemon
-        # would silently keep memory live after the operator disabled it.
+        # Disabling memory must strip stale keys; otherwise the daemon keeps memory live after the operator opts out.
         existing = {
             "version": 1,
             "env": {
@@ -1130,9 +1120,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
 
-        # Simulate a prior claude+extraction install. The wizard run
-        # below switches to goose; the extraction keys must not survive
-        # since bot.py:3609 silently ignores them on non-claude backends.
+        # Switching claude -> goose must drop extraction keys (bot.py:3609 silently ignores them on non-claude).
         existing = {
             "version": 1,
             "env": {

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -692,6 +692,7 @@ class TestCmdConfig:
                 "false",  # voice
                 "false",  # tts
                 "",  # claude user (empty)
+                "false",  # memory enabled
                 "",  # perplexity key (empty)
             ]
         )
@@ -756,6 +757,7 @@ class TestCmdConfig:
                 "false",  # voice
                 "false",  # tts
                 # no claude user prompt (skipped by advanced mode)
+                "false",  # memory enabled
                 "",  # perplexity key (empty)
             ]
         )
@@ -819,6 +821,7 @@ class TestCmdConfig:
                 "false",  # voice
                 "false",  # tts
                 "",  # claude user (empty)
+                "false",  # memory enabled
                 "",  # perplexity key (empty)
             ]
         )
@@ -873,6 +876,7 @@ class TestCmdConfig:
                 "false",  # voice
                 "false",  # tts
                 "",  # claude user (empty)
+                "false",  # memory enabled
                 "",  # perplexity key (empty)
             ]
         )
@@ -939,6 +943,154 @@ class TestCmdConfig:
         assert _validate_chat_id("12345") is True
         assert _validate_chat_id("0") is False
         assert _validate_chat_id("abc") is False
+
+    # ── Memory env var prompts (#343) ─────────────────────────────────
+
+    @staticmethod
+    def _base_inputs(memory_block: list[str]) -> list[str]:
+        """Build a default input list with a configurable memory block.
+
+        Captures the wizard's prompt order so each memory test only needs
+        to vary the section under test. Mirrors test_writes_install_conf.
+        """
+        return [
+            "/opt/kai",  # install dir
+            "/var/lib/kai",  # data dir
+            "kai",  # service user
+            "darwin",  # platform
+            "fake-token",  # bot token
+            "12345",  # admin telegram ID
+            "admin",  # admin display name
+            "false",  # advanced user options
+            "polling",  # transport
+            "claude",  # agent backend
+            "sonnet",  # model
+            "120",  # timeout
+            "10.0",  # budget
+            "200000",  # max context window
+            "80",  # autocompact pct
+            "8080",  # port
+            "test-secret",  # webhook secret
+            "~/Projects",  # workspace base
+            "",  # allowed workspaces
+            "false",  # pr review enabled
+            "900",  # pr review timeout
+            "1.0",  # pr review budget
+            "false",  # issue triage
+            "",  # github notify chat id
+            "false",  # voice
+            "false",  # tts
+            "",  # claude user
+            *memory_block,
+            "",  # perplexity key
+        ]
+
+    def test_memory_disabled_omits_env_keys(self, tmp_path, monkeypatch):
+        """MEMORY_ENABLED=false produces no MEMORY_* env entries."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+
+        inputs = iter(self._base_inputs(["false"]))  # memory disabled
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        conf = json.loads((tmp_path / "install.conf").read_text())
+        for key in conf["env"]:
+            assert not key.startswith("MEMORY_"), f"unexpected memory key: {key}"
+
+    def test_memory_enabled_writes_tunables(self, tmp_path, monkeypatch):
+        """MEMORY_ENABLED=true with extraction writes the chosen tunables."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+
+        # Memory on, extraction on, custom budget + token budget.
+        memory_block = [
+            "true",  # memory enabled
+            "true",  # extraction enabled (claude backend)
+            "0.05",  # extraction budget USD
+            "3000",  # token budget
+        ]
+        inputs = iter(self._base_inputs(memory_block))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        conf = json.loads((tmp_path / "install.conf").read_text())
+        env = conf["env"]
+        assert env["MEMORY_ENABLED"] == "true"
+        assert env["MEMORY_EXTRACTION_ENABLED"] == "true"
+        assert env["MEMORY_EXTRACTION_BUDGET_USD"] == "0.05"
+        assert env["MEMORY_TOKEN_BUDGET"] == "3000"
+
+    def test_memory_round_trip_through_env_file(self, tmp_path, monkeypatch):
+        """Wizard-captured memory vars survive _generate_env_file()."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+
+        memory_block = ["true", "true", "0.07", "2500"]
+        inputs = iter(self._base_inputs(memory_block))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        conf = json.loads((tmp_path / "install.conf").read_text())
+        # _generate_env_file is what _apply_secrets calls to render
+        # /etc/kai/env from the env dict. Round-tripping here proves the
+        # values reach the file the daemon actually reads at startup.
+        rendered = _generate_env_file(conf["env"])
+        assert 'MEMORY_ENABLED="true"' in rendered
+        assert 'MEMORY_EXTRACTION_ENABLED="true"' in rendered
+        assert 'MEMORY_EXTRACTION_BUDGET_USD="0.07"' in rendered
+        assert 'MEMORY_TOKEN_BUDGET="2500"' in rendered
+
+    def test_memory_defaults_from_existing_install_conf(self, tmp_path, monkeypatch):
+        """Re-running the wizard offers prior memory choices as defaults."""
+        monkeypatch.chdir(tmp_path)
+        conf_path = tmp_path / "install.conf"
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+
+        # Pre-seed install.conf with required fields plus memory tunables,
+        # then press Enter at every prompt so the wizard accepts each
+        # default. Required prompts without a default (bot token, webhook
+        # secret) would otherwise re-prompt forever against "" input.
+        existing = {
+            "version": 1,
+            "install_dir": "/opt/kai",
+            "data_dir": "/var/lib/kai",
+            "service_user": "kai",
+            "platform": "darwin",
+            "env": {
+                "TELEGRAM_BOT_TOKEN": "existing-token",
+                "WEBHOOK_SECRET": "existing-secret",
+                "MEMORY_ENABLED": "true",
+                "MEMORY_EXTRACTION_ENABLED": "true",
+                "MEMORY_EXTRACTION_BUDGET_USD": "0.08",
+                "MEMORY_TOKEN_BUDGET": "4000",
+            },
+        }
+        conf_path.write_text(json.dumps(existing))
+        # users.yaml prevents per-user prompts that lack defaults.
+        (tmp_path / "users.yaml").write_text("users:\n  - telegram_id: 999\n    name: existing\n    role: admin\n")
+
+        monkeypatch.setattr("builtins.input", lambda prompt: "")
+
+        _cmd_config()
+
+        conf = json.loads(conf_path.read_text())
+        env = conf["env"]
+        assert env["MEMORY_ENABLED"] == "true"
+        assert env["MEMORY_EXTRACTION_ENABLED"] == "true"
+        assert env["MEMORY_EXTRACTION_BUDGET_USD"] == "0.08"
+        assert env["MEMORY_TOKEN_BUDGET"] == "4000"
 
 
 # ── Apply subcommand ─────────────────────────────────────────────────

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1055,6 +1055,10 @@ class TestCmdConfig:
         # then press Enter at every prompt so the wizard accepts each
         # default. Required prompts without a default (bot token, webhook
         # secret) would otherwise re-prompt forever against "" input.
+        # AGENT_BACKEND is seeded explicitly: the extraction-keys cleanup
+        # block pops MEMORY_EXTRACTION_* on non-claude backends, so this
+        # test would silently fail if the wizard's backend default ever
+        # changed away from "claude".
         existing = {
             "version": 1,
             "install_dir": "/opt/kai",
@@ -1064,6 +1068,7 @@ class TestCmdConfig:
             "env": {
                 "TELEGRAM_BOT_TOKEN": "existing-token",
                 "WEBHOOK_SECRET": "existing-secret",
+                "AGENT_BACKEND": "claude",
                 "MEMORY_ENABLED": "true",
                 "MEMORY_EXTRACTION_ENABLED": "true",
                 "MEMORY_EXTRACTION_BUDGET_USD": "0.08",
@@ -1084,6 +1089,38 @@ class TestCmdConfig:
         assert env["MEMORY_EXTRACTION_ENABLED"] == "true"
         assert env["MEMORY_EXTRACTION_BUDGET_USD"] == "0.08"
         assert env["MEMORY_TOKEN_BUDGET"] == "4000"
+
+    def test_memory_toggle_off_drops_existing_keys(self, tmp_path, monkeypatch):
+        """Switching MEMORY_ENABLED true -> false strips stale MEMORY_* keys."""
+        monkeypatch.chdir(tmp_path)
+        conf_path = tmp_path / "install.conf"
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+
+        # Prior install had memory on with custom tunables. The wizard
+        # run below answers "false" to MEMORY_ENABLED. The output env
+        # must not retain any MEMORY_* keys - if it did, the daemon
+        # would silently keep memory live after the operator disabled it.
+        existing = {
+            "version": 1,
+            "env": {
+                "MEMORY_ENABLED": "true",
+                "MEMORY_EXTRACTION_ENABLED": "true",
+                "MEMORY_EXTRACTION_BUDGET_USD": "0.05",
+                "MEMORY_TOKEN_BUDGET": "3000",
+            },
+        }
+        conf_path.write_text(json.dumps(existing))
+
+        inputs = iter(self._base_inputs(["false"]))  # memory toggled off
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        env = json.loads(conf_path.read_text())["env"]
+        for key in env:
+            assert not key.startswith("MEMORY_"), f"stale memory key: {key}"
 
     def test_non_claude_backend_drops_stale_extraction_keys(self, tmp_path, monkeypatch):
         """Switching from claude to goose strips MEMORY_EXTRACTION_* keys."""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -948,11 +948,7 @@ class TestCmdConfig:
 
     @staticmethod
     def _base_inputs(memory_block: list[str]) -> list[str]:
-        """Build a default input list with a configurable memory block.
-
-        Captures the wizard's prompt order so each memory test only needs
-        to vary the section under test. Mirrors test_writes_install_conf.
-        """
+        """Default wizard inputs with a swappable memory block."""
         return [
             "/opt/kai",  # install dir
             "/var/lib/kai",  # data dir

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1085,6 +1085,73 @@ class TestCmdConfig:
         assert env["MEMORY_EXTRACTION_BUDGET_USD"] == "0.08"
         assert env["MEMORY_TOKEN_BUDGET"] == "4000"
 
+    def test_non_claude_backend_drops_stale_extraction_keys(self, tmp_path, monkeypatch):
+        """Switching from claude to goose strips MEMORY_EXTRACTION_* keys."""
+        monkeypatch.chdir(tmp_path)
+        conf_path = tmp_path / "install.conf"
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+
+        # Simulate a prior claude+extraction install. The wizard run
+        # below switches to goose; the extraction keys must not survive
+        # since bot.py:3609 silently ignores them on non-claude backends.
+        existing = {
+            "version": 1,
+            "env": {
+                "AGENT_BACKEND": "goose",
+                "MEMORY_ENABLED": "true",
+                "MEMORY_EXTRACTION_ENABLED": "true",
+                "MEMORY_EXTRACTION_BUDGET_USD": "0.05",
+            },
+        }
+        conf_path.write_text(json.dumps(existing))
+
+        inputs = iter(
+            [
+                "/opt/kai",  # install dir
+                "/var/lib/kai",  # data dir
+                "kai",  # service user
+                "darwin",  # platform
+                "fake-token",  # bot token
+                "12345",  # admin telegram ID
+                "admin",  # admin display name
+                "false",  # advanced user options
+                "polling",  # transport
+                "goose",  # agent backend (was claude)
+                "anthropic",  # goose provider
+                "sk-ant-test-key",  # API key
+                "sonnet",  # model
+                "120",  # timeout
+                "10.0",  # budget
+                "200000",  # max context window
+                "80",  # autocompact pct
+                "8080",  # port
+                "test-secret",  # webhook secret
+                "~/Projects",  # workspace base
+                "",  # allowed workspaces
+                "false",  # pr review enabled
+                "900",  # pr review timeout
+                "1.0",  # pr review budget
+                "false",  # issue triage
+                "",  # github notify chat id
+                "false",  # voice
+                "false",  # tts
+                "",  # claude user
+                "true",  # memory enabled (extraction prompt skipped: non-claude)
+                "2000",  # token budget
+                "",  # perplexity key
+            ]
+        )
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        env = json.loads(conf_path.read_text())["env"]
+        assert env["MEMORY_ENABLED"] == "true"
+        assert "MEMORY_EXTRACTION_ENABLED" not in env
+        assert "MEMORY_EXTRACTION_BUDGET_USD" not in env
+
 
 # ── Apply subcommand ─────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #343.

## Summary

The install wizard never prompted for `MEMORY_*` env vars, so every `sudo make install` wrote a fresh `/etc/kai/env` without `MEMORY_ENABLED`, silently disabling Mem0 + Qdrant for every user. Same regression class as #341 (sudoers wiped on reinstall): the wizard fails to capture state that the install path then destroys.

The dataclass fields and `load_config()` parsing already existed; only the wizard capture was missing.

## Changes

`src/kai/install.py` - new `-- Semantic memory --` section in `_cmd_config()`:
- `MEMORY_ENABLED` toggle (default false)
- If enabled and `agent_backend == "claude"`: `MEMORY_EXTRACTION_ENABLED` toggle, and (when extraction is enabled) `MEMORY_EXTRACTION_BUDGET_USD` with positive-float validation
- If enabled: `MEMORY_TOKEN_BUDGET` with positive-int validation

Other tunables (`MEMORY_SEARCH_LIMIT`, `MEMORY_EMBEDDING_MODEL`, `MEMORY_EXTRACTION_MODEL`, `MEMORY_EXTRACTION_TIMEOUT_S`) keep their dataclass defaults; operators wanting to override can hand-edit `install.conf`.

Captured values land in the `env` dict via the existing "if non-default, write" idiom, so `install.conf` -> `_apply_secrets` -> `/etc/kai/env` round-trips them on every apply.

`tests/test_install.py` - four new acceptance tests matching the issue:
- `test_memory_disabled_omits_env_keys` - `MEMORY_ENABLED=false` produces no `MEMORY_*` keys
- `test_memory_enabled_writes_tunables` - enabled + tunables land in env
- `test_memory_round_trip_through_env_file` - values survive `_generate_env_file()`
- `test_memory_defaults_from_existing_install_conf` - re-running with existing config defaults to prior choices

Existing `TestCmdConfig` input lists updated with the new prompt answer.

## Test plan
- [x] `make check` (ruff + ruff format)
- [x] `make test` for `tests/test_install.py::TestCmdConfig` (10/10 pass)
- [x] Full suite (1920 pass excluding pre-existing memory tests blocked by live daemon's Qdrant lock; unrelated to this change)
