### PR TITLE
docs: register /memory in Telegram popup; correct memory path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Run `make config` to generate `users.yaml`, or create one manually from `users.e
 Three layers of persistent context give the agent continuity across sessions:
 
 1. **Identity** (`home/.claude/CLAUDE.md`) - voice, rules, and operational guidelines. Lives in the home workspace. When the agent switches to a foreign workspace, Kai injects it so behavior stays consistent. In the home workspace, the agent reads it natively.
-2. **Home memory** (`DATA_DIR/memory/MEMORY.md`) - personal memory, always injected regardless of current workspace. Proactively updated by Kai.
+2. **Home memory** (`DATA_DIR/memory/<chat_id>/MEMORY.md`) - per-user personal memory, always injected regardless of current workspace. Proactively updated by Kai. Each user has their own file under `memory/<chat_id>/`, scoped by Telegram chat_id so memories stay private.
 3. **Conversation history** (`DATA_DIR/history/<chat_id>/`) - JSONL logs, one file per day per user. Searchable for past conversations.
 
 Workspaces can also define a system prompt via `workspaces.yaml` for workspace-specific instructions. See [System Architecture](https://github.com/dcellison/kai/wiki/System-Architecture).
@@ -149,6 +149,11 @@ If interrupted mid-response, Kai notifies you on restart and asks you to resend 
 | `/workspace deny <path>` | Remove an allowed workspace for your user |
 | `/workspace allowed` | List your allowed workspaces |
 | `/workspaces` | Interactive workspace picker |
+| `/memory` | Browse remembered facts grouped by tag (inline buttons) |
+| `/memory search <query>` | Semantic search over remembered facts |
+| `/memory stats` | Count of facts and confidence distribution |
+| `/memory forget <tag>` | Delete every fact with the given tag |
+| `/memory help` | `/memory` subcommand reference |
 | `/github` | Show GitHub notification settings |
 | `/github notify <chat_id>` | Route your GitHub notifications to a specific chat |
 | `/github reviews on\|off` | Enable or disable the PR review agent for you |

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -302,6 +302,8 @@ def main() -> None:
                     BotCommand("model", "Switch model directly"),
                     # Settings
                     BotCommand("settings", "Show or change your settings"),
+                    # Memory
+                    BotCommand("memory", "Browse and manage remembered facts"),
                     # Workspace
                     BotCommand("workspace", "Switch working directory"),
                     BotCommand("workspaces", "List recent workspaces"),

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -303,7 +303,7 @@ def main() -> None:
                     # Settings
                     BotCommand("settings", "Show or change your settings"),
                     # Memory
-                    BotCommand("memory", "Browse and manage remembered facts"),
+                    BotCommand("memory", "Browse, search, and manage remembered facts"),
                     # Workspace
                     BotCommand("workspace", "Switch working directory"),
                     BotCommand("workspaces", "List recent workspaces"),

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -4426,6 +4426,7 @@ EXPECTED_MENU_COMMANDS = {
     "github",
     "help",
     "job",
+    "memory",
     "model",
     "models",
     "new",


### PR DESCRIPTION
## Summary

Three doc fixes around the `/memory` command (introduced in #337) and the per-user MEMORY.md path (introduced in #347):

- `src/kai/main.py` - register `/memory` in the Telegram slash-command popup. The handler has been wired since #337 but the popup entry was never added, so `/memory` worked when typed but was invisible to users browsing the popup. Reported by the operator: "Commands like `/memory` can be typed but they aren't in the list of available commands in the pop-up in Telegram."
- `README.md` commands table - add five `/memory` rows mirroring the help text in `bot.py:2848-2852`.
- `README.md` memory section - update Layer 2 path from `DATA_DIR/memory/MEMORY.md` to `DATA_DIR/memory/<chat_id>/MEMORY.md` to reflect the per-user scoping shipped in PR #348.

## Wiki updates (separate)

The wiki's `Slash-Commands.md` is also missing `/memory` entirely (no section, no entry in the Quick reference table), and `System-Architecture.md` plus `Workspaces.md` describe the pre-#347 single-MEMORY.md model. Wiki commits will follow this PR directly to the wiki repo (no PR workflow on wikis).

## Operator note

Telegram clients cache the slash-command popup locally. After the service restarts and re-registers commands, users may need to leave and rejoin the chat (or restart the Telegram app) to see `/memory` in the popup.

## Test plan

- [x] `make check` passes (ruff check + ruff format).
- [ ] After deploy, confirm `/memory` appears in the Telegram popup on a fresh client session.
- [ ] Confirm the README table renders cleanly on GitHub.

## Related

- #337 / PR introducing `/memory`
- #347 / PR #348 introducing per-user MEMORY.md
