### PR TITLE
feat(preferences): per-user PREFERENCES.md always-on rule layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ kai.db
 logs/
 history/
 memory/
+preferences/
 files/
 .responding_to
 models/
@@ -41,6 +42,7 @@ home/*
 home/.claude/*
 !home/.claude/CLAUDE.md.example
 !home/.claude/MEMORY.md.example
+!home/.claude/PREFERENCES.md.example
 !home/config
 home/config/*
 !home/config/goose-config.yaml

--- a/home/.claude/PREFERENCES.md.example
+++ b/home/.claude/PREFERENCES.md.example
@@ -1,0 +1,11 @@
+# Preferences
+
+This file holds your always-on personal rules and preferences. Inner Claude reads it on every turn (injected as `[Your personal preferences (file: ...):]`) and writes to it via `Edit` or `Write` when persisting a new always-on rule.
+
+Keep this file tight. Anything that should fire every turn (writing style, formatting directives, behavioral rules tied to your specific working patterns) belongs here. Anything fact-shaped (project state, decisions, dated incidents, contextual references) belongs in `MEMORY.md` instead, where retrieval surfaces it on similarity rather than on every turn.
+
+## Style
+
+## Working Discipline
+
+## Behavioral

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -469,9 +469,9 @@ def ensure_user_preferences(chat_id: int | None, data_dir: Path) -> None:
 
     Sibling to ensure_user_memory(). Same idempotency, same OSError
     swallow behavior, same multi-user ownership caveats - the install
-    step (install.py `_apply_migrate`) pre-creates and chowns
-    `preferences/<chat_id>/` to the user's os_user when one is set in
-    users.yaml; lazy bootstrap is the runtime fallback for chat_ids
+    step (install.py `_apply_migrate`) pre-creates `preferences/<chat_id>/`
+    for every entry in users.yaml and chowns it to that user's os_user
+    when one is set; lazy bootstrap is the runtime fallback for chat_ids
     added between installs (a reinstall picks up the ownership in the
     `-- PREFERENCES.md directory ownership --` pass).
 

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -220,6 +220,27 @@ def build_session_context(
         except OSError:
             pass
 
+    # Always inject the per-user PREFERENCES.md as the always-on rule
+    # surface. Distinct from MEMORY.md, which is the per-user fact
+    # surface; PREFERENCES.md holds operator-personal directives that
+    # need to fire on every turn (writing style, formatting, behavioral
+    # rules), while MEMORY.md holds project state and notes that surface
+    # via similarity retrieval once the Qdrant-backed semantic memory
+    # is enabled. Injected above MEMORY.md so the inner Claude reads
+    # rules before facts on a top-to-bottom scan. When chat_id is None
+    # (one-shot CLI invocations) the block is omitted entirely; there
+    # is no global-fallback PREFERENCES.md.
+    if chat_id is not None:
+        pref_path = data_dir / "preferences" / str(chat_id) / "PREFERENCES.md"
+        try:
+            pref_text = pref_path.read_text().strip()
+            if pref_text:
+                parts.append(f"[Your personal preferences (file: {pref_path}):]\n{pref_text}")
+            else:
+                parts.append(f"[Your personal preferences (file: {pref_path}):]\n(currently empty)")
+        except OSError:
+            parts.append(f"[Your personal preferences (file: {pref_path}):]\n(file is missing or empty)")
+
     # Always inject Kai's personal memory from DATA_DIR. This file
     # lives outside the install tree (/var/lib/kai/memory/ in production)
     # so it survives make install. Available regardless of which
@@ -434,6 +455,63 @@ def ensure_user_memory(chat_id: int | None, data_dir: Path) -> None:
         log.warning(
             "ensure_user_memory: could not bootstrap %s",
             user_memory_file,
+            exc_info=True,
+        )
+
+
+def ensure_user_preferences(chat_id: int | None, data_dir: Path) -> None:
+    """
+    Lazily create the per-user PREFERENCES.md directory and seed file.
+
+    Sibling to ensure_user_memory(). Same idempotency, same OSError
+    swallow behavior, same multi-user ownership caveats - the install
+    step (install.py `_apply_migrate`) pre-creates and chowns
+    `preferences/<chat_id>/` to the user's os_user when one is set in
+    users.yaml; lazy bootstrap is the runtime fallback for chat_ids
+    added between installs (a reinstall picks up the ownership in the
+    `-- PREFERENCES.md directory ownership --` pass).
+
+    When chat_id is None we are on a one-shot CLI / test path: there
+    is no per-user PREFERENCES.md to seed because the inject path
+    (build_session_context) skips the block entirely when chat_id is
+    None. Return immediately; no global-fallback equivalent.
+
+    Silent on OSError: a permissions issue creating per-user
+    preferences must not prevent the bot from answering a message.
+    The read path in build_session_context already returns a
+    placeholder string on missing files, so the downstream session
+    still boots cleanly.
+    """
+    # No global-fallback path for PREFERENCES.md. The inject branch in
+    # build_session_context omits the block entirely when chat_id is
+    # None, so there is nothing to seed.
+    if chat_id is None:
+        return
+
+    user_pref_dir = data_dir / "preferences" / str(chat_id)
+    user_pref_file = user_pref_dir / "PREFERENCES.md"
+
+    try:
+        user_pref_dir.mkdir(parents=True, exist_ok=True)
+        if not user_pref_file.exists():
+            # Seed from the example template if one ships with the
+            # source tree. Copy2 preserves mode bits so a deliberately
+            # permissive example stays that way. Mirrors
+            # ensure_user_memory's seed step.
+            example = PROJECT_ROOT / "home" / ".claude" / "PREFERENCES.md.example"
+            if example.is_file():
+                shutil.copy2(example, user_pref_file)
+            else:
+                # No template available (unusual - only happens when
+                # the install tree is incomplete). Create a minimal
+                # placeholder so the subprocess has a writable file
+                # to edit. Matches ensure_user_memory's `# Memory\n`
+                # precedent for symmetry.
+                user_pref_file.write_text("# Preferences\n")
+    except OSError:
+        log.warning(
+            "ensure_user_preferences: could not bootstrap %s",
+            user_pref_file,
             exc_info=True,
         )
 

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -239,7 +239,11 @@ def build_session_context(
             else:
                 parts.append(f"[Your personal preferences (file: {pref_path}):]\n(currently empty)")
         except OSError:
-            parts.append(f"[Your personal preferences (file: {pref_path}):]\n(file is missing or empty)")
+            # OSError fires only on missing or unreadable files; the
+            # empty case is handled by the else branch above with a
+            # distinct "(currently empty)" placeholder. Match the
+            # MEMORY.md branch's wording for symmetry.
+            parts.append(f"[Your personal preferences (file: {pref_path}):]\n(not yet created)")
 
     # Always inject Kai's personal memory from DATA_DIR. This file
     # lives outside the install tree (/var/lib/kai/memory/ in production)

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -34,6 +34,7 @@ from kai.backend import (
     build_foreign_workspace_reminder,
     build_session_context,
     ensure_user_memory,
+    ensure_user_preferences,
     prepend_to_prompt,
 )
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
@@ -490,6 +491,11 @@ class ClaudeCodeBackend(AgentBackend):
             # acceptable; documenting it so future readers do not
             # assume self-healing.
             ensure_user_memory(chat_id, DATA_DIR)
+            # Sibling bootstrap for the per-user PREFERENCES.md surface.
+            # Same scope, same OSError-swallow semantics; see
+            # backend.ensure_user_preferences() for the multi-user
+            # ownership caveats.
+            ensure_user_preferences(chat_id, DATA_DIR)
             session_ctx = build_session_context(
                 workspace=self.workspace,
                 home_workspace=self.home_workspace,

--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -35,6 +35,7 @@ from kai.backend import (
     build_foreign_workspace_reminder,
     build_session_context,
     ensure_user_memory,
+    ensure_user_preferences,
     prepend_to_prompt,
 )
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file
@@ -363,6 +364,11 @@ class GooseBackend(AgentBackend):
             # acceptable; documenting it so future readers do not
             # assume self-healing.
             ensure_user_memory(chat_id, DATA_DIR)
+            # Sibling bootstrap for the per-user PREFERENCES.md surface.
+            # Same scope, same OSError-swallow semantics; see
+            # backend.ensure_user_preferences() for the multi-user
+            # ownership caveats.
+            ensure_user_preferences(chat_id, DATA_DIR)
             session_ctx = build_session_context(
                 workspace=self.workspace,
                 home_workspace=self.home_workspace,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2276,13 +2276,13 @@ def _apply_migrate(
     # "remember to also chown the file" reminder. Lazy bootstrap at
     # runtime (backend.ensure_user_preferences) is the fallback for
     # chat_ids added between installs.
-    preferences_root = data_path / "preferences"
+    preferences_tree = data_path / "preferences"
     preferences_template = PROJECT_ROOT / "home" / ".claude" / "PREFERENCES.md.example"
 
     for chat_id, _os_user in memory_owners:
         if chat_id is None:
             continue
-        pref_dir = preferences_root / str(chat_id)
+        pref_dir = preferences_tree / str(chat_id)
         pref_dst = pref_dir / "PREFERENCES.md"
 
         if dry_run:
@@ -2318,7 +2318,6 @@ def _apply_migrate(
     # This pass is what corrects ownership drift when os_user changes
     # between installs. Without it, the seeding block above would set
     # ownership on first-run only and stale files would persist.
-    preferences_tree = data_path / "preferences"
     if preferences_tree.is_dir():
         if dry_run:
             print(f"[DRY RUN] Would set ownership on {preferences_tree} (service + per-user)")

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2266,6 +2266,76 @@ def _apply_migrate(
                     # memory/<chat_id>/ whose user has no os_user set.
                     _set_ownership(entry, svc_uid, svc_gid, recursive=True)
 
+    # -- PREFERENCES.md per-user pre-creation --
+    # Mirror the MEMORY.md per-user pattern. For every users.yaml
+    # entry we pre-create DATA_DIR/preferences/<chat_id>/ and seed
+    # PREFERENCES.md from the example template if it does not exist.
+    # Initial ownership is set by the ownership pass below, not here;
+    # keeping the chown in a single block makes the os_user-change
+    # idempotency case fall out naturally rather than requiring a
+    # "remember to also chown the file" reminder. Lazy bootstrap at
+    # runtime (backend.ensure_user_preferences) is the fallback for
+    # chat_ids added between installs.
+    preferences_root = data_path / "preferences"
+    preferences_template = PROJECT_ROOT / "home" / ".claude" / "PREFERENCES.md.example"
+
+    for chat_id, _os_user in memory_owners:
+        if chat_id is None:
+            continue
+        pref_dir = preferences_root / str(chat_id)
+        pref_dst = pref_dir / "PREFERENCES.md"
+
+        if dry_run:
+            if not pref_dst.exists():
+                if preferences_template.is_file():
+                    print(f"[DRY RUN] Would seed {pref_dst} from {preferences_template}")
+                else:
+                    print(f"[DRY RUN] Would seed {pref_dst} with placeholder (template missing)")
+            continue
+
+        pref_dir.mkdir(parents=True, exist_ok=True)
+        if not pref_dst.exists():
+            if preferences_template.is_file():
+                shutil.copy2(preferences_template, pref_dst)
+                print(f"  Seeded {pref_dst} from PREFERENCES.md.example")
+            else:
+                # Match ensure_user_preferences() / ensure_user_memory()
+                # missing-template precedent so the subprocess always
+                # has a writable file. Warn so the operator notices the
+                # install tree gap, but continue.
+                pref_dst.write_text("# Preferences\n")
+                print(f"  WARNING: {preferences_template} not found; wrote placeholder to {pref_dst}")
+
+    # -- PREFERENCES.md directory ownership --
+    # Recursively chown DATA_DIR/preferences/ on every install, exactly
+    # mirroring the MEMORY.md ownership pass above. The top directory
+    # is service-owned so the service user can create new per-user
+    # subdirs on add-user flows. Per-user subdirs whose chat_id appears
+    # in users.yaml are chowned to that user's os_user. Stray entries
+    # (subdirs whose user has no os_user, or files at the top level)
+    # fall through to service ownership.
+    #
+    # This pass is what corrects ownership drift when os_user changes
+    # between installs. Without it, the seeding block above would set
+    # ownership on first-run only and stale files would persist.
+    preferences_tree = data_path / "preferences"
+    if preferences_tree.is_dir():
+        if dry_run:
+            print(f"[DRY RUN] Would set ownership on {preferences_tree} (service + per-user)")
+            for name, (uid, gid) in per_user_ids.items():
+                print(f"[DRY RUN]   {preferences_tree / name} -> ({uid}:{gid})")
+        else:
+            _set_ownership(preferences_tree, svc_uid, svc_gid, recursive=False)
+            for entry in preferences_tree.iterdir():
+                if entry.is_dir() and entry.name in per_user_ids:
+                    uid, gid = per_user_ids[entry.name]
+                    _set_ownership(entry, uid, gid, recursive=True)
+                else:
+                    # Subdirs whose chat_id has no os_user, or any
+                    # stray top-level entry, fall through to service
+                    # ownership. Same fallback as the memory pass.
+                    _set_ownership(entry, svc_uid, svc_gid, recursive=True)
+
     # -- Per-user home workspace pre-creation (#353) --
     # Mirror the per-user memory pattern above. For every users.yaml
     # entry we pre-create the directory the inner Claude subprocess
@@ -2541,6 +2611,12 @@ def _apply_directories(
         (data_path / "files", svc_uid, svc_gid, 0o755),
         (data_path / "history", svc_uid, svc_gid, 0o755),
         (data_path / "memory", svc_uid, svc_gid, 0o755),
+        # Per-user preferences root (#400). Top-level dir is service-
+        # owned so the bot can lazily create new preferences/<chat_id>/
+        # subdirs at first message; per-user subdirs are pre-created
+        # and chowned in _apply_migrate when the user has a distinct
+        # os_user.
+        (data_path / "preferences", svc_uid, svc_gid, 0o755),
         # Per-user home root (#353). Top-level dir is service-owned so
         # the bot can lazily create new home/<chat_id>/ subdirs at first
         # message; per-user subdirs are pre-created and chowned in

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -18,6 +18,7 @@ from kai.backend import (
     build_session_context,
     ensure_user_home,
     ensure_user_memory,
+    ensure_user_preferences,
     get_workspace_system_prompt,
     prepend_to_prompt,
     resolve_home_workspace,
@@ -151,6 +152,133 @@ class TestBuildSessionContext:
 
         assert result is not None
         assert "(currently empty)" in result
+
+    def test_preferences_block_with_content(self, tmp_path):
+        """PREFERENCES.md content is injected when chat_id is set and the file has content."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        # MEMORY.md path so the function does not fail on missing memory dir.
+        (data_dir / "memory" / "42").mkdir(parents=True)
+        # Per-user PREFERENCES.md exists with content.
+        pref_dir = data_dir / "preferences" / "42"
+        pref_dir.mkdir(parents=True)
+        (pref_dir / "PREFERENCES.md").write_text("Use Celsius for temperatures.")
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=42,
+                data_dir=data_dir,
+            )
+
+        assert "[Your personal preferences (file:" in result
+        assert "Use Celsius for temperatures." in result
+
+    def test_preferences_block_empty_file(self, tmp_path):
+        """'(currently empty)' placeholder when PREFERENCES.md exists but is blank."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        (data_dir / "memory" / "7").mkdir(parents=True)
+        pref_dir = data_dir / "preferences" / "7"
+        pref_dir.mkdir(parents=True)
+        (pref_dir / "PREFERENCES.md").write_text("")
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=7,
+                data_dir=data_dir,
+            )
+
+        assert "[Your personal preferences (file:" in result
+        # Two blocks may match the "(currently empty)" string (preferences
+        # and memory). Both can be empty here; check the preferences
+        # block contains it by anchoring on the block label.
+        pref_block_idx = result.find("[Your personal preferences (file:")
+        memory_block_idx = result.find("[Your persistent memory (file:")
+        # Slice between the preferences block start and the memory block
+        # start to verify the empty placeholder is in the preferences
+        # block specifically.
+        pref_block = result[pref_block_idx:memory_block_idx]
+        assert "(currently empty)" in pref_block
+
+    def test_preferences_block_missing_file(self, tmp_path):
+        """'(file is missing or empty)' when PREFERENCES.md is absent."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        (data_dir / "memory" / "100").mkdir(parents=True)
+        # No preferences/100/PREFERENCES.md.
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=100,
+                data_dir=data_dir,
+            )
+
+        assert "[Your personal preferences (file:" in result
+        assert "(file is missing or empty)" in result
+
+    def test_preferences_block_omitted_when_chat_id_none(self, tmp_path):
+        """No preferences block when chat_id is None (no per-user file to read)."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        (data_dir / "memory").mkdir(parents=True)
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=None,
+                data_dir=data_dir,
+            )
+
+        # chat_id=None means no per-user PREFERENCES.md to inject.
+        assert "[Your personal preferences (file:" not in result
+
+    def test_preferences_block_above_memory_block(self, tmp_path):
+        """Block ordering: PREFERENCES.md appears BEFORE MEMORY.md in the assembled context."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        memory_dir = data_dir / "memory" / "55"
+        memory_dir.mkdir(parents=True)
+        (memory_dir / "MEMORY.md").write_text("memory content")
+        pref_dir = data_dir / "preferences" / "55"
+        pref_dir.mkdir(parents=True)
+        (pref_dir / "PREFERENCES.md").write_text("preference content")
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=55,
+                data_dir=data_dir,
+            )
+
+        pref_idx = result.find("[Your personal preferences (file:")
+        memory_idx = result.find("[Your persistent memory (file:")
+        assert pref_idx >= 0, "preferences block missing"
+        assert memory_idx >= 0, "memory block missing"
+        # Rules out-rank facts; pin the relative ordering.
+        assert pref_idx < memory_idx, "PREFERENCES.md block must appear before MEMORY.md block"
 
     def test_history_included(self, tmp_path):
         """Recent history is included when available."""
@@ -781,6 +909,103 @@ class TestEnsureUserMemory:
 
         legacy = data_dir / "memory" / "MEMORY.md"
         assert legacy.read_text() == "# Memory\n"
+
+
+class TestEnsureUserPreferences:
+    """ensure_user_preferences bootstraps the per-user PREFERENCES.md surface."""
+
+    def test_seeds_from_example_template(self, tmp_path, monkeypatch):
+        """Creates preferences/<chat_id>/PREFERENCES.md from the example template."""
+        data_dir = tmp_path / "data"
+        project_root = tmp_path / "project"
+        example_dir = project_root / "home" / ".claude"
+        example_dir.mkdir(parents=True)
+        (example_dir / "PREFERENCES.md.example").write_text("# Preferences\n\n## Style\n")
+
+        monkeypatch.setattr("kai.backend.PROJECT_ROOT", project_root)
+
+        ensure_user_preferences(42, data_dir)
+
+        target = data_dir / "preferences" / "42" / "PREFERENCES.md"
+        assert target.is_file()
+        assert "Style" in target.read_text()
+
+    def test_no_template_creates_placeholder(self, tmp_path, monkeypatch):
+        """Falls back to '# Preferences\\n' placeholder when no example template exists."""
+        data_dir = tmp_path / "data"
+        project_root = tmp_path / "project"
+        # Empty home/.claude/, no PREFERENCES.md.example.
+        (project_root / "home" / ".claude").mkdir(parents=True)
+        monkeypatch.setattr("kai.backend.PROJECT_ROOT", project_root)
+
+        ensure_user_preferences(7, data_dir)
+
+        target = data_dir / "preferences" / "7" / "PREFERENCES.md"
+        assert target.is_file()
+        assert target.read_text() == "# Preferences\n"
+
+    def test_idempotent_does_not_overwrite(self, tmp_path, monkeypatch):
+        """Existing per-user PREFERENCES.md is preserved across repeated calls."""
+        data_dir = tmp_path / "data"
+        project_root = tmp_path / "project"
+        example_dir = project_root / "home" / ".claude"
+        example_dir.mkdir(parents=True)
+        (example_dir / "PREFERENCES.md.example").write_text("TEMPLATE")
+        monkeypatch.setattr("kai.backend.PROJECT_ROOT", project_root)
+
+        user_dir = data_dir / "preferences" / "100"
+        user_dir.mkdir(parents=True)
+        existing = user_dir / "PREFERENCES.md"
+        existing.write_text("operator-edited preferences")
+
+        ensure_user_preferences(100, data_dir)
+
+        assert existing.read_text() == "operator-edited preferences"
+
+    def test_chat_id_none_returns_immediately(self, tmp_path, monkeypatch):
+        """
+        chat_id=None is a no-op for preferences. Unlike ensure_user_memory,
+        which seeds a legacy global path for the dev / disabled-mode case,
+        ensure_user_preferences has no global fallback because the inject
+        path also skips the block when chat_id is None. No directory or
+        file should be created.
+        """
+        data_dir = tmp_path / "data"
+        project_root = tmp_path / "project"
+        example_dir = project_root / "home" / ".claude"
+        example_dir.mkdir(parents=True)
+        (example_dir / "PREFERENCES.md.example").write_text("TEMPLATE")
+        monkeypatch.setattr("kai.backend.PROJECT_ROOT", project_root)
+
+        ensure_user_preferences(None, data_dir)
+
+        # No preferences/ tree should have been created.
+        assert not (data_dir / "preferences").exists()
+
+    def test_oserror_swallowed(self, tmp_path, monkeypatch, caplog):
+        """OSError raised inside the body is swallowed via log.warning, not propagated."""
+        import logging
+
+        data_dir = tmp_path / "data"
+        project_root = tmp_path / "project"
+        (project_root / "home" / ".claude").mkdir(parents=True)
+        monkeypatch.setattr("kai.backend.PROJECT_ROOT", project_root)
+
+        # Force mkdir to raise; the function must swallow rather than
+        # let the bot die mid-message-bootstrap.
+        def boom(*args, **kwargs):
+            raise PermissionError("mkdir denied")
+
+        monkeypatch.setattr("pathlib.Path.mkdir", boom)
+
+        with caplog.at_level(logging.WARNING, logger="kai.backend"):
+            ensure_user_preferences(99, data_dir)
+
+        # No exception escaped.
+        assert any(
+            "ensure_user_preferences" in record.message and record.levelno == logging.WARNING
+            for record in caplog.records
+        )
 
 
 class TestPerUserMemoryIsolation:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -204,6 +204,12 @@ class TestBuildSessionContext:
         # block contains it by anchoring on the block label.
         pref_block_idx = result.find("[Your personal preferences (file:")
         memory_block_idx = result.find("[Your persistent memory (file:")
+        # Defensive: a -1 from str.find() would silently turn the slice
+        # below into a near-full-string slice and produce a false pass.
+        # Both labels are always emitted in this fixture (preferences
+        # because chat_id is set, memory unconditionally), so a missing
+        # block here is a regression worth surfacing immediately.
+        assert memory_block_idx >= 0, "memory block label missing - inject ordering may have regressed"
         # Slice between the preferences block start and the memory block
         # start to verify the empty placeholder is in the preferences
         # block specifically.
@@ -229,7 +235,7 @@ class TestBuildSessionContext:
             )
 
         assert "[Your personal preferences (file:" in result
-        assert "(file is missing or empty)" in result
+        assert "(not yet created)" in result
 
     def test_preferences_block_omitted_when_chat_id_none(self, tmp_path):
         """No preferences block when chat_id is None (no per-user file to read)."""

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -217,7 +217,7 @@ class TestBuildSessionContext:
         assert "(currently empty)" in pref_block
 
     def test_preferences_block_missing_file(self, tmp_path):
-        """'(file is missing or empty)' when PREFERENCES.md is absent."""
+        """'(not yet created)' placeholder when PREFERENCES.md is absent."""
         workspace = tmp_path / "ws"
         workspace.mkdir()
         data_dir = tmp_path / "data"

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -7,6 +7,7 @@ and the ApiContext/AgentResponse/StreamEvent data types. These functions are pur
 (no subprocess management), so tests are straightforward.
 """
 
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
@@ -990,8 +991,6 @@ class TestEnsureUserPreferences:
 
     def test_oserror_swallowed(self, tmp_path, monkeypatch, caplog):
         """OSError raised inside the body is swallowed via log.warning, not propagated."""
-        import logging
-
         data_dir = tmp_path / "data"
         project_root = tmp_path / "project"
         (project_root / "home" / ".claude").mkdir(parents=True)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3243,6 +3243,271 @@ class TestApplyMigratePerUserHome:
         )
 
 
+# ── Per-user PREFERENCES.md migration (#400) ─────────────────────────
+
+
+class TestApplyMigratePerUserPreferences:
+    """
+    Tests for the per-user PREFERENCES.md install-time work in
+    _apply_migrate (#400). Mirrors TestApplyMigratePerUserMemory shape:
+    seed block creates DATA_DIR/preferences/<chat_id>/PREFERENCES.md
+    from the example template; ownership pass re-chowns the tree on
+    every install so os_user changes propagate to existing files.
+    """
+
+    def _setup(self, tmp_path, monkeypatch, with_template: bool = True) -> Path:
+        """Common scaffolding: project root, data dirs, optional template."""
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path / "src")
+        claude_dir = tmp_path / "src" / "home" / ".claude"
+        claude_dir.mkdir(parents=True)
+        if with_template:
+            (claude_dir / "PREFERENCES.md.example").write_text("# Preferences\n\n## Style\n\n## Working Discipline\n")
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        (data_path / "logs").mkdir()
+        (data_path / "memory").mkdir()
+        return data_path
+
+    def test_seeds_per_user_preferences_from_example(self, tmp_path, monkeypatch):
+        """Single-user case: PREFERENCES.md is seeded from .example template."""
+        data_path = self._setup(tmp_path, monkeypatch)
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 7777\n    name: primary\n    role: admin\n")
+        monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        target = data_path / "preferences" / "7777" / "PREFERENCES.md"
+        assert target.is_file()
+        assert "Style" in target.read_text()
+
+    def test_seeds_each_user_in_multi_user_yaml(self, tmp_path, monkeypatch):
+        """Every users.yaml entry gets its own PREFERENCES.md seeded from .example."""
+        data_path = self._setup(tmp_path, monkeypatch)
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            "users:\n"
+            "  - telegram_id: 1001\n    name: alpha\n    role: admin\n"
+            "  - telegram_id: 1002\n    name: beta\n    role: user\n"
+        )
+        monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        assert (data_path / "preferences" / "1001" / "PREFERENCES.md").is_file()
+        assert (data_path / "preferences" / "1002" / "PREFERENCES.md").is_file()
+
+    def test_idempotent_does_not_overwrite_existing(self, tmp_path, monkeypatch):
+        """Pre-existing per-user PREFERENCES.md content is preserved across reinstalls."""
+        data_path = self._setup(tmp_path, monkeypatch)
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 8888\n    name: keeper\n    role: admin\n")
+
+        # Operator already has customized PREFERENCES.md; re-running install
+        # must not overwrite it.
+        existing = data_path / "preferences" / "8888"
+        existing.mkdir(parents=True)
+        target = existing / "PREFERENCES.md"
+        target.write_text("operator-customized rules")
+        monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        assert target.read_text() == "operator-customized rules"
+
+    def test_template_missing_writes_placeholder(self, tmp_path, monkeypatch, capsys):
+        """When .example template is absent, write '# Preferences\\n' placeholder + warn."""
+        data_path = self._setup(tmp_path, monkeypatch, with_template=False)
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 9999\n    name: u\n    role: admin\n")
+        monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        target = data_path / "preferences" / "9999" / "PREFERENCES.md"
+        assert target.is_file()
+        assert target.read_text() == "# Preferences\n"
+        # Warn so the operator notices an incomplete install tree.
+        out = capsys.readouterr().out
+        assert "WARNING" in out
+        assert "PREFERENCES.md.example" in out
+
+    def test_dry_run_makes_no_filesystem_changes(self, tmp_path, monkeypatch, capsys):
+        """Dry run prints intended actions but does not create any file or directory."""
+        data_path = self._setup(tmp_path, monkeypatch)
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 4242\n    name: u\n    role: admin\n")
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=True,
+            users_yaml_path=users_yaml,
+        )
+
+        out = capsys.readouterr().out
+        assert "Would seed" in out
+        assert "PREFERENCES.md" in out
+        # Nothing on disk under preferences/.
+        assert not (data_path / "preferences").exists()
+
+    def test_ownership_pass_chowns_tree(self, tmp_path, monkeypatch):
+        """
+        The recursive ownership pass walks DATA_DIR/preferences/ and
+        chowns every entry. Without this, an os_user change in
+        users.yaml between installs would leave existing PREFERENCES.md
+        files owned by the previous user, reproducing the #347
+        regression that motivated this layer.
+        """
+        data_path = self._setup(tmp_path, monkeypatch)
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 5555\n    name: u\n    role: admin\n")
+
+        # Pre-existing tree with a stale subdir/file from a prior install.
+        pref_root = data_path / "preferences"
+        pref_root.mkdir()
+        user_dir = pref_root / "5555"
+        user_dir.mkdir()
+        (user_dir / "PREFERENCES.md").write_text("existing")
+
+        chowned: list[tuple[str, int, int]] = []
+        monkeypatch.setattr(
+            "kai.install.os.chown",
+            lambda path, uid, gid: chowned.append((str(path), uid, gid)),
+        )
+        # _set_ownership uses os.lchown for symlinks; pin both so the
+        # test does not require root.
+        monkeypatch.setattr("kai.install.os.lchown", lambda path, uid, gid: chowned.append((str(path), uid, gid)))
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        chowned_paths = {entry[0] for entry in chowned}
+        assert str(pref_root) in chowned_paths
+        assert str(user_dir) in chowned_paths
+        assert str(user_dir / "PREFERENCES.md") in chowned_paths
+
+    def test_stray_subdir_falls_through_to_service_user(self, tmp_path, monkeypatch):
+        """
+        A subdir whose chat_id is not in users.yaml gets service-user
+        ownership (fallback path). Mirrors the memory ownership pass's
+        same fallback.
+        """
+        data_path = self._setup(tmp_path, monkeypatch)
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 100\n    name: u\n    role: admin\n")
+
+        # 999 is NOT in users.yaml; it should be chowned to service user.
+        pref_root = data_path / "preferences"
+        pref_root.mkdir()
+        stray = pref_root / "999"
+        stray.mkdir()
+        (stray / "PREFERENCES.md").write_text("stray content")
+
+        chowned: list[tuple[str, int, int]] = []
+        monkeypatch.setattr(
+            "kai.install.os.chown",
+            lambda path, uid, gid: chowned.append((str(path), uid, gid)),
+        )
+        monkeypatch.setattr("kai.install.os.lchown", lambda path, uid, gid: chowned.append((str(path), uid, gid)))
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        # The stray dir should be chowned to (501, 20), the service user.
+        stray_calls = [c for c in chowned if c[0] == str(stray)]
+        assert stray_calls, f"Expected chown call for stray dir {stray}"
+        assert all(uid == 501 and gid == 20 for _, uid, gid in stray_calls)
+
+
+class TestPreferencesExampleShipsViaCopyTree:
+    """
+    The PREFERENCES.md.example template ships into the install tree as
+    part of `_copy_tree(home/.claude/, ...)` in `_apply_source`. No
+    changes to _apply_source are needed; this test pins the contract
+    that `_HOME_CLAUDE_EXCLUDES` does NOT list the new template, so
+    a future excludes change cannot silently strip it.
+    """
+
+    def test_excludes_does_not_drop_preferences_example(self):
+        from kai.install import _HOME_CLAUDE_EXCLUDES
+
+        assert "PREFERENCES.md.example" not in _HOME_CLAUDE_EXCLUDES, (
+            "PREFERENCES.md.example must ship into the install tree; "
+            "adding it to _HOME_CLAUDE_EXCLUDES would silently drop it."
+        )
+
+
+class TestGitignorePreferencesRules:
+    """
+    .gitignore rules for PREFERENCES.md (#400). The runtime
+    preferences/ directory must be ignored (mirrors memory/), and the
+    tracked .example must be allowlisted under home/.claude/.
+    """
+
+    def _gitignore_path(self) -> Path:
+        # PROJECT_ROOT lives at src/kai/install.py - go up two parents
+        # to reach the repo root, then read .gitignore from there.
+        from kai import install
+
+        return Path(install.__file__).resolve().parents[2] / ".gitignore"
+
+    def test_runtime_preferences_dir_is_ignored(self):
+        """`preferences/` is listed under Runtime artifacts so dev-mode data does not leak."""
+        body = self._gitignore_path().read_text()
+        # Match the bare `preferences/` line, not a substring of a
+        # longer path. The exact line appears under the "# Runtime
+        # artifacts" block, between `memory/` and `files/`.
+        assert "\npreferences/\n" in body
+
+    def test_preferences_example_is_allowlisted(self):
+        """`!home/.claude/PREFERENCES.md.example` un-ignores the tracked template."""
+        body = self._gitignore_path().read_text()
+        assert "\n!home/.claude/PREFERENCES.md.example\n" in body
+
+
 # ── Service lifecycle ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Add a third per-operator rule surface, `PREFERENCES.md`, that sits between the universal `home/.claude/CLAUDE.md` baseline and the per-message-retrievable `MEMORY.md` / Qdrant fact store. PREFERENCES.md is per-`chat_id`, gitignored, and injected into every session unconditionally regardless of `MEMORY_ENABLED`. It is the always-on home for personal operator directives that need to fire every turn (writing style, formatting preferences, behavioral rules tied to one operator's working patterns).

This is Phase A of #399. Phase B (a four-way Memory Write Routing prose update in `CLAUDE.md.example`) is gated on #396 Phase 3 having merged and ships as a separate small PR later.

## Architecture

The per-user PREFERENCES.md mirrors the per-user MEMORY.md pattern from #347/#348:

| Path | Tracked? | Owner | Purpose |
|---|---|---|---|
| `home/.claude/PREFERENCES.md.example` | yes | root:wheel | Universal template; near-empty with placeholder section headings. |
| `<DATA_DIR>/preferences/<chat_id>/PREFERENCES.md` | no | per `users.yaml` `os_user` | Operator's personal preferences, edited from Telegram. |

Bootstrap is two-tier:

1. **Install-time pre-creation** in `_apply_migrate`: for every `chat_id` in `users.yaml`, seed `<DATA_DIR>/preferences/<chat_id>/PREFERENCES.md` from `.example` if missing, then run a recursive ownership pass that re-`chown`s the tree on every install. The ownership pass is what corrects drift when `os_user` changes between installs (the regression #347/#348 fixed for MEMORY.md).
2. **Lazy-on-first-message** via `backend.ensure_user_preferences()`: fallback for `chat_id`s added between installs. Idempotent, swallows `OSError` with `log.warning`.

The inject in `build_session_context()` emits a `[Your personal preferences (file: ...):]` block before the MEMORY.md block so rules out-rank facts on a top-to-bottom read. Block is omitted when `chat_id` is None.

## What changed

- `home/.claude/PREFERENCES.md.example` (new): tracked universal template.
- `.gitignore`: `preferences/` added under "Runtime artifacts"; `!home/.claude/PREFERENCES.md.example` added under the home-allowlist.
- `src/kai/backend.py`:
  - New context block in `build_session_context()` between identity and memory injects.
  - New `ensure_user_preferences(chat_id, data_dir)` sibling to `ensure_user_memory()`.
- `src/kai/claude.py`, `src/kai/goose.py`: call `ensure_user_preferences()` from the same send-pre-flight site that already calls `ensure_user_memory()`.
- `src/kai/install.py`:
  - `_apply_directories`: add `<DATA_DIR>/preferences/` to the directory list so the root is created with service-user ownership.
  - `_apply_migrate`: two new blocks. Seeding block creates per-user `PREFERENCES.md` from `.example` (or `# Preferences\n` placeholder if template is missing); ownership pass recursively `chown`s the tree based on `users.yaml`.

## Tests

- 10 new `test_backend.py` tests:
  - 5 for the inject path: with content, empty file, missing file, omitted when `chat_id` is None, and block ordering (PREFERENCES.md before MEMORY.md).
  - 5 for `ensure_user_preferences`: seeds from template, no-template placeholder, idempotent over existing content, `chat_id=None` is a no-op (no global fallback unlike MEMORY.md), and `OSError` swallow with warning logging.
- 10 new `test_install.py` tests:
  - 7 for `_apply_migrate` PREFERENCES.md handling: single-user seed, multi-user seed, idempotency, missing-template placeholder, dry-run no-op, ownership-pass chowns the tree, stray subdir falls through to service ownership.
  - 1 for `_HOME_CLAUDE_EXCLUDES` not dropping the new template (pins the S4 contract).
  - 2 for `.gitignore` rules: `preferences/` under runtime artifacts, `.example` allowlisted under home.
- Full suite: 2552 passed, 1 skipped.

## Test plan

- [x] `make check` (ruff check + format)
- [x] `pytest tests/test_backend.py::TestBuildSessionContext tests/test_backend.py::TestEnsureUserPreferences`
- [x] `pytest tests/test_install.py::TestApplyMigratePerUserPreferences tests/test_install.py::TestPreferencesExampleShipsViaCopyTree tests/test_install.py::TestGitignorePreferencesRules`
- [x] Full `pytest` suite
- [ ] Manual: `make config` + `sudo make install` on the production daemon. Verify `<DATA_DIR>/preferences/<chat_id>/PREFERENCES.md` is seeded from `.example` and chowned to the per-user `os_user`.
- [ ] Manual: send a message from Telegram. Verify the inner Claude's session context contains a `[Your personal preferences (file: ...):]` block above the `[Your persistent memory (file: ...):]` block.
- [ ] Manual: edit `<DATA_DIR>/preferences/<chat_id>/PREFERENCES.md` to add a directive. Send a follow-up message. Verify the inner Claude's response reflects the new directive (end-to-end inject + edit reachability).
- [ ] Manual: change `os_user` for an existing `chat_id` in `users.yaml`, re-run `sudo make install`. Verify ownership flips on the existing PREFERENCES.md while content is preserved.

fixes #400
refs #399
