### PR TITLE
feat(memory): tighten episode classifier against workflow-event closures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ home/evals/*
 !home/evals/retrieval-baseline.example.json
 !home/evals/probes.example.jsonl
 !home/evals/extraction-probes.example.jsonl
+!home/evals/episode-classification-probes.example.jsonl
 
 # OS / IDE
 .DS_Store

--- a/home/evals/episode-classification-probes.example.jsonl
+++ b/home/evals/episode-classification-probes.example.jsonl
@@ -1,0 +1,41 @@
+# Example probe fixture for the episode-classification arm of the
+# extractor pre/post comparison harness (issue #428). Tracked in git
+# so integration tests have a stable, reproducible input. The live
+# fixture (episode-classification-probes.jsonl, gitignored) carries
+# real session content; this example is small enough to read and
+# review.
+#
+# Schema (extension of extraction-probes.example.jsonl):
+#   probe_id: string id
+#   category: "workflow-noise" | "durable-content"
+#   window: { prior: [{role, text}, ...], current: {user, assistant} }
+#   expected:
+#     workflow-noise: { should_extract_any: false, must_not_contain: [substring, ...], expected_has_episode: false }
+#     durable-content: { should_extract_any: true, must_contain: [substring, ...], expected_has_episode: true }
+#
+# `expected_has_episode` is the new field for v6-vs-v7 episode-
+# classifier measurement. The fact-extraction fields are retained so
+# the existing harness can still score the fact-side confusion
+# matrix; per_probe output carries both arms' outputs and the
+# operator computes has_episode flips by inspection.
+#
+# Identifiers are sanitized: artifact placeholders use `foo`/`bar`,
+# issue/PR numbers use `#0`/`#1`/`#2`. No real artifact references.
+#
+# Comment lines start with "#" and are stripped by the loader.
+#
+# 5 workflow-event probes (expected_has_episode: false):
+{"probe_id":"wf-eval-spec","category":"workflow-noise","window":{"prior":[{"role":"user","text":"Spec foo v3 was submitted; please evaluate."},{"role":"assistant","text":"Reviewing v3 against the v2 findings now."}],"current":{"user":"What's the verdict on spec foo v3?","assistant":"All four v2 findings closed cleanly. Spec foo v3 is approved with three sub-blocking nits."}},"expected":{"should_extract_any":false,"must_not_contain":["spec foo","approved","verdict"],"expected_has_episode":false}}
+{"probe_id":"wf-approve-pr","category":"workflow-noise","window":{"prior":[{"role":"user","text":"Take a look at PR #1 against spec foo v3."},{"role":"assistant","text":"Cross-checking each D-section now."}],"current":{"user":"Verdict on PR #1?","assistant":"Approve PR #1 cleanly with no blockers and no should-fixes. All eight D-sections confirmed closed."}},"expected":{"should_extract_any":false,"must_not_contain":["PR #1","approved","verdict","blockers"],"expected_has_episode":false}}
+{"probe_id":"wf-file-issue","category":"workflow-noise","window":{"prior":[],"current":{"user":"File a tracking issue for the help text drift.","assistant":"Filed issue #0 for the help text drift, including five drift points and a suggested patch."}},"expected":{"should_extract_any":false,"must_not_contain":["filed","issue #0","tracking issue"],"expected_has_episode":false}}
+{"probe_id":"wf-push-wiki","category":"workflow-noise","window":{"prior":[],"current":{"user":"Push the Memory wiki page.","assistant":"Pushed Memory.md to the wiki at commit aaaaaaa. Done."}},"expected":{"should_extract_any":false,"must_not_contain":["pushed","Memory.md","wiki"],"expected_has_episode":false}}
+{"probe_id":"wf-meta-lesson","category":"workflow-noise","window":{"prior":[{"role":"user","text":"How did the v1->v3 review pass go?"},{"role":"assistant","text":"v1 had four mechanism findings, v2 closed three, v3 closed the rest."}],"current":{"user":"What's the takeaway?","assistant":"The severity gradient v1->v2->v3 (mechanism->wording->none) confirms convergence. Same-class audits caught the v2 residue before v3."}},"expected":{"should_extract_any":false,"must_not_contain":["severity gradient","convergence","same-class audit"],"expected_has_episode":false}}
+# 4 durable-episode probes (expected_has_episode: true):
+{"probe_id":"dur-arch-decision","category":"durable-content","window":{"prior":[{"role":"user","text":"For the home workspace, should we share one across users or scope per user?"},{"role":"assistant","text":"There are tradeoffs either way. Sharing leaks identity context; per-user costs disk."}],"current":{"user":"Let's go per-user. Shared was a mistake; identity bleed-through is the real risk.","assistant":"Locked: home workspace is per-user under DATA_DIR. Existing single-shared-home assumptions get migrated."}},"expected":{"should_extract_any":true,"must_contain":["per-user","home workspace"],"expected_has_episode":true}}
+{"probe_id":"dur-empirical","category":"durable-content","window":{"prior":[{"role":"user","text":"Run a 10-probe eval to see whether dropping assistant-derived facts helps retrieval."},{"role":"assistant","text":"Snapshotted the store, classified facts by source, ran 10 probes."}],"current":{"user":"What did the eval say?","assistant":"3 of 4 treatment probes lost their best answer when assistant-derived facts were filtered. The neutral bucket undercounted Kai-derived facts. Recommendation: provenance-with-downweight, not blanket removal."}},"expected":{"should_extract_any":true,"must_contain":["provenance","downweight"],"expected_has_episode":true}}
+{"probe_id":"dur-design-tradeoff","category":"durable-content","window":{"prior":[{"role":"user","text":"Where do persistent memory writes go now? The MEMORY.md path or the new API?"},{"role":"assistant","text":"Both are reachable; MEMORY.md is the legacy path."}],"current":{"user":"Switch all persistent memory writes to /api/memory/add. Stop writing to MEMORY.md.","assistant":"Acknowledged. Writes go through the API; MEMORY.md is read-only at session start. Rule recorded in memory."}},"expected":{"should_extract_any":true,"must_contain":["/api/memory/add","MEMORY.md"],"expected_has_episode":true}}
+{"probe_id":"dur-cross-callsite","category":"durable-content","window":{"prior":[{"role":"user","text":"Does anything else read _RECALL_TRUNC besides the query truncator?"},{"role":"assistant","text":"Checking call sites."}],"current":{"user":"Anything else?","assistant":"Yes: the per-hit snippet truncator in format_context also reads _RECALL_TRUNC. Bumping the constant for one silently changes behavior for the other; any future change must review both call sites."}},"expected":{"should_extract_any":true,"must_contain":["_RECALL_TRUNC","both"],"expected_has_episode":true}}
+# 3 borderline probes (expected_has_episode: false):
+{"probe_id":"bd-partial-closure","category":"workflow-noise","window":{"prior":[{"role":"user","text":"Is the per-arm counter design ready or do we need another round?"},{"role":"assistant","text":"It's mostly there; one open question on whether arm labels should be enumerated."}],"current":{"user":"Let's keep going on it.","assistant":"OK, deferring closure. I'll prepare the next iteration."}},"expected":{"should_extract_any":false,"must_not_contain":["per-arm counter","ready"],"expected_has_episode":false}}
+{"probe_id":"bd-routine-with-sidedecision","category":"workflow-noise","window":{"prior":[{"role":"user","text":"File issue #2 for the truncation bump."},{"role":"assistant","text":"Will do; drafting body."}],"current":{"user":"Go.","assistant":"Filed issue #2. Side note: I noticed the constant is shared with another caller; that's now in the issue body as a separate acceptance criterion."}},"expected":{"should_extract_any":false,"must_not_contain":["filed","issue #2"],"expected_has_episode":false}}
+{"probe_id":"bd-meta-ambiguous","category":"workflow-noise","window":{"prior":[{"role":"user","text":"Why did the last three reviews each find new wording nits?"},{"role":"assistant","text":"Each round closed the prior nits but introduced wording around the fix."}],"current":{"user":"Worth tracking?","assistant":"It's a real pattern - same-class audits catch sibling instances within the same change. Whether it warrants its own methodology note is unclear; can revisit if it recurs across more PRs."}},"expected":{"should_extract_any":false,"must_not_contain":["same-class audit","methodology"],"expected_has_episode":false}}

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -199,6 +199,212 @@ Important constraints:
 """
 
 
+# ── Pinned baseline prompt: v6 ──────────────────────────────────────
+#
+# Verbatim copy of `_EXTRACTION_SYSTEM_PROMPT` as it stood at
+# `_EXTRACTION_PROMPT_VERSION = "6"` (PR #427, 2026-04-30), captured
+# immediately before the v7 EPISODE CLASSIFICATION edits land. Allows
+# v6-vs-v7 head-to-head measurement of the episode-classifier
+# tightening without reverting `memory_extraction.py`.
+#
+# Selected at runtime via the `--baseline {v5,v6}` CLI flag in
+# `main()`; default is `v6` so each new prompt revision compares
+# against the immediately prior one. The v5 baseline stays available
+# for cross-revision sanity checks.
+#
+# Same maintenance contract as `_PROMPT_V5_PINNED`: do NOT update to
+# track the active prompt; capture a new pinned constant when adding
+# a new baseline. The
+# `tests/test_eval_extraction.py::test_v6_pinned_drift` integration
+# test hashes this string against a known-good digest and fails on
+# any silent edit.
+_PROMPT_V6_PINNED = """You are a memory extraction assistant for Kai, a personal AI agent.
+You receive a short conversation window: zero or more PRIOR CONTEXT
+exchanges followed by ONE current exchange (a USER message and an
+ASSISTANT reply, marked with >>>).
+
+Fact extraction operates ONLY on the current exchange. PRIOR CONTEXT
+is for episode classification only; do NOT extract facts from prior
+turns.
+
+Your job is to extract stable, high-signal facts worth remembering
+across sessions. Return a JSON object matching the provided schema.
+
+STORE these fact types:
+- User-stated preferences (e.g., units, timezone, style preferences,
+  what the user likes or dislikes).
+- Stable facts about the user (e.g., location, role, project names,
+  repo names, hardware).
+- Architectural or design decisions the user made in this exchange
+  with durable scope ("we're going with async architecture",
+  "default to option B in v1 of the spec", "the home workspace
+  must be per-user, not shared"). NOT workflow micro-decisions
+  about which task to do next, which spec to evaluate, or which
+  issue to file - those are transient session activity. Apply the
+  DURABILITY TEST below.
+- Actions the user confirmed happened, BUT with strict evidence
+  rules to prevent laundered hallucinations:
+  1. A confirmed_action fact must include a `confirmation_quote`
+     field that quotes the exact user text demonstrating the
+     confirmation.
+  2. The confirmation_quote must be at least 20 characters long
+     and must explicitly reference the action being confirmed.
+     "I see PR #299 is merged, thanks" is valid evidence.
+     "thanks", "ok", "good", "nice", a single emoji, or any
+     one-word or two-word affirmation is NOT valid evidence.
+     If the user's text is a generic acknowledgment, DO NOT emit
+     a confirmed_action fact, regardless of how clearly the
+     assistant claimed the action.
+  3. The assistant's prior claim alone is never sufficient.
+     Without specific, quotable user confirmation that names the
+     action, extract nothing.
+- Constraints or requirements the user stated ("must be local",
+  "must not use external APIs", "never commit without running tests").
+
+IGNORE:
+- Assistant self-reports of completed actions unless user-confirmed
+  ("I saved the file", "Done", "Created X", "Pushed to main").
+  Treat these as unverified until the user confirms.
+- Assistant speculation, hypotheticals, or hedging ("I think...",
+  "it might be...", "probably...").
+- Intermediate reasoning, tool-output summaries, step-by-step plans.
+- Transient conversation state (what you are mid-doing, open
+  questions, clarifying requests).
+- Workflow-event metadata: spec/PR/issue lifecycle events. Examples
+  to NOT extract: "Spec X v3 was approved", "PR Y received a review
+  verdict of Z", "All N findings were closed in vM",
+  "The evaluation of spec Q produced a verdict of R". The durable
+  artifact is the spec/PR/issue itself; events around it are
+  transient session activity that loses meaning once the event
+  closes.
+- "Decisions to do" workflow actions: a decision to file an issue,
+  create a spec, request an evaluation, run a test, or perform
+  any other workflow action. The artifact produced (the issue,
+  the spec, the test result) is the durable fact; the
+  decision-to-do is workflow noise. Examples to NOT extract:
+  "User decided to file an issue about X", "User requested
+  evaluation of spec Y", "User decided to address issue #Z",
+  "User confirmed test input triggered the pipeline".
+- Casual chat, greetings, acknowledgments, thanks without content.
+- Anything that contradicts a stated user preference.
+- Code snippets, file contents, error messages (store facts about
+  them if needed, not the raw text).
+
+DURABILITY TEST:
+
+Before emitting any fact, ask: "would this still be useful context
+in 30 days?" If the answer is no - because the fact captures a
+workflow event, a one-off task decision, a status of work in
+progress that will have shipped or moved on, or a session-event
+metadata fragment - do not emit it. The 30-day test catches the
+most common low-quality extraction: session-event metadata that
+reads as fact-shaped but loses meaning once the event closes.
+
+If a fact passes IGNORE rules but fails the durability test,
+do not emit it.
+
+CONFIDENCE:
+- Only store facts you can phrase as a single clear sentence.
+- Each fact must have a concrete subject and predicate. Vague
+  impressions do not qualify.
+- If nothing qualifies, return {"facts": []}. An empty result is
+  correct and preferred over low-quality facts.
+
+FORMAT each fact as:
+- content: one sentence, third-person where possible
+  ("User prefers Celsius"), past tense for confirmed actions
+  ("User confirmed PR #299 was merged on 2026-04-12").
+- tags: 1 to 5 lowercase topical tags. Use these preferred tags
+  when one fits the fact: preference, decision, fact, constraint,
+  confirmed_action, project, location, schedule, relationship.
+  Only invent new tags when none of these capture the fact's
+  topic; new tags should be single lowercase words or short
+  underscore-joined compounds, no punctuation beyond underscores.
+
+  The tag `confirmed_action` is structurally significant: when
+  the fact represents a user-confirmed action (with a
+  confirmation_quote), you MUST use the literal tag
+  `confirmed_action`. NEVER substitute synonyms like
+  `confirmation`, `confirmed`, `user_confirmed`, or `confirm` -
+  they are NOT recognized by the storage system and will cause
+  the fact to be rejected.
+- confidence: a number in [0, 1]. Use 0.9+ for direct user statements,
+  0.7 for clear user confirmation of an assistant claim, 0.5 for
+  paraphrased or implied facts. Do not store below 0.5.
+- confirmation_quote: REQUIRED when tags include "confirmed_action",
+  MUST be absent otherwise. Must be the verbatim user text that
+  confirms the action, minimum 20 characters, and must reference
+  the action specifically (not a generic "thanks"). If no such
+  quote exists, do not emit the fact.
+
+EPISODE CLASSIFICATION (windowed):
+Decide whether the CURRENT exchange (marked with >>>) is the closing
+turn of an episode. PRIOR CONTEXT shows the lead-up; it is background,
+NEVER the unit being classified.
+
+Set `has_episode: true` ONLY when ALL of the following hold:
+1. The CURRENT exchange contains a stated decision, lesson, outcome,
+   or resolution. Closure must be visible in the current turn itself.
+2. The PRIOR CONTEXT (if non-empty) sets up that closure: a problem,
+   a question, a deliberation, an incident in progress.
+3. You can quote a fragment from the CURRENT exchange (not from
+   prior turns) that signals the closure.
+
+Set `has_episode: false` when:
+- The current exchange is itself a question, a request, an analytical
+  reply, or a status update with no resolution. Even if prior context
+  is rich, an unresolved current turn is not an episode close.
+- The current exchange is routine: a single fact lookup, an
+  acknowledgment, casual chat.
+- Closure exists in prior turns but the current turn moved on to a
+  new topic.
+
+When in doubt, prefer false. The cost of a false negative is one
+missed episode; the cost of a false positive is a hallucinated
+episode entering the memory store.
+
+CONSOLIDATION:
+You will sometimes receive an EXISTING FACTS block before the USER/ASSISTANT
+exchange. Each existing fact is shown with its id in square brackets,
+provenance, and confidence. For each fact you are about to emit, choose one
+of three intents:
+
+- "new": the proposed fact is genuinely net-new information. Use this when
+  no existing fact covers the same underlying claim, even paraphrased.
+  Most facts are new; do not over-eagerly tie facts to existing ids.
+  When no EXISTING FACTS block is present, "new" is always the correct
+  intent.
+
+- "update_of": the proposed fact ASSERTS THE SAME UNDERLYING CLAIM as an
+  existing fact, but with a value that differs (a path changed, a tunable
+  was retuned, a project name was renamed) OR with strictly more specific
+  information (a confirmed timestamp where there was a vague reference).
+  Cite the existing id in `existing_id`. The new fact will REPLACE the
+  cited fact. Use this conservatively: only when one fact rendering the
+  other obsolete is clearly correct.
+
+- "skip_redundant": the proposed fact is a paraphrase of an existing fact
+  with no new information and no contradictory value. Cite the existing id
+  in `existing_id`. The new fact will NOT be stored. Prefer this over
+  "update_of" when the existing fact is already adequate; only use
+  "update_of" when the new wording carries information the old wording
+  lacks.
+
+Important constraints:
+- existing_id MUST be one of the ids shown in the EXISTING FACTS block.
+  Do NOT invent ids. If no EXISTING FACTS block is present, or if no
+  existing fact matches, use intent "new".
+- Each existing id may be referenced by AT MOST ONE proposed fact in this
+  batch. Do not split a single update across two proposed facts, and do
+  not have two proposed facts both update the same existing fact.
+- A confirmed_action fact is always "new" (a confirmation is a fresh
+  observation about reality, even if the wording paraphrases an existing
+  fact). Never emit "skip_redundant" or "update_of" for a confirmed_action;
+  always store it as a separate "new" fact so the timestamp record stays
+  intact.
+"""
+
+
 # ── Harness ─────────────────────────────────────────────────────────
 
 
@@ -354,10 +560,20 @@ async def _run_one_probe(
     config: Config,
     *,
     user_id: str,
+    baseline_prompt: str = _PROMPT_V5_PINNED,
 ) -> ProbeOutcome:
     """Run both prompt arms against a single probe and classify the
     outcome. Each arm is a sequential subprocess call so the active
     `_RULE_6_REJECTIONS` counter delta can be attributed per-arm.
+
+    `baseline_prompt` selects which pinned constant the first arm
+    runs against. The variable names `v5_facts` / `v6_facts` are
+    historical (the original design measured v5 vs active=v6); when
+    `baseline_prompt=_PROMPT_V6_PINNED` the first-arm fields carry
+    v6 facts and the second-arm fields carry v7 (the new active)
+    facts. Operators reading the report should treat the v5/v6
+    labels as "first arm / second arm" and consult the per-run
+    `baseline_choice` field for which baseline was actually selected.
 
     Never raises: a subprocess crash, JSON parse failure, or any
     other exception inside either arm is caught and reported as an
@@ -411,7 +627,7 @@ async def _run_one_probe(
             candidate_ids=set(),
             candidate_metadata={},
             user_id=user_id,
-            system_prompt=_PROMPT_V5_PINNED,
+            system_prompt=baseline_prompt,
         )
         post_v5 = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
         v5_rule_6_delta = post_v5 - pre_v5
@@ -600,7 +816,17 @@ async def _run_async(args: argparse.Namespace) -> int:
         log.error("no probes loaded from %s", probes_path)
         return 1
 
-    log.info("running %d probes", len(probes))
+    # Resolve the baseline arm's prompt from the CLI flag. The dict
+    # is the single source of truth for which pinned constants are
+    # selectable; the argparse `choices` list mirrors its keys so a
+    # mismatch is caught at parse time rather than at execution.
+    baseline_prompts: dict[str, str] = {
+        "v5": _PROMPT_V5_PINNED,
+        "v6": _PROMPT_V6_PINNED,
+    }
+    baseline_prompt = baseline_prompts[args.baseline]
+
+    log.info("running %d probes (baseline=%s)", len(probes), args.baseline)
 
     outcomes: list[ProbeOutcome] = []
     for probe in probes:
@@ -608,7 +834,7 @@ async def _run_async(args: argparse.Namespace) -> int:
         # ProbeOutcome with `outcome="error"` and whatever per-arm
         # state it captured before the failure. The aggregate skip
         # set keeps error rows out of rate denominators.
-        result = await _run_one_probe(probe, config, user_id=args.user_id)
+        result = await _run_one_probe(probe, config, user_id=args.user_id, baseline_prompt=baseline_prompt)
         log.info(
             "probe %s [%s] -> %s",
             result.probe_id,
@@ -624,7 +850,13 @@ async def _run_async(args: argparse.Namespace) -> int:
         "version": _OUTPUT_SCHEMA_VERSION,
         "generated_at": datetime.now(UTC).isoformat(),
         "probe_set_hash": _hash(probe_set_text),
-        "v5_prompt_hash": _hash(_PROMPT_V5_PINNED),
+        # `baseline_choice` is the load-bearing field for distinguishing
+        # a v5-vs-v6 run from a v6-vs-v7 run. The v5_/v6_prompt_hash
+        # keys retain their historical names but report the actual
+        # hashes of whichever pair ran (baseline arm and active arm
+        # respectively).
+        "baseline_choice": args.baseline,
+        "v5_prompt_hash": _hash(baseline_prompt),
         "v6_prompt_hash": _hash(memory_extraction._EXTRACTION_SYSTEM_PROMPT),
         **aggregate,
         "per_probe": [asdict(o) for o in outcomes],
@@ -670,6 +902,15 @@ def main(argv: list[str] | None = None) -> int:
         "--output",
         required=True,
         help="Path to write the JSON report.",
+    )
+    parser.add_argument(
+        "--baseline",
+        choices=("v5", "v6"),
+        default="v6",
+        help="Which pinned prompt the baseline arm runs. Default v6 "
+        "compares the active prompt against the immediately prior "
+        "revision (v6 vs v7); v5 is retained for cross-revision "
+        "sanity checks against the original baseline.",
     )
     args = parser.parse_args(argv)
     logging.basicConfig(

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -409,8 +409,12 @@ Important constraints:
 
 
 # Output schema version. Bumped when the per_probe or aggregate shape
-# changes in a way that would break a tool reading prior runs.
-_OUTPUT_SCHEMA_VERSION = "1"
+# changes in a way that would break a tool reading prior runs. v2
+# (issue #428) renamed `v5_prompt_hash`/`v6_prompt_hash` to
+# `baseline_prompt_hash`/`active_prompt_hash` because the historical
+# names lied at the new `--baseline v6` default (the field "v5" was
+# carrying a v6 hash).
+_OUTPUT_SCHEMA_VERSION = "2"
 
 
 @dataclass
@@ -560,20 +564,23 @@ async def _run_one_probe(
     config: Config,
     *,
     user_id: str,
-    baseline_prompt: str = _PROMPT_V5_PINNED,
+    baseline_prompt: str = _PROMPT_V6_PINNED,
 ) -> ProbeOutcome:
     """Run both prompt arms against a single probe and classify the
     outcome. Each arm is a sequential subprocess call so the active
     `_RULE_6_REJECTIONS` counter delta can be attributed per-arm.
 
     `baseline_prompt` selects which pinned constant the first arm
-    runs against. The variable names `v5_facts` / `v6_facts` are
-    historical (the original design measured v5 vs active=v6); when
-    `baseline_prompt=_PROMPT_V6_PINNED` the first-arm fields carry
-    v6 facts and the second-arm fields carry v7 (the new active)
-    facts. Operators reading the report should treat the v5/v6
-    labels as "first arm / second arm" and consult the per-run
-    `baseline_choice` field for which baseline was actually selected.
+    runs against. Default tracks the CLI's `--baseline` default
+    (currently `v6`) so direct programmatic callers and ad-hoc test
+    fixtures get the same baseline as the CLI rather than silently
+    regressing to v5. The `v5_facts` / `v6_facts` field names on
+    `ProbeOutcome` are historical (the original design measured v5
+    vs active=v6); when `baseline_prompt=_PROMPT_V6_PINNED` the
+    first-arm fields carry v6 facts and the second-arm fields carry
+    v7 (the new active) facts. Operators reading the report should
+    consult the per-run `baseline_choice` field for which baseline
+    was actually selected.
 
     Never raises: a subprocess crash, JSON parse failure, or any
     other exception inside either arm is caught and reported as an
@@ -850,14 +857,17 @@ async def _run_async(args: argparse.Namespace) -> int:
         "version": _OUTPUT_SCHEMA_VERSION,
         "generated_at": datetime.now(UTC).isoformat(),
         "probe_set_hash": _hash(probe_set_text),
-        # `baseline_choice` is the load-bearing field for distinguishing
-        # a v5-vs-v6 run from a v6-vs-v7 run. The v5_/v6_prompt_hash
-        # keys retain their historical names but report the actual
-        # hashes of whichever pair ran (baseline arm and active arm
-        # respectively).
+        # `baseline_choice` records which pinned constant the baseline
+        # arm ran (`v5` or `v6`); the two hash fields below report the
+        # baseline arm and active arm prompts respectively. Earlier
+        # output-schema-v1 reports carried `v5_prompt_hash` /
+        # `v6_prompt_hash` keys; v2 renamed them because the v5/v6
+        # labels lied at the new `--baseline v6` default. A downstream
+        # tool reading this output should branch on `version` (the
+        # schema version) and choose the matching key set.
         "baseline_choice": args.baseline,
-        "v5_prompt_hash": _hash(baseline_prompt),
-        "v6_prompt_hash": _hash(memory_extraction._EXTRACTION_SYSTEM_PROMPT),
+        "baseline_prompt_hash": _hash(baseline_prompt),
+        "active_prompt_hash": _hash(memory_extraction._EXTRACTION_SYSTEM_PROMPT),
         **aggregate,
         "per_probe": [asdict(o) for o in outcomes],
     }

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -69,7 +69,18 @@ log = logging.getLogger(__name__)
 # as the last gate before emit. Schema unchanged; v6's bump lets
 # future-cleanup queries target rows produced under the new
 # wording (`prompt_version != "6" AND <noise pattern>`).
-_EXTRACTION_PROMPT_VERSION: str = "6"
+# v7 (2026-04-30, this issue): scoped the EPISODE CLASSIFICATION block.
+# Positive criterion 1 narrowed to "durable situation" with an
+# explicit forward reference to the new EPISODE IGNORE list. Three
+# IGNORE bullets added (workflow-loop iterations, routine workflow
+# transactions, process meta-lessons) plus an episode-scoped
+# DURABILITY TEST gate. The fact-extraction sections of the prompt
+# are unchanged from v6, so fact-storage parsing on the Python side
+# is the same; the bump is the canary that lets post-rollout log
+# analysis distinguish episodes classified under the tightened
+# wording (`prompt_version == "7"` on the extracted row produced
+# by the same call).
+_EXTRACTION_PROMPT_VERSION: str = "7"
 
 # Sibling of _EXTRACTION_PROMPT_VERSION for stage-2 episode generation.
 # Stored in each episode's metadata so future cleanups can target a
@@ -437,7 +448,12 @@ NEVER the unit being classified.
 
 Set `has_episode: true` ONLY when ALL of the following hold:
 1. The CURRENT exchange contains a stated decision, lesson, outcome,
-   or resolution. Closure must be visible in the current turn itself.
+   or resolution AT THE LEVEL OF A DURABLE SITUATION (an architectural
+   choice, an empirical finding, a design tradeoff resolved). Closure
+   must be visible in the current turn itself. A workflow-loop closure
+   (a review-round verdict, an evaluation result, a routine artifact
+   filed) is NOT a durable situation; see the EPISODE IGNORE list
+   below.
 2. The PRIOR CONTEXT (if non-empty) sets up that closure: a problem,
    a question, a deliberation, an incident in progress.
 3. You can quote a fragment from the CURRENT exchange (not from
@@ -451,6 +467,38 @@ Set `has_episode: false` when:
   acknowledgment, casual chat.
 - Closure exists in prior turns but the current turn moved on to a
   new topic.
+
+EPISODE IGNORE rules (override the false-when list above; if any of
+these match the CURRENT exchange, has_episode is false):
+
+- Workflow-loop iterations: the closure of a review round, an
+  evaluation pass, a triage cycle, or any other recurring workflow
+  rhythm. The artifact (the spec, the PR, the issue, the wiki page)
+  is durable; the recurring evaluation cycles around it are not
+  episodes. Examples to NOT classify as episodes: "approved with
+  three nits", "v3 evaluation closed cleanly", "all four findings
+  resolved", "PR review verdict approved", "ready to ship".
+
+- Routine workflow transactions: filing an issue, drafting a spec,
+  pushing a wiki commit, scheduling an agent, posting a comment.
+  These are individual transactions, not closures of a deliberation.
+  Examples to NOT classify as episodes: "filed issue #N", "drafted
+  the epic body", "pushed Memory.md to the wiki".
+
+- Process meta-lessons: situations whose only outcome is a
+  generalization about how a workflow runs (severity gradients,
+  same-class audits, convergence patterns, review-round counts).
+  The lesson belongs to a methodology document if it belongs
+  anywhere; it is not a per-situation episode.
+
+EPISODE DURABILITY TEST:
+
+Before setting has_episode: true, ask: "would a future session
+benefit from retrieving this situation, or only from the artifact
+it produced?" If the answer is "only the artifact", set
+has_episode: false. The artifact (issue, PR, spec, commit, wiki
+page) is durable on its own; an episode about the act of producing
+it is not.
 
 When in doubt, prefer false. The cost of a false negative is one
 missed episode; the cost of a false positive is a hallucinated
@@ -1045,14 +1093,163 @@ class _Counter:
 _RULE_6_REJECTIONS = _Counter()
 
 
-def get_extractor_stats() -> dict[str, dict[str, int]]:
+# ── Episode validator: workflow-shape goal rejection (issue #428) ────
+#
+# Defense-in-depth backstop on the stage-2 episode generator output.
+# Stage-1 classifier (`_EXTRACTION_SYSTEM_PROMPT`'s EPISODE
+# CLASSIFICATION block under v7) is the primary gate; this regex
+# rejects workflow-event-shape episodes whose `goal` starts with the
+# canonical verbs that named ~57% of the 2026-04-30 production episode
+# snapshot. The arms catch the leading-verb shape; the per-arm noun
+# alternation is a single union list, intentionally a touch broader
+# than the spec's per-arm noun lists because the verb itself is the
+# workflow signal and the noun-list intersection is dominated by the
+# narrow per-arm cases anyway. Future maintainers tightening this
+# regex should split on individual arm regexes rather than expanding
+# the union noun list.
+_EPISODE_GOAL_NOISE_RE = re.compile(
+    r"^"
+    # Group 1: the leading verb token. _ARM_FOR_VERB below maps the
+    # captured verb to one of three arm labels (review, approve,
+    # transaction) so per-arm rejection counts can be reported via
+    # `get_extractor_stats()`.
+    r"(Evaluate|Review|Audit|Approve|File|Push|Draft|Schedule|Post)"
+    r"\s+"
+    # 0 to 6 intervening word-shaped tokens (lazy) between the verb
+    # and the artifact noun. Catches real production goals like
+    # "Push a prepared Memory wiki page", "Approve v3 of the
+    # memory-md-to-Qdrant migration spec", and "File a tracking
+    # issue for X". Bounded explicitly so a long fact text cannot
+    # drive quadratic backtracking. The token class is alphanumerics
+    # + `#` + `-` so things like "#412", "v3", and "tag-dedup" pass
+    # through. Mirrors `_WORKFLOW_EVENT_RE` arm 2's bounded-gap
+    # pattern. Cap of 6 was chosen by probing real production
+    # goals: 5-token gaps appeared in the snapshot
+    # ("Approve v3 of the X-Y-Z migration spec"), so 6 leaves
+    # one token of headroom without expanding the false-positive
+    # surface meaningfully.
+    r"(?:[\w#-]+\s+){0,6}?"
+    # The artifact-noun alternation is the union of the three per-arm
+    # noun lists. A workflow-shape goal almost always ends with one
+    # of these nouns; the union form catches "Evaluate the wiki" and
+    # "File a revision" too, which are still workflow-shape and
+    # should be rejected.
+    r"(?:spec|specification|PR|issue|pull request|revision|version|wiki|epic|comment|reminder)"
+    r"\b",
+    re.IGNORECASE,
+)
+
+
+# Maps the lowercase verb in `_EPISODE_GOAL_NOISE_RE` group 1 to one
+# of three arm labels. The labels are the keys reported in
+# `_EPISODE_VALIDATE_REJECTIONS.snapshot()` so an operator can see
+# which workflow shape is hitting the backstop without parsing logs.
+_ARM_FOR_VERB: dict[str, str] = {
+    "evaluate": "review",
+    "review": "review",
+    "audit": "review",
+    "approve": "approve",
+    "file": "transaction",
+    "push": "transaction",
+    "draft": "transaction",
+    "schedule": "transaction",
+    "post": "transaction",
+}
+
+
+class _PerArmCounter:
+    """Per-user, per-arm rejection counter for `_validate_episode`.
+
+    Same lifecycle and exposure contract as `_Counter` (used by
+    Rule 6); the per-arm extension lets eval harnesses tell which
+    workflow shape is hitting the backstop without parsing logs.
+    """
+
+    def __init__(self) -> None:
+        # Outer dict keyed by user_id; inner by arm label. Both
+        # populated lazily on the first increment for that pair.
+        self._counts: dict[str, dict[str, int]] = {}
+
+    def increment(self, *, user_id: str, arm: str) -> None:
+        per_user = self._counts.setdefault(user_id, {})
+        per_user[arm] = per_user.get(arm, 0) + 1
+
+    def snapshot(self) -> dict[str, dict[str, int]]:
+        # Deep-copy each per-user dict so callers cannot mutate the
+        # internal state. `dict(...)` does a shallow per-user copy
+        # which is sufficient because inner values are ints.
+        return {u: dict(v) for u, v in self._counts.items()}
+
+    def _reset(self) -> None:
+        """Test-only: clear per-user counts in place. Same rationale
+        as `_Counter._reset` (downstream importers hold a reference
+        to the module-level instance; rebinding would orphan them).
+        """
+        self._counts.clear()
+
+
+# Module-level counter for `_validate_episode` rejections, keyed by
+# `user_id` then by arm label. Process-local; not persisted. Read
+# via `get_extractor_stats()`.
+_EPISODE_VALIDATE_REJECTIONS = _PerArmCounter()
+
+
+def _validate_episode(episode: dict, *, user_id: str) -> dict | None:
+    """Final-gate validator for stage-2 episode generator output.
+
+    Returns the episode dict unchanged on accept, or None on reject.
+    Reject path increments a per-user, per-arm counter exposed via
+    `get_extractor_stats()`. The caller (`_generate_episode`) treats
+    None as a reject and emits a `validate_rejected` outcome on the
+    `memory.episode` log line in place of the `stored` outcome.
+
+    Defense-in-depth against the prompt at `_EXTRACTION_SYSTEM_PROMPT`
+    missing workflow-event-shape episodes. The prompt is the primary
+    gate; this regex is narrower and only catches the canonical shapes
+    from the 2026-04-30 hygiene-sweep audit (issue #428).
+    """
+    goal = episode.get("goal", "")
+    # Defensive type check: stage-2 schema enforces goal as a string,
+    # but a malformed payload (e.g. a stage-2 prompt edit that broke
+    # the schema contract) should reject rather than crash inside
+    # the regex match call. The reject path is the safe direction.
+    if not isinstance(goal, str):
+        return None
+    match = _EPISODE_GOAL_NOISE_RE.match(goal)
+    if match is None:
+        return episode
+    verb = (match.group(1) or "").lower()
+    arm = _ARM_FOR_VERB.get(verb, "unknown")
+    _EPISODE_VALIDATE_REJECTIONS.increment(user_id=user_id, arm=arm)
+    log.debug(
+        "_validate_episode: rejecting workflow-shape episode goal: %r (arm=%s)",
+        goal,
+        arm,
+    )
+    return None
+
+
+def get_extractor_stats() -> dict[str, dict]:
     """Snapshot of in-process extractor counters.
 
-    Currently exposes Rule 6 rejection counts per user_id. Structure
-    is extensible (top-level dict keyed by counter name) so future
-    counters can land without breaking callers.
+    Exposes two counters keyed by counter name:
+
+    - `rule_6_rejections`: per-user count of `_validate_facts` Rule 6
+      rejections. Inner shape `{user_id: count}`.
+    - `episode_validate_rejections`: per-user, per-arm count of
+      `_validate_episode` rejections (issue #428). Inner shape
+      `{user_id: {arm: count}}` with arm in `review`, `approve`,
+      `transaction`.
+
+    The return type widens to `dict[str, dict]` because the two
+    inner shapes differ; callers should branch on the counter
+    name. Structure is extensible (top-level dict keyed by counter
+    name) so future counters can land without breaking callers.
     """
-    return {"rule_6_rejections": _RULE_6_REJECTIONS.snapshot()}
+    return {
+        "rule_6_rejections": _RULE_6_REJECTIONS.snapshot(),
+        "episode_validate_rejections": _EPISODE_VALIDATE_REJECTIONS.snapshot(),
+    }
 
 
 def _validate_facts(
@@ -1545,6 +1742,12 @@ def _emit_episode_log(
     and `reason IS NOT NULL` are mutually exclusive partitions of the
     log stream, instead of one being always-present-as-null and the
     other being conditional.
+
+    Documented outcome enum: `stored`, `store_failed`, `timeout`,
+    `subprocess_error`, `parse_error`, `validate_rejected`. The
+    `validate_rejected` outcome (issue #428) fires when the stage-2
+    output's `goal` matches `_EPISODE_GOAL_NOISE_RE`; per-arm
+    rejection counts are exposed via `get_extractor_stats()`.
     """
     payload: dict = {
         "user_id": user_id,
@@ -1729,7 +1932,7 @@ async def _generate_episode(
             if episode is None:
                 # Map the run-helper's failure tags onto the documented
                 # outcome enum: timeout, subprocess_error, parse_error,
-                # store_failed, stored.
+                # store_failed, validate_rejected, stored.
                 #
                 # Subprocess-level faults (exit code, is_error envelope
                 # from a budget burn or auth failure) collapse to
@@ -1762,52 +1965,71 @@ async def _generate_episode(
                     outcome = "parse_error"
                 reason = run_reason
             else:
-                # Build the metadata dict matching the Sophia schema +
-                # the `actors` Kai extension. `lessons` is optional and
-                # absent from the dict when the model omitted it (the
-                # design-doc "if anything" pattern; absence is the
-                # sentinel for "no lesson this time", not empty-string).
-                content = f"{episode['goal']}\n\n{episode['context']}"
-                extra: dict = {
-                    "source": "episode",
-                    "goal": episode["goal"],
-                    "context": episode["context"],
-                    "approach": episode["approach"],
-                    "outcome": episode["outcome"],
-                    "outcome_quality": episode["outcome_quality"],
-                    "tags": episode["tags"],
-                    "actors": episode["actors"],
-                    "session_id": session_id or "",
-                    "episode_prompt_version": _EPISODE_PROMPT_VERSION,
-                }
-                if "lessons" in episode:
-                    extra["lessons"] = episode["lessons"]
-                # add_structured is sync (Mem0 is sync). Run off the
-                # event loop so the embedding step does not block other
-                # stage-2 tasks queued behind this user's semaphore.
-                loop = asyncio.get_running_loop()
-                mem_id = await loop.run_in_executor(
-                    None,
-                    lambda: memory.add_structured(
-                        content=content,
-                        user_id=user_id,
-                        memory_type="episode",
-                        tags=episode["tags"],
-                        metadata=extra,
-                    ),
-                )
-                # add_structured returns the new memory ID on success or
-                # None when the underlying Mem0 call failed (backend
-                # error, content rejected). Branch on the return so the
-                # `store_failed` outcome is reachable; without this only
-                # success outcomes would log.
-                if mem_id is not None:
-                    outcome = "stored"
-                    memory_id = mem_id
-                    reason = None
+                # Final-gate validation: reject workflow-event-shape
+                # episodes before they reach add_structured. The
+                # backstop catches the canonical `Evaluate spec`,
+                # `Approve PR`, `File issue`, `Push wiki` shapes that
+                # the v7 EPISODE IGNORE list aims to suppress at the
+                # prompt level. The reject path counts the rejection
+                # per-user-per-arm and emits a `validate_rejected`
+                # outcome on the memory.episode log line so an
+                # operator can see backstop activity without grepping
+                # logs.
+                validated = _validate_episode(episode, user_id=user_id)
+                if validated is None:
+                    outcome = "validate_rejected"
+                    reason = "goal matches workflow-event regex"
                 else:
-                    outcome = "store_failed"
-                    reason = "add_structured returned None"
+                    episode = validated
+                    # Build the metadata dict matching the Sophia
+                    # schema + the `actors` Kai extension. `lessons`
+                    # is optional and absent from the dict when the
+                    # model omitted it (the design-doc "if anything"
+                    # pattern; absence is the sentinel for "no lesson
+                    # this time", not empty-string).
+                    content = f"{episode['goal']}\n\n{episode['context']}"
+                    extra: dict = {
+                        "source": "episode",
+                        "goal": episode["goal"],
+                        "context": episode["context"],
+                        "approach": episode["approach"],
+                        "outcome": episode["outcome"],
+                        "outcome_quality": episode["outcome_quality"],
+                        "tags": episode["tags"],
+                        "actors": episode["actors"],
+                        "session_id": session_id or "",
+                        "episode_prompt_version": _EPISODE_PROMPT_VERSION,
+                    }
+                    if "lessons" in episode:
+                        extra["lessons"] = episode["lessons"]
+                    # add_structured is sync (Mem0 is sync). Run off
+                    # the event loop so the embedding step does not
+                    # block other stage-2 tasks queued behind this
+                    # user's semaphore.
+                    loop = asyncio.get_running_loop()
+                    mem_id = await loop.run_in_executor(
+                        None,
+                        lambda: memory.add_structured(
+                            content=content,
+                            user_id=user_id,
+                            memory_type="episode",
+                            tags=episode["tags"],
+                            metadata=extra,
+                        ),
+                    )
+                    # add_structured returns the new memory ID on
+                    # success or None when the underlying Mem0 call
+                    # failed (backend error, content rejected).
+                    # Branch on the return so the `store_failed`
+                    # outcome is reachable; without this only success
+                    # outcomes would log.
+                    if mem_id is not None:
+                        outcome = "stored"
+                        memory_id = mem_id
+                        reason = None
+                    else:
+                        outcome = "store_failed"
+                        reason = "add_structured returned None"
     except asyncio.CancelledError:
         # Cooperative-shutdown signal. Re-raise so the runner knows the
         # task was cancelled (not silently completed) - same posture as
@@ -2289,6 +2511,7 @@ __all__ = [
     "_run_extractor",
     "_store_facts",
     "_strip_role_labels",
+    "_validate_episode",
     "_validate_facts",
     "extract_and_store",
 ]

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1100,13 +1100,12 @@ _RULE_6_REJECTIONS = _Counter()
 # CLASSIFICATION block under v7) is the primary gate; this regex
 # rejects workflow-event-shape episodes whose `goal` starts with the
 # canonical verbs that named ~57% of the 2026-04-30 production episode
-# snapshot. The arms catch the leading-verb shape; the per-arm noun
-# alternation is a single union list, intentionally a touch broader
-# than the spec's per-arm noun lists because the verb itself is the
-# workflow signal and the noun-list intersection is dominated by the
-# narrow per-arm cases anyway. Future maintainers tightening this
-# regex should split on individual arm regexes rather than expanding
-# the union noun list.
+# snapshot. The arms catch the leading-verb shape; the noun
+# alternation is a single union list rather than a per-verb split
+# because the verb itself is the workflow signal and a per-verb noun
+# split would only narrow false positives that are already rare.
+# Future maintainers tightening this regex should split on individual
+# arm regexes rather than expanding the union noun list.
 _EPISODE_GOAL_NOISE_RE = re.compile(
     r"^"
     # Group 1: the leading verb token. _ARM_FOR_VERB below maps the

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1194,14 +1194,28 @@ class _PerArmCounter:
 _EPISODE_VALIDATE_REJECTIONS = _PerArmCounter()
 
 
-def _validate_episode(episode: dict, *, user_id: str) -> dict | None:
+def _validate_episode(episode: dict, *, user_id: str) -> tuple[dict | None, str | None]:
     """Final-gate validator for stage-2 episode generator output.
 
-    Returns the episode dict unchanged on accept, or None on reject.
-    Reject path increments a per-user, per-arm counter exposed via
-    `get_extractor_stats()`. The caller (`_generate_episode`) treats
-    None as a reject and emits a `validate_rejected` outcome on the
-    `memory.episode` log line in place of the `stored` outcome.
+    Returns `(episode, None)` on accept, or `(None, reason)` on
+    reject. The reason string is one of:
+
+    - `"workflow-event regex match"`: `goal` started with a workflow-
+      shape verb that `_EPISODE_GOAL_NOISE_RE` matched. The per-user,
+      per-arm counter increments under the matched arm
+      (`review` / `approve` / `transaction`).
+    - `"non-string goal"`: defensive guard. The stage-2 schema
+      enforces `goal` as a string, but a malformed payload (e.g. a
+      schema edit that allowed null) should reject rather than
+      crash inside the regex match call. Counter does NOT increment
+      because the workflow-shape arms have not classified the
+      payload; the rejection is visible through the log emission
+      and the explicit `reason`.
+
+    The caller (`_generate_episode`) maps each reason into the
+    `memory.episode` log line's `reason` field so an operator
+    triaging by reason sees the rejection mode without inspecting
+    the rejected payload.
 
     Defense-in-depth against the prompt at `_EXTRACTION_SYSTEM_PROMPT`
     missing workflow-event-shape episodes. The prompt is the primary
@@ -1209,24 +1223,36 @@ def _validate_episode(episode: dict, *, user_id: str) -> dict | None:
     from the 2026-04-30 hygiene-sweep audit (issue #428).
     """
     goal = episode.get("goal", "")
-    # Defensive type check: stage-2 schema enforces goal as a string,
-    # but a malformed payload (e.g. a stage-2 prompt edit that broke
-    # the schema contract) should reject rather than crash inside
-    # the regex match call. The reject path is the safe direction.
     if not isinstance(goal, str):
-        return None
+        # Schema contract says `goal` is a string; a non-string here
+        # means either a stage-2 prompt edit broke the schema or
+        # Mem0 returned a malformed payload. The reject path is the
+        # safe direction in either case. Counter is intentionally
+        # NOT incremented because the workflow-shape arms have not
+        # classified this payload; the log line is the visibility
+        # signal.
+        log.debug(
+            "_validate_episode: rejecting episode with non-string goal type=%s",
+            type(goal).__name__,
+        )
+        return None, "non-string goal"
     match = _EPISODE_GOAL_NOISE_RE.match(goal)
     if match is None:
-        return episode
+        return episode, None
+    # Direct dict lookup (not `.get`-with-default): every verb
+    # captured by group 1 of `_EPISODE_GOAL_NOISE_RE` is a key in
+    # `_ARM_FOR_VERB` by construction. A future regex edit that adds
+    # a verb without updating the map should fail loud here rather
+    # than silently miscount under an "unknown" sentinel arm.
     verb = (match.group(1) or "").lower()
-    arm = _ARM_FOR_VERB.get(verb, "unknown")
+    arm = _ARM_FOR_VERB[verb]
     _EPISODE_VALIDATE_REJECTIONS.increment(user_id=user_id, arm=arm)
     log.debug(
         "_validate_episode: rejecting workflow-shape episode goal: %r (arm=%s)",
         goal,
         arm,
     )
-    return None
+    return None, "workflow-event regex match"
 
 
 def get_extractor_stats() -> dict[str, dict]:
@@ -1971,14 +1997,17 @@ async def _generate_episode(
                 # `Approve PR`, `File issue`, `Push wiki` shapes that
                 # the v7 EPISODE IGNORE list aims to suppress at the
                 # prompt level. The reject path counts the rejection
-                # per-user-per-arm and emits a `validate_rejected`
-                # outcome on the memory.episode log line so an
-                # operator can see backstop activity without grepping
-                # logs.
-                validated = _validate_episode(episode, user_id=user_id)
+                # per-user-per-arm (when applicable) and emits a
+                # `validate_rejected` outcome on the memory.episode
+                # log line so an operator can see backstop activity
+                # without grepping logs. `_validate_episode` returns
+                # the rejection reason string directly so the
+                # workflow-regex path and the defensive non-string-
+                # goal path are distinguishable in the log line.
+                validated, reject_reason = _validate_episode(episode, user_id=user_id)
                 if validated is None:
                     outcome = "validate_rejected"
-                    reason = "goal matches workflow-event regex"
+                    reason = reject_reason
                 else:
                     episode = validated
                     # Build the metadata dict matching the Sophia

--- a/tests/test_eval_extraction.py
+++ b/tests/test_eval_extraction.py
@@ -49,6 +49,14 @@ _TEST_CONFIG = Config(
 # `f"sha256:{_V5_PROMPT_HASH}"`).
 _V5_PROMPT_HASH = "764f249d2556a6e00489ac7ba5eac265f4a4d09f27d21dc76f612b84f0874c13"
 
+# Hash of `_PROMPT_V6_PINNED` captured at #428 landing (the v6
+# active prompt immediately before the v7 EPISODE CLASSIFICATION
+# edits). Same drift-detection contract as `_V5_PROMPT_HASH`: a
+# silent edit of the pinned constant fails this test, while an
+# intentional capture of a new baseline must update both the
+# pinned constant AND this hash.
+_V6_PROMPT_HASH = "4f1e03dd37d9d52bb39724f949f7c382343837608497ebcd2ab3ae4990d3030c"
+
 
 def test_v5_pinned_drift():
     """The pinned baseline must remain byte-identical to the v5
@@ -60,6 +68,21 @@ def test_v5_pinned_drift():
     assert h == _V5_PROMPT_HASH, (
         "Pinned v5 prompt drifted. If this is intentional (capturing "
         "a new baseline), update _V5_PROMPT_HASH above to match."
+    )
+
+
+def test_v6_pinned_drift():
+    """The pinned v6 baseline must remain byte-identical to the v6
+    prompt as captured at #428 landing. Mirror of `test_v5_pinned_drift`
+    so that the v6-vs-v7 head-to-head measurement stays reproducible
+    across machines and across future prompt revisions. A future
+    intentional update to a new baseline requires updating both the
+    pinned constant AND `_V6_PROMPT_HASH` above; an accidental edit
+    fails this test."""
+    h = hashlib.sha256(extraction._PROMPT_V6_PINNED.encode()).hexdigest()
+    assert h == _V6_PROMPT_HASH, (
+        "Pinned v6 prompt drifted. If this is intentional (capturing "
+        "a new baseline), update _V6_PROMPT_HASH above to match."
     )
 
 
@@ -79,6 +102,34 @@ def test_example_probe_fixture_loads():
         assert "user" in p.window["current"]
         assert "assistant" in p.window["current"]
         assert isinstance(p.expected, dict)
+
+
+def test_episode_classification_fixture_loads():
+    """The tracked episode-classification example fixture parses
+    end-to-end with the documented 12-probe mix (5 workflow-event,
+    4 durable, 3 borderline). The borderline probes are categorized
+    as `workflow-noise` (their `expected_has_episode` is false) so
+    the existing fact-side classifier semantics still apply; the
+    new `expected_has_episode` field is the load-bearing dimension
+    for episode-classifier measurement and is asserted present on
+    every probe (issue #428)."""
+    path = Path(__file__).parent.parent / "home" / "evals" / "episode-classification-probes.example.jsonl"
+    probes = extraction.load_probes(path)
+    assert len(probes) == 12
+    cats = [p.category for p in probes]
+    # 5 workflow-event + 3 borderline = 8 workflow-noise category;
+    # 4 durable.
+    assert cats.count("workflow-noise") == 8
+    assert cats.count("durable-content") == 4
+    for p in probes:
+        # Existing schema: window.current.{user,assistant} present.
+        assert "current" in p.window
+        assert "user" in p.window["current"]
+        assert "assistant" in p.window["current"]
+        # New dimension: every probe asserts an expected has_episode
+        # value, even if the existing fact-side classifier ignores it.
+        assert "expected_has_episode" in p.expected
+        assert isinstance(p.expected["expected_has_episode"], bool)
 
 
 def test_load_probes_malformed_json_raises_with_path_and_line(tmp_path: Path):

--- a/tests/test_eval_extraction.py
+++ b/tests/test_eval_extraction.py
@@ -43,10 +43,13 @@ _TEST_CONFIG = Config(
 #
 # Stored as the raw hexdigest; the JSON report emitted by the
 # harness CLI prefixes the same value with "sha256:" via the
-# `_hash()` helper. An operator cross-checking a report's
-# `v5_prompt_hash` against this constant should strip the
-# prefix from the report value (or compare report value to
-# `f"sha256:{_V5_PROMPT_HASH}"`).
+# `_hash()` helper. An operator cross-checking the report's
+# `baseline_prompt_hash` (output schema v2) against this constant
+# should strip the prefix from the report value (or compare report
+# value to `f"sha256:{_V5_PROMPT_HASH}"`). The v1 schema's
+# `v5_prompt_hash` key was renamed to `baseline_prompt_hash` at
+# #428 landing; downstream tools should branch on the report's
+# top-level `version` field.
 _V5_PROMPT_HASH = "764f249d2556a6e00489ac7ba5eac265f4a4d09f27d21dc76f612b84f0874c13"
 
 # Hash of `_PROMPT_V6_PINNED` captured at #428 landing (the v6

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -26,6 +26,7 @@ from kai.config import Config
 from kai.memory import MemoryResult
 from kai.memory_extraction import (
     _CONFIRMATION_QUOTE_MIN_CHARS,
+    _EPISODE_VALIDATE_REJECTIONS,
     _EXTRACTION_PROMPT_VERSION,
     _EXTRACTION_SYSTEM_PROMPT,
     _FACT_SCHEMA,
@@ -41,6 +42,7 @@ from kai.memory_extraction import (
     _render_candidate_source,
     _store_facts,
     _strip_role_labels,
+    _validate_episode,
     _validate_facts,
     extract_and_store,
     get_extractor_stats,
@@ -2351,7 +2353,7 @@ class TestExtractionPromptSoftVocab:
     def test_extraction_prompt_version_bumped(self):
         """The version stamp on every fact's metadata; bumped
         whenever the schema or prompt changes meaningfully."""
-        assert _EXTRACTION_PROMPT_VERSION == "6"
+        assert _EXTRACTION_PROMPT_VERSION == "7"
 
     def test_extraction_prompt_version_history_extended(self):
         """The prompt-version history comment block (the sequence
@@ -2361,9 +2363,9 @@ class TestExtractionPromptSoftVocab:
         fragments so a future unrelated edit that introduces a `vN:`
         token elsewhere cannot satisfy this test vacuously.
 
-        Both v5 and v6 fragments are pinned: v5 stays in source
-        unchanged across the v6 bump, and v6 was appended in this
-        spec's history block."""
+        v5, v6, and v7 fragments are pinned: v5 and v6 stay in source
+        unchanged across the v7 bump, and v7 was appended in this
+        spec's history block (issue #428)."""
         from pathlib import Path
 
         import kai.memory_extraction
@@ -2372,6 +2374,8 @@ class TestExtractionPromptSoftVocab:
         assert "v5: free-form tag schema (enum dropped)" in src
         assert "v6 (2026-04-30, this issue)" in src
         assert "DURABILITY TEST gate" in src
+        assert "v7 (2026-04-30, this issue)" in src
+        assert "EPISODE CLASSIFICATION block" in src
 
 
 class TestRule6WorkflowEventRegex:
@@ -2681,3 +2685,263 @@ class TestValidateFactsRule4b:
         candidate_ids = {"prior-pref"}
         candidate_metadata = {"prior-pref": {"tags": ["preference"], "source": "extracted"}}
         assert _validate_facts(facts, candidate_ids, candidate_metadata=candidate_metadata, user_id="u-test") == facts
+
+
+class TestEpisodeClassificationIgnoreList:
+    """The v7 EPISODE CLASSIFICATION block adds three IGNORE bullets
+    (workflow-loop iterations, routine workflow transactions, process
+    meta-lessons) plus an EPISODE DURABILITY TEST gate. These tests
+    pin the prompt-side wording in source so a future edit cannot
+    silently drop any of the four sections (issue #428)."""
+
+    def test_workflow_loop_iterations_bullet_present(self):
+        """The first IGNORE bullet calls out review-round verdicts and
+        evaluation-pass closures. The exact opening sentence is pinned
+        so the bullet cannot be silently softened."""
+        assert "Workflow-loop iterations: the closure of a review round" in _EXTRACTION_SYSTEM_PROMPT
+
+    def test_routine_workflow_transactions_bullet_present(self):
+        """The second IGNORE bullet covers individual transactions
+        (file/push/draft) that are not deliberation closures."""
+        assert "Routine workflow transactions: filing an issue" in _EXTRACTION_SYSTEM_PROMPT
+
+    def test_process_meta_lessons_bullet_present(self):
+        """The third IGNORE bullet rejects situations whose only
+        outcome is a generalization about how a workflow runs."""
+        assert "Process meta-lessons: situations whose only outcome" in _EXTRACTION_SYSTEM_PROMPT
+
+    def test_episode_durability_test_present(self):
+        """The episode-scoped DURABILITY TEST asks "would a future
+        session benefit from retrieving this situation, or only from
+        the artifact it produced?". Both the section header and the
+        load-bearing artifact-vs-situation phrase are pinned so a
+        future edit cannot silently drop either. The pinned answer
+        phrase `"only the artifact"` (with quotes) is the unique
+        single-line fragment of the gate's verdict clause; the
+        question phrasing wraps across lines and is not pinned
+        directly."""
+        assert "EPISODE DURABILITY TEST:" in _EXTRACTION_SYSTEM_PROMPT
+        assert "would a future session" in _EXTRACTION_SYSTEM_PROMPT
+        assert '"only the artifact"' in _EXTRACTION_SYSTEM_PROMPT
+
+
+class TestValidateEpisodeWorkflowRegex:
+    """`_validate_episode` rejects stage-2 episode outputs whose `goal`
+    matches `_EPISODE_GOAL_NOISE_RE`. The regex catches three arms
+    (review, approve, transaction); per-arm rejection counts are
+    exposed via `get_extractor_stats()` (issue #428)."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_counter(self):
+        """Counter resets per test so per-arm assertions are not
+        affected by sibling tests in this class."""
+        _EPISODE_VALIDATE_REJECTIONS._reset()
+        yield
+        _EPISODE_VALIDATE_REJECTIONS._reset()
+
+    def test_arm1_evaluate_review_audit(self):
+        """Arm 1 maps Evaluate/Review/Audit verbs to the `review`
+        arm label. Sanitized artifact identifiers throughout (`#0`,
+        `foo`) so the test data carries no real spec/PR numbers."""
+        positives = [
+            "Evaluate v3 spec for issue #0",
+            "Review the v2 PR for component foo",
+            "Audit specification bar against current source",
+        ]
+        for goal in positives:
+            r = _validate_episode({"goal": goal}, user_id="u-test")
+            assert r is None, f"expected reject: {goal!r}"
+
+    def test_arm2_approve(self):
+        """Arm 2 maps Approve to the `approve` arm label. The
+        intervening-tokens cap admits multi-word artifact qualifiers
+        ("v3 of the foo-bar migration spec")."""
+        positives = [
+            "Approve the v4 specification revision",
+            "Approve PR #1",
+            "Approve v3 of the foo-bar migration spec",
+        ]
+        for goal in positives:
+            r = _validate_episode({"goal": goal}, user_id="u-test")
+            assert r is None, f"expected reject: {goal!r}"
+
+    def test_arm3_routine_transactions(self):
+        """Arm 3 covers File/Push/Draft/Schedule/Post verbs mapped
+        to the `transaction` arm label. Real production goals like
+        "Push a prepared Memory wiki page" sit at the upper end of
+        the intervening-token budget."""
+        positives = [
+            "File the GitHub issue for component bar",
+            "Push Memory wiki page",
+            "Push a prepared Memory wiki page to the kai repository",
+            "Draft an epic body for the migration",
+            "Schedule a reminder for tomorrow",
+            "Post a comment on PR #2",
+        ]
+        for goal in positives:
+            r = _validate_episode({"goal": goal}, user_id="u-test")
+            assert r is None, f"expected reject: {goal!r}"
+
+    def test_arm_counter_increments_per_user_per_arm(self):
+        """End-to-end: drive each arm once and assert the per-user,
+        per-arm counter snapshot reflects the rejections. The counter
+        is the load-bearing artifact for eval-harness assertions and
+        operator dashboards; without it, the harness cannot tell which
+        workflow shape is hitting the backstop."""
+        _validate_episode({"goal": "Evaluate spec foo"}, user_id="u1")
+        _validate_episode({"goal": "Approve PR #0"}, user_id="u1")
+        _validate_episode({"goal": "File a GitHub issue for bar"}, user_id="u1")
+        _validate_episode({"goal": "Audit specification baz"}, user_id="u2")
+        snap = _EPISODE_VALIDATE_REJECTIONS.snapshot()
+        assert snap == {
+            "u1": {"review": 1, "approve": 1, "transaction": 1},
+            "u2": {"review": 1},
+        }
+
+    def test_durable_goals_pass(self):
+        """Durable design-decision and empirical-investigation goals
+        are the load-bearing negatives. A regression that broadens
+        the regex to catch substantive content trips here first.
+        Pulled from the snapshot's 13 durable episodes (the inverse
+        of the 29-ID hygiene-sweep deletion list)."""
+        negatives = [
+            "Update wiki documentation to match the current bot command surface",
+            "Determine the correct cadence for surfacing the memory_enabled flag",
+            "Switch all persistent memory writes from MEMORY.md to the API",
+            "Confirm the five-stage memory episode pipeline fires end-to-end",
+            "Apply em-dashes consistently on an existing wiki page",
+            "Run a 10-probe eval to determine whether removing assistant-derived facts helps",
+            "Determine which iterate-epic candidate should land first",
+            "Correct two design mistakes in the memory feature plan",
+            "Establish that budget framing has no place in the claude backend",
+        ]
+        for goal in negatives:
+            r = _validate_episode({"goal": goal}, user_id="u-test")
+            assert r is not None, f"expected pass: {goal!r}"
+
+
+class TestValidateEpisodeIntegration:
+    """End-to-end behavior of the validator hookup in `_generate_episode`.
+    A workflow-shape goal returned by stage-2 must short-circuit before
+    `add_structured`, emit a `validate_rejected` outcome on the
+    memory.episode log line, and increment the per-arm counter
+    (issue #428).
+
+    Mock points:
+    - `_run_episode_extractor`: stubbed to return a known episode dict
+      so the test exercises the validate path without spawning a
+      subprocess.
+    - `memory.add_structured`: stubbed so the test does not touch a
+      real backend; reachability of this mock distinguishes accept
+      from reject paths.
+    - `_emit_episode_log`: captured to verify outcome / reason.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_counter(self):
+        _EPISODE_VALIDATE_REJECTIONS._reset()
+        yield
+        _EPISODE_VALIDATE_REJECTIONS._reset()
+
+    @pytest.mark.asyncio
+    async def test_workflow_shape_goal_rejected(self, monkeypatch):
+        """A stage-2 output whose `goal` matches arm 1 (Evaluate)
+        is rejected. Outcome is `validate_rejected`, reason names the
+        regex, the counter increments under the correct arm, and
+        `add_structured` is never called."""
+        from kai import memory_extraction
+
+        episode_payload = {
+            "goal": "Evaluate spec foo v3 for sub-issue #0",
+            "context": "ctx",
+            "approach": "ap",
+            "outcome": "out",
+            "outcome_quality": "success",
+            "tags": ["t1"],
+            "actors": ["user"],
+        }
+
+        async def _fake_runner(payload, config):
+            return episode_payload, 0.001, None
+
+        captured: dict = {}
+
+        def _fake_emit(**kwargs):
+            captured.update(kwargs)
+
+        add_structured_called = False
+
+        def _fake_add_structured(*args, **kwargs):
+            nonlocal add_structured_called
+            add_structured_called = True
+            return "should-not-reach-this-id"
+
+        monkeypatch.setattr(memory_extraction, "_run_episode_extractor", _fake_runner)
+        monkeypatch.setattr(memory_extraction, "_emit_episode_log", _fake_emit)
+        from kai import memory as memory_module
+
+        monkeypatch.setattr(memory_module, "add_structured", _fake_add_structured)
+
+        await memory_extraction._generate_episode(
+            user_text="evaluate it",
+            assistant_text="approved with three nits",
+            user_id="u-int",
+            session_id="s-1",
+            config=_cfg(),
+        )
+
+        assert captured["outcome"] == "validate_rejected"
+        assert "workflow-event regex" in (captured.get("reason") or "")
+        assert captured.get("memory_id") is None
+        assert add_structured_called is False
+        snap = _EPISODE_VALIDATE_REJECTIONS.snapshot()
+        assert snap == {"u-int": {"review": 1}}
+
+    @pytest.mark.asyncio
+    async def test_durable_goal_passes_to_storage(self, monkeypatch):
+        """A stage-2 output whose `goal` is durable shape passes
+        validation and reaches `add_structured`. Outcome is `stored`,
+        the counter does NOT increment, and the memory_id flows back
+        to the log emission."""
+        from kai import memory_extraction
+
+        episode_payload = {
+            "goal": "Lock per-user home workspace as the canonical layout",
+            "context": "ctx",
+            "approach": "ap",
+            "outcome": "out",
+            "outcome_quality": "success",
+            "tags": ["t1"],
+            "actors": ["user"],
+        }
+
+        async def _fake_runner(payload, config):
+            return episode_payload, 0.001, None
+
+        captured: dict = {}
+
+        def _fake_emit(**kwargs):
+            captured.update(kwargs)
+
+        def _fake_add_structured(*args, **kwargs):
+            return "stored-mem-id"
+
+        monkeypatch.setattr(memory_extraction, "_run_episode_extractor", _fake_runner)
+        monkeypatch.setattr(memory_extraction, "_emit_episode_log", _fake_emit)
+        from kai import memory as memory_module
+
+        monkeypatch.setattr(memory_module, "add_structured", _fake_add_structured)
+
+        await memory_extraction._generate_episode(
+            user_text="propose home layout",
+            assistant_text="locked: per-user home workspace",
+            user_id="u-int",
+            session_id="s-1",
+            config=_cfg(),
+        )
+
+        assert captured["outcome"] == "stored"
+        assert captured.get("memory_id") == "stored-mem-id"
+        assert captured.get("reason") is None
+        snap = _EPISODE_VALIDATE_REJECTIONS.snapshot()
+        assert snap == {}

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -2364,8 +2364,8 @@ class TestExtractionPromptSoftVocab:
         token elsewhere cannot satisfy this test vacuously.
 
         v5, v6, and v7 fragments are pinned: v5 and v6 stay in source
-        unchanged across the v7 bump, and v7 was appended in this
-        spec's history block (issue #428)."""
+        unchanged across the v7 bump, and the v7 entry was appended
+        for issue #428."""
         from pathlib import Path
 
         import kai.memory_extraction

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -2758,12 +2758,18 @@ class TestValidateEpisodeWorkflowRegex:
 
     def test_arm2_approve(self):
         """Arm 2 maps Approve to the `approve` arm label. The
-        intervening-tokens cap admits multi-word artifact qualifiers
-        ("v3 of the foo-bar migration spec")."""
+        intervening-tokens cap (6 tokens, lazy) lets the regex still
+        find the artifact noun in goals with multi-word qualifiers
+        like "v3 of the foo-bar migration spec". The `version` and
+        `pull request` artifact nouns are exercised here as the
+        only positive coverage of those alternation entries; without
+        these, a future regex edit could silently drop either form."""
         positives = [
             "Approve the v4 specification revision",
             "Approve PR #1",
             "Approve v3 of the foo-bar migration spec",
+            "Approve the new version",
+            "Approve the pull request",
         ]
         for goal in positives:
             episode, reason = _validate_episode({"goal": goal}, user_id="u-test")

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -2742,15 +2742,19 @@ class TestValidateEpisodeWorkflowRegex:
     def test_arm1_evaluate_review_audit(self):
         """Arm 1 maps Evaluate/Review/Audit verbs to the `review`
         arm label. Sanitized artifact identifiers throughout (`#0`,
-        `foo`) so the test data carries no real spec/PR numbers."""
+        `foo`) so the test data carries no real spec/PR numbers.
+        The validator returns `(None, reason)` on reject; the reason
+        string is pinned because operators triage by reason in the
+        memory.episode log line."""
         positives = [
             "Evaluate v3 spec for issue #0",
             "Review the v2 PR for component foo",
             "Audit specification bar against current source",
         ]
         for goal in positives:
-            r = _validate_episode({"goal": goal}, user_id="u-test")
-            assert r is None, f"expected reject: {goal!r}"
+            episode, reason = _validate_episode({"goal": goal}, user_id="u-test")
+            assert episode is None, f"expected reject: {goal!r}"
+            assert reason == "workflow-event regex match", (goal, reason)
 
     def test_arm2_approve(self):
         """Arm 2 maps Approve to the `approve` arm label. The
@@ -2762,8 +2766,9 @@ class TestValidateEpisodeWorkflowRegex:
             "Approve v3 of the foo-bar migration spec",
         ]
         for goal in positives:
-            r = _validate_episode({"goal": goal}, user_id="u-test")
-            assert r is None, f"expected reject: {goal!r}"
+            episode, reason = _validate_episode({"goal": goal}, user_id="u-test")
+            assert episode is None, f"expected reject: {goal!r}"
+            assert reason == "workflow-event regex match", (goal, reason)
 
     def test_arm3_routine_transactions(self):
         """Arm 3 covers File/Push/Draft/Schedule/Post verbs mapped
@@ -2779,8 +2784,9 @@ class TestValidateEpisodeWorkflowRegex:
             "Post a comment on PR #2",
         ]
         for goal in positives:
-            r = _validate_episode({"goal": goal}, user_id="u-test")
-            assert r is None, f"expected reject: {goal!r}"
+            episode, reason = _validate_episode({"goal": goal}, user_id="u-test")
+            assert episode is None, f"expected reject: {goal!r}"
+            assert reason == "workflow-event regex match", (goal, reason)
 
     def test_arm_counter_increments_per_user_per_arm(self):
         """End-to-end: drive each arm once and assert the per-user,
@@ -2788,6 +2794,9 @@ class TestValidateEpisodeWorkflowRegex:
         is the load-bearing artifact for eval-harness assertions and
         operator dashboards; without it, the harness cannot tell which
         workflow shape is hitting the backstop."""
+        # Return values discarded; the counter side-effect is what
+        # this test verifies. Each call must hit a distinct arm so
+        # the per-arm counts are unambiguous.
         _validate_episode({"goal": "Evaluate spec foo"}, user_id="u1")
         _validate_episode({"goal": "Approve PR #0"}, user_id="u1")
         _validate_episode({"goal": "File a GitHub issue for bar"}, user_id="u1")
@@ -2803,7 +2812,10 @@ class TestValidateEpisodeWorkflowRegex:
         are the load-bearing negatives. A regression that broadens
         the regex to catch substantive content trips here first.
         Pulled from the snapshot's 13 durable episodes (the inverse
-        of the 29-ID hygiene-sweep deletion list)."""
+        of the 29-ID hygiene-sweep deletion list).
+
+        Pass shape: `(episode_dict, None)` - the episode passes
+        through unchanged with no reason."""
         negatives = [
             "Update wiki documentation to match the current bot command surface",
             "Determine the correct cadence for surfacing the memory_enabled flag",
@@ -2816,8 +2828,25 @@ class TestValidateEpisodeWorkflowRegex:
             "Establish that budget framing has no place in the claude backend",
         ]
         for goal in negatives:
-            r = _validate_episode({"goal": goal}, user_id="u-test")
-            assert r is not None, f"expected pass: {goal!r}"
+            payload = {"goal": goal}
+            episode, reason = _validate_episode(payload, user_id="u-test")
+            assert episode is payload, f"expected pass-through: {goal!r}"
+            assert reason is None, (goal, reason)
+
+    def test_non_string_goal_rejected_with_distinct_reason(self):
+        """Defensive guard: a non-string `goal` rejects with reason
+        `"non-string goal"`, distinguishable from the workflow-regex
+        reject path. Counter does NOT increment because the workflow-
+        shape arms have not classified the payload; the rejection is
+        visible only through the log line and the explicit reason
+        string."""
+        for non_string in (None, 42, ["list-shaped goal"]):
+            episode, reason = _validate_episode({"goal": non_string}, user_id="u-test")
+            assert episode is None
+            assert reason == "non-string goal", (non_string, reason)
+        # Counter must reflect zero rejections under any arm because
+        # the non-string path skips the per-arm increment.
+        assert _EPISODE_VALIDATE_REJECTIONS.snapshot() == {}
 
 
 class TestValidateEpisodeIntegration:


### PR DESCRIPTION
Closes #428.

## Summary

Three coordinated changes mirroring PR #427's pattern, but for the episode classifier:

1. **Stage-1 prompt v6 -> v7.** Refines the `EPISODE CLASSIFICATION` block in `_EXTRACTION_SYSTEM_PROMPT` with a new EPISODE IGNORE list (workflow-loop iterations, routine workflow transactions, process meta-lessons) plus an episode-scoped DURABILITY TEST. Positive criterion 1 narrowed to "durable situation" with a forward reference to the IGNORE list. `_EXTRACTION_PROMPT_VERSION` bumps 6 -> 7; existing v3/v4/v5/v6 history-block prose is preserved alongside the new v7 paragraph.

2. **`_validate_episode` regex backstop.** A Python-side guard hooked into `_generate_episode` between the JSON-decoded stage-2 output and `add_structured`. `_EPISODE_GOAL_NOISE_RE` rejects goals starting with workflow-shape verbs (`Evaluate`, `Review`, `Audit`, `Approve`, `File`, `Push`, `Draft`, `Schedule`, `Post`) followed by an artifact noun, with a bounded intervening-tokens clause that admits real production goals like "Push a prepared Memory wiki page". Per-user, per-arm rejection counts via the new `_EPISODE_VALIDATE_REJECTIONS` counter; exposed through `get_extractor_stats()` paralleling `_RULE_6_REJECTIONS`. New `validate_rejected` outcome on the `memory.episode` log line.

3. **Eval harness extension.** `_PROMPT_V6_PINNED` captured verbatim before this PR's edits (SHA-256 `4f1e03dd37d9d52bb39724f949f7c382343837608497ebcd2ab3ae4990d3030c`). New `--baseline {v5,v6}` CLI flag threads through `_run_one_probe` to select which pinned constant the baseline arm runs against. Default flips to `v6` so each new prompt revision compares against the immediately prior one; `v5` retained for cross-revision sanity. Report carries a new `baseline_choice` field.

`_EPISODE_PROMPT_VERSION` intentionally stays at `"1"`. This PR does not change `_EPISODE_SYSTEM_PROMPT` or `_EPISODE_SCHEMA`, so the stage-2 version constant is unchanged. The hygiene sweep targets episodes by hand-curated ID list, not by prompt-version filter. Issue body's acceptance criterion 3 (bump to "2") is intentionally superseded; this is documented in the spec evaluation and the Acceptance section there.

## Tests

- 13 new tests added; existing test count rises from 2750 to 2764. Suite: **2764 passed, 1 skipped**.
- `TestEpisodeClassificationIgnoreList` (4): pin the four prompt-side wording fragments (three IGNORE bullets + DURABILITY TEST gate).
- `TestValidateEpisodeWorkflowRegex` (5): one positive-cases test per arm (review/approve/transaction), one per-user-per-arm counter integration test, one negatives test against durable-shape goals from the snapshot.
- `TestValidateEpisodeIntegration` (2): async tests driving `_generate_episode` end-to-end with mocked stage-2 runner and `add_structured`. Covers both reject (`outcome="validate_rejected"`, counter increments, `add_structured` not called) and accept (`outcome="stored"`, memory_id flows through, counter unchanged).
- Two existing methods in `TestExtractionPromptSoftVocab` updated in place per PR #427's precedent: version pin moves 6 -> 7, history-block fragment list extends with `"v7 (2026-04-30, this issue)"` and `"EPISODE CLASSIFICATION block"`.
- New `test_v6_pinned_drift` in `tests/test_eval_extraction.py` mirroring `test_v5_pinned_drift`. New `test_episode_classification_fixture_loads` validates the 12-probe example fixture.

## Operator follow-up after merge

Two operator actions land separately and are not part of this PR's CI:

- **Hygiene sweep.** `scripts/forget-episode-noise.py` (untracked, operator-local) deletes 29 hand-curated mundane episode IDs from production: 24 review-loop iterations + 5 routine workflow transactions. Run sequence:
  ```
  sudo launchctl bootout system/com.syrinx.kai
  .venv/bin/python scripts/forget-episode-noise.py --apply
  sudo launchctl bootstrap system /Library/LaunchDaemons/com.syrinx.kai.plist
  ```
  Expected drop: episode bucket 42 -> 13 (all durable). Mirrors the PR #427 fact-side sweep precedent.

- **v6-vs-v7 harness rerun.** Run during the PR-review cooldown window:
  ```
  .venv/bin/python -m kai.eval.extraction \
    --probes home/evals/episode-classification-probes.example.jsonl \
    --baseline v6 \
    --output /tmp/v6-v7-report.json
  ```
  Expected ~$0.30, ~10 minutes. The per-probe `has_episode` flips will be reported back here when complete; the spec's expected v7 result is workflow-event false-positive rate 0/5 (down from ~5/5 under v6) with durable-episode true-positive rate holding at 4/4. Borderline (3 probes) is the dimension to watch.

## Risks

- Regex over-rejection on legitimate review-shape goals (e.g. "Review the v3 architecture proposal"). Mitigation: arm anchors at `^`, the artifact-noun list does not include `architecture`, and the `_EPISODE_VALIDATE_REJECTIONS` counter is exposed in production for real-world false-positive tracking.
- Borderline-probe drift between v6 and v7. Mitigation: report drift probe-by-probe in this PR's harness rerun; goal is no regression on the 4 durable probes, not perfection on the 3 borderline.
- The example probe fixture is illustrative; the production probe fixture is operator-built post-merge.

## Spec history

Three rounds of independent review converged with descending severity:

- v1: 2 mechanism + 2 wording-class sub-blockers + 3 wording nits.
- v2: 1 wording-class sub-blocker (factual claim about `__all__` membership).
- v3: clean approval.

The implementation tracks v3 directly.
