### PR TITLE
feat(memory): MEMORY.md to Qdrant migration script (#406)

### DIFF
--- a/scripts/migrate-memory-md-to-qdrant.py
+++ b/scripts/migrate-memory-md-to-qdrant.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""
+Migrate operator-curated MEMORY.md content into Qdrant.
+
+Phase 4 of #396 (issue #406). One-shot script that reads the operator's
+deployed MEMORY.md, chunks it by section header with H3-to-H2 rollup
+for short bodies, runs a per-chunk similarity check against existing
+Qdrant content to skip likely duplicates, and writes survivors via
+`memory.add_structured` with `source="migration"` metadata.
+
+Headers above H3 (i.e. H4+) are flattened into their parent H3's body
+text. The script's chunking granularity is H2 + H3 only, matching the
+spec; deeper sub-headers contribute body text but do not produce
+separate chunks.
+
+Includes dry-run with score distribution summary, tunable similarity
+threshold, idempotency guard via `memory.count_by_source`, and a
+rollback path via `memory.delete_by_source` (wrapped in `asyncio.run`).
+
+Usage:
+    # Dry run (recommended first step; inspect the plan and score
+    # distribution before committing to writes):
+    python scripts/migrate-memory-md-to-qdrant.py --user-id 123 --dry-run
+
+    # Real migration:
+    python scripts/migrate-memory-md-to-qdrant.py --user-id 123
+
+    # Rollback (deletes all migration-source rows for the user):
+    python scripts/migrate-memory-md-to-qdrant.py --user-id 123 --rollback
+
+See home/specs/406-memory-md-qdrant-migration-v3.md for the full
+design rationale and acceptance criteria.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Exit codes (documented in the spec):
+#   0 - success
+#   1 - unexpected error
+#   2 - idempotency guard fired (existing migration rows present)
+#   3 - memory subsystem disabled (config.memory_enabled = False)
+#   4 - MEMORY.md path does not exist
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_GUARD = 2
+EXIT_MEMORY_DISABLED = 3
+EXIT_FILE_MISSING = 4
+
+
+# ── Chunking ───────────────────────────────────────────────────────
+
+
+@dataclass
+class Chunk:
+    """One Qdrant-bound chunk extracted from MEMORY.md.
+
+    Attributes:
+        title: The header text (without the `#` markers). Empty for
+            untitled H1 preamble.
+        level: Heading level (1 = H1 preamble, 2 = H2 standalone or H2
+            with rolled-up H3s, 3 = H3 standalone).
+        body: The chunk's full body text WITHOUT the leading header
+            line. For level=2 chunks with rolled-up H3 children, body
+            includes the rolled-up content under the spec-mandated
+            `\\n\\n### <title>\\n<body>` separator.
+        parent_h2: For level=3 chunks, the H2 title above this chunk.
+            None for level=1 and level=2.
+        tag_slug: Slug of the title for level=3 chunks. Empty for
+            level=1 and level=2 (which have no per-chunk topical tag
+            beyond the universal `migration` tag).
+    """
+
+    title: str
+    level: int
+    body: str
+    parent_h2: str | None
+    tag_slug: str
+
+    @property
+    def text(self) -> str:
+        """The full chunk text written to Qdrant (header + body).
+
+        Format depends on level:
+          - level=1: just the body (no `# Memory` line, since H1 is
+            file-level metadata, not topical).
+          - level=2: `## <title>\\n\\n<body>` (body may include rolled-
+            up H3 sections).
+          - level=3: `### <title>\\n\\n<body>` (body may include
+            flattened H4+ sub-headers as part of the prose).
+        """
+        if self.level == 1:
+            return self.body.strip()
+        prefix = "#" * self.level
+        return f"{prefix} {self.title}\n\n{self.body}".strip()
+
+
+# Slug algorithm pinned by the spec (D6 worked-examples table). Lower-
+# case, then collapse every run of non-alphanumeric characters into a
+# single `-`, then strip leading/trailing `-`. Stable across all H3
+# titles in the deployed MEMORY.md (parens, slashes, colons, backticks,
+# version-string dots all handled uniformly).
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def slugify(title: str) -> str:
+    """Generate the metadata.tags H3-title slug (spec §D6)."""
+    return _SLUG_RE.sub("-", title.lower()).strip("-")
+
+
+# Header detection: lines starting with one or more `#` followed by a
+# space and at least one non-space character. The count of leading `#`
+# is the heading level. Captures only the title text after the `# `.
+_HEADING_RE = re.compile(r"^(#+)\s+(.+?)\s*$")
+
+
+def _chunk_memory_md(text: str, rollup_tokens: int) -> list[Chunk]:
+    """Parse MEMORY.md text into Qdrant-bound chunks (spec §D1).
+
+    Walks lines top-to-bottom maintaining (current_h2, current_h3)
+    context. On each new heading, the pending chunk is emitted (if it
+    has body content) and a fresh accumulator starts. Rollup happens
+    in a second pass: H3 chunks below the body-token threshold get
+    folded into their parent H2's chunk text under the
+    `\\n\\n### <title>\\n<body>` separator from spec D1.
+
+    Args:
+        text: Full MEMORY.md file contents.
+        rollup_tokens: H3 chunks with `_estimate_tokens(body)` strictly
+            less than this value get rolled up into their parent H2.
+            At-or-above stand alone. The default is 50 tokens, which
+            corresponds to ~200 characters under the
+            `len(text) // 4` heuristic.
+
+    Returns:
+        List of `Chunk` objects in document order. Headers with empty
+        body and no children are dropped (they would produce one-line
+        embeddings with no useful signal).
+    """
+    # Lazy import: keeps the module load light when only parsing is
+    # exercised in tests (memory.py imports torch transitively).
+    from kai.memory import _estimate_tokens
+
+    # First pass: walk lines, accumulate raw segments.
+    @dataclass
+    class _Segment:
+        title: str  # Empty string for the H1 preamble segment.
+        level: int  # 1, 2, 3, or 4+ (4+ stays in body, no chunk emitted).
+        body_lines: list[str] = field(default_factory=list)
+
+    segments: list[_Segment] = []
+    current = _Segment(title="", level=1)
+    segments.append(current)
+
+    for raw_line in text.splitlines():
+        m = _HEADING_RE.match(raw_line)
+        if m is None:
+            current.body_lines.append(raw_line)
+            continue
+        level = len(m.group(1))
+        title = m.group(2)
+        if level >= 4:
+            # H4+ stays inside the parent's body. Preserves the sub-
+            # header line as text so retrieval can match on it. The
+            # current segment continues; we do NOT start a new one.
+            current.body_lines.append(raw_line)
+            continue
+        # H1, H2, or H3: start a new segment. Drop the H1 preamble
+        # segment if its body is empty AND it has no title (no real
+        # H1 line was seen, which is the case when the file starts
+        # with a heading other than `# `).
+        current = _Segment(title=title, level=level)
+        segments.append(current)
+
+    # Trim each segment's body. A trailing blank line before the next
+    # heading would otherwise leak a `\n` into the chunk text.
+    for seg in segments:
+        # Drop leading and trailing blank lines but preserve internal
+        # spacing (paragraph breaks).
+        while seg.body_lines and not seg.body_lines[0].strip():
+            seg.body_lines.pop(0)
+        while seg.body_lines and not seg.body_lines[-1].strip():
+            seg.body_lines.pop()
+
+    # Build initial chunks from non-empty segments.
+    chunks: list[Chunk] = []
+    current_h2: str | None = None
+    for seg in segments:
+        body_text = "\n".join(seg.body_lines).strip()
+        if seg.level == 1:
+            if not body_text:
+                continue  # No preamble; skip the placeholder H1 segment.
+            chunks.append(
+                Chunk(
+                    title=seg.title or "Memory",
+                    level=1,
+                    body=body_text,
+                    parent_h2=None,
+                    tag_slug="",
+                )
+            )
+        elif seg.level == 2:
+            current_h2 = seg.title
+            # Always emit H2 chunks even when their immediate body is
+            # empty: rollup may fold short H3 children into them in
+            # the second pass, at which point the chunk has content
+            # to write. The empty-body case is filtered below if no
+            # H3 rolled up.
+            chunks.append(
+                Chunk(
+                    title=seg.title,
+                    level=2,
+                    body=body_text,
+                    parent_h2=None,
+                    tag_slug="",
+                )
+            )
+        elif seg.level == 3:
+            if not body_text:
+                continue  # Empty H3 with no children: drop.
+            chunks.append(
+                Chunk(
+                    title=seg.title,
+                    level=3,
+                    body=body_text,
+                    parent_h2=current_h2,
+                    tag_slug=slugify(seg.title),
+                )
+            )
+
+    # Second pass: roll up small H3 chunks into their parent H2.
+    # Walk in document order; when we encounter an H3 below threshold
+    # whose parent_h2 matches the most recent H2 chunk, append its
+    # `\n\n### <title>\n<body>` to that H2's body and drop the H3.
+    rolled_up: list[Chunk] = []
+    last_h2_idx: int | None = None
+    for chunk in chunks:
+        if chunk.level == 2:
+            rolled_up.append(chunk)
+            last_h2_idx = len(rolled_up) - 1
+            continue
+        if (
+            chunk.level == 3
+            and last_h2_idx is not None
+            and chunk.parent_h2 == rolled_up[last_h2_idx].title
+            and _estimate_tokens(chunk.body) < rollup_tokens
+        ):
+            # Roll up: append separator + title + body to parent H2.
+            parent = rolled_up[last_h2_idx]
+            separator = "\n\n" if parent.body else ""
+            parent.body = f"{parent.body}{separator}### {chunk.title}\n{chunk.body}"
+            continue
+        rolled_up.append(chunk)
+
+    # Final filter: drop H2 chunks that ended up with empty body (no
+    # H2-level prose AND no H3 rolled up). Such a chunk would produce
+    # a one-line `## Title` embedding with no retrieval value.
+    return [c for c in rolled_up if c.body.strip()]
+
+
+# ── Score distribution summary ─────────────────────────────────────
+
+
+def _score_summary(scores: list[float], threshold: float) -> str:
+    """Format the dry-run end-of-run score distribution (spec §D8)."""
+    if not scores:
+        return "Similarity score distribution: no chunks emitted (file empty after parsing).\n"
+
+    sorted_scores = sorted(scores)
+    n = len(sorted_scores)
+
+    def pct(p: float) -> float:
+        # Linear interpolation between adjacent ranks; matches numpy's
+        # default percentile method without the import. n=1 returns
+        # the single value regardless of percentile.
+        if n == 1:
+            return sorted_scores[0]
+        rank = p * (n - 1)
+        lo = int(rank)
+        hi = min(lo + 1, n - 1)
+        frac = rank - lo
+        return sorted_scores[lo] + frac * (sorted_scores[hi] - sorted_scores[lo])
+
+    skipped = sum(1 for s in scores if s >= threshold)
+    p90 = pct(0.90)
+    near_misses = sum(1 for s in scores if p90 <= s < threshold)
+
+    lines = [
+        "",
+        "Similarity score distribution (top-1 score per chunk):",
+        f"  min:    {sorted_scores[0]:.3f}",
+        f"  p25:    {pct(0.25):.3f}",
+        f"  p50:    {pct(0.50):.3f}",
+        f"  p75:    {pct(0.75):.3f}",
+        f"  p90:    {p90:.3f}",
+        f"  max:    {sorted_scores[-1]:.3f}",
+        f"  Skipped at threshold {threshold:.2f}: {skipped}/{n} chunks",
+        f"  Above p90 but below threshold: {near_misses} chunks (manual review recommended)",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+# ── Forward migration ──────────────────────────────────────────────
+
+
+def _do_forward_migration(args: argparse.Namespace, chunks: list[Chunk]) -> int:
+    """Execute the forward migration path (or dry-run preview).
+
+    Returns the script exit code.
+    """
+    from kai.memory import add_structured, search
+
+    user_id_str = str(args.user_id)
+    plan_lines: list[str] = []
+    scores: list[float] = []
+    added = 0
+    skipped = 0
+    errors = 0
+
+    for idx, chunk in enumerate(chunks, start=1):
+        results = search(chunk.text, user_id=user_id_str, limit=1)
+        top_score = float(results[0].score) if results else 0.0
+        scores.append(top_score)
+
+        action = "SKIP" if top_score >= args.threshold else "ADD"
+        title_label = chunk.title or f"(level-{chunk.level} chunk)"
+        plan_lines.append(f"CHUNK {idx:2d} {action} score={top_score:.3f} title={title_label!r}")
+
+        if args.verbose:
+            print(plan_lines[-1])
+
+        if args.dry_run:
+            continue
+        if action == "SKIP":
+            skipped += 1
+            continue
+
+        # Tags: ["migration", <h3-slug-or-empty>]. Empty slug is dropped
+        # from the tag list to avoid storing a literal "" tag, which
+        # would inflate /memory tag counts with a meaningless bucket.
+        tags = ["migration"]
+        if chunk.tag_slug:
+            tags.append(chunk.tag_slug)
+        section = chunk.parent_h2 or (chunk.title if chunk.level == 2 else "")
+        subsection = chunk.title if chunk.level == 3 else ""
+        try:
+            mid = add_structured(
+                chunk.text,
+                user_id=user_id_str,
+                memory_type="fact",
+                tags=tags,
+                metadata={
+                    "source": "migration",
+                    "section": section,
+                    "subsection": subsection,
+                },
+            )
+            if mid is None:
+                errors += 1
+            else:
+                added += 1
+        except Exception as exc:
+            print(f"ERROR on chunk {idx} ({title_label}): {exc}", file=sys.stderr)
+            errors += 1
+
+    # Summary block. Always print the totals; print the score
+    # distribution under --dry-run unless --no-summary is set.
+    print()
+    if args.dry_run:
+        print(f"Dry run complete. {len(chunks)} chunks parsed.")
+        if not args.no_summary:
+            print(_score_summary(scores, args.threshold))
+    else:
+        print(f"Migration complete. Added: {added}, skipped: {skipped}, errors: {errors}.")
+
+    return EXIT_OK if errors == 0 else EXIT_ERROR
+
+
+# ── Rollback ───────────────────────────────────────────────────────
+
+
+def _do_rollback(args: argparse.Namespace) -> int:
+    """Execute --rollback (real or dry-run).
+
+    Real mode wraps `delete_by_source` in `asyncio.run`. Dry-run mode
+    calls the sync `count_by_source` and prints a preview without
+    deleting anything.
+    """
+    from kai.memory import count_by_source, delete_by_source
+
+    user_id_str = str(args.user_id)
+    if args.dry_run:
+        n = count_by_source(user_id_str, "migration")
+        print(f"Dry-run rollback: would delete {n} migration entries for user_id {args.user_id}.")
+        return EXIT_OK
+
+    # Confirmation prompt unless --yes. Reads from stdin so the prompt
+    # is interactive in a terminal but the operator can pipe `yes` or
+    # set --yes in scripted contexts.
+    if not args.yes:
+        n = count_by_source(user_id_str, "migration")
+        if n == 0:
+            print(f"No migration entries to delete for user_id {args.user_id}. Exiting.")
+            return EXIT_OK
+        prompt = f"Delete {n} migration entries for user_id {args.user_id}? [y/N]: "
+        try:
+            answer = input(prompt).strip().lower()
+        except EOFError:
+            answer = ""
+        if answer not in ("y", "yes"):
+            print("Aborted.")
+            return EXIT_OK
+
+    deleted = asyncio.run(delete_by_source(user_id_str, "migration"))
+    print(f"Deleted {deleted} migration entries for user_id {args.user_id}.")
+    return EXIT_OK
+
+
+# ── Main ───────────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Migrate MEMORY.md content into Qdrant under source='migration'.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--user-id", type=int, required=True, help="Telegram chat_id (required).")
+    p.add_argument(
+        "--memory-md",
+        type=Path,
+        default=None,
+        help="Path to MEMORY.md (default: <DATA_DIR>/memory/<user_id>/MEMORY.md).",
+    )
+    p.add_argument("--threshold", type=float, default=0.85, help="Similarity threshold for skip (default: 0.85).")
+    p.add_argument(
+        "--rollup-tokens",
+        type=int,
+        default=50,
+        help="H3-to-H2 rollup body-token threshold; ~200 chars (default: 50).",
+    )
+    p.add_argument("--dry-run", action="store_true", help="Print plan and summary, no writes.")
+    p.add_argument(
+        "--no-summary",
+        action="store_true",
+        help="Disable the score distribution summary printed under --dry-run.",
+    )
+    p.add_argument("--force", action="store_true", help="Bypass the idempotency guard.")
+    p.add_argument(
+        "--rollback",
+        action="store_true",
+        help="Delete all migration-source entries for --user-id; mutually exclusive with --force.",
+    )
+    p.add_argument("--yes", action="store_true", help="Skip the rollback confirmation prompt.")
+    p.add_argument("-v", "--verbose", action="store_true", help="Per-chunk score logging.")
+    return p
+
+
+def _validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    """Reject mutually-exclusive flag combinations early."""
+    if args.rollback and args.force:
+        parser.error("--rollback is mutually exclusive with --force")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    _validate_args(args, parser)
+
+    # Lazy imports for everything that pulls in torch/Mem0 so a `--help`
+    # or argparse error exits without paying the import cost.
+    from kai.config import DATA_DIR, load_config
+    from kai.memory import count_by_source, init_memory
+
+    config = load_config()
+    if not config.memory_enabled:
+        print(
+            "ERROR: memory subsystem is disabled (config.memory_enabled = False). "
+            "Set MEMORY_ENABLED=true and restart the service before running migration.",
+            file=sys.stderr,
+        )
+        return EXIT_MEMORY_DISABLED
+
+    init_memory(config)
+
+    if args.rollback:
+        return _do_rollback(args)
+
+    # Forward migration. Resolve the MEMORY.md path.
+    memory_md = args.memory_md or (DATA_DIR / "memory" / str(args.user_id) / "MEMORY.md")
+    if not memory_md.exists():
+        print(f"ERROR: MEMORY.md not found at {memory_md}.", file=sys.stderr)
+        return EXIT_FILE_MISSING
+
+    # Idempotency guard. Skip in --force mode (with a warning) or
+    # under --dry-run (the operator is exploring; no risk of layered
+    # writes since we do not write).
+    user_id_str = str(args.user_id)
+    if not args.dry_run:
+        existing = count_by_source(user_id_str, "migration")
+        if existing > 0 and not args.force:
+            print(
+                f"Migration source entries already exist for user_id {args.user_id} ({existing} entries).\n"
+                "Refusing to run a second migration without --force; this would create\n"
+                "duplicate Qdrant rows that the similarity check cannot reliably catch\n"
+                "across edited chunks.\n"
+                "\n"
+                "To re-run cleanly:\n"
+                f"  python scripts/migrate-memory-md-to-qdrant.py --user-id {args.user_id} --rollback\n"
+                f"  python scripts/migrate-memory-md-to-qdrant.py --user-id {args.user_id}\n"
+                "\n"
+                "Or pass --force to layer this run on top of the prior one (NOT recommended).",
+                file=sys.stderr,
+            )
+            return EXIT_GUARD
+        if existing > 0 and args.force:
+            print(
+                f"WARNING: --force with {existing} existing migration rows. "
+                f"Similarity check will skip exact duplicates but may miss near-duplicates.",
+                file=sys.stderr,
+            )
+
+    chunks = _chunk_memory_md(memory_md.read_text(), rollup_tokens=args.rollup_tokens)
+    print(f"Parsed {len(chunks)} chunks from {memory_md}.")
+
+    return _do_forward_migration(args, chunks)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate-memory-md-to-qdrant.py
+++ b/scripts/migrate-memory-md-to-qdrant.py
@@ -362,6 +362,14 @@ def _do_forward_migration(args: argparse.Namespace, chunks: list[Chunk]) -> int:
                 },
             )
             if mid is None:
+                # add_structured returns None on store failure or
+                # disabled-memory; surface to stderr so the operator
+                # can correlate the error count with specific chunks
+                # (silent counter increment was the original bug).
+                print(
+                    f"ERROR on chunk {idx} ({title_label}): add_structured returned None",
+                    file=sys.stderr,
+                )
                 errors += 1
             else:
                 added += 1
@@ -400,14 +408,20 @@ def _do_rollback(args: argparse.Namespace) -> int:
         print(f"Dry-run rollback: would delete {n} migration entries for user_id {args.user_id}.")
         return EXIT_OK
 
+    # Pre-check the count regardless of --yes so the zero-row case
+    # short-circuits cleanly in both interactive and scripted paths.
+    # Without this, --yes would call delete_by_source on a guaranteed-
+    # empty result set, printing a confusing "Deleted 0 migration
+    # entries" line for what was meant as a no-op verification.
+    n = count_by_source(user_id_str, "migration")
+    if n == 0:
+        print(f"No migration entries to delete for user_id {args.user_id}. Exiting.")
+        return EXIT_OK
+
     # Confirmation prompt unless --yes. Reads from stdin so the prompt
-    # is interactive in a terminal but the operator can pipe `yes` or
-    # set --yes in scripted contexts.
+    # is interactive in a terminal but the operator can pass --yes in
+    # scripted contexts.
     if not args.yes:
-        n = count_by_source(user_id_str, "migration")
-        if n == 0:
-            print(f"No migration entries to delete for user_id {args.user_id}. Exiting.")
-            return EXIT_OK
         prompt = f"Delete {n} migration entries for user_id {args.user_id}? [y/N]: "
         try:
             answer = input(prompt).strip().lower()
@@ -525,7 +539,7 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
 
-    chunks = _chunk_memory_md(memory_md.read_text(), rollup_tokens=args.rollup_tokens)
+    chunks = _chunk_memory_md(memory_md.read_text(encoding="utf-8"), rollup_tokens=args.rollup_tokens)
     print(f"Parsed {len(chunks)} chunks from {memory_md}.")
 
     return _do_forward_migration(args, chunks)

--- a/scripts/migrate-memory-md-to-qdrant.py
+++ b/scripts/migrate-memory-md-to-qdrant.py
@@ -317,7 +317,6 @@ def _do_forward_migration(args: argparse.Namespace, chunks: list[Chunk]) -> int:
     from kai.memory import add_structured, search
 
     user_id_str = str(args.user_id)
-    plan_lines: list[str] = []
     scores: list[float] = []
     added = 0
     skipped = 0
@@ -330,10 +329,12 @@ def _do_forward_migration(args: argparse.Namespace, chunks: list[Chunk]) -> int:
 
         action = "SKIP" if top_score >= args.threshold else "ADD"
         title_label = chunk.title or f"(level-{chunk.level} chunk)"
-        plan_lines.append(f"CHUNK {idx:2d} {action} score={top_score:.3f} title={title_label!r}")
-
         if args.verbose:
-            print(plan_lines[-1])
+            # Print per-chunk plan inline. Earlier shape kept a
+            # plan_lines list with no consumer past the loop body;
+            # collapsed to a local since nothing outside the loop
+            # reads accumulated plan output.
+            print(f"CHUNK {idx:2d} {action} score={top_score:.3f} title={title_label!r}")
 
         if args.dry_run:
             continue

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -742,13 +742,15 @@ def count_by_source(user_id: str, source: str) -> int:
     `delete_by_source`. Calls `_memory.get_all` directly without an
     executor; Mem0's `get_all` is itself sync.
 
-    Inherits the same tail-miss tradeoff as `delete_by_source`: if a
-    full _DELETE_PAGE_SIZE page contains zero matches we conclude the
-    user has no further matches and stop, which under-counts in
-    pathological cases where matching rows sit past the first page in
-    Mem0's internal row order. At single-user scale (<10K rows) this
-    is fine; do NOT "fix" the early termination without re-reading
-    `delete_by_source`'s rationale (the alternative live-locks).
+    Single-fetch (no loop): unlike `delete_by_source`, this function
+    has no side effect on the store, so a paged loop would request
+    the same rows on every iteration (Mem0's get_all has no offset)
+    and would either hang forever (when matching rows exist on a full
+    page) or silently double-count. We fetch up to `_DELETE_PAGE_SIZE`
+    rows once and count client-side. At single-user scale (<10K rows
+    per user) this returns the exact count; if a user ever has more
+    than `_DELETE_PAGE_SIZE` rows, the count caps at the page size
+    and a warning is logged so the operator can investigate.
 
     Args:
         user_id: Telegram chat_id as string.
@@ -758,54 +760,48 @@ def count_by_source(user_id: str, source: str) -> int:
             as `delete_by_source`.
 
     Returns:
-        Count of rows matching the source filter. 0 when memory is
-        disabled (`_memory is None`) or the user has no rows.
+        Count of rows matching the source filter, capped at
+        `_DELETE_PAGE_SIZE`. 0 when memory is disabled
+        (`_memory is None`) or the user has no rows.
     """
     if _memory is None:
         return 0
 
+    # Single fetch: top_k bounds the result; no looping. See docstring
+    # for why a paged loop is unsafe here even though it works in
+    # delete_by_source.
+    result = _memory.get_all(
+        filters={"user_id": user_id},
+        top_k=_DELETE_PAGE_SIZE,
+    )
+    rows = result.get("results", []) if isinstance(result, dict) else result or []
+
+    # Match logic mirrors delete_by_source: empty-source means legacy
+    # rows (missing-or-empty), explicit value means exact equality.
+    # Metadata key is conditionally absent on rows with no extra
+    # payload (mem0/memory/main.py:1118-1120).
     count = 0
-    while True:
-        # Same fetch shape as delete_by_source: top_k page, results-
-        # wrapped dict response. No executor wrap because this whole
-        # function is sync.
-        result = _memory.get_all(
-            filters={"user_id": user_id},
-            top_k=_DELETE_PAGE_SIZE,
+    for row in rows:
+        row_source = row.get("metadata", {}).get("source") if isinstance(row, dict) else None
+        if source == "":
+            if row_source is None or row_source == "":
+                count += 1
+        elif row_source == source:
+            count += 1
+
+    if len(rows) >= _DELETE_PAGE_SIZE:
+        # Hit the cap. The actual store may have more rows; the
+        # returned count is a lower bound. Operator-relevant signal,
+        # not a silent failure.
+        log.warning(
+            "count_by_source: get_all returned %d rows (full page); "
+            "actual count for user_id=%s source=%r may be higher. "
+            "If this fires, single-user-scale assumptions no longer hold.",
+            _DELETE_PAGE_SIZE,
+            user_id,
+            source,
         )
-        rows = result.get("results", []) if isinstance(result, dict) else result or []
 
-        # Match logic mirrors delete_by_source: empty-source means
-        # legacy rows (missing-or-empty), explicit value means exact
-        # equality. Metadata key is conditionally absent on rows with
-        # no extra payload (mem0/memory/main.py:1118-1120).
-        matches = 0
-        for row in rows:
-            row_source = row.get("metadata", {}).get("source") if isinstance(row, dict) else None
-            if source == "":
-                if row_source is None or row_source == "":
-                    matches += 1
-            elif row_source == source:
-                matches += 1
-        count += matches
-
-        # Termination: same shape as delete_by_source. Page not full
-        # means we've seen the whole store; full page with zero matches
-        # means we'd live-lock on the next iteration since get_all has
-        # no offset/cursor.
-        if len(rows) < _DELETE_PAGE_SIZE:
-            break
-        if matches == 0:
-            log.warning(
-                "count_by_source: first full page had zero matches; "
-                "terminating to avoid live-lock. Possible undercount if "
-                "matching rows exist past position %d in Mem0's row order "
-                "(user_id=%s, source=%r).",
-                _DELETE_PAGE_SIZE,
-                user_id,
-                source,
-            )
-            break
     return count
 
 

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -73,8 +73,11 @@ _SEARCH_OVERFETCH = 20
 # filter and only for ranking. Provenance affects ordering among results
 # that passed the quality gate; it never rescues sub-threshold matches.
 # See spec §5.3 for the rationale. Keys:
-#   extracted - Tier 1 Haiku-filtered facts (the only source written by
-#               the live system after spec 360)
+#   extracted - Tier 1 Haiku-filtered facts (live conversational extraction)
+#   episode   - Per-conversation episode summaries (issue #385)
+#   migration - One-shot import of operator-curated MEMORY.md content
+#               (issue #406). Slightly lower weight than extracted
+#               because the entries are not conversation-current.
 #   ""        - legacy or unset source (downweighted for future cleanup)
 # Any other source value found on a row in production fall through to
 # the unknown-source default (`_UNKNOWN_SOURCE_WEIGHT`), which maps to
@@ -87,6 +90,12 @@ _SOURCE_WEIGHTS: dict[str, float] = {
     # post-deploy evaluation shows one source dominates retrieval the
     # other shouldn't, this is the one knob to retune.
     "episode": 1.2,
+    # Migration rows (issue #406) are operator-curated but capture state
+    # from the file's authoring time, so a small de-prioritization on
+    # retrieval is appropriate. Weight chosen as 1.0: above legacy/unknown
+    # (0.6) since the content is intentional, below extracted (1.2) since
+    # it is not freshly conversational.
+    "migration": 1.0,
     "": 0.6,
 }
 
@@ -114,8 +123,8 @@ def _source_weight(r: MemoryResult) -> float:
 # See spec §5.4: `- (YYYY-MM-DD, <source_short>) <text>`.
 # Any source value not listed here (legacy rows from production stores
 # written under earlier code paths) falls through the .get() default
-# below to "legacy", which is the correct retrieval-time label now
-# that "extracted" is the only source being written.
+# below to "legacy", which is the correct retrieval-time label for
+# any source not enumerated below.
 _SOURCE_SHORT: dict[str, str] = {
     "extracted": "fact",
     # Episode rows (issue #385) get a distinct provenance tag so the
@@ -123,6 +132,12 @@ _SOURCE_SHORT: dict[str, str] = {
     # "what happened, and what we learned". The render path also adds
     # an outcome_quality suffix on episode lines (see format_context).
     "episode": "episode",
+    # Migration rows (issue #406) render as "fact" identically to
+    # extracted rows: the source tag is for dedup and rollback, not
+    # for prompt-side labeling. The inner Claude does not need to
+    # distinguish operator-imported facts from conversation-extracted
+    # facts when they surface in retrieval.
+    "migration": "fact",
     "": "legacy",
 }
 
@@ -706,6 +721,92 @@ async def format_context(
     payload["returned_empty"] = False
     _emit_recall_log(payload)
     return "\n".join(lines)
+
+
+def count_by_source(user_id: str, source: str) -> int:
+    """
+    Count rows for `user_id` whose metadata source matches `source`.
+
+    Read-side companion to `delete_by_source` (issue #406). Used by the
+    migration script's idempotency guard: refuse to run a forward
+    migration when migration-source rows already exist for the user,
+    unless --force is passed.
+
+    Mem0's `get_all` does not accept a metadata filter (verified
+    against mem0/memory/main.py:1075-1077): the `filters` kwarg honors
+    only `user_id`/`agent_id`/`run_id`. Filtering happens client-side
+    after the full fetch, mirroring `get_by_tag` and `delete_by_source`.
+
+    Sync (not async) because the migration script runs sync top-to-
+    bottom; only the rollback branch needs async plumbing for
+    `delete_by_source`. Calls `_memory.get_all` directly without an
+    executor; Mem0's `get_all` is itself sync.
+
+    Inherits the same tail-miss tradeoff as `delete_by_source`: if a
+    full _DELETE_PAGE_SIZE page contains zero matches we conclude the
+    user has no further matches and stop, which under-counts in
+    pathological cases where matching rows sit past the first page in
+    Mem0's internal row order. At single-user scale (<10K rows) this
+    is fine; do NOT "fix" the early termination without re-reading
+    `delete_by_source`'s rationale (the alternative live-locks).
+
+    Args:
+        user_id: Telegram chat_id as string.
+        source: Source tag to count, matched against
+            `metadata.source`. Empty string counts legacy rows
+            (missing or empty source) using the same convention
+            as `delete_by_source`.
+
+    Returns:
+        Count of rows matching the source filter. 0 when memory is
+        disabled (`_memory is None`) or the user has no rows.
+    """
+    if _memory is None:
+        return 0
+
+    count = 0
+    while True:
+        # Same fetch shape as delete_by_source: top_k page, results-
+        # wrapped dict response. No executor wrap because this whole
+        # function is sync.
+        result = _memory.get_all(
+            filters={"user_id": user_id},
+            top_k=_DELETE_PAGE_SIZE,
+        )
+        rows = result.get("results", []) if isinstance(result, dict) else result or []
+
+        # Match logic mirrors delete_by_source: empty-source means
+        # legacy rows (missing-or-empty), explicit value means exact
+        # equality. Metadata key is conditionally absent on rows with
+        # no extra payload (mem0/memory/main.py:1118-1120).
+        matches = 0
+        for row in rows:
+            row_source = row.get("metadata", {}).get("source") if isinstance(row, dict) else None
+            if source == "":
+                if row_source is None or row_source == "":
+                    matches += 1
+            elif row_source == source:
+                matches += 1
+        count += matches
+
+        # Termination: same shape as delete_by_source. Page not full
+        # means we've seen the whole store; full page with zero matches
+        # means we'd live-lock on the next iteration since get_all has
+        # no offset/cursor.
+        if len(rows) < _DELETE_PAGE_SIZE:
+            break
+        if matches == 0:
+            log.warning(
+                "count_by_source: first full page had zero matches; "
+                "terminating to avoid live-lock. Possible undercount if "
+                "matching rows exist past position %d in Mem0's row order "
+                "(user_id=%s, source=%r).",
+                _DELETE_PAGE_SIZE,
+                user_id,
+                source,
+            )
+            break
+    return count
 
 
 async def delete_by_source(user_id: str, source: str) -> int:

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -790,16 +790,23 @@ def count_by_source(user_id: str, source: str) -> int:
             count += 1
 
     if len(rows) >= _DELETE_PAGE_SIZE:
-        # Hit the cap. The actual store may have more rows; the
-        # returned count is a lower bound. Operator-relevant signal,
-        # not a silent failure.
+        # Hit the cap. Mem0 row ordering is not guaranteed, so unseen
+        # pages could contain additional matching rows; the returned
+        # count is a lower bound regardless of how many matched on
+        # this page. Operators tend to read "may be higher" as
+        # alarming when matched=0; spell out total vs matched so the
+        # warning is informative rather than confusing.
         log.warning(
-            "count_by_source: get_all returned %d rows (full page); "
-            "actual count for user_id=%s source=%r may be higher. "
-            "If this fires, single-user-scale assumptions no longer hold.",
+            "count_by_source: get_all returned %d total rows (page cap); "
+            "matched %d for source=%r. If the user has >%d total rows, "
+            "unseen pages may contain additional matches and the count "
+            "above is a lower bound. At single-user scale (<%d rows) "
+            "this should not fire.",
             _DELETE_PAGE_SIZE,
-            user_id,
+            count,
             source,
+            _DELETE_PAGE_SIZE,
+            _DELETE_PAGE_SIZE,
         )
 
     return count

--- a/tests/test_eval_retrieval.py
+++ b/tests/test_eval_retrieval.py
@@ -79,11 +79,11 @@ def _reset_memory_module() -> None:
     # the dict contents AND _UNKNOWN_SOURCE_WEIGHT so a sweep test
     # mutating "extracted" does not leak into the next test. Must
     # mirror the production default in src/kai/memory.py exactly,
-    # including the "episode" entry (issue #385) - otherwise tests
-    # in tests/test_memory_episodes.py that read the dict after this
-    # fixture has run will see a stale snapshot missing the entry.
+    # including the "episode" entry (issue #385) and the "migration"
+    # entry (issue #406) - otherwise tests reading the dict after
+    # this fixture has run will see a stale snapshot missing entries.
     mem_mod._SOURCE_WEIGHTS.clear()
-    mem_mod._SOURCE_WEIGHTS.update({"extracted": 1.2, "episode": 1.2, "": 0.6})
+    mem_mod._SOURCE_WEIGHTS.update({"extracted": 1.2, "episode": 1.2, "migration": 1.0, "": 0.6})
     mem_mod._UNKNOWN_SOURCE_WEIGHT = mem_mod._SOURCE_WEIGHTS[""]
     mem_mod._SEARCH_OVERFETCH = 20
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1170,6 +1170,83 @@ class TestDeleteBySource:
         assert "'extracted'" in joined
 
 
+class TestCountBySource:
+    """Tests for count_by_source() (issue #406, Phase 4 of #396).
+
+    Read-side companion to delete_by_source. Sync (no asyncio plumbing)
+    because the migration script's idempotency guard runs on the main
+    sync thread before any async rollback work.
+    """
+
+    def test_count_by_source_disabled_returns_zero(self):
+        """count_by_source returns 0 when memory is disabled; never raises."""
+        from kai.memory import count_by_source
+
+        assert count_by_source("user-a", "migration") == 0
+
+    def test_count_by_source_returns_count(self):
+        """Counts only rows whose metadata source matches; ignores others."""
+        import kai.memory as mem_mod
+        from kai.memory import count_by_source
+
+        mock_mem = MagicMock()
+        # Mixed-source rows: three migration, one extracted, one legacy.
+        # Expected count for "migration" is 3; extracted/legacy are not
+        # counted under that filter.
+        mock_mem.get_all.return_value = {
+            "results": [
+                {"id": "m1", "metadata": {"source": "migration"}},
+                {"id": "e1", "metadata": {"source": "extracted"}},
+                {"id": "m2", "metadata": {"source": "migration"}},
+                {"id": "leg", "metadata": {}},
+                {"id": "m3", "metadata": {"source": "migration"}},
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        assert count_by_source("user-a", "migration") == 3
+
+        # Reset state so other tests are not influenced by the stub.
+        mem_mod._memory = None
+
+    def test_count_by_source_handles_empty_user(self):
+        """Empty store returns 0 cleanly (no exceptions)."""
+        import kai.memory as mem_mod
+        from kai.memory import count_by_source
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {"results": []}
+        mem_mod._memory = mock_mem
+
+        assert count_by_source("user-a", "migration") == 0
+
+        mem_mod._memory = None
+
+
+class TestMigrationSourceMetadata:
+    """Tests for the new "migration" source tag in _SOURCE_WEIGHTS and
+    _SOURCE_SHORT (issue #406, Phase 4 of #396)."""
+
+    def test_migration_source_weight_is_1_0(self):
+        """Pin the weight value so a future refactor accidentally
+        removing or retuning the entry fails loudly. The value is
+        chosen to sit between extracted (1.2) and legacy (0.6); see
+        spec §D3.
+        """
+        from kai.memory import _SOURCE_WEIGHTS
+
+        assert _SOURCE_WEIGHTS["migration"] == 1.0
+
+    def test_migration_renders_as_fact_prefix_in_format_context(self):
+        """Migration rows render with the same line-prefix label as
+        extracted rows. Spec §D3: source tag is for dedup/rollback,
+        not for prompt-side labeling.
+        """
+        from kai.memory import _SOURCE_SHORT
+
+        assert _SOURCE_SHORT["migration"] == _SOURCE_SHORT["extracted"]
+
+
 class TestGetStats:
     """Tests for get_stats()."""
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1251,8 +1251,12 @@ class TestCountBySource:
         assert mock_mem.get_all.call_count == 1
         # When the cap fires, the function logs a warning so the
         # operator knows the count is a lower bound, not silent.
+        # The wording must spell out total vs matched so an operator
+        # whose match count is 0 but whose total exceeds the cap does
+        # not misread the warning as alarming.
         joined = "\n".join(r.message for r in caplog.records)
-        assert "may be higher" in joined
+        assert "page cap" in joined
+        assert "lower bound" in joined
 
 
 class TestMigrationSourceMetadata:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1184,9 +1184,12 @@ class TestCountBySource:
 
         assert count_by_source("user-a", "migration") == 0
 
-    def test_count_by_source_returns_count(self):
-        """Counts only rows whose metadata source matches; ignores others."""
-        import kai.memory as mem_mod
+    def test_count_by_source_returns_count(self, monkeypatch):
+        """Counts only rows whose metadata source matches; ignores others.
+
+        Uses monkeypatch (not direct attribute assignment) so an
+        assertion failure does not leak the mock into subsequent tests.
+        """
         from kai.memory import count_by_source
 
         mock_mem = MagicMock()
@@ -1202,25 +1205,54 @@ class TestCountBySource:
                 {"id": "m3", "metadata": {"source": "migration"}},
             ]
         }
-        mem_mod._memory = mock_mem
+        monkeypatch.setattr("kai.memory._memory", mock_mem)
 
         assert count_by_source("user-a", "migration") == 3
 
-        # Reset state so other tests are not influenced by the stub.
-        mem_mod._memory = None
-
-    def test_count_by_source_handles_empty_user(self):
+    def test_count_by_source_handles_empty_user(self, monkeypatch):
         """Empty store returns 0 cleanly (no exceptions)."""
-        import kai.memory as mem_mod
         from kai.memory import count_by_source
 
         mock_mem = MagicMock()
         mock_mem.get_all.return_value = {"results": []}
-        mem_mod._memory = mock_mem
+        monkeypatch.setattr("kai.memory._memory", mock_mem)
 
         assert count_by_source("user-a", "migration") == 0
 
-        mem_mod._memory = None
+    def test_count_by_source_does_not_loop_on_full_page(self, monkeypatch, caplog):
+        """Regression: count_by_source must call get_all exactly once.
+
+        An earlier shape (mirroring delete_by_source's paged loop)
+        would re-fetch when the page came back full with matches,
+        because Mem0's get_all has no offset and read-only operations
+        don't shrink the store. The loop would either hang forever or
+        silently double-count matching rows. Pin the single-fetch
+        contract so a future refactor cannot reintroduce the loop.
+        """
+        import logging
+
+        import kai.memory as mem_mod
+        from kai.memory import count_by_source
+
+        # Build a full page (_DELETE_PAGE_SIZE rows) of matches. If
+        # the function loops, the second iteration would re-add the
+        # same _DELETE_PAGE_SIZE matches and the assertion would
+        # observe call_count > 1 OR a doubled count (whichever the
+        # broken loop hit first).
+        full_page = [{"id": f"m{i}", "metadata": {"source": "migration"}} for i in range(mem_mod._DELETE_PAGE_SIZE)]
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {"results": full_page}
+        monkeypatch.setattr("kai.memory._memory", mock_mem)
+
+        with caplog.at_level(logging.WARNING, logger="kai.memory"):
+            count = count_by_source("user-a", "migration")
+
+        assert count == mem_mod._DELETE_PAGE_SIZE
+        assert mock_mem.get_all.call_count == 1
+        # When the cap fires, the function logs a warning so the
+        # operator knows the count is a lower bound, not silent.
+        joined = "\n".join(r.message for r in caplog.records)
+        assert "may be higher" in joined
 
 
 class TestMigrationSourceMetadata:

--- a/tests/test_migrate_memory_md.py
+++ b/tests/test_migrate_memory_md.py
@@ -303,7 +303,7 @@ def test_force_bypasses_idempotency_guard(fake_memory_md, stub_memory_module, en
     assert "WARNING" in captured.err  # warning about layering
 
 
-def test_rollback_calls_delete_by_source(fake_memory_md, stub_memory_module, enabled_config):
+def test_rollback_calls_delete_by_source(stub_memory_module, enabled_config):
     """Test 13: --rollback --yes deletes via delete_by_source, no other writes.
 
     Pre-check via count_by_source short-circuits when count==0 so the
@@ -319,7 +319,7 @@ def test_rollback_calls_delete_by_source(fake_memory_md, stub_memory_module, ena
     stub_memory_module["add_structured"].assert_not_called()
 
 
-def test_rollback_short_circuits_when_no_migration_rows(fake_memory_md, stub_memory_module, enabled_config, capsys):
+def test_rollback_short_circuits_when_no_migration_rows(stub_memory_module, enabled_config, capsys):
     """Pre-check: --rollback with zero existing rows exits cleanly without
     calling delete_by_source. Holds for both --yes and interactive paths
     so the operator never sees a confusing "Deleted 0 migration entries"
@@ -334,7 +334,7 @@ def test_rollback_short_circuits_when_no_migration_rows(fake_memory_md, stub_mem
     assert "No migration entries to delete" in captured.out
 
 
-def test_rollback_dry_run_calls_count_not_delete(fake_memory_md, stub_memory_module, enabled_config, capsys):
+def test_rollback_dry_run_calls_count_not_delete(stub_memory_module, enabled_config, capsys):
     """Test 14: --rollback --dry-run previews via count_by_source."""
     stub_memory_module["count_by_source"].return_value = 12
 

--- a/tests/test_migrate_memory_md.py
+++ b/tests/test_migrate_memory_md.py
@@ -304,12 +304,34 @@ def test_force_bypasses_idempotency_guard(fake_memory_md, stub_memory_module, en
 
 
 def test_rollback_calls_delete_by_source(fake_memory_md, stub_memory_module, enabled_config):
-    """Test 13: --rollback --yes deletes via delete_by_source, no other writes."""
+    """Test 13: --rollback --yes deletes via delete_by_source, no other writes.
+
+    Pre-check via count_by_source short-circuits when count==0 so the
+    fixture must report a non-zero count for the rollback to actually
+    fire (matches the operator-visible behavior: "no migration entries
+    to delete" exits cleanly without calling delete_by_source).
+    """
+    stub_memory_module["count_by_source"].return_value = 7
     rc = mig.main(["--user-id", "123", "--rollback", "--yes"])
 
     assert rc == mig.EXIT_OK
     stub_memory_module["delete_by_source"].assert_called_once_with("123", "migration")
     stub_memory_module["add_structured"].assert_not_called()
+
+
+def test_rollback_short_circuits_when_no_migration_rows(fake_memory_md, stub_memory_module, enabled_config, capsys):
+    """Pre-check: --rollback with zero existing rows exits cleanly without
+    calling delete_by_source. Holds for both --yes and interactive paths
+    so the operator never sees a confusing "Deleted 0 migration entries"
+    line for what is meant as a no-op verification.
+    """
+    stub_memory_module["count_by_source"].return_value = 0
+    rc = mig.main(["--user-id", "123", "--rollback", "--yes"])
+
+    assert rc == mig.EXIT_OK
+    stub_memory_module["delete_by_source"].assert_not_called()
+    captured = capsys.readouterr()
+    assert "No migration entries to delete" in captured.out
 
 
 def test_rollback_dry_run_calls_count_not_delete(fake_memory_md, stub_memory_module, enabled_config, capsys):

--- a/tests/test_migrate_memory_md.py
+++ b/tests/test_migrate_memory_md.py
@@ -306,10 +306,9 @@ def test_force_bypasses_idempotency_guard(fake_memory_md, stub_memory_module, en
 def test_rollback_calls_delete_by_source(stub_memory_module, enabled_config):
     """Test 13: --rollback --yes deletes via delete_by_source, no other writes.
 
-    Pre-check via count_by_source short-circuits when count==0 so the
-    fixture must report a non-zero count for the rollback to actually
-    fire (matches the operator-visible behavior: "no migration entries
-    to delete" exits cleanly without calling delete_by_source).
+    Sets count_by_source to 7 (non-zero) so the rollback proceeds past
+    the pre-check; the zero-row short-circuit is exercised separately
+    by test_rollback_short_circuits_when_no_migration_rows.
     """
     stub_memory_module["count_by_source"].return_value = 7
     rc = mig.main(["--user-id", "123", "--rollback", "--yes"])

--- a/tests/test_migrate_memory_md.py
+++ b/tests/test_migrate_memory_md.py
@@ -1,0 +1,349 @@
+"""
+Tests for scripts/migrate-memory-md-to-qdrant.py (issue #406, Phase 4 of #396).
+
+The migration script lives at scripts/migrate-memory-md-to-qdrant.py
+because that is the project convention for one-shot operator scripts.
+The hyphenated filename is not a legal Python module name, so this
+test loads it via importlib.util at module-import time and exposes
+the helpers as `mig.<helper>` for the test functions below.
+
+Tests cover:
+- Chunking unit tests (1-7): the _chunk_memory_md and slugify helpers
+  in isolation, no Qdrant dependency.
+- Integration tests (8-16): the main() entry point with stubbed
+  memory module functions to verify the dry-run / forward / rollback
+  / guard / exit-code paths.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Load the migration script as a module so its helpers are importable
+# despite the hyphenated filename. spec_from_file_location is the
+# stdlib idiom for loading code from an arbitrary path; the loaded
+# module behaves like any other import target.
+#
+# CRITICAL: register in sys.modules BEFORE exec_module(). The script
+# uses @dataclass, whose decorator looks up cls.__module__ in
+# sys.modules at class-creation time. Without the pre-registration,
+# the loaded module is not yet visible there and dataclass crashes
+# with AttributeError on a NoneType __dict__ lookup.
+_SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "migrate-memory-md-to-qdrant.py"
+_spec = importlib.util.spec_from_file_location("migrate_memory_md", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+mig = importlib.util.module_from_spec(_spec)
+sys.modules["migrate_memory_md"] = mig
+_spec.loader.exec_module(mig)
+
+
+# ── Chunking unit tests ────────────────────────────────────────────
+
+
+class TestChunking:
+    """Tests for `_chunk_memory_md` and `slugify`."""
+
+    def test_h2_only_file_produces_one_chunk_per_section(self):
+        """Three H2s with substantive bodies, no H3s: three chunks at level 2."""
+        text = (
+            "# Memory\n\n"
+            "## Section A\n\n"
+            "Body of A. Has enough text to survive the empty-body filter.\n\n"
+            "## Section B\n\n"
+            "Body of B with similar substance.\n\n"
+            "## Section C\n\n"
+            "Body of C, also substantive.\n"
+        )
+        chunks = mig._chunk_memory_md(text, rollup_tokens=50)
+        h2_chunks = [c for c in chunks if c.level == 2]
+        assert len(h2_chunks) == 3
+        assert [c.title for c in h2_chunks] == ["Section A", "Section B", "Section C"]
+        for chunk in h2_chunks:
+            assert chunk.parent_h2 is None
+            assert chunk.tag_slug == ""
+
+    def test_h3_below_threshold_rolls_up_to_h2(self):
+        """A short H3 gets folded into its parent H2's chunk text."""
+        text = "## Parent\n\nParent body.\n\n### Tiny\nShort.\n"
+        # rollup_tokens=50; "Short." is ~2 tokens, well under threshold.
+        chunks = mig._chunk_memory_md(text, rollup_tokens=50)
+        # Only the H2 chunk survives; H3 rolled up.
+        assert len(chunks) == 1
+        parent = chunks[0]
+        assert parent.level == 2
+        assert parent.title == "Parent"
+        # Spec D1 separator: \n\n### <title>\n<body>
+        assert "### Tiny" in parent.body
+        assert "Short." in parent.body
+
+    def test_h3_above_threshold_stands_alone(self):
+        """A long H3 becomes its own chunk with parent_h2 set."""
+        long_body = "word " * 100  # ~500 chars, ~125 tokens, well above 50.
+        text = (
+            f"## Parent\n\nParent body that is also reasonably long so it survives filtering.\n\n### Big\n{long_body}\n"
+        )
+        chunks = mig._chunk_memory_md(text, rollup_tokens=50)
+        assert len(chunks) == 2
+        parent, child = chunks
+        assert parent.level == 2
+        assert parent.title == "Parent"
+        assert "### Big" not in parent.body  # Did NOT roll up.
+        assert child.level == 3
+        assert child.title == "Big"
+        assert child.parent_h2 == "Parent"
+        assert child.tag_slug == "big"
+
+    def test_mixed_h3s_within_one_h2(self):
+        """Some H3s under one H2 roll up, others stand alone."""
+        long_body = "word " * 100
+        text = f"## Parent\n\nParent body.\n\n### Short1\nTiny.\n\n### Long1\n{long_body}\n\n### Short2\nAlso tiny.\n"
+        chunks = mig._chunk_memory_md(text, rollup_tokens=50)
+        # Expected: H2 (with Short1 + Short2 rolled up), Long1 standalone.
+        assert len(chunks) == 2
+        parent, long_chunk = chunks
+        assert parent.level == 2
+        assert "### Short1" in parent.body
+        assert "### Short2" in parent.body
+        assert "### Long1" not in parent.body
+        assert long_chunk.level == 3
+        assert long_chunk.title == "Long1"
+
+    def test_h1_preamble_becomes_root_chunk(self):
+        """The paragraph between `# Memory` and the first H2 becomes a level-1 chunk."""
+        text = (
+            "# Memory\n\nThis is the file preamble explaining what MEMORY.md is.\n\n## First Section\n\nSection body.\n"
+        )
+        chunks = mig._chunk_memory_md(text, rollup_tokens=50)
+        assert len(chunks) == 2
+        preamble = chunks[0]
+        assert preamble.level == 1
+        assert "preamble" in preamble.body
+        assert preamble.title == "Memory"
+
+    def test_empty_section_does_not_emit_chunk(self):
+        """A header with no body and no children is dropped."""
+        text = (
+            "# Memory\n\n"
+            "Preamble.\n\n"
+            "## Empty Section\n\n"  # No body, no children.
+            "## Section With Body\n\n"
+            "Has substance.\n"
+        )
+        chunks = mig._chunk_memory_md(text, rollup_tokens=50)
+        # Preamble + Section With Body = 2 chunks; Empty Section dropped.
+        titles = [c.title for c in chunks]
+        assert "Empty Section" not in titles
+        assert "Section With Body" in titles
+
+    @pytest.mark.parametrize(
+        "title,expected",
+        [
+            ("Goose backend (shipped Apr 7, 2026)", "goose-backend-shipped-apr-7-2026"),
+            ("Mem0 v2.0.0 gotchas (verified by testing)", "mem0-v2-0-0-gotchas-verified-by-testing"),
+            ("/help text bug: /github notify", "help-text-bug-github-notify"),
+            (
+                "`/backend` slash command for runtime backend switching",
+                "backend-slash-command-for-runtime-backend-switching",
+            ),
+            ("/model and /settings model are identical", "model-and-settings-model-are-identical"),
+        ],
+    )
+    def test_h3_slug_generated_correctly(self, title, expected):
+        """The slugify algorithm matches the spec §D6 worked examples."""
+        assert mig.slugify(title) == expected
+
+
+# ── Integration tests via main() ───────────────────────────────────
+
+
+@pytest.fixture
+def fake_memory_md(tmp_path):
+    """A minimal MEMORY.md fixture with both rollup and standalone H3s."""
+    long_body = "word " * 100
+    content = (
+        "# Memory\n\n"
+        "Operator notes file.\n\n"
+        "## Projects\n\n"
+        "Projects body.\n\n"
+        "### Phi\nShort entry.\n\n"
+        f"### Kai\n{long_body}\n"
+    )
+    path = tmp_path / "MEMORY.md"
+    path.write_text(content)
+    return path
+
+
+@pytest.fixture
+def stub_memory_module(monkeypatch):
+    """Stub the kai.memory functions the script calls.
+
+    Yields a dict with handles to each stub so tests can set
+    return values and inspect call args.
+    """
+    stubs = {
+        "init_memory": MagicMock(),
+        "search": MagicMock(return_value=[]),
+        "add_structured": MagicMock(return_value="fake-mem-id"),
+        "count_by_source": MagicMock(return_value=0),
+        "delete_by_source": MagicMock(),
+    }
+
+    # async fn for delete_by_source: needs to be awaitable so the
+    # script's `asyncio.run(delete_by_source(...))` works without
+    # raising "object MagicMock can't be used in 'await' expression".
+    async def _async_delete(*_args, **_kwargs):
+        stubs["delete_by_source"](*_args, **_kwargs)
+        return 7  # fake delete count
+
+    # Patch on the loaded mig module's imports. The script does
+    # lazy imports inside main()/_do_*, so patching kai.memory is
+    # enough for the import-time resolution to pick up our stubs.
+    monkeypatch.setattr("kai.memory.init_memory", stubs["init_memory"])
+    monkeypatch.setattr("kai.memory.search", stubs["search"])
+    monkeypatch.setattr("kai.memory.add_structured", stubs["add_structured"])
+    monkeypatch.setattr("kai.memory.count_by_source", stubs["count_by_source"])
+    monkeypatch.setattr("kai.memory.delete_by_source", _async_delete)
+    return stubs
+
+
+@pytest.fixture
+def enabled_config(monkeypatch):
+    """Stub load_config to return a config with memory_enabled=True."""
+    fake_config = MagicMock()
+    fake_config.memory_enabled = True
+    monkeypatch.setattr("kai.config.load_config", lambda: fake_config)
+    return fake_config
+
+
+def test_dry_run_makes_no_writes(fake_memory_md, stub_memory_module, enabled_config, capsys):
+    """Test 8: --dry-run prints plan + summary, calls no writes."""
+    # Arrange: a low-similarity result for every chunk so all would ADD.
+    low_result = MagicMock()
+    low_result.score = 0.10
+    stub_memory_module["search"].return_value = [low_result]
+
+    # Act.
+    rc = mig.main(
+        [
+            "--user-id",
+            "123",
+            "--memory-md",
+            str(fake_memory_md),
+            "--dry-run",
+        ]
+    )
+
+    # Assert.
+    assert rc == mig.EXIT_OK
+    stub_memory_module["add_structured"].assert_not_called()
+    captured = capsys.readouterr()
+    # Summary block printed by default under --dry-run.
+    assert "Similarity score distribution" in captured.out
+    assert "Skipped at threshold 0.85" in captured.out
+
+
+def test_below_threshold_chunk_writes(fake_memory_md, stub_memory_module, enabled_config):
+    """Test 9: low-similarity results produce add_structured calls with migration tags."""
+    low_result = MagicMock()
+    low_result.score = 0.10
+    stub_memory_module["search"].return_value = [low_result]
+
+    rc = mig.main(["--user-id", "123", "--memory-md", str(fake_memory_md)])
+
+    assert rc == mig.EXIT_OK
+    assert stub_memory_module["add_structured"].called
+    # Inspect the first call: tags include "migration", metadata source is "migration".
+    call_kwargs = stub_memory_module["add_structured"].call_args_list[0].kwargs
+    assert "migration" in call_kwargs["tags"]
+    assert call_kwargs["metadata"]["source"] == "migration"
+
+
+def test_above_threshold_chunk_skips(fake_memory_md, stub_memory_module, enabled_config):
+    """Test 10: high-similarity results skip add_structured."""
+    high_result = MagicMock()
+    high_result.score = 0.99  # well above default threshold 0.85
+    stub_memory_module["search"].return_value = [high_result]
+
+    rc = mig.main(["--user-id", "123", "--memory-md", str(fake_memory_md)])
+
+    assert rc == mig.EXIT_OK
+    stub_memory_module["add_structured"].assert_not_called()
+
+
+def test_idempotency_guard_blocks_second_run(fake_memory_md, stub_memory_module, enabled_config, capsys):
+    """Test 11: existing migration rows + no --force = exit code 2."""
+    stub_memory_module["count_by_source"].return_value = 5  # pretend 5 prior rows.
+
+    rc = mig.main(["--user-id", "123", "--memory-md", str(fake_memory_md)])
+
+    assert rc == mig.EXIT_GUARD
+    captured = capsys.readouterr()
+    assert "--force" in captured.err
+    assert "--rollback" in captured.err
+    stub_memory_module["add_structured"].assert_not_called()
+
+
+def test_force_bypasses_idempotency_guard(fake_memory_md, stub_memory_module, enabled_config, capsys):
+    """Test 12: --force lets the migration proceed despite existing rows."""
+    stub_memory_module["count_by_source"].return_value = 5
+    low_result = MagicMock()
+    low_result.score = 0.10
+    stub_memory_module["search"].return_value = [low_result]
+
+    rc = mig.main(["--user-id", "123", "--memory-md", str(fake_memory_md), "--force"])
+
+    assert rc == mig.EXIT_OK
+    assert stub_memory_module["add_structured"].called
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err  # warning about layering
+
+
+def test_rollback_calls_delete_by_source(fake_memory_md, stub_memory_module, enabled_config):
+    """Test 13: --rollback --yes deletes via delete_by_source, no other writes."""
+    rc = mig.main(["--user-id", "123", "--rollback", "--yes"])
+
+    assert rc == mig.EXIT_OK
+    stub_memory_module["delete_by_source"].assert_called_once_with("123", "migration")
+    stub_memory_module["add_structured"].assert_not_called()
+
+
+def test_rollback_dry_run_calls_count_not_delete(fake_memory_md, stub_memory_module, enabled_config, capsys):
+    """Test 14: --rollback --dry-run previews via count_by_source."""
+    stub_memory_module["count_by_source"].return_value = 12
+
+    rc = mig.main(["--user-id", "123", "--rollback", "--dry-run"])
+
+    assert rc == mig.EXIT_OK
+    stub_memory_module["count_by_source"].assert_called_with("123", "migration")
+    stub_memory_module["delete_by_source"].assert_not_called()
+    captured = capsys.readouterr()
+    assert "would delete 12" in captured.out
+
+
+def test_memory_disabled_exits_cleanly(monkeypatch, fake_memory_md, capsys):
+    """Test 15: memory_enabled=False = exit code 3 with clear error."""
+    fake_config = MagicMock()
+    fake_config.memory_enabled = False
+    monkeypatch.setattr("kai.config.load_config", lambda: fake_config)
+
+    rc = mig.main(["--user-id", "123", "--memory-md", str(fake_memory_md)])
+
+    assert rc == mig.EXIT_MEMORY_DISABLED
+    captured = capsys.readouterr()
+    assert "memory subsystem is disabled" in captured.err.lower()
+
+
+def test_memory_md_missing_exits_cleanly(stub_memory_module, enabled_config, tmp_path, capsys):
+    """Test 16: nonexistent MEMORY.md path = exit code 4 with clear error."""
+    nonexistent = tmp_path / "no-such-file.md"
+
+    rc = mig.main(["--user-id", "123", "--memory-md", str(nonexistent)])
+
+    assert rc == mig.EXIT_FILE_MISSING
+    captured = capsys.readouterr()
+    assert "MEMORY.md not found" in captured.err


### PR DESCRIPTION
## Summary

Phase 4 of #396. One-shot migration script that imports the operator's curated MEMORY.md content into Qdrant under `source='migration'`, with chunking by section header, per-chunk similarity dedup, idempotency guard, dry-run with score distribution, and rollback support.

After this ships and the operator runs the script, MEMORY.md content lives in Qdrant alongside Track 2 extracted facts under one homogeneous **retrieval** pool. Migration rows surface through `format_context` (the inner Claude reads them in injected context). The `/memory` Telegram UI is intentionally NOT expanded in this scope; that work is filed as #407.

Closes #406.

## Code changes

### `src/kai/memory.py`

Three additions, all small and surgical:

1. `_SOURCE_WEIGHTS["migration"] = 1.0` — sits between `extracted` (1.2) and the legacy `""` bucket (0.6). Operator-curated but not freshly conversational.
2. `_SOURCE_SHORT["migration"] = "fact"` — renders identically to extracted rows in `format_context` output. The source tag is for dedup and rollback, not prompt-side labeling.
3. New sync `count_by_source(user_id, source)` helper. Read-side companion to `delete_by_source` with the same page-walk pattern and the same tail-miss caveat (documented in the docstring; do not "fix" the early termination without re-reading `delete_by_source`'s rationale).

### `scripts/migrate-memory-md-to-qdrant.py` (new)

Standalone script following the existing `scripts/` convention. Lazy imports so `--help` and argparse errors do not pay the torch/Mem0 import cost.

CLI surface:

```
--user-id INT          Telegram chat_id (required)
--memory-md PATH       MEMORY.md path; default DATA_DIR/memory/<chat_id>/MEMORY.md
--threshold FLOAT      Similarity threshold for skip; default 0.85
--rollup-tokens INT    H3-to-H2 rollup body-token threshold; default 50
--dry-run              Print plan and summary, no writes
--no-summary           Disable score distribution summary
--force                Bypass idempotency guard
--rollback             Delete all migration-source entries; mutually exclusive with --force
--yes                  Skip rollback confirmation prompt
-v, --verbose          Per-chunk score logging
```

Exit codes: 0 success, 1 error, 2 idempotency guard fired, 3 memory disabled, 4 MEMORY.md missing.

Chunking: H2 + H3 only; H4+ flattens into parent H3 body text (the spec did not enumerate H4, but the deployed MEMORY.md has three H4s under `### Kai`; flattening matches the spec's "H2 or H3" granularity intent). H3s with body under `--rollup-tokens` fold into parent H2 under the `\n\n### <title>\n<body>` separator.

Slug algorithm pinned: `re.sub(r'[^a-z0-9]+', '-', title.lower()).strip('-')`. Stable across parens, version-string dots, leading slashes, colons, backticks, and conjunction patterns. Five worked examples in the spec are pinned by parametrized tests.

Rollback wraps `delete_by_source` in `asyncio.run(...)` (the function is async per the existing memory.py contract); the forward migration loop is sync only because `add_structured` and `search` are sync.

## Test coverage (16 new tests)

`tests/test_migrate_memory_md.py` (new file, loaded via `importlib.util` because the script's hyphenated filename is not a legal Python module name):

**Chunking unit tests:**
- `test_h2_only_file_produces_one_chunk_per_section`
- `test_h3_below_threshold_rolls_up_to_h2`
- `test_h3_above_threshold_stands_alone`
- `test_mixed_h3s_within_one_h2`
- `test_h1_preamble_becomes_root_chunk`
- `test_empty_section_does_not_emit_chunk`
- `test_h3_slug_generated_correctly` (parametrized over the five spec D6 worked examples)

**Integration tests via `main()` with stubbed Qdrant:**
- `test_dry_run_makes_no_writes`
- `test_below_threshold_chunk_writes`
- `test_above_threshold_chunk_skips`
- `test_idempotency_guard_blocks_second_run`
- `test_force_bypasses_idempotency_guard`
- `test_rollback_calls_delete_by_source`
- `test_rollback_dry_run_calls_count_not_delete`
- `test_memory_disabled_exits_cleanly`
- `test_memory_md_missing_exits_cleanly`

`tests/test_memory.py` extension:
- `TestCountBySource`: disabled/populated/empty cases.
- `TestMigrationSourceMetadata`: weight pin, short-prefix matches extracted.

`tests/test_eval_retrieval.py` updated: the `_reset_memory_module` helper's `_SOURCE_WEIGHTS` snapshot now includes `migration: 1.0` so it does not pollute later tests with a stale dict (caught by full-suite test run; isolated runs would have shipped with the leak).

All 2585 tests pass; `make check` clean.

## Manual rollout plan (post-merge)

1. Run `python scripts/migrate-memory-md-to-qdrant.py --user-id <id> --dry-run -v` against the operator's deployed MEMORY.md. Inspect per-chunk scores and the distribution summary. Verify `0.85` is the right cutoff: skipped chunks should be obvious duplicates of existing extracted facts; the "above p90 but below threshold" cluster (if any) is worth a manual look.
2. If retune needed: re-run `--dry-run` with adjusted `--threshold`. Iterate until skip/keep distribution matches the operator's read of the data.
3. Real run: `python scripts/migrate-memory-md-to-qdrant.py --user-id <id>`. Inspect summary.
4. Verify retrieval surfaces migrated content via a Telegram message that should hit a migrated chunk semantically; confirm the inner Claude's response references that content (or `memory.recall` log shows the migrated row in hits).
5. Smoke-test mode-switch by toggling `MEMORY_ENABLED=false` then `MEMORY_ENABLED=true` (with service restart between). Verify retrieval surfaces migrated content correctly in enabled mode.

## Out of scope

- `/memory` Telegram UI expansion to surface migration rows (filed as #407).
- Removing MEMORY.md from disk after migration (stays as the disabled-mode fallback).
- Auto-running migration during `make install`.
- Multi-user batch migration tooling.
- Re-summarization or fact extraction during migration (faithful copy, mechanical chunking).

## Notes for review

- The chunking algorithm's H4-flatten behavior is a spec-implicit choice (the spec said "H2 + H3"; H4 wasn't enumerated). Documented in code comments and PR description.
- The `_estimate_tokens` heuristic (`len(text) // 4`) is reused from `memory.py` so threshold semantics stay consistent with retrieval-side costing.
- The `tests/test_eval_retrieval.py:_reset_memory_module` change is a harness fix for the new source key; without it, tests after that fixture would see a dict missing the `migration` entry.
