### PR TITLE
feat(memory): surface episode and migration rows in /memory UI (#407)

### DIFF
--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -1297,17 +1297,23 @@ def get_stats(*, user_id: str) -> MemoryStats:
     for m in memories:
         by_type[m.memory_type] = by_type.get(m.memory_type, 0) + 1
 
-    # Extracted-only aggregates. Build the filtered list once; every
-    # downstream metric reads from it.
-    extracted = [m for m in memories if m.metadata.get("source") == "extracted"]
-
-    # Per-source counts (issue #407). Computed in one walk alongside
-    # the extracted list so the aggregation stays O(n) rather than
-    # O(n) per source. Confidence aggregates and `by_tag` stay scoped
-    # to extracted (see `MemoryStats` docstring); these counts are the
-    # only new aggregation work needed here.
-    episode_count = sum(1 for m in memories if m.metadata.get("source") == "episode")
-    migration_count = sum(1 for m in memories if m.metadata.get("source") == "migration")
+    # Per-source partition (issue #407). Single walk over `memories`;
+    # the extracted list feeds the confidence / by_tag / prompt_version
+    # aggregation below, while episode and migration counts are surfaced
+    # directly in MemoryStats. Confidence aggregates and `by_tag` stay
+    # scoped to extracted (see `MemoryStats` docstring); these counts
+    # are the only new per-source aggregation work needed here.
+    extracted: list[MemoryResult] = []
+    episode_count = 0
+    migration_count = 0
+    for m in memories:
+        src = m.metadata.get("source")
+        if src == "extracted":
+            extracted.append(m)
+        elif src == "episode":
+            episode_count += 1
+        elif src == "migration":
+            migration_count += 1
 
     by_tag: dict[str, int] = {}
     by_prompt_version: dict[str, int] = {}

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -148,6 +148,25 @@ _SOURCE_SHORT: dict[str, str] = {
 _DELETE_PAGE_SIZE = 10_000
 
 
+# Sources that the /memory Telegram UI surfaces as user-visible rows.
+# Used by `get_by_id` and `get_by_tag` (and via delegation, `delete_by_id`)
+# to gate addressability from the operator-facing surface. Three reasons
+# the set is intentional rather than "everything except legacy":
+#   - extracted: Track 2 Haiku-derived facts; the original target of the
+#     /memory dashboard.
+#   - episode:   per-conversation episode summaries (issue #385/#387).
+#     Tagged distinctly so the fact-view can render Sophia-style fields
+#     instead of empty extractor placeholders.
+#   - migration: operator-curated MEMORY.md content imported via #408.
+#     Fact-view header reads "Imported" so operators can distinguish at
+#     a glance from extracted facts whose freshness implications differ.
+# Legacy ""-source rows (from pre-spec ingestion paths or any future-
+# additional source not in this set) stay hidden in the UI; they are
+# managed via memory_admin.py / `delete_by_source`. A frozenset is used
+# so the constant cannot be mutated by importing callers.
+_USER_VISIBLE_SOURCES: frozenset[str] = frozenset({"extracted", "episode", "migration"})
+
+
 @dataclass(frozen=True)
 class MemoryResult:
     """A single memory from search or retrieval."""
@@ -186,6 +205,16 @@ class MemoryStats:
     sentinel (None for min/median/max, 0 for counts, empty dict for the
     grouped fields) so a caller that constructs `MemoryStats(total_count=0,
     by_type={})` (the legacy two-arg form) still produces a valid value.
+
+    `episode_count` and `migration_count` are parallel per-source counts,
+    added so the /memory dashboard and stats screens can surface
+    user-visible non-extracted sources alongside the extracted total.
+    Their sum with `extracted_count` may be less than `total_count`
+    because legacy ""-source rows still contribute to the total but are
+    not enumerated as a separate per-source field. Confidence aggregates
+    and `by_tag` stay scoped to extracted (see comments below) because
+    episode and migration rows do not carry confidence and use tag
+    spaces that are not enumerated by `_TAG_ENUM` in memory_command.py.
     """
 
     total_count: int
@@ -198,6 +227,12 @@ class MemoryStats:
     # because picking 0.0 would be misleading (it is a valid score
     # value, not "no data"). Counts default to 0 / empty dict.
     extracted_count: int = 0
+    # Parallel per-source counts (issue #407). Defaulted to zero so the
+    # legacy two-arg `MemoryStats(total_count=0, by_type={})`
+    # construction in tests stays source-compatible. Episode rows come
+    # from issue #385/#387; migration rows come from issue #406/#408.
+    episode_count: int = 0
+    migration_count: int = 0
     by_tag: dict[str, int] = field(default_factory=dict)
     confidence_min: float | None = None
     confidence_median: float | None = None
@@ -1063,19 +1098,21 @@ def get_all(*, user_id: str, limit: int | None = 1000) -> list[MemoryResult]:
 
 
 def get_by_tag(*, user_id: str, tag: str) -> list[MemoryResult]:
-    """Return all extracted facts for `user_id` carrying `tag`.
+    """Return user-visible facts for `user_id` carrying `tag`.
 
     Used by the /memory tag drill-down (spec 310 §6.2). Filters
     client-side because Mem0's `get_all` does not accept metadata
     filters. Two filter clauses, both load-bearing:
 
-      - `metadata.source == "extracted"`: defends against rows from
-        any other (legacy or future-additional) source leaking into
-        the extracted-only UI. With spec 360 landed, the only writer
-        is Track 2 extraction so the clause is largely a no-op in
-        production stores; keeping it means the UI contract does not
-        need re-reasoning the next time a second source is introduced.
-        Spec 310 §7.2.
+      - `metadata.source in _USER_VISIBLE_SOURCES`: defends against
+        legacy ""-source (or any future-additional non-UI) rows
+        leaking into the operator-facing surface. Issue #407 expanded
+        this from `== "extracted"` to the three-source set so episode
+        and migration rows that happen to carry an enum tag in their
+        own metadata become browsable from the dashboard's tag
+        buttons. The dashboard's `_TAG_ENUM` gate still limits which
+        tags get rendered as buttons; this filter only governs which
+        rows match a tapped tag.
       - `tag in metadata.tags`: the actual tag match. The `or []`
         guards against a malformed row that lacks the tags list
         entirely; such rows simply do not match any tag.
@@ -1093,7 +1130,9 @@ def get_by_tag(*, user_id: str, tag: str) -> list[MemoryResult]:
         return []
 
     rows = get_all(user_id=user_id, limit=None)
-    matches = [r for r in rows if r.metadata.get("source") == "extracted" and tag in (r.metadata.get("tags") or [])]
+    matches = [
+        r for r in rows if r.metadata.get("source") in _USER_VISIBLE_SOURCES and tag in (r.metadata.get("tags") or [])
+    ]
     # Newest-updated first; created_at is the fallback for rows whose
     # payload predates updated_at being recorded. String comparison on
     # ISO-8601 timestamps is correct because the format is
@@ -1103,7 +1142,7 @@ def get_by_tag(*, user_id: str, tag: str) -> list[MemoryResult]:
 
 
 def get_by_id(*, user_id: str, memory_id: str) -> MemoryResult | None:
-    """Fetch a single extracted memory by id, scoped to user.
+    """Fetch a single user-visible memory by id, scoped to user.
 
     Used by the /memory fact view and forget-fact confirmation
     (spec 310 §6.3, §6.4). Replaces the old pattern of pulling
@@ -1115,9 +1154,15 @@ def get_by_id(*, user_id: str, memory_id: str) -> MemoryResult | None:
       - Mem0's `get` does NOT scope by user_id, so we verify it
         manually. With multi-user installs the cost of a missed
         check is reading another user's memory.
-      - Track 1 / legacy rows are out of scope for /memory UI
+      - Legacy ""-source rows are out of scope for /memory UI
         surfaces; they belong to memory_admin.py. Hide them here
-        rather than letting the dashboard expose them.
+        rather than letting the dashboard expose them. The accepted
+        sources are those in `_USER_VISIBLE_SOURCES` (extracted,
+        episode, migration). Issue #407 expanded the set from
+        extracted-only so episode (#385/#387) and migration (#406/
+        #408) rows are addressable from the operator-facing surface;
+        `delete_by_id` inherits the broader admit list via its
+        delegation to this function.
 
     Returns None for not-found, ownership mismatch, source mismatch,
     or a Mem0 fetch failure. The fact-view caller treats all four
@@ -1151,9 +1196,12 @@ def get_by_id(*, user_id: str, memory_id: str) -> MemoryResult | None:
             user_id,
         )
         return None
-    if (row.get("metadata") or {}).get("source") != "extracted":
-        # Non-extracted rows are deliberately invisible to /memory.
-        # No log: this is a routine filter, not an anomaly.
+    if (row.get("metadata") or {}).get("source") not in _USER_VISIBLE_SOURCES:
+        # Legacy ""-source (or any future-additional non-UI source) is
+        # deliberately invisible to /memory. The user-visible set
+        # (extracted, episode, migration) is enumerated in
+        # `_USER_VISIBLE_SOURCES`. No log: this is a routine filter,
+        # not an anomaly.
         return None
 
     return _wrap_result(row)
@@ -1253,6 +1301,14 @@ def get_stats(*, user_id: str) -> MemoryStats:
     # downstream metric reads from it.
     extracted = [m for m in memories if m.metadata.get("source") == "extracted"]
 
+    # Per-source counts (issue #407). Computed in one walk alongside
+    # the extracted list so the aggregation stays O(n) rather than
+    # O(n) per source. Confidence aggregates and `by_tag` stay scoped
+    # to extracted (see `MemoryStats` docstring); these counts are the
+    # only new aggregation work needed here.
+    episode_count = sum(1 for m in memories if m.metadata.get("source") == "episode")
+    migration_count = sum(1 for m in memories if m.metadata.get("source") == "migration")
+
     by_tag: dict[str, int] = {}
     by_prompt_version: dict[str, int] = {}
     confidences: list[float] = []
@@ -1322,6 +1378,8 @@ def get_stats(*, user_id: str) -> MemoryStats:
         total_count=len(memories),
         by_type=by_type,
         extracted_count=len(extracted),
+        episode_count=episode_count,
+        migration_count=migration_count,
         by_tag=by_tag,
         confidence_min=confidence_min,
         confidence_median=confidence_median,

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -310,30 +310,38 @@ def _format_date(iso_str: str, with_time: bool = False) -> str:
 def _build_dashboard(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup | None]:
     """Render the dashboard text and keyboard from a MemoryStats.
 
-    The dashboard restricts itself to extracted-only counts (spec
-    §6.1). Tags with zero facts are hidden from the keyboard but
-    appear in `/memory stats` - see spec §6.1 final paragraph for
-    the asymmetry rationale.
+    The dashboard surfaces three user-visible source counts (extracted
+    facts, episode summaries, migration imports) and a per-tag button
+    grid. Tags with zero facts are hidden from the keyboard but appear
+    in `/memory stats` (see spec §6.1 for the asymmetry rationale);
+    `by_tag` is extracted-only by design (see MemoryStats docstring),
+    so an episode-only or migration-only operator legitimately renders
+    with zero tag buttons - the source-count headline is their signal
+    that the dashboard is alive.
 
-    Empty state: when `extracted_count` is zero, returns the empty
-    body text from `_MSG_NO_FACTS` and a `None` keyboard so the
-    caller skips inline buttons entirely.
+    Empty state: only when ALL three user-visible source counts are
+    zero. Issue #407 dropped the older "extracted == 0 OR no nonzero
+    enum tags" guard pair: an operator with episode or migration rows
+    but no extracted facts has user-visible memory worth showing.
     """
-    if stats.extracted_count == 0:
+    # Combined empty-state guard (issue #407). Replaces the prior
+    # extracted-only and `not nonzero` guards. When any user-visible
+    # source has rows, fall through to render the dashboard - even
+    # if `nonzero` ends up empty (all rows non-extracted, or extracted
+    # rows with off-enum tags), the source-count headline still
+    # communicates that memory is alive.
+    if stats.extracted_count == 0 and stats.episode_count == 0 and stats.migration_count == 0:
         return _MSG_NO_FACTS, None
 
     # Tags with at least one fact, sorted descending by count. Spec
     # §6.1 mock-up shows this ordering. Ties broken by enum order
     # (the iteration order of `_TAG_ENUM`) so output is deterministic.
+    # `by_tag` is extracted-only (MemoryStats); episode/migration rows
+    # are intentionally not represented here. The rare edge case where
+    # extracted_count > 0 but every extracted row carries off-enum
+    # tags renders as zero buttons + the search/stats footer below.
     nonzero = [(tag, stats.by_tag.get(tag, 0)) for tag in _TAG_ENUM if stats.by_tag.get(tag, 0) > 0]
     nonzero.sort(key=lambda item: (-item[1], _TAG_ENUM.index(item[0])))
-
-    if not nonzero:
-        # extracted_count > 0 but no row matched a known tag. This
-        # would only happen if a row's metadata.tags is empty or
-        # contains an off-enum value - possible if the schema is
-        # bypassed. Surface as empty rather than crashing.
-        return _MSG_NO_FACTS, None
 
     # Per-tag counts are carried by the inline buttons below
     # (`tag (count)` labels), so the dashboard text intentionally
@@ -343,19 +351,45 @@ def _build_dashboard(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup | No
     # operator feedback on real data showed the bars duplicated what
     # the buttons already telegraph through the parenthesized counts.
     lines: list[str] = []
-    summary = f"Memories: {stats.extracted_count} facts across {len(nonzero)} tags."
+    # Headline assembled from non-zero per-source counts so a fresh
+    # extracted-only operator still sees the original "Memories: <N>
+    # facts across <M> tags" wording (issue #407 backwards-compat),
+    # while a mixed-source operator gets distinct visibility into
+    # each source. Zero-valued sources are omitted from the comma list
+    # rather than rendered as "0 episodes" - readability over
+    # uniformity, since most operators have non-zero in only one or
+    # two of the three.
+    parts: list[str] = []
+    if stats.extracted_count:
+        parts.append(f"{stats.extracted_count} facts")
+    if stats.episode_count:
+        parts.append(f"{stats.episode_count} episodes")
+    if stats.migration_count:
+        parts.append(f"{stats.migration_count} imported")
+    summary = "Memories: " + ", ".join(parts) + f" across {len(nonzero)} tags."
     lines.append(summary)
     lines.append("")
-    # Footer line: median + min confidence. Spec §6.1 calls this the
-    # "first-glance tuning signal." Median is the persisted value;
-    # the spec mock-up labels it "avg" but median is more honest about
-    # what is shown.
+    # Footer line: three branches keep the action prompt accurate to
+    # what the keyboard actually offers (issue #407).
+    #   - With tag buttons + confidence data: pin median/min as the
+    #     "first-glance tuning signal" (spec §6.1). Median is the
+    #     persisted value; the spec mock-up labels it "avg" but median
+    #     is more honest about what is shown.
+    #   - With tag buttons but no confidence (extracted rows whose
+    #     metadata lost confidence values): the original "Tap a tag"
+    #     prompt without the confidence suffix.
+    #   - Without tag buttons (episode-only / migration-only operator,
+    #     or extracted rows whose tags are all off-enum): point at the
+    #     Search/Stats button row that always renders, since "Tap a
+    #     tag to browse" would be a lie when no tag buttons exist.
     median = stats.confidence_median
     minv = stats.confidence_min
-    if median is not None and minv is not None:
+    if nonzero and median is not None and minv is not None:
         lines.append(f"Tap a tag to browse. Confidence: median {median:.2f}, min {minv:.2f}.")
-    else:
+    elif nonzero:
         lines.append("Tap a tag to browse.")
+    else:
+        lines.append("Use Search to find specific memories, or tap Stats for details.")
 
     text = "\n".join(lines)
 
@@ -473,42 +507,103 @@ def _build_fact_view(
 ) -> tuple[str, InlineKeyboardMarkup]:
     """Render the fact detail screen (spec §6.3).
 
+    Three render shapes (issue #407), branched on `metadata.source`:
+      - extracted: `Fact` header + the existing six-row block (Tags,
+        Confidence, Date, Session, Prompt version, Confirmation).
+        Unchanged from the pre-#407 surface.
+      - episode:   `Episode (<outcome_quality>)` header (or `Episode`
+        when outcome_quality metadata is absent) + Tags + Date.
+        Confidence/Session/Prompt version/Confirmation are omitted
+        because episode rows do not carry those extractor-only fields;
+        rendering them as placeholders ("----" / "(none)" / "n/a")
+        would imply the data exists and is missing rather than
+        not-applicable.
+      - migration: `Imported` header + Tags + Date. Header chosen to
+        distinguish operator-curated MEMORY.md content from
+        Haiku-extracted facts at a glance, even though both render
+        with the same `_SOURCE_SHORT="fact"` in retrieval-time prompt
+        injection (see memory.py); the fact-view is operator-facing
+        and benefits from the visual distinction.
+
     `return_to` encodes where the back button should land. It can be
     None for callers (e.g., tests) that don't care; in that case the
-    back button defaults to the dashboard.
+    back button defaults to the dashboard. The keyboard is the same
+    (back / forget) across all three sources.
     """
     md = fact.metadata or {}
     tags = md.get("tags") or []
-    confidence = md.get("confidence")
-    session_id = md.get("session_id") or ""
-    prompt_version = md.get("prompt_version") or ""
-    confirmation = md.get("confirmation_quote") or ""
+    source = md.get("source", "")
 
-    if isinstance(confidence, (int, float)):
-        conf_str = f"{float(confidence):.2f}"
+    # Tags row is shared across all three source shapes; assembling
+    # once avoids duplication in the per-source branches below.
+    tags_line = f"Tags:  {', '.join(tags) if tags else '(none)'}"
+
+    if source == "episode":
+        # Episode rows surface the Sophia outcome_quality field as
+        # a header parenthetical when present (e.g., "Episode (good)")
+        # so the operator can tell at a glance how the conversation
+        # resolved. Date renders with HH:MM precision so episodes
+        # from the same day are distinguishable.
+        quality = md.get("outcome_quality") or ""
+        header = f"Episode ({quality})" if quality else "Episode"
+        lines = [
+            header,
+            "",
+            f'"{fact.text}"',
+            "",
+            tags_line,
+            f"Date:  {_format_date(fact.created_at, with_time=True)}",
+        ]
+    elif source == "migration":
+        # Migration rows already include the H3 title and section
+        # structure inside `fact.text` (the migration script writes
+        # the chunk as `### <title>\n<body>` per #408), so no
+        # additional section rendering is needed here. The header
+        # diverges from the prompt-side `_SOURCE_SHORT="fact"` on
+        # purpose - see docstring.
+        lines = [
+            "Imported",
+            "",
+            f'"{fact.text}"',
+            "",
+            tags_line,
+            f"Date:  {_format_date(fact.created_at, with_time=True)}",
+        ]
     else:
-        conf_str = "----"
+        # Extracted (or any defensive fallback for an unknown source
+        # that managed to reach this view). Renders the original
+        # six-row block unchanged so existing screenshots / muscle
+        # memory stay valid.
+        confidence = md.get("confidence")
+        session_id = md.get("session_id") or ""
+        prompt_version = md.get("prompt_version") or ""
+        confirmation = md.get("confirmation_quote") or ""
 
-    # Confirmation row: verbatim quote on confirmed_action facts,
-    # literal "n/a" elsewhere. The schema invariant ("confirmation
-    # _quote present iff tags includes confirmed_action", spec §4)
-    # is asserted at extraction time, so we can render confidently
-    # without re-validating.
-    confirmation_line = confirmation if confirmation else "n/a"
+        if isinstance(confidence, (int, float)):
+            conf_str = f"{float(confidence):.2f}"
+        else:
+            conf_str = "----"
 
-    lines = [
-        "Fact",
-        "",
-        f'"{fact.text}"',
-        "",
-        f"Tags:             {', '.join(tags) if tags else '(none)'}",
-        f"Confidence:       {conf_str}",
-        f"Date:             {_format_date(fact.created_at, with_time=True)}",
-        f"Session:          {session_id or '(none)'}",
-        f"Prompt version:   {prompt_version or '(none)'}",
-        "",
-        f"Confirmation:     {confirmation_line}",
-    ]
+        # Confirmation row: verbatim quote on confirmed_action facts,
+        # literal "n/a" elsewhere. The schema invariant ("confirmation
+        # _quote present iff tags includes confirmed_action", spec §4)
+        # is asserted at extraction time, so we can render confidently
+        # without re-validating.
+        confirmation_line = confirmation if confirmation else "n/a"
+
+        lines = [
+            "Fact",
+            "",
+            f'"{fact.text}"',
+            "",
+            f"Tags:             {', '.join(tags) if tags else '(none)'}",
+            f"Confidence:       {conf_str}",
+            f"Date:             {_format_date(fact.created_at, with_time=True)}",
+            f"Session:          {session_id or '(none)'}",
+            f"Prompt version:   {prompt_version or '(none)'}",
+            "",
+            f"Confirmation:     {confirmation_line}",
+        ]
     text = "\n".join(lines)
 
     back_callback = _encode_callback(return_to[0], *return_to[1]) if return_to is not None else _encode_callback("dash")
@@ -527,8 +622,22 @@ def _build_fact_view(
 
 
 def _build_forget_fact_confirm(fact: MemoryResult) -> tuple[str, InlineKeyboardMarkup]:
-    """Render the single-fact forget confirmation."""
-    text = f'Forget this fact?\n\n"{fact.text}"\n\nThis cannot be undone.'
+    """Render the single-fact forget confirmation.
+
+    Issue #407 expanded the noun in the prompt text per source so the
+    operator sees what is being forgotten (`fact` for extracted,
+    `episode` for episode summaries, `imported memory` for migration
+    rows). The verb (`Forget`), the warning sentence (`This cannot
+    be undone.`), and the inline-button flow (`confirm forget` /
+    `cancel`) are all preserved unchanged. Falls back to the generic
+    label `memory` for an unknown source value (defensive: should be
+    unreachable since `get_by_id` already gates on
+    `_USER_VISIBLE_SOURCES`, but a stale cache during a deploy
+    transition could in principle slip a different source through).
+    """
+    source = (fact.metadata or {}).get("source", "")
+    label = {"extracted": "fact", "episode": "episode", "migration": "imported memory"}.get(source, "memory")
+    text = f'Forget this {label}?\n\n"{fact.text}"\n\nThis cannot be undone.'
     kb = InlineKeyboardMarkup(
         [
             [
@@ -588,88 +697,119 @@ def _build_search_results(
 def _build_stats(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup]:
     """Render the read-only stats dashboard.
 
-    All aggregates are extracted-only by construction (memory.py
-    extends MemoryStats with that scoping). The tag list shows every
-    enum value, including zero-count tags - that is the asymmetry
-    documented in spec §6.1 (dashboard hides zero-count tags; stats
-    surfaces them as a tuning signal).
+    Issue #407 expanded the headline to surface per-source totals for
+    every user-visible source with non-zero rows (extracted facts,
+    episode summaries, migration imports). The four extracted-shaped
+    sections that follow (by-tag table, confidence block,
+    confirmed-actions line, prompt-version table) are conditional on
+    `extracted_count > 0` because they all read extractor-only
+    metadata; for an episode-only or migration-only operator they
+    would be all-zero noise without informational value. The tag list
+    still shows every enum value (including zero-count tags) when
+    rendered - that asymmetry vs the dashboard is documented in
+    spec §6.1.
     """
-    if stats.extracted_count == 0:
-        # Distinct empty-state text from the dashboard so the user
-        # who navigated to /memory stats specifically knows the call
-        # succeeded but the corpus is empty.
-        text = "Memory stats\n\nNo extracted facts yet."
+    # Combined empty-state guard (issue #407): only when every
+    # user-visible source is empty does the corpus count as "no
+    # memories yet." The wording was updated from the original
+    # "No extracted facts yet" because the original would lie about
+    # the empty-state's scope when the post-#407 surface knows about
+    # episode and migration rows too.
+    if stats.extracted_count == 0 and stats.episode_count == 0 and stats.migration_count == 0:
+        text = "Memory stats\n\nNo facts, episodes, or imported memory yet."
         kb = InlineKeyboardMarkup([[InlineKeyboardButton("back", callback_data=_encode_callback("dash"))]])
         return text, kb
 
-    lines = ["Memory stats", "", f"Total:            {stats.extracted_count} facts", "", "By tag:"]
-    # Pad tag column to the longest enum name for alignment.
-    label_width = max(len(t) for t in _TAG_ENUM)
-    for tag in _TAG_ENUM:
-        count = stats.by_tag.get(tag, 0)
-        lines.append(f"  {tag.ljust(label_width)}  {count:>3}")
+    # Headline block: per-source totals, one line per non-zero source.
+    # Padding chosen for alignment with the "By tag:" label column
+    # below (which uses an enum-width pad). Lines for zero-valued
+    # counts are omitted so a fresh extracted-only operator does not
+    # see two empty "Total episodes:" / "Total imported:" rows below
+    # their facts total.
+    lines = ["Memory stats", ""]
+    if stats.extracted_count:
+        lines.append(f"Total facts:      {stats.extracted_count}")
+    if stats.episode_count:
+        lines.append(f"Total episodes:   {stats.episode_count}")
+    if stats.migration_count:
+        lines.append(f"Total imported:   {stats.migration_count}")
 
-    # Confidence block. min/median/max are None when extracted_count
-    # is zero (we returned for that case above), so under current
-    # memory.py semantics they're always populated here. Render "n/a"
-    # rather than 0.00 if the invariant ever breaks: a misleading
-    # 0.00 looks like a real (very low) reading, while "n/a" is
-    # self-describing and makes the bug visible.
-    lines.append("")
-    lines.append("Confidence:")
-    minv = stats.confidence_min
-    medv = stats.confidence_median
-    maxv = stats.confidence_max
-    min_str = f"{minv:.2f}" if minv is not None else "n/a"
-    med_str = f"{medv:.2f}" if medv is not None else "n/a"
-    max_str = f"{maxv:.2f}" if maxv is not None else "n/a"
-    lines.append(f"  min               {min_str}")
-    lines.append(f"  median            {med_str}")
-    lines.append(f"  max               {max_str}")
-    # Below-threshold counts with parenthetical percentages. When
-    # confidence values are missing entirely (min/median/max all
-    # None) the counts are necessarily 0, but rendering them as
-    # "0 (0.0%)" reads as "all facts scored above the threshold"
-    # rather than "no confidence data". Mirror the n/a fallback
-    # above so the row stays honest about the underlying state.
-    has_confidence = minv is not None or medv is not None or maxv is not None
-    if has_confidence:
-        pct_07 = (stats.confidence_below_0_7 / stats.extracted_count) * 100
-        pct_06 = (stats.confidence_below_0_6 / stats.extracted_count) * 100
-        below_07 = f"{stats.confidence_below_0_7:>3}  ({pct_07:.1f}%)"
-        below_06 = f"{stats.confidence_below_0_6:>3}  ({pct_06:.1f}%)"
-    else:
-        below_07 = f"{stats.confidence_below_0_7:>3}  (n/a)"
-        below_06 = f"{stats.confidence_below_0_6:>3}  (n/a)"
-    lines.append(f"  below 0.7         {below_07}")
-    lines.append(f"  below 0.6         {below_06}")
-
-    lines.append("")
-    lines.append(f"Confirmed actions:  {stats.confirmation_quote_count} with confirmation_quote")
-
-    if stats.by_prompt_version:
+    # The four extracted-shaped sections below all read extractor-only
+    # metadata (tags, confidence, confirmation_quote, prompt_version).
+    # For an episode-only or migration-only operator (extracted_count
+    # == 0 but at least one other source > 0), rendering these would
+    # produce an all-zeros tag table and an all-n/a confidence block -
+    # noise without informational value. The headline alone is the
+    # operator's signal in that case.
+    if stats.extracted_count > 0:
         lines.append("")
-        lines.append("Prompt versions:")
-        # Sort by count desc, version asc for ties - deterministic.
-        # The tiebreaker key is wrapped in str() because dict keys
-        # may be mixed-type when a caller constructs MemoryStats
-        # directly (bypassing the aggregation cast in memory.py);
-        # Python 3 raises TypeError on int<->str comparison, so the
-        # cast here must happen before the sort runs - it cannot be
-        # deferred to the formatting step below.
-        sorted_versions = sorted(
-            stats.by_prompt_version.items(),
-            key=lambda item: (-item[1], str(item[0])),
-        )
-        # Aggregation in memory.py already casts prompt_version to
-        # str, but a caller that constructs MemoryStats by a
-        # different path (tests do this directly, and a future admin
-        # endpoint might) bypasses that guarantee. Wrapping len()
-        # and ljust() in str() keeps the renderer resilient on its
-        # own so a stray int key cannot raise TypeError here.
-        version_width = max(len(str(v)) for v, _ in sorted_versions)
-        for version, count in sorted_versions:
-            lines.append(f"  {str(version).ljust(version_width)}  {count:>3}")
+        lines.append("By tag:")
+        # Pad tag column to the longest enum name for alignment.
+        label_width = max(len(t) for t in _TAG_ENUM)
+        for tag in _TAG_ENUM:
+            count = stats.by_tag.get(tag, 0)
+            lines.append(f"  {tag.ljust(label_width)}  {count:>3}")
+
+        # Confidence block. min/median/max are None when no extracted
+        # row carried a confidence value (an extracted_count > 0 corpus
+        # whose rows were all written without the field; rare but
+        # possible on legacy data). Render "n/a" rather than 0.00 so
+        # the row stays honest about the underlying state.
+        lines.append("")
+        lines.append("Confidence:")
+        minv = stats.confidence_min
+        medv = stats.confidence_median
+        maxv = stats.confidence_max
+        min_str = f"{minv:.2f}" if minv is not None else "n/a"
+        med_str = f"{medv:.2f}" if medv is not None else "n/a"
+        max_str = f"{maxv:.2f}" if maxv is not None else "n/a"
+        lines.append(f"  min               {min_str}")
+        lines.append(f"  median            {med_str}")
+        lines.append(f"  max               {max_str}")
+        # Below-threshold counts with parenthetical percentages. When
+        # confidence values are missing entirely (min/median/max all
+        # None) the counts are necessarily 0, but rendering them as
+        # "0 (0.0%)" reads as "all facts scored above the threshold"
+        # rather than "no confidence data". Mirror the n/a fallback
+        # above so the row stays honest about the underlying state.
+        has_confidence = minv is not None or medv is not None or maxv is not None
+        if has_confidence:
+            pct_07 = (stats.confidence_below_0_7 / stats.extracted_count) * 100
+            pct_06 = (stats.confidence_below_0_6 / stats.extracted_count) * 100
+            below_07 = f"{stats.confidence_below_0_7:>3}  ({pct_07:.1f}%)"
+            below_06 = f"{stats.confidence_below_0_6:>3}  ({pct_06:.1f}%)"
+        else:
+            below_07 = f"{stats.confidence_below_0_7:>3}  (n/a)"
+            below_06 = f"{stats.confidence_below_0_6:>3}  (n/a)"
+        lines.append(f"  below 0.7         {below_07}")
+        lines.append(f"  below 0.6         {below_06}")
+
+        lines.append("")
+        lines.append(f"Confirmed actions:  {stats.confirmation_quote_count} with confirmation_quote")
+
+        if stats.by_prompt_version:
+            lines.append("")
+            lines.append("Prompt versions:")
+            # Sort by count desc, version asc for ties - deterministic.
+            # The tiebreaker key is wrapped in str() because dict keys
+            # may be mixed-type when a caller constructs MemoryStats
+            # directly (bypassing the aggregation cast in memory.py);
+            # Python 3 raises TypeError on int<->str comparison, so the
+            # cast here must happen before the sort runs - it cannot be
+            # deferred to the formatting step below.
+            sorted_versions = sorted(
+                stats.by_prompt_version.items(),
+                key=lambda item: (-item[1], str(item[0])),
+            )
+            # Aggregation in memory.py already casts prompt_version to
+            # str, but a caller that constructs MemoryStats by a
+            # different path (tests do this directly, and a future admin
+            # endpoint might) bypasses that guarantee. Wrapping len()
+            # and ljust() in str() keeps the renderer resilient on its
+            # own so a stray int key cannot raise TypeError here.
+            version_width = max(len(str(v)) for v, _ in sorted_versions)
+            for version, count in sorted_versions:
+                lines.append(f"  {str(version).ljust(version_width)}  {count:>3}")
 
     text = "\n".join(lines)
     kb = InlineKeyboardMarkup([[InlineKeyboardButton("back", callback_data=_encode_callback("dash"))]])

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -366,7 +366,15 @@ def _build_dashboard(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup | No
         parts.append(f"{stats.episode_count} episodes")
     if stats.migration_count:
         parts.append(f"{stats.migration_count} imported")
-    summary = "Memories: " + ", ".join(parts) + f" across {len(nonzero)} tags."
+    # tag_word handles two cases that the pre-#407 surface never
+    # reached: a `len(nonzero) == 1` extracted operator (singular
+    # "1 tag") and a `len(nonzero) == 0` episode-only / migration-only
+    # operator (zero "0 tags" reads awkwardly but is the honest count
+    # since `by_tag` is extracted-only). The "1 tags" mismatch was
+    # latent in the pre-#407 code; fixing it here in the same edit
+    # keeps the headline grammar consistent across all three branches.
+    tag_word = "tag" if len(nonzero) == 1 else "tags"
+    summary = "Memories: " + ", ".join(parts) + f" across {len(nonzero)} {tag_word}."
     lines.append(summary)
     lines.append("")
     # Footer line: three branches keep the action prompt accurate to
@@ -534,35 +542,31 @@ def _build_fact_view(
     tags = md.get("tags") or []
     source = md.get("source", "")
 
-    # Tags row is shared across all three source shapes; assembling
-    # once avoids duplication in the per-source branches below.
-    tags_line = f"Tags:  {', '.join(tags) if tags else '(none)'}"
-
-    if source == "episode":
-        # Episode rows surface the Sophia outcome_quality field as
-        # a header parenthetical when present (e.g., "Episode (good)")
-        # so the operator can tell at a glance how the conversation
-        # resolved. Date renders with HH:MM precision so episodes
-        # from the same day are distinguishable.
-        quality = md.get("outcome_quality") or ""
-        header = f"Episode ({quality})" if quality else "Episode"
+    if source == "episode" or source == "migration":
+        # Episode and migration rows share a minimal body shape:
+        # narrow Tags + Date with none of the extractor-only rows.
+        # Header differs (Episode (<outcome_quality>) vs Imported)
+        # but the rest of the layout is identical, so the tags
+        # line is computed once for both.
+        tags_line = f"Tags:  {', '.join(tags) if tags else '(none)'}"
+        if source == "episode":
+            # Episode rows surface the Sophia outcome_quality field as
+            # a header parenthetical when present (e.g., "Episode
+            # (good)") so the operator can tell at a glance how the
+            # conversation resolved. Date renders with HH:MM precision
+            # so episodes from the same day are distinguishable.
+            quality = md.get("outcome_quality") or ""
+            header = f"Episode ({quality})" if quality else "Episode"
+        else:
+            # Migration rows already include the H3 title and section
+            # structure inside `fact.text` (the migration script writes
+            # the chunk as `### <title>\n<body>` per #408), so no
+            # additional section rendering is needed here. The header
+            # diverges from the prompt-side `_SOURCE_SHORT="fact"` on
+            # purpose - see docstring.
+            header = "Imported"
         lines = [
             header,
-            "",
-            f'"{fact.text}"',
-            "",
-            tags_line,
-            f"Date:  {_format_date(fact.created_at, with_time=True)}",
-        ]
-    elif source == "migration":
-        # Migration rows already include the H3 title and section
-        # structure inside `fact.text` (the migration script writes
-        # the chunk as `### <title>\n<body>` per #408), so no
-        # additional section rendering is needed here. The header
-        # diverges from the prompt-side `_SOURCE_SHORT="fact"` on
-        # purpose - see docstring.
-        lines = [
-            "Imported",
             "",
             f'"{fact.text}"',
             "",

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -2135,6 +2135,376 @@ class TestGetStatsExtended:
         assert stats.by_prompt_version == {}
 
 
+class TestUserVisibleSources:
+    """Issue #407: episode and migration rows joined extracted as
+    addressable sources from the /memory UI.
+
+    The source-admit gate now lives in
+    `memory._USER_VISIBLE_SOURCES = {"extracted", "episode", "migration"}`,
+    used by `get_by_id` and `get_by_tag`. `delete_by_id` inherits via
+    its delegation to `get_by_id`. Legacy ""-source rows stay hidden;
+    they are managed via `delete_by_source` / memory_admin.py."""
+
+    # ── get_by_id ──────────────────────────────────────────────────
+
+    def test_get_by_id_returns_extracted_row(self):
+        """Extracted rows still resolve through get_by_id (regression
+        pin against the source-admit-set expansion). Mirrors the
+        existing `test_happy_path_wraps_result` but sized to the
+        post-#407 contract: an extracted row is one of three admitted
+        sources, not the only one."""
+        import kai.memory as mem_mod
+        from kai.memory import get_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "memory": "user prefers tea",
+            "user_id": "123",
+            "metadata": {"source": "extracted", "type": "preference"},
+            "created_at": "2026-04-29T10:00:00Z",
+        }
+        mem_mod._memory = mock_mem
+
+        result = get_by_id(user_id="123", memory_id="abc")
+        assert result is not None
+        assert result.id == "abc"
+        assert result.metadata.get("source") == "extracted"
+
+    def test_get_by_id_returns_episode_row(self):
+        """Episode rows (#385/#387) are now addressable from /memory
+        so the fact-view can render Sophia-style fields. Pre-#407
+        the same input returned None and the screen rendered "This
+        memory no longer exists." for a row the operator could see
+        in retrieval-time prompt injection."""
+        import kai.memory as mem_mod
+        from kai.memory import get_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "ep-1",
+            "memory": "Set up cron",
+            "user_id": "123",
+            "metadata": {"source": "episode", "outcome_quality": "good"},
+            "created_at": "2026-04-28T15:00:00Z",
+        }
+        mem_mod._memory = mock_mem
+
+        result = get_by_id(user_id="123", memory_id="ep-1")
+        assert result is not None
+        assert result.id == "ep-1"
+        assert result.metadata.get("source") == "episode"
+
+    def test_get_by_id_returns_migration_row(self):
+        """Migration rows (#406/#408) are also addressable so the
+        fact-view's `Imported` shape can render. Same regression
+        rationale as the episode case."""
+        import kai.memory as mem_mod
+        from kai.memory import get_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "mig-1",
+            "memory": "### /backend\nRole-based assignment",
+            "user_id": "123",
+            "metadata": {"source": "migration", "tags": ["migration"]},
+            "created_at": "2026-04-29T16:30:00Z",
+        }
+        mem_mod._memory = mock_mem
+
+        result = get_by_id(user_id="123", memory_id="mig-1")
+        assert result is not None
+        assert result.id == "mig-1"
+        assert result.metadata.get("source") == "migration"
+
+    def test_get_by_id_rejects_legacy_source(self):
+        """Legacy ""-source rows stay invisible to /memory after #407.
+        The admit list is intentionally enumerated rather than
+        "everything except legacy"; a value not in the set returns
+        None just like the pre-#407 non-extracted branch did."""
+        import kai.memory as mem_mod
+        from kai.memory import get_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "legacy-1",
+            "memory": "ancient row",
+            "user_id": "123",
+            "metadata": {"source": ""},
+        }
+        mem_mod._memory = mock_mem
+
+        assert get_by_id(user_id="123", memory_id="legacy-1") is None
+
+    # ── get_by_tag ─────────────────────────────────────────────────
+
+    def test_get_by_tag_includes_all_user_visible_sources(self):
+        """A tap on an enum tag returns rows of every user-visible
+        source that carries the tag in metadata. The dashboard's
+        `_TAG_ENUM` button gate is unchanged (the tag must be enum
+        for a button to render in the first place); this test
+        exercises the post-tap fetch only.
+
+        Note: in production, episode rows usually carry Sophia tags
+        and migration rows usually carry H3-slug tags - neither in
+        `_TAG_ENUM`. Cross-source overlap on enum tags is rare; it
+        is exercised here so the contract is regression-pinned for
+        the rare case."""
+        import kai.memory as mem_mod
+        from kai.memory import get_by_tag
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {
+            "results": [
+                {
+                    "id": "1",
+                    "memory": "Prefers Celsius",
+                    "score": 0.0,
+                    "metadata": {"source": "extracted", "tags": ["preference"]},
+                    "created_at": "2026-04-01T00:00:00",
+                    "updated_at": "2026-04-01T00:00:00",
+                },
+                {
+                    "id": "2",
+                    "memory": "Configured CI to run on PR",
+                    "score": 0.0,
+                    "metadata": {"source": "episode", "tags": ["preference"]},
+                    "created_at": "2026-04-02T00:00:00",
+                    "updated_at": "2026-04-02T00:00:00",
+                },
+                {
+                    "id": "3",
+                    "memory": "### preferences\nNo em dashes",
+                    "score": 0.0,
+                    "metadata": {"source": "migration", "tags": ["preference"]},
+                    "created_at": "2026-04-03T00:00:00",
+                    "updated_at": "2026-04-03T00:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        results = get_by_tag(user_id="123", tag="preference")
+        # Sort order is updated_at desc; assert membership rather
+        # than ordering so this test stays focused on the source
+        # admit-list expansion.
+        assert {r.id for r in results} == {"1", "2", "3"}
+
+    def test_get_by_tag_excludes_legacy_source(self):
+        """A legacy ""-source row that happens to carry an enum tag
+        in its metadata is still excluded - the admit list is the
+        gate, not the tag list."""
+        import kai.memory as mem_mod
+        from kai.memory import get_by_tag
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {
+            "results": [
+                {
+                    "id": "legacy",
+                    "memory": "Old preference row",
+                    "score": 0.0,
+                    "metadata": {"source": "", "tags": ["preference"]},
+                    "created_at": "2026-01-01T00:00:00",
+                    "updated_at": "2026-01-01T00:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        assert get_by_tag(user_id="123", tag="preference") == []
+
+    # ── delete_by_id (via get_by_id delegation) ────────────────────
+
+    def test_delete_by_id_allows_episode_via_delegation(self):
+        """delete_by_id has no source filter of its own; it delegates
+        ownership and source admit to get_by_id. Verifies the chain
+        works end-to-end for episode rows after #407."""
+        import kai.memory as mem_mod
+        from kai.memory import delete_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "ep-1",
+            "user_id": "123",
+            "metadata": {"source": "episode"},
+        }
+        mem_mod._memory = mock_mem
+
+        assert delete_by_id(user_id="123", memory_id="ep-1") is True
+        mock_mem.delete.assert_called_once_with(memory_id="ep-1")
+
+    def test_delete_by_id_allows_migration_via_delegation(self):
+        """Same delegation contract as the episode case - migration
+        rows also reach the actual Mem0 delete call now."""
+        import kai.memory as mem_mod
+        from kai.memory import delete_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "mig-1",
+            "user_id": "123",
+            "metadata": {"source": "migration"},
+        }
+        mem_mod._memory = mock_mem
+
+        assert delete_by_id(user_id="123", memory_id="mig-1") is True
+        mock_mem.delete.assert_called_once_with(memory_id="mig-1")
+
+    def test_delete_by_id_rejects_legacy_via_delegation(self):
+        """Legacy ""-source rows still cannot be deleted through
+        /memory - the inherited admit gate refuses them. They remain
+        managed via `delete_by_source` / memory_admin.py."""
+        import kai.memory as mem_mod
+        from kai.memory import delete_by_id
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "legacy-1",
+            "user_id": "123",
+            "metadata": {"source": ""},
+        }
+        mem_mod._memory = mock_mem
+
+        assert delete_by_id(user_id="123", memory_id="legacy-1") is False
+        mock_mem.delete.assert_not_called()
+
+    # ── get_stats per-source counts ───────────────────────────────
+
+    def test_get_stats_episode_count(self):
+        """`MemoryStats.episode_count` is computed over rows with
+        metadata.source == "episode". Counts are independent of
+        extracted_count and confidence aggregates."""
+        import kai.memory as mem_mod
+        from kai.memory import get_stats
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {
+            "results": [
+                {
+                    "id": "1",
+                    "memory": "ep one",
+                    "score": 0.0,
+                    "metadata": {"type": "fact", "source": "episode"},
+                    "created_at": "",
+                },
+                {
+                    "id": "2",
+                    "memory": "ep two",
+                    "score": 0.0,
+                    "metadata": {"type": "fact", "source": "episode"},
+                    "created_at": "",
+                },
+                {
+                    "id": "3",
+                    "memory": "extracted one",
+                    "score": 0.0,
+                    "metadata": {"type": "fact", "source": "extracted"},
+                    "created_at": "",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        stats = get_stats(user_id="123")
+        assert stats.episode_count == 2
+        # extracted_count is independent of episode_count.
+        assert stats.extracted_count == 1
+        assert stats.migration_count == 0
+
+    def test_get_stats_migration_count(self):
+        """`MemoryStats.migration_count` is computed over rows with
+        metadata.source == "migration". Same independence contract
+        as episode_count."""
+        import kai.memory as mem_mod
+        from kai.memory import get_stats
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {
+            "results": [
+                {
+                    "id": "1",
+                    "memory": "mig one",
+                    "score": 0.0,
+                    "metadata": {"type": "fact", "source": "migration"},
+                    "created_at": "",
+                },
+                {
+                    "id": "2",
+                    "memory": "mig two",
+                    "score": 0.0,
+                    "metadata": {"type": "fact", "source": "migration"},
+                    "created_at": "",
+                },
+                {
+                    "id": "3",
+                    "memory": "mig three",
+                    "score": 0.0,
+                    "metadata": {"type": "fact", "source": "migration"},
+                    "created_at": "",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        stats = get_stats(user_id="123")
+        assert stats.migration_count == 3
+        assert stats.extracted_count == 0
+        assert stats.episode_count == 0
+
+    def test_get_stats_confidence_stays_extracted_only(self):
+        """Confidence aggregates compute over extracted-source rows
+        only, regardless of whether non-extracted rows happen to
+        carry the field. Episode rows do not carry confidence in
+        production today; this test pins the principle (rather than
+        the current data shape) so a future schema where episodes
+        gain a confidence field cannot quietly contaminate the
+        confidence histogram."""
+        import kai.memory as mem_mod
+        from kai.memory import get_stats
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {
+            "results": [
+                # Extracted with high confidence - the only row that
+                # should contribute to the confidence aggregates.
+                {
+                    "id": "1",
+                    "memory": "fact",
+                    "score": 0.0,
+                    "metadata": {
+                        "type": "fact",
+                        "source": "extracted",
+                        "confidence": 0.9,
+                        "tags": ["fact"],
+                    },
+                    "created_at": "",
+                },
+                # Synthetic episode row carrying a low confidence
+                # value. Must NOT pull min/median/max down.
+                {
+                    "id": "2",
+                    "memory": "ep",
+                    "score": 0.0,
+                    "metadata": {
+                        "type": "fact",
+                        "source": "episode",
+                        "confidence": 0.1,
+                    },
+                    "created_at": "",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        stats = get_stats(user_id="123")
+        # Only the extracted row's 0.9 contributes; the episode's 0.1
+        # is excluded so min == max == 0.9.
+        assert stats.confidence_min == 0.9
+        assert stats.confidence_max == 0.9
+        assert stats.confidence_median == 0.9
+
+
 # ── Integration tests (real Mem0 + Qdrant, slower) ──────────────────
 
 

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -788,9 +788,11 @@ class TestDashboardMultiSource:
             confidence_min=0.8,
         )
         text, _ = memory_command._build_dashboard(stats)
-        # Exact match on the original wording so a future change to
-        # the headline format trips this regression test.
-        assert "Memories: 10 facts across 1 tags." in text
+        # Singular "tag" with len(nonzero)==1; the pre-#407 code
+        # rendered "1 tags" which was a latent mismatch. Verified
+        # so a future change to the headline format trips this
+        # regression test.
+        assert "Memories: 10 facts across 1 tag." in text
         assert "episodes" not in text
         assert "imported" not in text
 

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -74,6 +74,8 @@ def _fact(
 def _stats(
     *,
     extracted_count: int = 0,
+    episode_count: int = 0,
+    migration_count: int = 0,
     by_tag: dict[str, int] | None = None,
     confidence_min: float | None = None,
     confidence_median: float | None = None,
@@ -83,11 +85,19 @@ def _stats(
     confirmation_quote_count: int = 0,
     by_prompt_version: dict[str, int] | None = None,
 ) -> MemoryStats:
-    """Construct a MemoryStats with extracted-only aggregates."""
+    """Construct a MemoryStats with extracted-only aggregates.
+
+    `episode_count` and `migration_count` (issue #407) default to zero
+    so existing tests stay unchanged. Tests that exercise the
+    multi-source dashboard / stats / fact-view branches override them
+    explicitly.
+    """
     return MemoryStats(
-        total_count=extracted_count,
+        total_count=extracted_count + episode_count + migration_count,
         by_type={"fact": extracted_count} if extracted_count else {},
         extracted_count=extracted_count,
+        episode_count=episode_count,
+        migration_count=migration_count,
         by_tag=by_tag or {},
         confidence_min=confidence_min,
         confidence_median=confidence_median,
@@ -539,7 +549,11 @@ class TestBuildSearchResults:
 class TestBuildStats:
     def test_empty_state(self):
         text, kb = memory_command._build_stats(_stats(extracted_count=0))
-        assert "No extracted facts yet" in text
+        # Issue #407 changed the empty-state wording from
+        # "No extracted facts yet" because the post-#407 surface
+        # also accounts for episode and migration sources; the new
+        # wording is honest about the empty-state's full scope.
+        assert "No facts, episodes, or imported memory yet" in text
         assert kb.inline_keyboard[0][0].text == "back"
 
     def test_renders_full_aggregates(self):
@@ -565,8 +579,12 @@ class TestBuildStats:
             by_prompt_version={"v3": 128, "v2": 14},
         )
         text, _ = memory_command._build_stats(stats)
-        # Total
-        assert "Total:            142 facts" in text
+        # Total: per-source headline (issue #407). Extracted-only
+        # operator sees just the "Total facts:" line; episode and
+        # migration count lines are omitted when zero.
+        assert "Total facts:      142" in text
+        assert "Total episodes:" not in text
+        assert "Total imported:" not in text
         # Spec §6.1 asymmetry: zero-count tags ARE shown in stats.
         assert "location" in text
         assert "  0" in text  # location's zero count
@@ -663,6 +681,327 @@ class TestBuildStats:
         # Both buckets render without raising; presence is enough.
         assert "1" in text
         assert "2" in text
+
+
+# ── Issue #407: multi-source UI surface ────────────────────────────
+#
+# Episode and migration rows joined extracted as user-visible sources
+# in `/memory` (memory.py `_USER_VISIBLE_SOURCES`). The four classes
+# below exercise the dashboard, stats, fact-view, and forget-confirm
+# branches added by the spec.
+
+
+def _episode_fact(
+    fact_id: str = "ep-1",
+    text: str = "Set up CI for the kai repo. Outcome: succeeded.",
+    *,
+    tags: list[str] | None = None,
+    outcome_quality: str | None = "good",
+    created_at: str = "2026-04-28T15:00:00",
+) -> MemoryResult:
+    """Construct a MemoryResult shaped like an episode row.
+
+    Episode rows do not carry confidence / session_id / prompt_version
+    / confirmation_quote in production; tests deliberately omit those
+    fields so the renderer's "omit extractor-only rows" branch is
+    actually exercised. `outcome_quality` is None when the test wants
+    to drive the no-quality branch of the header.
+    """
+    metadata: dict[str, Any] = {
+        "source": "episode",
+        "tags": tags if tags is not None else [],
+        "type": "fact",
+    }
+    if outcome_quality is not None:
+        metadata["outcome_quality"] = outcome_quality
+    return MemoryResult(
+        id=fact_id,
+        text=text,
+        score=0.0,
+        memory_type="fact",
+        metadata=metadata,
+        created_at=created_at,
+        updated_at=created_at,
+    )
+
+
+def _migration_fact(
+    fact_id: str = "mig-1",
+    text: str = "### /backend\nRole-based backend assignment.",
+    *,
+    tags: list[str] | None = None,
+    created_at: str = "2026-04-29T16:30:00",
+) -> MemoryResult:
+    """Construct a MemoryResult shaped like a migration row (#408).
+
+    Tags default to ["migration"] which is what the migration script
+    writes for chunks without an H3 slug; tests exercising tag rendering
+    should pass an explicit list including the H3 slug too.
+    """
+    metadata: dict[str, Any] = {
+        "source": "migration",
+        "tags": tags if tags is not None else ["migration"],
+        "type": "fact",
+    }
+    return MemoryResult(
+        id=fact_id,
+        text=text,
+        score=0.0,
+        memory_type="fact",
+        metadata=metadata,
+        created_at=created_at,
+        updated_at=created_at,
+    )
+
+
+class TestDashboardMultiSource:
+    """`/memory` dashboard surfacing of episode and migration rows."""
+
+    def test_dashboard_shows_episode_and_migration_counts(self):
+        """Headline lists per-source counts when all three are non-zero.
+        The substrings "facts", "episodes", and "imported" each appear,
+        confirming the per-source wording rather than a single
+        aggregated total."""
+        stats = _stats(
+            extracted_count=12,
+            episode_count=3,
+            migration_count=25,
+            by_tag={"preference": 5},
+            confidence_median=0.85,
+            confidence_min=0.6,
+        )
+        text, _ = memory_command._build_dashboard(stats)
+        assert "12 facts" in text
+        assert "3 episodes" in text
+        assert "25 imported" in text
+
+    def test_dashboard_omits_zero_source_counts(self):
+        """A fresh extracted-only operator (episode_count==0,
+        migration_count==0) sees the original
+        "Memories: <N> facts across <M> tags." headline. Zero-valued
+        sources are omitted from the comma list rather than rendered
+        as "0 episodes" / "0 imported"."""
+        stats = _stats(
+            extracted_count=10,
+            by_tag={"preference": 5},
+            confidence_median=0.9,
+            confidence_min=0.8,
+        )
+        text, _ = memory_command._build_dashboard(stats)
+        # Exact match on the original wording so a future change to
+        # the headline format trips this regression test.
+        assert "Memories: 10 facts across 1 tags." in text
+        assert "episodes" not in text
+        assert "imported" not in text
+
+    def test_dashboard_episode_only_user_renders(self):
+        """An episode-only operator (`episode_count > 0`,
+        `extracted_count == 0`, `migration_count == 0`) sees the
+        dashboard rendered (NOT _MSG_NO_FACTS) with no tag buttons
+        (since `by_tag` is extracted-only and empty). Footer points
+        at the always-rendered Search/Stats button row.
+
+        Pins both empty-state guard fixes AND the footer conditional
+        simultaneously: the pre-#407 dashboard returned _MSG_NO_FACTS
+        for this input via its extracted-only guard."""
+        stats = _stats(episode_count=4)
+        text, kb = memory_command._build_dashboard(stats)
+        # Not the empty state.
+        assert "No memories yet" not in text
+        assert kb is not None
+        # Headline shows the episode count.
+        assert "4 episodes" in text
+        # Footer text is the no-tag-buttons branch.
+        assert "Use Search to find specific memories, or tap Stats for details." in text
+        assert "Tap a tag to browse" not in text
+        # Keyboard has only the footer Search/Stats row (no tag rows).
+        assert len(kb.inline_keyboard) == 1
+        footer = kb.inline_keyboard[-1]
+        assert [btn.text for btn in footer] == ["Search", "Stats"]
+
+    def test_dashboard_migration_only_user_renders(self):
+        """Same shape as the episode-only case: migration_count > 0,
+        extracted_count == 0, episode_count == 0. Same empty-state
+        guard fix and same no-tag-button footer assertion."""
+        stats = _stats(migration_count=25)
+        text, kb = memory_command._build_dashboard(stats)
+        assert "No memories yet" not in text
+        assert kb is not None
+        assert "25 imported" in text
+        assert "Use Search to find specific memories, or tap Stats for details." in text
+        assert "Tap a tag to browse" not in text
+        assert len(kb.inline_keyboard) == 1
+
+    def test_dashboard_all_zero_returns_empty_state(self):
+        """The empty state fires only when every user-visible source
+        is zero. Pins the combined-guard contract."""
+        stats = _stats()  # all three counts default to 0
+        text, kb = memory_command._build_dashboard(stats)
+        assert text == memory_command._MSG_NO_FACTS
+        assert kb is None
+
+
+class TestStatsMultiSource:
+    """`/memory stats` surfacing of episode and migration totals."""
+
+    def test_stats_view_shows_per_source_breakdown(self):
+        """The headline shows per-source totals on distinct lines for
+        all non-zero sources."""
+        stats = _stats(
+            extracted_count=12,
+            episode_count=3,
+            migration_count=25,
+            by_tag={"preference": 12},
+            confidence_min=0.6,
+            confidence_median=0.85,
+            confidence_max=0.95,
+        )
+        text, _ = memory_command._build_stats(stats)
+        assert "Total facts:      12" in text
+        assert "Total episodes:   3" in text
+        assert "Total imported:   25" in text
+
+    def test_stats_view_all_zero_says_no_memories_yet(self):
+        """All-zero empty-state text matches the dashboard's wording
+        update (per spec §D5)."""
+        stats = _stats()
+        text, kb = memory_command._build_stats(stats)
+        assert text == "Memory stats\n\nNo facts, episodes, or imported memory yet."
+        # Back button is still rendered so the user can return to the
+        # dashboard rather than being stuck on the stats screen.
+        assert kb.inline_keyboard[0][0].text == "back"
+
+    def test_stats_view_episode_only_omits_extracted_sections(self):
+        """An episode-only operator's stats output contains only the
+        per-source headline. The four extracted-shaped sections
+        (by-tag table, confidence block, confirmed-actions line,
+        prompt-version table) are omitted because they read
+        extractor-only metadata.
+
+        Pins §D5's "the four extracted-shaped sections are omitted"
+        contract for the extracted-zero case."""
+        stats = _stats(episode_count=5)
+        text, _ = memory_command._build_stats(stats)
+        assert "Total episodes:   5" in text
+        # None of the four extracted-shaped sections render.
+        assert "By tag:" not in text
+        assert "Confidence:" not in text
+        assert "Confirmed actions:" not in text
+        assert "Prompt versions:" not in text
+
+
+class TestFactViewMultiSource:
+    """`_build_fact_view` per-source render branches."""
+
+    def test_fact_view_renders_episode_with_outcome_quality(self):
+        """Episode header includes outcome_quality as a parenthetical
+        and the body shows Tags + Date only - none of the four
+        extractor-only rows (Confidence/Session/Prompt version/
+        Confirmation) appear."""
+        fact = _episode_fact(outcome_quality="good", tags=["sophia/topic"])
+        text, _ = memory_command._build_fact_view(fact, return_to=None)
+        # Header reads "Episode (good)".
+        assert "Episode (good)" in text
+        # Tags line renders.
+        assert "Tags:" in text
+        assert "sophia/topic" in text
+        # Date line renders with HH:MM precision.
+        assert "Date:" in text
+        # Extractor-only rows are absent. Each label is checked
+        # individually so a regression that adds back ANY one of them
+        # trips the assertion.
+        assert "Confidence:" not in text
+        assert "Session:" not in text
+        assert "Prompt version:" not in text
+        assert "Confirmation:" not in text
+
+    def test_fact_view_renders_episode_without_outcome_quality(self):
+        """When `outcome_quality` is missing from metadata the header
+        falls back to a bare "Episode" with no parenthetical."""
+        fact = _episode_fact(outcome_quality=None)
+        text, _ = memory_command._build_fact_view(fact, return_to=None)
+        # Header reads "Episode" without parenthetical. Use a regex-
+        # style assertion: line begins with "Episode\n" (no "(").
+        first_line = text.split("\n", 1)[0]
+        assert first_line == "Episode"
+
+    def test_fact_view_renders_migration_with_imported_header(self):
+        """Migration row renders the `Imported` header and the same
+        minimal Tags + Date body as the episode case. Distinct header
+        from `Fact` (extracted) and `Episode` so the operator can
+        tell the row's provenance at a glance."""
+        fact = _migration_fact(tags=["migration", "backend"])
+        text, _ = memory_command._build_fact_view(fact, return_to=None)
+        # Header is the load-bearing distinction.
+        first_line = text.split("\n", 1)[0]
+        assert first_line == "Imported"
+        # Tags include the migration H3 slug.
+        assert "migration" in text
+        assert "backend" in text
+        # Date renders.
+        assert "Date:" in text
+        # No extractor-only rows.
+        assert "Confidence:" not in text
+        assert "Session:" not in text
+        assert "Prompt version:" not in text
+        assert "Confirmation:" not in text
+
+    def test_fact_view_renders_extracted_unchanged(self):
+        """Pins the unchanged-extracted-shape contract: extracted
+        rows still render the original six-row block (Tags,
+        Confidence, Date, Session, Prompt version, Confirmation).
+        A regression that accidentally routes extracted rows
+        through the episode / migration shape would drop four of
+        these labels."""
+        fact = _fact("id1", "Prefers tea.", ["preference"], confidence=0.85, prompt_version="v3")
+        text, _ = memory_command._build_fact_view(fact, return_to=None)
+        first_line = text.split("\n", 1)[0]
+        assert first_line == "Fact"
+        assert "Tags:" in text
+        assert "Confidence:" in text
+        assert "Date:" in text
+        assert "Session:" in text
+        assert "Prompt version:" in text
+        assert "Confirmation:" in text
+
+
+class TestForgetConfirmMultiSource:
+    """`_build_forget_fact_confirm` per-source label injection."""
+
+    def test_delete_confirm_extracted_keeps_verb_and_warning(self):
+        """Pins the verb + warning regression-test contract per D4:
+        the verb stays `Forget`, the noun for extracted rows stays
+        `fact`, and the irreversibility cue (`This cannot be undone.`)
+        remains. A future change that swaps wording should be a
+        deliberate spec change, not a silent edit."""
+        fact = _fact("id1", "Prefers tea.", ["preference"])
+        text, kb = memory_command._build_forget_fact_confirm(fact)
+        assert text.startswith("Forget")
+        assert "fact" in text
+        assert "This cannot be undone." in text
+        # Inline-button flow unchanged.
+        labels = [btn.text for btn in kb.inline_keyboard[0]]
+        assert labels == ["confirm forget", "cancel"]
+
+    def test_delete_confirm_episode_uses_episode_label(self):
+        """Episode rows render the prompt with the `episode` noun.
+        Verb and warning sentence are unchanged from the extracted
+        case so the operator sees one consistent surface."""
+        fact = _episode_fact()
+        text, _ = memory_command._build_forget_fact_confirm(fact)
+        assert text.startswith("Forget")
+        assert "episode" in text
+        assert "This cannot be undone." in text
+
+    def test_delete_confirm_migration_uses_imported_memory_label(self):
+        """Migration rows render the prompt with the `imported memory`
+        noun. The label includes a space so a future code change that
+        forgets the multi-word rendering trips this assertion."""
+        fact = _migration_fact()
+        text, _ = memory_command._build_forget_fact_confirm(fact)
+        assert text.startswith("Forget")
+        assert "imported memory" in text
+        assert "This cannot be undone." in text
 
 
 # ── Subcommand parsing dispatch ────────────────────────────────────


### PR DESCRIPTION
## Summary

- Expands `/memory` from extracted-only to the three user-visible sources (extracted, episode, migration). New `_USER_VISIBLE_SOURCES` constant in `memory.py` gates `get_by_id` and `get_by_tag`; `delete_by_id` inherits via delegation.
- Adds `episode_count` and `migration_count` to `MemoryStats` (parallel per-source counts; confidence aggregates and `by_tag` stay extracted-only).
- Dashboard and stats screens combine empty-state guards into one all-zero check, surface per-source headlines, and (for the dashboard) gain a three-branch footer that points at Search/Stats when no tag buttons render.
- Fact view branches on `metadata.source`: extracted keeps the original six-row block; episode shows `Episode (<outcome_quality>)` + Tags + Date; migration shows `Imported` + Tags + Date.
- Forget-confirm injects per-source noun (`fact` / `episode` / `imported memory`); the verb (`Forget`), warning (`This cannot be undone.`), and inline-button flow are unchanged.

Fixes #407.

## Test plan

- [x] `make test` (all 2614 tests pass; +27 new across `tests/test_memory.py` and `tests/test_memory_command.py`).
- [x] `make check` (ruff lint + format).
- [ ] Smoke-test on production after deploy:
  - `/memory` headline shows per-source counts when episodes / migration rows exist.
  - `/memory stats` shows `Total facts:` / `Total episodes:` / `Total imported:` lines as appropriate; an episode-only operator sees no by-tag table.
  - Tap a tag button (e.g. `preference`) when a migration or episode row carries it; verify the row appears.
  - Open a migration row's fact view: header reads `Imported`; body has Tags + Date only.
  - Open an episode row's fact view: header reads `Episode (<outcome_quality>)` (or `Episode`); body has Tags + Date only.
  - Tap `forget` on a migration row: confirmation prompt reads `Forget this imported memory? "<text>" This cannot be undone.`; tap `cancel`.
