### PR TITLE
feat(memory): add facts browser to /memory dashboard (#420)

### DIFF
--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -1175,6 +1175,60 @@ def get_all_episodes(*, user_id: str) -> list[MemoryResult]:
     return matches
 
 
+# A literal frozen set, NOT an alias for `USER_VISIBLE_SOURCES`. The two
+# admit lists serve different purposes and must not drift together: the
+# shared list (extracted, episode, migration) gates per-id and per-tag
+# reads where any of the three sources is acceptable; this list
+# (extracted, migration) gates the fact-bucket enumeration where
+# episodes are intentionally excluded because they have their own
+# browser. Aliasing would silently change the function's semantics if
+# `USER_VISIBLE_SOURCES` ever gains a fourth source. The duplication
+# is deliberate.
+_FACT_BUCKET_SOURCES: frozenset[str] = frozenset({"extracted", "migration"})
+
+
+def get_all_facts(*, user_id: str) -> list[MemoryResult]:
+    """Return all fact-bucket memories for `user_id`, newest first.
+
+    Read-side primitive for the /memory dashboard's facts-list browser.
+    The "fact bucket" combines two sources that the operator cannot
+    meaningfully tell apart in a list view: extracted facts (Haiku
+    pulled them out of conversation) and migration facts (the operator
+    imported them from MEMORY.md). The fact-view detail screen still
+    surfaces the per-source distinction via different headers; this
+    enumeration helper exists for the source-agnostic list view.
+
+    Source-filter taxonomy. This module has three filter-site
+    categories; this function is the third:
+      1. Multi-source admit list (`USER_VISIBLE_SOURCES`, all three
+         user-visible sources). Used by `get_by_id`, `get_by_tag`,
+         `delete_by_id`, and the `_send_search` UI post-filter.
+      2. Single-source enumeration (`get_all_episodes`, scoped to the
+         literal `"episode"`).
+      3. Multi-source enumeration scoped to the fact bucket (this
+         function, scoped to `{"extracted", "migration"}`).
+    Category 3 is narrower than the shared admit list (it omits
+    episode) and broader than category 2 (it admits two sources, not
+    one). It does NOT participate in `USER_VISIBLE_SOURCES`; see the
+    `_FACT_BUCKET_SOURCES` comment above for the rationale.
+
+    Sort: `updated_at` descending, with `created_at` as the fallback
+    for rows whose payload predates the field. Mirrors `get_by_tag`
+    and `get_all_episodes` so the convention is uniform across all
+    list surfaces. ISO-8601 strings are lexicographically sortable, so
+    no `datetime` parse is needed. The full row set comes from
+    `get_all(limit=None)` so a user with thousands of facts still
+    gets a complete listing rather than the default 1000-row ceiling.
+    """
+    if _memory is None:
+        return []
+
+    rows = get_all(user_id=user_id, limit=None)
+    matches = [r for r in rows if r.metadata.get("source") in _FACT_BUCKET_SOURCES]
+    matches.sort(key=lambda r: r.updated_at or r.created_at, reverse=True)
+    return matches
+
+
 def get_by_id(*, user_id: str, memory_id: str) -> MemoryResult | None:
     """Fetch a single user-visible memory by id, scoped to user.
 

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -20,20 +20,34 @@ Architectural shape:
   reaper task. Losing the cache on process restart is acceptable
   (spec 310 §7.4); the user just retypes `/memory`.
 
-Source filtering uses `memory.USER_VISIBLE_SOURCES` (the frozenset
-of `extracted`, `episode`, `migration`). The data-layer gate is
-canonical: `memory.get_by_id` and `memory.get_by_tag` admit only
-those sources, and `memory.delete_by_id` inherits the gate via its
-delegation. The one UI-side reference is `_send_search`'s
-post-filter, which exists because `memory.search` is a Mem0 vector
-lookup that spans every source, including legacy `""`-source rows
-that must not surface in the operator-facing UI. Both sites read
-`USER_VISIBLE_SOURCES` from `memory.py` so a future change to the
-admit list lives in one place. `memory.get_all_episodes` is the one
-narrower-than-`USER_VISIBLE_SOURCES` filter, scoped to the literal
-`"episode"` source for the dashboard's episode-list browser; it does
-not participate in the shared admit list because its purpose is
-single-source enumeration, not multi-source admission.
+Source filtering has three filter-site categories:
+
+  1. Multi-source admit list (`memory.USER_VISIBLE_SOURCES`, the
+     frozenset of `extracted`, `episode`, `migration`). The data-
+     layer gate is canonical: `memory.get_by_id` and
+     `memory.get_by_tag` admit only those sources, and
+     `memory.delete_by_id` inherits the gate via its delegation.
+     The one UI-side reference is `_send_search`'s post-filter,
+     which exists because `memory.search` is a Mem0 vector lookup
+     that spans every source, including legacy `""`-source rows
+     that must not surface in the operator-facing UI. Both sites
+     read `USER_VISIBLE_SOURCES` from `memory.py` so a future
+     change to the admit list lives in one place.
+  2. Single-source enumeration: `memory.get_all_episodes`, scoped
+     to the literal `"episode"` source for the dashboard's episode-
+     list browser.
+  3. Multi-source enumeration scoped to the fact bucket:
+     `memory.get_all_facts`, scoped to `{"extracted", "migration"}`
+     for the dashboard's facts-list browser. Narrower than
+     `USER_VISIBLE_SOURCES` (excludes episode), broader than
+     `get_all_episodes` (admits two sources). Episodes are
+     intentionally excluded because they have their own browser.
+
+Categories 2 and 3 do not participate in `USER_VISIBLE_SOURCES`:
+their purpose is enumeration, not multi-source admission. The
+duplication of source literals is deliberate so that a future
+change to the shared admit list cannot silently broaden either
+enumeration.
 
 See `home/specs/310-memory-command.md` for the canonical UX flows
 and design rationale.
@@ -299,10 +313,20 @@ def _build_dashboard(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup | No
 
     The dashboard surfaces three user-visible source counts (extracted
     facts, episode summaries, migration imports) and a single utility
-    keyboard row holding an optional Episodes button (when
+    keyboard row holding two optional browse buttons (Facts when
+    extracted_count + migration_count > 0; Episodes when
     episode_count > 0), plus unconditional Search and Stats buttons.
     There is no per-source filter axis: the parent decision in #388
     settled tags as row decoration only, not a primary browse axis.
+
+    Facts vs Episodes split: extracted and migration rows fold into a
+    single "facts" bucket because the extracted/imported distinction
+    is internal plumbing from an operator's perspective. The fact-
+    view detail screen still renders per-source headers (Fact for
+    extracted, Imported for migration) so the provenance surfaces
+    when the operator drills in. Episodes have a distinct semantic
+    shape (outcome quality, approach, lessons) that justifies a
+    separate browser.
 
     Empty state: only when ALL three user-visible source counts are
     zero. An operator with episode or migration rows but no extracted
@@ -315,6 +339,16 @@ def _build_dashboard(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup | No
     if stats.extracted_count == 0 and stats.episode_count == 0 and stats.migration_count == 0:
         return _MSG_NO_FACTS, None
 
+    # Cache the visibility predicates once. The Facts button rolls
+    # extracted and migration into one count; the Episodes button is
+    # episode-only. The empty-state guard above ensures at least one
+    # of facts_visible or episode_count > 0 is true on every reachable
+    # path through the rest of this function (otherwise all three
+    # counts would be zero, which the guard already returns for).
+    facts_count = stats.extracted_count + stats.migration_count
+    facts_visible = facts_count > 0
+    episodes_visible = stats.episode_count > 0
+
     lines: list[str] = []
     # Headline assembled from non-zero per-source counts so a fresh
     # extracted-only operator gets a tight "Memories: N facts."
@@ -322,7 +356,10 @@ def _build_dashboard(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup | No
     # each source. Zero-valued sources are omitted from the comma
     # list rather than rendered as "0 episodes" - readability over
     # uniformity, since most operators have non-zero in only one or
-    # two of the three.
+    # two of the three. The headline keeps extracted and migration
+    # split (rather than merging them like the Facts button label)
+    # because the headline communicates "where did your memory come
+    # from", which is the question the per-source split answers.
     parts: list[str] = []
     if stats.extracted_count:
         parts.append(f"{stats.extracted_count} facts")
@@ -333,25 +370,42 @@ def _build_dashboard(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup | No
     summary = "Memories: " + ", ".join(parts) + "."
     lines.append(summary)
     lines.append("")
-    # Footer line: two branches keep the action prompt accurate to
-    # what the keyboard actually offers.
-    #   - Episodes button visible (episode_count > 0): name every
-    #     utility-row affordance the operator can tap.
-    #   - No Episodes button: only Search and Stats render.
-    if stats.episode_count > 0:
+    # Footer line: three reachable branches keep the action prompt
+    # accurate to what the keyboard actually offers. The fourth
+    # branch (no browse buttons at all) is unreachable in production
+    # because the empty-state guard above would have returned; the
+    # `else` arm is retained as a safety net so a future change to
+    # the empty-state guard cannot silently produce a broken footer.
+    #   - Both browse buttons: name both, plus Search and Stats.
+    #   - Facts only: Tap Facts to browse, then Search and Stats.
+    #   - Episodes only: existing post-410 wording, unchanged.
+    #   - Neither (unreachable): pre-410 fallback wording.
+    if facts_visible and episodes_visible:
+        lines.append("Tap Facts or Episodes to browse, Search to find specific memories, or Stats for details.")
+    elif facts_visible:
+        lines.append("Tap Facts to browse, Search to find specific memories, or Stats for details.")
+    elif episodes_visible:
         lines.append("Tap Episodes to browse, Search to find specific memories, or Stats for details.")
     else:
         lines.append("Use Search to find specific memories, or tap Stats for details.")
 
     text = "\n".join(lines)
 
-    # Keyboard: a single utility row holds the cross-corpus actions.
-    # Episodes button only renders when there is content to browse,
-    # so an operator with no episodes does not see a button that
-    # would lead to an empty list. Search and Stats always render.
+    # Keyboard: a single utility row holds the cross-corpus actions
+    # in this exact left-to-right order: Facts (if any), Episodes
+    # (if any), Search, Stats. Both browse buttons hide when their
+    # bucket is empty so an operator does not see a button that
+    # would open an empty list. Search and Stats always render.
     rows: list[list[InlineKeyboardButton]] = []
     utility_row: list[InlineKeyboardButton] = []
-    if stats.episode_count > 0:
+    if facts_visible:
+        utility_row.append(
+            InlineKeyboardButton(
+                f"Facts ({facts_count})",
+                callback_data=_encode_callback("facts", "0"),
+            )
+        )
+    if episodes_visible:
         utility_row.append(
             InlineKeyboardButton(
                 f"Episodes ({stats.episode_count})",
@@ -476,6 +530,90 @@ def _build_episode_list_view(
             InlineKeyboardButton(
                 "next >",
                 callback_data=_encode_callback("eps", str(clamped + 1)),
+            )
+        )
+    return text, InlineKeyboardMarkup([number_row, nav_row]), memory_ids, clamped, total
+
+
+# ── Builder: facts list view ────────────────────────────────────────
+
+
+def _build_facts_list_view(
+    facts: list[MemoryResult],
+    page: int,
+) -> tuple[str, InlineKeyboardMarkup, list[str], int, int]:
+    """Render a paginated facts list folding extracted and migration.
+
+    Returns the (text, keyboard, memory_ids, clamped_page,
+    total_pages) tuple consumed by `_send_facts_list`. The
+    memory_ids list backs the screen cache so numbered button taps
+    resolve to memory ids via integer index, keeping callback data
+    well under the 64-byte Telegram ceiling.
+
+    Per-row layout:
+        N.  <truncated text>
+            <date>
+
+    No bracket field. The list view is source-agnostic: extracted
+    and migration rows are visually indistinguishable in this
+    surface because the operator cannot meaningfully act on the
+    distinction at the list level. The fact-view detail screen
+    (rendered when a number is tapped) keeps the per-source
+    rendering from issue #407.
+
+    Header reads `"Facts  (page X of Y)"` with two spaces between
+    the label and the parenthetical; matches the episode header
+    convention so both list views look uniform side by side.
+    """
+    window, clamped, total = _paginate(facts, page)
+
+    if not window:
+        # Reachable only when an operator with facts_visible at
+        # dashboard-fetch time deletes their last extracted/migration
+        # row mid-session, since the dashboard hides the Facts button
+        # at zero. Render a graceful empty state with a back button
+        # rather than an empty-pagination screen.
+        text = "Facts\n\nNo facts yet."
+        kb = InlineKeyboardMarkup([[InlineKeyboardButton("back", callback_data=_encode_callback("dash"))]])
+        return text, kb, [], 0, 1
+
+    lines = [f"Facts  (page {clamped + 1} of {total})", ""]
+    memory_ids: list[str] = []
+    for idx, fact in enumerate(window, start=1):
+        date_str = _format_date(fact.updated_at or fact.created_at)
+        lines.append(f"{idx}.  {_truncate(fact.text)}")
+        # Four-space indent visually nests the date under the start
+        # of the truncated fact text on the line above (after the
+        # "N.  " prefix). Compare with the episode list, which uses
+        # twelve spaces because its bracket label sits there; with
+        # no bracket on this surface, four is the right alignment.
+        lines.append(f"    {date_str}")
+        lines.append("")
+        memory_ids.append(fact.id)
+
+    text = "\n".join(lines).rstrip()
+
+    # Number buttons reuse the existing `fact` verb. The integer
+    # index resolves against `cache.memory_ids` by position; the
+    # verb does not need to know which list type populated the
+    # cache. Same pattern the episode list uses today.
+    number_row = [
+        InlineKeyboardButton(str(i + 1), callback_data=_encode_callback("fact", str(i))) for i in range(len(window))
+    ]
+    nav_row: list[InlineKeyboardButton] = []
+    if clamped > 0:
+        nav_row.append(
+            InlineKeyboardButton(
+                "< prev",
+                callback_data=_encode_callback("facts", str(clamped - 1)),
+            )
+        )
+    nav_row.append(InlineKeyboardButton("back", callback_data=_encode_callback("dash")))
+    if clamped < total - 1:
+        nav_row.append(
+            InlineKeyboardButton(
+                "next >",
+                callback_data=_encode_callback("facts", str(clamped + 1)),
             )
         )
     return text, InlineKeyboardMarkup([number_row, nav_row]), memory_ids, clamped, total
@@ -879,6 +1017,7 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
     Verbs:
       dash              - re-render dashboard
       eps <page>        - episode list at page
+      facts <page>      - facts list (extracted + migration) at page
       fact <idx>        - open fact at index (resolved against cache)
       stats             - re-render stats
       help              - help text (Search button on dashboard)
@@ -956,6 +1095,21 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
             await _send_episode_list(update, context, chat_id, page, edit=True)
             await query.answer()
             return
+        if verb == "facts":
+            # Facts list browser (extracted + migration). Same page-
+            # arg shape as `eps`; invalid integer falls back to page
+            # 0. The unknown-verb dismiss at the bottom of this
+            # handler covers any future retirement of the verb,
+            # which would silently no-op stale callbacks in chat
+            # history (same compatibility path the retired `tag`
+            # verb relies on).
+            try:
+                page = int(args[0]) if args else 0
+            except ValueError:
+                page = 0
+            await _send_facts_list(update, context, chat_id, page, edit=True)
+            await query.answer()
+            return
         if verb == "fact":
             cache = _get_cache(chat_id)
             if cache is None or not args:
@@ -1015,7 +1169,9 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
             return_to = cache.return_to
             ok = memory.delete_by_id(user_id=str(chat_id), memory_id=memory_id)
             # Return to whatever screen the user was on before the
-            # fact view. Episode list if known; otherwise dashboard.
+            # fact view. Episode list, facts list, or dashboard
+            # fallback. The branches mirror the return_to encodings
+            # set in _send_fact_view.
             if return_to is not None and return_to[0] == "eps" and len(return_to[1]) >= 1:
                 # Issue #410: facts opened from the episode list
                 # return to that list at the same page after delete.
@@ -1024,6 +1180,17 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
                 except ValueError:
                     page = 0
                 await _send_episode_list(update, context, chat_id, page, edit=True)
+            elif return_to is not None and return_to[0] == "facts" and len(return_to[1]) >= 1:
+                # Mirrors the eps branch above: facts opened from the
+                # facts list return to that list at the same page
+                # after delete, so the operator can keep deleting
+                # contiguous rows without bouncing back to the
+                # dashboard each time.
+                try:
+                    page = int(return_to[1][0])
+                except ValueError:
+                    page = 0
+                await _send_facts_list(update, context, chat_id, page, edit=True)
             else:
                 await _send_dashboard(update, context, chat_id, edit=True)
             await query.answer("Forgotten." if ok else "Not found.")
@@ -1095,6 +1262,37 @@ async def _send_episode_list(
     await _send_or_edit(update, text, kb, edit=edit)
 
 
+async def _send_facts_list(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    page: int,
+    edit: bool = False,
+) -> None:
+    """Render and send/edit the facts list at `page`.
+
+    Fetches via `memory.get_all_facts` (the fact-bucket enumeration
+    that folds extracted and migration), builds via
+    `_build_facts_list_view`, and sets the cache screen to `"facts"`
+    so a fact opened from this list can route back to the same page
+    via `_send_fact_view`'s return_to logic. Distinct from the
+    `"fact"` (singular) sentinel, which identifies the fact-detail
+    view.
+    """
+    try:
+        facts = memory.get_all_facts(user_id=str(chat_id))
+    except Exception as exc:
+        log.exception("get_all_facts failed: %s", exc)
+        await _send_or_edit(update, _MSG_QUERY_FAILED, None, edit=edit)
+        return
+    text, kb, memory_ids, clamped_page, _total = _build_facts_list_view(facts, page)
+    _set_cache(
+        chat_id,
+        _ScreenCache(screen="facts", page=clamped_page, memory_ids=memory_ids),
+    )
+    await _send_or_edit(update, text, kb, edit=edit)
+
+
 async def _send_fact_view(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
@@ -1115,6 +1313,13 @@ async def _send_fact_view(
         # that list at the same page on back-nav. Page is the only
         # arg needed; the eps verb decodes a single-element args list.
         return_to = ("eps", [str(cache.page)])
+    elif cache is not None and cache.screen == "facts":
+        # Mirrors the episodes branch: facts opened from the facts
+        # list return to that list at the same page on back-nav.
+        # The new `"facts"` cache sentinel (set by `_send_facts_list`)
+        # is what distinguishes this path from the search path; the
+        # encoded back-target is `mem:facts:<page>`.
+        return_to = ("facts", [str(cache.page)])
     elif cache is not None and cache.screen == "search" and cache.query is not None:
         # Searches re-execute on back-nav. Encoding the full query in
         # callback data would risk the 64-byte limit; for now, back

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -2810,6 +2810,148 @@ class TestGetAllEpisodes:
         assert mock_mem.get_all.call_args.kwargs["top_k"] >= 100_000
 
 
+class TestGetAllFacts:
+    """Multi-source enumeration helper backing the /memory dashboard's
+    facts-list browser. Filter is `metadata.source in {"extracted",
+    "migration"}` -- narrower than `USER_VISIBLE_SOURCES` (which also
+    admits episode) and broader than `get_all_episodes` (which is
+    scoped to a single source). Episodes are intentionally excluded
+    because they have their own list view."""
+
+    def test_get_all_facts_returns_only_extracted_and_migration_sources(self):
+        """Mixed-source store: only the extracted and migration rows
+        come back. Episode and legacy ""-source rows are filtered
+        out at the data layer rather than in the UI, so the UI cache
+        can't accidentally surface a non-fact-bucket row."""
+        import kai.memory as mem_mod
+        from kai.memory import get_all_facts
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {
+            "results": [
+                {
+                    "id": "ext",
+                    "memory": "extracted fact",
+                    "score": 0.0,
+                    "metadata": {"source": "extracted", "type": "fact"},
+                    "created_at": "2026-04-01T00:00:00",
+                    "updated_at": "2026-04-01T00:00:00",
+                },
+                {
+                    "id": "ep1",
+                    "memory": "episode one",
+                    "score": 0.0,
+                    "metadata": {"source": "episode", "outcome_quality": "success"},
+                    "created_at": "2026-04-02T00:00:00",
+                    "updated_at": "2026-04-02T00:00:00",
+                },
+                {
+                    "id": "mig",
+                    "memory": "migration row",
+                    "score": 0.0,
+                    "metadata": {"source": "migration", "tags": ["migration"]},
+                    "created_at": "2026-04-03T00:00:00",
+                    "updated_at": "2026-04-03T00:00:00",
+                },
+                {
+                    "id": "legacy",
+                    "memory": "legacy row",
+                    "score": 0.0,
+                    "metadata": {"source": ""},
+                    "created_at": "2026-01-01T00:00:00",
+                    "updated_at": "2026-01-01T00:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        results = get_all_facts(user_id="123")
+        # Sort order is recency-desc on updated_at, so migration
+        # (2026-04-03) precedes extracted (2026-04-01). Episode and
+        # legacy rows are excluded.
+        assert [r.id for r in results] == ["mig", "ext"]
+
+    def test_get_all_facts_sorts_newest_first(self):
+        """Two rows with different `updated_at` (one extracted, one
+        migration) so the sort spans the full fact bucket. Mirrors
+        `get_all_episodes`'s sort contract."""
+        import kai.memory as mem_mod
+        from kai.memory import get_all_facts
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {
+            "results": [
+                {
+                    "id": "old",
+                    "memory": "older extracted",
+                    "score": 0.0,
+                    "metadata": {"source": "extracted"},
+                    "created_at": "2026-01-01T00:00:00",
+                    "updated_at": "2026-01-01T00:00:00",
+                },
+                {
+                    "id": "new",
+                    "memory": "newer migration",
+                    "score": 0.0,
+                    "metadata": {"source": "migration"},
+                    "created_at": "2026-04-01T00:00:00",
+                    "updated_at": "2026-04-15T00:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        results = get_all_facts(user_id="123")
+        assert [r.id for r in results] == ["new", "old"]
+
+    def test_get_all_facts_empty_when_no_matching_sources(self):
+        """Episode-only store: empty list, not None or an exception.
+        The episode rows are visible to `get_all_episodes` but not to
+        this helper."""
+        import kai.memory as mem_mod
+        from kai.memory import get_all_facts
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {
+            "results": [
+                {
+                    "id": "ep",
+                    "memory": "episode",
+                    "score": 0.0,
+                    "metadata": {"source": "episode"},
+                    "created_at": "",
+                    "updated_at": "",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+
+        assert get_all_facts(user_id="123") == []
+
+    def test_get_all_facts_disabled_returns_empty(self):
+        """With memory disabled (`_memory is None`), helper short-
+        circuits to empty list. No exception, no get_all call."""
+        from kai.memory import get_all_facts
+
+        # The autouse `_clean_memory_state` fixture leaves _memory at
+        # None unless the test sets it explicitly.
+        assert get_all_facts(user_id="123") == []
+
+    def test_get_all_facts_passes_limit_none(self):
+        """get_all is called with the high ceiling (top_k >= 100_000)
+        so users with thousands of fact-bucket rows get a complete
+        listing. Parallel to test_get_all_episodes_passes_limit_none."""
+        import kai.memory as mem_mod
+        from kai.memory import get_all_facts
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {"results": []}
+        mem_mod._memory = mock_mem
+
+        get_all_facts(user_id="123")
+        assert mock_mem.get_all.call_args.kwargs["top_k"] >= 100_000
+
+
 # ── Integration tests (real Mem0 + Qdrant, slower) ──────────────────
 
 

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -684,17 +684,21 @@ class TestDashboardMultiSource:
         assert [btn.text for btn in utility_row] == ["Episodes (4)", "Search", "Stats"]
 
     def test_dashboard_migration_only_user_renders(self):
-        """Same shape as the episode-only case: migration_count > 0,
-        extracted_count == 0, episode_count == 0. Same empty-state
-        guard fix; the keyboard renders only the Search/Stats utility
-        row because no Episodes button shows when episode_count == 0."""
+        """Migration-only operator: migration_count > 0,
+        extracted_count == 0, episode_count == 0. The empty-state
+        guard does not fire because migration_count is positive.
+        The Facts button renders (extracted + migration > 0) and
+        the footer points to it; Episodes does not render."""
         stats = _stats(migration_count=25)
         text, kb = memory_command._build_dashboard(stats)
         assert "No memories yet" not in text
         assert kb is not None
         assert "25 imported" in text
-        assert "Use Search to find specific memories, or tap Stats for details." in text
+        # Migration-only is the facts-only footer branch.
+        assert "Tap Facts to browse, Search to find specific memories, or Stats for details." in text
         assert len(kb.inline_keyboard) == 1
+        utility_row = kb.inline_keyboard[-1]
+        assert [btn.text for btn in utility_row] == ["Facts (25)", "Search", "Stats"]
 
     def test_dashboard_all_zero_returns_empty_state(self):
         """The empty state fires only when every user-visible source
@@ -991,32 +995,38 @@ class TestDashboardEpisodesButton:
     footer prose changes that ride alongside."""
 
     def test_dashboard_renders_episodes_button_when_episode_count_nonzero(self):
+        # Mixed-source fixture: extracted_count=10 makes the Facts
+        # button visible too, so the row is the both-buttons shape.
+        # Episodes sits at index 1 (Facts at 0).
         stats = _stats(extracted_count=10, episode_count=4, by_tag={"preference": 5})
         _, kb = memory_command._build_dashboard(stats)
         assert kb is not None
         utility_row = kb.inline_keyboard[-1]
         labels = [btn.text for btn in utility_row]
-        assert labels == ["Episodes (4)", "Search", "Stats"]
+        assert labels == ["Facts (10)", "Episodes (4)", "Search", "Stats"]
         # Callback shape: mem:eps:<page>; initial page is 0.
-        episodes_btn = utility_row[0]
+        # Episodes is at index 1 because Facts now occupies index 0.
+        episodes_btn = utility_row[1]
         assert episodes_btn.callback_data == "mem:eps:0"
 
     def test_dashboard_omits_episodes_button_when_episode_count_zero(self):
-        # Pre-#410 shape: utility row is exactly [Search, Stats].
-        # Pin so a future regression that always emits the Episodes
-        # button trips this test.
+        # extracted_count=10 makes Facts visible, so the row is
+        # [Facts (10), Search, Stats]. Episodes is correctly absent.
+        # The test name still describes the omit-when-zero intent;
+        # the row contents now also confirm the new Facts presence.
         stats = _stats(extracted_count=10, episode_count=0, by_tag={"preference": 5})
         _, kb = memory_command._build_dashboard(stats)
         assert kb is not None
         utility_row = kb.inline_keyboard[-1]
         labels = [btn.text for btn in utility_row]
-        assert labels == ["Search", "Stats"]
+        assert labels == ["Facts (10)", "Search", "Stats"]
 
     def test_dashboard_episode_only_user_renders_episodes_button(self):
         # Episode-only operator: utility row is the only keyboard
         # row, with Episodes alongside Search and Stats. Pins the
         # cross-section of the episode-only surface and the Episodes
-        # button placement.
+        # button placement. Facts is hidden because extracted_count
+        # and migration_count both default to zero in _stats().
         stats = _stats(episode_count=4)
         _, kb = memory_command._build_dashboard(stats)
         assert kb is not None
@@ -1027,23 +1037,139 @@ class TestDashboardEpisodesButton:
         assert labels == ["Episodes (4)", "Search", "Stats"]
 
     def test_dashboard_with_episodes_footer_wording(self):
-        # Footer when Episodes is rendered: enumerates every
-        # utility-row affordance. Pins against the pre-#410 wording
-        # which would lie by enumerating only Search and Stats.
+        # Footer when Episodes is rendered (and Facts is not):
+        # enumerates every utility-row affordance. Pins against the
+        # pre-#410 wording which would lie by enumerating only
+        # Search and Stats. Episode-only fixture; extracted and
+        # migration both default to zero so Facts stays hidden.
         stats = _stats(episode_count=4)
         text, _ = memory_command._build_dashboard(stats)
         assert "Tap Episodes to browse, Search to find specific memories, or Stats for details." in text
 
-    def test_dashboard_no_episodes_footer_wording(self):
-        # Footer when no Episodes button renders: matches the
-        # pre-#410 wording. Pins the migration-only operator's
-        # surface.
+    def test_dashboard_facts_only_footer_wording(self):
+        # Migration-only operator hits the facts-only footer branch
+        # (extracted=0, episode=0, migration=25), so Facts is the
+        # only browse button visible. Renamed from
+        # `test_dashboard_no_episodes_footer_wording` because the
+        # scenario now produces a Facts button rather than the
+        # pre-#410 no-browse-button wording. Negative regression on
+        # "Tap Episodes" stays valid: Episodes really is hidden here.
         stats = _stats(migration_count=25)
         text, _ = memory_command._build_dashboard(stats)
-        assert "Use Search to find specific memories, or tap Stats for details." in text
+        assert "Tap Facts to browse, Search to find specific memories, or Stats for details." in text
         # Negative regression: the Episodes branch wording must NOT
         # appear when no Episodes button is rendered.
         assert "Tap Episodes to browse" not in text
+
+
+class TestDashboardFactsButton:
+    """Facts (N) button on the dashboard utility row.
+
+    Conditional on `stats.extracted_count + stats.migration_count > 0`.
+    The label sums extracted and migration; the headline keeps them
+    split (extracted as "facts", migration as "imported"). Order on
+    the utility row, when both Facts and Episodes are visible, is
+    Facts first (left), then Episodes, then Search, then Stats.
+
+    The empty-state guard at the top of `_build_dashboard` returns
+    early when all three source counts are zero, so the
+    no-browse-buttons footer wording is unreachable production code
+    and is intentionally not pinned by a test."""
+
+    def test_dashboard_renders_facts_button_when_extracted_or_migration_nonzero(self):
+        # Facts label sums extracted (10) and migration (2). Episode
+        # count is zero so this is the facts-only row shape.
+        stats = _stats(extracted_count=10, migration_count=2)
+        _, kb = memory_command._build_dashboard(stats)
+        assert kb is not None
+        utility_row = kb.inline_keyboard[-1]
+        labels = [btn.text for btn in utility_row]
+        assert labels == ["Facts (12)", "Search", "Stats"]
+        # Callback shape: mem:facts:<page>; initial page is 0.
+        facts_btn = utility_row[0]
+        assert facts_btn.callback_data == "mem:facts:0"
+
+    def test_dashboard_facts_button_label_sums_extracted_and_migration(self):
+        # Explicit sum check on a fixture where both contributions
+        # are non-zero. Pins the sum semantics so a regression that
+        # uses only one of the two counts trips this assertion.
+        stats = _stats(extracted_count=7, migration_count=18)
+        _, kb = memory_command._build_dashboard(stats)
+        assert kb is not None
+        utility_row = kb.inline_keyboard[-1]
+        labels = [btn.text for btn in utility_row]
+        assert "Facts (25)" in labels
+
+    def test_dashboard_omits_facts_button_when_extracted_and_migration_both_zero(self):
+        # Episode-only operator: facts_visible is false, so the row
+        # should be [Episodes, Search, Stats] with no Facts button.
+        # Pins the negative case so a future regression that always
+        # emits Facts trips here.
+        stats = _stats(episode_count=4)
+        _, kb = memory_command._build_dashboard(stats)
+        assert kb is not None
+        utility_row = kb.inline_keyboard[-1]
+        labels = [btn.text for btn in utility_row]
+        assert labels == ["Episodes (4)", "Search", "Stats"]
+        assert not any(label.startswith("Facts ") for label in labels)
+
+    def test_dashboard_facts_only_user_renders_facts_button(self):
+        # Migration-only operator: the row is exactly [Facts, Search,
+        # Stats] (no Episodes). Tests the migration-only case and the
+        # facts-only row shape together.
+        stats = _stats(migration_count=25)
+        _, kb = memory_command._build_dashboard(stats)
+        assert kb is not None
+        utility_row = kb.inline_keyboard[-1]
+        labels = [btn.text for btn in utility_row]
+        assert labels == ["Facts (25)", "Search", "Stats"]
+
+    def test_dashboard_both_browse_buttons_renders_facts_first(self):
+        # Both browse buttons visible: Facts must come first
+        # (left-most), then Episodes, then Search, then Stats. Pins
+        # the placement so a regression that swaps the two browse
+        # buttons trips here.
+        stats = _stats(extracted_count=10, migration_count=2, episode_count=4)
+        _, kb = memory_command._build_dashboard(stats)
+        assert kb is not None
+        utility_row = kb.inline_keyboard[-1]
+        labels = [btn.text for btn in utility_row]
+        assert labels == ["Facts (12)", "Episodes (4)", "Search", "Stats"]
+
+    def test_dashboard_footer_both_browse_wording(self):
+        # When both Facts and Episodes render, the footer enumerates
+        # both browse buttons. Pins the new "Tap Facts or Episodes"
+        # phrasing so a regression to either single-button branch
+        # trips this assertion.
+        stats = _stats(extracted_count=10, episode_count=4)
+        text, _ = memory_command._build_dashboard(stats)
+        assert "Tap Facts or Episodes to browse, Search to find specific memories, or Stats for details." in text
+
+    def test_dashboard_footer_facts_only_wording(self):
+        # When Facts renders but Episodes does not, footer says
+        # "Tap Facts to browse..." (without Episodes). Migration-
+        # only fixture; the cross-test of the facts-only footer
+        # also lives in TestDashboardEpisodesButton's renamed
+        # `test_dashboard_facts_only_footer_wording` for historical
+        # continuity. Both pin the same branch from different angles.
+        stats = _stats(extracted_count=15)
+        text, _ = memory_command._build_dashboard(stats)
+        assert "Tap Facts to browse, Search to find specific memories, or Stats for details." in text
+        # Negative regression: the both-buttons phrasing must NOT
+        # leak in when only Facts is visible.
+        assert "Tap Facts or Episodes" not in text
+
+    def test_dashboard_footer_episodes_only_wording_unchanged(self):
+        # When Episodes renders but Facts does not, footer keeps the
+        # existing post-410 wording verbatim. Pins the unchanged
+        # branch so a sloppy refactor of the four-branch matrix
+        # cannot silently rewrite the episodes-only message.
+        stats = _stats(episode_count=4)
+        text, _ = memory_command._build_dashboard(stats)
+        assert "Tap Episodes to browse, Search to find specific memories, or Stats for details." in text
+        # Negative regression: Facts-related wording must not leak
+        # into the episodes-only branch.
+        assert "Tap Facts" not in text
 
 
 class TestBuildEpisodeListView:
@@ -1146,6 +1272,141 @@ class TestBuildEpisodeListView:
         assert text.startswith("Episodes  (page 1 of 1)")
 
 
+class TestBuildFactsListView:
+    """Paginated list view of fact-bucket rows (extracted + migration).
+
+    The list surface is intentionally source-agnostic: rows from both
+    sources render with the same shape (`N. <text>` + indented date),
+    no bracket field, no source label. The per-source distinction
+    surfaces only on the fact-view detail screen, which inherits the
+    issue #407 per-source rendering."""
+
+    def _row(
+        self,
+        fact_id: str,
+        text: str,
+        source: str = "extracted",
+        *,
+        created_at: str = "2026-04-29T10:00:00",
+        updated_at: str | None = None,
+    ) -> MemoryResult:
+        return MemoryResult(
+            id=fact_id,
+            text=text,
+            score=0.0,
+            memory_type="fact",
+            metadata={"source": source, "type": "fact"},
+            created_at=created_at,
+            updated_at=updated_at if updated_at is not None else created_at,
+        )
+
+    def test_renders_extracted_and_migration_rows_indistinguishably(self):
+        # Mixed list: one extracted row, one migration row. The list
+        # view must not surface any source distinction in the rendered
+        # text or in any per-row affordance. The fact-view detail
+        # screen handles the per-source rendering separately.
+        rows = [
+            self._row("e1", "Extracted one", source="extracted"),
+            self._row("m1", "Migration one", source="migration"),
+        ]
+        text, _kb, ids, _, _ = memory_command._build_facts_list_view(rows, 0)
+        # No source labels, no bracket fields.
+        assert "[extracted]" not in text
+        assert "[migration]" not in text
+        assert "Imported" not in text
+        assert "Fact:" not in text
+        # Both rows present, in input order (caller pre-sorts).
+        assert "1.  Extracted one" in text
+        assert "2.  Migration one" in text
+        assert ids == ["e1", "m1"]
+
+    def test_paginates(self):
+        # 12 rows at page-size 5 -> page 1: 5, page 2: 5, page 3: 2.
+        rows = [self._row(f"f{i}", f"Fact {i}") for i in range(12)]
+        # Page 1 (index 0).
+        _, kb, ids, page, total = memory_command._build_facts_list_view(rows, 0)
+        assert len(ids) == 5
+        assert page == 0
+        assert total == 3
+        nav_labels = [btn.text for btn in kb.inline_keyboard[-1]]
+        assert nav_labels == ["back", "next >"]
+        # Page 2 (middle).
+        _, kb, ids, page, total = memory_command._build_facts_list_view(rows, 1)
+        assert len(ids) == 5
+        assert page == 1
+        nav_labels = [btn.text for btn in kb.inline_keyboard[-1]]
+        assert nav_labels == ["< prev", "back", "next >"]
+        # Page 3 (partial last).
+        _, kb, ids, page, total = memory_command._build_facts_list_view(rows, 2)
+        assert len(ids) == 2
+        assert page == 2
+        nav_labels = [btn.text for btn in kb.inline_keyboard[-1]]
+        assert nav_labels == ["< prev", "back"]
+
+    def test_empty_state(self):
+        text, kb, ids, page, total = memory_command._build_facts_list_view([], 0)
+        assert text == "Facts\n\nNo facts yet."
+        assert ids == []
+        assert page == 0
+        assert total == 1
+        # Single back button on the keyboard.
+        assert len(kb.inline_keyboard) == 1
+        assert kb.inline_keyboard[0][0].text == "back"
+        # Back goes to dashboard, not to a stale facts page.
+        assert kb.inline_keyboard[0][0].callback_data == "mem:dash"
+
+    def test_truncates_long_text(self):
+        long_text = "x" * 200
+        rows = [self._row("f1", long_text)]
+        text, _, _, _, _ = memory_command._build_facts_list_view(rows, 0)
+        assert long_text not in text
+        assert "…" in text
+
+    def test_header_uses_two_space_separator(self):
+        # Header label and parenthetical are separated by exactly
+        # two spaces, matching the episode header convention. Pin
+        # so a single-space regression trips this test.
+        rows = [self._row("f1", "Just one")]
+        text, _, _, _, _ = memory_command._build_facts_list_view(rows, 0)
+        assert text.startswith("Facts  (page 1 of 1)")
+
+    def test_date_indent_four_spaces(self):
+        # Date line is indented exactly four spaces, lining up under
+        # the start of the fact text after the "N.  " prefix. Pin
+        # the indent so a regression to twelve spaces (the episode
+        # list's indent) trips this test.
+        rows = [self._row("f1", "Some fact", created_at="2026-04-30T10:00:00")]
+        text, _, _, _, _ = memory_command._build_facts_list_view(rows, 0)
+        # The date line is the second non-blank content line.
+        date_line = next(line for line in text.split("\n") if line.lstrip().startswith("2026-04-30"))
+        assert date_line == "    2026-04-30"
+
+    def test_number_buttons_use_fact_verb(self):
+        # Number buttons share the `fact` verb with the episode list.
+        # The fact-detail open is source-agnostic (cache.memory_ids
+        # at integer index); the list-screen sentinel determines the
+        # back-target, not the number-button verb.
+        rows = [self._row(f"f{i}", f"Fact {i}") for i in range(3)]
+        _, kb, _, _, _ = memory_command._build_facts_list_view(rows, 0)
+        number_row = kb.inline_keyboard[0]
+        assert [btn.text for btn in number_row] == ["1", "2", "3"]
+        for i, btn in enumerate(number_row):
+            assert btn.callback_data == f"mem:fact:{i}"
+
+    def test_nav_buttons_use_facts_verb(self):
+        # Prev and next buttons must encode `mem:facts:<page>`, not
+        # `mem:eps:<page>`. Pin the verb so a copy-paste regression
+        # from the episode list trips here.
+        rows = [self._row(f"f{i}", f"Fact {i}") for i in range(12)]
+        # Middle page so both prev and next render.
+        _, kb, _, _, _ = memory_command._build_facts_list_view(rows, 1)
+        nav_row = kb.inline_keyboard[-1]
+        prev_btn = next(btn for btn in nav_row if btn.text == "< prev")
+        next_btn = next(btn for btn in nav_row if btn.text == "next >")
+        assert prev_btn.callback_data == "mem:facts:0"
+        assert next_btn.callback_data == "mem:facts:2"
+
+
 class TestEpsCallbackDispatch:
     """Issue #410: handle_memory_callback `eps` verb dispatch."""
 
@@ -1229,6 +1490,179 @@ class TestFactViewEpisodeReturn:
         back_btn = kb.inline_keyboard[0][0]
         assert back_btn.text == "back"
         assert back_btn.callback_data == "mem:eps:2"
+
+
+class TestFactsCallbackDispatch:
+    """handle_memory_callback `facts` verb dispatch.
+
+    Mirrors `TestEpsCallbackDispatch`: the `facts` verb is the
+    initial entry point for the facts list browser, with a single
+    integer page argument."""
+
+    @pytest.mark.asyncio
+    async def test_facts_verb_dispatches_to_send_facts_list(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        captured: dict[str, Any] = {}
+
+        async def fake_send(update, context, chat_id, page, edit=False):
+            captured["chat_id"] = chat_id
+            captured["page"] = page
+            captured["edit"] = edit
+
+        monkeypatch.setattr(memory_command, "_send_facts_list", fake_send)
+        upd = update_factory(callback_data="mem:facts:0")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+        assert captured["chat_id"] == 100
+        assert captured["page"] == 0
+        assert captured["edit"] is True
+
+    @pytest.mark.asyncio
+    async def test_facts_verb_invalid_page_falls_back_to_zero(self, monkeypatch, update_factory, context_factory):
+        # Stale or crafted callback with a non-integer page must
+        # not crash; the dispatch falls back to page 0. Same
+        # contract as `eps`.
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        captured: dict[str, Any] = {}
+
+        async def fake_send(update, context, chat_id, page, edit=False):
+            captured["page"] = page
+
+        monkeypatch.setattr(memory_command, "_send_facts_list", fake_send)
+        upd = update_factory(callback_data="mem:facts:notaninteger")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+        assert captured["page"] == 0
+
+
+class TestFactViewFactsReturn:
+    """Back-navigation from a fact opened from the facts list returns
+    to the same page of that list. Mirrors `TestFactViewEpisodeReturn`
+    using the new `"facts"` cache sentinel."""
+
+    @pytest.mark.asyncio
+    async def test_fact_view_back_returns_to_facts_list(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+
+        # Prime the cache as if the user is on page 2 of the facts
+        # list.
+        memory_command._set_cache(
+            100,
+            memory_command._ScreenCache(
+                screen="facts",
+                page=2,
+                memory_ids=["f1"],
+            ),
+        )
+
+        # Stub get_by_id to return an extracted-shaped row so the
+        # fact view renders. The source value here is irrelevant to
+        # the back-target wiring; the cache sentinel is what
+        # determines the back-target.
+        fact = MemoryResult(
+            id="f1",
+            text="Some fact",
+            score=0.0,
+            memory_type="fact",
+            metadata={"source": "extracted", "tags": ["preference"]},
+            created_at="2026-04-29T10:00:00",
+            updated_at="2026-04-29T10:00:00",
+        )
+        monkeypatch.setattr(memory_command.memory, "get_by_id", lambda *, user_id, memory_id: fact)
+
+        upd = update_factory(callback_data="mem:fact:0")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+
+        # The fact view's edit_message_text was called with a
+        # keyboard whose back button targets the facts list at page
+        # 2 (mem:facts:2). Distinct from the existing eps target.
+        edit_call = upd.callback_query.edit_message_text.call_args
+        assert edit_call is not None
+        kb = edit_call.kwargs["reply_markup"]
+        back_btn = kb.inline_keyboard[0][0]
+        assert back_btn.text == "back"
+        assert back_btn.callback_data == "mem:facts:2"
+
+
+class TestForgetFactReturnFacts:
+    """Post-delete return-to wiring for facts opened from the facts
+    list. Mirrors the existing eps-branch behavior on `ffd`."""
+
+    @pytest.mark.asyncio
+    async def test_forget_fact_from_facts_list_returns_to_facts_list(
+        self, monkeypatch, update_factory, context_factory
+    ):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        # Mock the delete to succeed so the post-delete branch fires.
+        monkeypatch.setattr(memory_command.memory, "delete_by_id", lambda *, user_id, memory_id: True)
+
+        # Capture the post-delete dispatch by stubbing
+        # _send_facts_list. The branch should call this rather than
+        # _send_dashboard.
+        captured: dict[str, Any] = {}
+
+        async def fake_send_facts(update, context, chat_id, page, edit=False):
+            captured["facts_called"] = True
+            captured["page"] = page
+
+        async def fake_send_dashboard(update, context, chat_id, edit=False):
+            captured["dashboard_called"] = True
+
+        monkeypatch.setattr(memory_command, "_send_facts_list", fake_send_facts)
+        monkeypatch.setattr(memory_command, "_send_dashboard", fake_send_dashboard)
+
+        # Prime the cache as if the user is on the fact-detail view
+        # for a fact opened from page 1 of the facts list.
+        memory_command._set_cache(
+            100,
+            memory_command._ScreenCache(
+                screen="fact",
+                memory_ids=["f1"],
+                return_to=("facts", ["1"]),
+            ),
+        )
+
+        upd = update_factory(callback_data="mem:ffd")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+
+        # _send_facts_list must have been called with page 1, and
+        # the dashboard fallback must NOT have been invoked.
+        assert captured.get("facts_called") is True
+        assert captured["page"] == 1
+        assert captured.get("dashboard_called") is not True
+
+    @pytest.mark.asyncio
+    async def test_forget_fact_from_facts_list_invalid_page_falls_back_to_zero(
+        self, monkeypatch, update_factory, context_factory
+    ):
+        # Defensive parsing: a malformed return_to page (e.g., from
+        # a corrupted in-memory cache) must not crash; it falls back
+        # to page 0. Same contract as the eps branch.
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        monkeypatch.setattr(memory_command.memory, "delete_by_id", lambda *, user_id, memory_id: True)
+
+        captured: dict[str, Any] = {}
+
+        async def fake_send_facts(update, context, chat_id, page, edit=False):
+            captured["page"] = page
+
+        monkeypatch.setattr(memory_command, "_send_facts_list", fake_send_facts)
+
+        memory_command._set_cache(
+            100,
+            memory_command._ScreenCache(
+                screen="fact",
+                memory_ids=["f1"],
+                return_to=("facts", ["notaninteger"]),
+            ),
+        )
+
+        upd = update_factory(callback_data="mem:ffd")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+        assert captured["page"] == 0
 
 
 class TestHelpTextSummaryLine:


### PR DESCRIPTION
## Summary

Adds a recency-ordered `Facts (N)` button to the `/memory` dashboard that opens a paginated list folding `source: extracted` and `source: migration` rows into a single source-agnostic view. Closes the browse-axis gap left by the tag dismantle and parallels the existing Episodes (N) browser.

The fact-view detail screen keeps its per-source rendering (Fact header for extracted, Imported for migration). The list view is intentionally source-agnostic because the imported/extracted distinction is internal plumbing from the operator's perspective.

Closes #420.

## Changes

- **Data layer**: `memory.get_all_facts` enumerates the fact bucket (`{extracted, migration}`). Third source-filter category alongside `USER_VISIBLE_SOURCES` (admit list) and `get_all_episodes` (single-source enumeration). Module docstrings in `memory_command.py` updated to reflect the three-category taxonomy.
- **Dashboard**: `Facts (N)` button left of `Episodes (N)` on the utility row; visible when `extracted_count + migration_count > 0`. Three-branch footer matrix (both browse buttons, facts-only, episodes-only); the all-zero case is gated upstream by the existing empty-state guard.
- **Builder**: `_build_facts_list_view` mirrors the episode list shape but with no bracket and a four-space date indent.
- **Send helper**: `_send_facts_list` with new `"facts"` cache sentinel (distinct from `"fact"` for fact-detail).
- **Dispatch**: `facts <page>` verb adjacent to `eps`. Bad-int falls back to page 0; unknown-verb dismiss handles forward compatibility for any future retirement.
- **Return-to wiring**: `_send_fact_view` learns a `("facts", [page])` branch when opened from the facts list. The `ffd` post-delete handler grows a parallel facts branch so the operator lands back on the same page.

## Tests

- `TestGetAllFacts`: 5 tests parallel to `TestGetAllEpisodes` (filter, sort, empty, disabled short-circuit, limit=None).
- `TestDashboardFactsButton`: 8 tests covering the visibility predicate, sum semantics, both-buttons placement, and three reachable footer-wording branches.
- `TestBuildFactsListView`: 8 tests covering the indistinguishable rendering, pagination, empty state, truncation, header, four-space indent, and per-button verb assignments.
- `TestFactsCallbackDispatch`: 2 tests (happy path + bad-int fallback).
- `TestFactViewFactsReturn`: 1 test (back-nav targets `mem:facts:<page>`).
- `TestForgetFactReturnFacts`: 2 tests (post-delete returns to facts list; bad-page fallback).
- Updated existing tests in `TestDashboardEpisodesButton` and `TestDashboardMultiSource` whose fixtures now produce a Facts button under the new behavior. One test renamed (`test_dashboard_no_episodes_footer_wording` -> `test_dashboard_facts_only_footer_wording`).

## Out of scope

- Per-source browser separation. Operators told us the imported/extracted distinction is internal plumbing.
- Visible source labels in the list. Provenance lives in the fact-view detail.
- Latency instrumentation. The full `get_all` fetch is the same shape as `get_all_episodes`; tracked under #336.

## Test plan

- [ ] `make check` passes.
- [ ] `make test` passes (2710 tests).
- [ ] Manual: dashboard shows `Facts (N), Episodes (N), Search, Stats` for a mixed-source operator.
- [ ] Manual: tap Facts; numbered tap opens fact-view; back returns to same page.
- [ ] Manual: forget from facts list returns to facts list, not dashboard.
- [ ] Manual: episode-only operator sees only `Episodes (N), Search, Stats` (no Facts).
