### PR TITLE
feat: per-user home workspace under DATA_DIR

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -15,6 +15,7 @@ prompt assembly that is identical across all backends.
 """
 
 import logging
+import os
 import shutil
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
@@ -498,17 +499,28 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
     # but dev paths and the tests go straight through lazy bootstrap).
     # exist_ok=True means this is safe to call on every session init.
     path.mkdir(parents=True, exist_ok=True, mode=0o755)
+    # mkdir's mode= argument is masked by the process umask, so on a
+    # service configured with umask 0o027 the directory can end up 0o750
+    # instead of 0o755. That blocks group traversal and can break the
+    # inner subprocess when sudo -u targets a different identity. Force
+    # the intended bits explicitly - this is the same pattern install.py
+    # `_apply_migrate` uses after its mkdir calls. Idempotent on reuse.
+    os.chmod(path, 0o755)
     return path
 
 
-def resolve_home_workspace(chat_id: int | None, config: Config) -> Path:
+def resolve_home_workspace(
+    chat_id: int | None,
+    config: Config,
+    data_dir: Path | None = None,
+) -> Path:
     """
     Return the user's home workspace path.
 
     Resolution order:
     1. `user.home_workspace` from users.yaml when set (admin override,
        returned as-is with no second-guessing).
-    2. `DATA_DIR/home/<chat_id>/`, auto-created via ensure_user_home().
+    2. `<data_dir>/home/<chat_id>/`, auto-created via ensure_user_home().
 
     All call sites (pool.py session init / get_workspace fallback,
     bot.py `/workspace home` handler and workspace listings) MUST go
@@ -521,6 +533,17 @@ def resolve_home_workspace(chat_id: int | None, config: Config) -> Path:
     Passing `config` (not just its admin home field) keeps the
     resolution decision local: the caller does not need to know whether
     to prefer users.yaml or the per-user default.
+
+    The `data_dir` parameter is exposed for tests that want to thread a
+    tmp_path in cleanly (beats monkeypatching the module attribute,
+    because a test that forgets the patch would silently write to the
+    real `/var/lib/kai`). When None, we resolve from the module-level
+    DATA_DIR at CALL time (not definition time): a `data_dir=DATA_DIR`
+    default would freeze the value at import, defeating the
+    `monkeypatch.setattr("kai.backend.DATA_DIR", ...)` pattern that
+    pool.py and bot.py tests still depend on. The underlying
+    ensure_user_home already takes data_dir as a parameter; this
+    mirrors that signature.
     """
     # Admin-authored override from users.yaml wins outright. No check
     # that the path exists - the config-load validator (config.py
@@ -532,9 +555,13 @@ def resolve_home_workspace(chat_id: int | None, config: Config) -> Path:
         return user.home_workspace
 
     # No users.yaml override: use the per-user Kai-managed directory
-    # under DATA_DIR. ensure_user_home is idempotent so calling it on
-    # every resolution is cheap.
-    return ensure_user_home(chat_id, DATA_DIR)
+    # under data_dir. Resolve DATA_DIR from the module here (not as a
+    # default arg value) so monkeypatching `kai.backend.DATA_DIR` in
+    # tests still flows through. ensure_user_home is idempotent so
+    # calling it on every resolution is cheap.
+    if data_dir is None:
+        data_dir = DATA_DIR
+    return ensure_user_home(chat_id, data_dir)
 
 
 def build_foreign_workspace_reminder(workspace: Path, home_workspace: Path) -> str | None:

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -21,7 +21,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from kai.config import PROJECT_ROOT, WorkspaceConfig
+from kai.config import DATA_DIR, PROJECT_ROOT, Config, WorkspaceConfig
 from kai.history import get_recent_history
 
 log = logging.getLogger(__name__)
@@ -435,6 +435,106 @@ def ensure_user_memory(chat_id: int | None, data_dir: Path) -> None:
             user_memory_file,
             exc_info=True,
         )
+
+
+def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
+    """
+    Lazily create the per-user home workspace directory.
+
+    Returns the path that should be used as the user's home workspace
+    when users.yaml does not set an explicit home_workspace override.
+    Idempotent and cheap: a stat and a possible mkdir. Called on every
+    session init (and on `/workspace home`) so that any user without a
+    pre-created `home/<chat_id>/` - single-user dev, test runs, or a
+    user added to users.yaml after install - still lands in a valid
+    directory on their first message.
+
+    This is the companion to ensure_user_memory() above. Same scope
+    caveats apply (copied verbatim because the multi-user ownership
+    semantics are identical):
+
+    * Production multi-user (users.yaml entry has an explicit os_user
+      different from the service user): the install step (install.py
+      `_apply_migrate`) pre-creates and chowns `home/<chat_id>/` to the
+      user's os_user. mkdir here is then a no-op and the directory is
+      already writable by the subprocess identity.
+    * A user added to users.yaml AFTER install with a distinct os_user:
+      lazy bootstrap is NOT enough. mkdir here runs as the bot/service
+      identity, so the new directory is service-owned. The inner
+      subprocess (sudo -H -u <os_user>) can read but not write - the
+      same #347 regression that memory hit. A reinstall (or a manual
+      chown) is required for that case.
+    * Dev / single-user / users without a distinct os_user: lazy
+      bootstrap does the whole job. mkdir inherits the caller's
+      ownership, which IS the subprocess identity.
+
+    When chat_id is None (admin-less startup paths: tests, webhook
+    health checks, dev smoke tests) the function returns a fixed
+    `data_dir/home/anon` path. That path is only used when there is no
+    real user; it is not shared between actual Telegram users because
+    any real message carries a chat_id.
+
+    Mode 0755 with per-user chown at install time is what isolates
+    users from each other. Matches memory/ exactly (install.py
+    `_apply_migrate` uses the same ownership rules). Isolation comes
+    from ownership, not mode bits.
+
+    Unlike ensure_user_memory this does NOT seed a template file. The
+    home workspace is an empty directory that the user populates
+    themselves (cloning a repo, dropping notes, etc.).
+    """
+    # chat_id of None means we have no real Telegram session to key on
+    # (test runs, health checks, smoke runs without users.yaml). Use a
+    # fixed "anon" subdir so the resolver always returns a concrete
+    # path rather than None; avoids defensive None-checks at every call
+    # site.
+    if chat_id is None:
+        path = data_dir / "home" / "anon"
+    else:
+        path = data_dir / "home" / str(chat_id)
+
+    # mkdir parents=True is load-bearing: on a brand-new install the
+    # data_dir/home/ root may not exist yet (the installer creates it,
+    # but dev paths and the tests go straight through lazy bootstrap).
+    # exist_ok=True means this is safe to call on every session init.
+    path.mkdir(parents=True, exist_ok=True, mode=0o755)
+    return path
+
+
+def resolve_home_workspace(chat_id: int | None, config: Config) -> Path:
+    """
+    Return the user's home workspace path.
+
+    Resolution order:
+    1. `user.home_workspace` from users.yaml when set (admin override,
+       returned as-is with no second-guessing).
+    2. `DATA_DIR/home/<chat_id>/`, auto-created via ensure_user_home().
+
+    All call sites (pool.py session init / get_workspace fallback,
+    bot.py `/workspace home` handler and workspace listings) MUST go
+    through this function rather than reading any global home field on
+    Config directly - that field was removed by issue #353. The old
+    global fallback (PROJECT_ROOT / "home" / shared "/opt/kai/home/")
+    was a multi-user privacy hazard (every user landed in a directory
+    every other user could read).
+
+    Passing `config` (not just its admin home field) keeps the
+    resolution decision local: the caller does not need to know whether
+    to prefer users.yaml or the per-user default.
+    """
+    # Admin-authored override from users.yaml wins outright. No check
+    # that the path exists - the config-load validator (config.py
+    # load_config) already filtered out bad paths, and a path that
+    # became invalid post-load (unmounted drive, etc.) is the admin's
+    # problem to fix, not ours to paper over.
+    user = config.get_user_config(chat_id) if chat_id is not None else None
+    if user and user.home_workspace:
+        return user.home_workspace
+
+    # No users.yaml override: use the per-user Kai-managed directory
+    # under DATA_DIR. ensure_user_home is idempotent so calling it on
+    # every resolution is cheap.
+    return ensure_user_home(chat_id, DATA_DIR)
 
 
 def build_foreign_workspace_reminder(workspace: Path, home_workspace: Path) -> str | None:

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -55,6 +55,7 @@ from telegram.ext import (
 )
 
 from kai import github_api, memory_command, services, sessions, webhook
+from kai.backend import resolve_home_workspace
 from kai.config import (
     DATA_DIR,
     MAX_CONTEXT_CEILING,
@@ -1259,7 +1260,10 @@ async def _do_switch_workspace(context: ContextTypes.DEFAULT_TYPE, chat_id: int,
     """
     pool = _get_pool(context)
     config: Config = context.bot_data["config"]
-    home = config.claude_workspace
+    # "home" for this user is per-user post-#353. Same resolver pool.py
+    # uses, so the equality check below matches the directory the user
+    # would land in on `/workspace home` or session restart.
+    home = resolve_home_workspace(chat_id, config)
 
     # Layer DB overrides (from /workspace config) on top of YAML baseline.
     yaml_config = config.get_workspace_config(path)
@@ -1288,7 +1292,9 @@ async def _switch_workspace(update: Update, context: ContextTypes.DEFAULT_TYPE, 
     assert update.message is not None
     pool = _get_pool(context)
     config: Config = context.bot_data["config"]
-    home = config.claude_workspace
+    # Per-user resolution: this is what `/workspace home` would route to
+    # for THIS user, not a shared default.
+    home = resolve_home_workspace(_chat_id(update), config)
 
     if path == pool.get_workspace(_chat_id(update)):
         await update.message.reply_text("Already in that workspace.")
@@ -1749,7 +1755,9 @@ async def handle_workspaces(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     history = await sessions.get_workspace_history(chat_id)
     pool = _get_pool(context)
     current = str(pool.get_workspace(chat_id))
-    home = str(config.claude_workspace)
+    # Per-user home for the listing's "Home" pin and the empty-state
+    # short-circuit below.
+    home = str(resolve_home_workspace(chat_id, config))
 
     if not history and not allowed and current == home:
         await update.message.reply_text("No workspace history yet.\nUse /workspace new <name> to create one.")
@@ -1778,7 +1786,9 @@ async def handle_workspace_callback(update: Update, context: ContextTypes.DEFAUL
     assert query.data is not None
     data = query.data.removeprefix("ws:")
     pool = _get_pool(context)
-    home = config.claude_workspace
+    # Per-user resolution: the "Home" keyboard button maps to THIS user's
+    # home directory, not a shared one.
+    home = resolve_home_workspace(chat_id, config)
 
     # Resolve per-user workspace access for this user
     base, allowed = await sessions.resolve_workspace_access(chat_id, config)
@@ -2031,7 +2041,9 @@ async def handle_workspace(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     chat_id = _chat_id(update)
     pool = _get_pool(context)
     config: Config = context.bot_data["config"]
-    home = config.claude_workspace
+    # Per-user `/workspace home` destination. The user-visible fix for
+    # #353: prior to this, "home" was a shared directory.
+    home = resolve_home_workspace(chat_id, config)
 
     # Resolve per-user workspace access (workspace_base + allowed list)
     base, allowed = await sessions.resolve_workspace_access(chat_id, config)

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -303,7 +303,6 @@ class Config:
             for users without a per-user max_budget in users.yaml.
         claude_max_session_hours: Hours before the inner Claude process is recycled. Prevents
             unbounded V8 memory growth that can trigger macOS Jetsam kernel panics. 0 = no limit.
-        claude_workspace: Working directory for the inner Claude Code process
         session_db_path: Path to the SQLite database for sessions, jobs, and settings
         webhook_port: Port for the local aiohttp server (webhooks + scheduling API)
         webhook_secret: HMAC secret for verifying incoming webhook payloads
@@ -336,7 +335,6 @@ class Config:
     budget_ceiling: float = 10.0
     claude_max_session_hours: float = 0  # 0 = no limit
     claude_idle_timeout: int = 1800  # seconds before idle subprocess eviction; 0 = no eviction
-    claude_workspace: Path = field(default_factory=lambda: PROJECT_ROOT / "home")
 
     # Context window tuning. Both settings help control token usage and
     # reduce cache invalidation pressure on the inner Claude process.
@@ -901,7 +899,7 @@ def _load_user_configs(
         # Validate home_workspace. Warn but don't skip the user if
         # the directory doesn't exist - it may be on an unmounted drive
         # or not yet created. The user keeps access; the workspace
-        # falls back to the global default at runtime.
+        # falls back to the per-user default at runtime.
         home_workspace = entry.get("home_workspace")
         if home_workspace is not None:
             # Guard against empty strings: Path("").resolve() silently
@@ -912,8 +910,13 @@ def _load_user_configs(
             else:
                 home_workspace = Path(home_workspace_str).expanduser().resolve()
                 if not home_workspace.is_dir():
+                    # Null it out and let the runtime resolver
+                    # (backend.resolve_home_workspace) fall through to
+                    # DATA_DIR/home/<chat_id>/. There is no longer a
+                    # shared "global default" directory - that was the
+                    # multi-user privacy hazard #353 removed.
                     log.warning(
-                        "users.yaml: home_workspace not found for %s: %s; using global default",
+                        "users.yaml: home_workspace not found for %s: %s; falling back to per-user default",
                         name,
                         home_workspace,
                     )

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -378,12 +378,15 @@ def _cmd_config() -> None:
                     break
                 print("  Username may only contain letters, numbers, dots, hyphens, and underscores.")
 
-            # Default home_workspace to PROJECT_ROOT.
-            default_home = str(PROJECT_ROOT)
-            admin_home_workspace = _prompt("Home workspace", default_home) or None
-            if admin_home_workspace:
-                # Resolve to absolute path for consistency with config.py parsing.
-                admin_home_workspace = str(Path(admin_home_workspace).expanduser().resolve())
+            # No wizard prompt for home_workspace post-#353. The admin lands
+            # in DATA_DIR/home/<chat_id>/ like any other user; the per-user
+            # default is private to them. An admin who wants a path outside
+            # DATA_DIR (a clone of the dev tree, a synced volume, etc.) can
+            # add `home_workspace: /absolute/path` to their users.yaml entry
+            # by hand after install. Removing the prompt prevents the wizard
+            # from defaulting back to the shared PROJECT_ROOT directory the
+            # spec exists to eliminate.
+            admin_home_workspace = None
 
         # Write users.yaml to project root. _apply_secrets() copies it
         # to /etc/kai/users.yaml during 'make install'.
@@ -1264,6 +1267,69 @@ def _collect_user_memory_owners(users_yaml_path: str | Path) -> list[tuple[int, 
     return result
 
 
+def _collect_user_home_overrides(users_yaml_path: str | Path) -> dict[int, Path]:
+    """
+    Read users.yaml and return a chat_id -> home_workspace override mapping.
+
+    Used by the install migration to decide which `home/<chat_id>/`
+    subdirectories to skip pre-creating: a user who pinned an explicit
+    home_workspace path is opting out of the Kai-managed per-user
+    directory (#353), so the installer should not provision one for
+    them. Their override path is the operator's responsibility.
+
+    Only entries with a string `home_workspace` field are included.
+    Missing / null / empty / non-string values are silently skipped -
+    those users get the default per-user directory provisioned.
+
+    Mirrors the loose validation of _collect_user_memory_owners:
+    silent return on missing / empty / malformed-top-level files,
+    no exceptions for malformed individual entries.
+
+    Args:
+        users_yaml_path: Path to users.yaml (typically /etc/kai/users.yaml).
+
+    Returns:
+        Mapping of telegram_id (chat_id) to absolute Path of the override.
+        Empty dict if the file is missing, empty, or has no overrides.
+    """
+    path = Path(users_yaml_path)
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+
+    if not text.strip():
+        return {}
+
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        return {}
+
+    users = data.get("users")
+    if not isinstance(users, list):
+        return {}
+
+    result: dict[int, Path] = {}
+    for entry in users:
+        if not isinstance(entry, dict):
+            continue
+        telegram_id = entry.get("telegram_id")
+        if not isinstance(telegram_id, int):
+            continue
+        home_ws_raw = entry.get("home_workspace")
+        if not isinstance(home_ws_raw, str):
+            continue
+        home_ws = home_ws_raw.strip()
+        if not home_ws:
+            continue
+        # expanduser on the install host is fine: paths in users.yaml
+        # are admin-authored and are expected to refer to the install
+        # host's filesystem. Same expansion as config.py's loader.
+        result[telegram_id] = Path(home_ws).expanduser().resolve()
+    return result
+
+
 def _generate_sudoers(
     service_user: str,
     claude_user: str | None = None,
@@ -1931,6 +1997,50 @@ def _apply_migrate(
                     # memory/<chat_id>/ whose user has no os_user set.
                     _set_ownership(entry, svc_uid, svc_gid, recursive=True)
 
+    # -- Per-user home workspace pre-creation (#353) --
+    # Mirror the per-user memory pattern above. For every users.yaml
+    # entry we pre-create DATA_DIR/home/<chat_id>/ so the inner Claude
+    # subprocess (sudo -H -u <os_user>) can write into it on first
+    # message. Users with an explicit home_workspace override are split:
+    #   * Override path under DATA_DIR (rare, but valid): provision the
+    #     override path itself, since it lives in our tree.
+    #   * Override path outside DATA_DIR: skip - the override is
+    #     operator-managed (a clone of the dev tree, a synced volume,
+    #     etc.). Provisioning here would chown a directory we do not own.
+    # Subdirectories whose chat_id has no os_user fall through to the
+    # service-owned tier, matching the memory tier-(a) rule above.
+    home_root = data_path / "home"
+    home_overrides = _collect_user_home_overrides(users_yaml_path)
+    if home_root.is_dir():
+        for chat_id, _os_user in memory_owners:
+            override = home_overrides.get(chat_id)
+            # Skip when the operator has pinned an absolute path outside
+            # DATA_DIR. is_relative_to is the cleanest way to test path
+            # containment; on PY 3.9+ it returns bool without raising.
+            if override is not None and not override.is_relative_to(data_path):
+                continue
+            user_dir = home_root / str(chat_id)
+            if user_dir.exists():
+                continue  # idempotent across reinstalls
+            if dry_run:
+                if str(chat_id) in per_user_ids:
+                    uid, gid = per_user_ids[str(chat_id)]
+                    print(f"[DRY RUN] Would create {user_dir} ({uid}:{gid})")
+                else:
+                    print(f"[DRY RUN] Would create {user_dir} ({svc_uid}:{svc_gid})")
+                continue
+            user_dir.mkdir(parents=True, exist_ok=True, mode=0o755)
+            # mkdir does not always honor mode (it is masked by umask).
+            # Force the intended bits explicitly so the per-user dir
+            # ends up 0755 regardless of the install-time umask.
+            os.chmod(user_dir, 0o755)
+            if str(chat_id) in per_user_ids:
+                uid, gid = per_user_ids[str(chat_id)]
+                _set_ownership(user_dir, uid, gid, recursive=False)
+            else:
+                _set_ownership(user_dir, svc_uid, svc_gid, recursive=False)
+            print(f"  Created {user_dir}")
+
 
 def _cmd_apply() -> None:
     """
@@ -2125,6 +2235,11 @@ def _apply_directories(
         (data_path / "files", svc_uid, svc_gid, 0o755),
         (data_path / "history", svc_uid, svc_gid, 0o755),
         (data_path / "memory", svc_uid, svc_gid, 0o755),
+        # Per-user home root (#353). Top-level dir is service-owned so
+        # the bot can lazily create new home/<chat_id>/ subdirs at first
+        # message; per-user subdirs are pre-created and chowned in
+        # _apply_migrate when the user has a distinct os_user.
+        (data_path / "home", svc_uid, svc_gid, 0o755),
         (Path("/etc/kai"), 0, 0, 0o755),
     ]
 

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2037,12 +2037,21 @@ def _apply_migrate(
         # 0o755 mode. Force the bits explicitly - same pattern as
         # ensure_user_home and the user_dir.chmod two lines below.
         os.chmod(home_root, 0o755)
+    # Resolve data_path once for the symlink-safe containment check
+    # below. _collect_user_home_overrides canonicalizes each override
+    # via Path.resolve(); comparing against an unresolved data_path
+    # would mis-classify legitimately-internal overrides as external on
+    # any host where DATA_DIR traverses a symlink (e.g., macOS where
+    # /var/lib is a symlink to /private/var/lib). Resolving both sides
+    # makes is_relative_to a true containment test rather than a
+    # string-prefix comparison.
+    data_path_resolved = data_path.resolve()
     for chat_id, _os_user in memory_owners:
         override = home_overrides.get(chat_id)
         # Case 3: override pinned outside DATA_DIR - operator-managed,
         # skip. is_relative_to is the cleanest way to test path
         # containment; on Python 3.9+ it returns bool without raising.
-        if override is not None and not override.is_relative_to(data_path):
+        if override is not None and not override.is_relative_to(data_path_resolved):
             continue
         # Case 2: override under DATA_DIR - provision THAT path, since
         # resolve_home_workspace returns it verbatim at runtime. Case

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2029,6 +2029,14 @@ def _apply_migrate(
     # chown here would mask the real bug rather than fix it.
     if not dry_run:
         home_root.mkdir(parents=True, exist_ok=True, mode=0o755)
+        # mkdir's mode= is masked by umask. Under the production
+        # service umask of 0o027 the directory ends up 0o750, which
+        # blocks group traversal: a distinct-os_user subprocess that
+        # is not in the service group cannot enter home_root to reach
+        # its own per-user slot, even though that slot has correct
+        # 0o755 mode. Force the bits explicitly - same pattern as
+        # ensure_user_home and the user_dir.chmod two lines below.
+        os.chmod(home_root, 0o755)
     for chat_id, _os_user in memory_owners:
         override = home_overrides.get(chat_id)
         # Case 3: override pinned outside DATA_DIR - operator-managed,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1999,47 +1999,67 @@ def _apply_migrate(
 
     # -- Per-user home workspace pre-creation (#353) --
     # Mirror the per-user memory pattern above. For every users.yaml
-    # entry we pre-create DATA_DIR/home/<chat_id>/ so the inner Claude
-    # subprocess (sudo -H -u <os_user>) can write into it on first
-    # message. Users with an explicit home_workspace override are split:
-    #   * Override path under DATA_DIR (rare, but valid): provision the
-    #     override path itself, since it lives in our tree.
-    #   * Override path outside DATA_DIR: skip - the override is
-    #     operator-managed (a clone of the dev tree, a synced volume,
-    #     etc.). Provisioning here would chown a directory we do not own.
+    # entry we pre-create the directory the inner Claude subprocess
+    # (sudo -H -u <os_user>) will write into on first message. Three
+    # cases, all handled below:
+    #   1. No override: create DATA_DIR/home/<chat_id>/.
+    #   2. Override path under DATA_DIR (rare, but valid): create the
+    #      override path itself, since it lives in our tree and
+    #      resolve_home_workspace() will route the user there at
+    #      runtime. Creating DATA_DIR/home/<chat_id>/ instead would
+    #      leave the actual runtime directory un-provisioned and the
+    #      user's first write would fail.
+    #   3. Override path outside DATA_DIR: skip entirely - the override
+    #      is operator-managed (a clone of the dev tree, a synced
+    #      volume, etc.). Provisioning here would chown a directory we
+    #      do not own.
     # Subdirectories whose chat_id has no os_user fall through to the
     # service-owned tier, matching the memory tier-(a) rule above.
     home_root = data_path / "home"
     home_overrides = _collect_user_home_overrides(users_yaml_path)
-    if home_root.is_dir():
-        for chat_id, _os_user in memory_owners:
-            override = home_overrides.get(chat_id)
-            # Skip when the operator has pinned an absolute path outside
-            # DATA_DIR. is_relative_to is the cleanest way to test path
-            # containment; on PY 3.9+ it returns bool without raising.
-            if override is not None and not override.is_relative_to(data_path):
-                continue
-            user_dir = home_root / str(chat_id)
-            if user_dir.exists():
-                continue  # idempotent across reinstalls
-            if dry_run:
-                if str(chat_id) in per_user_ids:
-                    uid, gid = per_user_ids[str(chat_id)]
-                    print(f"[DRY RUN] Would create {user_dir} ({uid}:{gid})")
-                else:
-                    print(f"[DRY RUN] Would create {user_dir} ({svc_uid}:{svc_gid})")
-                continue
-            user_dir.mkdir(parents=True, exist_ok=True, mode=0o755)
-            # mkdir does not always honor mode (it is masked by umask).
-            # Force the intended bits explicitly so the per-user dir
-            # ends up 0755 regardless of the install-time umask.
-            os.chmod(user_dir, 0o755)
+    # Defensive: `_apply_directories` already creates home_root with
+    # the right ownership, but we cannot assume ordering (future
+    # refactors could split these steps). A missing home_root here
+    # would otherwise silently skip every per-user provisioning step
+    # and leave the installer reporting success while subsequent
+    # first-messages crash. mkdir(exist_ok=True) is cheap and
+    # idempotent. We deliberately do NOT chown home_root in this
+    # fallback path: if _apply_directories ran (the normal case)
+    # ownership is already correct, and if it did not run a defensive
+    # chown here would mask the real bug rather than fix it.
+    if not dry_run:
+        home_root.mkdir(parents=True, exist_ok=True, mode=0o755)
+    for chat_id, _os_user in memory_owners:
+        override = home_overrides.get(chat_id)
+        # Case 3: override pinned outside DATA_DIR - operator-managed,
+        # skip. is_relative_to is the cleanest way to test path
+        # containment; on Python 3.9+ it returns bool without raising.
+        if override is not None and not override.is_relative_to(data_path):
+            continue
+        # Case 2: override under DATA_DIR - provision THAT path, since
+        # resolve_home_workspace returns it verbatim at runtime. Case
+        # 1: no override - provision the per-user default slot.
+        user_dir = override if override is not None else home_root / str(chat_id)
+        if user_dir.exists():
+            continue  # idempotent across reinstalls
+        if dry_run:
             if str(chat_id) in per_user_ids:
                 uid, gid = per_user_ids[str(chat_id)]
-                _set_ownership(user_dir, uid, gid, recursive=False)
+                print(f"[DRY RUN] Would create {user_dir} ({uid}:{gid})")
             else:
-                _set_ownership(user_dir, svc_uid, svc_gid, recursive=False)
-            print(f"  Created {user_dir}")
+                print(f"[DRY RUN] Would create {user_dir} ({svc_uid}:{svc_gid})")
+            continue
+        user_dir.mkdir(parents=True, exist_ok=True, mode=0o755)
+        # mkdir does not always honor mode (it is masked by umask).
+        # Force the intended bits explicitly so the per-user dir
+        # ends up 0755 regardless of the install-time umask.
+        os.chmod(user_dir, 0o755)
+        if str(chat_id) in per_user_ids:
+            uid, gid = per_user_ids[str(chat_id)]
+            _set_ownership(user_dir, uid, gid, recursive=False)
+        else:
+            _set_ownership(user_dir, svc_uid, svc_gid, recursive=False)
+        print(f"  Created {user_dir}")
 
 
 def _cmd_apply() -> None:

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -166,6 +166,18 @@ class SubprocessPool:
         # workspace reminder. Same resolution as the workspace above so
         # the two cannot drift; pre-#353 this took a different path that
         # could disagree with the active workspace for unconfigured users.
+        #
+        # This is a deliberate second call to resolve_home_workspace and
+        # NOT an alias for `workspace`: workspace is the INITIAL landing
+        # directory and can be overridden (DB /workspace switch, a
+        # per-user workspace_config pinning a non-home path, etc.) but
+        # home_ws is always the canonical per-user home the backend
+        # uses to detect "foreign workspace" and inject the identity
+        # reminder. If we wrote `home_ws = workspace` the reminder
+        # injection would silently break the moment a user pins a
+        # non-home default. The redundant stat/mkdir inside
+        # ensure_user_home is cheap (idempotent mkdir + chmod); the
+        # clarity of two separate resolution calls is worth it.
         home_ws = resolve_home_workspace(chat_id, self._config)
 
         # Backend selection: "goose" uses Goose ACP, anything else

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -20,7 +20,7 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from kai import sessions
-from kai.backend import AgentBackend, StreamEvent
+from kai.backend import AgentBackend, StreamEvent, resolve_home_workspace
 from kai.claude import ClaudeCodeBackend
 from kai.config import (
     OPEN_ENDED_PROVIDERS,
@@ -108,10 +108,11 @@ class SubprocessPool:
         """
         user = self._config.get_user_config(chat_id)
 
-        # Determine the user's home workspace
-        workspace = self._config.claude_workspace
-        if user and user.home_workspace:
-            workspace = user.home_workspace
+        # Resolve through the single backend.resolve_home_workspace
+        # helper: users.yaml override first, else DATA_DIR/home/<chat_id>/.
+        # The old global home field on Config was removed by #353 because
+        # it pointed every unconfigured user at a shared directory.
+        workspace = resolve_home_workspace(chat_id, self._config)
 
         ws_config = self._config.get_workspace_config(workspace)
 
@@ -161,7 +162,11 @@ class SubprocessPool:
         context_window = (
             user.context_window if user and user.context_window is not None else self._config.claude_max_context_window
         )
-        home_ws = user.home_workspace if user else self._config.claude_workspace
+        # home_ws is what the backend treats as "home" for the foreign-
+        # workspace reminder. Same resolution as the workspace above so
+        # the two cannot drift; pre-#353 this took a different path that
+        # could disagree with the active workspace for unconfigured users.
+        home_ws = resolve_home_workspace(chat_id, self._config)
 
         # Backend selection: "goose" uses Goose ACP, anything else
         # (including the default "claude") uses Claude Code CLI.
@@ -423,9 +428,16 @@ class SubprocessPool:
         instance.model = model
 
     def get_workspace(self, chat_id: int) -> Path:
-        """Get the active workspace for a user."""
+        """
+        Get the active workspace for a user.
+
+        When no backend instance exists yet (user has not sent their
+        first message in this process lifetime) we resolve the per-user
+        home directory rather than the removed global default. This
+        matches what _build_backend would do on first send().
+        """
         instance = self.get_if_exists(chat_id)
-        return instance.workspace if instance else self._config.claude_workspace
+        return instance.workspace if instance else resolve_home_workspace(chat_id, self._config)
 
     def is_alive(self, chat_id: int) -> bool:
         """True if this user's subprocess is running."""

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -221,9 +221,13 @@ async def _resolve_local_repo(repo_full_name: str, app: web.Application) -> str 
     # Extract just the repo name from "owner/repo"
     repo_name = repo_full_name.split("/")[-1]
 
-    # 1. Home workspace - the workspace parent is the repo root.
-    # app["workspace"] is the workspace subdirectory (e.g., /opt/kai/workspace),
-    # so .parent gives the repo root (e.g., /opt/kai/).
+    # 1. Home workspace - parent of the active workspace.
+    # app["workspace"] is None at startup post-#353 (no global default),
+    # populated by update_workspace() on the first `/workspace` switch.
+    # When set, .parent gives the repo root candidate, e.g. workspace
+    # /Users/kai/Projects/kai/home → parent /Users/kai/Projects/kai
+    # → name "kai" matches a webhook for dcellison/kai. Steps 2-4 cover
+    # the cold-start case (no switch yet).
     workspace = app.get("workspace")
     if workspace:
         home_path = Path(workspace).parent
@@ -1623,10 +1627,16 @@ async def start(telegram_app, config) -> None:
     # Prevents prompt injection from routing messages to arbitrary users.
     _app["allowed_user_ids"] = config.allowed_user_ids
 
-    # Store workspace path for send-file path confinement (fallback when
-    # pool is not available). Phase 3 uses pool.get_workspace(chat_id)
-    # for per-user confinement at request time.
-    _app["workspace"] = str(config.claude_workspace)
+    # Initialize workspace slot to None. Per-user confinement for the
+    # send-file endpoint comes from pool.get_workspace(chat_id) at
+    # request time; there is no longer a shared global workspace to
+    # fall back on (#353 removed it). The slot is subsequently
+    # overwritten by update_workspace() on `/workspace` switch, which
+    # remains load-bearing for send-file path containment post-switch.
+    # When the pool is unavailable AND no switch has happened, the
+    # fallback at line 1417 returns 403 - acceptable because the pool
+    # is always present in production when send-file fires.
+    _app["workspace"] = None
 
     # Store config for GitHub actor routing in _handle_github()
     _app["config"] = config

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -206,10 +206,9 @@ async def _resolve_local_repo(repo_full_name: str, app: web.Application) -> str 
     Matches the repo part of the full name (e.g., "kai" from "dcellison/kai")
     against known workspace locations. Checks in priority order:
 
-    1. Home workspace (derived from app["workspace"] parent)
-    2. WORKSPACE_BASE children
-    3. ALLOWED_WORKSPACES entries
-    4. workspace_history entries from the database
+    1. WORKSPACE_BASE children
+    2. ALLOWED_WORKSPACES entries
+    3. workspace_history entries from the database
 
     Args:
         repo_full_name: Full GitHub repo name (e.g., "dcellison/kai").
@@ -221,32 +220,19 @@ async def _resolve_local_repo(repo_full_name: str, app: web.Application) -> str 
     # Extract just the repo name from "owner/repo"
     repo_name = repo_full_name.split("/")[-1]
 
-    # 1. Home workspace - parent of the active workspace.
-    # app["workspace"] is None at startup post-#353 (no global default),
-    # populated by update_workspace() on the first `/workspace` switch.
-    # When set, .parent gives the repo root candidate, e.g. workspace
-    # /Users/kai/Projects/kai/home → parent /Users/kai/Projects/kai
-    # → name "kai" matches a webhook for dcellison/kai. Steps 2-4 cover
-    # the cold-start case (no switch yet).
-    workspace = app.get("workspace")
-    if workspace:
-        home_path = Path(workspace).parent
-        if home_path.name == repo_name and home_path.is_dir():
-            return str(home_path)
-
-    # 2. WORKSPACE_BASE - scan immediate children for matching dir name
+    # 1. WORKSPACE_BASE - scan immediate children for matching dir name
     workspace_base = app.get("workspace_base")
     if workspace_base:
         candidate = Path(workspace_base) / repo_name
         if candidate.is_dir():
             return str(candidate)
 
-    # 3. ALLOWED_WORKSPACES - check each entry's directory name
+    # 2. ALLOWED_WORKSPACES - check each entry's directory name
     for allowed in app.get("allowed_workspaces", []):
         if Path(allowed).name == repo_name and Path(allowed).is_dir():
             return str(allowed)
 
-    # 4. workspace_history - search all users' history since webhook
+    # 3. workspace_history - search all users' history since webhook
     # routing has no user context (server-to-server GitHub payload)
     history_paths = await sessions.get_all_workspace_paths(limit=50)
     for path_str in history_paths:
@@ -1410,17 +1396,14 @@ async def _handle_send_file(request: web.Request) -> web.Response:
     path = Path(file_path).resolve()
 
     # Confine to the requesting user's workspace to prevent path traversal.
-    # Uses Path.relative_to() which raises ValueError on escape. With
-    # per-user subprocesses (Phase 3), each user has their own workspace
-    # resolved from the pool. Falls back to the global workspace setting
-    # for backward compatibility.
+    # Uses Path.relative_to() which raises ValueError on escape. Each user
+    # has their own per-user home workspace resolved from the pool (#353).
+    # When the pool is unavailable (transient startup state) we refuse the
+    # request rather than opening a global fallback path.
     pool = request.app.get("pool")
-    if pool:
-        workspace = str(pool.get_workspace(chat_id))
-    else:
-        workspace = request.app.get("workspace")
-    if not workspace:
+    if pool is None:
         return web.json_response({"error": "No workspace configured"}, status=403)
+    workspace = str(pool.get_workspace(chat_id))
     # Allow files from either the workspace or DATA_DIR/files/.
     # DATA_DIR/files/ is where uploaded files now live (PR #145).
     # Confinement to DATA_DIR/"files" (not all of DATA_DIR) is deliberate;
@@ -1627,17 +1610,6 @@ async def start(telegram_app, config) -> None:
     # Prevents prompt injection from routing messages to arbitrary users.
     _app["allowed_user_ids"] = config.allowed_user_ids
 
-    # Initialize workspace slot to None. Per-user confinement for the
-    # send-file endpoint comes from pool.get_workspace(chat_id) at
-    # request time; there is no longer a shared global workspace to
-    # fall back on (#353 removed it). The slot is subsequently
-    # overwritten by update_workspace() on `/workspace` switch, which
-    # remains load-bearing for send-file path containment post-switch.
-    # When the pool is unavailable AND no switch has happened, the
-    # fallback at line 1417 returns 403 - acceptable because the pool
-    # is always present in production when send-file fires.
-    _app["workspace"] = None
-
     # Store config for GitHub actor routing in _handle_github()
     _app["config"] = config
 
@@ -1805,27 +1777,6 @@ async def stop() -> None:
 def is_running() -> bool:
     """True if the webhook server is currently running."""
     return _runner is not None
-
-
-def update_workspace(workspace: str) -> None:
-    """
-    Update the workspace path used by the send-file endpoint's confinement check.
-
-    Called by _do_switch_workspace in bot.py whenever the user switches workspaces,
-    and by main.py after startup if a non-default workspace was restored from the
-    settings table. Without this, the confinement check keeps using the initial
-    home workspace path set at startup, causing send-file to return 403 for any
-    file in the current (switched) workspace.
-
-    The server must already be running when this is called - callers in main.py
-    should invoke this after webhook.start(), not before, since start() sets the
-    path from config and would overwrite an earlier call.
-
-    Args:
-        workspace: Absolute path string of the new current workspace.
-    """
-    if _app is not None:
-        _app["workspace"] = workspace
 
 
 def add_allowed_chat_id(chat_id: int) -> None:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -16,11 +16,13 @@ from kai.backend import (
     StreamEvent,
     build_foreign_workspace_reminder,
     build_session_context,
+    ensure_user_home,
     ensure_user_memory,
     get_workspace_system_prompt,
     prepend_to_prompt,
+    resolve_home_workspace,
 )
-from kai.config import WorkspaceConfig
+from kai.config import Config, UserConfig, WorkspaceConfig
 
 # ── Test build_session_context ──────────────────────────────────────
 
@@ -321,18 +323,141 @@ class TestBuildForeignWorkspaceReminder:
 
     def test_home_workspace_returns_none(self):
         """No reminder when workspace == home_workspace."""
-        ws = Path("/opt/kai/home")
+        # Path string is illustrative - the assertion compares via Path
+        # equality and never touches the filesystem. Using the new
+        # per-user shape from #353 keeps the test aligned with reality.
+        ws = Path("/var/lib/kai/home/12345")
         assert build_foreign_workspace_reminder(ws, ws) is None
 
     def test_foreign_workspace_returns_reminder(self):
         """Reminder string returned when in a foreign workspace."""
         result = build_foreign_workspace_reminder(
             Path("/home/user/project"),
-            Path("/opt/kai/home"),
+            Path("/var/lib/kai/home/12345"),
         )
         assert result is not None
         assert "IMPORTANT" in result
         assert "Respond ONLY" in result
+
+
+# ── Test ensure_user_home / resolve_home_workspace (#353) ───────────
+
+
+class TestEnsureUserHome:
+    """
+    Tests for the per-user home workspace bootstrap.
+
+    Mirrors TestEnsureUserMemory shape since the two helpers are
+    intentionally parallel (#353 reuses the #347 pattern).
+    """
+
+    def test_creates_directory(self, tmp_path):
+        """First call materializes home/<chat_id>/ under data_dir."""
+        result = ensure_user_home(12345, tmp_path)
+        assert result == tmp_path / "home" / "12345"
+        assert result.is_dir()
+
+    def test_is_idempotent(self, tmp_path):
+        """
+        Repeated calls must not raise or rewrite content. The user owns
+        the directory after first creation; clobbering it would lose
+        user-authored files (cloned repos, notes, etc.).
+        """
+        first = ensure_user_home(12345, tmp_path)
+        # Drop a sentinel so we can verify the second call leaves it alone.
+        sentinel = first / "userfile.txt"
+        sentinel.write_text("user content")
+
+        second = ensure_user_home(12345, tmp_path)
+        assert second == first
+        assert sentinel.read_text() == "user content"
+
+    def test_handles_none_chat_id(self, tmp_path):
+        """
+        chat_id=None routes to the fixed "anon" subdirectory used by
+        admin-less startup paths (tests, health checks). Returning None
+        would force defensive None-checks at every call site.
+        """
+        result = ensure_user_home(None, tmp_path)
+        assert result == tmp_path / "home" / "anon"
+        assert result.is_dir()
+
+    def test_directory_is_0755(self, tmp_path):
+        """
+        Mode 0755 matches the memory pattern (#347): isolation comes
+        from per-user chown at install time, not from mode bits. Other
+        users on the host can list and traverse but cannot write.
+        """
+        import stat
+
+        result = ensure_user_home(99, tmp_path)
+        # Mask off file-type bits; we only care about the permission bits.
+        mode = stat.S_IMODE(result.stat().st_mode)
+        # umask may strip group/other write bits but never adds them, so
+        # we assert the upper bound is 0o755 and owner has full access.
+        assert mode & 0o700 == 0o700, f"owner bits not full rwx: {oct(mode)}"
+        assert mode & 0o022 == 0, f"group/other write set: {oct(mode)}"
+
+
+class TestResolveHomeWorkspace:
+    """
+    Tests for the public resolver used by pool.py and bot.py.
+
+    The resolver is the single source of truth for "where does this
+    user's home live?" - both call sites must go through it so the
+    answer cannot drift between session init and `/workspace home`.
+    """
+
+    def _config(self, user_configs=None) -> Config:
+        """Build a minimal Config with optional user_configs dict."""
+        return Config(
+            telegram_bot_token="test",
+            allowed_user_ids={1},
+            user_configs=user_configs,
+        )
+
+    def test_prefers_users_yaml(self, tmp_path, monkeypatch):
+        """
+        When users.yaml sets home_workspace, that path is returned
+        verbatim. ensure_user_home is NOT called - the operator's
+        choice wins outright.
+        """
+        explicit = tmp_path / "explicit"
+        explicit.mkdir()
+        config = self._config(
+            user_configs={42: UserConfig(telegram_id=42, name="u", home_workspace=explicit)},
+        )
+        # Patch DATA_DIR so a bug that falls through to ensure_user_home
+        # would create a sibling directory we can detect (and fail on).
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path / "data")
+
+        result = resolve_home_workspace(42, config)
+        assert result == explicit
+        # Bug guard: DATA_DIR/home/42 must NOT have been created.
+        assert not (tmp_path / "data" / "home" / "42").exists()
+
+    def test_falls_back_to_data_dir(self, tmp_path, monkeypatch):
+        """
+        When no users.yaml override exists, the resolver lands the user
+        in DATA_DIR/home/<chat_id>/ via ensure_user_home (which creates
+        the directory as a side effect).
+        """
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+        config = self._config()
+        result = resolve_home_workspace(42, config)
+        assert result == tmp_path / "home" / "42"
+        assert result.is_dir()
+
+    def test_anon_when_chat_id_none(self, tmp_path, monkeypatch):
+        """
+        chat_id=None happens in admin-less startup paths. Return the
+        fixed anon subdir so callers always get a concrete Path back.
+        """
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+        config = self._config()
+        result = resolve_home_workspace(None, config)
+        assert result == tmp_path / "home" / "anon"
+        assert result.is_dir()
 
 
 # ── Test prepend_to_prompt ──────────────────────────────────────────

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -382,21 +382,33 @@ class TestEnsureUserHome:
         assert result == tmp_path / "home" / "anon"
         assert result.is_dir()
 
-    def test_directory_is_0755(self, tmp_path):
+    def test_directory_mode_is_exactly_0755(self, tmp_path):
         """
-        Mode 0755 matches the memory pattern (#347): isolation comes
-        from per-user chown at install time, not from mode bits. Other
-        users on the host can list and traverse but cannot write.
+        Mode must be EXACTLY 0o755 after ensure_user_home, regardless
+        of the process umask. The umask on a hardened service is
+        commonly 0o027, which would mask mkdir(mode=0o755) down to
+        0o750 - blocking group traversal and breaking the inner
+        subprocess when sudo -u targets a different identity. The
+        helper must chmod explicitly after mkdir to force the intended
+        bits; this test fails loudly if that chmod is ever removed.
+
+        A weaker assertion (mode & 0o022 == 0) would accept 0o750 and
+        silently mask a regression of exactly this kind.
         """
+        # Set a hostile umask to simulate the production service config
+        # (umask 0o027 on the launchd plist). Without the explicit chmod
+        # in ensure_user_home, mkdir(mode=0o755) would return 0o750 here.
+        import os as _os
         import stat
 
-        result = ensure_user_home(99, tmp_path)
-        # Mask off file-type bits; we only care about the permission bits.
+        prev_umask = _os.umask(0o027)
+        try:
+            result = ensure_user_home(99, tmp_path)
+        finally:
+            _os.umask(prev_umask)
+
         mode = stat.S_IMODE(result.stat().st_mode)
-        # umask may strip group/other write bits but never adds them, so
-        # we assert the upper bound is 0o755 and owner has full access.
-        assert mode & 0o700 == 0o700, f"owner bits not full rwx: {oct(mode)}"
-        assert mode & 0o022 == 0, f"group/other write set: {oct(mode)}"
+        assert mode == 0o755, f"expected 0o755, got {oct(mode)}"
 
 
 class TestResolveHomeWorkspace:
@@ -416,46 +428,47 @@ class TestResolveHomeWorkspace:
             user_configs=user_configs,
         )
 
-    def test_prefers_users_yaml(self, tmp_path, monkeypatch):
+    def test_prefers_users_yaml(self, tmp_path):
         """
         When users.yaml sets home_workspace, that path is returned
         verbatim. ensure_user_home is NOT called - the operator's
         choice wins outright.
+
+        Passing data_dir= explicitly (rather than monkeypatching
+        kai.backend.DATA_DIR) means a test that forgets the arg gets
+        a real production DATA_DIR path, which is caught loudly rather
+        than silently writing there.
         """
         explicit = tmp_path / "explicit"
         explicit.mkdir()
         config = self._config(
             user_configs={42: UserConfig(telegram_id=42, name="u", home_workspace=explicit)},
         )
-        # Patch DATA_DIR so a bug that falls through to ensure_user_home
-        # would create a sibling directory we can detect (and fail on).
-        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path / "data")
+        data_dir = tmp_path / "data"
 
-        result = resolve_home_workspace(42, config)
+        result = resolve_home_workspace(42, config, data_dir=data_dir)
         assert result == explicit
-        # Bug guard: DATA_DIR/home/42 must NOT have been created.
-        assert not (tmp_path / "data" / "home" / "42").exists()
+        # Bug guard: data_dir/home/42 must NOT have been created.
+        assert not (data_dir / "home" / "42").exists()
 
-    def test_falls_back_to_data_dir(self, tmp_path, monkeypatch):
+    def test_falls_back_to_data_dir(self, tmp_path):
         """
         When no users.yaml override exists, the resolver lands the user
-        in DATA_DIR/home/<chat_id>/ via ensure_user_home (which creates
+        in data_dir/home/<chat_id>/ via ensure_user_home (which creates
         the directory as a side effect).
         """
-        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
         config = self._config()
-        result = resolve_home_workspace(42, config)
+        result = resolve_home_workspace(42, config, data_dir=tmp_path)
         assert result == tmp_path / "home" / "42"
         assert result.is_dir()
 
-    def test_anon_when_chat_id_none(self, tmp_path, monkeypatch):
+    def test_anon_when_chat_id_none(self, tmp_path):
         """
         chat_id=None happens in admin-less startup paths. Return the
         fixed anon subdir so callers always get a concrete Path back.
         """
-        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
         config = self._config()
-        result = resolve_home_workspace(None, config)
+        result = resolve_home_workspace(None, config, data_dir=tmp_path)
         assert result == tmp_path / "home" / "anon"
         assert result.is_dir()
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1371,7 +1371,6 @@ class TestHandleWorkspace:
             patch("kai.bot.sessions.clear_session", new_callable=AsyncMock),
             patch("kai.bot.sessions.delete_setting", new_callable=AsyncMock),
             patch("kai.bot.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
-            patch("kai.bot.webhook.update_workspace"),
         ):
             await handle_workspace(update, ctx)
         claude.change_workspace.assert_called_once()
@@ -1405,7 +1404,6 @@ class TestHandleWorkspace:
             patch("kai.bot.sessions.clear_session", new_callable=AsyncMock),
             patch("kai.bot.sessions.delete_setting", new_callable=AsyncMock),
             patch("kai.bot.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
-            patch("kai.bot.webhook.update_workspace"),
         ):
             await handle_workspace(update, ctx)
 
@@ -1486,7 +1484,6 @@ class TestHandleWorkspace:
             patch("kai.bot.sessions.set_setting", new_callable=AsyncMock),
             patch("kai.bot.sessions.upsert_workspace_history", new_callable=AsyncMock),
             patch("kai.bot.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
-            patch("kai.bot.webhook.update_workspace"),
         ):
             await handle_workspace(update, ctx)
         # Directory should have been created
@@ -1510,7 +1507,6 @@ class TestHandleWorkspace:
             patch("kai.bot.sessions.set_setting", new_callable=AsyncMock),
             patch("kai.bot.sessions.upsert_workspace_history", new_callable=AsyncMock),
             patch("kai.bot.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
-            patch("kai.bot.webhook.update_workspace"),
         ):
             await handle_workspace(update, ctx)
         # Warning about git init failure was sent
@@ -1535,7 +1531,6 @@ class TestHandleWorkspace:
             patch("kai.bot.sessions.set_setting", new_callable=AsyncMock),
             patch("kai.bot.sessions.upsert_workspace_history", new_callable=AsyncMock),
             patch("kai.bot.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
-            patch("kai.bot.webhook.update_workspace"),
         ):
             await handle_workspace(update, ctx)
         # Should switch to the workspace, not show "Usage: /workspace new <name>"
@@ -1566,7 +1561,6 @@ class TestHandleWorkspace:
             patch("kai.bot.sessions.set_setting", new_callable=AsyncMock),
             patch("kai.bot.sessions.upsert_workspace_history", new_callable=AsyncMock),
             patch("kai.bot.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
-            patch("kai.bot.webhook.update_workspace"),
         ):
             await handle_workspace(update, ctx)
         claude.change_workspace.assert_called_once()
@@ -1586,7 +1580,6 @@ class TestHandleWorkspace:
             patch("kai.bot.sessions.set_setting", new_callable=AsyncMock),
             patch("kai.bot.sessions.upsert_workspace_history", new_callable=AsyncMock),
             patch("kai.bot.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
-            patch("kai.bot.webhook.update_workspace"),
         ):
             await handle_workspace(update, ctx)
         claude.change_workspace.assert_called_once()
@@ -1698,7 +1691,6 @@ class TestHandleWorkspaceCallback:
             patch("kai.bot.sessions.clear_session", new_callable=AsyncMock),
             patch("kai.bot.sessions.delete_setting", new_callable=AsyncMock),
             patch("kai.bot.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
-            patch("kai.bot.webhook.update_workspace"),
         ):
             await handle_workspace_callback(update, ctx)
         claude.change_workspace.assert_called_once()
@@ -1720,7 +1712,6 @@ class TestHandleWorkspaceCallback:
             patch("kai.bot.sessions.set_setting", new_callable=AsyncMock),
             patch("kai.bot.sessions.upsert_workspace_history", new_callable=AsyncMock),
             patch("kai.bot.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
-            patch("kai.bot.webhook.update_workspace"),
         ):
             await handle_workspace_callback(update, ctx)
         claude.change_workspace.assert_called_once()
@@ -1770,7 +1761,6 @@ class TestHandleWorkspaceCallback:
             patch("kai.bot.sessions.set_setting", new_callable=AsyncMock),
             patch("kai.bot.sessions.upsert_workspace_history", new_callable=AsyncMock),
             patch("kai.bot.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
-            patch("kai.bot.webhook.update_workspace"),
         ):
             await handle_workspace_callback(update, ctx)
         claude.change_workspace.assert_called_once()
@@ -2083,7 +2073,6 @@ class TestWorkspaceSubcommandRouting:
             patch("kai.bot.sessions.set_setting", new_callable=AsyncMock),
             patch("kai.bot.sessions.upsert_workspace_history", new_callable=AsyncMock),
             patch("kai.bot.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
-            patch("kai.bot.webhook.update_workspace"),
         ):
             await handle_workspace(update, ctx)
         claude.change_workspace.assert_called_once()

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -281,11 +281,26 @@ def _make_config(**overrides) -> Config:
     Accepts any Config field as a keyword override. Used by both the pure
     function tests (workspace_base, allowed_workspaces) and the handler
     tests (tts_enabled, voice_enabled, webhook_secret, etc.).
+
+    `claude_workspace=` is accepted as a back-compat alias for pre-#353
+    tests that wanted a specific home directory. Config no longer has
+    that field; instead the value is wired into a UserConfig override
+    for chat 12345 (the default chat_id used by _make_update) so that
+    bot.resolve_home_workspace returns the requested path. Tests that
+    pass their own `user_configs` win over the back-compat translation.
     """
+    legacy_home = overrides.pop("claude_workspace", None)
+    if legacy_home is not None and "user_configs" not in overrides:
+        overrides["user_configs"] = {
+            12345: UserConfig(
+                telegram_id=12345,
+                name="test",
+                home_workspace=legacy_home,
+            ),
+        }
     defaults: dict = {
         "telegram_bot_token": "test-token",
         "allowed_user_ids": {1},
-        "claude_workspace": Path("/home/workspace"),
         "workspace_base": None,
         "allowed_workspaces": [],
         "webhook_secret": "test-secret",
@@ -1360,6 +1375,49 @@ class TestHandleWorkspace:
         ):
             await handle_workspace(update, ctx)
         claude.change_workspace.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_workspace_home_lands_in_per_user_directory(self, tmp_path, monkeypatch):
+        """
+        Spec 353 acceptance: `/workspace home` for a user with no
+        users.yaml home_workspace override must land in DATA_DIR/home/<chat_id>/,
+        NOT in a shared global directory.
+
+        This is the multi-user privacy guarantee. We patch backend.DATA_DIR
+        to tmp_path so resolve_home_workspace creates a per-user directory
+        under the test root, then capture the path passed to
+        Claude.change_workspace and assert it matches that user's slot.
+        """
+        # Point backend.DATA_DIR at the test root so ensure_user_home
+        # creates the per-user dir under tmp_path rather than /var/lib/kai.
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+
+        # No claude_workspace= override -> no UserConfig.home_workspace,
+        # so resolve_home_workspace must fall through to ensure_user_home.
+        config = _make_config()
+        claude = _make_mock_claude(workspace=Path("/other"))
+        # _make_update defaults to chat_id=12345; the per-user home
+        # directory therefore lands at tmp_path/home/12345.
+        update = _make_update()
+        ctx = _make_context(claude=claude, config=config, args=["home"])
+        with (
+            _mock_resolve(),
+            patch("kai.bot.sessions.clear_session", new_callable=AsyncMock),
+            patch("kai.bot.sessions.delete_setting", new_callable=AsyncMock),
+            patch("kai.bot.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
+            patch("kai.bot.webhook.update_workspace"),
+        ):
+            await handle_workspace(update, ctx)
+
+        # Assert change_workspace was passed the per-user directory.
+        # Positional arg 0 is chat_id; positional arg 1 is the target Path.
+        claude.change_workspace.assert_called_once()
+        call_args = claude.change_workspace.call_args
+        target_path = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs["workspace"]
+        expected = tmp_path / "home" / "12345"
+        assert target_path == expected, f"Expected {expected}, got {target_path}"
+        # The directory must actually exist (ensure_user_home creates it).
+        assert expected.is_dir()
 
     @pytest.mark.asyncio
     async def test_absolute_path_rejected(self):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -800,7 +800,15 @@ class TestCmdConfig:
         assert data["users"][0]["role"] == "admin"
 
     def test_advanced_user_options(self, tmp_path, monkeypatch):
-        """Advanced path writes os_user and home_workspace, skips CLAUDE_USER."""
+        """
+        Advanced path writes os_user and skips CLAUDE_USER.
+
+        Post-#353: the wizard no longer prompts for home_workspace and
+        the admin's users.yaml entry does not carry that field - the
+        admin lands in DATA_DIR/home/<chat_id>/ like any other user.
+        See test_wizard_defaults_do_not_reintroduce_shared_home for the
+        regression guard.
+        """
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
@@ -817,7 +825,7 @@ class TestCmdConfig:
                 "admin",  # admin display name
                 "true",  # advanced user options
                 "testuser",  # os_user
-                str(tmp_path),  # home_workspace
+                # no home_workspace prompt post-#353
                 "polling",  # transport
                 "claude",  # agent backend
                 "sonnet",  # model
@@ -845,17 +853,151 @@ class TestCmdConfig:
 
         _cmd_config()
 
-        # Verify users.yaml has os_user and home_workspace
+        # Verify users.yaml has os_user and (post-#353) NO home_workspace.
+        # The admin lands in DATA_DIR/home/<chat_id>/ like any other user;
+        # the field is absent from the wizard output by design.
         yaml_path = tmp_path / "users.yaml"
         assert yaml_path.exists()
         data = yaml.safe_load(yaml_path.read_text())
         entry = data["users"][0]
         assert entry["os_user"] == "testuser"
-        assert entry["home_workspace"] == str(tmp_path.resolve())
+        assert "home_workspace" not in entry, (
+            "Wizard regression: admin entry should not carry home_workspace post-#353. See _cmd_config in install.py."
+        )
 
         # CLAUDE_USER should not be in the env (skipped because os_user was set)
         conf = json.loads((tmp_path / "install.conf").read_text())
         assert "CLAUDE_USER" not in conf["env"]
+
+    def test_wizard_defaults_do_not_reintroduce_shared_home(self, tmp_path, monkeypatch):
+        """
+        Regression guard for spec #353.
+
+        Prior to #353, the wizard defaulted home_workspace to a shared
+        PROJECT_ROOT/home directory. That shared default was the source
+        of the multi-user privacy hazard the spec exists to fix. This
+        test pins the post-#353 behavior across BOTH wizard paths:
+
+        1. The non-advanced path (advanced=false) must not emit a
+           home_workspace key into the admin's users.yaml entry.
+        2. The advanced path (advanced=true, no explicit home_workspace
+           prompt) must also not emit one.
+        3. The generated env must not carry a CLAUDE_WORKSPACE override
+           (the env var that pre-#353 wired the shared global home).
+
+        If any future change re-introduces a global default home, one
+        of these three assertions will fail.
+        """
+        # ---- Path 1: non-advanced wizard ----
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+
+        inputs_basic = iter(
+            [
+                "/opt/kai",  # install dir
+                "/var/lib/kai",  # data dir
+                "kai",  # service user
+                "darwin",  # platform
+                "fake-token",  # bot token
+                "12345",  # admin telegram ID
+                "admin",  # admin display name
+                "false",  # advanced user options -> no os_user, no home prompt
+                "polling",  # transport
+                "claude",  # agent backend
+                "sonnet",  # model
+                "120",  # timeout
+                "10.0",  # budget
+                "200000",  # max context window
+                "80",  # autocompact pct
+                "8080",  # port
+                "test-secret",  # webhook secret
+                "~/Projects",  # workspace base
+                "",  # allowed workspaces
+                "false",  # pr review enabled
+                "900",  # pr review timeout
+                "1.0",  # pr review budget
+                "false",  # issue triage enabled
+                "",  # github notify chat id
+                "false",  # voice
+                "false",  # tts
+                "",  # claude user (empty)
+                "false",  # memory enabled
+                "",  # perplexity key (empty)
+            ]
+        )
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs_basic))
+        _cmd_config()
+
+        yaml_path = tmp_path / "users.yaml"
+        data = yaml.safe_load(yaml_path.read_text())
+        basic_entry = data["users"][0]
+        assert "home_workspace" not in basic_entry, (
+            "Regression: non-advanced wizard re-introduced a shared home_workspace default. "
+            "Spec #353 requires per-user homes under DATA_DIR/home/<chat_id>/."
+        )
+
+        conf = json.loads((tmp_path / "install.conf").read_text())
+        # CLAUDE_WORKSPACE was the legacy env that wired a global home;
+        # pinning it absent ensures the wizard never re-emits the var.
+        assert "CLAUDE_WORKSPACE" not in conf["env"], (
+            "Regression: wizard wrote CLAUDE_WORKSPACE env. Spec #353 removed the global home field; "
+            "pool.py + bot.py now resolve home per chat_id."
+        )
+
+        # ---- Path 2: advanced wizard (admin chooses os_user) ----
+        # Re-run the wizard from a clean tmp dir to verify the advanced
+        # path also stays clean. We use a sibling dir so monkeypatched
+        # PROJECT_ROOT and INSTALL_CONF point somewhere fresh.
+        adv_root = tmp_path / "adv"
+        adv_root.mkdir()
+        monkeypatch.chdir(adv_root)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", adv_root / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", adv_root)
+
+        inputs_advanced = iter(
+            [
+                "/opt/kai",
+                "/var/lib/kai",
+                "kai",
+                "darwin",
+                "fake-token",
+                "12345",
+                "admin",
+                "true",  # advanced -> os_user prompt
+                "testuser",  # os_user (no home_workspace prompt should follow)
+                "polling",
+                "claude",
+                "sonnet",
+                "120",
+                "10.0",
+                "200000",
+                "80",
+                "8080",
+                "test-secret",
+                "~/Projects",
+                "",
+                "false",
+                "900",
+                "1.0",
+                "false",
+                "",
+                "false",
+                "false",
+                "false",  # memory enabled
+                "",  # perplexity key
+            ]
+        )
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs_advanced))
+        _cmd_config()
+
+        adv_data = yaml.safe_load((adv_root / "users.yaml").read_text())
+        adv_entry = adv_data["users"][0]
+        assert "home_workspace" not in adv_entry, (
+            "Regression: advanced wizard re-introduced home_workspace. The wizard removed the prompt "
+            "in spec #353; an admin who needs a custom path must hand-edit users.yaml."
+        )
 
     def test_goose_backend_writes_env(self, tmp_path, monkeypatch):
         """Selecting goose backend writes AGENT_BACKEND to env."""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2699,7 +2699,18 @@ class TestApplyMigratePerUserHome:
 
         Pre-fix: the block was guarded by `if home_root.is_dir():`
         which silently skipped everything when the parent was absent.
+
+        Round 2 review fix: home_root must end up at exactly 0o755,
+        not whatever the umask leaves behind. mkdir(mode=0o755) is
+        masked by the process umask; under the production service
+        umask of 0o027 this would leave home_root at 0o750, blocking
+        group traversal for distinct-os_user subprocesses. We set a
+        hostile umask inside the test to prove the explicit chmod
+        survives it.
         """
+        import os as _os
+        import stat
+
         data_path = self._setup(tmp_path, monkeypatch)
         # Note: _setup does NOT create data_path/home. The defensive
         # mkdir in _apply_migrate must create it.
@@ -2711,18 +2722,32 @@ class TestApplyMigratePerUserHome:
             "users:\n  - telegram_id: 8888\n    name: u\n    role: admin\n",
         )
 
-        _apply_migrate(
-            data_path,
-            tmp_path / "install",
-            svc_uid=501,
-            svc_gid=20,
-            dry_run=False,
-            users_yaml_path=users_yaml,
-        )
+        # Hostile umask matches the production service launchd config.
+        # Without the explicit os.chmod after mkdir, home_root would
+        # come out as 0o750 here.
+        prev_umask = _os.umask(0o027)
+        try:
+            _apply_migrate(
+                data_path,
+                tmp_path / "install",
+                svc_uid=501,
+                svc_gid=20,
+                dry_run=False,
+                users_yaml_path=users_yaml,
+            )
+        finally:
+            _os.umask(prev_umask)
 
         # Both the parent home/ and the per-user slot exist.
-        assert (data_path / "home").is_dir()
-        assert (data_path / "home" / "8888").is_dir()
+        home_root = data_path / "home"
+        assert home_root.is_dir()
+        assert (home_root / "8888").is_dir()
+        # Both at exactly 0o755 (group/other read+traverse, no write).
+        assert stat.S_IMODE(home_root.stat().st_mode) == 0o755, (
+            f"home_root mode {oct(stat.S_IMODE(home_root.stat().st_mode))} - "
+            "umask masked the mkdir mode and explicit chmod did not run"
+        )
+        assert stat.S_IMODE((home_root / "8888").stat().st_mode) == 0o755
 
 
 # ── Service lifecycle ────────────────────────────────────────────────

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2749,6 +2749,71 @@ class TestApplyMigratePerUserHome:
         )
         assert stat.S_IMODE((home_root / "8888").stat().st_mode) == 0o755
 
+    def test_override_resolves_through_data_path_symlink(self, tmp_path, monkeypatch):
+        """
+        Round 3 review fix: when DATA_DIR traverses a symlink (the
+        macOS case where /var/lib is a symlink to /private/var/lib),
+        the override-containment check must resolve both sides.
+
+        Pre-fix: `_collect_user_home_overrides` calls `Path.resolve()`
+        on every override but `_apply_migrate` compared the resolved
+        override against an unresolved data_path. An operator who
+        wrote `home_workspace: /private/var/lib/kai/custom` against a
+        `data_path` of `/var/lib/kai` would get is_relative_to=False
+        and the entry would silently fall through to Case 3 (skip).
+        First-write under a distinct os_user would then crash.
+
+        This test pins the symlink case by creating a symlink that
+        points at the real data_path and passing the symlink as the
+        installer's data_path argument. Without `data_path.resolve()`
+        the override (already resolved through the symlink) compares
+        as external and the test fails.
+        """
+        # Real data_path lives under tmp_path/real_data; the installer
+        # is invoked with a symlink at tmp_path/data_link that points
+        # at it. This mirrors the macOS /var/lib -> /private/var/lib
+        # situation that triggered the round-3 review finding.
+        real_data = tmp_path / "real_data"
+        real_data.mkdir()
+        (real_data / "logs").mkdir()
+        (real_data / "memory").mkdir()
+        data_link = tmp_path / "data_link"
+        data_link.symlink_to(real_data)
+
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path / "src")
+        (tmp_path / "src").mkdir()
+        monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
+
+        # Override path written against the REAL location (post-resolve
+        # form), simulating an operator who already canonicalized in
+        # users.yaml. _collect_user_home_overrides will resolve() it
+        # again to the same value.
+        override_real = real_data / "custom_workspace"
+        users_yaml = tmp_path / "users.yaml"
+        self._write_users_yaml(
+            users_yaml,
+            (f"users:\n  - telegram_id: 9999\n    name: u\n    role: admin\n    home_workspace: {override_real}\n"),
+        )
+
+        # Pass the symlinked path as data_path - this is what the
+        # round-3 bug needed to surface.
+        _apply_migrate(
+            data_link,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        # The override path under the REAL data dir was provisioned -
+        # proves the symlink-aware containment check classified it as
+        # internal (Case 2) instead of external (Case 3).
+        assert override_real.is_dir(), (
+            "Override under symlinked DATA_DIR was not provisioned - "
+            "is_relative_to comparison did not resolve data_path"
+        )
+
 
 # ── Service lifecycle ────────────────────────────────────────────────
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2571,6 +2571,160 @@ class TestApplyMigratePerUserMemory:
         assert not (data_path / "memory" / "MEMORY.md").exists()
 
 
+class TestApplyMigratePerUserHome:
+    """
+    Tests for the per-user home workspace provisioning in _apply_migrate
+    (#353). Mirrors TestApplyMigratePerUserMemory shape; the install-time
+    block is a pure file-system effect (mkdir + chown + chmod), so these
+    tests exercise the directory layout that gets produced.
+    """
+
+    def _write_users_yaml(self, path: Path, body: str) -> None:
+        path.write_text(body)
+
+    def _setup(self, tmp_path, monkeypatch) -> Path:
+        """Common scaffolding: project root, data dirs, no-op chown."""
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path / "src")
+        (tmp_path / "src").mkdir()
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        (data_path / "logs").mkdir()
+        (data_path / "memory").mkdir()
+        # chown is a no-op in tests: we are not root, and the test is
+        # only checking which paths got created, not their ownership.
+        monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
+        return data_path
+
+    def test_no_override_creates_home_chat_id_dir(self, tmp_path, monkeypatch):
+        """
+        Case 1 (default): a user with no users.yaml home_workspace lands
+        in DATA_DIR/home/<chat_id>/. This is the spec #353 default.
+        """
+        data_path = self._setup(tmp_path, monkeypatch)
+        users_yaml = tmp_path / "users.yaml"
+        self._write_users_yaml(
+            users_yaml,
+            "users:\n  - telegram_id: 5555\n    name: u\n    role: admin\n",
+        )
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        assert (data_path / "home" / "5555").is_dir()
+
+    def test_override_under_data_dir_provisions_override_path(self, tmp_path, monkeypatch):
+        """
+        Case 2 (W2 review fix): when home_workspace is set to a path
+        INSIDE DATA_DIR, the installer must create THAT path (the one
+        runtime resolve_home_workspace returns), NOT the default
+        DATA_DIR/home/<chat_id>/ slot.
+
+        Pre-fix bug: installer always created home/<chat_id>/, leaving
+        the actual override path un-provisioned. First runtime write to
+        the override would crash. This test pins the corrected behavior.
+        """
+        data_path = self._setup(tmp_path, monkeypatch)
+        # Override path lives under data_path/custom_workspace/.
+        override = data_path / "custom_workspace"
+        users_yaml = tmp_path / "users.yaml"
+        self._write_users_yaml(
+            users_yaml,
+            (f"users:\n  - telegram_id: 6666\n    name: u\n    role: admin\n    home_workspace: {override}\n"),
+        )
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        # The override path itself was created.
+        assert override.is_dir(), f"Override path {override} not provisioned"
+        # The default slot must NOT be created - it is never used at
+        # runtime when an override is set, so creating it would leave a
+        # dead directory under DATA_DIR.
+        assert not (data_path / "home" / "6666").exists(), (
+            "Default per-user slot should not be created when override is set"
+        )
+
+    def test_override_outside_data_dir_skips_provisioning(self, tmp_path, monkeypatch):
+        """
+        Case 3: when home_workspace points OUTSIDE DATA_DIR, the
+        installer must skip the entry entirely. The override is
+        operator-managed (a clone of a dev tree, a synced volume, etc.)
+        and we have no business chowning it.
+        """
+        data_path = self._setup(tmp_path, monkeypatch)
+        # Path outside data_path: a sibling under tmp_path.
+        external = tmp_path / "external_home"
+        external.mkdir()
+        users_yaml = tmp_path / "users.yaml"
+        self._write_users_yaml(
+            users_yaml,
+            (f"users:\n  - telegram_id: 7777\n    name: u\n    role: admin\n    home_workspace: {external}\n"),
+        )
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        # Default slot must NOT be created (we honored the override).
+        assert not (data_path / "home" / "7777").exists()
+        # External path must be left strictly alone (we did not chmod
+        # or otherwise touch it - verify it is still empty).
+        assert external.is_dir()
+        assert list(external.iterdir()) == []
+
+    def test_creates_home_root_when_missing(self, tmp_path, monkeypatch):
+        """
+        W3 review fix: if data_path/home/ does not exist when the
+        per-user block runs (e.g., a future refactor splits
+        _apply_directories from _apply_migrate), the block must still
+        provision per-user dirs rather than silently no-op'ing. The
+        defensive home_root.mkdir guarantees this.
+
+        Pre-fix: the block was guarded by `if home_root.is_dir():`
+        which silently skipped everything when the parent was absent.
+        """
+        data_path = self._setup(tmp_path, monkeypatch)
+        # Note: _setup does NOT create data_path/home. The defensive
+        # mkdir in _apply_migrate must create it.
+        assert not (data_path / "home").exists()
+
+        users_yaml = tmp_path / "users.yaml"
+        self._write_users_yaml(
+            users_yaml,
+            "users:\n  - telegram_id: 8888\n    name: u\n    role: admin\n",
+        )
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        # Both the parent home/ and the per-user slot exist.
+        assert (data_path / "home").is_dir()
+        assert (data_path / "home" / "8888").is_dir()
+
+
 # ── Service lifecycle ────────────────────────────────────────────────
 
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -24,7 +24,21 @@ from kai.pool import SubprocessPool
 
 
 def _make_config(**overrides) -> Config:
-    """Create a Config for pool tests."""
+    """
+    Create a Config for pool tests.
+
+    `claude_workspace=` is accepted as a back-compat alias for pre-#353
+    tests that wanted a specific home directory for the default test
+    chat. It translates to a UserConfig home_workspace override for
+    chat IDs 111 and 222 (the test fixture's two default users), since
+    Config no longer has a global claude_workspace field. Tests that
+    pass their own `user_configs` win over the back-compat translation.
+    """
+    legacy_home = overrides.pop("claude_workspace", None)
+    if legacy_home is not None and "user_configs" not in overrides:
+        overrides["user_configs"] = {
+            cid: UserConfig(telegram_id=cid, name=f"u{cid}", home_workspace=legacy_home) for cid in (111, 222)
+        }
     defaults: dict = {
         "telegram_bot_token": "test",
         "allowed_user_ids": {111, 222},
@@ -33,7 +47,6 @@ def _make_config(**overrides) -> Config:
         "budget_ceiling": 1.0,
         "claude_max_session_hours": 0,
         "claude_idle_timeout": 1800,
-        "claude_workspace": Path("/home/workspace"),
         "webhook_port": 8080,
         "webhook_secret": "secret",
     }
@@ -75,13 +88,23 @@ class TestInstanceCreation:
         assert instance.claude_user == "alice_os"
         assert instance.workspace == ws
 
-    def test_get_falls_back_to_defaults(self):
-        """User not in users.yaml gets global defaults."""
+    def test_get_falls_back_to_defaults(self, tmp_path, monkeypatch):
+        """
+        User not in users.yaml gets global defaults plus the per-user
+        DATA_DIR/home/<chat_id>/ landing directory (#353). The shared
+        global home was removed; the new fallback is keyed by chat_id.
+        """
+        # Point the resolver at a tmp DATA_DIR so the test does not
+        # touch the host's real /var/lib/kai or PROJECT_ROOT tree.
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
         config = _make_config(claude_user=None)
         pool = SubprocessPool(config=config, services_info=[])
         instance = pool.get(999)
         assert instance.claude_user is None
-        assert instance.workspace == Path("/home/workspace")
+        # Per-user landing directory under the patched DATA_DIR.
+        assert instance.workspace == tmp_path / "home" / "999"
+        # ensure_user_home is idempotent and creates the dir on resolve.
+        assert (tmp_path / "home" / "999").is_dir()
 
     def test_create_uses_user_config_settings(self, tmp_path):
         """User with model/timeout/budget/context_window in users.yaml gets those values."""
@@ -307,10 +330,17 @@ class TestPropertyAccessors:
         ):
             assert await pool.get_effective_model(999) == "opus"
 
-    def test_get_workspace_no_instance(self):
-        """get_workspace returns global default when no instance exists."""
+    def test_get_workspace_no_instance(self, tmp_path, monkeypatch):
+        """
+        get_workspace returns the per-user default when no instance exists.
+
+        Post-#353 the fallback resolves through resolve_home_workspace
+        instead of the removed global Config field, landing the user in
+        DATA_DIR/home/<chat_id>/.
+        """
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
         pool = SubprocessPool(config=_make_config(), services_info=[])
-        assert pool.get_workspace(999) == Path("/home/workspace")
+        assert pool.get_workspace(999) == tmp_path / "home" / "999"
 
     def test_is_alive_no_instance(self):
         """is_alive returns False when no instance exists."""

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1251,7 +1251,14 @@ class TestTriageErrorContent:
             labels=[],
         )
 
-        sensitive_path = "/opt/kai/home/.claude/CLAUDE.md"
+        # Substituted post-#353 because /opt/kai/home/.claude/CLAUDE.md
+        # no longer exists on production installs (the shared home was
+        # removed; CLAUDE.md is per-user under DATA_DIR/memory/).
+        # /etc/kai/env is the production secrets file - if its path ever
+        # leaked into a user-facing error notification it would expose
+        # the location of TELEGRAM_BOT_TOKEN and other secrets, which
+        # matches the original test's "represent a sensitive path" intent.
+        sensitive_path = "/etc/kai/env"
         error = FileNotFoundError(f"[Errno 2] No such file or directory: '{sensitive_path}'")
 
         with (

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -412,10 +412,10 @@ def _build_test_app(
     # Config needed by review background tasks
     app["webhook_port"] = 8080
     app["claude_user"] = None
-    # Workspace config for review agent repo resolution. The workspace
-    # path parent name ("repo") matches the test payload repo name so
-    # _resolve_local_repo() finds it via the home workspace check.
-    app["workspace"] = "/home/user/repo/workspace"
+    # Workspace config for review agent repo resolution. Tests that need
+    # _resolve_local_repo() to return a specific path populate workspace_base
+    # or allowed_workspaces; the default is empty so _mock_resolve_repo is
+    # used for routing tests that don't care about the resolution result.
     app["workspace_base"] = None
     app["allowed_workspaces"] = []
     app["spec_dir"] = "specs"
@@ -697,23 +697,6 @@ class TestResolveLocalRepo:
     """Tests for workspace-aware repo resolution."""
 
     @pytest.mark.asyncio
-    async def test_home_workspace(self, tmp_path):
-        """Resolves via home workspace when parent dir name matches repo."""
-        # Create a directory structure like /tmp/.../kai/workspace
-        repo_dir = tmp_path / "kai"
-        repo_dir.mkdir()
-        workspace_dir = repo_dir / "workspace"
-        workspace_dir.mkdir()
-
-        app = web.Application()
-        app["workspace"] = str(workspace_dir)
-        app["workspace_base"] = None
-        app["allowed_workspaces"] = []
-
-        result = await _resolve_local_repo("dcellison/kai", app)
-        assert result == str(repo_dir)
-
-    @pytest.mark.asyncio
     async def test_workspace_base(self, tmp_path):
         """Resolves via WORKSPACE_BASE when a child dir matches repo name."""
         # Create ~/Projects/anvil/ structure
@@ -721,7 +704,6 @@ class TestResolveLocalRepo:
         anvil_dir.mkdir()
 
         app = web.Application()
-        app["workspace"] = "/nonexistent/workspace"
         app["workspace_base"] = str(tmp_path)
         app["allowed_workspaces"] = []
 
@@ -735,7 +717,6 @@ class TestResolveLocalRepo:
         myrepo.mkdir()
 
         app = web.Application()
-        app["workspace"] = "/nonexistent/workspace"
         app["workspace_base"] = None
         app["allowed_workspaces"] = [str(myrepo)]
 
@@ -749,7 +730,6 @@ class TestResolveLocalRepo:
         history_repo.mkdir()
 
         app = web.Application()
-        app["workspace"] = "/nonexistent/workspace"
         app["workspace_base"] = None
         app["allowed_workspaces"] = []
 
@@ -762,32 +742,9 @@ class TestResolveLocalRepo:
         assert result == str(history_repo)
 
     @pytest.mark.asyncio
-    async def test_priority_order(self, tmp_path):
-        """Home workspace wins over workspace_base."""
-        # Both home and base have a matching "kai" directory
-        home_repo = tmp_path / "home" / "kai"
-        home_repo.mkdir(parents=True)
-        home_workspace = home_repo / "workspace"
-        home_workspace.mkdir()
-
-        base_dir = tmp_path / "base"
-        base_kai = base_dir / "kai"
-        base_kai.mkdir(parents=True)
-
-        app = web.Application()
-        app["workspace"] = str(home_workspace)
-        app["workspace_base"] = str(base_dir)
-        app["allowed_workspaces"] = []
-
-        result = await _resolve_local_repo("dcellison/kai", app)
-        # Home workspace should win
-        assert result == str(home_repo)
-
-    @pytest.mark.asyncio
     async def test_no_match(self, tmp_path):
         """Returns None when no workspace matches the repo."""
         app = web.Application()
-        app["workspace"] = str(tmp_path / "unrelated" / "workspace")
         app["workspace_base"] = str(tmp_path)
         app["allowed_workspaces"] = []
 
@@ -803,7 +760,6 @@ class TestResolveLocalRepo:
     async def test_nonexistent_dir_skipped(self, tmp_path):
         """History entries pointing to deleted directories are skipped."""
         app = web.Application()
-        app["workspace"] = "/nonexistent/workspace"
         app["workspace_base"] = None
         app["allowed_workspaces"] = []
 
@@ -822,7 +778,6 @@ class TestResolveLocalRepo:
         other_user_repo.mkdir()
 
         app = web.Application()
-        app["workspace"] = "/nonexistent/workspace"
         app["workspace_base"] = None
         app["allowed_workspaces"] = []
 

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from aiohttp import web
 
-import kai.webhook as webhook_mod
 from kai import sessions
 from kai.services import ServiceResponse
 from kai.webhook import (
@@ -25,7 +24,6 @@ from kai.webhook import (
     _handle_telegram_update,
     _handle_update_job,
     _resolve_chat_id,
-    update_workspace,
 )
 
 
@@ -323,12 +321,17 @@ class TestUpdateJob:
 @pytest.fixture
 def send_file_request(tmp_path):
     """Create a mock request for the send-file endpoint with workspace confinement."""
+    # Post-#353 send-file resolves the workspace via pool.get_workspace(chat_id)
+    # rather than a global app["workspace"] slot. The fixture supplies a mock
+    # pool whose get_workspace() returns tmp_path so path confinement passes.
+    mock_pool = MagicMock()
+    mock_pool.get_workspace = MagicMock(return_value=tmp_path)
     request = MagicMock(spec=web.Request)
     request.app = {
         "webhook_secret": "test-secret",
         "telegram_bot": AsyncMock(),
         "chat_id": 123,
-        "workspace": str(tmp_path),
+        "pool": mock_pool,
     }
     request.headers = {"X-Webhook-Secret": "test-secret"}
     return request
@@ -475,28 +478,6 @@ class TestSendMessage:
         send_message_request.app["telegram_bot"].send_message = AsyncMock(side_effect=RuntimeError("Boom"))
         resp = await _handle_send_message(send_message_request)
         assert resp.status == 500
-
-
-# ── update_workspace() ──────────────────────────────────────────────
-
-
-class TestUpdateWorkspace:
-    def test_updates_app_workspace(self, monkeypatch):
-        """update_workspace() changes the path stored in the live aiohttp app dict."""
-        # Simulate a running server by setting _app to a real Application instance
-        app = web.Application()
-        app["workspace"] = "/original/workspace"
-        monkeypatch.setattr(webhook_mod, "_app", app)
-
-        update_workspace("/switched/workspace")
-
-        assert app["workspace"] == "/switched/workspace"
-
-    def test_no_op_when_server_not_running(self, monkeypatch):
-        """update_workspace() is a no-op (no exception) when the server hasn't started."""
-        monkeypatch.setattr(webhook_mod, "_app", None)
-        # Should not raise
-        update_workspace("/any/path")
 
 
 # ── POST /webhook/telegram ─────────────────────────────────────────


### PR DESCRIPTION
Closes #353.

## Summary

- Replaces the shared `/opt/kai/home/` fallback with per-chat_id `DATA_DIR/home/<chat_id>/`, closing the multi-user privacy hazard
- Honors `user.home_workspace` from `users.yaml` when explicitly set (opt-out from Kai-managed directory)
- Mirrors the per-user MEMORY.md migration pattern from PR #348

## Changes

**Backend** (`src/kai/backend.py`)
- `ensure_user_home(chat_id, data_dir)` - lazy `mkdir` for `DATA_DIR/home/<chat_id>/`, idempotent, 0755
- `resolve_home_workspace(chat_id, config)` - prefers `users.yaml` override, falls back to `ensure_user_home`
- Single resolver used by `pool.py` and `bot.py`

**Config** (`src/kai/config.py`)
- Removes `claude_workspace` field from `Config`; validator logs "falling back to per-user default" instead of the old global path

**Pool / bot / webhook**
- `pool.py`: 3 call sites now use `resolve_home_workspace(chat_id, self._config)`
- `bot.py`: 5 call sites (including `/workspace home`, `/workspace` keyboard) use the resolver
- `webhook.py`: `_app["workspace"]` and `update_workspace()` removed entirely (post-review cleanup - see below). Send-file confinement reads `pool.get_workspace(chat_id)` at request time; `_resolve_local_repo` resolves GitHub webhook repos via WORKSPACE_BASE / ALLOWED_WORKSPACES / workspace_history

**Install wizard** (`src/kai/install.py`)
- Drops `home_workspace` prompt (admin lands in per-user directory like everyone else)
- `_apply_migrate` creates each user's `home/<chat_id>/` slot with correct ownership, skipping overrides that pin a path outside `DATA_DIR`
- `_collect_user_home_overrides()` helper reads `users.yaml` to detect opt-outs

**Tests**
- `test_backend.py`: `TestEnsureUserHome` + `TestResolveHomeWorkspace` (idempotency, None chat_id, users.yaml precedence)
- `test_bot.py`: `test_workspace_home_lands_in_per_user_directory` - pins the multi-user privacy guarantee at the `/workspace home` flow
- `test_install.py`: `test_wizard_defaults_do_not_reintroduce_shared_home` - regression guard across both basic and advanced wizard paths
- 1948 tests pass

## Migration steps (release notes)

Existing installations have content under `/opt/kai/home/` (or equivalent `PROJECT_ROOT/home/`). After deploying this change, that directory is **no longer read by Kai at runtime**. Operators should:

1. **Stop the service**: `sudo launchctl bootout system/com.syrinx.kai` (macOS) or systemd equivalent.
2. **Decide per user whether to migrate content**:
   - For each active `chat_id`, move desired files from `/opt/kai/home/` into `/var/lib/kai/home/<chat_id>/`.
   - `sudo chown -R <os_user>:<os_user> /var/lib/kai/home/<chat_id>` if that user has a distinct `os_user` in `users.yaml`; otherwise leave service-owned.
   - Users who want a workspace outside `DATA_DIR` (a clone of a dev tree, a synced volume, etc.) can hand-add `home_workspace: /absolute/path` to their `users.yaml` entry.
3. **Reinstall**: `sudo make install`. The `_apply_migrate` step will lazily create any still-missing `home/<chat_id>/` directories for known users.
4. **Restart the service**.
5. **Archive or remove** `/opt/kai/home/` once you've confirmed nothing important remained. It will not be re-created by Kai.

Users with `home_workspace` already set in `users.yaml` are unaffected - they continue to use their pinned path.

## Post-review cleanup (v6)

After the automated reviewer approved at round 5, an independent audit found that `webhook.update_workspace()` had been silently decoupled from `_do_switch_workspace` earlier in the spec revision history but left in the codebase for backward compatibility. With `_do_switch_workspace` no longer calling it and send-file now reading `pool.get_workspace(chat_id)` at request time, the `_app["workspace"]` slot and the `update_workspace()` setter contributed to nothing - including to the "load-bearing for send-file confinement" rationale that v5 cited for keeping them. A state labeled "update_workspace looks live but never runs, and a spec that describes behavior the code no longer has" is the worst of both worlds.

v6 removes:

- `update_workspace()` function definition in `webhook.py`
- `_app["workspace"] = None` initialization
- `_resolve_local_repo` step 1 (home-workspace-via-parent heuristic - only fired when the slot was populated, which it never is post-v6)
- The `request.app.get("workspace")` fallback in the send-file handler (redundant: pool-based path already covers every real request)
- `TestUpdateWorkspace` test class, `test_home_workspace` / `test_priority_order` from `TestResolveLocalRepo`, and 11 now-unused `patch("kai.bot.webhook.update_workspace")` guards in `test_bot.py`

Net diff: 22 insertions, 146 deletions. No user-visible behavior change.

## Test plan

- [x] `make check` (ruff check + format)
- [x] `make test` - 1948 passing
- [ ] Deploy to Mac mini, verify `/workspace home` for admin lands in `/var/lib/kai/home/<admin_chat_id>/`
- [ ] Verify a second user's `/workspace home` lands in their own `home/<chat_id>/`, not the admin's
- [ ] Confirm `users.yaml` `home_workspace` overrides still route correctly
- [ ] `sudo make install` twice in a row is idempotent (no duplicate chown churn)

