### PR TITLE
fix: drop --max-budget-usd flag on claude backend (#390)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,10 +99,12 @@ WEBHOOK_SECRET=your-webhook-secret
 # stuck processes should be reaped faster. Must be a positive integer.
 #PR_REVIEW_TIMEOUT_S=900
 
-# Hard USD ceiling for one PR review subprocess (passed to
-# claude --max-budget-usd). Not a typical-run estimate - Sonnet reviews
-# of normal PRs cost well under this. Treat as a safety limit, not a
-# target. Must be a positive number.
+# Hard USD ceiling for one PR review subprocess. Informational only on
+# the claude backend (Max-plan OAuth makes the CLI's computed-cost
+# ceiling a phantom signal; --max-budget-usd is omitted from claude
+# --print argv). Enforced on non-claude backends (e.g. Goose), which
+# run on pay-per-token billing where the ceiling is a real cost gate.
+# Must be a positive number.
 #PR_REVIEW_BUDGET_USD=1.0
 
 # Deprecated: review agent now resolves repos via workspace config
@@ -165,14 +167,14 @@ MEMORY_ENABLED=false
 # is the same flag.
 #MEMORY_EXTRACTION_ENABLED=false
 #MEMORY_EXTRACTION_MODEL=claude-haiku-4-5-20251001
-# Per-call budget ceiling (USD). Observed cost is ~$0.02-$0.03 per
-# call at Haiku rates (cache-creation tokens account for most of it;
-# a single extraction creates ~7-8k cache tokens). The default 0.01
-# is NOT sufficient to complete a typical call and will exit the
-# subprocess early with error_max_budget_usd. Raise to 0.05 or higher
-# before enabling extraction in production. Max-plan billing does NOT
-# apply to this subprocess (contrary to earlier assumptions) - it
-# bills per-token like any other claude --print invocation.
+# Per-call budget ceiling (USD). Informational only on the claude
+# backend (Max-plan OAuth makes the CLI's computed-cost ceiling a
+# phantom signal; --max-budget-usd is omitted from claude --print
+# argv, and runaway protection comes from MEMORY_EXTRACTION_TIMEOUT_S
+# instead). Enforced on non-claude backends, which run on
+# pay-per-token billing where the ceiling is a real cost gate; raise
+# to 0.05 or higher there because Haiku-rate cache-creation tokens
+# typically dominate per-call cost.
 #MEMORY_EXTRACTION_BUDGET_USD=0.01
 # Subprocess timeout (seconds). Haiku typically finishes in 2-4s.
 #MEMORY_EXTRACTION_TIMEOUT_S=10
@@ -189,16 +191,18 @@ MEMORY_ENABLED=false
 # Sophia-shaped narrative record per episode-worthy turn. Honors
 # MEMORY_ENABLED; no dedicated kill switch.
 # Sonnet is recommended for narrative quality across the 7-8 episode
-# fields. On a Max-plan OAuth subscription headless `claude --print`
-# does not bill per-token, so the budget below is a safety rail
-# rather than a real cost gate. Leave blank to inherit
-# MEMORY_EXTRACTION_MODEL (Haiku) - useful for tests or for
-# operators who deliberately want both stages on the same model.
+# fields. Leave blank to inherit MEMORY_EXTRACTION_MODEL (Haiku) -
+# useful for tests or for operators who deliberately want both stages
+# on the same model.
 #MEMORY_EPISODE_MODEL=claude-sonnet-4-6
-# Budget ceiling per episode call (USD). Stage 2 reads the FULL
-# uncapped (user, assistant) pair, so it costs more than stage 1.
-# Default 0.15 fits Sonnet; drop to 0.05 if you set
-# MEMORY_EPISODE_MODEL to Haiku.
+# Budget ceiling per episode call (USD). Informational only on the
+# claude backend (Max-plan OAuth makes the CLI's computed-cost
+# ceiling a phantom signal; --max-budget-usd is omitted from claude
+# --print argv, and runaway protection comes from
+# MEMORY_EPISODE_TIMEOUT_S instead). Enforced on non-claude backends
+# where stage 2 reads the FULL uncapped (user, assistant) pair and
+# costs more than stage 1: 0.15 fits Sonnet, drop to 0.05 if you set
+# MEMORY_EPISODE_MODEL to Haiku there.
 #MEMORY_EPISODE_BUDGET_USD=0.15
 # Subprocess timeout (seconds). Default 120 - twice the production
 # stage-1 value. Stage 2 is fire-and-forget off the user turn, so a

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ cp .env.example .env
 
 *Deprecated vars still work for backward compatibility when `users.yaml` is absent. When `users.yaml` is present, `users.yaml` wins and a warning is logged. Run `make config` to migrate.
 
-`BUDGET_CEILING` limits spending in a single session. For Claude Code, this maps to the `--max-budget-usd` CLI flag (on Pro/Max plans, purely a runaway prevention mechanism). Goose does not currently enforce this limit. The session resets on `/new`, model switch, or workspace switch.
+`BUDGET_CEILING` limits spending in a single session. On the Claude Code backend the flag is omitted on Max-plan OAuth (no real cost is incurred); runaway prevention is handled by the per-session timeout instead. Goose does not currently enforce this limit. The session resets on `/new`, model switch, or workspace switch.
 
 ## Running
 

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -74,8 +74,16 @@ class ClaudeCodeBackend(AgentBackend):
     lock to prevent interleaving.
 
     The process runs with --permission-mode bypassPermissions (required
-    for headless operation via Telegram) and --max-budget-usd to cap
-    per-session spending.
+    for headless operation via Telegram). No --max-budget-usd is emitted:
+    the claude backend is committed to Max-plan OAuth, where the CLI's
+    computed-cost ceiling has no relation to actual billing (the CLI
+    tracks pay-per-token rates whether or not the operator owes any of
+    that money). Terminating the subprocess at a phantom ceiling would
+    just stop work that is not costing anything. Runaway protection
+    comes from the per-message stdout-read timeouts and idle detection
+    (both derived from `timeout_seconds`) - a stuck or recursive
+    subprocess surfaces via stream-read failure rather than holding
+    the executor indefinitely.
     """
 
     def __init__(
@@ -221,8 +229,6 @@ class ClaudeCodeBackend(AgentBackend):
             self.claude_effort_level,
             "--permission-mode",
             "bypassPermissions",
-            "--max-budget-usd",
-            str(self.max_budget_usd),
         ]
 
         # Limit context window size to reduce token usage and cache

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -320,6 +320,11 @@ class Config:
         budget_ceiling: Global budget ceiling in USD. Users cannot exceed
             this via /settings budget. Also serves as the fallback default
             for users without a per-user max_budget in users.yaml.
+            Informational only on the claude backend (Max-plan OAuth makes
+            the CLI's computed-cost ceiling a phantom signal; the
+            --max-budget-usd flag is omitted from claude --print argv).
+            Enforced on non-claude backends, which run on pay-per-token
+            billing where the ceiling is a real cost gate.
         claude_max_session_hours: Hours before the inner Claude process is recycled. Prevents
             unbounded V8 memory growth that can trigger macOS Jetsam kernel panics. 0 = no limit.
         session_db_path: Path to the SQLite database for sessions, jobs, and settings
@@ -415,10 +420,13 @@ class Config:
     # a long time; the default gives thinking-heavy reviews room while
     # still terminating genuinely stuck processes.
     pr_review_timeout_s: int = 900
-    # Hard USD ceiling for one PR review subprocess. Passed through to
-    # claude --max-budget-usd. Not a typical-run estimate - Sonnet reviews
-    # of normal PRs cost well under this. The ceiling is a safety limit
-    # against runaway invocations, not a cost target.
+    # Hard USD ceiling for one PR review subprocess. Omitted from claude
+    # --print argv on the claude backend (Max-plan OAuth makes the CLI's
+    # computed-cost ceiling a phantom signal); the field is consulted by
+    # non-claude backends, where reviews run on pay-per-token billing
+    # and the ceiling is a real cost gate. Field stays defined so
+    # operators with hand-edited /etc/kai/env from a previous install
+    # are not affected by upgrade.
     pr_review_budget_usd: float = 1.0
     # Deprecated: review agent now resolves repos via workspace config.
     # Kept for backwards compatibility with existing .env files; the value
@@ -478,13 +486,14 @@ class Config:
     memory_extraction_enabled: bool = False
     # Claude model name for extraction. Default is Haiku 4.5.
     memory_extraction_model: str = "claude-haiku-4-5-20251001"
-    # Per-call budget ceiling, passed via --max-budget-usd. The
-    # subprocess bills pay-per-token at Haiku rates regardless of the
-    # operator's Max-plan status (observed ~$0.02-$0.03 per call, mostly
-    # cache-creation tokens). The 0.01 default is a strict safety rail
-    # and is intentionally insufficient for a single real extraction;
-    # operators enabling MEMORY_EXTRACTION_ENABLED should raise this to
-    # at least 0.05 after reading the expected cost.
+    # Per-call budget ceiling. Omitted from claude --print argv on the
+    # claude backend (Max-plan OAuth makes the CLI's computed-cost
+    # ceiling a phantom signal; runaway protection comes from
+    # memory_extraction_timeout_s instead). Field stays defined for
+    # non-claude backends, which run on pay-per-token billing where
+    # the ceiling is a real cost gate, and so operators upgrading a
+    # deployment with MEMORY_EXTRACTION_BUDGET_USD already set in
+    # /etc/kai/env do not see a startup error after upgrade.
     memory_extraction_budget_usd: float = 0.01
     # Timeout (seconds) for a single extraction subprocess. Haiku
     # typically finishes in 2-4s; 10s gives headroom without stranding
@@ -521,17 +530,19 @@ class Config:
     # is never the effective value. Test fixtures that construct Config
     # directly should set this explicitly to a real model name.
     memory_episode_model: str = ""
-    # Per-call budget ceiling (USD). Default 0.15 is sized for a
-    # Sonnet-class model on the FULL uncapped (user, assistant) pair;
-    # stage 2 deliberately bypasses stage-1's 500-char assistant cap.
-    # Sonnet is the recommended stage-2 model because it produces
-    # materially better narratives across the 7-8 Sophia episode
-    # fields, and stage 2 is fully out-of-band (latency invisible to
-    # the user). Operators on a Max-plan OAuth subscription do not
-    # bill per-token for headless `claude --print`, so this ceiling
-    # is a safety rail rather than a real cost gate. Operators
-    # downgrading memory_episode_model to Haiku can drop this to
-    # 0.05 or lower; the wizard recommends 0.15 as the default.
+    # Per-call budget ceiling (USD). Omitted from claude --print argv
+    # on the claude backend (Max-plan OAuth makes the CLI's
+    # computed-cost ceiling a phantom signal; runaway protection comes
+    # from memory_episode_timeout_s instead). Field stays defined for
+    # non-claude backends, which run on pay-per-token billing where
+    # the ceiling is a real cost gate, and so operators upgrading a
+    # deployment with MEMORY_EPISODE_BUDGET_USD already set in
+    # /etc/kai/env do not see a startup error after upgrade. Default
+    # 0.15 is sized for a Sonnet-class model on the FULL uncapped
+    # (user, assistant) pair; stage 2 deliberately bypasses stage-1's
+    # 500-char assistant cap. Operators downgrading memory_episode_model
+    # to Haiku can drop this to 0.05 or lower; the wizard recommends
+    # 0.15 as the default for non-claude backends.
     memory_episode_budget_usd: float = 0.15
     # Subprocess timeout (seconds). Default 120 - twice the production-
     # tuned stage-1 value (60s) and 12x the stage-1 dataclass default

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -515,14 +515,26 @@ def _cmd_config() -> None:
                 break
             print("  Must be a positive integer.")
 
-        while True:
-            budget = _prompt(
-                "Claude budget (USD)",
-                existing_env.get("BUDGET_CEILING", existing_env.get("CLAUDE_MAX_BUDGET_USD", "10.0")),
-            )
-            if _validate_positive_float(budget):
-                break
-            print("  Must be a positive number.")
+        # Skip the budget prompt on the claude backend: --max-budget-usd
+        # is no longer emitted to claude --print argv (Max-plan OAuth
+        # makes the CLI's computed-cost ceiling a phantom signal), so
+        # asking the operator for a value that is never enforced would
+        # be wizard noise. Pre-init `budget = ""` here; the BUDGET_CEILING
+        # env emission below (in the env-build block) skips writing the
+        # key entirely on the claude branch, leaving Config.budget_ceiling
+        # at its dataclass default for the (informational) /settings
+        # budget readback.
+        if agent_backend != "claude":
+            while True:
+                budget = _prompt(
+                    "Claude budget (USD)",
+                    existing_env.get("BUDGET_CEILING", existing_env.get("CLAUDE_MAX_BUDGET_USD", "10.0")),
+                )
+                if _validate_positive_float(budget):
+                    break
+                print("  Must be a positive number.")
+        else:
+            budget = ""
 
         # Context window tuning - smaller windows reduce token usage and
         # cache invalidation pressure on the inner Claude process.
@@ -674,14 +686,22 @@ def _cmd_config() -> None:
         if _validate_positive_int(pr_review_timeout_s):
             break
         print("  Must be a positive integer.")
-    while True:
-        pr_review_budget_usd = _prompt(
-            "Review subprocess USD budget ceiling",
-            existing_env.get("PR_REVIEW_BUDGET_USD", "1.0"),
-        )
-        if _validate_positive_float(pr_review_budget_usd):
-            break
-        print("  Must be a positive number.")
+    # Skip the PR review budget prompt on the claude backend:
+    # --max-budget-usd is no longer emitted to claude --print argv on
+    # this site either (review.py:738 else branch). Pre-init to the
+    # dataclass default so the env emission below correctly suppresses
+    # writing PR_REVIEW_BUDGET_USD on the claude branch.
+    if agent_backend != "claude":
+        while True:
+            pr_review_budget_usd = _prompt(
+                "Review subprocess USD budget ceiling",
+                existing_env.get("PR_REVIEW_BUDGET_USD", "1.0"),
+            )
+            if _validate_positive_float(pr_review_budget_usd):
+                break
+            print("  Must be a positive number.")
+    else:
+        pr_review_budget_usd = "1.0"
     print()
 
     # -- Issue triage agent --
@@ -798,14 +818,14 @@ def _cmd_config() -> None:
                 existing_env.get("MEMORY_EXTRACTION_ENABLED", "false").lower() in ("1", "true", "yes"),
             )
             if memory_extraction_enabled:
-                while True:
-                    memory_extraction_budget_usd = _prompt(
-                        "Per-extraction USD budget (suggest 0.05 or higher)",
-                        existing_env.get("MEMORY_EXTRACTION_BUDGET_USD", "0.01"),
-                    )
-                    if _validate_positive_float(memory_extraction_budget_usd):
-                        break
-                    print("  Must be a positive number.")
+                # No MEMORY_EXTRACTION_BUDGET_USD prompt on this branch:
+                # --max-budget-usd is omitted from the stage-1 claude
+                # --print argv (memory_extraction.py:_run_extractor),
+                # so prompting for a value that is never enforced would
+                # be wizard noise. The pre-init `memory_extraction_budget_usd
+                # = "0.01"` from above is left untouched; the env emission
+                # below double-gates on agent_backend != "claude" so the
+                # key is never written on the claude branch.
                 # Extraction timeout is the LLM-call hard cap inside
                 # memory_extraction.py:541. Default 10s is too aggressive
                 # for production - real extractions routinely take 20-30s
@@ -862,14 +882,14 @@ def _cmd_config() -> None:
                     "Episode generator model (Sonnet recommended for narrative quality)",
                     existing_env.get("MEMORY_EPISODE_MODEL", "claude-sonnet-4-6"),
                 )
-                while True:
-                    memory_episode_budget_usd = _prompt(
-                        "Per-episode USD budget (0.15 for Sonnet, 0.05 for Haiku)",
-                        existing_env.get("MEMORY_EPISODE_BUDGET_USD", "0.15"),
-                    )
-                    if _validate_positive_float(memory_episode_budget_usd):
-                        break
-                    print("  Must be a positive number.")
+                # No MEMORY_EPISODE_BUDGET_USD prompt on this branch:
+                # --max-budget-usd is omitted from the stage-2 claude
+                # --print argv (memory_extraction.py:_run_episode_extractor)
+                # for the same Max-plan reason as stage 1. The pre-init
+                # `memory_episode_budget_usd = "0.15"` above is left
+                # untouched; the env emission below double-gates on
+                # agent_backend != "claude" so the key is never written
+                # on the claude branch.
                 # Episode timeout has a 10s floor: Haiku's warm-up alone
                 # routinely runs several seconds, so a sub-floor timeout
                 # would surface as systematic timeouts that mask real
@@ -946,9 +966,18 @@ def _cmd_config() -> None:
     env.pop("CLAUDE_MODEL", None)
     env.pop("CLAUDE_MAX_BUDGET_USD", None)
 
-    # BUDGET_CEILING is global (not per-user), so always write it
-    # regardless of whether users.yaml exists.
-    env["BUDGET_CEILING"] = budget
+    # BUDGET_CEILING is global (not per-user). Skipped entirely on the
+    # claude backend (--max-budget-usd is omitted from claude --print
+    # argv). The `and budget` truthiness check is load-bearing, not
+    # defensive: on the users.yaml branch, `budget` is initialized via
+    # `existing_env.get("BUDGET_CEILING", existing_env.get("CLAUDE_MAX_BUDGET_USD", ""))`
+    # which defaults to "" when neither key is in the existing env, and
+    # writing `BUDGET_CEILING=` (empty value) into /etc/kai/env would
+    # crash load_config()'s float() parsing at startup. The legacy
+    # branch's _validate_positive_float loop guarantees a non-empty
+    # number string there, so the guard is a no-op for that branch.
+    if agent_backend != "claude" and budget:
+        env["BUDGET_CEILING"] = budget
 
     # Deprecated per-user vars: only include without users.yaml
     # (legacy single-user mode). With users.yaml, these are noise.
@@ -1012,7 +1041,7 @@ def _cmd_config() -> None:
     # they apply globally to any review, regardless of users.yaml presence.
     if pr_review_timeout_s != "900":
         env["PR_REVIEW_TIMEOUT_S"] = pr_review_timeout_s
-    if pr_review_budget_usd != "1.0":
+    if agent_backend != "claude" and pr_review_budget_usd != "1.0":
         env["PR_REVIEW_BUDGET_USD"] = pr_review_budget_usd
 
     # Semantic memory: global env vars (per-user partitioning is runtime).
@@ -1024,7 +1053,16 @@ def _cmd_config() -> None:
         env["MEMORY_ENABLED"] = "true"
         if memory_extraction_enabled:
             env["MEMORY_EXTRACTION_ENABLED"] = "true"
-            if float(memory_extraction_budget_usd) != 0.01:
+            # Double-gate (agent_backend AND non-default value) is
+            # intentionally redundant: the wizard now skips the
+            # extraction-budget prompt on claude, so the value is
+            # always "0.01" on that branch and the float comparison
+            # alone would also exclude it. The explicit
+            # `agent_backend != "claude"` makes the intent legible at
+            # the emission site without forcing the reader to trace
+            # the pre-init default. Same shape as the autocompact
+            # and effort emissions earlier in the function.
+            if agent_backend != "claude" and float(memory_extraction_budget_usd) != 0.01:
                 env["MEMORY_EXTRACTION_BUDGET_USD"] = memory_extraction_budget_usd
             # Timeout written under the same gate as budget: both are
             # extraction-only tunables. Numeric compare so "10" vs "10 "
@@ -1047,7 +1085,8 @@ def _cmd_config() -> None:
             # key out so the inheritance path stays intact across reinstall.
             if memory_episode_model.strip():
                 env["MEMORY_EPISODE_MODEL"] = memory_episode_model.strip()
-            if float(memory_episode_budget_usd) != 0.15:
+            # Double-gate matches the stage-1 budget treatment above.
+            if agent_backend != "claude" and float(memory_episode_budget_usd) != 0.15:
                 env["MEMORY_EPISODE_BUDGET_USD"] = memory_episode_budget_usd
             if int(memory_episode_timeout_s) != 120:
                 env["MEMORY_EPISODE_TIMEOUT_S"] = memory_episode_timeout_s

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1036,12 +1036,18 @@ async def _run_extractor(
       disable all tools`). The extractor only reads stdin and writes JSON.
     - --no-session-persistence keeps ~/.claude/projects/ from growing a
       directory per extraction.
-    - --max-budget-usd is a strict safety rail. The extractor subprocess
-      bills pay-per-token at Haiku rates regardless of Max-plan status
-      (observed ~$0.02-$0.03 per call, dominated by cache-creation
-      tokens), so this ceiling is a real cost gate, not a "Max means
-      free" shortcut. See config.memory_extraction_budget_usd for the
-      default and the expected-cost caveat.
+    - NO --max-budget-usd on the claude backend. The flag enforces a
+      computed-cost ceiling that has no relation to actual billing under
+      Max-plan OAuth (the CLI tracks token rates whether or not money is
+      charged), so terminating a subprocess at the configured ceiling
+      would just stop work that is not costing anything. Runaway-loop
+      protection comes from `memory_extraction_timeout_s` (passed to
+      `asyncio.wait_for` below), which is sufficient: a stuck or
+      recursive extractor cannot hold the executor longer than the
+      timeout, regardless of how many tokens it has notionally generated.
+      The `memory_extraction_budget_usd` Config field stays defined so
+      non-claude backends - which run on pay-per-token billing and need
+      a real ceiling - can read it through their own dispatch.
     - --permission-mode bypassPermissions is acceptable because
       --tools "" leaves nothing to permit or deny.
 
@@ -1077,8 +1083,6 @@ async def _run_extractor(
         "json",
         "--json-schema",
         json.dumps(_FACT_SCHEMA),
-        "--max-budget-usd",
-        str(config.memory_extraction_budget_usd),
         "--system-prompt",
         _EXTRACTION_SYSTEM_PROMPT,
         "--permission-mode",
@@ -1254,10 +1258,13 @@ async def _run_episode_extractor(
     Single-return-shape on every path keeps the caller's branch table
     flat and makes the stage-2 outcome enum easy to populate downstream.
 
-    Flag set is identical to stage 1 except for model, budget, timeout,
-    schema, and system prompt - the env allowlist, sandboxing flags,
-    auth posture, and stdin-only payload delivery are all reused so the
+    Flag set is identical to stage 1 except for model, timeout, schema,
+    and system prompt - the env allowlist, sandboxing flags, auth
+    posture, and stdin-only payload delivery are all reused so the
     security review of stage 1 transfers without re-evaluation.
+    --max-budget-usd is omitted for the same Max-plan reason documented
+    on `_run_extractor`; runaway protection comes from
+    `memory_episode_timeout_s` at the `asyncio.wait_for` call below.
     """
     _ensure_extractor_cwd()
 
@@ -1270,8 +1277,6 @@ async def _run_episode_extractor(
         "json",
         "--json-schema",
         json.dumps(_EPISODE_SCHEMA),
-        "--max-budget-usd",
-        str(config.memory_episode_budget_usd),
         "--system-prompt",
         _EPISODE_SYSTEM_PROMPT,
         "--permission-mode",

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -51,11 +51,17 @@ _MAX_DIFF_CHARS = 100_000
 # Opus tokens. Sonnet is more than capable for code review.
 _REVIEW_MODEL = "sonnet"
 
-# Default per-review budget cap in USD. Overridable via PR_REVIEW_BUDGET_USD
-# in config; the Config field is the runtime source of truth. Kept here as a
-# fallback default for direct run_review() callers (tests, scripts) that do
-# not thread config through. Sonnet reviews of typical PRs cost well under
-# $0.50, so 1.0 is a headroom ceiling rather than a typical cost.
+# Default per-review budget cap in USD. Vestigial after #390:
+# --max-budget-usd is no longer emitted to claude --print argv on the
+# claude branch (Max-plan OAuth makes the CLI's computed-cost ceiling
+# a phantom signal), and the Goose branch uses --max-turns 1 rather
+# than a dollar ceiling, so the constant's only remaining role is to
+# provide the default for the `budget_usd` parameter on `run_review`
+# / `run_review_session` - a parameter that is itself unused on every
+# currently-exercised path. Retained for symmetry with
+# _TRIAGE_BUDGET_USD and to avoid changing public signatures (see
+# PR_REVIEW_BUDGET_USD env var); cleanup deferred to a separate
+# refactor that can also drop the `budget_usd` parameter.
 _REVIEW_BUDGET_USD = 1.0
 
 # Default subprocess timeout for a single review, in seconds. Overridable
@@ -661,6 +667,12 @@ async def run_review(
     agent_backend: str = "claude",
     provider: str = "",
     timeout_s: int = _REVIEW_TIMEOUT,
+    # `budget_usd` is unused on every currently-exercised path: the
+    # claude branch no longer emits --max-budget-usd to argv (#390),
+    # and the Goose branch uses --max-turns 1 rather than a dollar
+    # ceiling. Kept on the signature to avoid a public API break in
+    # this fix; cleanup deferred to a separate refactor that updates
+    # webhook.py and the test suite together.
     budget_usd: float = _REVIEW_BUDGET_USD,
 ) -> str:
     """
@@ -908,6 +920,8 @@ async def review_pr(
     agent_backend: str = "claude",
     provider: str = "",
     timeout_s: int = _REVIEW_TIMEOUT,
+    # See `run_review` above for why `budget_usd` is currently unused
+    # on every exercised path; cleanup deferred to a separate refactor.
     budget_usd: float = _REVIEW_BUDGET_USD,
 ) -> None:
     """

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -754,12 +754,10 @@ async def run_review(
         # of whether any money is being charged. Passing the flag would
         # terminate the subprocess at a ceiling that does not correspond to
         # real billing. Runaway protection comes from `timeout_s` at the
-        # asyncio.wait_for call below. The `budget_usd` parameter is still
-        # accepted on this function's signature for backward compatibility
-        # and for a future non-claude review path; cleanup of the now-unused
-        # parameter is deferred to a separate refactor (out of spec scope
-        # here because it would change a public signature consumed by
-        # webhook.py and the review test corpus).
+        # asyncio.wait_for call below. The `budget_usd` parameter on the
+        # signature is unused on every currently-exercised path - see the
+        # comment on the parameter declaration above for the full rationale
+        # and why cleanup is deferred to a separate refactor.
         cmd = [
             "claude",
             "--print",

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -737,17 +737,22 @@ async def run_review(
             raise RuntimeError(f"Review subprocess timed out after {timeout_s}s") from None
     else:
         # Claude one-shot mode: --print reads from stdin, writes to stdout.
-        # Format budget as fixed-point (f-string :.4f) rather than str() so
-        # very small values never render in scientific notation like
-        # "1e-05", which the Claude CLI's numeric parser may reject. Four
-        # fractional digits cover any realistic per-review ceiling.
+        # No --max-budget-usd on this branch: the claude backend runs under
+        # Max-plan OAuth, where the CLI tracks computed token cost regardless
+        # of whether any money is being charged. Passing the flag would
+        # terminate the subprocess at a ceiling that does not correspond to
+        # real billing. Runaway protection comes from `timeout_s` at the
+        # asyncio.wait_for call below. The `budget_usd` parameter is still
+        # accepted on this function's signature for backward compatibility
+        # and for a future non-claude review path; cleanup of the now-unused
+        # parameter is deferred to a separate refactor (out of spec scope
+        # here because it would change a public signature consumed by
+        # webhook.py and the review test corpus).
         cmd = [
             "claude",
             "--print",
             "--model",
             _REVIEW_MODEL,
-            "--max-budget-usd",
-            f"{budget_usd:.4f}",
         ]
 
         # Resolve self-sudo: skip sudo when claude_user matches the bot

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -45,7 +45,13 @@ log = logging.getLogger(__name__)
 # no need for Opus tokens. Sonnet handles classification and analysis well.
 _TRIAGE_MODEL = "sonnet"
 
-# Per-triage budget cap in USD.
+# Per-triage budget cap in USD. Vestigial after #390: --max-budget-usd
+# is no longer emitted to claude --print argv on the claude branch
+# (Max-plan OAuth makes the CLI's computed-cost ceiling a phantom
+# signal), and the Goose branch uses --max-turns 1 rather than a
+# dollar ceiling, so this constant has no consumer at present.
+# Retained for symmetry with _REVIEW_BUDGET_USD and for future
+# non-claude triage paths; cleanup deferred to a separate refactor.
 _TRIAGE_BUDGET_USD = 1.0
 
 # Timeout for the triage subprocess in seconds.

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -457,13 +457,21 @@ async def run_triage(
             raise RuntimeError(f"Triage subprocess timed out after {_TRIAGE_TIMEOUT}s") from None
     else:
         # Claude one-shot mode: --print reads from stdin, writes to stdout.
+        # No --max-budget-usd on this branch: the claude backend runs under
+        # Max-plan OAuth, where the CLI tracks computed token cost regardless
+        # of whether any money is being charged. Passing the flag would
+        # terminate the subprocess at a ceiling that does not correspond to
+        # real billing. Runaway protection comes from _TRIAGE_TIMEOUT at the
+        # asyncio.wait_for call below: a stuck subprocess cannot hold the
+        # executor longer than that timeout, regardless of how many tokens
+        # it has notionally produced. _TRIAGE_BUDGET_USD stays defined for
+        # symmetry with the other budget defaults in this codebase; cleanup
+        # is deferred to a separate refactor.
         cmd = [
             "claude",
             "--print",
             "--model",
             _TRIAGE_MODEL,
-            "--max-budget-usd",
-            str(_TRIAGE_BUDGET_USD),
         ]
 
         # Resolve self-sudo: skip sudo when claude_user matches the bot

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -414,6 +414,44 @@ class TestCommandConstruction:
             idx = cmd.index("--effort")
             assert cmd[idx + 1] == "xhigh"
 
+    @pytest.mark.asyncio
+    async def test_max_budget_usd_flag_absent_on_claude_backend(self):
+        """--max-budget-usd must NOT be emitted to the inner Claude
+        argv (issue #390). ClaudeCodeBackend is only instantiated for
+        the claude backend (pool.py selects between ClaudeCodeBackend
+        and GooseBackend by agent_backend), so the absence is
+        unconditional at this site. Max-plan OAuth makes the CLI's
+        computed-cost ceiling a phantom signal; runaway protection
+        comes from timeout_seconds at the per-message wait_for() call.
+        The max_budget_usd attribute on the instance stays so
+        /settings budget can read it back, but the value no longer
+        reaches the subprocess argv. Pinned as an absence assertion
+        so a future regression that re-adds the flag fails here.
+        """
+        # Construct with a non-default max_budget_usd so the assertion
+        # would catch a regression that simply forgot to remove the
+        # argv pair (rather than a regression that emits the dataclass
+        # default 1.0). Using an obviously-non-default 7.0 makes the
+        # intent legible at the call site.
+        claude = _make_claude(max_budget_usd=7.0)
+        assert claude.max_budget_usd == 7.0  # constructor wired it through
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = AsyncMock()
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+            cmd = mock_exec.call_args[0]
+            assert "--max-budget-usd" not in cmd
+            # The numeric value also must not slip into argv as a
+            # bare positional. Belt-and-suspenders: covers a regression
+            # that drops the flag name but accidentally leaves the
+            # value behind in the list.
+            assert "7.0" not in cmd
+
 
 # ── Process signal handling ──────────────────────────────────────────
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1238,6 +1238,20 @@ class TestCmdConfig:
         if agent_backend == "claude":
             claude_user_entry = [""]
 
+        # BUDGET_CEILING and PR_REVIEW_BUDGET_USD prompts are skipped
+        # on the claude backend (issue #390): --max-budget-usd is no
+        # longer emitted to claude --print argv, so prompting for a
+        # value that is never enforced would be wizard noise. The
+        # fixture entries are conditional to match the wizard's
+        # runtime conditional. Same shape as claude_only_pre_webhook
+        # immediately above; the inverted conditional reflects that
+        # these prompts now fire ONLY on non-claude backends.
+        budget_entry: list[str] = []
+        pr_review_budget_entry: list[str] = []
+        if agent_backend != "claude":
+            budget_entry = ["10.0"]  # BUDGET_CEILING
+            pr_review_budget_entry = ["1.0"]  # PR_REVIEW_BUDGET_USD
+
         return [
             "/opt/kai",  # install dir
             "/var/lib/kai",  # data dir
@@ -1252,7 +1266,7 @@ class TestCmdConfig:
             *backend_block,  # llm_provider + api_key (non-claude only)
             "sonnet",  # model
             "120",  # timeout
-            "10.0",  # budget
+            *budget_entry,  # BUDGET_CEILING (non-claude only)
             "200000",  # max context window
             *claude_only_pre_webhook,  # autocompact + effort (claude only)
             "8080",  # port
@@ -1261,7 +1275,7 @@ class TestCmdConfig:
             "",  # allowed workspaces
             "false",  # pr review enabled
             "900",  # pr review timeout
-            "1.0",  # pr review budget
+            *pr_review_budget_entry,  # PR_REVIEW_BUDGET_USD (non-claude only)
             "false",  # issue triage
             "",  # github notify chat id
             "false",  # voice
@@ -1420,11 +1434,14 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
 
-        # Memory on, extraction on, custom budget + timeout + consolidation candidates + episode tunables + token budget + search limit.
+        # Memory on, extraction on, custom timeout + consolidation candidates + episode tunables + token budget + search limit.
+        # Budget prompts (extraction, episode) are skipped on the claude
+        # backend per issue #390 - --max-budget-usd is no longer emitted
+        # to claude --print argv at either stage, so the wizard does not
+        # ask for a value that would never be enforced.
         memory_block = [
             "true",  # memory enabled
             "true",  # extraction enabled (claude backend)
-            "0.05",  # extraction budget USD
             "60",  # extraction timeout seconds (#345)
             "5",  # consolidation candidates (non-default, exercises emission branch)
             # Episode model: empty input now resolves to the wizard's
@@ -1432,7 +1449,6 @@ class TestCmdConfig:
             # string. To exercise the explicit-override emission
             # branch, type a different model literal here.
             "claude-haiku-4-5-20251001",  # episode model (explicit override)
-            "0.07",  # episode budget USD (non-default; exercises emission branch)
             "60",  # episode timeout seconds (non-default)
             "3000",  # token budget
             "20",  # search limit (#345)
@@ -1446,7 +1462,9 @@ class TestCmdConfig:
         env = conf["env"]
         assert env["MEMORY_ENABLED"] == "true"
         assert env["MEMORY_EXTRACTION_ENABLED"] == "true"
-        assert env["MEMORY_EXTRACTION_BUDGET_USD"] == "0.05"
+        # Budget keys absent on claude backend: prompt is skipped, value
+        # stays at dataclass default, double-gated emission suppresses.
+        assert "MEMORY_EXTRACTION_BUDGET_USD" not in env
         assert env["MEMORY_EXTRACTION_TIMEOUT_S"] == "60"
         assert env["MEMORY_CONSOLIDATION_CANDIDATES_N"] == "5"
         # Episode model: the wizard's non-blank default means an
@@ -1454,7 +1472,7 @@ class TestCmdConfig:
         # written to the env. This test asserts the explicit-override
         # path: a model literal typed in the prompt survives to env.
         assert env["MEMORY_EPISODE_MODEL"] == "claude-haiku-4-5-20251001"
-        assert env["MEMORY_EPISODE_BUDGET_USD"] == "0.07"
+        assert "MEMORY_EPISODE_BUDGET_USD" not in env
         assert env["MEMORY_EPISODE_TIMEOUT_S"] == "60"
         assert env["MEMORY_TOKEN_BUDGET"] == "3000"
         assert env["MEMORY_SEARCH_LIMIT"] == "20"
@@ -1478,14 +1496,15 @@ class TestCmdConfig:
         # default so the emission gates suppress non-episode keys.
         # Asserted on the negative side below for the episode keys;
         # the positive assertion is on the Sonnet model entry.
+        # Budget prompts (extraction, episode) are skipped on the
+        # claude backend per issue #390, so they are absent from
+        # the input list rather than supplying the dataclass default.
         memory_block = [
             "true",  # memory enabled
             "true",  # extraction enabled
-            "0.01",  # extraction budget (stage-1 dataclass default; suppressed)
             "10",  # extraction timeout (dataclass default; suppressed)
             "8",  # consolidation candidates (dataclass default; suppressed)
             "",  # episode model: accept wizard default = claude-sonnet-4-6
-            "0.15",  # episode budget (dataclass default; suppressed)
             "120",  # episode timeout (dataclass default; suppressed)
             "2000",  # token budget (dataclass default; suppressed)
             "10",  # search limit (dataclass default; suppressed)
@@ -1515,15 +1534,15 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
 
-        # Inputs in wizard order: enabled, ext enabled, budget, timeout, consolidation, episode model/budget/timeout, token budget, search limit.
+        # Inputs in wizard order: enabled, ext enabled, timeout, consolidation, episode model/timeout, token budget, search limit.
+        # Budget prompts (extraction, episode) are skipped on the claude
+        # backend per issue #390, so they are absent from this input list.
         memory_block = [
             "true",
             "true",
-            "0.07",
             "45",
             "4",
             "claude-haiku-4-5-future",
-            "0.10",
             "90",
             "2500",
             "15",
@@ -1537,14 +1556,17 @@ class TestCmdConfig:
         rendered = _generate_env_file(conf["env"])
         assert 'MEMORY_ENABLED="true"' in rendered
         assert 'MEMORY_EXTRACTION_ENABLED="true"' in rendered
-        assert 'MEMORY_EXTRACTION_BUDGET_USD="0.07"' in rendered
+        # Budget keys never reach the env file on claude (prompt skipped,
+        # double-gated emission suppresses) - asserted absent here as the
+        # round-trip equivalent of test_memory_enabled_writes_tunables.
+        assert "MEMORY_EXTRACTION_BUDGET_USD" not in rendered
         assert 'MEMORY_EXTRACTION_TIMEOUT_S="45"' in rendered
         assert 'MEMORY_CONSOLIDATION_CANDIDATES_N="4"' in rendered
         # Episode tunables: explicit model entry survives, non-default
-        # budget and timeout survive. Round-trip parity with the
-        # extraction tunables above.
+        # timeout survives. Round-trip parity with the extraction tunables
+        # above. Budget is suppressed on claude for the same reason.
         assert 'MEMORY_EPISODE_MODEL="claude-haiku-4-5-future"' in rendered
-        assert 'MEMORY_EPISODE_BUDGET_USD="0.10"' in rendered
+        assert "MEMORY_EPISODE_BUDGET_USD" not in rendered
         assert 'MEMORY_EPISODE_TIMEOUT_S="90"' in rendered
         assert 'MEMORY_TOKEN_BUDGET="2500"' in rendered
         assert 'MEMORY_SEARCH_LIMIT="15"' in rendered
@@ -1588,7 +1610,14 @@ class TestCmdConfig:
         env = conf["env"]
         assert env["MEMORY_ENABLED"] == "true"
         assert env["MEMORY_EXTRACTION_ENABLED"] == "true"
-        assert env["MEMORY_EXTRACTION_BUDGET_USD"] == "0.08"
+        # Budget key dropped on claude backend per issue #390: prompt
+        # is skipped, the pre-init "0.01" stays untouched (existing env
+        # is no longer consulted for this key on claude), and the
+        # double-gated emission suppresses. A previously-set value on
+        # an upgrade path is intentionally cleared - the field is
+        # informational only on claude, so a stale operator value does
+        # not need to round-trip.
+        assert "MEMORY_EXTRACTION_BUDGET_USD" not in env
         assert env["MEMORY_EXTRACTION_TIMEOUT_S"] == "75"
         assert env["MEMORY_TOKEN_BUDGET"] == "4000"
         assert env["MEMORY_SEARCH_LIMIT"] == "25"
@@ -1692,14 +1721,18 @@ class TestCmdConfig:
         assert "MEMORY_EXTRACTION_TIMEOUT_S" not in env
 
     def test_extraction_disabled_skips_timeout_prompt(self, tmp_path, monkeypatch):
-        """Extraction off must skip the budget, timeout, AND consolidation prompts; search limit still asked.
+        """Extraction off must skip the timeout, consolidation, AND episode prompts; search limit still asked.
 
-        Regression guard for the off-by-one trap: timeout and consolidation
-        sit inside the extraction-enabled branch, so disabling extraction
-        must consume exactly three fewer prompts (budget + timeout +
-        consolidation candidates). If the gating drifts, the input iterator
-        desynchronises and the wizard reads search limit as if it were one
-        of the extraction-only prompts - the assertion below catches that.
+        Regression guard for the off-by-one trap: timeout, consolidation,
+        and the entire episode block sit inside the extraction-enabled
+        branch, so disabling extraction must consume strictly fewer
+        prompts than enabling it. (Issue #390 removed the extraction
+        budget and episode budget prompts from the claude branch
+        entirely; the extraction-enabled branch now drives only timeout,
+        consolidation, episode model, and episode timeout.) If the
+        gating drifts, the input iterator desynchronises and the wizard
+        reads search limit as if it were one of the extraction-only
+        prompts - the assertion below catches that.
         """
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
@@ -1708,7 +1741,7 @@ class TestCmdConfig:
 
         memory_block = [
             "true",  # memory enabled
-            "false",  # extraction disabled (skips budget + timeout prompts)
+            "false",  # extraction disabled (skips timeout + consolidation + episode block)
             "3000",  # token budget
             "20",  # search limit
         ]

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -869,7 +869,11 @@ class TestStage2SubprocessAssembly:
 
         args = captured["args"]
         assert args[args.index("--model") + 1] == "claude-sonnet-4-6"
-        assert args[args.index("--max-budget-usd") + 1] == "0.15"
+        # --max-budget-usd is NOT emitted on the claude backend (issue
+        # #390): Max-plan OAuth makes the CLI's computed-cost ceiling a
+        # phantom signal. Runaway protection comes from
+        # memory_episode_timeout_s instead.
+        assert "--max-budget-usd" not in args
         assert args[args.index("--system-prompt") + 1] == _EPISODE_SYSTEM_PROMPT
         # Schema arg is the episode schema, not the fact schema.
         schema_str = args[args.index("--json-schema") + 1]

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -481,11 +481,18 @@ class TestSubprocessCommandAssembly:
         # Positional flags we rely on
         assert "--print" in args
         assert "--output-format" in args
-        # --model, --max-budget-usd, --json-schema must be present with
-        # the configured values immediately following them
+        # --model and --json-schema must be present with the configured
+        # values immediately following them.
         assert args[args.index("--model") + 1] == "claude-haiku-4-5-20251001"
-        assert args[args.index("--max-budget-usd") + 1] == "0.05"
         assert args[args.index("--output-format") + 1] == "json"
+        # --max-budget-usd is NOT emitted on the claude backend (issue
+        # #390): Max-plan OAuth makes the CLI's computed-cost ceiling a
+        # phantom signal. Runaway protection comes from
+        # memory_extraction_timeout_s instead. Pinned as an absence
+        # assertion so a future regression that re-adds the flag fails
+        # here rather than silently re-introducing phantom-cost
+        # subprocess termination.
+        assert "--max-budget-usd" not in args
         # Schema arg must be a JSON string that round-trips. Both root
         # required fields are present: `facts` (the original extractor
         # output) and `has_episode` (the stage-2 classifier; issue

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -518,22 +518,25 @@ class TestRunReview:
         assert "sonnet" in cmd
 
     @pytest.mark.asyncio
-    async def test_budget_argv_uses_fixed_point_for_small_values(self):
+    async def test_max_budget_usd_flag_absent_on_claude_backend(self):
         """
-        --max-budget-usd must be rendered as fixed-point, not scientific
-        notation. str(1e-5) yields '1e-05', which some numeric parsers
-        reject; using f'{budget:.4f}' keeps the argv stable.
+        --max-budget-usd must NOT be emitted to claude --print argv
+        on the claude backend (issue #390): Max-plan OAuth makes the
+        CLI's computed-cost ceiling a phantom signal, so passing the
+        flag would terminate the subprocess at a ceiling that does
+        not correspond to real billing. Runaway protection comes from
+        the per-review timeout instead. Pinned as an absence assertion
+        so a future regression that re-adds the flag fails here.
         """
         mock_proc = _mock_process(stdout=b"ok")
 
         with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_review("prompt", budget_usd=1e-4)
+            # agent_backend defaults to "claude"; budget_usd is still
+            # accepted on the signature but no longer reaches argv.
+            await run_review("prompt", budget_usd=1.0)
 
         cmd = mock_exec.call_args[0]
-        budget_idx = cmd.index("--max-budget-usd")
-        budget_value = cmd[budget_idx + 1]
-        assert "e" not in budget_value.lower()
-        assert budget_value == "0.0001"
+        assert "--max-budget-usd" not in cmd
 
     @pytest.mark.asyncio
     async def test_failure_raises(self):

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -316,6 +316,26 @@ class TestRunTriage:
         assert result == expected
 
     @pytest.mark.asyncio
+    async def test_max_budget_usd_flag_absent_on_claude_backend(self):
+        """
+        --max-budget-usd must NOT be emitted to claude --print argv on
+        the claude backend (issue #390). Max-plan OAuth makes the CLI's
+        computed-cost ceiling a phantom signal, and the triage
+        subprocess's runaway protection comes from _TRIAGE_TIMEOUT
+        instead. Pinned as an absence assertion so a future regression
+        that re-adds the flag fails here.
+        """
+        mock_proc = _mock_subprocess(returncode=0, stdout='{"labels": []}')
+
+        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            # agent_backend defaults to "claude" via the kwarg default
+            # on run_triage; explicit pass for clarity.
+            await run_triage("prompt", agent_backend="claude")
+
+        cmd = mock_exec.call_args[0]
+        assert "--max-budget-usd" not in cmd
+
+    @pytest.mark.asyncio
     async def test_timeout(self):
         """Timed-out subprocess raises RuntimeError and kills the process."""
         mock_proc = AsyncMock()


### PR DESCRIPTION
## Summary

On Max-plan OAuth, the CLI's `--max-budget-usd` ceiling has no relation to actual billing - the CLI tracks pay-per-token rates whether or not the operator owes any of that money. Sessions, memory extraction, episode generation, issue triage, and PR review subprocesses terminate at $10 (or $0.05, $0.15, $1.00) of computed cost that was never charged.

Fix: omit `--max-budget-usd` at every `claude --print` site that runs on the claude backend. Per-call timeouts already cover runaway-loop protection at every site - no behavior is lost on that axis.

Closes #390.

## What changes

**Argv removals (5 sites):** inner Claude session (`claude.py`), stage-1 memory extraction and stage-2 episode generation (`memory_extraction.py`), GitHub issue triage (`triage.py`), PR review (`review.py`). Each removal sits in the existing claude-vs-Goose dispatch (or, for `claude.py` and `memory_extraction.py`, the structurally claude-only path).

**Wizard prompts gated:** `BUDGET_CEILING`, `PR_REVIEW_BUDGET_USD`, `MEMORY_EXTRACTION_BUDGET_USD`, `MEMORY_EPISODE_BUDGET_USD` no longer fire on the claude backend. The `BUDGET_CEILING` env emission is double-gated with an `and budget` truthiness check that is load-bearing, not defensive: on the users.yaml branch, an empty `BUDGET_CEILING=` would land in the env file and crash `load_config()`'s `float()` parsing at startup.

**Backward compat preserved:** every dollar-amount `Config` field and env var stays defined. Operators upgrading a deployment with hand-edited `/etc/kai/env` see no startup error. Non-claude backends (Goose) continue to pass per-token billing values through.

**In-module budget constants stay defined:** `_TRIAGE_BUDGET_USD = 1.0` and `_REVIEW_BUDGET_USD = 1.0` are now vestigial but kept for symmetry; the broader `budget_usd` parameter cleanup on `run_review` / `run_review_session` is deferred to a separate refactor PR (would change a public signature with wide blast radius across `webhook.py` and the test suite).

**Eval framework + measurement script:** `src/kai/eval/behavioral.py` and `scripts/measure-extraction-timing.py` continue to emit `--max-budget-usd` deliberately (cost-measurement scaffolding, not phantom-cost protection). Out of scope.

## Tests

- New `--max-budget-usd not in argv` assertions added at all five sites: `tests/test_claude.py`, `tests/test_memory_extraction.py`, `tests/test_memory_episodes.py`, `tests/test_review.py`, `tests/test_triage.py`.
- Wizard test corpus updated: input lists realigned, assertions flipped where claude-branch behavior changed.
- The fixed-point regression test in `tests/test_review.py` (guarding against scientific-notation rendering of `--max-budget-usd`) was deleted - it was protecting a flag that is no longer emitted on the claude path.

Full suite: **2499 passed, 1 skipped** (skip is pre-existing). `make check` clean.

## Test plan

- [ ] CI passes
- [ ] Manual smoke: a fresh inner Claude session that runs long enough to have hit the old `BUDGET_CEILING=10` does NOT terminate with `Reached maximum budget`
- [ ] Manual smoke: a stage-1 extraction succeeds and the structured log line `memory.consolidate.intent` reports a non-zero `cost_usd` (the CLI envelope still carries computed cost; the field is informational)
- [ ] Manual: run `make config` with `AGENT_BACKEND=claude` and confirm the four budget prompts are skipped; run with `AGENT_BACKEND=goose` and confirm they fire
