### PR TITLE
feat(eval): synthetic Track 1 reconstruction for Layer 2 pollution test

### DIFF
--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -295,6 +295,17 @@ class BehavioralConfig:
     # arg) so it surfaces in the output JSON automatically alongside
     # seed and max_concurrency, making each saved run self-describing.
     pollution_lines: int = 0
+    # Snapshot of load_config().data_dir captured once at run start.
+    # Threaded through BehavioralConfig (rather than re-loaded inside
+    # _run_all_probes) so the memory snapshot read by init_memory and
+    # the history snapshot read by _load_user_history_messages share a
+    # single source of truth. If KAI_DATA_DIR were ever to change
+    # between two load_config() calls (subprocess wrapper rewriting
+    # the env mid-run, fixture cleanup racing the eval), the two
+    # snapshots could diverge silently. Default points at the dev tree
+    # so test fixtures that build a config without invoking the CLI
+    # still get a sensible path.
+    data_dir: Path = Path(".")
 
 
 @dataclass
@@ -818,6 +829,17 @@ def _load_user_history_messages(user_id: str, data_dir: Path) -> list[str]:
     after a power-loss restart) rather than failing the whole load.
     The bot's own history reader follows the same convention.
     """
+    # Path-traversal guard: user_id flows in from --user-id with no
+    # validation upstream, and we are about to use it as a path
+    # component under data_dir. A value like "../../etc" would escape
+    # the history root entirely. Path(user_id).name strips any
+    # directory parts and any platform-specific separators; equality
+    # against the input means user_id is exactly one segment, no
+    # slashes, no parent refs. Eval-only operator-run code, so the
+    # guard is consistent with _positive_int / _non_negative_int rather
+    # than a security boundary.
+    if Path(user_id).name != user_id or user_id in ("", ".", ".."):
+        raise ValueError(f"invalid user_id for history path: {user_id!r}")
     history_dir = data_dir / "history" / user_id
     if not history_dir.is_dir():
         return []
@@ -873,9 +895,19 @@ def _sample_pollution_for_probe(
     """
     if n <= 0 or not history:
         return []
+    # Domain-separated SHA256 update: each field is followed by a NUL
+    # delimiter so concatenation cannot collide. Without delimiters,
+    # ("ab", "cde", "pollution") and ("abc", "de", "pollution") feed
+    # the same bytes into the hash and would draw identical samples.
+    # NUL is the conventional choice because it cannot appear in the
+    # UTF-8 encoding of any of these fields (base_seed is hex chars,
+    # expected_fact_id is the upstream UUID/string, neither of which
+    # contains a literal 0 byte).
     h = hashlib.sha256()
     h.update(base_seed.encode("utf-8"))
+    h.update(b"\x00")
     h.update(expected_fact_id.encode("utf-8"))
+    h.update(b"\x00")
     h.update(b"pollution")
     rng = random.Random(int(h.hexdigest()[:16], 16))
     return rng.sample(history, min(n, len(history)))
@@ -1263,18 +1295,16 @@ async def _run_all_probes(
     # the data_dir path to surface in the operator-facing message.
     pollution_history: list[str] = []
     if config.pollution_lines > 0:
-        # Late import to keep the module's startup cost off the
-        # critical path for the (common) no-pollution invocation;
-        # load_config touches the env, the .env file, and the SQLite
-        # config table, none of which the no-pollution path needs.
-        from kai.config import load_config
-
-        data_dir = load_config().data_dir
-        pollution_history = _load_user_history_messages(user_id, data_dir)
+        # data_dir was captured once into BehavioralConfig at run start
+        # (in _run_cli) so the history snapshot here uses exactly the
+        # same root that init_memory used for the memory snapshot. A
+        # second load_config() here would re-read the env and could
+        # diverge if KAI_DATA_DIR were rewritten mid-run by a wrapper.
+        pollution_history = _load_user_history_messages(user_id, config.data_dir)
         if not pollution_history:
             print(
                 f"eval: --pollution-lines={config.pollution_lines} requested but "
-                f"no user history found at {data_dir}/history/{user_id}/; "
+                f"no user history found at {config.data_dir}/history/{user_id}/; "
                 f"injection will be a no-op",
                 file=sys.stderr,
             )
@@ -1860,21 +1890,28 @@ def _build_parser() -> argparse.ArgumentParser:
             f"block of the memory-on arm. Used to test whether removing "
             f"raw-utterance pollution mattered more than adding semantic "
             f"retrieval (the open Layer 2 hypothesis). Defaults to "
-            f"{_DEFAULT_POLLUTION_LINES} (no injection); set to 0 for the "
-            f"clean A/B baseline. The memory-off arm is never polluted, "
-            f"by design; pollution is a property of the memory-on prompt."
+            f"{_DEFAULT_POLLUTION_LINES} (no injection). The memory-off arm "
+            f"is never polluted, by design; pollution is a property of "
+            f"the memory-on prompt."
         ),
     )
     return parser
 
 
-def _initialize_memory() -> bool:
-    """Load config and call init_memory(); return True on success.
+def _initialize_memory() -> Path | None:
+    """Load config and call init_memory(); return data_dir on success.
 
     Mirrors Layer 1's discipline. The harness runs against the live
     store, so the same init path keeps embedding model, Qdrant
     directory, and history DB settings consistent with the bot
     runtime. Errors print to stderr and the caller exits with status 1.
+
+    Returns the loaded `data_dir` (rather than a bool) so the caller
+    can populate BehavioralConfig.data_dir from the SAME load_config()
+    call that drove init_memory. Without this, _run_all_probes would
+    have to re-load the config to find the history snapshot root,
+    risking divergence if the env changed between calls. None signals
+    failure (init exception, memory disabled).
     """
     try:
         from kai.config import load_config
@@ -1887,11 +1924,11 @@ def _initialize_memory() -> bool:
                 "eval: memory is not enabled. Set MEMORY_ENABLED=true and verify the store is readable.",
                 file=sys.stderr,
             )
-            return False
-        return True
+            return None
+        return config.data_dir
     except Exception as e:
         print(f"eval: init failed: {e}", file=sys.stderr)
-        return False
+        return None
 
 
 def _resolve_ground_truth(
@@ -1955,7 +1992,8 @@ async def _run_cli(args: argparse.Namespace) -> int:
         print(f"eval: no probes loaded from {args.probes}", file=sys.stderr)
         return 2
 
-    if not _initialize_memory():
+    data_dir = _initialize_memory()
+    if data_dir is None:
         return 1
 
     # Drift detection + tag mapping — reuses Layer 1's helper so the
@@ -1984,6 +2022,7 @@ async def _run_cli(args: argparse.Namespace) -> int:
         seed=_resolve_seed(cli_seed=args.seed, probes=probes, user_id=args.user_id),
         max_concurrency=args.max_concurrency,
         pollution_lines=args.pollution_lines,
+        data_dir=data_dir,
     )
 
     claude_cli_version = _capture_claude_cli_version()

--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -156,6 +156,34 @@ _DEFAULT_GEN_TIMEOUT_S = 120
 _DEFAULT_MAX_CONCURRENCY = 4
 
 
+# Default pollution-injection count. Eval-only mechanism: when this is
+# greater than zero, the harness loads the user's history JSONLs once
+# at run start and per-probe samples N entries to splice into the
+# memory context block as `- User said: <text>` bullets, mimicking the
+# prompt shape Track 1 produced before PR #361 deleted that ingestion
+# path. Used by the three-way compare in eval epic #362 to test
+# whether retrieval-block pollution materially hurts behavioral
+# outcomes WITHOUT resurrecting the deleted Track 1 machinery (which
+# carries a real risk surface: any single bit-flip of an "eval-only"
+# flag in production would re-introduce the bug PR #361 fixed).
+# Default zero means today's runs stay byte-identical to the existing
+# baseline; the byte-level A/B isolation guarantee in test 1 depends
+# on this no-op default.
+_DEFAULT_POLLUTION_LINES = 0
+
+
+# Per-line truncation cap for synthetic-pollution lines. Matches
+# memory_extraction._MAX_USER_CHARS so the synthesized prompt shape
+# faithfully mirrors what Track 1 actually produced; Track 1 itself
+# truncated user utterances to the same 2000-char ceiling before
+# storing them as `User said: <text>` rows. Lines longer than this
+# are truncated with a trailing ellipsis, same as the extractor's
+# convention. Held as a separate module-level constant rather than
+# imported from memory_extraction so behavioral.py stays free of an
+# eval-time dependency on the extractor module's private internals.
+_MAX_POLLUTION_LINE_CHARS = 2000
+
+
 # JSON Schema passed to `claude --print --json-schema` for the judge
 # call. The four-value `choice` enum maps directly to the harness's
 # outcome buckets (after de-anonymization). `additionalProperties=false`
@@ -258,6 +286,15 @@ class BehavioralConfig:
     gen_timeout_s: int
     seed: str
     max_concurrency: int
+    # Eval-only synthetic-pollution count. Defaults to 0 so existing
+    # tests and existing CLI invocations stay byte-for-byte identical
+    # to today's behavior; a non-zero value opts the run into the
+    # Track 1 pollution comparison without changing the schema for
+    # callers that do not use the feature. Field kept on
+    # BehavioralConfig (rather than threaded as a separate function
+    # arg) so it surfaces in the output JSON automatically alongside
+    # seed and max_concurrency, making each saved run self-describing.
+    pollution_lines: int = 0
 
 
 @dataclass
@@ -749,10 +786,144 @@ def _rollup_outcome(*, judge_choice: str, memory_arm_letter: str) -> str:
     return "judge_error"
 
 
+# ── Eval-only synthetic-pollution helpers ──────────────────────────
+
+
+def _load_user_history_messages(user_id: str, data_dir: Path) -> list[str]:
+    """Load every user-role message from a chat_id's history JSONLs.
+
+    Reads every `*.jsonl` under `<data_dir>/history/<user_id>/` and
+    returns the `text` field of rows whose `dir == "user"`. Used as
+    the raw source for synthetic-pollution sampling; the harness loads
+    this once at run start and re-samples per-probe rather than
+    reading from disk for every probe.
+
+    Lines longer than _MAX_POLLUTION_LINE_CHARS are truncated with a
+    trailing ellipsis. Track 1 itself truncated user utterances to the
+    same length before storing them, so this preserves the prompt
+    shape we are trying to reproduce; an un-truncated injection would
+    NOT be a faithful reconstruction of the deleted behavior.
+
+    Returns an empty list when the history directory does not exist
+    or contains no user messages. Callers are expected to treat empty
+    as "no pollution available, proceed without it" rather than as an
+    error, because the harness must remain runnable against fresh
+    users with no history (e.g. new operators bringing up Layer 2 on
+    a clean install). The CLI prints a one-line stderr warning when
+    pollution is requested but no history is found, so the empty-list
+    fall-through is visible without halting the run.
+
+    Skips silently on individual JSONDecodeError lines (corrupt rows
+    in long-running history files, e.g. truncated final-line writes
+    after a power-loss restart) rather than failing the whole load.
+    The bot's own history reader follows the same convention.
+    """
+    history_dir = data_dir / "history" / user_id
+    if not history_dir.is_dir():
+        return []
+    messages: list[str] = []
+    for path in sorted(history_dir.glob("*.jsonl")):
+        for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            if not raw.strip():
+                continue
+            try:
+                row = json.loads(raw)
+            except json.JSONDecodeError:
+                # Corrupt line in history file; skip silently.
+                continue
+            if row.get("dir") != "user":
+                continue
+            text = row.get("text") or ""
+            if not text.strip():
+                continue
+            if len(text) > _MAX_POLLUTION_LINE_CHARS:
+                text = text[:_MAX_POLLUTION_LINE_CHARS] + "..."
+            messages.append(text)
+    return messages
+
+
+def _sample_pollution_for_probe(
+    history: list[str],
+    n: int,
+    *,
+    base_seed: str,
+    expected_fact_id: str,
+) -> list[str]:
+    """Deterministically sample N pollution lines for one probe.
+
+    Uses a SEPARATE RNG seeded from
+    `sha256(base_seed + expected_fact_id + b"pollution")[:16]`,
+    distinct from the per-probe RNG that drives the A/B coin flip in
+    _run_all_probes. Keeping these RNGs strictly separate is the
+    invariant that lets the operator compare a pollution-on run
+    against a pollution-off run of the same (probes, user_id, seed)
+    triple: the arm letter assigned to memory-on for each probe must
+    NOT shift when pollution is enabled, otherwise per-probe wins/
+    losses become incomparable across runs and the whole point of
+    the deterministic seed is lost. The trailing `b"pollution"` salt
+    is what guarantees this independence: any other RNG seeded from
+    (base_seed, expected_fact_id) without the salt would re-derive
+    the same hash and consume identical bytes.
+
+    Sampling is WITHOUT replacement; if N exceeds the history size
+    the entire history is returned in shuffled order. Returns an
+    empty list when n <= 0 or history is empty so callers can
+    unconditionally pass the result through to build_arm_prompt
+    without re-checking the no-op case.
+    """
+    if n <= 0 or not history:
+        return []
+    h = hashlib.sha256()
+    h.update(base_seed.encode("utf-8"))
+    h.update(expected_fact_id.encode("utf-8"))
+    h.update(b"pollution")
+    rng = random.Random(int(h.hexdigest()[:16], 16))
+    return rng.sample(history, min(n, len(history)))
+
+
+def _inject_synthetic_pollution(memory_ctx: str, lines: list[str]) -> str:
+    """Append `- User said: <text>` bullets to a memory context block.
+
+    Bullets are appended AFTER the existing facts in `memory_ctx`,
+    matching where the most-recent Track 1 rows used to land in the
+    pre-#361 prompt: Mem0's recency-weighted ranking placed user-said
+    rows near the bottom of the retrieval block (closest to the
+    question), which is exactly the position the model is most likely
+    to weigh heavily. The bullet prefix matches Mem0's own
+    output-formatting (`- <fact>`) so the synthetic lines visually
+    blend with the genuine facts and the model has no easy way to
+    distinguish "this came from extraction" from "this came from
+    Track 1"; that visual indistinguishability is the core mechanism
+    PR #361's commit message identified as the failure mode.
+
+    No-ops when `lines` is empty. The byte-level A/B isolation test
+    (test 1) depends on this no-op contract: a default
+    pollution_lines=0 invocation must leave memory_ctx byte-identical
+    to today's production format_context output, otherwise the
+    foundational A/B-arms-differ-in-exactly-one-place guarantee
+    would silently regress for non-eval callers.
+    """
+    if not lines:
+        return memory_ctx
+    bullets = [f"- User said: {line.strip()}" for line in lines]
+    # rstrip() to avoid a double-newline if format_context already
+    # ends in \n; the join-with-\n pattern then produces exactly one
+    # newline between the existing facts and the first synthetic
+    # bullet, matching the bullet-per-line shape format_context itself
+    # uses.
+    return memory_ctx.rstrip() + "\n" + "\n".join(bullets)
+
+
 # ── Arm prompt assembly ────────────────────────────────────────────
 
 
-async def build_arm_prompt(question: str, user_id: str, *, memory_enabled: bool) -> str:
+async def build_arm_prompt(
+    question: str,
+    user_id: str,
+    *,
+    memory_enabled: bool,
+    pollution_lines: list[str] | None = None,
+) -> str:
     """Build the user prompt for one A/B arm.
 
     The hypothesis "memory helps generation" only holds if the two
@@ -772,6 +943,17 @@ async def build_arm_prompt(question: str, user_id: str, *, memory_enabled: bool)
     `src/kai/backend.py`; reusing it rather than reimplementing the
     join means the byte-level isolation test (test 1) stays valid
     even if the production join's separator ever changes.
+
+    `pollution_lines` is the eval-only Track 1 reconstruction knob:
+    when non-empty AND memory is enabled AND format_context returned
+    a non-empty block, the lines are spliced into memory_ctx before
+    prepend_to_prompt is called. When None, empty, or paired with
+    memory_enabled=False, the call is byte-identical to today's
+    no-pollution behavior (the byte-level isolation test depends on
+    this contract). The memory-off arm is intentionally never
+    polluted because the question being tested ("does noise inside
+    the memory block hurt?") is undefined when there is no memory
+    block to put noise into.
     """
     from kai.backend import prepend_to_prompt
     from kai.memory import format_context
@@ -783,6 +965,16 @@ async def build_arm_prompt(question: str, user_id: str, *, memory_enabled: bool)
     if memory_enabled:
         memory_ctx = await format_context(question, user_id=user_id)
         if memory_ctx:
+            if pollution_lines:
+                # Inject BEFORE prepend so the pollution lives inside
+                # the memory context block (where Track 1 lines used
+                # to live), not above or below it. Keeping the
+                # injection point here also means the production
+                # prepend_to_prompt sees a single concatenated block
+                # and applies its delimiter rules uniformly to both
+                # genuine facts and synthetic lines, matching how the
+                # pre-#361 codepath behaved.
+                memory_ctx = _inject_synthetic_pollution(memory_ctx, pollution_lines)
             # prepend_to_prompt returns str | list; for a str input it
             # always returns str. The cast via assignment is safe because
             # we just passed a str in. type: ignore would be the more
@@ -889,6 +1081,7 @@ async def _run_one_probe(
     ground_truth_text: str,
     cwd: Path,
     env: dict[str, str],
+    pollution_lines: list[str] | None = None,
 ) -> ProbeOutcome:
     """Drive one probe through both arms + judge; return the rolled-up outcome.
 
@@ -917,7 +1110,19 @@ async def _run_one_probe(
     # may fail (Mem0 not initialized, store unreadable) — that
     # surfaces as an exception here, propagating to the gather() in
     # _run_all_probes which wraps it as a generation_error outcome.
-    memory_on_prompt = await build_arm_prompt(probe.question, user_id, memory_enabled=True)
+    # Only the memory-on arm receives pollution_lines: the question
+    # under test ("does noise inside the memory block hurt?") is
+    # undefined for the memory-off arm because there is no memory
+    # block to splice noise into. Passing the same lines to both
+    # would inflate the memory-off prompt with unrelated user-said
+    # text, conflating the pollution measurement with a generic
+    # added-context-helps measurement.
+    memory_on_prompt = await build_arm_prompt(
+        probe.question,
+        user_id,
+        memory_enabled=True,
+        pollution_lines=pollution_lines,
+    )
     memory_off_prompt = await build_arm_prompt(probe.question, user_id, memory_enabled=False)
     arm_prompts: dict[str, str] = {
         memory_arm_letter: memory_on_prompt,
@@ -1048,6 +1253,32 @@ async def _run_all_probes(
     _ensure_extractor_cwd()
     env = _subprocess_env()
 
+    # Load the user's history ONCE per run (not per probe) so the
+    # reading cost stays O(history_size) rather than O(history_size
+    # * probe_count). When pollution_lines == 0 we skip the load
+    # entirely; the helper would just return [] but reading the
+    # JSONL files is real I/O on a live snapshot and there is no
+    # reason to pay it when the feature is off. The empty-history
+    # warning lives here (not in the helper) because here we have
+    # the data_dir path to surface in the operator-facing message.
+    pollution_history: list[str] = []
+    if config.pollution_lines > 0:
+        # Late import to keep the module's startup cost off the
+        # critical path for the (common) no-pollution invocation;
+        # load_config touches the env, the .env file, and the SQLite
+        # config table, none of which the no-pollution path needs.
+        from kai.config import load_config
+
+        data_dir = load_config().data_dir
+        pollution_history = _load_user_history_messages(user_id, data_dir)
+        if not pollution_history:
+            print(
+                f"eval: --pollution-lines={config.pollution_lines} requested but "
+                f"no user history found at {data_dir}/history/{user_id}/; "
+                f"injection will be a no-op",
+                file=sys.stderr,
+            )
+
     sem = asyncio.Semaphore(config.max_concurrency)
 
     async def _run_under_semaphore(probe: Probe) -> ProbeOutcome:
@@ -1098,6 +1329,19 @@ async def _run_all_probes(
                 probe.expected_fact_id,
             )
 
+        # Sample pollution OUTSIDE the semaphore: the sampling is pure
+        # CPU and deterministic per (probe, seed), and doing it
+        # outside the slot avoids holding a Semaphore slot during the
+        # sample call. With pollution_lines=0 the helper returns []
+        # without consulting history, which keeps the no-pollution
+        # path zero-cost.
+        pollution = _sample_pollution_for_probe(
+            pollution_history,
+            config.pollution_lines,
+            base_seed=config.seed,
+            expected_fact_id=probe.expected_fact_id,
+        )
+
         async with sem:
             try:
                 return await _run_one_probe(
@@ -1109,6 +1353,7 @@ async def _run_all_probes(
                     ground_truth_text=gt,
                     cwd=_EXTRACTOR_CWD,
                     env=env,
+                    pollution_lines=pollution,
                 )
             except Exception as e:
                 # An unexpected exception (Mem0 not initialized, OS
@@ -1387,6 +1632,13 @@ def build_output_json(
         "gen_model": config.gen_model,
         "seed": config.seed,
         "max_concurrency": config.max_concurrency,
+        # `pollution_lines` is recorded even when zero so an operator
+        # diff-ing two run JSONs can confirm at a glance whether the
+        # second run had pollution enabled. Omitting the field on
+        # zero would force the operator to remember the default and
+        # mentally fill it in, defeating the self-describing-output
+        # property the rest of the envelope was built around.
+        "pollution_lines": config.pollution_lines,
         "outcomes": counts,
         **rates,
         "by_tag": by_tag,
@@ -1414,21 +1666,33 @@ def _render_summary(output: dict[str, Any]) -> str:
         f"Claude CLI: {output['claude_cli_version']}",
         f"Models: gen={output['gen_model']}, judge={output['judge_model']}",
         f"Seed: {output['seed']} (max_concurrency={output['max_concurrency']})",
-        "",
-        "Outcomes:",
-        f"  memory_wins:      {counts['memory_wins']}",
-        f"  memory_loses:     {counts['memory_loses']}",
-        f"  tie:              {counts['tie']}",
-        f"  both_wrong:       {counts['both_wrong']}",
-        f"  judge_error:      {counts['judge_error']}",
-        f"  generation_error: {counts['generation_error']}",
-        "",
-        "Rates (over scorable = wins+loses+tie+both_wrong):",
-        f"  win_rate_pct:        {output['win_rate_pct']:.2f}",
-        f"  loss_rate_pct:       {output['loss_rate_pct']:.2f}",
-        f"  tie_rate_pct:        {output['tie_rate_pct']:.2f}",
-        f"  both_wrong_rate_pct: {output['both_wrong_rate_pct']:.2f}",
     ]
+    # Pollution line is conditional on a non-zero count so the default
+    # summary (the common case) stays clean. When the operator opts
+    # into pollution they want to see the count loud and clear in the
+    # header so a pasted summary in a chat or bug report cannot be
+    # mistaken for a non-pollution baseline run.
+    pollution_n = output.get("pollution_lines", 0)
+    if pollution_n > 0:
+        lines.append(f"Pollution: {pollution_n} synthetic 'User said:' lines per probe (eval-only)")
+    lines.extend(
+        [
+            "",
+            "Outcomes:",
+            f"  memory_wins:      {counts['memory_wins']}",
+            f"  memory_loses:     {counts['memory_loses']}",
+            f"  tie:              {counts['tie']}",
+            f"  both_wrong:       {counts['both_wrong']}",
+            f"  judge_error:      {counts['judge_error']}",
+            f"  generation_error: {counts['generation_error']}",
+            "",
+            "Rates (over scorable = wins+loses+tie+both_wrong):",
+            f"  win_rate_pct:        {output['win_rate_pct']:.2f}",
+            f"  loss_rate_pct:       {output['loss_rate_pct']:.2f}",
+            f"  tie_rate_pct:        {output['tie_rate_pct']:.2f}",
+            f"  both_wrong_rate_pct: {output['both_wrong_rate_pct']:.2f}",
+        ]
+    )
     by_tag = output.get("by_tag", {})
     if by_tag:
         lines.append("")
@@ -1475,6 +1739,27 @@ def _positive_int(raw: str) -> int:
         raise argparse.ArgumentTypeError(f"expected integer, got {raw!r}") from None
     if value < 1:
         raise argparse.ArgumentTypeError(f"must be >= 1 (got {value})")
+    return value
+
+
+def _non_negative_int(raw: str) -> int:
+    """argparse `type=` callable that rejects negative integers but allows 0.
+
+    Used for --pollution-lines, where 0 is the legitimate default
+    (no injection, today's behavior) and a typoed negative would
+    otherwise pass argparse's plain `type=int` and reach
+    _sample_pollution_for_probe with `n=-3`. random.sample raises a
+    confusing ValueError on negative `k`; rejecting at the parse
+    boundary turns that into a one-line argparse error before any
+    subprocess or history load is attempted, mirroring the
+    _positive_int discipline applied to --max-concurrency.
+    """
+    try:
+        value = int(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"expected integer, got {raw!r}") from None
+    if value < 0:
+        raise argparse.ArgumentTypeError(f"must be >= 0 (got {value})")
     return value
 
 
@@ -1552,6 +1837,32 @@ def _build_parser() -> argparse.ArgumentParser:
             f"within a probe run sequentially, so this is also the cap "
             f"on concurrent claude subprocesses "
             f"(default: {_DEFAULT_MAX_CONCURRENCY})."
+        ),
+    )
+    # --pollution-lines is the eval-only switch that lets the harness
+    # measure how Track-1-style raw-utterance noise in the memory
+    # context block degrades behavioral outcomes, WITHOUT resurrecting
+    # the deleted production code path (which carried a real input-loss
+    # bug). The default is 0 (no injection), and the byte-level A/B
+    # isolation invariant continues to hold at the default. Source for
+    # the injected lines is the user's actual chat history at
+    # DATA_DIR/history/<user_id>/, so the snapshot procedure must copy
+    # `history/` alongside `memory/` when running against an isolated
+    # KAI_DATA_DIR. See _inject_synthetic_pollution / _sample_pollution_for_probe.
+    parser.add_argument(
+        "--pollution-lines",
+        type=_non_negative_int,
+        default=_DEFAULT_POLLUTION_LINES,
+        help=(
+            f"Eval-only: inject N synthetic 'User said:' lines, sampled "
+            f"deterministically per probe from the user's chat history "
+            f"at DATA_DIR/history/<user_id>/, into the memory context "
+            f"block of the memory-on arm. Used to test whether removing "
+            f"raw-utterance pollution mattered more than adding semantic "
+            f"retrieval (the open Layer 2 hypothesis). Defaults to "
+            f"{_DEFAULT_POLLUTION_LINES} (no injection); set to 0 for the "
+            f"clean A/B baseline. The memory-off arm is never polluted, "
+            f"by design; pollution is a property of the memory-on prompt."
         ),
     )
     return parser
@@ -1672,6 +1983,7 @@ async def _run_cli(args: argparse.Namespace) -> int:
         gen_timeout_s=args.gen_timeout_s,
         seed=_resolve_seed(cli_seed=args.seed, probes=probes, user_id=args.user_id),
         max_concurrency=args.max_concurrency,
+        pollution_lines=args.pollution_lines,
     )
 
     claude_cli_version = _capture_claude_cli_version()

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -868,7 +868,7 @@ class TestOutputWriteFailure:
         # see its docstring). Mock it as a plain return_value so the
         # caller's non-await call site works correctly.
         with (
-            patch.object(behavioral, "_initialize_memory", return_value=True),
+            patch.object(behavioral, "_initialize_memory", return_value=tmp_path),
             patch.object(
                 behavioral,
                 "detect_drift",
@@ -1070,13 +1070,33 @@ class TestPollutionInjection:
         ab_seed_int = int(ab_h.hexdigest()[:16], 16)
 
         # The pollution RNG seeding (mirrors _sample_pollution_for_probe).
+        # NUL delimiters between fields prevent concatenation collisions;
+        # the A/B side intentionally does not use them because changing
+        # that would shift every recorded baseline's arm assignments.
         poll_h = hashlib.sha256()
         poll_h.update(base_seed.encode("utf-8"))
+        poll_h.update(b"\x00")
         poll_h.update(fact_id.encode("utf-8"))
+        poll_h.update(b"\x00")
         poll_h.update(b"pollution")
         poll_seed_int = int(poll_h.hexdigest()[:16], 16)
 
         assert ab_seed_int != poll_seed_int
+
+    def test_sample_no_collision_under_concatenation_ambiguity(self):
+        # Domain-separation guard: without NUL delimiters between fields,
+        # SHA256.update() is purely concatenative, so (seed="ab",
+        # fact_id="cde") and (seed="abc", fact_id="de") would draw the
+        # same pollution sample because both feed b"abcde" + b"pollution"
+        # into the hash. The delimiter byte makes those two cases
+        # distinguishable. Without this property, two probes whose IDs
+        # happen to share a string boundary with a different seed could
+        # silently get identical pollution sets, breaking the per-probe
+        # determinism property the rest of this class locks down.
+        history = [f"msg-{i}" for i in range(40)]
+        sample_a = _sample_pollution_for_probe(history, 5, base_seed="ab", expected_fact_id="cde")
+        sample_b = _sample_pollution_for_probe(history, 5, base_seed="abc", expected_fact_id="de")
+        assert sample_a != sample_b
 
     def test_sample_returns_all_when_n_exceeds_history(self):
         # When n >= len(history), sampling returns the full history
@@ -1093,6 +1113,18 @@ class TestPollutionInjection:
         # The helper returns [] and the CLI emits a stderr warning;
         # nothing raises.
         assert _load_user_history_messages("does-not-exist", tmp_path) == []
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["../etc", "../../etc/passwd", "foo/bar", "", ".", "..", "/abs/path"],
+    )
+    def test_load_history_rejects_path_traversal(self, tmp_path: Path, bad: str):
+        # Defense-in-depth against an operator passing --user-id with a
+        # traversal payload (or accidentally with an empty/dot value
+        # that would resolve to data_dir/history itself, returning every
+        # user's messages). The helper raises before touching disk.
+        with pytest.raises(ValueError, match="invalid user_id"):
+            _load_user_history_messages(bad, tmp_path)
 
     def test_load_history_filters_to_user_role_and_truncates(self, tmp_path: Path):
         # End-to-end through the JSONL parser: round-trip a synthetic

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -63,13 +63,17 @@ from kai.eval.behavioral import (
     _build_gen_cmd,
     _build_judge_cmd,
     _compute_rates,
+    _inject_synthetic_pollution,
+    _load_user_history_messages,
     _make_drift_outcome,
+    _non_negative_int,
     _parse_judge_stdout,
     _positive_int,
     _render_judge_user_payload,
     _resolve_seed,
     _rollup_outcome,
     _run_subprocess,
+    _sample_pollution_for_probe,
     build_arm_prompt,
 )
 from kai.eval.retrieval import Probe
@@ -839,6 +843,7 @@ class TestOutputWriteFailure:
         args.gen_timeout_s = 120
         args.seed = None
         args.max_concurrency = 1
+        args.pollution_lines = 0
 
         # Mock the heavy machinery: init succeeds, drift detection
         # produces one scored probe, all_probes returns one
@@ -959,3 +964,263 @@ class TestPositiveIntCLIArg:
     @pytest.mark.parametrize("good,expected", [("1", 1), ("4", 4), ("128", 128)])
     def test_accepts_positive(self, good: str, expected: int):
         assert _positive_int(good) == expected
+
+
+# ── Pollution injection (eval-only Track 1 reconstruction) ─────────
+
+
+class TestPollutionInjection:
+    """Synthetic pollution: helpers, determinism, A/B-isolation respect.
+
+    The pollution feature exists to test the Layer 2 hypothesis that
+    removing Track 1 raw-utterance noise mattered more than adding
+    semantic retrieval. The tests below lock down the invariants the
+    feature MUST preserve for that hypothesis test to be meaningful:
+
+    1. Default (pollution_lines=0) is byte-identical to today's
+       behavior; the existing A/B isolation guarantee in
+       TestArmPromptIsolation still holds, so the no-pollution baseline
+       is interpretable as "exactly the production memory-on prompt".
+    2. The pollution RNG is independent of the A/B coin-flip RNG, so
+       enabling pollution does NOT shift arm assignments. Without this,
+       a pollution-on vs pollution-off comparison would conflate the
+       pollution effect with arbitrary arm-letter changes.
+    3. The memory-off arm is never polluted; the asymmetry IS the
+       experimental contrast.
+    """
+
+    def test_inject_with_empty_lines_is_noop(self):
+        # Byte-level no-op when no lines are sampled (the pollution-off
+        # case). This is what protects test 1's isolation invariant from
+        # accidentally regressing once the pollution code path is wired
+        # into build_arm_prompt; if the helper added even a trailing
+        # newline here, every existing memory-on arm would silently
+        # diverge from production format_context output.
+        ctx = "[Relevant memories]\n- foo\n- bar"
+        assert _inject_synthetic_pollution(ctx, []) == ctx
+
+    def test_inject_appends_user_said_bullets(self):
+        # The "User said:" prefix is the literal Track 1 prompt shape
+        # we are reconstructing. Whitespace is stripped per-line so that
+        # history entries with trailing newlines do not produce ragged
+        # bullets that would tip off the judge that something synthetic
+        # is happening.
+        ctx = "[Relevant memories]\n- favorite color is blue"
+        out = _inject_synthetic_pollution(ctx, ["hello world  ", "  what time is it"])
+        # Original facts preserved verbatim, bullets appended with one
+        # newline separator (rstrip on ctx tolerates an existing trailing
+        # newline without producing a blank-line gap).
+        assert out == (
+            "[Relevant memories]\n- favorite color is blue\n- User said: hello world\n- User said: what time is it"
+        )
+
+    def test_inject_strips_existing_trailing_newline(self):
+        # format_context returns text ending in "\n" in some paths; the
+        # rstrip + explicit "\n" join produces a single separator
+        # regardless. This test is the regression guard against a future
+        # change that drops the rstrip and produces double-newlines.
+        ctx = "[Relevant memories]\n- a\n"
+        out = _inject_synthetic_pollution(ctx, ["x"])
+        assert "\n\n" not in out
+        assert out.endswith("- User said: x")
+
+    def test_sample_returns_empty_for_zero_n(self):
+        assert _sample_pollution_for_probe(["a", "b", "c"], 0, base_seed="seed", expected_fact_id="fid") == []
+
+    def test_sample_returns_empty_for_empty_history(self):
+        assert _sample_pollution_for_probe([], 5, base_seed="seed", expected_fact_id="fid") == []
+
+    def test_sample_is_deterministic_for_same_seed_and_fact_id(self):
+        # Same (seed, fact_id) -> same sample. This is the property that
+        # lets a re-run produce identical pollution per probe, which is
+        # required for any "did the fix help?" comparison to be valid.
+        history = [f"msg-{i}" for i in range(50)]
+        a = _sample_pollution_for_probe(history, 5, base_seed="s", expected_fact_id="f")
+        b = _sample_pollution_for_probe(history, 5, base_seed="s", expected_fact_id="f")
+        assert a == b
+        assert len(a) == 5
+
+    def test_sample_differs_across_probes(self):
+        # Different fact_ids -> different samples (with high
+        # probability). 30 lines / 5 sampled gives ~3.4M unique combos;
+        # collision is essentially impossible. If this ever fails, the
+        # hash domain separation is broken.
+        history = [f"msg-{i}" for i in range(30)]
+        a = _sample_pollution_for_probe(history, 5, base_seed="s", expected_fact_id="fact-A")
+        b = _sample_pollution_for_probe(history, 5, base_seed="s", expected_fact_id="fact-B")
+        assert a != b
+
+    def test_sample_independent_of_ab_coin_flip_rng(self):
+        # CRITICAL invariant: enabling pollution must NOT shift arm
+        # assignments. The pollution RNG seeds with `+ b"pollution"`
+        # salt; the A/B RNG (in _run_all_probes) seeds without it. This
+        # test reproduces both seedings and asserts the salt actually
+        # changes the byte stream, which is the only thing keeping
+        # pollution-on vs pollution-off comparisons valid against the
+        # same (probes, user_id, seed) triple.
+        import hashlib
+
+        base_seed = "seed-xyz"
+        fact_id = "fact-1"
+
+        # The A/B RNG seeding (mirrors _run_all_probes:_run_under_semaphore).
+        ab_h = hashlib.sha256()
+        ab_h.update(base_seed.encode("utf-8"))
+        ab_h.update(fact_id.encode("utf-8"))
+        ab_seed_int = int(ab_h.hexdigest()[:16], 16)
+
+        # The pollution RNG seeding (mirrors _sample_pollution_for_probe).
+        poll_h = hashlib.sha256()
+        poll_h.update(base_seed.encode("utf-8"))
+        poll_h.update(fact_id.encode("utf-8"))
+        poll_h.update(b"pollution")
+        poll_seed_int = int(poll_h.hexdigest()[:16], 16)
+
+        assert ab_seed_int != poll_seed_int
+
+    def test_sample_returns_all_when_n_exceeds_history(self):
+        # When n >= len(history), sampling returns the full history
+        # (in shuffled order). The harness must not crash on a small
+        # history with --pollution-lines set high; this exercises the
+        # min(n, len(history)) clamp inside _sample_pollution_for_probe.
+        history = ["a", "b", "c"]
+        out = _sample_pollution_for_probe(history, 100, base_seed="s", expected_fact_id="f")
+        assert sorted(out) == ["a", "b", "c"]
+
+    def test_load_history_returns_empty_when_dir_missing(self, tmp_path: Path):
+        # Running against a fresh KAI_DATA_DIR with no history directory
+        # is a legitimate path (e.g. a new operator bringing up Layer 2).
+        # The helper returns [] and the CLI emits a stderr warning;
+        # nothing raises.
+        assert _load_user_history_messages("does-not-exist", tmp_path) == []
+
+    def test_load_history_filters_to_user_role_and_truncates(self, tmp_path: Path):
+        # End-to-end through the JSONL parser: round-trip a synthetic
+        # history file with a mix of user/assistant rows, blank lines,
+        # corrupt lines, and one over-length user row. The expected
+        # output exercises every filter branch in one fixture.
+        history_dir = tmp_path / "history" / "user-1"
+        history_dir.mkdir(parents=True)
+        long_text = "x" * 2500
+        rows = [
+            json.dumps({"ts": 1, "dir": "user", "chat_id": 1, "text": "first user msg"}),
+            json.dumps({"ts": 2, "dir": "assistant", "chat_id": 1, "text": "ignored bot reply"}),
+            json.dumps({"ts": 3, "dir": "user", "chat_id": 1, "text": "  "}),  # whitespace-only, dropped
+            "",  # blank line, dropped
+            "{not valid json",  # corrupt row, skipped silently
+            json.dumps({"ts": 4, "dir": "user", "chat_id": 1, "text": long_text}),
+            json.dumps({"ts": 5, "dir": "user", "chat_id": 1, "text": "second user msg"}),
+        ]
+        (history_dir / "001.jsonl").write_text("\n".join(rows), encoding="utf-8")
+
+        out = _load_user_history_messages("user-1", tmp_path)
+        # Three user-role messages: assistant + whitespace + blank +
+        # corrupt all dropped.
+        assert len(out) == 3
+        assert out[0] == "first user msg"
+        # Long row truncated to _MAX_POLLUTION_LINE_CHARS (2000) + "...".
+        assert out[1].startswith("x" * 2000)
+        assert out[1].endswith("...")
+        assert len(out[1]) == 2003
+        assert out[2] == "second user msg"
+
+    def test_load_history_reads_multiple_jsonl_files_in_sorted_order(self, tmp_path: Path):
+        # Production history rotates into multiple JSONL files; the
+        # loader concatenates them in lexicographic filename order
+        # (matching the bot's own reader). Test asserts both ordering
+        # and that the loader does not stop at the first file.
+        history_dir = tmp_path / "history" / "user-2"
+        history_dir.mkdir(parents=True)
+        (history_dir / "001.jsonl").write_text(
+            json.dumps({"ts": 1, "dir": "user", "chat_id": 2, "text": "from-001"}) + "\n",
+            encoding="utf-8",
+        )
+        (history_dir / "002.jsonl").write_text(
+            json.dumps({"ts": 2, "dir": "user", "chat_id": 2, "text": "from-002"}) + "\n",
+            encoding="utf-8",
+        )
+        out = _load_user_history_messages("user-2", tmp_path)
+        assert out == ["from-001", "from-002"]
+
+    @pytest.mark.parametrize("bad", ["-1", "-100"])
+    def test_non_negative_int_rejects_negatives(self, bad: str):
+        with pytest.raises(argparse.ArgumentTypeError, match=r"must be >= 0"):
+            _non_negative_int(bad)
+
+    def test_non_negative_int_rejects_non_integer(self):
+        with pytest.raises(argparse.ArgumentTypeError, match=r"expected integer"):
+            _non_negative_int("ten")
+
+    @pytest.mark.parametrize("good,expected", [("0", 0), ("1", 1), ("100", 100)])
+    def test_non_negative_int_accepts_zero_and_positives(self, good: str, expected: int):
+        # 0 is the legitimate default (pollution off); the divergence
+        # from _positive_int's contract is exactly what makes this a
+        # separate validator rather than a parameter on the existing one.
+        assert _non_negative_int(good) == expected
+
+    def test_build_arm_prompt_with_pollution_none_matches_today(self):
+        # Byte-level isolation extends to the new pollution_lines arg:
+        # the default (None) MUST produce the exact prompt today's code
+        # produces. This is the regression guard that the existing
+        # TestArmPromptIsolation cases continue to hold once the
+        # pollution code path is wired in.
+        memory_block = "[Relevant memories]\n- the user's favorite color is blue"
+        question = "What's my favorite color?"
+
+        with patch("kai.memory.format_context", new=AsyncMock(return_value=memory_block)):
+            arm_default = asyncio.run(build_arm_prompt(question, "user-1", memory_enabled=True))
+            arm_explicit_none = asyncio.run(
+                build_arm_prompt(question, "user-1", memory_enabled=True, pollution_lines=None)
+            )
+            arm_empty_list = asyncio.run(build_arm_prompt(question, "user-1", memory_enabled=True, pollution_lines=[]))
+
+        # Default, explicit None, and empty list all produce the exact
+        # same prompt as the production memory-on path: no separator,
+        # no marker, no whitespace difference.
+        assert arm_default == arm_explicit_none == arm_empty_list
+
+    def test_build_arm_prompt_injects_when_pollution_lines_supplied(self):
+        # Positive case: with pollution_lines passed and memory enabled,
+        # the bullets land inside the memory block (before
+        # prepend_to_prompt fuses it with the question), so the user-
+        # message marker added by prepend_to_prompt still cleanly
+        # separates the polluted memory block from the question.
+        memory_block = "[Relevant memories]\n- favorite color is blue"
+        question = "What's my favorite color?"
+
+        with patch("kai.memory.format_context", new=AsyncMock(return_value=memory_block)):
+            arm_polluted = asyncio.run(
+                build_arm_prompt(
+                    question,
+                    "user-1",
+                    memory_enabled=True,
+                    pollution_lines=["I had pizza yesterday", "where did I park"],
+                )
+            )
+
+        # Pollution bullets present.
+        assert "- User said: I had pizza yesterday" in arm_polluted
+        assert "- User said: where did I park" in arm_polluted
+        # Original fact preserved.
+        assert "favorite color is blue" in arm_polluted
+        # Question still in there (memory-on arm always ends with the question).
+        assert "What's my favorite color?" in arm_polluted
+
+    def test_build_arm_prompt_memory_off_ignores_pollution_lines(self):
+        # The memory-off arm is the no-injection control by definition;
+        # passing pollution_lines into a memory_enabled=False call must
+        # be a no-op. If this ever fails, the experimental contrast
+        # collapses (both arms polluted equally -> nothing being
+        # measured).
+        question = "What's my favorite color?"
+        with patch("kai.memory.format_context", new=AsyncMock(return_value="ignored")):
+            arm_off = asyncio.run(
+                build_arm_prompt(
+                    question,
+                    "user-1",
+                    memory_enabled=False,
+                    pollution_lines=["should-not-appear"],
+                )
+            )
+        assert arm_off == question
+        assert "should-not-appear" not in arm_off


### PR DESCRIPTION
## Summary

Adds an eval-only `--pollution-lines N` flag to the Layer 2 behavioral A/B harness. When set, the memory-on arm's memory context block is appended with N synthetic `- User said: <text>` bullets sampled deterministically per probe from the user's actual chat history at `DATA_DIR/history/<user_id>/`. The memory-off arm is never polluted.

The motivation is the open Layer 2 hypothesis: did removing raw-utterance pollution (the deleted ingestion path) matter more than adding semantic retrieval? Reconstructing Track 1's full machinery to answer that is hundreds of lines plus a real risk surface (one bit-flip of an "eval-only" flag in production reintroduces the original input-loss bug). Synthetic pollution mimics the prompt SHAPE Track 1 produced without resurrecting the production code path, so the comparison can run safely.

## Design invariants (locked by tests)

1. `--pollution-lines 0` (the default) is byte-identical to today's harness behavior. The existing A/B isolation invariant continues to hold, and the established memory-on baseline remains directly comparable.
2. The pollution sampler uses a SEPARATE RNG seeded with `sha256(seed + fact_id + b"pollution")[:16]`. The A/B coin-flip RNG omits the `b"pollution"` salt, so enabling pollution does NOT shift arm assignments; pollution-on vs pollution-off runs against the same `(probes, user_id, seed)` triple stay comparable per probe.
3. The memory-off arm ignores `pollution_lines` even when supplied. The asymmetry IS the experimental contrast.
4. Per-line truncation matches the deleted Track 1 cap (2000 chars), so the reconstructed prompt shape is faithful rather than artificially shorter.

## Run procedure

Snapshot must include `history/` alongside `memory/`:

```
rm -rf /tmp/kai-eval-snapshot && mkdir -p /tmp/kai-eval-snapshot
cp -R <data_dir>/memory /tmp/kai-eval-snapshot/memory
cp -R <data_dir>/history /tmp/kai-eval-snapshot/history
rm -f /tmp/kai-eval-snapshot/memory/qdrant/.lock
```

Three-way compare (clean baseline / moderate pollution / heavy pollution):

```
KAI_DATA_DIR=/tmp/kai-eval-snapshot \
  MEM0_DIR=/tmp/kai-eval-snapshot/mem0-telemetry \
  MEMORY_ENABLED=true \
  .venv/bin/python -m kai.eval.behavioral \
  --probes home/evals/probes.jsonl --user-id <user_id> \
  --pollution-lines 0 --output /tmp/behavioral-clean.json
```

Repeat with `--pollution-lines 10` and `--pollution-lines 20` to walk up the noise dose. The clean run should match the most recent published baseline; deviations are pollution effect.

## Test plan

- [x] Lint clean (`ruff check`, `ruff format --check`)
- [x] Full pytest suite: 2198 tests pass (21 new in `TestPollutionInjection`)
- [x] No em or en dashes in the diff
- [ ] Manual: run `--pollution-lines 0` against a fresh snapshot; verify outcomes match the established Layer 2 baseline within noise
- [ ] Manual: run `--pollution-lines 10` and `--pollution-lines 20`; record headline win/loss/tie/both_wrong shifts vs the clean run
