### PR TITLE
feat(memory): tighten extractor against workflow-event noise (#426)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ home/config/*
 home/evals/*
 !home/evals/retrieval-baseline.example.json
 !home/evals/probes.example.jsonl
+!home/evals/extraction-probes.example.jsonl
 
 # OS / IDE
 .DS_Store

--- a/home/evals/extraction-probes.example.jsonl
+++ b/home/evals/extraction-probes.example.jsonl
@@ -1,0 +1,18 @@
+# Example probe fixture for the extractor pre/post comparison harness.
+# Tracked in git so integration tests have a stable, reproducible
+# input. The live fixture (extraction-probes.jsonl, gitignored) carries
+# real session content; this file is small enough to read and review.
+#
+# Schema:
+#   probe_id: string id
+#   category: "workflow-noise" | "durable-content"
+#   window: { prior: [{role, text}, ...], current: {user, assistant} }
+#   expected:
+#     workflow-noise: { should_extract_any: false, must_not_contain: [substring, ...] }
+#     durable-content: { should_extract_any: true, must_contain: [substring, ...] }
+#
+# Comments lines start with "#" and are stripped by the loader.
+{"probe_id":"wf-ex-001","category":"workflow-noise","window":{"prior":[],"current":{"user":"Let's evaluate spec 414 v3 next.","assistant":"OK, I'll run the evaluation against the v3 spec and report findings."}},"expected":{"should_extract_any":false,"must_not_contain":["evaluation","spec 414","approved"]}}
+{"probe_id":"wf-ex-002","category":"workflow-noise","window":{"prior":[],"current":{"user":"Please file an issue about the memory.recall query truncation.","assistant":"Filed issue #395 covering the query truncation."}},"expected":{"should_extract_any":false,"must_not_contain":["decided to file","filed an issue"]}}
+{"probe_id":"dur-ex-001","category":"durable-content","window":{"prior":[],"current":{"user":"I prefer Earl Grey over English Breakfast.","assistant":"Got it, Earl Grey noted."}},"expected":{"should_extract_any":true,"must_contain":["earl grey"]}}
+{"probe_id":"dur-ex-002","category":"durable-content","window":{"prior":[],"current":{"user":"The home workspace must be per-user, not shared. Going forward, every user gets their own home dir under DATA_DIR.","assistant":"Understood, per-user home workspaces under DATA_DIR."}},"expected":{"should_extract_any":true,"must_contain":["per-user","home"]}}

--- a/home/evals/extraction-probes.example.jsonl
+++ b/home/evals/extraction-probes.example.jsonl
@@ -11,7 +11,7 @@
 #     workflow-noise: { should_extract_any: false, must_not_contain: [substring, ...] }
 #     durable-content: { should_extract_any: true, must_contain: [substring, ...] }
 #
-# Comments lines start with "#" and are stripped by the loader.
+# Comment lines start with "#" and are stripped by the loader.
 {"probe_id":"wf-ex-001","category":"workflow-noise","window":{"prior":[],"current":{"user":"Let's evaluate spec 414 v3 next.","assistant":"OK, I'll run the evaluation against the v3 spec and report findings."}},"expected":{"should_extract_any":false,"must_not_contain":["evaluation","spec 414","approved"]}}
 {"probe_id":"wf-ex-002","category":"workflow-noise","window":{"prior":[],"current":{"user":"Please file an issue about the memory.recall query truncation.","assistant":"Filed issue #395 covering the query truncation."}},"expected":{"should_extract_any":false,"must_not_contain":["decided to file","filed an issue"]}}
 {"probe_id":"dur-ex-001","category":"durable-content","window":{"prior":[],"current":{"user":"I prefer Earl Grey over English Breakfast.","assistant":"Got it, Earl Grey noted."}},"expected":{"should_extract_any":true,"must_contain":["earl grey"]}}

--- a/home/evals/extraction-probes.example.jsonl
+++ b/home/evals/extraction-probes.example.jsonl
@@ -12,7 +12,7 @@
 #     durable-content: { should_extract_any: true, must_contain: [substring, ...] }
 #
 # Comment lines start with "#" and are stripped by the loader.
-{"probe_id":"wf-ex-001","category":"workflow-noise","window":{"prior":[],"current":{"user":"Let's evaluate spec 414 v3 next.","assistant":"OK, I'll run the evaluation against the v3 spec and report findings."}},"expected":{"should_extract_any":false,"must_not_contain":["evaluation","spec 414","approved"]}}
+{"probe_id":"wf-ex-001","category":"workflow-noise","window":{"prior":[],"current":{"user":"Let's evaluate spec foo v3 next.","assistant":"OK, I'll run the evaluation against the v3 spec and report findings."}},"expected":{"should_extract_any":false,"must_not_contain":["evaluation","spec foo","approved"]}}
 {"probe_id":"wf-ex-002","category":"workflow-noise","window":{"prior":[],"current":{"user":"Please file an issue about the memory.recall query truncation.","assistant":"Filed issue #395 covering the query truncation."}},"expected":{"should_extract_any":false,"must_not_contain":["decided to file","filed an issue"]}}
 {"probe_id":"dur-ex-001","category":"durable-content","window":{"prior":[],"current":{"user":"I prefer Earl Grey over English Breakfast.","assistant":"Got it, Earl Grey noted."}},"expected":{"should_extract_any":true,"must_contain":["earl grey"]}}
 {"probe_id":"dur-ex-002","category":"durable-content","window":{"prior":[],"current":{"user":"The home workspace must be per-user, not shared. Going forward, every user gets their own home dir under DATA_DIR.","assistant":"Understood, per-user home workspaces under DATA_DIR."}},"expected":{"should_extract_any":true,"must_contain":["per-user","home"]}}

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -225,6 +225,13 @@ class Probe:
     expected: dict
 
 
+# Closed set of categories recognised by `_classify_outcome`. Used
+# at load time by `load_probes` to reject typo'd category strings
+# before the harness starts running, since the classifier silently
+# returns "ambiguous" for unknown categories.
+_VALID_CATEGORIES: frozenset[str] = frozenset({"workflow-noise", "durable-content"})
+
+
 @dataclass
 class ProbeOutcome:
     """Per-probe result of running v5 and v6 extractor arms.
@@ -295,6 +302,17 @@ def load_probes(path: Path) -> list[Probe]:
             current = probe.window["current"]
             if not isinstance(current, dict) or not current.get("user") or not current.get("assistant"):
                 raise ValueError(f"{path}:{line_number}: window.current must have non-empty user and assistant")
+            # Validate category against the closed set so a typo
+            # (e.g. underscore-vs-hyphen `workflow_noise`) raises at
+            # load time. The classifier's `if probe.category ==`
+            # comparisons would otherwise silently fall through to
+            # `ambiguous` for every probe in the file, yielding
+            # `None` rates with no indication of why.
+            if probe.category not in _VALID_CATEGORIES:
+                raise ValueError(
+                    f"{path}:{line_number}: unknown category {probe.category!r}"
+                    f" (must be one of {sorted(_VALID_CATEGORIES)})"
+                )
             probes.append(probe)
     return probes
 

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -280,15 +280,21 @@ def load_probes(path: Path) -> list[Probe]:
             except KeyError as exc:
                 raise ValueError(f"{path}:{line_number}: missing required field {exc}") from exc
             # Validate the window structure at load time so a fixture
-            # missing `current` raises an actionable error here instead
-            # of silently routing through `_run_one_probe`'s
-            # error-bucket path at run time. The harness's
-            # `_window_to_extractor_args` tolerates missing `current`
-            # via `.get("current") or {}` for defensive runtime
-            # behavior; the load-time check is the operator's
-            # diagnostic anchor.
+            # missing `current` (or with a typo'd inner field like
+            # `typo_user` instead of `user`) raises an actionable
+            # error here instead of silently routing through
+            # `_run_one_probe`'s error-bucket path at run time with
+            # empty extractor inputs and an unrecoverable subprocess
+            # cost. The harness's `_window_to_extractor_args`
+            # tolerates missing fields via `.get("user", "")` for
+            # defensive runtime behavior; the load-time check is the
+            # operator's diagnostic anchor and catches the typo
+            # class the runtime fallback can't surface.
             if not isinstance(probe.window, dict) or "current" not in probe.window:
                 raise ValueError(f"{path}:{line_number}: window.current is required")
+            current = probe.window["current"]
+            if not isinstance(current, dict) or not current.get("user") or not current.get("assistant"):
+                raise ValueError(f"{path}:{line_number}: window.current must have non-empty user and assistant")
             probes.append(probe)
     return probes
 
@@ -434,6 +440,20 @@ def _classify_outcome(probe: Probe, *, v5_facts: list[str], v6_facts: list[str])
     outcome string. The labels feed the aggregate counters and
     drive the workflow_drop_rate / durable_preservation_rate
     arithmetic.
+
+    Substring-matching semantics:
+
+    - `must_not_contain` is OR: v6 fails if ANY listed substring
+      appears in any v6 fact. The list enumerates banned
+      substrings; one hit is enough to flag a regression.
+    - `must_contain` is also OR: v6 succeeds if ANY listed
+      substring appears in any v6 fact. The list enumerates
+      acceptable anchors and the probe scores `durable_preserved`
+      on the first hit. A future fixture author who needs strict
+      AND semantics ("v6 must mention BOTH home AND per-user")
+      should split into two probes or extend the schema with a
+      `must_contain_all` field; bare `any()` is the documented
+      behavior here.
     """
     must_not_contain = probe.expected.get("must_not_contain") or []
     must_contain = probe.expected.get("must_contain") or []

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -232,6 +232,11 @@ class ProbeOutcome:
     v5_facts: list[str]
     v6_facts: list[str]
     expected_outcome: str
+    # Rule 6 fires per-arm; the harness reports both deltas
+    # separately so the v6 number is not inflated by v5's
+    # higher rejection rate (v5 produces more workflow-event
+    # content by design).
+    v5_rule_6_rejections_delta: int
     v6_rule_6_rejections_delta: int
 
 
@@ -295,13 +300,19 @@ async def _run_one_probe(
         user_text, assistant_text, candidates=None, prior_pairs=prior_pairs
     )
 
-    pre_count = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
-
     # v5 arm: thread the pinned prompt. The `confirmed_action` skip
     # in Rule 6 still applies on this arm since the regex is part of
     # the active validator regardless of which prompt produced the
     # candidate facts; that is the right behavior because Rule 6 is
     # the SAME validator the harness is measuring against.
+    #
+    # Rule 6 fires on BOTH arms (the active validator runs against
+    # whatever facts each arm emits), and v5 is expected to fire it
+    # more because v5 produces more workflow-event content. We
+    # snapshot the counter around each arm separately so the v6
+    # delta is attributed to v6 only - lumping the two arms together
+    # would inflate the v6 metric with v5's more numerous rejections.
+    pre_v5 = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
     v5_result = await memory_extraction._run_extractor(
         payload,
         config,
@@ -310,8 +321,10 @@ async def _run_one_probe(
         user_id=user_id,
         system_prompt=_PROMPT_V5_PINNED,
     )
+    post_v5 = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
 
     # v6 arm: default kwarg, inherits the active `_EXTRACTION_SYSTEM_PROMPT`.
+    pre_v6 = post_v5
     v6_result = await memory_extraction._run_extractor(
         payload,
         config,
@@ -319,8 +332,10 @@ async def _run_one_probe(
         candidate_metadata={},
         user_id=user_id,
     )
+    post_v6 = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
 
-    post_count = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
+    v5_rule_6_delta = post_v5 - pre_v5
+    v6_rule_6_delta = post_v6 - pre_v6
 
     v5_facts = [str(f.get("content", "")) for f in v5_result.facts]
     v6_facts = [str(f.get("content", "")) for f in v6_result.facts]
@@ -333,7 +348,8 @@ async def _run_one_probe(
         v5_facts=v5_facts,
         v6_facts=v6_facts,
         expected_outcome=expected_outcome,
-        v6_rule_6_rejections_delta=post_count - pre_count,
+        v5_rule_6_rejections_delta=v5_rule_6_delta,
+        v6_rule_6_rejections_delta=v6_rule_6_delta,
     )
 
 
@@ -358,8 +374,23 @@ def _classify_outcome(probe: Probe, *, v5_facts: list[str], v6_facts: list[str])
         # we cannot say v6 "dropped" something v5 also did not produce.
         if not v5_facts:
             return "ambiguous"
-        if should_extract_any is False and not v6_facts:
-            return "workflow_dropped"
+        # Strict win condition: when the probe declares
+        # `should_extract_any: false`, only a fully-empty v6 counts
+        # as `workflow_dropped`. Earlier wording let a partial drop
+        # (v6 still emitted facts, just none containing the
+        # forbidden substrings) score as a win, which inflated
+        # workflow_drop_rate on probes where v6 partially-suppresses
+        # but the operator asked for zero extraction.
+        if should_extract_any is False:
+            if not v6_facts:
+                return "workflow_dropped"
+            return "regression"
+        # When the probe does NOT declare should_extract_any: false
+        # (no opinion on whether v6 must be empty), a v6 that
+        # produced fewer facts than v5 AND avoided every forbidden
+        # substring still counts as `workflow_dropped`. This is the
+        # softer win condition for probes where some durable signal
+        # may legitimately remain.
         if not v6_violates_must_not and len(v6_facts) < len(v5_facts):
             return "workflow_dropped"
         return "regression"
@@ -387,9 +418,11 @@ def _aggregate(outcomes: list[ProbeOutcome]) -> dict:
     workflow_drops = 0
     durable_total = 0
     durable_preserves = 0
-    rule_6_total = 0
+    v5_rule_6_total = 0
+    v6_rule_6_total = 0
     for o in outcomes:
-        rule_6_total += o.v6_rule_6_rejections_delta
+        v5_rule_6_total += o.v5_rule_6_rejections_delta
+        v6_rule_6_total += o.v6_rule_6_rejections_delta
         if o.category == "workflow-noise" and o.expected_outcome != "ambiguous":
             workflow_total += 1
             if o.expected_outcome == "workflow_dropped":
@@ -401,7 +434,8 @@ def _aggregate(outcomes: list[ProbeOutcome]) -> dict:
     return {
         "workflow_drop_rate": (workflow_drops / workflow_total) if workflow_total else None,
         "durable_preservation_rate": (durable_preserves / durable_total) if durable_total else None,
-        "rule_6_rejections": rule_6_total,
+        "v5_rule_6_rejections": v5_rule_6_total,
+        "v6_rule_6_rejections": v6_rule_6_total,
         "scorable_workflow_count": workflow_total,
         "scorable_durable_count": durable_total,
     }
@@ -465,10 +499,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--user-id",
-        default="2114582497",
+        default="eval-harness",
         help="user_id passed through to the extractor (cosmetic for "
         "this harness; the harness does not read or write the live "
-        "memory store).",
+        "memory store). The Rule 6 rejection counter is keyed by "
+        "user_id, so setting this to a stable label makes a long-"
+        "running session's rejection counts easy to attribute.",
     )
     parser.add_argument(
         "--output",

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -509,14 +509,19 @@ def _classify_outcome(probe: Probe, *, v5_facts: list[str], v6_facts: list[str])
             return "workflow_dropped"
         return "regression"
     if probe.category == "durable-content":
-        # The win condition: v6 produced at least one fact carrying
-        # the required substrings. Symmetric ambiguity check first:
-        # if BOTH arms came up empty the probe window is too sparse
-        # to inform v5-vs-v6 (parallel to the workflow-noise
-        # branch's `if not v5_facts: return "ambiguous"`). When v5
-        # produced facts but v6 did not, that IS a regression
-        # because the durable fact must come through under v6.
-        if not v5_facts and not v6_facts:
+        # The win condition: v6 PRESERVED a fact v5 also produced.
+        # Symmetric ambiguity checks come first:
+        #   - both arms empty: probe window too sparse to inform.
+        #   - v5 empty, v6 non-empty: v6 found something v5 missed.
+        #     Nothing was "preserved" because v5 had nothing to
+        #     start with; treat as ambiguous rather than counting
+        #     a v6 strict-improvement as preservation. Mirrors the
+        #     workflow-noise branch's `if not v5_facts: return
+        #     "ambiguous"` symmetric guard.
+        # When v5 produced facts but v6 did not, that IS a
+        # regression because the durable fact must come through
+        # under v6.
+        if not v5_facts:
             return "ambiguous"
         if not v6_facts:
             return "regression"
@@ -544,15 +549,15 @@ def _aggregate(outcomes: list[ProbeOutcome]) -> dict:
     # `_run_async` for the per-probe try/except). Both go in the
     # report so the operator sees them, but they do not feed the
     # workflow_drop_rate or durable_preservation_rate arithmetic.
-    _SKIP_OUTCOMES = {"ambiguous", "error"}
+    skip_outcomes = {"ambiguous", "error"}
     for o in outcomes:
         v5_rule_6_total += o.v5_rule_6_rejections_delta
         v6_rule_6_total += o.v6_rule_6_rejections_delta
-        if o.category == "workflow-noise" and o.outcome not in _SKIP_OUTCOMES:
+        if o.category == "workflow-noise" and o.outcome not in skip_outcomes:
             workflow_total += 1
             if o.outcome == "workflow_dropped":
                 workflow_drops += 1
-        elif o.category == "durable-content" and o.outcome not in _SKIP_OUTCOMES:
+        elif o.category == "durable-content" and o.outcome not in skip_outcomes:
             durable_total += 1
             if o.outcome == "durable_preserved":
                 durable_preserves += 1

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -323,21 +323,27 @@ async def _run_one_probe(
     report: an attributable accounting of partial progress, not a
     silent loss of v5's rejections to the error bucket.
     """
-    user_text, assistant_text, prior_pairs = _window_to_extractor_args(probe.window)
-    payload = memory_extraction._build_extraction_payload(
-        user_text, assistant_text, candidates=None, prior_pairs=prior_pairs
-    )
-
     # Initialize all per-arm state to zero/empty so an exception in
-    # either arm leaves the partial-progress accounting accurate.
-    # The control flow inside the try block updates these in place
-    # as each arm completes.
+    # either arm (or the payload-build below) leaves the
+    # partial-progress accounting accurate. The control flow inside
+    # the try block updates these in place as each step completes.
     v5_facts: list[str] = []
     v6_facts: list[str] = []
     v5_rule_6_delta = 0
     v6_rule_6_delta = 0
 
     try:
+        # Payload construction lives inside the try block so a
+        # malformed probe (e.g., a window field that violates an
+        # invariant `_build_extraction_payload` does not check
+        # defensively) routes through the same error-bucket path
+        # as a subprocess crash. Without the guard the docstring's
+        # "Never raises" contract would have a hole - the exact
+        # failure mode the per-probe try/except exists to prevent.
+        user_text, assistant_text, prior_pairs = _window_to_extractor_args(probe.window)
+        payload = memory_extraction._build_extraction_payload(
+            user_text, assistant_text, candidates=None, prior_pairs=prior_pairs
+        )
         # v5 arm: thread the pinned prompt. The `confirmed_action`
         # skip in Rule 6 still applies on this arm since the regex
         # is part of the active validator regardless of which prompt

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -255,19 +255,32 @@ def load_probes(path: Path) -> list[Probe]:
     """Parse a JSONL probe file. `#`-prefixed lines are comments."""
     probes: list[Probe] = []
     with path.open() as f:
-        for raw in f:
+        for line_number, raw in enumerate(f, start=1):
             line = raw.strip()
             if not line or line.startswith("#"):
                 continue
-            obj = json.loads(line)
-            probes.append(
-                Probe(
-                    probe_id=obj["probe_id"],
-                    category=obj["category"],
-                    window=obj["window"],
-                    expected=obj.get("expected", {}),
+            # Wrap JSON parsing so a malformed fixture line surfaces
+            # the file path and line number rather than a bare
+            # JSONDecodeError. Operators curate this fixture by
+            # hand from session history, so a typo on probe 12 of
+            # 20 should not produce a traceback that buries which
+            # probe broke. Same shape applies to a missing required
+            # field (probe_id / category / window).
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_number}: invalid JSON: {exc}") from exc
+            try:
+                probes.append(
+                    Probe(
+                        probe_id=obj["probe_id"],
+                        category=obj["category"],
+                        window=obj["window"],
+                        expected=obj.get("expected", {}),
+                    )
                 )
-            )
+            except KeyError as exc:
+                raise ValueError(f"{path}:{line_number}: missing required field {exc}") from exc
     return probes
 
 

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -271,16 +271,25 @@ def load_probes(path: Path) -> list[Probe]:
             except json.JSONDecodeError as exc:
                 raise ValueError(f"{path}:{line_number}: invalid JSON: {exc}") from exc
             try:
-                probes.append(
-                    Probe(
-                        probe_id=obj["probe_id"],
-                        category=obj["category"],
-                        window=obj["window"],
-                        expected=obj.get("expected", {}),
-                    )
+                probe = Probe(
+                    probe_id=obj["probe_id"],
+                    category=obj["category"],
+                    window=obj["window"],
+                    expected=obj.get("expected", {}),
                 )
             except KeyError as exc:
                 raise ValueError(f"{path}:{line_number}: missing required field {exc}") from exc
+            # Validate the window structure at load time so a fixture
+            # missing `current` raises an actionable error here instead
+            # of silently routing through `_run_one_probe`'s
+            # error-bucket path at run time. The harness's
+            # `_window_to_extractor_args` tolerates missing `current`
+            # via `.get("current") or {}` for defensive runtime
+            # behavior; the load-time check is the operator's
+            # diagnostic anchor.
+            if not isinstance(probe.window, dict) or "current" not in probe.window:
+                raise ValueError(f"{path}:{line_number}: window.current is required")
+            probes.append(probe)
     return probes
 
 

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -1,0 +1,497 @@
+"""Layer 4 evaluation: extractor prompt pre/post comparison.
+
+Subprocess-driven head-to-head of the active extractor prompt against
+a pinned baseline. For each probe in a JSONL fixture, the harness
+runs `_run_extractor` twice (one arm per prompt) and reports a
+confusion matrix: workflow-noise dropped (the v5 → v6 win condition)
+versus durable-fact preservation (the regression we must avoid).
+
+The pinned baseline (`_PROMPT_V5_PINNED` below) is the v5 prompt
+captured verbatim before #426's prompt edits landed. It is checked
+in so the eval is reproducible across machines and across future
+prompt revisions; updating it requires capturing a new baseline at
+that revision's landing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from kai import memory_extraction
+from kai.config import load_config
+
+log = logging.getLogger(__name__)
+
+
+# ── Pinned baseline prompt ──────────────────────────────────────────
+#
+# Verbatim copy of `_EXTRACTION_SYSTEM_PROMPT` as it stood at
+# `_EXTRACTION_PROMPT_VERSION = "5"` (PR #415, 2026-04-30). The
+# eval harness threads this string into `_run_extractor` via the
+# `system_prompt` keyword-only parameter so the v5 arm runs without
+# reverting `memory_extraction.py`.
+#
+# Update this constant ONLY when adding a new pinned baseline (e.g.,
+# capturing v6 to compare against a future v7). Do NOT track it with
+# the active prompt; that defeats the head-to-head purpose. The
+# `tests/test_eval_extraction.py::test_v5_pinned_drift` integration
+# test hashes this string against a known-good digest and fails on
+# any silent edit.
+_PROMPT_V5_PINNED = """You are a memory extraction assistant for Kai, a personal AI agent.
+You receive a short conversation window: zero or more PRIOR CONTEXT
+exchanges followed by ONE current exchange (a USER message and an
+ASSISTANT reply, marked with >>>).
+
+Fact extraction operates ONLY on the current exchange. PRIOR CONTEXT
+is for episode classification only; do NOT extract facts from prior
+turns.
+
+Your job is to extract stable, high-signal facts worth remembering
+across sessions. Return a JSON object matching the provided schema.
+
+STORE these fact types:
+- User-stated preferences (e.g., units, timezone, style preferences,
+  what the user likes or dislikes).
+- Stable facts about the user (e.g., location, role, project names,
+  repo names, hardware).
+- Decisions the user made in this exchange ("we're going with X",
+  "let's use Y", "I decided Z").
+- Actions the user confirmed happened, BUT with strict evidence
+  rules to prevent laundered hallucinations:
+  1. A confirmed_action fact must include a `confirmation_quote`
+     field that quotes the exact user text demonstrating the
+     confirmation.
+  2. The confirmation_quote must be at least 20 characters long
+     and must explicitly reference the action being confirmed.
+     "I see PR #299 is merged, thanks" is valid evidence.
+     "thanks", "ok", "good", "nice", a single emoji, or any
+     one-word or two-word affirmation is NOT valid evidence.
+     If the user's text is a generic acknowledgment, DO NOT emit
+     a confirmed_action fact, regardless of how clearly the
+     assistant claimed the action.
+  3. The assistant's prior claim alone is never sufficient.
+     Without specific, quotable user confirmation that names the
+     action, extract nothing.
+- Constraints or requirements the user stated ("must be local",
+  "must not use external APIs", "never commit without running tests").
+
+IGNORE:
+- Assistant self-reports of completed actions unless user-confirmed
+  ("I saved the file", "Done", "Created X", "Pushed to main").
+  Treat these as unverified until the user confirms.
+- Assistant speculation, hypotheticals, or hedging ("I think...",
+  "it might be...", "probably...").
+- Intermediate reasoning, tool-output summaries, step-by-step plans.
+- Transient conversation state (what you are mid-doing, open
+  questions, clarifying requests).
+- Casual chat, greetings, acknowledgments, thanks without content.
+- Anything that contradicts a stated user preference.
+- Code snippets, file contents, error messages (store facts about
+  them if needed, not the raw text).
+
+CONFIDENCE:
+- Only store facts you can phrase as a single clear sentence.
+- Each fact must have a concrete subject and predicate. Vague
+  impressions do not qualify.
+- If nothing qualifies, return {"facts": []}. An empty result is
+  correct and preferred over low-quality facts.
+
+FORMAT each fact as:
+- content: one sentence, third-person where possible
+  ("User prefers Celsius"), past tense for confirmed actions
+  ("User confirmed PR #299 was merged on 2026-04-12").
+- tags: 1 to 5 lowercase topical tags. Use these preferred tags
+  when one fits the fact: preference, decision, fact, constraint,
+  confirmed_action, project, location, schedule, relationship.
+  Only invent new tags when none of these capture the fact's
+  topic; new tags should be single lowercase words or short
+  underscore-joined compounds, no punctuation beyond underscores.
+
+  The tag `confirmed_action` is structurally significant: when
+  the fact represents a user-confirmed action (with a
+  confirmation_quote), you MUST use the literal tag
+  `confirmed_action`. NEVER substitute synonyms like
+  `confirmation`, `confirmed`, `user_confirmed`, or `confirm` -
+  they are NOT recognized by the storage system and will cause
+  the fact to be rejected.
+- confidence: a number in [0, 1]. Use 0.9+ for direct user statements,
+  0.7 for clear user confirmation of an assistant claim, 0.5 for
+  paraphrased or implied facts. Do not store below 0.5.
+- confirmation_quote: REQUIRED when tags include "confirmed_action",
+  MUST be absent otherwise. Must be the verbatim user text that
+  confirms the action, minimum 20 characters, and must reference
+  the action specifically (not a generic "thanks"). If no such
+  quote exists, do not emit the fact.
+
+EPISODE CLASSIFICATION (windowed):
+Decide whether the CURRENT exchange (marked with >>>) is the closing
+turn of an episode. PRIOR CONTEXT shows the lead-up; it is background,
+NEVER the unit being classified.
+
+Set `has_episode: true` ONLY when ALL of the following hold:
+1. The CURRENT exchange contains a stated decision, lesson, outcome,
+   or resolution. Closure must be visible in the current turn itself.
+2. The PRIOR CONTEXT (if non-empty) sets up that closure: a problem,
+   a question, a deliberation, an incident in progress.
+3. You can quote a fragment from the CURRENT exchange (not from
+   prior turns) that signals the closure.
+
+Set `has_episode: false` when:
+- The current exchange is itself a question, a request, an analytical
+  reply, or a status update with no resolution. Even if prior context
+  is rich, an unresolved current turn is not an episode close.
+- The current exchange is routine: a single fact lookup, an
+  acknowledgment, casual chat.
+- Closure exists in prior turns but the current turn moved on to a
+  new topic.
+
+When in doubt, prefer false. The cost of a false negative is one
+missed episode; the cost of a false positive is a hallucinated
+episode entering the memory store.
+
+CONSOLIDATION:
+You will sometimes receive an EXISTING FACTS block before the USER/ASSISTANT
+exchange. Each existing fact is shown with its id in square brackets,
+provenance, and confidence. For each fact you are about to emit, choose one
+of three intents:
+
+- "new": the proposed fact is genuinely net-new information. Use this when
+  no existing fact covers the same underlying claim, even paraphrased.
+  Most facts are new; do not over-eagerly tie facts to existing ids.
+  When no EXISTING FACTS block is present, "new" is always the correct
+  intent.
+
+- "update_of": the proposed fact ASSERTS THE SAME UNDERLYING CLAIM as an
+  existing fact, but with a value that differs (a path changed, a tunable
+  was retuned, a project name was renamed) OR with strictly more specific
+  information (a confirmed timestamp where there was a vague reference).
+  Cite the existing id in `existing_id`. The new fact will REPLACE the
+  cited fact. Use this conservatively: only when one fact rendering the
+  other obsolete is clearly correct.
+
+- "skip_redundant": the proposed fact is a paraphrase of an existing fact
+  with no new information and no contradictory value. Cite the existing id
+  in `existing_id`. The new fact will NOT be stored. Prefer this over
+  "update_of" when the existing fact is already adequate; only use
+  "update_of" when the new wording carries information the old wording
+  lacks.
+
+Important constraints:
+- existing_id MUST be one of the ids shown in the EXISTING FACTS block.
+  Do NOT invent ids. If no EXISTING FACTS block is present, or if no
+  existing fact matches, use intent "new".
+- Each existing id may be referenced by AT MOST ONE proposed fact in this
+  batch. Do not split a single update across two proposed facts, and do
+  not have two proposed facts both update the same existing fact.
+- A confirmed_action fact is always "new" (a confirmation is a fresh
+  observation about reality, even if the wording paraphrases an existing
+  fact). Never emit "skip_redundant" or "update_of" for a confirmed_action;
+  always store it as a separate "new" fact so the timestamp record stays
+  intact.
+"""
+
+
+# ── Harness ─────────────────────────────────────────────────────────
+
+
+# Output schema version. Bumped when the per_probe or aggregate shape
+# changes in a way that would break a tool reading prior runs.
+_OUTPUT_SCHEMA_VERSION = "1"
+
+
+@dataclass
+class Probe:
+    """One labelled probe from `extraction-probes.jsonl`.
+
+    `category` selects the success criterion: workflow-noise probes
+    are scored on whether v6 dropped extractions that v5 produced;
+    durable-content probes are scored on whether v6 preserved them.
+    `expected.must_not_contain` (workflow-noise) and
+    `expected.must_contain` (durable-content) carry per-probe
+    substring assertions for finer-grained outcome classification.
+    """
+
+    probe_id: str
+    category: str
+    window: dict
+    expected: dict
+
+
+@dataclass
+class ProbeOutcome:
+    probe_id: str
+    category: str
+    v5_facts: list[str]
+    v6_facts: list[str]
+    expected_outcome: str
+    v6_rule_6_rejections_delta: int
+
+
+def load_probes(path: Path) -> list[Probe]:
+    """Parse a JSONL probe file. `#`-prefixed lines are comments."""
+    probes: list[Probe] = []
+    with path.open() as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            obj = json.loads(line)
+            probes.append(
+                Probe(
+                    probe_id=obj["probe_id"],
+                    category=obj["category"],
+                    window=obj["window"],
+                    expected=obj.get("expected", {}),
+                )
+            )
+    return probes
+
+
+def _window_to_extractor_args(window: dict) -> tuple[str, str, list[tuple[str, str]]]:
+    """Convert a probe window into the positional args
+    `_build_extraction_payload` expects.
+
+    `prior` is rendered as a list of `(user_text, assistant_text)`
+    pairs, mirroring the production `prior_pairs` shape; an entry
+    is omitted when its role's text is missing (the schema allows
+    asymmetric prior turns). `current.user` and `current.assistant`
+    map directly onto the function's first two positional args.
+    """
+    prior_raw = window.get("prior", []) or []
+    prior_pairs: list[tuple[str, str]] = []
+    pending_user: str | None = None
+    for entry in prior_raw:
+        role = entry.get("role")
+        text = entry.get("text", "")
+        if role == "user":
+            pending_user = text
+        elif role == "assistant" and pending_user is not None:
+            prior_pairs.append((pending_user, text))
+            pending_user = None
+    current = window.get("current") or {}
+    return current.get("user", ""), current.get("assistant", ""), prior_pairs
+
+
+async def _run_one_probe(
+    probe: Probe,
+    config,
+    *,
+    user_id: str,
+) -> ProbeOutcome:
+    """Run both prompt arms against a single probe and classify the
+    outcome. Each arm is a sequential subprocess call so the active
+    `_RULE_6_REJECTIONS` counter delta can be attributed to v6.
+    """
+    user_text, assistant_text, prior_pairs = _window_to_extractor_args(probe.window)
+    payload = memory_extraction._build_extraction_payload(
+        user_text, assistant_text, candidates=None, prior_pairs=prior_pairs
+    )
+
+    pre_count = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
+
+    # v5 arm: thread the pinned prompt. The `confirmed_action` skip
+    # in Rule 6 still applies on this arm since the regex is part of
+    # the active validator regardless of which prompt produced the
+    # candidate facts; that is the right behavior because Rule 6 is
+    # the SAME validator the harness is measuring against.
+    v5_result = await memory_extraction._run_extractor(
+        payload,
+        config,
+        candidate_ids=set(),
+        candidate_metadata={},
+        user_id=user_id,
+        system_prompt=_PROMPT_V5_PINNED,
+    )
+
+    # v6 arm: default kwarg, inherits the active `_EXTRACTION_SYSTEM_PROMPT`.
+    v6_result = await memory_extraction._run_extractor(
+        payload,
+        config,
+        candidate_ids=set(),
+        candidate_metadata={},
+        user_id=user_id,
+    )
+
+    post_count = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
+
+    v5_facts = [str(f.get("content", "")) for f in v5_result.facts]
+    v6_facts = [str(f.get("content", "")) for f in v6_result.facts]
+
+    expected_outcome = _classify_outcome(probe, v5_facts=v5_facts, v6_facts=v6_facts)
+
+    return ProbeOutcome(
+        probe_id=probe.probe_id,
+        category=probe.category,
+        v5_facts=v5_facts,
+        v6_facts=v6_facts,
+        expected_outcome=expected_outcome,
+        v6_rule_6_rejections_delta=post_count - pre_count,
+    )
+
+
+def _classify_outcome(probe: Probe, *, v5_facts: list[str], v6_facts: list[str]) -> str:
+    """Map (category, v5_facts, v6_facts, expected) to a labelled
+    outcome string. The labels feed the aggregate counters and
+    drive the workflow_drop_rate / durable_preservation_rate
+    arithmetic.
+    """
+    must_not_contain = probe.expected.get("must_not_contain") or []
+    must_contain = probe.expected.get("must_contain") or []
+    should_extract_any = probe.expected.get("should_extract_any")
+
+    v6_text_lower = " ".join(v6_facts).lower()
+    v6_violates_must_not = any(s.lower() in v6_text_lower for s in must_not_contain)
+    v6_satisfies_must = not must_contain or any(s.lower() in v6_text_lower for s in must_contain)
+
+    if probe.category == "workflow-noise":
+        # The win condition: v6 produced no facts (or no facts
+        # carrying the workflow-event substrings the probe forbids).
+        # If v5 itself was empty the probe is uninformative ("ambiguous"):
+        # we cannot say v6 "dropped" something v5 also did not produce.
+        if not v5_facts:
+            return "ambiguous"
+        if should_extract_any is False and not v6_facts:
+            return "workflow_dropped"
+        if not v6_violates_must_not and len(v6_facts) < len(v5_facts):
+            return "workflow_dropped"
+        return "regression"
+    if probe.category == "durable-content":
+        # The win condition: v6 produced at least one fact carrying
+        # the required substrings. A v5-empty probe is not informative
+        # for this category either, but a v6-empty probe IS a
+        # regression because the durable fact must come through.
+        if not v6_facts:
+            return "regression"
+        if v6_satisfies_must:
+            return "durable_preserved"
+        return "regression"
+    return "ambiguous"
+
+
+def _aggregate(outcomes: list[ProbeOutcome]) -> dict:
+    """Collapse per-probe outcomes into the documented aggregate
+    fields (workflow_drop_rate, durable_preservation_rate,
+    rule_6_rejections). Rates are computed over the scorable subset
+    of each category (excluding `ambiguous`) so a fixture with a few
+    uninformative probes does not drag the rate down.
+    """
+    workflow_total = 0
+    workflow_drops = 0
+    durable_total = 0
+    durable_preserves = 0
+    rule_6_total = 0
+    for o in outcomes:
+        rule_6_total += o.v6_rule_6_rejections_delta
+        if o.category == "workflow-noise" and o.expected_outcome != "ambiguous":
+            workflow_total += 1
+            if o.expected_outcome == "workflow_dropped":
+                workflow_drops += 1
+        elif o.category == "durable-content" and o.expected_outcome != "ambiguous":
+            durable_total += 1
+            if o.expected_outcome == "durable_preserved":
+                durable_preserves += 1
+    return {
+        "workflow_drop_rate": (workflow_drops / workflow_total) if workflow_total else None,
+        "durable_preservation_rate": (durable_preserves / durable_total) if durable_total else None,
+        "rule_6_rejections": rule_6_total,
+        "scorable_workflow_count": workflow_total,
+        "scorable_durable_count": durable_total,
+    }
+
+
+def _hash(s: str) -> str:
+    return "sha256:" + hashlib.sha256(s.encode()).hexdigest()
+
+
+async def _run_async(args: argparse.Namespace) -> int:
+    config = load_config()
+
+    probes_path = Path(args.probes)
+    if not probes_path.exists():
+        log.error("probes file not found: %s", probes_path)
+        return 1
+    probes = load_probes(probes_path)
+    if not probes:
+        log.error("no probes loaded from %s", probes_path)
+        return 1
+
+    log.info("running %d probes", len(probes))
+
+    outcomes: list[ProbeOutcome] = []
+    for probe in probes:
+        outcome = await _run_one_probe(probe, config, user_id=args.user_id)
+        log.info(
+            "probe %s [%s] -> %s",
+            outcome.probe_id,
+            outcome.category,
+            outcome.expected_outcome,
+        )
+        outcomes.append(outcome)
+
+    aggregate = _aggregate(outcomes)
+    probe_set_text = "\n".join(json.dumps(asdict(p), sort_keys=True) for p in probes)
+
+    report = {
+        "version": _OUTPUT_SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "probe_set_hash": _hash(probe_set_text),
+        "v5_prompt_hash": _hash(_PROMPT_V5_PINNED),
+        "v6_prompt_hash": _hash(memory_extraction._EXTRACTION_SYSTEM_PROMPT),
+        **aggregate,
+        "per_probe": [asdict(o) for o in outcomes],
+    }
+
+    out_path = Path(args.output)
+    out_path.write_text(json.dumps(report, indent=2))
+    print(json.dumps({k: v for k, v in report.items() if k != "per_probe"}, indent=2))
+    log.info("wrote %s", out_path)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--probes",
+        required=True,
+        help="Path to the JSONL probe fixture (one probe per line; `#`-prefixed lines are comments).",
+    )
+    parser.add_argument(
+        "--user-id",
+        default="2114582497",
+        help="user_id passed through to the extractor (cosmetic for "
+        "this harness; the harness does not read or write the live "
+        "memory store).",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to write the JSON report.",
+    )
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    return asyncio.run(_run_async(args))
+
+
+__all__ = [
+    "_OUTPUT_SCHEMA_VERSION",
+    "_PROMPT_V5_PINNED",
+    "Probe",
+    "ProbeOutcome",
+    "load_probes",
+    "main",
+]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -311,54 +311,84 @@ async def _run_one_probe(
 ) -> ProbeOutcome:
     """Run both prompt arms against a single probe and classify the
     outcome. Each arm is a sequential subprocess call so the active
-    `_RULE_6_REJECTIONS` counter delta can be attributed to v6.
+    `_RULE_6_REJECTIONS` counter delta can be attributed per-arm.
+
+    Never raises: a subprocess crash, JSON parse failure, or any
+    other exception inside either arm is caught and reported as an
+    `outcome="error"` ProbeOutcome with whatever per-arm deltas
+    were captured before the failure. Specifically, if v5 completes
+    cleanly but v6 raises, `v5_rule_6_rejections_delta` carries the
+    v5 arm's real delta (already snapshotted before v6 ran) rather
+    than zero. This is the right shape for the operator-facing
+    report: an attributable accounting of partial progress, not a
+    silent loss of v5's rejections to the error bucket.
     """
     user_text, assistant_text, prior_pairs = _window_to_extractor_args(probe.window)
     payload = memory_extraction._build_extraction_payload(
         user_text, assistant_text, candidates=None, prior_pairs=prior_pairs
     )
 
-    # v5 arm: thread the pinned prompt. The `confirmed_action` skip
-    # in Rule 6 still applies on this arm since the regex is part of
-    # the active validator regardless of which prompt produced the
-    # candidate facts; that is the right behavior because Rule 6 is
-    # the SAME validator the harness is measuring against.
-    #
-    # Rule 6 fires on BOTH arms (the active validator runs against
-    # whatever facts each arm emits), and v5 is expected to fire it
-    # more because v5 produces more workflow-event content. We
-    # snapshot the counter around each arm separately so the v6
-    # delta is attributed to v6 only - lumping the two arms together
-    # would inflate the v6 metric with v5's more numerous rejections.
-    pre_v5 = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
-    v5_result = await memory_extraction._run_extractor(
-        payload,
-        config,
-        candidate_ids=set(),
-        candidate_metadata={},
-        user_id=user_id,
-        system_prompt=_PROMPT_V5_PINNED,
-    )
-    post_v5 = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
+    # Initialize all per-arm state to zero/empty so an exception in
+    # either arm leaves the partial-progress accounting accurate.
+    # The control flow inside the try block updates these in place
+    # as each arm completes.
+    v5_facts: list[str] = []
+    v6_facts: list[str] = []
+    v5_rule_6_delta = 0
+    v6_rule_6_delta = 0
 
-    # v6 arm: default kwarg, inherits the active `_EXTRACTION_SYSTEM_PROMPT`.
-    pre_v6 = post_v5
-    v6_result = await memory_extraction._run_extractor(
-        payload,
-        config,
-        candidate_ids=set(),
-        candidate_metadata={},
-        user_id=user_id,
-    )
-    post_v6 = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
+    try:
+        # v5 arm: thread the pinned prompt. The `confirmed_action`
+        # skip in Rule 6 still applies on this arm since the regex
+        # is part of the active validator regardless of which prompt
+        # produced the candidate facts; that is the right behavior
+        # because Rule 6 is the SAME validator the harness is
+        # measuring against.
+        #
+        # Rule 6 fires on BOTH arms (the active validator runs
+        # against whatever facts each arm emits), and v5 is expected
+        # to fire it more because v5 produces more workflow-event
+        # content. We snapshot the counter around each arm
+        # separately so the v6 delta is attributed to v6 only -
+        # lumping the two arms together would inflate the v6 metric
+        # with v5's more numerous rejections.
+        pre_v5 = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
+        v5_result = await memory_extraction._run_extractor(
+            payload,
+            config,
+            candidate_ids=set(),
+            candidate_metadata={},
+            user_id=user_id,
+            system_prompt=_PROMPT_V5_PINNED,
+        )
+        post_v5 = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
+        v5_rule_6_delta = post_v5 - pre_v5
+        v5_facts = [str(f.get("content", "")) for f in v5_result.facts]
 
-    v5_rule_6_delta = post_v5 - pre_v5
-    v6_rule_6_delta = post_v6 - pre_v6
+        # v6 arm: default kwarg, inherits the active `_EXTRACTION_SYSTEM_PROMPT`.
+        pre_v6 = post_v5
+        v6_result = await memory_extraction._run_extractor(
+            payload,
+            config,
+            candidate_ids=set(),
+            candidate_metadata={},
+            user_id=user_id,
+        )
+        post_v6 = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
+        v6_rule_6_delta = post_v6 - pre_v6
+        v6_facts = [str(f.get("content", "")) for f in v6_result.facts]
 
-    v5_facts = [str(f.get("content", "")) for f in v5_result.facts]
-    v6_facts = [str(f.get("content", "")) for f in v6_result.facts]
-
-    classified = _classify_outcome(probe, v5_facts=v5_facts, v6_facts=v6_facts)
+        classified = _classify_outcome(probe, v5_facts=v5_facts, v6_facts=v6_facts)
+    except Exception as exc:
+        # One probe failure must not abort the whole run; a live
+        # 20-probe run wastes meaningful subprocess cost if it
+        # bails on a transient JSON parse error or a timeout.
+        # Preserve whatever per-arm state we captured before the
+        # exception (see the local-variable initialization above)
+        # so the report attributes Rule 6 rejections accurately
+        # even on partial-completion failures.
+        log.exception("probe %s failed: %s", probe.probe_id, exc)
+        classified = "error"
 
     return ProbeOutcome(
         probe_id=probe.probe_id,
@@ -414,9 +444,14 @@ def _classify_outcome(probe: Probe, *, v5_facts: list[str], v6_facts: list[str])
         return "regression"
     if probe.category == "durable-content":
         # The win condition: v6 produced at least one fact carrying
-        # the required substrings. A v5-empty probe is not informative
-        # for this category either, but a v6-empty probe IS a
-        # regression because the durable fact must come through.
+        # the required substrings. Symmetric ambiguity check first:
+        # if BOTH arms came up empty the probe window is too sparse
+        # to inform v5-vs-v6 (parallel to the workflow-noise
+        # branch's `if not v5_facts: return "ambiguous"`). When v5
+        # produced facts but v6 did not, that IS a regression
+        # because the durable fact must come through under v6.
+        if not v5_facts and not v6_facts:
+            return "ambiguous"
         if not v6_facts:
             return "regression"
         if v6_satisfies_must:
@@ -485,26 +520,11 @@ async def _run_async(args: argparse.Namespace) -> int:
 
     outcomes: list[ProbeOutcome] = []
     for probe in probes:
-        try:
-            result = await _run_one_probe(probe, config, user_id=args.user_id)
-        except Exception as exc:
-            # One probe failure must not abort the whole run. A live
-            # 20-probe run wastes meaningful subprocess cost if it
-            # bails on a transient JSON parse error or a timeout.
-            # Record the failure as an "error" outcome so the report
-            # carries a row, then continue. The aggregate counters
-            # exclude error outcomes (same denominator-shielding the
-            # ambiguous bucket gets).
-            log.exception("probe %s failed: %s", probe.probe_id, exc)
-            result = ProbeOutcome(
-                probe_id=probe.probe_id,
-                category=probe.category,
-                v5_facts=[],
-                v6_facts=[],
-                outcome="error",
-                v5_rule_6_rejections_delta=0,
-                v6_rule_6_rejections_delta=0,
-            )
+        # `_run_one_probe` never raises; on exception it returns a
+        # ProbeOutcome with `outcome="error"` and whatever per-arm
+        # state it captured before the failure. The aggregate skip
+        # set keeps error rows out of rate denominators.
+        result = await _run_one_probe(probe, config, user_id=args.user_id)
         log.info(
             "probe %s [%s] -> %s",
             result.probe_id,

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -26,7 +26,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from kai import memory_extraction
-from kai.config import load_config
+from kai.config import Config, load_config
 
 log = logging.getLogger(__name__)
 
@@ -318,7 +318,7 @@ def _window_to_extractor_args(window: dict) -> tuple[str, str, list[tuple[str, s
 
 async def _run_one_probe(
     probe: Probe,
-    config,
+    config: Config,
     *,
     user_id: str,
 ) -> ProbeOutcome:
@@ -566,7 +566,20 @@ async def _run_async(args: argparse.Namespace) -> int:
     }
 
     out_path = Path(args.output)
-    out_path.write_text(json.dumps(report, indent=2))
+    # Guard the write: at $0.32 / 20-probe run, losing the report
+    # to a missing parent directory or a read-only output path is
+    # an expensive failure. Convert the OSError into a logged
+    # error and a non-zero return so the operator sees what went
+    # wrong AND can inspect the in-memory aggregate (still printed
+    # below) before re-running.
+    try:
+        out_path.write_text(json.dumps(report, indent=2))
+    except OSError as exc:
+        log.error("failed to write %s: %s", out_path, exc)
+        # Print the aggregate before returning so the caller has
+        # the rate numbers even though the JSON file did not land.
+        print(json.dumps({k: v for k, v in report.items() if k != "per_probe"}, indent=2))
+        return 1
     print(json.dumps({k: v for k, v in report.items() if k != "per_probe"}, indent=2))
     log.info("wrote %s", out_path)
     return 0
@@ -601,9 +614,13 @@ def main(argv: list[str] | None = None) -> int:
     return asyncio.run(_run_async(args))
 
 
+# Public API: dataclasses, the JSONL probe loader, and the CLI
+# entry point. `_PROMPT_V5_PINNED`, `_OUTPUT_SCHEMA_VERSION`, and
+# the helper functions retain their leading-underscore privacy and
+# are not exported via `__all__`. Tests reach in via attribute
+# access (e.g. `extraction._PROMPT_V5_PINNED`) which bypasses
+# `__all__` and is the supported pattern for cross-module pinning.
 __all__ = [
-    "_OUTPUT_SCHEMA_VERSION",
-    "_PROMPT_V5_PINNED",
     "Probe",
     "ProbeOutcome",
     "load_probes",

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -577,7 +577,20 @@ async def _run_async(args: argparse.Namespace) -> int:
     if not probes_path.exists():
         log.error("probes file not found: %s", probes_path)
         return 1
-    probes = load_probes(probes_path)
+    # `load_probes` raises ValueError on a malformed fixture
+    # (invalid JSON, missing required field, missing
+    # `window.current`, unknown category). The message already
+    # carries `{path}:{line}: ...` context, so logging the
+    # exception text and returning non-zero is the right shape
+    # for the operator-facing CLI: a parse failure looks the
+    # same as the file-not-found and empty-fixture cases above
+    # rather than surfacing as a Python traceback through
+    # `asyncio.run`.
+    try:
+        probes = load_probes(probes_path)
+    except ValueError as exc:
+        log.error("failed to parse probes from %s: %s", probes_path, exc)
+        return 1
     if not probes:
         log.error("no probes loaded from %s", probes_path)
         return 1

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -227,11 +227,22 @@ class Probe:
 
 @dataclass
 class ProbeOutcome:
+    """Per-probe result of running v5 and v6 extractor arms.
+
+    `outcome` is the v6 classification, NOT what the probe expected.
+    Possible values: `"workflow_dropped"`, `"durable_preserved"`,
+    `"regression"`, `"ambiguous"`, `"error"`. The first two are
+    wins; `regression` is a v6 failure; `ambiguous` is an
+    uninformative probe (e.g., v5 was empty so we cannot say v6
+    "dropped" anything); `error` is a probe that raised mid-run
+    and was captured rather than aborting the whole batch.
+    """
+
     probe_id: str
     category: str
     v5_facts: list[str]
     v6_facts: list[str]
-    expected_outcome: str
+    outcome: str
     # Rule 6 fires per-arm; the harness reports both deltas
     # separately so the v6 number is not inflated by v5's
     # higher rejection rate (v5 produces more workflow-event
@@ -265,10 +276,17 @@ def _window_to_extractor_args(window: dict) -> tuple[str, str, list[tuple[str, s
     `_build_extraction_payload` expects.
 
     `prior` is rendered as a list of `(user_text, assistant_text)`
-    pairs, mirroring the production `prior_pairs` shape; an entry
-    is omitted when its role's text is missing (the schema allows
-    asymmetric prior turns). `current.user` and `current.assistant`
-    map directly onto the function's first two positional args.
+    pairs, mirroring the production `prior_pairs` shape. Orphan
+    turns are silently dropped in BOTH directions: a user turn with
+    no following assistant reply is omitted (the user reply has
+    nothing to pair with), and an assistant turn that arrives
+    before any user turn (`pending_user is None`) is also omitted.
+    The schema allows asymmetric prior turns at the JSON layer for
+    fixture-author flexibility; the function commits to a paired
+    rendering for the production payload, so a fixture author who
+    wants an orphan to surface should restructure the window.
+    `current.user` and `current.assistant` map directly onto the
+    function's first two positional args.
     """
     prior_raw = window.get("prior", []) or []
     prior_pairs: list[tuple[str, str]] = []
@@ -340,14 +358,14 @@ async def _run_one_probe(
     v5_facts = [str(f.get("content", "")) for f in v5_result.facts]
     v6_facts = [str(f.get("content", "")) for f in v6_result.facts]
 
-    expected_outcome = _classify_outcome(probe, v5_facts=v5_facts, v6_facts=v6_facts)
+    classified = _classify_outcome(probe, v5_facts=v5_facts, v6_facts=v6_facts)
 
     return ProbeOutcome(
         probe_id=probe.probe_id,
         category=probe.category,
         v5_facts=v5_facts,
         v6_facts=v6_facts,
-        expected_outcome=expected_outcome,
+        outcome=classified,
         v5_rule_6_rejections_delta=v5_rule_6_delta,
         v6_rule_6_rejections_delta=v6_rule_6_delta,
     )
@@ -420,16 +438,22 @@ def _aggregate(outcomes: list[ProbeOutcome]) -> dict:
     durable_preserves = 0
     v5_rule_6_total = 0
     v6_rule_6_total = 0
+    # Outcomes excluded from rate denominators: `ambiguous` (probe
+    # was uninformative) and `error` (probe raised mid-run; see
+    # `_run_async` for the per-probe try/except). Both go in the
+    # report so the operator sees them, but they do not feed the
+    # workflow_drop_rate or durable_preservation_rate arithmetic.
+    _SKIP_OUTCOMES = {"ambiguous", "error"}
     for o in outcomes:
         v5_rule_6_total += o.v5_rule_6_rejections_delta
         v6_rule_6_total += o.v6_rule_6_rejections_delta
-        if o.category == "workflow-noise" and o.expected_outcome != "ambiguous":
+        if o.category == "workflow-noise" and o.outcome not in _SKIP_OUTCOMES:
             workflow_total += 1
-            if o.expected_outcome == "workflow_dropped":
+            if o.outcome == "workflow_dropped":
                 workflow_drops += 1
-        elif o.category == "durable-content" and o.expected_outcome != "ambiguous":
+        elif o.category == "durable-content" and o.outcome not in _SKIP_OUTCOMES:
             durable_total += 1
-            if o.expected_outcome == "durable_preserved":
+            if o.outcome == "durable_preserved":
                 durable_preserves += 1
     return {
         "workflow_drop_rate": (workflow_drops / workflow_total) if workflow_total else None,
@@ -461,14 +485,33 @@ async def _run_async(args: argparse.Namespace) -> int:
 
     outcomes: list[ProbeOutcome] = []
     for probe in probes:
-        outcome = await _run_one_probe(probe, config, user_id=args.user_id)
+        try:
+            result = await _run_one_probe(probe, config, user_id=args.user_id)
+        except Exception as exc:
+            # One probe failure must not abort the whole run. A live
+            # 20-probe run wastes meaningful subprocess cost if it
+            # bails on a transient JSON parse error or a timeout.
+            # Record the failure as an "error" outcome so the report
+            # carries a row, then continue. The aggregate counters
+            # exclude error outcomes (same denominator-shielding the
+            # ambiguous bucket gets).
+            log.exception("probe %s failed: %s", probe.probe_id, exc)
+            result = ProbeOutcome(
+                probe_id=probe.probe_id,
+                category=probe.category,
+                v5_facts=[],
+                v6_facts=[],
+                outcome="error",
+                v5_rule_6_rejections_delta=0,
+                v6_rule_6_rejections_delta=0,
+            )
         log.info(
             "probe %s [%s] -> %s",
-            outcome.probe_id,
-            outcome.category,
-            outcome.expected_outcome,
+            result.probe_id,
+            result.category,
+            result.outcome,
         )
-        outcomes.append(outcome)
+        outcomes.append(result)
 
     aggregate = _aggregate(outcomes)
     probe_set_text = "\n".join(json.dumps(asdict(p), sort_keys=True) for p in probes)

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1027,6 +1027,18 @@ class _Counter:
     def snapshot(self) -> dict[str, int]:
         return dict(self._counts)
 
+    def _reset(self) -> None:
+        """Test-only: clear the per-user counts in place.
+
+        The leading underscore signals "tests only"; production
+        code should never call this. Resetting in place rather than
+        rebinding `_RULE_6_REJECTIONS` matters because other
+        modules (e.g. `tests/test_memory_extraction.py`) import the
+        counter object by name and would hold a stale reference if
+        the module-level binding moved.
+        """
+        self._counts.clear()
+
 
 # Module-level counter for Rule 6 rejections, keyed by `user_id`.
 # Process-local; not persisted. Read via `get_extractor_stats()`.

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -970,15 +970,19 @@ _WORKFLOW_EVENT_RE = re.compile(
     r"(file|create|address|conduct|evaluate|perform|update|push)\b"
     r"|"
     # Arm 2: "Spec X / PR Y / issue Z (intervening tokens)?
-    # was/were/received ... <verdict>". The `(\S+\s+)*?` allows
-    # multi-word identifiers and version qualifiers between the
-    # artifact id and the verb, e.g., "Specification 412 version 3
-    # was approved" or "Spec 416 (memory UI tag dismantle) version 4
-    # received final approval"; lazy quantification keeps the
-    # capture short.
+    # was/were/received ... <verdict>". The intervening-token group
+    # is bounded with `{0,8}?` (a few words plus a parenthetical at
+    # most, lazy) so a long fact text cannot drive quadratic
+    # backtracking through the unbounded `(\S+\s+)*?` form. The
+    # gap between `was/were/received` and the verdict word is
+    # bounded with `{0,80}` (chars, not tokens) for the same reason.
+    # Real examples: "Specification 412 version 3 was approved"
+    # (1 token between id and verb), "Spec 416 (memory UI tag
+    # dismantle) version 4 received final approval" (5 tokens),
+    # "PR #424 received a code review verdict" (0 tokens).
     r"\b(spec(ification)?\s+\S+|PR\s+#?\d+|issue\s+#?\d+)"
-    r"\s+(\S+\s+)*?(was|were|received)\b"
-    r".*\b(approved|approval|reviewed|merged|verdict|finding)\b"
+    r"\s+(\S+\s+){0,8}?(was|were|received)\b"
+    r".{0,80}?\b(approved|approval|reviewed|merged|verdict|finding)\b"
     r"|"
     # Arm 3: "All N findings were closed in vM" /
     # "All N v1 findings were closed"

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -965,7 +965,16 @@ _CONSOLIDATION_INTENTS: frozenset[str] = frozenset({"new", "update_of", "skip_re
 _WORKFLOW_EVENT_RE = re.compile(
     r"("
     # Arm 1: "User/OC decided/requested to file/create/address/
-    # conduct/evaluate/perform/update/push <something>"
+    # conduct/evaluate/perform/update/push <something>". The `^`
+    # anchor only matches when the subject is at the start of the
+    # fact content; a paraphrased fact like "In this exchange, User
+    # decided to file an issue about X" is not caught. The active
+    # extraction prompt formats facts as third-person leading with
+    # "User ..." or "OC ..." so the anchor is the right shape for
+    # the production case; broader paraphrases are left for the
+    # prompt's IGNORE rules. A future maintainer who needs to
+    # catch non-leading subjects should drop the `^` rather than
+    # only adding more verbs.
     r"^(User|OC)\s+(decided|requested)\s+to\s+"
     r"(file|create|address|conduct|evaluate|perform|update|push)\b"
     r"|"

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -969,12 +969,13 @@ _WORKFLOW_EVENT_RE = re.compile(
     # anchor only matches when the subject is at the start of the
     # fact content; a paraphrased fact like "In this exchange, User
     # decided to file an issue about X" is not caught. The active
-    # extraction prompt formats facts as third-person leading with
-    # "User ..." or "OC ..." so the anchor is the right shape for
-    # the production case; broader paraphrases are left for the
-    # prompt's IGNORE rules. A future maintainer who needs to
-    # catch non-leading subjects should drop the `^` rather than
-    # only adding more verbs.
+    # extraction prompt formats facts third-person leading with
+    # "User ..." (the canonical example in FORMAT); the operator-
+    # specific "OC" subject is included as defense-in-depth for
+    # operator history that contains it. Broader paraphrases are
+    # left for the prompt's IGNORE rules. A future maintainer who
+    # needs to catch non-leading subjects should drop the `^`
+    # rather than only adding more verbs.
     r"^(User|OC)\s+(decided|requested)\s+to\s+"
     r"(file|create|address|conduct|evaluate|perform|update|push)\b"
     r"|"
@@ -997,11 +998,10 @@ _WORKFLOW_EVENT_RE = re.compile(
     # "All N v1 findings were closed"
     r"\bAll\s+\w+\s+(v\d+\s+)?findings?\s+(were|are)\s+closed\b"
     r"|"
-    # Arm 4: "The evaluation of spec/issue/PR X
-    # produced/was/determined Y". The v1 spec proposed an "OC's vN
-    # evaluation ..." sub-arm that was dropped to keep internal
-    # review-loop vocabulary out of production source; the prompt's
-    # IGNORE rules cover the residual shape.
+    # Arm 4: "The evaluation of (spec|specification|issue|PR) X
+    # (produced|was|determined) Y". Past-tense / determined
+    # variants only; broader paraphrases are left to the prompt's
+    # IGNORE rules.
     r"\b(evaluation\s+of\s+(spec(ification)?|issue|PR)\s+\S+"
     r"\s+(produced|was|determined))\b"
     r")",

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -59,7 +59,17 @@ log = logging.getLogger(__name__)
 # existing confirmation rows. `maxItems` raised from 4 to 5 to
 # match `_EPISODE_SCHEMA` per the parent issue's "single tag
 # taxonomy" decision.
-_EXTRACTION_PROMPT_VERSION: str = "5"
+# v6 (2026-04-30, this issue): scoped Decisions / workflow-event
+# IGNORE / DURABILITY TEST gate. The STORE / Decisions bullet was
+# narrowed to durable architectural and design decisions only;
+# workflow micro-decisions ("which task to do next", "which spec
+# to evaluate", "which issue to file") were carved out into the
+# IGNORE list as transient session activity. A new DURABILITY
+# TEST section asks "would this fact still be useful in 30 days?"
+# as the last gate before emit. Schema unchanged; v6's bump lets
+# future-cleanup queries target rows produced under the new
+# wording (`prompt_version != "6" AND <noise pattern>`).
+_EXTRACTION_PROMPT_VERSION: str = "6"
 
 # Sibling of _EXTRACTION_PROMPT_VERSION for stage-2 episode generation.
 # Stored in each episode's metadata so future cleanups can target a
@@ -318,8 +328,13 @@ STORE these fact types:
   what the user likes or dislikes).
 - Stable facts about the user (e.g., location, role, project names,
   repo names, hardware).
-- Decisions the user made in this exchange ("we're going with X",
-  "let's use Y", "I decided Z").
+- Architectural or design decisions the user made in this exchange
+  with durable scope ("we're going with async architecture",
+  "default to option B in v1 of the spec", "the home workspace
+  must be per-user, not shared"). NOT workflow micro-decisions
+  about which task to do next, which spec to evaluate, or which
+  issue to file - those are transient session activity. Apply the
+  DURABILITY TEST below.
 - Actions the user confirmed happened, BUT with strict evidence
   rules to prevent laundered hallucinations:
   1. A confirmed_action fact must include a `confirmation_quote`
@@ -348,10 +363,38 @@ IGNORE:
 - Intermediate reasoning, tool-output summaries, step-by-step plans.
 - Transient conversation state (what you are mid-doing, open
   questions, clarifying requests).
+- Workflow-event metadata: spec/PR/issue lifecycle events. Examples
+  to NOT extract: "Spec X v3 was approved", "PR Y received a review
+  verdict of Z", "All N findings were closed in vM",
+  "The evaluation of spec Q produced a verdict of R". The durable
+  artifact is the spec/PR/issue itself; events around it are
+  transient session activity that loses meaning once the event
+  closes.
+- "Decisions to do" workflow actions: a decision to file an issue,
+  create a spec, request an evaluation, run a test, or perform
+  any other workflow action. The artifact produced (the issue,
+  the spec, the test result) is the durable fact; the
+  decision-to-do is workflow noise. Examples to NOT extract:
+  "User decided to file an issue about X", "User requested
+  evaluation of spec Y", "User decided to address issue #Z",
+  "User confirmed test input triggered the pipeline".
 - Casual chat, greetings, acknowledgments, thanks without content.
 - Anything that contradicts a stated user preference.
 - Code snippets, file contents, error messages (store facts about
   them if needed, not the raw text).
+
+DURABILITY TEST:
+
+Before emitting any fact, ask: "would this still be useful context
+in 30 days?" If the answer is no - because the fact captures a
+workflow event, a one-off task decision, a status of work in
+progress that will have shipped or moved on, or a session-event
+metadata fragment - do not emit it. The 30-day test catches the
+most common low-quality extraction: session-event metadata that
+reads as fact-shaped but loses meaning once the event closes.
+
+If a fact passes IGNORE rules but fails the durability test,
+do not emit it.
 
 CONFIDENCE:
 - Only store facts you can phrase as a single clear sentence.
@@ -903,6 +946,90 @@ def _build_extraction_payload(
 _CONSOLIDATION_INTENTS: frozenset[str] = frozenset({"new", "update_of", "skip_redundant"})
 
 
+# Workflow-event regex (Rule 6 in `_validate_facts`). Rejects facts
+# whose content is pure session-event metadata: spec/PR/issue
+# lifecycle events and "User decided/requested to <workflow-action>"
+# wordings. Pattern is intentionally narrower than the prompt's
+# IGNORE rules; the prompt is the primary gate, this regex is
+# defense-in-depth for the cases where the model emits noise despite
+# the prompt. The model can defeat the regex by paraphrasing; a
+# future broader pattern (or per-extractor model upgrade) can be
+# added later without churning Rule 6's structure.
+#
+# Each arm catches a distinct shape observed in the 2026-04-30
+# hygiene sweep's 70-row deletion set; the inline comment above each
+# arm names the shape and any known coverage gap. Confirmation rows
+# can match arm 2 (e.g., "User confirmed PR #299 was merged on
+# 2026-04-12"); the per-fact `confirmed_action` skip in Rule 6
+# handles that case before this regex evaluates.
+_WORKFLOW_EVENT_RE = re.compile(
+    r"("
+    # Arm 1: "User/OC decided/requested to file/create/address/
+    # conduct/evaluate/perform/update/push <something>"
+    r"^(User|OC)\s+(decided|requested)\s+to\s+"
+    r"(file|create|address|conduct|evaluate|perform|update|push)\b"
+    r"|"
+    # Arm 2: "Spec X / PR Y / issue Z (intervening tokens)?
+    # was/were/received ... <verdict>". The `(\S+\s+)*?` allows
+    # multi-word identifiers and version qualifiers between the
+    # artifact id and the verb, e.g., "Specification 412 version 3
+    # was approved" or "Spec 416 (memory UI tag dismantle) version 4
+    # received final approval"; lazy quantification keeps the
+    # capture short.
+    r"\b(spec(ification)?\s+\S+|PR\s+#?\d+|issue\s+#?\d+)"
+    r"\s+(\S+\s+)*?(was|were|received)\b"
+    r".*\b(approved|approval|reviewed|merged|verdict|finding)\b"
+    r"|"
+    # Arm 3: "All N findings were closed in vM" /
+    # "All N v1 findings were closed"
+    r"\bAll\s+\w+\s+(v\d+\s+)?findings?\s+(were|are)\s+closed\b"
+    r"|"
+    # Arm 4: "The evaluation of spec/issue/PR X
+    # produced/was/determined Y". The v1 spec proposed an "OC's vN
+    # evaluation ..." sub-arm that was dropped to keep internal
+    # review-loop vocabulary out of production source; the prompt's
+    # IGNORE rules cover the residual shape.
+    r"\b(evaluation\s+of\s+(spec(ification)?|issue|PR)\s+\S+"
+    r"\s+(produced|was|determined))\b"
+    r")",
+    re.IGNORECASE,
+)
+
+
+class _Counter:
+    """Per-user rejection counter for `_validate_facts` Rule 6.
+
+    Lives in-process; resets on extractor restart. Exposed via
+    `get_extractor_stats()` for operational dashboards or eval
+    harnesses (the Layer 4 head-to-head harness reads it to assert
+    on rejection rates without parsing log lines).
+    """
+
+    def __init__(self) -> None:
+        self._counts: dict[str, int] = {}
+
+    def increment(self, *, user_id: str) -> None:
+        self._counts[user_id] = self._counts.get(user_id, 0) + 1
+
+    def snapshot(self) -> dict[str, int]:
+        return dict(self._counts)
+
+
+# Module-level counter for Rule 6 rejections, keyed by `user_id`.
+# Process-local; not persisted. Read via `get_extractor_stats()`.
+_RULE_6_REJECTIONS = _Counter()
+
+
+def get_extractor_stats() -> dict[str, dict[str, int]]:
+    """Snapshot of in-process extractor counters.
+
+    Currently exposes Rule 6 rejection counts per user_id. Structure
+    is extensible (top-level dict keyed by counter name) so future
+    counters can land without breaking callers.
+    """
+    return {"rule_6_rejections": _RULE_6_REJECTIONS.snapshot()}
+
+
 def _validate_facts(
     facts: list[dict],
     candidate_ids: set[str],
@@ -1099,6 +1226,32 @@ def _validate_facts(
             )
             continue
 
+        # Rule 6: reject workflow-event-shaped content. Defense-in-depth
+        # against the prompt's IGNORE rules missing edge cases. The
+        # rejection is logged at INFO (not DEBUG) because the rate of
+        # Rule 6 rejections is itself an operational signal: if Rule 6
+        # fires often the prompt is leaking, and the prompt should be
+        # tightened rather than the regex broadened.
+        # `_RULE_6_REJECTIONS` increments per user so the rate is
+        # observable via `get_extractor_stats()` without grepping logs.
+        #
+        # Confirmed-action rows are skipped because the canonical
+        # confirmation example "User confirmed PR #299 was merged on
+        # 2026-04-12" matches arm 2 of `_WORKFLOW_EVENT_RE`. The
+        # existing Rule 1/2/4/4b chain already gates the
+        # confirmed_action path with strict quote and tag rules;
+        # trusting them here keeps Rule 6 narrowly scoped to its
+        # purpose (workflow-event noise without a confirmation anchor).
+        if "confirmed_action" not in tags:
+            content = fact.get("content", "")
+            if isinstance(content, str) and _WORKFLOW_EVENT_RE.search(content):
+                log.info(
+                    "_validate_facts: rejecting workflow-event-shaped fact: %r",
+                    content[:120],
+                )
+                _RULE_6_REJECTIONS.increment(user_id=user_id)
+                continue
+
         # Confirmation-quote rules (preserved from the pre-consolidation
         # validator). These run AFTER the consolidation rules so a
         # fact that hits both classes of rejection is rejected for the
@@ -1167,6 +1320,7 @@ async def _run_extractor(
     candidate_ids: set[str],
     candidate_metadata: dict[str, dict],
     user_id: str,
+    system_prompt: str = _EXTRACTION_SYSTEM_PROMPT,
 ) -> ExtractionResult:
     """
     Spawn `claude --print` with the extractor prompt and parse the JSON.
@@ -1245,7 +1399,7 @@ async def _run_extractor(
         "--json-schema",
         json.dumps(_FACT_SCHEMA),
         "--system-prompt",
-        _EXTRACTION_SYSTEM_PROMPT,
+        system_prompt,
         "--permission-mode",
         "bypassPermissions",
         "--tools",

--- a/tests/test_eval_extraction.py
+++ b/tests/test_eval_extraction.py
@@ -130,6 +130,19 @@ class TestClassifyOutcome:
         )
         assert outcome == "regression"
 
+    def test_workflow_noise_partial_drop_is_regression_when_should_extract_any_false(self, workflow_probe):
+        """Pin the strict classification: when the probe declares
+        `should_extract_any: false`, v6 must produce zero facts to
+        score `workflow_dropped`. A partial drop where v6 emits
+        non-forbidden content is a regression because the probe
+        asked for nothing and v6 did not deliver nothing."""
+        outcome = extraction._classify_outcome(
+            workflow_probe,
+            v5_facts=["User decided to file an issue.", "Spec X v3 was approved."],
+            v6_facts=["User mentioned a project name."],
+        )
+        assert outcome == "regression"
+
     def test_durable_v6_preserves_with_must_contain(self, durable_probe):
         """v6 produced a fact carrying the required substring =>
         durable_preserved."""
@@ -166,12 +179,16 @@ class TestAggregate:
         """Ambiguous outcomes drop out of the denominator so a few
         uninformative probes do not drag the rate down."""
         outcomes = [
+            # v5 fired Rule 6 four times across the workflow probes
+            # (v5 produces workflow-event content); v6 fired it once
+            # (defense-in-depth on a leak the prompt missed).
             extraction.ProbeOutcome(
                 probe_id="wf-1",
                 category="workflow-noise",
                 v5_facts=["x"],
                 v6_facts=[],
                 expected_outcome="workflow_dropped",
+                v5_rule_6_rejections_delta=2,
                 v6_rule_6_rejections_delta=0,
             ),
             extraction.ProbeOutcome(
@@ -180,6 +197,7 @@ class TestAggregate:
                 v5_facts=["x"],
                 v6_facts=["x"],
                 expected_outcome="regression",
+                v5_rule_6_rejections_delta=1,
                 v6_rule_6_rejections_delta=0,
             ),
             extraction.ProbeOutcome(
@@ -188,6 +206,7 @@ class TestAggregate:
                 v5_facts=[],
                 v6_facts=[],
                 expected_outcome="ambiguous",
+                v5_rule_6_rejections_delta=1,
                 v6_rule_6_rejections_delta=0,
             ),
             extraction.ProbeOutcome(
@@ -196,6 +215,7 @@ class TestAggregate:
                 v5_facts=["x"],
                 v6_facts=["x"],
                 expected_outcome="durable_preserved",
+                v5_rule_6_rejections_delta=0,
                 v6_rule_6_rejections_delta=0,
             ),
             extraction.ProbeOutcome(
@@ -204,6 +224,7 @@ class TestAggregate:
                 v5_facts=["x"],
                 v6_facts=[],
                 expected_outcome="regression",
+                v5_rule_6_rejections_delta=0,
                 v6_rule_6_rejections_delta=1,
             ),
         ]
@@ -215,9 +236,10 @@ class TestAggregate:
         # 1 durable_preserved of 2 scorable durable probes.
         assert agg["durable_preservation_rate"] == 0.5
         assert agg["scorable_durable_count"] == 2
-        # Counter delta is the sum across all probes regardless of
-        # category or scorability.
-        assert agg["rule_6_rejections"] == 1
+        # Per-arm counter sums attributed correctly: v5 fired four
+        # times (the workflow-noise probes), v6 fired once.
+        assert agg["v5_rule_6_rejections"] == 4
+        assert agg["v6_rule_6_rejections"] == 1
 
     def test_aggregate_zero_scorable_returns_none(self):
         """All-ambiguous category => rate is None, not 0.0, so a
@@ -230,6 +252,7 @@ class TestAggregate:
                 v5_facts=[],
                 v6_facts=[],
                 expected_outcome="ambiguous",
+                v5_rule_6_rejections_delta=0,
                 v6_rule_6_rejections_delta=0,
             ),
         ]

--- a/tests/test_eval_extraction.py
+++ b/tests/test_eval_extraction.py
@@ -22,7 +22,19 @@ from pathlib import Path
 import pytest
 
 from kai import memory_extraction
+from kai.config import Config
 from kai.eval import extraction
+
+# Minimal Config for the harness tests. Mirrors _BASE_CONFIG in
+# test_memory_extraction.py. The harness stubs `_run_extractor` so
+# the Config fields are never actually exercised; this exists to
+# satisfy the typed `config: Config` parameter on
+# `_run_one_probe` without needing real credentials.
+_TEST_CONFIG = Config(
+    telegram_bot_token="test-token",
+    allowed_user_ids={12345},
+    webhook_secret="test-secret",
+)
 
 # Hash of `_PROMPT_V5_PINNED` captured at #426 landing. If the
 # pinned constant drifts (intentional or not), this test fails and
@@ -411,7 +423,7 @@ class TestRunOneProbeErrorPath:
             expected={"should_extract_any": False, "must_not_contain": []},
         )
 
-        outcome = asyncio.run(extraction._run_one_probe(probe, config=None, user_id="probe-x"))
+        outcome = asyncio.run(extraction._run_one_probe(probe, config=_TEST_CONFIG, user_id="probe-x"))
 
         assert outcome.outcome == "error"
         # v5 arm completed: the increment we drove in fake_run_extractor

--- a/tests/test_eval_extraction.py
+++ b/tests/test_eval_extraction.py
@@ -1,0 +1,272 @@
+"""Integration tests for `src/kai/eval/extraction.py`.
+
+These tests do NOT call the live extractor (cost + non-determinism);
+the harness's full end-to-end behavior runs on demand via the CLI.
+What we pin here:
+
+- The pinned v5 prompt has not drifted from the v5 hash captured at
+  the time #426 landed.
+- The example probe fixture parses cleanly and matches the
+  documented schema.
+- `_classify_outcome` returns the right label for each
+  (category, v5_facts, v6_facts) triple.
+- The harness aggregate arithmetic produces the documented rates.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from kai.eval import extraction
+
+# Hash of `_PROMPT_V5_PINNED` captured at #426 landing. If the
+# pinned constant drifts (intentional or not), this test fails and
+# either the constant must be reverted or this hash must be updated
+# to a new captured baseline.
+_V5_PROMPT_HASH = "764f249d2556a6e00489ac7ba5eac265f4a4d09f27d21dc76f612b84f0874c13"
+
+
+def test_v5_pinned_drift():
+    """The pinned baseline must remain byte-identical to the v5
+    prompt as captured at #426 landing. A future intentional update
+    to a new baseline (capturing v6, etc.) requires updating both
+    the pinned constant AND `_V5_PROMPT_HASH` above; an accidental
+    edit fails this test."""
+    h = hashlib.sha256(extraction._PROMPT_V5_PINNED.encode()).hexdigest()
+    assert h == _V5_PROMPT_HASH, (
+        "Pinned v5 prompt drifted. If this is intentional (capturing "
+        "a new baseline), update _V5_PROMPT_HASH above to match."
+    )
+
+
+def test_example_probe_fixture_loads():
+    """The tracked example fixture parses end-to-end and contains
+    the documented mix (2 workflow-noise + 2 durable-content)."""
+    path = Path(__file__).parent.parent / "home" / "evals" / "extraction-probes.example.jsonl"
+    probes = extraction.load_probes(path)
+    assert len(probes) == 4
+    cats = [p.category for p in probes]
+    assert cats.count("workflow-noise") == 2
+    assert cats.count("durable-content") == 2
+    # Schema sanity: every probe has window.current.{user,assistant}
+    # and an `expected` block.
+    for p in probes:
+        assert "current" in p.window
+        assert "user" in p.window["current"]
+        assert "assistant" in p.window["current"]
+        assert isinstance(p.expected, dict)
+
+
+def test_load_probes_skips_comments_and_blanks(tmp_path: Path):
+    """`#`-prefixed lines and blank lines must be ignored so the
+    fixture format can carry inline documentation."""
+    f = tmp_path / "probes.jsonl"
+    f.write_text(
+        "# header comment\n"
+        "\n"
+        '{"probe_id":"p1","category":"workflow-noise",'
+        '"window":{"prior":[],"current":{"user":"u","assistant":"a"}},'
+        '"expected":{}}\n'
+        "# trailing comment\n"
+        "\n"
+    )
+    probes = extraction.load_probes(f)
+    assert len(probes) == 1
+    assert probes[0].probe_id == "p1"
+
+
+@pytest.fixture
+def workflow_probe() -> extraction.Probe:
+    return extraction.Probe(
+        probe_id="wf-1",
+        category="workflow-noise",
+        window={"prior": [], "current": {"user": "u", "assistant": "a"}},
+        expected={"should_extract_any": False, "must_not_contain": ["filed", "approved"]},
+    )
+
+
+@pytest.fixture
+def durable_probe() -> extraction.Probe:
+    return extraction.Probe(
+        probe_id="dur-1",
+        category="durable-content",
+        window={"prior": [], "current": {"user": "u", "assistant": "a"}},
+        expected={"should_extract_any": True, "must_contain": ["earl grey"]},
+    )
+
+
+class TestClassifyOutcome:
+    def test_workflow_noise_v5_extracts_v6_drops(self, workflow_probe):
+        """The win condition for a workflow-noise probe: v5 produced
+        facts, v6 produced none. Labeled `workflow_dropped`."""
+        outcome = extraction._classify_outcome(
+            workflow_probe,
+            v5_facts=["User decided to file an issue."],
+            v6_facts=[],
+        )
+        assert outcome == "workflow_dropped"
+
+    def test_workflow_noise_v5_empty_is_ambiguous(self, workflow_probe):
+        """If v5 was already empty, v6 cannot have "dropped"
+        anything. Treat as ambiguous so the rate denominator
+        excludes it."""
+        outcome = extraction._classify_outcome(
+            workflow_probe,
+            v5_facts=[],
+            v6_facts=[],
+        )
+        assert outcome == "ambiguous"
+
+    def test_workflow_noise_v6_violates_must_not(self, workflow_probe):
+        """v6 still emits a fact carrying a forbidden substring
+        => regression."""
+        outcome = extraction._classify_outcome(
+            workflow_probe,
+            v5_facts=["User decided to file an issue."],
+            v6_facts=["User filed an issue about Z."],
+        )
+        assert outcome == "regression"
+
+    def test_durable_v6_preserves_with_must_contain(self, durable_probe):
+        """v6 produced a fact carrying the required substring =>
+        durable_preserved."""
+        outcome = extraction._classify_outcome(
+            durable_probe,
+            v5_facts=["User prefers Earl Grey over English Breakfast."],
+            v6_facts=["User prefers Earl Grey."],
+        )
+        assert outcome == "durable_preserved"
+
+    def test_durable_v6_drops_required_substring(self, durable_probe):
+        """v6 produced a fact but it lacks the required substring =>
+        regression."""
+        outcome = extraction._classify_outcome(
+            durable_probe,
+            v5_facts=["User prefers Earl Grey."],
+            v6_facts=["User prefers tea."],
+        )
+        assert outcome == "regression"
+
+    def test_durable_v6_empty_is_regression(self, durable_probe):
+        """Durable category cares about preservation; an empty v6 is
+        a regression even if v5 was also empty."""
+        outcome = extraction._classify_outcome(
+            durable_probe,
+            v5_facts=["User prefers Earl Grey."],
+            v6_facts=[],
+        )
+        assert outcome == "regression"
+
+
+class TestAggregate:
+    def test_aggregate_rates_skip_ambiguous(self):
+        """Ambiguous outcomes drop out of the denominator so a few
+        uninformative probes do not drag the rate down."""
+        outcomes = [
+            extraction.ProbeOutcome(
+                probe_id="wf-1",
+                category="workflow-noise",
+                v5_facts=["x"],
+                v6_facts=[],
+                expected_outcome="workflow_dropped",
+                v6_rule_6_rejections_delta=0,
+            ),
+            extraction.ProbeOutcome(
+                probe_id="wf-2",
+                category="workflow-noise",
+                v5_facts=["x"],
+                v6_facts=["x"],
+                expected_outcome="regression",
+                v6_rule_6_rejections_delta=0,
+            ),
+            extraction.ProbeOutcome(
+                probe_id="wf-3",
+                category="workflow-noise",
+                v5_facts=[],
+                v6_facts=[],
+                expected_outcome="ambiguous",
+                v6_rule_6_rejections_delta=0,
+            ),
+            extraction.ProbeOutcome(
+                probe_id="dur-1",
+                category="durable-content",
+                v5_facts=["x"],
+                v6_facts=["x"],
+                expected_outcome="durable_preserved",
+                v6_rule_6_rejections_delta=0,
+            ),
+            extraction.ProbeOutcome(
+                probe_id="dur-2",
+                category="durable-content",
+                v5_facts=["x"],
+                v6_facts=[],
+                expected_outcome="regression",
+                v6_rule_6_rejections_delta=1,
+            ),
+        ]
+        agg = extraction._aggregate(outcomes)
+        # 1 workflow_dropped of 2 scorable workflow probes (the
+        # ambiguous one is excluded).
+        assert agg["workflow_drop_rate"] == 0.5
+        assert agg["scorable_workflow_count"] == 2
+        # 1 durable_preserved of 2 scorable durable probes.
+        assert agg["durable_preservation_rate"] == 0.5
+        assert agg["scorable_durable_count"] == 2
+        # Counter delta is the sum across all probes regardless of
+        # category or scorability.
+        assert agg["rule_6_rejections"] == 1
+
+    def test_aggregate_zero_scorable_returns_none(self):
+        """All-ambiguous category => rate is None, not 0.0, so a
+        downstream consumer can distinguish "no data" from "all
+        regressions"."""
+        outcomes = [
+            extraction.ProbeOutcome(
+                probe_id="wf-1",
+                category="workflow-noise",
+                v5_facts=[],
+                v6_facts=[],
+                expected_outcome="ambiguous",
+                v6_rule_6_rejections_delta=0,
+            ),
+        ]
+        agg = extraction._aggregate(outcomes)
+        assert agg["workflow_drop_rate"] is None
+        assert agg["durable_preservation_rate"] is None
+
+
+class TestWindowToExtractorArgs:
+    def test_pairs_user_assistant_sequentially(self):
+        """Two complete prior turns + a current exchange => two
+        prior pairs and the current user/assistant strings."""
+        window = {
+            "prior": [
+                {"role": "user", "text": "u1"},
+                {"role": "assistant", "text": "a1"},
+                {"role": "user", "text": "u2"},
+                {"role": "assistant", "text": "a2"},
+            ],
+            "current": {"user": "uc", "assistant": "ac"},
+        }
+        user, assistant, prior_pairs = extraction._window_to_extractor_args(window)
+        assert user == "uc"
+        assert assistant == "ac"
+        assert prior_pairs == [("u1", "a1"), ("u2", "a2")]
+
+    def test_orphan_user_without_following_assistant_dropped(self):
+        """A user turn with no matching assistant reply is omitted
+        from the pair list. The schema allows asymmetric prior turns
+        but the production payload expects pairs."""
+        window = {
+            "prior": [
+                {"role": "user", "text": "u1"},
+                {"role": "assistant", "text": "a1"},
+                {"role": "user", "text": "u2-orphan"},
+            ],
+            "current": {"user": "uc", "assistant": "ac"},
+        }
+        _, _, prior_pairs = extraction._window_to_extractor_args(window)
+        assert prior_pairs == [("u1", "a1")]

--- a/tests/test_eval_extraction.py
+++ b/tests/test_eval_extraction.py
@@ -187,7 +187,7 @@ class TestAggregate:
                 category="workflow-noise",
                 v5_facts=["x"],
                 v6_facts=[],
-                expected_outcome="workflow_dropped",
+                outcome="workflow_dropped",
                 v5_rule_6_rejections_delta=2,
                 v6_rule_6_rejections_delta=0,
             ),
@@ -196,7 +196,7 @@ class TestAggregate:
                 category="workflow-noise",
                 v5_facts=["x"],
                 v6_facts=["x"],
-                expected_outcome="regression",
+                outcome="regression",
                 v5_rule_6_rejections_delta=1,
                 v6_rule_6_rejections_delta=0,
             ),
@@ -205,7 +205,7 @@ class TestAggregate:
                 category="workflow-noise",
                 v5_facts=[],
                 v6_facts=[],
-                expected_outcome="ambiguous",
+                outcome="ambiguous",
                 v5_rule_6_rejections_delta=1,
                 v6_rule_6_rejections_delta=0,
             ),
@@ -214,7 +214,7 @@ class TestAggregate:
                 category="durable-content",
                 v5_facts=["x"],
                 v6_facts=["x"],
-                expected_outcome="durable_preserved",
+                outcome="durable_preserved",
                 v5_rule_6_rejections_delta=0,
                 v6_rule_6_rejections_delta=0,
             ),
@@ -223,7 +223,7 @@ class TestAggregate:
                 category="durable-content",
                 v5_facts=["x"],
                 v6_facts=[],
-                expected_outcome="regression",
+                outcome="regression",
                 v5_rule_6_rejections_delta=0,
                 v6_rule_6_rejections_delta=1,
             ),
@@ -251,7 +251,7 @@ class TestAggregate:
                 category="workflow-noise",
                 v5_facts=[],
                 v6_facts=[],
-                expected_outcome="ambiguous",
+                outcome="ambiguous",
                 v5_rule_6_rejections_delta=0,
                 v6_rule_6_rejections_delta=0,
             ),
@@ -259,6 +259,50 @@ class TestAggregate:
         agg = extraction._aggregate(outcomes)
         assert agg["workflow_drop_rate"] is None
         assert agg["durable_preservation_rate"] is None
+
+    def test_aggregate_excludes_error_outcomes_from_denominators(self):
+        """`error` outcomes are recorded in the report (operator
+        sees the failure) but skipped in the rate denominators
+        (parallel to `ambiguous`). Pins the per-probe-exception
+        behavior added so a single mid-run subprocess crash does
+        not poison the workflow_drop_rate or
+        durable_preservation_rate metrics."""
+        outcomes = [
+            extraction.ProbeOutcome(
+                probe_id="wf-1",
+                category="workflow-noise",
+                v5_facts=["x"],
+                v6_facts=[],
+                outcome="workflow_dropped",
+                v5_rule_6_rejections_delta=0,
+                v6_rule_6_rejections_delta=0,
+            ),
+            extraction.ProbeOutcome(
+                probe_id="wf-2",
+                category="workflow-noise",
+                v5_facts=[],
+                v6_facts=[],
+                outcome="error",
+                v5_rule_6_rejections_delta=0,
+                v6_rule_6_rejections_delta=0,
+            ),
+            extraction.ProbeOutcome(
+                probe_id="dur-1",
+                category="durable-content",
+                v5_facts=[],
+                v6_facts=[],
+                outcome="error",
+                v5_rule_6_rejections_delta=0,
+                v6_rule_6_rejections_delta=0,
+            ),
+        ]
+        agg = extraction._aggregate(outcomes)
+        # 1 of 1 scorable workflow probe; the error probe is excluded.
+        assert agg["workflow_drop_rate"] == 1.0
+        assert agg["scorable_workflow_count"] == 1
+        # Both durable probes are errors; the rate is None (not 0.0).
+        assert agg["durable_preservation_rate"] is None
+        assert agg["scorable_durable_count"] == 0
 
 
 class TestWindowToExtractorArgs:
@@ -288,6 +332,22 @@ class TestWindowToExtractorArgs:
                 {"role": "user", "text": "u1"},
                 {"role": "assistant", "text": "a1"},
                 {"role": "user", "text": "u2-orphan"},
+            ],
+            "current": {"user": "uc", "assistant": "ac"},
+        }
+        _, _, prior_pairs = extraction._window_to_extractor_args(window)
+        assert prior_pairs == [("u1", "a1")]
+
+    def test_orphan_assistant_without_preceding_user_dropped(self):
+        """An assistant turn that arrives before any user turn is
+        also dropped. Pinned alongside the user-orphan case so the
+        BOTH-DIRECTIONS contract documented in the function's
+        docstring is enforced symmetrically."""
+        window = {
+            "prior": [
+                {"role": "assistant", "text": "a-orphan"},
+                {"role": "user", "text": "u1"},
+                {"role": "assistant", "text": "a1"},
             ],
             "current": {"user": "uc", "assistant": "ac"},
         }

--- a/tests/test_eval_extraction.py
+++ b/tests/test_eval_extraction.py
@@ -104,6 +104,23 @@ def test_load_probes_malformed_json_raises_with_path_and_line(tmp_path: Path):
     assert "invalid JSON" in msg
 
 
+def test_load_probes_missing_window_current_raises_with_path_and_line(tmp_path: Path):
+    """A fixture line that is valid JSON and has the top-level
+    Probe fields but is missing `window.current` should fail at
+    load time, not silently route through `_run_one_probe`'s
+    error-bucket path. The load-time check is the operator's
+    diagnostic anchor; runtime tolerance for an empty current is
+    a separate concern handled by `_window_to_extractor_args`."""
+    f = tmp_path / "probes.jsonl"
+    f.write_text('{"probe_id":"p1","category":"workflow-noise","window":{"prior":[]},"expected":{}}\n')
+    with pytest.raises(ValueError) as exc_info:
+        extraction.load_probes(f)
+    msg = str(exc_info.value)
+    assert str(f) in msg
+    assert ":1:" in msg
+    assert "window.current is required" in msg
+
+
 def test_load_probes_missing_required_field_raises_with_path_and_line(tmp_path: Path):
     """Same diagnostic context applies when a line is valid JSON
     but lacks one of the required Probe fields. The KeyError raised

--- a/tests/test_eval_extraction.py
+++ b/tests/test_eval_extraction.py
@@ -325,6 +325,21 @@ class TestClassifyOutcome:
         )
         assert outcome == "ambiguous"
 
+    def test_durable_v5_empty_v6_extracts_is_ambiguous(self, durable_probe):
+        """v5 produced nothing; v6 found a fact carrying the
+        must_contain anchor. Nothing was "preserved" because v5
+        had nothing to preserve; counting this as
+        `durable_preserved` would inflate the rate by classifying
+        a v6 strict-improvement as preservation. Mirrors the
+        workflow-noise branch's symmetric `not v5_facts ->
+        ambiguous` guard."""
+        outcome = extraction._classify_outcome(
+            durable_probe,
+            v5_facts=[],
+            v6_facts=["User prefers Earl Grey."],
+        )
+        assert outcome == "ambiguous"
+
 
 class TestAggregate:
     def test_aggregate_rates_skip_ambiguous(self):

--- a/tests/test_eval_extraction.py
+++ b/tests/test_eval_extraction.py
@@ -121,6 +121,42 @@ def test_load_probes_missing_window_current_raises_with_path_and_line(tmp_path: 
     assert "window.current is required" in msg
 
 
+def test_load_probes_typo_in_window_current_user_raises(tmp_path: Path):
+    """A fixture line that misspells `user` (e.g., `typo_user`)
+    inside `window.current` passes the outer `current` existence
+    check but produces empty extractor inputs at run time. The
+    deeper validation catches the typo class at load time so the
+    operator does not waste subprocess cost on a probe that will
+    silently route to `error`."""
+    f = tmp_path / "probes.jsonl"
+    f.write_text(
+        '{"probe_id":"p1","category":"workflow-noise",'
+        '"window":{"prior":[],"current":{"typo_user":"u","assistant":"a"}},'
+        '"expected":{}}\n'
+    )
+    with pytest.raises(ValueError) as exc_info:
+        extraction.load_probes(f)
+    msg = str(exc_info.value)
+    assert str(f) in msg
+    assert ":1:" in msg
+    assert "non-empty user and assistant" in msg
+
+
+def test_load_probes_empty_assistant_raises(tmp_path: Path):
+    """Empty-string assistant is rejected too. An empty turn would
+    short-circuit the extractor's confirmation rules and silently
+    produce a meaningless run."""
+    f = tmp_path / "probes.jsonl"
+    f.write_text(
+        '{"probe_id":"p1","category":"workflow-noise",'
+        '"window":{"prior":[],"current":{"user":"u","assistant":""}},'
+        '"expected":{}}\n'
+    )
+    with pytest.raises(ValueError) as exc_info:
+        extraction.load_probes(f)
+    assert "non-empty user and assistant" in str(exc_info.value)
+
+
 def test_load_probes_missing_required_field_raises_with_path_and_line(tmp_path: Path):
     """Same diagnostic context applies when a line is valid JSON
     but lacks one of the required Probe fields. The KeyError raised

--- a/tests/test_eval_extraction.py
+++ b/tests/test_eval_extraction.py
@@ -28,6 +28,13 @@ from kai.eval import extraction
 # pinned constant drifts (intentional or not), this test fails and
 # either the constant must be reverted or this hash must be updated
 # to a new captured baseline.
+#
+# Stored as the raw hexdigest; the JSON report emitted by the
+# harness CLI prefixes the same value with "sha256:" via the
+# `_hash()` helper. An operator cross-checking a report's
+# `v5_prompt_hash` against this constant should strip the
+# prefix from the report value (or compare report value to
+# `f"sha256:{_V5_PROMPT_HASH}"`).
 _V5_PROMPT_HASH = "764f249d2556a6e00489ac7ba5eac265f4a4d09f27d21dc76f612b84f0874c13"
 
 

--- a/tests/test_eval_extraction.py
+++ b/tests/test_eval_extraction.py
@@ -472,11 +472,12 @@ class TestRunOneProbeErrorPath:
         carry outcome=`error`, the v5 delta from the real arm, and
         v6 delta = 0 (v6 never produced facts)."""
         # Reset the counter's contents in-place so the test's delta
-        # arithmetic is independent of preceding tests' state. We
-        # do NOT reassign `_RULE_6_REJECTIONS` because other test
-        # modules import it by name; reassignment would leave them
-        # pointing at the old (stale) counter object.
-        memory_extraction._RULE_6_REJECTIONS._counts.clear()
+        # arithmetic is independent of preceding tests' state.
+        # `_Counter._reset` is the test-only entry point; reassigning
+        # `_RULE_6_REJECTIONS` would leave other test modules
+        # (which import the counter by name) holding a stale
+        # reference to the old object.
+        memory_extraction._RULE_6_REJECTIONS._reset()
 
         call_count = {"n": 0}
 

--- a/tests/test_eval_extraction.py
+++ b/tests/test_eval_extraction.py
@@ -69,6 +69,44 @@ def test_example_probe_fixture_loads():
         assert isinstance(p.expected, dict)
 
 
+def test_load_probes_malformed_json_raises_with_path_and_line(tmp_path: Path):
+    """A typo in a fixture line surfaces the file path and 1-based
+    line number, not a bare JSONDecodeError. Operators curate this
+    fixture by hand; the diagnostic context shortens the
+    typo-find-fix loop."""
+    f = tmp_path / "probes.jsonl"
+    f.write_text(
+        '{"probe_id":"p1","category":"workflow-noise",'
+        '"window":{"prior":[],"current":{"user":"u","assistant":"a"}},"expected":{}}\n'
+        "this is not json\n"
+    )
+    with pytest.raises(ValueError) as exc_info:
+        extraction.load_probes(f)
+    msg = str(exc_info.value)
+    # Path is in the message.
+    assert str(f) in msg
+    # Line number is 1-based; the bad line is the second one.
+    assert ":2:" in msg
+    # The underlying JSONDecodeError detail is preserved via the
+    # f-string so the operator sees what was wrong, not just where.
+    assert "invalid JSON" in msg
+
+
+def test_load_probes_missing_required_field_raises_with_path_and_line(tmp_path: Path):
+    """Same diagnostic context applies when a line is valid JSON
+    but lacks one of the required Probe fields. The KeyError raised
+    by the dict access is converted into the same ValueError shape
+    so the operator does not need to distinguish failure modes."""
+    f = tmp_path / "probes.jsonl"
+    f.write_text('{"probe_id":"p1","category":"workflow-noise"}\n')
+    with pytest.raises(ValueError) as exc_info:
+        extraction.load_probes(f)
+    msg = str(exc_info.value)
+    assert str(f) in msg
+    assert ":1:" in msg
+    assert "missing required field" in msg
+
+
 def test_load_probes_skips_comments_and_blanks(tmp_path: Path):
     """`#`-prefixed lines and blank lines must be ignored so the
     fixture format can carry inline documentation."""

--- a/tests/test_eval_extraction.py
+++ b/tests/test_eval_extraction.py
@@ -15,11 +15,13 @@ What we pin here:
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 from pathlib import Path
 
 import pytest
 
+from kai import memory_extraction
 from kai.eval import extraction
 
 # Hash of `_PROMPT_V5_PINNED` captured at #426 landing. If the
@@ -163,15 +165,29 @@ class TestClassifyOutcome:
         )
         assert outcome == "regression"
 
-    def test_durable_v6_empty_is_regression(self, durable_probe):
-        """Durable category cares about preservation; an empty v6 is
-        a regression even if v5 was also empty."""
+    def test_durable_v5_extracts_v6_empty_is_regression(self, durable_probe):
+        """Durable category cares about preservation; when v5
+        produced a fact but v6 did not, that is a regression
+        because the durable fact must come through under v6."""
         outcome = extraction._classify_outcome(
             durable_probe,
             v5_facts=["User prefers Earl Grey."],
             v6_facts=[],
         )
         assert outcome == "regression"
+
+    def test_durable_both_empty_is_ambiguous(self, durable_probe):
+        """Symmetric to workflow-noise: a durable-content probe
+        whose window is too sparse to produce extractions on either
+        arm is uninformative, not a v6 failure. Treating it as a
+        regression silently inflates the regression count and
+        deflates `durable_preservation_rate`."""
+        outcome = extraction._classify_outcome(
+            durable_probe,
+            v5_facts=[],
+            v6_facts=[],
+        )
+        assert outcome == "ambiguous"
 
 
 class TestAggregate:
@@ -303,6 +319,64 @@ class TestAggregate:
         # Both durable probes are errors; the rate is None (not 0.0).
         assert agg["durable_preservation_rate"] is None
         assert agg["scorable_durable_count"] == 0
+
+
+class TestRunOneProbeErrorPath:
+    """`_run_one_probe` never raises. On exception it returns a
+    ProbeOutcome with outcome=`error` and whatever per-arm Rule 6
+    deltas it captured before the failure. Pinned because the
+    error-path delta accuracy is operator-facing: a v5 arm that
+    completed should report its real rejection delta even when v6
+    crashes mid-run, otherwise `_aggregate`'s v5_rule_6_rejections
+    total is silently under-counted."""
+
+    def test_v6_exception_preserves_v5_delta(self, monkeypatch):
+        """Drive v5 to completion (returning a fact that fires
+        Rule 6) and v6 to raise. The returned ProbeOutcome must
+        carry outcome=`error`, the v5 delta from the real arm, and
+        v6 delta = 0 (v6 never produced facts)."""
+        # Reset the counter's contents in-place so the test's delta
+        # arithmetic is independent of preceding tests' state. We
+        # do NOT reassign `_RULE_6_REJECTIONS` because other test
+        # modules import it by name; reassignment would leave them
+        # pointing at the old (stale) counter object.
+        memory_extraction._RULE_6_REJECTIONS._counts.clear()
+
+        call_count = {"n": 0}
+
+        async def fake_run_extractor(payload, config, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # v5 arm: emit a workflow-event fact so Rule 6
+                # fires and the counter increments.
+                memory_extraction._RULE_6_REJECTIONS.increment(user_id="probe-x")
+                return memory_extraction.ExtractionResult(
+                    facts=[{"content": "User prefers tea.", "tags": ["preference"]}],
+                    has_episode=False,
+                )
+            # v6 arm: simulate a subprocess crash.
+            raise RuntimeError("v6 subprocess crashed")
+
+        monkeypatch.setattr(memory_extraction, "_run_extractor", fake_run_extractor)
+
+        probe = extraction.Probe(
+            probe_id="probe-x",
+            category="workflow-noise",
+            window={"prior": [], "current": {"user": "u", "assistant": "a"}},
+            expected={"should_extract_any": False, "must_not_contain": []},
+        )
+
+        outcome = asyncio.run(extraction._run_one_probe(probe, config=None, user_id="probe-x"))
+
+        assert outcome.outcome == "error"
+        # v5 arm completed: the increment we drove in fake_run_extractor
+        # should be visible as a real per-arm delta.
+        assert outcome.v5_rule_6_rejections_delta == 1
+        # v6 arm raised before completing: delta stays at 0.
+        assert outcome.v6_rule_6_rejections_delta == 0
+        # v5_facts captured pre-exception; v6_facts empty.
+        assert outcome.v5_facts == ["User prefers tea."]
+        assert outcome.v6_facts == []
 
 
 class TestWindowToExtractorArgs:

--- a/tests/test_eval_extraction.py
+++ b/tests/test_eval_extraction.py
@@ -121,6 +121,32 @@ def test_load_probes_missing_window_current_raises_with_path_and_line(tmp_path: 
     assert "window.current is required" in msg
 
 
+def test_load_probes_unknown_category_raises_with_path_and_line(tmp_path: Path):
+    """A category typo (e.g. underscore instead of hyphen) would
+    otherwise silently route every probe in the file to
+    `ambiguous` in `_classify_outcome`, yielding `None` rates
+    with no indication of the cause. The load-time check raises
+    a ValueError naming the offending category and the allowed
+    set so the operator can find and fix the typo."""
+    f = tmp_path / "probes.jsonl"
+    f.write_text(
+        '{"probe_id":"p1","category":"workflow_noise",'
+        '"window":{"prior":[],"current":{"user":"u","assistant":"a"}},'
+        '"expected":{}}\n'
+    )
+    with pytest.raises(ValueError) as exc_info:
+        extraction.load_probes(f)
+    msg = str(exc_info.value)
+    assert str(f) in msg
+    assert ":1:" in msg
+    assert "unknown category" in msg
+    # The error names the typo'd value AND the allowed set, so the
+    # operator does not have to grep the source for the right names.
+    assert "workflow_noise" in msg
+    assert "workflow-noise" in msg
+    assert "durable-content" in msg
+
+
 def test_load_probes_typo_in_window_current_user_raises(tmp_path: Path):
     """A fixture line that misspells `user` (e.g., `typo_user`)
     inside `window.current` passes the outer `current` existence

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -2454,7 +2454,7 @@ class TestRule6WorkflowEventRegex:
         `_validate_facts` is dropped, the rejection counter
         increments, and the legitimate fact in the same batch
         survives."""
-        # Reset the counter so test order does not affect the delta.
+        # Snapshot the baseline so test order does not affect the delta.
         before = sum(_RULE_6_REJECTIONS.snapshot().values())
         facts = [
             {

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -2558,10 +2558,6 @@ class TestRunExtractorSystemPromptDefault:
         captured argv carries `_EXTRACTION_SYSTEM_PROMPT` (the
         active module-level constant) at the slot following
         `--system-prompt`."""
-        import asyncio
-
-        from kai import memory_extraction
-
         captured: dict = {}
 
         class _StubProc:

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -2387,10 +2387,10 @@ class TestRule6WorkflowEventRegex:
         Catches "User/OC decided/requested to <verb>" workflow
         actions."""
         positives = [
-            "User decided to file an issue about memory.recall query truncation.",
-            "User requested to update issue #385 with the Sophia field set.",
-            "OC decided to perform a code review of PR #409.",
-            "User decided to address issue #338",
+            "User decided to file an issue about query truncation.",
+            "User requested to update issue #0 with the Sophia field set.",
+            "OC decided to perform a code review of PR #1.",
+            "User decided to address issue #2",
         ]
         for content in positives:
             assert _WORKFLOW_EVENT_RE.search(content), content
@@ -2408,9 +2408,9 @@ class TestRule6WorkflowEventRegex:
         IGNORE rules cover that shape; the regex stays scoped to
         the past-tense / received variants."""
         positives = [
-            "PR #424 received a code review verdict of approved cleanly with no blockers.",
-            "Specification 412 version 3 was approved with three sub-blocking nits.",
-            "Spec 416 (memory UI tag dismantle) version 4 received final approval.",
+            "PR #0 received a code review verdict of approved cleanly with no blockers.",
+            "Specification foo version 3 was approved with three sub-blocking nits.",
+            "Spec bar (some component) version 4 received final approval.",
         ]
         for content in positives:
             assert _WORKFLOW_EVENT_RE.search(content), content
@@ -2428,9 +2428,9 @@ class TestRule6WorkflowEventRegex:
         """Arm 4: `evaluation of (spec|specification|issue|PR) X
         (produced|was|determined) Y`."""
         positives = [
-            "The evaluation of specification 380 was written to /tmp/spec-380-evaluation-v1.md",
-            "The evaluation of spec 416 produced a verdict of 'changes requested'.",
-            "The evaluation of PR #X determined three should-fix items.",
+            "The evaluation of specification foo was written to /tmp/spec-foo-evaluation-v1.md",
+            "The evaluation of spec foo produced a verdict of 'changes requested'.",
+            "The evaluation of PR #3 determined three should-fix items.",
         ]
         for content in positives:
             assert _WORKFLOW_EVENT_RE.search(content), content
@@ -2483,11 +2483,11 @@ class TestRule6WorkflowEventRegex:
         assert after - before == 1
 
     def test_rule_6_skips_confirmed_action_rows(self):
-        """Pins B2 of the spec eval: a confirmed_action fact whose
-        content matches arm 2 ("User confirmed PR #299 was merged
-        on 2026-04-12") must NOT be rejected because the per-fact
-        skip ahead of Rule 6 trusts the existing Rule 1/2/4/4b
-        confirmation chain."""
+        """Pin the confirmed_action skip ahead of Rule 6: a
+        confirmation row whose content matches arm 2 ("User
+        confirmed PR #299 was merged on 2026-04-12") must NOT be
+        rejected, because the existing Rule 1/2/4/4b chain already
+        gates the confirmed_action path."""
         before = sum(_RULE_6_REJECTIONS.snapshot().values())
         facts = [
             {
@@ -2546,7 +2546,7 @@ class TestExtractionPromptDurability:
 
 
 class TestRunExtractorSystemPromptDefault:
-    """Pins B1's compatibility contract: `_run_extractor` accepts a
+    """Pin the compatibility contract: `_run_extractor` accepts a
     keyword-only `system_prompt` parameter that defaults to the
     active `_EXTRACTION_SYSTEM_PROMPT`. Production callers that omit
     the kwarg see byte-identical subprocess argv compared to before

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -30,6 +30,8 @@ from kai.memory_extraction import (
     _EXTRACTION_SYSTEM_PROMPT,
     _FACT_SCHEMA,
     _GENERIC_CONFIRMATION_RE,
+    _RULE_6_REJECTIONS,
+    _WORKFLOW_EVENT_RE,
     _build_extraction_payload,
     _capped_assistant,
     _emit_intent_log,
@@ -41,6 +43,7 @@ from kai.memory_extraction import (
     _strip_role_labels,
     _validate_facts,
     extract_and_store,
+    get_extractor_stats,
 )
 
 # ── Fixtures ─────────────────────────────────────────────────────────
@@ -2347,23 +2350,263 @@ class TestExtractionPromptSoftVocab:
 
     def test_extraction_prompt_version_bumped(self):
         """The version stamp on every fact's metadata; bumped
-        because the schema and prompt changed in tandem."""
-        assert _EXTRACTION_PROMPT_VERSION == "5"
+        whenever the schema or prompt changes meaningfully."""
+        assert _EXTRACTION_PROMPT_VERSION == "6"
 
     def test_extraction_prompt_version_history_extended(self):
         """The prompt-version history comment block (the sequence
         of `#` comments preceding `_EXTRACTION_PROMPT_VERSION`) is
         NOT a module docstring; importable runtime state cannot
-        capture it. Read source text and grep for the unique
-        history fragment so a future unrelated edit that
-        introduces a `v5:` token elsewhere cannot satisfy this
-        test vacuously."""
+        capture it. Read source text and grep for unique history
+        fragments so a future unrelated edit that introduces a `vN:`
+        token elsewhere cannot satisfy this test vacuously.
+
+        Both v5 and v6 fragments are pinned: v5 stays in source
+        unchanged across the v6 bump, and v6 was appended in this
+        spec's history block."""
         from pathlib import Path
 
         import kai.memory_extraction
 
         src = Path(kai.memory_extraction.__file__).read_text()
         assert "v5: free-form tag schema (enum dropped)" in src
+        assert "v6 (2026-04-30, this issue)" in src
+        assert "DURABILITY TEST gate" in src
+
+
+class TestRule6WorkflowEventRegex:
+    """Rule 6 in `_validate_facts` rejects facts whose `content` is
+    pure session-event metadata. The regex catches four shapes,
+    each pinned with positive and negative cases drawn from the
+    2026-04-30 hygiene sweep deletion set + the 8 KEEP entries
+    audited from that sweep."""
+
+    def test_arm1_user_or_oc_decided_to_workflow_action(self):
+        """Arm 1: `^(User|OC)\\s+(decided|requested)\\s+to\\s+
+        (file|create|address|conduct|evaluate|perform|update|push)`.
+        Catches "User/OC decided/requested to <verb>" workflow
+        actions."""
+        positives = [
+            "User decided to file an issue about memory.recall query truncation.",
+            "User requested to update issue #385 with the Sophia field set.",
+            "OC decided to perform a code review of PR #409.",
+            "User decided to address issue #338",
+        ]
+        for content in positives:
+            assert _WORKFLOW_EVENT_RE.search(content), content
+
+    def test_arm2_spec_pr_issue_event(self):
+        """Arm 2: artifact-shape + intervening tokens? +
+        was/were/received + verdict-class noun. Catches "Spec X /
+        PR Y / issue Z (version qualifier)? was/were/received
+        ... <verdict>" wordings.
+
+        Coverage note: "Spec X v1 evaluation verdict IS changes
+        requested" (using "is") is NOT caught by arm 2 because
+        adding "is" to the verb list would false-positive on
+        ordinary statements like "Memory is enabled". The prompt's
+        IGNORE rules cover that shape; the regex stays scoped to
+        the past-tense / received variants."""
+        positives = [
+            "PR #424 received a code review verdict of approved cleanly with no blockers.",
+            "Specification 412 version 3 was approved with three sub-blocking nits.",
+            "Spec 416 (memory UI tag dismantle) version 4 received final approval.",
+        ]
+        for content in positives:
+            assert _WORKFLOW_EVENT_RE.search(content), content
+
+    def test_arm3_findings_closed(self):
+        """Arm 3: `All N (vM)? findings? (were|are) closed`."""
+        positives = [
+            "All eleven v1 findings were closed in v2 with verified-against-source fixes.",
+            "All eight findings are closed.",
+        ]
+        for content in positives:
+            assert _WORKFLOW_EVENT_RE.search(content), content
+
+    def test_arm4_evaluation_of_artifact(self):
+        """Arm 4: `evaluation of (spec|specification|issue|PR) X
+        (produced|was|determined) Y`."""
+        positives = [
+            "The evaluation of specification 380 was written to /tmp/spec-380-evaluation-v1.md",
+            "The evaluation of spec 416 produced a verdict of 'changes requested'.",
+            "The evaluation of PR #X determined three should-fix items.",
+        ]
+        for content in positives:
+            assert _WORKFLOW_EVENT_RE.search(content), content
+
+    def test_durable_content_does_not_match(self):
+        """Durable design decisions, constraints, and preferences
+        are the load-bearing negatives. A regression that broadens
+        the regex to catch substantive content trips here first."""
+        negatives = [
+            "User decided stage 2 should provide only single-turn context (architecture A).",
+            "User stated that collision possibilities between MEMORY.md and Qdrant must be mitigated.",
+            "User prefers Earl Grey over English Breakfast.",
+            "User decided to use a 3-4 turn window for the Haiku memory extraction process.",
+            "User decided the shared /opt/kai/home/ directory must be removed entirely.",
+        ]
+        for content in negatives:
+            assert not _WORKFLOW_EVENT_RE.search(content), content
+
+    def test_rule_6_rejects_workflow_fact_via_validate_facts(self):
+        """End-to-end: a workflow-event fact passed through
+        `_validate_facts` is dropped, the rejection counter
+        increments, and the legitimate fact in the same batch
+        survives."""
+        # Reset the counter so test order does not affect the delta.
+        before = sum(_RULE_6_REJECTIONS.snapshot().values())
+        facts = [
+            {
+                "content": "User decided to file an issue about Track 1.",
+                "tags": ["decision", "project"],
+                "confidence": 0.95,
+                "intent": "new",
+            },
+            {
+                "content": "User prefers Earl Grey over English Breakfast.",
+                "tags": ["preference"],
+                "confidence": 0.9,
+                "intent": "new",
+            },
+        ]
+        validated = _validate_facts(
+            facts,
+            candidate_ids=set(),
+            candidate_metadata={},
+            user_id="test-user-rule6",
+        )
+        kept = [f["content"] for f in validated]
+        assert "User decided to file an issue about Track 1." not in kept
+        assert "User prefers Earl Grey over English Breakfast." in kept
+        after = sum(_RULE_6_REJECTIONS.snapshot().values())
+        assert after - before == 1
+
+    def test_rule_6_skips_confirmed_action_rows(self):
+        """Pins B2 of the spec eval: a confirmed_action fact whose
+        content matches arm 2 ("User confirmed PR #299 was merged
+        on 2026-04-12") must NOT be rejected because the per-fact
+        skip ahead of Rule 6 trusts the existing Rule 1/2/4/4b
+        confirmation chain."""
+        before = sum(_RULE_6_REJECTIONS.snapshot().values())
+        facts = [
+            {
+                "content": "User confirmed PR #299 was merged on 2026-04-12.",
+                "tags": ["confirmed_action"],
+                "confidence": 0.9,
+                "intent": "new",
+                "confirmation_quote": "I see PR #299 is merged, thanks for the update.",
+            },
+        ]
+        validated = _validate_facts(
+            facts,
+            candidate_ids=set(),
+            candidate_metadata={},
+            user_id="test-user-rule6-skip",
+        )
+        kept = [f["content"] for f in validated]
+        # The fact survives. The regex matches the content, but the
+        # confirmed_action skip protects it.
+        assert "User confirmed PR #299 was merged on 2026-04-12." in kept
+        # Counter unchanged: Rule 6 did not fire on this fact.
+        after = sum(_RULE_6_REJECTIONS.snapshot().values())
+        assert after - before == 0
+
+    def test_get_extractor_stats_exposes_rule_6_counter(self):
+        """`get_extractor_stats()` returns the documented top-level
+        shape with the per-user counter map under `rule_6_rejections`."""
+        stats = get_extractor_stats()
+        assert "rule_6_rejections" in stats
+        assert isinstance(stats["rule_6_rejections"], dict)
+
+
+class TestExtractionPromptDurability:
+    """Pins the v6 prompt content additions: STORE / Decisions
+    refinement, two new IGNORE bullets, and the DURABILITY TEST
+    section header. Substring assertions only; the exact wording
+    is captured byte-for-byte by the source-text history-fragment
+    test in TestExtractionPromptSoftVocab."""
+
+    def test_store_decisions_scoped_to_durable(self):
+        assert "durable scope" in _EXTRACTION_SYSTEM_PROMPT
+        assert "NOT workflow micro-decisions" in _EXTRACTION_SYSTEM_PROMPT
+
+    def test_ignore_bullets_added(self):
+        assert "Workflow-event metadata" in _EXTRACTION_SYSTEM_PROMPT
+        assert "Decisions to do" in _EXTRACTION_SYSTEM_PROMPT
+        # Concrete examples carried in the bullets so the model has
+        # specific noise patterns to match against.
+        assert "Spec X v3 was approved" in _EXTRACTION_SYSTEM_PROMPT
+        assert "User decided to file an issue about X" in _EXTRACTION_SYSTEM_PROMPT
+
+    def test_durability_test_section_present(self):
+        assert "DURABILITY TEST:" in _EXTRACTION_SYSTEM_PROMPT
+        # The 30-day frame is the operationally usable phrasing.
+        assert "30 days" in _EXTRACTION_SYSTEM_PROMPT
+
+
+class TestRunExtractorSystemPromptDefault:
+    """Pins B1's compatibility contract: `_run_extractor` accepts a
+    keyword-only `system_prompt` parameter that defaults to the
+    active `_EXTRACTION_SYSTEM_PROMPT`. Production callers that omit
+    the kwarg see byte-identical subprocess argv compared to before
+    the parameter was added."""
+
+    def test_default_kwarg_threads_active_prompt(self, monkeypatch):
+        """Stub `asyncio.create_subprocess_exec` to capture argv.
+        Call `_run_extractor` without `system_prompt`. Assert the
+        captured argv carries `_EXTRACTION_SYSTEM_PROMPT` (the
+        active module-level constant) at the slot following
+        `--system-prompt`."""
+        import asyncio
+
+        from kai import memory_extraction
+
+        captured: dict = {}
+
+        class _StubProc:
+            returncode = 0
+            stdout = None
+            stderr = None
+
+            async def communicate(self, input=None):
+                # Return a minimal valid extractor JSON response so
+                # the caller's parse path does not raise.
+                payload = b'{"facts": [], "has_episode": false}'
+                return (payload, b"")
+
+            async def wait(self):
+                return 0
+
+            def kill(self):
+                pass
+
+        async def _stub_create_subprocess_exec(*args, **kwargs):
+            captured["argv"] = args
+            return _StubProc()
+
+        monkeypatch.setattr(
+            memory_extraction.asyncio,
+            "create_subprocess_exec",
+            _stub_create_subprocess_exec,
+        )
+
+        async def _run():
+            return await memory_extraction._run_extractor(
+                "test payload",
+                _BASE_CONFIG,
+                candidate_ids=set(),
+                candidate_metadata={},
+                user_id="test-user-default-kwarg",
+            )
+
+        asyncio.run(_run())
+
+        argv = captured["argv"]
+        # Find the slot following `--system-prompt`.
+        idx = argv.index("--system-prompt")
+        threaded = argv[idx + 1]
+        assert threaded == _EXTRACTION_SYSTEM_PROMPT, "default kwarg must thread the active prompt byte-for-byte"
 
 
 class TestValidateFactsRule4b:


### PR DESCRIPTION
## Summary

The Haiku extractor was producing too many workflow-event "facts" (spec/PR/issue lifecycle events, "User decided to file an issue", review-round verdicts) that have no durable value. A 2026-04-30 hygiene sweep deleted 70 such facts (23% of the extracted-source store) and Layer 2 confirmed the wrong-fact-retrieval failure mode this caused fully resolves with the noise gone (loss count 2 -> 1 between pre-sweep and post-sweep on the same probe set; scorable win rate 88.46% -> 90.48%). Without an extractor change the noise will return at the observed 2.5x-per-week rate; this PR addresses that.

Three coordinated changes:

1. **Prompt v5 -> v6**: scoped the STORE / Decisions bullet to durable architectural decisions, added two IGNORE bullets for workflow-event metadata, added a "DURABILITY TEST" gate (would this fact still be useful in 30 days?), bumped `_EXTRACTION_PROMPT_VERSION` for targeted future cleanup.
2. **`_validate_facts` Rule 6 (Python backstop)**: regex rejecting four shapes of workflow-event content, with a `confirmed_action` skip so canonical confirmation rows like "User confirmed PR #299 was merged on 2026-04-12" pass through unrejected. Per-user rejection counter exposed via `get_extractor_stats()`.
3. **Eval harness `src/kai/eval/extraction.py`**: subprocess-driven head-to-head of v5 vs v6 prompts on a labeled probe fixture. `_PROMPT_V5_PINNED` captures the v5 prompt verbatim so the comparison runs without reverting source. `_run_extractor` gained a keyword-only `system_prompt` parameter (default = active prompt, production callers unchanged).

Closes #426.

## Why three layers

- **Prompt** is the primary gate: the model produces fewer workflow-event candidates in the first place.
- **Regex** is defense-in-depth: catches what slips past the prompt. Logged at INFO so the fire rate is observable; high rate means the prompt is leaking and should be tightened (rather than the regex broadened).
- **Harness** measures the change: the prompt edit is the most load-bearing correctness artifact in the memory pipeline; we want to assert improvement empirically rather than vibe-check it.

## Tests

- **16 new unit tests** in `tests/test_memory_extraction.py`:
  - `TestRule6WorkflowEventRegex`: each of the four regex arms gets positive cases drawn from the real deletion set, plus a shared negative case set covering durable preferences, constraints, and design decisions. End-to-end tests through `_validate_facts` pin the rejection counter delta and the `confirmed_action` skip path (the spec eval's B2 regression).
  - `TestExtractionPromptDurability`: substring pins for the three D1 prompt edits.
  - `TestRunExtractorSystemPromptDefault`: stubs `asyncio.create_subprocess_exec` to capture argv; asserts the default kwarg threads `_EXTRACTION_SYSTEM_PROMPT` byte-for-byte (compatibility contract for callers that omit `system_prompt`).
  - Updated `TestExtractionPromptSoftVocab` for v5 -> v6 version pin and v6 history-fragment pin (existing v5 substring stays valid).
- **14 integration tests** in `tests/test_eval_extraction.py`:
  - `test_v5_pinned_drift`: SHA-256 hash gate so any silent edit to `_PROMPT_V5_PINNED` fails CI.
  - Probe-fixture loader tests + comment/blank-line skipping.
  - `TestClassifyOutcome`: the (category, v5_facts, v6_facts) -> outcome mapping for workflow_dropped / regression / durable_preserved / ambiguous, including the strict `should_extract_any: false` branch.
  - `TestAggregate`: rates skip ambiguous (so uninformative probes do not drag denominators); v5 and v6 Rule 6 rejection counters are reported separately.

Full suite: 2740 passed, 1 skipped. `make check` clean.

## Live extraction harness

This PR ships the harness scaffolding and an example fixture (4 probes); it does NOT ship a live probe fixture (10+ per category). The live fixture is gitignored by design (operator-specific session content). The operator builds it from `DATA_DIR/history/<chat_id>/` when they want to run real measurements; the example fixture exercises the harness wiring end-to-end and is what the integration tests run against.

The harness runs probes sequentially (no `asyncio.gather` / semaphore). For 20 probes at ~10s per subprocess Claude call x 2 prompt arms, expect roughly 7 minutes walltime. Cost estimate at Haiku 4.5 rates (~5K input + ~1K output tokens per call): ~$0.32 per run.

## Out of scope (deliberately)

- **Confidence calibration**: 83% of extracted facts sit at 0.95 today; the field is functionally useless. Real problem, separate fix.
- **Anti-fabrication system prompt for the inner Claude**: Layer 2 post-sweep showed the hallucination failure mode (probe 20) persists with a clean memory store, so the fix site is the inner Claude's prompt, not the extractor. Iterate-epic candidate.
- **Schema-level minimums on `content` text length**: too coarse; the prompt-side handles it.
- **Live probe fixture curation**: gitignored; operator builds it locally.

## Test plan

- [ ] `make check` passes
- [ ] `make test` passes (2740 tests)
- [ ] After deploy: `get_extractor_stats()["rule_6_rejections"]` increments are observable in production logs (look for `_validate_facts: rejecting workflow-event-shaped fact:`)
- [ ] After deploy: spot-check `/memory` to confirm new extracted rows do not include workflow-event content
- [ ] Optional: operator runs the harness end-to-end against a live probe fixture to baseline workflow_drop_rate / durable_preservation_rate
