### PR TITLE
feat(eval): Layer 3 longitudinal friction analysis harness

### DIFF
--- a/src/kai/eval/friction.py
+++ b/src/kai/eval/friction.py
@@ -1,0 +1,1722 @@
+"""
+Layer 3 longitudinal friction analysis.
+
+Reads an operator's chat history from DATA_DIR/history/<user_id>/, runs
+four pre-committed friction-detection signal families over the ordered
+records, buckets events by milestone (PR #333 and PR #361 merge instants),
+normalizes counts by user-turn volume, and emits a schema-versioned JSON
+report plus an optional redacted markdown summary.
+
+The harness is observational: it never writes to the live history or
+memory stores. It complements Layer 1 (retrieval-only A/B; src/kai/eval/
+retrieval.py) and Layer 2 (behavioral A/B; src/kai/eval/behavioral.py)
+with a real-traffic signal that survives the contrived-probe critique.
+
+Designed to run offline against a SNAPSHOT of DATA_DIR. The typical
+invocation copies history/ and memory/ to /tmp/kai-eval-snapshot,
+points KAI_DATA_DIR there, and invokes `python -m kai.eval.friction`.
+
+This file is intentionally self-contained: no production code path
+imports from it. Outbound dependencies are kai.config (for DATA_DIR
+resolution) and kai.memory (for stage 3b known-fact overlap; optional -
+the harness degrades gracefully when memory is unreachable).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import re
+import sys
+import tempfile
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# ── Schema version and milestone bucket anchors ──────────────────────
+
+# Bumped when the JSON output shape changes incompatibly. Convention
+# matches `_OUTPUT_SCHEMA_VERSION = 1` at src/kai/eval/behavioral.py:115.
+# Downstream comparison scripts pin against this to detect schema drift
+# without parsing the whole report shape.
+_OUTPUT_SCHEMA_VERSION = 1
+
+# Two milestone anchors carved into module-level constants because they
+# define the entire bucket scheme. They are squash-merge commits on
+# `main` and will not move; treat as authoritative.
+#
+# Original git log timestamps came back in Eastern (-04:00):
+#   commit 5796286 -> 2026-04-17T13:54:27-04:00 -> 2026-04-17T17:54:27Z
+#   commit e508662 -> 2026-04-22T08:43:55-04:00 -> 2026-04-22T12:43:55Z
+# UTC normalization is done here so every downstream comparison is
+# timezone-aware against a single canonical instant. Confirm with
+# `git log --format="%H %aI" -1 <hash>` before changing either anchor.
+_BUCKET_ANCHORS = (
+    datetime(2026, 4, 17, 17, 54, 27, tzinfo=UTC),
+    datetime(2026, 4, 22, 12, 43, 55, tzinfo=UTC),
+)
+
+
+# ── Volume floor and classification thresholds ───────────────────────
+
+# Buckets with fewer user_turns than this floor cannot anchor a confident
+# cross-bucket comparison. The classifier emits
+# `matched_pattern="inconclusive"` when ANY of A/B/C falls below the
+# floor. 30 picked on the same back-of-envelope basis as Layer 1's
+# 26-probe minimum: rate estimates with single-digit denominators have
+# wide enough confidence intervals that label flips are noise-driven.
+_USER_TURN_FLOOR = 30
+
+# "material drop": new-bucket rate is at most this fraction of the prior.
+# The boundary at exactly 0.85x belongs to material drop (the flat band's
+# lower edge is open). Widened from v1's 0.66x to 0.85x in v3 so the
+# bands tile [0, +inf) without an unclassifiable gap.
+_MATERIAL_DROP_RATIO = 0.85
+
+# "up" cutoff: new-bucket rate exceeds this fraction of the prior. The
+# boundary at exactly 1.15x belongs to flat. Used by both the `up` shape
+# in the 9-cell grid and by the `regression` row's B->C condition.
+_UP_RATIO = 1.15
+
+# Pre-committed prediction the harness was built to test. Hardcoded at
+# v1 of the harness; if the prediction itself becomes a tunable
+# parameter, a future revision would expose this as a CLI flag, but
+# tunability via CLI invites post-hoc threshold-fishing so the default
+# stance is "compile-time constant".
+_PREDICTED_PATTERN = "prediction-holds"
+
+
+# ── Signal-family pattern sets ───────────────────────────────────────
+
+# Signal 1: operator-side frustration markers. Substring match on the
+# lowercased user message. Pre-committed: changes to this set require a
+# changelog entry AND a test-suite update so a phrase added after
+# seeing data does not constitute post-hoc pattern-hunting.
+_FRUSTRATION_PHRASES = (
+    "i already told you",
+    "i said earlier",
+    "i just said",
+    "as i mentioned",
+    "as i said",
+    "remember i",
+    "remember that i",
+    "you forgot",
+    "you already",
+    "why are you asking",
+    "why do you keep asking",
+    "i told you",
+)
+
+# Signal 2: stopwords excluded from the content-word set. Filters out
+# common conversational filler so the "3 distinct content-words"
+# threshold reflects substantive overlap rather than incidental shared
+# articles and modal verbs. Frozen so a typo in a test cannot mutate it.
+_STOPWORDS = frozenset(
+    {
+        "this",
+        "that",
+        "with",
+        "from",
+        "have",
+        "will",
+        "what",
+        "when",
+        "where",
+        "which",
+        "would",
+        "could",
+        "should",
+        "about",
+        "there",
+        "their",
+        "your",
+        "they",
+        "them",
+        "been",
+        "were",
+        "than",
+        "then",
+        "into",
+        "some",
+        "such",
+        "more",
+        "most",
+        "also",
+        "does",
+    }
+)
+
+# Signal 2 + stage 3b: the "3 distinct content-words" floor is the
+# false-positive cliff in informal observation - generic clarifications
+# rarely share three or more substantive tokens with prior user content.
+_CONTENT_WORD_FLOOR = 3
+
+# Signal 2: lookback window for prior records. Capping at 20 preceding
+# entries (user + assistant interleaved) keeps the per-record cost
+# bounded; long histories would otherwise scale O(N^2) on the
+# question-answer pair count.
+_KAI_ASKS_BACK_WINDOW = 20
+
+# Signal 3: stage 3a regex set. All compiled with re.IGNORECASE because
+# Telegram traffic routinely capitalizes the first letter of a message
+# via mobile autocorrect ("DON'T", "I Prefer"); without the flag those
+# would silently miss. Word-boundary anchors keep matches honest, e.g.
+# "construction" does not match "instead of" via "instead".
+_CORRECTION_PATTERNS = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"\bdon'?t\b",
+        r"\bstop (doing|using|asking)\b",
+        r"\bnot that\b",
+        r"\bplease (use|don'?t)\b",
+        r"\balways (use|say|start)\b",
+        r"\bnever (use|say|do)\b",
+        r"\binstead of\b",
+        r"\bi prefer\b",
+    )
+)
+
+# Signal 4: fact-shape prefixes. Compiled into a single alternation so
+# the per-record cost stays linear in record length rather than scaling
+# with the prefix-set size. Word-boundary anchors avoid matching the
+# prefix substring inside an unrelated word.
+_FACT_SHAPE_RE = re.compile(
+    r"\b(?:"
+    r"i am|i'm|my|we use|we're using|"
+    r"i prefer|i always|i use|i don't"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# Signal 4: 5-character shingles + Jaccard similarity threshold. Tuned
+# high enough that paraphrases of the same fact register as a repeat
+# without flagging unrelated user messages that happen to share a few
+# word fragments. Strictly > (not >=) so a synthetic test fixture at
+# exactly 0.4 verifies the open boundary.
+_REPEAT_SHINGLE_K = 5
+_REPEAT_JACCARD_FLOOR = 0.4
+
+# Signal 4: cap the per-record lookback to 200 prior user-turns. Same
+# rationale as Signal 2's window: bound worst-case cost on long
+# histories without losing realistic-repeat detection range.
+_REPEAT_LOOKBACK = 200
+
+
+# ── Surface-text redaction patterns (for --include-snippets) ─────────
+
+# Order matters when patterns overlap. URLs first because they may
+# contain `@` (user:pass URL form); email next because it contains `@`;
+# @handles next because they are pure `@…`; phone last because the loose
+# digit-run pattern would otherwise gobble URL/email substrings. Per-
+# event excerpt cap is enforced separately at _SNIPPET_MAX_CHARS.
+_REDACT_URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+_REDACT_EMAIL_RE = re.compile(r"\b[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}\b")
+_REDACT_HANDLE_RE = re.compile(r"@[A-Za-z0-9_]{3,}")
+# Phone: 7+ groups of "digit + optional separator", ending in a digit.
+# Wide enough to cover international and US formats; narrow enough to
+# avoid matching short numeric IDs (e.g. issue #333) which would create
+# false redactions in a chat that frequently references issue numbers.
+_REDACT_PHONE_RE = re.compile(r"(?:\+?\d[\s.-]?){7,}\d")
+_REDACT_REPLACEMENTS = (
+    (_REDACT_URL_RE, "<redacted-url>"),
+    (_REDACT_EMAIL_RE, "<redacted-email>"),
+    (_REDACT_HANDLE_RE, "<redacted-handle>"),
+    (_REDACT_PHONE_RE, "<redacted-phone>"),
+)
+
+# Cap on the surface_text the JSON report may carry per event when
+# --include-snippets is set. 200 chars is plenty to identify the matching
+# message without turning the report into a chat-log copy.
+_SNIPPET_MAX_CHARS = 200
+
+
+# ── Tokenization helper ──────────────────────────────────────────────
+
+# Punctuation stripping uses a simple class-based regex (not the broader
+# unicode category) so it is fast and predictable. Apostrophe is kept
+# inside the character class so contractions like "don't" survive as a
+# single token; downstream stopword filtering does not include "don't"
+# so the token simply does not contribute to the content-word set.
+_PUNCT_RE = re.compile(r"[^\w\s']")
+
+
+def _content_words(text: str) -> set[str]:
+    """Return distinct content-words for overlap comparisons.
+
+    A "content-word" is a token of length >= 4 after lowercasing and
+    stripping punctuation (other than apostrophe), excluding the small
+    `_STOPWORDS` set. Used by Signal 2 (kai_asks_back) and Signal 3
+    stage 3b (known-fact overlap), both of which need a substantive-
+    token overlap floor that is not perturbed by common filler.
+
+    Returns a `set` so callers can intersect via `&`; the floor check
+    is `len(a & b) >= _CONTENT_WORD_FLOOR`.
+    """
+    cleaned = _PUNCT_RE.sub(" ", text.lower())
+    return {t for t in cleaned.split() if len(t) >= 4 and t not in _STOPWORDS}
+
+
+# ── Memory-availability tri-state ────────────────────────────────────
+
+
+class MemoryAvailability(Enum):
+    """Tri-state result of attempting to initialize the memory store.
+
+    DIVERGES from `_initialize_memory` at src/kai/eval/behavioral.py:1901
+    in that the friction harness MUST NOT exit on a non-ENABLED result.
+    A friction analysis without stage 3b is still a valid (degraded)
+    report; the run completes with a `memory-unreachable-frustration-
+    only` caveat instead of failing. Layer 2 cannot run without retrieval
+    so it exits; Layer 3 can.
+
+    Members:
+      ENABLED  - init succeeded and is_enabled() returned True.
+      DISABLED - init succeeded but is_enabled() returned False (the
+                 store is configured off via MEMORY_ENABLED=false or
+                 the embedding-dim validation rejected the model).
+      ERROR    - init raised; the captured exception text is reported
+                 in `memory_store_error_message` for debuggability.
+    """
+
+    ENABLED = "enabled"
+    DISABLED = "disabled"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class MemoryInitResult:
+    """Return shape from `_initialize_memory_local`.
+
+    `error_message` is populated only when `availability == ERROR`.
+    Carrying it on the result rather than logging in the helper lets the
+    renderer surface the message in the report itself, which is what an
+    operator running the harness against a damaged Qdrant directory
+    needs to see.
+    """
+
+    availability: MemoryAvailability
+    error_message: str | None
+
+
+# ── Data shapes ──────────────────────────────────────────────────────
+
+# Sentinel used when a record's timestamp is missing or unparseable.
+# Strictly before _BUCKET_ANCHORS[0] so `_classify_bucket` routes the
+# record to bucket A. Module-level so callers (and tests) can compare
+# against it directly rather than reconstructing the literal.
+_BAD_TS_SENTINEL = datetime(1, 1, 1, tzinfo=UTC)
+
+
+@dataclass(frozen=True)
+class HistoryRecord:
+    """One line of a JSONL history file, parsed.
+
+    Mirrors the fields written by `log_message` at src/kai/history.py:67-74.
+    `ts_utc` is the parsed datetime already normalized to UTC; `ts_raw`
+    keeps the original ISO string so the report can cite it verbatim
+    without re-formatting.
+
+    For lines whose `ts` is missing, empty, or unparseable, `ts_utc` is
+    set to `_BAD_TS_SENTINEL` (year 1) so bucket assignment routes the
+    record to bucket A (oldest, pre-semantic-memory era). The
+    conservative rule is "bad timestamps land in the oldest bucket so
+    the newest bucket is never inflated by data of unknown vintage."
+    """
+
+    ts_utc: datetime
+    ts_raw: str
+    direction: str
+    chat_id: int
+    text: str
+    media: dict | None
+    source_path: str
+    line_no: int
+
+
+@dataclass(frozen=True)
+class Bucket:
+    """A milestone-defined bucket with start + end boundaries.
+
+    `start` is inclusive, `end` is exclusive. `end=None` encodes the
+    open-ended current bucket (C). `start=None` encodes the open-ended
+    pre-history bucket (A). Labels match the issue body: 'A', 'B', 'C'.
+    """
+
+    label: str
+    start: datetime | None
+    end: datetime | None
+
+
+_BUCKETS = (
+    Bucket(label="A", start=None, end=_BUCKET_ANCHORS[0]),
+    Bucket(label="B", start=_BUCKET_ANCHORS[0], end=_BUCKET_ANCHORS[1]),
+    Bucket(label="C", start=_BUCKET_ANCHORS[1], end=None),
+)
+
+
+@dataclass(frozen=True)
+class FrictionEvent:
+    """One detected friction event with enough context to audit later.
+
+    `surface_text` is always populated at detection time so downstream
+    tests can verify match correctness. The render layer strips it
+    before JSON emission unless `--include-snippets` is passed.
+
+    `metadata` carries signal-family-specific annotations. The contract
+    by family is:
+      - "frustration":           {} (always)
+      - "kai_asks_back":         {} (always)
+      - "preference_correction": {"known_fact_overlap": bool,
+                                  "overlapping_fact_ids": tuple[str, ...]}
+                                 where overlap=False -> overlapping_fact_ids=()
+      - "repeated_fact":         {} (always)
+
+    `metadata` MUST be wrapped in `MappingProxyType` at construction
+    time so the frozen-dataclass invariant extends to the dict's
+    contents. Without the wrapper, a plain dict on a frozen dataclass
+    remains mutable through the field, breaking any downstream "this
+    event is immutable" assumption.
+
+    `context_message_ids` lists prior message IDs that grounded the
+    detection. Empty for "frustration" and for "preference_correction"
+    (which grounds via `metadata.overlapping_fact_ids` instead). Non-
+    empty for "kai_asks_back" (the prior user messages whose content-
+    words overlapped) and for every emitted "repeated_fact" event (the
+    prior fact-shape statement). First-occurrence fact-shape records
+    never reach emission per Signal 4's definition - the Jaccard
+    requirement is against a PRIOR matching record - so a record with
+    no prior match never produces an event.
+    """
+
+    timestamp_utc: datetime
+    bucket_label: str
+    signal_family: str
+    message_id: str
+    surface_text: str
+    context_message_ids: tuple[str, ...]
+    metadata: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class BucketAggregate:
+    """Per-bucket-per-signal count plus per-100-user-turns rate.
+
+    `rate_per_100_user_turns` is rounded to two decimal places at
+    construction time so JSON serialization emits stable strings; the
+    classifier reads the same float for band assignment and re-rounds
+    derived ratios to three decimals at emission time.
+    """
+
+    bucket_label: str
+    signal_family: str
+    count: int
+    user_turns_in_bucket: int
+    rate_per_100_user_turns: float
+
+
+@dataclass(frozen=True)
+class FrictionConfig:
+    """CLI-driven configuration for one run.
+
+    Mirrors the `BehavioralConfig` shape at src/kai/eval/behavioral.py:273.
+    `run_started_at_utc` is captured exactly once in `main()` and
+    threaded through every downstream call so cutoff math and the
+    JSON's `generated_at_utc` derive from a single wall-clock read.
+    Tests pin this by monkey-patching the module's `datetime` reference
+    inside a pytest fixture (e.g. `monkeypatch.setattr("kai.eval.friction.datetime", FakeDatetime)`),
+    NOT by passing a hidden CLI flag. Production users do not pass a
+    reference time; introducing a flag would be a code path that runs
+    only in tests.
+    """
+
+    user_id: str
+    data_dir: Path
+    output_path: Path
+    sample_days: int | None
+    include_snippets: bool
+    markdown_summary_path: Path | None
+    run_started_at_utc: datetime
+
+
+@dataclass(frozen=True)
+class TrendSummary:
+    """Output of the trend classifier.
+
+    Carries the band assignment in-memory for the markdown renderer (so
+    it can label bands without re-running the classifier); the band
+    field is NOT emitted at the top level of the JSON because the
+    JSON's narrative already names the bands in prose.
+    `per_signal_rate_breakdown` and `zero_prior_rate_caveats` feed the
+    narrative and the caveats list respectively, neither surfacing as
+    their own JSON fields.
+    """
+
+    predicted_pattern: str
+    matched_pattern: str
+    verdict_driving_sum: dict[str, float]
+    ratios: dict[str, float | None]
+    bands: dict[str, str | None]
+    per_signal_rate_breakdown: dict[str, dict[str, float]]
+    zero_prior_rate_caveats: tuple[tuple[str, str, float], ...]
+    narrative: str
+
+
+# ── History reading ─────────────────────────────────────────────────
+
+
+def _validate_user_id(user_id: str) -> None:
+    """Reject values that would escape the history root.
+
+    Mirrors the path-traversal guard at src/kai/eval/behavioral.py:841.
+    Treated as eval-only operator-run code so the guard is a defensive
+    shape check (one segment, no parent refs, no slashes) rather than
+    a security boundary; a determined operator running their own
+    harness can still reach arbitrary paths via --data-dir. The guard
+    keeps an honest mistake from silently widening the read scope.
+    """
+    if Path(user_id).name != user_id or user_id in ("", ".", ".."):
+        raise ValueError(f"invalid user_id for history path: {user_id!r}")
+
+
+def _parse_record_timestamp(ts_raw: str) -> tuple[datetime, str | None]:
+    """Parse the ts field with explicit per-edge-case routing.
+
+    Returns (parsed_datetime, parse_reason). When parse_reason is None
+    the parse succeeded; otherwise it is a stable label suitable for
+    inclusion in the friction.timestamp_skip debug log line. Three edge
+    cases:
+      1. Missing or empty `ts` -> sentinel + "ts_missing_or_empty".
+      2. Non-empty but unparseable -> sentinel + "ts_unparseable".
+      3. Parsed but naive -> assume UTC (log_message has always written
+         tz-aware ISO; only hand-edited or legacy rows would be naive).
+    """
+    if not ts_raw:
+        return _BAD_TS_SENTINEL, "ts_missing_or_empty"
+    try:
+        parsed = datetime.fromisoformat(ts_raw)
+    except ValueError:
+        return _BAD_TS_SENTINEL, "ts_unparseable"
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    else:
+        parsed = parsed.astimezone(UTC)
+    return parsed, None
+
+
+def read_history(data_dir: Path, user_id: str) -> Iterator[HistoryRecord]:
+    """Yield every parsed HistoryRecord under data_dir/history/<user_id>/.
+
+    Streams file-by-file, line-by-line. The whole list at current
+    volumes (dozens of MB at worst) is small enough to materialize, but
+    the iterator-shaped contract keeps the harness honest against a
+    future 10x growth in history size.
+
+    JSONL parse mirrors the pattern at src/kai/history.py:136-153:
+    read_text + splitlines + json.loads inside a try/except. Malformed
+    lines do NOT abort the run; they log at debug level and skip,
+    matching the bot's own history reader.
+
+    Three timestamp edge cases each route to bucket A via the
+    `_BAD_TS_SENTINEL` value and a stable `friction.timestamp_skip`
+    debug log line so an operator can grep for them. The sentinel is
+    strictly older than _BUCKET_ANCHORS[0] so bucket assignment lands
+    the record in A without special-casing.
+    """
+    _validate_user_id(user_id)
+    history_dir = data_dir / "history" / user_id
+    if not history_dir.is_dir():
+        return
+    for path in sorted(history_dir.glob("*.jsonl")):
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError:
+            log.exception("friction.read_history_file_unreadable path=%s", path)
+            continue
+        for line_no, line in enumerate(raw.splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                log.debug(
+                    "friction.timestamp_skip path=%s line=%d reason=json_decode_error",
+                    path,
+                    line_no,
+                )
+                continue
+            if not isinstance(row, dict):
+                # Defensive: a top-level non-object JSON line (e.g. an
+                # array) shouldn't appear, but skipping it keeps the
+                # parser from raising AttributeError on .get below.
+                log.debug(
+                    "friction.timestamp_skip path=%s line=%d reason=row_not_object",
+                    path,
+                    line_no,
+                )
+                continue
+            ts_raw = row.get("ts") or ""
+            ts_utc, parse_reason = _parse_record_timestamp(ts_raw)
+            if parse_reason:
+                log.debug(
+                    "friction.timestamp_skip path=%s line=%d reason=%s ts=%s",
+                    path,
+                    line_no,
+                    parse_reason,
+                    ts_raw[:80] if isinstance(ts_raw, str) else "",
+                )
+            yield HistoryRecord(
+                ts_utc=ts_utc,
+                ts_raw=ts_raw if isinstance(ts_raw, str) else "",
+                direction=str(row.get("dir") or ""),
+                chat_id=int(row.get("chat_id") or 0),
+                text=str(row.get("text") or ""),
+                media=row.get("media") if isinstance(row.get("media"), dict) else None,
+                source_path=str(path),
+                line_no=line_no,
+            )
+
+
+# ── Bucket assignment ───────────────────────────────────────────────
+
+
+def _classify_bucket(ts_utc: datetime) -> str:
+    """Map a UTC timestamp to its milestone bucket label.
+
+    Inclusive-start / exclusive-end contract:
+      - Bucket A: ts < _BUCKET_ANCHORS[0]
+      - Bucket B: _BUCKET_ANCHORS[0] <= ts < _BUCKET_ANCHORS[1]
+      - Bucket C: ts >= _BUCKET_ANCHORS[1]
+
+    A record with the bad-timestamp sentinel sorts before A's end, so
+    routing for malformed records is correct without a separate branch.
+    """
+    if ts_utc < _BUCKET_ANCHORS[0]:
+        return "A"
+    if ts_utc < _BUCKET_ANCHORS[1]:
+        return "B"
+    return "C"
+
+
+def _message_id(record: HistoryRecord, data_dir: Path) -> str:
+    """Stable per-record identifier suitable for inclusion in the JSON.
+
+    Format: "<user_id>/<file>.jsonl:<line_no>". The relative path keeps
+    the message_id short (no /tmp prefix) and portable across
+    snapshot-vs-production data dirs. Falls back to the
+    bare filename when the record's source path falls outside the
+    history root (e.g. tests that construct records by hand without
+    placing them under data_dir/history/).
+    """
+    try:
+        rel = Path(record.source_path).relative_to(data_dir / "history")
+        return f"{rel}:{record.line_no}"
+    except ValueError:
+        return f"{Path(record.source_path).name}:{record.line_no}"
+
+
+# ── Signal-family detectors ─────────────────────────────────────────
+
+_SIGNAL_FAMILIES = (
+    "frustration",
+    "kai_asks_back",
+    "preference_correction",
+    "repeated_fact",
+)
+
+
+def _detect_frustration(records: list[HistoryRecord], data_dir: Path) -> list[FrictionEvent]:
+    """Signal 1: operator-side frustration markers.
+
+    Lowercases the user message and tests for substring presence of any
+    `_FRUSTRATION_PHRASES` entry. One event per matching record; the
+    inner `break` enforces this even when multiple phrases would match
+    a single message (e.g. "i told you i already told you" emits one
+    event, not two).
+    """
+    events: list[FrictionEvent] = []
+    for record in records:
+        if record.direction != "user":
+            continue
+        normalized = record.text.lower()
+        for phrase in _FRUSTRATION_PHRASES:
+            if phrase in normalized:
+                events.append(
+                    FrictionEvent(
+                        timestamp_utc=record.ts_utc,
+                        bucket_label=_classify_bucket(record.ts_utc),
+                        signal_family="frustration",
+                        message_id=_message_id(record, data_dir),
+                        surface_text=record.text,
+                        context_message_ids=(),
+                        metadata=MappingProxyType({}),
+                    )
+                )
+                break
+    return events
+
+
+def _ends_with_question_mark(text: str) -> bool:
+    """Detect "?" ending after stripping trailing whitespace and closers.
+
+    Closers stripped: `)`, `"`, `'`. Conservative set so common quoted
+    or parenthesized question forms ("...?)", "...?\"") still register
+    as questions while "Hello?" does not get accidentally counted as a
+    statement by aggressive trimming.
+    """
+    stripped = text.rstrip()
+    while stripped and stripped[-1] in ")\"'":
+        stripped = stripped[:-1].rstrip()
+    return stripped.endswith("?")
+
+
+def _detect_kai_asks_back(records: list[HistoryRecord], data_dir: Path) -> list[FrictionEvent]:
+    """Signal 2: Kai asking for information previously given.
+
+    For each assistant record ending with `?`, compute its content-word
+    set and look back over the immediately-preceding `_KAI_ASKS_BACK_WINDOW`
+    records. If any prior USER record's content-words overlap by at
+    least `_CONTENT_WORD_FLOOR`, emit one event with all matching
+    priors cited in `context_message_ids`.
+
+    The window is `records[max(0, i-20):i]` - 20 entries immediately
+    preceding the assistant record at index i, NOT counting the
+    assistant record itself. The first 20 records of any history have
+    a smaller effective window; do not pad. This is the noisiest of
+    the four signals; the report flags this in caveats.
+    """
+    events: list[FrictionEvent] = []
+    for i, record in enumerate(records):
+        if record.direction != "assistant":
+            continue
+        if not _ends_with_question_mark(record.text):
+            continue
+        own_words = _content_words(record.text)
+        if len(own_words) < _CONTENT_WORD_FLOOR:
+            # The assistant question itself has fewer than 3 substantive
+            # tokens; it cannot meet the overlap floor against ANY prior,
+            # so skip the inner loop entirely.
+            continue
+        window = records[max(0, i - _KAI_ASKS_BACK_WINDOW) : i]
+        matching_ids: list[str] = []
+        for prior in window:
+            if prior.direction != "user":
+                continue
+            prior_words = _content_words(prior.text)
+            if len(own_words & prior_words) >= _CONTENT_WORD_FLOOR:
+                matching_ids.append(_message_id(prior, data_dir))
+        if not matching_ids:
+            continue
+        events.append(
+            FrictionEvent(
+                timestamp_utc=record.ts_utc,
+                bucket_label=_classify_bucket(record.ts_utc),
+                signal_family="kai_asks_back",
+                message_id=_message_id(record, data_dir),
+                surface_text=record.text,
+                context_message_ids=tuple(matching_ids),
+                metadata=MappingProxyType({}),
+            )
+        )
+    return events
+
+
+def _stage_3a_matches(text: str) -> bool:
+    """True iff `text` matches any `_CORRECTION_PATTERNS` regex.
+
+    Searches (not matches), so the pattern can appear anywhere in the
+    text. All patterns carry re.IGNORECASE.
+    """
+    return any(p.search(text) for p in _CORRECTION_PATTERNS)
+
+
+def _parse_fact_created_at(value: str | None) -> datetime | None:
+    """Parse a fact's `created_at` field for stage-3b time-comparison.
+
+    Returns None for empty, missing, or unparseable strings - the
+    conservative "we don't know when this fact was written, so we
+    cannot claim it pre-existed the correction" path. `updated_at` is
+    NOT used as a fallback: a fact bumped by re-extraction must not
+    silently qualify as a fact that pre-existed the correction.
+    """
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    else:
+        parsed = parsed.astimezone(UTC)
+    return parsed
+
+
+def _detect_preference_correction(
+    records: list[HistoryRecord],
+    data_dir: Path,
+    *,
+    facts: list,
+) -> list[FrictionEvent]:
+    """Signal 3: preference corrections (raw + known-fact overlap).
+
+    Stage 3a: any user record matching `_CORRECTION_PATTERNS` is a raw
+    correction. Stage 3b: query `get_by_tag(tag='preference')` ONCE
+    upstream; for each raw match, intersect the correction's content-
+    words with each fact's content-words and require:
+      1. Fact `created_at` parses (per `_parse_fact_created_at`).
+      2. Fact `created_at` is <= correction's `timestamp_utc`.
+      3. Overlap >= `_CONTENT_WORD_FLOOR`.
+
+    Pre-computes the (created_at, fact_id, content_words) tuple per
+    fact ONCE, outside the per-record loop, so the per-correction cost
+    is O(F) intersections rather than re-shingling F facts F times.
+    """
+    fact_signatures: list[tuple[datetime, str, set[str]]] = []
+    for fact in facts:
+        created = _parse_fact_created_at(getattr(fact, "created_at", ""))
+        if created is None:
+            log.debug(
+                "friction.fact_skip id=%s reason=created_at_missing_or_unparseable",
+                getattr(fact, "id", "?"),
+            )
+            continue
+        fact_signatures.append((created, getattr(fact, "id", ""), _content_words(getattr(fact, "text", "") or "")))
+
+    events: list[FrictionEvent] = []
+    for record in records:
+        if record.direction != "user":
+            continue
+        if not _stage_3a_matches(record.text):
+            continue
+        own_words = _content_words(record.text)
+        overlapping_ids: list[str] = []
+        for created, fact_id, fact_words in fact_signatures:
+            if created > record.ts_utc:
+                continue
+            if len(own_words & fact_words) >= _CONTENT_WORD_FLOOR:
+                overlapping_ids.append(fact_id)
+        meta = MappingProxyType(
+            {
+                "known_fact_overlap": bool(overlapping_ids),
+                "overlapping_fact_ids": tuple(overlapping_ids),
+            }
+        )
+        events.append(
+            FrictionEvent(
+                timestamp_utc=record.ts_utc,
+                bucket_label=_classify_bucket(record.ts_utc),
+                signal_family="preference_correction",
+                message_id=_message_id(record, data_dir),
+                surface_text=record.text,
+                context_message_ids=(),
+                metadata=meta,
+            )
+        )
+    return events
+
+
+def _shingles(text: str, k: int = _REPEAT_SHINGLE_K) -> set[str]:
+    """Return the set of k-character shingles after lowercase + whitespace strip.
+
+    Empty text -> empty set. Text shorter than k -> single-element set
+    containing the whole (cleaned) text, so very short fact-shape
+    statements still produce a comparable signature.
+    """
+    cleaned = re.sub(r"\s+", "", text.lower())
+    if not cleaned:
+        return set()
+    if len(cleaned) < k:
+        return {cleaned}
+    return {cleaned[i : i + k] for i in range(len(cleaned) - k + 1)}
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    """Jaccard similarity of two shingle sets.
+
+    Returns 0.0 when either set is empty; division by union size is
+    guarded so an empty union (both empty) returns 0.0 rather than
+    raising ZeroDivisionError.
+    """
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def _detect_repeated_fact(records: list[HistoryRecord], data_dir: Path) -> list[FrictionEvent]:
+    """Signal 4: repeated-fact statements.
+
+    For each user record matching `_FACT_SHAPE_RE`, walk back over the
+    most recent `_REPEAT_LOOKBACK` user-turns (most recent first) and
+    emit one event citing the FIRST prior fact-shape match whose
+    Jaccard similarity exceeds `_REPEAT_JACCARD_FLOOR`. The break-on-
+    first-match keeps emission to one event per repeat AND ensures the
+    cited prior is the most recent (most relevant) one.
+
+    First-occurrence fact-shape records never emit (no prior to compare
+    against), so every emitted event has a non-empty `context_message_ids`.
+    """
+    user_indices = [i for i, r in enumerate(records) if r.direction == "user"]
+    # Cache shingles only for fact-shape user records; non-fact-shape
+    # priors don't qualify as a comparison target (the prior record
+    # must itself be a fact-shape match), so there's no point building
+    # their shingle sets.
+    shingle_cache: dict[int, set[str]] = {}
+    events: list[FrictionEvent] = []
+    for pos, idx in enumerate(user_indices):
+        record = records[idx]
+        if not _FACT_SHAPE_RE.search(record.text):
+            continue
+        shingle_cache[idx] = _shingles(record.text)
+        # Walk priors most-recent-first; break on the first qualifying
+        # match so the cited prior is the closest in time.
+        start = max(0, pos - _REPEAT_LOOKBACK)
+        for prior_pos in range(pos - 1, start - 1, -1):
+            prior_idx = user_indices[prior_pos]
+            if prior_idx not in shingle_cache:
+                continue
+            score = _jaccard(shingle_cache[idx], shingle_cache[prior_idx])
+            if score > _REPEAT_JACCARD_FLOOR:
+                events.append(
+                    FrictionEvent(
+                        timestamp_utc=record.ts_utc,
+                        bucket_label=_classify_bucket(record.ts_utc),
+                        signal_family="repeated_fact",
+                        message_id=_message_id(record, data_dir),
+                        surface_text=record.text,
+                        context_message_ids=(_message_id(records[prior_idx], data_dir),),
+                        metadata=MappingProxyType({}),
+                    )
+                )
+                break
+    return events
+
+
+def detect_events(
+    records: list[HistoryRecord],
+    data_dir: Path,
+    *,
+    facts: list,
+) -> list[FrictionEvent]:
+    """Run all four signal detectors and concatenate their event lists.
+
+    Detectors share no state and run independently; concatenation
+    preserves the per-detector emission order, and the final report
+    re-sorts by `(timestamp_utc, message_id)` for byte-stable output
+    (see `_build_report`).
+    """
+    events: list[FrictionEvent] = []
+    events.extend(_detect_frustration(records, data_dir))
+    events.extend(_detect_kai_asks_back(records, data_dir))
+    events.extend(_detect_preference_correction(records, data_dir, facts=facts))
+    events.extend(_detect_repeated_fact(records, data_dir))
+    return events
+
+
+# ── Aggregation and trend classification ────────────────────────────
+
+
+def aggregate(
+    records: list[HistoryRecord], events: list[FrictionEvent]
+) -> tuple[list[BucketAggregate], dict[str, int]]:
+    """Compute per-bucket-per-signal aggregates and per-bucket user-turn counts.
+
+    Initializes the (bucket, family) matrix with zero counts so every
+    cell is present in the JSON even when no events fired in that
+    bucket-family combination; downstream test assertions pin the
+    matrix shape and missing rows would be a regression.
+
+    Returns (aggregates, user_turns_by_bucket). `user_turns` is the
+    denominator the trend classifier uses for the volume floor check;
+    aggregating it here keeps the bucket-walk single-pass.
+    """
+    user_turns: dict[str, int] = {label: 0 for label in ("A", "B", "C")}
+    for record in records:
+        if record.direction == "user":
+            user_turns[_classify_bucket(record.ts_utc)] += 1
+    counts: dict[tuple[str, str], int] = {
+        (bucket, family): 0 for bucket in ("A", "B", "C") for family in _SIGNAL_FAMILIES
+    }
+    for ev in events:
+        counts[(ev.bucket_label, ev.signal_family)] += 1
+    aggregates: list[BucketAggregate] = []
+    for bucket in ("A", "B", "C"):
+        denom = user_turns[bucket]
+        for family in _SIGNAL_FAMILIES:
+            count = counts[(bucket, family)]
+            # 0.0 (NOT NaN) when the denominator is zero. NaN would
+            # break downstream JSON parsing and table renders.
+            rate = round(count / denom * 100, 2) if denom > 0 else 0.0
+            aggregates.append(
+                BucketAggregate(
+                    bucket_label=bucket,
+                    signal_family=family,
+                    count=count,
+                    user_turns_in_bucket=denom,
+                    rate_per_100_user_turns=rate,
+                )
+            )
+    return aggregates, user_turns
+
+
+def _classify_band(prior: float, new: float) -> str:
+    """Return 'drop' | 'flat' | 'up' for new vs prior under the pinned bands.
+
+    Band semantics:
+      - drop: new <= 0.85 * prior (boundary inclusive on this side)
+      - flat: 0.85 * prior < new <= 1.15 * prior (open lower, closed upper)
+      - up:   new > 1.15 * prior
+
+    Zero-prior is handled by the caller via _band_for_transition; this
+    helper assumes prior > 0. Tests that exercise the `unclassified`
+    catch-all monkey-patch this helper to return a sentinel value
+    outside `{drop, flat, up}`, then assert the classifier emits
+    `unclassified` with the correct narrative.
+    """
+    if new <= _MATERIAL_DROP_RATIO * prior:
+        return "drop"
+    if new <= _UP_RATIO * prior:
+        return "flat"
+    return "up"
+
+
+# Map (A->B band, B->C band) -> matched_pattern identifier. Exhaustive
+# over the 9-cell `{drop, flat, up}^2` grid. `regression` absorbs the
+# three (any, up) cells since any post-#361 increase is the
+# verdict-driving observation. Missing keys would land in `unclassified`
+# via the dict.get fallback in classify_trend; under the pinned rules
+# this should never happen.
+_GRID_TO_PATTERN: dict[tuple[str, str], str] = {
+    ("drop", "drop"): "both-milestones-helped",
+    ("drop", "flat"): "prediction-holds",
+    ("drop", "up"): "regression",
+    ("flat", "drop"): "track-1-carried-win",
+    ("flat", "flat"): "no-effect",
+    ("flat", "up"): "regression",
+    ("up", "drop"): "retrieval-helped-pollution-hurt",
+    ("up", "flat"): "retrieval-hurt-no-recovery",
+    ("up", "up"): "regression",
+}
+
+
+_BAND_DESCRIPTIONS = {
+    "drop": f"material drop, <= {_MATERIAL_DROP_RATIO}x",
+    "flat": f"flat, in ({_MATERIAL_DROP_RATIO}x, {_UP_RATIO}x]",
+    "up": f"up, > {_UP_RATIO}x",
+}
+
+
+def _band_for_transition(prior: float, new: float) -> tuple[str, bool]:
+    """Compute band with zero-prior fallback.
+
+    Returns (band_label, undefined_ratio). When prior=0 + new>0, the
+    band falls back to "up" AND the caller is expected to record a
+    zero-prior-rate caveat AND emit JSON `null` for the ratio.
+    `undefined_ratio` is True only in that case; (0, 0) gives ("flat",
+    False) since the ratio is reported as 1.0 by convention.
+    """
+    if prior == 0 and new == 0:
+        return "flat", False
+    if prior == 0 and new > 0:
+        return "up", True
+    return _classify_band(prior, new), False
+
+
+def classify_trend(
+    *,
+    aggregates: list[BucketAggregate],
+    events: list[FrictionEvent],
+    user_turns: dict[str, int],
+    memory_state: MemoryAvailability,
+) -> TrendSummary:
+    """Compute the trend classification + narrative for one run.
+
+    Order of operations (inconclusive precedence first):
+      1. Compute per-signal rates per bucket + the known-fact-overlap
+         subset count for preference_correction.
+      2. Compute verdict_driving_sum per bucket (frustration +
+         preference_correction known-fact-overlap subset). When memory
+         is unreachable the overlap count is zero by construction, so
+         the sum collapses to frustration alone without special-casing.
+      3. Compute A->B and B->C ratios with zero-denominator handling
+         (prior=0 + new=0 -> 1.0; prior=0 + new>0 -> null).
+      4. Inconclusive precedence: any bucket with user_turns < 30 fires
+         `inconclusive` and skips the 9-cell grid.
+      5. Inconclusive precedence: any zero-prior-rate transition (which
+         pushes a `null` ratio AND a fallback-to-up band) also fires
+         `inconclusive`.
+      6. Otherwise, classify both transitions via _classify_band and
+         look up the 9-cell grid; emit `unclassified` if the lookup
+         misses (defensive catch-all that should never fire under the
+         pinned rules).
+
+    `verdict_driving_sum` and `ratios` are ALWAYS computed and emitted,
+    even when matched_pattern is `inconclusive`, so the JSON preserves
+    diagnostic value when band classification did not run.
+    """
+    rates_by_bucket = {
+        bucket: {agg.signal_family: agg.rate_per_100_user_turns for agg in aggregates if agg.bucket_label == bucket}
+        for bucket in ("A", "B", "C")
+    }
+    overlap_counts = {b: 0 for b in ("A", "B", "C")}
+    for ev in events:
+        if ev.signal_family != "preference_correction":
+            continue
+        if ev.metadata.get("known_fact_overlap"):
+            overlap_counts[ev.bucket_label] += 1
+    overlap_rates = {
+        bucket: (round(overlap_counts[bucket] / user_turns[bucket] * 100, 2) if user_turns[bucket] > 0 else 0.0)
+        for bucket in ("A", "B", "C")
+    }
+    verdict_sum = {
+        bucket: round(rates_by_bucket[bucket].get("frustration", 0.0) + overlap_rates[bucket], 2)
+        for bucket in ("A", "B", "C")
+    }
+    # Per-signal breakdown for the narrative; the preference_correction
+    # row in the breakdown is the known-fact-overlap subset rate, NOT
+    # the raw stage 3a rate. Same convention as the verdict sum.
+    per_signal_breakdown = {
+        bucket: {
+            "frustration": rates_by_bucket[bucket].get("frustration", 0.0),
+            "preference_correction": overlap_rates[bucket],
+            "kai_asks_back": rates_by_bucket[bucket].get("kai_asks_back", 0.0),
+            "repeated_fact": rates_by_bucket[bucket].get("repeated_fact", 0.0),
+        }
+        for bucket in ("A", "B", "C")
+    }
+    # Compute ratios + bands per transition. Any zero-prior-rate
+    # transition (prior=0 + new>0) triggers an inconclusive caveat;
+    # we accumulate the caveats and let the inconclusive-precedence
+    # check below decide whether to also flip the matched_pattern.
+    zero_prior_caveats: list[tuple[str, str, float]] = []
+    ratios: dict[str, float | None] = {}
+    bands: dict[str, str | None] = {}
+    for prior_label, new_label, key in (("A", "B", "A_to_B"), ("B", "C", "B_to_C")):
+        prior, new = verdict_sum[prior_label], verdict_sum[new_label]
+        if prior == 0 and new == 0:
+            ratios[key] = 1.0
+            bands[key] = "flat"
+        elif prior == 0 and new > 0:
+            ratios[key] = None
+            bands[key] = "up"
+            zero_prior_caveats.append((prior_label, new_label, new))
+        else:
+            ratios[key] = round(new / prior, 3)
+            bands[key] = _classify_band(prior, new)
+
+    def _summary(matched_pattern: str, band_pair: tuple[str | None, str | None]) -> TrendSummary:
+        return TrendSummary(
+            predicted_pattern=_PREDICTED_PATTERN,
+            matched_pattern=matched_pattern,
+            verdict_driving_sum=verdict_sum,
+            ratios=ratios,
+            bands=bands,
+            per_signal_rate_breakdown=per_signal_breakdown,
+            zero_prior_rate_caveats=tuple(zero_prior_caveats),
+            narrative=_render_narrative(
+                matched=matched_pattern,
+                verdict_sum=verdict_sum,
+                ratios=ratios,
+                per_signal_breakdown=per_signal_breakdown,
+                bands=band_pair,
+            ),
+        )
+
+    # Inconclusive precedence: volume floor.
+    if any(user_turns[b] < _USER_TURN_FLOOR for b in ("A", "B", "C")):
+        return _summary("inconclusive", (bands["A_to_B"], bands["B_to_C"]))
+    # Inconclusive precedence: zero-prior-rate.
+    if zero_prior_caveats:
+        return _summary("inconclusive", (bands["A_to_B"], bands["B_to_C"]))
+    # 9-cell grid lookup; defensive catch-all for `unclassified`.
+    matched = _GRID_TO_PATTERN.get((bands["A_to_B"], bands["B_to_C"]), "unclassified")
+    return _summary(matched, (bands["A_to_B"], bands["B_to_C"]))
+
+
+def _render_narrative(
+    *,
+    matched: str,
+    verdict_sum: dict[str, float],
+    ratios: dict[str, float | None],
+    per_signal_breakdown: dict[str, dict[str, float]],
+    bands: tuple[str | None, str | None],
+) -> str:
+    """Build the prose narrative for the trend_summary block.
+
+    Names the verdict-driving sum per bucket, both ratios with band
+    labels, the matched pattern, and the per-signal breakdown. Keeps
+    everything inline so the narrative is one paste-able block; the
+    markdown summary references this same text.
+    """
+    band_a_to_b, band_b_to_c = bands
+    a_to_b = ratios.get("A_to_B")
+    b_to_c = ratios.get("B_to_C")
+    a_to_b_str = "undefined" if a_to_b is None else f"{a_to_b:.3f}x"
+    b_to_c_str = "undefined" if b_to_c is None else f"{b_to_c:.3f}x"
+    band_a_to_b_str = _BAND_DESCRIPTIONS.get(band_a_to_b or "", "see caveats")
+    band_b_to_c_str = _BAND_DESCRIPTIONS.get(band_b_to_c or "", "see caveats")
+    parts: list[str] = []
+    parts.append(
+        "Verdict-driving sum (frustration + preference_correction known-fact overlap): "
+        f"A={verdict_sum['A']:.2f}, B={verdict_sum['B']:.2f}, C={verdict_sum['C']:.2f}."
+    )
+    parts.append(f"A->B ratio: {a_to_b_str} ({band_a_to_b_str}); B->C ratio: {b_to_c_str} ({band_b_to_c_str}).")
+    parts.append(f"Classification: {matched}.")
+    parts.append(
+        "Per-signal breakdown: "
+        f"frustration {per_signal_breakdown['A']['frustration']:.2f} -> "
+        f"{per_signal_breakdown['B']['frustration']:.2f} -> "
+        f"{per_signal_breakdown['C']['frustration']:.2f}; "
+        "preference_correction (known-fact overlap) "
+        f"{per_signal_breakdown['A']['preference_correction']:.2f} -> "
+        f"{per_signal_breakdown['B']['preference_correction']:.2f} -> "
+        f"{per_signal_breakdown['C']['preference_correction']:.2f}; "
+        f"kai_asks_back {per_signal_breakdown['A']['kai_asks_back']:.2f} -> "
+        f"{per_signal_breakdown['B']['kai_asks_back']:.2f} -> "
+        f"{per_signal_breakdown['C']['kai_asks_back']:.2f} (noisy); "
+        f"repeated_fact {per_signal_breakdown['A']['repeated_fact']:.2f} -> "
+        f"{per_signal_breakdown['B']['repeated_fact']:.2f} -> "
+        f"{per_signal_breakdown['C']['repeated_fact']:.2f} (noisy)."
+    )
+    return " ".join(parts)
+
+
+# ── Memory-store integration ────────────────────────────────────────
+
+
+def _initialize_memory_local() -> MemoryInitResult:
+    """Tri-state memory init that NEVER calls sys.exit.
+
+    Diverges from the canonical _initialize_memory at
+    src/kai/eval/behavioral.py:1901 in that the friction harness must
+    complete a degraded run when memory is unavailable. The caller
+    interprets ENABLED as "stage 3b will run", DISABLED as "stage 3b
+    is a no-op via configuration", ERROR as "stage 3b is a no-op via
+    crash" (the latter additionally surfaced in the report's
+    `memory_store_error_message` field).
+
+    Imports happen lazily inside the try/except so a missing optional
+    `[memory]` extra (mem0ai, sentence-transformers, qdrant-client)
+    surfaces as ERROR rather than crashing the harness at module import.
+    """
+    try:
+        from kai.config import load_config
+        from kai.memory import init_memory, is_enabled
+
+        config = load_config()
+        init_memory(config)
+        if not is_enabled():
+            return MemoryInitResult(MemoryAvailability.DISABLED, None)
+        return MemoryInitResult(MemoryAvailability.ENABLED, None)
+    except Exception as e:
+        return MemoryInitResult(MemoryAvailability.ERROR, str(e))
+
+
+def _load_facts_for_user(user_id: str, memory_state: MemoryInitResult) -> list:
+    """Cache `get_by_tag(tag='preference')` once per run; empty list otherwise.
+
+    A non-ENABLED memory state degrades stage 3b to a no-op (every
+    preference_correction event ends up with `known_fact_overlap=False`).
+    Stage 3b never re-queries per event; this function is the single
+    fact fetch for the whole run.
+    """
+    if memory_state.availability != MemoryAvailability.ENABLED:
+        return []
+    try:
+        from kai.memory import get_by_tag
+
+        return get_by_tag(user_id=user_id, tag="preference")
+    except Exception:
+        log.exception("friction.fact_query_failed user_id=%s", user_id)
+        return []
+
+
+# ── Render layer ────────────────────────────────────────────────────
+
+
+def _redact_text(text: str) -> str:
+    """Apply the redaction regex set and truncate to the snippet cap.
+
+    Pattern order is fixed in `_REDACT_REPLACEMENTS` so URL-then-email-
+    then-handle-then-phone resolves overlap cases consistently.
+    Truncation happens AFTER redaction so a redacted token is never
+    split mid-replacement.
+    """
+    out = text
+    for pattern, replacement in _REDACT_REPLACEMENTS:
+        out = pattern.sub(replacement, out)
+    return out[:_SNIPPET_MAX_CHARS]
+
+
+def _build_event_payload(event: FrictionEvent, *, include_snippets: bool) -> dict:
+    """Produce the JSON-serializable dict for one event.
+
+    `metadata=dict(event.metadata)` is the load-bearing conversion from
+    `MappingProxyType` to a plain dict; the default `json` encoder
+    rejects MappingProxyType because `isinstance(MappingProxyType({}), dict)`
+    is False. Without this conversion, the immutability wrapper at
+    construction time silently breaks the render path the first time
+    it is exercised; the test suite has a regression for this exact case.
+    """
+    surface = _redact_text(event.surface_text) if include_snippets else None
+    return {
+        "timestamp_utc": event.timestamp_utc.isoformat(),
+        "bucket_label": event.bucket_label,
+        "signal_family": event.signal_family,
+        "message_id": event.message_id,
+        "context_message_ids": list(event.context_message_ids),
+        "metadata": dict(event.metadata),
+        "surface_text": surface,
+    }
+
+
+def _build_bucket_payload(records: list[HistoryRecord]) -> list[dict]:
+    """Per-bucket volume rows for the JSON `buckets` block.
+
+    `messages_total` counts every record (user + assistant + media);
+    `user_turns` counts only `direction == "user"`. The classifier and
+    the rate denominator both read user_turns; messages_total is
+    surfaced for diagnostic value only.
+    """
+    user_turns: dict[str, int] = {b: 0 for b in ("A", "B", "C")}
+    messages_total: dict[str, int] = {b: 0 for b in ("A", "B", "C")}
+    for record in records:
+        bucket = _classify_bucket(record.ts_utc)
+        messages_total[bucket] += 1
+        if record.direction == "user":
+            user_turns[bucket] += 1
+    payload: list[dict] = []
+    for bucket in _BUCKETS:
+        payload.append(
+            {
+                "label": bucket.label,
+                "start_utc": bucket.start.isoformat() if bucket.start else None,
+                "end_utc": bucket.end.isoformat() if bucket.end else None,
+                "user_turns": user_turns[bucket.label],
+                "messages_total": messages_total[bucket.label],
+            }
+        )
+    return payload
+
+
+def _build_caveats(
+    *,
+    bucket_user_turns: dict[str, int],
+    memory_state: MemoryInitResult,
+    sample_days: int | None,
+    sample_cutoff_utc: datetime | None,
+    ratios_undefined: list[tuple[str, str, float]],
+) -> list[str]:
+    """Build the caveats list.
+
+    Two unconditional caveats lead the list (the noisy-signal warnings),
+    followed by conditional triggers in a stable order so the JSON is
+    byte-stable across runs with the same set of triggered conditions.
+    """
+    caveats: list[str] = [
+        "signal_family 'kai_asks_back' is noisy; bucket-level trend is the unit of interpretation.",
+        "signal_family 'repeated_fact' is the noisiest of the four; treat per-event matches with skepticism and rely on bucket-level trend.",
+    ]
+    if memory_state.availability != MemoryAvailability.ENABLED:
+        # Caveat label uses uppercase {DISABLED|ERROR}; .name preserves
+        # the enum's uppercase form (vs .value which is lowercase).
+        status_label = memory_state.availability.name
+        caveats.append(
+            f"memory-unreachable-frustration-only: memory store was {status_label}; "
+            "preference_correction known-fact-overlap subset is empty by construction; "
+            "verdict is single-signal (frustration only)."
+        )
+    if memory_state.availability == MemoryAvailability.ERROR and memory_state.error_message:
+        caveats.append(f"memory_store_error_message: {memory_state.error_message}")
+    for bucket in ("A", "B", "C"):
+        n = bucket_user_turns.get(bucket, 0)
+        if n < _USER_TURN_FLOOR:
+            caveats.append(
+                f"inconclusive: bucket {bucket} has user_turns={n} (< {_USER_TURN_FLOOR}); "
+                "cross-bucket comparison is ill-defined."
+            )
+    if sample_days is not None and sample_cutoff_utc is not None:
+        caveats.append(
+            f"--sample-days={sample_days} restricts to records with "
+            f"ts_utc >= {sample_cutoff_utc.isoformat()}; older history is excluded from this report."
+        )
+    for prior_label, new_label, rate_new in ratios_undefined:
+        caveats.append(
+            f"zero-prior-rate: rate for bucket {prior_label} is 0 and bucket "
+            f"{new_label} is {rate_new}; ratio is undefined and band classification "
+            "falls back to up."
+        )
+    return caveats
+
+
+def _build_report(
+    *,
+    config: FrictionConfig,
+    records: list[HistoryRecord],
+    events: list[FrictionEvent],
+    aggregates: list[BucketAggregate],
+    user_turns: dict[str, int],
+    trend: TrendSummary,
+    memory_state: MemoryInitResult,
+    sample_cutoff_utc: datetime | None,
+) -> dict:
+    """Produce the top-level JSON report dict.
+
+    Events are sorted by `(timestamp_utc, message_id)` so the JSON is
+    byte-stable across runs against a fixed history snapshot, which is
+    what makes regression tests possible.
+
+    `memory_store_error_message` is included only when status is ERROR;
+    omitting the field on the success path keeps the JSON shape
+    minimal in the common case.
+    """
+    sorted_events = sorted(events, key=lambda e: (e.timestamp_utc, e.message_id))
+    report: dict[str, Any] = {
+        "version": _OUTPUT_SCHEMA_VERSION,
+        "generated_at_utc": config.run_started_at_utc.isoformat(),
+        "user_id": config.user_id,
+        "data_dir": str(config.data_dir),
+        "sample_days": config.sample_days,
+        "memory_store_reachable": memory_state.availability == MemoryAvailability.ENABLED,
+        "memory_store_status": memory_state.availability.value,
+    }
+    if memory_state.availability == MemoryAvailability.ERROR:
+        report["memory_store_error_message"] = memory_state.error_message
+    report["buckets"] = _build_bucket_payload(records)
+    report["aggregates"] = [
+        {
+            "bucket_label": agg.bucket_label,
+            "signal_family": agg.signal_family,
+            "count": agg.count,
+            "user_turns_in_bucket": agg.user_turns_in_bucket,
+            "rate_per_100_user_turns": agg.rate_per_100_user_turns,
+        }
+        for agg in aggregates
+    ]
+    report["events"] = [_build_event_payload(ev, include_snippets=config.include_snippets) for ev in sorted_events]
+    report["trend_summary"] = {
+        "predicted_pattern": trend.predicted_pattern,
+        "matched_pattern": trend.matched_pattern,
+        "verdict_driving_sum": trend.verdict_driving_sum,
+        "ratios": trend.ratios,
+        "narrative": trend.narrative,
+    }
+    report["caveats"] = _build_caveats(
+        bucket_user_turns=user_turns,
+        memory_state=memory_state,
+        sample_days=config.sample_days,
+        sample_cutoff_utc=sample_cutoff_utc,
+        ratios_undefined=list(trend.zero_prior_rate_caveats),
+    )
+    return report
+
+
+def _json_default(obj: Any) -> Any:
+    """Default encoder for any object the standard encoder rejects.
+
+    Defensive net for `MappingProxyType` (which `_build_event_payload`
+    already converts at the event layer). If this ever fires it
+    indicates a NEW code path forgot the MappingProxyType -> dict
+    conversion that `_build_event_payload` performs.
+    """
+    if isinstance(obj, Mapping):
+        return dict(obj)
+    raise TypeError(f"unserializable: {type(obj).__name__}")
+
+
+def _render_json(report: dict) -> str:
+    """Serialize the report dict; pretty-printed for human review."""
+    return json.dumps(report, indent=2, ensure_ascii=False, default=_json_default)
+
+
+def _render_markdown(report: dict, trend: TrendSummary) -> str:
+    """Build the redacted markdown summary suitable for paste-into-issue.
+
+    Always redacts surface text regardless of `--include-snippets` (the
+    flag only affects the JSON report and only for local inspection).
+    The user_id is rendered as the literal "<user_id-redacted>" so
+    posting the markdown publicly does not leak the chat ID.
+
+    Bands are read from the in-memory `TrendSummary` object rather than
+    re-derived from the JSON, so the markdown's band labels stay in
+    sync with the classifier's view without duplicate logic.
+    """
+    buckets = report["buckets"]
+    aggregates = report["aggregates"]
+    rate_by_cell = {(agg["bucket_label"], agg["signal_family"]): agg["rate_per_100_user_turns"] for agg in aggregates}
+    lines: list[str] = []
+    lines.append("## Layer 3 evaluation: results")
+    lines.append("")
+    lines.append("Friction analysis of <user_id-redacted> chat history across three milestone buckets.")
+    lines.append("")
+    lines.append("### Bucket volumes")
+    lines.append("")
+    lines.append("| bucket | dates (UTC) | user_turns | messages_total |")
+    lines.append("|---|---|---|---|")
+    for bucket in buckets:
+        start = bucket["start_utc"] or "(open)"
+        end = bucket["end_utc"] or "(open)"
+        lines.append(f"| {bucket['label']} | {start} -> {end} | {bucket['user_turns']} | {bucket['messages_total']} |")
+    lines.append("")
+    lines.append("### Friction rates (per 100 user-turns)")
+    lines.append("")
+    lines.append("| signal | bucket A | bucket B | bucket C |")
+    lines.append("|---|---|---|---|")
+    for family in _SIGNAL_FAMILIES:
+        lines.append(
+            f"| {family} | {rate_by_cell[('A', family)]:.2f} | "
+            f"{rate_by_cell[('B', family)]:.2f} | {rate_by_cell[('C', family)]:.2f} |"
+        )
+    lines.append("")
+    lines.append("### Trend")
+    lines.append("")
+    lines.append(f"Predicted: {trend.predicted_pattern}. Matched: {trend.matched_pattern}.")
+    lines.append("")
+    a_to_b = trend.ratios.get("A_to_B")
+    b_to_c = trend.ratios.get("B_to_C")
+    a_to_b_str = "undefined" if a_to_b is None else f"{a_to_b:.3f}x"
+    b_to_c_str = "undefined" if b_to_c is None else f"{b_to_c:.3f}x"
+    band_a_to_b_str = _BAND_DESCRIPTIONS.get(trend.bands.get("A_to_B") or "", "see caveats")
+    band_b_to_c_str = _BAND_DESCRIPTIONS.get(trend.bands.get("B_to_C") or "", "see caveats")
+    lines.append(
+        "Verdict-driving sum (frustration + preference_correction known-fact overlap, "
+        f"per 100 user-turns): A={trend.verdict_driving_sum['A']:.2f}, "
+        f"B={trend.verdict_driving_sum['B']:.2f}, "
+        f"C={trend.verdict_driving_sum['C']:.2f}. "
+        f"A->B ratio: {a_to_b_str} ({band_a_to_b_str}); "
+        f"B->C ratio: {b_to_c_str} ({band_b_to_c_str})."
+    )
+    lines.append("")
+    lines.append(f"Narrative: {trend.narrative}")
+    lines.append("")
+    lines.append("### Caveats")
+    lines.append("")
+    for caveat in report["caveats"]:
+        lines.append(f"- {caveat}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write content to path atomically via temp-file + os.replace.
+
+    A partial write (process killed mid-write, disk full mid-flush)
+    would corrupt the report and silently pollute downstream comparison
+    scripts. `os.replace` is atomic on both POSIX and Windows. The temp
+    file is created in the SAME directory as the destination so the
+    rename is intra-filesystem and the atomicity guarantee holds.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_str = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    temp_path = Path(temp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(temp_path, path)
+    except Exception:
+        # Best-effort cleanup of the temp file on any write failure;
+        # leaving it would accumulate stale .tmp files in the output
+        # directory across repeated failed runs.
+        if temp_path.exists():
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
+        raise
+
+
+# ── CLI ─────────────────────────────────────────────────────────────
+
+
+def _non_negative_int(value: str) -> int:
+    """argparse type validator: integer >= 0.
+
+    Mirrors `_non_negative_int` at src/kai/eval/behavioral.py:1775.
+    Duplicated rather than imported to keep the two eval modules
+    independently runnable (a partial install with only friction.py
+    available should still parse its CLI).
+    """
+    try:
+        n = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected integer, got {value!r}") from exc
+    if n < 0:
+        raise argparse.ArgumentTypeError(f"expected non-negative integer, got {value!r}")
+    return n
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Construct the argparse parser for the friction CLI surface."""
+    parser = argparse.ArgumentParser(
+        prog="python -m kai.eval.friction",
+        description=(
+            "Layer 3 longitudinal friction analysis. Reads chat history "
+            "for a single user, runs four pre-committed friction-detection "
+            "signal families, buckets events by milestone (PR #333 and "
+            "PR #361 merge instants), and emits a schema-versioned JSON "
+            "report plus an optional redacted markdown summary."
+        ),
+    )
+    parser.add_argument(
+        "--user-id",
+        required=True,
+        help="Chat ID subdirectory under DATA_DIR/history/. Single user per run.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Absolute path for the JSON report. Atomic temp+rename is used.",
+    )
+    parser.add_argument(
+        "--markdown-summary",
+        type=Path,
+        default=None,
+        help="Optional path for the redacted markdown summary suitable for paste-into-issue.",
+    )
+    parser.add_argument(
+        "--sample-days",
+        type=_non_negative_int,
+        default=None,
+        help=(
+            "Restrict to records with ts_utc >= run_started_at_utc - timedelta(days=N). "
+            "0 means 'today UTC' (midnight UTC of the run's calendar day). "
+            "Omit to include all history."
+        ),
+    )
+    parser.add_argument(
+        "--include-snippets",
+        action="store_true",
+        help=(
+            "Populate surface_text in the JSON report (still redacted: "
+            "URLs, email addresses, @handles, and phone-shaped digit "
+            "runs are scrubbed; per-event excerpt capped at 200 chars). "
+            "The markdown summary always omits surface_text regardless."
+        ),
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=None,
+        help="Override DATA_DIR resolution. Tests pass tmp_path; production uses KAI_DATA_DIR.",
+    )
+    return parser
+
+
+def _resolve_sample_cutoff(run_started_at_utc: datetime, sample_days: int | None) -> datetime | None:
+    """Compute the inclusive lower bound for the --sample-days filter.
+
+    `--sample-days 0` means "today UTC" (midnight UTC of the run's
+    calendar day) by convention. `None` means no filter; the caller
+    treats a `None` cutoff as "include every record."
+    """
+    if sample_days is None:
+        return None
+    if sample_days == 0:
+        return run_started_at_utc.replace(hour=0, minute=0, second=0, microsecond=0)
+    return run_started_at_utc - timedelta(days=sample_days)
+
+
+def _resolve_data_dir(override: Path | None) -> Path:
+    """Use the CLI override when provided, else the module-level DATA_DIR.
+
+    DATA_DIR is evaluated once at import time from KAI_DATA_DIR; the
+    operator's run procedure sets KAI_DATA_DIR BEFORE invoking python
+    so the constant matches the snapshot. The CLI override exists for
+    tests (which point at tmp_path) and for the rare ad-hoc operator
+    run that wants a different path without re-launching python.
+    """
+    if override is not None:
+        return override
+    from kai.config import DATA_DIR
+
+    return DATA_DIR
+
+
+async def _run_cli(args: argparse.Namespace, run_started_at_utc: datetime) -> int:
+    """CLI dispatch. Returns process exit code: 0 success, 2 on bad CLI input.
+
+    `_run_cli` is `async` to mirror behavioral.py's convention even
+    though the friction harness has no awaitable work; future
+    extensions (parallel detector execution, async fact lookups) would
+    sit naturally inside this function without requiring a top-level
+    refactor.
+    """
+    try:
+        _validate_user_id(args.user_id)
+    except ValueError as e:
+        print(f"friction: {e}", file=sys.stderr)
+        return 2
+    data_dir = _resolve_data_dir(args.data_dir)
+    config = FrictionConfig(
+        user_id=args.user_id,
+        data_dir=data_dir,
+        output_path=args.output,
+        sample_days=args.sample_days,
+        include_snippets=args.include_snippets,
+        markdown_summary_path=args.markdown_summary,
+        run_started_at_utc=run_started_at_utc,
+    )
+    sample_cutoff = _resolve_sample_cutoff(run_started_at_utc, config.sample_days)
+    memory_state = _initialize_memory_local()
+    facts = _load_facts_for_user(config.user_id, memory_state)
+    records = list(read_history(config.data_dir, config.user_id))
+    if sample_cutoff is not None:
+        records = [r for r in records if r.ts_utc >= sample_cutoff]
+    events = detect_events(records, config.data_dir, facts=facts)
+    aggregates, user_turns = aggregate(records, events)
+    trend = classify_trend(
+        aggregates=aggregates,
+        events=events,
+        user_turns=user_turns,
+        memory_state=memory_state.availability,
+    )
+    report = _build_report(
+        config=config,
+        records=records,
+        events=events,
+        aggregates=aggregates,
+        user_turns=user_turns,
+        trend=trend,
+        memory_state=memory_state,
+        sample_cutoff_utc=sample_cutoff,
+    )
+    _atomic_write(config.output_path, _render_json(report) + "\n")
+    if config.markdown_summary_path is not None:
+        _atomic_write(config.markdown_summary_path, _render_markdown(report, trend))
+    print(
+        f"friction: {len(events)} events across {sum(user_turns.values())} user-turns "
+        f"-> {config.output_path} (matched: {trend.matched_pattern})",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Process entry point.
+
+    Captures `_run_started_at_utc` exactly once before any reading
+    happens, threading it through the entire run via `FrictionConfig`.
+    This is the only `datetime.now(UTC)` call the harness makes in
+    production; everything downstream derives from this single
+    wall-clock read so a run that straddles a day boundary while
+    reading still produces consistent cutoffs (the single-clock-read
+    invariant is what makes outputs deterministic across replays).
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    run_started_at_utc = datetime.now(UTC)
+    return asyncio.run(_run_cli(args, run_started_at_utc))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kai/eval/friction.py
+++ b/src/kai/eval/friction.py
@@ -765,7 +765,7 @@ def _detect_preference_correction(
     records: list[HistoryRecord],
     data_dir: Path,
     *,
-    facts: list,
+    facts: list[Any],
 ) -> list[FrictionEvent]:
     """Signal 3: preference corrections (raw + known-fact overlap).
 
@@ -869,7 +869,9 @@ def _detect_repeated_fact(records: list[HistoryRecord], data_dir: Path) -> list[
     # Cache shingles only for fact-shape user records; non-fact-shape
     # priors don't qualify as a comparison target (the prior record
     # must itself be a fact-shape match), so there's no point building
-    # their shingle sets.
+    # their shingle sets. Bounded by the lookback window (see eviction
+    # below), so peak memory is O(_REPEAT_LOOKBACK) entries regardless
+    # of total history length.
     shingle_cache: dict[int, set[str]] = {}
     events: list[FrictionEvent] = []
     for pos, idx in enumerate(user_indices):
@@ -877,6 +879,13 @@ def _detect_repeated_fact(records: list[HistoryRecord], data_dir: Path) -> list[
         if not _FACT_SHAPE_RE.search(record.text):
             continue
         shingle_cache[idx] = _shingles(record.text)
+        # Evict the entry that just fell out of the lookback window;
+        # nothing later in the loop can read it. Without this the cache
+        # grows unbounded across a long history, even though only the
+        # last _REPEAT_LOOKBACK entries are ever touched.
+        evict_pos = pos - _REPEAT_LOOKBACK - 1
+        if evict_pos >= 0:
+            shingle_cache.pop(user_indices[evict_pos], None)
         # Walk priors most-recent-first; break on the first qualifying
         # match so the cited prior is the closest in time.
         start = max(0, pos - _REPEAT_LOOKBACK)
@@ -905,7 +914,7 @@ def detect_events(
     records: list[HistoryRecord],
     data_dir: Path,
     *,
-    facts: list,
+    facts: list[Any],
 ) -> list[FrictionEvent]:
     """Run all four signal detectors and concatenate their event lists.
 
@@ -1204,7 +1213,7 @@ def _initialize_memory_local() -> MemoryInitResult:
         return MemoryInitResult(MemoryAvailability.ERROR, str(e))
 
 
-def _load_facts_for_user(user_id: str, memory_state: MemoryInitResult) -> list:
+def _load_facts_for_user(user_id: str, memory_state: MemoryInitResult) -> list[Any]:
     """Cache `get_by_tag(tag='preference')` once per run; empty list otherwise.
 
     A non-ENABLED memory state degrades stage 3b to a no-op (every
@@ -1508,9 +1517,12 @@ def _atomic_write(path: Path, content: str) -> None:
     except Exception:
         # Best-effort cleanup of the temp file on any write failure;
         # leaving it would accumulate stale .tmp files in the output
-        # directory across repeated failed runs. Also close the raw fd
-        # defensively in case os.fdopen itself raised before taking
-        # ownership - otherwise the descriptor leaks.
+        # directory across repeated failed runs. The os.close(fd) call
+        # covers the narrow window where os.fdopen raised before taking
+        # ownership of the raw fd from mkstemp; in the common case
+        # (os.fdopen succeeded, the with-block already closed the fd,
+        # then os.replace failed) this os.close is a no-op that raises
+        # EBADF, which the inner OSError handler intentionally swallows.
         try:
             os.close(fd)
         except OSError:

--- a/src/kai/eval/friction.py
+++ b/src/kai/eval/friction.py
@@ -882,23 +882,26 @@ def _detect_repeated_fact(records: list[HistoryRecord], data_dir: Path) -> list[
     # Cache shingles only for fact-shape user records; non-fact-shape
     # priors don't qualify as a comparison target (the prior record
     # must itself be a fact-shape match), so there's no point building
-    # their shingle sets. Bounded by the lookback window (see eviction
-    # below), so peak memory is O(_REPEAT_LOOKBACK) entries regardless
-    # of total history length.
+    # their shingle sets. With the eviction below running on every
+    # user record (not just fact-shape ones), peak memory is bounded
+    # at most _REPEAT_LOOKBACK + 1 entries regardless of total
+    # history length.
     shingle_cache: dict[int, set[str]] = {}
     events: list[FrictionEvent] = []
     for pos, idx in enumerate(user_indices):
+        # Evict the entry that just fell out of the lookback window;
+        # nothing later in the loop can read it. This runs BEFORE the
+        # fact-shape check so the eviction fires once per user record
+        # rather than once per fact-shape record - otherwise sparse
+        # fact-shape histories would skip the eviction step on most
+        # iterations and let the cache grow unbounded.
+        evict_pos = pos - _REPEAT_LOOKBACK - 1
+        if evict_pos >= 0:
+            shingle_cache.pop(user_indices[evict_pos], None)
         record = records[idx]
         if not _FACT_SHAPE_RE.search(record.text):
             continue
         shingle_cache[idx] = _shingles(record.text)
-        # Evict the entry that just fell out of the lookback window;
-        # nothing later in the loop can read it. Without this the cache
-        # grows unbounded across a long history, even though only the
-        # last _REPEAT_LOOKBACK entries are ever touched.
-        evict_pos = pos - _REPEAT_LOOKBACK - 1
-        if evict_pos >= 0:
-            shingle_cache.pop(user_indices[evict_pos], None)
         # Walk priors most-recent-first; break on the first qualifying
         # match so the cited prior is the closest in time.
         start = max(0, pos - _REPEAT_LOOKBACK)

--- a/src/kai/eval/friction.py
+++ b/src/kai/eval/friction.py
@@ -976,8 +976,8 @@ def _classify_band(prior: float, new: float) -> str:
       - flat: 0.85 * prior < new <= 1.15 * prior (open lower, closed upper)
       - up:   new > 1.15 * prior
 
-    Zero-prior is handled by the caller via _band_for_transition; this
-    helper assumes prior > 0. Tests that exercise the `unclassified`
+    Zero-prior is handled inline by `classify_trend`; this helper
+    assumes prior > 0. Tests that exercise the `unclassified`
     catch-all monkey-patch this helper to return a sentinel value
     outside `{drop, flat, up}`, then assert the classifier emits
     `unclassified` with the correct narrative.
@@ -1015,28 +1015,11 @@ _BAND_DESCRIPTIONS = {
 }
 
 
-def _band_for_transition(prior: float, new: float) -> tuple[str, bool]:
-    """Compute band with zero-prior fallback.
-
-    Returns (band_label, undefined_ratio). When prior=0 + new>0, the
-    band falls back to "up" AND the caller is expected to record a
-    zero-prior-rate caveat AND emit JSON `null` for the ratio.
-    `undefined_ratio` is True only in that case; (0, 0) gives ("flat",
-    False) since the ratio is reported as 1.0 by convention.
-    """
-    if prior == 0 and new == 0:
-        return "flat", False
-    if prior == 0 and new > 0:
-        return "up", True
-    return _classify_band(prior, new), False
-
-
 def classify_trend(
     *,
     aggregates: list[BucketAggregate],
     events: list[FrictionEvent],
     user_turns: dict[str, int],
-    memory_state: MemoryAvailability,
 ) -> TrendSummary:
     """Compute the trend classification + narrative for one run.
 
@@ -1525,7 +1508,13 @@ def _atomic_write(path: Path, content: str) -> None:
     except Exception:
         # Best-effort cleanup of the temp file on any write failure;
         # leaving it would accumulate stale .tmp files in the output
-        # directory across repeated failed runs.
+        # directory across repeated failed runs. Also close the raw fd
+        # defensively in case os.fdopen itself raised before taking
+        # ownership - otherwise the descriptor leaks.
+        try:
+            os.close(fd)
+        except OSError:
+            pass
         if temp_path.exists():
             try:
                 temp_path.unlink()
@@ -1678,7 +1667,6 @@ async def _run_cli(args: argparse.Namespace, run_started_at_utc: datetime) -> in
         aggregates=aggregates,
         events=events,
         user_turns=user_turns,
-        memory_state=memory_state.availability,
     )
     report = _build_report(
         config=config,

--- a/src/kai/eval/friction.py
+++ b/src/kai/eval/friction.py
@@ -338,7 +338,7 @@ class HistoryRecord:
     direction: str
     chat_id: int
     text: str
-    media: dict | None
+    media: dict[str, Any] | None
     source_path: str
     line_no: int
 
@@ -1265,7 +1265,7 @@ def _redact_text(text: str) -> str:
     return out[:_SNIPPET_MAX_CHARS]
 
 
-def _build_event_payload(event: FrictionEvent, *, include_snippets: bool) -> dict:
+def _build_event_payload(event: FrictionEvent, *, include_snippets: bool) -> dict[str, Any]:
     """Produce the JSON-serializable dict for one event.
 
     `metadata=dict(event.metadata)` is the load-bearing conversion from
@@ -1287,7 +1287,7 @@ def _build_event_payload(event: FrictionEvent, *, include_snippets: bool) -> dic
     }
 
 
-def _build_bucket_payload(records: list[HistoryRecord]) -> list[dict]:
+def _build_bucket_payload(records: list[HistoryRecord]) -> list[dict[str, Any]]:
     """Per-bucket volume rows for the JSON `buckets` block.
 
     `messages_total` counts every record (user + assistant + media);
@@ -1302,7 +1302,7 @@ def _build_bucket_payload(records: list[HistoryRecord]) -> list[dict]:
         messages_total[bucket] += 1
         if record.direction == "user":
             user_turns[bucket] += 1
-    payload: list[dict] = []
+    payload: list[dict[str, Any]] = []
     for bucket in _BUCKETS:
         payload.append(
             {
@@ -1376,7 +1376,7 @@ def _build_report(
     trend: TrendSummary,
     memory_state: MemoryInitResult,
     sample_cutoff_utc: datetime | None,
-) -> dict:
+) -> dict[str, Any]:
     """Produce the top-level JSON report dict.
 
     Events are sorted by `(timestamp_utc, message_id)` so the JSON is
@@ -1441,12 +1441,12 @@ def _json_default(obj: Any) -> Any:
     raise TypeError(f"unserializable: {type(obj).__name__}")
 
 
-def _render_json(report: dict) -> str:
+def _render_json(report: dict[str, Any]) -> str:
     """Serialize the report dict; pretty-printed for human review."""
     return json.dumps(report, indent=2, ensure_ascii=False, default=_json_default)
 
 
-def _render_markdown(report: dict, trend: TrendSummary) -> str:
+def _render_markdown(report: dict[str, Any], trend: TrendSummary) -> str:
     """Build the redacted markdown summary suitable for paste-into-issue.
 
     Always redacts surface text regardless of `--include-snippets` (the

--- a/src/kai/eval/friction.py
+++ b/src/kai/eval/friction.py
@@ -574,11 +574,24 @@ def read_history(data_dir: Path, user_id: str) -> Iterator[HistoryRecord]:
                     parse_reason,
                     ts_raw[:80] if isinstance(ts_raw, str) else "",
                 )
+            # Production JSONL always has integer chat_id, but a hand-
+            # edited or corrupted row could carry a non-numeric value.
+            # Skip the line rather than aborting the run; the docstring
+            # promises malformed rows do not crash the harness.
+            try:
+                chat_id_value = int(row.get("chat_id") or 0)
+            except (TypeError, ValueError):
+                log.debug(
+                    "friction.timestamp_skip path=%s line=%d reason=chat_id_not_integer",
+                    path,
+                    line_no,
+                )
+                continue
             yield HistoryRecord(
                 ts_utc=ts_utc,
                 ts_raw=ts_raw if isinstance(ts_raw, str) else "",
                 direction=str(row.get("dir") or ""),
-                chat_id=int(row.get("chat_id") or 0),
+                chat_id=chat_id_value,
                 text=str(row.get("text") or ""),
                 media=row.get("media") if isinstance(row.get("media"), dict) else None,
                 source_path=str(path),

--- a/tests/test_eval_friction.py
+++ b/tests/test_eval_friction.py
@@ -436,10 +436,12 @@ class TestKaiAsksBackSignal:
                     line_no=n + 1,
                 )
             )
-        # The single matching prior is at position 21; the assistant
-        # question lands at position 42 (21 + 21 fillers between them),
-        # so the matching prior is exactly one slot OUTSIDE the 20-record
-        # lookback window.
+        # After the insert, the layout is: indices 0-20 (21 noise),
+        # index 21 (matching prior), indices 22-42 (21 more noise),
+        # index 43 (assistant question). The matching prior is 22
+        # slots back from the assistant; the 20-record lookback
+        # window covers indices 23-42, so the prior at index 21 is
+        # 2 slots outside the window.
         records.insert(
             21,
             HistoryRecord(

--- a/tests/test_eval_friction.py
+++ b/tests/test_eval_friction.py
@@ -655,6 +655,26 @@ class TestKnownFactOverlap:
         events = _detect_preference_correction([self._correction_record(tmp_path)], tmp_path, facts=[fact])
         assert events[0].metadata["known_fact_overlap"] is False
 
+    def test_fact_with_empty_created_at_excluded(self, tmp_path: Path):
+        # Third of the three mandated exclusion paths: empty-string
+        # created_at. Production handles this via `if not value: return
+        # None` in _parse_fact_created_at, which collapses both None and
+        # "" to the same exclusion path. We assert the empty case
+        # explicitly so a future refactor that swaps the falsy check for
+        # `if value is None` cannot silently regress: the unparseable
+        # test would still pass (independent try/except branch) and the
+        # after-correction test would still pass (never reaches the
+        # empty-string branch), making this the only guard against the
+        # None-vs-falsy slip.
+        fact = _FakeFact(
+            id="f1",
+            text="user prefers postgres docker container deployment",
+            created_at="",
+        )
+        events = _detect_preference_correction([self._correction_record(tmp_path)], tmp_path, facts=[fact])
+        assert events[0].metadata["known_fact_overlap"] is False
+        assert events[0].metadata["overlapping_fact_ids"] == ()
+
     def test_multiple_overlapping_facts_all_in_overlapping_fact_ids(self, tmp_path: Path):
         # Two facts both overlap and both predate the correction; both
         # IDs must appear in the metadata tuple (no first-match break).

--- a/tests/test_eval_friction.py
+++ b/tests/test_eval_friction.py
@@ -221,6 +221,21 @@ class TestHistoryReader:
         out = [r.text for r in read_history(tmp_path, "u1")]
         assert out == ["good"]
 
+    def test_non_integer_chat_id_skipped_not_aborted(self, tmp_path: Path):
+        # A row with a non-numeric chat_id is valid JSON, so the parse
+        # guard above lets it through; the int() cast must not crash
+        # the run. The docstring promises malformed rows do not abort.
+        history_dir = tmp_path / "history" / "u1"
+        history_dir.mkdir(parents=True)
+        bad = {"ts": _IN_B, "dir": "user", "chat_id": "corrupted", "text": "bad"}
+        good = _user_msg(_IN_B, "good")
+        (history_dir / "2026-04-18.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in (bad, good)) + "\n",
+            encoding="utf-8",
+        )
+        out = [r.text for r in read_history(tmp_path, "u1")]
+        assert out == ["good"]
+
 
 # ── TestBucketAssignment ────────────────────────────────────────────
 
@@ -466,7 +481,10 @@ class TestKaiAsksBackSignal:
         events = _detect_kai_asks_back(records, tmp_path)
         # Window covers the 20 most recent priors before the assistant
         # record; the matching prior is 22 slots back, outside the cap.
-        assert events == [] or all("outside.jsonl" not in mid for ev in events for mid in ev.context_message_ids)
+        # The disjunctive form would mask a future regression (any
+        # event from any other source would still pass), so assert
+        # no events fire at all.
+        assert events == []
 
     def test_question_mark_detector_handles_closers(self):
         # A question wrapped in quotes ("...?") still counts as a

--- a/tests/test_eval_friction.py
+++ b/tests/test_eval_friction.py
@@ -1,0 +1,1541 @@
+"""
+Tests for src/kai/eval/friction.py (Layer 3 longitudinal friction analysis).
+
+The friction harness reads chat history from `data_dir/history/<user_id>/`
+directly via its own `--data-dir` argument; the autouse
+`_isolate_history_dir` fixture at tests/conftest.py:65-81 only redirects
+WRITES from `kai.history.log_message` and does NOT cover this read path.
+Every test that needs history data therefore writes via the local
+`_write_history` helper below and passes `tmp_path` as `--data-dir`
+explicitly. Removing the explicit `--data-dir` would silently fall back
+to the production `KAI_DATA_DIR`, which is exactly the contamination
+this fixture exists to prevent for OTHER test paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import MappingProxyType
+
+import pytest
+
+from kai.eval import friction
+from kai.eval.friction import (
+    _BAD_TS_SENTINEL,
+    _BUCKET_ANCHORS,
+    _FRUSTRATION_PHRASES,
+    _MATERIAL_DROP_RATIO,
+    _PREDICTED_PATTERN,
+    _SIGNAL_FAMILIES,
+    _UP_RATIO,
+    _USER_TURN_FLOOR,
+    BucketAggregate,
+    FrictionEvent,
+    HistoryRecord,
+    MemoryAvailability,
+    MemoryInitResult,
+    _classify_band,
+    _classify_bucket,
+    _content_words,
+    _detect_frustration,
+    _detect_kai_asks_back,
+    _detect_preference_correction,
+    _detect_repeated_fact,
+    _ends_with_question_mark,
+    _non_negative_int,
+    _parse_record_timestamp,
+    _redact_text,
+    _validate_user_id,
+    aggregate,
+    classify_trend,
+    detect_events,
+    main,
+    read_history,
+)
+
+# ── Test helpers ────────────────────────────────────────────────────
+
+
+def _write_history(tmp_path: Path, user_id: str, records: list[dict]) -> Path:
+    """Build a synthetic history/<user_id>/ tree under tmp_path.
+
+    Records are grouped by UTC date into YYYY-MM-DD.jsonl files, matching
+    the on-disk scheme at src/kai/history.py:67, 75. Returns the data_dir
+    root (tmp_path), which is what the harness receives via --data-dir.
+
+    The helper is local to this module by convention; behavioral.py's
+    inline pattern at tests/test_eval_behavioral.py:1129-1176 is the
+    reference shape but was deliberately not extracted to a shared
+    fixture - keeping the helper here avoids a production-side refactor.
+    """
+    history_dir = tmp_path / "history" / user_id
+    history_dir.mkdir(parents=True, exist_ok=True)
+    by_date: dict[str, list[dict]] = {}
+    for rec in records:
+        ts = rec.get("ts", "")
+        date_part = ts[:10] if isinstance(ts, str) and len(ts) >= 10 else "0001-01-01"
+        by_date.setdefault(date_part, []).append(rec)
+    for date_str, day_records in by_date.items():
+        path = history_dir / f"{date_str}.jsonl"
+        path.write_text(
+            "\n".join(json.dumps(r) for r in day_records) + "\n",
+            encoding="utf-8",
+        )
+    return tmp_path
+
+
+def _user_msg(ts: str, text: str, chat_id: int = 1) -> dict:
+    """Shorthand: a user-direction JSONL row with the given ts and text."""
+    return {"ts": ts, "dir": "user", "chat_id": chat_id, "text": text}
+
+
+def _bot_msg(ts: str, text: str, chat_id: int = 1) -> dict:
+    """Shorthand: an assistant-direction JSONL row with the given ts and text."""
+    return {"ts": ts, "dir": "assistant", "chat_id": chat_id, "text": text}
+
+
+@dataclass
+class _FakeFact:
+    """Stand-in for kai.memory.MemoryResult with the three fields stage 3b reads.
+
+    The detector accesses fields via getattr so this minimal shape is
+    sufficient; using a real MemoryResult would force constructing the
+    full Mem0 metadata dict which has nothing to do with what stage 3b
+    actually exercises (id, text, created_at).
+    """
+
+    id: str
+    text: str
+    created_at: str
+
+
+def _make_aggregates(rates: dict[str, dict[str, float]]) -> list[BucketAggregate]:
+    """Build a BucketAggregate list from a {bucket: {signal: rate}} mapping.
+
+    Sets user_turns_in_bucket=100 so the per-100 rate equals the
+    literal rate input; the classifier reads only the rate field for
+    its band math, so the count / user_turns choice here is cosmetic.
+    Missing (bucket, family) cells default to 0.0.
+    """
+    out: list[BucketAggregate] = []
+    for bucket in ("A", "B", "C"):
+        for family in _SIGNAL_FAMILIES:
+            rate = rates.get(bucket, {}).get(family, 0.0)
+            out.append(
+                BucketAggregate(
+                    bucket_label=bucket,
+                    signal_family=family,
+                    count=int(rate),
+                    user_turns_in_bucket=100,
+                    rate_per_100_user_turns=rate,
+                )
+            )
+    return out
+
+
+# Anchor-relative datetime helpers; tests reference offsets from the
+# milestone anchors so the synthetic records always land in the
+# intended bucket regardless of the absolute calendar dates.
+_BEFORE_A = (_BUCKET_ANCHORS[0] - timedelta(days=10)).isoformat()  # bucket A
+_IN_B = (_BUCKET_ANCHORS[0] + timedelta(hours=1)).isoformat()  # bucket B
+_IN_C = (_BUCKET_ANCHORS[1] + timedelta(hours=1)).isoformat()  # bucket C
+
+
+# ── TestHistoryReader ───────────────────────────────────────────────
+
+
+class TestHistoryReader:
+    """Round-trip behaviour of read_history against synthetic JSONL trees."""
+
+    def test_empty_directory_returns_empty_iterator(self, tmp_path: Path):
+        # A data_dir with no history/ subtree is a valid input shape; the
+        # iterator yields nothing rather than raising. This is the path a
+        # fresh operator hits before any chat traffic exists.
+        assert list(read_history(tmp_path, "u1")) == []
+
+    def test_missing_user_returns_empty_iterator(self, tmp_path: Path):
+        # history/ exists but no <user_id>/ subdir. Empty iterator with
+        # no log noise; the harness keeps running and emits a zero-count
+        # report (matches the "no crash on empty history" acceptance shape).
+        (tmp_path / "history").mkdir()
+        assert list(read_history(tmp_path, "u1")) == []
+
+    def test_malformed_json_line_skipped(self, tmp_path: Path):
+        # Mirror the behaviour at src/kai/history.py:136-153: a single
+        # bad line does not abort parsing; surrounding good lines still
+        # land in the record list.
+        history_dir = tmp_path / "history" / "u1"
+        history_dir.mkdir(parents=True)
+        rows = [
+            json.dumps(_user_msg(_IN_B, "good before")),
+            "{not valid json",
+            "",
+            json.dumps(_user_msg(_IN_B, "good after")),
+        ]
+        (history_dir / "2026-04-18.jsonl").write_text("\n".join(rows), encoding="utf-8")
+        out = list(read_history(tmp_path, "u1"))
+        assert [r.text for r in out] == ["good before", "good after"]
+
+    def test_bad_timestamp_routes_to_sentinel(self, tmp_path: Path):
+        # Missing/empty/unparseable ts -> _BAD_TS_SENTINEL.
+        # Sentinel is year 1 so bucket assignment routes the record to
+        # A without a special branch (verified separately in
+        # TestBucketAssignment).
+        _write_history(
+            tmp_path,
+            "u1",
+            [
+                {"ts": "", "dir": "user", "chat_id": 1, "text": "no ts"},
+                {"ts": "not-iso", "dir": "user", "chat_id": 1, "text": "bad ts"},
+            ],
+        )
+        out = list(read_history(tmp_path, "u1"))
+        assert all(r.ts_utc == _BAD_TS_SENTINEL for r in out)
+
+    def test_multiple_files_concatenated_in_sorted_order(self, tmp_path: Path):
+        # Production history rotates daily; the reader stitches all
+        # YYYY-MM-DD.jsonl files in lexicographic order so chronological
+        # ordering is preserved without any per-record sort.
+        history_dir = tmp_path / "history" / "u1"
+        history_dir.mkdir(parents=True)
+        (history_dir / "2026-04-18.jsonl").write_text(json.dumps(_user_msg(_IN_B, "from-18")) + "\n", encoding="utf-8")
+        (history_dir / "2026-04-19.jsonl").write_text(json.dumps(_user_msg(_IN_B, "from-19")) + "\n", encoding="utf-8")
+        out = [r.text for r in read_history(tmp_path, "u1")]
+        assert out == ["from-18", "from-19"]
+
+    def test_non_object_json_lines_skipped(self, tmp_path: Path):
+        # A top-level JSON array or string is structurally invalid but
+        # might appear from a hand-edit; the parser must not call .get
+        # on a non-dict and must skip silently.
+        history_dir = tmp_path / "history" / "u1"
+        history_dir.mkdir(parents=True)
+        rows = [
+            json.dumps(["not", "a", "row"]),
+            json.dumps(_user_msg(_IN_B, "good")),
+        ]
+        (history_dir / "2026-04-18.jsonl").write_text("\n".join(rows), encoding="utf-8")
+        out = [r.text for r in read_history(tmp_path, "u1")]
+        assert out == ["good"]
+
+
+# ── TestBucketAssignment ────────────────────────────────────────────
+
+
+class TestBucketAssignment:
+    """Boundary semantics for the milestone-bucket classifier."""
+
+    def test_record_at_anchor_a_lands_in_b(self):
+        # Bucket B is [anchor_A, anchor_B). Inclusive lower bound
+        # means a record at exactly anchor_A is the first row of B.
+        assert _classify_bucket(_BUCKET_ANCHORS[0]) == "B"
+
+    def test_record_just_before_anchor_a_lands_in_a(self):
+        # One microsecond before anchor_A is still bucket A; this nails
+        # the exclusive upper bound on A.
+        ts = _BUCKET_ANCHORS[0] - timedelta(microseconds=1)
+        assert _classify_bucket(ts) == "A"
+
+    def test_record_at_anchor_b_lands_in_c(self):
+        # Same inclusive-lower contract for bucket C.
+        assert _classify_bucket(_BUCKET_ANCHORS[1]) == "C"
+
+    def test_record_just_before_anchor_b_lands_in_b(self):
+        ts = _BUCKET_ANCHORS[1] - timedelta(microseconds=1)
+        assert _classify_bucket(ts) == "B"
+
+    def test_bad_timestamp_sentinel_routes_to_a(self):
+        # Bad timestamps land in the oldest bucket by design; the
+        # sentinel is year 1, strictly older than anchor_A.
+        assert _classify_bucket(_BAD_TS_SENTINEL) == "A"
+
+
+# ── TestFrustrationSignal ───────────────────────────────────────────
+
+
+class TestFrustrationSignal:
+    """Signal 1 detection: operator-side frustration markers."""
+
+    @pytest.mark.parametrize("phrase", list(_FRUSTRATION_PHRASES))
+    def test_each_phrase_emits_exactly_one_event(self, phrase: str, tmp_path: Path):
+        # Pre-committed phrase set; every phrase must trigger the
+        # detector or the lock-it-before-running promise is broken.
+        records = [
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(hours=1),
+                ts_raw=_IN_B,
+                direction="user",
+                chat_id=1,
+                text=f"hey {phrase} about that",
+                media=None,
+                source_path=str(tmp_path / "history" / "u1" / "2026-04-18.jsonl"),
+                line_no=1,
+            )
+        ]
+        events = _detect_frustration(records, tmp_path)
+        assert len(events) == 1
+        assert events[0].signal_family == "frustration"
+
+    def test_assistant_messages_never_flagged(self, tmp_path: Path):
+        # Frustration is operator-side only; the same phrase from the
+        # assistant must not register, otherwise Kai's own apologetic
+        # boilerplate would inflate the rate.
+        records = [
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(hours=1),
+                ts_raw=_IN_B,
+                direction="assistant",
+                chat_id=1,
+                text="i already told you the answer",
+                media=None,
+                source_path=str(tmp_path / "h.jsonl"),
+                line_no=1,
+            )
+        ]
+        assert _detect_frustration(records, tmp_path) == []
+
+    def test_case_insensitive_matching(self, tmp_path: Path):
+        # Telegram autocorrect capitalizes message starts; without
+        # case-insensitive matching every "I told you" would silently
+        # miss. The detector lowercases before substring match.
+        records = [
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(hours=1),
+                ts_raw=_IN_B,
+                direction="user",
+                chat_id=1,
+                text="I TOLD YOU about the bug",
+                media=None,
+                source_path=str(tmp_path / "h.jsonl"),
+                line_no=1,
+            )
+        ]
+        assert len(_detect_frustration(records, tmp_path)) == 1
+
+    def test_multiple_phrases_in_one_message_emit_one_event(self, tmp_path: Path):
+        # One message containing two phrases must NOT emit two events
+        # (the inner break enforces this); double-counting would distort
+        # per-bucket rates on operators with a verbose vent style.
+        records = [
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(hours=1),
+                ts_raw=_IN_B,
+                direction="user",
+                chat_id=1,
+                text="i told you and i already told you",
+                media=None,
+                source_path=str(tmp_path / "h.jsonl"),
+                line_no=1,
+            )
+        ]
+        assert len(_detect_frustration(records, tmp_path)) == 1
+
+
+# ── TestKaiAsksBackSignal ───────────────────────────────────────────
+
+
+class TestKaiAsksBackSignal:
+    """Signal 2 detection: Kai asking for information already provided."""
+
+    @staticmethod
+    def _records_for_overlap(tmp_path: Path, prior_text: str, question_text: str):
+        # Build a 2-record window: prior user message then assistant
+        # question. Used by overlap-floor tests; keeps the construction
+        # noise out of the test bodies.
+        return [
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(hours=1),
+                ts_raw=_IN_B,
+                direction="user",
+                chat_id=1,
+                text=prior_text,
+                media=None,
+                source_path=str(tmp_path / "h.jsonl"),
+                line_no=1,
+            ),
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(hours=2),
+                ts_raw=_IN_B,
+                direction="assistant",
+                chat_id=1,
+                text=question_text,
+                media=None,
+                source_path=str(tmp_path / "h.jsonl"),
+                line_no=2,
+            ),
+        ]
+
+    def test_assistant_question_with_3_overlap_emits(self, tmp_path: Path):
+        # Three substantive shared content-words crosses the floor; the
+        # detector emits one event citing the prior user message.
+        records = self._records_for_overlap(
+            tmp_path,
+            "deployment uses postgres docker container",
+            "what database deployment container does postgres use?",
+        )
+        events = _detect_kai_asks_back(records, tmp_path)
+        assert len(events) == 1
+        assert events[0].signal_family == "kai_asks_back"
+        assert len(events[0].context_message_ids) == 1
+
+    def test_assistant_question_with_2_overlap_does_not_emit(self, tmp_path: Path):
+        # Two shared content-words is below the floor; no event.
+        # Calibrated to keep generic "what about that" clarifications
+        # from being miscounted as memory misses.
+        records = self._records_for_overlap(
+            tmp_path,
+            "deployment uses postgres",
+            "what database deployment uses?",
+        )
+        assert _detect_kai_asks_back(records, tmp_path) == []
+
+    def test_assistant_message_without_question_mark_skipped(self, tmp_path: Path):
+        # The signal requires a literal "?" ending; a declarative
+        # response that happens to share content words must not register.
+        records = self._records_for_overlap(
+            tmp_path,
+            "deployment uses postgres docker container",
+            "the database deployment container is postgres",
+        )
+        assert _detect_kai_asks_back(records, tmp_path) == []
+
+    def test_window_excludes_records_beyond_lookback(self, tmp_path: Path):
+        # The lookback window is records[max(0, i-20):i]. The 21st prior
+        # is OUTSIDE the window and must not be cited even if it shares
+        # all content-words with the assistant question.
+        records: list[HistoryRecord] = []
+        # 21 noise user records first.
+        for n in range(21):
+            records.append(
+                HistoryRecord(
+                    ts_utc=_BUCKET_ANCHORS[0] + timedelta(minutes=n),
+                    ts_raw=_IN_B,
+                    direction="user",
+                    chat_id=1,
+                    text=f"unrelated noise {n}",
+                    media=None,
+                    source_path=str(tmp_path / "h.jsonl"),
+                    line_no=n + 1,
+                )
+            )
+        # The single matching prior is at position 21; the assistant
+        # question lands at position 42 (21 + 21 fillers between them),
+        # so the matching prior is exactly one slot OUTSIDE the 20-record
+        # lookback window.
+        records.insert(
+            21,
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(minutes=21),
+                ts_raw=_IN_B,
+                direction="user",
+                chat_id=1,
+                text="deployment uses postgres docker container",
+                media=None,
+                source_path=str(tmp_path / "outside.jsonl"),
+                line_no=999,
+            ),
+        )
+        for n in range(21):
+            records.append(
+                HistoryRecord(
+                    ts_utc=_BUCKET_ANCHORS[0] + timedelta(minutes=22 + n),
+                    ts_raw=_IN_B,
+                    direction="user",
+                    chat_id=1,
+                    text=f"more noise {n}",
+                    media=None,
+                    source_path=str(tmp_path / "h.jsonl"),
+                    line_no=1000 + n,
+                )
+            )
+        records.append(
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(minutes=99),
+                ts_raw=_IN_B,
+                direction="assistant",
+                chat_id=1,
+                text="what database deployment container does postgres use?",
+                media=None,
+                source_path=str(tmp_path / "h.jsonl"),
+                line_no=2000,
+            )
+        )
+        events = _detect_kai_asks_back(records, tmp_path)
+        # Window covers the 20 most recent priors before the assistant
+        # record; the matching prior is 22 slots back, outside the cap.
+        assert events == [] or all("outside.jsonl" not in mid for ev in events for mid in ev.context_message_ids)
+
+    def test_question_mark_detector_handles_closers(self):
+        # A question wrapped in quotes ("...?") still counts as a
+        # question; the closer-stripping logic preserves common
+        # parenthesized/quoted forms.
+        assert _ends_with_question_mark("really?")
+        assert _ends_with_question_mark('really?"')
+        assert _ends_with_question_mark("really?)")
+        assert not _ends_with_question_mark("really.")
+
+
+# ── TestPreferenceCorrectionSignal ──────────────────────────────────
+
+
+class TestPreferenceCorrectionSignal:
+    """Signal 3 stage 3a: regex-based correction detection."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "don't do that",
+            "stop asking for the same thing",
+            "not that one",
+            "please use the new flag",
+            "always use snake_case",
+            "never use camelCase",
+            "instead of foo, try bar",
+            "i prefer the longer form",
+        ],
+    )
+    def test_each_correction_pattern_matches(self, text: str, tmp_path: Path):
+        # Each pre-committed regex must catch its sentinel phrase; this
+        # locks the regex set so a typo or a renamed pattern fails the
+        # test instead of silently missing in production.
+        records = [
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(hours=1),
+                ts_raw=_IN_B,
+                direction="user",
+                chat_id=1,
+                text=text,
+                media=None,
+                source_path=str(tmp_path / "h.jsonl"),
+                line_no=1,
+            )
+        ]
+        events = _detect_preference_correction(records, tmp_path, facts=[])
+        assert len(events) == 1
+        assert events[0].signal_family == "preference_correction"
+
+    def test_assistant_corrections_not_flagged(self, tmp_path: Path):
+        # Stage 3a is operator-side only; an assistant message that
+        # happens to contain "don't" must not inflate the rate.
+        records = [
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(hours=1),
+                ts_raw=_IN_B,
+                direction="assistant",
+                chat_id=1,
+                text="don't worry, i'll handle it",
+                media=None,
+                source_path=str(tmp_path / "h.jsonl"),
+                line_no=1,
+            )
+        ]
+        assert _detect_preference_correction(records, tmp_path, facts=[]) == []
+
+    def test_non_correction_text_not_flagged(self, tmp_path: Path):
+        # Plain content with no correction marker; rate stays at zero.
+        records = [
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(hours=1),
+                ts_raw=_IN_B,
+                direction="user",
+                chat_id=1,
+                text="here is some context for the next task",
+                media=None,
+                source_path=str(tmp_path / "h.jsonl"),
+                line_no=1,
+            )
+        ]
+        assert _detect_preference_correction(records, tmp_path, facts=[]) == []
+
+    def test_event_has_known_fact_overlap_false_when_no_facts(self, tmp_path: Path):
+        # No facts available -> stage 3b cannot mark any event as
+        # known-fact-overlap; metadata.known_fact_overlap MUST be False
+        # AND overlapping_fact_ids MUST be the empty tuple. This is the
+        # baseline shape the verdict-driving sum collapses against when
+        # memory is unreachable.
+        records = [
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(hours=1),
+                ts_raw=_IN_B,
+                direction="user",
+                chat_id=1,
+                text="don't do that thing again",
+                media=None,
+                source_path=str(tmp_path / "h.jsonl"),
+                line_no=1,
+            )
+        ]
+        events = _detect_preference_correction(records, tmp_path, facts=[])
+        assert events[0].metadata["known_fact_overlap"] is False
+        assert events[0].metadata["overlapping_fact_ids"] == ()
+
+
+# ── TestKnownFactOverlap ────────────────────────────────────────────
+
+
+class TestKnownFactOverlap:
+    """Signal 3 stage 3b: known-fact overlap (the verdict-driving subset)."""
+
+    @staticmethod
+    def _correction_record(tmp_path: Path):
+        # Single user record carrying enough content-words to overlap
+        # against the test facts. "deployment postgres docker container"
+        # is the shared substantive payload.
+        return HistoryRecord(
+            ts_utc=_BUCKET_ANCHORS[0] + timedelta(days=2),
+            ts_raw=_IN_B,
+            direction="user",
+            chat_id=1,
+            text="don't change the deployment postgres docker container",
+            media=None,
+            source_path=str(tmp_path / "h.jsonl"),
+            line_no=1,
+        )
+
+    def test_fact_created_before_correction_marks_known(self, tmp_path: Path):
+        # The fact predates the correction by 1 day and shares 4
+        # content-words; stage 3b must mark this as known-fact overlap.
+        fact = _FakeFact(
+            id="f1",
+            text="user prefers postgres docker container deployment",
+            created_at=(_BUCKET_ANCHORS[0] + timedelta(days=1)).isoformat(),
+        )
+        events = _detect_preference_correction([self._correction_record(tmp_path)], tmp_path, facts=[fact])
+        assert events[0].metadata["known_fact_overlap"] is True
+        assert events[0].metadata["overlapping_fact_ids"] == ("f1",)
+
+    def test_fact_created_after_correction_excluded(self, tmp_path: Path):
+        # Stage 3b's time-comparison rule: a fact whose created_at is
+        # AFTER the correction cannot have grounded the operator's
+        # frustration; including it would inflate the verdict-driving
+        # sum with retro-extracted facts.
+        fact = _FakeFact(
+            id="f1",
+            text="user prefers postgres docker container deployment",
+            created_at=(_BUCKET_ANCHORS[0] + timedelta(days=5)).isoformat(),
+        )
+        events = _detect_preference_correction([self._correction_record(tmp_path)], tmp_path, facts=[fact])
+        assert events[0].metadata["known_fact_overlap"] is False
+        assert events[0].metadata["overlapping_fact_ids"] == ()
+
+    def test_fact_with_unparseable_created_at_excluded(self, tmp_path: Path):
+        # Conservative: "we don't know when this fact was written, so
+        # we can't claim it pre-existed the correction." The known-fact
+        # overlap detector deliberately does NOT fall back to updated_at.
+        fact = _FakeFact(
+            id="f1",
+            text="user prefers postgres docker container deployment",
+            created_at="not-a-timestamp",
+        )
+        events = _detect_preference_correction([self._correction_record(tmp_path)], tmp_path, facts=[fact])
+        assert events[0].metadata["known_fact_overlap"] is False
+
+    def test_multiple_overlapping_facts_all_in_overlapping_fact_ids(self, tmp_path: Path):
+        # Two facts both overlap and both predate the correction; both
+        # IDs must appear in the metadata tuple (no first-match break).
+        f1 = _FakeFact(
+            id="f1",
+            text="user prefers postgres docker container deployment",
+            created_at=(_BUCKET_ANCHORS[0] + timedelta(hours=1)).isoformat(),
+        )
+        f2 = _FakeFact(
+            id="f2",
+            text="postgres docker container deployment is canonical",
+            created_at=(_BUCKET_ANCHORS[0] + timedelta(hours=2)).isoformat(),
+        )
+        events = _detect_preference_correction([self._correction_record(tmp_path)], tmp_path, facts=[f1, f2])
+        assert set(events[0].metadata["overlapping_fact_ids"]) == {"f1", "f2"}
+
+
+# ── TestRepeatedFactSignal ──────────────────────────────────────────
+
+
+class TestRepeatedFactSignal:
+    """Signal 4: repeated fact-shape statements via Jaccard on shingles."""
+
+    @staticmethod
+    def _fact_shape_records(tmp_path: Path, *texts: str):
+        # All records are user-direction with consecutive timestamps so
+        # the Jaccard comparison walks them as a single conversation.
+        out = []
+        for n, text in enumerate(texts):
+            out.append(
+                HistoryRecord(
+                    ts_utc=_BUCKET_ANCHORS[0] + timedelta(minutes=n),
+                    ts_raw=_IN_B,
+                    direction="user",
+                    chat_id=1,
+                    text=text,
+                    media=None,
+                    source_path=str(tmp_path / "h.jsonl"),
+                    line_no=n + 1,
+                )
+            )
+        return out
+
+    def test_jaccard_above_threshold_emits(self, tmp_path: Path):
+        # Two near-identical fact-shape statements; shingle overlap is
+        # well above the 0.4 floor. The second statement is the repeat;
+        # only it emits an event citing the first as context.
+        records = self._fact_shape_records(
+            tmp_path,
+            "i prefer postgres docker container deployment",
+            "i prefer postgres docker container deployment as before",
+        )
+        events = _detect_repeated_fact(records, tmp_path)
+        assert len(events) == 1
+        assert events[0].signal_family == "repeated_fact"
+        assert events[0].context_message_ids  # invariant: every event has non-empty context
+
+    def test_non_fact_shape_records_never_flagged(self, tmp_path: Path):
+        # Both records are paraphrases but neither matches the
+        # _FACT_SHAPE_RE prefix set; the detector does not flag them
+        # even though their Jaccard would clear the floor.
+        records = self._fact_shape_records(
+            tmp_path,
+            "the weather is nice today and clear and sunny",
+            "the weather is nice today and clear and sunny",
+        )
+        assert _detect_repeated_fact(records, tmp_path) == []
+
+    def test_first_occurrence_never_flagged(self, tmp_path: Path):
+        # A standalone fact-shape statement with no prior cannot emit;
+        # this preserves the harness invariant that every emitted event
+        # has a non-empty context_message_ids tuple.
+        records = self._fact_shape_records(tmp_path, "i prefer postgres docker container deployment")
+        assert _detect_repeated_fact(records, tmp_path) == []
+
+    def test_unrelated_fact_shape_pair_not_flagged(self, tmp_path: Path):
+        # Two fact-shape statements that share NO shingles must not
+        # emit; otherwise every "i ..." sentence would inflate the
+        # repeated_fact rate.
+        records = self._fact_shape_records(
+            tmp_path,
+            "i prefer postgres for analytics workloads",
+            "my deployment runs on kubernetes nodes",
+        )
+        assert _detect_repeated_fact(records, tmp_path) == []
+
+
+# ── TestNormalization ───────────────────────────────────────────────
+
+
+class TestNormalization:
+    """Per-100-user-turns rate math under normal and edge inputs."""
+
+    def test_zero_user_turns_returns_zero_not_nan(self, tmp_path: Path):
+        # A bucket with zero user_turns has rate 0.0 (NOT NaN);
+        # NaN would break JSON serialization downstream.
+        aggregates, _ = aggregate(records=[], events=[])
+        for agg in aggregates:
+            assert agg.rate_per_100_user_turns == 0.0
+
+    def test_two_decimal_place_rounding(self):
+        # 1 frustration event over 3 user-turns -> 33.33333... -> 33.33.
+        records = [
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(hours=1),
+                ts_raw=_IN_B,
+                direction="user",
+                chat_id=1,
+                text=f"u{n}",
+                media=None,
+                source_path="x",
+                line_no=n,
+            )
+            for n in range(3)
+        ]
+        ev = FrictionEvent(
+            timestamp_utc=records[0].ts_utc,
+            bucket_label="B",
+            signal_family="frustration",
+            message_id="x:1",
+            surface_text="x",
+            context_message_ids=(),
+            metadata=MappingProxyType({}),
+        )
+        aggregates, _ = aggregate(records, [ev])
+        b_frustration = next(a for a in aggregates if a.bucket_label == "B" and a.signal_family == "frustration")
+        assert b_frustration.rate_per_100_user_turns == 33.33
+
+    def test_user_turn_denominator_excludes_assistant_messages(self):
+        # The denominator MUST be user_turns, not messages_total. An
+        # assistant-heavy bucket would otherwise dilute the rate.
+        records = [
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(hours=1),
+                ts_raw=_IN_B,
+                direction="user",
+                chat_id=1,
+                text="u1",
+                media=None,
+                source_path="x",
+                line_no=1,
+            ),
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(hours=2),
+                ts_raw=_IN_B,
+                direction="assistant",
+                chat_id=1,
+                text="bot1",
+                media=None,
+                source_path="x",
+                line_no=2,
+            ),
+        ]
+        _, user_turns = aggregate(records, [])
+        assert user_turns["B"] == 1
+
+
+# ── TestOutputDeterminism ───────────────────────────────────────────
+
+
+class _FakeNow:
+    """Subclass-of-datetime sentinel for monkey-patching `datetime.now`.
+
+    Subclassing (not Mock) so the module's other datetime usage
+    (fromisoformat, constructor calls) keeps working; only `.now` is
+    overridden. The convention is pytest monkeypatch of the module's
+    datetime reference rather than a hidden CLI flag that would only
+    run in tests.
+    """
+
+    @classmethod
+    def now(cls, tz=None):
+        return datetime(2026, 4, 23, 14, 0, 0, tzinfo=tz or UTC)
+
+    def __new__(cls, *args, **kwargs):
+        return datetime(*args, **kwargs)
+
+
+class _FakeDatetime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        # Pinned reference time; same return value across runs makes the
+        # JSON's generated_at_utc field byte-stable for determinism tests.
+        return datetime(2026, 4, 23, 14, 0, 0, tzinfo=tz or UTC)
+
+
+class TestOutputDeterminism:
+    """Byte-stability of JSON output across runs against a fixed input."""
+
+    def _run_once(self, tmp_path: Path, output_name: str, monkeypatch) -> str:
+        # Helper: write a tiny synthetic history, run the harness, and
+        # return the raw JSON file contents. Two consecutive calls must
+        # produce byte-identical strings (determinism contract).
+        _write_history(
+            tmp_path,
+            "u1",
+            [
+                _user_msg(_BEFORE_A, "old context message"),
+                _user_msg(_IN_B, "i told you about that bug"),
+                _user_msg(_IN_C, "don't change the deploy script"),
+            ],
+        )
+        monkeypatch.setattr("kai.eval.friction.datetime", _FakeDatetime)
+        monkeypatch.setattr(
+            "kai.eval.friction._initialize_memory_local",
+            lambda: MemoryInitResult(MemoryAvailability.DISABLED, None),
+        )
+        out = tmp_path / output_name
+        rc = main(
+            [
+                "--user-id",
+                "u1",
+                "--output",
+                str(out),
+                "--data-dir",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 0
+        return out.read_text(encoding="utf-8")
+
+    def test_same_input_produces_byte_identical_json(self, tmp_path: Path, monkeypatch):
+        a = self._run_once(tmp_path, "a.json", monkeypatch)
+        b = self._run_once(tmp_path, "b.json", monkeypatch)
+        assert a == b
+
+    def test_events_sorted_by_timestamp_then_message_id(self, tmp_path: Path, monkeypatch):
+        # Two events with the same timestamp but different message_ids;
+        # the report MUST sort them lexically by message_id so output
+        # is deterministic across runs.
+        ts = _BUCKET_ANCHORS[0] + timedelta(hours=1)
+        events = [
+            FrictionEvent(
+                timestamp_utc=ts,
+                bucket_label="B",
+                signal_family="frustration",
+                message_id="z.jsonl:1",
+                surface_text="late",
+                context_message_ids=(),
+                metadata=MappingProxyType({}),
+            ),
+            FrictionEvent(
+                timestamp_utc=ts,
+                bucket_label="B",
+                signal_family="frustration",
+                message_id="a.jsonl:1",
+                surface_text="early",
+                context_message_ids=(),
+                metadata=MappingProxyType({}),
+            ),
+        ]
+        sorted_events = sorted(events, key=lambda e: (e.timestamp_utc, e.message_id))
+        # Lexically a < z, so a.jsonl event must be first regardless of
+        # construction order.
+        assert sorted_events[0].message_id == "a.jsonl:1"
+
+
+# ── TestSurfaceTextRedaction ────────────────────────────────────────
+
+
+class TestSurfaceTextRedaction:
+    """Redaction applied when --include-snippets is set."""
+
+    def test_url_redacted(self):
+        out = _redact_text("see https://example.com/path?q=1 for details")
+        assert "<redacted-url>" in out
+        assert "https://" not in out
+
+    def test_email_redacted(self):
+        out = _redact_text("write to user@example.com please")
+        assert "<redacted-email>" in out
+        assert "@example.com" not in out
+
+    def test_handle_redacted(self):
+        out = _redact_text("ping @username about it")
+        assert "<redacted-handle>" in out
+        assert "@username" not in out
+
+    def test_phone_redacted(self):
+        out = _redact_text("call 555-123-4567 for support")
+        assert "<redacted-phone>" in out
+        assert "555-123-4567" not in out
+
+    def test_snippet_capped_at_200_chars(self):
+        # The redaction layer caps at _SNIPPET_MAX_CHARS so a long
+        # message cannot dump a full chat-log paragraph into the report.
+        long_text = "x" * 500
+        assert len(_redact_text(long_text)) == 200
+
+    def test_include_snippets_false_nulls_surface_text(self, tmp_path: Path, monkeypatch):
+        # End-to-end: default (no --include-snippets) must emit
+        # surface_text=null. Verifies the render-layer guard.
+        _write_history(
+            tmp_path,
+            "u1",
+            [_user_msg(_IN_B, "i told you that already")],
+        )
+        monkeypatch.setattr("kai.eval.friction.datetime", _FakeDatetime)
+        monkeypatch.setattr(
+            "kai.eval.friction._initialize_memory_local",
+            lambda: MemoryInitResult(MemoryAvailability.DISABLED, None),
+        )
+        out = tmp_path / "report.json"
+        main(
+            [
+                "--user-id",
+                "u1",
+                "--output",
+                str(out),
+                "--data-dir",
+                str(tmp_path),
+            ]
+        )
+        report = json.loads(out.read_text())
+        assert all(ev["surface_text"] is None for ev in report["events"])
+
+    def test_include_snippets_true_populates(self, tmp_path: Path, monkeypatch):
+        # With --include-snippets, surface_text is populated (still
+        # redacted, still capped); the operator can now diff the
+        # specific messages a signal fired on.
+        _write_history(
+            tmp_path,
+            "u1",
+            [_user_msg(_IN_B, "i told you that already")],
+        )
+        monkeypatch.setattr("kai.eval.friction.datetime", _FakeDatetime)
+        monkeypatch.setattr(
+            "kai.eval.friction._initialize_memory_local",
+            lambda: MemoryInitResult(MemoryAvailability.DISABLED, None),
+        )
+        out = tmp_path / "report.json"
+        main(
+            [
+                "--user-id",
+                "u1",
+                "--output",
+                str(out),
+                "--data-dir",
+                str(tmp_path),
+                "--include-snippets",
+            ]
+        )
+        report = json.loads(out.read_text())
+        assert any(ev["surface_text"] for ev in report["events"])
+
+
+# ── TestCLIIntegration ──────────────────────────────────────────────
+
+
+class TestCLIIntegration:
+    """Full CLI invocation against a synthetic history tree."""
+
+    def test_end_to_end_writes_json_and_markdown(self, tmp_path: Path, monkeypatch):
+        # Round-trip: history -> harness -> JSON + markdown files. Both
+        # outputs must exist and the JSON must parse.
+        _write_history(
+            tmp_path,
+            "u1",
+            [
+                _user_msg(_BEFORE_A, "context one"),
+                _user_msg(_IN_B, "i told you about that"),
+                _user_msg(_IN_C, "don't change the deploy"),
+            ],
+        )
+        monkeypatch.setattr("kai.eval.friction.datetime", _FakeDatetime)
+        monkeypatch.setattr(
+            "kai.eval.friction._initialize_memory_local",
+            lambda: MemoryInitResult(MemoryAvailability.DISABLED, None),
+        )
+        json_out = tmp_path / "report.json"
+        md_out = tmp_path / "report.md"
+        rc = main(
+            [
+                "--user-id",
+                "u1",
+                "--output",
+                str(json_out),
+                "--markdown-summary",
+                str(md_out),
+                "--data-dir",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 0
+        report = json.loads(json_out.read_text())
+        assert report["version"] == friction._OUTPUT_SCHEMA_VERSION
+        assert report["user_id"] == "u1"
+        # Markdown summary must redact the user_id literally.
+        md = md_out.read_text()
+        assert "<user_id-redacted>" in md
+        assert "u1" not in md.split("Friction analysis")[0]
+
+    def test_bad_user_id_returns_exit_code_2(self, tmp_path: Path):
+        # Invalid --user-id is an argparse-shape error; the harness
+        # must reject before any disk read.
+        rc = main(
+            [
+                "--user-id",
+                "../etc",
+                "--output",
+                str(tmp_path / "out.json"),
+                "--data-dir",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 2
+
+    def test_empty_history_produces_zero_count_report(self, tmp_path: Path, monkeypatch):
+        # No history files for the user -> zero counts everywhere, no
+        # crash. The "no history must not abort" acceptance shape.
+        monkeypatch.setattr("kai.eval.friction.datetime", _FakeDatetime)
+        monkeypatch.setattr(
+            "kai.eval.friction._initialize_memory_local",
+            lambda: MemoryInitResult(MemoryAvailability.DISABLED, None),
+        )
+        out = tmp_path / "report.json"
+        rc = main(
+            [
+                "--user-id",
+                "u1",
+                "--output",
+                str(out),
+                "--data-dir",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 0
+        report = json.loads(out.read_text())
+        assert all(agg["count"] == 0 for agg in report["aggregates"])
+
+    def test_sample_days_zero_means_today_utc(self, tmp_path: Path, monkeypatch):
+        # --sample-days 0 -> today UTC (midnight UTC of the run's day).
+        # A pre-anchor record falls outside this window and is excluded
+        # from the report.
+        _write_history(
+            tmp_path,
+            "u1",
+            [_user_msg(_BEFORE_A, "old message i told you")],
+        )
+        monkeypatch.setattr("kai.eval.friction.datetime", _FakeDatetime)
+        monkeypatch.setattr(
+            "kai.eval.friction._initialize_memory_local",
+            lambda: MemoryInitResult(MemoryAvailability.DISABLED, None),
+        )
+        out = tmp_path / "report.json"
+        rc = main(
+            [
+                "--user-id",
+                "u1",
+                "--output",
+                str(out),
+                "--data-dir",
+                str(tmp_path),
+                "--sample-days",
+                "0",
+            ]
+        )
+        assert rc == 0
+        report = json.loads(out.read_text())
+        # All bucket counts should be zero since the only record is
+        # filtered out.
+        assert all(b["user_turns"] == 0 for b in report["buckets"])
+
+
+# ── TestTraversalGuard ──────────────────────────────────────────────
+
+
+class TestTraversalGuard:
+    """Defensive shape check on --user-id; mirrors behavioral.py:841."""
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["../etc", "../../etc/passwd", "foo/bar", "", ".", "..", "/abs/path"],
+    )
+    def test_invalid_user_id_rejected(self, bad: str):
+        with pytest.raises(ValueError, match="invalid user_id"):
+            _validate_user_id(bad)
+
+    def test_valid_user_id_accepted(self):
+        # Plain segment with no separators, dots, or empty value passes.
+        # 12345 is the chat_id format used in production.
+        _validate_user_id("12345")
+        _validate_user_id("user-1")
+
+
+# ── TestTrendClassifier ─────────────────────────────────────────────
+
+
+class TestTrendClassifier:
+    """All 9 grid cells + inconclusive precedence + unclassified catch-all."""
+
+    @staticmethod
+    def _ut_ok() -> dict[str, int]:
+        # Three buckets each above the volume floor; lets the classifier
+        # reach the band-classification path instead of short-circuiting
+        # on inconclusive precedence.
+        return {"A": 100, "B": 100, "C": 100}
+
+    def _summary(self, frustration_rates: tuple[float, float, float]) -> friction.TrendSummary:
+        # Build aggregates with the supplied frustration rates per
+        # bucket (events left empty so verdict_sum equals frustration
+        # alone) and return the classifier's verdict.
+        rates = {
+            "A": {"frustration": frustration_rates[0]},
+            "B": {"frustration": frustration_rates[1]},
+            "C": {"frustration": frustration_rates[2]},
+        }
+        return classify_trend(
+            aggregates=_make_aggregates(rates),
+            events=[],
+            user_turns=self._ut_ok(),
+            memory_state=MemoryAvailability.ENABLED,
+        )
+
+    def test_prediction_holds_drop_then_flat(self):
+        # A=10 -> B=5 (drop), B=5 -> C=5 (flat). The pre-committed
+        # hypothesis lands cleanly.
+        s = self._summary((10.0, 5.0, 5.0))
+        assert s.matched_pattern == "prediction-holds"
+        assert s.predicted_pattern == _PREDICTED_PATTERN
+
+    def test_both_milestones_helped_drop_then_drop(self):
+        # A=20 -> B=10 (drop), B=10 -> C=4 (drop). Both rollouts
+        # contributed signal reductions.
+        s = self._summary((20.0, 10.0, 4.0))
+        assert s.matched_pattern == "both-milestones-helped"
+
+    def test_regression_drop_then_up(self):
+        # A=10 -> B=5 (drop), B=5 -> C=10 (up). Track 1 cleanup helped,
+        # then post-Track-1 regressed.
+        s = self._summary((10.0, 5.0, 10.0))
+        assert s.matched_pattern == "regression"
+
+    def test_track_1_carried_win_flat_then_drop(self):
+        # A=10 -> B=10 (flat), B=10 -> C=4 (drop). Track 1 removal was
+        # the actual carrier of the post-#361 improvement.
+        s = self._summary((10.0, 10.0, 4.0))
+        assert s.matched_pattern == "track-1-carried-win"
+
+    def test_no_effect_flat_then_flat(self):
+        # A=10 -> B=10 -> C=10. Neither milestone moved the verdict.
+        s = self._summary((10.0, 10.0, 10.0))
+        assert s.matched_pattern == "no-effect"
+
+    def test_regression_flat_then_up(self):
+        # A=10 -> B=10 (flat), B=10 -> C=20 (up). Regression in C.
+        s = self._summary((10.0, 10.0, 20.0))
+        assert s.matched_pattern == "regression"
+
+    def test_retrieval_helped_pollution_hurt_up_then_drop(self):
+        # A=5 -> B=10 (up), B=10 -> C=4 (drop). Track 1's pollution
+        # outweighed the retrieval gain in B; removing it fixed C.
+        s = self._summary((5.0, 10.0, 4.0))
+        assert s.matched_pattern == "retrieval-helped-pollution-hurt"
+
+    def test_retrieval_hurt_no_recovery_up_then_flat(self):
+        # A=5 -> B=10 (up), B=10 -> C=10 (flat). The B regression
+        # persisted; removing Track 1 didn't help.
+        s = self._summary((5.0, 10.0, 10.0))
+        assert s.matched_pattern == "retrieval-hurt-no-recovery"
+
+    def test_regression_up_then_up(self):
+        # A=5 -> B=10 -> C=20. Both transitions worsen the verdict.
+        s = self._summary((5.0, 10.0, 20.0))
+        assert s.matched_pattern == "regression"
+
+    def test_inconclusive_volume_floor_short_bucket(self):
+        # Any bucket below the floor fires inconclusive BEFORE band
+        # classification runs (volume floor takes precedence).
+        s = classify_trend(
+            aggregates=_make_aggregates(
+                {
+                    "A": {"frustration": 10.0},
+                    "B": {"frustration": 5.0},
+                    "C": {"frustration": 5.0},
+                }
+            ),
+            events=[],
+            user_turns={"A": 100, "B": 100, "C": 5},  # C below 30
+            memory_state=MemoryAvailability.ENABLED,
+        )
+        assert s.matched_pattern == "inconclusive"
+
+    def test_inconclusive_zero_prior_rate(self):
+        # prior=0 + new>0 fires inconclusive (zero-prior-rate path) AND
+        # records a caveat. Band falls back to "up" but matched_pattern
+        # is inconclusive: the ratio is undefined when the divisor is 0.
+        s = self._summary((0.0, 5.0, 5.0))
+        assert s.matched_pattern == "inconclusive"
+        assert s.zero_prior_rate_caveats  # at least one caveat
+
+    def test_unclassified_via_band_monkey_patch(self, monkeypatch):
+        # Mock _classify_band to return a sentinel outside {drop, flat,
+        # up}; the dict.get fallback in classify_trend must emit
+        # "unclassified". Verifies the defensive catch-all wiring is
+        # actually reachable.
+        monkeypatch.setattr("kai.eval.friction._classify_band", lambda p, n: "sideways")
+        s = self._summary((10.0, 10.0, 10.0))
+        assert s.matched_pattern == "unclassified"
+
+    def test_band_boundary_at_0_85_is_drop(self):
+        # The flat band's lower edge is open at 0.85x; exactly 0.85x
+        # belongs to drop. _MATERIAL_DROP_RATIO * 100 = 85.0.
+        assert _classify_band(100.0, 100.0 * _MATERIAL_DROP_RATIO) == "drop"
+
+    def test_band_boundary_just_above_0_85_is_flat(self):
+        # Just above 0.85x is the flat band's lower edge.
+        assert _classify_band(100.0, 100.0 * _MATERIAL_DROP_RATIO + 0.01) == "flat"
+
+    def test_band_boundary_at_1_15_is_flat(self):
+        # The flat band's upper edge is closed at 1.15x; exactly
+        # 1.15x belongs to flat, not up.
+        assert _classify_band(100.0, 100.0 * _UP_RATIO) == "flat"
+
+    def test_band_boundary_just_above_1_15_is_up(self):
+        assert _classify_band(100.0, 100.0 * _UP_RATIO + 0.01) == "up"
+
+    def test_zero_prior_zero_new_yields_flat_ratio_one(self):
+        # Both buckets quiet; the convention is ratio 1.0 + flat band,
+        # NOT zero-prior-rate caveat. Quiet -> quiet is no signal at all.
+        s = self._summary((0.0, 0.0, 0.0))
+        assert s.ratios["A_to_B"] == 1.0
+        assert s.ratios["B_to_C"] == 1.0
+        # No zero-prior caveats fire because new=0 too.
+        assert s.zero_prior_rate_caveats == ()
+
+    def test_verdict_sum_and_ratios_emitted_when_inconclusive(self):
+        # verdict_driving_sum and ratios are ALWAYS computed and
+        # emitted even when matched_pattern is inconclusive. Operators
+        # reading the report still see the underlying numbers for
+        # debugging the call.
+        s = classify_trend(
+            aggregates=_make_aggregates(
+                {
+                    "A": {"frustration": 10.0},
+                    "B": {"frustration": 5.0},
+                    "C": {"frustration": 5.0},
+                }
+            ),
+            events=[],
+            user_turns={"A": 100, "B": 100, "C": 5},
+            memory_state=MemoryAvailability.ENABLED,
+        )
+        assert s.matched_pattern == "inconclusive"
+        assert s.verdict_driving_sum["A"] == 10.0
+        assert s.ratios["A_to_B"] == 0.5
+
+    def test_memory_disabled_collapses_verdict_to_frustration(self):
+        # When events list contains no preference_correction events
+        # with known_fact_overlap=True (the memory-unreachable case),
+        # verdict_sum == frustration alone. Same matched_pattern as the
+        # all-frustration baseline.
+        s = self._summary((10.0, 5.0, 5.0))
+        assert s.verdict_driving_sum["A"] == 10.0
+        assert s.matched_pattern == "prediction-holds"
+
+
+# ── TestRender (regression: MappingProxyType -> dict) ───────────────
+
+
+class TestRender:
+    """Render-layer regressions: MappingProxyType serialization, redaction."""
+
+    def test_mappingproxytype_metadata_serializes(self):
+        # FrictionEvent.metadata is MappingProxyType (frozen dataclass
+        # immutability); the JSON encoder rejects it unless the render
+        # layer converts to dict first. This test catches the silent-
+        # break case where the immutability invariant meets the renderer.
+        ev = FrictionEvent(
+            timestamp_utc=_BUCKET_ANCHORS[0] + timedelta(hours=1),
+            bucket_label="B",
+            signal_family="preference_correction",
+            message_id="x.jsonl:1",
+            surface_text="don't do that",
+            context_message_ids=(),
+            metadata=MappingProxyType(
+                {
+                    "known_fact_overlap": True,
+                    "overlapping_fact_ids": ("f1", "f2"),
+                }
+            ),
+        )
+        payload = friction._build_event_payload(ev, include_snippets=False)
+        # json.dumps must succeed without TypeError.
+        rendered = json.dumps(payload)
+        assert "f1" in rendered
+        assert "f2" in rendered
+
+    def test_markdown_summary_omits_surface_text_even_with_include_snippets(self, tmp_path: Path, monkeypatch):
+        # The markdown summary always omits surface text by design;
+        # --include-snippets only affects the JSON, not the markdown.
+        # Posting the markdown publicly must never leak chat content.
+        _write_history(
+            tmp_path,
+            "u1",
+            [_user_msg(_IN_B, "i told you about the postgres deploy")],
+        )
+        monkeypatch.setattr("kai.eval.friction.datetime", _FakeDatetime)
+        monkeypatch.setattr(
+            "kai.eval.friction._initialize_memory_local",
+            lambda: MemoryInitResult(MemoryAvailability.DISABLED, None),
+        )
+        json_out = tmp_path / "report.json"
+        md_out = tmp_path / "report.md"
+        main(
+            [
+                "--user-id",
+                "u1",
+                "--output",
+                str(json_out),
+                "--markdown-summary",
+                str(md_out),
+                "--data-dir",
+                str(tmp_path),
+                "--include-snippets",
+            ]
+        )
+        md = md_out.read_text()
+        # The frustration phrase from the input must NOT appear in the
+        # markdown even though --include-snippets is set.
+        assert "i told you about the postgres deploy" not in md
+
+    def test_caveats_include_inconclusive_when_volume_floor(self, tmp_path: Path, monkeypatch):
+        # The caveats list must surface every triggered condition; an
+        # under-volume bucket emits a caveat naming the bucket and the
+        # floor so an operator scanning the report knows why the
+        # classification is inconclusive.
+        _write_history(
+            tmp_path,
+            "u1",
+            [_user_msg(_IN_C, "single message")],
+        )
+        monkeypatch.setattr("kai.eval.friction.datetime", _FakeDatetime)
+        monkeypatch.setattr(
+            "kai.eval.friction._initialize_memory_local",
+            lambda: MemoryInitResult(MemoryAvailability.DISABLED, None),
+        )
+        out = tmp_path / "report.json"
+        main(
+            [
+                "--user-id",
+                "u1",
+                "--output",
+                str(out),
+                "--data-dir",
+                str(tmp_path),
+            ]
+        )
+        report = json.loads(out.read_text())
+        joined = " ".join(report["caveats"])
+        assert "inconclusive" in joined
+        assert str(_USER_TURN_FLOOR) in joined
+
+
+# ── TestArgparseHelpers ─────────────────────────────────────────────
+
+
+class TestArgparseHelpers:
+    """Validators duplicated locally to keep the eval modules independent."""
+
+    @pytest.mark.parametrize("bad", ["-1", "-100"])
+    def test_non_negative_int_rejects_negatives(self, bad: str):
+        with pytest.raises(argparse.ArgumentTypeError, match="non-negative"):
+            _non_negative_int(bad)
+
+    def test_non_negative_int_rejects_non_integer(self):
+        with pytest.raises(argparse.ArgumentTypeError, match="expected integer"):
+            _non_negative_int("ten")
+
+    @pytest.mark.parametrize("good,expected", [("0", 0), ("1", 1), ("100", 100)])
+    def test_non_negative_int_accepts_zero_and_positives(self, good: str, expected: int):
+        # 0 is the legitimate "today UTC" value for --sample-days; the
+        # validator must NOT reject it.
+        assert _non_negative_int(good) == expected
+
+
+# ── TestParseRecordTimestamp ────────────────────────────────────────
+
+
+class TestParseRecordTimestamp:
+    """Edge cases of the per-record timestamp parser."""
+
+    def test_empty_string_returns_sentinel(self):
+        ts, reason = _parse_record_timestamp("")
+        assert ts == _BAD_TS_SENTINEL
+        assert reason == "ts_missing_or_empty"
+
+    def test_unparseable_returns_sentinel(self):
+        ts, reason = _parse_record_timestamp("not-iso-format")
+        assert ts == _BAD_TS_SENTINEL
+        assert reason == "ts_unparseable"
+
+    def test_naive_assumed_utc(self):
+        # log_message has always written tz-aware ISO; only legacy or
+        # hand-edited rows are naive. The conservative rule is "treat
+        # naive as UTC" so the bucket assignment is at least consistent.
+        ts, reason = _parse_record_timestamp("2026-04-18T10:00:00")
+        assert reason is None
+        assert ts.tzinfo == UTC
+
+    def test_aware_normalized_to_utc(self):
+        # An Eastern-TZ ISO string normalizes to UTC; the bucket math
+        # operates exclusively in UTC.
+        ts, reason = _parse_record_timestamp("2026-04-18T10:00:00-04:00")
+        assert reason is None
+        assert ts.utcoffset() == timedelta(0)
+        assert ts.hour == 14
+
+
+# ── TestContentWords ────────────────────────────────────────────────
+
+
+class TestContentWords:
+    """The shared tokenizer that backs Signal 2 and stage 3b overlap."""
+
+    def test_tokens_below_length_4_excluded(self):
+        # "the", "is", "a" all drop because they're shorter than 4.
+        assert _content_words("the cat is here") == {"here"}
+
+    def test_stopwords_excluded(self):
+        # "this", "that", "with" etc. are pre-committed stopwords; they
+        # do not contribute to the substantive overlap floor.
+        assert _content_words("this with that") == set()
+
+    def test_lowercased_and_punctuation_stripped(self):
+        # Mixed case with punctuation collapses to a single canonical
+        # set; "Database!" -> "database".
+        assert "database" in _content_words("Database! works correctly.")
+
+    def test_apostrophe_preserved_in_token(self):
+        # Apostrophe is kept inside the character class so contractions
+        # survive as single tokens; "don't" stays as "don't" rather than
+        # splitting into "don" + "t".
+        assert "don't" in _content_words("don't change the deployment")
+
+
+# ── TestDetectEventsOrchestrator ────────────────────────────────────
+
+
+class TestDetectEventsOrchestrator:
+    """detect_events runs all four signal detectors and concatenates."""
+
+    def test_returns_events_from_each_signal_family(self, tmp_path: Path):
+        # Synthetic history hits all four signals: frustration phrase,
+        # an assistant question with overlap, a correction pattern, and
+        # a fact-shape repeat. The orchestrator MUST emit at least one
+        # event per family so the per-bucket-per-signal aggregate matrix
+        # has a non-empty row in each family.
+        records = [
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(minutes=1),
+                ts_raw=_IN_B,
+                direction="user",
+                chat_id=1,
+                text="i prefer postgres docker container deployment",
+                media=None,
+                source_path=str(tmp_path / "h.jsonl"),
+                line_no=1,
+            ),
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(minutes=2),
+                ts_raw=_IN_B,
+                direction="user",
+                chat_id=1,
+                text="i prefer postgres docker container deployment as before",
+                media=None,
+                source_path=str(tmp_path / "h.jsonl"),
+                line_no=2,
+            ),
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(minutes=3),
+                ts_raw=_IN_B,
+                direction="user",
+                chat_id=1,
+                text="i told you about the postgres docker container",
+                media=None,
+                source_path=str(tmp_path / "h.jsonl"),
+                line_no=3,
+            ),
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(minutes=4),
+                ts_raw=_IN_B,
+                direction="assistant",
+                chat_id=1,
+                text="what postgres docker container should i use?",
+                media=None,
+                source_path=str(tmp_path / "h.jsonl"),
+                line_no=4,
+            ),
+            HistoryRecord(
+                ts_utc=_BUCKET_ANCHORS[0] + timedelta(minutes=5),
+                ts_raw=_IN_B,
+                direction="user",
+                chat_id=1,
+                text="don't change the postgres docker container deployment",
+                media=None,
+                source_path=str(tmp_path / "h.jsonl"),
+                line_no=5,
+            ),
+        ]
+        events = detect_events(records, tmp_path, facts=[])
+        families = {ev.signal_family for ev in events}
+        assert "frustration" in families
+        assert "kai_asks_back" in families
+        assert "preference_correction" in families
+        assert "repeated_fact" in families

--- a/tests/test_eval_friction.py
+++ b/tests/test_eval_friction.py
@@ -1144,7 +1144,6 @@ class TestTrendClassifier:
             aggregates=_make_aggregates(rates),
             events=[],
             user_turns=self._ut_ok(),
-            memory_state=MemoryAvailability.ENABLED,
         )
 
     def test_prediction_holds_drop_then_flat(self):
@@ -1212,7 +1211,6 @@ class TestTrendClassifier:
             ),
             events=[],
             user_turns={"A": 100, "B": 100, "C": 5},  # C below 30
-            memory_state=MemoryAvailability.ENABLED,
         )
         assert s.matched_pattern == "inconclusive"
 
@@ -1274,7 +1272,6 @@ class TestTrendClassifier:
             ),
             events=[],
             user_turns={"A": 100, "B": 100, "C": 5},
-            memory_state=MemoryAvailability.ENABLED,
         )
         assert s.matched_pattern == "inconclusive"
         assert s.verdict_driving_sum["A"] == 10.0

--- a/tests/test_eval_friction.py
+++ b/tests/test_eval_friction.py
@@ -117,8 +117,10 @@ def _make_aggregates(rates: dict[str, dict[str, float]]) -> list[BucketAggregate
     """Build a BucketAggregate list from a {bucket: {signal: rate}} mapping.
 
     Sets user_turns_in_bucket=100 so the per-100 rate equals the
-    literal rate input; the classifier reads only the rate field for
-    its band math, so the count / user_turns choice here is cosmetic.
+    literal rate input; classifier-focused tests read only the rate
+    field, but `count` is rounded (not truncated) so any future
+    JSON-output test that asserts on the count field sees the
+    arithmetically consistent value (rate=2.7 -> count=3, not 2).
     Missing (bucket, family) cells default to 0.0.
     """
     out: list[BucketAggregate] = []
@@ -129,7 +131,7 @@ def _make_aggregates(rates: dict[str, dict[str, float]]) -> list[BucketAggregate
                 BucketAggregate(
                     bucket_label=bucket,
                     signal_family=family,
-                    count=int(rate),
+                    count=round(rate),
                     user_turns_in_bucket=100,
                     rate_per_100_user_turns=rate,
                 )


### PR DESCRIPTION
## Summary

- Adds `src/kai/eval/friction.py`: a single-user, three-bucket longitudinal friction-trend evaluator.
- Reads `DATA_DIR/history/<user_id>/`, runs four pre-committed signal families (frustration, kai_asks_back, preference correction with optional known-fact overlap via Mem0, repeated fact-shape statements), normalizes per 100 user-turns, and buckets around two pinned milestone instants.
- Emits a schema-versioned JSON report and an optional redacted markdown summary suitable for paste-into-issue.
- Trend classifier tiles the `{drop, flat, up}^2` grid into nine named outcomes plus `inconclusive` (volume floor / zero-prior-rate) and a defensive `unclassified` catch-all.
- 111 new tests; full suite at 2320 passing.

## Design notes

- **Determinism contract**: byte-stable JSON for identical inputs. Events sort by `(timestamp_utc, message_id)`, `generated_at_utc` derives from a single wall-clock read in `main()`, and `FrictionEvent.metadata` is `MappingProxyType` -> `dict` only at the render boundary.
- **Memory tri-state**: `MemoryAvailability` is `ENABLED | DISABLED | ERROR`; the harness never `sys.exit`s on a memory failure. Stage 3b (known-fact overlap) silently degrades to "no overlap" when memory is unavailable, and the report records the state.
- **Redaction**: surface text is scrubbed (URLs, emails, @handles, phone-shaped digit runs) and capped at 200 chars; the markdown summary always omits surface text regardless of `--include-snippets`.
- **Traversal guard**: `--user-id` is validated by `_validate_user_id` (rejects empty / `.` / `..` and any value where `Path(user_id).name != user_id`) before any disk read; bad input -> exit code 2 with no I/O. The check is a defensive shape guard, not a hard security boundary - a determined operator running their own harness can still reach arbitrary paths via `--data-dir`.
- **Atomic writes**: temp file + `os.replace()` so a partial write never produces a half-written report at the destination.

## Test plan

- [x] `make check` (ruff + format) clean
- [x] `pytest tests/test_eval_friction.py` 111/111 passed in 0.17s
- [x] Full suite: 2320 passed in 17.82s (above the 2200 acceptance floor)
- [ ] Operator: dry-run against a snapshot copy of production history to spot-check the JSON report shape and markdown summary

fixes #373
