### PR TITLE
feat(eval): Layer 1 retrieval evaluation harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,13 @@ home/.claude/*
 !home/config
 home/config/*
 !home/config/goose-config.yaml
+# Evaluation harness: committed examples show the schema; real
+# baselines and probe sets contain per-operator data (conversation
+# fragments, IDs specific to that store) and must stay gitignored.
+!home/evals
+home/evals/*
+!home/evals/retrieval-baseline.example.json
+!home/evals/probes.example.jsonl
 
 # OS / IDE
 .DS_Store

--- a/home/evals/probes.example.jsonl
+++ b/home/evals/probes.example.jsonl
@@ -1,0 +1,11 @@
+# Example probe set for the Layer 1 retrieval eval harness.
+# Lines starting with `#` are comments and skipped by the loader.
+# Real probes live in home/evals/probes.jsonl (gitignored) so each
+# operator's actual conversation excerpts stay out of the repo.
+
+# probes added 2026-04-22 covering tag=preferences
+{"question": "what timezone am I in?", "expected_fact_id": "00000000-0000-0000-0000-000000000001", "source_turn_ts": "2026-04-01T10:15:00", "notes": "from session covering travel scheduling"}
+{"question": "which editor do I use?", "expected_fact_id": "00000000-0000-0000-0000-000000000002", "source_turn_ts": "2026-04-03T19:42:00", "notes": "asked while debugging a config tweak"}
+
+# probes added 2026-04-22 covering tag=infra
+{"question": "where does the bot run?", "expected_fact_id": "00000000-0000-0000-0000-000000000003", "source_turn_ts": "2026-04-08T08:00:00", "notes": "from a deployment-status check"}

--- a/home/evals/retrieval-baseline.example.json
+++ b/home/evals/retrieval-baseline.example.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "generated_at": "2026-04-22T15:00:00Z",
+  "probe_set_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "probe_count": 47,
+  "drift_count": 2,
+  "config": {
+    "floor": 0.3,
+    "extracted_weight": 1.2,
+    "legacy_weight": 0.6,
+    "overfetch": 20
+  },
+  "metrics": {
+    "precision_at_1": 0.68,
+    "precision_at_3": 0.81,
+    "precision_at_5": 0.83,
+    "precision_at_lines_used": 0.77,
+    "mrr": 0.74,
+    "fraction_in_prompt": 0.77,
+    "latency_p50_ms": 43,
+    "latency_p95_ms": 127
+  },
+  "by_tag": {
+    "preferences": {
+      "precision_at_k": {"1": 0.71, "3": 0.84, "5": 0.86},
+      "recall_at_k": {"1": 0.71, "3": 0.84, "5": 0.86},
+      "precision_at_lines_used": 0.79,
+      "mrr": 0.78,
+      "fraction_in_prompt": 0.79
+    },
+    "infra": {
+      "precision_at_k": {"1": 0.62, "3": 0.75, "5": 0.78},
+      "recall_at_k": {"1": 0.62, "3": 0.75, "5": 0.78},
+      "precision_at_lines_used": 0.72,
+      "mrr": 0.69,
+      "fraction_in_prompt": 0.72
+    }
+  }
+}

--- a/home/evals/retrieval-baseline.example.json
+++ b/home/evals/retrieval-baseline.example.json
@@ -24,14 +24,22 @@
   },
   "by_tag": {
     "preferences": {
-      "precision_at_k": {"1": 0.71, "3": 0.84, "5": 0.86},
-      "recall_at_k": {"1": 0.71, "3": 0.84, "5": 0.86},
+      "precision_at_1": 0.71,
+      "precision_at_3": 0.84,
+      "precision_at_5": 0.86,
+      "recall_at_1": 0.71,
+      "recall_at_3": 0.84,
+      "recall_at_5": 0.86,
       "mrr": 0.78,
       "fraction_in_prompt": 0.79
     },
     "infra": {
-      "precision_at_k": {"1": 0.62, "3": 0.75, "5": 0.78},
-      "recall_at_k": {"1": 0.62, "3": 0.75, "5": 0.78},
+      "precision_at_1": 0.62,
+      "precision_at_3": 0.75,
+      "precision_at_5": 0.78,
+      "recall_at_1": 0.62,
+      "recall_at_3": 0.75,
+      "recall_at_5": 0.78,
       "mrr": 0.69,
       "fraction_in_prompt": 0.72
     }

--- a/home/evals/retrieval-baseline.example.json
+++ b/home/evals/retrieval-baseline.example.json
@@ -14,7 +14,9 @@
     "precision_at_1": 0.68,
     "precision_at_3": 0.81,
     "precision_at_5": 0.83,
-    "precision_at_lines_used": 0.77,
+    "recall_at_1": 0.68,
+    "recall_at_3": 0.81,
+    "recall_at_5": 0.83,
     "mrr": 0.74,
     "fraction_in_prompt": 0.77,
     "latency_p50_ms": 43,
@@ -24,14 +26,12 @@
     "preferences": {
       "precision_at_k": {"1": 0.71, "3": 0.84, "5": 0.86},
       "recall_at_k": {"1": 0.71, "3": 0.84, "5": 0.86},
-      "precision_at_lines_used": 0.79,
       "mrr": 0.78,
       "fraction_in_prompt": 0.79
     },
     "infra": {
       "precision_at_k": {"1": 0.62, "3": 0.75, "5": 0.78},
       "recall_at_k": {"1": 0.62, "3": 0.75, "5": 0.78},
-      "precision_at_lines_used": 0.72,
       "mrr": 0.69,
       "fraction_in_prompt": 0.72
     }

--- a/src/kai/eval/__init__.py
+++ b/src/kai/eval/__init__.py
@@ -1,0 +1,9 @@
+"""
+Evaluation package for the Kai memory pipeline.
+
+Currently houses Layer 1 only (`retrieval`): precision / recall / MRR
+on a probe set scored against the live `format_context` log line.
+Future layers (end-to-end A/B, longitudinal friction) will land as
+sibling modules so they share probe loaders, output formatting, and
+the same package home.
+"""

--- a/src/kai/eval/retrieval.py
+++ b/src/kai/eval/retrieval.py
@@ -406,8 +406,13 @@ def score_probes(results: list[ProbeResult]) -> dict[str, Any]:
     }
 
 
-def _percentile(values: list[float], pct: float) -> float:
-    """Return the requested percentile from values (0-100 scale).
+def _percentile(values: list[float], pct: int) -> float:
+    """Return the requested percentile from values (1-99 integer scale).
+
+    `pct` is `int` not `float` so a fractional percentile (e.g. 50.9)
+    cannot be silently truncated to the 50th by `int(pct) - 1`. The
+    only callers today are `_percentile(latencies, 50)` and `(_, 95)`,
+    so narrowing the contract costs nothing and removes the footgun.
 
     Uses statistics.quantiles for the standard linear-interpolation
     estimate. Returns 0.0 on empty input rather than raising so the
@@ -419,13 +424,12 @@ def _percentile(values: list[float], pct: float) -> float:
         return 0.0
     if len(values) == 1:
         return float(values[0])
-    # n=100 partitions plus boundary fix-up gives us linear-interp
-    # percentile lookup at any integer percentage. quantiles returns
-    # the 99 cut points for n=100, so index `pct - 1` is the
-    # requested percentile (1-indexed math collapses to the simple
-    # subtraction).
+    # n=100 partitions gives 99 cut points (quantiles returns n-1
+    # cuts for n partitions), so index `pct - 1` is the requested
+    # 1-indexed percentile. clamp() defends against pct == 0 or
+    # pct >= 100, which would index out of the cuts list.
     cuts = statistics.quantiles(values, n=100)
-    idx = int(pct) - 1
+    idx = pct - 1
     idx = max(0, min(idx, len(cuts) - 1))
     return float(cuts[idx])
 

--- a/src/kai/eval/retrieval.py
+++ b/src/kai/eval/retrieval.py
@@ -184,7 +184,6 @@ class Metrics:
     n_drift: int
     precision_at_k: dict[int, float]
     recall_at_k: dict[int, float]
-    precision_at_lines_used: float
     mrr: float
     fraction_in_prompt: float
     latency_p50_ms: float
@@ -346,21 +345,17 @@ def score_probes(results: list[ProbeResult]) -> dict[str, Any]:
     """Compute aggregate metrics over a list of ProbeResult.
 
     Pure function: takes scored per-probe outcomes (rank, lines_used,
-    in_prompt) and returns the metrics dict. Test #1 exercises this
-    directly with hand-constructed inputs, including a mix of scored-
-    hit, scored-miss, and drift probes, asserting that drift probes
-    are excluded from BOTH numerator and denominator. The caller is
-    responsible for filtering out drift probes before invoking this
-    function; that contract is enforced by the type signature
-    (drift probes don't produce a ProbeResult at all).
+    in_prompt) and returns the metrics dict. The harness's drift-
+    detection step filters drifted probes out before they reach this
+    function; the type signature does NOT enforce that contract (any
+    list[ProbeResult] type-checks), so the caller is responsible.
 
     For the single-answer case (each probe has exactly one expected
     fact), recall@K equals precision@K. They are reported separately
     so a future multi-answer probe format can diverge without
-    reshaping the output. fraction_in_prompt differs from precision
-    @lines_used: in_prompt is computed per probe against that probe's
-    actual lines_used (varies with budget exhaustion), whereas
-    precision@K uses a fixed K across all probes.
+    reshaping the output. fraction_in_prompt is the per-probe variant:
+    each probe is checked against its own lines_used (varies with
+    budget exhaustion), whereas precision@K uses a fixed K.
     """
     n = len(results)
     if n == 0:
@@ -372,7 +367,6 @@ def score_probes(results: list[ProbeResult]) -> dict[str, Any]:
         return {
             "precision_at_k": {k: 0.0 for k in _K_VALUES},
             "recall_at_k": {k: 0.0 for k in _K_VALUES},
-            "precision_at_lines_used": 0.0,
             "mrr": 0.0,
             "fraction_in_prompt": 0.0,
         }
@@ -389,11 +383,13 @@ def score_probes(results: list[ProbeResult]) -> dict[str, Any]:
         precision_at_k[k] = hits_in_top_k / n
         recall_at_k[k] = hits_in_top_k / n
 
-    # precision_at_lines_used is the per-probe variant: uses each
-    # probe's own lines_used as the K. A probe whose lines_used was
-    # zero (header-only output, never observed in practice but
-    # possible if budget < header tokens) cannot have an in-prompt
-    # hit, which falls out naturally from the rank <= 0 check.
+    # fraction_in_prompt: per-probe variant where K = each probe's
+    # actual lines_used (the slice the agent saw). Computed from
+    # ProbeResult.in_prompt which was set in _run_one_probe as
+    # `rank is not None and rank <= lines_used`. A probe whose
+    # lines_used was zero (header-only output, possible if budget <
+    # header tokens) cannot have an in-prompt hit, which falls out
+    # naturally from the rank <= 0 check at probe-execution time.
     in_prompt_count = sum(1 for r in results if r.in_prompt)
 
     # MRR: mean of 1/rank, treating misses as 0. The miss-as-zero
@@ -405,7 +401,6 @@ def score_probes(results: list[ProbeResult]) -> dict[str, Any]:
     return {
         "precision_at_k": precision_at_k,
         "recall_at_k": recall_at_k,
-        "precision_at_lines_used": in_prompt_count / n,
         "mrr": mrr_sum / n,
         "fraction_in_prompt": in_prompt_count / n,
     }
@@ -471,7 +466,6 @@ def aggregate_metrics(
         n_drift=n_drift,
         precision_at_k=base["precision_at_k"],
         recall_at_k=base["recall_at_k"],
-        precision_at_lines_used=base["precision_at_lines_used"],
         mrr=base["mrr"],
         fraction_in_prompt=base["fraction_in_prompt"],
         latency_p50_ms=_percentile(latencies, 50),
@@ -626,15 +620,21 @@ def _detach_capture(capture: _RecallLogCapture) -> None:
         logger.setLevel(capture._saved_level)
 
 
-async def evaluate(probes: list[Probe], user_id: str) -> Metrics:
-    """Run drift detection + scoring for one configuration.
+async def _score_against_store(
+    scored: list[Probe],
+    drifted: list[Probe],
+    tags_by_id: dict[str, tuple[str, ...]],
+    user_id: str,
+) -> Metrics:
+    """Run probes through the live store and aggregate metrics.
 
-    The configuration is whatever is currently loaded into
-    `kai.memory` module state - this function does NOT mutate that
-    state. The sweep loop layers config mutation on top by calling
-    `evaluate` once per grid point inside its own try/finally.
+    Split out from `evaluate` so the sweep loop can pre-compute drift
+    once at sweep entry and reuse it across every grid point: drift
+    state (which expected_fact_ids resolve via get_by_id) does not
+    depend on the floor / extracted_weight / overfetch knobs that the
+    sweep mutates, so re-running detect_drift per grid point would
+    issue grid_size * len(probes) get_by_id calls for no new signal.
     """
-    scored, drifted, tags_by_id = detect_drift(probes, user_id)
     capture = _attach_capture()
     try:
         results = await _run_probes(scored, user_id, capture, tags_by_id)
@@ -644,7 +644,24 @@ async def evaluate(probes: list[Probe], user_id: str) -> Metrics:
         # runs in a long-lived process (Python REPL, future test
         # suite) would stack capture handlers.
         _detach_capture(capture)
-    return aggregate_metrics(results, n_probes=len(probes), n_drift=len(drifted))
+    return aggregate_metrics(
+        results,
+        n_probes=len(scored) + len(drifted),
+        n_drift=len(drifted),
+    )
+
+
+async def evaluate(probes: list[Probe], user_id: str) -> Metrics:
+    """Run drift detection + scoring for one configuration.
+
+    The configuration is whatever is currently loaded into
+    `kai.memory` module state - this function does NOT mutate that
+    state. The sweep loop calls `_score_against_store` directly with
+    pre-computed drift to avoid redundant get_by_id calls per grid
+    point; single-config callers go through this wrapper.
+    """
+    scored, drifted, tags_by_id = detect_drift(probes, user_id)
+    return await _score_against_store(scored, drifted, tags_by_id, user_id)
 
 
 # ── Sweep mode ─────────────────────────────────────────────────────
@@ -705,6 +722,14 @@ async def run_sweep(
     saved_weights: dict[str, float] = dict(_mem._SOURCE_WEIGHTS)
     saved_overfetch: int = _mem._SEARCH_OVERFETCH
 
+    # Drift detection is independent of the swept knobs: get_by_id
+    # consults Mem0 row presence and source filtering, neither of
+    # which the floor/weight/overfetch grid touches. Computing once
+    # at sweep entry collapses grid_size * len(probes) get_by_id
+    # calls down to len(probes) total. The store is assumed stable
+    # across the sweep (which runs in minutes, not hours).
+    scored, drifted, tags_by_id = detect_drift(probes, user_id)
+
     out: list[tuple[ConfigOverride, Metrics]] = []
     try:
         for i, override in enumerate(grid, start=1):
@@ -722,7 +747,7 @@ async def run_sweep(
             # object is also passed to other modules at init time, but
             # those modules cache nothing, so a rebind here is sufficient.
             _mem._config = dataclasses.replace(saved_config, memory_search_floor=override.floor)
-            metrics = await evaluate(probes, user_id)
+            metrics = await _score_against_store(scored, drifted, tags_by_id, user_id)
             out.append((override, metrics))
     finally:
         # Restore from snapshot regardless of whether the loop ran to
@@ -798,7 +823,6 @@ def _metrics_to_dict(m: Metrics, *, include_by_tag: bool = True) -> dict[str, An
         # what jq will see anyway.
         "precision_at_k": {str(k): round(v, 4) for k, v in m.precision_at_k.items()},
         "recall_at_k": {str(k): round(v, 4) for k, v in m.recall_at_k.items()},
-        "precision_at_lines_used": round(m.precision_at_lines_used, 4),
         "mrr": round(m.mrr, 4),
         "fraction_in_prompt": round(m.fraction_in_prompt, 4),
         "latency_p50_ms": round(m.latency_p50_ms, 1),
@@ -809,7 +833,6 @@ def _metrics_to_dict(m: Metrics, *, include_by_tag: bool = True) -> dict[str, An
             tag: {
                 "precision_at_k": {str(k): round(v, 4) for k, v in vals["precision_at_k"].items()},
                 "recall_at_k": {str(k): round(v, 4) for k, v in vals["recall_at_k"].items()},
-                "precision_at_lines_used": round(vals["precision_at_lines_used"], 4),
                 "mrr": round(vals["mrr"], 4),
                 "fraction_in_prompt": round(vals["fraction_in_prompt"], 4),
             }
@@ -830,11 +853,10 @@ def _render_single_metrics(m: Metrics) -> str:
         f"Probes: {m.n_probes} total, {m.n_scored} scored, {m.n_drift} drifted",
         "",
         "Precision @K:",
-        *[f"  K={k}: {m.precision_at_k[k]:.3f}" for k in _K_VALUES],
-        f"  K=lines_used (per probe): {m.precision_at_lines_used:.3f}",
+        *[f"  K={k}: {m.precision_at_k.get(k, 0.0):.3f}" for k in _K_VALUES],
         "",
         "Recall @K (single-answer = precision):",
-        *[f"  K={k}: {m.recall_at_k[k]:.3f}" for k in _K_VALUES],
+        *[f"  K={k}: {m.recall_at_k.get(k, 0.0):.3f}" for k in _K_VALUES],
         "",
         f"MRR: {m.mrr:.3f}",
         f"fraction_in_prompt: {m.fraction_in_prompt:.3f}",
@@ -843,15 +865,10 @@ def _render_single_metrics(m: Metrics) -> str:
     ]
     if m.by_tag:
         lines.append("")
-        lines.append("Per-tag (precision@5 / fraction_in_prompt / probe count):")
+        lines.append("Per-tag (precision@5 / fraction_in_prompt):")
         for tag, vals in m.by_tag.items():
             p5 = vals["precision_at_k"].get(5, 0.0)
             fip = vals["fraction_in_prompt"]
-            # Per-tag probe count: count of probes whose expected
-            # fact carries this tag. Recovered from the by_tag dict's
-            # presence rather than re-walking results, since by_tag
-            # is computed from the same buckets and we trust the
-            # math above.
             lines.append(f"  {tag}: p@5={p5:.3f} in_prompt={fip:.3f}")
     return "\n".join(lines)
 
@@ -877,9 +894,14 @@ def _render_sweep_table(sweep_results: list[tuple[ConfigOverride, Metrics]]) -> 
     sep = "-" * len(header)
     rows = []
     for cfg, m in sorted_results:
+        # `.get(k, 0.0)` defends against _K_VALUES drifting out from
+        # under this renderer; matches the pattern in pareto_frontier.
+        p1 = m.precision_at_k.get(1, 0.0)
+        p3 = m.precision_at_k.get(3, 0.0)
+        p5 = m.precision_at_k.get(5, 0.0)
         rows.append(
             f"{cfg.floor:>6.2f} {cfg.extracted_weight:>6.2f} {cfg.overfetch:>5d}  "
-            f"{m.precision_at_k[1]:>6.3f} {m.precision_at_k[3]:>6.3f} {m.precision_at_k[5]:>6.3f}  "
+            f"{p1:>6.3f} {p3:>6.3f} {p5:>6.3f}  "
             f"{m.mrr:>6.3f} {m.fraction_in_prompt:>6.3f}  "
             f"{m.latency_p50_ms:>5.0f} {m.latency_p95_ms:>5.0f}"
         )
@@ -997,10 +1019,12 @@ def _build_baseline_json(
             "overfetch": cfg.overfetch,
         },
         "metrics": {
-            "precision_at_1": round(metrics.precision_at_k[1], 4),
-            "precision_at_3": round(metrics.precision_at_k[3], 4),
-            "precision_at_5": round(metrics.precision_at_k[5], 4),
-            "precision_at_lines_used": round(metrics.precision_at_lines_used, 4),
+            "precision_at_1": round(metrics.precision_at_k.get(1, 0.0), 4),
+            "precision_at_3": round(metrics.precision_at_k.get(3, 0.0), 4),
+            "precision_at_5": round(metrics.precision_at_k.get(5, 0.0), 4),
+            "recall_at_1": round(metrics.recall_at_k.get(1, 0.0), 4),
+            "recall_at_3": round(metrics.recall_at_k.get(3, 0.0), 4),
+            "recall_at_5": round(metrics.recall_at_k.get(5, 0.0), 4),
             "mrr": round(metrics.mrr, 4),
             "fraction_in_prompt": round(metrics.fraction_in_prompt, 4),
             "latency_p50_ms": round(metrics.latency_p50_ms, 1),

--- a/src/kai/eval/retrieval.py
+++ b/src/kai/eval/retrieval.py
@@ -1,0 +1,1109 @@
+"""
+Layer 1 retrieval evaluation harness.
+
+Reachable as `python -m kai.eval.retrieval`.
+
+Given a probe set of `(question, expected_fact_id)` pairs, runs each
+probe through the live memory pipeline, parses the resulting
+`memory.recall` log line emitted by `format_context`, and emits
+precision@K, recall@K, mean reciprocal rank, and the fraction of
+probes whose expected fact actually reached the injected prompt
+(`fraction_in_prompt`). Optionally sweeps a parameter grid and
+reports the Pareto frontier of (precision, latency).
+
+Design rationale (the part that is not obvious from the code):
+
+- The harness scores against `format_context`, not `search` directly.
+  `format_context` is what production runs; scoring a reduced pipeline
+  (search without floor filtering or budget walking) would measure a
+  code path the agent never uses. `format_context` is already
+  instrumented with a structured `memory.recall` log line, so the
+  harness reads the log rather than wrapping retrieval. This doubles
+  as a regression test: if the log emit ever stops being parseable,
+  the harness fails loudly.
+
+- Probes whose expected fact has been deleted from the store between
+  authoring and evaluation are bucketed as "probe-set drift" rather
+  than counted as retrieval misses. Mixing the two would conflate
+  "retrieval failed" with "probe set went stale" - different operator
+  actions (tune retrieval vs. refresh probes). Drift count is reported
+  separately. All four metric denominators are computed against
+  N_scored = N_probes - N_drift; drift probes are excluded from both
+  numerator and denominator.
+
+- The sweep mutates module-level state in `kai.memory`
+  (`_SOURCE_WEIGHTS`, `_SEARCH_OVERFETCH`) and replaces `_config` with
+  a `dataclasses.replace(...)` clone for each grid point. Restoration
+  in `try/finally` defends against a probe raising mid-sweep. The
+  process is short-lived and has no other consumers of the memory
+  module, so in-place mutation is safe.
+
+PII posture: probe questions and expected_fact_id values are operator
+data and remain in the gitignored probes file. The committed
+`*.example.*` fixtures use synthetic data only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import hashlib
+import json
+import logging
+import statistics
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# ── Constants ───────────────────────────────────────────────────────
+
+
+# K values reported for precision / recall. Includes the per-probe
+# `lines_used` (resolved at eval time, varies per probe) which is
+# computed separately rather than pre-listed here. The fixed K values
+# are the ones the eval table renders columns for: 1 (the strictest
+# top-pick metric), 3 (typical mid-budget), and 5 (the default Pareto
+# axis - top-K large enough to absorb tie-break noise, small enough
+# to match typical budget walks).
+_K_VALUES: tuple[int, ...] = (1, 3, 5)
+
+
+# Default sweep grid. Every grid axis multiplied gives 6*4*3 = 72
+# configurations; at typical per-call latency (50-200 ms) the full
+# sweep runs in a few minutes for a probe set of a few dozen probes.
+# Operators can narrow each axis via CLI flags.
+_DEFAULT_FLOOR_GRID: tuple[float, ...] = (0.15, 0.20, 0.25, 0.30, 0.35, 0.40)
+_DEFAULT_EXTRACTED_WEIGHT_GRID: tuple[float, ...] = (1.0, 1.2, 1.5, 2.0)
+_DEFAULT_OVERFETCH_GRID: tuple[int, ...] = (10, 20, 30)
+
+
+# Production defaults that the harness treats as the baseline
+# configuration. Used both when the operator runs a single eval
+# (no --sweep) without overrides and when computing the schema
+# example baseline.
+_PRODUCTION_FLOOR = 0.30
+_PRODUCTION_EXTRACTED_WEIGHT = 1.2
+_PRODUCTION_LEGACY_WEIGHT = 0.6
+_PRODUCTION_OVERFETCH = 20
+
+
+# Greppable prefix on every memory.recall log line. Mirrored in
+# `kai.memory._emit_recall_log`; if either ever changes, the parser
+# in `_RecallLogCapture` must move with it. The trailing space is
+# part of the prefix so empty-payload edge cases still tokenize.
+_RECALL_PREFIX = "memory.recall "
+
+
+# Schema version written into baseline JSON output. Bump when the
+# baseline file shape changes in a way that operators reading older
+# files would misinterpret. Drift detection in the harness compares
+# probe-set hashes, not schema versions, so this number is purely
+# informational for humans.
+_BASELINE_SCHEMA_VERSION = 1
+
+
+# ── Data classes ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Probe:
+    """A single eval probe.
+
+    `question` is the text fed to format_context; `expected_fact_id`
+    is the Mem0 row ID the question should have surfaced. The
+    optional fields (`source_turn_ts`, `notes`) are operator
+    bookkeeping - they let an author trace a failing probe back to
+    the conversation it was drawn from but do not feed scoring.
+    """
+
+    question: str
+    expected_fact_id: str
+    source_turn_ts: str = ""
+    notes: str = ""
+
+
+@dataclass
+class ConfigOverride:
+    """One point in the sweep grid.
+
+    Each override flows into the harness's sweep loop and is the
+    only mutable state per iteration: floor (replaces
+    `_config.memory_search_floor`), extracted_weight (replaces
+    `_SOURCE_WEIGHTS["extracted"]`), and overfetch (replaces
+    `_SEARCH_OVERFETCH` on the module). The legacy weight (the ""
+    bucket in `_SOURCE_WEIGHTS`, currently 0.6) is intentionally
+    fixed: the eval is for tuning the "extracted" source's relative
+    boost, not for re-tuning the legacy floor.
+    """
+
+    floor: float
+    extracted_weight: float
+    overfetch: int
+
+
+@dataclass
+class ProbeResult:
+    """Per-probe scoring outcome.
+
+    `rank` is 1-indexed position of expected_fact_id in the recall
+    payload's hits, or None if the expected fact was not retrieved
+    at all. `in_prompt` is True iff the fact reached the slice of
+    hits the agent actually saw (rank <= lines_used). `tags` carries
+    the expected fact's tags for per-tag breakdowns; collected once
+    during drift detection rather than re-fetched at scoring time.
+    `latency_ms` mirrors the value in the recall payload, surfaced
+    here so per-probe latencies can be aggregated without re-parsing.
+    """
+
+    probe: Probe
+    rank: int | None
+    in_prompt: bool
+    lines_used: int
+    latency_ms: int
+    tags: tuple[str, ...]
+
+
+@dataclass
+class Metrics:
+    """Aggregated metrics for one configuration over a probe set.
+
+    Stored as plain dicts so JSON serialization is direct. Per-tag
+    metrics are computed by re-running the same scoring math over
+    each tag's subset of probes; `by_tag` is a dict of tag -> the
+    same shape as the top-level metrics dict (minus `by_tag` itself).
+    """
+
+    n_probes: int
+    n_scored: int
+    n_drift: int
+    precision_at_k: dict[int, float]
+    recall_at_k: dict[int, float]
+    precision_at_lines_used: float
+    mrr: float
+    fraction_in_prompt: float
+    latency_p50_ms: float
+    latency_p95_ms: float
+    by_tag: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+# ── Probe file loading ─────────────────────────────────────────────
+
+
+def load_probes(path: Path) -> list[Probe]:
+    """Load and validate probes from a JSONL file.
+
+    Documented format extension: lines that, after lstrip, begin with
+    `#` are treated as comments and skipped. This lets operators
+    annotate a probe file in-place without an external metadata file.
+    Empty/whitespace-only lines are also skipped. Every other line is
+    parsed as JSON and must carry `question` (non-empty string) and
+    `expected_fact_id` (non-empty string); `source_turn_ts` and
+    `notes` are optional.
+
+    Validation errors include the file path and 1-indexed line number
+    so an operator with a multi-hundred-line probe set can find the
+    bad row immediately. Line order is preserved in the returned list
+    so per-probe output rows align with the probe file.
+    """
+    probes: list[Probe] = []
+    raw = path.read_text(encoding="utf-8").splitlines()
+    for lineno, line in enumerate(raw, start=1):
+        stripped = line.lstrip()
+        # Skip comment and blank lines BEFORE attempting JSON parse.
+        # Putting the comment check on `lstrip()` (not the raw line)
+        # accepts indented annotations like `    # category notes`,
+        # which operators may use when grouping probes visually.
+        if not stripped or stripped.startswith("#"):
+            continue
+        try:
+            obj = json.loads(stripped)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"{path}:{lineno}: malformed JSON ({e.msg})") from e
+        if not isinstance(obj, dict):
+            raise ValueError(f"{path}:{lineno}: expected JSON object, got {type(obj).__name__}")
+        # Required fields. Type check both presence and string-ness so
+        # an int slip-through (e.g. `expected_fact_id: 42` from a
+        # spreadsheet export) fails at load time rather than on the
+        # first hit comparison where the type mismatch would silently
+        # prevent every match.
+        question = obj.get("question")
+        expected = obj.get("expected_fact_id")
+        if not isinstance(question, str) or not question.strip():
+            raise ValueError(f"{path}:{lineno}: 'question' missing or not a non-empty string")
+        if not isinstance(expected, str) or not expected.strip():
+            raise ValueError(f"{path}:{lineno}: 'expected_fact_id' missing or not a non-empty string")
+        source_turn_ts = obj.get("source_turn_ts", "")
+        notes = obj.get("notes", "")
+        if not isinstance(source_turn_ts, str):
+            raise ValueError(f"{path}:{lineno}: 'source_turn_ts' must be a string when present")
+        if not isinstance(notes, str):
+            raise ValueError(f"{path}:{lineno}: 'notes' must be a string when present")
+        probes.append(
+            Probe(
+                question=question,
+                expected_fact_id=expected,
+                source_turn_ts=source_turn_ts,
+                notes=notes,
+            )
+        )
+    return probes
+
+
+def probe_set_hash(probes: list[Probe]) -> str:
+    """SHA-256 of the sorted (question, expected_fact_id) list.
+
+    Locks a baseline measurement to its probe set: comparing two
+    baseline files with different hashes is meaningless even if the
+    metric numbers look similar. Sorted to make the hash invariant
+    under reordering of the probe file. Source turn timestamps and
+    notes are excluded - they are bookkeeping, not scoring inputs.
+    """
+    pairs = sorted((p.question, p.expected_fact_id) for p in probes)
+    blob = json.dumps(pairs, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(blob).hexdigest()
+
+
+# ── Log capture ─────────────────────────────────────────────────────
+
+
+class _RecallLogCapture(logging.Handler):
+    """Buffer memory.recall log records for later draining.
+
+    Attached to the `kai.memory` logger so it sees every record the
+    module emits. Filters down to records whose message starts with
+    the `memory.recall ` prefix so unrelated info-level logs (init,
+    delete, etc.) are ignored. The handler keeps full records, not
+    just the parsed payloads, so per-record diagnostics (logger name,
+    timestamp) remain accessible if a future debug hook needs them.
+
+    Carries `_saved_level` so the attach helper can restore the
+    `kai.memory` logger's effective level on detach. The harness
+    forces the level to INFO at attach time because operators may
+    run with LOG_LEVEL=WARNING in production - without the bump,
+    `memory.recall` records would never reach any handler and the
+    harness would loudly fail with "expected one record, got zero."
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.INFO)
+        self._records: list[logging.LogRecord] = []
+        self._saved_level: int | None = None
+
+    def emit(self, record: logging.LogRecord) -> None:
+        # `getMessage()` is the documented stable API; `.message` is
+        # set as a side effect of Formatter.format() and is not
+        # guaranteed to be populated for every handler. Test #4 round-
+        # trips against this exact path.
+        if record.getMessage().startswith(_RECALL_PREFIX):
+            self._records.append(record)
+
+    def drain(self) -> list[dict[str, Any]]:
+        """Return parsed payloads for every buffered record and clear.
+
+        Strips the `memory.recall ` prefix and decodes the remainder
+        as JSON. The harness expects exactly one record per call to
+        `format_context`; the caller (`_run_one_probe`) asserts on
+        the count and aborts loudly on zero or more-than-one - the
+        log-shape contract is the harness's only signal that the
+        retrieval path ran as expected.
+        """
+        parsed: list[dict[str, Any]] = []
+        for r in self._records:
+            blob = r.getMessage()[len(_RECALL_PREFIX) :]
+            try:
+                payload = json.loads(blob)
+            except json.JSONDecodeError as e:
+                raise RuntimeError(f"unparseable memory.recall payload: {e.msg}") from e
+            parsed.append(payload)
+        self._records.clear()
+        return parsed
+
+
+# ── Scoring math ────────────────────────────────────────────────────
+
+
+def compute_rank(hits: list[dict[str, Any]], expected_fact_id: str) -> int | None:
+    """Return the 1-indexed position of expected_fact_id in hits, or None.
+
+    Relies on the per-hit `id` field in the recall payload (carried
+    from MemoryResult.id by format_context). Without it, this match
+    would have to fall back to fragile snippet-substring comparison
+    against the 80-char truncated text.
+    """
+    for i, h in enumerate(hits):
+        if h.get("id") == expected_fact_id:
+            return i + 1
+    return None
+
+
+def score_probes(results: list[ProbeResult]) -> dict[str, Any]:
+    """Compute aggregate metrics over a list of ProbeResult.
+
+    Pure function: takes scored per-probe outcomes (rank, lines_used,
+    in_prompt) and returns the metrics dict. Test #1 exercises this
+    directly with hand-constructed inputs, including a mix of scored-
+    hit, scored-miss, and drift probes, asserting that drift probes
+    are excluded from BOTH numerator and denominator. The caller is
+    responsible for filtering out drift probes before invoking this
+    function; that contract is enforced by the type signature
+    (drift probes don't produce a ProbeResult at all).
+
+    For the single-answer case (each probe has exactly one expected
+    fact), recall@K equals precision@K. They are reported separately
+    so a future multi-answer probe format can diverge without
+    reshaping the output. fraction_in_prompt differs from precision
+    @lines_used: in_prompt is computed per probe against that probe's
+    actual lines_used (varies with budget exhaustion), whereas
+    precision@K uses a fixed K across all probes.
+    """
+    n = len(results)
+    if n == 0:
+        # Empty input is ambiguous: it can mean "all probes drifted"
+        # (caller's responsibility to surface separately) or "no
+        # probes loaded." Return zeroes rather than raising so the
+        # caller can distinguish via n_scored=0 in the wrapping
+        # Metrics object.
+        return {
+            "precision_at_k": {k: 0.0 for k in _K_VALUES},
+            "recall_at_k": {k: 0.0 for k in _K_VALUES},
+            "precision_at_lines_used": 0.0,
+            "mrr": 0.0,
+            "fraction_in_prompt": 0.0,
+        }
+
+    precision_at_k: dict[int, float] = {}
+    recall_at_k: dict[int, float] = {}
+    for k in _K_VALUES:
+        # A hit "counts at K" iff it was retrieved (rank not None) AND
+        # the rank falls within the top K. Combining the two guards
+        # in a single comprehension keeps the math obviously correct
+        # at a glance and avoids a None-check followed by a comparison
+        # that would crash on a missed probe.
+        hits_in_top_k = sum(1 for r in results if r.rank is not None and r.rank <= k)
+        precision_at_k[k] = hits_in_top_k / n
+        recall_at_k[k] = hits_in_top_k / n
+
+    # precision_at_lines_used is the per-probe variant: uses each
+    # probe's own lines_used as the K. A probe whose lines_used was
+    # zero (header-only output, never observed in practice but
+    # possible if budget < header tokens) cannot have an in-prompt
+    # hit, which falls out naturally from the rank <= 0 check.
+    in_prompt_count = sum(1 for r in results if r.in_prompt)
+
+    # MRR: mean of 1/rank, treating misses as 0. The miss-as-zero
+    # convention is standard in IR literature; explicit so a reader
+    # does not assume "skip misses" semantics that would inflate the
+    # number on poor-coverage probe sets.
+    mrr_sum = sum(1.0 / r.rank if r.rank else 0.0 for r in results)
+
+    return {
+        "precision_at_k": precision_at_k,
+        "recall_at_k": recall_at_k,
+        "precision_at_lines_used": in_prompt_count / n,
+        "mrr": mrr_sum / n,
+        "fraction_in_prompt": in_prompt_count / n,
+    }
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Return the requested percentile from values (0-100 scale).
+
+    Uses statistics.quantiles for the standard linear-interpolation
+    estimate. Returns 0.0 on empty input rather than raising so the
+    caller can render zero-data tables without a special case.
+    statistics.quantiles requires at least n=2 points; the singleton
+    case returns the lone value to avoid the library exception.
+    """
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return float(values[0])
+    # n=100 partitions plus boundary fix-up gives us linear-interp
+    # percentile lookup at any integer percentage. quantiles returns
+    # the 99 cut points for n=100, so index `pct - 1` is the
+    # requested percentile (1-indexed math collapses to the simple
+    # subtraction).
+    cuts = statistics.quantiles(values, n=100)
+    idx = int(pct) - 1
+    idx = max(0, min(idx, len(cuts) - 1))
+    return float(cuts[idx])
+
+
+def aggregate_metrics(
+    results: list[ProbeResult],
+    n_probes: int,
+    n_drift: int,
+) -> Metrics:
+    """Build the full Metrics object from per-probe results plus drift.
+
+    `n_probes` is the original probe count; `n_drift` is the count of
+    probes excluded due to drift detection; `len(results)` is
+    therefore N_scored = n_probes - n_drift. The caller computes
+    drift before invoking this function. Per-tag breakdowns re-run
+    score_probes over each tag's subset; a probe whose expected fact
+    has multiple tags contributes to each tag's slice (intentional -
+    a multi-tag fact is a multi-tag probe by construction).
+    """
+    base = score_probes(results)
+    latencies = [float(r.latency_ms) for r in results]
+
+    # Per-tag breakdown: bucket probes by each tag the expected fact
+    # carries, then score each bucket independently. A probe with
+    # tags ("preferences", "tech") appears in both buckets. This
+    # matches the operator's mental model: "how does retrieval look
+    # for facts tagged 'preferences'?" should not exclude facts that
+    # also happen to carry another tag.
+    by_tag_buckets: dict[str, list[ProbeResult]] = {}
+    for r in results:
+        for tag in r.tags:
+            by_tag_buckets.setdefault(tag, []).append(r)
+    by_tag = {tag: score_probes(bucket) for tag, bucket in sorted(by_tag_buckets.items())}
+
+    return Metrics(
+        n_probes=n_probes,
+        n_scored=len(results),
+        n_drift=n_drift,
+        precision_at_k=base["precision_at_k"],
+        recall_at_k=base["recall_at_k"],
+        precision_at_lines_used=base["precision_at_lines_used"],
+        mrr=base["mrr"],
+        fraction_in_prompt=base["fraction_in_prompt"],
+        latency_p50_ms=_percentile(latencies, 50),
+        latency_p95_ms=_percentile(latencies, 95),
+        by_tag=by_tag,
+    )
+
+
+# ── Drift detection ────────────────────────────────────────────────
+
+
+def detect_drift(probes: list[Probe], user_id: str) -> tuple[list[Probe], list[Probe], dict[str, tuple[str, ...]]]:
+    """Bucket probes into (scored, drifted) and collect tag mapping.
+
+    Calls `memory.get_by_id` for each probe's expected_fact_id. A
+    None return means the fact has been deleted, the probe was
+    authored against the wrong user_id (ownership mismatch), the
+    fact's source is not "extracted" (filtered by get_by_id by
+    design), or the recorded ID was never valid (typo at probe
+    authoring). All four collapse to "drift": the probe cannot be
+    scored honestly. The tag mapping is built here rather than at
+    scoring time so we don't re-fetch the same fact twice; the cost
+    is one get_by_id call per probe regardless.
+
+    Returns:
+        (scored_probes, drifted_probes, tags_by_probe_id) where
+        tags_by_probe_id maps each scored probe's expected_fact_id
+        to the tuple of tags the fact carries (empty tuple if the
+        fact has none).
+    """
+    from kai import memory as _mem
+
+    scored: list[Probe] = []
+    drifted: list[Probe] = []
+    tags_by_id: dict[str, tuple[str, ...]] = {}
+    for p in probes:
+        fact = _mem.get_by_id(user_id=user_id, memory_id=p.expected_fact_id)
+        if fact is None:
+            drifted.append(p)
+            continue
+        scored.append(p)
+        # `tags` may be absent or None on legacy rows; defensive
+        # `or []` matches the shape used elsewhere in memory.py
+        # (e.g. memory.py:949). Convert to tuple for hash-friendly
+        # storage in the ProbeResult.
+        raw_tags = (fact.metadata.get("tags") if fact.metadata else None) or []
+        tags_by_id[p.expected_fact_id] = tuple(raw_tags)
+    return scored, drifted, tags_by_id
+
+
+# ── Per-probe execution ────────────────────────────────────────────
+
+
+async def _run_one_probe(
+    probe: Probe,
+    user_id: str,
+    capture: _RecallLogCapture,
+    tags: tuple[str, ...],
+) -> ProbeResult:
+    """Run format_context for one probe and score its result.
+
+    Drains the log capture buffer immediately after the call. The
+    contract that exactly one `memory.recall` line is emitted per
+    `format_context` call is enforced here: zero or more than one
+    indicates a regression in the memory module's logging discipline,
+    which would silently break this harness's scoring math, so we
+    raise RuntimeError rather than silently picking one.
+    """
+    from kai.memory import format_context
+
+    await format_context(probe.question, user_id=user_id)
+    payloads = capture.drain()
+    if len(payloads) != 1:
+        raise RuntimeError(
+            f"expected exactly one memory.recall log per probe, got {len(payloads)} for question {probe.question!r}"
+        )
+    payload = payloads[0]
+    hits = payload.get("hits", [])
+    lines_used = int(payload.get("lines_used", 0))
+    latency_ms = int(payload.get("latency_ms", 0))
+    rank = compute_rank(hits, probe.expected_fact_id)
+    in_prompt = rank is not None and rank <= lines_used
+    return ProbeResult(
+        probe=probe,
+        rank=rank,
+        in_prompt=in_prompt,
+        lines_used=lines_used,
+        latency_ms=latency_ms,
+        tags=tags,
+    )
+
+
+async def _run_probes(
+    probes: list[Probe],
+    user_id: str,
+    capture: _RecallLogCapture,
+    tags_by_id: dict[str, tuple[str, ...]],
+) -> list[ProbeResult]:
+    """Run a probe set sequentially.
+
+    Sequential, not parallel: format_context drives an embedding +
+    Qdrant lookup that is CPU-bound on the local process; running in
+    parallel would not speed it up and would make the per-probe
+    latency_ms numbers meaningless (concurrent calls would inflate
+    each other's wall time). The probe count is small (a few dozen)
+    so total wall time is modest.
+    """
+    out: list[ProbeResult] = []
+    for p in probes:
+        tags = tags_by_id.get(p.expected_fact_id, ())
+        out.append(await _run_one_probe(p, user_id, capture, tags))
+    return out
+
+
+# ── Single-config evaluation ──────────────────────────────────────
+
+
+def _attach_capture() -> _RecallLogCapture:
+    """Attach a recall-log capture handler to kai.memory's logger.
+
+    Caller is responsible for detaching after use (see
+    `_detach_capture`). The handler is additive (does NOT set
+    propagate=False on the logger) so existing log destinations
+    still receive the lines; the harness only intercepts a copy.
+
+    Forces the `kai.memory` logger level to INFO if it is currently
+    higher (e.g. WARNING in a quiet operator config). Without this,
+    info-level `memory.recall` records would be filtered out before
+    reaching any handler and the harness would abort with
+    "expected one log, got zero." The original level is saved on
+    the capture object so detach can restore it.
+    """
+    logger = logging.getLogger("kai.memory")
+    capture = _RecallLogCapture()
+    capture._saved_level = logger.level
+    if logger.level == logging.NOTSET or logger.level > logging.INFO:
+        logger.setLevel(logging.INFO)
+    logger.addHandler(capture)
+    return capture
+
+
+def _detach_capture(capture: _RecallLogCapture) -> None:
+    """Symmetric removal of the handler installed by _attach_capture.
+
+    Restores the `kai.memory` logger's pre-attach level so a
+    long-lived process running multiple harness invocations does
+    not slowly accumulate verbosity changes.
+    """
+    logger = logging.getLogger("kai.memory")
+    logger.removeHandler(capture)
+    if capture._saved_level is not None:
+        logger.setLevel(capture._saved_level)
+
+
+async def evaluate(probes: list[Probe], user_id: str) -> Metrics:
+    """Run drift detection + scoring for one configuration.
+
+    The configuration is whatever is currently loaded into
+    `kai.memory` module state - this function does NOT mutate that
+    state. The sweep loop layers config mutation on top by calling
+    `evaluate` once per grid point inside its own try/finally.
+    """
+    scored, drifted, tags_by_id = detect_drift(probes, user_id)
+    capture = _attach_capture()
+    try:
+        results = await _run_probes(scored, user_id, capture, tags_by_id)
+    finally:
+        # Detach in finally so a probe raising mid-run still removes
+        # the harness-installed handler. Otherwise repeated harness
+        # runs in a long-lived process (Python REPL, future test
+        # suite) would stack capture handlers.
+        _detach_capture(capture)
+    return aggregate_metrics(results, n_probes=len(probes), n_drift=len(drifted))
+
+
+# ── Sweep mode ─────────────────────────────────────────────────────
+
+
+def _grid_iter(
+    floors: list[float],
+    weights: list[float],
+    overfetches: list[int],
+) -> list[ConfigOverride]:
+    """Materialize the grid as a flat list of ConfigOverride objects.
+
+    Materialized (not generator) so the caller can `len()` the grid
+    for progress reporting and iterate it more than once if needed.
+    The triple loop is order-stable: outer floor, middle weight,
+    inner overfetch. Operators reading the table top-to-bottom see
+    floor change slowest, which makes scanning for "what does
+    raising the floor do" easier than the reverse order would.
+    """
+    out: list[ConfigOverride] = []
+    for f in floors:
+        for w in weights:
+            for o in overfetches:
+                out.append(ConfigOverride(floor=f, extracted_weight=w, overfetch=o))
+    return out
+
+
+async def run_sweep(
+    probes: list[Probe],
+    user_id: str,
+    grid: list[ConfigOverride],
+) -> list[tuple[ConfigOverride, Metrics]]:
+    """Run `evaluate` once per grid point with module-state restoration.
+
+    Mutates three pieces of `kai.memory` module state per iteration:
+    `_config` (replaced via dataclasses.replace because Config is
+    frozen), `_SOURCE_WEIGHTS["extracted"]` (mutated in place; dict
+    is not frozen), and `_SEARCH_OVERFETCH` (replaced via setattr on
+    the module). Restoration in `try/finally` per iteration defends
+    against a probe raising mid-sweep; the OUTER try/finally restores
+    once at the very end, ensuring a SIGINT during a long sweep does
+    not leave the process with mutated module state if a future caller
+    keeps the process alive after the sweep.
+
+    Note on the snapshot vs read-back tradeoff: we snapshot the
+    originals at sweep entry and restore from the snapshot, rather
+    than restoring "whatever was there one iteration ago." If a
+    probe somehow mutates module state (it should not), the snapshot
+    restoration still leaves the module in a consistent post-sweep
+    state matching its pre-sweep state.
+    """
+    from kai import memory as _mem
+
+    if _mem._config is None:
+        raise RuntimeError("memory not initialized; cannot sweep")
+
+    saved_config = _mem._config
+    saved_weights: dict[str, float] = dict(_mem._SOURCE_WEIGHTS)
+    saved_overfetch: int = _mem._SEARCH_OVERFETCH
+
+    out: list[tuple[ConfigOverride, Metrics]] = []
+    try:
+        for i, override in enumerate(grid, start=1):
+            log.info("sweep %d/%d: %s", i, len(grid), override)
+            # _SOURCE_WEIGHTS is a module-level dict consulted live
+            # in _source_weight() at format_context call time; in-
+            # place mutation propagates without a module-attr swap.
+            _mem._SOURCE_WEIGHTS["extracted"] = override.extracted_weight
+            # _SEARCH_OVERFETCH is read via the module global at call
+            # time; assigning to the module attribute is the standard
+            # way to override it from outside.
+            _mem._SEARCH_OVERFETCH = override.overfetch
+            # Config is frozen; produce a clone with the floor swapped
+            # and rebind the module-level reference. The same Config
+            # object is also passed to other modules at init time, but
+            # those modules cache nothing, so a rebind here is sufficient.
+            _mem._config = dataclasses.replace(saved_config, memory_search_floor=override.floor)
+            metrics = await evaluate(probes, user_id)
+            out.append((override, metrics))
+    finally:
+        # Restore from snapshot regardless of whether the loop ran to
+        # completion. Repeated assignment is cheap; the cost of a
+        # double-restore (snapshot equal to current state) is one dict
+        # copy and two attribute writes.
+        _mem._SOURCE_WEIGHTS.clear()
+        _mem._SOURCE_WEIGHTS.update(saved_weights)
+        _mem._SEARCH_OVERFETCH = saved_overfetch
+        _mem._config = saved_config
+    return out
+
+
+def pareto_frontier(
+    sweep_results: list[tuple[ConfigOverride, Metrics]],
+) -> list[tuple[ConfigOverride, Metrics]]:
+    """Return the configurations not dominated on (precision@5, latency_p50).
+
+    A config A dominates config B iff A has higher-or-equal precision
+    AND lower-or-equal latency, with at least one strict inequality.
+    The frontier is the set of configs not dominated by any other.
+    Axes are fixed at (precision@5, latency_p50): operators wanting
+    alternate dimensions work from the full sweep table rather than
+    re-running the sweep with different flags. This keeps the harness
+    output deterministic across runs and avoids a multiplicative blow-
+    up of CLI options for what is a one-line jq filter.
+    """
+    frontier: list[tuple[ConfigOverride, Metrics]] = []
+    for cand_cfg, cand_metrics in sweep_results:
+        cand_p = cand_metrics.precision_at_k.get(5, 0.0)
+        cand_l = cand_metrics.latency_p50_ms
+        dominated = False
+        for other_cfg, other_metrics in sweep_results:
+            if other_cfg is cand_cfg:
+                continue
+            other_p = other_metrics.precision_at_k.get(5, 0.0)
+            other_l = other_metrics.latency_p50_ms
+            # Strict-domination check: other is at least as good on
+            # both axes AND strictly better on at least one. The
+            # `>` in either axis combined with `>=`/`<=` on both
+            # encodes the standard Pareto definition without
+            # awkward tie-breaking.
+            if other_p >= cand_p and other_l <= cand_l and (other_p > cand_p or other_l < cand_l):
+                dominated = True
+                break
+        if not dominated:
+            frontier.append((cand_cfg, cand_metrics))
+    # Sort frontier by precision descending so the table reads
+    # "best quality" -> "worst quality" top-to-bottom; ties broken
+    # by lower latency.
+    frontier.sort(key=lambda t: (-t[1].precision_at_k.get(5, 0.0), t[1].latency_p50_ms))
+    return frontier
+
+
+# ── Output formatting ─────────────────────────────────────────────
+
+
+def _metrics_to_dict(m: Metrics, *, include_by_tag: bool = True) -> dict[str, Any]:
+    """Convert a Metrics object to a JSON-serializable dict.
+
+    Used both for the baseline file and for sweep table rows. The
+    `include_by_tag` flag suppresses the per-tag breakdown for sweep
+    rows where it would balloon the output without adding signal
+    (operators reading a 72-row sweep table want top-line metrics,
+    not per-tag rollups for each row).
+    """
+    d: dict[str, Any] = {
+        "n_probes": m.n_probes,
+        "n_scored": m.n_scored,
+        "n_drift": m.n_drift,
+        # Stringify the int K to keep the JSON shape stable: JSON
+        # object keys must be strings, and `{"1": 0.68, ...}` is
+        # what jq will see anyway.
+        "precision_at_k": {str(k): round(v, 4) for k, v in m.precision_at_k.items()},
+        "recall_at_k": {str(k): round(v, 4) for k, v in m.recall_at_k.items()},
+        "precision_at_lines_used": round(m.precision_at_lines_used, 4),
+        "mrr": round(m.mrr, 4),
+        "fraction_in_prompt": round(m.fraction_in_prompt, 4),
+        "latency_p50_ms": round(m.latency_p50_ms, 1),
+        "latency_p95_ms": round(m.latency_p95_ms, 1),
+    }
+    if include_by_tag:
+        d["by_tag"] = {
+            tag: {
+                "precision_at_k": {str(k): round(v, 4) for k, v in vals["precision_at_k"].items()},
+                "recall_at_k": {str(k): round(v, 4) for k, v in vals["recall_at_k"].items()},
+                "precision_at_lines_used": round(vals["precision_at_lines_used"], 4),
+                "mrr": round(vals["mrr"], 4),
+                "fraction_in_prompt": round(vals["fraction_in_prompt"], 4),
+            }
+            for tag, vals in m.by_tag.items()
+        }
+    return d
+
+
+def _render_single_metrics(m: Metrics) -> str:
+    """Human-readable rendering of one Metrics object for stdout.
+
+    Plain text, no color codes - the harness output is meant to be
+    pasteable into a bug report or log without ANSI escapes. Per-tag
+    breakdown is included when present; if no probes carry tags
+    (synthetic example fixture, e.g.) the section is omitted.
+    """
+    lines = [
+        f"Probes: {m.n_probes} total, {m.n_scored} scored, {m.n_drift} drifted",
+        "",
+        "Precision @K:",
+        *[f"  K={k}: {m.precision_at_k[k]:.3f}" for k in _K_VALUES],
+        f"  K=lines_used (per probe): {m.precision_at_lines_used:.3f}",
+        "",
+        "Recall @K (single-answer = precision):",
+        *[f"  K={k}: {m.recall_at_k[k]:.3f}" for k in _K_VALUES],
+        "",
+        f"MRR: {m.mrr:.3f}",
+        f"fraction_in_prompt: {m.fraction_in_prompt:.3f}",
+        "",
+        f"Latency: p50={m.latency_p50_ms:.0f}ms, p95={m.latency_p95_ms:.0f}ms",
+    ]
+    if m.by_tag:
+        lines.append("")
+        lines.append("Per-tag (precision@5 / fraction_in_prompt / probe count):")
+        for tag, vals in m.by_tag.items():
+            p5 = vals["precision_at_k"].get(5, 0.0)
+            fip = vals["fraction_in_prompt"]
+            # Per-tag probe count: count of probes whose expected
+            # fact carries this tag. Recovered from the by_tag dict's
+            # presence rather than re-walking results, since by_tag
+            # is computed from the same buckets and we trust the
+            # math above.
+            lines.append(f"  {tag}: p@5={p5:.3f} in_prompt={fip:.3f}")
+    return "\n".join(lines)
+
+
+def _render_sweep_table(sweep_results: list[tuple[ConfigOverride, Metrics]]) -> str:
+    """ASCII table of every sweep configuration.
+
+    Columns: floor, extracted_weight, overfetch, p@1, p@3, p@5, MRR,
+    in_prompt, p50_ms, p95_ms. Sorted by precision@5 descending so
+    the operator's eye lands on the strongest configs first; ties
+    broken by lower latency.
+    """
+    sorted_results = sorted(
+        sweep_results,
+        key=lambda t: (-t[1].precision_at_k.get(5, 0.0), t[1].latency_p50_ms),
+    )
+    header = (
+        f"{'floor':>6} {'ext_w':>6} {'over':>5}  "
+        f"{'p@1':>6} {'p@3':>6} {'p@5':>6}  "
+        f"{'MRR':>6} {'in_pr':>6}  "
+        f"{'p50':>5} {'p95':>5}"
+    )
+    sep = "-" * len(header)
+    rows = []
+    for cfg, m in sorted_results:
+        rows.append(
+            f"{cfg.floor:>6.2f} {cfg.extracted_weight:>6.2f} {cfg.overfetch:>5d}  "
+            f"{m.precision_at_k[1]:>6.3f} {m.precision_at_k[3]:>6.3f} {m.precision_at_k[5]:>6.3f}  "
+            f"{m.mrr:>6.3f} {m.fraction_in_prompt:>6.3f}  "
+            f"{m.latency_p50_ms:>5.0f} {m.latency_p95_ms:>5.0f}"
+        )
+    return "\n".join([header, sep, *rows])
+
+
+def _render_pareto(frontier: list[tuple[ConfigOverride, Metrics]]) -> str:
+    """Render just the Pareto-frontier rows from a sweep."""
+    return _render_sweep_table(frontier)
+
+
+# ── CLI ────────────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Top-level argparse for `python -m kai.eval.retrieval`."""
+    parser = argparse.ArgumentParser(
+        prog="python -m kai.eval.retrieval",
+        description="Layer 1 retrieval evaluation harness (precision/recall/MRR).",
+    )
+    parser.add_argument(
+        "--probes",
+        required=True,
+        type=Path,
+        help="Path to probes.jsonl (JSONL format; #-prefixed lines are comments).",
+    )
+    parser.add_argument(
+        "--user-id",
+        required=True,
+        help="Telegram chat_id (string) whose memory store to evaluate against.",
+    )
+    parser.add_argument(
+        "--sweep",
+        action="store_true",
+        help="Run the full parameter grid and report Pareto frontier + table.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write a baseline JSON file matching the *.example.json schema.",
+    )
+    # Sweep grid override flags. Each takes one or more values; if not
+    # supplied, the default grid in the constants above is used.
+    # nargs="+" so an operator can pass `--floor 0.2 0.3 0.4` without
+    # quoting.
+    parser.add_argument(
+        "--floor",
+        type=float,
+        nargs="+",
+        help="Override the memory_search_floor sweep axis (default: 0.15..0.40).",
+    )
+    parser.add_argument(
+        "--extracted-weight",
+        type=float,
+        nargs="+",
+        help="Override the extracted-weight sweep axis (default: 1.0..2.0).",
+    )
+    parser.add_argument(
+        "--overfetch",
+        type=int,
+        nargs="+",
+        help="Override the search-overfetch sweep axis (default: 10/20/30).",
+    )
+    return parser
+
+
+def _initialize_memory() -> bool:
+    """Load config and call init_memory(); return True on success.
+
+    Mirrors the discipline in memory_admin: the harness runs against
+    the live store, so the same init path keeps embedding model,
+    Qdrant directory, and history DB settings consistent with the bot
+    runtime. Errors print to stderr and the caller exits with status 1.
+    """
+    try:
+        from kai.config import load_config
+        from kai.memory import init_memory, is_enabled
+
+        config = load_config()
+        init_memory(config)
+        if not is_enabled():
+            print(
+                "eval: memory is not enabled. Set MEMORY_ENABLED=true and verify the store is readable.",
+                file=sys.stderr,
+            )
+            return False
+        return True
+    except Exception as e:
+        print(f"eval: init failed: {e}", file=sys.stderr)
+        return False
+
+
+def _build_baseline_json(
+    probes: list[Probe],
+    metrics: Metrics,
+    cfg: ConfigOverride,
+) -> dict[str, Any]:
+    """Construct the baseline JSON envelope around a Metrics object.
+
+    Matches the schema in the committed `*.example.json` fixture.
+    `probe_set_hash` makes a baseline file meaningful only against its
+    specific probe set; comparing baselines across probe sets would
+    silently produce noise that looks like quality drift.
+    """
+    return {
+        "version": _BASELINE_SCHEMA_VERSION,
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "probe_set_hash": probe_set_hash(probes),
+        "probe_count": metrics.n_probes,
+        "drift_count": metrics.n_drift,
+        "config": {
+            "floor": cfg.floor,
+            "extracted_weight": cfg.extracted_weight,
+            "legacy_weight": _PRODUCTION_LEGACY_WEIGHT,
+            "overfetch": cfg.overfetch,
+        },
+        "metrics": {
+            "precision_at_1": round(metrics.precision_at_k[1], 4),
+            "precision_at_3": round(metrics.precision_at_k[3], 4),
+            "precision_at_5": round(metrics.precision_at_k[5], 4),
+            "precision_at_lines_used": round(metrics.precision_at_lines_used, 4),
+            "mrr": round(metrics.mrr, 4),
+            "fraction_in_prompt": round(metrics.fraction_in_prompt, 4),
+            "latency_p50_ms": round(metrics.latency_p50_ms, 1),
+            "latency_p95_ms": round(metrics.latency_p95_ms, 1),
+        },
+        "by_tag": _metrics_to_dict(metrics, include_by_tag=True)["by_tag"],
+    }
+
+
+async def _run_cli(args: argparse.Namespace) -> int:
+    """CLI dispatch.
+
+    Returns process exit code: 0 on success, 1 on init / IO failure,
+    2 on probe-file validation failure (distinct so an automation
+    harness can tell "your probe file is broken" apart from "the
+    eval ran but something else went wrong").
+    """
+    try:
+        probes = load_probes(args.probes)
+    except (OSError, ValueError) as e:
+        print(f"eval: failed to load probes: {e}", file=sys.stderr)
+        return 2
+    if not probes:
+        print(f"eval: no probes loaded from {args.probes}", file=sys.stderr)
+        return 2
+
+    if not _initialize_memory():
+        return 1
+
+    if args.sweep:
+        floors = list(args.floor) if args.floor else list(_DEFAULT_FLOOR_GRID)
+        weights = list(args.extracted_weight) if args.extracted_weight else list(_DEFAULT_EXTRACTED_WEIGHT_GRID)
+        overfetches = list(args.overfetch) if args.overfetch else list(_DEFAULT_OVERFETCH_GRID)
+        grid = _grid_iter(floors, weights, overfetches)
+        sweep_results = await run_sweep(probes, args.user_id, grid)
+        print("Pareto frontier (precision@5 / latency_p50):")
+        print(_render_pareto(pareto_frontier(sweep_results)))
+        print()
+        print("Full sweep table:")
+        print(_render_sweep_table(sweep_results))
+        if args.output:
+            # Sweep output mode: write a JSON file containing every
+            # config + metrics tuple plus the frontier subset, so a
+            # downstream consumer can re-render either view without
+            # re-running the sweep.
+            payload = {
+                "version": _BASELINE_SCHEMA_VERSION,
+                "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "probe_set_hash": probe_set_hash(probes),
+                "probe_count": len(probes),
+                "sweep": [
+                    {
+                        "config": {
+                            "floor": cfg.floor,
+                            "extracted_weight": cfg.extracted_weight,
+                            "overfetch": cfg.overfetch,
+                        },
+                        "metrics": _metrics_to_dict(m, include_by_tag=False),
+                    }
+                    for cfg, m in sweep_results
+                ],
+            }
+            args.output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            print(f"\nWrote {args.output}")
+        return 0
+
+    # Single-config mode: use whatever production defaults the live
+    # config carries. The baseline scenario (floor=0.3, extracted_
+    # weight=1.2, overfetch=20) matches the production defaults at
+    # the time of writing; an operator who has tuned their .env will
+    # see whatever values they set.
+    metrics = await evaluate(probes, args.user_id)
+    print(_render_single_metrics(metrics))
+    if args.output:
+        # Reflect whatever live config was in effect into the saved
+        # baseline. Since we did not sweep, we read the values back
+        # from the memory module rather than carrying them through
+        # an override object.
+        from kai import memory as _mem
+
+        cfg = ConfigOverride(
+            floor=_mem._config.memory_search_floor if _mem._config else _PRODUCTION_FLOOR,
+            extracted_weight=_mem._SOURCE_WEIGHTS.get("extracted", _PRODUCTION_EXTRACTED_WEIGHT),
+            overfetch=_mem._SEARCH_OVERFETCH,
+        )
+        args.output.write_text(
+            json.dumps(_build_baseline_json(probes, metrics, cfg), indent=2),
+            encoding="utf-8",
+        )
+        print(f"\nWrote {args.output}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entrypoint for `python -m kai.eval.retrieval`.
+
+    `argv` defaults to `sys.argv[1:]`. Returns the exit code for
+    the caller; `__main__` block below propagates it via sys.exit.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return asyncio.run(_run_cli(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kai/eval/retrieval.py
+++ b/src/kai/eval/retrieval.py
@@ -704,11 +704,12 @@ async def run_sweep(
     `_config` (replaced via dataclasses.replace because Config is
     frozen), `_SOURCE_WEIGHTS["extracted"]` (mutated in place; dict
     is not frozen), and `_SEARCH_OVERFETCH` (replaced via setattr on
-    the module). Restoration in `try/finally` per iteration defends
-    against a probe raising mid-sweep; the OUTER try/finally restores
-    once at the very end, ensuring a SIGINT during a long sweep does
-    not leave the process with mutated module state if a future caller
-    keeps the process alive after the sweep.
+    the module). A single `try/finally` wraps the entire grid loop
+    and restores all three from the entry-time snapshot in `finally`.
+    Any exception from any iteration (a probe raising mid-sweep, a
+    SIGINT) unwinds through the outer finally before propagating, so
+    the module is left in its pre-sweep state regardless of how the
+    loop exits.
 
     Note on the snapshot vs read-back tradeoff: we snapshot the
     originals at sweep entry and restore from the snapshot, rather

--- a/src/kai/eval/retrieval.py
+++ b/src/kai/eval/retrieval.py
@@ -1119,9 +1119,17 @@ async def _run_cli(args: argparse.Namespace) -> int:
                 "probe_count": len(probes),
                 "sweep": [
                     {
+                        # `legacy_weight` is fixed across the sweep
+                        # (the grid only varies floor/extracted_weight/
+                        # overfetch) but is included here so each per-
+                        # row config block matches the shape of the
+                        # single-config baseline's `config` envelope.
+                        # A downstream parser can read both file types
+                        # uniformly without a special case.
                         "config": {
                             "floor": cfg.floor,
                             "extracted_weight": cfg.extracted_weight,
+                            "legacy_weight": _PRODUCTION_LEGACY_WEIGHT,
                             "overfetch": cfg.overfetch,
                         },
                         "metrics": _metrics_to_dict(m, include_by_tag=False),

--- a/src/kai/eval/retrieval.py
+++ b/src/kai/eval/retrieval.py
@@ -946,7 +946,13 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--output",
         type=Path,
-        help="Write a baseline JSON file matching the *.example.json schema.",
+        help=(
+            "Write results to a JSON file. Without --sweep: a single-config "
+            "baseline matching retrieval-baseline.example.json. With --sweep: "
+            "a sweep envelope (version, generated_at, probe_set_hash, "
+            "probe_count, drift_count, sweep[]) with one row per grid point; "
+            "this shape does NOT match the baseline example schema."
+        ),
     )
     # Sweep grid override flags. Each takes one or more values; if not
     # supplied, the default grid in the constants above is used.
@@ -1110,9 +1116,11 @@ async def _run_cli(args: argparse.Namespace) -> int:
         print(_render_sweep_table(sweep_results))
         if args.output:
             # Sweep output mode: write a JSON file containing every
-            # config + metrics tuple plus the frontier subset, so a
-            # downstream consumer can re-render either view without
-            # re-running the sweep.
+            # config + metrics tuple. The Pareto frontier is not
+            # serialized separately because it is cheaply re-derivable
+            # from `sweep` via `pareto_frontier()`; a downstream
+            # consumer that wants the frontier view runs that one
+            # function rather than parsing a redundant sub-array.
             payload = {
                 "version": _BASELINE_SCHEMA_VERSION,
                 "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),

--- a/src/kai/eval/retrieval.py
+++ b/src/kai/eval/retrieval.py
@@ -1117,6 +1117,15 @@ async def _run_cli(args: argparse.Namespace) -> int:
                 "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
                 "probe_set_hash": probe_set_hash(probes),
                 "probe_count": len(probes),
+                # Hoist drift_count to the envelope. Every per-row
+                # Metrics carries the same n_drift (drift detection
+                # runs once before the grid loop, not per config),
+                # so the value belongs at the top alongside
+                # probe_count, mirroring the single-config baseline
+                # written by _build_baseline_json. A downstream
+                # parser can read drift_count off either file shape
+                # without descending into the per-row metrics.
+                "drift_count": next((m.n_drift for _, m in sweep_results), 0),
                 "sweep": [
                     {
                         # `legacy_weight` is fixed across the sweep

--- a/src/kai/eval/retrieval.py
+++ b/src/kai/eval/retrieval.py
@@ -994,6 +994,35 @@ def _initialize_memory() -> bool:
         return False
 
 
+def _flatten_score_block(
+    precision_at_k: dict[int, float],
+    recall_at_k: dict[int, float],
+    mrr: float,
+    fraction_in_prompt: float,
+) -> dict[str, Any]:
+    """Render a metrics block with flat keys (precision_at_1, etc.).
+
+    Used by `_build_baseline_json` for both the top-level `metrics`
+    block and each `by_tag` entry, so a jq script diffing two
+    baselines can use the same metric path under both scopes
+    (`.metrics.precision_at_5` and `.by_tag.<tag>.precision_at_5`).
+    The sweep-mode JSON output uses the nested `precision_at_k` shape
+    via `_metrics_to_dict` instead, because per-row table data is
+    consumed differently (iterate K values) and never compared key-
+    for-key against another baseline.
+    """
+    return {
+        "precision_at_1": round(precision_at_k.get(1, 0.0), 4),
+        "precision_at_3": round(precision_at_k.get(3, 0.0), 4),
+        "precision_at_5": round(precision_at_k.get(5, 0.0), 4),
+        "recall_at_1": round(recall_at_k.get(1, 0.0), 4),
+        "recall_at_3": round(recall_at_k.get(3, 0.0), 4),
+        "recall_at_5": round(recall_at_k.get(5, 0.0), 4),
+        "mrr": round(mrr, 4),
+        "fraction_in_prompt": round(fraction_in_prompt, 4),
+    }
+
+
 def _build_baseline_json(
     probes: list[Probe],
     metrics: Metrics,
@@ -1005,7 +1034,19 @@ def _build_baseline_json(
     `probe_set_hash` makes a baseline file meaningful only against its
     specific probe set; comparing baselines across probe sets would
     silently produce noise that looks like quality drift.
+
+    Top-level `metrics` and each `by_tag` entry share the flat key
+    shape via `_flatten_score_block`, so cross-scope diffs use the
+    same path for the same metric.
     """
+    metrics_block = _flatten_score_block(
+        metrics.precision_at_k,
+        metrics.recall_at_k,
+        metrics.mrr,
+        metrics.fraction_in_prompt,
+    )
+    metrics_block["latency_p50_ms"] = round(metrics.latency_p50_ms, 1)
+    metrics_block["latency_p95_ms"] = round(metrics.latency_p95_ms, 1)
     return {
         "version": _BASELINE_SCHEMA_VERSION,
         "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -1018,19 +1059,16 @@ def _build_baseline_json(
             "legacy_weight": _PRODUCTION_LEGACY_WEIGHT,
             "overfetch": cfg.overfetch,
         },
-        "metrics": {
-            "precision_at_1": round(metrics.precision_at_k.get(1, 0.0), 4),
-            "precision_at_3": round(metrics.precision_at_k.get(3, 0.0), 4),
-            "precision_at_5": round(metrics.precision_at_k.get(5, 0.0), 4),
-            "recall_at_1": round(metrics.recall_at_k.get(1, 0.0), 4),
-            "recall_at_3": round(metrics.recall_at_k.get(3, 0.0), 4),
-            "recall_at_5": round(metrics.recall_at_k.get(5, 0.0), 4),
-            "mrr": round(metrics.mrr, 4),
-            "fraction_in_prompt": round(metrics.fraction_in_prompt, 4),
-            "latency_p50_ms": round(metrics.latency_p50_ms, 1),
-            "latency_p95_ms": round(metrics.latency_p95_ms, 1),
+        "metrics": metrics_block,
+        "by_tag": {
+            tag: _flatten_score_block(
+                vals["precision_at_k"],
+                vals["recall_at_k"],
+                vals["mrr"],
+                vals["fraction_in_prompt"],
+            )
+            for tag, vals in metrics.by_tag.items()
         },
-        "by_tag": _metrics_to_dict(metrics, include_by_tag=True)["by_tag"],
     }
 
 

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -597,8 +597,16 @@ async def format_context(
     # "what the agent actually saw" and `hits[lines_used:]` for
     # "survived ranking but lost to budget"; distinguishing these two
     # is what makes precision/recall scoring accurate.
+    # `id` is the Mem0 row identifier (MemoryResult.id, required field
+    # at line 120). Carried in the per-hit object so a downstream parser
+    # can match a probe's expected_fact_id against the actual hit
+    # without re-issuing get_by_id per hit or fragile snippet-substring
+    # matching (snippet is truncated to 80 chars and not unique).
+    # Without this field, precision/recall scoring against a known
+    # expected_fact_id has no honest way to identify which hit corresponds.
     payload["hits"] = [
         {
+            "id": r.id,
             "source": (r.metadata.get("source") if r.metadata else None) or "",
             "score": round(r.score, 4),
             "adj": round(r.score * w, 4),

--- a/tests/test_eval_retrieval.py
+++ b/tests/test_eval_retrieval.py
@@ -1,0 +1,557 @@
+"""Tests for the Layer 1 retrieval eval harness (kai.eval.retrieval).
+
+Six test classes covering the harness's load-bearing seams:
+
+1. TestMetricComputation - precision/recall/MRR math, including the
+   drift-denominator contract (drift probes excluded from BOTH
+   numerator and denominator).
+2. TestProbeLoading - JSONL parsing with the #-comment extension,
+   error paths for malformed JSON / missing keys / wrong types, and
+   probe_set_hash invariance under reorder.
+3. TestSweepRestoration - run_sweep restores all three pieces of
+   mutated module state when a probe raises mid-sweep.
+4. TestLogParserRoundTrip - capture a real memory.recall record via
+   format_context (with Mem0 mocked) and assert the per-hit `id`
+   field round-trips through the parser into compute_rank.
+5. TestDriftDetection - get_by_id returning None buckets a probe as
+   drift; pareto_frontier dominates correctly on (precision@5, p50).
+6. TestEvaluateEndToEnd - drift detection + scoring composed through
+   evaluate(); confirms metrics use N_scored, not N_probes.
+
+Math tests are pure functions (no Mem0, no logging fixtures), so the
+file is fast to run independently of the heavyweight memory fixtures.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kai.config import Config
+from kai.eval import retrieval
+from kai.eval.retrieval import (
+    ConfigOverride,
+    Probe,
+    ProbeResult,
+    aggregate_metrics,
+    compute_rank,
+    detect_drift,
+    evaluate,
+    load_probes,
+    pareto_frontier,
+    probe_set_hash,
+    run_sweep,
+    score_probes,
+)
+
+# Shared test config: memory enabled, modest budget, production floor.
+# Used in tests that swap the live `_config` for a stable known shape
+# so sweep-restoration assertions can compare the saved snapshot
+# against the post-sweep state.
+_BASE_CONFIG = Config(
+    telegram_bot_token="test-token",
+    allowed_user_ids={12345},
+    webhook_secret="test-secret",
+    memory_enabled=True,
+    memory_search_limit=10,
+    memory_token_budget=2000,
+    memory_search_floor=0.3,
+)
+
+
+def _reset_memory_module() -> None:
+    """Restore memory module state between tests.
+
+    Mirrors the helper in tests/test_memory.py: harness tests mutate
+    `_memory`, `_config`, `_SOURCE_WEIGHTS`, and `_SEARCH_OVERFETCH`,
+    and a leak between tests would silently couple them.
+    """
+    import kai.memory as mem_mod
+
+    mem_mod._memory = None
+    mem_mod._config = None
+    # _SOURCE_WEIGHTS is the production default snapshot; reset both
+    # the dict contents AND _UNKNOWN_SOURCE_WEIGHT so a sweep test
+    # mutating "extracted" does not leak into the next test.
+    mem_mod._SOURCE_WEIGHTS.clear()
+    mem_mod._SOURCE_WEIGHTS.update({"extracted": 1.2, "": 0.6})
+    mem_mod._UNKNOWN_SOURCE_WEIGHT = mem_mod._SOURCE_WEIGHTS[""]
+    mem_mod._SEARCH_OVERFETCH = 20
+
+
+@pytest.fixture(autouse=True)
+def _clean_memory_state():
+    _reset_memory_module()
+    yield
+    _reset_memory_module()
+
+
+# ── Test helpers ────────────────────────────────────────────────────
+
+
+def _make_probe_result(
+    *,
+    expected_id: str,
+    rank: int | None,
+    lines_used: int,
+    latency_ms: int = 50,
+    tags: tuple[str, ...] = (),
+) -> ProbeResult:
+    """Construct a ProbeResult without going through format_context.
+
+    The harness's scoring math is deliberately decoupled from the
+    log-parsing path, so test #1 builds these directly. `in_prompt`
+    is computed the same way the harness computes it (rank within
+    lines_used) so we don't drift between test and production logic.
+    """
+    in_prompt = rank is not None and rank <= lines_used
+    return ProbeResult(
+        probe=Probe(question="q", expected_fact_id=expected_id),
+        rank=rank,
+        in_prompt=in_prompt,
+        lines_used=lines_used,
+        latency_ms=latency_ms,
+        tags=tags,
+    )
+
+
+# ── Test 1: Metric computation incl. drift denominator ─────────────
+
+
+class TestMetricComputation:
+    """The math layer of the harness, pure-function tested.
+
+    The combination of scored-hit, scored-miss, and drift probes is
+    the load-bearing case: drift probes must be excluded from BOTH
+    numerator and denominator (N_scored = N_probes - N_drift). A
+    naive implementation that counted drift as zero-rank misses
+    would silently understate retrieval quality on every probe set.
+    """
+
+    def test_precision_and_recall_at_k_single_hit(self):
+        # One probe, fact at rank 2. Precision@1 = 0/1 = 0; @3 = 1/1.
+        results = [_make_probe_result(expected_id="x", rank=2, lines_used=3)]
+        out = score_probes(results)
+        assert out["precision_at_k"][1] == 0.0
+        assert out["precision_at_k"][3] == 1.0
+        assert out["precision_at_k"][5] == 1.0
+        # In single-answer mode (one expected_fact_id per probe), the
+        # numerator/denominator are the same for precision and recall,
+        # so the two dicts must match. Reported separately so a future
+        # multi-answer probe format can diverge without reshaping.
+        assert out["recall_at_k"] == out["precision_at_k"]
+
+    def test_mrr_treats_misses_as_zero(self):
+        # Two probes: one at rank 2 (1/2 = 0.5), one missed (0).
+        # MRR = (0.5 + 0) / 2 = 0.25.
+        results = [
+            _make_probe_result(expected_id="a", rank=2, lines_used=5),
+            _make_probe_result(expected_id="b", rank=None, lines_used=5),
+        ]
+        out = score_probes(results)
+        assert out["mrr"] == pytest.approx(0.25)
+
+    def test_in_prompt_uses_per_probe_lines_used(self):
+        # Probe A: rank 3, lines_used 2 -> not in prompt (truncated).
+        # Probe B: rank 1, lines_used 5 -> in prompt.
+        # fraction_in_prompt = 1/2 = 0.5.
+        results = [
+            _make_probe_result(expected_id="a", rank=3, lines_used=2),
+            _make_probe_result(expected_id="b", rank=1, lines_used=5),
+        ]
+        out = score_probes(results)
+        assert out["fraction_in_prompt"] == pytest.approx(0.5)
+        assert results[0].in_prompt is False
+        assert results[1].in_prompt is True
+
+    def test_drift_excluded_from_denominator(self):
+        # Three original probes: one scored hit, one scored miss, one
+        # drifted. The harness builds ProbeResult only for the two
+        # scored probes; n_drift=1 is passed through. With a hit and
+        # a miss in the scored bucket, precision@5 must be 1/2 = 0.5,
+        # NOT 1/3 (which would be the wrong denominator).
+        scored_results = [
+            _make_probe_result(expected_id="hit", rank=1, lines_used=3),
+            _make_probe_result(expected_id="miss", rank=None, lines_used=3),
+        ]
+        m = aggregate_metrics(scored_results, n_probes=3, n_drift=1)
+        assert m.n_probes == 3
+        assert m.n_scored == 2
+        assert m.n_drift == 1
+        # The whole point of the drift bucket: 1/2 not 1/3.
+        assert m.precision_at_k[5] == pytest.approx(0.5)
+        assert m.recall_at_k[5] == pytest.approx(0.5)
+        # MRR also computed against N_scored: 1.0 (the hit) / 2 = 0.5.
+        assert m.mrr == pytest.approx(0.5)
+
+    def test_per_tag_buckets_share_multitag_probes(self):
+        # A probe whose fact carries two tags appears in both buckets;
+        # this matches the operator's mental model of "show me retrieval
+        # quality for every probe whose fact touches tag X" rather than
+        # partitioning probes across tags. A multi-tag fact is a multi-
+        # tag probe by construction.
+        results = [
+            _make_probe_result(expected_id="a", rank=1, lines_used=3, tags=("preferences", "tech")),
+            _make_probe_result(expected_id="b", rank=None, lines_used=3, tags=("tech",)),
+        ]
+        m = aggregate_metrics(results, n_probes=2, n_drift=0)
+        assert "preferences" in m.by_tag
+        assert "tech" in m.by_tag
+        # preferences sees only probe a (a hit at rank 1) -> p@5 = 1.0.
+        assert m.by_tag["preferences"]["precision_at_k"][5] == pytest.approx(1.0)
+        # tech sees both probes (one hit, one miss) -> p@5 = 0.5.
+        assert m.by_tag["tech"]["precision_at_k"][5] == pytest.approx(0.5)
+
+    def test_compute_rank_returns_one_indexed_or_none(self):
+        # First hit -> rank 1 (1-indexed). No match -> None.
+        hits = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+        assert compute_rank(hits, "a") == 1
+        assert compute_rank(hits, "c") == 3
+        assert compute_rank(hits, "z") is None
+        # Empty hits cleanly return None rather than raising.
+        assert compute_rank([], "a") is None
+
+
+# ── Test 2: Probe file parsing ─────────────────────────────────────
+
+
+class TestProbeLoading:
+    """JSONL parsing with the documented #-comment extension."""
+
+    def test_loads_well_formed_lines_and_skips_comments(self, tmp_path: Path):
+        # The probe file demonstrates every supported feature: leading
+        # comment, blank line, indented comment, trailing newline. The
+        # assertion below also locks in line-order preservation, which
+        # is what lets per-probe output rows align back to source.
+        text = (
+            "# overall annotation\n"
+            "\n"
+            '{"question": "where do I live?", "expected_fact_id": "fact-1"}\n'
+            "    # indented annotation between probes\n"
+            '{"question": "what is my timezone?", "expected_fact_id": "fact-2", '
+            '"source_turn_ts": "2026-04-01T10:00:00", "notes": "from session 12"}\n'
+        )
+        path = tmp_path / "probes.jsonl"
+        path.write_text(text, encoding="utf-8")
+        probes = load_probes(path)
+        assert len(probes) == 2
+        # Order preserved: probe 1 is the live-where question.
+        assert probes[0].expected_fact_id == "fact-1"
+        assert probes[1].expected_fact_id == "fact-2"
+        assert probes[1].source_turn_ts == "2026-04-01T10:00:00"
+        assert probes[1].notes == "from session 12"
+
+    def test_rejects_malformed_json(self, tmp_path: Path):
+        path = tmp_path / "probes.jsonl"
+        path.write_text('{"question": "bad json"\n', encoding="utf-8")
+        with pytest.raises(ValueError, match="malformed JSON"):
+            load_probes(path)
+
+    def test_rejects_missing_required_keys(self, tmp_path: Path):
+        # `expected_fact_id` absent: must fail at load time so a
+        # large probe set's bad row surfaces before any retrieval cost.
+        path = tmp_path / "probes.jsonl"
+        path.write_text('{"question": "no expected id here"}\n', encoding="utf-8")
+        with pytest.raises(ValueError, match="expected_fact_id"):
+            load_probes(path)
+
+    def test_rejects_wrong_type(self, tmp_path: Path):
+        # `expected_fact_id` is an int (spreadsheet export landmine):
+        # without this guard the eventual hit comparison would silently
+        # never match and report 0% precision.
+        path = tmp_path / "probes.jsonl"
+        path.write_text('{"question": "q", "expected_fact_id": 42}\n', encoding="utf-8")
+        with pytest.raises(ValueError, match="not a non-empty string"):
+            load_probes(path)
+
+    def test_probe_set_hash_invariant_under_reorder(self, tmp_path: Path):
+        # Two files with the same probes in different order must
+        # produce the same hash; otherwise a baseline file's hash
+        # would invalidate after a benign reorder.
+        a = [
+            Probe(question="q1", expected_fact_id="id1"),
+            Probe(question="q2", expected_fact_id="id2"),
+        ]
+        b = list(reversed(a))
+        assert probe_set_hash(a) == probe_set_hash(b)
+        # Different content -> different hash, defending the
+        # baseline-comparison contract.
+        c = [Probe(question="q1", expected_fact_id="id1")]
+        assert probe_set_hash(a) != probe_set_hash(c)
+
+
+# ── Test 3: Sweep restoration after exception ──────────────────────
+
+
+class TestSweepRestoration:
+    """run_sweep must restore module state even if a probe raises mid-sweep."""
+
+    def test_module_state_restored_after_midsweep_exception(self):
+        import kai.memory as mem_mod
+
+        # Install known-good baseline state. Capture explicit copies
+        # so post-sweep assertions can compare against frozen values
+        # that won't accidentally alias the dict the harness mutated.
+        mem_mod._config = _BASE_CONFIG
+        original_floor = mem_mod._config.memory_search_floor
+        original_weights = dict(mem_mod._SOURCE_WEIGHTS)
+        original_overfetch = mem_mod._SEARCH_OVERFETCH
+
+        # `evaluate` is patched to raise on the second call, mid-sweep.
+        # The first call completes normally; the second raises and the
+        # exception propagates out. The try/finally inside run_sweep
+        # must still restore the original state.
+        call_count = {"n": 0}
+
+        async def faulty_evaluate(probes, user_id):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise RuntimeError("simulated mid-sweep failure")
+            from kai.eval.retrieval import Metrics
+
+            return Metrics(
+                n_probes=1,
+                n_scored=1,
+                n_drift=0,
+                precision_at_k={1: 0.0, 3: 0.0, 5: 0.0},
+                recall_at_k={1: 0.0, 3: 0.0, 5: 0.0},
+                precision_at_lines_used=0.0,
+                mrr=0.0,
+                fraction_in_prompt=0.0,
+                latency_p50_ms=0.0,
+                latency_p95_ms=0.0,
+            )
+
+        grid = [
+            ConfigOverride(floor=0.20, extracted_weight=1.5, overfetch=10),
+            ConfigOverride(floor=0.40, extracted_weight=2.0, overfetch=30),
+        ]
+        with (
+            patch("kai.eval.retrieval.evaluate", side_effect=faulty_evaluate),
+            pytest.raises(RuntimeError, match="simulated mid-sweep failure"),
+        ):
+            asyncio.run(
+                run_sweep(
+                    [Probe(question="q", expected_fact_id="id")],
+                    user_id="42",
+                    grid=grid,
+                )
+            )
+
+        # The whole point of test 3: state restored despite the abort.
+        assert mem_mod._config.memory_search_floor == original_floor
+        assert original_weights == mem_mod._SOURCE_WEIGHTS
+        assert original_overfetch == mem_mod._SEARCH_OVERFETCH
+
+
+# ── Test 4: Log parser end-to-end (round-trip on `id` field) ──────
+
+
+class TestLogParserRoundTrip:
+    """Capture a real memory.recall record, parse it, assert id passthrough.
+
+    The harness's ranking logic depends on each per-hit dict in the
+    recall payload carrying `id` matching MemoryResult.id. This test
+    wires the harness's `_RecallLogCapture` to a real format_context
+    call (with a mocked Mem0 search) and confirms the id flows through
+    end-to-end via the structured log line, not via any side-channel.
+    """
+
+    def test_capture_and_parse_id_field(self):
+        import kai.memory as mem_mod
+        from kai.memory import format_context
+
+        # Mock Mem0 to return two rows with known IDs. The harness's
+        # log capture handler reads format_context's emit; the parsed
+        # payload must carry both IDs so a downstream `compute_rank`
+        # against expected_fact_id="row-b" returns 2 (not None).
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {
+            "results": [
+                {
+                    "id": "row-a",
+                    "memory": "Fact A text",
+                    "score": 0.9,
+                    "metadata": {"type": "fact", "source": "extracted"},
+                    "created_at": "2026-04-01T10:00:00",
+                },
+                {
+                    "id": "row-b",
+                    "memory": "Fact B text",
+                    "score": 0.8,
+                    "metadata": {"type": "fact", "source": "extracted"},
+                    "created_at": "2026-04-02T10:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+        mem_mod._config = _BASE_CONFIG
+
+        # Attach the harness's capture handler exactly the way the
+        # production code path does. _attach_capture also forces the
+        # kai.memory logger level to INFO if it was higher (test runs
+        # default to WARNING via pytest config), so the recall record
+        # is guaranteed to reach the handler.
+        capture = retrieval._attach_capture()
+        try:
+            asyncio.run(format_context("any query", user_id="42"))
+            payloads = capture.drain()
+        finally:
+            retrieval._detach_capture(capture)
+
+        assert len(payloads) == 1
+        payload = payloads[0]
+        ids = [h["id"] for h in payload["hits"]]
+        # IDs round-tripped via JSON; compute_rank must locate row-b
+        # at position 2 to score the prerequisite-dependent contract.
+        assert ids == ["row-a", "row-b"]
+        assert compute_rank(payload["hits"], "row-b") == 2
+        assert compute_rank(payload["hits"], "missing-id") is None
+
+
+# ── Test 5: Drift detection ────────────────────────────────────────
+
+
+class TestDriftDetection:
+    """A probe with a get_by_id None must bucket as drift, not a miss."""
+
+    def test_none_from_get_by_id_buckets_as_drift(self):
+        # Two probes: alive-fact resolves to a real MemoryResult,
+        # dead-fact returns None (deleted, ownership mismatch, source
+        # mismatch, or never-existed - all collapse to drift).
+        from kai.memory import MemoryResult
+
+        alive = MemoryResult(
+            id="alive-fact",
+            text="...",
+            score=0.0,
+            memory_type="fact",
+            metadata={"source": "extracted", "tags": ["preferences"]},
+            created_at="2026-04-01T00:00:00",
+        )
+
+        def fake_get_by_id(*, user_id: str, memory_id: str):
+            return alive if memory_id == "alive-fact" else None
+
+        with patch("kai.memory.get_by_id", side_effect=fake_get_by_id):
+            scored, drifted, tags_by_id = detect_drift(
+                [
+                    Probe(question="q1", expected_fact_id="alive-fact"),
+                    Probe(question="q2", expected_fact_id="dead-fact"),
+                ],
+                user_id="42",
+            )
+
+        assert [p.expected_fact_id for p in scored] == ["alive-fact"]
+        assert [p.expected_fact_id for p in drifted] == ["dead-fact"]
+        # Tag mapping captured during drift detection so the per-tag
+        # rollup later reuses this lookup instead of refetching.
+        assert tags_by_id == {"alive-fact": ("preferences",)}
+
+    def test_pareto_frontier_dominates_correctly(self):
+        # Three configs:
+        #   A: precision 0.8, latency 50  - dominates B (worse on both).
+        #   B: precision 0.7, latency 100 - dominated.
+        #   C: precision 0.9, latency 200 - non-dominated (better quality, worse latency).
+        # Frontier should be {A, C}, sorted by precision desc -> [C, A].
+        def _m(p5: float, lat: float):
+            from kai.eval.retrieval import Metrics
+
+            return Metrics(
+                n_probes=1,
+                n_scored=1,
+                n_drift=0,
+                precision_at_k={1: p5, 3: p5, 5: p5},
+                recall_at_k={1: p5, 3: p5, 5: p5},
+                precision_at_lines_used=p5,
+                mrr=p5,
+                fraction_in_prompt=p5,
+                latency_p50_ms=lat,
+                latency_p95_ms=lat,
+            )
+
+        cfg_a = ConfigOverride(floor=0.2, extracted_weight=1.0, overfetch=10)
+        cfg_b = ConfigOverride(floor=0.3, extracted_weight=1.2, overfetch=20)
+        cfg_c = ConfigOverride(floor=0.4, extracted_weight=2.0, overfetch=30)
+        sweep = [(cfg_a, _m(0.8, 50)), (cfg_b, _m(0.7, 100)), (cfg_c, _m(0.9, 200))]
+        front = pareto_frontier(sweep)
+        front_cfgs = [c for c, _ in front]
+        assert cfg_a in front_cfgs
+        assert cfg_c in front_cfgs
+        assert cfg_b not in front_cfgs  # dominated by A on both axes
+        # Sort order: precision desc -> C (0.9) before A (0.8).
+        assert front[0][0] is cfg_c
+        assert front[1][0] is cfg_a
+
+
+# ── Bonus: drift end-to-end through evaluate() ─────────────────────
+
+
+class TestEvaluateEndToEnd:
+    """evaluate() integrates drift detection + scoring; exercise the seam."""
+
+    def test_evaluate_excludes_drift_from_metrics(self):
+        # Mock the memory module: get_by_id resolves only "alive"
+        # probes (so the dead probe falls into the drift bucket
+        # before format_context is ever called), and format_context
+        # emits a stub recall log naming alive-fact at rank 1. The
+        # combined behavior must produce metrics that count the alive
+        # probe but not the drifted one.
+        import kai.memory as mem_mod
+        from kai.memory import MemoryResult
+
+        mem_mod._config = _BASE_CONFIG
+
+        alive = MemoryResult(
+            id="alive-fact",
+            text="...",
+            score=0.0,
+            memory_type="fact",
+            metadata={"source": "extracted", "tags": []},
+            created_at="2026-04-01T00:00:00",
+        )
+
+        async def fake_format_context(query: str, *, user_id: str, token_budget=None):
+            # Emit one memory.recall line per call so the harness's
+            # capture handler sees exactly one record (the contract
+            # the harness aborts loudly on if violated).
+            payload = {
+                "user_id": user_id,
+                "query": query,
+                "hits": [{"id": "alive-fact", "source": "extracted", "score": 0.9, "adj": 1.08, "snippet": "..."}],
+                "lines_used": 1,
+                "latency_ms": 7,
+            }
+            logging.getLogger("kai.memory").info("memory.recall %s", json.dumps(payload))
+            return ""
+
+        def fake_get_by_id(*, user_id: str, memory_id: str):
+            return alive if memory_id == "alive-fact" else None
+
+        with (
+            patch("kai.memory.get_by_id", side_effect=fake_get_by_id),
+            patch("kai.memory.format_context", side_effect=fake_format_context),
+        ):
+            metrics = asyncio.run(
+                evaluate(
+                    [
+                        Probe(question="q1", expected_fact_id="alive-fact"),
+                        Probe(question="q2", expected_fact_id="dead-fact"),
+                    ],
+                    user_id="42",
+                )
+            )
+
+        assert metrics.n_probes == 2
+        assert metrics.n_scored == 1
+        assert metrics.n_drift == 1
+        # The single scored probe was a hit at rank 1 -> p@5 = 1.0,
+        # MRR = 1.0; both computed against N_scored=1, not N_probes=2.
+        assert metrics.precision_at_k[5] == pytest.approx(1.0)
+        assert metrics.mrr == pytest.approx(1.0)
+        assert metrics.fraction_in_prompt == pytest.approx(1.0)

--- a/tests/test_eval_retrieval.py
+++ b/tests/test_eval_retrieval.py
@@ -302,13 +302,16 @@ class TestSweepRestoration:
         original_weights = dict(mem_mod._SOURCE_WEIGHTS)
         original_overfetch = mem_mod._SEARCH_OVERFETCH
 
-        # `evaluate` is patched to raise on the second call, mid-sweep.
-        # The first call completes normally; the second raises and the
-        # exception propagates out. The try/finally inside run_sweep
-        # must still restore the original state.
+        # The sweep loop now calls `_score_against_store` per grid
+        # point (drift is hoisted to a single call at sweep entry, so
+        # we also stub `detect_drift` to a no-op tuple). The stub is
+        # patched to raise on the second call, mid-sweep. The first
+        # call completes normally; the second raises and the exception
+        # propagates out. The try/finally inside run_sweep must still
+        # restore the original module state.
         call_count = {"n": 0}
 
-        async def faulty_evaluate(probes, user_id):
+        async def faulty_score(scored, drifted, tags_by_id, user_id):
             call_count["n"] += 1
             if call_count["n"] == 2:
                 raise RuntimeError("simulated mid-sweep failure")
@@ -320,7 +323,6 @@ class TestSweepRestoration:
                 n_drift=0,
                 precision_at_k={1: 0.0, 3: 0.0, 5: 0.0},
                 recall_at_k={1: 0.0, 3: 0.0, 5: 0.0},
-                precision_at_lines_used=0.0,
                 mrr=0.0,
                 fraction_in_prompt=0.0,
                 latency_p50_ms=0.0,
@@ -332,7 +334,11 @@ class TestSweepRestoration:
             ConfigOverride(floor=0.40, extracted_weight=2.0, overfetch=30),
         ]
         with (
-            patch("kai.eval.retrieval.evaluate", side_effect=faulty_evaluate),
+            patch(
+                "kai.eval.retrieval.detect_drift",
+                return_value=([Probe(question="q", expected_fact_id="id")], [], {"id": ()}),
+            ),
+            patch("kai.eval.retrieval._score_against_store", side_effect=faulty_score),
             pytest.raises(RuntimeError, match="simulated mid-sweep failure"),
         ):
             asyncio.run(
@@ -468,7 +474,6 @@ class TestDriftDetection:
                 n_drift=0,
                 precision_at_k={1: p5, 3: p5, 5: p5},
                 recall_at_k={1: p5, 3: p5, 5: p5},
-                precision_at_lines_used=p5,
                 mrr=p5,
                 fraction_in_prompt=p5,
                 latency_p50_ms=lat,

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -741,12 +741,24 @@ class TestRecallLogging:
         assert payload["latency_ms"] >= 0  # wall-time, can be 0 for mocked instant search
         assert isinstance(payload["hits"], list) and len(payload["hits"]) == 2
 
-        # Per-hit shape: source, score, adj, snippet.
+        # Per-hit shape: id, source, score, adj, snippet. `id` was added
+        # so a downstream consumer (the retrieval eval harness) can
+        # match a probe's expected_fact_id against the actual hit. The
+        # mock returns rows with ids "a" and "b"; the assertion below
+        # locks in the ID-passthrough contract.
         for hit in payload["hits"]:
-            assert set(hit.keys()) == {"source", "score", "adj", "snippet"}
+            assert set(hit.keys()) == {"id", "source", "score", "adj", "snippet"}
+            assert isinstance(hit["id"], str)
             assert isinstance(hit["score"], float)
             assert isinstance(hit["adj"], float)
             assert isinstance(hit["snippet"], str)
+
+        # Per-hit `id` passes through from MemoryResult.id. The mocked
+        # search returned rows with ids "a" (extracted) and "b" (legacy);
+        # both must appear in the payload's hits array. Asserting on the
+        # set rather than ordered list keeps this independent of the
+        # adjusted-score sort assertion below.
+        assert {hit["id"] for hit in payload["hits"]} == {"a", "b"}
 
         # Post-sort order: extracted (1.2x weight) outranks legacy (0.6x)
         # by adjusted score, so the extracted hit must come first in


### PR DESCRIPTION
fixes #365

## What

Adds a Layer 1 retrieval-eval harness at `src/kai/eval/retrieval.py`, runnable as `python -m kai.eval.retrieval`. Given a JSONL probe set of `(question, expected_fact_id)` pairs, it runs each probe through the live `format_context` pipeline, parses the structured `memory.recall` log line, and reports precision@K, recall@K, MRR, `fraction_in_prompt`, and p50/p95 latency.

Two modes:

- **Single config**: scores against whatever `_config` / `_SOURCE_WEIGHTS` / `_SEARCH_OVERFETCH` the live memory module currently carries; an `--output` flag writes a baseline JSON file matching the committed `*.example.json` schema.
- **Sweep** (`--sweep`): iterates a `(floor, extracted_weight, overfetch)` grid by mutating module-level state per iteration with `try/finally` restoration, then prints the Pareto frontier on `(precision@5, latency_p50)` followed by the full table sorted best-quality-first.

## Why

Without this, "did that retrieval tweak help?" is judged eyeball-only. The harness gives a reproducible answer per probe set, and the baseline JSON makes regression detection a `jq` diff away. Per-tag breakdowns surface category-level quality (e.g. preferences vs. infra) so a tweak that helps overall but hurts one category is visible.

## Drift handling

Probes whose expected fact has been deleted or filtered out by `get_by_id` (ownership mismatch, source mismatch, or never-existed) are bucketed as drift and excluded from BOTH the numerator and the denominator. `N_scored = N_probes - N_drift`. Mixing drift with retrieval misses would conflate "retrieval failed" with "probe set went stale" - different operator actions.

## Prerequisite (commit 1 of 2)

Adds an `id` field to each per-hit dict in the `memory.recall` payload, sourced from `MemoryResult.id`. The harness's ranking logic depends on it; otherwise scoring would have to fall back to fragile snippet-substring matching against the 80-char truncated text. One existing test asserts the per-hit key set; it's updated in the same commit.

## Files

- `src/kai/eval/__init__.py` - package init (room for future Layer 2/3 here)
- `src/kai/eval/retrieval.py` - harness + CLI (~1,100 lines)
- `tests/test_eval_retrieval.py` - 16 tests across 6 classes
- `home/evals/probes.example.jsonl` - schema demo, three synthetic probes
- `home/evals/retrieval-baseline.example.json` - baseline file shape
- `.gitignore` - real probe set + baseline gitignored, examples tracked
- `src/kai/memory.py` + `tests/test_memory.py` - prerequisite `id` field

## Why probes are gitignored

Real probe questions are conversation excerpts, and `expected_fact_id` values are Mem0 row IDs specific to one operator's store. Both are operator data; only the synthetic `*.example.*` fixtures ship in the repo.

## Test plan

- [ ] `make check` (ruff lint + format)
- [ ] `make test` (full suite, including new `tests/test_eval_retrieval.py`)
- [ ] `python -m kai.eval.retrieval --probes home/evals/probes.example.jsonl --user-id <chat_id>` smoke run against a real store
- [ ] `python -m kai.eval.retrieval --probes ... --user-id ... --sweep` smoke run on a small grid
