### PR TITLE
fix: drop redundant tag-row text from /memory dashboard

### DIFF
--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -101,17 +101,6 @@ _LIST_TRUNCATE_LEN = 80
 # hard ceiling on session duration.
 _CACHE_TTL_S = 30 * 60
 
-# Unicode block character for the dashboard bar chart (spec §6.1
-# mock-up uses ▓). Plain text mode renders this fine on every
-# Telegram client.
-_BAR_CHAR = "\u2593"
-
-# Width of the dashboard bar chart in characters, scaled to the
-# largest tag count. Eight is wide enough to show contrast between
-# 38 and 5 without overflowing the typical phone screen.
-_BAR_WIDTH = 8
-
-
 # ── Per-chat navigation cache ───────────────────────────────────────
 
 
@@ -315,20 +304,6 @@ def _format_date(iso_str: str, with_time: bool = False) -> str:
     return iso_str[:10]
 
 
-def _bar(count: int, max_count: int, width: int = _BAR_WIDTH) -> str:
-    """Render a unicode-block bar of length proportional to count.
-
-    A bar is at least one block wide for any nonzero count so a tag
-    with a single fact is visually distinguishable from a tag with
-    zero facts (which is hidden from the dashboard anyway, but the
-    builder is also reused for stats).
-    """
-    if max_count <= 0 or count <= 0:
-        return ""
-    n = max(1, round((count / max_count) * width))
-    return _BAR_CHAR * n
-
-
 # ── Builder: dashboard ──────────────────────────────────────────────
 
 
@@ -360,23 +335,19 @@ def _build_dashboard(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup | No
         # bypassed. Surface as empty rather than crashing.
         return _MSG_NO_FACTS, None
 
-    max_count = nonzero[0][1]
-    # Pad tag column to longest tag name so the count column is
-    # column-aligned without monospace assumptions (it'll still
-    # left-align in proportional fonts; alignment in monospace is
-    # the bonus).
-    label_width = max(len(tag) for tag, _ in nonzero)
-
+    # Per-tag counts are carried by the inline buttons below
+    # (`tag (count)` labels), so the dashboard text intentionally
+    # stops at the summary header and confidence footer. Per #351,
+    # rendering the same counts in both surfaces was redundant - the
+    # original spec §6.1 mock-up included a bar chart here, but
+    # operator feedback on real data showed the bars duplicated what
+    # the buttons already telegraph through the parenthesized counts.
     lines: list[str] = []
     summary = f"Memories: {stats.extracted_count} facts across {len(nonzero)} tags."
     lines.append(summary)
     lines.append("")
-    for tag, count in nonzero:
-        bar = _bar(count, max_count)
-        lines.append(f"  {tag.ljust(label_width)}  {count:>3}   {bar}")
-    lines.append("")
-    # Footer summary: median + min confidence. Spec §6.1 calls this
-    # the "first-glance tuning signal." Median is the persisted value;
+    # Footer line: median + min confidence. Spec §6.1 calls this the
+    # "first-glance tuning signal." Median is the persisted value;
     # the spec mock-up labels it "avg" but median is more honest about
     # what is shown.
     median = stats.confidence_median

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -225,20 +225,6 @@ class TestFormatDate:
         assert memory_command._format_date("2026-04-17", with_time=True) == "2026-04-17"
 
 
-class TestBar:
-    def test_zero_count_empty_bar(self):
-        assert memory_command._bar(0, 10) == ""
-
-    def test_max_count_full_width(self):
-        bar = memory_command._bar(10, 10, width=8)
-        assert bar == "\u2593" * 8
-
-    def test_nonzero_min_one_block(self):
-        # A single-fact tag should not render as an empty bar; users
-        # would lose the visual signal that the tag exists.
-        assert memory_command._bar(1, 100, width=8) == "\u2593"
-
-
 # ── Builder: dashboard ─────────────────────────────────────────────
 
 
@@ -257,14 +243,24 @@ class TestBuildDashboard:
         )
         text, kb = memory_command._build_dashboard(stats)
         assert "10 facts across 3 tags" in text
-        # Sort order: descending count. Use the leading-space prefix
-        # so the bare tag rows match without colliding with the
-        # "X facts across" wording in the summary header.
-        assert text.index("  preference") < text.index("  fact") < text.index("  decision")
         assert "median 0.86, min 0.52" in text
+        # Per #351 the dashboard text intentionally omits per-tag
+        # rows - counts live on the buttons. Two regression checks:
+        # (1) the bar-chart unicode block must be gone entirely; (2)
+        # the leading-space row prefix that the old per-tag rows used
+        # ("  preference" etc.) must not appear. Substring checks for
+        # bare tag names would false-match "facts" in the summary
+        # header, so we anchor on the row prefix instead.
+        assert "\u2593" not in text, "bar-chart character should not appear in dashboard text"
+        for tag in ("preference", "fact", "decision"):
+            assert f"  {tag}" not in text, f"per-tag row for {tag!r} should not appear in dashboard text"
         assert kb is not None
         # 3 tag rows + 1 footer row of (Search, Stats).
         assert len(kb.inline_keyboard) == 4
+        # Tag buttons carry the count in parens, ordered by descending
+        # count. Each button is in its own row (one row per tag).
+        tag_button_labels = [row[0].text for row in kb.inline_keyboard[:-1]]
+        assert tag_button_labels == ["preference (5)", "fact (3)", "decision (2)"]
         # Footer row holds the two utility buttons.
         footer = kb.inline_keyboard[-1]
         assert [btn.text for btn in footer] == ["Search", "Stats"]


### PR DESCRIPTION
Closes #351.

## Summary

The `/memory` dashboard renders each tag's count in two places: a text bar-chart block and the inline keyboard buttons below. The text rows duplicate what the buttons already show, so the dashboard is roughly twice as tall as needed. Operator feedback on real data confirmed the bars added no value the button labels weren't already carrying through their `(N)` suffixes.

## Changes

**`src/kai/memory_command.py`:**
- `_build_dashboard` no longer emits the per-tag rows. The text now stops at the summary header (`Memories: N facts across M tags.`) and the confidence footer (`Tap a tag to browse. Confidence: median X, min Y.`).
- `_bar`, `_BAR_CHAR`, `_BAR_WIDTH` removed - unused after the rows are gone.
- `_build_stats` is unchanged; it has its own per-tag rendering that never called `_bar`.

**`tests/test_memory_command.py`:**
- `TestBar` (3 tests) deleted along with `_bar`.
- `test_renders_summary_and_tags` reworked: asserts the bar character (▓) is gone, the per-tag row prefixes are gone, and the buttons carry the counts in descending order (`preference (5)`, `fact (3)`, `decision (2)`).

Net diff: +23 / -56 (-33 lines).

## Before / after

Before:
```
Memories: 73 facts across 8 tags.

  project            18   ▓▓▓▓▓▓▓▓
  fact               16   ▓▓▓▓▓▓▓
  preference         15   ▓▓▓▓▓▓▓
  constraint         10   ▓▓▓▓
  decision            9   ▓▓▓▓
  location            3   ▓
  confirmed_action    1   ▓
  relationship        1   ▓

Tap a tag to browse. Confidence: median 0.86, min 0.52.
[project (18)] [fact (16)] ...
[Search] [Stats]
```

After:
```
Memories: 73 facts across 8 tags.

Tap a tag to browse. Confidence: median 0.86, min 0.52.
[project (18)] [fact (16)] ...
[Search] [Stats]
```

## Spec drift

This intentionally diverges from spec 310 §6.1's bar-chart mock-up. All other §6.1 elements (summary header, confidence footer, asymmetry between dashboard and stats around zero-count tags) are preserved. Issue #351 documents the rationale.

## Test plan

- [x] `make check` passes (ruff check + ruff format).
- [x] `pytest tests/test_memory_command.py` - 83 passed.
- [ ] After deploy, send `/memory` and confirm the dashboard renders without the per-tag rows but with summary + footer + tag buttons + Search/Stats.
- [ ] Confirm `/memory stats` still renders its full per-tag table (not affected by this change).

## Related

- #351 - feature request
- #306 / spec 310 - original dashboard design (§6.1 bar chart now superseded)
- PR #337 - dashboard implementation
