### PR TITLE
feat(memory): free-form LLM tags on extracted rows (#414)

### DIFF
--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -906,6 +906,7 @@ _CONSOLIDATION_INTENTS: frozenset[str] = frozenset({"new", "update_of", "skip_re
 def _validate_facts(
     facts: list[dict],
     candidate_ids: set[str],
+    *,
     candidate_metadata: dict[str, dict],
     user_id: str,
 ) -> list[dict]:
@@ -1070,7 +1071,15 @@ def _validate_facts(
         # dropped (issue #414), the validator carries that contract
         # explicitly.
         if intent in ("skip_redundant", "update_of") and isinstance(existing_id, str):
-            existing_meta = candidate_metadata.get(existing_id, {})
+            # `or {}` collapses both "key absent" and "key present
+            # with a None payload" to the same empty-dict default.
+            # `.get(key, {})` only handles the first case; a
+            # MemoryResult constructed with metadata=None (a type
+            # violation but possible via direct dataclass
+            # construction in tests or future code) would store
+            # None as the dict value, and the next `.get("tags")`
+            # call would AttributeError.
+            existing_meta = candidate_metadata.get(existing_id) or {}
             existing_tags = existing_meta.get("tags") or []
             if "confirmed_action" in existing_tags:
                 log.debug(
@@ -1321,7 +1330,7 @@ async def _run_extractor(
     facts_raw = payload_root.get("facts") or []
     has_episode = bool(payload_root.get("has_episode"))
     return ExtractionResult(
-        facts=_validate_facts(facts_raw, candidate_ids, candidate_metadata, user_id),
+        facts=_validate_facts(facts_raw, candidate_ids, candidate_metadata=candidate_metadata, user_id=user_id),
         has_episode=has_episode,
     )
 

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1071,15 +1071,7 @@ def _validate_facts(
         # dropped (issue #414), the validator carries that contract
         # explicitly.
         if intent in ("skip_redundant", "update_of") and isinstance(existing_id, str):
-            # `or {}` collapses both "key absent" and "key present
-            # with a None payload" to the same empty-dict default.
-            # `.get(key, {})` only handles the first case; a
-            # MemoryResult constructed with metadata=None (a type
-            # violation but possible via direct dataclass
-            # construction in tests or future code) would store
-            # None as the dict value, and the next `.get("tags")`
-            # call would AttributeError.
-            existing_meta = candidate_metadata.get(existing_id) or {}
+            existing_meta = candidate_metadata.get(existing_id, {})
             existing_tags = existing_meta.get("tags") or []
             if "confirmed_action" in existing_tags:
                 log.debug(
@@ -1959,7 +1951,15 @@ async def extract_and_store(
             # tags to detect a confirmation row being consolidated by
             # a synonym-tagged fact. The full `candidates` list is
             # already in scope, so building the dict here is one line.
-            candidate_metadata: dict[str, dict] = {c.id: c.metadata for c in candidates}
+            # `or {}` at construction collapses any null metadata
+            # payload to an empty dict so the `dict[str, dict]`
+            # annotation is truthful and Rule 4b's lookup can stay
+            # clean (no second `or {}` at the consumer site). The
+            # MemoryResult dataclass types metadata as `dict` rather
+            # than `dict | None`, so this defends against a direct-
+            # construction type violation rather than a real runtime
+            # path - cheap insurance.
+            candidate_metadata: dict[str, dict] = {c.id: c.metadata or {} for c in candidates}
             # Emit the candidate-set log line exactly once per
             # extraction call, AFTER the fetch and BEFORE the
             # subprocess spawn. Always emitted (even when empty) so

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -50,7 +50,16 @@ log = logging.getLogger(__name__)
 # fact-storage parsing on the Python side is the same; the bump is
 # the canary that lets post-rollout log analysis distinguish facts
 # produced by the windowed prompt from facts produced by v3.
-_EXTRACTION_PROMPT_VERSION: str = "4"
+# v5: free-form tag schema (enum dropped). Soft-vocab seed in prompt
+# names the prior nine values as preferred but advisory; the LLM may
+# invent new tags when nothing fits. `confirmed_action` remains a
+# structurally significant magic string with explicit synonym
+# prohibition in the prompt; `_validate_facts` Rule 4b added to
+# defend the consolidation gate against synonym-tagged updates of
+# existing confirmation rows. `maxItems` raised from 4 to 5 to
+# match `_EPISODE_SCHEMA` per the parent issue's "single tag
+# taxonomy" decision.
+_EXTRACTION_PROMPT_VERSION: str = "5"
 
 # Sibling of _EXTRACTION_PROMPT_VERSION for stage-2 episode generation.
 # Stored in each episode's metadata so future cleanups can target a
@@ -225,23 +234,21 @@ _FACT_SCHEMA: dict = {
                 "properties": {
                     "content": {"type": "string", "minLength": 1, "maxLength": 500},
                     "tags": {
+                        # Free-form per issue #388 / #414: the closed
+                        # enum was retired so the same LLM-generated
+                        # tag system can apply across extracted and
+                        # episode rows. Shape mirrors `_EPISODE_SCHEMA`
+                        # exactly. The structurally significant
+                        # `confirmed_action` magic string is no longer
+                        # enforced at the schema layer; the prompt
+                        # carries an explicit synonym prohibition,
+                        # and `_validate_facts` enforces the
+                        # confirmation-quote and consolidation rules
+                        # that key off the literal tag.
                         "type": "array",
-                        "items": {
-                            "type": "string",
-                            "enum": [
-                                "preference",
-                                "decision",
-                                "fact",
-                                "constraint",
-                                "confirmed_action",
-                                "project",
-                                "location",
-                                "schedule",
-                                "relationship",
-                            ],
-                        },
+                        "items": {"type": "string", "minLength": 1, "maxLength": 50},
                         "minItems": 1,
-                        "maxItems": 4,
+                        "maxItems": 5,
                     },
                     "confidence": {"type": "number", "minimum": 0.5, "maximum": 1.0},
                     "confirmation_quote": {
@@ -357,9 +364,20 @@ FORMAT each fact as:
 - content: one sentence, third-person where possible
   ("User prefers Celsius"), past tense for confirmed actions
   ("User confirmed PR #299 was merged on 2026-04-12").
-- tags: 1 to 4 lowercase topical tags. Pick the most relevant ones
-  from: preference, decision, fact, constraint, confirmed_action,
-  project, location, schedule, relationship.
+- tags: 1 to 5 lowercase topical tags. Use these preferred tags
+  when one fits the fact: preference, decision, fact, constraint,
+  confirmed_action, project, location, schedule, relationship.
+  Only invent new tags when none of these capture the fact's
+  topic; new tags should be single lowercase words or short
+  underscore-joined compounds, no punctuation beyond underscores.
+
+  The tag `confirmed_action` is structurally significant: when
+  the fact represents a user-confirmed action (with a
+  confirmation_quote), you MUST use the literal tag
+  `confirmed_action`. NEVER substitute synonyms like
+  `confirmation`, `confirmed`, `user_confirmed`, or `confirm` -
+  they are NOT recognized by the storage system and will cause
+  the fact to be rejected.
 - confidence: a number in [0, 1]. Use 0.9+ for direct user statements,
   0.7 for clear user confirmation of an assistant claim, 0.5 for
   paraphrased or implied facts. Do not store below 0.5.
@@ -888,14 +906,16 @@ _CONSOLIDATION_INTENTS: frozenset[str] = frozenset({"new", "update_of", "skip_re
 def _validate_facts(
     facts: list[dict],
     candidate_ids: set[str],
+    candidate_metadata: dict[str, dict],
     user_id: str,
 ) -> list[dict]:
     """
     Drop facts that violate confirmation-quote or consolidation rules.
 
     The CLI's JSON Schema validation already constrains property names,
-    tag enum, and primitive types. This function enforces the cross-field
-    and batch-internal rules JSON Schema does NOT express cleanly:
+    tag shape, and primitive types. This function enforces the
+    cross-field and batch-internal rules JSON Schema does NOT express
+    cleanly:
 
     Confirmation-quote rules (existed pre-consolidation; unchanged):
       A. If tags includes "confirmed_action": confirmation_quote MUST
@@ -904,7 +924,7 @@ def _validate_facts(
       B. If tags does NOT include "confirmed_action": confirmation_quote
          MUST be absent entirely.
 
-    Consolidation rules (new):
+    Consolidation rules:
       1. `intent` is present and is one of the three enum values.
          Defense-in-depth against schema regression; the schema already
          enforces this, but a future too-permissive schema edit would
@@ -920,9 +940,24 @@ def _validate_facts(
          the ONE rule that emits a structured log line; the others are
          DEBUG-only because they represent schema-shape violations or
          batch-internal inconsistencies, not real classification decisions.
-      4. `intent == "skip_redundant"`: tags MUST NOT include
-         `confirmed_action`. A confirmation is a fresh observation about
-         reality even if the wording paraphrases an existing fact.
+      4. `intent in ("skip_redundant", "update_of")`: tags MUST NOT
+         include `confirmed_action`. A confirmation is a fresh
+         observation about reality even if the wording paraphrases an
+         existing fact; a confirmation row's timestamp and
+         `confirmation_quote` are load-bearing storage artifacts that
+         must not be erased by consolidation. Defense-in-depth gate
+         against the model disobeying the prompt's "use new for
+         confirmed_action" instruction; keys off the NEW fact's tags.
+      4b. `intent in ("skip_redundant", "update_of")` AND the existing
+         row's metadata tags include `confirmed_action`: REJECTED.
+         Defends the consolidation gate against synonym-tagged
+         updates that bypass Rule 4 (which keys off the NEW fact's
+         tags). With a free-form tag space, the LLM can emit
+         `tags=["confirmation"]` (a synonym) on a fact whose intent
+         is to overwrite a prior confirmation row; Rule 4 would not
+         fire, but the existing row's stored tags would still mark
+         it as a confirmation. Reading `existing_metadata["tags"]`
+         via the `candidate_metadata` parameter closes the gap.
       5. Existing-id uniqueness within the batch: if two proposed facts
          cite the same `existing_id`, BOTH are dropped. The failure
          mode being defended against is the extractor emitting two
@@ -938,8 +973,8 @@ def _validate_facts(
     emission co-located rather than splitting the two across modules.
 
     Rejected facts are dropped silently (DEBUG log) for rules 1, 2, 4,
-    5 and confirmation-quote rules. Rule 3 emits the structured log
-    line documented above.
+    4b, 5 and confirmation-quote rules. Rule 3 emits the structured
+    log line documented above.
     """
     # Pre-pass: count existing_id citations across the batch so rule 5
     # (uniqueness) can be evaluated without two passes through the per-
@@ -1021,6 +1056,30 @@ def _validate_facts(
             log.debug("_validate_facts: rejecting %s on confirmed_action fact", intent)
             continue
 
+        # Rule 4b: cannot consolidate against an existing confirmation
+        # row. A confirmation is a load-bearing storage artifact (the
+        # timestamp and the confirmation_quote both matter) that must
+        # not be erased by an update_of from a non-confirmation fact.
+        # Defends against the case where a free-form tag space lets the
+        # LLM emit a synonym tag (`confirmation`, `confirmed`,
+        # `user_confirmed`, ...) that bypasses Rule 4 above. Rule 4
+        # checks the NEW fact's tags; this rule checks the EXISTING
+        # row's tags, looked up via candidate_metadata. The schema's
+        # prior closed enum implicitly defended this gate by making
+        # synonym tags impossible at the CLI boundary; with the enum
+        # dropped (issue #414), the validator carries that contract
+        # explicitly.
+        if intent in ("skip_redundant", "update_of") and isinstance(existing_id, str):
+            existing_meta = candidate_metadata.get(existing_id, {})
+            existing_tags = existing_meta.get("tags") or []
+            if "confirmed_action" in existing_tags:
+                log.debug(
+                    "_validate_facts: rejecting %s against existing confirmed_action row %s",
+                    intent,
+                    existing_id,
+                )
+                continue
+
         # Rule 5: existing-id uniqueness across the batch. Pre-counted
         # above so this check is O(1) per fact. Only non-`new` facts
         # are subject to the rule because a `new` fact without an
@@ -1099,6 +1158,7 @@ async def _run_extractor(
     config: Config,
     *,
     candidate_ids: set[str],
+    candidate_metadata: dict[str, dict],
     user_id: str,
 ) -> ExtractionResult:
     """
@@ -1261,7 +1321,7 @@ async def _run_extractor(
     facts_raw = payload_root.get("facts") or []
     has_episode = bool(payload_root.get("has_episode"))
     return ExtractionResult(
-        facts=_validate_facts(facts_raw, candidate_ids, user_id),
+        facts=_validate_facts(facts_raw, candidate_ids, candidate_metadata, user_id),
         has_episode=has_episode,
     )
 
@@ -1885,6 +1945,12 @@ async def extract_and_store(
                 # to the documented contract (a list).
                 candidates = candidates or []
             candidate_id_set: set[str] = {c.id for c in candidates}
+            # Per-id metadata lookup for `_validate_facts` Rule 4b
+            # (issue #414): the rule needs the existing row's stored
+            # tags to detect a confirmation row being consolidated by
+            # a synonym-tagged fact. The full `candidates` list is
+            # already in scope, so building the dict here is one line.
+            candidate_metadata: dict[str, dict] = {c.id: c.metadata for c in candidates}
             # Emit the candidate-set log line exactly once per
             # extraction call, AFTER the fetch and BEFORE the
             # subprocess spawn. Always emitted (even when empty) so
@@ -1911,6 +1977,7 @@ async def extract_and_store(
                 payload,
                 config,
                 candidate_ids=candidate_id_set,
+                candidate_metadata=candidate_metadata,
                 user_id=user_id,
             )
             # Restructured for stage-2 (issue #385): facts and has_episode

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1070,7 +1070,13 @@ def _validate_facts(
         # synonym tags impossible at the CLI boundary; with the enum
         # dropped (issue #414), the validator carries that contract
         # explicitly.
-        if intent in ("skip_redundant", "update_of") and isinstance(existing_id, str):
+        if intent in ("skip_redundant", "update_of"):
+            # Rule 3 already guaranteed `existing_id` is a non-empty
+            # str on this branch, so no isinstance guard here. The
+            # `.get(..., {})` default covers the case where Mem0
+            # returned a candidate with no metadata payload at all
+            # (the metadata key is conditionally absent on rows with
+            # no extra payload, per mem0/memory/main.py).
             existing_meta = candidate_metadata.get(existing_id, {})
             existing_tags = existing_meta.get("tags") or []
             if "confirmed_action" in existing_tags:
@@ -1948,18 +1954,12 @@ async def extract_and_store(
             candidate_id_set: set[str] = {c.id for c in candidates}
             # Per-id metadata lookup for `_validate_facts` Rule 4b
             # (issue #414): the rule needs the existing row's stored
-            # tags to detect a confirmation row being consolidated by
-            # a synonym-tagged fact. The full `candidates` list is
-            # already in scope, so building the dict here is one line.
-            # `or {}` at construction collapses any null metadata
-            # payload to an empty dict so the `dict[str, dict]`
-            # annotation is truthful and Rule 4b's lookup can stay
-            # clean (no second `or {}` at the consumer site). The
-            # MemoryResult dataclass types metadata as `dict` rather
-            # than `dict | None`, so this defends against a direct-
-            # construction type violation rather than a real runtime
-            # path - cheap insurance.
-            candidate_metadata: dict[str, dict] = {c.id: c.metadata or {} for c in candidates}
+            # tags to detect a confirmation row being consolidated
+            # by a synonym-tagged fact. The full `candidates` list
+            # is already in scope, so building the dict here is one
+            # line. `MemoryResult.metadata` is typed `dict`, so the
+            # comprehension produces a real `dict[str, dict]`.
+            candidate_metadata: dict[str, dict] = {c.id: c.metadata for c in candidates}
             # Emit the candidate-set log line exactly once per
             # extraction call, AFTER the fetch and BEFORE the
             # subprocess spawn. Always emitted (even when empty) so

--- a/tests/test_episode_classifier_eval.py
+++ b/tests/test_episode_classifier_eval.py
@@ -107,7 +107,9 @@ async def test_episode_classifier_precision_recall():
         payload = _build_extraction_payload(user, assistant, [])
         start = time.monotonic()
         try:
-            result = await _run_extractor(payload, config, candidate_ids=set(), user_id=f"eval-{item_id}")
+            result = await _run_extractor(
+                payload, config, candidate_ids=set(), candidate_metadata={}, user_id=f"eval-{item_id}"
+            )
             predicted: bool = result.has_episode
             error: str | None = None
         except Exception as e:

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -2100,20 +2100,3 @@ class TestCallbackDispatch:
         assert upd.callback_query.answer.await_count == 1
         toast = upd.callback_query.answer.call_args.args[0]
         assert toast == memory_command._MSG_QUERY_FAILED
-
-
-# ── Tag enum drift guard ───────────────────────────────────────────
-
-
-def test_tag_enum_matches_extraction_schema():
-    """The `_TAG_ENUM` mirror must stay in sync with the schema source.
-
-    Drift would silently exclude valid tags from `/memory stats`
-    (a tag with rows but no enum entry would never appear). Both
-    lists are short and unlikely to change often, but a unit test
-    catches the next time they do.
-    """
-    from kai.memory_extraction import _FACT_SCHEMA
-
-    schema_enum = tuple(_FACT_SCHEMA["properties"]["facts"]["items"]["properties"]["tags"]["items"]["enum"])
-    assert schema_enum == memory_command._TAG_ENUM

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -187,7 +187,7 @@ class TestExtractionResultClassifier:
             return _make_proc(stdout=_stage1_envelope(facts=[], has_episode=True))
 
         monkeypatch.setattr(memory_extraction.asyncio, "create_subprocess_exec", _fake_exec)
-        result = await _run_extractor("payload", _cfg(), candidate_ids=set(), user_id="u1")
+        result = await _run_extractor("payload", _cfg(), candidate_ids=set(), candidate_metadata={}, user_id="u1")
         assert isinstance(result, ExtractionResult)
         assert result.has_episode is True
         assert result.facts == []
@@ -202,7 +202,7 @@ class TestExtractionResultClassifier:
             return _make_proc(stdout=_stage1_envelope(facts=[], has_episode=False))
 
         monkeypatch.setattr(memory_extraction.asyncio, "create_subprocess_exec", _fake_exec)
-        result = await _run_extractor("payload", _cfg(), candidate_ids=set(), user_id="u1")
+        result = await _run_extractor("payload", _cfg(), candidate_ids=set(), candidate_metadata={}, user_id="u1")
         assert result.has_episode is False
 
     @pytest.mark.asyncio
@@ -228,7 +228,7 @@ class TestExtractionResultClassifier:
             return build_proc()
 
         monkeypatch.setattr(memory_extraction.asyncio, "create_subprocess_exec", _fake_exec)
-        result = await _run_extractor("payload", _cfg(), candidate_ids=set(), user_id="u1")
+        result = await _run_extractor("payload", _cfg(), candidate_ids=set(), candidate_metadata={}, user_id="u1")
         assert result.has_episode is False
         assert result.facts == []
 

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -383,7 +383,7 @@ class TestValidateFacts:
                 "intent": "new",
             }
         ]
-        assert _validate_facts(facts, set(), {}, "u-test") == facts
+        assert _validate_facts(facts, set(), candidate_metadata={}, user_id="u-test") == facts
 
     def test_valid_confirmed_action_fact_passes(self):
         quote = "I see PR #299 is merged, thanks"
@@ -397,7 +397,7 @@ class TestValidateFacts:
                 "intent": "new",
             }
         ]
-        assert _validate_facts(facts, set(), {}, "u-test") == facts
+        assert _validate_facts(facts, set(), candidate_metadata={}, user_id="u-test") == facts
 
     def test_confirmed_action_without_quote_rejected(self):
         facts = [
@@ -408,7 +408,7 @@ class TestValidateFacts:
                 "intent": "new",
             }
         ]
-        assert _validate_facts(facts, set(), {}, "u-test") == []
+        assert _validate_facts(facts, set(), candidate_metadata={}, user_id="u-test") == []
 
     def test_confirmed_action_with_short_quote_rejected(self):
         """A quote shorter than _CONFIRMATION_QUOTE_MIN_CHARS (20) is
@@ -422,7 +422,7 @@ class TestValidateFacts:
                 "intent": "new",
             }
         ]
-        assert _validate_facts(facts, set(), {}, "u-test") == []
+        assert _validate_facts(facts, set(), candidate_metadata={}, user_id="u-test") == []
 
     @pytest.mark.parametrize(
         "quote",
@@ -461,7 +461,9 @@ class TestValidateFacts:
                 "intent": "new",
             }
         ]
-        assert _validate_facts(facts_bare, set(), {}, "u-test") == [], f"{quote!r} should be rejected"
+        assert _validate_facts(facts_bare, set(), candidate_metadata={}, user_id="u-test") == [], (
+            f"{quote!r} should be rejected"
+        )
         assert padded  # silence unused-var; padded is the name-only form
 
     def test_regex_fullmatch_behavior_only_rejects_pure_generic(self):
@@ -485,17 +487,17 @@ class TestValidateFacts:
                 "intent": "new",
             }
         ]
-        assert _validate_facts(facts, set(), {}, "u-test") == []
+        assert _validate_facts(facts, set(), candidate_metadata={}, user_id="u-test") == []
 
     def test_non_dict_fact_skipped(self):
         """Defensive: schema guarantees dicts but a future
         subprocess-response change should not crash the loop."""
-        assert _validate_facts([None, "string", 42], set(), {}, "u-test") == []
+        assert _validate_facts([None, "string", 42], set(), candidate_metadata={}, user_id="u-test") == []
 
     def test_mixed_batch_keeps_valid_drops_invalid(self):
         good = {"content": "X", "tags": ["preference"], "confidence": 0.9, "intent": "new"}
         bad = {"content": "Y", "tags": ["confirmed_action"], "confidence": 0.8, "intent": "new"}
-        result = _validate_facts([good, bad], set(), {}, "u-test")
+        result = _validate_facts([good, bad], set(), candidate_metadata={}, user_id="u-test")
         assert result == [good]
 
 
@@ -1377,11 +1379,11 @@ class TestValidateFactsConsolidation:
     def test_rule1_unknown_intent_rejected(self):
         """Rule 1 defense-in-depth against a future schema regression."""
         facts = [{"content": "x", "tags": ["fact"], "confidence": 0.9, "intent": "merge"}]
-        assert _validate_facts(facts, set(), {}, "u1") == []
+        assert _validate_facts(facts, set(), candidate_metadata={}, user_id="u1") == []
 
     def test_rule1_missing_intent_rejected(self):
         facts = [{"content": "x", "tags": ["fact"], "confidence": 0.9}]
-        assert _validate_facts(facts, set(), {}, "u1") == []
+        assert _validate_facts(facts, set(), candidate_metadata={}, user_id="u1") == []
 
     def test_rule2_new_with_existing_id_rejected(self):
         facts = [
@@ -1393,12 +1395,12 @@ class TestValidateFactsConsolidation:
                 "existing_id": "stray-id",
             }
         ]
-        assert _validate_facts(facts, {"stray-id"}, {}, "u1") == []
+        assert _validate_facts(facts, {"stray-id"}, candidate_metadata={}, user_id="u1") == []
 
     def test_rule3_update_of_missing_id_rejected_silently(self, caplog):
         facts = [{"content": "x", "tags": ["fact"], "confidence": 0.9, "intent": "update_of"}]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            assert _validate_facts(facts, set(), {}, "u1") == []
+            assert _validate_facts(facts, set(), candidate_metadata={}, user_id="u1") == []
         # Missing id is a schema-shape violation, NOT a real
         # classification decision - so no consolidate.intent line.
         assert not any("memory.consolidate.intent" in r.getMessage() for r in caplog.records)
@@ -1418,7 +1420,7 @@ class TestValidateFactsConsolidation:
             }
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            assert _validate_facts(facts, {"real-id"}, {}, "u1") == []
+            assert _validate_facts(facts, {"real-id"}, candidate_metadata={}, user_id="u1") == []
         record = next(r for r in caplog.records if "memory.consolidate.intent" in r.getMessage())
         json_part = record.getMessage().split("memory.consolidate.intent ", 1)[1]
         payload = json.loads(json_part)
@@ -1440,7 +1442,7 @@ class TestValidateFactsConsolidation:
             }
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            _validate_facts(facts, {"real-id"}, {}, "u1")
+            _validate_facts(facts, {"real-id"}, candidate_metadata={}, user_id="u1")
         record = next(r for r in caplog.records if "memory.consolidate.intent" in r.getMessage())
         payload = json.loads(record.getMessage().split("memory.consolidate.intent ", 1)[1])
         assert payload["original_intent"] == "skip_redundant"
@@ -1457,7 +1459,7 @@ class TestValidateFactsConsolidation:
             }
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            assert _validate_facts(facts, {"real-id"}, {}, "u1") == []
+            assert _validate_facts(facts, {"real-id"}, candidate_metadata={}, user_id="u1") == []
         # Rule 4 is DEBUG-only, no consolidate.intent.
         assert not any("memory.consolidate.intent" in r.getMessage() for r in caplog.records)
 
@@ -1479,7 +1481,7 @@ class TestValidateFactsConsolidation:
             }
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            assert _validate_facts(facts, {"prior-confirmation-id"}, {}, "u1") == []
+            assert _validate_facts(facts, {"prior-confirmation-id"}, candidate_metadata={}, user_id="u1") == []
         # Rule 4 is DEBUG-only - consistent with skip_redundant case above.
         assert not any("memory.consolidate.intent" in r.getMessage() for r in caplog.records)
 
@@ -1501,7 +1503,7 @@ class TestValidateFactsConsolidation:
             },
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            assert _validate_facts(facts, {"shared-id"}, {}, "u1") == []
+            assert _validate_facts(facts, {"shared-id"}, candidate_metadata={}, user_id="u1") == []
         # Rule 5 is DEBUG-only AND deliberately avoids double-logging
         # the pair: zero consolidate.intent lines, not two.
         assert not any("memory.consolidate.intent" in r.getMessage() for r in caplog.records)
@@ -1519,7 +1521,7 @@ class TestValidateFactsConsolidation:
                 "existing_id": "unique-id",
             }
         ]
-        result = _validate_facts(facts, {"unique-id"}, {}, "u1")
+        result = _validate_facts(facts, {"unique-id"}, candidate_metadata={}, user_id="u1")
         assert len(result) == 1
 
     def test_empty_candidate_set_drops_non_new_via_rule3(self, caplog):
@@ -1536,7 +1538,7 @@ class TestValidateFactsConsolidation:
             }
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            assert _validate_facts(facts, set(), {}, "u1") == []
+            assert _validate_facts(facts, set(), candidate_metadata={}, user_id="u1") == []
         # Rule 3 fires (the model decided update_of, we couldn't anchor it).
         record = next(r for r in caplog.records if "memory.consolidate.intent" in r.getMessage())
         payload = json.loads(record.getMessage().split("memory.consolidate.intent ", 1)[1])
@@ -1557,7 +1559,7 @@ class TestValidateFactsConsolidation:
             }
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            _validate_facts(facts, {"real-id"}, {}, "user-12345")
+            _validate_facts(facts, {"real-id"}, candidate_metadata={}, user_id="user-12345")
         record = next(r for r in caplog.records if "memory.consolidate.intent" in r.getMessage())
         payload = json.loads(record.getMessage().split("memory.consolidate.intent ", 1)[1])
         assert payload["user_id"] == "user-12345"
@@ -2309,24 +2311,20 @@ class TestExtractionPromptSoftVocab:
     )
 
     def test_extraction_prompt_seeds_exactly_nine_preferred_tags(self):
-        """The seed names exactly the nine prior-enum values; no
-        more, no fewer. Tightens vs. a "contains all nine" pin so
-        a future edit that adds a tenth seed value (which would be
-        a vocabulary-design judgment call orthogonal to Sub A)
-        trips the assertion."""
-        # Whitespace-normalize the entire prompt before locating
-        # the seed sentence, since the prompt wraps lines and the
-        # sentinel spans a newline (`Use these preferred tags\n
-        # when one fits the fact:`).
+        """The seed names exactly the nine prior-enum values in
+        the documented order. Pin via a literal substring after
+        whitespace-normalizing the prompt (the seed list wraps
+        across lines in the source). A literal-substring pin is
+        more robust than parsing-up-to-the-next-period, which
+        would break if a future prompt edit introduces an
+        abbreviation period inside the seed region."""
         normalized = " ".join(_EXTRACTION_SYSTEM_PROMPT.split())
-        sentinel = "Use these preferred tags when one fits the fact: "
-        assert sentinel in normalized, "seed sentence missing"
-        idx = normalized.index(sentinel) + len(sentinel)
-        # Read until the next period that ends the sentence.
-        end = normalized.index(".", idx)
-        listed = normalized[idx:end]
-        names = tuple(t.strip() for t in listed.split(","))
-        assert names == self._PREFERRED_TAGS
+        expected = (
+            "Use these preferred tags when one fits the fact: "
+            "preference, decision, fact, constraint, confirmed_action, "
+            "project, location, schedule, relationship."
+        )
+        assert expected in normalized
 
     def test_extraction_prompt_includes_synonym_prohibition(self):
         """Pins all four synonyms named in the spec so a future
@@ -2383,7 +2381,7 @@ class TestValidateFactsRule4b:
                 "intent": "new",
             }
         ]
-        assert _validate_facts(facts, set(), {}, "u-test") == facts
+        assert _validate_facts(facts, set(), candidate_metadata={}, user_id="u-test") == facts
 
     def test_validate_facts_rejects_update_of_against_existing_confirmation_row(self):
         """A new fact with synonym tags + intent=update_of cites an
@@ -2402,7 +2400,7 @@ class TestValidateFactsRule4b:
         ]
         candidate_ids = {"prior-conf"}
         candidate_metadata = {"prior-conf": {"tags": ["confirmed_action"], "source": "extracted"}}
-        assert _validate_facts(facts, candidate_ids, candidate_metadata, "u-test") == []
+        assert _validate_facts(facts, candidate_ids, candidate_metadata=candidate_metadata, user_id="u-test") == []
 
     def test_validate_facts_rejects_skip_redundant_against_existing_confirmation_row(self):
         """Mirror of the update_of case: the second consolidation
@@ -2418,7 +2416,7 @@ class TestValidateFactsRule4b:
         ]
         candidate_ids = {"prior-conf"}
         candidate_metadata = {"prior-conf": {"tags": ["confirmed_action"], "source": "extracted"}}
-        assert _validate_facts(facts, candidate_ids, candidate_metadata, "u-test") == []
+        assert _validate_facts(facts, candidate_ids, candidate_metadata=candidate_metadata, user_id="u-test") == []
 
     def test_validate_facts_allows_update_of_against_non_confirmation_row(self):
         """Pins the negative-space contract for Rule 4b: only
@@ -2438,4 +2436,4 @@ class TestValidateFactsRule4b:
         ]
         candidate_ids = {"prior-pref"}
         candidate_metadata = {"prior-pref": {"tags": ["preference"], "source": "extracted"}}
-        assert _validate_facts(facts, candidate_ids, candidate_metadata, "u-test") == facts
+        assert _validate_facts(facts, candidate_ids, candidate_metadata=candidate_metadata, user_id="u-test") == facts

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -2327,11 +2327,12 @@ class TestExtractionPromptSoftVocab:
         assert expected in normalized
 
     def test_extraction_prompt_includes_synonym_prohibition(self):
-        """Pins all four synonyms named in the spec so a future
-        prompt edit that drops one cannot weaken the synonym
-        prohibition surface without tripping a test. The looser
-        "at least three" bar from v2 of the spec was a regression
-        magnet."""
+        """Pins all four synonyms named in the prompt's synonym
+        prohibition list so a future prompt edit that drops one
+        cannot weaken the prohibition surface without tripping a
+        test. An earlier 'at least three' formulation was a
+        regression magnet; the test must mirror the prompt's
+        contract exactly to be useful."""
         # Whitespace-normalize before the magic-string callout
         # check so the assertion holds whether the prompt wraps
         # "MUST use the literal tag `confirmed_action`" across a
@@ -2350,12 +2351,13 @@ class TestExtractionPromptSoftVocab:
         assert _EXTRACTION_PROMPT_VERSION == "5"
 
     def test_extraction_prompt_version_history_extended(self):
-        """The version-history block at memory_extraction.py:38-52
-        is a sequence of `#` comments, NOT a module docstring;
-        importable runtime state cannot capture it. Read source
-        text and grep for the unique D3 fragment so a future
-        unrelated edit that introduces a `v5:` token elsewhere
-        cannot satisfy this test vacuously."""
+        """The prompt-version history comment block (the sequence
+        of `#` comments preceding `_EXTRACTION_PROMPT_VERSION`) is
+        NOT a module docstring; importable runtime state cannot
+        capture it. Read source text and grep for the unique
+        history fragment so a future unrelated edit that
+        introduces a `v5:` token elsewhere cannot satisfy this
+        test vacuously."""
         from pathlib import Path
 
         import kai.memory_extraction

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -383,7 +383,7 @@ class TestValidateFacts:
                 "intent": "new",
             }
         ]
-        assert _validate_facts(facts, set(), "u-test") == facts
+        assert _validate_facts(facts, set(), {}, "u-test") == facts
 
     def test_valid_confirmed_action_fact_passes(self):
         quote = "I see PR #299 is merged, thanks"
@@ -397,7 +397,7 @@ class TestValidateFacts:
                 "intent": "new",
             }
         ]
-        assert _validate_facts(facts, set(), "u-test") == facts
+        assert _validate_facts(facts, set(), {}, "u-test") == facts
 
     def test_confirmed_action_without_quote_rejected(self):
         facts = [
@@ -408,7 +408,7 @@ class TestValidateFacts:
                 "intent": "new",
             }
         ]
-        assert _validate_facts(facts, set(), "u-test") == []
+        assert _validate_facts(facts, set(), {}, "u-test") == []
 
     def test_confirmed_action_with_short_quote_rejected(self):
         """A quote shorter than _CONFIRMATION_QUOTE_MIN_CHARS (20) is
@@ -422,7 +422,7 @@ class TestValidateFacts:
                 "intent": "new",
             }
         ]
-        assert _validate_facts(facts, set(), "u-test") == []
+        assert _validate_facts(facts, set(), {}, "u-test") == []
 
     @pytest.mark.parametrize(
         "quote",
@@ -461,7 +461,7 @@ class TestValidateFacts:
                 "intent": "new",
             }
         ]
-        assert _validate_facts(facts_bare, set(), "u-test") == [], f"{quote!r} should be rejected"
+        assert _validate_facts(facts_bare, set(), {}, "u-test") == [], f"{quote!r} should be rejected"
         assert padded  # silence unused-var; padded is the name-only form
 
     def test_regex_fullmatch_behavior_only_rejects_pure_generic(self):
@@ -485,17 +485,17 @@ class TestValidateFacts:
                 "intent": "new",
             }
         ]
-        assert _validate_facts(facts, set(), "u-test") == []
+        assert _validate_facts(facts, set(), {}, "u-test") == []
 
     def test_non_dict_fact_skipped(self):
         """Defensive: schema guarantees dicts but a future
         subprocess-response change should not crash the loop."""
-        assert _validate_facts([None, "string", 42], set(), "u-test") == []
+        assert _validate_facts([None, "string", 42], set(), {}, "u-test") == []
 
     def test_mixed_batch_keeps_valid_drops_invalid(self):
         good = {"content": "X", "tags": ["preference"], "confidence": 0.9, "intent": "new"}
         bad = {"content": "Y", "tags": ["confirmed_action"], "confidence": 0.8, "intent": "new"}
-        result = _validate_facts([good, bad], set(), "u-test")
+        result = _validate_facts([good, bad], set(), {}, "u-test")
         assert result == [good]
 
 
@@ -1377,11 +1377,11 @@ class TestValidateFactsConsolidation:
     def test_rule1_unknown_intent_rejected(self):
         """Rule 1 defense-in-depth against a future schema regression."""
         facts = [{"content": "x", "tags": ["fact"], "confidence": 0.9, "intent": "merge"}]
-        assert _validate_facts(facts, set(), "u1") == []
+        assert _validate_facts(facts, set(), {}, "u1") == []
 
     def test_rule1_missing_intent_rejected(self):
         facts = [{"content": "x", "tags": ["fact"], "confidence": 0.9}]
-        assert _validate_facts(facts, set(), "u1") == []
+        assert _validate_facts(facts, set(), {}, "u1") == []
 
     def test_rule2_new_with_existing_id_rejected(self):
         facts = [
@@ -1393,12 +1393,12 @@ class TestValidateFactsConsolidation:
                 "existing_id": "stray-id",
             }
         ]
-        assert _validate_facts(facts, {"stray-id"}, "u1") == []
+        assert _validate_facts(facts, {"stray-id"}, {}, "u1") == []
 
     def test_rule3_update_of_missing_id_rejected_silently(self, caplog):
         facts = [{"content": "x", "tags": ["fact"], "confidence": 0.9, "intent": "update_of"}]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            assert _validate_facts(facts, set(), "u1") == []
+            assert _validate_facts(facts, set(), {}, "u1") == []
         # Missing id is a schema-shape violation, NOT a real
         # classification decision - so no consolidate.intent line.
         assert not any("memory.consolidate.intent" in r.getMessage() for r in caplog.records)
@@ -1418,7 +1418,7 @@ class TestValidateFactsConsolidation:
             }
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            assert _validate_facts(facts, {"real-id"}, "u1") == []
+            assert _validate_facts(facts, {"real-id"}, {}, "u1") == []
         record = next(r for r in caplog.records if "memory.consolidate.intent" in r.getMessage())
         json_part = record.getMessage().split("memory.consolidate.intent ", 1)[1]
         payload = json.loads(json_part)
@@ -1440,7 +1440,7 @@ class TestValidateFactsConsolidation:
             }
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            _validate_facts(facts, {"real-id"}, "u1")
+            _validate_facts(facts, {"real-id"}, {}, "u1")
         record = next(r for r in caplog.records if "memory.consolidate.intent" in r.getMessage())
         payload = json.loads(record.getMessage().split("memory.consolidate.intent ", 1)[1])
         assert payload["original_intent"] == "skip_redundant"
@@ -1457,7 +1457,7 @@ class TestValidateFactsConsolidation:
             }
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            assert _validate_facts(facts, {"real-id"}, "u1") == []
+            assert _validate_facts(facts, {"real-id"}, {}, "u1") == []
         # Rule 4 is DEBUG-only, no consolidate.intent.
         assert not any("memory.consolidate.intent" in r.getMessage() for r in caplog.records)
 
@@ -1479,7 +1479,7 @@ class TestValidateFactsConsolidation:
             }
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            assert _validate_facts(facts, {"prior-confirmation-id"}, "u1") == []
+            assert _validate_facts(facts, {"prior-confirmation-id"}, {}, "u1") == []
         # Rule 4 is DEBUG-only - consistent with skip_redundant case above.
         assert not any("memory.consolidate.intent" in r.getMessage() for r in caplog.records)
 
@@ -1501,7 +1501,7 @@ class TestValidateFactsConsolidation:
             },
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            assert _validate_facts(facts, {"shared-id"}, "u1") == []
+            assert _validate_facts(facts, {"shared-id"}, {}, "u1") == []
         # Rule 5 is DEBUG-only AND deliberately avoids double-logging
         # the pair: zero consolidate.intent lines, not two.
         assert not any("memory.consolidate.intent" in r.getMessage() for r in caplog.records)
@@ -1519,7 +1519,7 @@ class TestValidateFactsConsolidation:
                 "existing_id": "unique-id",
             }
         ]
-        result = _validate_facts(facts, {"unique-id"}, "u1")
+        result = _validate_facts(facts, {"unique-id"}, {}, "u1")
         assert len(result) == 1
 
     def test_empty_candidate_set_drops_non_new_via_rule3(self, caplog):
@@ -1536,7 +1536,7 @@ class TestValidateFactsConsolidation:
             }
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            assert _validate_facts(facts, set(), "u1") == []
+            assert _validate_facts(facts, set(), {}, "u1") == []
         # Rule 3 fires (the model decided update_of, we couldn't anchor it).
         record = next(r for r in caplog.records if "memory.consolidate.intent" in r.getMessage())
         payload = json.loads(record.getMessage().split("memory.consolidate.intent ", 1)[1])
@@ -1557,7 +1557,7 @@ class TestValidateFactsConsolidation:
             }
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            _validate_facts(facts, {"real-id"}, "user-12345")
+            _validate_facts(facts, {"real-id"}, {}, "user-12345")
         record = next(r for r in caplog.records if "memory.consolidate.intent" in r.getMessage())
         payload = json.loads(record.getMessage().split("memory.consolidate.intent ", 1)[1])
         assert payload["user_id"] == "user-12345"
@@ -2247,3 +2247,195 @@ class TestPayloadSizeBound:
         # catching any future change that grows the payload by
         # hundreds of chars.
         assert len(payload) < 7800
+
+
+# ── Issue #414: free-form fact tags ────────────────────────────────
+
+
+class TestFactSchemaFreeFormTags:
+    """The fact-extraction schema dropped its closed-vocab tag enum
+    in favor of a free-form string array matching the episode schema.
+    These tests pin the schema shape, the array bounds, and the prompt
+    seed so a future regression that re-introduces the enum or alters
+    the soft-vocab guidance is caught at the unit-test boundary."""
+
+    def test_fact_schema_tags_field_is_free_form(self):
+        """The closed enum is gone; the items shape mirrors the
+        episode schema (type + length bounds, no enum)."""
+        from kai.memory_extraction import _EPISODE_SCHEMA
+
+        items = _FACT_SCHEMA["properties"]["facts"]["items"]["properties"]["tags"]["items"]
+        assert "enum" not in items, "fact tags must be free-form post-#414"
+        assert items["type"] == "string"
+        assert items["minLength"] == 1
+        assert items["maxLength"] == 50
+
+        # Mirror the episode schema's tag-item shape exactly.
+        episode_items = _EPISODE_SCHEMA["properties"]["episode"]["properties"]["tags"]["items"]
+        assert items == episode_items
+
+    def test_fact_schema_tag_array_bounds_match_episode(self):
+        """maxItems was raised from 4 to 5 to match the episode
+        schema per the parent issue's "single tag taxonomy"
+        decision. minItems unchanged at 1."""
+        from kai.memory_extraction import _EPISODE_SCHEMA
+
+        fact_tags = _FACT_SCHEMA["properties"]["facts"]["items"]["properties"]["tags"]
+        episode_tags = _EPISODE_SCHEMA["properties"]["episode"]["properties"]["tags"]
+        assert fact_tags["minItems"] == 1
+        assert fact_tags["maxItems"] == 5
+        assert fact_tags["minItems"] == episode_tags["minItems"]
+        assert fact_tags["maxItems"] == episode_tags["maxItems"]
+
+
+class TestExtractionPromptSoftVocab:
+    """Pins the soft-vocab seed list and the synonym-prohibition
+    paragraph in the stage-1 system prompt. The prompt is the only
+    enforcement mechanism for tag vocabulary now that the schema is
+    free-form, so silent prompt regressions are dangerous."""
+
+    # The exact preferred-tag list seeded in the prompt. Pre-#414
+    # closed-vocab enum, now advisory.
+    _PREFERRED_TAGS = (
+        "preference",
+        "decision",
+        "fact",
+        "constraint",
+        "confirmed_action",
+        "project",
+        "location",
+        "schedule",
+        "relationship",
+    )
+
+    def test_extraction_prompt_seeds_exactly_nine_preferred_tags(self):
+        """The seed names exactly the nine prior-enum values; no
+        more, no fewer. Tightens vs. a "contains all nine" pin so
+        a future edit that adds a tenth seed value (which would be
+        a vocabulary-design judgment call orthogonal to Sub A)
+        trips the assertion."""
+        # Whitespace-normalize the entire prompt before locating
+        # the seed sentence, since the prompt wraps lines and the
+        # sentinel spans a newline (`Use these preferred tags\n
+        # when one fits the fact:`).
+        normalized = " ".join(_EXTRACTION_SYSTEM_PROMPT.split())
+        sentinel = "Use these preferred tags when one fits the fact: "
+        assert sentinel in normalized, "seed sentence missing"
+        idx = normalized.index(sentinel) + len(sentinel)
+        # Read until the next period that ends the sentence.
+        end = normalized.index(".", idx)
+        listed = normalized[idx:end]
+        names = tuple(t.strip() for t in listed.split(","))
+        assert names == self._PREFERRED_TAGS
+
+    def test_extraction_prompt_includes_synonym_prohibition(self):
+        """Pins all four synonyms named in the spec so a future
+        prompt edit that drops one cannot weaken the synonym
+        prohibition surface without tripping a test. The looser
+        "at least three" bar from v2 of the spec was a regression
+        magnet."""
+        # The magic-string callout itself.
+        assert "structurally significant" in _EXTRACTION_SYSTEM_PROMPT
+        assert "MUST use the literal tag\n  `confirmed_action`" in _EXTRACTION_SYSTEM_PROMPT or (
+            "MUST use the literal tag `confirmed_action`" in _EXTRACTION_SYSTEM_PROMPT
+        )
+        # All four synonyms named in D2.
+        for synonym in ("confirmation", "confirmed", "user_confirmed", "confirm"):
+            assert f"`{synonym}`" in _EXTRACTION_SYSTEM_PROMPT, f"synonym `{synonym}` missing"
+
+    def test_extraction_prompt_version_bumped(self):
+        """The version stamp on every fact's metadata; bumped
+        because the schema and prompt changed in tandem."""
+        assert _EXTRACTION_PROMPT_VERSION == "5"
+
+    def test_extraction_prompt_version_history_extended(self):
+        """The version-history block at memory_extraction.py:38-52
+        is a sequence of `#` comments, NOT a module docstring;
+        importable runtime state cannot capture it. Read source
+        text and grep for the unique D3 fragment so a future
+        unrelated edit that introduces a `v5:` token elsewhere
+        cannot satisfy this test vacuously."""
+        from pathlib import Path
+
+        import kai.memory_extraction
+
+        src = Path(kai.memory_extraction.__file__).read_text()
+        assert "v5: free-form tag schema (enum dropped)" in src
+
+
+class TestValidateFactsRule4b:
+    """Rule 4b protects the consolidation gate against synonym-tagged
+    updates of existing confirmation rows. The schema's prior closed
+    enum implicitly defended this gate by making synonym tags
+    impossible at the CLI boundary; with the enum dropped, the rule
+    is the explicit defense."""
+
+    def test_validate_facts_accepts_free_form_tags(self):
+        """A fact tagged with a value outside the prior nine
+        survives validation. Closes the negative-space contract:
+        with the schema's enum removed, the validator no longer
+        rejects free-form tags."""
+        facts = [
+            {
+                "content": "User uses Vault for credentials.",
+                "tags": ["tooling"],
+                "confidence": 0.9,
+                "intent": "new",
+            }
+        ]
+        assert _validate_facts(facts, set(), {}, "u-test") == facts
+
+    def test_validate_facts_rejects_update_of_against_existing_confirmation_row(self):
+        """A new fact with synonym tags + intent=update_of cites an
+        existing row whose stored tags include `confirmed_action`.
+        Rule 4 (which keys off the new fact's tags) does not fire,
+        but Rule 4b reads the existing row's tags via
+        candidate_metadata and rejects."""
+        facts = [
+            {
+                "content": "User confirmed the build.",
+                "tags": ["confirmation"],
+                "confidence": 0.9,
+                "intent": "update_of",
+                "existing_id": "prior-conf",
+            }
+        ]
+        candidate_ids = {"prior-conf"}
+        candidate_metadata = {"prior-conf": {"tags": ["confirmed_action"], "source": "extracted"}}
+        assert _validate_facts(facts, candidate_ids, candidate_metadata, "u-test") == []
+
+    def test_validate_facts_rejects_skip_redundant_against_existing_confirmation_row(self):
+        """Mirror of the update_of case: the second consolidation
+        intent gets the same Rule 4b rejection."""
+        facts = [
+            {
+                "content": "User confirmed the build (again).",
+                "tags": ["confirmation"],
+                "confidence": 0.9,
+                "intent": "skip_redundant",
+                "existing_id": "prior-conf",
+            }
+        ]
+        candidate_ids = {"prior-conf"}
+        candidate_metadata = {"prior-conf": {"tags": ["confirmed_action"], "source": "extracted"}}
+        assert _validate_facts(facts, candidate_ids, candidate_metadata, "u-test") == []
+
+    def test_validate_facts_allows_update_of_against_non_confirmation_row(self):
+        """Pins the negative-space contract for Rule 4b: only
+        confirmation rows trigger the gate. The new fact's tags are
+        explicitly `["preference"]` (a non-magic, on-seed value)
+        because picking `["confirmed_action"]` would trip Rule 4
+        and reject for the wrong reason - masking the negative-
+        space behavior this test verifies."""
+        facts = [
+            {
+                "content": "User now prefers Earl Grey over English Breakfast.",
+                "tags": ["preference"],
+                "confidence": 0.9,
+                "intent": "update_of",
+                "existing_id": "prior-pref",
+            }
+        ]
+        candidate_ids = {"prior-pref"}
+        candidate_metadata = {"prior-pref": {"tags": ["preference"], "source": "extracted"}}
+        assert _validate_facts(facts, candidate_ids, candidate_metadata, "u-test") == facts

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -2332,12 +2332,15 @@ class TestExtractionPromptSoftVocab:
         prohibition surface without tripping a test. The looser
         "at least three" bar from v2 of the spec was a regression
         magnet."""
-        # The magic-string callout itself.
-        assert "structurally significant" in _EXTRACTION_SYSTEM_PROMPT
-        assert "MUST use the literal tag\n  `confirmed_action`" in _EXTRACTION_SYSTEM_PROMPT or (
-            "MUST use the literal tag `confirmed_action`" in _EXTRACTION_SYSTEM_PROMPT
-        )
-        # All four synonyms named in D2.
+        # Whitespace-normalize before the magic-string callout
+        # check so the assertion holds whether the prompt wraps
+        # "MUST use the literal tag `confirmed_action`" across a
+        # newline (the current shape) or on a single line (a
+        # plausible future reformat).
+        normalized = " ".join(_EXTRACTION_SYSTEM_PROMPT.split())
+        assert "structurally significant" in normalized
+        assert "MUST use the literal tag `confirmed_action`" in normalized
+        # All four synonyms named in the prompt's prohibition list.
         for synonym in ("confirmation", "confirmed", "user_confirmed", "confirm"):
             assert f"`{synonym}`" in _EXTRACTION_SYSTEM_PROMPT, f"synonym `{synonym}` missing"
 


### PR DESCRIPTION
## Summary

- Replaces the closed-vocab tag enum on `_FACT_SCHEMA` with a free-form string array matching `_EPISODE_SCHEMA` (items free-form 1-50 chars; bounds 1-5).
- Rewrites the stage-1 extraction prompt with a soft-vocab seed paragraph (the prior nine values as preferred but advisory) and an explicit synonym-prohibition for the structurally significant `confirmed_action` magic string.
- Adds Rule 4b to `_validate_facts`: rejects `update_of` / `skip_redundant` consolidation against an existing row whose stored tags include `confirmed_action`. Defends the laundered-hallucination gate against synonym-tagged updates that would bypass Rule 4 (which keys off the new fact's tags).
- Threads a new `candidate_metadata: dict[str, dict]` parameter through `_validate_facts` and `_run_extractor`. The caller in `extract_and_store` builds it from the existing `candidates: list[MemoryResult]` already in scope.
- Bumps `_EXTRACTION_PROMPT_VERSION` 4 → 5; extends the version-history comment block.
- Folds in a pre-existing rule-4 docstring drift fix (mentioned only `skip_redundant`; code covers both consolidation intents).
- Sweeps 23 existing test call sites across `tests/test_memory_extraction.py`, `tests/test_memory_episodes.py`, and `tests/test_episode_classifier_eval.py` to add `candidate_metadata={}`. Deletes the obsolete `test_tag_enum_matches_extraction_schema`.

10 new tests across three classes pin the schema shape, the prompt seed and synonym-prohibition, the version bump and history extension, and Rule 4b's positive and negative space.

This is Sub A of #388; UI dismantle (Sub B) and periodic dedup (Sub D) remain on the parent issue's plan. Fixes #414.

## Test plan

- [x] `make test` (2655 tests pass).
- [x] `make check` (ruff lint + format).
- [ ] Smoke-test on production after deploy:
  - Send a message that triggers fact extraction. Verify the resulting Qdrant row's metadata: `tags` is an array, `prompt_version` is `"5"`.
  - Send a message stating a fact whose topic falls outside the nine-value seed (e.g., a credential preference). Verify at least one tag is a free-form value, not one of the nine seed values.
  - Send a confirmation message. Verify the row carries `tags=["confirmed_action"]` literally, not a synonym.
