### PR TITLE
fix(error-ux): surface real error + budget recovery directive (#326)

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -172,7 +172,7 @@ _QUEUED_MESSAGE_MARKER = (
 _LOCK_ACQUIRE_TIMEOUT = 3600  # 1 hour
 
 
-# Budget-exhaustion recovery directive (issue #326).
+# Budget-exhaustion recovery directive.
 #
 # When the inner Claude session hits BUDGET_CEILING (default $10), the
 # CLI emits an `is_error=true` event whose `errors` field carries the
@@ -202,7 +202,12 @@ _BUDGET_RECOVERY_HINT_NO_AMOUNT = (
 # amount can't be extracted, and the no-amount hint is sent. The chat
 # still surfaces the real error string from claude.py either way -
 # only the dollar-amount-aware directive is missed.
-_BUDGET_PHRASE_RE = re.compile(r"maximum budget \(\$([\d.]+)\)", re.IGNORECASE)
+#
+# `\d+(?:\.\d+)?` accepts integer ($10) or one-decimal ($10.50)
+# amounts and rejects malformed compositions like $1.2.3.4. Tighter
+# than `[\d.]+`; signals intent to a future reader that we expect a
+# single decimal point at most.
+_BUDGET_PHRASE_RE = re.compile(r"maximum budget \(\$(\d+(?:\.\d+)?)\)", re.IGNORECASE)
 
 
 def _is_budget_exhaustion(error_text: str | None) -> bool:
@@ -3603,16 +3608,21 @@ async def _handle_response(
         # Send the error notice as a NEW message (not an edit of the
         # live streamed message), so any tool-use, partial reasoning,
         # and intermediate output the user was watching stays visible.
-        # Pre-#326 the live_msg.edit_text overwrite erased that
-        # context entirely, which on long sessions could mean minutes
-        # of visible work disappearing into a single error line.
-        await update.message.reply_text(error_text)
+        # The previous in-place edit erased that context entirely,
+        # which on long sessions could mean minutes of visible work
+        # disappearing into a single error line. _reply_safe is the
+        # right wrapper here: error strings can carry markdown-like
+        # characters (parens, dollar signs, brackets) that Telegram's
+        # Markdown parser sometimes rejects, and the wrapper falls
+        # back to plain text on BadRequest while letting network
+        # errors propagate naturally.
+        await _reply_safe(update.message, error_text)
         # Budget-exhaustion gets a recovery directive as a second
         # follow-up message. Other error types fall through with no
         # extra guidance; structure leaves room for additional
         # error-class directives if recurring patterns emerge.
         if _is_budget_exhaustion(real_error):
-            await update.message.reply_text(_budget_recovery_hint(real_error))
+            await _reply_safe(update.message, _budget_recovery_hint(real_error))
         return
 
     # Persist session info for /stats (cost accumulates across interactions)

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -172,6 +172,63 @@ _QUEUED_MESSAGE_MARKER = (
 _LOCK_ACQUIRE_TIMEOUT = 3600  # 1 hour
 
 
+# Budget-exhaustion recovery directive (issue #326).
+#
+# When the inner Claude session hits BUDGET_CEILING (default $10), the
+# CLI emits an `is_error=true` event whose `errors` field carries the
+# string "Reached maximum budget ($N)". `claude.py` populates
+# AgentResponse.error from that field; the bot uses the helper below
+# to detect the budget variant and append a recovery hint as a
+# follow-up message.
+#
+# The hint is a SEPARATE message, not appended to the error notice
+# itself, so Telegram clients show it with a notification badge and
+# the user immediately sees "what to do next" alongside "what
+# happened". The bot remains responsive to /new (and every other
+# command) after the error - the per-chat lock is released by the
+# return below, and the dispatch loop continues unaffected.
+_BUDGET_RECOVERY_HINT_WITH_AMOUNT = (
+    "Hit session budget ({amount}). Type /new to start a fresh session, "
+    "or ask your operator to raise BUDGET_CEILING in /etc/kai/env."
+)
+_BUDGET_RECOVERY_HINT_NO_AMOUNT = (
+    "Hit session budget. Type /new to start a fresh session, "
+    "or ask your operator to raise BUDGET_CEILING in /etc/kai/env."
+)
+
+# Matches the CLI's "Reached maximum budget ($N)" wording. The regex
+# is anchored on the documented phrasing; if Anthropic ever changes the
+# wording the budget detection regresses to "no match", the dollar
+# amount can't be extracted, and the no-amount hint is sent. The chat
+# still surfaces the real error string from claude.py either way -
+# only the dollar-amount-aware directive is missed.
+_BUDGET_PHRASE_RE = re.compile(r"maximum budget \(\$([\d.]+)\)", re.IGNORECASE)
+
+
+def _is_budget_exhaustion(error_text: str | None) -> bool:
+    """True iff the error string indicates BUDGET_CEILING exhaustion.
+
+    Substring match on the CLI's documented phrasing. Wording change
+    in a future Anthropic release would silently regress this to
+    False, in which case the recovery hint stops appearing - the
+    error notice itself still surfaces. A regression test pins the
+    current phrasing.
+    """
+    if not error_text:
+        return False
+    return "maximum budget" in error_text.lower()
+
+
+def _budget_recovery_hint(error_text: str | None) -> str:
+    """Return the budget-exhaustion recovery directive, with the
+    dollar amount inlined when extractable from the error string."""
+    if error_text:
+        match = _BUDGET_PHRASE_RE.search(error_text)
+        if match:
+            return _BUDGET_RECOVERY_HINT_WITH_AMOUNT.format(amount=f"${match.group(1)}")
+    return _BUDGET_RECOVERY_HINT_NO_AMOUNT
+
+
 async def _acquire_lock_or_kill(
     chat_id: int,
     pool: "SubprocessPool",
@@ -3534,12 +3591,28 @@ async def _handle_response(
         return
 
     if not final_response.success:
-        error_text = f"Error: {final_response.error}"
-        log_message(direction="assistant", chat_id=chat_id, text=f"[error: {final_response.error}]")
-        if live_msg:
-            await _edit_message_safe(live_msg, error_text)
-        else:
-            await update.message.reply_text(error_text)
+        # Defensive fallback: claude.py now always populates `error`
+        # with a non-None string for is_error events (see the
+        # response_error resolution there). The `or` here is belt-and-
+        # suspenders against a future change that re-introduces None,
+        # so the literal "Error: None" string can't reappear via this
+        # surface even on a regression.
+        real_error = final_response.error or "no error detail provided"
+        error_text = f"Error: {real_error}"
+        log_message(direction="assistant", chat_id=chat_id, text=f"[error: {real_error}]")
+        # Send the error notice as a NEW message (not an edit of the
+        # live streamed message), so any tool-use, partial reasoning,
+        # and intermediate output the user was watching stays visible.
+        # Pre-#326 the live_msg.edit_text overwrite erased that
+        # context entirely, which on long sessions could mean minutes
+        # of visible work disappearing into a single error line.
+        await update.message.reply_text(error_text)
+        # Budget-exhaustion gets a recovery directive as a second
+        # follow-up message. Other error types fall through with no
+        # extra guidance; structure leaves room for additional
+        # error-class directives if recurring patterns emerge.
+        if _is_budget_exhaustion(real_error):
+            await update.message.reply_text(_budget_recovery_hint(real_error))
         return
 
     # Persist session info for /stats (cost accumulates across interactions)

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -662,16 +662,21 @@ class ClaudeCodeBackend(AgentBackend):
                     #   (b) `result` empty BUT `errors` populated with a
                     #       list of strings (the documented variant for
                     #       BUDGET_CEILING exhaustion: errors carries
-                    #       ["Reached maximum budget ($N)"]). Pre-#326
-                    #       this fell through to None, which `bot.py`
-                    #       rendered as the literal "Error: None"
-                    #       string in chat.
+                    #       ["Reached maximum budget ($N)"]).
                     #
                     # Falls back to a non-None sentinel when both fields
-                    # are empty so downstream rendering never re-introduces
-                    # the "Error: None" surface, even on a future CLI
-                    # variant that emits is_error=true with neither field
-                    # populated.
+                    # are empty so downstream rendering never produces
+                    # the literal "Error: None" string in chat, even on
+                    # a future CLI variant that emits is_error=true with
+                    # neither field populated.
+                    #
+                    # Note on `result_text`: it is `event.get("result", "")`
+                    # captured a few lines above, with no transformation
+                    # applied. Using `result_text` here (rather than
+                    # `event.get("result")` again) is equivalent and avoids
+                    # the second dict lookup; the truthiness check still
+                    # catches the empty-string case which is what the
+                    # branch table targets.
                     response_error: str | None = None
                     if event.get("is_error", False):
                         if result_text:

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -654,13 +654,41 @@ class ClaudeCodeBackend(AgentBackend):
                             event.get("duration_ms"),
                             sorted(event.keys()),
                         )
+                    # Resolve the error string for downstream consumers.
+                    # The CLI's `is_error=true` events come in two shapes:
+                    #
+                    #   (a) `result` populated with a human-readable
+                    #       reason. Use it directly.
+                    #   (b) `result` empty BUT `errors` populated with a
+                    #       list of strings (the documented variant for
+                    #       BUDGET_CEILING exhaustion: errors carries
+                    #       ["Reached maximum budget ($N)"]). Pre-#326
+                    #       this fell through to None, which `bot.py`
+                    #       rendered as the literal "Error: None"
+                    #       string in chat.
+                    #
+                    # Falls back to a non-None sentinel when both fields
+                    # are empty so downstream rendering never re-introduces
+                    # the "Error: None" surface, even on a future CLI
+                    # variant that emits is_error=true with neither field
+                    # populated.
+                    response_error: str | None = None
+                    if event.get("is_error", False):
+                        if result_text:
+                            response_error = result_text
+                        else:
+                            errors_list = event.get("errors")
+                            if isinstance(errors_list, list) and errors_list:
+                                response_error = "; ".join(str(e) for e in errors_list)
+                            else:
+                                response_error = "no error detail provided"
                     response = AgentResponse(
                         success=not event.get("is_error", False),
                         text=text,
                         session_id=event.get("session_id", self._session_id),
                         cost_usd=event.get("total_cost_usd", 0.0),
                         duration_ms=event.get("duration_ms", 0),
-                        error=event.get("result") if event.get("is_error") else None,
+                        error=response_error,
                     )
                     yield StreamEvent(text_so_far=response.text, done=True, response=response)
                     return

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2645,7 +2645,13 @@ class TestHandleResponse:
 
     @pytest.mark.asyncio
     async def test_error_response_with_live_msg(self):
-        """success=False with existing live message: edits error into live message."""
+        """success=False with existing live message: error appears as
+        a NEW follow-up reply (not edited into the live message). The
+        live streamed content stays visible so any tool-use, partial
+        reasoning, and intermediate output the user was watching
+        survives the error. This contract changed in issue #326;
+        pre-#326 the error overwrote live_msg via edit_text and erased
+        all the streamed context."""
         from kai.bot import _handle_response
 
         update = _make_update()
@@ -2665,9 +2671,17 @@ class TestHandleResponse:
         with patch.multiple("kai.bot", **self._base_patches()):
             await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
 
-        # Error should be edited into the live message
-        last_edit = live_msg.edit_text.call_args_list[-1]
-        assert "Error" in last_edit[0][0]
+        # The error path no longer touches live_msg.edit_text. The
+        # last edit on live_msg is whatever the streaming loop wrote
+        # before the error arrived (or nothing, if the error was the
+        # first event). Asserted below: any reply_text call that
+        # carries the "Error" surface must come AFTER live_msg was
+        # last touched - i.e., a separate message, not an in-place
+        # edit. Pinning the negative property because the absence of
+        # an edit is the load-bearing contract change.
+        error_replies = [call for call in update.message.reply_text.call_args_list if call[0] and "Error" in call[0][0]]
+        assert len(error_replies) >= 1, "expected the error to appear as a follow-up reply_text call"
+        assert "Something broke" in error_replies[-1][0][0]
 
     @pytest.mark.asyncio
     async def test_error_response_no_live_msg(self):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2646,12 +2646,20 @@ class TestHandleResponse:
     @pytest.mark.asyncio
     async def test_error_response_with_live_msg(self):
         """success=False with existing live message: error appears as
-        a NEW follow-up reply (not edited into the live message). The
-        live streamed content stays visible so any tool-use, partial
-        reasoning, and intermediate output the user was watching
-        survives the error. This contract changed in issue #326;
-        pre-#326 the error overwrote live_msg via edit_text and erased
-        all the streamed context."""
+        a NEW follow-up reply via _reply_safe (not edited into the
+        live message via _edit_message_safe). The live streamed
+        content stays visible so any tool-use, partial reasoning, and
+        intermediate output the user was watching survives the error.
+
+        Patches kai.bot._reply_safe directly rather than relying on
+        its internal call to reply_text - the latter would couple
+        this assertion to _reply_safe's implementation, and a future
+        refactor of _reply_safe (e.g., to use a different telegram
+        method on its first attempt) would silently void this
+        assertion. The streaming loop also uses _reply_safe to
+        create live_msg, so we filter the captured calls to those
+        carrying an "Error" prefix to isolate the error-path
+        invocations from the streaming-text invocations."""
         from kai.bot import _handle_response
 
         update = _make_update()
@@ -2668,20 +2676,34 @@ class TestHandleResponse:
         )
         ctx = _make_context(claude=claude)
 
-        with patch.multiple("kai.bot", **self._base_patches()):
+        with (
+            patch.multiple("kai.bot", **self._base_patches()),
+            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply_safe,
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock) as mock_edit_safe,
+        ):
             await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
 
-        # The error path no longer touches live_msg.edit_text. The
-        # last edit on live_msg is whatever the streaming loop wrote
-        # before the error arrived (or nothing, if the error was the
-        # first event). Asserted below: any reply_text call that
-        # carries the "Error" surface must come AFTER live_msg was
-        # last touched - i.e., a separate message, not an in-place
-        # edit. Pinning the negative property because the absence of
-        # an edit is the load-bearing contract change.
-        error_replies = [call for call in update.message.reply_text.call_args_list if call[0] and "Error" in call[0][0]]
-        assert len(error_replies) >= 1, "expected the error to appear as a follow-up reply_text call"
-        assert "Something broke" in error_replies[-1][0][0]
+        # The error path uses _reply_safe (NOT _edit_message_safe) -
+        # error appears as a follow-up message, not an in-place edit.
+        # Pinning the negative property because the absence of an
+        # edit is the load-bearing contract change. Length guard on
+        # args[1] mirrors the pattern used in test_error_recovery.py
+        # so a future _reply_safe call site that omits the text arg
+        # produces a meaningful assertion failure rather than
+        # IndexError.
+        for call in mock_edit_safe.await_args_list:
+            text_arg = call.args[1] if len(call.args) > 1 else ""
+            assert "Error" not in text_arg, (
+                f"_edit_message_safe was called with an error string ({text_arg!r}), "
+                f"violating the append-not-overwrite contract"
+            )
+        error_calls = [
+            call
+            for call in mock_reply_safe.await_args_list
+            if (call.args[1] if len(call.args) > 1 else "").startswith("Error")
+        ]
+        assert len(error_calls) >= 1, "expected the error to appear via _reply_safe"
+        assert "Something broke" in error_calls[-1].args[1]
 
     @pytest.mark.asyncio
     async def test_error_response_no_live_msg(self):

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -245,18 +245,33 @@ class TestBudgetDetection:
 class TestErrorMessageLifecycle:
     """End-to-end behavior of `_handle_response` when the stream ends
     in an error: append (don't overwrite), no "Error: None", budget
-    errors get the directive, non-budget errors don't."""
+    errors get the directive, non-budget errors don't.
 
-    def _make_pool_yielding_error(self, error_text: str | None = "Reached maximum budget ($10)"):
-        """Mock pool whose .send() yields one done StreamEvent with
-        success=False and the given error string."""
+    All five tests stream a text event BEFORE the terminal error so
+    `_handle_response` actually creates a live_msg via the streaming
+    loop. Without that, the live_msg branch in the error path is
+    never exercised and the overwrite-not-called assertion is
+    trivially true regardless of the fix. Assertions on the error
+    path target the patched `_reply_safe` directly rather than its
+    internal `reply_text` call, so a future refactor of `_reply_safe`
+    cannot silently void these tests."""
+
+    def _make_pool_text_then_error(self, error_text: str | None = "Reached maximum budget ($10)"):
+        """Mock pool whose .send() yields a text event followed by a
+        done StreamEvent with the given error string. The text event
+        triggers live_msg creation in the streaming loop, so the
+        error path's append-not-overwrite contract is exercised
+        against an actually-existing live_msg."""
 
         async def _fake_stream(*args, **kwargs):
+            # First a text event so the streaming loop creates live_msg.
+            yield StreamEvent(text_so_far="streamed work", done=False, response=None)
+            # Then the terminal error.
             yield StreamEvent(
-                text_so_far="",
+                text_so_far="streamed work",
                 done=True,
                 response=AgentResponse(
-                    text="",
+                    text="streamed work",
                     success=False,
                     error=error_text,
                     cost_usd=10.10,
@@ -269,12 +284,21 @@ class TestErrorMessageLifecycle:
         pool.send = MagicMock(side_effect=_fake_stream)
         return pool
 
-    def _make_update(self):
+    def _make_update_with_live_msg(self):
+        """Build an update whose `update.message.reply_text` returns a
+        mock `live_msg` (with its own AsyncMock `edit_text`). The
+        streaming loop calls reply_text once to create live_msg; that
+        first call returns the mock and live_msg becomes truthy in the
+        error branch. Subsequent reply_text traffic on update.message
+        (e.g., from `_reply_safe` calling reply_text internally) keeps
+        going through the same AsyncMock and is observable separately."""
+        live_msg = MagicMock()
+        live_msg.edit_text = AsyncMock()
         update = MagicMock()
         update.message = MagicMock()
-        update.message.reply_text = AsyncMock()
+        update.message.reply_text = AsyncMock(return_value=live_msg)
         update.effective_chat.id = 12345
-        return update
+        return update, live_msg
 
     def _make_context(self):
         from kai.config import Config
@@ -294,51 +318,91 @@ class TestErrorMessageLifecycle:
     @pytest.mark.asyncio
     async def test_error_does_not_overwrite_live_msg(self):
         """The streamed message stays untouched; the error is sent as
-        a reply_text. Pre-#326 the live_msg.edit_text overwrite
-        erased visible tool-use context; the new behavior preserves
-        it. Asserted by patching _edit_message_safe and asserting it
-        was never called for the error path."""
-        update = self._make_update()
+        a follow-up via _reply_safe. Pre-fix the live_msg.edit_text
+        overwrite (via _edit_message_safe) erased visible tool-use
+        context; the new behavior preserves it. Asserted by exercising
+        the live_msg path (text event triggers creation) and pinning
+        that _edit_message_safe is never invoked for the error
+        rendering AND _reply_safe IS invoked with an error notice."""
+        update, live_msg = self._make_update_with_live_msg()
         ctx = self._make_context()
-        pool = self._make_pool_yielding_error("Reached maximum budget ($10)")
+        pool = self._make_pool_text_then_error("Reached maximum budget ($10)")
 
         with (
             patch("kai.bot.log_message"),
             patch("kai.bot.sessions"),
-            patch("kai.bot._edit_message_safe", new_callable=AsyncMock) as mock_edit,
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock) as mock_edit_safe,
+            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply_safe,
         ):
             await bot._handle_response(update, ctx, chat_id=12345, prompt="hi", pool=pool, model="sonnet")
 
-        # The error path never touches live_msg via edit_text or
-        # _edit_message_safe; it sends new messages instead.
-        mock_edit.assert_not_called()
-        # At least one reply_text call (the error notice). Budget
-        # variant adds a second; tested separately below.
-        assert update.message.reply_text.await_count >= 1
+        # The error path never overwrites live_msg via the safe
+        # editor. _edit_message_safe may have been called by the
+        # streaming loop's chunk-by-chunk update path (depending on
+        # debouncing/edit cadence), but it must NOT have been called
+        # with the error string.
+        for call in mock_edit_safe.await_args_list:
+            text_arg = call.args[1] if len(call.args) > 1 else ""
+            assert "Error" not in text_arg, (
+                f"_edit_message_safe was called with an error string ({text_arg!r}), "
+                f"violating the append-not-overwrite contract"
+            )
+        # The error notice WAS sent via _reply_safe (asserts the
+        # follow-up message path is taken).
+        error_calls = [c for c in mock_reply_safe.await_args_list if "Error" in c.args[1]]
+        assert len(error_calls) >= 1, "_reply_safe was not called with an error notice"
+        # live_msg.edit_text directly should not carry the error
+        # either (defensive against bypassing the wrapper).
+        for call in live_msg.edit_text.await_args_list:
+            text_arg = call.args[0] if call.args else ""
+            assert "Error" not in text_arg
+
+    @staticmethod
+    def _error_path_calls(mock_reply_safe) -> list:
+        """Filter `_reply_safe` calls to those carrying an error
+        notice or budget directive, separating them from the
+        streaming-loop's live_msg-creation call (which uses the same
+        wrapper to send the initial text chunk). Error-path calls
+        are identified by the "Error: " prefix or the presence of
+        BUDGET_CEILING in the directive - both of which the
+        streaming text would never legitimately contain."""
+        out = []
+        for call in mock_reply_safe.await_args_list:
+            text = call.args[1] if len(call.args) > 1 else ""
+            if text.startswith("Error: ") or "BUDGET_CEILING" in text:
+                out.append(call)
+        return out
 
     @pytest.mark.asyncio
     async def test_budget_error_sends_two_messages(self):
         """Budget-exhaustion: error notice + recovery directive,
-        sent as two separate reply_text calls."""
-        update = self._make_update()
+        sent as two separate _reply_safe calls (in addition to the
+        streaming loop's live_msg-creation call)."""
+        update, _live_msg = self._make_update_with_live_msg()
         ctx = self._make_context()
-        pool = self._make_pool_yielding_error("Reached maximum budget ($10)")
+        pool = self._make_pool_text_then_error("Reached maximum budget ($10)")
 
         with (
             patch("kai.bot.log_message"),
             patch("kai.bot.sessions"),
             patch("kai.bot._edit_message_safe", new_callable=AsyncMock),
+            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply_safe,
         ):
             await bot._handle_response(update, ctx, chat_id=12345, prompt="hi", pool=pool, model="sonnet")
 
-        assert update.message.reply_text.await_count == 2
-        first_call = update.message.reply_text.await_args_list[0].args[0]
-        second_call = update.message.reply_text.await_args_list[1].args[0]
-        assert first_call == "Error: Reached maximum budget ($10)"
-        # The directive carries the dollar amount and the recovery hint.
-        assert "$10" in second_call
-        assert "/new" in second_call
-        assert "BUDGET_CEILING" in second_call
+        # Filter to error-path calls so the streaming-loop's
+        # live_msg-creation call (which also goes through _reply_safe)
+        # does not pollute the count. Patching _reply_safe directly
+        # (rather than asserting on the inner reply_text) keeps this
+        # test stable against future _reply_safe internal changes.
+        error_calls = self._error_path_calls(mock_reply_safe)
+        assert len(error_calls) == 2
+        first_text = error_calls[0].args[1]
+        second_text = error_calls[1].args[1]
+        assert first_text == "Error: Reached maximum budget ($10)"
+        assert "$10" in second_text
+        assert "/new" in second_text
+        assert "BUDGET_CEILING" in second_text
 
     @pytest.mark.asyncio
     async def test_non_budget_error_sends_one_message(self):
@@ -346,19 +410,21 @@ class TestErrorMessageLifecycle:
         get just the error notice; no directive. Structure leaves
         room for additional error-class directives if recurring
         patterns emerge."""
-        update = self._make_update()
+        update, _live_msg = self._make_update_with_live_msg()
         ctx = self._make_context()
-        pool = self._make_pool_yielding_error("Authentication failed")
+        pool = self._make_pool_text_then_error("Authentication failed")
 
         with (
             patch("kai.bot.log_message"),
             patch("kai.bot.sessions"),
             patch("kai.bot._edit_message_safe", new_callable=AsyncMock),
+            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply_safe,
         ):
             await bot._handle_response(update, ctx, chat_id=12345, prompt="hi", pool=pool, model="sonnet")
 
-        assert update.message.reply_text.await_count == 1
-        assert update.message.reply_text.await_args.args[0] == "Error: Authentication failed"
+        error_calls = self._error_path_calls(mock_reply_safe)
+        assert len(error_calls) == 1
+        assert error_calls[0].args[1] == "Error: Authentication failed"
 
     @pytest.mark.asyncio
     async def test_no_error_none_literal_in_user_facing_output(self):
@@ -368,30 +434,25 @@ class TestErrorMessageLifecycle:
         the literal "Error: None" string from appearing. Pin the
         full chain so a future change at either layer can't
         re-introduce it."""
-        update = self._make_update()
+        update, _live_msg = self._make_update_with_live_msg()
         ctx = self._make_context()
-        pool = self._make_pool_yielding_error(None)  # forces fallback path
+        pool = self._make_pool_text_then_error(None)  # forces fallback path
 
-        captured_chat: list[str] = []
         captured_log: list[str] = []
 
         def _capture_log(*, direction, chat_id, text):
             captured_log.append(text)
 
-        async def _capture_reply(text, *args, **kwargs):
-            captured_chat.append(text)
-            return MagicMock()
-
-        update.message.reply_text = AsyncMock(side_effect=_capture_reply)
-
         with (
             patch("kai.bot.log_message", side_effect=_capture_log),
             patch("kai.bot.sessions"),
             patch("kai.bot._edit_message_safe", new_callable=AsyncMock),
+            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply_safe,
         ):
             await bot._handle_response(update, ctx, chat_id=12345, prompt="hi", pool=pool, model="sonnet")
 
-        for text in captured_chat:
+        for call in mock_reply_safe.await_args_list:
+            text = call.args[1]
             assert "Error: None" not in text, f"chat surface re-introduced the bug: {text!r}"
         for text in captured_log:
             assert "[error: None]" not in text, f"history log re-introduced the bug: {text!r}"
@@ -403,9 +464,9 @@ class TestErrorMessageLifecycle:
         so a post-hoc grep of the log lands on the same text the
         operator could see in chat. Divergence would break
         debuggability."""
-        update = self._make_update()
+        update, _live_msg = self._make_update_with_live_msg()
         ctx = self._make_context()
-        pool = self._make_pool_yielding_error("Reached maximum budget ($10)")
+        pool = self._make_pool_text_then_error("Reached maximum budget ($10)")
 
         captured_log: list[str] = []
 
@@ -416,12 +477,17 @@ class TestErrorMessageLifecycle:
             patch("kai.bot.log_message", side_effect=_capture_log),
             patch("kai.bot.sessions"),
             patch("kai.bot._edit_message_safe", new_callable=AsyncMock),
+            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply_safe,
         ):
             await bot._handle_response(update, ctx, chat_id=12345, prompt="hi", pool=pool, model="sonnet")
 
-        # First reply is the error notice; first log entry should
-        # carry the same reason inside the [error: <reason>] format.
-        chat_error = update.message.reply_text.await_args_list[0].args[0]
+        # The error-path _reply_safe call (filtered from the
+        # streaming-loop's live_msg-creation call) carries the error
+        # notice; the first log entry carries the same reason inside
+        # the [error: <reason>] format.
+        error_calls = self._error_path_calls(mock_reply_safe)
+        assert len(error_calls) >= 1
+        chat_error = error_calls[0].args[1]
         assert "Reached maximum budget ($10)" in chat_error
         # Synthetic history entry uses the same reason string.
         assert any("Reached maximum budget ($10)" in t for t in captured_log)

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -34,7 +34,7 @@ from kai.backend import AgentResponse, StreamEvent
 from kai.bot import _budget_recovery_hint, _is_budget_exhaustion
 from kai.claude import ClaudeCodeBackend
 
-# ── §9.1 claude.py error-event handling ──────────────────────────────
+# ── claude.py error-event handling ──────────────────────────────────
 
 
 def _make_claude(**kwargs) -> ClaudeCodeBackend:
@@ -178,7 +178,7 @@ class TestClaudeErrorPopulation:
         assert response.error == "Model self-reported error"
 
 
-# ── §9.3 budget detection + recovery directive ───────────────────────
+# ── budget detection helpers ────────────────────────────────────────
 
 
 class TestBudgetDetection:
@@ -239,7 +239,7 @@ class TestBudgetDetection:
         assert "BUDGET_CEILING" in hint
 
 
-# ── §9.2 + §9.3 bot.py message lifecycle on error ────────────────────
+# ── bot.py error message lifecycle ──────────────────────────────────
 
 
 class TestErrorMessageLifecycle:

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -1,0 +1,427 @@
+"""
+Tests for error-recovery UX (issue #326).
+
+Three layers of behavior change:
+
+1. claude.py: when the CLI emits an `is_error=true` event with an
+   empty `result` field, the actual reason now comes from the
+   `errors` field (where BUDGET_CEILING exhaustion places it). Falls
+   back to a non-None sentinel string when both are empty so the
+   downstream "Error: None" surface can never recur.
+
+2. bot.py: error rendering APPENDS a follow-up message instead of
+   OVERWRITING the live streamed message. Pre-#326 the error edit
+   erased any tool-use, partial reasoning, and intermediate output
+   the user was watching - on long sessions, minutes of visible
+   work disappearing into a single error line.
+
+3. bot.py: budget-exhaustion errors send a recovery directive as a
+   second follow-up message ("Type /new to start fresh, or ask your
+   operator to raise BUDGET_CEILING"). Other error types fall
+   through with no extra guidance for v1.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kai import bot
+from kai.backend import AgentResponse, StreamEvent
+from kai.bot import _budget_recovery_hint, _is_budget_exhaustion
+from kai.claude import ClaudeCodeBackend
+
+# ── §9.1 claude.py error-event handling ──────────────────────────────
+
+
+def _make_claude(**kwargs) -> ClaudeCodeBackend:
+    """Mirror of test_claude.py's helper. Local copy so this file is
+    self-contained and a future move of the cross-file helper does
+    not break this suite silently."""
+    defaults = {
+        "model": "sonnet",
+        "workspace": Path("/tmp/test-workspace"),
+        "max_budget_usd": 1.0,
+        "timeout_seconds": 30,
+    }
+    defaults.update(kwargs)
+    return ClaudeCodeBackend(**defaults)
+
+
+def _json_line(obj: dict) -> bytes:
+    return json.dumps(obj).encode() + b"\n"
+
+
+def _make_mock_proc(stdout_lines: list[bytes]) -> MagicMock:
+    """Mock subprocess that yields the given stdout lines and then
+    EOF (b'' as the last entry). Mirrors test_claude.py's helper."""
+    proc = MagicMock()
+    proc.returncode = None
+    proc.stdin = MagicMock()
+    proc.stdin.write = MagicMock()
+    proc.stdin.drain = AsyncMock()
+    proc.stdout = MagicMock()
+    proc.stdout.readline = AsyncMock(side_effect=stdout_lines)
+    proc.stderr = MagicMock()
+    proc.stderr.readline = AsyncMock(return_value=b"")
+    proc.wait = AsyncMock()
+    proc.send_signal = MagicMock()
+    return proc
+
+
+async def _collect_events(claude: ClaudeCodeBackend, prompt: str = "test") -> list[StreamEvent]:
+    return [event async for event in claude._send_locked(prompt)]
+
+
+def _system_event(session_id: str = "sess-326") -> bytes:
+    return _json_line({"type": "system", "session_id": session_id})
+
+
+class TestClaudeErrorPopulation:
+    """The CLI's `is_error=true` events come in two shapes (per #326):
+    (a) `result` populated with a human-readable reason, (b) `result`
+    empty BUT `errors` populated with a list of strings (the
+    BUDGET_CEILING variant). Pre-#326 only shape (a) produced a
+    non-None error string; shape (b) silently fell through to None
+    and rendered as the literal "Error: None" in chat. The fix reads
+    `errors` when `result` is empty, with a sentinel fallback for the
+    pathological case where both fields are absent."""
+
+    @pytest.mark.asyncio
+    async def test_errors_field_populates_response_error_when_result_empty(self):
+        """The BUDGET_CEILING variant: result is empty, errors carries
+        the reason. AgentResponse.error must reflect the errors-field
+        content, not None."""
+        result_event = _json_line(
+            {
+                "type": "result",
+                "result": "",
+                "is_error": True,
+                "errors": ["Reached maximum budget ($10)"],
+                "session_id": "sess-326",
+                "total_cost_usd": 10.103919,
+                "duration_ms": 90000,
+            }
+        )
+        claude = _make_claude()
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = _make_mock_proc([_system_event(), result_event, b""])
+            events = await _collect_events(claude)
+
+        done = [e for e in events if e.done]
+        assert len(done) == 1
+        response = done[0].response
+        assert response is not None
+        assert response.success is False
+        assert response.error == "Reached maximum budget ($10)"
+
+    @pytest.mark.asyncio
+    async def test_empty_result_and_empty_errors_falls_back_to_sentinel(self):
+        """Pathological case: is_error=true with neither result nor
+        errors populated. Must still produce a non-None error string
+        so the "Error: None" rendering can't recur. Sentinel value is
+        a documented placeholder, not a real error reason."""
+        result_event = _json_line(
+            {
+                "type": "result",
+                "result": "",
+                "is_error": True,
+                "session_id": "sess-326",
+                "total_cost_usd": 0.0,
+                "duration_ms": 100,
+            }
+        )
+        claude = _make_claude()
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = _make_mock_proc([_system_event(), result_event, b""])
+            events = await _collect_events(claude)
+
+        done = [e for e in events if e.done]
+        response = done[0].response
+        assert response is not None
+        assert response.success is False
+        assert response.error is not None
+        assert response.error != ""
+        # Sentinel string is "no error detail provided" per the spec;
+        # asserted exactly so a future change to the sentinel surfaces
+        # here as a test failure rather than silently slipping by.
+        assert response.error == "no error detail provided"
+
+    @pytest.mark.asyncio
+    async def test_nonempty_result_takes_precedence_over_errors_field(self):
+        """Classic happy-failure path: is_error=true with a populated
+        `result` field (e.g., the model returned an error message it
+        composed itself). The result field wins; errors is ignored.
+        Pinned so the new branch logic doesn't accidentally regress
+        the original code path."""
+        result_event = _json_line(
+            {
+                "type": "result",
+                "result": "Model self-reported error",
+                "is_error": True,
+                "errors": ["should-be-ignored"],
+                "session_id": "sess-326",
+                "total_cost_usd": 0.05,
+                "duration_ms": 1500,
+            }
+        )
+        claude = _make_claude()
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = _make_mock_proc([_system_event(), result_event, b""])
+            events = await _collect_events(claude)
+
+        response = next(e for e in events if e.done).response
+        assert response is not None
+        assert response.error == "Model self-reported error"
+
+
+# ── §9.3 budget detection + recovery directive ───────────────────────
+
+
+class TestBudgetDetection:
+    """`_is_budget_exhaustion` and `_budget_recovery_hint` are pure
+    helpers, easiest to verify directly. The bot.py message-lifecycle
+    integration exercises them through the response handler in the
+    next class."""
+
+    def test_is_budget_exhaustion_matches_canonical_phrasing(self):
+        """The CLI's documented error text includes 'maximum budget'.
+        Substring match is case-insensitive and tolerant of dollar
+        amount variation."""
+        assert _is_budget_exhaustion("Reached maximum budget ($10)") is True
+        assert _is_budget_exhaustion("Reached maximum budget ($25.50)") is True
+        # Case-insensitive: a future CLI capitalization tweak still matches.
+        assert _is_budget_exhaustion("REACHED MAXIMUM BUDGET ($10)") is True
+
+    def test_is_budget_exhaustion_rejects_non_matches(self):
+        """Auth failures, network errors, generic strings, and
+        None/empty all return False - the directive should NOT fire
+        for these."""
+        assert _is_budget_exhaustion("Authentication failed") is False
+        assert _is_budget_exhaustion("Connection refused") is False
+        assert _is_budget_exhaustion("no error detail provided") is False
+        assert _is_budget_exhaustion(None) is False
+        assert _is_budget_exhaustion("") is False
+
+    def test_budget_recovery_hint_includes_dollar_amount_when_extractable(self):
+        """The hint inlines the actual ceiling so the user sees the
+        number they hit, not a generic placeholder."""
+        hint = _budget_recovery_hint("Reached maximum budget ($10)")
+        assert "$10" in hint
+        assert "/new" in hint
+        assert "BUDGET_CEILING" in hint
+
+        hint_2 = _budget_recovery_hint("Reached maximum budget ($25.50)")
+        assert "$25.50" in hint_2
+
+    def test_budget_recovery_hint_falls_back_when_amount_unparseable(self):
+        """If the CLI ever emits the budget phrasing without a dollar
+        amount in parens (or with a different format), the hint
+        gracefully drops the amount rather than failing or rendering
+        a malformed string."""
+        hint = _budget_recovery_hint("Reached maximum budget")
+        # No $ amount in the output, but the directive is still useful
+        assert "/new" in hint
+        assert "BUDGET_CEILING" in hint
+        # No "$N" leakage from the template
+        assert "{amount}" not in hint
+        assert "$" not in hint
+
+    def test_budget_recovery_hint_tolerates_none(self):
+        """Defensive: hint should not crash on None input, since the
+        caller's contract relies on this being safe even on
+        unexpected error-string shapes."""
+        hint = _budget_recovery_hint(None)
+        assert "/new" in hint
+        assert "BUDGET_CEILING" in hint
+
+
+# ── §9.2 + §9.3 bot.py message lifecycle on error ────────────────────
+
+
+class TestErrorMessageLifecycle:
+    """End-to-end behavior of `_handle_response` when the stream ends
+    in an error: append (don't overwrite), no "Error: None", budget
+    errors get the directive, non-budget errors don't."""
+
+    def _make_pool_yielding_error(self, error_text: str | None = "Reached maximum budget ($10)"):
+        """Mock pool whose .send() yields one done StreamEvent with
+        success=False and the given error string."""
+
+        async def _fake_stream(*args, **kwargs):
+            yield StreamEvent(
+                text_so_far="",
+                done=True,
+                response=AgentResponse(
+                    text="",
+                    success=False,
+                    error=error_text,
+                    cost_usd=10.10,
+                    duration_ms=90000,
+                    session_id="sess-326",
+                ),
+            )
+
+        pool = MagicMock()
+        pool.send = MagicMock(side_effect=_fake_stream)
+        return pool
+
+    def _make_update(self):
+        update = MagicMock()
+        update.message = MagicMock()
+        update.message.reply_text = AsyncMock()
+        update.effective_chat.id = 12345
+        return update
+
+    def _make_context(self):
+        from kai.config import Config
+
+        ctx = MagicMock()
+        ctx.bot_data = {
+            "config": Config(
+                telegram_bot_token="t",
+                allowed_user_ids={1},
+                webhook_secret="s",
+                tts_enabled=False,  # voice-mode lookup is skipped
+            ),
+        }
+        ctx.bot.send_chat_action = AsyncMock()
+        return ctx
+
+    @pytest.mark.asyncio
+    async def test_error_does_not_overwrite_live_msg(self):
+        """The streamed message stays untouched; the error is sent as
+        a reply_text. Pre-#326 the live_msg.edit_text overwrite
+        erased visible tool-use context; the new behavior preserves
+        it. Asserted by patching _edit_message_safe and asserting it
+        was never called for the error path."""
+        update = self._make_update()
+        ctx = self._make_context()
+        pool = self._make_pool_yielding_error("Reached maximum budget ($10)")
+
+        with (
+            patch("kai.bot.log_message"),
+            patch("kai.bot.sessions"),
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock) as mock_edit,
+        ):
+            await bot._handle_response(update, ctx, chat_id=12345, prompt="hi", pool=pool, model="sonnet")
+
+        # The error path never touches live_msg via edit_text or
+        # _edit_message_safe; it sends new messages instead.
+        mock_edit.assert_not_called()
+        # At least one reply_text call (the error notice). Budget
+        # variant adds a second; tested separately below.
+        assert update.message.reply_text.await_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_budget_error_sends_two_messages(self):
+        """Budget-exhaustion: error notice + recovery directive,
+        sent as two separate reply_text calls."""
+        update = self._make_update()
+        ctx = self._make_context()
+        pool = self._make_pool_yielding_error("Reached maximum budget ($10)")
+
+        with (
+            patch("kai.bot.log_message"),
+            patch("kai.bot.sessions"),
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock),
+        ):
+            await bot._handle_response(update, ctx, chat_id=12345, prompt="hi", pool=pool, model="sonnet")
+
+        assert update.message.reply_text.await_count == 2
+        first_call = update.message.reply_text.await_args_list[0].args[0]
+        second_call = update.message.reply_text.await_args_list[1].args[0]
+        assert first_call == "Error: Reached maximum budget ($10)"
+        # The directive carries the dollar amount and the recovery hint.
+        assert "$10" in second_call
+        assert "/new" in second_call
+        assert "BUDGET_CEILING" in second_call
+
+    @pytest.mark.asyncio
+    async def test_non_budget_error_sends_one_message(self):
+        """Generic errors (auth failures, transport errors, etc.)
+        get just the error notice; no directive. Structure leaves
+        room for additional error-class directives if recurring
+        patterns emerge."""
+        update = self._make_update()
+        ctx = self._make_context()
+        pool = self._make_pool_yielding_error("Authentication failed")
+
+        with (
+            patch("kai.bot.log_message"),
+            patch("kai.bot.sessions"),
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock),
+        ):
+            await bot._handle_response(update, ctx, chat_id=12345, prompt="hi", pool=pool, model="sonnet")
+
+        assert update.message.reply_text.await_count == 1
+        assert update.message.reply_text.await_args.args[0] == "Error: Authentication failed"
+
+    @pytest.mark.asyncio
+    async def test_no_error_none_literal_in_user_facing_output(self):
+        """Belt-and-suspenders: even if AgentResponse.error
+        regresses to None (despite claude.py's defensive sentinel),
+        bot.py's `or "no error detail provided"` fallback prevents
+        the literal "Error: None" string from appearing. Pin the
+        full chain so a future change at either layer can't
+        re-introduce it."""
+        update = self._make_update()
+        ctx = self._make_context()
+        pool = self._make_pool_yielding_error(None)  # forces fallback path
+
+        captured_chat: list[str] = []
+        captured_log: list[str] = []
+
+        def _capture_log(*, direction, chat_id, text):
+            captured_log.append(text)
+
+        async def _capture_reply(text, *args, **kwargs):
+            captured_chat.append(text)
+            return MagicMock()
+
+        update.message.reply_text = AsyncMock(side_effect=_capture_reply)
+
+        with (
+            patch("kai.bot.log_message", side_effect=_capture_log),
+            patch("kai.bot.sessions"),
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock),
+        ):
+            await bot._handle_response(update, ctx, chat_id=12345, prompt="hi", pool=pool, model="sonnet")
+
+        for text in captured_chat:
+            assert "Error: None" not in text, f"chat surface re-introduced the bug: {text!r}"
+        for text in captured_log:
+            assert "[error: None]" not in text, f"history log re-introduced the bug: {text!r}"
+
+    @pytest.mark.asyncio
+    async def test_chat_string_matches_history_log(self):
+        """The synthetic history entry written by log_message and the
+        chat-rendered error notice must carry the same error string,
+        so a post-hoc grep of the log lands on the same text the
+        operator could see in chat. Divergence would break
+        debuggability."""
+        update = self._make_update()
+        ctx = self._make_context()
+        pool = self._make_pool_yielding_error("Reached maximum budget ($10)")
+
+        captured_log: list[str] = []
+
+        def _capture_log(*, direction, chat_id, text):
+            captured_log.append(text)
+
+        with (
+            patch("kai.bot.log_message", side_effect=_capture_log),
+            patch("kai.bot.sessions"),
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock),
+        ):
+            await bot._handle_response(update, ctx, chat_id=12345, prompt="hi", pool=pool, model="sonnet")
+
+        # First reply is the error notice; first log entry should
+        # carry the same reason inside the [error: <reason>] format.
+        chat_error = update.message.reply_text.await_args_list[0].args[0]
+        assert "Reached maximum budget ($10)" in chat_error
+        # Synthetic history entry uses the same reason string.
+        assert any("Reached maximum budget ($10)" in t for t in captured_log)

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -348,8 +348,12 @@ class TestErrorMessageLifecycle:
                 f"violating the append-not-overwrite contract"
             )
         # The error notice WAS sent via _reply_safe (asserts the
-        # follow-up message path is taken).
-        error_calls = [c for c in mock_reply_safe.await_args_list if "Error" in c.args[1]]
+        # follow-up message path is taken). Routes through the
+        # `_error_path_calls` helper so the args-length guard is
+        # consistent with the other tests in this class - a future
+        # call site that omits the text arg won't raise IndexError
+        # here, just produce a meaningful "no error notice" failure.
+        error_calls = self._error_path_calls(mock_reply_safe)
         assert len(error_calls) >= 1, "_reply_safe was not called with an error notice"
         # live_msg.edit_text directly should not carry the error
         # either (defensive against bypassing the wrapper).

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -455,8 +455,16 @@ class TestErrorMessageLifecycle:
         ):
             await bot._handle_response(update, ctx, chat_id=12345, prompt="hi", pool=pool, model="sonnet")
 
+        # Iterate over ALL _reply_safe calls (not just error-path
+        # ones) because the streaming text is also user-facing
+        # output that must not contain the bug string. The
+        # `_error_path_calls` helper would over-filter here.
+        # Length guard mirrors the helper's pattern - protects
+        # against a future call site that omits the text arg
+        # raising IndexError instead of producing the meaningful
+        # "Error: None re-introduced" failure.
         for call in mock_reply_safe.await_args_list:
-            text = call.args[1]
+            text = call.args[1] if len(call.args) > 1 else ""
             assert "Error: None" not in text, f"chat surface re-introduced the bug: {text!r}"
         for text in captured_log:
             assert "[error: None]" not in text, f"history log re-introduced the bug: {text!r}"


### PR DESCRIPTION
## Summary

Three behavior changes addressing all four acceptance criteria of issue #326. The dominant trigger of the empty-payload `is_error` variant in production is `BUDGET_CEILING` exhaustion (default $10/session); pre-#326 this surfaced as the literal string `"Error: None"` in chat with no recovery guidance. This PR makes the failure honest, contextual, and recoverable.

Fixes #326.

## Implementation

### claude.py — error-event population

`_send_locked`'s result-event handler now reads from `event.get("errors")` when `result_text` is empty. The CLI's `is_error=true` events come in two shapes: (a) `result` populated with a human-readable reason, (b) `result` empty BUT `errors` populated with a list of strings (the documented BUDGET_CEILING variant: `errors: ["Reached maximum budget ($10)"]`). Pre-#326 only shape (a) produced a non-None error string; shape (b) silently fell through to None.

Falls back to `"no error detail provided"` sentinel when both fields are empty so the downstream `"Error: None"` surface cannot recur on a future CLI variant.

### bot.py — message lifecycle

The error-rendering block in `_handle_response` no longer calls `_edit_message_safe(live_msg, error_text)`. It sends a new `reply_text` instead. Pre-#326 the in-place edit erased any tool-use, partial reasoning, and intermediate output the user was watching - on long sessions, minutes of visible work disappeared into a single error line.

```python
if not final_response.success:
    real_error = final_response.error or "no error detail provided"
    error_text = f"Error: {real_error}"
    log_message(direction="assistant", chat_id=chat_id, text=f"[error: {real_error}]")
    # Append, never overwrite - preserve the streamed context.
    await update.message.reply_text(error_text)
    if _is_budget_exhaustion(real_error):
        await update.message.reply_text(_budget_recovery_hint(real_error))
    return
```

### bot.py — budget-exhaustion recovery directive

Two new module-level helpers:

- `_is_budget_exhaustion(error_text)` - case-insensitive substring match on the CLI's documented `"maximum budget"` phrasing
- `_budget_recovery_hint(error_text)` - inlines the dollar amount via regex; falls back to a no-amount template when the amount isn't extractable

Sent as a separate Telegram message (not appended to the error notice on the same line) so clients show it with a notification badge and the user immediately sees "what to do next" alongside "what happened":

```
Hit session budget ($10). Type /new to start a fresh session, or ask
your operator to raise BUDGET_CEILING in /etc/kai/env.
```

### Bot responsiveness post-error

The bot remains responsive to `/new` and other commands after the error - the per-chat lock is released by the existing return path and the dispatch loop is unaffected. No code change needed for that property; preserved by structure.

## Tests

New `tests/test_error_recovery.py` (13 tests):

- **claude.py error-event handling (3):** `errors` field populates response error; empty-both-fields falls back to sentinel; non-empty `result` takes precedence.
- **Budget detection helpers (5):** canonical phrasing match, non-match rejection (auth/network/None/empty), dollar-amount inlining, fallback when amount unparseable, None-tolerance.
- **bot.py message lifecycle (5):** error doesn't overwrite live_msg; budget error sends two messages; non-budget error sends one; no `"Error: None"` literal in any user-facing or log-facing output; chat string matches history-log entry.

Updated `tests/test_bot.py::test_error_response_with_live_msg`: it pinned the OLD overwrite contract and asserted the edit happened. Now pins the NEW append-not-overwrite contract; comment captures the pre-#326 vs post-#326 invariant.

Full suite: **2497 passed, 1 skipped** (the opt-in classifier eval, gated by `RUN_CLASSIFIER_EVAL=1`).

## Acceptance criteria from #326 (all four)

- [x] **Failing mid-stream after tool use no longer wipes the user-visible streaming message.** The error appears as a follow-up reply, not as a replacement.
- [x] **Every `is_error=true` event produces a log line correlating to the synthetic history entry.** Already partially satisfied by PR #332's diagnostic warning; verified preserved.
- [x] **`Error: None` is replaced with the real reason from the CLI's `errors` field.** Belt-and-suspenders fallback at both layers (claude.py sentinel + bot.py `or` clause) prevents recurrence.
- [x] **Budget-exhaustion errors include the recovery directive.** Bot stays responsive to `/new` after the error.

## Test plan

- [x] `make check` (ruff check + format) - local: passes
- [x] `make test` (full suite) - local: 2497 passed, 1 skipped
- [ ] After deploy, send a message that exceeds session budget; confirm chat shows `Error: Reached maximum budget ($10)` followed by the directive message. Verify `/new` works immediately after.
- [ ] After deploy, look for `kai.claude WARNING Result event with is_error=true has no result field` log lines; for any that appear, confirm the corresponding chat message no longer reads `Error: None`.
- [ ] Spot-check a normal long-running session ends without the streamed message getting wiped on any error path.

## Out of scope

- Auto-recovery (transparent new-session creation with handoff). Significant design work; most of the value is captured by surfacing the error + guidance, not by automation.
- Operator-side budget tuning workflow (raising `BUDGET_CEILING` via wizard). Already exists; the directive points at it.
- Error-class taxonomy beyond "budget" vs "other". Stage-2 episode generation has its own log surface (`memory.episode`); episode failures are not in scope here.
