### PR TITLE
feat(memory): add episode browser to /memory dashboard (#410)

### DIFF
--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -164,7 +164,7 @@ _DELETE_PAGE_SIZE = 10_000
 # additional source not in this set) stay hidden in the UI; they are
 # managed via memory_admin.py / `delete_by_source`. A frozenset is used
 # so the constant cannot be mutated by importing callers.
-_USER_VISIBLE_SOURCES: frozenset[str] = frozenset({"extracted", "episode", "migration"})
+USER_VISIBLE_SOURCES: frozenset[str] = frozenset({"extracted", "episode", "migration"})
 
 
 @dataclass(frozen=True)
@@ -1104,7 +1104,7 @@ def get_by_tag(*, user_id: str, tag: str) -> list[MemoryResult]:
     client-side because Mem0's `get_all` does not accept metadata
     filters. Two filter clauses, both load-bearing:
 
-      - `metadata.source in _USER_VISIBLE_SOURCES`: defends against
+      - `metadata.source in USER_VISIBLE_SOURCES`: defends against
         legacy ""-source (or any future-additional non-UI) rows
         leaking into the operator-facing surface. Issue #407 expanded
         this from `== "extracted"` to the three-source set so episode
@@ -1131,7 +1131,7 @@ def get_by_tag(*, user_id: str, tag: str) -> list[MemoryResult]:
 
     rows = get_all(user_id=user_id, limit=None)
     matches = [
-        r for r in rows if r.metadata.get("source") in _USER_VISIBLE_SOURCES and tag in (r.metadata.get("tags") or [])
+        r for r in rows if r.metadata.get("source") in USER_VISIBLE_SOURCES and tag in (r.metadata.get("tags") or [])
     ]
     # Newest-updated first; created_at is the fallback for rows whose
     # payload predates updated_at being recorded. String comparison on
@@ -1151,7 +1151,7 @@ def get_all_episodes(*, user_id: str) -> list[MemoryResult]:
     enumerates every episode in one place.
 
     The source filter here is intentionally narrower than
-    `_USER_VISIBLE_SOURCES`: this function's purpose is single-source
+    `USER_VISIBLE_SOURCES`: this function's purpose is single-source
     enumeration ("give me everything in the episode bucket"), not
     multi-source admission. The shared admit list lives in
     `get_by_id` / `get_by_tag`; this helper does not participate in
@@ -1189,7 +1189,7 @@ def get_by_id(*, user_id: str, memory_id: str) -> MemoryResult | None:
       - Legacy ""-source rows are out of scope for /memory UI
         surfaces; they belong to memory_admin.py. Hide them here
         rather than letting the dashboard expose them. The accepted
-        sources are those in `_USER_VISIBLE_SOURCES` (extracted,
+        sources are those in `USER_VISIBLE_SOURCES` (extracted,
         episode, migration). Issue #407 expanded the set from
         extracted-only so episode (#385/#387) and migration (#406/
         #408) rows are addressable from the operator-facing surface;
@@ -1228,11 +1228,11 @@ def get_by_id(*, user_id: str, memory_id: str) -> MemoryResult | None:
             user_id,
         )
         return None
-    if (row.get("metadata") or {}).get("source") not in _USER_VISIBLE_SOURCES:
+    if (row.get("metadata") or {}).get("source") not in USER_VISIBLE_SOURCES:
         # Legacy ""-source (or any future-additional non-UI source) is
         # deliberately invisible to /memory. The user-visible set
         # (extracted, episode, migration) is enumerated in
-        # `_USER_VISIBLE_SOURCES`. No log: this is a routine filter,
+        # `USER_VISIBLE_SOURCES`. No log: this is a routine filter,
         # not an anomaly.
         return None
 

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -1141,6 +1141,38 @@ def get_by_tag(*, user_id: str, tag: str) -> list[MemoryResult]:
     return matches
 
 
+def get_all_episodes(*, user_id: str) -> list[MemoryResult]:
+    """Return all episode-source memories for `user_id`, newest first.
+
+    Read-side primitive for the /memory dashboard's episode-list
+    browser (issue #410). Episode rows mostly carry Sophia-style tags
+    that are not in `_TAG_ENUM`, so the existing tag-button surface
+    cannot reach them; this helper backs a dedicated screen that
+    enumerates every episode in one place.
+
+    The source filter here is intentionally narrower than
+    `_USER_VISIBLE_SOURCES`: this function's purpose is single-source
+    enumeration ("give me everything in the episode bucket"), not
+    multi-source admission. The shared admit list lives in
+    `get_by_id` / `get_by_tag`; this helper does not participate in
+    it. See the `memory_command.py` module docstring for the
+    canonical map of source-filter sites.
+
+    Sort: `updated_at` descending, with `created_at` as the fallback
+    for rows whose payload predates the field. Mirrors `get_by_tag`'s
+    sort contract so the same conventions hold across both list
+    surfaces. The full row set comes from `get_all(limit=None)` so a
+    user with thousands of episodes still gets a complete listing.
+    """
+    if _memory is None:
+        return []
+
+    rows = get_all(user_id=user_id, limit=None)
+    matches = [r for r in rows if r.metadata.get("source") == "episode"]
+    matches.sort(key=lambda r: r.updated_at or r.created_at, reverse=True)
+    return matches
+
+
 def get_by_id(*, user_id: str, memory_id: str) -> MemoryResult | None:
     """Fetch a single user-visible memory by id, scoped to user.
 

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -20,7 +20,7 @@ Architectural shape:
   reaper task. Losing the cache on process restart is acceptable
   (spec 310 §7.4); the user just retypes `/memory`.
 
-Source filtering uses `memory._USER_VISIBLE_SOURCES` (the frozenset
+Source filtering uses `memory.USER_VISIBLE_SOURCES` (the frozenset
 of `extracted`, `episode`, `migration`). The data-layer gate is
 canonical: `memory.get_by_id` and `memory.get_by_tag` admit only
 those sources, and `memory.delete_by_id` inherits the gate via its
@@ -28,9 +28,9 @@ delegation. The one UI-side reference is `_send_search`'s
 post-filter, which exists because `memory.search` is a Mem0 vector
 lookup that spans every source, including legacy `""`-source rows
 that must not surface in the operator-facing UI. Both sites read
-`_USER_VISIBLE_SOURCES` from `memory.py` so a future change to the
+`USER_VISIBLE_SOURCES` from `memory.py` so a future change to the
 admit list lives in one place. `memory.get_all_episodes` is the one
-narrower-than-`_USER_VISIBLE_SOURCES` filter, scoped to the literal
+narrower-than-`USER_VISIBLE_SOURCES` filter, scoped to the literal
 `"episode"` source for the dashboard's episode-list browser; it does
 not participate in the shared admit list because its purpose is
 single-source enumeration, not multi-source admission.
@@ -763,7 +763,7 @@ def _build_forget_fact_confirm(fact: MemoryResult) -> tuple[str, InlineKeyboardM
     `cancel`) are all preserved unchanged. Falls back to the generic
     label `memory` for an unknown source value (defensive: should be
     unreachable since `get_by_id` already gates on
-    `_USER_VISIBLE_SOURCES`, but a stale cache during a deploy
+    `USER_VISIBLE_SOURCES`, but a stale cache during a deploy
     transition could in principle slip a different source through).
     """
     source = (fact.metadata or {}).get("source", "")
@@ -1467,10 +1467,10 @@ async def _send_search(
     # render "This memory no longer exists." for a row the user just
     # saw - confusing and wrong. Filtering here keeps the UI honest:
     # what the user sees in results is what they can act on.
-    # `_USER_VISIBLE_SOURCES` (the {extracted, episode, migration}
+    # `USER_VISIBLE_SOURCES` (the {extracted, episode, migration}
     # frozenset) is read from `memory.py` so a future change to the
     # admit list lives in one place.
-    filtered = [r for r in results if r.score >= floor and r.metadata.get("source") in memory._USER_VISIBLE_SOURCES]
+    filtered = [r for r in results if r.score >= floor and r.metadata.get("source") in memory.USER_VISIBLE_SOURCES]
     text, kb, memory_ids = _build_search_results(query, filtered, floor)
     _set_cache(
         chat_id,

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -20,11 +20,20 @@ Architectural shape:
   reaper task. Losing the cache on process restart is acceptable
   (spec 310 §7.4); the user just retypes `/memory`.
 
-The `source == "extracted"` filter is applied by the underlying
-`memory.get_by_tag` / `memory.delete_by_id` helpers (memory.py
-§7.2). This module never references `metadata.source` directly so
-that a future change to the source-filter rule lives in exactly one
-place.
+Source filtering uses `memory._USER_VISIBLE_SOURCES` (the frozenset
+of `extracted`, `episode`, `migration`). The data-layer gate is
+canonical: `memory.get_by_id` and `memory.get_by_tag` admit only
+those sources, and `memory.delete_by_id` inherits the gate via its
+delegation. The one UI-side reference is `_send_search`'s
+post-filter, which exists because `memory.search` is a Mem0 vector
+lookup that spans every source, including legacy `""`-source rows
+that must not surface in the operator-facing UI. Both sites read
+`_USER_VISIBLE_SOURCES` from `memory.py` so a future change to the
+admit list lives in one place. `memory.get_all_episodes` is the one
+narrower-than-`_USER_VISIBLE_SOURCES` filter, scoped to the literal
+`"episode"` source for the dashboard's episode-list browser; it does
+not participate in the shared admit list because its purpose is
+single-source enumeration, not multi-source admission.
 
 See `home/specs/310-memory-command.md` for the canonical UX flows
 and design rationale.
@@ -257,7 +266,7 @@ _MSG_NO_SEARCH_RESULTS = "No matching memories found."
 # is invisible in Telegram's alert modal anyway since the modal
 # doesn't render with a monospace font.
 _HELP_TEXT = (
-    "/memory - Browse by tag\n"
+    "/memory - Browse memories\n"
     "/memory search <q> - Semantic search\n"
     "/memory stats - Counts and confidence distribution\n"
     "/memory forget <tag> - Delete all memories with a tag\n"
@@ -396,23 +405,43 @@ def _build_dashboard(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup | No
         lines.append(f"Tap a tag to browse. Confidence: median {median:.2f}, min {minv:.2f}.")
     elif nonzero:
         lines.append("Tap a tag to browse.")
+    elif stats.episode_count > 0:
+        # No tag buttons render but the Episodes button does. Footer
+        # names every utility-row affordance the operator can tap.
+        # Without this branch the footer would lie by enumerating only
+        # Search and Stats while the keyboard also rendered Episodes
+        # (issue #410 D6).
+        lines.append("Tap Episodes to browse, Search to find specific memories, or Stats for details.")
     else:
+        # No tag buttons AND no Episodes button. Utility row is just
+        # [Search, Stats]; pre-#410 wording is accurate for this case.
         lines.append("Use Search to find specific memories, or tap Stats for details.")
 
     text = "\n".join(lines)
 
     # Keyboard: one row per tag (preserves ordering, lets a busy
-    # dashboard scroll). A short trailing row holds Search and Stats.
+    # dashboard scroll). A short trailing utility row holds the
+    # cross-corpus actions: an optional Episodes button (issue #410,
+    # only when episode_count > 0), then Search and Stats.
     rows: list[list[InlineKeyboardButton]] = []
     for tag, count in nonzero:
         label = f"{tag} ({count})"
         rows.append([InlineKeyboardButton(label, callback_data=_encode_callback("tag", tag, "0"))])
-    rows.append(
-        [
-            InlineKeyboardButton("Search", callback_data=_encode_callback("help")),
-            InlineKeyboardButton("Stats", callback_data=_encode_callback("stats")),
-        ]
-    )
+    utility_row: list[InlineKeyboardButton] = []
+    if stats.episode_count > 0:
+        # Episodes button only renders when there is content to browse,
+        # mirroring the dashboard's existing zero-count tag suppression.
+        # The "0" arg is the initial page index; `eps:<page>` matches
+        # the `tag:<tag>:<page>` callback shape.
+        utility_row.append(
+            InlineKeyboardButton(
+                f"Episodes ({stats.episode_count})",
+                callback_data=_encode_callback("eps", "0"),
+            )
+        )
+    utility_row.append(InlineKeyboardButton("Search", callback_data=_encode_callback("help")))
+    utility_row.append(InlineKeyboardButton("Stats", callback_data=_encode_callback("stats")))
+    rows.append(utility_row)
     return text, InlineKeyboardMarkup(rows)
 
 
@@ -501,6 +530,104 @@ def _build_tag_view(
             InlineKeyboardButton(
                 "next >",
                 callback_data=_encode_callback("tag", tag, str(clamped + 1)),
+            )
+        )
+    return text, InlineKeyboardMarkup([number_row, nav_row]), memory_ids, clamped, total
+
+
+# ── Builder: episode list view (issue #410) ────────────────────────
+
+
+# The closed enum of `outcome_quality` values written by the
+# memory_extraction.py episode classifier. Episodes whose metadata
+# contains an off-enum string still render via the `[----]` fallback;
+# the strict check defends against a schema drift where a value like
+# `"good"` or `"unknown"` could leak in and look like a real category.
+# Mirrored here (rather than imported) for the same reason as
+# `_TAG_ENUM`: importing memory_extraction would pull in the Anthropic
+# SDK on the UI path. A drift between the two lists shows up
+# immediately in the episode list view (every row would render as
+# `[----]`).
+_OUTCOME_QUALITY_ENUM: tuple[str, ...] = ("success", "partial", "failure")
+
+
+def _build_episode_list_view(
+    facts: list[MemoryResult],
+    page: int,
+) -> tuple[str, InlineKeyboardMarkup, list[str], int, int]:
+    """Render a paginated episode list (issue #410).
+
+    Returns (text, keyboard, memory_ids, clamped_page, total_pages),
+    parallel in shape to `_build_tag_view`. The memory_ids list backs
+    the screen cache so numbered button taps resolve to memory ids
+    via integer index, keeping callback data well under the 64-byte
+    Telegram ceiling.
+
+    Per-row layout:
+        N.  [<outcome_quality>]  <truncated text>
+                                 <date>
+
+    Bracket text is the literal `outcome_quality` string from
+    metadata when it is one of the enumerated values
+    (`success` / `partial` / `failure`); otherwise `[----]`. Episode
+    rows do not carry confidence; the bracket field is the
+    closest-shaped per-row signal to confidence in the tag view.
+
+    Header reads `"Episodes  (page X of Y)"` with two spaces between
+    the label and the parenthetical, matching the tag view convention.
+    """
+    window, clamped, total = _paginate(facts, page)
+
+    if not window:
+        # Reachable only when an operator with episode_count > 0
+        # deletes their last episode mid-session, since the dashboard
+        # hides the Episodes button at zero. Render a graceful empty
+        # state with a back button rather than an empty-pagination
+        # screen.
+        text = "Episodes\n\nNo episodes yet."
+        kb = InlineKeyboardMarkup([[InlineKeyboardButton("back", callback_data=_encode_callback("dash"))]])
+        return text, kb, [], 0, 1
+
+    lines = [f"Episodes  (page {clamped + 1} of {total})", ""]
+    memory_ids: list[str] = []
+    for idx, fact in enumerate(window, start=1):
+        quality = fact.metadata.get("outcome_quality")
+        # Strict enum check (not a truthy-string check). Defends
+        # against schema drift where an off-enum value could leak
+        # in and look like a real category in the UI.
+        if quality in _OUTCOME_QUALITY_ENUM:
+            quality_str = f"[{quality}]"
+        else:
+            quality_str = "[----]"
+        date_str = _format_date(fact.updated_at or fact.created_at)
+        lines.append(f"{idx}.  {quality_str}  {_truncate(fact.text)}")
+        # Indent matches the tag view's date row (the `[0.92]`
+        # bracket is six chars; the longest enum value `[failure]`
+        # is nine chars, so the indent compromise lands at twelve
+        # spaces - same column as the tag view's date row.
+        lines.append(f"            {date_str}")
+        lines.append("")
+        memory_ids.append(fact.id)
+
+    text = "\n".join(lines).rstrip()
+
+    number_row = [
+        InlineKeyboardButton(str(i + 1), callback_data=_encode_callback("fact", str(i))) for i in range(len(window))
+    ]
+    nav_row: list[InlineKeyboardButton] = []
+    if clamped > 0:
+        nav_row.append(
+            InlineKeyboardButton(
+                "< prev",
+                callback_data=_encode_callback("eps", str(clamped - 1)),
+            )
+        )
+    nav_row.append(InlineKeyboardButton("back", callback_data=_encode_callback("dash")))
+    if clamped < total - 1:
+        nav_row.append(
+            InlineKeyboardButton(
+                "next >",
+                callback_data=_encode_callback("eps", str(clamped + 1)),
             )
         )
     return text, InlineKeyboardMarkup([number_row, nav_row]), memory_ids, clamped, total
@@ -1020,6 +1147,18 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
             await _send_tag_view(update, context, chat_id, tag, page, edit=True)
             await query.answer()
             return
+        if verb == "eps":
+            # Episode list browser (issue #410). Single-arg page
+            # index; no further validation gate (no enum to check
+            # against, unlike tag). Invalid integer falls back to
+            # page 0 so a stale callback never blocks navigation.
+            try:
+                page = int(args[0]) if args else 0
+            except ValueError:
+                page = 0
+            await _send_episode_list(update, context, chat_id, page, edit=True)
+            await query.answer()
+            return
         if verb == "fact":
             cache = _get_cache(chat_id)
             if cache is None or not args:
@@ -1079,7 +1218,8 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
             return_to = cache.return_to
             ok = memory.delete_by_id(user_id=str(chat_id), memory_id=memory_id)
             # Return to whatever screen the user was on before the
-            # fact view. Tag view if known; otherwise dashboard.
+            # fact view. Tag view or episode list if known; otherwise
+            # dashboard.
             if return_to is not None and return_to[0] == "tag" and len(return_to[1]) >= 2:
                 tag = return_to[1][0]
                 try:
@@ -1087,6 +1227,14 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
                 except ValueError:
                     page = 0
                 await _send_tag_view(update, context, chat_id, tag, page, edit=True)
+            elif return_to is not None and return_to[0] == "eps" and len(return_to[1]) >= 1:
+                # Issue #410: facts opened from the episode list
+                # return to that list at the same page after delete.
+                try:
+                    page = int(return_to[1][0])
+                except ValueError:
+                    page = 0
+                await _send_episode_list(update, context, chat_id, page, edit=True)
             else:
                 await _send_dashboard(update, context, chat_id, edit=True)
             await query.answer("Forgotten." if ok else "Not found.")
@@ -1177,6 +1325,35 @@ async def _send_tag_view(
     await _send_or_edit(update, text, kb, edit=edit)
 
 
+async def _send_episode_list(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    page: int,
+    edit: bool = False,
+) -> None:
+    """Render and send/edit the episode list at `page` (issue #410).
+
+    Mirrors `_send_tag_view` exactly except for the data source:
+    fetches via `memory.get_all_episodes`, builds via
+    `_build_episode_list_view`, and sets the cache screen to
+    `"episodes"` so a fact opened from this list can route back to
+    the same page via `_send_fact_view`'s return_to logic.
+    """
+    try:
+        episodes = memory.get_all_episodes(user_id=str(chat_id))
+    except Exception as exc:
+        log.exception("get_all_episodes failed: %s", exc)
+        await _send_or_edit(update, _MSG_QUERY_FAILED, None, edit=edit)
+        return
+    text, kb, memory_ids, clamped_page, _total = _build_episode_list_view(episodes, page)
+    _set_cache(
+        chat_id,
+        _ScreenCache(screen="episodes", page=clamped_page, memory_ids=memory_ids),
+    )
+    await _send_or_edit(update, text, kb, edit=edit)
+
+
 async def _send_fact_view(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
@@ -1196,6 +1373,12 @@ async def _send_fact_view(
     # the user where they started rather than at the root.
     if cache is not None and cache.screen == "tag" and cache.tag is not None:
         return_to = ("tag", [cache.tag, str(cache.page)])
+    elif cache is not None and cache.screen == "episodes":
+        # Issue #410: facts opened from the episode list return to
+        # that list at the same page on back-nav. Page is the only
+        # arg needed (unlike tag, which carries both tag and page);
+        # the eps verb decodes a single-element args list.
+        return_to = ("eps", [str(cache.page)])
     elif cache is not None and cache.screen == "search" and cache.query is not None:
         # Searches re-execute on back-nav. Encoding the full query in
         # callback data would risk the 64-byte limit; for now, back
@@ -1274,16 +1457,20 @@ async def _send_search(
     # Apply the floor in the UI path the same way `format_context`
     # does (spec §7.5: one knob, two paths).
     #
-    # Also enforce the source==extracted scope here. Every other read
-    # path in this module (`get_by_tag`, `get_by_id`) filters at the
-    # data layer, but `memory.search` is a Mem0 vector lookup that
-    # spans all sources (Track 1 exchanges, legacy rows). Without this
-    # post-filter, a search hit could surface a non-extracted row;
-    # tapping it would call `get_by_id`, fail the source check, and
+    # Also enforce the user-visible source admit list here. Every
+    # other read path in this module (`get_by_tag`, `get_by_id`)
+    # filters at the data layer, but `memory.search` is a Mem0 vector
+    # lookup that spans every source, including legacy ""-source rows
+    # that must not surface in the operator-facing UI. Without this
+    # post-filter, a search hit could surface a non-user-visible row;
+    # tapping it would call `get_by_id`, fail the admit check, and
     # render "This memory no longer exists." for a row the user just
     # saw - confusing and wrong. Filtering here keeps the UI honest:
     # what the user sees in results is what they can act on.
-    filtered = [r for r in results if r.score >= floor and r.metadata.get("source") == "extracted"]
+    # `_USER_VISIBLE_SOURCES` (the {extracted, episode, migration}
+    # frozenset) is read from `memory.py` so a future change to the
+    # admit list lives in one place.
+    filtered = [r for r in results if r.score >= floor and r.metadata.get("source") in memory._USER_VISIBLE_SOURCES]
     text, kb, memory_ids = _build_search_results(query, filtered, floor)
     _set_cache(
         chat_id,

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -547,8 +547,11 @@ def _build_tag_view(
 # `_TAG_ENUM`: importing memory_extraction would pull in the Anthropic
 # SDK on the UI path. A drift between the two lists shows up
 # immediately in the episode list view (every row would render as
-# `[----]`).
-_OUTCOME_QUALITY_ENUM: tuple[str, ...] = ("success", "partial", "failure")
+# `[----]`). frozenset (not tuple) because the only operation here
+# is `in` membership; matches the `USER_VISIBLE_SOURCES` pattern.
+# `_TAG_ENUM` is a tuple because iteration order matters for the
+# dashboard tag-button rendering; here it does not.
+_OUTCOME_QUALITY_ENUM: frozenset[str] = frozenset({"success", "partial", "failure"})
 
 
 def _build_episode_list_view(

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -2505,6 +2505,141 @@ class TestUserVisibleSources:
         assert stats.confidence_median == 0.9
 
 
+class TestGetAllEpisodes:
+    """Issue #410: single-source enumeration helper backing the
+    /memory dashboard's episode-list browser. Sources outside the
+    literal "episode" string are excluded - this is intentionally
+    narrower than `_USER_VISIBLE_SOURCES` because the function's
+    purpose is single-source enumeration, not multi-source admission."""
+
+    def test_get_all_episodes_returns_only_episode_source(self):
+        """Mixed-source store: only the episode rows come back. The
+        `_USER_VISIBLE_SOURCES` admit list is broader (it accepts
+        extracted and migration too) but does not apply here."""
+        import kai.memory as mem_mod
+        from kai.memory import get_all_episodes
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {
+            "results": [
+                {
+                    "id": "ext",
+                    "memory": "extracted fact",
+                    "score": 0.0,
+                    "metadata": {"source": "extracted", "type": "fact"},
+                    "created_at": "2026-04-01T00:00:00",
+                    "updated_at": "2026-04-01T00:00:00",
+                },
+                {
+                    "id": "ep1",
+                    "memory": "episode one",
+                    "score": 0.0,
+                    "metadata": {"source": "episode", "outcome_quality": "success"},
+                    "created_at": "2026-04-02T00:00:00",
+                    "updated_at": "2026-04-02T00:00:00",
+                },
+                {
+                    "id": "mig",
+                    "memory": "migration row",
+                    "score": 0.0,
+                    "metadata": {"source": "migration", "tags": ["migration"]},
+                    "created_at": "2026-04-03T00:00:00",
+                    "updated_at": "2026-04-03T00:00:00",
+                },
+                {
+                    "id": "legacy",
+                    "memory": "legacy row",
+                    "score": 0.0,
+                    "metadata": {"source": ""},
+                    "created_at": "2026-01-01T00:00:00",
+                    "updated_at": "2026-01-01T00:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        results = get_all_episodes(user_id="123")
+        assert [r.id for r in results] == ["ep1"]
+
+    def test_get_all_episodes_sorts_newest_first(self):
+        """Two episode rows with different `updated_at`; assert
+        descending order. Mirrors `get_by_tag`'s sort contract so
+        the same conventions hold across both list surfaces."""
+        import kai.memory as mem_mod
+        from kai.memory import get_all_episodes
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {
+            "results": [
+                {
+                    "id": "old",
+                    "memory": "older episode",
+                    "score": 0.0,
+                    "metadata": {"source": "episode"},
+                    "created_at": "2026-01-01T00:00:00",
+                    "updated_at": "2026-01-01T00:00:00",
+                },
+                {
+                    "id": "new",
+                    "memory": "newer episode",
+                    "score": 0.0,
+                    "metadata": {"source": "episode"},
+                    "created_at": "2026-04-01T00:00:00",
+                    "updated_at": "2026-04-15T00:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        results = get_all_episodes(user_id="123")
+        assert [r.id for r in results] == ["new", "old"]
+
+    def test_get_all_episodes_empty_when_no_episodes(self):
+        """Extracted-only store: empty list, not a None or an exception."""
+        import kai.memory as mem_mod
+        from kai.memory import get_all_episodes
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {
+            "results": [
+                {
+                    "id": "ext",
+                    "memory": "fact",
+                    "score": 0.0,
+                    "metadata": {"source": "extracted"},
+                    "created_at": "",
+                    "updated_at": "",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        assert get_all_episodes(user_id="123") == []
+
+    def test_get_all_episodes_disabled_returns_empty(self):
+        """With memory disabled (`_memory is None`), helper short-
+        circuits to empty list. No exception, no get_all call."""
+        from kai.memory import get_all_episodes
+
+        # The autouse `_clean_memory_state` fixture leaves _memory at
+        # None unless the test sets it explicitly.
+        assert get_all_episodes(user_id="123") == []
+
+    def test_get_all_episodes_passes_limit_none(self):
+        """get_all is called with the high ceiling (top_k >= 100_000)
+        so users with thousands of episodes get a complete listing.
+        Parallel to test_passes_limit_none_to_get_all for get_by_tag."""
+        import kai.memory as mem_mod
+        from kai.memory import get_all_episodes
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {"results": []}
+        mem_mod._memory = mock_mem
+
+        get_all_episodes(user_id="123")
+        assert mock_mem.get_all.call_args.kwargs["top_k"] >= 100_000
+
+
 # ── Integration tests (real Mem0 + Qdrant, slower) ──────────────────
 
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -2140,7 +2140,7 @@ class TestUserVisibleSources:
     addressable sources from the /memory UI.
 
     The source-admit gate now lives in
-    `memory._USER_VISIBLE_SOURCES = {"extracted", "episode", "migration"}`,
+    `memory.USER_VISIBLE_SOURCES = {"extracted", "episode", "migration"}`,
     used by `get_by_id` and `get_by_tag`. `delete_by_id` inherits via
     its delegation to `get_by_id`. Legacy ""-source rows stay hidden;
     they are managed via `delete_by_source` / memory_admin.py."""
@@ -2509,12 +2509,12 @@ class TestGetAllEpisodes:
     """Issue #410: single-source enumeration helper backing the
     /memory dashboard's episode-list browser. Sources outside the
     literal "episode" string are excluded - this is intentionally
-    narrower than `_USER_VISIBLE_SOURCES` because the function's
+    narrower than `USER_VISIBLE_SOURCES` because the function's
     purpose is single-source enumeration, not multi-source admission."""
 
     def test_get_all_episodes_returns_only_episode_source(self):
         """Mixed-source store: only the episode rows come back. The
-        `_USER_VISIBLE_SOURCES` admit list is broader (it accepts
+        `USER_VISIBLE_SOURCES` admit list is broader (it accepts
         extracted and migration too) but does not apply here."""
         import kai.memory as mem_mod
         from kai.memory import get_all_episodes

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -813,13 +813,16 @@ class TestDashboardMultiSource:
         assert kb is not None
         # Headline shows the episode count.
         assert "4 episodes" in text
-        # Footer text is the no-tag-buttons branch.
-        assert "Use Search to find specific memories, or tap Stats for details." in text
+        # Footer text is the no-tag-buttons-with-Episodes branch
+        # (issue #410 D6): when Episodes button is rendered, footer
+        # names every utility-row affordance.
+        assert "Tap Episodes to browse, Search to find specific memories, or Stats for details." in text
         assert "Tap a tag to browse" not in text
-        # Keyboard has only the footer Search/Stats row (no tag rows).
+        # Keyboard has only the utility row, which now includes the
+        # Episodes button (issue #410) alongside Search and Stats.
         assert len(kb.inline_keyboard) == 1
-        footer = kb.inline_keyboard[-1]
-        assert [btn.text for btn in footer] == ["Search", "Stats"]
+        utility_row = kb.inline_keyboard[-1]
+        assert [btn.text for btn in utility_row] == ["Episodes (4)", "Search", "Stats"]
 
     def test_dashboard_migration_only_user_renders(self):
         """Same shape as the episode-only case: migration_count > 0,
@@ -965,6 +968,268 @@ class TestFactViewMultiSource:
         assert "Session:" in text
         assert "Prompt version:" in text
         assert "Confirmation:" in text
+
+
+class TestDashboardEpisodesButton:
+    """Issue #410: Episodes (N) button on the dashboard utility row.
+
+    Conditional on `stats.episode_count > 0`. The pre-#410 utility
+    row was `[Search, Stats]`; post-#410 it can be either
+    `[Search, Stats]` (no episodes) or `[Episodes (N), Search, Stats]`
+    (episodes exist). Tests pin both shapes plus the per-source
+    footer prose changes that ride alongside."""
+
+    def test_dashboard_renders_episodes_button_when_episode_count_nonzero(self):
+        stats = _stats(extracted_count=10, episode_count=4, by_tag={"preference": 5})
+        _, kb = memory_command._build_dashboard(stats)
+        assert kb is not None
+        utility_row = kb.inline_keyboard[-1]
+        labels = [btn.text for btn in utility_row]
+        assert labels == ["Episodes (4)", "Search", "Stats"]
+        # Callback shape: mem:eps:<page>; initial page is 0.
+        episodes_btn = utility_row[0]
+        assert episodes_btn.callback_data == "mem:eps:0"
+
+    def test_dashboard_omits_episodes_button_when_episode_count_zero(self):
+        # Pre-#410 shape: utility row is exactly [Search, Stats].
+        # Pin so a future regression that always emits the Episodes
+        # button trips this test.
+        stats = _stats(extracted_count=10, episode_count=0, by_tag={"preference": 5})
+        _, kb = memory_command._build_dashboard(stats)
+        assert kb is not None
+        utility_row = kb.inline_keyboard[-1]
+        labels = [btn.text for btn in utility_row]
+        assert labels == ["Search", "Stats"]
+
+    def test_dashboard_episode_only_user_renders_episodes_button(self):
+        # Episode-only operator: by_tag is extracted-only (and
+        # therefore empty), so no tag-button rows render. The
+        # Episodes button is on the utility row alongside Search
+        # and Stats. Pins the cross-section of the episode-only
+        # surface and the Episodes button placement.
+        stats = _stats(episode_count=4)
+        _, kb = memory_command._build_dashboard(stats)
+        assert kb is not None
+        # Only one row total: the utility row.
+        assert len(kb.inline_keyboard) == 1
+        utility_row = kb.inline_keyboard[0]
+        labels = [btn.text for btn in utility_row]
+        assert labels == ["Episodes (4)", "Search", "Stats"]
+
+    def test_dashboard_no_tag_buttons_with_episodes_footer_wording(self):
+        # D6 footer branch when no tag buttons render and Episodes
+        # is rendered: footer names every utility-row affordance.
+        # Pins against the pre-#410 wording (which would lie by
+        # enumerating only Search and Stats).
+        stats = _stats(episode_count=4)
+        text, _ = memory_command._build_dashboard(stats)
+        assert "Tap Episodes to browse, Search to find specific memories, or Stats for details." in text
+
+    def test_dashboard_no_tag_buttons_no_episodes_footer_wording(self):
+        # D6 footer branch when no tag buttons AND no Episodes
+        # button render: footer matches pre-#410 wording. Pins
+        # the migration-only operator's surface.
+        stats = _stats(migration_count=25)
+        text, _ = memory_command._build_dashboard(stats)
+        assert "Use Search to find specific memories, or tap Stats for details." in text
+        # Negative regression: the Episodes branch wording must NOT
+        # appear when no Episodes button is rendered.
+        assert "Tap Episodes to browse" not in text
+
+
+class TestBuildEpisodeListView:
+    """Issue #410: paginated list view of episode rows."""
+
+    def _episode(
+        self,
+        fact_id: str,
+        text: str,
+        outcome_quality: str | None = "success",
+        *,
+        created_at: str = "2026-04-29T10:00:00",
+        updated_at: str | None = None,
+    ) -> MemoryResult:
+        metadata: dict[str, Any] = {"source": "episode", "type": "fact"}
+        if outcome_quality is not None:
+            metadata["outcome_quality"] = outcome_quality
+        return MemoryResult(
+            id=fact_id,
+            text=text,
+            score=0.0,
+            memory_type="fact",
+            metadata=metadata,
+            created_at=created_at,
+            updated_at=updated_at if updated_at is not None else created_at,
+        )
+
+    def test_outcome_quality_brackets_render(self):
+        eps = [
+            self._episode("e1", "First episode", outcome_quality="success"),
+            self._episode("e2", "Second episode", outcome_quality="partial"),
+        ]
+        text, _, ids, _, _ = memory_command._build_episode_list_view(eps, 0)
+        assert "[success]  First episode" in text
+        assert "[partial]  Second episode" in text
+        assert ids == ["e1", "e2"]
+
+    def test_falls_back_to_dashes_for_missing_outcome_quality(self):
+        # outcome_quality absent from metadata: render [----].
+        eps = [self._episode("e1", "Episode without quality", outcome_quality=None)]
+        text, _, _, _, _ = memory_command._build_episode_list_view(eps, 0)
+        assert "[----]" in text
+
+    def test_falls_back_to_dashes_for_off_enum_outcome_quality(self):
+        # Strict enum check (D2 line 59 / Implementation step 3
+        # docstring): an off-enum value renders [----] rather than
+        # the literal string. Defends against schema drift.
+        eps = [self._episode("e1", "Episode with bad value", outcome_quality="good")]
+        text, _, _, _, _ = memory_command._build_episode_list_view(eps, 0)
+        assert "[----]" in text
+        assert "[good]" not in text
+
+    def test_paginates(self):
+        # 12 episodes at page-size 5 -> page 1: 5, page 2: 5, page 3: 2.
+        eps = [self._episode(f"e{i}", f"Episode {i}") for i in range(12)]
+        # Page 1 (index 0).
+        _, kb, ids, page, total = memory_command._build_episode_list_view(eps, 0)
+        assert len(ids) == 5
+        assert page == 0
+        assert total == 3
+        nav_labels = [btn.text for btn in kb.inline_keyboard[-1]]
+        assert nav_labels == ["back", "next >"]
+        # Page 2 (middle).
+        _, kb, ids, page, total = memory_command._build_episode_list_view(eps, 1)
+        assert len(ids) == 5
+        assert page == 1
+        nav_labels = [btn.text for btn in kb.inline_keyboard[-1]]
+        assert nav_labels == ["< prev", "back", "next >"]
+        # Page 3 (partial last).
+        _, kb, ids, page, total = memory_command._build_episode_list_view(eps, 2)
+        assert len(ids) == 2
+        assert page == 2
+        nav_labels = [btn.text for btn in kb.inline_keyboard[-1]]
+        assert nav_labels == ["< prev", "back"]
+
+    def test_empty_state(self):
+        text, kb, ids, page, total = memory_command._build_episode_list_view([], 0)
+        assert text == "Episodes\n\nNo episodes yet."
+        assert ids == []
+        assert page == 0
+        assert total == 1
+        # Single back button on the keyboard.
+        assert len(kb.inline_keyboard) == 1
+        assert kb.inline_keyboard[0][0].text == "back"
+
+    def test_truncates_long_text(self):
+        long_text = "x" * 200
+        eps = [self._episode("e1", long_text)]
+        text, _, _, _, _ = memory_command._build_episode_list_view(eps, 0)
+        assert long_text not in text
+        assert "…" in text
+
+    def test_header_uses_two_space_separator(self):
+        # D2 / W5 (v1 evaluation): header label and parenthetical
+        # are separated by exactly two spaces, matching the tag
+        # view convention. Pin so a single-space regression trips
+        # this test.
+        eps = [self._episode("e1", "Just one")]
+        text, _, _, _, _ = memory_command._build_episode_list_view(eps, 0)
+        assert text.startswith("Episodes  (page 1 of 1)")
+
+
+class TestEpsCallbackDispatch:
+    """Issue #410: handle_memory_callback `eps` verb dispatch."""
+
+    @pytest.mark.asyncio
+    async def test_eps_verb_dispatches_to_send_episode_list(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        captured: dict[str, Any] = {}
+
+        async def fake_send(update, context, chat_id, page, edit=False):
+            captured["chat_id"] = chat_id
+            captured["page"] = page
+            captured["edit"] = edit
+
+        monkeypatch.setattr(memory_command, "_send_episode_list", fake_send)
+        upd = update_factory(callback_data="mem:eps:0")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+        assert captured["chat_id"] == 100
+        assert captured["page"] == 0
+        assert captured["edit"] is True
+
+    @pytest.mark.asyncio
+    async def test_eps_verb_invalid_page_falls_back_to_zero(self, monkeypatch, update_factory, context_factory):
+        # Stale or crafted callback with a non-integer page must
+        # not crash; the dispatch falls back to page 0.
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        captured: dict[str, Any] = {}
+
+        async def fake_send(update, context, chat_id, page, edit=False):
+            captured["page"] = page
+
+        monkeypatch.setattr(memory_command, "_send_episode_list", fake_send)
+        upd = update_factory(callback_data="mem:eps:notaninteger")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+        assert captured["page"] == 0
+
+
+class TestFactViewEpisodeReturn:
+    """Issue #410: back-navigation from a fact opened from the
+    episode list returns to the same page of that list."""
+
+    @pytest.mark.asyncio
+    async def test_fact_view_back_returns_to_episode_list(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+
+        # Prime the cache as if the user is on page 2 of the
+        # episode list.
+        memory_command._set_cache(
+            100,
+            memory_command._ScreenCache(
+                screen="episodes",
+                page=2,
+                memory_ids=["e1"],
+            ),
+        )
+
+        # Stub get_by_id to return an episode-shaped row so the
+        # fact view actually renders.
+        episode = MemoryResult(
+            id="e1",
+            text="Some episode",
+            score=0.0,
+            memory_type="fact",
+            metadata={"source": "episode", "outcome_quality": "success"},
+            created_at="2026-04-29T10:00:00",
+            updated_at="2026-04-29T10:00:00",
+        )
+        monkeypatch.setattr(memory_command.memory, "get_by_id", lambda *, user_id, memory_id: episode)
+
+        upd = update_factory(callback_data="mem:fact:0")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+
+        # The fact view's edit_message_text was called with a
+        # keyboard whose back button targets the episode list at
+        # page 2 (mem:eps:2).
+        edit_call = upd.callback_query.edit_message_text.call_args
+        assert edit_call is not None
+        kb = edit_call.kwargs["reply_markup"]
+        back_btn = kb.inline_keyboard[0][0]
+        assert back_btn.text == "back"
+        assert back_btn.callback_data == "mem:eps:2"
+
+
+class TestHelpTextSummaryLine:
+    """Issue #410 D7: `_HELP_TEXT` first line wording change."""
+
+    def test_help_text_says_browse_memories(self):
+        assert "/memory - Browse memories" in memory_command._HELP_TEXT
+        # Pre-#410 wording must be gone so a future revert trips
+        # this assertion.
+        assert "Browse by tag" not in memory_command._HELP_TEXT
 
 
 class TestForgetConfirmMultiSource:
@@ -1128,23 +1393,24 @@ class TestCommandDispatch:
         assert called["user_id"] == "100"  # chat_id stringified
 
     @pytest.mark.asyncio
-    async def test_search_filters_out_non_extracted_rows(self, monkeypatch, update_factory, context_factory):
-        # Spec §7.5 / round-5 review #1: every read path must scope to
-        # source=="extracted". `memory.search()` is a Mem0 vector
-        # lookup that spans all sources (Track 1 exchanges, legacy
-        # rows). Without a post-filter, a non-extracted row could
-        # surface in results, then fail get_by_id's source check on
-        # tap and render "no longer exists." for a row the user just
-        # saw. The filter lives in `_send_search` alongside the score
-        # floor.
+    async def test_search_filters_out_non_user_visible_rows(self, monkeypatch, update_factory, context_factory):
+        # Search results are post-filtered to `_USER_VISIBLE_SOURCES`
+        # (`extracted` + `episode` + `migration`); rows from any
+        # other source - most importantly legacy ""-source rows -
+        # are dropped before reaching the operator. This site exists
+        # because `memory.search` is a Mem0 vector lookup spanning
+        # every source, while the data-layer reads (`get_by_id`,
+        # `get_by_tag`) already gate at fetch time. Issue #410
+        # widened this from extracted-only.
         monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
 
-        # Build one extracted hit (kept) and one non-extracted hit
-        # (dropped). Both clear the score floor so only source
-        # decides. The legacy/Track-1 row uses the same MemoryResult
-        # shape Mem0 returns; the only difference is metadata.source.
+        # Build one user-visible hit (kept) and one non-user-visible
+        # hit (dropped). Both clear the score floor so only source
+        # decides. The non-user-visible row uses `source="track1"`,
+        # exercising the negative-space contract for any value
+        # outside the admit list.
         extracted = _fact("e1", "kept", ["preference"], score=0.9)
-        non_extracted = MemoryResult(
+        non_user_visible = MemoryResult(
             id="t1",
             text="dropped",
             score=0.95,
@@ -1155,7 +1421,7 @@ class TestCommandDispatch:
         )
 
         def fake_search(query, *, user_id, limit):
-            return [extracted, non_extracted]
+            return [extracted, non_user_visible]
 
         monkeypatch.setattr(memory_command.memory, "search", fake_search)
         upd = update_factory()
@@ -1163,11 +1429,73 @@ class TestCommandDispatch:
         await memory_command.handle_memory_command(upd, ctx)
 
         # The cache memory_ids list is populated from the filtered
-        # results - if the non-extracted row leaked through, "t1"
+        # results - if the non-user-visible row leaked through, "t1"
         # would appear here. It must not.
         cache = memory_command._get_cache(100)
         assert cache is not None
         assert cache.memory_ids == ["e1"]
+
+    @pytest.mark.asyncio
+    async def test_search_post_filter_admits_user_visible_sources_drops_legacy(
+        self, monkeypatch, update_factory, context_factory
+    ):
+        # Issue #410 D4: `_send_search` post-filter widens from
+        # extracted-only to `_USER_VISIBLE_SOURCES`. This test drives
+        # the comprehensive contract: extracted + episode + migration
+        # all surface; legacy ""-source rows are dropped. Replaces
+        # v1's redundant 14/15/16 with a single multi-source fixture.
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+
+        extracted = MemoryResult(
+            id="ext-1",
+            text="extracted fact",
+            score=0.9,
+            memory_type="fact",
+            metadata={"source": "extracted"},
+            created_at="2026-04-29T10:00:00",
+            updated_at="2026-04-29T10:00:00",
+        )
+        episode = MemoryResult(
+            id="ep-1",
+            text="episode summary",
+            score=0.85,
+            memory_type="fact",
+            metadata={"source": "episode", "outcome_quality": "success"},
+            created_at="2026-04-29T10:00:00",
+            updated_at="2026-04-29T10:00:00",
+        )
+        migration = MemoryResult(
+            id="mig-1",
+            text="imported memory",
+            score=0.8,
+            memory_type="fact",
+            metadata={"source": "migration", "tags": ["migration"]},
+            created_at="2026-04-29T10:00:00",
+            updated_at="2026-04-29T10:00:00",
+        )
+        legacy = MemoryResult(
+            id="legacy-1",
+            text="legacy row",
+            score=0.95,  # high score still gets dropped on source filter
+            memory_type="fact",
+            metadata={"source": ""},
+            created_at="2026-04-29T10:00:00",
+            updated_at="2026-04-29T10:00:00",
+        )
+
+        def fake_search(query, *, user_id, limit):
+            return [extracted, episode, migration, legacy]
+
+        monkeypatch.setattr(memory_command.memory, "search", fake_search)
+        upd = update_factory()
+        ctx = context_factory(args=["search", "anything"])
+        await memory_command.handle_memory_command(upd, ctx)
+
+        # All three user-visible sources surfaced; legacy was dropped.
+        cache = memory_command._get_cache(100)
+        assert cache is not None
+        assert set(cache.memory_ids) == {"ext-1", "ep-1", "mig-1"}
+        assert "legacy-1" not in cache.memory_ids
 
     @pytest.mark.asyncio
     async def test_forget_unknown_tag_rejected(self, monkeypatch, update_factory, context_factory):

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -686,7 +686,7 @@ class TestBuildStats:
 # ── Issue #407: multi-source UI surface ────────────────────────────
 #
 # Episode and migration rows joined extracted as user-visible sources
-# in `/memory` (memory.py `_USER_VISIBLE_SOURCES`). The four classes
+# in `/memory` (memory.py `USER_VISIBLE_SOURCES`). The four classes
 # below exercise the dashboard, stats, fact-view, and forget-confirm
 # branches added by the spec.
 
@@ -1394,7 +1394,7 @@ class TestCommandDispatch:
 
     @pytest.mark.asyncio
     async def test_search_filters_out_non_user_visible_rows(self, monkeypatch, update_factory, context_factory):
-        # Search results are post-filtered to `_USER_VISIBLE_SOURCES`
+        # Search results are post-filtered to `USER_VISIBLE_SOURCES`
         # (`extracted` + `episode` + `migration`); rows from any
         # other source - most importantly legacy ""-source rows -
         # are dropped before reaching the operator. This site exists
@@ -1440,7 +1440,7 @@ class TestCommandDispatch:
         self, monkeypatch, update_factory, context_factory
     ):
         # Issue #410 D4: `_send_search` post-filter widens from
-        # extracted-only to `_USER_VISIBLE_SOURCES`. This test drives
+        # extracted-only to `USER_VISIBLE_SOURCES`. This test drives
         # the comprehensive contract: extracted + episode + migration
         # all surface; legacy ""-source rows are dropped. Replaces
         # v1's redundant 14/15/16 with a single multi-source fixture.


### PR DESCRIPTION
## Summary

- Adds an `Episodes (N)` button to the `/memory` dashboard utility row when `stats.episode_count > 0`. Tapping it opens a paginated list view (same shape as the tag drill-down) showing all episode rows for the operator, formatted as `N. [<outcome_quality>] <text>\n   <date>`. Tapping a numbered button opens the existing fact view, which already renders the `Episode (<outcome_quality>)` shape; back returns to the same page of the episode list.
- Widens `_send_search` post-filter from `source == "extracted"` to `source in _USER_VISIBLE_SOURCES`, so `/memory search` surfaces episode and migration rows alongside extracted ones. Legacy `""`-source rows still drop.
- Updates the dashboard footer prose to name the Episodes button when it is rendered without tag buttons (D6).
- Updates `_HELP_TEXT`'s first line to "Browse memories" (D7).
- Rewrites the module docstring to map the post-#407 / post-#410 source-filter sites (D5).

Fixes #410.

## Test plan

- [x] `make test` (2636 tests pass; +22 new across `tests/test_memory.py` and `tests/test_memory_command.py`; one existing test updated for the new footer wording).
- [x] `make check` (ruff lint + format).
- [ ] Smoke-test on production after deploy:
  - `/memory` headline shows the Episodes button when episodes exist; verify count matches `MemoryStats.episode_count`.
  - Tap `Episodes (N)`; verify the paginated list renders with `[success]` / `[partial]` / `[failure]` brackets and dates.
  - Tap a numbered button; verify the fact view opens with the `Episode (<outcome_quality>)` header. Back returns to the same page.
  - `/memory search "evaluate spec"` (or another query likely to hit an episode); verify episode rows now surface in results.
  - Confirm migration-only operator (no extracted, no episodes) still sees the pre-#410 footer wording (`Use Search to find specific memories, or tap Stats for details.`).
