### PR TITLE
fix(memory): per-user MEMORY.md scoped by chat_id

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -15,12 +15,13 @@ prompt assembly that is identical across all backends.
 """
 
 import logging
+import shutil
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from kai.config import WorkspaceConfig
+from kai.config import PROJECT_ROOT, WorkspaceConfig
 from kai.history import get_recent_history
 
 log = logging.getLogger(__name__)
@@ -223,7 +224,20 @@ def build_session_context(
     # so it survives make install. Available regardless of which
     # workspace the inner Claude is operating in. try/except guards
     # against race and permission errors (same pattern as identity).
-    memory_path = data_dir / "memory" / "MEMORY.md"
+    #
+    # Per-user scoping (#347): when chat_id is set, the file lives under
+    # memory/<chat_id>/MEMORY.md so each user has their own writable
+    # copy. The inner Claude subprocess runs as that user's os_user
+    # (via sudo -H -u), so ownership of the subdirectory is set to
+    # match. A non-service user cannot write the legacy single-global
+    # file, which was the bug this scoping fixes. Falls back to the
+    # legacy global path when chat_id is None (local-dev backends
+    # with no multi-user config) so nothing regresses on single-user
+    # setups that never hit the multi-user pool path.
+    if chat_id is not None:
+        memory_path = data_dir / "memory" / str(chat_id) / "MEMORY.md"
+    else:
+        memory_path = data_dir / "memory" / "MEMORY.md"
     try:
         memory = memory_path.read_text().strip()
         if memory:
@@ -344,6 +358,60 @@ def build_session_context(
     # No trailing \n\n here - prepend_to_prompt() adds the separator
     # between the context block and the user's message.
     return "\n\n".join(parts)
+
+
+def ensure_user_memory(chat_id: int | None, data_dir: Path) -> None:
+    """
+    Lazily create the per-user MEMORY.md directory and seed file.
+
+    Idempotent and cheap: a stat, a possible mkdir, a possible copy2.
+    Called on every send() path before build_session_context() so that
+    a user who appeared after install (e.g., a new entry in users.yaml
+    without a reinstall) still gets a writable memory surface on their
+    first message.
+
+    In production the install step (install.py ~line 1715) pre-creates
+    and chowns `memory/<chat_id>/` to that user's os_user, so mkdir
+    here is a no-op. For dev/test runs without a prior install, this
+    function does the whole job - mkdir + seed copy - inheriting the
+    caller's ownership. That matches the single-user dev case where
+    the bot process is the only identity in play.
+
+    Intentionally no-ops when chat_id is None. That path reads and
+    writes `memory/MEMORY.md` directly (legacy global location) for
+    backends that never see a chat_id - dev harnesses, smoke scripts.
+
+    Silent on OSError: a permissions issue creating per-user memory
+    must not prevent the bot from answering a message. The read path
+    in build_session_context already returns a placeholder string on
+    missing files, so the downstream session still boots cleanly.
+    """
+    if chat_id is None:
+        return
+
+    user_memory_dir = data_dir / "memory" / str(chat_id)
+    user_memory_file = user_memory_dir / "MEMORY.md"
+
+    try:
+        user_memory_dir.mkdir(parents=True, exist_ok=True)
+        if not user_memory_file.exists():
+            # Seed from the example template if one ships with the
+            # source tree. Copy2 preserves mode bits so a deliberately
+            # permissive example stays that way.
+            example = PROJECT_ROOT / "home" / ".claude" / "MEMORY.md.example"
+            if example.is_file():
+                shutil.copy2(example, user_memory_file)
+            else:
+                # No template available (unusual - only happens when the
+                # install tree is incomplete). Create a minimal placeholder
+                # so the subprocess has a writable file to edit.
+                user_memory_file.write_text("# Memory\n")
+    except OSError:
+        log.warning(
+            "ensure_user_memory: could not bootstrap %s",
+            user_memory_file,
+            exc_info=True,
+        )
 
 
 def build_foreign_workspace_reminder(workspace: Path, home_workspace: Path) -> str | None:

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -388,20 +388,32 @@ def ensure_user_memory(chat_id: int | None, data_dir: Path) -> None:
       bootstrap does the whole job - mkdir + seed copy - inheriting
       the caller's ownership, which IS the writer. Good.
 
-    Intentionally no-ops when chat_id is None. That path reads and
-    writes `memory/MEMORY.md` directly (legacy global location) for
-    backends that never see a chat_id - dev harnesses, smoke scripts.
+    When chat_id is None (legacy/dev path - no users.yaml, no real
+    Telegram session), the function ensures `data_dir/memory/MEMORY.md`
+    exists with the same seed-or-placeholder semantics. This mirrors
+    the removed main._bootstrap_memory() so the legacy global path
+    continues to be writable from a fresh install where memory is
+    disabled and users.yaml is absent.
 
     Silent on OSError: a permissions issue creating per-user memory
     must not prevent the bot from answering a message. The read path
     in build_session_context already returns a placeholder string on
     missing files, so the downstream session still boots cleanly.
     """
+    # When chat_id is None we are on the legacy/dev path: there is no
+    # users.yaml to drive a per-user subdir, so the file lives at
+    # data_dir/memory/MEMORY.md. This mirrors the behavior of the
+    # removed main._bootstrap_memory() function so a fresh
+    # `python -m kai` (no users.yaml, no prior install, memory disabled)
+    # still has a writable memory_root for the inner Claude to update.
+    # Without this branch a write attempt from the subprocess would
+    # FileNotFoundError on the missing parent directory.
     if chat_id is None:
-        return
-
-    user_memory_dir = data_dir / "memory" / str(chat_id)
-    user_memory_file = user_memory_dir / "MEMORY.md"
+        user_memory_dir = data_dir / "memory"
+        user_memory_file = user_memory_dir / "MEMORY.md"
+    else:
+        user_memory_dir = data_dir / "memory" / str(chat_id)
+        user_memory_file = user_memory_dir / "MEMORY.md"
 
     try:
         user_memory_dir.mkdir(parents=True, exist_ok=True)

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -366,16 +366,27 @@ def ensure_user_memory(chat_id: int | None, data_dir: Path) -> None:
 
     Idempotent and cheap: a stat, a possible mkdir, a possible copy2.
     Called on every send() path before build_session_context() so that
-    a user who appeared after install (e.g., a new entry in users.yaml
-    without a reinstall) still gets a writable memory surface on their
-    first message.
+    a user without a pre-created `memory/<chat_id>/` (single-user dev,
+    test runs, or any deployment where the inner Claude runs as the
+    same identity as the bot) still gets a writable memory surface on
+    their first message.
 
-    In production the install step (install.py ~line 1715) pre-creates
-    and chowns `memory/<chat_id>/` to that user's os_user, so mkdir
-    here is a no-op. For dev/test runs without a prior install, this
-    function does the whole job - mkdir + seed copy - inheriting the
-    caller's ownership. That matches the single-user dev case where
-    the bot process is the only identity in play.
+    Scope of what this function fixes - read carefully:
+
+    * Production multi-user (users.yaml entry has an explicit os_user
+      different from the service user): the install step (install.py
+      `_apply_migrate`) pre-creates and chowns `memory/<chat_id>/` to
+      the user's os_user. mkdir here is then a no-op (the dir already
+      exists), and the seed file is already in place. Good.
+    * A user added to users.yaml AFTER install with a distinct os_user:
+      lazy bootstrap is NOT enough. mkdir here runs as the bot/service
+      identity, so the new dir and file are service-owned. The inner
+      subprocess (sudo -H -u <os_user>) can read but not write them -
+      the same #347 regression. A reinstall (or a manual chown) is
+      required for that case.
+    * Dev / single-user / users without a distinct os_user: lazy
+      bootstrap does the whole job - mkdir + seed copy - inheriting
+      the caller's ownership, which IS the writer. Good.
 
     Intentionally no-ops when chat_id is None. That path reads and
     writes `memory/MEMORY.md` directly (legacy global location) for

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -33,6 +33,7 @@ from kai.backend import (
     StreamEvent,
     build_foreign_workspace_reminder,
     build_session_context,
+    ensure_user_memory,
     prepend_to_prompt,
 )
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
@@ -398,6 +399,15 @@ class ClaudeCodeBackend(AgentBackend):
         # in backend.py as shared functions usable by any backend.
         if self._fresh_session:
             self._fresh_session = False
+            # Ensure this user's MEMORY.md exists before the session
+            # context is built. In production, install.py pre-creates
+            # the per-user directory; this call is a no-op then. For
+            # users added after install (or local dev with no install
+            # at all), it seeds the directory + file so the subprocess
+            # has a writable target and build_session_context reads a
+            # real file rather than falling back to the "not yet
+            # created" placeholder. See backend.ensure_user_memory().
+            ensure_user_memory(chat_id, DATA_DIR)
             session_ctx = build_session_context(
                 workspace=self.workspace,
                 home_workspace=self.home_workspace,

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -407,6 +407,17 @@ class ClaudeCodeBackend(AgentBackend):
             # has a writable target and build_session_context reads a
             # real file rather than falling back to the "not yet
             # created" placeholder. See backend.ensure_user_memory().
+            #
+            # Retry limitation: this call is gated on _fresh_session,
+            # which the line above flips to False unconditionally. A
+            # transient OSError inside ensure_user_memory (logged as a
+            # warning, not raised) is therefore not retried on
+            # subsequent messages of the same session - the session
+            # would have to be rebuilt for another attempt. In
+            # practice the failure modes are persistent (permissions,
+            # missing parent dir), not transient, so this is
+            # acceptable; documenting it so future readers do not
+            # assume self-healing.
             ensure_user_memory(chat_id, DATA_DIR)
             session_ctx = build_session_context(
                 workspace=self.workspace,

--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -353,6 +353,15 @@ class GooseBackend(AgentBackend):
             # per-user MEMORY.md directory exists before building the
             # session context. See backend.ensure_user_memory() for
             # why this is a cheap, idempotent no-op in production.
+            #
+            # Retry limitation: this call is gated on _fresh_session,
+            # which the line above flips to False unconditionally. A
+            # transient OSError inside ensure_user_memory (logged as a
+            # warning, not raised) is not retried later in the same
+            # session. Failure modes here are persistent (permissions,
+            # missing parent dir), not transient, so this is
+            # acceptable; documenting it so future readers do not
+            # assume self-healing.
             ensure_user_memory(chat_id, DATA_DIR)
             session_ctx = build_session_context(
                 workspace=self.workspace,

--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -34,6 +34,7 @@ from kai.backend import (
     StreamEvent,
     build_foreign_workspace_reminder,
     build_session_context,
+    ensure_user_memory,
     prepend_to_prompt,
 )
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file
@@ -348,6 +349,11 @@ class GooseBackend(AgentBackend):
         # lives in backend.py as shared functions.
         if self._fresh_session:
             self._fresh_session = False
+            # Mirror the ClaudeCodeBackend.send() path: ensure the
+            # per-user MEMORY.md directory exists before building the
+            # session context. See backend.ensure_user_memory() for
+            # why this is a cheap, idempotent no-op in production.
+            ensure_user_memory(chat_id, DATA_DIR)
             session_ctx = build_session_context(
                 workspace=self.workspace,
                 home_workspace=self.home_workspace,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1194,6 +1194,76 @@ def _collect_os_users_from_yaml(users_yaml_path: str | Path) -> list[str]:
     return result
 
 
+def _collect_user_memory_owners(users_yaml_path: str | Path) -> list[tuple[int, str | None]]:
+    """
+    Read users.yaml and return (telegram_id, os_user) tuples.
+
+    Used by the install migration to know which `memory/<chat_id>/`
+    subdirectories to pre-create and which OS user each one should be
+    chowned to. An os_user of None means that user's inner Claude runs
+    as the service user - their memory subdir stays service-owned.
+
+    Mirrors the behavior of _collect_os_users_from_yaml: silently
+    returns [] on missing / empty / malformed-top-level files, raises
+    on true YAML parse errors, and hard-fails on a non-empty os_user
+    that fails _validate_os_user (same sudoers-injection rationale).
+
+    First-seen order is preserved so that callers who care about the
+    "primary operator" can take tuples[0] deterministically. Entries
+    with a non-int or missing telegram_id are skipped, not raised, to
+    match the loose validation elsewhere in this module (a bad yaml
+    surfaces later as a runtime failure with a clearer message).
+
+    Args:
+        users_yaml_path: Path to users.yaml (typically /etc/kai/users.yaml).
+
+    Returns:
+        List of (telegram_id, os_user_or_None) tuples in yaml order.
+
+    Raises:
+        ValueError: If any non-empty os_user value fails username validation.
+        yaml.YAMLError: If the file exists but cannot be parsed.
+    """
+    path = Path(users_yaml_path)
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+
+    if not text.strip():
+        return []
+
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        return []
+
+    users = data.get("users")
+    if not isinstance(users, list):
+        return []
+
+    result: list[tuple[int, str | None]] = []
+    for entry in users:
+        if not isinstance(entry, dict):
+            continue
+        telegram_id = entry.get("telegram_id")
+        if not isinstance(telegram_id, int):
+            # Users without a valid telegram_id cannot map to a chat_id
+            # directory. Skip silently - config._load_user_configs will
+            # surface the real validation error at runtime.
+            continue
+        os_user_raw = entry.get("os_user")
+        os_user: str | None
+        if isinstance(os_user_raw, str) and os_user_raw.strip():
+            os_user = os_user_raw.strip()
+            if not _validate_os_user(os_user):
+                raise ValueError(f"Invalid os_user {os_user!r} in {path}: must match {_OS_USER_RE.pattern}")
+        else:
+            os_user = None
+        result.append((telegram_id, os_user))
+    return result
+
+
 def _generate_sudoers(
     service_user: str,
     claude_user: str | None = None,
@@ -1549,7 +1619,14 @@ def _start_service(platform: str, dry_run: bool, **_kwargs: object) -> None:
     print(f"  Warning: service start failed ({' '.join(cmd[:2])}){hint}")
 
 
-def _apply_migrate(data_path: Path, install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool) -> None:
+def _apply_migrate(
+    data_path: Path,
+    install_path: Path,
+    svc_uid: int,
+    svc_gid: int,
+    dry_run: bool,
+    users_yaml_path: Path = Path("/etc/kai/users.yaml"),
+) -> None:
     """
     Migrate runtime data from the development directory to the data directory.
 
@@ -1564,6 +1641,11 @@ def _apply_migrate(data_path: Path, install_path: Path, svc_uid: int, svc_gid: i
         svc_uid: Numeric UID for file ownership.
         svc_gid: Numeric GID for file ownership.
         dry_run: If True, print actions without executing.
+        users_yaml_path: Path to the installed users.yaml. Defaults to
+            /etc/kai/users.yaml (the post-_apply_secrets location).
+            Parameterized so tests can supply a fixture path without
+            patching module globals; production callers always rely on
+            the default.
     """
     # -- Database migration --
     db_src = PROJECT_ROOT / "kai.db"
@@ -1645,21 +1727,87 @@ def _apply_migrate(data_path: Path, install_path: Path, svc_uid: int, svc_gid: i
             print("  History already migrated or no files to copy")
 
     # -- MEMORY.md migration --
-    # One-time: copy personal memory from the source tree
-    # (home/.claude/MEMORY.md, pre-DATA_DIR location) to DATA_DIR/memory/.
-    # If the file doesn't exist at the source location
-    # (common - it was never created on most installs), _bootstrap_memory()
-    # in main.py handles creation from the example template at startup.
-    memory_src = PROJECT_ROOT / "home" / ".claude" / "MEMORY.md"
-    memory_dst = data_path / "memory" / "MEMORY.md"
-    if memory_src.is_file() and not memory_dst.exists():
-        if dry_run:
-            print(f"[DRY RUN] Would copy MEMORY.md: {memory_src} -> {memory_dst}")
-        else:
-            (data_path / "memory").mkdir(parents=True, exist_ok=True)
-            shutil.copy2(memory_src, memory_dst)
-            os.chown(memory_dst, svc_uid, svc_gid)
-            print(f"  Migrated MEMORY.md to {memory_dst}")
+    # One-time: land personal memory at the per-user path
+    # DATA_DIR/memory/<chat_id>/MEMORY.md. The "primary operator"
+    # (first entry in users.yaml, typically an admin) gets any legacy
+    # content. Two legacy source locations are handled:
+    #   1) DATA_DIR/memory/MEMORY.md  - pre-#347 global location; the
+    #      common case on existing installs.
+    #   2) PROJECT_ROOT/home/.claude/MEMORY.md - pre-DATA_DIR location
+    #      from before the DATA_DIR migration shipped.
+    # Both are moved (not copied) so the global path cannot later read
+    # as stale state. If neither source exists, a per-user MEMORY.md
+    # is seeded from the home/.claude/MEMORY.md.example template so
+    # the inner Claude has a writable starting point on first message.
+    # Subsequent users in users.yaml get the template, not the legacy
+    # content, because one user's memory never belongs to another.
+    #
+    # This migration deliberately runs with users.yaml loaded from
+    # the resolved install path (post-_apply_secrets, default
+    # /etc/kai/users.yaml) so that all known operators get a seeded
+    # directory on the install where this code first lands.
+    memory_owners = _collect_user_memory_owners(users_yaml_path)
+    memory_root = data_path / "memory"
+    legacy_global = memory_root / "MEMORY.md"
+    legacy_src_tree = PROJECT_ROOT / "home" / ".claude" / "MEMORY.md"
+    example_template = PROJECT_ROOT / "home" / ".claude" / "MEMORY.md.example"
+
+    # Resolve the primary operator's chat_id (first yaml entry). When
+    # users.yaml is absent or empty (first-ever install, single-user
+    # dev), leave memory/MEMORY.md alone - runtime code falls back to
+    # that legacy path when chat_id is None. This keeps local `make
+    # run` workflows identical to pre-#347 behavior.
+    primary_chat_id: int | None = memory_owners[0][0] if memory_owners else None
+
+    if primary_chat_id is not None:
+        primary_dir = memory_root / str(primary_chat_id)
+        primary_dst = primary_dir / "MEMORY.md"
+
+        if not primary_dst.exists():
+            if dry_run:
+                if legacy_global.is_file():
+                    print(f"[DRY RUN] Would move {legacy_global} -> {primary_dst}")
+                elif legacy_src_tree.is_file():
+                    print(f"[DRY RUN] Would copy {legacy_src_tree} -> {primary_dst}")
+                elif example_template.is_file():
+                    print(f"[DRY RUN] Would seed {primary_dst} from {example_template}")
+            else:
+                primary_dir.mkdir(parents=True, exist_ok=True)
+                if legacy_global.is_file():
+                    # Move, not copy - the legacy global path must not
+                    # survive this migration, or a stale file will shadow
+                    # the per-user read once one user's subdir fills up.
+                    shutil.move(str(legacy_global), str(primary_dst))
+                    print(f"  Migrated MEMORY.md to {primary_dst}")
+                elif legacy_src_tree.is_file():
+                    shutil.copy2(legacy_src_tree, primary_dst)
+                    print(f"  Migrated MEMORY.md to {primary_dst}")
+                elif example_template.is_file():
+                    shutil.copy2(example_template, primary_dst)
+                    print(f"  Seeded {primary_dst} from example template")
+                else:
+                    # Last-resort placeholder so the file is writable.
+                    primary_dst.write_text("# Memory\n")
+                    print(f"  Created empty {primary_dst}")
+
+        # Seed every other known user from the example template. Skips
+        # the primary (handled above) and any user whose subdir already
+        # has a MEMORY.md (idempotent across reinstalls).
+        for chat_id, _os_user in memory_owners[1:]:
+            user_dir = memory_root / str(chat_id)
+            user_dst = user_dir / "MEMORY.md"
+            if user_dst.exists():
+                continue
+            if dry_run:
+                print(f"[DRY RUN] Would seed {user_dst} from example template")
+                continue
+            user_dir.mkdir(parents=True, exist_ok=True)
+            if example_template.is_file():
+                shutil.copy2(example_template, user_dst)
+                print(f"  Seeded {user_dst} from example template")
+            else:
+                user_dst.write_text("# Memory\n")
+                print(f"  Created empty {user_dst}")
 
     # -- Uploaded files migration --
     # One-time: copy user-uploaded files from the install tree
@@ -1702,17 +1850,50 @@ def _apply_migrate(data_path: Path, install_path: Path, svc_uid: int, svc_gid: i
             print("  Uploaded files already migrated or no files to copy")
 
     # -- Memory directory ownership --
-    # Ensure the entire memory/ tree is owned by the service user.
-    # Subdirectories like qdrant/ are created at runtime by init_memory(),
-    # but if the service was ever started as root (e.g., a manual test run)
-    # or a prior install left stale ownership, those directories would be
-    # root-owned and the service user could not write to them.
+    # Two ownership tiers in a single tree:
+    #   (a) Service-owned: memory/, memory/qdrant/, memory/mem0_history.db,
+    #       memory/extractor_cwd/, and any other kai-written artifacts.
+    #       Init_memory() creates qdrant/ and mem0_history.db at runtime
+    #       in the main process (service user), so they must be writable
+    #       by the service user.
+    #   (b) Per-user-owned: memory/<chat_id>/ subdirectories whose chat_id
+    #       maps to a users.yaml entry with an explicit os_user. The
+    #       inner Claude subprocess for that user runs via sudo -H -u
+    #       <os_user>, so MEMORY.md ownership must match or writes fail
+    #       with the #347 regression.
+    # Subdirectories whose chat_id does not appear in users.yaml (or whose
+    # user has no os_user - i.e., runs as the service user) fall through
+    # to the service-owned tier. Same for any stray file at the top level.
     memory_tree = data_path / "memory"
     if memory_tree.is_dir():
+        # Build a chat_id -> (uid, gid) map for users with an explicit
+        # os_user. pwd.getpwnam failures (username in users.yaml that
+        # does not exist on this host) are hard-failed: silently falling
+        # back to service ownership would recreate the #347 bug. Better
+        # to surface the misconfiguration now.
+        per_user_ids: dict[str, tuple[int, int]] = {}
+        for chat_id, os_user in memory_owners:
+            if os_user is None:
+                continue
+            pwd_entry = pwd.getpwnam(os_user)
+            per_user_ids[str(chat_id)] = (pwd_entry.pw_uid, pwd_entry.pw_gid)
+
         if dry_run:
-            print(f"[DRY RUN] Would set ownership on {memory_tree} ({svc_uid}:{svc_gid})")
+            print(f"[DRY RUN] Would set ownership on {memory_tree} (service + per-user)")
+            for name, (uid, gid) in per_user_ids.items():
+                print(f"[DRY RUN]   {memory_tree / name} -> ({uid}:{gid})")
         else:
-            _set_ownership(memory_tree, svc_uid, svc_gid, recursive=True)
+            # Top-level directory: service-owned so the service user
+            # can create new per-user subdirs on add-user flows.
+            _set_ownership(memory_tree, svc_uid, svc_gid, recursive=False)
+            for entry in memory_tree.iterdir():
+                if entry.is_dir() and entry.name in per_user_ids:
+                    uid, gid = per_user_ids[entry.name]
+                    _set_ownership(entry, uid, gid, recursive=True)
+                else:
+                    # qdrant/, mem0_history.db, extractor_cwd/, and any
+                    # memory/<chat_id>/ whose user has no os_user set.
+                    _set_ownership(entry, svc_uid, svc_gid, recursive=True)
 
 
 def _cmd_apply() -> None:

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1752,6 +1752,30 @@ def _apply_migrate(
     legacy_src_tree = PROJECT_ROOT / "home" / ".claude" / "MEMORY.md"
     example_template = PROJECT_ROOT / "home" / ".claude" / "MEMORY.md.example"
 
+    # Resolve every os_user against the host's passwd database BEFORE
+    # touching disk. If users.yaml names an OS user that does not exist
+    # on this host (typo, new user listed before useradd, copy/paste
+    # from another machine), pwd.getpwnam raises bare KeyError(name)
+    # with no chat_id, no path, no hint. Hoist validation here so the
+    # install hard-fails with a clear message before the migration
+    # block creates, copies, or moves any MEMORY.md files. Surfacing
+    # the misconfiguration after disk mutation would leave operators
+    # diagnosing a half-applied state.
+    per_user_ids: dict[str, tuple[int, int]] = {}
+    for chat_id, os_user in memory_owners:
+        if os_user is None:
+            continue
+        try:
+            pwd_entry = pwd.getpwnam(os_user)
+        except KeyError as exc:
+            raise ValueError(
+                f"users.yaml entry chat_id={chat_id} names os_user "
+                f"{os_user!r}, which does not exist on this host. Source: "
+                f"{users_yaml_path}. Create the OS account or correct the "
+                f"users.yaml entry, then re-run sudo make install."
+            ) from exc
+        per_user_ids[str(chat_id)] = (pwd_entry.pw_uid, pwd_entry.pw_gid)
+
     # Resolve the primary operator's chat_id (first yaml entry). When
     # users.yaml is absent or empty (first-ever install, single-user
     # dev), leave memory/MEMORY.md alone - runtime code falls back to
@@ -1799,7 +1823,15 @@ def _apply_migrate(
             if user_dst.exists():
                 continue
             if dry_run:
-                print(f"[DRY RUN] Would seed {user_dst} from example template")
+                # Match the real branch below: the template may not ship
+                # with the install tree, in which case the real path
+                # writes a placeholder. Printing "from example template"
+                # unconditionally misleads operators on hosts where the
+                # template is missing.
+                if example_template.is_file():
+                    print(f"[DRY RUN] Would seed {user_dst} from example template")
+                else:
+                    print(f"[DRY RUN] Would create empty {user_dst} (no example template)")
                 continue
             user_dir.mkdir(parents=True, exist_ok=True)
             if example_template.is_file():
@@ -1866,17 +1898,10 @@ def _apply_migrate(
     # to the service-owned tier. Same for any stray file at the top level.
     memory_tree = data_path / "memory"
     if memory_tree.is_dir():
-        # Build a chat_id -> (uid, gid) map for users with an explicit
-        # os_user. pwd.getpwnam failures (username in users.yaml that
-        # does not exist on this host) are hard-failed: silently falling
-        # back to service ownership would recreate the #347 bug. Better
-        # to surface the misconfiguration now.
-        per_user_ids: dict[str, tuple[int, int]] = {}
-        for chat_id, os_user in memory_owners:
-            if os_user is None:
-                continue
-            pwd_entry = pwd.getpwnam(os_user)
-            per_user_ids[str(chat_id)] = (pwd_entry.pw_uid, pwd_entry.pw_gid)
+        # per_user_ids was built and validated at the top of this
+        # function, before any disk mutation. Reusing it here means a
+        # bad os_user has already aborted the install with a clear
+        # ValueError; we cannot reach this block in that state.
 
         if dry_run:
             print(f"[DRY RUN] Would set ownership on {memory_tree} (service + per-user)")

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1735,10 +1735,13 @@ def _apply_migrate(
     #      common case on existing installs.
     #   2) PROJECT_ROOT/home/.claude/MEMORY.md - pre-DATA_DIR location
     #      from before the DATA_DIR migration shipped.
-    # Both are moved (not copied) so the global path cannot later read
-    # as stale state. If neither source exists, a per-user MEMORY.md
-    # is seeded from the home/.claude/MEMORY.md.example template so
-    # the inner Claude has a writable starting point on first message.
+    # legacy_global is moved (not copied) so the DATA_DIR global path
+    # cannot later read as stale state. legacy_src_tree is copied: it
+    # lives in a git-tracked directory and moving it would dirty the
+    # working tree on every install. If neither source exists, a
+    # per-user MEMORY.md is seeded from the home/.claude/MEMORY.md.example
+    # template so the inner Claude has a writable starting point on
+    # first message.
     # Subsequent users in users.yaml get the template, not the legacy
     # content, because one user's memory never belongs to another.
     #

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1795,6 +1795,14 @@ def _apply_migrate(
                     print(f"[DRY RUN] Would copy {legacy_src_tree} -> {primary_dst}")
                 elif example_template.is_file():
                     print(f"[DRY RUN] Would seed {primary_dst} from {example_template}")
+                else:
+                    # Mirror the real branch's last-resort placeholder
+                    # below: when none of the source files exist (minimal
+                    # host, broken install tree), the real path writes
+                    # `# Memory\n` and prints "Created empty ...". Without
+                    # this `else` the dry-run prints nothing and the
+                    # operator sees a silent gap they cannot diagnose.
+                    print(f"[DRY RUN] Would create empty {primary_dst} (no template found)")
             else:
                 primary_dir.mkdir(parents=True, exist_ok=True)
                 if legacy_global.is_file():

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -35,7 +35,6 @@ The shutdown sequence (in the finally block) reverses this order:
 import asyncio
 import logging
 import re
-import shutil
 from datetime import UTC, datetime, timedelta
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
@@ -88,30 +87,6 @@ def setup_logging() -> None:
     # Silence noisy per-request HTTP logs and APScheduler tick logs
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("apscheduler.executors.default").setLevel(logging.WARNING)
-
-
-def _bootstrap_memory() -> None:
-    """
-    Create MEMORY.md from the example template if it doesn't exist yet.
-
-    Called once at startup. Creates the DATA_DIR/memory/ directory and
-    copies MEMORY.md.example from the home workspace as a starting point.
-    After this one-time setup, the inner Claude maintains the file.
-    """
-    memory_dir = DATA_DIR / "memory"
-    memory_file = memory_dir / "MEMORY.md"
-    if memory_file.exists():
-        return
-
-    memory_dir.mkdir(parents=True, exist_ok=True)
-    example = PROJECT_ROOT / "home" / ".claude" / "MEMORY.md.example"
-    if example.exists():
-        shutil.copy2(example, memory_file)
-        logging.info("Bootstrapped MEMORY.md from example template")
-    else:
-        # Create a minimal file so the inner Claude has something to write to
-        memory_file.write_text("# Memory\n")
-        logging.info("Created empty MEMORY.md (no example template found)")
 
 
 # ── File cleanup ─────────────────────────────────────────────────────
@@ -277,13 +252,10 @@ def main() -> None:
         # SubprocessPool. Each user's workspace is restored lazily on
         # their first message (in pool.send()). No startup restore needed.
 
-        # Bootstrap personal memory if it doesn't exist yet.
-        # Non-fatal: a permission or disk error here should not prevent
-        # the bot from starting. The memory layer is a nice-to-have.
-        try:
-            _bootstrap_memory()
-        except OSError:
-            logging.warning("Could not bootstrap MEMORY.md", exc_info=True)
+        # Personal MEMORY.md is now per-user under memory/<chat_id>/
+        # and is bootstrapped lazily by the backend on first session
+        # (backend.ensure_user_memory). No startup bootstrap is needed;
+        # that call is intentionally gone. See issue #347.
 
         # Semantic memory (Mem0 + Qdrant). init_memory() is the single
         # entry point; it no-ops when MEMORY_ENABLED is False, so this

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -16,6 +16,7 @@ from kai.backend import (
     StreamEvent,
     build_foreign_workspace_reminder,
     build_session_context,
+    ensure_user_memory,
     get_workspace_system_prompt,
     prepend_to_prompt,
 )
@@ -423,3 +424,214 @@ class TestDataTypes:
         """ApiContext services_info defaults to empty list."""
         ctx = ApiContext(webhook_port=8080, webhook_secret="s")
         assert ctx.services_info == []
+
+
+# ── Per-user MEMORY.md (#347) ───────────────────────────────────────
+#
+# #347: MEMORY.md moved from a single global file at
+# DATA_DIR/memory/MEMORY.md to a per-user path at
+# DATA_DIR/memory/<chat_id>/MEMORY.md. The tests below cover the four
+# scoped behaviors called out in the issue's acceptance criteria:
+#
+#   (a) build_session_context reads the chat_id-scoped path when
+#       chat_id is set;
+#   (b) build_session_context falls back to the legacy global path
+#       when chat_id is None (dev / single-user harnesses);
+#   (c) ensure_user_memory seeds the per-user directory + file so a
+#       user added post-install has a writable starting point;
+#   (d) two chat_ids end up with independent files, so writes to one
+#       user's memory never surface in another user's context.
+
+
+class TestPerUserMemoryRead:
+    """build_session_context reads the chat_id-scoped MEMORY.md."""
+
+    def _api(self) -> ApiContext:
+        return ApiContext(webhook_port=8080, webhook_secret="s")
+
+    def test_reads_chat_scoped_path(self, tmp_path):
+        """Memory at memory/<chat_id>/MEMORY.md is read when chat_id is set."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        user_memory_dir = data_dir / "memory" / "12345"
+        user_memory_dir.mkdir(parents=True)
+        (user_memory_dir / "MEMORY.md").write_text("Fact for user 12345.")
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=12345,
+                data_dir=data_dir,
+            )
+
+        assert "Fact for user 12345." in result
+        assert "persistent memory" in result
+
+    def test_ignores_legacy_global_when_chat_id_set(self, tmp_path):
+        """With chat_id set, the legacy global MEMORY.md is not read.
+
+        Prevents a half-migrated install (legacy file still present,
+        per-user dir empty) from silently leaking another user's notes.
+        """
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        memory_root = data_dir / "memory"
+        memory_root.mkdir(parents=True)
+        # Legacy global content that must NOT leak:
+        (memory_root / "MEMORY.md").write_text("STALE GLOBAL DO NOT LEAK")
+        # Per-user dir exists but is empty (no MEMORY.md yet):
+        (memory_root / "99").mkdir()
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=99,
+                data_dir=data_dir,
+            )
+
+        assert "STALE GLOBAL DO NOT LEAK" not in result
+        # And the per-user read path reports "not yet created", matching
+        # the OSError branch in build_session_context.
+        assert "(not yet created)" in result
+
+    def test_none_chat_id_uses_legacy_path(self, tmp_path):
+        """chat_id=None falls back to the legacy global path (dev case)."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        memory_root = data_dir / "memory"
+        memory_root.mkdir(parents=True)
+        (memory_root / "MEMORY.md").write_text("Dev-mode single-user content.")
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=None,
+                data_dir=data_dir,
+            )
+
+        assert "Dev-mode single-user content." in result
+
+
+class TestEnsureUserMemory:
+    """ensure_user_memory bootstraps the per-user directory + file."""
+
+    def test_seeds_from_example_template(self, tmp_path, monkeypatch):
+        """Creates memory/<chat_id>/MEMORY.md from the example template."""
+        data_dir = tmp_path / "data"
+        project_root = tmp_path / "project"
+        example_dir = project_root / "home" / ".claude"
+        example_dir.mkdir(parents=True)
+        (example_dir / "MEMORY.md.example").write_text("# Memory\n\n## About the User\n")
+
+        # ensure_user_memory reads PROJECT_ROOT module-level at call
+        # time, so patching backend.PROJECT_ROOT is sufficient.
+        monkeypatch.setattr("kai.backend.PROJECT_ROOT", project_root)
+
+        ensure_user_memory(42, data_dir)
+
+        target = data_dir / "memory" / "42" / "MEMORY.md"
+        assert target.is_file()
+        assert "About the User" in target.read_text()
+
+    def test_no_template_creates_placeholder(self, tmp_path, monkeypatch):
+        """Falls back to minimal '# Memory\\n' when no example template exists."""
+        data_dir = tmp_path / "data"
+        project_root = tmp_path / "project"
+        # No example file under home/.claude/.
+        (project_root / "home" / ".claude").mkdir(parents=True)
+
+        monkeypatch.setattr("kai.backend.PROJECT_ROOT", project_root)
+
+        ensure_user_memory(7, data_dir)
+
+        target = data_dir / "memory" / "7" / "MEMORY.md"
+        assert target.is_file()
+        assert target.read_text() == "# Memory\n"
+
+    def test_idempotent_does_not_overwrite(self, tmp_path, monkeypatch):
+        """Existing per-user MEMORY.md is preserved across repeated calls."""
+        data_dir = tmp_path / "data"
+        project_root = tmp_path / "project"
+        example_dir = project_root / "home" / ".claude"
+        example_dir.mkdir(parents=True)
+        (example_dir / "MEMORY.md.example").write_text("TEMPLATE")
+
+        monkeypatch.setattr("kai.backend.PROJECT_ROOT", project_root)
+
+        user_dir = data_dir / "memory" / "100"
+        user_dir.mkdir(parents=True)
+        existing = user_dir / "MEMORY.md"
+        existing.write_text("already-captured user content")
+
+        ensure_user_memory(100, data_dir)
+
+        # Same content, not the template.
+        assert existing.read_text() == "already-captured user content"
+
+    def test_chat_id_none_is_noop(self, tmp_path, monkeypatch):
+        """chat_id=None does nothing - the dev/legacy path handles that case."""
+        data_dir = tmp_path / "data"
+        project_root = tmp_path / "project"
+        (project_root / "home" / ".claude").mkdir(parents=True)
+        monkeypatch.setattr("kai.backend.PROJECT_ROOT", project_root)
+
+        ensure_user_memory(None, data_dir)
+
+        # No memory/ directory was created.
+        assert not (data_dir / "memory").exists()
+
+
+class TestPerUserMemoryIsolation:
+    """Writes to one user's MEMORY.md never appear in another user's context."""
+
+    def _api(self) -> ApiContext:
+        return ApiContext(webhook_port=8080, webhook_secret="s")
+
+    def test_two_users_independent_files(self, tmp_path):
+        """Two chat_ids get two distinct MEMORY.md files on disk, and
+        build_session_context routes each request to the correct file."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+
+        user_a = data_dir / "memory" / "1001"
+        user_b = data_dir / "memory" / "1002"
+        user_a.mkdir(parents=True)
+        user_b.mkdir(parents=True)
+        (user_a / "MEMORY.md").write_text("USER_A_SECRET")
+        (user_b / "MEMORY.md").write_text("USER_B_SECRET")
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result_a = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=1001,
+                data_dir=data_dir,
+            )
+            result_b = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=1002,
+                data_dir=data_dir,
+            )
+
+        assert "USER_A_SECRET" in result_a
+        assert "USER_B_SECRET" not in result_a
+        assert "USER_B_SECRET" in result_b
+        assert "USER_A_SECRET" not in result_b

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -580,17 +580,69 @@ class TestEnsureUserMemory:
         # Same content, not the template.
         assert existing.read_text() == "already-captured user content"
 
-    def test_chat_id_none_is_noop(self, tmp_path, monkeypatch):
-        """chat_id=None does nothing - the dev/legacy path handles that case."""
+    def test_chat_id_none_seeds_legacy_path(self, tmp_path, monkeypatch):
+        """
+        chat_id=None bootstraps the legacy data_dir/memory/MEMORY.md
+        (no per-user subdir). This is the dev / no-users.yaml / memory-
+        disabled path, where the previously removed _bootstrap_memory
+        function used to create the directory + seed file. Without
+        this, a fresh `python -m kai` would have no memory_root at
+        all, and any inner Claude write attempt would FileNotFoundError
+        on the missing parent.
+        """
         data_dir = tmp_path / "data"
         project_root = tmp_path / "project"
+        example_dir = project_root / "home" / ".claude"
+        example_dir.mkdir(parents=True)
+        (example_dir / "MEMORY.md.example").write_text("# Memory\n\n## Dev\n")
+        monkeypatch.setattr("kai.backend.PROJECT_ROOT", project_root)
+
+        ensure_user_memory(None, data_dir)
+
+        legacy = data_dir / "memory" / "MEMORY.md"
+        assert legacy.is_file()
+        assert "Dev" in legacy.read_text()
+        # No per-user subdir was created (chat_id=None must not
+        # leak into a numeric subdirectory name).
+        assert list((data_dir / "memory").iterdir()) == [legacy]
+
+    def test_chat_id_none_idempotent(self, tmp_path, monkeypatch):
+        """
+        Repeated chat_id=None calls do not overwrite an existing
+        legacy MEMORY.md. Same idempotence contract as the per-user
+        branch - operators may have edited it between runs.
+        """
+        data_dir = tmp_path / "data"
+        project_root = tmp_path / "project"
+        example_dir = project_root / "home" / ".claude"
+        example_dir.mkdir(parents=True)
+        (example_dir / "MEMORY.md.example").write_text("FRESH_TEMPLATE")
+        monkeypatch.setattr("kai.backend.PROJECT_ROOT", project_root)
+
+        memory_dir = data_dir / "memory"
+        memory_dir.mkdir(parents=True)
+        legacy = memory_dir / "MEMORY.md"
+        legacy.write_text("operator-edited content")
+
+        ensure_user_memory(None, data_dir)
+
+        assert legacy.read_text() == "operator-edited content"
+
+    def test_chat_id_none_no_template_creates_placeholder(self, tmp_path, monkeypatch):
+        """
+        chat_id=None with no example template falls back to '# Memory\\n',
+        matching the per-user branch and the old _bootstrap_memory.
+        """
+        data_dir = tmp_path / "data"
+        project_root = tmp_path / "project"
+        # No example template exists.
         (project_root / "home" / ".claude").mkdir(parents=True)
         monkeypatch.setattr("kai.backend.PROJECT_ROOT", project_root)
 
         ensure_user_memory(None, data_dir)
 
-        # No memory/ directory was created.
-        assert not (data_dir / "memory").exists()
+        legacy = data_dir / "memory" / "MEMORY.md"
+        assert legacy.read_text() == "# Memory\n"
 
 
 class TestPerUserMemoryIsolation:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2361,6 +2361,73 @@ class TestApplyMigratePerUserMemory:
         # No per-user dirs created, no global file written.
         assert list((data_path / "memory").iterdir()) == []
 
+    def test_unknown_os_user_aborts_before_disk_mutation(self, tmp_path, monkeypatch):
+        """
+        A users.yaml entry naming an os_user that does not exist on
+        the host must raise ValueError BEFORE the migration block
+        creates, copies, or moves any MEMORY.md file. The earlier
+        implementation let pwd.getpwnam raise a bare KeyError after
+        the migration had already touched disk, leaving operators to
+        diagnose a half-applied state with no chat_id or path in the
+        traceback. The validation block now hoisted to the top of
+        _apply_migrate is the fix; this test guards against
+        regressions where someone moves the validation back below
+        the migration.
+        """
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path / "src")
+        claude_dir = tmp_path / "src" / "home" / ".claude"
+        claude_dir.mkdir(parents=True)
+        # Source-tree MEMORY.md is what the legacy-copy branch would
+        # try to land at the primary user's destination if validation
+        # did not abort first.
+        (claude_dir / "MEMORY.md").write_text("would-be-leaked content")
+
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        (data_path / "logs").mkdir()
+        (data_path / "memory").mkdir()
+
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            "users:\n  - telegram_id: 4242\n    name: ghost\n    role: admin\n    os_user: nobody-by-this-name-12345\n"
+        )
+
+        # Force getpwnam to behave as it would for a missing user on
+        # any host: raise KeyError(name). pwd.getpwnam itself raises
+        # bare KeyError, no PermissionError, no ValueError.
+        monkeypatch.setattr(
+            "kai.install.pwd.getpwnam",
+            lambda name: (_ for _ in ()).throw(KeyError(name)),
+        )
+        # No-op chown: if validation did not abort and the test got
+        # this far, the ownership block would otherwise try to chown
+        # outside tmp_path on a CI box.
+        monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
+
+        with pytest.raises(ValueError) as exc_info:
+            _apply_migrate(
+                data_path,
+                tmp_path / "install",
+                svc_uid=501,
+                svc_gid=20,
+                dry_run=False,
+                users_yaml_path=users_yaml,
+            )
+
+        # Error message must include the chat_id, the bad username,
+        # and the source path so the operator knows where to fix it.
+        msg = str(exc_info.value)
+        assert "4242" in msg
+        assert "nobody-by-this-name-12345" in msg
+        assert str(users_yaml) in msg
+
+        # Critical: no MEMORY.md was written under the primary's dir,
+        # because validation aborted before the migration block ran.
+        # Half-applied state (some files moved, some not, ownership
+        # still pending) is exactly the scenario this test guards.
+        assert not (data_path / "memory" / "4242").exists()
+        assert not (data_path / "memory" / "MEMORY.md").exists()
+
 
 # ── Service lifecycle ────────────────────────────────────────────────
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -28,6 +28,7 @@ from kai.install import (
     _cmd_config,
     _cmd_status,
     _collect_os_users_from_yaml,
+    _collect_user_memory_owners,
     _copy_tree,
     _file_checksum,
     _generate_env_file,
@@ -576,6 +577,85 @@ class TestCollectOsUsersFromYaml:
         )
         with pytest.raises(ValueError, match=str(path)):
             _collect_os_users_from_yaml(path)
+
+
+class TestCollectUserMemoryOwners:
+    """
+    Tests for the (telegram_id, os_user) loader used by the per-user
+    MEMORY.md migration in #347. Mirrors the structure of
+    TestCollectOsUsersFromYaml: same trust boundary, same validation
+    semantics, but returns tuples instead of just usernames.
+    """
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert _collect_user_memory_owners(tmp_path / "nope.yaml") == []
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        path = tmp_path / "users.yaml"
+        path.write_text("", encoding="utf-8")
+        assert _collect_user_memory_owners(path) == []
+
+    def test_no_users_key_returns_empty(self, tmp_path):
+        path = tmp_path / "users.yaml"
+        path.write_text("other_key: 1\n", encoding="utf-8")
+        assert _collect_user_memory_owners(path) == []
+
+    def test_user_without_telegram_id_skipped(self, tmp_path):
+        """A user entry without an int telegram_id cannot map to a chat dir."""
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            yaml.safe_dump({"users": [{"name": "anon"}, {"telegram_id": 42}]}),
+            encoding="utf-8",
+        )
+        assert _collect_user_memory_owners(path) == [(42, None)]
+
+    def test_user_without_os_user_returns_none(self, tmp_path):
+        """No os_user means the inner Claude runs as the service user."""
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            yaml.safe_dump({"users": [{"telegram_id": 11, "name": "primary"}]}),
+            encoding="utf-8",
+        )
+        assert _collect_user_memory_owners(path) == [(11, None)]
+
+    def test_user_with_os_user_returns_tuple(self, tmp_path):
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            yaml.safe_dump({"users": [{"telegram_id": 11, "os_user": "alpha"}]}),
+            encoding="utf-8",
+        )
+        assert _collect_user_memory_owners(path) == [(11, "alpha")]
+
+    def test_first_seen_order_preserved(self, tmp_path):
+        """The migration depends on tuples[0] being the primary operator."""
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "users": [
+                        {"telegram_id": 100, "os_user": "alpha"},
+                        {"telegram_id": 200, "os_user": "beta"},
+                        {"telegram_id": 300},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert _collect_user_memory_owners(path) == [
+            (100, "alpha"),
+            (200, "beta"),
+            (300, None),
+        ]
+
+    def test_invalid_os_user_raises(self, tmp_path):
+        """Same hard-fail as _collect_os_users_from_yaml: never silently skip."""
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            yaml.safe_dump({"users": [{"telegram_id": 1, "os_user": "bad)user"}]}),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match=str(path)):
+            _collect_user_memory_owners(path)
 
 
 class TestGenerateSudoersValidation:
@@ -1773,6 +1853,19 @@ class TestSrcChecksum:
 
 
 class TestApplyMigrate:
+    @pytest.fixture(autouse=True)
+    def _isolate_users_yaml(self, monkeypatch):
+        """
+        Default the per-user MEMORY.md migration to a no-op for tests
+        that do not care about it. Without this fixture, _apply_migrate
+        falls through to its real default of /etc/kai/users.yaml, which
+        on a developer machine is a populated file that triggers
+        chown calls outside the tmp_path sandbox. Tests that DO care
+        about memory migration pass `users_yaml_path=` explicitly and
+        are unaffected by this stub.
+        """
+        monkeypatch.setattr("kai.install._collect_user_memory_owners", lambda _path: [])
+
     def test_copies_database(self, tmp_path, monkeypatch):
         """Copies kai.db from PROJECT_ROOT to data_path when destination doesn't exist."""
         # Set up source database
@@ -1953,50 +2046,6 @@ class TestApplyMigrate:
         output = capsys.readouterr().out
         assert "already migrated" in output
 
-    def test_copies_memory(self, tmp_path, monkeypatch, capsys):
-        """Copies MEMORY.md from home/.claude/ to data_path/memory/."""
-        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path / "src")
-        claude_dir = tmp_path / "src" / "home" / ".claude"
-        claude_dir.mkdir(parents=True)
-        (claude_dir / "MEMORY.md").write_text("User prefers dry humor.")
-
-        data_path = tmp_path / "data"
-        data_path.mkdir()
-        (data_path / "logs").mkdir()
-        (data_path / "memory").mkdir()
-
-        monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
-
-        _apply_migrate(data_path, tmp_path / "install", svc_uid=501, svc_gid=20, dry_run=False)
-
-        memory_dst = data_path / "memory" / "MEMORY.md"
-        assert memory_dst.exists()
-        assert memory_dst.read_text() == "User prefers dry humor."
-        # Source preserved
-        assert (claude_dir / "MEMORY.md").exists()
-        assert "Migrated MEMORY.md" in capsys.readouterr().out
-
-    def test_memory_skips_existing(self, tmp_path, monkeypatch):
-        """Does not overwrite MEMORY.md that already exists at the destination."""
-        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path / "src")
-        claude_dir = tmp_path / "src" / "home" / ".claude"
-        claude_dir.mkdir(parents=True)
-        (claude_dir / "MEMORY.md").write_text("old content")
-
-        data_path = tmp_path / "data"
-        data_path.mkdir()
-        (data_path / "logs").mkdir()
-        memory_dir = data_path / "memory"
-        memory_dir.mkdir()
-        (memory_dir / "MEMORY.md").write_text("existing personalized content")
-
-        # Mock chown - the ownership fix walks the memory tree unconditionally
-        monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
-
-        _apply_migrate(data_path, tmp_path / "install", svc_uid=501, svc_gid=20, dry_run=False)
-
-        assert (memory_dir / "MEMORY.md").read_text() == "existing personalized content"
-
     def test_copies_uploaded_files(self, tmp_path, monkeypatch):
         """Copies uploaded files from home/files/ to data_path/files/."""
         install_path = tmp_path / "install"
@@ -2102,6 +2151,215 @@ class TestApplyMigrate:
         assert str(memory_dir / "MEMORY.md") in chowned_paths
         # All entries should use the service user's uid/gid.
         assert all(uid == 501 and gid == 20 for _, uid, gid in chowned)
+
+
+# ── Per-user MEMORY.md migration ─────────────────────────────────────
+#
+# These tests intentionally live OUTSIDE TestApplyMigrate so that the
+# autouse `_isolate_users_yaml` fixture (which stubs
+# _collect_user_memory_owners to return []) does not apply. The tests
+# below need the real function to exercise the per-user migration path
+# end-to-end. Each test passes `users_yaml_path=` explicitly, isolated
+# under tmp_path, so nothing escapes the sandbox.
+
+
+class TestApplyMigratePerUserMemory:
+    def test_copies_memory_to_primary_chat_dir(self, tmp_path, monkeypatch, capsys):
+        """
+        Migration copies MEMORY.md from the legacy source-tree location
+        to the per-user directory of the first user in users.yaml (the
+        primary operator). Pre-#347 the destination was a single global
+        memory/MEMORY.md; the per-user split made that path unreachable
+        for non-service-user subprocesses.
+        """
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path / "src")
+        claude_dir = tmp_path / "src" / "home" / ".claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "MEMORY.md").write_text("User prefers dry humor.")
+
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        (data_path / "logs").mkdir()
+        (data_path / "memory").mkdir()
+
+        # Minimal users.yaml: one user, no os_user (runs as service user).
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 7777\n    name: primary\n    role: admin\n")
+
+        monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        # The legacy source-tree file landed under memory/<chat_id>/.
+        memory_dst = data_path / "memory" / "7777" / "MEMORY.md"
+        assert memory_dst.exists()
+        assert memory_dst.read_text() == "User prefers dry humor."
+        # Source-tree backup preserved (move/copy semantics: source-tree
+        # legacy path is copied, not moved, so the backup survives).
+        assert (claude_dir / "MEMORY.md").exists()
+        # No stray file at the legacy global path.
+        assert not (data_path / "memory" / "MEMORY.md").exists()
+        assert "Migrated MEMORY.md" in capsys.readouterr().out
+
+    def test_moves_legacy_global_memory_to_primary(self, tmp_path, monkeypatch, capsys):
+        """
+        A pre-#347 install that already migrated to the global
+        memory/MEMORY.md gets that file MOVED into the primary user's
+        subdirectory. Move (not copy) is required: a stale global file
+        would shadow the per-user read once additional users join.
+        """
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path / "src")
+        (tmp_path / "src").mkdir()
+
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        (data_path / "logs").mkdir()
+        memory_dir = data_path / "memory"
+        memory_dir.mkdir()
+        legacy_global = memory_dir / "MEMORY.md"
+        legacy_global.write_text("operator notes from before #347")
+
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 8888\n    name: primary\n    role: admin\n")
+
+        monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        primary_dst = memory_dir / "8888" / "MEMORY.md"
+        assert primary_dst.exists()
+        assert primary_dst.read_text() == "operator notes from before #347"
+        # Critical: legacy global MUST be gone (move, not copy) so a
+        # later read at memory/MEMORY.md cannot leak this content.
+        assert not legacy_global.exists()
+        assert "Migrated MEMORY.md" in capsys.readouterr().out
+
+    def test_memory_skips_existing_per_user(self, tmp_path, monkeypatch):
+        """
+        Does not overwrite a per-user MEMORY.md that already exists at
+        the destination. Idempotent across reinstalls.
+        """
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path / "src")
+        claude_dir = tmp_path / "src" / "home" / ".claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "MEMORY.md").write_text("legacy content from source tree")
+
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        (data_path / "logs").mkdir()
+        primary_dir = data_path / "memory" / "9999"
+        primary_dir.mkdir(parents=True)
+        existing = primary_dir / "MEMORY.md"
+        existing.write_text("existing personalized content")
+
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 9999\n    name: primary\n    role: admin\n")
+
+        monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        assert existing.read_text() == "existing personalized content"
+
+    def test_seeds_additional_users_from_template(self, tmp_path, monkeypatch):
+        """
+        Users beyond the primary get a fresh MEMORY.md seeded from the
+        example template, never the legacy content. One operator's notes
+        must not become another's starting state.
+        """
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path / "src")
+        claude_dir = tmp_path / "src" / "home" / ".claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "MEMORY.md").write_text("PRIMARY_PRIVATE_NOTES")
+        (claude_dir / "MEMORY.md.example").write_text("# Memory\n\n## About the User\n")
+
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        (data_path / "logs").mkdir()
+        (data_path / "memory").mkdir()
+
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            "users:\n"
+            "  - telegram_id: 100\n"
+            "    name: primary\n"
+            "    role: admin\n"
+            "  - telegram_id: 200\n"
+            "    name: secondary\n"
+            "    role: user\n"
+        )
+
+        monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        primary = (data_path / "memory" / "100" / "MEMORY.md").read_text()
+        secondary = (data_path / "memory" / "200" / "MEMORY.md").read_text()
+
+        # Primary inherits legacy content.
+        assert "PRIMARY_PRIVATE_NOTES" in primary
+        # Secondary gets template only - never the primary's content.
+        assert "PRIMARY_PRIVATE_NOTES" not in secondary
+        assert "About the User" in secondary
+
+    def test_memory_no_users_yaml_is_noop(self, tmp_path, monkeypatch):
+        """
+        With no users.yaml (first-ever install / single-user dev), the
+        memory migration is a no-op. Runtime falls back to the legacy
+        global path when chat_id is None, so leaving the legacy file
+        in place keeps `python -m kai` working unchanged.
+        """
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path / "src")
+        claude_dir = tmp_path / "src" / "home" / ".claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "MEMORY.md").write_text("dev content")
+
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        (data_path / "logs").mkdir()
+        (data_path / "memory").mkdir()
+
+        monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=tmp_path / "does-not-exist.yaml",
+        )
+
+        # No per-user dirs created, no global file written.
+        assert list((data_path / "memory").iterdir()) == []
 
 
 # ── Service lifecycle ────────────────────────────────────────────────

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,12 @@
 """
-Tests for main.py - setup_logging(), _bootstrap_memory(), _file_age/_file_cleanup_loop.
+Tests for main.py - setup_logging() and _file_age / _file_cleanup_loop.
 
 The main() and _init_and_run() functions orchestrate the full application
 lifecycle and are impractical to unit test. The helper functions are
 testable in isolation.
+
+MEMORY.md bootstrapping moved to the backend (per-user, lazy) in #347;
+coverage for that path now lives in tests/test_backend.py.
 """
 
 import asyncio
@@ -15,7 +18,7 @@ from unittest.mock import patch
 
 import pytest
 
-from kai.main import _bootstrap_memory, _file_age, _file_cleanup_loop, setup_logging
+from kai.main import _file_age, _file_cleanup_loop, setup_logging
 
 # ── setup_logging() ──────────────────────────────────────────────────
 
@@ -84,58 +87,6 @@ class TestSetupLogging:
         with patch("kai.main.DATA_DIR", tmp_path):
             setup_logging()
         assert logging.getLogger("apscheduler.executors.default").level == logging.WARNING
-
-
-# ── _bootstrap_memory() ──────────────────────────────────────────────
-
-
-class TestBootstrapMemory:
-    def test_from_example_template(self, tmp_path, monkeypatch):
-        """Creates MEMORY.md from example template when missing."""
-        data_dir = tmp_path / "data"
-        project_root = tmp_path / "project"
-        example_dir = project_root / "home" / ".claude"
-        example_dir.mkdir(parents=True)
-        (example_dir / "MEMORY.md.example").write_text("# Memory\n\n## About the User\n")
-
-        monkeypatch.setattr("kai.main.DATA_DIR", data_dir)
-        monkeypatch.setattr("kai.main.PROJECT_ROOT", project_root)
-
-        _bootstrap_memory()
-
-        memory_file = data_dir / "memory" / "MEMORY.md"
-        assert memory_file.exists()
-        assert "About the User" in memory_file.read_text()
-
-    def test_no_example_creates_minimal(self, tmp_path, monkeypatch):
-        """Creates a minimal MEMORY.md when no example template exists."""
-        data_dir = tmp_path / "data"
-        project_root = tmp_path / "project"
-        (project_root / "home" / ".claude").mkdir(parents=True)
-
-        monkeypatch.setattr("kai.main.DATA_DIR", data_dir)
-        monkeypatch.setattr("kai.main.PROJECT_ROOT", project_root)
-
-        _bootstrap_memory()
-
-        memory_file = data_dir / "memory" / "MEMORY.md"
-        assert memory_file.exists()
-        assert memory_file.read_text() == "# Memory\n"
-
-    def test_skips_existing(self, tmp_path, monkeypatch):
-        """Does not overwrite an existing MEMORY.md."""
-        data_dir = tmp_path / "data"
-        memory_dir = data_dir / "memory"
-        memory_dir.mkdir(parents=True)
-        memory_file = memory_dir / "MEMORY.md"
-        memory_file.write_text("User prefers dry humor.")
-
-        monkeypatch.setattr("kai.main.DATA_DIR", data_dir)
-        monkeypatch.setattr("kai.main.PROJECT_ROOT", tmp_path / "project")
-
-        _bootstrap_memory()
-
-        assert memory_file.read_text() == "User prefers dry humor."
 
 
 # ── _file_age() ──────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #347.

## Summary
- MEMORY.md was the only memory surface still single-global. The path `/var/lib/kai/memory/MEMORY.md` is owned by the service user mode 644, so an inner Claude subprocess spawned via `sudo -H -u <os_user>` could read but not write it. The subprocess surfaced this in-session as "I can't write to the memory file."
- This PR scopes MEMORY.md per chat_id under `DATA_DIR/memory/<chat_id>/MEMORY.md`, mirroring the existing `history/<chat_id>/` layout. Each per-user subdirectory is chowned to the matching `os_user` from `users.yaml` at install time. The `qdrant/` tree and `mem0_history.db` stay service-owned because the service writes them, not the subprocess.
- Mem0 facts and chat history were already per-user (code-layer `user_id=chat_id` filters at `memory.py:380/949/1038`, history at `history/<chat_id>/`). MEMORY.md is now consistent with both.

## Changes
- `src/kai/backend.py` - `_build_context` derives `memory_path` from `chat_id`. Falls back to legacy `memory/MEMORY.md` when `chat_id is None` so `python -m kai` single-user dev continues to work unchanged.
- `src/kai/backend.py` - new `ensure_user_memory(chat_id, data_dir)` lazy bootstrap. Startup cannot know the full chat_id set in advance, so per-user MEMORY.md is created on first message instead.
- `src/kai/claude.py`, `src/kai/goose.py` - call `ensure_user_memory` before `build_session_context` in the per-message path.
- `src/kai/main.py` - removed `_bootstrap_memory()`. Startup no longer pre-creates any MEMORY.md.
- `src/kai/install.py` - new `_collect_user_memory_owners(users_yaml_path)` reads `users.yaml` and returns `[(chat_id, os_user)]`. `_apply_migrate` now: (1) copies source-tree `home/.claude/MEMORY.md` into the primary user's dir, (2) MOVES any legacy global `memory/MEMORY.md` into the primary's dir (move, not copy, so a stale global cannot shadow per-user reads), (3) seeds additional users from `MEMORY.md.example`, (4) chowns each `memory/<chat_id>/` subdir to the resolved `os_user`.

## Migration semantics
- First-ever install (no `users.yaml`): no-op. Runtime falls back to legacy global path.
- Existing single-global install: legacy `memory/MEMORY.md` is MOVED to the primary user's subdirectory. Move (not copy) is required; a stale global file would shadow per-user reads once additional users join.
- Reinstall: idempotent. Existing per-user MEMORY.md files are not overwritten.
- Multi-user: additional users beyond primary get a fresh `MEMORY.md.example`-seeded file. The primary's notes never become another user's starting state.

## Tests
- `tests/test_backend.py` - three new classes covering per-user read scoping, lazy bootstrap (creation, idempotence, OSError tolerance, fallback when chat_id is None), and cross-user isolation (writes to one chat_id never appear in another).
- `tests/test_install.py` - `TestCollectUserMemoryOwners` (8 tests for users.yaml parsing edge cases) and `TestApplyMigratePerUserMemory` (5 tests for the migration paths above). The new migration class deliberately lives outside `TestApplyMigrate` so its `_isolate_users_yaml` autouse fixture (which stubs `_collect_user_memory_owners` to `[]`) does not neuter them.
- `tests/test_main.py` - removed `TestBootstrapMemory` since `_bootstrap_memory()` no longer exists.
- Local: 2060 pytest pass; ruff check + format clean. The 2 failures + 5 errors in `test_memory.py` are a pre-existing environmental flake (the running Kai service holds an exclusive flock on the global `~/.mem0/migrations_qdrant/.lock`); none of those tests reference symbols this PR touches and they fail in isolation against `main`.

## Test plan
- [ ] CI green
- [ ] `sudo make install` on a host with multi-user `users.yaml`: confirm `memory/<chat_id>/MEMORY.md` exists per user and is owned by the correct `os_user`
- [ ] Inner Claude as a non-service `os_user` can write its own chat's MEMORY.md
- [ ] A user's notes do not appear in another user's session context
