### PR TITLE
fix(preferences): clarify PREFERENCES.md is curated, not auto-edited

### DIFF
--- a/home/.claude/PREFERENCES.md.example
+++ b/home/.claude/PREFERENCES.md.example
@@ -1,8 +1,10 @@
 # Preferences
 
-This file holds your always-on personal rules and preferences. Inner Claude reads it on every turn (injected as `[Your personal preferences (file: ...):]`) and writes to it via `Edit` or `Write` when persisting a new always-on rule.
+This file is your always-on personal rule layer. Inner Claude reads it on every turn (injected as `[Your personal preferences (file: ...):]`) but does NOT auto-edit it. Treat it like `CLAUDE.md`: a curated set of always-on rules, edited deliberately, never silently appended.
 
-Keep this file tight. Anything that should fire every turn (writing style, formatting directives, behavioral rules tied to your specific working patterns) belongs here. Anything fact-shaped (project state, decisions, dated incidents, contextual references) belongs in `MEMORY.md` instead, where retrieval surfaces it on similarity rather than on every turn.
+Write to PREFERENCES.md ONLY when the operator explicitly instructs ("save this as a preference," "add this to PREFERENCES," "make this always-on"). Even then, surface the proposed wording and confirm before persisting. Proactive saves of inferred preferences route to `MEMORY.md` (or Qdrant in enabled mode), NOT here.
+
+Keep this file tight. Anything that should fire every turn (writing style, formatting directives, behavioral rules tied to your specific working patterns) belongs here. Anything fact-shaped (project state, decisions, dated incidents, contextual references) belongs in `MEMORY.md`, where retrieval surfaces it on similarity rather than on every turn.
 
 ## Style
 

--- a/home/.claude/PREFERENCES.md.example
+++ b/home/.claude/PREFERENCES.md.example
@@ -4,7 +4,7 @@ This file is your always-on personal rule layer. Inner Claude reads it on every 
 
 Write to PREFERENCES.md ONLY when the operator explicitly instructs ("save this as a preference," "add this to PREFERENCES," "make this always-on"). Even then, surface the proposed wording and confirm before persisting. Proactive saves of inferred preferences route to `MEMORY.md` (or Qdrant in enabled mode), NOT here.
 
-Keep this file tight. Anything that should fire every turn (writing style, formatting directives, behavioral rules tied to your specific working patterns) belongs here. Anything fact-shaped (project state, decisions, dated incidents, contextual references) belongs in `MEMORY.md`, where retrieval surfaces it on similarity rather than on every turn.
+Keep PREFERENCES.md tight. Anything that should fire every turn (writing style, formatting directives, behavioral rules tied to the operator's specific working patterns) belongs here. Anything fact-shaped (project state, decisions, dated incidents, contextual references) belongs in `MEMORY.md`, where retrieval surfaces it on similarity rather than on every turn.
 
 ## Style
 


### PR DESCRIPTION
## Summary

The `PREFERENCES.md.example` header (shipped via the per-user PREFERENCES.md feature in PR #401) invited inner Claude to write to PREFERENCES.md the same way it writes to MEMORY.md. Combined with the proactive-save behavior in CLAUDE.md, that would let PREFERENCES.md grow turn-by-turn into another always-injected MEMORY.md, defeating its purpose as a curated rule layer.

The semantic distinction "PREFERENCES.md is always-on, MEMORY.md is on-similarity" only described READS; the WRITE policy was implicit and inherited the wrong analog. This PR makes the policy explicit:

- Read every turn (unchanged).
- Treat like CLAUDE.md: curated, edited deliberately, never silently appended.
- Write only on explicit operator instruction, with proposed wording surfaced and confirmed first.
- Proactive saves of inferred preferences continue to route to MEMORY.md (or Qdrant in enabled mode), not here.

Doc-only; no code or test changes.

## Test plan

- [x] All 20 preferences-related tests in `test_backend.py` and `test_install.py` pass locally; they assert structure (file exists, copytree includes it, gitignore allowlist) rather than specific header text.
- [ ] CI passes.
- [ ] Existing operators with a seeded `<DATA_DIR>/preferences/<chat_id>/PREFERENCES.md` keep the old header until they edit their copy directly. `ensure_user_preferences()` only seeds when the file is missing, so a reinstall does not overwrite. New operators get the fixed header on first install.
