### PR TITLE
feat(config): add CLAUDE_EFFORT_LEVEL for inner Claude --effort flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,13 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 # Per-user defaults are set via 'max_budget' in users.yaml.
 #BUDGET_CEILING=10.0
 
+# Effort level for inner Claude reasoning (low|medium|high|xhigh|max).
+# Higher = more thinking tokens per turn = better answers + higher
+# token spend. Interacts with BUDGET_CEILING: high effort spends tokens
+# faster, so pair with a higher BUDGET_CEILING for long sessions.
+# Truly global; applies to every chat's inner Claude subprocess.
+#CLAUDE_EFFORT_LEVEL=high
+
 # Maximum session age in hours before recycling (0 = no limit).
 # Prevents unbounded memory growth in the inner Claude process.
 # Recommended: 4-8 hours for memory-constrained machines.

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -94,6 +94,11 @@ class ClaudeCodeBackend(AgentBackend):
         workspace_config: WorkspaceConfig | None = None,
         max_context_window: int = 0,
         autocompact_pct: int = 0,
+        # Default duplicated from Config.claude_effort_level (config.py).
+        # Production calls (pool.py) always pass an explicit value from
+        # config so the duplication is invisible there; the default here
+        # exists so direct ClaudeCodeBackend(...) instantiation in tests
+        # does not have to plumb an effort kwarg. Keep the two in sync.
         claude_effort_level: str = "high",
     ):
         # ABC-required attributes (pool.py reads/writes these)

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -94,6 +94,7 @@ class ClaudeCodeBackend(AgentBackend):
         workspace_config: WorkspaceConfig | None = None,
         max_context_window: int = 0,
         autocompact_pct: int = 0,
+        claude_effort_level: str = "high",
     ):
         # ABC-required attributes (pool.py reads/writes these)
         self.model = model
@@ -103,6 +104,15 @@ class ClaudeCodeBackend(AgentBackend):
         self.timeout_seconds = timeout_seconds
         self.workspace_config = workspace_config
         self.max_context_window = max_context_window
+        # Effort level for the inner Claude --effort flag. Stored on the
+        # instance so the value is fixed for the life of the subprocess
+        # rather than re-read from config on every claude_cmd build, and
+        # so subclasses / tests can override it without monkey-patching
+        # config. No _default_claude_effort_level shadow because there
+        # is no workspace-level override path that would need to restore
+        # a default after a /workspace switch (see workspace_config block
+        # below for the pattern that DOES need a default shadow).
+        self.claude_effort_level = claude_effort_level
         self.provider = "anthropic"  # Claude CLI always uses Anthropic
 
         # Claude-Code-specific attributes (not on the ABC)
@@ -191,6 +201,19 @@ class ClaudeCodeBackend(AgentBackend):
             "--verbose",
             "--model",
             self.model,
+            # Effort level controls how many reasoning tokens Claude spends
+            # per turn. Passed as a CLI flag (verified against `claude --help`)
+            # rather than via the --settings JSON path below, because CLI
+            # flags fail loudly on typo at subprocess startup while the
+            # --settings JSON path is reserved for keys that have no
+            # dedicated CLI entry. Future maintainer: do NOT migrate this
+            # into the --settings JSON without first re-verifying the key
+            # name against `claude --help`. The value is validated at
+            # config load (config.py _VALID_EFFORT_LEVELS) so by the time
+            # it reaches this point it is guaranteed to be one of the
+            # five accepted strings.
+            "--effort",
+            self.claude_effort_level,
             "--permission-mode",
             "bypassPermissions",
             "--max-budget-usd",

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -120,14 +120,21 @@ def get_effective_provider(backend: str, llm_provider: str) -> str:
 
 # Valid values for the inner Claude --effort flag, taken verbatim from
 # `claude --help` output. If Anthropic adds a new tier (e.g. "ultra"),
-# this set must be updated here or otherwise-valid configs will be
-# rejected at config-load time. Pinned as a module-level frozenset so
-# the membership check is O(1) and the values are not re-allocated on
-# every config load. Validation against this set keeps an invalid
-# CLAUDE_EFFORT_LEVEL from reaching the inner-Claude subprocess: a
-# bad value would otherwise cost a full session to discover (the
-# subprocess would fail at startup, not at config load).
-_VALID_EFFORT_LEVELS: frozenset[str] = frozenset({"low", "medium", "high", "xhigh", "max"})
+# update EFFORT_LEVELS here or otherwise-valid configs will be rejected
+# at config-load time. Two shapes intentionally:
+#   - EFFORT_LEVELS (ordered tuple): operator-facing surface. Used in
+#     error messages and wizard prompts so the listing reads as an
+#     intensity progression (low -> max) rather than alphabetical
+#     ('high','low','max','medium','xhigh'), which is what sorted()
+#     on the frozenset would produce and would confuse an operator.
+#   - _VALID_EFFORT_LEVELS (derived frozenset): internal membership
+#     check, O(1). Derived from EFFORT_LEVELS so the two cannot drift.
+# Validation against the frozenset keeps an invalid CLAUDE_EFFORT_LEVEL
+# from reaching the inner-Claude subprocess: a bad value would otherwise
+# cost a full session to discover (the subprocess would fail at startup,
+# not at config load).
+EFFORT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
+_VALID_EFFORT_LEVELS: frozenset[str] = frozenset(EFFORT_LEVELS)
 
 
 def validate_model_for_provider(model: str, provider: str) -> bool:
@@ -1362,9 +1369,11 @@ def load_config() -> Config:
     # operator-visible behavior consistent across the cluster.
     claude_effort_level = os.environ.get("CLAUDE_EFFORT_LEVEL", "high").strip().lower() or "high"
     if claude_effort_level not in _VALID_EFFORT_LEVELS:
-        raise SystemExit(
-            f"CLAUDE_EFFORT_LEVEL must be one of {sorted(_VALID_EFFORT_LEVELS)}, got {claude_effort_level!r}"
-        )
+        # Use the ordered tuple, not sorted(_VALID_EFFORT_LEVELS) - the
+        # latter would print alphabetically ('high','low','max','medium',
+        # 'xhigh'), which mangles the intensity progression an operator
+        # expects to see in an error string.
+        raise SystemExit(f"CLAUDE_EFFORT_LEVEL must be one of {list(EFFORT_LEVELS)}, got {claude_effort_level!r}")
 
     # PR review agent config
     pr_review_enabled = os.environ.get("PR_REVIEW_ENABLED", "").lower() in ("1", "true", "yes")

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -118,6 +118,18 @@ def get_effective_provider(backend: str, llm_provider: str) -> str:
     return llm_provider
 
 
+# Valid values for the inner Claude --effort flag, taken verbatim from
+# `claude --help` output. If Anthropic adds a new tier (e.g. "ultra"),
+# this set must be updated here or otherwise-valid configs will be
+# rejected at config-load time. Pinned as a module-level frozenset so
+# the membership check is O(1) and the values are not re-allocated on
+# every config load. Validation against this set keeps an invalid
+# CLAUDE_EFFORT_LEVEL from reaching the inner-Claude subprocess: a
+# bad value would otherwise cost a full session to discover (the
+# subprocess would fail at startup, not at config load).
+_VALID_EFFORT_LEVELS: frozenset[str] = frozenset({"low", "medium", "high", "xhigh", "max"})
+
+
 def validate_model_for_provider(model: str, provider: str) -> bool:
     """Check if a model is valid for a provider.
 
@@ -341,6 +353,20 @@ class Config:
     # 0 = use Claude Code defaults (1M window, ~83% autocompact threshold).
     claude_max_context_window: int = 0  # tokens; passed as --max-context-window CLI flag
     claude_autocompact_pct: int = 0  # 1-100; passed as CLAUDE_AUTOCOMPACT_PCT_OVERRIDE env var
+
+    # Effort level passed to inner Claude as `--effort <value>`. Higher
+    # settings spend more reasoning tokens per turn, improving answer
+    # quality at the cost of latency and budget. Default "high" matches
+    # the operator's outer-Claude default; switching to "medium" globally
+    # would silently downgrade existing reasoning quality. Critical when
+    # CLAUDE_USER / users.yaml `os_user` is set, because inner Claude
+    # then runs as a different OS user and does NOT inherit the outer
+    # operator's settings.json effort default - without this CLI value,
+    # user-isolated installs would silently fall to whatever the claude
+    # binary picks as its own default. Validated at config load against
+    # _VALID_EFFORT_LEVELS so a typo fails fast rather than at the
+    # subprocess startup of the next chat session.
+    claude_effort_level: str = "high"
 
     # Database - uses DATA_DIR so the db lands in the writable data directory
     session_db_path: Path = field(default_factory=lambda: DATA_DIR / "kai.db")
@@ -1323,6 +1349,23 @@ def load_config() -> Config:
     except ValueError:
         raise SystemExit("CLAUDE_AUTOCOMPACT_PCT must be an integer") from None
 
+    # CLAUDE_EFFORT_LEVEL: validated against the documented `claude --help`
+    # allow-list (_VALID_EFFORT_LEVELS at module top). Lowercase + strip so
+    # "HIGH " or " medium" copy-pasted from docs do not become silent
+    # operator footguns. Empty string / unset both fall back to the
+    # dataclass default ("high") via the `or "high"` short-circuit on the
+    # stripped value. Parsing is a simple membership check rather than the
+    # surrounding numeric blocks' try/except ValueError pattern, because
+    # str.strip().lower() cannot raise; the membership check is the only
+    # way to fail. SystemExit on bad input mirrors how the surrounding
+    # CLAUDE_* parsing blocks signal config-load failure, keeping the
+    # operator-visible behavior consistent across the cluster.
+    claude_effort_level = os.environ.get("CLAUDE_EFFORT_LEVEL", "high").strip().lower() or "high"
+    if claude_effort_level not in _VALID_EFFORT_LEVELS:
+        raise SystemExit(
+            f"CLAUDE_EFFORT_LEVEL must be one of {sorted(_VALID_EFFORT_LEVELS)}, got {claude_effort_level!r}"
+        )
+
     # PR review agent config
     pr_review_enabled = os.environ.get("PR_REVIEW_ENABLED", "").lower() in ("1", "true", "yes")
     try:
@@ -1582,6 +1625,7 @@ def load_config() -> Config:
         claude_idle_timeout=claude_idle_timeout,
         claude_max_context_window=claude_max_context_window,
         claude_autocompact_pct=claude_autocompact_pct,
+        claude_effort_level=claude_effort_level,
         webhook_port=webhook_port,
         webhook_secret=os.environ.get("WEBHOOK_SECRET", ""),
         voice_enabled=os.environ.get("VOICE_ENABLED", "").lower() in ("1", "true", "yes"),

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -40,6 +40,7 @@ from pathlib import Path
 import yaml
 
 from kai.config import (
+    EFFORT_LEVELS,
     MAX_CONTEXT_CEILING,
     OPEN_ENDED_PROVIDERS,
     PROJECT_ROOT,
@@ -565,9 +566,14 @@ def _cmd_config() -> None:
     # the runtime allow-list check in config._VALID_EFFORT_LEVELS so the
     # operator cannot persist an invalid value to install.conf and have
     # it fail later at service startup.
+    # Use the canonical EFFORT_LEVELS tuple from config so the wizard
+    # prompt and the runtime allow-list cannot drift out of sync. Cast
+    # to list because _prompt_choice expects a list (it joins with "/"
+    # for the display string and uses `in` for membership; tuple would
+    # work for both but the type signature asks for list).
     claude_effort_level = _prompt_choice(
         "Inner Claude effort level",
-        ["low", "medium", "high", "xhigh", "max"],
+        list(EFFORT_LEVELS),
         existing_env.get("CLAUDE_EFFORT_LEVEL", "high"),
     )
     print()

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -557,6 +557,21 @@ def _cmd_config() -> None:
         print("  Must be 0-100.")
     print()
 
+    # CLAUDE_EFFORT_LEVEL is a truly-global setting (single value applies
+    # to every chat's inner Claude subprocess), so the prompt sits OUT-
+    # SIDE the per-user-vs-global if/else above and runs unconditionally.
+    # This matches the autocompact_pct precedent immediately above.
+    # _prompt_choice enforces the allow-list at wizard time, mirroring
+    # the runtime allow-list check in config._VALID_EFFORT_LEVELS so the
+    # operator cannot persist an invalid value to install.conf and have
+    # it fail later at service startup.
+    claude_effort_level = _prompt_choice(
+        "Inner Claude effort level",
+        ["low", "medium", "high", "xhigh", "max"],
+        existing_env.get("CLAUDE_EFFORT_LEVEL", "high"),
+    )
+    print()
+
     # -- Webhook server --
     print("-- Webhook server --")
     while True:
@@ -856,6 +871,16 @@ def _cmd_config() -> None:
         env["CLAUDE_MAX_CONTEXT_WINDOW"] = max_context_window
     if int(autocompact_pct) != 0:
         env["CLAUDE_AUTOCOMPACT_PCT"] = autocompact_pct
+
+    # CLAUDE_EFFORT_LEVEL is global (not per-user), so it is considered
+    # regardless of users.yaml. Only emit when the operator picked a
+    # non-default value to keep install.conf as a delta from defaults
+    # rather than a snapshot of every available knob - matches the
+    # autocompact_pct treatment immediately above. The wizard's
+    # _prompt_choice already validated the value against the same
+    # allow-list config.py uses, so no re-validation here.
+    if claude_effort_level != "high":
+        env["CLAUDE_EFFORT_LEVEL"] = claude_effort_level
 
     # Conditionally add optional values
     if transport == "webhook":

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -215,6 +215,7 @@ class SubprocessPool:
             workspace_config=ws_config,
             max_context_window=context_window,
             autocompact_pct=self._config.claude_autocompact_pct,
+            claude_effort_level=self._config.claude_effort_level,
         )
 
     # ── Prompt routing ──────────────────────────────────────────────

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -368,6 +368,52 @@ class TestCommandConstruction:
             env = mock_exec.call_args[1]["env"]
             assert "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE" not in env
 
+    @pytest.mark.asyncio
+    async def test_effort_flag_default_in_cmd(self):
+        """--effort high is always present in the command, even when no
+        explicit value is passed. The default at the kwarg layer must
+        propagate to the subprocess so user-isolated installs do not
+        silently fall to the claude binary's own internal default."""
+        claude = _make_claude()
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = AsyncMock()
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+            cmd = mock_exec.call_args[0]
+            # `--effort` must appear with its value at the next index.
+            # Asserting adjacency catches a regression where the flag
+            # name and value get separated by an inserted arg.
+            assert "--effort" in cmd, f"--effort missing from cmd: {cmd}"
+            idx = cmd.index("--effort")
+            assert cmd[idx + 1] == "high", f"expected default 'high', got {cmd[idx + 1]!r}"
+
+    @pytest.mark.asyncio
+    async def test_effort_flag_custom_value_in_cmd(self):
+        """A non-default effort_level threads from the constructor kwarg
+        into the subprocess command line. This is the contract that the
+        whole config -> pool -> backend -> subprocess plumbing exists
+        to satisfy; if it breaks, operator-set CLAUDE_EFFORT_LEVEL
+        becomes a silent no-op."""
+        claude = _make_claude(claude_effort_level="xhigh")
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = AsyncMock()
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+            cmd = mock_exec.call_args[0]
+            assert "--effort" in cmd
+            idx = cmd.index("--effort")
+            assert cmd[idx + 1] == "xhigh"
+
 
 # ── Process signal handling ──────────────────────────────────────────
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,7 @@ _CONFIG_ENV_VARS = [
     "GITHUB_NOTIFY_CHAT_ID",
     "CLAUDE_MAX_CONTEXT_WINDOW",
     "CLAUDE_AUTOCOMPACT_PCT",
+    "CLAUDE_EFFORT_LEVEL",
     "TOTP_SESSION_MINUTES",
     "TOTP_CHALLENGE_SECONDS",
     "TOTP_LOCKOUT_ATTEMPTS",
@@ -1186,6 +1187,75 @@ class TestLegacyEnvOnlyMode:
         with caplog.at_level(logging.WARNING, logger="kai.config"):
             load_config()
         assert "deprecated" not in caplog.text.lower()
+
+
+# ── CLAUDE_EFFORT_LEVEL config ───────────────────────────────────────
+
+
+class TestClaudeEffortLevel:
+    """Coverage for the CLAUDE_EFFORT_LEVEL env var: a single global
+    string validated against a hard-coded allow-list pulled from
+    `claude --help` output. Default "high" is intentional - it must
+    match the operator's outer-Claude default so user-isolated inner
+    Claude (CLAUDE_USER / users.yaml `os_user`) does not silently
+    fall to whatever the binary picks as its own default. Tests here
+    cover happy path, allow-list rejection, and the two normalization
+    behaviors (case + whitespace) that exist to absorb common copy-
+    paste shapes from .env files."""
+
+    def test_default_when_unset(self, monkeypatch):
+        # Default "high" applies when the env var is not set at all.
+        # Critical because operators on existing installs will deploy
+        # without setting CLAUDE_EFFORT_LEVEL and must get the same
+        # reasoning quality as before this PR landed.
+        _set_required(monkeypatch)
+        config = load_config()
+        assert config.claude_effort_level == "high"
+
+    def test_valid_value_parses(self, monkeypatch):
+        # All five allow-list values must round-trip cleanly. If the
+        # `claude --help` output ever adds a value, this list (and the
+        # _VALID_EFFORT_LEVELS frozenset in config.py) must be updated
+        # together; failing one without the other would silently
+        # reject otherwise-valid configs at load time.
+        _set_required(monkeypatch)
+        for value in ["low", "medium", "high", "xhigh", "max"]:
+            monkeypatch.setenv("CLAUDE_EFFORT_LEVEL", value)
+            config = load_config()
+            assert config.claude_effort_level == value, f"value {value!r} did not round-trip"
+
+    def test_invalid_value_raises(self, monkeypatch):
+        # Anything outside the allow-list must SystemExit at config load,
+        # not silently fall through to the inner-Claude subprocess. A
+        # subprocess-level rejection would burn an entire chat session
+        # before the operator saw the error; the allow-list check fails
+        # at startup before any chat is served.
+        _set_required(monkeypatch)
+        monkeypatch.setenv("CLAUDE_EFFORT_LEVEL", "extreme")
+        with pytest.raises(SystemExit, match="CLAUDE_EFFORT_LEVEL"):
+            load_config()
+
+    def test_uppercase_normalized(self, monkeypatch):
+        # `.lower()` in the parser must accept "HIGH" / "Medium" / etc.
+        # Without normalization, mixed case copied from docs or upper-
+        # cased by an operator's editor would be silently rejected, and
+        # the rejection reason ("not in allow-list") would be opaque
+        # because the values look identical to a casual reader.
+        _set_required(monkeypatch)
+        monkeypatch.setenv("CLAUDE_EFFORT_LEVEL", "HIGH")
+        config = load_config()
+        assert config.claude_effort_level == "high"
+
+    def test_whitespace_stripped(self, monkeypatch):
+        # `.strip()` must absorb surrounding whitespace from copy-paste
+        # of .env entries (a common source of "value looks right but is
+        # rejected" footguns). Same reason as the case test: prevents
+        # an opaque allow-list rejection on a value that visually
+        # matches an allowed one.
+        _set_required(monkeypatch)
+        monkeypatch.setenv("CLAUDE_EFFORT_LEVEL", "  medium  ")
+        config = load_config()
+        assert config.claude_effort_level == "medium"
 
 
 # ── Memory extraction config (spec §6.4, §13.1) ─────────────────────

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1257,6 +1257,22 @@ class TestClaudeEffortLevel:
         config = load_config()
         assert config.claude_effort_level == "medium"
 
+    def test_whitespace_only_falls_back_to_default(self, monkeypatch):
+        # The `or "high"` fallback in the parser fires only when the
+        # stripped value is empty - i.e. when the env var is set but
+        # contains only whitespace. test_whitespace_stripped above
+        # uses a real value with surrounding whitespace; this case
+        # closes the gap by exercising the fallback branch directly.
+        # Without this test, a regression that dropped the `or "high"`
+        # would let an empty string slip past the strip and hit the
+        # allow-list check, producing a SystemExit instead of the
+        # silent default behavior an operator would expect when the
+        # env var is effectively unset.
+        _set_required(monkeypatch)
+        monkeypatch.setenv("CLAUDE_EFFORT_LEVEL", "   ")
+        config = load_config()
+        assert config.claude_effort_level == "high"
+
 
 # ── Memory extraction config (spec §6.4, §13.1) ─────────────────────
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -760,6 +760,7 @@ class TestCmdConfig:
                 "10.0",  # budget
                 "200000",  # max context window
                 "80",  # autocompact pct
+                "",  # claude effort level (take default "high")
                 "8080",  # port
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
@@ -833,6 +834,7 @@ class TestCmdConfig:
                 "10.0",  # budget
                 "200000",  # max context window
                 "80",  # autocompact pct
+                "",  # claude effort level (take default "high")
                 "8080",  # port
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
@@ -911,6 +913,7 @@ class TestCmdConfig:
                 "10.0",  # budget
                 "200000",  # max context window
                 "80",  # autocompact pct
+                "",  # claude effort level (take default "high")
                 "8080",  # port
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
@@ -974,6 +977,7 @@ class TestCmdConfig:
                 "10.0",
                 "200000",
                 "80",
+                "",  # claude effort level (take default "high")
                 "8080",
                 "test-secret",
                 "~/Projects",
@@ -1031,6 +1035,7 @@ class TestCmdConfig:
                 "10.0",  # budget
                 "200000",  # max context window
                 "80",  # autocompact pct
+                "",  # claude effort level (take default "high")
                 "8080",  # port
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
@@ -1086,6 +1091,7 @@ class TestCmdConfig:
                 "10.0",  # budget
                 "200000",  # max context window
                 "80",  # autocompact pct
+                "",  # claude effort level (take default "high")
                 "8080",  # port
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
@@ -1187,6 +1193,7 @@ class TestCmdConfig:
             "10.0",  # budget
             "200000",  # max context window
             "80",  # autocompact pct
+            "",  # claude effort level (take default "high")
             "8080",  # port
             "test-secret",  # webhook secret
             "~/Projects",  # workspace base
@@ -1391,6 +1398,7 @@ class TestCmdConfig:
                 "10.0",  # budget
                 "200000",  # max context window
                 "80",  # autocompact pct
+                "",  # claude effort level (take default "high")
                 "8080",  # port
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1175,8 +1175,15 @@ class TestCmdConfig:
     # ── Memory env var prompts (#343) ─────────────────────────────────
 
     @staticmethod
-    def _base_inputs(memory_block: list[str]) -> list[str]:
-        """Default wizard inputs with a swappable memory block."""
+    def _base_inputs(memory_block: list[str], effort: str = "") -> list[str]:
+        """Default wizard inputs with a swappable memory block.
+
+        `effort` lets a test exercise a non-default CLAUDE_EFFORT_LEVEL
+        without rebuilding the whole input list. Empty string accepts
+        the wizard default ("high"); pass any allow-list value (low,
+        medium, high, xhigh, max) to drive the non-default emission
+        branch in install.py.
+        """
         return [
             "/opt/kai",  # install dir
             "/var/lib/kai",  # data dir
@@ -1193,7 +1200,7 @@ class TestCmdConfig:
             "10.0",  # budget
             "200000",  # max context window
             "80",  # autocompact pct
-            "",  # claude effort level (take default "high")
+            effort,  # claude effort level ("" = default "high")
             "8080",  # port
             "test-secret",  # webhook secret
             "~/Projects",  # workspace base
@@ -1225,6 +1232,47 @@ class TestCmdConfig:
         conf = json.loads((tmp_path / "install.conf").read_text())
         for key in conf["env"]:
             assert not key.startswith("MEMORY_"), f"unexpected memory key: {key}"
+
+    def test_effort_level_default_omits_env_key(self, tmp_path, monkeypatch):
+        """The CLAUDE_EFFORT_LEVEL env key is omitted when the operator
+        accepts the wizard default. install.conf is meant to be a delta
+        from defaults, so the absence of the key is the positive signal
+        that nothing was overridden. Pairs with the non-default test
+        below to pin both sides of the emission branch in install.py."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+
+        inputs = iter(self._base_inputs(["false"], effort=""))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        conf = json.loads((tmp_path / "install.conf").read_text())
+        assert "CLAUDE_EFFORT_LEVEL" not in conf["env"]
+
+    def test_effort_level_non_default_writes_env_key(self, tmp_path, monkeypatch):
+        """A non-default CLAUDE_EFFORT_LEVEL must round-trip from the
+        wizard prompt into install.conf. Closes the gap noted in PR
+        review: previously every test took the default, leaving the
+        emission branch (`if claude_effort_level != "high": env[...] =`)
+        untested as a positive case. xhigh is chosen because it is
+        unambiguously non-default and is also the value used by the
+        unit test in tests/test_claude.py for the matching subprocess
+        side, keeping a single non-default value across both layers."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+
+        inputs = iter(self._base_inputs(["false"], effort="xhigh"))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        conf = json.loads((tmp_path / "install.conf").read_text())
+        assert conf["env"].get("CLAUDE_EFFORT_LEVEL") == "xhigh"
 
     def test_memory_enabled_writes_tunables(self, tmp_path, monkeypatch):
         """MEMORY_ENABLED=true with extraction writes the chosen tunables."""


### PR DESCRIPTION
## Summary

- Adds `CLAUDE_EFFORT_LEVEL` global env var (and matching `claude_effort_level` Config field) that threads through to the inner Claude subprocess as `--effort <value>`. Allowed values are `low|medium|high|xhigh|max`, validated at config load against an allow-list pulled verbatim from `claude --help`.
- Default value is `high`, matching the operator's outer-Claude default. Critical when `CLAUDE_USER` or per-user `os_user` is set: inner Claude runs as a different OS user and does NOT inherit the operator's settings.json effort default, so without an explicit CLI value user-isolated installs would silently fall to whatever the binary picks as its own default.
- Wizard (`make config`) prompts for the value after the autocompact threshold prompt and emits the env var only when non-default, matching the existing "delta from default" pattern in `install.conf`.
- Naming refinement vs. issue: issue body proposed `EFFORT_LEVEL`; the implemented name is `CLAUDE_EFFORT_LEVEL` to match the established `CLAUDE_*` env-var cluster for inner-Claude knobs (`CLAUDE_TIMEOUT_SECONDS`, `CLAUDE_MAX_SESSION_HOURS`, `CLAUDE_MAX_CONTEXT_WINDOW`, `CLAUDE_AUTOCOMPACT_PCT`). Recorded in an issue comment before this PR.

Fixes #378

## Test plan

- [ ] `make check` (ruff check + format) — local: passes
- [ ] `make test` (full suite, 2382 tests) — local: passes
- [ ] `TestClaudeEffortLevel` (6 new tests in `tests/test_config.py`): defaults, valid value parsing, invalid value rejection, uppercase normalization, whitespace stripping, whitespace-only falls back to default (the last added in round-1 review to cover the `or "high"` fallback branch directly)
- [ ] `test_effort_flag_default_in_cmd` and `test_effort_flag_custom_value_in_cmd` (2 new tests in `tests/test_claude.py`): assert `--effort <value>` appears adjacently in the constructed subprocess command
- [ ] `test_effort_level_default_omits_env_key` and `test_effort_level_non_default_writes_env_key` (2 new tests in `tests/test_install.py` from round-1 review): pin both sides of the install.conf delta-from-default emission branch
- [ ] Existing `tests/test_install.py` wizard sequences (8 sites) updated to include the new prompt; all pass
- [ ] Verify `make config` walk-through prompts for the new value and persists `CLAUDE_EFFORT_LEVEL` to `install.conf` only when non-default
- [ ] Spot-check that a running install with `CLAUDE_EFFORT_LEVEL=xhigh` in env produces `--effort xhigh` in the inner-Claude subprocess command line (e.g. via `ps -ef | grep claude`)

## Out of scope

- Per-user `claude_effort_level` via `users.yaml` — separate follow-up issue if/when there is a use case
- Per-workspace overrides via `WorkspaceConfig` — same reasoning
- The unrelated `--settings` JSON `maxContextWindow` no-op bug in `claude.py` — separate follow-up issue
- The Haiku memory-extraction subprocess — its effort is controlled implicitly by the Haiku model choice and per-extraction budget envelope
