### PR TITLE
fix(tests): isolate Mem0 telemetry Qdrant via MEM0_DIR

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,61 @@ Fixtures here apply to ALL tests automatically, providing safety
 guarantees that individual tests don't need to remember to set up.
 """
 
+# ── Session-wide Mem0 isolation ─────────────────────────────────────
+#
+# Mem0 opens a telemetry/migration-tracking Qdrant client at
+# `$MEM0_DIR/migrations_qdrant` (see mem0/memory/main.py:378-379 and
+# the parallel construction at line 1819). That path is hardcoded
+# outside the user's `vector_store.config` and defaults to
+# `$HOME/.mem0/migrations_qdrant`. If the production Kai service is
+# running on the same machine, it holds a portalocker lock on that
+# folder and any test-suite run racing against it dies with
+# `Storage folder ... is already accessed by another instance of
+# Qdrant client`. See issue #357.
+#
+# The path is resolved at module-import time in
+# `mem0/memory/setup.py:8` (and again, independently, in
+# `mem0/configs/base.py:13`), which means the override must be in
+# `os.environ` BEFORE any test module imports `mem0`.
+# `tests/test_memory.py:80` does `import mem0` at module top to
+# detect availability, so a fixture-level override is too late -
+# pytest collects the test module after conftest runs but before
+# any fixture body executes. conftest.py module-top is the only
+# hook that fires before test collection, making this the right
+# place for the env-var set.
+import atexit
+import os
+import shutil
+import tempfile
 from unittest.mock import patch
 
 import pytest
+
+# Hard override (NOT setdefault). A dev who happens to run the
+# suite with `MEM0_DIR=$HOME/.mem0` exported in their shell is the
+# exact scenario this fix targets; respecting an inherited value
+# would silently reopen the bug. tempfile.mkdtemp is used instead
+# of pytest's tmp_path_factory because that factory is only
+# accessible from inside fixtures - module-top code has no clean
+# way to reach it without poking at private pytest internals.
+_MEM0_TEST_DIR = tempfile.mkdtemp(prefix="kai-test-mem0-")
+os.environ["MEM0_DIR"] = _MEM0_TEST_DIR
+
+
+@atexit.register
+def _cleanup_mem0_test_dir() -> None:
+    """Best-effort removal of the per-run Mem0 telemetry root.
+
+    `tempfile.mkdtemp` does not auto-clean; without this hook every
+    `make test` invocation leaks one directory under /tmp/. Errors
+    are swallowed (ignore_errors=True) so a stray open file handle
+    from a crashed worker cannot mask a real test failure with a
+    secondary traceback at interpreter shutdown.
+    """
+    shutil.rmtree(_MEM0_TEST_DIR, ignore_errors=True)
+
+
+# ── Per-test history isolation ──────────────────────────────────────
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -142,6 +142,46 @@ class TestInitMemory:
         assert not is_enabled()
 
     @integration
+    def test_mem0_telemetry_path_is_isolated(self):
+        """Mem0's hardcoded telemetry Qdrant path must live under the
+        test-only MEM0_DIR set by conftest, never under $HOME/.mem0.
+
+        Regression guard for issue #357. Mem0 opens a second Qdrant
+        local-mode client at $MEM0_DIR/migrations_qdrant for its own
+        telemetry/migration tracking, with the path resolved at module
+        import time (mem0/memory/setup.py:8). If MEM0_DIR is not set
+        before any `import mem0` runs, that path freezes to the
+        production default $HOME/.mem0 and collides with the running
+        production service's portalocker lock - making the entire
+        TestMemoryIntegration suite unrunnable on a dev machine.
+
+        If a future refactor removes the conftest-level env override,
+        this test fails fast on CI and on dev machines alike, before
+        the heavier integration tests hit the RuntimeError.
+        """
+        import os
+        from pathlib import Path
+
+        mem0_dir_env = os.environ.get("MEM0_DIR", "")
+        assert mem0_dir_env, "MEM0_DIR must be set by conftest.py"
+
+        # Must not be the production default - catches a regression
+        # where someone replaces tempfile.mkdtemp with a literal
+        # path that happens to land on the user's home dir.
+        assert Path(mem0_dir_env).resolve() != (Path.home() / ".mem0").resolve()
+
+        # Cross-check against mem0's own resolved constant. This is
+        # the load-bearing freeze-detector: if MEM0_DIR was set
+        # AFTER mem0 was imported, mem0_resolved is frozen to the
+        # wrong value (the production default) and this assertion
+        # fires. The other two assertions only catch coarser
+        # breakage (env unset, env pointing at home) - this one
+        # catches the subtle ordering bug that motivated the fix.
+        from mem0.memory.setup import mem0_dir as mem0_resolved
+
+        assert Path(mem0_resolved).resolve() == Path(mem0_dir_env).resolve()
+
+    @integration
     def test_init_creates_qdrant_dir(self, tmp_path):
         """init_memory() creates the Qdrant storage directory."""
         from kai.memory import init_memory, is_enabled

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -159,9 +159,6 @@ class TestInitMemory:
         this test fails fast on CI and on dev machines alike, before
         the heavier integration tests hit the RuntimeError.
         """
-        import os
-        from pathlib import Path
-
         mem0_dir_env = os.environ.get("MEM0_DIR", "")
         assert mem0_dir_env, "MEM0_DIR must be set by conftest.py"
 


### PR DESCRIPTION
## Summary

Mem0 opens a hardcoded telemetry/migration Qdrant client at `$MEM0_DIR/migrations_qdrant`, outside the user's `vector_store.config`. Default is `$HOME/.mem0/migrations_qdrant`, which collides with the production Kai service's portalocker lock on dev machines and kills 7 memory tests with `Storage folder ... is already accessed by another instance of Qdrant client`. CI was green because containers don't have the production daemon running.

Set `MEM0_DIR` to a per-run `tempfile.mkdtemp` at `tests/conftest.py` module-top so the override is in `os.environ` before pytest collects `test_memory.py` and triggers its top-level `import mem0`. A fixture-scoped override would be too late: `mem0_dir` is frozen into `mem0.memory.main`'s namespace at first import via the chain `mem0/__init__.py:6` → `mem0/memory/main.py:25` → `mem0/memory/setup.py:8`.

`atexit` cleans up the per-run temp dir at interpreter shutdown.

## Regression test

Adds `TestInitMemory::test_mem0_telemetry_path_is_isolated` with three assertions:

1. `MEM0_DIR` is set - catches conftest simplification that drops the override.
2. Not `$HOME/.mem0` - catches a literal-default replacement.
3. Matches `mem0.memory.setup.mem0_dir` - catches the load-ordering trap where the env var is set after `import mem0` has already cached the wrong path. This is the freeze-detector that pinpoints the failure mode the spec is preventing.

Gated by `@integration` so CI without the `[memory]` extra skips rather than errors on the `mem0.memory.setup` import.

## Test plan

- [x] All 7 originally-failing tests now pass with the production Kai service running on the same machine
- [x] New `test_mem0_telemetry_path_is_isolated` passes
- [x] `make check` clean (ruff check + format)
- [x] Full suite green: 2082 passed (up from 2072 - 9 newly-passing + 1 new regression test)
- [x] `$HOME/.mem0/migrations_qdrant` mtime unchanged before and after the suite (still `Apr 16 10:28:25`, the production service's last touch)
- [x] `/tmp/kai-test-mem0-*` removed by `atexit` after the process exits

fixes #357
