### PR TITLE
feat(memory): foundation REST API for explicit fact storage

### DIFF
--- a/home/IDENTITY.md
+++ b/home/IDENTITY.md
@@ -147,6 +147,77 @@ curl -s -X POST http://localhost:8080/api/send-file \
 - `caption` - string; optional
 - Images (png, jpg, webp) are sent as photos (rendered inline). Everything else is sent as a document attachment.
 
+## Memory System
+
+You have a per-user vector store that holds extracted facts about the user (preferences, decisions, identity, locations, constraints). Two paths populate it: a Haiku extraction pass that runs automatically over conversations, and the explicit API documented here. Use the API to deliberately store a fact when you notice something worth recalling later, instead of waiting for the extractor to find it.
+
+This is distinct from your `MEMORY.md` file, which is monolithic identity text injected at every turn. MEMORY.md is for stable identity and rules; the memory store is for queryable, retrievable facts that you may or may not need on a given turn.
+
+### When to store a fact via the API
+
+- The user states a stable preference, constraint, or piece of identity
+- The user confirms an architectural decision worth recalling later
+- You complete a task whose outcome (succeeded / failed / lessons) is worth recalling
+- Don't store: anything that's already in MEMORY.md, ephemeral conversation context, or anything that violates the user's privacy preferences
+
+### Storing a fact
+
+```bash
+curl -s -X POST http://localhost:8080/api/memory/add \
+  -H 'Content-Type: application/json' \
+  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
+  -d '{"chat_id": <chat_id>, "content": "User prefers Earl Grey over English Breakfast", "memory_type": "preference", "tags": ["beverage", "preference"], "metadata": {"source": "explicit"}}'
+```
+
+Fields: `content` (string, required), `memory_type` (string, default `"fact"`), `tags` (list of strings, optional), `metadata` (dict, optional), `chat_id` (integer, required for routing). Response: `{"id": "<mem0-uuid>"}`.
+
+### Searching memories
+
+```bash
+curl -s -X POST http://localhost:8080/api/memory/search \
+  -H 'Content-Type: application/json' \
+  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
+  -d '{"chat_id": <chat_id>, "query": "what tea does the user like"}'
+```
+
+Fields: `query` (string, required), `limit` (integer, optional), `chat_id` (integer, required). Response: `{"results": [{"id": ..., "text": ..., "score": ..., "memory_type": ..., "metadata": {...}, "created_at": ...}, ...]}`. Empty `results` means no matches above the relevance threshold; this is a normal 200, not an error.
+
+### Stats
+
+```bash
+curl -s "http://localhost:8080/api/memory/stats?chat_id=<chat_id>" \
+  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET"
+```
+
+Returns the stats object at the top level: `{"total_count": N, "by_type": {...}, "extracted_count": M, "by_tag": {...}, "confidence_min": ..., "confidence_median": ..., "confidence_max": ..., ...}`.
+
+For a fresh user with no extracted facts (`extracted_count == 0`), the confidence fields ship as `null`:
+
+```json
+{"total_count": 0, "by_type": {}, "extracted_count": 0, "confidence_min": null, "confidence_median": null, "confidence_max": null, ...}
+```
+
+`null` here means "no extracted facts to summarize," NOT a store failure. Treat it as expected for new users.
+
+### Deleting all memories
+
+```bash
+curl -s -X DELETE http://localhost:8080/api/memory/all \
+  -H 'Content-Type: application/json' \
+  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
+  -d '{"chat_id": <chat_id>, "confirm": "delete-all-memories"}'
+```
+
+The `confirm` field MUST equal the literal string `"delete-all-memories"`. Anything else returns 400. This is intentional: a stray curl or prompt-injected fetch call cannot accidentally wipe a user's memory store. Only invoke this when the user has explicitly asked to clear their memories. Response: `{"status": "deleted"}`.
+
+### Error handling
+
+- `400` - your request was bad (missing field, invalid JSON, wrong confirm token). Fix the request and retry.
+- `401` - wrong webhook secret. Configuration bug; surface to the operator.
+- `403` - the chat_id you sent isn't authorized. Use your own chat_id.
+- `503` - the memory system is disabled. Don't retry; surface to the operator. Same status across all four memory endpoints, so a single retry policy covers the disabled case.
+- `500` - on `/api/memory/add` only, the underlying store call failed despite memory being enabled. May be transient; retrying once with a short backoff is reasonable. Persistent 500s should be surfaced to the operator.
+
 ## Issue-First Workflow
 
 For non-trivial work (new features, bug fixes, design changes), create a GitHub issue before opening a PR. This lets the issue triage agent label and categorize the work, and keeps the "why" (issue) separate from the "how" (PR).

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -1529,9 +1529,29 @@ async def _handle_memory_add(request: web.Request) -> web.Response:
     # this ordering, a caller debugging a missing-field bug while memory
     # happens to be disabled would chase a 503 red herring instead of
     # seeing the real 400.
-    content = payload.get("content", "").strip()
-    if not content:
+    #
+    # isinstance(...) guards before .strip() / iteration are deliberate.
+    # JSON delivers numbers, booleans, lists, nulls, and dicts; calling
+    # `.strip()` on a number raises AttributeError that escapes to
+    # aiohttp as a framework 500 with no clean error body. Same logic
+    # for the optional-field checks below: validate at the API boundary
+    # so the 400 surface stays the contract that callers actually see.
+    content = payload.get("content")
+    if not isinstance(content, str) or not content.strip():
         return web.json_response({"error": "Missing required field: content"}, status=400)
+    content = content.strip()
+
+    memory_type = payload.get("memory_type", "fact")
+    if not isinstance(memory_type, str):
+        return web.json_response({"error": "memory_type must be a string"}, status=400)
+
+    tags = payload.get("tags")
+    if tags is not None and (not isinstance(tags, list) or not all(isinstance(t, str) for t in tags)):
+        return web.json_response({"error": "tags must be a list of strings"}, status=400)
+
+    metadata = payload.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        return web.json_response({"error": "metadata must be a JSON object"}, status=400)
 
     try:
         chat_id = _resolve_chat_id(request, payload)
@@ -1552,9 +1572,9 @@ async def _handle_memory_add(request: web.Request) -> web.Response:
     memory_id = memory.add_structured(
         content,
         user_id=user_id,
-        memory_type=payload.get("memory_type", "fact"),
-        tags=payload.get("tags"),
-        metadata=payload.get("metadata"),
+        memory_type=memory_type,
+        tags=tags,
+        metadata=metadata,
     )
 
     if memory_id is None:
@@ -1599,9 +1619,22 @@ async def _handle_memory_search(request: web.Request) -> web.Response:
     except json.JSONDecodeError:
         return web.json_response({"error": "Invalid JSON"}, status=400)
 
-    query = payload.get("query", "").strip()
-    if not query:
+    # Same isinstance-before-.strip() rationale as _handle_memory_add:
+    # a non-string `query` from JSON would raise AttributeError on .strip()
+    # and escape to aiohttp.
+    query = payload.get("query")
+    if not isinstance(query, str) or not query.strip():
         return web.json_response({"error": "Missing required field: query"}, status=400)
+    query = query.strip()
+
+    # Optional `limit`: must be a positive int when provided. The
+    # `isinstance(limit, bool)` short-circuit is load-bearing because
+    # bool is a subclass of int in Python (`isinstance(True, int)` is
+    # True), so without the bool check `{"limit": true}` would be
+    # accepted as `limit=1` and silently truncate results to one row.
+    limit = payload.get("limit")
+    if limit is not None and (isinstance(limit, bool) or not isinstance(limit, int) or limit < 1):
+        return web.json_response({"error": "limit must be a positive integer"}, status=400)
 
     try:
         chat_id = _resolve_chat_id(request, payload)
@@ -1619,9 +1652,16 @@ async def _handle_memory_search(request: web.Request) -> web.Response:
         return _memory_disabled_response()
 
     user_id = str(chat_id)
-    limit = payload.get("limit")
 
-    results = memory.search(query, user_id=user_id, limit=limit)
+    # search() catches its own exceptions and returns [] today, so this
+    # try/except is defense-in-depth: if a future refactor ever lets
+    # an exception escape, the handler still returns a clean 500 JSON
+    # body instead of letting aiohttp render an HTML 500 page.
+    try:
+        results = memory.search(query, user_id=user_id, limit=limit)
+    except Exception:
+        log.exception("memory.search failed for chat %d", chat_id)
+        return web.json_response({"error": "Memory search failed"}, status=500)
 
     # asdict() flattens each frozen dataclass to a plain dict. Every
     # value inside MemoryResult.metadata is JSON-native because Mem0
@@ -1674,7 +1714,16 @@ async def _handle_memory_stats(request: web.Request) -> web.Response:
         return _memory_disabled_response()
 
     user_id = str(chat_id)
-    stats = memory.get_stats(user_id=user_id)
+
+    # get_stats() doesn't have its own try/except; aggregation errors on
+    # malformed rows could surface here. Defense-in-depth guard so the
+    # handler returns a clean 500 JSON body rather than an aiohttp HTML
+    # 500 page if the primitive ever raises.
+    try:
+        stats = memory.get_stats(user_id=user_id)
+    except Exception:
+        log.exception("memory.get_stats failed for chat %d", chat_id)
+        return web.json_response({"error": "Memory stats failed"}, status=500)
 
     # asdict() preserves None for the optional confidence_* fields, which
     # become JSON null on the wire. The IDENTITY.md "Memory System"

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -26,6 +26,10 @@ Routes are organized into these groups:
     - /api/services/{name}  - External service proxy (injects auth from .env)
     - /api/send-message     - Send a text message to the Telegram chat
     - /api/send-file        - Send a file from the filesystem to the Telegram chat
+    - /api/memory/add       - Store a structured memory (POST)
+    - /api/memory/search    - Search memories by query (POST)
+    - /api/memory/stats     - Memory statistics for a user (GET)
+    - /api/memory/all       - Delete all memories for a user (DELETE, requires confirm token)
 
 The Telegram webhook route uses its own secret (TELEGRAM_WEBHOOK_SECRET) and is
 only registered in webhook mode. All other webhook/API endpoints require
@@ -45,13 +49,14 @@ import json
 import logging
 import re
 import time
+from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
 
 from aiohttp import web
 from telegram import Bot, Update
 
-from kai import cron, review, services, sessions, triage
+from kai import cron, memory, review, services, sessions, triage
 from kai.config import DATA_DIR, IMAGE_EXTENSIONS, Config, UserConfig
 from kai.telegram_utils import chunk_text
 
@@ -1443,6 +1448,307 @@ async def _handle_send_file(request: web.Request) -> web.Response:
     return web.json_response({"status": "sent", "file": path.name})
 
 
+# ── Memory API ───────────────────────────────────────────────────────
+# Four thin REST handlers wrapping memory.py primitives. Implementation
+# notes that apply uniformly across all four:
+#
+#   - All four share the symmetric `is_enabled()` precheck. Returns 503
+#     when memory is off, even on read endpoints whose primitives degrade
+#     gracefully (search returns [], get_stats returns zeroed). Returning
+#     the degraded value at the API would conflate "memory off" with
+#     "no data" and inner Claude could not pick a retry policy from the
+#     status code alone.
+#
+#   - Memory primitives take user_id as a string; _resolve_chat_id returns
+#     int. Stringify at the boundary in every handler. Removing the cast
+#     is a load-bearing bug: Mem0 keys are stored under the string form,
+#     so a missed cast would silently isolate the caller's memories from
+#     their existing facts.
+#
+#   - Handlers import memory as a module (`from kai import memory`) so
+#     tests can patch `kai.memory.<func>` uniformly. Function-level
+#     imports would force tests to patch the local binding
+#     (kai.webhook.add_structured), which is a known mocking pitfall.
+
+# Static well-known token for the DELETE /api/memory/all confirmation
+# field. Picked over a per-request UUID because the threat model is
+# typo-resistance and prompt-injection defense, not replay protection;
+# a static descriptive string is sufficient for both. The exact value
+# also appears in the 400 error body so a stray curl gets a clear hint
+# at what was missing.
+_DELETE_ALL_CONFIRM_TOKEN = "delete-all-memories"
+
+
+def _memory_disabled_response() -> web.Response:
+    """503 response used by the symmetric is_enabled() precheck.
+
+    Centralized so all four memory handlers return the identical body and
+    status. The 503 contract (vs the 500 used for `add_structured` failure
+    in /api/memory/add) is documented in IDENTITY.md: 503 means the
+    operator must enable memory, so callers should NOT retry; 500 means
+    the underlying store call failed and may be transient.
+    """
+    return web.json_response({"error": "Memory system disabled"}, status=503)
+
+
+@_require_secret
+async def _handle_memory_add(request: web.Request) -> web.Response:
+    """
+    Store a structured memory via memory.add_structured().
+
+    Wraps the existing add_structured() primitive used by the Haiku
+    extraction path. Lets inner Claude (and other localhost clients)
+    deliberately store facts without waiting for the extractor to pass
+    over a conversation. The primitive itself is unchanged; this handler
+    only adds the HTTP surface.
+
+    Request body (JSON):
+        content: str, required, non-empty after strip
+        memory_type: str, optional, default "fact"
+        tags: list[str], optional
+        metadata: dict, optional (keys "type" and "tags" are reserved by
+            add_structured; user values for those will be overwritten)
+        chat_id: int, optional, defaults to app["chat_id"]
+
+    Responses:
+        200 {"id": "<mem0-uuid>"} on success
+        400 on bad input (invalid JSON, missing/empty content, bad chat_id)
+        401 on bad/missing X-Webhook-Secret (handled by the decorator)
+        403 on unauthorized chat_id
+        503 when memory is disabled (precheck; do not retry, escalate)
+        500 when add_structured() returns None despite memory being enabled
+            (the underlying store call failed; may be transient)
+    """
+    try:
+        payload = await request.json()
+    except json.JSONDecodeError:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    # Required-field validation runs BEFORE the is_enabled() precheck so
+    # callers learn about bad-input bugs even when memory is off. Without
+    # this ordering, a caller debugging a missing-field bug while memory
+    # happens to be disabled would chase a 503 red herring instead of
+    # seeing the real 400.
+    content = payload.get("content", "").strip()
+    if not content:
+        return web.json_response({"error": "Missing required field: content"}, status=400)
+
+    try:
+        chat_id = _resolve_chat_id(request, payload)
+    except ValueError as e:
+        return web.json_response({"error": str(e)}, status=400)
+    except UnauthorizedChatIdError as e:
+        return web.json_response({"error": str(e)}, status=403)
+
+    # Symmetric is_enabled() precheck. Runs after auth + 400-level
+    # validation but before the primitive call. See the §Memory API
+    # block comment above for why all four memory handlers share this.
+    if not memory.is_enabled():
+        return _memory_disabled_response()
+
+    # int -> str at the memory boundary; do NOT remove the cast.
+    user_id = str(chat_id)
+
+    memory_id = memory.add_structured(
+        content,
+        user_id=user_id,
+        memory_type=payload.get("memory_type", "fact"),
+        tags=payload.get("tags"),
+        metadata=payload.get("metadata"),
+    )
+
+    if memory_id is None:
+        # Reaching here means is_enabled() was True at precheck (so we
+        # know memory was up), but add_structured returned None anyway.
+        # The only remaining None path inside add_structured (after the
+        # empty-content path which we filtered above with the 400 check)
+        # is the caught Exception around _memory.add(). 500 distinguishes
+        # this transient store failure from the 503 hard-disabled case
+        # so callers can pick a different retry policy per status code.
+        return web.json_response({"error": "Memory storage failed"}, status=500)
+
+    log.info("Stored memory %s for chat %d via API", memory_id, chat_id)
+    return web.json_response({"id": memory_id})
+
+
+@_require_secret
+async def _handle_memory_search(request: web.Request) -> web.Response:
+    """
+    Search memories via memory.search().
+
+    POST chosen over GET because user-message-shaped queries can be long
+    enough to bump against URL-length limits on some HTTP clients, and
+    POST also matches the rest of the /api/* surface (POST except
+    /api/jobs* GET).
+
+    Request body (JSON):
+        query: str, required, non-empty after strip
+        limit: int, optional (defaults to config.memory_search_limit)
+        chat_id: int, optional, defaults to app["chat_id"]
+
+    Responses:
+        200 {"results": [<MemoryResult-dict>, ...]} on success (empty list
+            is a valid 200 result for "no matches")
+        400 on bad input
+        401 on bad secret
+        403 on unauthorized chat_id
+        503 when memory is disabled
+    """
+    try:
+        payload = await request.json()
+    except json.JSONDecodeError:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    query = payload.get("query", "").strip()
+    if not query:
+        return web.json_response({"error": "Missing required field: query"}, status=400)
+
+    try:
+        chat_id = _resolve_chat_id(request, payload)
+    except ValueError as e:
+        return web.json_response({"error": str(e)}, status=400)
+    except UnauthorizedChatIdError as e:
+        return web.json_response({"error": str(e)}, status=403)
+
+    # search() degrades to [] when memory is disabled, but returning []
+    # at the API layer would be indistinguishable from "no matches".
+    # Inner Claude needs to pick "log no relevant memories and continue"
+    # vs "memory is off, surface to operator" - the only distinguishing
+    # signal is the status code, so the precheck is required.
+    if not memory.is_enabled():
+        return _memory_disabled_response()
+
+    user_id = str(chat_id)
+    limit = payload.get("limit")
+
+    results = memory.search(query, user_id=user_id, limit=limit)
+
+    # asdict() flattens each frozen dataclass to a plain dict. Every
+    # value inside MemoryResult.metadata is JSON-native because Mem0
+    # stores metadata in Qdrant as JSON, so json_response can serialize
+    # the whole structure without a custom encoder.
+    return web.json_response({"results": [asdict(r) for r in results]})
+
+
+@_require_secret
+async def _handle_memory_stats(request: web.Request) -> web.Response:
+    """
+    Return memory statistics via memory.get_stats().
+
+    GET endpoint reads chat_id from query params, mirroring _handle_get_jobs.
+
+    Query params:
+        chat_id: int, optional (defaults to app["chat_id"])
+
+    Response is the MemoryStats object at the top level, NOT wrapped in
+    {"results": ...} - single-object reads return the object bare per
+    the API's response-shape rule (matches /api/jobs/{id} returning
+    `job` at top level).
+
+    Note on null fields: confidence_min, confidence_median, confidence_max
+    are JSON null when extracted_count == 0. This is correct for users
+    with no extracted facts and is NOT a store-failure signal. Callers
+    should treat null in those fields as "no data to summarize."
+
+    Responses:
+        200 <MemoryStats-dict> on success
+        400 on bad chat_id
+        401 on bad secret
+        403 on unauthorized chat_id
+        503 when memory is disabled
+    """
+    # GET handlers feed query params to _resolve_chat_id; established
+    # pattern at _handle_get_jobs.
+    try:
+        chat_id = _resolve_chat_id(request, dict(request.query))
+    except ValueError as e:
+        return web.json_response({"error": str(e)}, status=400)
+    except UnauthorizedChatIdError as e:
+        return web.json_response({"error": str(e)}, status=403)
+
+    # get_stats() returns zeroed MemoryStats when memory is disabled,
+    # but - same as search - "memory off" and "user has no facts yet"
+    # would be indistinguishable at the API. The 503 precheck preserves
+    # the distinction at the status-code layer.
+    if not memory.is_enabled():
+        return _memory_disabled_response()
+
+    user_id = str(chat_id)
+    stats = memory.get_stats(user_id=user_id)
+
+    # asdict() preserves None for the optional confidence_* fields, which
+    # become JSON null on the wire. The IDENTITY.md "Memory System"
+    # section documents this so inner Claude does not misread null as
+    # a store failure.
+    return web.json_response(asdict(stats))
+
+
+@_require_secret
+async def _handle_memory_delete_all(request: web.Request) -> web.Response:
+    """
+    Delete all memories for a user via memory.delete_all().
+
+    Requires an exact-match confirm token in the body. Static
+    well-known token (not per-request UUID) because the threat model
+    is typo + prompt-injection defense, not replay protection.
+
+    Convention divergence (deliberate): _handle_delete_job reads chat_id
+    from query params, but this handler reads chat_id from the body
+    alongside the confirm token, since the body already exists for the
+    confirm field. Splitting confirm into the body and chat_id into the
+    query would be inconsistent within the same endpoint.
+
+    Request body (JSON):
+        confirm: str, required, must equal "delete-all-memories"
+        chat_id: int, optional, defaults to app["chat_id"]
+
+    Responses:
+        200 {"status": "deleted"} on success
+        400 on missing/wrong confirm or bad chat_id
+        401 on bad secret
+        403 on unauthorized chat_id
+        503 when memory is disabled
+
+    Caveat: delete_all() swallows internal errors (memory.py:1066-1069).
+    Partial failures inside Mem0 are logged but invisible at the API
+    layer. Surfacing them would require widening memory.py's error
+    contract, which is out of scope for the foundation issue.
+    """
+    try:
+        payload = await request.json()
+    except json.JSONDecodeError:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    # Confirm-token check before chat_id resolution: a request with the
+    # wrong token is structurally bad input regardless of which user it
+    # was aimed at, and rejecting it first means we don't waste a
+    # _resolve_chat_id call on requests we will reject anyway.
+    if payload.get("confirm") != _DELETE_ALL_CONFIRM_TOKEN:
+        return web.json_response(
+            {"error": (f'Missing or incorrect confirm field; expected "{_DELETE_ALL_CONFIRM_TOKEN}"')},
+            status=400,
+        )
+
+    try:
+        chat_id = _resolve_chat_id(request, payload)
+    except ValueError as e:
+        return web.json_response({"error": str(e)}, status=400)
+    except UnauthorizedChatIdError as e:
+        return web.json_response({"error": str(e)}, status=403)
+
+    # Symmetric precheck. delete_all() is a no-op when disabled, but
+    # callers asking the API to wipe their memories deserve to know the
+    # operation didn't actually run because the system was off.
+    if not memory.is_enabled():
+        return _memory_disabled_response()
+
+    user_id = str(chat_id)
+    memory.delete_all(user_id=user_id)
+
+    log.info("Deleted all memories for chat %d via API", chat_id)
+    return web.json_response({"status": "deleted"})
+
+
 # ── Webhook health monitor ───────────────────────────────────────────
 
 
@@ -1676,6 +1982,10 @@ async def start(telegram_app, config) -> None:
         _app.router.add_post("/api/services/{name}", _handle_service_call)
         _app.router.add_post("/api/send-message", _handle_send_message)
         _app.router.add_post("/api/send-file", _handle_send_file)
+        _app.router.add_post("/api/memory/add", _handle_memory_add)
+        _app.router.add_post("/api/memory/search", _handle_memory_search)
+        _app.router.add_get("/api/memory/stats", _handle_memory_stats)
+        _app.router.add_delete("/api/memory/all", _handle_memory_delete_all)
     else:
         log.warning("WEBHOOK_SECRET not set - webhook and scheduling endpoints disabled")
 

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -1792,7 +1792,19 @@ async def _handle_memory_delete_all(request: web.Request) -> web.Response:
         return _memory_disabled_response()
 
     user_id = str(chat_id)
-    memory.delete_all(user_id=user_id)
+    # Defense-in-depth guard, matching the pattern used in
+    # _handle_memory_search and _handle_memory_stats. delete_all()
+    # catches its own internal errors today (memory.py:1066-1069), so
+    # this try/except mostly never fires - but if a future refactor
+    # ever lets an exception escape (or if the call raises before
+    # reaching the inner try, e.g. on a TypeError from a bad argument
+    # shape), the handler still returns a clean 500 JSON body instead
+    # of an aiohttp HTML 500 page.
+    try:
+        memory.delete_all(user_id=user_id)
+    except Exception:
+        log.exception("memory.delete_all failed for chat %d", chat_id)
+        return web.json_response({"error": "Memory delete failed"}, status=500)
 
     log.info("Deleted all memories for chat %d via API", chat_id)
     return web.json_response({"status": "deleted"})

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -1569,22 +1569,36 @@ async def _handle_memory_add(request: web.Request) -> web.Response:
     # int -> str at the memory boundary; do NOT remove the cast.
     user_id = str(chat_id)
 
-    memory_id = memory.add_structured(
-        content,
-        user_id=user_id,
-        memory_type=memory_type,
-        tags=tags,
-        metadata=metadata,
-    )
+    # Defense-in-depth guard, matching the pattern used in the other
+    # three memory handlers. add_structured catches its own internal
+    # exceptions and returns None (which the None-check below maps to
+    # 500), but if the call raises BEFORE reaching that internal try
+    # (init failure, bad argument shape, network error during connection
+    # setup), the exception would otherwise escape to aiohttp as an HTML
+    # 500. The wider guard collapses both failure modes into the same
+    # clean 500 JSON body.
+    try:
+        memory_id = memory.add_structured(
+            content,
+            user_id=user_id,
+            memory_type=memory_type,
+            tags=tags,
+            metadata=metadata,
+        )
+    except Exception:
+        log.exception("memory.add_structured failed for chat %d", chat_id)
+        return web.json_response({"error": "Memory storage failed"}, status=500)
 
     if memory_id is None:
         # Reaching here means is_enabled() was True at precheck (so we
-        # know memory was up), but add_structured returned None anyway.
-        # The only remaining None path inside add_structured (after the
-        # empty-content path which we filtered above with the 400 check)
-        # is the caught Exception around _memory.add(). 500 distinguishes
-        # this transient store failure from the 503 hard-disabled case
-        # so callers can pick a different retry policy per status code.
+        # know memory was up) and add_structured did not raise, but it
+        # returned None anyway. The only remaining None path inside
+        # add_structured (after the empty-content path which we filtered
+        # above with the 400 check) is the caught Exception around
+        # _memory.add(). Same 500 response body as the wider guard above
+        # because callers cannot meaningfully distinguish "primitive
+        # raised" from "primitive caught and returned None" - both are
+        # transient store failures.
         return web.json_response({"error": "Memory storage failed"}, status=500)
 
     log.info("Stored memory %s for chat %d via API", memory_id, chat_id)

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -1653,21 +1653,25 @@ async def _handle_memory_search(request: web.Request) -> web.Response:
 
     user_id = str(chat_id)
 
-    # search() catches its own exceptions and returns [] today, so this
-    # try/except is defense-in-depth: if a future refactor ever lets
-    # an exception escape, the handler still returns a clean 500 JSON
-    # body instead of letting aiohttp render an HTML 500 page.
+    # Defense-in-depth around the full risky path: primitive call AND
+    # serialization. search() catches its own exceptions and returns []
+    # today, and asdict() should always succeed on the frozen dataclass
+    # MemoryResult, but extending the guard to cover the asdict+
+    # json_response step keeps the 500-as-clean-JSON contract intact
+    # even if a future refactor changes search()'s return type or if
+    # MemoryResult.metadata ever contains non-JSON-native values.
+    # Without the wider guard, asdict raising TypeError or json_response
+    # raising ValueError would escape to aiohttp as an unstyled HTML 500.
     try:
         results = memory.search(query, user_id=user_id, limit=limit)
+        # asdict() flattens each frozen dataclass to a plain dict. Every
+        # value inside MemoryResult.metadata is JSON-native because Mem0
+        # stores metadata in Qdrant as JSON, so json_response can
+        # serialize the whole structure without a custom encoder.
+        return web.json_response({"results": [asdict(r) for r in results]})
     except Exception:
         log.exception("memory.search failed for chat %d", chat_id)
         return web.json_response({"error": "Memory search failed"}, status=500)
-
-    # asdict() flattens each frozen dataclass to a plain dict. Every
-    # value inside MemoryResult.metadata is JSON-native because Mem0
-    # stores metadata in Qdrant as JSON, so json_response can serialize
-    # the whole structure without a custom encoder.
-    return web.json_response({"results": [asdict(r) for r in results]})
 
 
 @_require_secret
@@ -1715,21 +1719,22 @@ async def _handle_memory_stats(request: web.Request) -> web.Response:
 
     user_id = str(chat_id)
 
-    # get_stats() doesn't have its own try/except; aggregation errors on
-    # malformed rows could surface here. Defense-in-depth guard so the
-    # handler returns a clean 500 JSON body rather than an aiohttp HTML
-    # 500 page if the primitive ever raises.
+    # Wider guard around primitive call AND serialization, matching the
+    # search handler. get_stats() doesn't have its own try/except today
+    # (aggregation errors on a malformed row could surface here), and
+    # extending the guard to the asdict+json_response step closes the
+    # remaining route by which an exception could escape to aiohttp as
+    # an HTML 500.
     try:
         stats = memory.get_stats(user_id=user_id)
+        # asdict() preserves None for the optional confidence_* fields,
+        # which become JSON null on the wire. The IDENTITY.md
+        # "Memory System" section documents this so inner Claude does
+        # not misread null as a store failure.
+        return web.json_response(asdict(stats))
     except Exception:
         log.exception("memory.get_stats failed for chat %d", chat_id)
         return web.json_response({"error": "Memory stats failed"}, status=500)
-
-    # asdict() preserves None for the optional confidence_* fields, which
-    # become JSON null on the wire. The IDENTITY.md "Memory System"
-    # section documents this so inner Claude does not misread null as
-    # a store failure.
-    return web.json_response(asdict(stats))
 
 
 @_require_secret

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -1541,7 +1541,17 @@ async def _handle_memory_add(request: web.Request) -> web.Response:
         return web.json_response({"error": "Missing required field: content"}, status=400)
     content = content.strip()
 
-    memory_type = payload.get("memory_type", "fact")
+    # Two-step handling: collapse explicit None to the default first, then
+    # type-check. This makes `{"memory_type": null}` behave the same as
+    # omitting the field entirely (both fall back to "fact"), matching the
+    # lenient None handling used for `tags` and `metadata` below.
+    # `payload.get("memory_type", "fact")` alone would only apply the
+    # default when the key is ABSENT - an explicit null would slip through
+    # and fail isinstance, surprising callers who reasonably expect null
+    # and missing-key to be equivalent in JSON.
+    memory_type = payload.get("memory_type")
+    if memory_type is None:
+        memory_type = "fact"
     if not isinstance(memory_type, str):
         return web.json_response({"error": "memory_type must be a string"}, status=400)
 
@@ -1793,7 +1803,7 @@ async def _handle_memory_delete_all(request: web.Request) -> web.Response:
     # _resolve_chat_id call on requests we will reject anyway.
     if payload.get("confirm") != _DELETE_ALL_CONFIRM_TOKEN:
         return web.json_response(
-            {"error": (f'Missing or incorrect confirm field; expected "{_DELETE_ALL_CONFIRM_TOKEN}"')},
+            {"error": f'Missing or incorrect confirm field; expected "{_DELETE_ALL_CONFIRM_TOKEN}"'},
             status=400,
         )
 

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -2159,6 +2159,28 @@ class TestMemoryAdd:
         assert resp.status == 403
         mock_add.assert_not_called()
 
+    async def test_returns_500_when_add_structured_raises(self, mock_request):
+        """Unexpected exception in add_structured() -> clean 500 JSON.
+
+        Defense-in-depth: add_structured catches its own exceptions and
+        returns None (handled by the None-check 500 path), but the
+        handler also wraps in case the call raises BEFORE reaching that
+        internal try (init failure, bad argument shape, etc.). Pins the
+        contract that BOTH failure modes produce the same 500 JSON body.
+        """
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": "x"})
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.add_structured", side_effect=RuntimeError("boom")),
+        ):
+            resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 500
+        body = json.loads(resp.body.decode())
+        assert body == {"error": "Memory storage failed"}
+
     async def test_returns_400_on_non_string_content(self, mock_request):
         """Non-string content (number, bool, list, etc.) -> 400, not 500.
 
@@ -2436,6 +2458,20 @@ class TestMemorySearch:
         body = json.loads(resp.body.decode())
         assert body == {"error": "Memory search failed"}
 
+    async def test_returns_403_on_unauthorized_chat_id(self, mock_request):
+        """chat_id not in allowed_user_ids -> 403, primitive not called."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"query": "x", "chat_id": 999})
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.search") as mock_search,
+        ):
+            resp = await _handle_memory_search(mock_request)
+
+        assert resp.status == 403
+        mock_search.assert_not_called()
+
 
 class TestMemoryStats:
     """GET /api/memory/stats"""
@@ -2680,3 +2716,22 @@ class TestMemoryDeleteAll:
         assert resp.status == 500
         body = json.loads(resp.body.decode())
         assert body == {"error": "Memory delete failed"}
+
+    async def test_returns_403_on_unauthorized_chat_id(self, mock_request):
+        """chat_id not in allowed_user_ids -> 403, primitive not called.
+
+        Verifies the 403 path runs even when the confirm token is
+        correct: an unauthorized caller with the right token should
+        still be blocked at the chat_id resolution step.
+        """
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"confirm": self._CONFIRM, "chat_id": 999})
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.delete_all") as mock_del,
+        ):
+            resp = await _handle_memory_delete_all(mock_request)
+
+        assert resp.status == 403
+        mock_del.assert_not_called()

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -17,6 +17,10 @@ from kai.webhook import (
     _handle_get_job,
     _handle_get_jobs,
     _handle_github,
+    _handle_memory_add,
+    _handle_memory_delete_all,
+    _handle_memory_search,
+    _handle_memory_stats,
     _handle_schedule,
     _handle_send_file,
     _handle_send_message,
@@ -1985,3 +1989,468 @@ class TestWALMode:
             assert row[0] == "wal"
         finally:
             await sessions.close_db()
+
+
+# ── /api/memory/* ────────────────────────────────────────────────────
+# Tests for the four memory REST endpoints. The underlying primitives
+# (memory.add_structured, memory.search, memory.get_stats,
+# memory.delete_all, memory.is_enabled) are independently tested in
+# tests/test_memory.py - these tests cover only handler-level behavior
+# (auth, validation, JSON serialization, status-code mapping, and the
+# symmetric is_enabled() precheck).
+#
+# Patch targets are kai.memory.<func> because webhook.py imports memory
+# as a module (`from kai import memory`) and calls it via the module
+# attribute. Patching `kai.webhook.add_structured` would miss because
+# that name does not exist on webhook.
+
+
+class TestMemoryAdd:
+    """POST /api/memory/add"""
+
+    async def test_returns_200_with_id_on_success(self, mock_request):
+        """Happy path: enabled memory + valid body -> 200 with the new id."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": "User likes Earl Grey"})
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.add_structured", return_value="mem-uuid-123"),
+        ):
+            resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 200
+        body = json.loads(resp.body.decode())
+        assert body == {"id": "mem-uuid-123"}
+
+    async def test_returns_503_when_memory_disabled(self, mock_request):
+        """Precheck path: is_enabled() False -> 503; primitive NOT called."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": "anything"})
+
+        with patch("kai.memory.is_enabled", return_value=False), patch("kai.memory.add_structured") as mock_add:
+            resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 503
+        body = json.loads(resp.body.decode())
+        assert body == {"error": "Memory system disabled"}
+        # The whole point of the precheck is to avoid invoking the
+        # primitive when memory is off; assert that contract explicitly.
+        mock_add.assert_not_called()
+
+    async def test_returns_500_when_storage_fails(self, mock_request):
+        """Storage-failure path: enabled but add returns None -> 500."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": "anything"})
+
+        with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.add_structured", return_value=None):
+            resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 500
+        body = json.loads(resp.body.decode())
+        assert body == {"error": "Memory storage failed"}
+
+    async def test_returns_400_on_missing_content(self, mock_request):
+        """Required-field validation: missing `content` -> 400."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"memory_type": "fact"})
+
+        resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 400
+        body = json.loads(resp.body.decode())
+        assert "content" in body["error"]
+
+    async def test_returns_400_on_whitespace_only_content(self, mock_request):
+        """Empty-after-strip check: whitespace-only content -> 400."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": "   \n\t  "})
+
+        resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 400
+
+    async def test_returns_400_on_invalid_json(self, mock_request):
+        """Malformed JSON body -> 400 with a clear error."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(side_effect=json.JSONDecodeError("expecting value", "", 0))
+
+        resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 400
+        body = json.loads(resp.body.decode())
+        assert body == {"error": "Invalid JSON"}
+
+    async def test_returns_401_on_missing_secret(self, mock_request):
+        """No X-Webhook-Secret header -> 401 from the decorator."""
+        mock_request.headers = {}
+        mock_request.json = AsyncMock(return_value={"content": "x"})
+
+        resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 401
+
+    async def test_returns_401_on_wrong_secret(self, mock_request):
+        """Wrong X-Webhook-Secret -> 401 from the decorator."""
+        mock_request.headers = {"X-Webhook-Secret": "nope"}
+        mock_request.json = AsyncMock(return_value={"content": "x"})
+
+        resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 401
+
+    async def test_passes_optional_fields_through(self, mock_request):
+        """memory_type, tags, metadata are forwarded to add_structured verbatim."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(
+            return_value={
+                "content": "User prefers dark mode",
+                "memory_type": "preference",
+                "tags": ["ui", "preference"],
+                "metadata": {"source": "explicit"},
+            }
+        )
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.add_structured", return_value="id-1") as mock_add,
+        ):
+            await _handle_memory_add(mock_request)
+
+        # Verify each optional field reached the primitive intact - if any
+        # got dropped or renamed, this catches the regression at the
+        # handler boundary rather than letting it surface as missing data
+        # in the vector store.
+        kwargs = mock_add.call_args.kwargs
+        assert kwargs["memory_type"] == "preference"
+        assert kwargs["tags"] == ["ui", "preference"]
+        assert kwargs["metadata"] == {"source": "explicit"}
+
+    async def test_stringifies_chat_id_for_user_id(self, mock_request):
+        """Handler converts int chat_id -> str user_id at the memory boundary.
+
+        This is load-bearing: Mem0 keys memories by the string form of
+        user_id. A missed cast would isolate API-stored memories from the
+        existing facts under the same chat_id (silently, since both writes
+        succeed).
+        """
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": "x", "chat_id": 456})
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.add_structured", return_value="id-1") as mock_add,
+        ):
+            await _handle_memory_add(mock_request)
+
+        kwargs = mock_add.call_args.kwargs
+        assert kwargs["user_id"] == "456"
+        assert isinstance(kwargs["user_id"], str)
+
+    async def test_returns_403_on_unauthorized_chat_id(self, mock_request):
+        """chat_id not in allowed_user_ids -> 403, primitive not called."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        # 999 is not in the fixture's allowed_user_ids = {123, 456}
+        mock_request.json = AsyncMock(return_value={"content": "x", "chat_id": 999})
+
+        with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.add_structured") as mock_add:
+            resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 403
+        mock_add.assert_not_called()
+
+
+class TestMemorySearch:
+    """POST /api/memory/search"""
+
+    async def test_returns_200_with_results(self, mock_request):
+        """Happy path: results from search() are serialized into {"results": [...]}."""
+        from kai.memory import MemoryResult
+
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"query": "tea preferences"})
+
+        fake_hit = MemoryResult(
+            id="m1",
+            text="User likes Earl Grey",
+            score=0.85,
+            memory_type="fact",
+            metadata={"source": "extracted", "tags": ["preference"]},
+            created_at="2026-04-23T10:00:00Z",
+        )
+        with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.search", return_value=[fake_hit]):
+            resp = await _handle_memory_search(mock_request)
+
+        assert resp.status == 200
+        body = json.loads(resp.body.decode())
+        # Verify the result structure preserves the dataclass shape via
+        # asdict; metadata round-trips as a nested dict including its
+        # tags list.
+        assert len(body["results"]) == 1
+        assert body["results"][0]["id"] == "m1"
+        assert body["results"][0]["text"] == "User likes Earl Grey"
+        assert body["results"][0]["metadata"]["tags"] == ["preference"]
+
+    async def test_returns_200_with_empty_results(self, mock_request):
+        """No matches: still 200, just an empty list - 503 is reserved for disabled."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"query": "no matches"})
+
+        with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.search", return_value=[]):
+            resp = await _handle_memory_search(mock_request)
+
+        assert resp.status == 200
+        body = json.loads(resp.body.decode())
+        assert body == {"results": []}
+
+    async def test_returns_503_when_memory_disabled(self, mock_request):
+        """Precheck overrides search()'s graceful-degrade [] return."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"query": "anything"})
+
+        with patch("kai.memory.is_enabled", return_value=False), patch("kai.memory.search") as mock_search:
+            resp = await _handle_memory_search(mock_request)
+
+        assert resp.status == 503
+        # Without the precheck, search() would have returned [] and the
+        # API would have returned 200 - indistinguishable from "no
+        # matches". Asserting not_called makes the M-8 contract a test
+        # invariant, not just a code comment.
+        mock_search.assert_not_called()
+
+    async def test_returns_400_on_missing_query(self, mock_request):
+        """Required-field validation."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={})
+
+        resp = await _handle_memory_search(mock_request)
+
+        assert resp.status == 400
+        body = json.loads(resp.body.decode())
+        assert "query" in body["error"]
+
+    async def test_returns_400_on_empty_query(self, mock_request):
+        """Whitespace-only query is rejected like missing."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"query": "   "})
+
+        resp = await _handle_memory_search(mock_request)
+
+        assert resp.status == 400
+
+    async def test_returns_401_on_bad_secret(self, mock_request):
+        mock_request.headers = {"X-Webhook-Secret": "nope"}
+        mock_request.json = AsyncMock(return_value={"query": "x"})
+
+        resp = await _handle_memory_search(mock_request)
+
+        assert resp.status == 401
+
+    async def test_passes_limit_through(self, mock_request):
+        """Caller-supplied `limit` is forwarded as-is to search()."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"query": "x", "limit": 5})
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.search", return_value=[]) as mock_search,
+        ):
+            await _handle_memory_search(mock_request)
+
+        assert mock_search.call_args.kwargs["limit"] == 5
+
+    async def test_passes_none_limit_when_omitted(self, mock_request):
+        """When `limit` is omitted, the handler passes None so search()
+        falls back to its config default rather than a hardcoded number."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"query": "x"})
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.search", return_value=[]) as mock_search,
+        ):
+            await _handle_memory_search(mock_request)
+
+        assert mock_search.call_args.kwargs["limit"] is None
+
+
+class TestMemoryStats:
+    """GET /api/memory/stats"""
+
+    async def test_returns_200_with_stats_at_top_level(self, mock_request):
+        """Stats are returned bare, not wrapped in {"results": ...}."""
+        from kai.memory import MemoryStats
+
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.query = {}
+
+        fake_stats = MemoryStats(
+            total_count=5,
+            by_type={"fact": 4, "preference": 1},
+            extracted_count=4,
+            by_tag={"food": 2, "ui": 1},
+            confidence_min=0.7,
+            confidence_median=0.8,
+            confidence_max=0.95,
+            confidence_below_0_7=0,
+            confidence_below_0_6=0,
+            confirmation_quote_count=1,
+            by_prompt_version={"v2": 4},
+        )
+        with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.get_stats", return_value=fake_stats):
+            resp = await _handle_memory_stats(mock_request)
+
+        assert resp.status == 200
+        body = json.loads(resp.body.decode())
+        # Top-level fields means body["total_count"] not body["stats"]["total_count"].
+        # Catches a regression that wraps the stats dict accidentally.
+        assert body["total_count"] == 5
+        assert body["extracted_count"] == 4
+        assert body["by_type"] == {"fact": 4, "preference": 1}
+
+    async def test_serializes_null_confidence_fields(self, mock_request):
+        """Fresh user (extracted_count == 0): confidence_* fields ship as JSON null.
+
+        The handler MUST preserve None as JSON null, not coerce to 0 or
+        omit the field, because IDENTITY.md tells inner Claude that null
+        means "no extracted facts to summarize" - changing the encoding
+        would silently break that contract.
+        """
+        from kai.memory import MemoryStats
+
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.query = {}
+
+        empty_stats = MemoryStats(total_count=0, by_type={})
+        with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.get_stats", return_value=empty_stats):
+            resp = await _handle_memory_stats(mock_request)
+
+        body = json.loads(resp.body.decode())
+        assert body["confidence_min"] is None
+        assert body["confidence_median"] is None
+        assert body["confidence_max"] is None
+
+    async def test_returns_503_when_memory_disabled(self, mock_request):
+        """Precheck overrides get_stats()'s zeroed-stats degrade."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.query = {}
+
+        with patch("kai.memory.is_enabled", return_value=False), patch("kai.memory.get_stats") as mock_get_stats:
+            resp = await _handle_memory_stats(mock_request)
+
+        assert resp.status == 503
+        mock_get_stats.assert_not_called()
+
+    async def test_reads_chat_id_from_query_string(self, mock_request):
+        """GET endpoint: chat_id comes from query params, mirroring _handle_get_jobs."""
+        from kai.memory import MemoryStats
+
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        # 456 is in allowed_user_ids; query params come in as strings.
+        mock_request.query = {"chat_id": "456"}
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.get_stats", return_value=MemoryStats(total_count=0, by_type={})) as mock_get_stats,
+        ):
+            resp = await _handle_memory_stats(mock_request)
+
+        assert resp.status == 200
+        # Verify the int->str cast happened at the memory boundary.
+        assert mock_get_stats.call_args.kwargs["user_id"] == "456"
+
+    async def test_returns_401_on_bad_secret(self, mock_request):
+        mock_request.headers = {"X-Webhook-Secret": "nope"}
+        mock_request.query = {}
+
+        resp = await _handle_memory_stats(mock_request)
+
+        assert resp.status == 401
+
+    async def test_returns_403_on_unauthorized_chat_id(self, mock_request):
+        """Query-string chat_id outside allowed_user_ids -> 403."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.query = {"chat_id": "999"}
+
+        with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.get_stats") as mock_get_stats:
+            resp = await _handle_memory_stats(mock_request)
+
+        assert resp.status == 403
+        mock_get_stats.assert_not_called()
+
+
+class TestMemoryDeleteAll:
+    """DELETE /api/memory/all"""
+
+    _CONFIRM = "delete-all-memories"
+
+    async def test_returns_200_on_correct_confirm(self, mock_request):
+        """Happy path: correct confirm token -> 200 with deletion ack."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"confirm": self._CONFIRM})
+
+        with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.delete_all"):
+            resp = await _handle_memory_delete_all(mock_request)
+
+        assert resp.status == 200
+        body = json.loads(resp.body.decode())
+        assert body == {"status": "deleted"}
+
+    async def test_returns_400_on_missing_confirm(self, mock_request):
+        """No confirm field -> 400; delete_all is never called."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={})
+
+        with patch("kai.memory.delete_all") as mock_del:
+            resp = await _handle_memory_delete_all(mock_request)
+
+        assert resp.status == 400
+        body = json.loads(resp.body.decode())
+        # Error body must echo the expected token so a stray curl gets
+        # a directly fixable error message.
+        assert self._CONFIRM in body["error"]
+        mock_del.assert_not_called()
+
+    async def test_returns_400_on_wrong_confirm(self, mock_request):
+        """Wrong confirm value -> 400; delete_all is never called."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"confirm": "yes-please"})
+
+        with patch("kai.memory.delete_all") as mock_del:
+            resp = await _handle_memory_delete_all(mock_request)
+
+        assert resp.status == 400
+        mock_del.assert_not_called()
+
+    async def test_returns_503_when_memory_disabled(self, mock_request):
+        """Precheck blocks delete even when confirm is correct."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"confirm": self._CONFIRM})
+
+        with patch("kai.memory.is_enabled", return_value=False), patch("kai.memory.delete_all") as mock_del:
+            resp = await _handle_memory_delete_all(mock_request)
+
+        assert resp.status == 503
+        # The user explicitly asked for a delete; if memory is off, we
+        # tell them the delete didn't actually run rather than silently
+        # acking a no-op.
+        mock_del.assert_not_called()
+
+    async def test_calls_delete_all_with_stringified_user_id(self, mock_request):
+        """int -> str cast at the memory boundary, same as add."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"confirm": self._CONFIRM, "chat_id": 456})
+
+        with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.delete_all") as mock_del:
+            await _handle_memory_delete_all(mock_request)
+
+        assert mock_del.call_args.kwargs["user_id"] == "456"
+        assert isinstance(mock_del.call_args.kwargs["user_id"], str)
+
+    async def test_returns_401_on_bad_secret(self, mock_request):
+        mock_request.headers = {"X-Webhook-Secret": "nope"}
+        mock_request.json = AsyncMock(return_value={"confirm": self._CONFIRM})
+
+        resp = await _handle_memory_delete_all(mock_request)
+
+        assert resp.status == 401

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -2615,3 +2615,24 @@ class TestMemoryDeleteAll:
         resp = await _handle_memory_delete_all(mock_request)
 
         assert resp.status == 401
+
+    async def test_returns_500_when_delete_all_raises(self, mock_request):
+        """Unexpected exception in delete_all() -> clean 500 JSON.
+
+        Same defense-in-depth pattern as the search and stats handlers
+        (added in the prior review round). delete_all() catches its own
+        internal errors today but the handler-level guard makes the 500
+        contract structural rather than primitive-dependent.
+        """
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"confirm": self._CONFIRM})
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.delete_all", side_effect=RuntimeError("boom")),
+        ):
+            resp = await _handle_memory_delete_all(mock_request)
+
+        assert resp.status == 500
+        body = json.loads(resp.body.decode())
+        assert body == {"error": "Memory delete failed"}

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -2209,6 +2209,27 @@ class TestMemoryAdd:
         body = json.loads(resp.body.decode())
         assert "memory_type" in body["error"]
 
+    async def test_treats_null_memory_type_as_default(self, mock_request):
+        """memory_type: null falls back to "fact" rather than 400.
+
+        Matches the lenient None handling already used for tags and
+        metadata (None is equivalent to omitting the field). Pinning
+        the contract so a future "simplify" that switches back to
+        `payload.get("memory_type", "fact")` and rejects explicit
+        nulls would fail this test.
+        """
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": "x", "memory_type": None})
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.add_structured", return_value="id-1") as mock_add,
+        ):
+            resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 200
+        assert mock_add.call_args.kwargs["memory_type"] == "fact"
+
     async def test_returns_400_on_non_list_tags(self, mock_request):
         """tags must be a list when provided (not a string or dict)."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -2414,6 +2414,28 @@ class TestMemorySearch:
         body = json.loads(resp.body.decode())
         assert body == {"error": "Memory search failed"}
 
+    async def test_returns_500_when_serialization_raises(self, mock_request):
+        """asdict failure on a non-dataclass return -> wrapped into 500.
+
+        Pins the contract that the try/except guard covers BOTH the
+        primitive call and the asdict serialization, not just the
+        primitive. Without the wider guard, asdict raising TypeError
+        would escape to aiohttp as an HTML 500.
+        """
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"query": "x"})
+
+        # Returning a non-dataclass forces asdict() to TypeError.
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.search", return_value=["not a dataclass"]),
+        ):
+            resp = await _handle_memory_search(mock_request)
+
+        assert resp.status == 500
+        body = json.loads(resp.body.decode())
+        assert body == {"error": "Memory search failed"}
+
 
 class TestMemoryStats:
     """GET /api/memory/stats"""
@@ -2532,6 +2554,28 @@ class TestMemoryStats:
         with (
             patch("kai.memory.is_enabled", return_value=True),
             patch("kai.memory.get_stats", side_effect=RuntimeError("boom")),
+        ):
+            resp = await _handle_memory_stats(mock_request)
+
+        assert resp.status == 500
+        body = json.loads(resp.body.decode())
+        assert body == {"error": "Memory stats failed"}
+
+    async def test_returns_500_when_serialization_raises(self, mock_request):
+        """asdict failure on a non-dataclass return -> wrapped into 500.
+
+        Same wider-guard contract as the search handler: try/except
+        covers both get_stats() and the asdict step. A future refactor
+        that returns a dict (or anything non-dataclass) instead of
+        MemoryStats would otherwise leak as HTML 500.
+        """
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.query = {}
+
+        # asdict() raises TypeError on a plain dict.
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.get_stats", return_value={"not": "a dataclass"}),
         ):
             resp = await _handle_memory_stats(mock_request)
 

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -2159,6 +2159,67 @@ class TestMemoryAdd:
         assert resp.status == 403
         mock_add.assert_not_called()
 
+    async def test_returns_400_on_non_string_content(self, mock_request):
+        """Non-string content (number, bool, list, etc.) -> 400, not 500.
+
+        Without the isinstance guard at the API boundary, a JSON number
+        or null reaching .strip() would raise AttributeError and escape
+        to aiohttp as an unstyled 500. This test pins the contract that
+        the handler always returns a clean 400 with a JSON error body.
+        """
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": 123})
+
+        resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 400
+        body = json.loads(resp.body.decode())
+        assert "content" in body["error"]
+
+    async def test_returns_400_on_non_string_memory_type(self, mock_request):
+        """memory_type must be a string when provided."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": "x", "memory_type": 42})
+
+        resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 400
+        body = json.loads(resp.body.decode())
+        assert "memory_type" in body["error"]
+
+    async def test_returns_400_on_non_list_tags(self, mock_request):
+        """tags must be a list when provided (not a string or dict)."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": "x", "tags": "single-tag"})
+
+        resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 400
+        body = json.loads(resp.body.decode())
+        assert "tags" in body["error"]
+
+    async def test_returns_400_on_tags_with_non_string_element(self, mock_request):
+        """All tag elements must be strings; mixed-type list -> 400."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": "x", "tags": ["ok", 42]})
+
+        resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 400
+        body = json.loads(resp.body.decode())
+        assert "tags" in body["error"]
+
+    async def test_returns_400_on_non_dict_metadata(self, mock_request):
+        """metadata must be a JSON object when provided."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": "x", "metadata": ["a", "b"]})
+
+        resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 400
+        body = json.loads(resp.body.decode())
+        assert "metadata" in body["error"]
+
 
 class TestMemorySearch:
     """POST /api/memory/search"""
@@ -2273,6 +2334,86 @@ class TestMemorySearch:
 
         assert mock_search.call_args.kwargs["limit"] is None
 
+    async def test_returns_400_on_non_string_query(self, mock_request):
+        """Non-string query (number, bool, list, etc.) -> 400.
+
+        Same isinstance-before-.strip() guard as content in the add
+        handler. Pinning the contract so a future refactor can't
+        regress to the AttributeError-escapes-as-500 failure mode.
+        """
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"query": 42})
+
+        resp = await _handle_memory_search(mock_request)
+
+        assert resp.status == 400
+        body = json.loads(resp.body.decode())
+        assert "query" in body["error"]
+
+    async def test_returns_400_on_non_int_limit(self, mock_request):
+        """`limit` must be an int when provided; string -> 400."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"query": "x", "limit": "five"})
+
+        resp = await _handle_memory_search(mock_request)
+
+        assert resp.status == 400
+        body = json.loads(resp.body.decode())
+        assert "limit" in body["error"]
+
+    async def test_returns_400_on_zero_limit(self, mock_request):
+        """`limit` must be positive; 0 -> 400."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"query": "x", "limit": 0})
+
+        resp = await _handle_memory_search(mock_request)
+
+        assert resp.status == 400
+
+    async def test_returns_400_on_negative_limit(self, mock_request):
+        """Negative `limit` -> 400."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"query": "x", "limit": -3})
+
+        resp = await _handle_memory_search(mock_request)
+
+        assert resp.status == 400
+
+    async def test_returns_400_on_bool_limit(self, mock_request):
+        """`limit: true` rejected: bool is an int subclass in Python.
+
+        Without the explicit isinstance(limit, bool) short-circuit,
+        `{"limit": true}` would pass `isinstance(limit, int)` and be
+        treated as `limit=1`, silently truncating results. This test
+        is the contract that this Python-specific footgun stays closed.
+        """
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"query": "x", "limit": True})
+
+        resp = await _handle_memory_search(mock_request)
+
+        assert resp.status == 400
+
+    async def test_returns_500_when_search_raises(self, mock_request):
+        """Unexpected exception in search() -> clean 500 JSON, not aiohttp 500 page.
+
+        Defense-in-depth: search() catches its own exceptions today, but
+        the handler still wraps to ensure the 500 contract is structural
+        rather than dependent on the primitive's internal behavior.
+        """
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"query": "x"})
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.search", side_effect=RuntimeError("boom")),
+        ):
+            resp = await _handle_memory_search(mock_request)
+
+        assert resp.status == 500
+        body = json.loads(resp.body.decode())
+        assert body == {"error": "Memory search failed"}
+
 
 class TestMemoryStats:
     """GET /api/memory/stats"""
@@ -2377,6 +2518,26 @@ class TestMemoryStats:
 
         assert resp.status == 403
         mock_get_stats.assert_not_called()
+
+    async def test_returns_500_when_get_stats_raises(self, mock_request):
+        """Unexpected exception in get_stats() -> clean 500 JSON.
+
+        get_stats() doesn't catch its own exceptions today (the
+        aggregation could raise on a malformed row), so this guard is
+        the actual error contract, not just defense-in-depth.
+        """
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.query = {}
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.get_stats", side_effect=RuntimeError("boom")),
+        ):
+            resp = await _handle_memory_stats(mock_request)
+
+        assert resp.status == 500
+        body = json.loads(resp.body.decode())
+        assert body == {"error": "Memory stats failed"}
 
 
 class TestMemoryDeleteAll:


### PR DESCRIPTION
## Summary

Adds four REST endpoints in `webhook.py` that wrap the existing `memory.py` primitives so inner Claude (and other localhost clients) can deliberately store, retrieve, and inspect memories via curl. No changes to `memory.py` — the primitives all already exist and are independently tested.

| Endpoint | Method | Wraps |
|---|---|---|
| `/api/memory/add` | POST | `memory.add_structured()` |
| `/api/memory/search` | POST | `memory.search()` |
| `/api/memory/stats` | GET | `memory.get_stats()` |
| `/api/memory/all` | DELETE | `memory.delete_all()` |

All four share a symmetric `memory.is_enabled()` precheck that returns 503 when memory is disabled. Same status code across the API surface so callers pick a single retry policy: 503 means memory is off, do not retry, escalate to operator. Without the precheck, the three read endpoints whose primitives degrade gracefully would return their degraded outputs (empty results, zeroed stats, silent no-op) at 200, conflating "memory off" with "no data."

`/api/memory/add` adds a second failure-mode status: 500 when `add_structured()` returns `None` despite memory being enabled (the underlying store call failed; may be transient). The split lets callers pick different retry policies per status code.

`/api/memory/all` requires an exact-match confirm token in the request body (`"delete-all-memories"`). Static well-known string rather than per-request UUID because the threat model is typo and prompt-injection defense, not replay protection. A stray curl that omits the token gets a 400 with a clear hint at the expected value.

`IDENTITY.md` (canonical inner-Claude identity file) gains a Memory System section with curl examples for each endpoint, when-to-store guidance, and an explicit note that null `confidence_*` fields in `/api/memory/stats` indicate "no extracted facts to summarize," not a store failure.

Episodes and preferences (the rest of the explicit memory API designed in #308) remain tracked at #308 and will be filed as separate sub-issues if eval data warrants. This is the foundation sub-issue.

Closes #375.

## Test plan

- [x] `make check` clean (ruff check + format)
- [x] `make test` 2353 passed (was 2321 on main; +32 new tests)
- [x] 31 new handler tests in `tests/test_webhook_api.py` covering all four endpoints
  - 200 happy paths for each endpoint
  - 503 precheck path for each endpoint, with `assert_not_called()` on the underlying primitive (M-8 contract enforcement)
  - 500 storage-failure path for `/api/memory/add`
  - 400 paths: invalid JSON, missing fields, empty fields, wrong/missing confirm token
  - 401 paths: missing and wrong `X-Webhook-Secret`
  - 403 paths: unauthorized chat_id
  - `int → str` chat_id cast at the memory boundary verified via mock call args
  - Optional fields (`tags`, `metadata`, `memory_type`, `limit`) round-trip through to primitives
  - Frozen-dataclass JSON serialization including `None → null` for fresh-user confidence fields
- [x] Smoke import of `kai.webhook` confirms handlers and registrations are wired

## Notes for review

- The four handlers import memory as a module (`from kai import memory`) so tests can patch `kai.memory.<name>` uniformly. Function-level imports would force tests to patch the local binding `kai.webhook.add_structured`, a known mocking pitfall.
- DELETE handler reads `chat_id` from the JSON body alongside the `confirm` token, diverging from `_handle_delete_job` which reads `chat_id` from query params. Splitting `confirm` into the body and `chat_id` into the query would be inconsistent within the same endpoint; flagged in the handler docstring.
- POST chosen for `/api/memory/search` (not GET) because user-message-shaped queries can be long and would hit URL-length limits, and POST matches the rest of the `/api/*` surface.
