### PR TITLE
fix(install): gate Claude-only wizard prompts on agent_backend

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -543,40 +543,53 @@ def _cmd_config() -> None:
     # conversation history. Lower values compact sooner, reducing token
     # usage at the cost of losing raw context earlier. Claude Code caps
     # this at ~83% regardless of what you set - values above that are
-    # silently clamped.
-    while True:
-        autocompact_pct = _prompt(
-            "Autocompact threshold (% of context window, 0 = default ~83%)",
-            existing_env.get("CLAUDE_AUTOCOMPACT_PCT", "80"),
-        )
-        try:
-            val = int(autocompact_pct)
-            if 0 <= val <= 100:
-                break
-        except ValueError:
-            pass
-        print("  Must be 0-100.")
-    print()
+    # silently clamped. Claude-binary specific (CLAUDE_AUTOCOMPACT_PCT
+    # is consumed only by ClaudeCodeBackend per claude.py); Goose has
+    # no autocompact concept, so the prompt is suppressed when goose is
+    # the selected backend. Initialize to "0" first (the dataclass
+    # default) so the env-emission check `int(autocompact_pct) != 0`
+    # below correctly skips writing the var for goose without needing
+    # a parallel gate down at the emission site.
+    autocompact_pct = "0"
+    if agent_backend == "claude":
+        while True:
+            autocompact_pct = _prompt(
+                "Autocompact threshold (% of context window, 0 = default ~83%)",
+                existing_env.get("CLAUDE_AUTOCOMPACT_PCT", "80"),
+            )
+            try:
+                val = int(autocompact_pct)
+                if 0 <= val <= 100:
+                    break
+            except ValueError:
+                pass
+            print("  Must be 0-100.")
+        print()
 
-    # CLAUDE_EFFORT_LEVEL is a truly-global setting (single value applies
-    # to every chat's inner Claude subprocess), so the prompt sits OUT-
-    # SIDE the per-user-vs-global if/else above and runs unconditionally.
-    # This matches the autocompact_pct precedent immediately above.
-    # _prompt_choice enforces the allow-list at wizard time, mirroring
-    # the runtime allow-list check in config._VALID_EFFORT_LEVELS so the
-    # operator cannot persist an invalid value to install.conf and have
-    # it fail later at service startup.
-    # Use the canonical EFFORT_LEVELS tuple from config so the wizard
-    # prompt and the runtime allow-list cannot drift out of sync. Cast
-    # to list because _prompt_choice expects a list (it joins with "/"
-    # for the display string and uses `in` for membership; tuple would
-    # work for both but the type signature asks for list).
-    claude_effort_level = _prompt_choice(
-        "Inner Claude effort level",
-        list(EFFORT_LEVELS),
-        existing_env.get("CLAUDE_EFFORT_LEVEL", "high"),
-    )
-    print()
+    # CLAUDE_EFFORT_LEVEL is consumed only by ClaudeCodeBackend's
+    # `--effort` CLI flag (claude.py); Goose has no equivalent flag,
+    # so the prompt is suppressed when goose is the selected backend.
+    # Initialize to "high" first (matches Config.claude_effort_level
+    # default) so the env-emission check `claude_effort_level != "high"`
+    # below correctly skips writing the var for goose without needing
+    # a parallel gate down at the emission site. _prompt_choice still
+    # enforces the allow-list at wizard time for the claude path,
+    # mirroring the runtime allow-list check in config._VALID_EFFORT_LEVELS
+    # so the operator cannot persist an invalid value to install.conf
+    # and have it fail later at service startup.
+    claude_effort_level = "high"
+    if agent_backend == "claude":
+        # Use the canonical EFFORT_LEVELS tuple from config so the wizard
+        # prompt and the runtime allow-list cannot drift out of sync. Cast
+        # to list because _prompt_choice expects a list (it joins with "/"
+        # for the display string and uses `in` for membership; tuple would
+        # work for both but the type signature asks for list).
+        claude_effort_level = _prompt_choice(
+            "Inner Claude effort level",
+            list(EFFORT_LEVELS),
+            existing_env.get("CLAUDE_EFFORT_LEVEL", "high"),
+        )
+        print()
 
     # -- Webhook server --
     print("-- Webhook server --")
@@ -725,6 +738,16 @@ def _cmd_config() -> None:
         print("  OS user isolation is now per-user. Set 'os_user' in users.yaml.")
         claude_user = ""
     elif admin_os_user:
+        claude_user = ""
+    elif agent_backend != "claude":
+        # CLAUDE_USER is the legacy global fallback for sudo subprocess
+        # isolation. Only ClaudeCodeBackend wires it through (claude.py
+        # invokes `sudo -H -u <user> -- claude ...`). Goose has no sudo
+        # path - GooseBackend in pool.py:186-198 takes no claude_user
+        # kwarg - so the prompt has no meaning when agent_backend is
+        # not claude. Short-circuit to "" here matches the two branches
+        # above, both of which suppress the prompt for the same shape
+        # of "this prompt does not apply" reason.
         claude_user = ""
     else:
         claude_user = _prompt(

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -743,8 +743,8 @@ def _cmd_config() -> None:
         # CLAUDE_USER is the legacy global fallback for sudo subprocess
         # isolation. Only ClaudeCodeBackend wires it through (claude.py
         # invokes `sudo -H -u <user> -- claude ...`). Goose has no sudo
-        # path - GooseBackend in pool.py:186-198 takes no claude_user
-        # kwarg - so the prompt has no meaning when agent_backend is
+        # path - GooseBackend takes no claude_user kwarg in pool.py,
+        # so the prompt has no meaning when agent_backend is
         # not claude. Short-circuit to "" here matches the two branches
         # above, both of which suppress the prompt for the same shape
         # of "this prompt does not apply" reason.

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -772,7 +772,7 @@ class TestCmdConfig:
                 "",  # github notify chat id (empty)
                 "false",  # voice
                 "false",  # tts
-                "",  # claude user (empty)
+                "",  # claude user (legacy single-user mode)
                 "false",  # memory enabled
                 "",  # perplexity key (empty)
             ]
@@ -925,7 +925,7 @@ class TestCmdConfig:
                 "",  # github notify chat id
                 "false",  # voice
                 "false",  # tts
-                "",  # claude user (empty)
+                "",  # claude user (legacy single-user mode)
                 "false",  # memory enabled
                 "",  # perplexity key (empty)
             ]
@@ -1034,8 +1034,6 @@ class TestCmdConfig:
                 "120",  # timeout
                 "10.0",  # budget
                 "200000",  # max context window
-                "80",  # autocompact pct
-                "",  # claude effort level (take default "high")
                 "8080",  # port
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
@@ -1047,7 +1045,6 @@ class TestCmdConfig:
                 "",  # github notify chat id (empty)
                 "false",  # voice
                 "false",  # tts
-                "",  # claude user (empty)
                 "false",  # memory enabled
                 "",  # perplexity key (empty)
             ]
@@ -1090,8 +1087,6 @@ class TestCmdConfig:
                 "120",  # timeout
                 "10.0",  # budget
                 "200000",  # max context window
-                "80",  # autocompact pct
-                "",  # claude effort level (take default "high")
                 "8080",  # port
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
@@ -1103,7 +1098,6 @@ class TestCmdConfig:
                 "",  # github notify chat id (empty)
                 "false",  # voice
                 "false",  # tts
-                "",  # claude user (empty)
                 "false",  # memory enabled
                 "",  # perplexity key (empty)
             ]
@@ -1175,15 +1169,60 @@ class TestCmdConfig:
     # ── Memory env var prompts (#343) ─────────────────────────────────
 
     @staticmethod
-    def _base_inputs(memory_block: list[str], effort: str = "") -> list[str]:
-        """Default wizard inputs with a swappable memory block.
+    def _base_inputs(
+        memory_block: list[str],
+        effort: str = "",
+        agent_backend: str = "claude",
+        llm_provider: str = "anthropic",
+        llm_api_key: str = "sk-ant-test-key",
+    ) -> list[str]:
+        """Default wizard inputs with swappable memory block, effort, and backend.
 
         `effort` lets a test exercise a non-default CLAUDE_EFFORT_LEVEL
         without rebuilding the whole input list. Empty string accepts
         the wizard default ("high"); pass any allow-list value (low,
         medium, high, xhigh, max) to drive the non-default emission
         branch in install.py.
+
+        `agent_backend` lets a test exercise the goose path. When set
+        to anything other than "claude", the helper:
+          - Inserts an llm_provider prompt answer (and the API key for
+            non-ollama providers) immediately after the agent_backend
+            slot, matching the wizard's flow for non-claude backends.
+          - Omits the autocompact, effort, and claude_user entries that
+            the wizard now skips for non-claude backends per issue #380.
+        Defaults (anthropic + sk-ant-test-key) are sufficient for the
+        gating tests. For exotic providers, override llm_provider /
+        llm_api_key as needed - or set llm_api_key=None for ollama
+        (which skips the API key prompt).
         """
+        # Wizard prompts for provider + API key only for non-claude
+        # backends. The API key prompt itself is skipped when provider
+        # is "ollama" (local model, no auth).
+        backend_block: list[str] = []
+        if agent_backend != "claude":
+            backend_block.append(llm_provider)
+            if llm_provider != "ollama":
+                backend_block.append(llm_api_key)
+
+        # Autocompact + effort prompts are gated on agent_backend ==
+        # "claude" by issue #380. Their fixture entries are conditional
+        # to match the wizard's runtime conditional.
+        claude_only_pre_webhook: list[str] = []
+        if agent_backend == "claude":
+            claude_only_pre_webhook = [
+                "80",  # autocompact pct
+                effort,  # claude effort level ("" = default "high")
+            ]
+
+        # Legacy CLAUDE_USER prompt at install.py:730 is gated on
+        # agent_backend == "claude" by issue #380 (Change 4). The
+        # fixture entry is conditional so the input iterator does not
+        # carry a surplus value when the prompt is skipped.
+        claude_user_entry: list[str] = []
+        if agent_backend == "claude":
+            claude_user_entry = [""]
+
         return [
             "/opt/kai",  # install dir
             "/var/lib/kai",  # data dir
@@ -1194,13 +1233,13 @@ class TestCmdConfig:
             "admin",  # admin display name
             "false",  # advanced user options
             "polling",  # transport
-            "claude",  # agent backend
+            agent_backend,  # agent backend
+            *backend_block,  # llm_provider + api_key (non-claude only)
             "sonnet",  # model
             "120",  # timeout
             "10.0",  # budget
             "200000",  # max context window
-            "80",  # autocompact pct
-            effort,  # claude effort level ("" = default "high")
+            *claude_only_pre_webhook,  # autocompact + effort (claude only)
             "8080",  # port
             "test-secret",  # webhook secret
             "~/Projects",  # workspace base
@@ -1212,7 +1251,7 @@ class TestCmdConfig:
             "",  # github notify chat id
             "false",  # voice
             "false",  # tts
-            "",  # claude user
+            *claude_user_entry,  # claude user (claude only)
             *memory_block,
             "",  # perplexity key
         ]
@@ -1273,6 +1312,90 @@ class TestCmdConfig:
 
         conf = json.loads((tmp_path / "install.conf").read_text())
         assert conf["env"].get("CLAUDE_EFFORT_LEVEL") == "xhigh"
+
+    def test_goose_backend_skips_claude_only_prompts(self, tmp_path, monkeypatch):
+        """When agent_backend is goose, the Claude-only wizard prompts
+        (autocompact, effort, legacy claude_user) must not fire and the
+        corresponding env keys must not appear in install.conf.
+
+        Pins the gating from issue #380. Without this test, a future
+        refactor that re-introduces an unconditional prompt would slip
+        through silently because every other fixture passes 'claude'.
+
+        Note: the admin_os_user prompt at install.py:382 is NOT gated
+        in this PR (it lives inside the `if advanced:` block, and
+        agent_backend is not yet defined at that point in the wizard).
+        Deferred to the broader multi-backend revisit; tracked in
+        memory as project_multi_backend_revisit_pending.md."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+
+        inputs = iter(self._base_inputs(["false"], agent_backend="goose"))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        conf = json.loads((tmp_path / "install.conf").read_text())
+        env = conf["env"]
+        # The three Claude-only env keys gated by issue #380. Their
+        # absence is the positive signal that the prompts were skipped:
+        # the wizard would have written them on a non-default value,
+        # and the value cannot be set to non-default without the
+        # prompt firing.
+        assert "CLAUDE_AUTOCOMPACT_PCT" not in env
+        assert "CLAUDE_EFFORT_LEVEL" not in env
+        assert "CLAUDE_USER" not in env
+
+        # Sanity: AGENT_BACKEND was emitted (it always is for non-claude).
+        assert env.get("AGENT_BACKEND") == "goose"
+
+    def test_goose_backend_prunes_existing_claude_only_keys(self, tmp_path, monkeypatch):
+        """When the operator switches an existing claude install to
+        goose and re-runs the wizard, the previously-set Claude-only
+        env keys must disappear from install.conf.
+
+        This is an implicit side-effect of the gating in issue #380:
+        the prompt is skipped, the variable stays at its dataclass
+        default, and the existing `if value != default` emission check
+        correctly drops the write. Pinning the auto-prune so a future
+        refactor that adds an `else: keep existing value` fallback to
+        the gate cannot silently regress it."""
+        monkeypatch.chdir(tmp_path)
+        conf_path = tmp_path / "install.conf"
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+
+        # Pre-seed: an install.conf as if the operator had previously
+        # configured the wizard under claude with non-default values
+        # for all three of the env keys gated by this PR.
+        pre_existing = {
+            "version": 1,
+            "env": {
+                "AGENT_BACKEND": "claude",
+                "CLAUDE_AUTOCOMPACT_PCT": "50",
+                "CLAUDE_EFFORT_LEVEL": "xhigh",
+                "CLAUDE_USER": "kai",
+            },
+        }
+        conf_path.write_text(json.dumps(pre_existing))
+
+        # Re-run wizard, switch to goose this time.
+        inputs = iter(self._base_inputs(["false"], agent_backend="goose"))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        conf = json.loads(conf_path.read_text())
+        env = conf["env"]
+        # All three previously-set Claude-only keys must be absent.
+        # AGENT_BACKEND must reflect the new selection.
+        assert "CLAUDE_AUTOCOMPACT_PCT" not in env
+        assert "CLAUDE_EFFORT_LEVEL" not in env
+        assert "CLAUDE_USER" not in env
+        assert env.get("AGENT_BACKEND") == "goose"
 
     def test_memory_enabled_writes_tunables(self, tmp_path, monkeypatch):
         """MEMORY_ENABLED=true with extraction writes the chosen tunables."""
@@ -1445,8 +1568,6 @@ class TestCmdConfig:
                 "120",  # timeout
                 "10.0",  # budget
                 "200000",  # max context window
-                "80",  # autocompact pct
-                "",  # claude effort level (take default "high")
                 "8080",  # port
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
@@ -1458,7 +1579,6 @@ class TestCmdConfig:
                 "",  # github notify chat id
                 "false",  # voice
                 "false",  # tts
-                "",  # claude user
                 "true",  # memory enabled (extraction + timeout prompts skipped: non-claude)
                 "2000",  # token budget
                 "10",  # search limit

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1337,8 +1337,8 @@ class TestCmdConfig:
         refactor that re-introduces an unconditional prompt would slip
         through silently because every other fixture passes 'claude'.
 
-        Note: the admin_os_user prompt at install.py:382 is NOT gated
-        in this PR. It lives inside the `if advanced:` block, and
+        Note: the admin_os_user prompt is NOT gated in this PR. It
+        lives inside the `if advanced:` block in install.py, and
         agent_backend is not yet defined at that point in the wizard;
         honoring the gate would require structural reordering. Deferred
         to a separate cleanup once the broader multi-backend rework

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1230,7 +1230,7 @@ class TestCmdConfig:
                 effort,  # claude effort level ("" = default "high")
             ]
 
-        # Legacy CLAUDE_USER prompt at install.py:730 is gated on
+        # Legacy CLAUDE_USER prompt in install.py is gated on
         # agent_backend == "claude" by issue #380. The
         # fixture entry is conditional so the input iterator does not
         # carry a surplus value when the prompt is skipped.

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1231,7 +1231,7 @@ class TestCmdConfig:
             ]
 
         # Legacy CLAUDE_USER prompt at install.py:730 is gated on
-        # agent_backend == "claude" by issue #380 (Change 4). The
+        # agent_backend == "claude" by issue #380. The
         # fixture entry is conditional so the input iterator does not
         # carry a surplus value when the prompt is skipped.
         claude_user_entry: list[str] = []

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1182,7 +1182,9 @@ class TestCmdConfig:
         without rebuilding the whole input list. Empty string accepts
         the wizard default ("high"); pass any allow-list value (low,
         medium, high, xhigh, max) to drive the non-default emission
-        branch in install.py.
+        branch in install.py. Only meaningful when agent_backend is
+        "claude" - passing effort with another backend raises
+        ValueError to prevent silent no-ops.
 
         `agent_backend` lets a test exercise the goose path. When set
         to anything other than "claude", the helper:
@@ -1192,10 +1194,23 @@ class TestCmdConfig:
           - Omits the autocompact, effort, and claude_user entries that
             the wizard now skips for non-claude backends per issue #380.
         Defaults (anthropic + sk-ant-test-key) are sufficient for the
-        gating tests. For exotic providers, override llm_provider /
-        llm_api_key as needed - or set llm_api_key=None for ollama
-        (which skips the API key prompt).
+        gating tests. For ollama, the API key prompt is skipped by the
+        wizard, so the llm_api_key default is harmless and unused (no
+        need to override it).
         """
+        # Guard against silent no-ops: a caller passing effort="xhigh"
+        # with a non-claude backend would expect the value to land in
+        # the wizard's effort prompt, but that prompt does not fire for
+        # non-claude backends (gated by issue #380). Raise loudly here
+        # rather than silently dropping the value, which would be a
+        # confusing failure mode for a future test author.
+        if agent_backend != "claude" and effort:
+            raise ValueError(
+                f"_base_inputs: effort={effort!r} is ignored for non-claude "
+                f"backend ({agent_backend!r}). The wizard does not prompt for "
+                f"effort under non-claude backends. Pass effort only with "
+                f"agent_backend='claude'."
+            )
         # Wizard prompts for provider + API key only for non-claude
         # backends. The API key prompt itself is skipped when provider
         # is "ollama" (local model, no auth).
@@ -1323,10 +1338,11 @@ class TestCmdConfig:
         through silently because every other fixture passes 'claude'.
 
         Note: the admin_os_user prompt at install.py:382 is NOT gated
-        in this PR (it lives inside the `if advanced:` block, and
-        agent_backend is not yet defined at that point in the wizard).
-        Deferred to the broader multi-backend revisit; tracked in
-        memory as project_multi_backend_revisit_pending.md."""
+        in this PR. It lives inside the `if advanced:` block, and
+        agent_backend is not yet defined at that point in the wizard;
+        honoring the gate would require structural reordering. Deferred
+        to a separate cleanup once the broader multi-backend rework
+        revisits the wizard end-to-end."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)


### PR DESCRIPTION
## Summary

- Three wizard prompts in `_cmd_config()` previously fired regardless of the operator's selected agent backend, even though the captured values are consumed only by `ClaudeCodeBackend`. Goose-backend operators were asked to set values that would be silently ignored at runtime. This PR adds backend-conditional gating for `CLAUDE_AUTOCOMPACT_PCT`, `CLAUDE_EFFORT_LEVEL`, and the legacy `CLAUDE_USER` prompt at install.py:730.
- Each gate uses the "initialize-before-gate" pattern: the captured variable is set to its dataclass default before the conditional, and the existing emission check (`if value != default`) correctly skips writing the env key under goose without needing a parallel emission gate. As a free side effect, this implicitly auto-prunes previously-set values from `install.conf` on a claude→goose switch — pinned by a regression test.
- The fourth planned gate from the spec (the `admin_os_user` prompt at install.py:382) is intentionally NOT included. That prompt fires inside `if advanced:`, which runs before `agent_backend` is defined at line 440. Honoring the gate would require structural reordering of the wizard. Deferred to the broader multi-backend rework per operator direction.

Fixes #380 (partial — three of four planned gates; admin_os_user gate deferred per above).

## Test plan

- [ ] `make check` (ruff check + format) — local: passes
- [ ] `make test` (full suite, 2384 tests) — local: passes
- [ ] `test_goose_backend_skips_claude_only_prompts` (new): asserts CLAUDE_AUTOCOMPACT_PCT, CLAUDE_EFFORT_LEVEL, CLAUDE_USER all absent from install.conf when wizard ran under goose
- [ ] `test_goose_backend_prunes_existing_claude_only_keys` (new): pre-seeds install.conf with all three keys at non-default values, runs wizard under goose, asserts all three disappear (pins the implicit auto-prune)
- [ ] Three existing goose fixtures trimmed to remove the three surplus entries each (autocompact, effort, claude_user)
- [ ] Three pre-existing claude tests had been passing on borrowed time without explicit autocompact / effort / claude_user entries (relying on the retry-on-empty default fallback to absorb downstream entries by mistake; pytest output capture hid the validation prints). Updated to provide the entries explicitly so the tests do not depend on absorption side-effects.
- [ ] Verify `make config` walk-through under goose backend skips the autocompact, effort, and CLAUDE_USER prompts but otherwise behaves as before
- [ ] Verify `make config` walk-through under claude backend prompts for all three knobs as before (no behavior regression)

## Out of scope

- The `admin_os_user` prompt at install.py:382 (described above; deferred to broader multi-backend rework).
- Adding wizard prompts for `CLAUDE_MAX_SESSION_HOURS` / `CLAUDE_IDLE_TIMEOUT` (Claude-only at the consumer but no wizard prompt today).
- Explicit prune-on-switch logic for env vars not gated by this PR. The implicit auto-prune that this PR produces for the three gated keys is acknowledged and tested; broader prune-on-switch is a separate concern.
- Shared-with-Goose `CLAUDE_*` prompts (`CLAUDE_TIMEOUT_SECONDS`, `CLAUDE_MAX_CONTEXT_WINDOW`, `CLAUDE_MAX_BUDGET_USD` → `BUDGET_CEILING`, `CLAUDE_MODEL` → `DEFAULT_MODEL`). All four are consumed by both backends and are correctly NOT gated today.
