### PR TITLE
fix(install): wizard prompts for MEMORY_EXTRACTION_TIMEOUT_S, MEMORY_SEARCH_LIMIT

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -741,7 +741,7 @@ def _cmd_config() -> None:
                 # rebuilds wholesale on every reinstall.
                 while True:
                     memory_extraction_timeout_s = _prompt(
-                        "Per-extraction timeout in seconds (suggest 60 or higher)",
+                        "Per-extraction timeout in seconds",
                         existing_env.get("MEMORY_EXTRACTION_TIMEOUT_S", "10"),
                     )
                     if _validate_positive_int(memory_extraction_timeout_s):

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -710,7 +710,9 @@ def _cmd_config() -> None:
     # (or memory_enabled=true itself) are written to the env dict below.
     memory_extraction_enabled = False
     memory_extraction_budget_usd = "0.01"
+    memory_extraction_timeout_s = "10"
     memory_token_budget = "2000"
+    memory_search_limit = "10"
     if memory_enabled:
         # Haiku extraction only fires when the active backend is Claude
         # (bot.py:3609 silently skips it otherwise - no startup error,
@@ -730,12 +732,40 @@ def _cmd_config() -> None:
                     if _validate_positive_float(memory_extraction_budget_usd):
                         break
                     print("  Must be a positive number.")
+                # Extraction timeout is the LLM-call hard cap inside
+                # memory_extraction.py:541. Default 10s is too aggressive
+                # for production - real extractions routinely take 20-30s
+                # and silently abort at the boundary (#345). Operators
+                # MUST be able to raise this without hand-editing the
+                # generated install.conf, which `sudo make install`
+                # rebuilds wholesale on every reinstall.
+                while True:
+                    memory_extraction_timeout_s = _prompt(
+                        "Per-extraction timeout in seconds (suggest 60 or higher)",
+                        existing_env.get("MEMORY_EXTRACTION_TIMEOUT_S", "10"),
+                    )
+                    if _validate_positive_int(memory_extraction_timeout_s):
+                        break
+                    print("  Must be a positive integer.")
         while True:
             memory_token_budget = _prompt(
                 "Memory context token budget per turn",
                 existing_env.get("MEMORY_TOKEN_BUDGET", "2000"),
             )
             if _validate_positive_int(memory_token_budget):
+                break
+            print("  Must be a positive integer.")
+        # Search limit caps the retrieval set returned from Mem0/Qdrant
+        # before the token-budget filter. Lower values reduce noise but
+        # may miss relevant facts; higher values pay an embedding-search
+        # cost per turn. Operator-tunable for the same reason as the
+        # token budget: workload-specific, regression class #345.
+        while True:
+            memory_search_limit = _prompt(
+                "Memory search result limit per query",
+                existing_env.get("MEMORY_SEARCH_LIMIT", "10"),
+            )
+            if _validate_positive_int(memory_search_limit):
                 break
             print("  Must be a positive integer.")
     print()
@@ -846,8 +876,20 @@ def _cmd_config() -> None:
             env["MEMORY_EXTRACTION_ENABLED"] = "true"
             if float(memory_extraction_budget_usd) != 0.01:
                 env["MEMORY_EXTRACTION_BUDGET_USD"] = memory_extraction_budget_usd
+            # Timeout written under the same gate as budget: both are
+            # extraction-only tunables. Numeric compare so "10" vs "10 "
+            # or "010" do not produce a spurious env entry equal to
+            # the dataclass default.
+            if int(memory_extraction_timeout_s) != 10:
+                env["MEMORY_EXTRACTION_TIMEOUT_S"] = memory_extraction_timeout_s
         if int(memory_token_budget) != 2000:
             env["MEMORY_TOKEN_BUDGET"] = memory_token_budget
+        # Search limit applies to retrieval (read path), not extraction
+        # (write path), so it sits outside the extraction guard but
+        # inside the memory_enabled guard. Disabling memory entirely
+        # naturally drops this key via the surrounding if.
+        if int(memory_search_limit) != 10:
+            env["MEMORY_SEARCH_LIMIT"] = memory_search_limit
 
     # Drop stale extraction keys when the backend isn't Claude. Mirrors
     # the CLAUDE_MODEL/CLAUDE_MAX_BUDGET_USD cleanup above: bot.py:3609
@@ -857,6 +899,7 @@ def _cmd_config() -> None:
     if agent_backend != "claude":
         env.pop("MEMORY_EXTRACTION_ENABLED", None)
         env.pop("MEMORY_EXTRACTION_BUDGET_USD", None)
+        env.pop("MEMORY_EXTRACTION_TIMEOUT_S", None)
 
     # Build and write install.conf
     conf = {

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1132,7 +1132,8 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
 
-        # Switching claude -> goose must drop extraction keys (bot.py:3609 silently ignores them on non-claude). MEMORY_EXTRACTION_TIMEOUT_S seeded so the cleanup pop is exercised.
+        # Switching claude -> goose must drop extraction keys: bot.py:3609 silently ignores them on non-claude.
+        # MEMORY_EXTRACTION_TIMEOUT_S seeded so the cleanup pop is exercised, not just defaulted away.
         existing = {
             "version": 1,
             "env": {

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1004,12 +1004,14 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
 
-        # Memory on, extraction on, custom budget + token budget.
+        # Memory on, extraction on, custom budget + timeout + token budget + search limit.
         memory_block = [
             "true",  # memory enabled
             "true",  # extraction enabled (claude backend)
             "0.05",  # extraction budget USD
+            "60",  # extraction timeout seconds (#345)
             "3000",  # token budget
+            "20",  # search limit (#345)
         ]
         inputs = iter(self._base_inputs(memory_block))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
@@ -1021,7 +1023,9 @@ class TestCmdConfig:
         assert env["MEMORY_ENABLED"] == "true"
         assert env["MEMORY_EXTRACTION_ENABLED"] == "true"
         assert env["MEMORY_EXTRACTION_BUDGET_USD"] == "0.05"
+        assert env["MEMORY_EXTRACTION_TIMEOUT_S"] == "60"
         assert env["MEMORY_TOKEN_BUDGET"] == "3000"
+        assert env["MEMORY_SEARCH_LIMIT"] == "20"
 
     def test_memory_round_trip_through_env_file(self, tmp_path, monkeypatch):
         """Wizard-captured memory vars survive _generate_env_file()."""
@@ -1030,7 +1034,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
 
-        memory_block = ["true", "true", "0.07", "2500"]
+        memory_block = ["true", "true", "0.07", "45", "2500", "15"]
         inputs = iter(self._base_inputs(memory_block))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
 
@@ -1041,7 +1045,9 @@ class TestCmdConfig:
         assert 'MEMORY_ENABLED="true"' in rendered
         assert 'MEMORY_EXTRACTION_ENABLED="true"' in rendered
         assert 'MEMORY_EXTRACTION_BUDGET_USD="0.07"' in rendered
+        assert 'MEMORY_EXTRACTION_TIMEOUT_S="45"' in rendered
         assert 'MEMORY_TOKEN_BUDGET="2500"' in rendered
+        assert 'MEMORY_SEARCH_LIMIT="15"' in rendered
 
     def test_memory_defaults_from_existing_install_conf(self, tmp_path, monkeypatch):
         """Re-running the wizard offers prior memory choices as defaults."""
@@ -1065,7 +1071,9 @@ class TestCmdConfig:
                 "MEMORY_ENABLED": "true",
                 "MEMORY_EXTRACTION_ENABLED": "true",
                 "MEMORY_EXTRACTION_BUDGET_USD": "0.08",
+                "MEMORY_EXTRACTION_TIMEOUT_S": "75",
                 "MEMORY_TOKEN_BUDGET": "4000",
+                "MEMORY_SEARCH_LIMIT": "25",
             },
         }
         conf_path.write_text(json.dumps(existing))
@@ -1081,7 +1089,9 @@ class TestCmdConfig:
         assert env["MEMORY_ENABLED"] == "true"
         assert env["MEMORY_EXTRACTION_ENABLED"] == "true"
         assert env["MEMORY_EXTRACTION_BUDGET_USD"] == "0.08"
+        assert env["MEMORY_EXTRACTION_TIMEOUT_S"] == "75"
         assert env["MEMORY_TOKEN_BUDGET"] == "4000"
+        assert env["MEMORY_SEARCH_LIMIT"] == "25"
 
     def test_memory_toggle_off_drops_existing_keys(self, tmp_path, monkeypatch):
         """Switching MEMORY_ENABLED true -> false strips stale MEMORY_* keys."""
@@ -1098,7 +1108,9 @@ class TestCmdConfig:
                 "MEMORY_ENABLED": "true",
                 "MEMORY_EXTRACTION_ENABLED": "true",
                 "MEMORY_EXTRACTION_BUDGET_USD": "0.05",
+                "MEMORY_EXTRACTION_TIMEOUT_S": "60",
                 "MEMORY_TOKEN_BUDGET": "3000",
+                "MEMORY_SEARCH_LIMIT": "20",
             },
         }
         conf_path.write_text(json.dumps(existing))
@@ -1120,7 +1132,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
 
-        # Switching claude -> goose must drop extraction keys (bot.py:3609 silently ignores them on non-claude).
+        # Switching claude -> goose must drop extraction keys (bot.py:3609 silently ignores them on non-claude). MEMORY_EXTRACTION_TIMEOUT_S seeded so the cleanup pop is exercised.
         existing = {
             "version": 1,
             "env": {
@@ -1128,6 +1140,7 @@ class TestCmdConfig:
                 "MEMORY_ENABLED": "true",
                 "MEMORY_EXTRACTION_ENABLED": "true",
                 "MEMORY_EXTRACTION_BUDGET_USD": "0.05",
+                "MEMORY_EXTRACTION_TIMEOUT_S": "60",
             },
         }
         conf_path.write_text(json.dumps(existing))
@@ -1163,8 +1176,9 @@ class TestCmdConfig:
                 "false",  # voice
                 "false",  # tts
                 "",  # claude user
-                "true",  # memory enabled (extraction prompt skipped: non-claude)
+                "true",  # memory enabled (extraction + timeout prompts skipped: non-claude)
                 "2000",  # token budget
+                "10",  # search limit
                 "",  # perplexity key
             ]
         )
@@ -1176,6 +1190,40 @@ class TestCmdConfig:
         assert env["MEMORY_ENABLED"] == "true"
         assert "MEMORY_EXTRACTION_ENABLED" not in env
         assert "MEMORY_EXTRACTION_BUDGET_USD" not in env
+        assert "MEMORY_EXTRACTION_TIMEOUT_S" not in env
+
+    def test_extraction_disabled_skips_timeout_prompt(self, tmp_path, monkeypatch):
+        """Extraction off must skip the budget AND timeout prompts; search limit still asked.
+
+        Regression guard for the off-by-one trap: timeout sits inside the
+        extraction-enabled branch, so disabling extraction must consume
+        exactly two fewer prompts (budget + timeout). If the gating drifts,
+        the input iterator desynchronises and the wizard reads search limit
+        as if it were the timeout - the assertion below catches that.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+
+        memory_block = [
+            "true",  # memory enabled
+            "false",  # extraction disabled (skips budget + timeout prompts)
+            "3000",  # token budget
+            "20",  # search limit
+        ]
+        inputs = iter(self._base_inputs(memory_block))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        env = json.loads((tmp_path / "install.conf").read_text())["env"]
+        assert env["MEMORY_ENABLED"] == "true"
+        assert "MEMORY_EXTRACTION_ENABLED" not in env
+        assert "MEMORY_EXTRACTION_BUDGET_USD" not in env
+        assert "MEMORY_EXTRACTION_TIMEOUT_S" not in env
+        assert env["MEMORY_TOKEN_BUDGET"] == "3000"
+        assert env["MEMORY_SEARCH_LIMIT"] == "20"
 
 
 # ── Apply subcommand ─────────────────────────────────────────────────


### PR DESCRIPTION
Closes #345.

## Summary

Adds the two missing operator-tunable wizard prompts that #344 left out. After PR #344 merged, my own first reinstall silently reset `MEMORY_EXTRACTION_TIMEOUT_S` from 60 to 10, and every memory extraction (which routinely takes 20-30 seconds in production) immediately started timing out at the boundary. Same regression class as #343, just one layer deeper - the wizard fails to capture state that the install path then destroys.

## Changes

`src/kai/install.py`:
- `MEMORY_EXTRACTION_TIMEOUT_S` prompt nested under the existing `if memory_extraction_enabled:` guard. It is the LLM-call hard cap inside `memory_extraction.py:541`; irrelevant when extraction is off.
- `MEMORY_SEARCH_LIMIT` prompt at the top `if memory_enabled:` level. Retrieval (read path) runs regardless of extraction (write path), so this sits outside the extraction guard.
- Both use the validated `_validate_positive_int` loop and the "if non-default, write" idiom with numeric (not string) comparison.
- Non-claude cleanup pop also drops `MEMORY_EXTRACTION_TIMEOUT_S`, mirroring the existing pattern for `MEMORY_EXTRACTION_ENABLED` and `MEMORY_EXTRACTION_BUDGET_USD`.

`tests/test_install.py`:
- Existing six memory tests extended for the new prompt slots and seeded values.
- New `test_extraction_disabled_skips_timeout_prompt` guards the off-by-one trap: disabling extraction must consume exactly two fewer prompts (budget + timeout). If the gating drifts, the input iterator desynchronises and the wizard reads search limit as if it were the timeout.

## Out of scope

`MEMORY_EMBEDDING_MODEL` and `MEMORY_EXTRACTION_MODEL` stay non-tunable:
- Embedding-model changes break the existing Qdrant collection (different vector dimensions).
- Extraction-model is code-coupled (Haiku-tuned prompts in `memory_extraction.py`).

These are code-level decisions, not operator knobs. The wizard's silence on them is intentional.

## Test plan
- [x] `make check` (ruff + format)
- [x] `pytest tests/test_install.py::TestCmdConfig` - 13/13 pass (12 existing + 1 new)
- [x] Full suite passes outside the pre-existing `test_memory.py` failures (Qdrant lock held by the live daemon - same exclusion as #344, unrelated)
