### PR TITLE
fix(eval): _initialize_memory uses kai.config.DATA_DIR (module constant)

### DIFF
--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -295,16 +295,16 @@ class BehavioralConfig:
     # arg) so it surfaces in the output JSON automatically alongside
     # seed and max_concurrency, making each saved run self-describing.
     pollution_lines: int = 0
-    # Snapshot of load_config().data_dir captured once at run start.
-    # Threaded through BehavioralConfig (rather than re-loaded inside
+    # Snapshot of kai.config.DATA_DIR captured once at run start.
+    # Threaded through BehavioralConfig (rather than re-imported inside
     # _run_all_probes) so the memory snapshot read by init_memory and
     # the history snapshot read by _load_user_history_messages share a
-    # single source of truth. If KAI_DATA_DIR were ever to change
-    # between two load_config() calls (subprocess wrapper rewriting
-    # the env mid-run, fixture cleanup racing the eval), the two
-    # snapshots could diverge silently. Default points at the dev tree
-    # so test fixtures that build a config without invoking the CLI
-    # still get a sensible path.
+    # single source of truth. DATA_DIR is a module-level constant
+    # evaluated at import time from KAI_DATA_DIR; storing it on config
+    # makes the binding visible at the call sites instead of relying
+    # on every reader to re-import. Default points at the dev tree so
+    # test fixtures that build a config without invoking the CLI still
+    # get a sensible path.
     data_dir: Path = Path(".")
 
 
@@ -1906,15 +1906,19 @@ def _initialize_memory() -> Path | None:
     directory, and history DB settings consistent with the bot
     runtime. Errors print to stderr and the caller exits with status 1.
 
-    Returns the loaded `data_dir` (rather than a bool) so the caller
-    can populate BehavioralConfig.data_dir from the SAME load_config()
-    call that drove init_memory. Without this, _run_all_probes would
-    have to re-load the config to find the history snapshot root,
-    risking divergence if the env changed between calls. None signals
+    Returns the active `DATA_DIR` (rather than a bool) so the caller
+    can populate BehavioralConfig.data_dir from the SAME process's
+    view of the env. `DATA_DIR` is a module-level constant in
+    kai.config (NOT a field on the Config dataclass returned by
+    load_config), evaluated once at import time from the
+    KAI_DATA_DIR env var. Because the eval CLI sets KAI_DATA_DIR
+    BEFORE the Python process starts, that one-shot read is
+    correct; rebinding it post-import would not propagate to
+    callers that have already imported the constant. None signals
     failure (init exception, memory disabled).
     """
     try:
-        from kai.config import load_config
+        from kai.config import DATA_DIR, load_config
         from kai.memory import init_memory, is_enabled
 
         config = load_config()
@@ -1925,7 +1929,7 @@ def _initialize_memory() -> Path | None:
                 file=sys.stderr,
             )
             return None
-        return config.data_dir
+        return DATA_DIR
     except Exception as e:
         print(f"eval: init failed: {e}", file=sys.stderr)
         return None

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -1292,6 +1292,18 @@ class TestInitializeMemoryDataDirContract:
         # If the function tries to access a non-existent attr (the
         # exact bug we shipped), it lands in the except branch and
         # returns None, which the assertion catches loudly.
+        #
+        # Mechanics note for future readers extending this pattern:
+        # _initialize_memory uses a function-local `from kai.config
+        # import DATA_DIR`, which Python resolves by reading
+        # sys.modules["kai.config"].DATA_DIR at call time, NOT at
+        # test-module import time. monkeypatch.setattr on the module
+        # object therefore takes effect for every subsequent
+        # function-local import in the same process. The same logic
+        # applies to `patch("kai.memory.init_memory")` and
+        # `patch("kai.memory.is_enabled")`: those patch the module
+        # attribute, which the function-local `from kai.memory
+        # import ...` re-reads each call.
         from kai import config as _cfg
 
         monkeypatch.setattr(_cfg, "DATA_DIR", tmp_path)

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -1256,3 +1256,63 @@ class TestPollutionInjection:
             )
         assert arm_off == question
         assert "should-not-appear" not in arm_off
+
+
+class TestInitializeMemoryDataDirContract:
+    """`_initialize_memory` returns the live DATA_DIR, not a Config attr.
+
+    Regression guard for a bug shipped in the synthetic-pollution PR:
+    the function originally returned `load_config().data_dir`, but
+    `Config` is a dataclass with no `data_dir` field; DATA_DIR is a
+    module-level constant in kai.config. The bug was masked in tests
+    because every behavioral test that exercises _initialize_memory
+    mocks it with `return_value=tmp_path`, so the real attribute access
+    never ran. This class is the integration-style check that the
+    function's import contract still holds against the actual
+    kai.config module.
+    """
+
+    def test_kai_config_exposes_data_dir_constant(self):
+        # Import contract: kai.config.DATA_DIR is a Path. If a future
+        # config refactor renames or removes it, the import inside
+        # _initialize_memory raises ImportError at run time and the
+        # whole eval CLI fails to launch. This one-line assertion
+        # catches that earlier than the broken-CLI symptom.
+        from kai.config import DATA_DIR
+
+        assert isinstance(DATA_DIR, Path)
+
+    def test_initialize_memory_returns_path_when_memory_enabled(self, tmp_path: Path, monkeypatch):
+        # End-to-end through _initialize_memory with the heavy init
+        # mocked but the actual import path exercised. The previous
+        # bug shipped because every test in the suite stubbed
+        # _initialize_memory itself; this test stubs only its
+        # collaborators (init_memory, is_enabled) so the function's
+        # own body, including `return DATA_DIR`, runs under test.
+        # If the function tries to access a non-existent attr (the
+        # exact bug we shipped), it lands in the except branch and
+        # returns None, which the assertion catches loudly.
+        from kai import config as _cfg
+
+        monkeypatch.setattr(_cfg, "DATA_DIR", tmp_path)
+        with (
+            patch.object(_cfg, "load_config", return_value=MagicMock()),
+            patch("kai.memory.init_memory"),
+            patch("kai.memory.is_enabled", return_value=True),
+        ):
+            result = behavioral._initialize_memory()
+        assert result == tmp_path
+
+    def test_initialize_memory_returns_none_when_memory_disabled(self, monkeypatch):
+        # The disabled-path is the other live branch; locked to keep
+        # the bool-vs-Path return-type contract honest after the
+        # type change from `bool` to `Path | None`.
+        from kai import config as _cfg
+
+        with (
+            patch.object(_cfg, "load_config", return_value=MagicMock()),
+            patch("kai.memory.init_memory"),
+            patch("kai.memory.is_enabled", return_value=False),
+        ):
+            result = behavioral._initialize_memory()
+        assert result is None


### PR DESCRIPTION
## Summary

Fix-forward for the synthetic-pollution PR that was just merged. `_initialize_memory` returned `config.data_dir`, but `Config` (the dataclass returned by `load_config`) has no `data_dir` field — `DATA_DIR` is a module-level constant in `kai.config`, evaluated at import time from `KAI_DATA_DIR`. Every CLI invocation failed at startup with `eval: init failed: 'Config' object has no attribute 'data_dir'`.

## Why the bug shipped

The behavioral test suite mocks `_initialize_memory` wholesale (`patch.object(behavioral, "_initialize_memory", return_value=tmp_path)`), so the real attribute access never ran under test. The CI suite was green; the broken code only surfaced on the first real eval-campaign launch.

## Fix

Import `DATA_DIR` from `kai.config` instead of reading a non-existent attribute on the loaded config:

```python
from kai.config import DATA_DIR, load_config
...
return DATA_DIR
```

The CLI sets `KAI_DATA_DIR` before the Python process starts, so the import-time evaluation captures the right path.

## Regression tests

Three new tests in `TestInitializeMemoryDataDirContract`:

1. `test_kai_config_exposes_data_dir_constant` - asserts `kai.config.DATA_DIR` exists and is a `Path`. Locks the import contract; if a future config refactor renames or removes the constant, this fails before the broken-CLI symptom.
2. `test_initialize_memory_returns_path_when_memory_enabled` - exercises the live success branch by mocking only the collaborators (`load_config`, `init_memory`, `is_enabled`), letting `_initialize_memory`'s own body run. The previously-shipped bug would have failed this test.
3. `test_initialize_memory_returns_none_when_memory_disabled` - exercises the live disabled branch, locking the `Path | None` return-type contract.

The lesson is broader than this one bug: a function that's mocked end-to-end across the whole test suite has zero unit coverage on its body, so any internal contract change can ship green. The new tests stub only the collaborators, not the function itself.

## Verification

- `make check` clean
- Full pytest: 2209 pass (3 new)
- `python -m kai.eval.behavioral --help` launches without error against the snapshot env
- No em or en dashes in the diff

## Test plan

- [x] Lint clean
- [x] Full pytest 2209/2209
- [x] CLI `--help` smoke test
- [ ] Manual: `--pollution-lines 0` end-to-end against a fresh snapshot reaches `Wrote /tmp/...json` (the symptom that surfaced this bug)
