### PR TITLE
fix(webhook): reject non-object JSON bodies with 400

### DIFF
--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -880,7 +880,10 @@ async def _handle_generic(request: web.Request) -> web.Response:
         return web.Response(status=400, text="Invalid JSON")
 
     # Reject non-object JSON shapes (null, lists, scalars, strings) before
-    # any payload.get() call. See _handle_schedule for the shared rationale.
+    # any payload.get() call. JSON bodies like `null`, `[]`, `42`, or
+    # `"string"` parse successfully (no JSONDecodeError) but raise
+    # AttributeError on .get(), which would escape as an unstyled HTML
+    # 500 traceback instead of a clean JSON 400.
     if not isinstance(payload, dict):
         return web.json_response({"error": "Request body must be a JSON object"}, status=400)
 

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -879,6 +879,11 @@ async def _handle_generic(request: web.Request) -> web.Response:
     except json.JSONDecodeError:
         return web.Response(status=400, text="Invalid JSON")
 
+    # Reject non-object JSON shapes (null, lists, scalars, strings) before
+    # any payload.get() call. See _handle_schedule for the shared rationale.
+    if not isinstance(payload, dict):
+        return web.json_response({"error": "Request body must be a JSON object"}, status=400)
+
     # Use the "message" field if present (including empty string),
     # otherwise dump the full JSON. `is not None` avoids treating "" as absent.
     msg = payload.get("message")
@@ -1002,6 +1007,14 @@ async def _handle_schedule(request: web.Request) -> web.Response:
         payload = await request.json()
     except json.JSONDecodeError:
         return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    # Reject non-object JSON shapes (null, lists, scalars, strings) before
+    # any payload.get() call. JSON bodies like `null`, `[]`, `42`, or
+    # `"string"` parse successfully (no JSONDecodeError) but raise
+    # AttributeError on .get(), which would escape as an unstyled HTML
+    # 500 traceback instead of a clean JSON 400.
+    if not isinstance(payload, dict):
+        return web.json_response({"error": "Request body must be a JSON object"}, status=400)
 
     # Extract and validate required fields
     name = payload.get("name")
@@ -1193,6 +1206,14 @@ async def _handle_update_job(request: web.Request) -> web.Response:
     except json.JSONDecodeError:
         return web.json_response({"error": "Invalid JSON"}, status=400)
 
+    # Reject non-object JSON shapes (null, lists, scalars, strings) before
+    # any payload.get() call. JSON bodies like `null`, `[]`, `42`, or
+    # `"string"` parse successfully (no JSONDecodeError) but raise
+    # AttributeError on .get(), which would escape as an unstyled HTML
+    # 500 traceback instead of a clean JSON 400.
+    if not isinstance(payload, dict):
+        return web.json_response({"error": "Request body must be a JSON object"}, status=400)
+
     # Validate schedule_type if provided
     new_schedule_type = payload.get("schedule_type")
     if new_schedule_type and new_schedule_type not in _VALID_SCHEDULE_TYPES:
@@ -1290,12 +1311,21 @@ async def _handle_service_call(request: web.Request) -> web.Response:
     # Extract service name from URL path
     service_name = request.match_info["name"]
 
-    # Parse optional JSON body with request parameters
+    # Parse optional JSON body with request parameters. The body is
+    # genuinely optional here (services with no JSON-body config still
+    # work), so JSONDecodeError is silently treated as "no body provided"
+    # and the field defaults stay in effect. A non-object JSON value
+    # (null, lists, scalars, strings) is treated as a structural error
+    # and rejected with 400, matching the other handlers - silently
+    # accepting `null` as "no body" would mask client bugs that send a
+    # malformed body intending to send fields.
     body = None
     params = None
     path_suffix = ""
     try:
         payload = await request.json()
+        if not isinstance(payload, dict):
+            return web.json_response({"error": "Request body must be a JSON object"}, status=400)
         body = payload.get("body")
         params = payload.get("params")
         path_suffix = payload.get("path_suffix", "")
@@ -1337,6 +1367,14 @@ async def _handle_send_message(request: web.Request) -> web.Response:
         payload = await request.json()
     except json.JSONDecodeError:
         return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    # Reject non-object JSON shapes (null, lists, scalars, strings) before
+    # any payload.get() call. JSON bodies like `null`, `[]`, `42`, or
+    # `"string"` parse successfully (no JSONDecodeError) but raise
+    # AttributeError on .get(), which would escape as an unstyled HTML
+    # 500 traceback instead of a clean JSON 400.
+    if not isinstance(payload, dict):
+        return web.json_response({"error": "Request body must be a JSON object"}, status=400)
 
     text = payload.get("text", "").strip()
     if not text:
@@ -1385,6 +1423,14 @@ async def _handle_send_file(request: web.Request) -> web.Response:
         payload = await request.json()
     except json.JSONDecodeError:
         return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    # Reject non-object JSON shapes (null, lists, scalars, strings) before
+    # any payload.get() call. JSON bodies like `null`, `[]`, `42`, or
+    # `"string"` parse successfully (no JSONDecodeError) but raise
+    # AttributeError on .get(), which would escape as an unstyled HTML
+    # 500 traceback instead of a clean JSON 400.
+    if not isinstance(payload, dict):
+        return web.json_response({"error": "Request body must be a JSON object"}, status=400)
 
     file_path = payload.get("path")
     if not file_path:
@@ -1524,6 +1570,14 @@ async def _handle_memory_add(request: web.Request) -> web.Response:
     except json.JSONDecodeError:
         return web.json_response({"error": "Invalid JSON"}, status=400)
 
+    # Reject non-object JSON shapes (null, lists, scalars, strings) before
+    # any payload.get() call. JSON bodies like `null`, `[]`, `42`, or
+    # `"string"` parse successfully (no JSONDecodeError) but raise
+    # AttributeError on .get(), which would escape as an unstyled HTML
+    # 500 traceback instead of a clean JSON 400.
+    if not isinstance(payload, dict):
+        return web.json_response({"error": "Request body must be a JSON object"}, status=400)
+
     # Required-field validation runs BEFORE the is_enabled() precheck so
     # callers learn about bad-input bugs even when memory is off. Without
     # this ordering, a caller debugging a missing-field bug while memory
@@ -1642,6 +1696,14 @@ async def _handle_memory_search(request: web.Request) -> web.Response:
         payload = await request.json()
     except json.JSONDecodeError:
         return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    # Reject non-object JSON shapes (null, lists, scalars, strings) before
+    # any payload.get() call. JSON bodies like `null`, `[]`, `42`, or
+    # `"string"` parse successfully (no JSONDecodeError) but raise
+    # AttributeError on .get(), which would escape as an unstyled HTML
+    # 500 traceback instead of a clean JSON 400.
+    if not isinstance(payload, dict):
+        return web.json_response({"error": "Request body must be a JSON object"}, status=400)
 
     # Same isinstance-before-.strip() rationale as _handle_memory_add:
     # a non-string `query` from JSON would raise AttributeError on .strip()
@@ -1796,6 +1858,14 @@ async def _handle_memory_delete_all(request: web.Request) -> web.Response:
         payload = await request.json()
     except json.JSONDecodeError:
         return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    # Reject non-object JSON shapes (null, lists, scalars, strings) before
+    # any payload.get() call. JSON bodies like `null`, `[]`, `42`, or
+    # `"string"` parse successfully (no JSONDecodeError) but raise
+    # AttributeError on .get(), which would escape as an unstyled HTML
+    # 500 traceback instead of a clean JSON 400.
+    if not isinstance(payload, dict):
+        return web.json_response({"error": "Request body must be a JSON object"}, status=400)
 
     # Confirm-token check before chat_id resolution: a request with the
     # wrong token is structurally bad input regardless of which user it

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -2756,3 +2756,87 @@ class TestMemoryDeleteAll:
 
         assert resp.status == 403
         mock_del.assert_not_called()
+
+
+# ── Cross-handler payload-shape rejection (issue #377) ────────────────
+
+
+# Every JSON-body handler must reject non-object JSON shapes (null,
+# lists, scalars, strings) with a clean 400 instead of crashing on
+# AttributeError when the next payload.get() is called. This grew out
+# of a PR #376 review suggestion: the existing `try: payload =
+# await request.json() except json.JSONDecodeError` guard catches
+# malformed JSON only - valid JSON that happens to be `null`, `[]`,
+# `42`, or `"string"` parses successfully and then escapes as an
+# unstyled HTML 500 traceback the moment a `.get()` runs.
+#
+# The fix is one isinstance check after the existing JSONDecodeError
+# guard, applied uniformly across all 9 handlers. These tests pin the
+# rejection at every handler so a future refactor that drops the check
+# at any one site fails loudly here.
+
+# (handler_func, fixture_overrides) tuples for each in-scope handler.
+# fixture_overrides is a callable that takes the mock_request and
+# applies any handler-specific setup needed to reach the isinstance
+# check (e.g., match_info["name"] for service_call). Keep the override
+# minimal - the goal is to reach the isinstance check, not to exercise
+# the rest of the handler.
+_NON_OBJECT_HANDLERS = [
+    pytest.param(_handle_generic, lambda r: None, id="generic"),
+    pytest.param(_handle_schedule, lambda r: None, id="schedule"),
+    pytest.param(
+        _handle_update_job,
+        lambda r: r.match_info.update({"id": "1"}),
+        id="update_job",
+    ),
+    pytest.param(
+        _handle_service_call,
+        lambda r: r.match_info.update({"name": "perplexity"}),
+        id="service_call",
+    ),
+    pytest.param(_handle_send_message, lambda r: None, id="send_message"),
+    pytest.param(_handle_send_file, lambda r: None, id="send_file"),
+    pytest.param(_handle_memory_add, lambda r: None, id="memory_add"),
+    pytest.param(_handle_memory_search, lambda r: None, id="memory_search"),
+    pytest.param(_handle_memory_delete_all, lambda r: None, id="memory_delete_all"),
+]
+
+# Non-object JSON shapes the handlers must reject. `True` is included
+# because Python's `bool` is a subclass of `int`, so a True payload
+# would pass an `isinstance(payload, int)` check that someone might
+# someday be tempted to write - covers the bool/int subclass footgun.
+_NON_OBJECT_PAYLOADS = [
+    pytest.param(None, id="null"),
+    pytest.param([], id="empty_list"),
+    pytest.param([1, 2, 3], id="non_empty_list"),
+    pytest.param(42, id="int"),
+    pytest.param("a string", id="string"),
+    pytest.param(True, id="bool"),
+]
+
+
+class TestNonObjectPayloadRejection:
+    """Issue #377: every JSON-body handler must reject non-object
+    JSON shapes with 400 instead of crashing on AttributeError."""
+
+    @pytest.mark.parametrize("payload", _NON_OBJECT_PAYLOADS)
+    @pytest.mark.parametrize("handler, override", _NON_OBJECT_HANDLERS)
+    async def test_non_object_payload_returns_400(self, mock_request, handler, override, payload):
+        # Apply the handler-specific override (e.g., match_info) to reach
+        # the isinstance check. The mock_request fixture already supplies
+        # webhook_secret, telegram_app/bot, chat_id, and match_info as
+        # an empty dict ready for in-place updates.
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value=payload)
+        override(mock_request)
+
+        resp = await handler(mock_request)
+
+        # The isinstance check fires before any handler-specific work
+        # (storage, scheduling, sending), so no kai.memory / sessions /
+        # bot patches are needed. A 400 response confirms the check
+        # caught the bad shape; anything else (200, 500, exception)
+        # means the check is missing or misordered for this handler.
+        assert resp.status == 400, (
+            f"{handler.__name__} accepted non-object payload {payload!r} (status={resp.status}); expected 400"
+        )

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -2763,12 +2763,11 @@ class TestMemoryDeleteAll:
 
 # Every JSON-body handler must reject non-object JSON shapes (null,
 # lists, scalars, strings) with a clean 400 instead of crashing on
-# AttributeError when the next payload.get() is called. This grew out
-# of a PR #376 review suggestion: the existing `try: payload =
-# await request.json() except json.JSONDecodeError` guard catches
-# malformed JSON only - valid JSON that happens to be `null`, `[]`,
-# `42`, or `"string"` parses successfully and then escapes as an
-# unstyled HTML 500 traceback the moment a `.get()` runs.
+# AttributeError when the next payload.get() is called. The existing
+# `try: payload = await request.json() except json.JSONDecodeError`
+# guard catches malformed JSON only - valid JSON that happens to be
+# `null`, `[]`, `42`, or `"string"` parses successfully and then
+# escapes as an unstyled HTML 500 traceback the moment a `.get()` runs.
 #
 # The fix is one isinstance check after the existing JSONDecodeError
 # guard, applied uniformly across all 9 handlers. These tests pin the
@@ -2816,8 +2815,8 @@ _NON_OBJECT_PAYLOADS = [
 
 
 class TestNonObjectPayloadRejection:
-    """Issue #377: every JSON-body handler must reject non-object
-    JSON shapes with 400 instead of crashing on AttributeError."""
+    """Every JSON-body handler must reject non-object JSON shapes with
+    400 instead of crashing on AttributeError."""
 
     @pytest.mark.parametrize("payload", _NON_OBJECT_PAYLOADS)
     @pytest.mark.parametrize("handler, override", _NON_OBJECT_HANDLERS)


### PR DESCRIPTION
## Summary

- Adds an `isinstance(payload, dict)` check to all 9 JSON-body handlers in `webhook.py`. Without it, valid-but-non-object JSON (`null`, `[]`, `42`, `"string"`) parsed cleanly past the existing `JSONDecodeError` guard and then raised `AttributeError` on the next `payload.get()`, escaping as an unstyled HTML 500 traceback.
- Eight of the nine sites get an identical insertion immediately after the existing `JSONDecodeError` guard. The ninth (`_handle_service_call`) is structurally different: it treats `JSONDecodeError` as "no body provided" and continues with field defaults, so the new check goes inside the existing try block. Previously a literal `null` body to that handler raised `AttributeError` and escaped as 500; now it returns 400, matching the other handlers. Silently accepting `null` would mask client bugs that meant to send a body.
- New `TestNonObjectPayloadRejection` cross-handler parametrized test class. 9 handlers × 6 non-object shapes (null, empty list, non-empty list, int, string, bool) = 54 test cases. Bool is included because Python's `bool` is a subclass of `int`, which would silently pass an `isinstance(payload, int)` check that someone might be tempted to write later.

Fixes #377

## Test plan

- [ ] `make check` (ruff check + format) — local: passes
- [ ] `make test` (full suite, 2438 tests) — local: passes (was 2384; +54 from new parametrized test cases)
- [ ] `TestNonObjectPayloadRejection` (new): 54 test cases verify every handler rejects every non-object shape with 400
- [ ] No new line-number cross-file references in code comments (per the rule that bit PR #381 three times)
- [ ] Manual smoke: `curl -X POST http://localhost:8080/api/memory/add -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" -H "Content-Type: application/json" -d 'null'` should return `{"error": "Request body must be a JSON object"}` with HTTP 400 (not the prior unstyled HTML 500)

## Risk

Low. All affected routes are localhost-only with secret authentication, so the failure mode requires either an authenticated client error or a misconfigured caller. Behavior change for `_handle_service_call` (literal `null` body now 400 instead of 500) is in the direction the issue intends; any existing client sending `null` was already broken.

## Out of scope

- Refactoring the inconsistent JSONDecodeError response styles. Two of the 9 sites still use `web.Response(text=...)` for the JSONDecodeError path while the other seven use `web.json_response({"error": ...})`. Aligning these is a separate concern; this PR only adds the missing isinstance check at each site.
- Adding handler-helper extraction (`_parse_json_object()` or similar). The pattern is identical at 8 of 9 sites, so extracting a helper is a reasonable refactor — but doing it as part of this fix would expand scope and obscure the bug-fix in a refactor diff.
