### PR TITLE
feat(memory): switch-point gating for MEMORY_ENABLED toggle (#403)

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -187,6 +187,7 @@ def build_session_context(
     workspace_config: WorkspaceConfig | None,
     chat_id: int | None,
     data_dir: Path,
+    memory_enabled: bool = False,
 ) -> str:
     """
     Build the context prefix for the first message of a new session.
@@ -204,6 +205,13 @@ def build_session_context(
         workspace_config: Per-workspace config (for system_prompt).
         chat_id: Telegram chat ID for history scoping and API routing.
         data_dir: Root data directory (memory, history, files live here).
+        memory_enabled: Operator-intent flag (Config.memory_enabled).
+            Drives the memory subsystem marker emission and gates
+            MEMORY.md injection. Reflects intent, not runtime success;
+            the runtime-success surface is `memory.is_enabled()`. Passed
+            as a bool rather than the full Config to match the existing
+            convention of backends taking individual config fields at
+            construction.
     """
     parts: list[str] = []
 
@@ -219,6 +227,18 @@ def build_session_context(
                 parts.append(f"[Your core identity and instructions:]\n{identity}")
         except OSError:
             pass
+
+    # Memory subsystem state marker. Tells the inner Claude where to
+    # route new fact saves: enabled = POST /api/memory/add (Qdrant),
+    # disabled = Edit MEMORY.md. Reflects operator INTENT (Config.
+    # memory_enabled), not runtime success; if Qdrant init failed at
+    # startup, the marker still says "enabled" so write attempts
+    # surface the failure as 503s rather than silently re-routing to
+    # MEMORY.md. Always emit (per-deployment, not per-user) so the
+    # routing rule in CLAUDE.md / PREFERENCES.md can branch on a
+    # uniformly-present signal.
+    mode = "enabled" if memory_enabled else "disabled"
+    parts.append(f"[Memory subsystem: {mode}]")
 
     # Always inject the per-user PREFERENCES.md as the always-on rule
     # surface. Distinct from MEMORY.md, which is the per-user fact
@@ -245,11 +265,17 @@ def build_session_context(
             # MEMORY.md branch's wording for symmetry.
             parts.append(f"[Your personal preferences (file: {pref_path}):]\n(not yet created)")
 
-    # Always inject Kai's personal memory from DATA_DIR. This file
-    # lives outside the install tree (/var/lib/kai/memory/ in production)
-    # so it survives make install. Available regardless of which
-    # workspace the inner Claude is operating in. try/except guards
-    # against race and permission errors (same pattern as identity).
+    # Inject Kai's personal memory from DATA_DIR ONLY in disabled mode.
+    # In enabled mode, Qdrant is the active fact surface (retrieved via
+    # memory.format_context in claude.py), and MEMORY.md is dormant;
+    # injecting it would create a dual-source collision where retrieval
+    # results and MEMORY.md content diverge over time. Gate on operator
+    # INTENT (config.memory_enabled), not runtime success: if intent is
+    # "Qdrant is the surface" and init failed, do not re-show MEMORY.md.
+    #
+    # The file lives outside the install tree (/var/lib/kai/memory/ in
+    # production) so it survives make install. try/except guards against
+    # race and permission errors (same pattern as identity).
     #
     # Per-user scoping (#347): when chat_id is set, the file lives under
     # memory/<chat_id>/MEMORY.md so each user has their own writable
@@ -260,18 +286,19 @@ def build_session_context(
     # legacy global path when chat_id is None (local-dev backends
     # with no multi-user config) so nothing regresses on single-user
     # setups that never hit the multi-user pool path.
-    if chat_id is not None:
-        memory_path = data_dir / "memory" / str(chat_id) / "MEMORY.md"
-    else:
-        memory_path = data_dir / "memory" / "MEMORY.md"
-    try:
-        memory = memory_path.read_text().strip()
-        if memory:
-            parts.append(f"[Your persistent memory (file: {memory_path}):]\n{memory}")
+    if not memory_enabled:
+        if chat_id is not None:
+            memory_path = data_dir / "memory" / str(chat_id) / "MEMORY.md"
         else:
-            parts.append(f"[Your persistent memory (file: {memory_path}):]\n(currently empty)")
-    except OSError:
-        parts.append(f"[Your persistent memory (file: {memory_path}):]\n(not yet created)")
+            memory_path = data_dir / "memory" / "MEMORY.md"
+        try:
+            memory = memory_path.read_text().strip()
+            if memory:
+                parts.append(f"[Your persistent memory (file: {memory_path}):]\n{memory}")
+            else:
+                parts.append(f"[Your persistent memory (file: {memory_path}):]\n(currently empty)")
+        except OSError:
+            parts.append(f"[Your persistent memory (file: {memory_path}):]\n(not yet created)")
 
     # Per-workspace system prompt from workspaces.yaml. Injected
     # between the identity/memory block and conversation history,

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -109,6 +109,13 @@ class ClaudeCodeBackend(AgentBackend):
         # exists so direct ClaudeCodeBackend(...) instantiation in tests
         # does not have to plumb an effort kwarg. Keep the two in sync.
         claude_effort_level: str = "high",
+        # Operator-intent flag for the memory subsystem (Config.
+        # memory_enabled). Drives the [Memory subsystem: ...] marker
+        # emission and gates MEMORY.md inject in build_session_context.
+        # Default False so direct test instantiations need not plumb
+        # the kwarg; production callers (pool.py) always pass an
+        # explicit value.
+        memory_enabled: bool = False,
     ):
         # ABC-required attributes (pool.py reads/writes these)
         self.model = model
@@ -133,6 +140,7 @@ class ClaudeCodeBackend(AgentBackend):
         self.claude_user = claude_user
         self.max_session_hours = max_session_hours
         self.autocompact_pct = autocompact_pct
+        self.memory_enabled = memory_enabled
 
         # API context for session injection (passed to build_session_context)
         self._api_context = ApiContext(
@@ -503,6 +511,7 @@ class ClaudeCodeBackend(AgentBackend):
                 workspace_config=self.workspace_config,
                 chat_id=chat_id,
                 data_dir=DATA_DIR,
+                memory_enabled=self.memory_enabled,
             )
             prompt = prepend_to_prompt(prompt, session_ctx)
 

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1533,6 +1533,15 @@ def load_config() -> Config:
     # other memory_* fields: try/except ValueError, SystemExit on bad
     # input, and reject negatives explicitly on numeric fields.
     memory_extraction_enabled = os.environ.get("MEMORY_EXTRACTION_ENABLED", "").lower() in ("1", "true", "yes")
+    # memory_extraction_enabled is a sub-toggle of memory_enabled. The
+    # dataclass docstring documents this dependency, but without
+    # parse-time enforcement the extraction subprocess fires when
+    # MEMORY_EXTRACTION_ENABLED=true is set with MEMORY_ENABLED=false,
+    # burning ~$0.01/turn of Haiku budget whose result silently no-ops
+    # in the `_memory is None` guard inside add_structured. Compose
+    # here so the dependency is explicit and the budget-burn hole is
+    # closed regardless of operator env-var ordering.
+    memory_extraction_enabled = memory_extraction_enabled and memory_enabled
     memory_extraction_model = (
         os.environ.get("MEMORY_EXTRACTION_MODEL", "claude-haiku-4-5-20251001").strip() or "claude-haiku-4-5-20251001"
     )

--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -86,6 +86,13 @@ class GooseBackend(AgentBackend):
         workspace_config: WorkspaceConfig | None = None,
         max_context_window: int = 0,
         provider: str = "",
+        # Operator-intent flag for the memory subsystem (Config.
+        # memory_enabled). Drives the [Memory subsystem: ...] marker
+        # emission and gates MEMORY.md inject in build_session_context.
+        # Default False so direct test instantiations need not plumb
+        # the kwarg; production callers (pool.py) always pass an
+        # explicit value.
+        memory_enabled: bool = False,
     ):
         # ABC-required attributes (pool.py reads/writes these)
         self.model = model
@@ -96,6 +103,7 @@ class GooseBackend(AgentBackend):
         self.workspace_config = workspace_config
         self.max_context_window = max_context_window
         self.provider = provider  # ABC-mandated; bot.py reads this
+        self.memory_enabled = memory_enabled
 
         # API context for session injection (passed to build_session_context)
         self._api_context = ApiContext(
@@ -376,6 +384,7 @@ class GooseBackend(AgentBackend):
                 workspace_config=self.workspace_config,
                 chat_id=chat_id,
                 data_dir=DATA_DIR,
+                memory_enabled=self.memory_enabled,
             )
             prompt = prepend_to_prompt(prompt, session_ctx)
 

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -195,6 +195,7 @@ class SubprocessPool:
                 workspace_config=ws_config,
                 max_context_window=context_window,
                 provider=provider,
+                memory_enabled=self._config.memory_enabled,
             )
 
         # os_user for sudo -u isolation. None = run as bot user.
@@ -216,6 +217,7 @@ class SubprocessPool:
             max_context_window=context_window,
             autocompact_pct=self._config.claude_autocompact_pct,
             claude_effort_level=self._config.claude_effort_level,
+            memory_enabled=self._config.memory_enabled,
         )
 
     # ── Prompt routing ──────────────────────────────────────────────

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -540,8 +540,12 @@ class TestBuildSessionContext:
             )
 
         assert "[Memory subsystem: enabled]" in result
-        # Identity block correctly skipped; marker still present.
-        assert "core identity and instructions" not in result
+        # Identity block correctly skipped (workspace == home_workspace,
+        # so the file is never read). Assert against the file content
+        # itself rather than the wrapper prose: a regression that broke
+        # the skip condition but emitted only the wrapper without the
+        # body would silently pass an "instructions" substring check.
+        assert "identity content" not in result
 
     # ── MEMORY.md inject gate (issue #403) ──────────────────────────
 
@@ -596,6 +600,50 @@ class TestBuildSessionContext:
 
         assert "User likes concise answers." in result
         assert "[Your persistent memory" in result
+
+    def test_memory_md_gate_per_user_chat_id(self, tmp_path):
+        """The MEMORY.md inject gate applies on the per-user `chat_id is not None`
+        branch the same way it does on the global branch.
+
+        Both `chat_id=None` (global path at `memory/MEMORY.md`) and `chat_id=123`
+        (per-user path at `memory/<chat_id>/MEMORY.md`, introduced in #347) must
+        skip injection in enabled mode and inject in disabled mode. This pins the
+        gate's symmetry across both code paths.
+        """
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        per_user_dir = data_dir / "memory" / "123"
+        per_user_dir.mkdir(parents=True)
+        (per_user_dir / "MEMORY.md").write_text("Per-user fact.")
+
+        # Disabled mode: per-user MEMORY.md IS injected.
+        with patch("kai.backend.get_recent_history", return_value=""):
+            disabled_result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=123,
+                data_dir=data_dir,
+                memory_enabled=False,
+            )
+        assert "Per-user fact." in disabled_result
+        assert "memory/123/MEMORY.md" in disabled_result
+
+        # Enabled mode: per-user MEMORY.md is NOT injected.
+        with patch("kai.backend.get_recent_history", return_value=""):
+            enabled_result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=123,
+                data_dir=data_dir,
+                memory_enabled=True,
+            )
+        assert "Per-user fact." not in enabled_result
+        assert "[Your persistent memory" not in enabled_result
 
 
 # ── Test build_foreign_workspace_reminder ───────────────────────────

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -449,6 +449,154 @@ class TestBuildSessionContext:
         assert "Workspace Instructions" in result
         assert "Always respond in haiku form." in result
 
+    # ── Memory subsystem state marker (issue #403) ──────────────────
+
+    def test_memory_subsystem_marker_enabled(self, tmp_path):
+        """Marker line shows 'enabled' when memory_enabled=True is passed."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        (data_dir / "memory").mkdir(parents=True)
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=None,
+                data_dir=data_dir,
+                memory_enabled=True,
+            )
+
+        assert "[Memory subsystem: enabled]" in result
+        assert "[Memory subsystem: disabled]" not in result
+
+    def test_memory_subsystem_marker_disabled(self, tmp_path):
+        """Marker line shows 'disabled' when memory_enabled=False is passed."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        (data_dir / "memory").mkdir(parents=True)
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=None,
+                data_dir=data_dir,
+                memory_enabled=False,
+            )
+
+        assert "[Memory subsystem: disabled]" in result
+        assert "[Memory subsystem: enabled]" not in result
+
+    def test_memory_subsystem_marker_emitted_when_chat_id_none(self, tmp_path):
+        """Marker emits even when chat_id is None (per-deployment, not per-user)."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        (data_dir / "memory").mkdir(parents=True)
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=None,
+                data_dir=data_dir,
+                memory_enabled=True,
+            )
+
+        assert "[Memory subsystem: enabled]" in result
+
+    def test_memory_subsystem_marker_emitted_in_home_workspace(self, tmp_path):
+        """Marker emits even when workspace == home_workspace.
+
+        The identity block is conditionally skipped in this case (lines 214-221
+        in backend.py); the marker is not workspace-scoped and must always
+        emit so the routing rule in CLAUDE.md / PREFERENCES.md has a uniformly-
+        present signal to branch on.
+        """
+        workspace = tmp_path / "home"
+        workspace.mkdir()
+        (workspace / ".claude").mkdir()
+        (workspace / ".claude" / "CLAUDE.md").write_text("identity content")
+        data_dir = tmp_path / "data"
+        (data_dir / "memory").mkdir(parents=True)
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=None,
+                data_dir=data_dir,
+                memory_enabled=True,
+            )
+
+        assert "[Memory subsystem: enabled]" in result
+        # Identity block correctly skipped; marker still present.
+        assert "core identity and instructions" not in result
+
+    # ── MEMORY.md inject gate (issue #403) ──────────────────────────
+
+    def test_memory_md_skipped_when_enabled(self, tmp_path):
+        """MEMORY.md content is NOT injected when memory_enabled=True.
+
+        In enabled mode, Qdrant is the active fact surface (retrieved via
+        memory.format_context in claude.py). Injecting MEMORY.md would
+        create a dual-source collision. The block must be omitted entirely
+        even when MEMORY.md exists with content on disk.
+        """
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        memory_dir = data_dir / "memory"
+        memory_dir.mkdir(parents=True)
+        (memory_dir / "MEMORY.md").write_text("User likes concise answers.")
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=None,
+                data_dir=data_dir,
+                memory_enabled=True,
+            )
+
+        assert "User likes concise answers." not in result
+        assert "[Your persistent memory" not in result
+
+    def test_memory_md_injected_when_disabled(self, tmp_path):
+        """MEMORY.md IS injected when memory_enabled=False (current behavior preserved)."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        memory_dir = data_dir / "memory"
+        memory_dir.mkdir(parents=True)
+        (memory_dir / "MEMORY.md").write_text("User likes concise answers.")
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=None,
+                data_dir=data_dir,
+                memory_enabled=False,
+            )
+
+        assert "User likes concise answers." in result
+        assert "[Your persistent memory" in result
+
 
 # ── Test build_foreign_workspace_reminder ───────────────────────────
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1296,9 +1296,30 @@ class TestMemoryExtractionConfig:
 
     def test_enabled_from_env(self, monkeypatch):
         _set_required(monkeypatch)
+        # memory_extraction_enabled is a sub-toggle of memory_enabled
+        # (compositional gate at parse time, issue #403). Both flags
+        # must be set for extraction to run.
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
         config = load_config()
         assert config.memory_extraction_enabled is True
+
+    def test_extraction_requires_memory_enabled(self, monkeypatch):
+        """Compositional gate at parse time (issue #403).
+
+        Without enforcement, MEMORY_EXTRACTION_ENABLED=true with
+        MEMORY_ENABLED=false would let the Haiku extraction subprocess
+        fire every turn, burning ~$0.01/turn of budget whose result
+        silently no-ops in the `_memory is None` guard inside
+        add_structured. Pin the dependency so future refactors don't
+        accidentally remove it.
+        """
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_ENABLED", "false")
+        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
+        config = load_config()
+        assert config.memory_extraction_enabled is False
+        assert config.memory_enabled is False
 
     def test_model_override(self, monkeypatch):
         _set_required(monkeypatch)


### PR DESCRIPTION
## Summary

Phase 3 of #396. Make `MEMORY_ENABLED` a clean binary toggle between Qdrant-active and MEMORY.md-active modes. Closes the structural collision where both stores could be active simultaneously, with writes to one silently invalidating the other.

Three new gating sites; one parse-time compositional gate; three other sites verified already correct via the existing `init_memory()` no-op.

Fixes #403.

## Changes per site

**Site 0 — thread `memory_enabled` through:**

- `ClaudeCodeBackend.__init__` and `GooseBackend.__init__` take `memory_enabled: bool = False`.
- `pool.py` passes `memory_enabled=self._config.memory_enabled` to both backend constructors.
- Default `False` so direct test instantiations don't need to plumb the kwarg; production callers always pass an explicit value.

**Site 1 — MEMORY.md inject gate (`backend.build_session_context`):**

In enabled mode, Qdrant is the active fact surface (retrieved via `memory.format_context` in `claude.py`); MEMORY.md is dormant. The block is now wrapped in `if not memory_enabled:`, gated on operator intent.

**Site 2 — session-context marker (`backend.build_session_context`):**

New `[Memory subsystem: enabled]` or `[Memory subsystem: disabled]` line, emitted between identity and PREFERENCES.md. Always emits — per-deployment, not per-user, not workspace-scoped. The routing rule in CLAUDE.md and PREFERENCES.md (deployed via #399 / #401) has been live but referencing a marker that did not yet exist; this PR makes that prose load-bearing.

**Site 3 — Qdrant retrieval (verified, no change):**

The call site in `claude.py` `_send_locked` calls `memory.format_context()`, which short-circuits cleanly when `is_enabled()` is False and emits a `memory.recall reason=disabled` log line. No wasted work pre-call. Behavior preserved.

**Site 4 — `/memory` slash commands (verified, no change):**

`memory_command.handle_memory_command` and `handle_memory_callback` already gate on `memory.is_enabled()` and reply with `_MSG_DISABLED`. The earlier draft of the spec proposed adding new guards; that would have been duplicate code.

**Site 5 — Track 2 extraction parse-time gate (`config.load_config`):**

New: `memory_extraction_enabled = memory_extraction_enabled and memory_enabled`. The dataclass docstring documents this dependency, but without parse-time enforcement `MEMORY_EXTRACTION_ENABLED=true MEMORY_ENABLED=false` would let the Haiku subprocess fire every turn, burning budget for no persisted result.

**Site 6 — logging emission (verified, no change):**

`memory.recall` correctly emits in both modes (with `reason=disabled` in disabled mode — preserved observability signal that the eval harness reads). `memory.extraction` and `memory.episode` are silent in disabled mode by virtue of the Site 5 gate preventing the subprocess from firing.

## Gate-surface stance per site

The marker and MEMORY.md inject gate use `config.memory_enabled` (operator intent). `/memory` and Qdrant retrieval use `memory.is_enabled()` (runtime success). The two diverge on init failure:

| State | `config.memory_enabled` | `is_enabled()` | Marker | MEMORY.md inject | `/memory` | Qdrant retrieval |
|-------|-------------------------|----------------|--------|------------------|-----------|------------------|
| `MEMORY_ENABLED=false` | False | False | disabled | injected | disabled reply | unreached |
| `MEMORY_ENABLED=true`, init succeeded | True | True | enabled | not injected | dashboard | active |
| `MEMORY_ENABLED=true`, init failed | True | False | enabled | not injected | disabled reply | reaches `format_context`, short-circuits with `reason=disabled` |

The init-failure case is now a documented mode rather than an undefined edge: the marker tells the inner Claude where operator intent points, and `/memory` truthfully reports UI capability.

## Tests

Six new in `tests/test_backend.py`:

- `test_memory_subsystem_marker_enabled`
- `test_memory_subsystem_marker_disabled`
- `test_memory_subsystem_marker_emitted_when_chat_id_none`
- `test_memory_subsystem_marker_emitted_in_home_workspace`
- `test_memory_md_skipped_when_enabled`
- `test_memory_md_injected_when_disabled`

One new in `tests/test_config.py`:

- `test_extraction_requires_memory_enabled`

Plus an updated existing `test_enabled_from_env` that now sets both flags. The disabled-branch recall log emission is already pinned by `tests/test_memory.py::TestRecallLogging::test_memory_recall_log_uniform_shape_on_short_circuit[disabled-disabled]`; no new test needed.

Full test suite: 2559 passed, 1 skipped, no regressions. `make check` clean.

## Manual mode-switch smoke test (planned post-merge)

1. Start with `MEMORY_ENABLED=false`. Send a Telegram message. Verify: MEMORY.md content appears in injected context, marker is `[Memory subsystem: disabled]`, `/memory` returns `_MSG_DISABLED`.
2. Stop service. Set `MEMORY_ENABLED=true`. Restart. Send a Telegram message. Verify: MEMORY.md does not appear in injected context, marker is `[Memory subsystem: enabled]`, `/memory` returns the dashboard, `memory.recall` emits with a real reason (not `disabled`).

## Out of scope (separate sub-issues to follow)

- Data migration from MEMORY.md to Qdrant.
- `CLAUDE.md.example` Memory Write Routing prose update from three-branch to four-way matrix.
- Mode-switch verification harness beyond the manual smoke test.
- Live reload of `MEMORY_ENABLED` without service restart.
