### PR TITLE
feat(memory): expand episode detail view with approach/outcome/lessons/actors (#412)

### DIFF
--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -674,11 +674,15 @@ def _build_fact_view(
 
     if source == "episode" or source == "migration":
         # Episode and migration rows share a minimal body shape:
-        # narrow Tags + Date with none of the extractor-only rows.
-        # Header differs (Episode (<outcome_quality>) vs Imported)
-        # but the rest of the layout is identical, so the tags
-        # line is computed once for both.
+        # Tags + Date with none of the extractor-only rows. Header
+        # differs (Episode (<outcome_quality>) vs Imported), and
+        # episodes (issue #412) splice in the four substantive
+        # Sophia fields (Approach, Outcome, Lessons-when-present,
+        # Actors) between the body quote and the Tags / Date footer.
+        # Migration rows skip the splice entirely - they have no
+        # equivalent metadata.
         tags_line = f"Tags:  {', '.join(tags) if tags else '(none)'}"
+        detail_lines: list[str] = []
         if source == "episode":
             # Episode rows surface the Sophia outcome_quality field as
             # a header parenthetical when present (e.g., "Episode
@@ -687,6 +691,30 @@ def _build_fact_view(
             # so episodes from the same day are distinguishable.
             quality = md.get("outcome_quality") or ""
             header = f"Episode ({quality})" if quality else "Episode"
+            # Substantive Sophia fields written by the stage-2
+            # generator (memory_extraction.py:1525-1538). approach /
+            # outcome / actors are schema-required and always present
+            # in production; the `or ""` / `or []` defensive fallbacks
+            # surface malformed-data corruption rather than hiding it
+            # (D3 in spec 412). lessons is optional-by-design and
+            # absent (not empty) when the generator chose to omit
+            # it - rendering `Lessons:  (none)` would lie about that
+            # design intent (D2).
+            approach = md.get("approach") or ""
+            outcome = md.get("outcome") or ""
+            actors_list = md.get("actors") or []
+            actors_str = ", ".join(actors_list) if actors_list else "(none)"
+            lessons = md.get("lessons")
+            detail_lines.append(f"Approach:  {approach}")
+            detail_lines.append(f"Outcome:  {outcome}")
+            # Presence-check, NOT truthy-check. The schema's
+            # minLength=20 makes the two equivalent in practice today,
+            # but `is not None` matches the storage contract literally
+            # (absent key is the sentinel for "no lesson this time")
+            # and protects against future schema relaxation.
+            if lessons is not None:
+                detail_lines.append(f"Lessons:  {lessons}")
+            detail_lines.append(f"Actors:  {actors_str}")
         else:
             # Migration rows already include the H3 title and section
             # structure inside `fact.text` (the migration script writes
@@ -700,6 +728,7 @@ def _build_fact_view(
             "",
             f'"{fact.text}"',
             "",
+            *detail_lines,
             tags_line,
             f"Date:  {_format_date(fact.created_at, with_time=True)}",
         ]

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -692,14 +692,14 @@ def _build_fact_view(
             quality = md.get("outcome_quality") or ""
             header = f"Episode ({quality})" if quality else "Episode"
             # Substantive Sophia fields written by the stage-2
-            # generator (memory_extraction.py:1525-1538). approach /
-            # outcome / actors are schema-required and always present
-            # in production; the `or ""` / `or []` defensive fallbacks
-            # surface malformed-data corruption rather than hiding it
-            # (D3 in spec 412). lessons is optional-by-design and
-            # absent (not empty) when the generator chose to omit
-            # it - rendering `Lessons:  (none)` would lie about that
-            # design intent (D2).
+            # generator's metadata-write block in memory_extraction.
+            # approach / outcome / actors are schema-required and
+            # always present in production; the `or ""` / `or []`
+            # defensive fallbacks surface malformed-data corruption
+            # rather than hiding it. lessons is optional-by-design
+            # and absent (not empty) when the generator chose to
+            # omit it - rendering `Lessons:  (none)` would lie about
+            # that design intent.
             approach = md.get("approach") or ""
             outcome = md.get("outcome") or ""
             actors_list = md.get("actors") or []

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -697,6 +697,10 @@ def _episode_fact(
     *,
     tags: list[str] | None = None,
     outcome_quality: str | None = "good",
+    approach: str | None = "Configured GitHub Actions step-by-step.",
+    outcome: str | None = "CI ran on every PR within an hour.",
+    actors: list[str] | None = None,
+    lessons: str | None = None,
     created_at: str = "2026-04-28T15:00:00",
 ) -> MemoryResult:
     """Construct a MemoryResult shaped like an episode row.
@@ -706,6 +710,20 @@ def _episode_fact(
     fields so the renderer's "omit extractor-only rows" branch is
     actually exercised. `outcome_quality` is None when the test wants
     to drive the no-quality branch of the header.
+
+    `approach`, `outcome`, `actors`, and `lessons` are issue #412
+    metadata. Defaults populate `approach`, `outcome`, and `actors`
+    (the schema-required content-bearing fields, so existing tests
+    that pre-date #412 render with a realistic body shape rather than
+    empty `Approach:  ` / `Outcome:  ` rows). `lessons` defaults to
+    None (the generator's "no lesson this time" sentinel), so tests
+    must opt in to render the Lessons row.
+
+    Presence-check (`is not None`) on `actors` matters: a caller that
+    passes `actors=[]` to test the empty-list defensive-fallback path
+    must see an empty list survive helper transit. `actors or
+    ["operator"]` would silently collapse the empty list to the
+    default and the test's intent would never reach the renderer.
     """
     metadata: dict[str, Any] = {
         "source": "episode",
@@ -714,6 +732,13 @@ def _episode_fact(
     }
     if outcome_quality is not None:
         metadata["outcome_quality"] = outcome_quality
+    if approach is not None:
+        metadata["approach"] = approach
+    if outcome is not None:
+        metadata["outcome"] = outcome
+    metadata["actors"] = actors if actors is not None else ["operator"]
+    if lessons is not None:
+        metadata["lessons"] = lessons
     return MemoryResult(
         id=fact_id,
         text=text,
@@ -968,6 +993,121 @@ class TestFactViewMultiSource:
         assert "Session:" in text
         assert "Prompt version:" in text
         assert "Confirmation:" in text
+
+    # ── Issue #412: episode detail-fields ──────────────────────────
+    #
+    # Adds `Approach`, `Outcome`, `Lessons` (when present), `Actors`
+    # rows to the episode branch of `_build_fact_view`, between the
+    # body quote and the existing `Tags` / `Date` footer. The
+    # extracted and migration branches stay unchanged.
+
+    def test_fact_view_episode_renders_approach_outcome(self):
+        """approach and outcome are schema-required Sophia fields;
+        always render. Two-space-after-colon formatting per spec D4."""
+        fact = _episode_fact(approach="A1", outcome="O1")
+        text, _ = memory_command._build_fact_view(fact, return_to=None)
+        assert "Approach:  A1" in text
+        assert "Outcome:  O1" in text
+
+    def test_fact_view_episode_renders_lessons_when_present(self):
+        """lessons is optional; when the metadata key is set, the
+        Lessons row renders alongside the always-on rows."""
+        fact = _episode_fact(lessons="L1")
+        text, _ = memory_command._build_fact_view(fact, return_to=None)
+        assert "Lessons:  L1" in text
+
+    def test_fact_view_episode_omits_lessons_row_when_absent(self):
+        """Pins D2: absence of lessons in metadata is the design-
+        intended sentinel for "no lesson this time" - the row is
+        dropped entirely, NOT rendered as `Lessons:  (none)`. A
+        regression that switched to a `(none)` placeholder would
+        misrepresent the generator's intent."""
+        fact = _episode_fact(lessons=None)
+        text, _ = memory_command._build_fact_view(fact, return_to=None)
+        assert "Lessons:" not in text
+
+    def test_fact_view_episode_renders_actors_comma_joined(self):
+        fact = _episode_fact(actors=["alice", "bob"])
+        text, _ = memory_command._build_fact_view(fact, return_to=None)
+        assert "Actors:  alice, bob" in text
+
+    def test_fact_view_episode_actors_empty_list_renders_none(self):
+        """Exercises the defensive-fallback path in D3; production
+        data cannot produce empty `actors` because the schema
+        enforces `minItems=1`, so the test pins a code path that
+        production cannot reach. Documented as an unreachable-state
+        pin so a future reader does not delete it as testing an
+        impossible state."""
+        fact = _episode_fact(actors=[])
+        text, _ = memory_command._build_fact_view(fact, return_to=None)
+        assert "Actors:  (none)" in text
+
+    def test_fact_view_episode_field_order(self):
+        """Pins D1's vertical ordering against future edits. The
+        four new rows render in priority order before the existing
+        Tags / Date footer."""
+        # Custom body text avoids the labels appearing inside the
+        # body quote (the default helper text contains "Outcome:"
+        # in narrative form). text.index(label) on the rendered
+        # string would otherwise pick up the body occurrence.
+        fact = _episode_fact(
+            text="A short body without label collisions.",
+            approach="aaa",
+            outcome="bbb",
+            lessons="ccc",
+            actors=["alice"],
+            tags=["sophia/topic"],
+        )
+        text, _ = memory_command._build_fact_view(fact, return_to=None)
+        positions = {
+            label: text.index(label) for label in ("Approach:", "Outcome:", "Lessons:", "Actors:", "Tags:", "Date:")
+        }
+        assert positions["Approach:"] < positions["Outcome:"]
+        assert positions["Outcome:"] < positions["Lessons:"]
+        assert positions["Lessons:"] < positions["Actors:"]
+        assert positions["Actors:"] < positions["Tags:"]
+        assert positions["Tags:"] < positions["Date:"]
+
+    def test_fact_view_episode_label_uses_two_spaces_after_colon(self):
+        """Pins D4's formatting decision in code so the spec's prose
+        decision does not drift away from the implementation. The
+        label uses exactly two spaces after the colon - not one (which
+        would read cramped) and not pad-aligned (which the spec
+        reserves for the wider extracted-row label set)."""
+        fact = _episode_fact(approach="A")
+        text, _ = memory_command._build_fact_view(fact, return_to=None)
+        assert "Approach:  A" in text
+        # Negative regression: pad-aligned form (3+ spaces) must NOT
+        # appear; single-space form must NOT appear.
+        assert "Approach:   " not in text
+        assert "Approach: A" not in text
+
+    def test_fact_view_episode_unchanged_extracted_branch(self):
+        """Confirms the extracted six-row block stays unchanged: a
+        regression that accidentally routed extracted rows through
+        the episode shape would drop the extractor-only labels and
+        could pick up the new labels. Both directions are pinned
+        here."""
+        fact = _fact("id1", "Prefers tea.", ["preference"])
+        text, _ = memory_command._build_fact_view(fact, return_to=None)
+        for label in ("Approach:", "Outcome:", "Lessons:", "Actors:"):
+            assert label not in text
+
+    def test_fact_view_episode_unchanged_migration_branch(self):
+        """Required as a separate test even though the assertion is
+        identical to the extracted-branch test, because the two cases
+        exercise different code paths: extracted goes through the
+        standalone `else:` arm at memory_command.py:706 (which never
+        touches `detail_lines`), while migration goes through the
+        combined branch with `detail_lines = []` initialized and the
+        inner `if source == "episode":` guard skipped, leaving the
+        splice empty. A regression mis-indenting the
+        `detail_lines.append(...)` calls so they fire for migration
+        too would only be caught by this test."""
+        fact = _migration_fact(tags=["migration", "backend"])
+        text, _ = memory_command._build_fact_view(fact, return_to=None)
+        for label in ("Approach:", "Outcome:", "Lessons:", "Actors:"):
+            assert label not in text
 
 
 class TestDashboardEpisodesButton:

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -1070,17 +1070,45 @@ class TestFactViewMultiSource:
 
     def test_fact_view_episode_label_uses_two_spaces_after_colon(self):
         """Pins D4's formatting decision in code so the spec's prose
-        decision does not drift away from the implementation. The
-        label uses exactly two spaces after the colon - not one (which
-        would read cramped) and not pad-aligned (which the spec
-        reserves for the wider extracted-row label set)."""
-        fact = _episode_fact(approach="A")
+        decision does not drift away from the implementation. Each
+        of the four new labels uses exactly two spaces after the
+        colon - not one (cramped) and not pad-aligned (which the
+        spec reserves for the wider extracted-row label set).
+        Asserts on every label individually so a copy-paste error
+        on any one row trips the test."""
+        fact = _episode_fact(approach="A", outcome="O", lessons="L", actors=["X"])
         text, _ = memory_command._build_fact_view(fact, return_to=None)
+        # Positive: every label rendered with two-space spacing.
         assert "Approach:  A" in text
-        # Negative regression: pad-aligned form (3+ spaces) must NOT
-        # appear; single-space form must NOT appear.
-        assert "Approach:   " not in text
+        assert "Outcome:  O" in text
+        assert "Lessons:  L" in text
+        assert "Actors:  X" in text
+        # Negative regression for each label: pad-aligned form
+        # (3+ spaces) and single-space form must NOT appear.
+        for label in ("Approach", "Outcome", "Lessons", "Actors"):
+            assert f"{label}:   " not in text
         assert "Approach: A" not in text
+        assert "Outcome: O" not in text
+        assert "Lessons: L" not in text
+        assert "Actors: X" not in text
+
+    def test_fact_view_episode_absent_approach_outcome_render_empty_fallback(self):
+        """`approach` and `outcome` are schema-required content-bearing
+        fields. The renderer's `or ""` defensive fallback for an
+        absent metadata key surfaces the corruption as an empty
+        labeled row rather than crashing. Production data cannot
+        produce this state because the schema requires both fields,
+        so the test pins a code path that production cannot reach -
+        analogous to the actors-empty-list pin (D3). Documented as
+        unreachable-state coverage so a future reader does not
+        delete it."""
+        fact = _episode_fact(approach=None, outcome=None)
+        text, _ = memory_command._build_fact_view(fact, return_to=None)
+        # Both rows render with empty values after the two-space
+        # separator. The trailing-whitespace match would be ambiguous
+        # so anchor on a label-followed-by-newline pattern.
+        assert "Approach:  \n" in text
+        assert "Outcome:  \n" in text
 
     def test_fact_view_episode_unchanged_extracted_branch(self):
         """Confirms the extracted six-row block stays unchanged: a

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -1003,7 +1003,7 @@ class TestFactViewMultiSource:
 
     def test_fact_view_episode_renders_approach_outcome(self):
         """approach and outcome are schema-required Sophia fields;
-        always render. Two-space-after-colon formatting per spec D4."""
+        always render with two-space-after-colon formatting."""
         fact = _episode_fact(approach="A1", outcome="O1")
         text, _ = memory_command._build_fact_view(fact, return_to=None)
         assert "Approach:  A1" in text
@@ -1017,11 +1017,12 @@ class TestFactViewMultiSource:
         assert "Lessons:  L1" in text
 
     def test_fact_view_episode_omits_lessons_row_when_absent(self):
-        """Pins D2: absence of lessons in metadata is the design-
-        intended sentinel for "no lesson this time" - the row is
-        dropped entirely, NOT rendered as `Lessons:  (none)`. A
-        regression that switched to a `(none)` placeholder would
-        misrepresent the generator's intent."""
+        """Pins the lessons-absence design intent: the metadata key
+        is absent (not empty-string) when the generator chose not
+        to record a lesson. The row is dropped entirely rather than
+        rendered as `Lessons:  (none)`, which would misrepresent
+        the generator's intent as "considered and rejected" rather
+        than "no lesson this time"."""
         fact = _episode_fact(lessons=None)
         text, _ = memory_command._build_fact_view(fact, return_to=None)
         assert "Lessons:" not in text
@@ -1032,20 +1033,20 @@ class TestFactViewMultiSource:
         assert "Actors:  alice, bob" in text
 
     def test_fact_view_episode_actors_empty_list_renders_none(self):
-        """Exercises the defensive-fallback path in D3; production
-        data cannot produce empty `actors` because the schema
-        enforces `minItems=1`, so the test pins a code path that
-        production cannot reach. Documented as an unreachable-state
-        pin so a future reader does not delete it as testing an
-        impossible state."""
+        """Exercises the defensive `(none)` fallback for an empty
+        actors list. Production data cannot produce this state
+        because the schema enforces `minItems=1`, so the test pins
+        a code path that production cannot reach. Documented as an
+        unreachable-state pin so a future reader does not delete
+        it as testing an impossible state."""
         fact = _episode_fact(actors=[])
         text, _ = memory_command._build_fact_view(fact, return_to=None)
         assert "Actors:  (none)" in text
 
     def test_fact_view_episode_field_order(self):
-        """Pins D1's vertical ordering against future edits. The
-        four new rows render in priority order before the existing
-        Tags / Date footer."""
+        """Pins the four-row vertical ordering against future edits:
+        Approach -> Outcome -> Lessons (when present) -> Actors,
+        before the existing Tags / Date footer."""
         # Custom body text avoids the labels appearing inside the
         # body quote (the default helper text contains "Outcome:"
         # in narrative form). text.index(label) on the rendered
@@ -1069,13 +1070,14 @@ class TestFactViewMultiSource:
         assert positions["Tags:"] < positions["Date:"]
 
     def test_fact_view_episode_label_uses_two_spaces_after_colon(self):
-        """Pins D4's formatting decision in code so the spec's prose
-        decision does not drift away from the implementation. Each
-        of the four new labels uses exactly two spaces after the
-        colon - not one (cramped) and not pad-aligned (which the
-        spec reserves for the wider extracted-row label set).
-        Asserts on every label individually so a copy-paste error
-        on any one row trips the test."""
+        """Pins the two-space-after-colon formatting in code so the
+        convention does not drift away from prose comments. Each of
+        the four new labels uses exactly two spaces after the colon
+        - not one (cramped) and not pad-aligned, which is reserved
+        for the wider extracted-row label set ("Confidence:",
+        "Prompt version:", "Confirmation:") where pad-alignment
+        improves scanability. Asserts on every label individually
+        so a copy-paste error on any one row trips the test."""
         fact = _episode_fact(approach="A", outcome="O", lessons="L", actors=["X"])
         text, _ = memory_command._build_fact_view(fact, return_to=None)
         # Positive: every label rendered with two-space spacing.
@@ -1099,7 +1101,8 @@ class TestFactViewMultiSource:
         labeled row rather than crashing. Production data cannot
         produce this state because the schema requires both fields,
         so the test pins a code path that production cannot reach -
-        analogous to the actors-empty-list pin (D3). Documented as
+        analogous to the actors-empty-list defensive-fallback pin.
+        Documented as
         unreachable-state coverage so a future reader does not
         delete it."""
         fact = _episode_fact(approach=None, outcome=None)
@@ -1124,12 +1127,13 @@ class TestFactViewMultiSource:
     def test_fact_view_episode_unchanged_migration_branch(self):
         """Required as a separate test even though the assertion is
         identical to the extracted-branch test, because the two cases
-        exercise different code paths: extracted goes through the
-        standalone `else:` arm at memory_command.py:706 (which never
-        touches `detail_lines`), while migration goes through the
-        combined branch with `detail_lines = []` initialized and the
-        inner `if source == "episode":` guard skipped, leaving the
-        splice empty. A regression mis-indenting the
+        exercise different code paths in `_build_fact_view`:
+        extracted goes through the standalone extracted-branch
+        `else:` arm (which never touches `detail_lines`), while
+        migration goes through the combined episode-or-migration
+        branch with `detail_lines = []` initialized and the inner
+        `if source == "episode":` guard skipped, leaving the splice
+        empty. A regression mis-indenting the
         `detail_lines.append(...)` calls so they fire for migration
         too would only be caught by this test."""
         fact = _migration_fact(tags=["migration", "backend"])


### PR DESCRIPTION
## Summary

- Adds `Approach`, `Outcome`, `Lessons` (when present), `Actors` rows to the episode branch of `_build_fact_view` so an operator looking at a stored episode can read its full record. The four rows splice between the body quote and the existing `Tags` / `Date` footer.
- Three contract-driven missing-data treatments: `or ""` defensive fallback for schema-required content-bearing fields (`approach`, `outcome`); presence-check (`is not None`) for the optional `lessons` so absence stays the design-intended sentinel for "no lesson this time"; `(none)` defensive fallback for the always-non-empty `actors`.
- `session_id` and `episode_prompt_version` stay out of scope (operator-debug fields, and `session_id` is routinely empty in storage; rendering would produce useless empty rows).
- Migration and extracted detail views unchanged.

Fixes #412.

## Test plan

- [x] `make test` (2645 tests pass; +9 new under `TestFactViewMultiSource`; `_episode_fact` helper extended with `approach` / `outcome` / `actors` / `lessons` kwargs).
- [x] `make check` (ruff lint + format).
- [ ] Smoke-test on production after deploy:
  - `/memory` → tap `Episodes (N)` → tap a row. Verify the detail screen shows `Approach:`, `Outcome:`, `Actors:` rows; `Lessons:` row when the row has one stored, omitted otherwise.
  - Tap an extracted fact and a migration row to confirm their detail views are unchanged.
