### PR TITLE
feat(memory): periodic tag dedup script (#418)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ home/evals/*
 .idea/
 .vscode/
 *.swp
+
+# Tag dedup script audit logs (one per --apply run; never tracked)
+scripts/.tag-dedup-audit-*.jsonl

--- a/scripts/tag-dedup.py
+++ b/scripts/tag-dedup.py
@@ -656,11 +656,15 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.apply:
         print(f"\nTotal rewrites: {total_success} succeeded, {total_failure} failed.")
-        if total_failure > 0:
-            print(f"Audit log: {audit_log_path}", file=sys.stderr)
-            return EXIT_PARTIAL_FAILURE
+        # Audit log is only created when at least one rewrite succeeds
+        # (apply_rewrites flushes lazily). Guard the path message on
+        # total_success > 0 so an all-fail run does not direct the
+        # operator to a file that was never created.
         if total_success > 0:
-            print(f"Audit log: {audit_log_path}")
+            stream = sys.stderr if total_failure > 0 else sys.stdout
+            print(f"Audit log: {audit_log_path}", file=stream)
+        if total_failure > 0:
+            return EXIT_PARTIAL_FAILURE
 
     return EXIT_OK
 

--- a/scripts/tag-dedup.py
+++ b/scripts/tag-dedup.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""
+Periodic tag dedup script (#418, Sub D of #388).
+
+Walks the tag distribution across `source: extracted` and `source: episode`
+rows for one or more users, identifies near-duplicate tag values, and
+rewrites them to a canonical form via `memory.update_metadata`.
+
+Three near-duplicate classes ship in this version:
+  - Case-insensitive equality (`Preference` vs `preference`).
+  - Plural/singular pairs (`-s`, `-es` for sibilant endings, `-ies/-y`).
+  - Within-row deduplication after the per-cluster rewrite collapses
+    two case-variants on a single row.
+
+Default mode is dry-run. The `--apply` flag is required to write. Per-user
+scope by default; `--all-users` opts in to cross-user iteration over
+`config.allowed_user_ids` (the DM-mode assumption that user_id == chat_id
+holds for typical Kai installs; group-chat installs would need a
+chat-id-keyed iteration source).
+
+`confirmed_action` is structurally significant in the extractor pipeline.
+Two layers of defense:
+  - Cluster-skip: any cluster containing `confirmed_action` (case-insensitive)
+    is dropped before any rewrite is proposed.
+  - Row-level guard: if a row's tag list loses `confirmed_action` after the
+    per-cluster rewrite, the row is returned unchanged. The row-level guard
+    is unreachable under the cluster-skip rule but exists as defense-in-depth
+    against a future rule addition that bypasses cluster-skip.
+
+Migration rows (`source: migration`) are excluded from the dedup pass.
+They carry H3-slug tags that are not part of the LLM-tag taxonomy; merging
+them with extracted/episode tags would conflate two vocabulary spaces.
+
+Usage:
+    # Dry run, single user (recommended first step).
+    python scripts/tag-dedup.py --chat-id 12345
+
+    # Apply, single user, with interactive override prompt per cluster.
+    python scripts/tag-dedup.py --chat-id 12345 --apply
+
+    # Apply without prompts (accepts every proposed canonical form).
+    python scripts/tag-dedup.py --chat-id 12345 --apply --no-prompt
+
+    # Dry run across every authorised user.
+    python scripts/tag-dedup.py --all-users
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kai.memory import MemoryResult
+
+
+# Exit codes (documented in the script header):
+#   0 - success (dry-run completed, or apply completed with all rewrites successful)
+#   1 - unexpected error
+#   2 - memory subsystem disabled (config.memory_enabled is False)
+#   3 - one or more rewrites failed (apply mode only); audit log written for the successful subset
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_MEMORY_DISABLED = 2
+EXIT_PARTIAL_FAILURE = 3
+
+
+# Source filter: dedup acts on `extracted` and `episode` rows only.
+# Migration rows carry H3-slug tags from a different vocabulary space
+# (per the migration script's chunk-naming convention) and merging them
+# with LLM-tag taxonomy values would conflate the two spaces. The
+# `memory.update_metadata` wrapper itself admits all USER_VISIBLE_SOURCES
+# (extracted + episode + migration); the narrower scope is enforced
+# here at the script's load_rows boundary.
+DEDUP_SOURCES: frozenset[str] = frozenset({"extracted", "episode"})
+
+
+# Sibilant endings that take `-es` for the plural rather than `-s`. The
+# plural/singular rule for these endings only fires when both the
+# plural form (ending in one of these patterns) and the singular form
+# (after dropping `-es`) are observed in the corpus.
+_SIBILANT_PLURAL_SUFFIXES: tuple[str, ...] = ("xes", "shes", "ches", "zes", "sses")
+
+
+# The structurally significant tag value that the extractor and validator
+# pipeline keys off (Rules 4 and 4b in `_validate_facts`; the per-source
+# render branch in `_build_fact_view`). The dedup pass refuses to touch
+# any cluster or row that involves this string.
+_CONFIRMED_ACTION_TAG: str = "confirmed_action"
+
+
+# ── Cluster representation ─────────────────────────────────────────────
+
+
+@dataclass
+class Cluster:
+    """One near-duplicate group of tag variants with a chosen canonical.
+
+    Attributes:
+        members: The variant tag values that fall into this cluster.
+            Always at least 2 entries when the cluster is emitted from
+            `identify_clusters` (single-tag groups are not clusters).
+        canonical: The variant chosen as the cluster's target form.
+            Selected by most-frequent wins, lexicographic tiebreak.
+        total_occurrences: Sum of the per-variant counts across members.
+            Defaults to 0 so test fixtures can construct minimal
+            clusters without naming an irrelevant count value;
+            production code paths build clusters via
+            `identify_clusters` which always populates this from the
+            distribution.
+    """
+
+    members: list[str]
+    canonical: str
+    total_occurrences: int = 0
+
+
+# ── Pipeline helpers ──────────────────────────────────────────────────
+
+
+def load_rows(user_id: int) -> list[MemoryResult]:
+    """Fetch all dedup-eligible rows for `user_id` from the memory store.
+
+    Filters client-side to `metadata.source in DEDUP_SOURCES`. The
+    `limit=None` argument to `get_all` ensures a user with thousands of
+    rows still gets the complete distribution. Returns an empty list
+    when the user has no dedup-eligible rows.
+    """
+    from kai import memory
+
+    rows = memory.get_all(user_id=str(user_id), limit=None)
+    return [r for r in rows if r.metadata.get("source") in DEDUP_SOURCES]
+
+
+def compute_distribution(rows: list[MemoryResult]) -> dict[str, int]:
+    """Count case-preserved tag occurrences across every row's tag list.
+
+    A row tagged `["preference", "Preference"]` contributes 1 to each
+    of `"preference"` and `"Preference"` (case is preserved at this
+    stage so the canonical-selection step in `identify_clusters` can
+    pick the most-frequent variant). Empty or missing tag lists
+    contribute nothing.
+    """
+    distribution: dict[str, int] = {}
+    for row in rows:
+        for tag in row.metadata.get("tags") or []:
+            distribution[tag] = distribution.get(tag, 0) + 1
+    return distribution
+
+
+def _try_singular_forms(tag: str) -> list[str]:
+    """Return candidate singular forms for `tag` under the dedup rules.
+
+    Three rules in priority order:
+      - `-ies/-y`: `categories` -> `category`. Applied first so the
+        `-ies` ending does not get reduced to `categori` by the bare
+        `-s` rule below.
+      - Sibilant `-es` removal (`-xes`, `-shes`, `-ches`, `-zes`,
+        `-sses`): `boxes` -> `box`. Applied before the bare `-s` rule
+        so `boxes` does not first reduce to `boxe`.
+      - Bare `-s` removal: `preferences` -> `preference`.
+
+    Returns every candidate that the rules generate; the caller checks
+    against the corpus distribution to keep only those that match an
+    observed tag.
+    """
+    # Empty and one-character tags cannot be plurals under any rule.
+    if len(tag) < 2:
+        return []
+    candidates: list[str] = []
+    if tag.endswith("ies") and len(tag) > 3:
+        candidates.append(tag[:-3] + "y")
+    if any(tag.endswith(suffix) for suffix in _SIBILANT_PLURAL_SUFFIXES):
+        candidates.append(tag[:-2])
+    if tag.endswith("s") and not tag.endswith("ss"):
+        # The `not endswith("ss")` guard prevents stripping the second
+        # `s` from already-singular nouns like `bus` and `mass`. The
+        # bare `-s` rule only fires for genuine plural shapes.
+        candidates.append(tag[:-1])
+    return candidates
+
+
+def _select_canonical(members: list[str], distribution: dict[str, int]) -> str:
+    """Pick the cluster's canonical form from its members.
+
+    Most-frequent wins; ties broken lexicographically. The negative
+    count in the sort key turns "most" into "first" under ascending
+    sort, and the secondary key (the variant string) handles ties
+    deterministically.
+    """
+    # Build (count, variant) pairs, then sort by descending count then
+    # ascending variant. Python's tuple comparison handles the dual key
+    # naturally when the count is negated.
+    return min(members, key=lambda m: (-distribution.get(m, 0), m))
+
+
+def identify_clusters(distribution: dict[str, int]) -> list[Cluster]:
+    """Group tag variants into clusters and pick a canonical per group.
+
+    Three cluster-detection rules in priority order:
+      - Case-insensitive equality: tags whose lowercase forms match
+        cluster together.
+      - Plural/singular pairs: applied AFTER case folding so
+        `Preferences` and `preference` cluster correctly.
+      - Within-row deduplication is handled per-row in
+        `apply_cluster_to_row`, not here.
+
+    Skips any cluster where any member equals `confirmed_action`
+    (case-insensitive) per D5: the structurally significant tag must
+    not participate in any rewrite.
+    """
+    # Track which variants have already been assigned to a cluster so
+    # a tag is never claimed by two clusters. The cluster-key (the
+    # case-folded representative) doubles as the lookup key.
+    assigned: set[str] = set()
+    clusters: list[Cluster] = []
+
+    # Group by case-folded form first (rule 1). Iterate the distribution
+    # in deterministic order so the test surface is stable.
+    by_case_fold: dict[str, list[str]] = {}
+    for variant in sorted(distribution.keys()):
+        case_fold = variant.lower()
+        by_case_fold.setdefault(case_fold, []).append(variant)
+
+    # First pass: emit clusters for case-fold groups with multiple
+    # members. Single-member groups are candidates for the plural/
+    # singular pass below.
+    for case_fold, members in by_case_fold.items():
+        if len(members) < 2:
+            continue
+        # Cluster-skip: drop any cluster that touches confirmed_action.
+        # Compare case-folded so a hypothetical `Confirmed_Action`
+        # variant also trips the skip.
+        if case_fold == _CONFIRMED_ACTION_TAG:
+            continue
+        canonical = _select_canonical(members, distribution)
+        total = sum(distribution[m] for m in members)
+        clusters.append(Cluster(members=list(members), canonical=canonical, total_occurrences=total))
+        assigned.update(members)
+
+    # Second pass: plural/singular pairs across case-folded representatives.
+    # For each unassigned case-fold key, generate singular candidates and
+    # check whether any of them is also an unassigned case-fold key.
+    case_fold_keys = sorted(by_case_fold.keys())
+    for plural_key in case_fold_keys:
+        # Skip case-fold groups already covered by the first pass.
+        if any(member in assigned for member in by_case_fold[plural_key]):
+            continue
+        for singular_key in _try_singular_forms(plural_key):
+            if singular_key == plural_key:
+                continue
+            if singular_key not in by_case_fold:
+                continue
+            # Cluster-skip again: never collapse anything into or out
+            # of confirmed_action via the plural/singular rule.
+            if plural_key == _CONFIRMED_ACTION_TAG or singular_key == _CONFIRMED_ACTION_TAG:
+                continue
+            # Skip if either side has already been assigned.
+            singular_members = by_case_fold[singular_key]
+            if any(member in assigned for member in singular_members):
+                continue
+            plural_members = by_case_fold[plural_key]
+            members = list(plural_members) + list(singular_members)
+            canonical = _select_canonical(members, distribution)
+            total = sum(distribution[m] for m in members)
+            clusters.append(Cluster(members=members, canonical=canonical, total_occurrences=total))
+            assigned.update(members)
+            # First matching singular wins; do not also try other forms.
+            break
+
+    return clusters
+
+
+def apply_cluster_to_row(
+    row_tags: list[str],
+    clusters: list[Cluster],
+) -> tuple[list[str], bool]:
+    """Apply every relevant cluster's canonical-form rewrite to a row's tag list.
+
+    Walks `row_tags`, looks each tag up across the clusters, and emits
+    the cluster's canonical when a match is found. Within-row duplicate
+    collapse is the second pass: after all rewrites land, `dict.fromkeys`
+    deduplicates while preserving order.
+
+    Row-level `confirmed_action` guard (D5 layer 2): if the input list
+    contained `confirmed_action` but the output does not, return the
+    input unchanged with a False change flag. This is unreachable under
+    the cluster-skip in `identify_clusters` plus the rule that the
+    plural/singular rule cannot map `confirmed_action` to anything else,
+    but the explicit row-level check catches a future rule addition that
+    bypasses cluster-skip (e.g. a synonym-detection pass that sneaks
+    `confirmed_action` into a cluster).
+
+    Returns the new tag list and a boolean indicating whether any
+    rewrite landed (or whether the within-row dedup collapsed any
+    duplicates). False means the caller should skip the write entirely.
+    """
+    # Build a member-to-canonical lookup once per call. Multiple
+    # clusters can claim multiple member tags; the dict is the cheap
+    # way to fan out the per-tag rewrite without scanning every cluster
+    # for every tag.
+    member_to_canonical: dict[str, str] = {}
+    for cluster in clusters:
+        for member in cluster.members:
+            member_to_canonical[member] = cluster.canonical
+
+    # First pass: rewrite each tag if it's a cluster member.
+    rewritten = [member_to_canonical.get(tag, tag) for tag in row_tags]
+
+    # Second pass: collapse within-row duplicates while preserving order.
+    # `dict.fromkeys` is the idiomatic order-preserving dedup.
+    deduped = list(dict.fromkeys(rewritten))
+
+    # Row-level confirmed_action guard. Refuse to publish a tag list
+    # that drops the magic string from a row that originally had it.
+    if _CONFIRMED_ACTION_TAG in row_tags and _CONFIRMED_ACTION_TAG not in deduped:
+        return list(row_tags), False
+
+    changed = deduped != row_tags
+    return deduped, changed
+
+
+def format_dry_run_report(distribution: dict[str, int], clusters: list[Cluster]) -> str:
+    """Render the dry-run report as a multi-line string.
+
+    Three sections: tag distribution before, proposed merges (one line
+    per cluster), and tag distribution after. The "after" distribution
+    is computed by simulating every cluster rewrite; this is purely
+    presentational so the operator can see the post-dedup shape before
+    committing to writes.
+    """
+    lines: list[str] = []
+    lines.append("=== Tag distribution (before) ===")
+    if not distribution:
+        lines.append("  (no tags)")
+    else:
+        for variant, count in sorted(distribution.items(), key=lambda item: (-item[1], item[0])):
+            lines.append(f"  {variant:<40s}  {count:>5d}")
+    lines.append("")
+    lines.append(f"=== Proposed merges ({len(clusters)} cluster(s)) ===")
+    if not clusters:
+        lines.append("  (no merges proposed)")
+    else:
+        for cluster in clusters:
+            members_with_counts = ", ".join(
+                f"{m!r} ({distribution.get(m, 0)})"
+                for m in sorted(cluster.members, key=lambda v: (-distribution.get(v, 0), v))
+            )
+            lines.append(f"  -> {cluster.canonical!r}: [{members_with_counts}]")
+
+    # Compute the post-dedup distribution by remapping each variant.
+    member_to_canonical: dict[str, str] = {}
+    for cluster in clusters:
+        for member in cluster.members:
+            member_to_canonical[member] = cluster.canonical
+    after: dict[str, int] = {}
+    for variant, count in distribution.items():
+        canonical = member_to_canonical.get(variant, variant)
+        after[canonical] = after.get(canonical, 0) + count
+
+    lines.append("")
+    lines.append("=== Tag distribution (after) ===")
+    if not after:
+        lines.append("  (no tags)")
+    else:
+        for variant, count in sorted(after.items(), key=lambda item: (-item[1], item[0])):
+            lines.append(f"  {variant:<40s}  {count:>5d}")
+    return "\n".join(lines)
+
+
+def prompt_for_override(cluster: Cluster, distribution: dict[str, int]) -> str | None:
+    """Interactive prompt for the operator to accept, edit, or skip a cluster.
+
+    Returns the chosen canonical form, or None to skip this cluster.
+    The `edit` branch loops until the operator picks a valid existing
+    member (an arbitrary string would defeat the dedup-into-known-form
+    invariant; the rewritten tag must be one the corpus already holds).
+    """
+    members_with_counts = ", ".join(
+        f"{m!r} ({distribution.get(m, 0)})" for m in sorted(cluster.members, key=lambda v: (-distribution.get(v, 0), v))
+    )
+    print(f"\nCluster: [{members_with_counts}]")
+    print(f"Canonical: {cluster.canonical!r}")
+    while True:
+        choice = input("Apply? [y/n/edit/skip]: ").strip().lower()
+        if choice in ("y", "yes"):
+            return cluster.canonical
+        if choice in ("", "n", "no", "skip"):
+            return None
+        if choice in ("edit", "e"):
+            new_canonical = input("New canonical (must match a cluster member): ").strip()
+            if new_canonical in cluster.members:
+                return new_canonical
+            print(f"Invalid: {new_canonical!r} is not a member of the cluster.")
+            # Fall through to re-prompt the y/n/edit/skip choice.
+            continue
+        print(f"Unrecognised choice {choice!r}. Use y, n, edit, or skip.")
+
+
+@dataclass
+class _RewritePlan:
+    """Per-row plan for the apply pass.
+
+    Holds the row, its computed new tag list, and a snapshot of the
+    pre-rewrite metadata for the audit log. Built in `apply_rewrites`
+    so the operator-prompt path and the no-prompt path share the same
+    structure.
+    """
+
+    row: MemoryResult
+    new_tags: list[str]
+    old_tags: list[str]
+
+
+def apply_rewrites(
+    rows: list[MemoryResult],
+    clusters: list[Cluster],
+    user_id: int,
+    audit_log_path: Path,
+) -> tuple[int, int]:
+    """Apply each row's tag-list rewrite via `memory.update_metadata`.
+
+    For every row whose tag list changes, builds the new metadata dict
+    by COPYING the existing metadata and overwriting only the `tags`
+    field. This is the read-merge-write pattern that the wrapper's
+    docstring mandates: the wrapper does NOT auto-merge; passing a
+    sparse dict like `{"tags": [...]}` would destroy every other field
+    on the row.
+
+    Writes one JSONL audit log entry per successful rewrite. The audit
+    log file is opened in append mode so multiple `--apply` runs in the
+    same session accumulate rather than truncating each other.
+
+    Returns (success_count, fail_count). The `fail_count` includes any
+    row whose `update_metadata` call returned False (Mem0 raise, row
+    vanished between read and write, etc.).
+    """
+    from kai import memory
+
+    success = 0
+    failure = 0
+    with audit_log_path.open("a", encoding="utf-8") as audit_log:
+        for row in rows:
+            new_tags, changed = apply_cluster_to_row(row.metadata.get("tags") or [], clusters)
+            if not changed:
+                continue
+            # Read-merge-write: copy the existing metadata dict, set the
+            # new tags, pass the merged dict. If we passed
+            # `{"tags": new_tags}` directly to the wrapper, Mem0's
+            # `_update_memory` would destroy every other metadata field
+            # (source, confidence, prompt_version, ...) per the wrapper's
+            # documented contract.
+            new_metadata = dict(row.metadata)
+            new_metadata["tags"] = new_tags
+            ok = memory.update_metadata(
+                user_id=str(user_id),
+                memory_id=row.id,
+                data=row.text,
+                metadata=new_metadata,
+            )
+            if ok:
+                success += 1
+                audit_entry = {
+                    "ts": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "memory_id": row.id,
+                    "user_id": str(user_id),
+                    "old_tags": row.metadata.get("tags") or [],
+                    "new_tags": new_tags,
+                    "old_text": row.text,
+                }
+                audit_log.write(json.dumps(audit_entry) + "\n")
+            else:
+                failure += 1
+                print(f"WARN: update_metadata returned False for {row.id}", file=sys.stderr)
+    return success, failure
+
+
+# ── CLI plumbing ──────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Periodic tag dedup script (#418, Sub D of #388).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument(
+        "--chat-id",
+        type=int,
+        help="Telegram chat_id to scan (DM-mode: chat_id == user_id).",
+    )
+    target.add_argument(
+        "--all-users",
+        action="store_true",
+        help="Iterate over every authorised user from config.allowed_user_ids.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually rewrite tags. Without this flag the script runs in dry-run mode.",
+    )
+    parser.add_argument(
+        "--no-prompt",
+        action="store_true",
+        help="Skip the interactive override prompt; accept every proposed canonical form.",
+    )
+    parser.add_argument(
+        "--audit-log",
+        type=Path,
+        default=None,
+        help="Override the default audit-log path (only used with --apply).",
+    )
+    return parser
+
+
+def _resolve_audit_log_path(override: Path | None) -> Path:
+    """Return the audit-log path, defaulting to a timestamped name in scripts/."""
+    if override is not None:
+        return override
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    # The script lives in scripts/; use that as the default location so
+    # the .gitignore entry (`scripts/.tag-dedup-audit-*.jsonl`) catches
+    # the file without an explicit `--audit-log` path.
+    scripts_dir = Path(__file__).resolve().parent
+    return scripts_dir / f".tag-dedup-audit-{timestamp}.jsonl"
+
+
+def _run_for_user(
+    user_id: int,
+    *,
+    apply: bool,
+    no_prompt: bool,
+    audit_log_path: Path,
+) -> tuple[int, int]:
+    """Run the dedup pipeline for one user; return (success, failure) on apply, (0, 0) on dry-run."""
+    rows = load_rows(user_id)
+    distribution = compute_distribution(rows)
+    clusters = identify_clusters(distribution)
+
+    print(f"\n### user_id={user_id} ###")
+    print(format_dry_run_report(distribution, clusters))
+
+    if not apply:
+        return (0, 0)
+
+    if not clusters:
+        # Nothing to rewrite; skip the apply pass without opening the
+        # audit log file (which would otherwise be created empty on
+        # every no-op run).
+        return (0, 0)
+
+    # Operator-prompt phase: filter clusters to the operator-accepted
+    # set. Each cluster's canonical may be edited.
+    accepted_clusters: list[Cluster] = []
+    for cluster in clusters:
+        if no_prompt:
+            accepted_clusters.append(cluster)
+            continue
+        chosen = prompt_for_override(cluster, distribution)
+        if chosen is None:
+            continue
+        if chosen != cluster.canonical:
+            cluster = Cluster(members=cluster.members, canonical=chosen, total_occurrences=cluster.total_occurrences)
+        accepted_clusters.append(cluster)
+
+    if not accepted_clusters:
+        print("\nNo clusters accepted; skipping apply.")
+        return (0, 0)
+
+    return apply_rewrites(rows, accepted_clusters, user_id, audit_log_path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    # Lazy imports for everything that pulls in torch/Mem0 so a `--help`
+    # or argparse error exits without paying the import cost.
+    from kai.config import load_config
+    from kai.memory import init_memory
+
+    config = load_config()
+    if not config.memory_enabled:
+        print(
+            "ERROR: memory subsystem is disabled (config.memory_enabled = False).",
+            file=sys.stderr,
+        )
+        return EXIT_MEMORY_DISABLED
+
+    init_memory(config)
+
+    audit_log_path = _resolve_audit_log_path(args.audit_log)
+
+    if args.all_users:
+        # Iterate config.allowed_user_ids (Telegram user IDs). Under the
+        # DM-mode assumption (user_id == chat_id) these match the memory
+        # store's chat_id-keyed user_id field. Group-chat installs would
+        # need a chat-id-keyed iteration source instead.
+        target_ids = sorted(config.allowed_user_ids)
+    else:
+        target_ids = [int(args.chat_id)]
+
+    total_success = 0
+    total_failure = 0
+    for target_id in target_ids:
+        success, failure = _run_for_user(
+            target_id,
+            apply=args.apply,
+            no_prompt=args.no_prompt,
+            audit_log_path=audit_log_path,
+        )
+        total_success += success
+        total_failure += failure
+
+    if args.apply:
+        print(f"\nTotal rewrites: {total_success} succeeded, {total_failure} failed.")
+        if total_failure > 0:
+            print(f"Audit log: {audit_log_path}", file=sys.stderr)
+            return EXIT_PARTIAL_FAILURE
+        if total_success > 0:
+            print(f"Audit log: {audit_log_path}")
+
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tag-dedup.py
+++ b/scripts/tag-dedup.py
@@ -53,7 +53,7 @@ import sys
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from kai.memory import MemoryResult
@@ -456,9 +456,11 @@ def apply_rewrites(
     sparse dict like `{"tags": [...]}` would destroy every other field
     on the row.
 
-    Writes one JSONL audit log entry per successful rewrite. The audit
-    log file is opened in append mode so multiple `--apply` runs in the
-    same session accumulate rather than truncating each other.
+    Successful rewrites are collected in memory and flushed to the
+    audit log in a single append at the end. The flush is skipped
+    entirely when no rewrite landed, so the file is never created
+    empty. Multiple `--apply` runs targeting the same path accumulate
+    via append mode.
 
     Returns (success_count, fail_count). The `fail_count` includes any
     row whose `update_metadata` call returned False (Mem0 raise, row
@@ -468,28 +470,29 @@ def apply_rewrites(
 
     success = 0
     failure = 0
-    with audit_log_path.open("a", encoding="utf-8") as audit_log:
-        for row in rows:
-            new_tags, changed = apply_cluster_to_row(row.metadata.get("tags") or [], clusters)
-            if not changed:
-                continue
-            # Read-merge-write: copy the existing metadata dict, set the
-            # new tags, pass the merged dict. If we passed
-            # `{"tags": new_tags}` directly to the wrapper, Mem0's
-            # `_update_memory` would destroy every other metadata field
-            # (source, confidence, prompt_version, ...) per the wrapper's
-            # documented contract.
-            new_metadata = dict(row.metadata)
-            new_metadata["tags"] = new_tags
-            ok = memory.update_metadata(
-                user_id=str(user_id),
-                memory_id=row.id,
-                data=row.text,
-                metadata=new_metadata,
-            )
-            if ok:
-                success += 1
-                audit_entry = {
+    audit_entries: list[dict[str, Any]] = []
+    for row in rows:
+        new_tags, changed = apply_cluster_to_row(row.metadata.get("tags") or [], clusters)
+        if not changed:
+            continue
+        # Read-merge-write: copy the existing metadata dict, set the
+        # new tags, pass the merged dict. If we passed
+        # `{"tags": new_tags}` directly to the wrapper, Mem0's
+        # `_update_memory` would destroy every other metadata field
+        # (source, confidence, prompt_version, ...) per the wrapper's
+        # documented contract.
+        new_metadata = dict(row.metadata)
+        new_metadata["tags"] = new_tags
+        ok = memory.update_metadata(
+            user_id=str(user_id),
+            memory_id=row.id,
+            data=row.text,
+            metadata=new_metadata,
+        )
+        if ok:
+            success += 1
+            audit_entries.append(
+                {
                     "ts": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "memory_id": row.id,
                     "user_id": str(user_id),
@@ -497,10 +500,20 @@ def apply_rewrites(
                     "new_tags": new_tags,
                     "old_text": row.text,
                 }
-                audit_log.write(json.dumps(audit_entry) + "\n")
-            else:
-                failure += 1
-                print(f"WARN: update_metadata returned False for {row.id}", file=sys.stderr)
+            )
+        else:
+            failure += 1
+            print(f"WARN: update_metadata returned False for {row.id}", file=sys.stderr)
+
+    # Flush only when there's actually something to write. Skipping
+    # the open call entirely on the empty case avoids creating a
+    # zero-byte audit log file when clusters were proposed but no row
+    # in the corpus carried a matching tag (rare but possible if the
+    # corpus changed between load_rows and apply_rewrites).
+    if audit_entries:
+        with audit_log_path.open("a", encoding="utf-8") as audit_log:
+            for entry in audit_entries:
+                audit_log.write(json.dumps(entry) + "\n")
     return success, failure
 
 

--- a/scripts/tag-dedup.py
+++ b/scripts/tag-dedup.py
@@ -84,7 +84,14 @@ DEDUP_SOURCES: frozenset[str] = frozenset({"extracted", "episode"})
 # plural/singular rule for these endings only fires when both the
 # plural form (ending in one of these patterns) and the singular form
 # (after dropping `-es`) are observed in the corpus.
-_SIBILANT_PLURAL_SUFFIXES: tuple[str, ...] = ("xes", "shes", "ches", "zes", "sses")
+#
+# `zzes` (not `zes`): a singular-z word like `size` makes its plural
+# via the bare `-s` rule (`size` + `s` -> `sizes`), not via `-es`.
+# Matching `zes` would generate a spurious `siz` candidate for `sizes`,
+# which the corpus check filters out in practice but wastes a candidate
+# slot. Restricting to `zzes` keeps the rule firing for genuine
+# sibilant-z plurals (`buzzes` -> `buzz`, `fizzes` -> `fizz`).
+_SIBILANT_PLURAL_SUFFIXES: tuple[str, ...] = ("xes", "shes", "ches", "zzes", "sses")
 
 
 # The structurally significant tag value that the extractor and validator
@@ -160,7 +167,7 @@ def _try_singular_forms(tag: str) -> list[str]:
       - `-ies/-y`: `categories` -> `category`. Applied first so the
         `-ies` ending does not get reduced to `categori` by the bare
         `-s` rule below.
-      - Sibilant `-es` removal (`-xes`, `-shes`, `-ches`, `-zes`,
+      - Sibilant `-es` removal (`-xes`, `-shes`, `-ches`, `-zzes`,
         `-sses`): `boxes` -> `box`. Applied before the bare `-s` rule
         so `boxes` does not first reduce to `boxe`.
       - Bare `-s` removal: `preferences` -> `preference`.
@@ -202,76 +209,93 @@ def _select_canonical(members: list[str], distribution: dict[str, int]) -> str:
 def identify_clusters(distribution: dict[str, int]) -> list[Cluster]:
     """Group tag variants into clusters and pick a canonical per group.
 
-    Three cluster-detection rules in priority order:
+    Three cluster-detection rules:
       - Case-insensitive equality: tags whose lowercase forms match
         cluster together.
-      - Plural/singular pairs: applied AFTER case folding so
-        `Preferences` and `preference` cluster correctly.
+      - Plural/singular pairs: case-fold representatives are joined
+        when one's singular candidate is another's case-fold form.
       - Within-row deduplication is handled per-row in
         `apply_cluster_to_row`, not here.
 
-    Skips any cluster where any member equals `confirmed_action`
-    (case-insensitive) per D5: the structurally significant tag must
-    not participate in any rewrite.
-    """
-    # Track which variants have already been assigned to a cluster so
-    # a tag is never claimed by two clusters. The cluster-key (the
-    # case-folded representative) doubles as the lookup key.
-    assigned: set[str] = set()
-    clusters: list[Cluster] = []
+    Implementation uses a union-find pass over case-fold keys so a
+    three-way overlap like `{"Preferences", "preferences", "preference"}`
+    collapses into a single cluster. A simpler "case-fold pass first,
+    then plural/singular pass" sequencing would emit two disjoint
+    clusters for that input because the first pass would eagerly claim
+    `["Preferences", "preferences"]` and the second pass would refuse
+    to link the already-assigned plural to the singular.
 
-    # Group by case-folded form first (rule 1). Iterate the distribution
-    # in deterministic order so the test surface is stable.
+    Skips any cluster where any member equals `confirmed_action`
+    (case-insensitive): the structurally significant tag must not
+    participate in any rewrite (the extractor pipeline keys off it
+    in `_validate_facts` Rules 4 and 4b plus the per-source render
+    branch in `_build_fact_view`).
+    """
+    # Group by case-folded form first. Iterate the distribution in
+    # deterministic order so the test surface is stable.
     by_case_fold: dict[str, list[str]] = {}
     for variant in sorted(distribution.keys()):
         case_fold = variant.lower()
         by_case_fold.setdefault(case_fold, []).append(variant)
 
-    # First pass: emit clusters for case-fold groups with multiple
-    # members. Single-member groups are candidates for the plural/
-    # singular pass below.
-    for case_fold, members in by_case_fold.items():
-        if len(members) < 2:
-            continue
-        # Cluster-skip: drop any cluster that touches confirmed_action.
-        # Compare case-folded so a hypothetical `Confirmed_Action`
-        # variant also trips the skip.
-        if case_fold == _CONFIRMED_ACTION_TAG:
-            continue
-        canonical = _select_canonical(members, distribution)
-        total = sum(distribution[m] for m in members)
-        clusters.append(Cluster(members=list(members), canonical=canonical, total_occurrences=total))
-        assigned.update(members)
+    # Union-find over case-fold keys. Two keys are in the same
+    # component when (a) they share a case-fold representative
+    # trivially (each key is its own initial component), or (b) one
+    # key's plural/singular candidate matches another key. Connected
+    # components emit one cluster each.
+    parent: dict[str, str] = {key: key for key in by_case_fold}
 
-    # Second pass: plural/singular pairs across case-folded representatives.
-    # For each unassigned case-fold key, generate singular candidates and
-    # check whether any of them is also an unassigned case-fold key.
-    case_fold_keys = sorted(by_case_fold.keys())
-    for plural_key in case_fold_keys:
-        # Skip case-fold groups already covered by the first pass.
-        if any(member in assigned for member in by_case_fold[plural_key]):
-            continue
+    def find(key: str) -> str:
+        # Iterative path compression. The while loop walks up the
+        # parent chain and rewires each node directly to the eventual
+        # root so subsequent finds are O(1).
+        while parent[key] != key:
+            parent[key] = parent[parent[key]]
+            key = parent[key]
+        return key
+
+    def union(a: str, b: str) -> None:
+        root_a, root_b = find(a), find(b)
+        if root_a != root_b:
+            parent[root_a] = root_b
+
+    # Walk the case-fold keys and link any pair where the plural's
+    # singular candidate matches another key. Iterate in sorted order
+    # for deterministic component-roots across runs.
+    for plural_key in sorted(by_case_fold.keys()):
         for singular_key in _try_singular_forms(plural_key):
             if singular_key == plural_key:
                 continue
             if singular_key not in by_case_fold:
                 continue
-            # Cluster-skip again: never collapse anything into or out
-            # of confirmed_action via the plural/singular rule.
+            # Cluster-skip: never link confirmed_action to anything via
+            # the plural/singular rule. Trips before the union so the
+            # confirmation case-fold key stays in its own component.
             if plural_key == _CONFIRMED_ACTION_TAG or singular_key == _CONFIRMED_ACTION_TAG:
                 continue
-            # Skip if either side has already been assigned.
-            singular_members = by_case_fold[singular_key]
-            if any(member in assigned for member in singular_members):
-                continue
-            plural_members = by_case_fold[plural_key]
-            members = list(plural_members) + list(singular_members)
-            canonical = _select_canonical(members, distribution)
-            total = sum(distribution[m] for m in members)
-            clusters.append(Cluster(members=members, canonical=canonical, total_occurrences=total))
-            assigned.update(members)
-            # First matching singular wins; do not also try other forms.
-            break
+            union(plural_key, singular_key)
+
+    # Build per-component member lists. Components with only one
+    # variant (single case-fold key, no plural/singular link, only one
+    # variant under the case-fold) are not clusters.
+    components: dict[str, list[str]] = {}
+    for case_fold_key in by_case_fold:
+        root = find(case_fold_key)
+        components.setdefault(root, []).extend(by_case_fold[case_fold_key])
+
+    clusters: list[Cluster] = []
+    for component_members in components.values():
+        if len(component_members) < 2:
+            continue
+        # Cluster-skip: drop any component that touches confirmed_action.
+        # Catches both the all-confirmation case-fold cluster and any
+        # hypothetical bypass that links confirmed_action to another
+        # form despite the union-skip above.
+        if any(member.lower() == _CONFIRMED_ACTION_TAG for member in component_members):
+            continue
+        canonical = _select_canonical(component_members, distribution)
+        total = sum(distribution[m] for m in component_members)
+        clusters.append(Cluster(members=list(component_members), canonical=canonical, total_occurrences=total))
 
     return clusters
 
@@ -287,7 +311,7 @@ def apply_cluster_to_row(
     collapse is the second pass: after all rewrites land, `dict.fromkeys`
     deduplicates while preserving order.
 
-    Row-level `confirmed_action` guard (D5 layer 2): if the input list
+    Row-level `confirmed_action` guard (defense-in-depth): if the input list
     contained `confirmed_action` but the output does not, return the
     input unchanged with a False change flag. This is unreachable under
     the cluster-skip in `identify_clusters` plus the rule that the
@@ -603,7 +627,7 @@ def main(argv: list[str] | None = None) -> int:
         # need a chat-id-keyed iteration source instead.
         target_ids = sorted(config.allowed_user_ids)
     else:
-        target_ids = [int(args.chat_id)]
+        target_ids = [args.chat_id]
 
     total_success = 0
     total_failure = 0

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -1281,6 +1281,56 @@ def delete_by_id(*, user_id: str, memory_id: str) -> bool:
     return True
 
 
+def update_metadata(*, user_id: str, memory_id: str, data: str, metadata: dict) -> bool:
+    """Replace the metadata dict for `memory_id` belonging to `user_id`.
+
+    IMPORTANT: Mem0's underlying `update` REPLACES the metadata dict
+    wholesale. Auto-preserved fields are: `data`, `hash`,
+    `text_lemmatized`, `created_at`, `updated_at`, `user_id` (when
+    absent in new), `agent_id` (when absent in new), `run_id` (when
+    absent in new), `actor_id` (always), `role` (when absent in new).
+    Every other field on the existing row (e.g. `source`, `confidence`,
+    `prompt_version`, `confirmation_quote`, `tags`, `outcome_quality`,
+    `approach`, `outcome`, `lessons`, `actors`) is DESTROYED unless the
+    caller passes it explicitly. Callers that want to change only
+    specific fields must read the existing row first, modify those
+    fields on the existing metadata dict, and pass the merged dict to
+    this wrapper. Failure to follow this pattern silently erases
+    metadata that may matter for downstream reads (UI rendering,
+    extractor consolidation gates, etc.).
+
+    Mem0's `update` requires the row's text content (`data`) and
+    recomputes the embedding regardless. Callers that want to change
+    only metadata still pay one embedding API call per row.
+
+    Source-scope: the user-id gate admits any row whose
+    `metadata.source` is in `USER_VISIBLE_SOURCES` (extracted, episode,
+    migration). Callers wanting narrower scope must filter at the
+    caller level. The `confirmed_action`-tag protection used by the
+    tag dedup pass is the caller's responsibility, not this wrapper's.
+
+    Returns True on success, False when the row is not found, does not
+    belong to `user_id`, or the source filter rejects it. Mem0
+    exceptions are caught, logged, and surface as False.
+    """
+    if _memory is None:
+        return False
+
+    # Single source of truth for ownership + source scoping. Mirrors
+    # the gate used by delete_by_id; if get_by_id returns None for any
+    # reason (missing, wrong user, source not in USER_VISIBLE_SOURCES,
+    # fetch error) we refuse to update.
+    if get_by_id(user_id=user_id, memory_id=memory_id) is None:
+        return False
+
+    try:
+        _memory.update(memory_id=memory_id, data=data, metadata=metadata)
+    except Exception:
+        log.warning("update_metadata: update failed for %s", memory_id, exc_info=True)
+        return False
+    return True
+
+
 def delete_all(*, user_id: str) -> None:
     """
     Delete all memories for a user.

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -27,6 +27,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field
+from typing import Any
 
 from kai.config import DATA_DIR, Config
 
@@ -1281,7 +1282,7 @@ def delete_by_id(*, user_id: str, memory_id: str) -> bool:
     return True
 
 
-def update_metadata(*, user_id: str, memory_id: str, data: str, metadata: dict) -> bool:
+def update_metadata(*, user_id: str, memory_id: str, data: str, metadata: dict[str, Any]) -> bool:
     """Replace the metadata dict for `memory_id` belonging to `user_id`.
 
     IMPORTANT: Mem0's underlying `update` REPLACES the metadata dict

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1794,6 +1794,181 @@ class TestDeleteById:
         mock_mem.delete.assert_not_called()
 
 
+class TestUpdateMetadataWrapper:
+    """Issue #418, Sub D of #388: thin wrapper around Mem0's
+    `update` that pins ownership + source and forwards the call.
+
+    The wrapper's docstring documents (a) the metadata-overwrite
+    contract (Mem0 REPLACES wholesale; callers must read-merge-write
+    for partial updates) and (b) the source-scope contract (admits any
+    USER_VISIBLE_SOURCES row). These tests pin both contracts so a
+    future "helpful" auto-merge refactor cannot silently change the
+    semantics that callers depend on."""
+
+    def test_disabled_returns_false(self):
+        from kai.memory import update_metadata
+
+        assert update_metadata(user_id="123", memory_id="abc", data="x", metadata={"tags": []}) is False
+
+    def test_returns_false_when_row_missing(self):
+        import kai.memory as mem_mod
+        from kai.memory import update_metadata
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = None
+        mem_mod._memory = mock_mem
+
+        result = update_metadata(
+            user_id="123",
+            memory_id="missing",
+            data="x",
+            metadata={"tags": ["preference"]},
+        )
+        assert result is False
+        mock_mem.update.assert_not_called()
+
+    def test_returns_false_on_user_mismatch(self):
+        """Cross-user metadata writes are the worst-case consequence
+        of a malformed memory_id leak; the gate must refuse."""
+        import kai.memory as mem_mod
+        from kai.memory import update_metadata
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "user_id": "other-user",
+            "metadata": {"source": "extracted"},
+        }
+        mem_mod._memory = mock_mem
+
+        result = update_metadata(
+            user_id="123",
+            memory_id="abc",
+            data="x",
+            metadata={"tags": ["preference"]},
+        )
+        assert result is False
+        mock_mem.update.assert_not_called()
+
+    def test_returns_false_on_source_outside_user_visible(self):
+        """Legacy ""-source rows and any future non-USER_VISIBLE
+        sources are admin-CLI territory; refuse to write to them
+        through this wrapper."""
+        import kai.memory as mem_mod
+        from kai.memory import update_metadata
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "user_id": "123",
+            "metadata": {"source": ""},  # legacy
+        }
+        mem_mod._memory = mock_mem
+
+        result = update_metadata(
+            user_id="123",
+            memory_id="abc",
+            data="x",
+            metadata={"tags": ["preference"]},
+        )
+        assert result is False
+        mock_mem.update.assert_not_called()
+
+    def test_mem0_exception_returns_false(self):
+        """A Mem0 raise during update is caught, logged, and surfaces
+        as False. Callers can treat False as "nothing to do" without
+        an exception bubble."""
+        import kai.memory as mem_mod
+        from kai.memory import update_metadata
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "user_id": "123",
+            "metadata": {"source": "extracted"},
+        }
+        mock_mem.update.side_effect = RuntimeError("vector store down")
+        mem_mod._memory = mock_mem
+
+        result = update_metadata(
+            user_id="123",
+            memory_id="abc",
+            data="x",
+            metadata={"tags": ["preference"]},
+        )
+        assert result is False
+
+    def test_happy_path_calls_mem0_update_and_returns_true(self):
+        import kai.memory as mem_mod
+        from kai.memory import update_metadata
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "user_id": "123",
+            "metadata": {"source": "extracted"},
+        }
+        mem_mod._memory = mock_mem
+
+        result = update_metadata(
+            user_id="123",
+            memory_id="abc",
+            data="fact text",
+            metadata={"source": "extracted", "tags": ["preference"]},
+        )
+        assert result is True
+        # The wrapper passes the caller-provided metadata dict through
+        # to Mem0 unchanged; no auto-merge happens at this layer.
+        mock_mem.update.assert_called_once_with(
+            memory_id="abc",
+            data="fact text",
+            metadata={"source": "extracted", "tags": ["preference"]},
+        )
+
+    def test_sparse_metadata_passes_through_unchanged(self):
+        """Pin the wrapper's destructive behavior: a sparse caller-
+        provided metadata dict (e.g. {"tags": [...]}) MUST be passed
+        through to Mem0 unmodified. The wrapper does NOT auto-merge
+        with the existing row; callers wanting to preserve other
+        fields are responsible for read-merge-write at the call site.
+
+        A future "helpful" refactor that auto-merges in the wrapper
+        would change the contract that the dedup script's
+        apply_rewrites depends on (the script reads, merges, then
+        passes the merged dict). Surfacing the pin here means the
+        refactor cannot land silently."""
+        import kai.memory as mem_mod
+        from kai.memory import update_metadata
+
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "user_id": "123",
+            "metadata": {
+                "source": "extracted",
+                "confidence": 0.9,
+                "tags": ["original"],
+            },
+        }
+        mem_mod._memory = mock_mem
+
+        # Caller passes a sparse dict; the wrapper forwards it AS-IS.
+        result = update_metadata(
+            user_id="123",
+            memory_id="abc",
+            data="x",
+            metadata={"tags": ["new"]},  # missing source, confidence
+        )
+        assert result is True
+        # Verify Mem0 received the sparse dict literally; no merge with
+        # existing fields happened in the wrapper.
+        call_args = mock_mem.update.call_args
+        passed_metadata = call_args.kwargs["metadata"]
+        assert passed_metadata == {"tags": ["new"]}
+        assert "source" not in passed_metadata
+        assert "confidence" not in passed_metadata
+
+
 class TestGetStatsExtended:
     """Spec 310 §6.6 / §7.2: extended MemoryStats fields.
 

--- a/tests/test_tag_dedup.py
+++ b/tests/test_tag_dedup.py
@@ -1,0 +1,436 @@
+"""
+Tests for scripts/tag-dedup.py (issue #418, Sub D of #388).
+
+The script lives at scripts/tag-dedup.py because that is the project
+convention for one-shot operator scripts. The hyphenated filename is
+not a legal Python module name, so this test loads it via
+importlib.util at module-import time and exposes the helpers as
+`dedup.<helper>` for the test functions below.
+
+Tests cover:
+- compute_distribution: empty, single tag, multi-tag, case-preserved counts.
+- identify_clusters: case-insensitive equality, plural/singular pairs,
+  -ies/-y swap, -es removal for sibilant endings, singletons,
+  confirmed_action skip (lowercase and mixed-case).
+- canonical selection: most-frequent wins, lexicographic tiebreak,
+  single-member cluster's canonical is itself.
+- apply_cluster_to_row: no-change, single rewrite, multi rewrite,
+  within-row dedup, confirmed_action row untouched, fixture-driven
+  row-level guard against a cluster that bypasses cluster-skip.
+- apply_rewrites: success path with metadata preservation, failure path,
+  audit-log entry shape.
+- CLI dispatch: dry-run vs apply, --all-users iteration, mutex
+  enforcement, exit codes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from kai.memory import MemoryResult
+
+# Load the dedup script as a module so its helpers are importable
+# despite the hyphenated filename. spec_from_file_location is the
+# stdlib idiom for loading code from an arbitrary path; the loaded
+# module behaves like any other import target.
+#
+# CRITICAL: register in sys.modules BEFORE exec_module(). The script
+# uses @dataclass, whose decorator looks up cls.__module__ in
+# sys.modules at class-creation time. Without the pre-registration,
+# the loaded module is not yet visible there and dataclass crashes
+# with AttributeError on a NoneType __dict__ lookup.
+_SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "tag-dedup.py"
+_spec = importlib.util.spec_from_file_location("tag_dedup", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+dedup = importlib.util.module_from_spec(_spec)
+sys.modules["tag_dedup"] = dedup
+_spec.loader.exec_module(dedup)
+
+
+# ── Fixture helpers ───────────────────────────────────────────────────
+
+
+def _row(
+    fact_id: str,
+    text: str,
+    tags: list[str],
+    source: str = "extracted",
+    extra_metadata: dict | None = None,
+) -> MemoryResult:
+    """Construct a MemoryResult with the metadata shape the dedup pass
+    actually walks. `extra_metadata` lets a test pin non-tag fields
+    (confidence, prompt_version, etc.) so the apply-pass tests can
+    verify they survive the read-merge-write."""
+    metadata = {"source": source, "tags": list(tags), "type": "fact"}
+    if extra_metadata is not None:
+        metadata.update(extra_metadata)
+    return MemoryResult(
+        id=fact_id,
+        text=text,
+        score=0.0,
+        memory_type="fact",
+        metadata=metadata,
+        created_at="2026-04-30T13:00:00",
+        updated_at="2026-04-30T13:00:00",
+    )
+
+
+# ── compute_distribution ──────────────────────────────────────────────
+
+
+class TestComputeDistribution:
+    def test_empty_rows_returns_empty_distribution(self):
+        assert dedup.compute_distribution([]) == {}
+
+    def test_single_tag_row(self):
+        rows = [_row("a", "x", ["preference"])]
+        assert dedup.compute_distribution(rows) == {"preference": 1}
+
+    def test_multi_tag_row(self):
+        rows = [_row("a", "x", ["preference", "constraint"])]
+        assert dedup.compute_distribution(rows) == {"preference": 1, "constraint": 1}
+
+    def test_case_preserved_counts(self):
+        # Case is preserved at this stage so the canonical-selection step
+        # in identify_clusters can pick the most-frequent variant. A
+        # case-folding distribution would lose the variant data.
+        rows = [
+            _row("a", "x", ["Preference"]),
+            _row("b", "y", ["preference"]),
+            _row("c", "z", ["preference"]),
+        ]
+        assert dedup.compute_distribution(rows) == {"Preference": 1, "preference": 2}
+
+    def test_missing_tags_field_contributes_nothing(self):
+        # A row with no tags key (or empty list) must not crash and
+        # must not appear in the distribution.
+        result = MemoryResult(
+            id="a",
+            text="x",
+            score=0.0,
+            memory_type="fact",
+            metadata={"source": "extracted"},  # no tags key
+            created_at="2026-04-30T13:00:00",
+            updated_at="2026-04-30T13:00:00",
+        )
+        assert dedup.compute_distribution([result]) == {}
+
+
+# ── identify_clusters ─────────────────────────────────────────────────
+
+
+class TestIdentifyClusters:
+    def test_case_insensitive_equality_clusters(self):
+        clusters = dedup.identify_clusters({"Preference": 1, "preference": 5})
+        assert len(clusters) == 1
+        assert sorted(clusters[0].members) == ["Preference", "preference"]
+        assert clusters[0].canonical == "preference"  # most-frequent
+        assert clusters[0].total_occurrences == 6
+
+    def test_plural_singular_s_pair(self):
+        # Both forms exist; the bare -s rule fires.
+        clusters = dedup.identify_clusters({"preferences": 2, "preference": 5})
+        assert len(clusters) == 1
+        assert sorted(clusters[0].members) == ["preference", "preferences"]
+        assert clusters[0].canonical == "preference"
+
+    def test_ies_y_swap(self):
+        clusters = dedup.identify_clusters({"categories": 1, "category": 4})
+        assert len(clusters) == 1
+        assert sorted(clusters[0].members) == ["categories", "category"]
+        assert clusters[0].canonical == "category"
+
+    def test_sibilant_es_removal(self):
+        # `boxes` -> `box` only fires because (a) `boxes` ends in `-xes`
+        # and (b) `box` is also in the corpus.
+        clusters = dedup.identify_clusters({"boxes": 1, "box": 3})
+        assert len(clusters) == 1
+        assert sorted(clusters[0].members) == ["box", "boxes"]
+        assert clusters[0].canonical == "box"
+
+    def test_singleton_tag_produces_no_cluster(self):
+        # A tag with no near-duplicate in the corpus is not in a cluster.
+        clusters = dedup.identify_clusters({"preference": 5})
+        assert clusters == []
+
+    def test_bare_s_rule_skips_double_s_endings(self):
+        # The bare-s rule has an explicit `not endswith("ss")` guard
+        # so genuinely-singular -ss nouns are not paired with a stem.
+        # Fixture: "mass" (singular, ends in -ss) plus "ma" (a
+        # hypothetical separate tag); the bare-s rule must NOT pair
+        # them because "mass" doesn't end in a single trailing -s.
+        clusters = dedup.identify_clusters({"mass": 5, "ma": 1})
+        assert clusters == []
+
+    def test_confirmed_action_lowercase_skipped(self):
+        # The cluster-skip rule fires when any case-fold member equals
+        # `confirmed_action`. Verified by giving the corpus two case
+        # variants that would cluster under rule 1 but should be left
+        # untouched.
+        clusters = dedup.identify_clusters({"confirmed_action": 5, "Confirmed_Action": 1})
+        assert clusters == []
+
+    def test_confirmed_action_mixed_case_skipped(self):
+        # Even an all-uppercase variant cannot drag the cluster into
+        # play; case-fold equality is the comparison key.
+        clusters = dedup.identify_clusters({"CONFIRMED_ACTION": 1, "confirmed_action": 7})
+        assert clusters == []
+
+
+# ── canonical selection ───────────────────────────────────────────────
+
+
+class TestCanonicalSelection:
+    def test_most_frequent_wins(self):
+        clusters = dedup.identify_clusters({"alpha": 10, "Alpha": 1})
+        assert clusters[0].canonical == "alpha"
+
+    def test_lexicographic_tiebreak(self):
+        # Equal counts: "Alpha" sorts before "alpha" under lexicographic
+        # comparison (uppercase ASCII precedes lowercase). Pin so a future
+        # change to the sort key trips this regression.
+        clusters = dedup.identify_clusters({"alpha": 1, "Alpha": 1})
+        assert clusters[0].canonical == "Alpha"
+
+    def test_single_member_cluster_canonical_is_itself(self):
+        # Direct construction: bypasses identify_clusters (which would
+        # reject single-member groups). Verifies the canonical-selection
+        # helper handles the trivial case.
+        canonical = dedup._select_canonical(["sole"], {"sole": 3})
+        assert canonical == "sole"
+
+
+# ── apply_cluster_to_row ──────────────────────────────────────────────
+
+
+class TestApplyClusterToRow:
+    def test_no_change_row(self):
+        # Tags already canonical; the rewrite is a no-op.
+        cluster = dedup.Cluster(members=["preference", "Preference"], canonical="preference")
+        new_tags, changed = dedup.apply_cluster_to_row(["preference"], [cluster])
+        assert new_tags == ["preference"]
+        assert changed is False
+
+    def test_single_tag_rewritten(self):
+        cluster = dedup.Cluster(members=["preference", "Preference"], canonical="preference")
+        new_tags, changed = dedup.apply_cluster_to_row(["Preference"], [cluster])
+        assert new_tags == ["preference"]
+        assert changed is True
+
+    def test_multi_tag_rewrite(self):
+        c1 = dedup.Cluster(members=["preference", "Preference"], canonical="preference")
+        c2 = dedup.Cluster(members=["constraint", "Constraint"], canonical="constraint")
+        new_tags, changed = dedup.apply_cluster_to_row(["Preference", "Constraint"], [c1, c2])
+        assert new_tags == ["preference", "constraint"]
+        assert changed is True
+
+    def test_within_row_duplicate_collapse(self):
+        # Both `preference` and `Preference` rewrite to `preference`,
+        # producing a duplicate that the within-row dedup pass must
+        # collapse. The change flag is True because the list shape
+        # changed from 2 elements to 1.
+        cluster = dedup.Cluster(members=["preference", "Preference"], canonical="preference")
+        new_tags, changed = dedup.apply_cluster_to_row(["preference", "Preference"], [cluster])
+        assert new_tags == ["preference"]
+        assert changed is True
+
+    def test_confirmed_action_row_untouched_via_cluster_skip(self):
+        # Production path: identify_clusters refused to build a cluster
+        # touching confirmed_action, so apply_cluster_to_row sees no
+        # cluster matching the confirmation tag. The other tags are
+        # rewritten, the confirmation tag stays put.
+        cluster = dedup.Cluster(members=["preference", "Preference"], canonical="preference")
+        new_tags, changed = dedup.apply_cluster_to_row(["confirmed_action", "Preference"], [cluster])
+        assert new_tags == ["confirmed_action", "preference"]
+        assert changed is True
+
+    def test_row_level_guard_when_cluster_bypasses_skip(self):
+        # Defense-in-depth path: a future rule addition could sneak
+        # confirmed_action into a cluster, bypassing the cluster-skip
+        # in identify_clusters. Construct that hypothetical cluster
+        # directly. The row-level guard in apply_cluster_to_row must
+        # refuse to drop confirmed_action from the output and return
+        # the row unchanged. The script never builds this cluster in
+        # production; the test exists to pin the row-level guard's
+        # contract against future rule additions.
+        cluster = dedup.Cluster(
+            members=["confirmed_action", "user_confirmed"],
+            canonical="user_confirmed",
+        )
+        new_tags, changed = dedup.apply_cluster_to_row(["confirmed_action"], [cluster])
+        assert new_tags == ["confirmed_action"]
+        assert changed is False
+
+
+# ── apply_rewrites ────────────────────────────────────────────────────
+
+
+class TestApplyRewrites:
+    def test_successful_rewrite_increments_success_count(self, monkeypatch, tmp_path):
+        # Mock memory.update_metadata to succeed for every call. The
+        # test verifies (a) success/failure counts, (b) the audit log
+        # gets one JSONL entry per success, and (c) update_metadata is
+        # called with a merged metadata dict that preserves non-tags
+        # fields (the read-merge-write contract).
+        captured_calls: list[dict] = []
+
+        def fake_update(*, user_id, memory_id, data, metadata):
+            captured_calls.append({"memory_id": memory_id, "metadata": metadata})
+            return True
+
+        from kai import memory as kai_memory
+
+        monkeypatch.setattr(kai_memory, "update_metadata", fake_update)
+
+        rows = [
+            _row(
+                "row-1",
+                "fact text",
+                ["Preference"],
+                extra_metadata={
+                    "confidence": 0.92,
+                    "prompt_version": "5",
+                    "session_id": "sess-abc",
+                    "confirmation_quote": None,
+                },
+            )
+        ]
+        cluster = dedup.Cluster(members=["preference", "Preference"], canonical="preference")
+        audit_log = tmp_path / "audit.jsonl"
+
+        success, failure = dedup.apply_rewrites(rows, [cluster], 12345, audit_log)
+
+        assert success == 1
+        assert failure == 0
+        assert len(captured_calls) == 1
+
+        # Read-merge-write verification: the metadata passed to
+        # update_metadata MUST include every non-tags field from the
+        # original row. Without read-merge-write the script would pass
+        # only the tags and Mem0 would destroy the rest.
+        passed_metadata = captured_calls[0]["metadata"]
+        assert passed_metadata["tags"] == ["preference"]
+        assert passed_metadata["confidence"] == 0.92
+        assert passed_metadata["prompt_version"] == "5"
+        assert passed_metadata["session_id"] == "sess-abc"
+        assert passed_metadata["source"] == "extracted"
+
+        # Audit log entry shape.
+        audit_entries = [json.loads(line) for line in audit_log.read_text().splitlines()]
+        assert len(audit_entries) == 1
+        entry = audit_entries[0]
+        assert entry["memory_id"] == "row-1"
+        assert entry["user_id"] == "12345"
+        assert entry["old_tags"] == ["Preference"]
+        assert entry["new_tags"] == ["preference"]
+        assert entry["old_text"] == "fact text"
+
+    def test_failed_rewrite_increments_failure_count(self, monkeypatch, tmp_path):
+        # update_metadata returns False (Mem0 raise, row vanished, etc.).
+        # The audit log gets NO entry for the failed row.
+        from kai import memory as kai_memory
+
+        monkeypatch.setattr(kai_memory, "update_metadata", lambda **kw: False)
+
+        rows = [_row("row-1", "x", ["Preference"])]
+        cluster = dedup.Cluster(members=["preference", "Preference"], canonical="preference")
+        audit_log = tmp_path / "audit.jsonl"
+
+        success, failure = dedup.apply_rewrites(rows, [cluster], 12345, audit_log)
+
+        assert success == 0
+        assert failure == 1
+        # Audit log was created (apply_rewrites opens in append mode)
+        # but contains no entries for failed rewrites.
+        if audit_log.exists():
+            assert audit_log.read_text() == ""
+
+
+# ── CLI dispatch ──────────────────────────────────────────────────────
+
+
+class TestCliDispatch:
+    def test_chat_id_and_all_users_are_mutually_exclusive(self):
+        # argparse exits with code 2 on mutex violation. SystemExit
+        # carries that code; pytest.raises captures it.
+        with pytest.raises(SystemExit) as excinfo:
+            dedup.main(["--chat-id", "12345", "--all-users"])
+        assert excinfo.value.code == 2
+
+    def test_one_target_required(self):
+        # Neither --chat-id nor --all-users is provided.
+        with pytest.raises(SystemExit) as excinfo:
+            dedup.main([])
+        assert excinfo.value.code == 2
+
+    def test_memory_disabled_returns_exit_code_2(self, monkeypatch):
+        # When config.memory_enabled is False, the script must NOT
+        # init_memory and must return EXIT_MEMORY_DISABLED.
+        from kai import config as kai_config
+        from kai import memory as kai_memory
+
+        fake_config = MagicMock()
+        fake_config.memory_enabled = False
+        monkeypatch.setattr(kai_config, "load_config", lambda: fake_config)
+        # init_memory must NOT be called when memory_enabled is False.
+        monkeypatch.setattr(kai_memory, "init_memory", lambda c: pytest.fail("init_memory should not run"))
+        rc = dedup.main(["--chat-id", "12345"])
+        assert rc == dedup.EXIT_MEMORY_DISABLED
+
+    def test_dry_run_does_not_call_update_metadata(self, monkeypatch):
+        # Without --apply, update_metadata must never be called even
+        # if the corpus has clusterable tags.
+        from kai import config as kai_config
+        from kai import memory as kai_memory
+
+        fake_config = MagicMock()
+        fake_config.memory_enabled = True
+        fake_config.allowed_user_ids = {12345}
+        monkeypatch.setattr(kai_config, "load_config", lambda: fake_config)
+        monkeypatch.setattr(kai_memory, "init_memory", lambda c: None)
+        # Two rows that would form a case-fold cluster.
+        monkeypatch.setattr(
+            dedup,
+            "load_rows",
+            lambda user_id: [
+                _row("a", "x", ["Preference"]),
+                _row("b", "y", ["preference"]),
+            ],
+        )
+        # Trip the test if update_metadata is called.
+        monkeypatch.setattr(
+            kai_memory,
+            "update_metadata",
+            lambda **kw: pytest.fail("update_metadata called in dry-run"),
+        )
+        rc = dedup.main(["--chat-id", "12345"])
+        assert rc == dedup.EXIT_OK
+
+    def test_all_users_iterates_each_authorised_user(self, monkeypatch):
+        # --all-users walks config.allowed_user_ids and runs the
+        # per-user pipeline for each. Each user's load_rows is invoked
+        # exactly once.
+        from kai import config as kai_config
+        from kai import memory as kai_memory
+
+        fake_config = MagicMock()
+        fake_config.memory_enabled = True
+        fake_config.allowed_user_ids = {111, 222, 333}
+        monkeypatch.setattr(kai_config, "load_config", lambda: fake_config)
+        monkeypatch.setattr(kai_memory, "init_memory", lambda c: None)
+        seen_user_ids: list[int] = []
+
+        def fake_load(user_id):
+            seen_user_ids.append(user_id)
+            return []
+
+        monkeypatch.setattr(dedup, "load_rows", fake_load)
+        rc = dedup.main(["--all-users"])
+        assert rc == dedup.EXIT_OK
+        assert sorted(seen_user_ids) == [111, 222, 333]

--- a/tests/test_tag_dedup.py
+++ b/tests/test_tag_dedup.py
@@ -450,3 +450,68 @@ class TestCliDispatch:
         rc = dedup.main(["--all-users"])
         assert rc == dedup.EXIT_OK
         assert sorted(seen_user_ids) == [111, 222, 333]
+
+    def test_apply_no_prompt_invokes_update_metadata(self, monkeypatch, tmp_path):
+        # End-to-end CLI verification of the apply path: --apply with
+        # --no-prompt accepts every proposed cluster and runs the
+        # rewrite pipeline. Without this test, a regression that wires
+        # --apply to the wrong branch of _run_for_user (e.g. an early
+        # return that skips apply_rewrites) would not trip any other
+        # test - the unit tests for apply_rewrites itself would still
+        # pass since they call the helper directly.
+        from kai import config as kai_config
+        from kai import memory as kai_memory
+
+        fake_config = MagicMock()
+        fake_config.memory_enabled = True
+        fake_config.allowed_user_ids = {12345}
+        monkeypatch.setattr(kai_config, "load_config", lambda: fake_config)
+        monkeypatch.setattr(kai_memory, "init_memory", lambda c: None)
+        # Three rows. The two extra "preference" rows make "preference"
+        # the most-frequent canonical (3 occurrences vs 1 for
+        # "Preference"); without that imbalance, lexicographic tiebreak
+        # picks "Preference" and the canonical-matching row would not
+        # be rewritten, leaving only one update_metadata call.
+        monkeypatch.setattr(
+            dedup,
+            "load_rows",
+            lambda user_id: [
+                _row("a", "first", ["Preference"]),
+                _row("b", "second", ["preference"]),
+                _row("c", "third", ["preference"]),
+                _row("d", "fourth", ["preference"]),
+            ],
+        )
+        update_calls: list[dict[str, Any]] = []
+
+        def fake_update(*, user_id, memory_id, data, metadata):
+            update_calls.append({"memory_id": memory_id, "tags": metadata["tags"]})
+            return True
+
+        monkeypatch.setattr(kai_memory, "update_metadata", fake_update)
+
+        # Audit log to a temp path; the real default would write to
+        # scripts/.tag-dedup-audit-* which the test should not touch.
+        audit_log = tmp_path / "audit.jsonl"
+        rc = dedup.main(
+            [
+                "--chat-id",
+                "12345",
+                "--apply",
+                "--no-prompt",
+                "--audit-log",
+                str(audit_log),
+            ]
+        )
+        assert rc == dedup.EXIT_OK
+        # Only row "a" (tagged "Preference") has a non-canonical tag,
+        # so only it gets rewritten. The three "preference" rows match
+        # the canonical and skip the update_metadata call. The point
+        # of this test is end-to-end CLI -> update_metadata wiring;
+        # one call is sufficient to verify the pipeline.
+        assert len(update_calls) == 1
+        assert update_calls[0]["memory_id"] == "a"
+        assert update_calls[0]["tags"] == ["preference"]
+        # Audit log should exist with one entry (success path).
+        assert audit_log.exists()
+        assert len(audit_log.read_text().splitlines()) == 1

--- a/tests/test_tag_dedup.py
+++ b/tests/test_tag_dedup.py
@@ -29,6 +29,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -61,7 +62,7 @@ def _row(
     text: str,
     tags: list[str],
     source: str = "extracted",
-    extra_metadata: dict | None = None,
+    extra_metadata: dict[str, Any] | None = None,
 ) -> MemoryResult:
     """Construct a MemoryResult with the metadata shape the dedup pass
     actually walks. `extra_metadata` lets a test pin non-tag fields
@@ -347,7 +348,10 @@ class TestApplyRewrites:
 
     def test_failed_rewrite_increments_failure_count(self, monkeypatch, tmp_path):
         # update_metadata returns False (Mem0 raise, row vanished, etc.).
-        # The audit log gets NO entry for the failed row.
+        # The audit log file is NOT created at all when no rewrite
+        # succeeds; the lazy-flush path skips the open call entirely
+        # so an `--apply` run that fails for every row leaves no
+        # zero-byte file behind.
         from kai import memory as kai_memory
 
         monkeypatch.setattr(kai_memory, "update_metadata", lambda **kw: False)
@@ -360,9 +364,8 @@ class TestApplyRewrites:
 
         assert success == 0
         assert failure == 1
-        # Audit log was created (apply_rewrites opens in append mode
-        # unconditionally) but contains no entries for failed rewrites.
-        assert audit_log.read_text() == ""
+        # File should not exist: no entries means no flush.
+        assert not audit_log.exists()
 
 
 # ── CLI dispatch ──────────────────────────────────────────────────────

--- a/tests/test_tag_dedup.py
+++ b/tests/test_tag_dedup.py
@@ -154,6 +154,20 @@ class TestIdentifyClusters:
         assert sorted(clusters[0].members) == ["box", "boxes"]
         assert clusters[0].canonical == "box"
 
+    def test_three_way_case_and_plural_collapse(self):
+        # A case-fold pair AND a plural/singular link must collapse into
+        # one cluster, not two. The earlier two-pass implementation
+        # eagerly clustered `["Preferences", "preferences"]` in pass 1,
+        # then refused to link them to `"preference"` in pass 2 because
+        # the plural side was already assigned. Union-find over case-fold
+        # keys joins all three into one component.
+        clusters = dedup.identify_clusters({"Preferences": 1, "preferences": 2, "preference": 5})
+        assert len(clusters) == 1
+        assert sorted(clusters[0].members) == ["Preferences", "preference", "preferences"]
+        # Most-frequent wins: "preference" with 5 occurrences.
+        assert clusters[0].canonical == "preference"
+        assert clusters[0].total_occurrences == 8
+
     def test_singleton_tag_produces_no_cluster(self):
         # A tag with no near-duplicate in the corpus is not in a cluster.
         clusters = dedup.identify_clusters({"preference": 5})
@@ -346,10 +360,9 @@ class TestApplyRewrites:
 
         assert success == 0
         assert failure == 1
-        # Audit log was created (apply_rewrites opens in append mode)
-        # but contains no entries for failed rewrites.
-        if audit_log.exists():
-            assert audit_log.read_text() == ""
+        # Audit log was created (apply_rewrites opens in append mode
+        # unconditionally) but contains no entries for failed rewrites.
+        assert audit_log.read_text() == ""
 
 
 # ── CLI dispatch ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #418. Sub D of #388.

After Sub A (#414) replaced the closed `_TAG_ENUM` with free-form LLM tags and Sub B (#416) retired the dashboard tag-button surface, the tag space is unbounded. This PR adds the agreed vocabulary-control mechanism (option (a) from #388's open question): an admin-side periodic dedup script.

`scripts/tag-dedup.py` walks the tag distribution across `extracted` and `episode` rows, identifies near-duplicate clusters, and rewrites them to a canonical form via a new `memory.update_metadata` wrapper. Default mode is dry-run; `--apply` is required to write.

## What changed

**New file `scripts/tag-dedup.py`:**

- argparse CLI: `--chat-id` and `--all-users` are mutually exclusive; `--apply` flips dry-run off; `--no-prompt` skips the interactive override; `--audit-log` overrides the default audit-log path.
- Three cluster-detection rules: case-insensitive equality (`Preference` vs `preference`); plural/singular pairs (`-s`, sibilant `-es`, `-ies/-y`); within-row duplicate collapse.
- Canonical-form selection: most-frequent wins, lexicographic tiebreak.
- Two-layer `confirmed_action` defense: cluster-skip in `identify_clusters` (production path) plus a row-level guard in `apply_cluster_to_row` (defense-in-depth against future rule additions that bypass cluster-skip).
- Migration rows excluded from the dedup pass (different vocabulary space).
- Read-merge-write at the apply call site preserves every non-`tags` metadata field.
- JSONL audit log on `--apply`.

**New `memory.update_metadata` wrapper (in `src/kai/memory.py`):**

Thin wrapper around Mem0's `Memory.update`. The docstring pins two contracts verbatim:

- **Metadata-overwrite contract.** Mem0's underlying `update` REPLACES the metadata dict wholesale. Auto-preserved fields are `data`, `hash`, `text_lemmatized`, `created_at`, `updated_at`, `user_id` (when absent in new), `agent_id` (when absent in new), `run_id` (when absent in new), `actor_id` (always), `role` (when absent in new). Every other field is destroyed unless the caller passes it explicitly. Callers wanting partial updates must read-merge-write at the call site.
- **Source-scope contract.** The user-id gate admits any row whose `metadata.source` is in `USER_VISIBLE_SOURCES` (extracted, episode, migration). Callers wanting narrower scope must filter at the caller level. The `confirmed_action`-tag protection used by the tag dedup pass is the caller's responsibility, not the wrapper's.

**Tests:**

- `tests/test_tag_dedup.py`: 29 tests across 6 classes (`TestComputeDistribution`, `TestIdentifyClusters`, `TestCanonicalSelection`, `TestApplyClusterToRow`, `TestApplyRewrites`, `TestCliDispatch`).
  - The row-level `confirmed_action` guard is verified via a fixture-driven test that constructs a `Cluster` mapping `confirmed_action` to something else, bypassing the cluster-skip; the row stays untouched.
  - `TestApplyRewrites` verifies the read-merge-write discipline: every non-`tags` metadata field on the original row appears on the call to `update_metadata`.
- `tests/test_memory.py::TestUpdateMetadataWrapper`: 7 tests pinning ownership/source gates, Mem0 exception handling, and the wrapper's destructive-by-design metadata semantics (sparse-metadata-passes-through-unchanged so a future "helpful" auto-merge refactor cannot land silently).

**`.gitignore`:**

- `scripts/.tag-dedup-audit-*.jsonl` (audit logs from `--apply` runs).

## Diff stat

```
 .gitignore                |   3 +
 scripts/tag-dedup.py      | 480 +++++++++++++++++++ (new)
 src/kai/memory.py         |  50 ++
 tests/test_memory.py      | 175 +++++++++
 tests/test_tag_dedup.py   | 588 ++++++++++++++++++++++ (new)
 5 files changed, 1296 insertions(+)
```

## Verification

- `make test`: 2682 passed (36 new), 1 skipped (pre-existing).
- `make check`: ruff check + ruff format both clean.
- Personal pre-push gate (spec refs, cross-file line numbers, em/en dashes) clean across the diff.

## Test plan

- [x] Full test suite passes (`make test`).
- [x] Lint clean (`make check`).
- [ ] After deploy on a development chat with mixed-case tags: `python scripts/tag-dedup.py --chat-id <dev_id>` shows the dry-run report enumerating case-folding clusters.
- [ ] Same chat with `--apply --no-prompt`: rewrite count matches the proposed cluster size sum, and the audit log is written.
- [ ] Re-run dry-run after apply: zero proposed merges.
- [ ] Spot-check via `/memory stats`: surviving tag set has no case duplicates.
- [ ] `confirmed_action`-tagged row is untouched after `--apply`.
- [ ] Spot-check fact-view detail screen: a rewritten row's other metadata (confidence, prompt_version, etc.) is intact.
