### PR TITLE
docs(claude-md-example): four-way Memory Write Routing for PREFERENCES.md tier

### DIFF
--- a/home/.claude/CLAUDE.md.example
+++ b/home/.claude/CLAUDE.md.example
@@ -28,6 +28,10 @@ When producing content destined for a public surface (GitHub issues, pull reques
 
 ## Memory Write Routing
 
+Two distinct write categories with different policies: facts (auto-saveable) and rules (curated, explicit-only).
+
+### Facts go to MEMORY.md or Qdrant
+
 Your session context should contain a line like `[Memory subsystem: enabled]` or `[Memory subsystem: disabled]` inside the API context block.
 
 - When the line says `enabled`, persist new facts via `POST /api/memory/add` (see Memory System below).
@@ -35,9 +39,15 @@ Your session context should contain a line like `[Memory subsystem: enabled]` or
 - When the line is absent but the `[Your persistent memory (file: ...):]` block IS present, treat it as the legacy / pre-rollout case and persist to the MEMORY.md path.
 - When neither the `[Memory subsystem: ...]` line nor the `[Your persistent memory (file: ...):]` block is present, do NOT guess or skip. Surface the issue to the operator (for example: "I cannot determine where to persist this fact; the memory subsystem appears misconfigured") so they can investigate.
 
-Never write to both stores in the same turn.
+Never write to MEMORY.md and Qdrant in the same turn.
 
-**Proactive saves (authorized exception to the explicit-instruction rule):** periodically update memory on your own when you notice information worth persisting (operator preferences, personal facts, corrections, decisions, recurring interests). Do this quietly without announcing it. Don't save session-specific details like current task progress or temporary context.
+**Proactive fact saves (authorized exception to the explicit-instruction rule):** periodically update fact memory on your own when you notice information worth persisting (operator personal facts, corrections, decisions, recurring interests). Do this quietly without announcing it. Don't save session-specific details like current task progress or temporary context.
+
+### Rules go to PREFERENCES.md, but only on explicit instruction
+
+The `[Your personal preferences (file: ...):]` block injects PREFERENCES.md, the curated always-on rule layer. It is NOT a target for proactive saves. Treat it like CLAUDE.md: read every turn, edited deliberately, never silently appended.
+
+Write to PREFERENCES.md ONLY when the operator explicitly instructs ("save this as a preference," "add this to PREFERENCES," "make this always-on"). Even on explicit instruction, surface the proposed wording and confirm before persisting. Each entry pays a token cost on every turn, so growth must be deliberate.
 
 ## Behavioral Rules
 


### PR DESCRIPTION
## Summary

Phase B of #399. The shipped `home/.claude/CLAUDE.md.example` Memory Write Routing section was three-branch (enabled MEMORY.md/Qdrant, disabled MEMORY.md, legacy fallback). This PR rewrites it as four-way:

- **Facts go to MEMORY.md or Qdrant** — unchanged routing for fact saves, including the marker-driven enabled/disabled split. The `Proactive saves` block is renamed `Proactive fact saves` to make the scope explicit.
- **Rules go to PREFERENCES.md, but only on explicit instruction** — new subsection clarifying that PREFERENCES.md is the curated always-on rule layer, NOT a target for proactive saves. Mirrors the policy already deployed in operator CLAUDE.md / PREFERENCES.md (PR #401, PR #402).

Removes a real ambiguity for new operators whose CLAUDE.md.example seeded their inner Claude with the older prose: fact-saves continued to route correctly, but rule-saves had no specified destination.

## Why now

Phase B was gated on Phase 3 of #396 (PR #404) merging because the new prose references the `[Memory subsystem: enabled|disabled]` marker that #404 made always-emitted. With #404 in, the marker exists in every session; this PR makes the prose that depends on it ship to operators.

## Changes

`home/.claude/CLAUDE.md.example` only. The Facts subsection bullets are preserved from the previous version, with two intentional refinements:

1. The previous "Never write to both stores in the same turn" is narrowed to "Never write to MEMORY.md and Qdrant in the same turn." This is deliberate: PREFERENCES.md writes are explicit-instruction with confirmation, so combining a proactive fact save with an operator-confirmed preference edit in one turn is permitted by policy. The blanket prohibition only needs to apply to the two fact stores.
2. `operator preferences` is removed from the proactive-saves enumeration since preferences now route to a separate destination (PREFERENCES.md) under different rules (explicit-only, no proactive saves).

The Rules subsection is new.

Doc-only; no code or test changes.

## Test plan

- [x] `tests/test_backend.py` and `tests/test_install.py` pass locally (316 tests). No test pins the Memory Write Routing prose; existing tests use synthetic example content.
- [ ] CI passes.
- [ ] After merge: existing operators keep their already-deployed CLAUDE.md (gitignored, not overwritten by reinstall). New operators get the four-way prose on first install via `make install`. Operators who want the new prose in their own CLAUDE.md merge it manually.

## Out of scope

- Phase 4 of #396 (Qdrant migration): separate sub-issue.
- Updating the `Memory System` H2 prose later in CLAUDE.md.example: covered indirectly by the new Rules subsection; no further changes needed in this PR.
