### PR TITLE
feat(memory): mode-switch verification harness (#432)

### DIFF
--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -138,10 +138,15 @@ _FIXTURE_CHAT_ID = 1
 _FIXTURE_QUERY = "test fixture for mode-switch verification"
 
 
-# Seeded fact content. Same bland-but-distinctive shape as the
-# MEMORY.md fixture; a substring match between the seeded fact and
-# the format_context output proves the recall path is hitting our
-# isolated store rather than the production one.
+# Seeded fact content. The recall-path invariant the harness asserts
+# is the format_context OUTPUT SHAPE (empty string or starts with
+# the recall-block prefix); content is not asserted programmatically.
+# The real isolation guarantee is `_isolated_data_dir`'s `DATA_DIR`
+# patch + the `MEM0_DIR` env redirect at the top of `_run_verify`.
+# This string is deliberately distinctive so that if a future
+# diagnostic wants to scan the recall output for evidence the
+# isolated store is being hit (rather than the production one), the
+# substring is unique enough to find without false positives.
 _FIXTURE_SEED_FACT = "Mode-switch test fixture marker phrase 7f3a2b1c"
 
 

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -256,9 +256,14 @@ async def _run_verify() -> int:
     any failure.
 
     Each invariant is computed once and recorded as an
-    `_InvariantResult`. The harness prints results as it goes
-    (rather than batching at the end) so a failure surfaces
-    immediately even if a later invariant raises.
+    `_InvariantResult`. Results are batched in a list and printed
+    together after all invariants run (and after the
+    `MEM0_DIR`/singleton-state restoration in the `finally` block).
+    If an exception is raised mid-run, the operator sees the
+    traceback without partial-progress output; the env-state
+    restoration still fires via `finally`. Operators wanting per-
+    invariant streaming should run individual unit tests in
+    `tests/test_eval_modeswitch.py::TestVerifyInvariants` instead.
     """
     results: list[_InvariantResult] = []
 

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -1,0 +1,584 @@
+"""Mode-switch verification harness for the dual-mode memory subsystem.
+
+The MEMORY_ENABLED toggle promises that exactly one fact surface is
+active per mode: in disabled mode, MEMORY.md drives behavior and Qdrant
+is unreached; in enabled mode, Qdrant drives behavior and MEMORY.md is
+dormant. This module verifies that promise without requiring a service
+restart by importing the production code paths
+(`build_session_context`, `format_context`) and asserting the gating
+contract directly.
+
+Two subcommands:
+
+    python -m kai.eval.modeswitch verify
+        Black-box logic verification. Imports the production code and
+        asserts every gating invariant under both flag values. Uses an
+        isolated tmp-dir Qdrant store so the live memory directory at
+        $DATA_DIR/memory/qdrant is never touched. Exits 0 on full
+        pass, 1 on any failure.
+
+    python -m kai.eval.modeswitch check
+        Runtime sanity check against the running service. Reports the
+        live effective mode plus the deployed prompt versions. Reads
+        WEBHOOK_SECRET from the process environment; source
+        /etc/kai/env first under sudo:
+
+            sudo bash -c 'source /etc/kai/env && env | grep WEBHOOK_SECRET'
+
+        Exit codes: 0 on a clean read; 2 if WEBHOOK_SECRET is not in
+        the environment; 1 if /health is down or /api/memory/stats
+        returns an unexpected status.
+
+The verify subcommand is the merge gate. The check subcommand is
+informational and can be re-run as production state changes.
+
+Operator round-trip (manual; sudo-gated; not automated by this script):
+
+    1. operator: sudo edit /etc/kai/env, set MEMORY_ENABLED=false
+    2. operator restarts the service:
+       macOS: sudo launchctl bootout system/com.syrinx.kai
+              sudo launchctl bootstrap system /Library/LaunchDaemons/com.syrinx.kai.plist
+       Linux: sudo systemctl stop kai && sudo systemctl start kai
+    3. source /etc/kai/env  # pull WEBHOOK_SECRET into the shell env
+       python -m kai.eval.modeswitch check    # confirms disabled
+    4. python -m kai.eval.modeswitch verify   # logic invariants under both flags
+    5. operator: sudo edit /etc/kai/env, set MEMORY_ENABLED=true
+    6. operator restarts the service (same commands as step 2)
+    7. python -m kai.eval.modeswitch check    # confirms enabled
+
+Step 4's verify is mode-independent: it asserts both flag-value
+behaviors regardless of the running service's flag, so running it
+once anywhere in the procedure is sufficient. Steps 3 and 7 are the
+only checks that observe the live service state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import re
+import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
+
+from kai.backend import ApiContext, build_session_context
+from kai.config import Config
+
+log = logging.getLogger(__name__)
+
+
+# ── Verify: invariant assertions ────────────────────────────────────
+
+
+@dataclass
+class _InvariantResult:
+    """Outcome of one invariant check.
+
+    `name` is the human-readable assertion label printed in the
+    report. `passed` is the binary outcome. `detail` carries a
+    short explanation on failure (a substring that was present
+    when it should not have been, or a substring that was missing
+    when it should have been). On pass, `detail` is the empty
+    string.
+    """
+
+    name: str
+    passed: bool
+    detail: str
+
+
+# Substring markers from `build_session_context` (the [Memory subsystem:
+# enabled/disabled] line) and from `memory.format_context` (the
+# [Relevant memories from past conversations ...] header). These are
+# the load-bearing strings the harness asserts on.
+#
+# `_MARKER_PERSISTENT_MEMORY` matches the `[Your persistent memory
+# (file: ...):]` block that build_session_context emits ONLY in
+# disabled mode. The match is a leading-substring check rather than
+# a full-line match so the test does not have to predict the
+# tmp-path part of the format string.
+#
+# `_MARKER_RELEVANT_MEMORIES` matches the recall-block header that
+# format_context emits when search returns non-empty after the
+# floor and budget filters. Same leading-substring approach.
+_MARKER_DISABLED = "[Memory subsystem: disabled]"
+_MARKER_ENABLED = "[Memory subsystem: enabled]"
+_MARKER_PERSISTENT_MEMORY = "[Your persistent memory (file:"
+_MARKER_RELEVANT_MEMORIES = "[Relevant memories from past conversations"
+
+
+# Minimal MEMORY.md fixture used by the verify subcommand. A single
+# truthy line is enough to drive build_session_context's read branch
+# (memory_path.read_text().strip() returns truthy), avoiding the
+# "(currently empty)" / "(not yet created)" placeholder branches.
+# The content is deliberately bland so it cannot be mistaken for
+# operator data if the file ever leaks via test logs.
+_FIXTURE_MEMORY_MD = "Test fixture content for mode-switch verification.\n"
+
+
+# Test fixture chat_id used to scope the temporary MEMORY.md and the
+# Qdrant user_id for the seeded fact. A small positive integer (not
+# a real chat_id) is used to make it visually obvious in any
+# diagnostic output that this is a test value, not production data.
+_FIXTURE_CHAT_ID = 1
+
+
+# Test fixture query string that is guaranteed to share enough
+# semantic surface with the seeded fact to land above the relevance
+# floor. The seeded fact mentions "test fixture" and "mode-switch";
+# the query mentions both, so the embedder produces a high cosine.
+_FIXTURE_QUERY = "test fixture for mode-switch verification"
+
+
+# Seeded fact content. Same bland-but-distinctive shape as the
+# MEMORY.md fixture; a substring match between the seeded fact and
+# the format_context output proves the recall path is hitting our
+# isolated store rather than the production one.
+_FIXTURE_SEED_FACT = "Mode-switch test fixture marker phrase 7f3a2b1c"
+
+
+@contextmanager
+def _isolated_data_dir(tmp_root: Path) -> Iterator[Path]:
+    """Patch `kai.memory.DATA_DIR` to `tmp_root` for the duration of
+    the with-block, reset memory module singleton state on exit.
+
+    Mirrors the existing storage-redirect pattern in
+    `tests/test_memory.py` (the per-test `with patch("kai.memory.DATA_DIR", tmp_path)`
+    block in the integration tests), plus the singleton-state
+    teardown in that file's `_reset_memory_module` helper
+    (`_memory = None; _config = None`) so a subsequent invocation in
+    the same process is not affected by the prior init_memory call.
+
+    init_memory reads `DATA_DIR / "memory" / "qdrant"` from
+    kai.memory at module-resolution time, with no parameter to
+    redirect storage. Patching the module attribute is the
+    supported test pattern.
+    """
+    from kai import memory as memory_module
+
+    with patch.object(memory_module, "DATA_DIR", tmp_root):
+        try:
+            yield tmp_root
+        finally:
+            # Reset singleton state so a follow-up init_memory call
+            # (in the next test, or the next subcommand invocation)
+            # constructs a fresh client against its own DATA_DIR.
+            memory_module._memory = None
+            memory_module._config = None
+
+
+def _build_test_configs(memory_enabled_value: bool) -> Config:
+    """Build a Config with the requested memory_enabled value plus
+    enough surrounding fields to satisfy the production code paths
+    that will read it.
+
+    The verify subcommand never spawns subprocesses or hits the
+    network, so the Telegram and webhook fields are placeholder
+    strings. allowed_user_ids contains the fixture chat_id so the
+    user-id scoping in build_session_context resolves the per-user
+    MEMORY.md path correctly.
+    """
+    return Config(
+        telegram_bot_token="modeswitch-test",
+        allowed_user_ids={_FIXTURE_CHAT_ID},
+        webhook_secret="modeswitch-test",
+        memory_enabled=memory_enabled_value,
+    )
+
+
+def _seed_fixture_memory_md(tmp_root: Path) -> Path:
+    """Create a per-user MEMORY.md fixture under tmp_root. Returns
+    the path so the caller can pass it to build_session_context's
+    data_dir argument.
+
+    Layout matches the production scoping convention:
+    `<data_dir>/memory/<chat_id>/MEMORY.md`. build_session_context
+    will read this file when called with memory_enabled=False.
+    """
+    user_dir = tmp_root / "memory" / str(_FIXTURE_CHAT_ID)
+    user_dir.mkdir(parents=True, exist_ok=True)
+    memory_path = user_dir / "MEMORY.md"
+    memory_path.write_text(_FIXTURE_MEMORY_MD)
+    return memory_path
+
+
+async def _seed_fixture_fact(user_id: str) -> None:
+    """Write one canned fact to the active memory store via
+    `add_structured`. Caller must have already called init_memory
+    inside an `_isolated_data_dir` block so the write lands in
+    the tmp Qdrant.
+
+    Source role tag matches the production extracted-fact shape so
+    the row passes the source-bucket weighting at retrieval time.
+    """
+    from kai import memory as memory_module
+
+    # add_structured is sync (Mem0 is sync). Wrap in
+    # run_in_executor so this coroutine stays cooperative even
+    # though the harness runs it serially.
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(
+        None,
+        lambda: memory_module.add_structured(
+            content=_FIXTURE_SEED_FACT,
+            user_id=user_id,
+            memory_type="fact",
+            tags=["fact"],
+            metadata={"source": "extracted", "confidence": 0.9},
+        ),
+    )
+
+
+def _api_ctx_for_verify() -> ApiContext:
+    """Construct an ApiContext for the verify subcommand. The verify
+    path does not exercise any API endpoints; the context is needed
+    only to satisfy build_session_context's signature.
+    """
+    return ApiContext(
+        webhook_port=8080,
+        webhook_secret="modeswitch-test",
+        services_info=[],
+    )
+
+
+async def _run_verify() -> int:
+    """Drive every invariant under both flag values; print PASS/FAIL
+    per invariant and a final summary. Return 0 on full pass, 1 on
+    any failure.
+
+    Each invariant is computed once and recorded as an
+    `_InvariantResult`. The harness prints results as it goes
+    (rather than batching at the end) so a failure surfaces
+    immediately even if a later invariant raises.
+    """
+    results: list[_InvariantResult] = []
+
+    with tempfile.TemporaryDirectory(prefix="modeswitch-") as tmp_str:
+        tmp_root = Path(tmp_str)
+        # Redirect Mem0's home directory so the per-instance
+        # `migrations_qdrant` and `mem0_history.db` it auto-creates
+        # land under the tmp tree rather than the operator's
+        # `~/.mem0/`. The live service holds the lock on the real
+        # `~/.mem0/migrations_qdrant`; without this redirect, the
+        # harness's `init_memory` call would deadlock against it.
+        # Set BEFORE the first import of `kai.memory` (which
+        # transitively imports mem0); mem0 reads `MEM0_DIR` at
+        # module-import time, so setting it later than the first
+        # import has no effect. backend.py and config.py do not
+        # import kai.memory; the first kai.memory import happens
+        # inside `_isolated_data_dir`'s body.
+        os.environ["MEM0_DIR"] = str(tmp_root / "mem0")
+        _seed_fixture_memory_md(tmp_root)
+        api_ctx = _api_ctx_for_verify()
+        # workspace and home_workspace coincide so the optional
+        # identity-injection branch in build_session_context (which
+        # fires only when the two differ) does not pollute the
+        # output and confuse the substring assertions.
+        ws = tmp_root / "workspace"
+        ws.mkdir()
+
+        # ── Disabled-mode invariants ──────────────────────────
+        disabled_ctx = build_session_context(
+            workspace=ws,
+            home_workspace=ws,
+            api=api_ctx,
+            workspace_config=None,
+            chat_id=_FIXTURE_CHAT_ID,
+            data_dir=tmp_root,
+            memory_enabled=False,
+        )
+
+        results.append(
+            _InvariantResult(
+                name="disabled: subsystem marker present",
+                passed=_MARKER_DISABLED in disabled_ctx,
+                detail=f"missing {_MARKER_DISABLED!r}" if _MARKER_DISABLED not in disabled_ctx else "",
+            )
+        )
+        results.append(
+            _InvariantResult(
+                name="disabled: persistent-memory block injected",
+                passed=_MARKER_PERSISTENT_MEMORY in disabled_ctx,
+                detail=f"missing {_MARKER_PERSISTENT_MEMORY!r}"
+                if _MARKER_PERSISTENT_MEMORY not in disabled_ctx
+                else "",
+            )
+        )
+        results.append(
+            _InvariantResult(
+                name="disabled: relevant-memories block omitted",
+                passed=_MARKER_RELEVANT_MEMORIES not in disabled_ctx,
+                detail=f"unexpectedly contained {_MARKER_RELEVANT_MEMORIES!r}"
+                if _MARKER_RELEVANT_MEMORIES in disabled_ctx
+                else "",
+            )
+        )
+
+        # ── Enabled-mode invariants ───────────────────────────
+        enabled_ctx = build_session_context(
+            workspace=ws,
+            home_workspace=ws,
+            api=api_ctx,
+            workspace_config=None,
+            chat_id=_FIXTURE_CHAT_ID,
+            data_dir=tmp_root,
+            memory_enabled=True,
+        )
+
+        results.append(
+            _InvariantResult(
+                name="enabled: subsystem marker present",
+                passed=_MARKER_ENABLED in enabled_ctx,
+                detail=f"missing {_MARKER_ENABLED!r}" if _MARKER_ENABLED not in enabled_ctx else "",
+            )
+        )
+        results.append(
+            _InvariantResult(
+                name="enabled: persistent-memory block omitted",
+                passed=_MARKER_PERSISTENT_MEMORY not in enabled_ctx,
+                detail=f"unexpectedly contained {_MARKER_PERSISTENT_MEMORY!r}"
+                if _MARKER_PERSISTENT_MEMORY in enabled_ctx
+                else "",
+            )
+        )
+
+        # The enabled-mode format_context probe runs in an
+        # isolated tmp-dir Qdrant. We seed one fact, query for it,
+        # and assert the recall block either is empty or starts
+        # with the expected header. Both shapes are valid; the
+        # invariant is the prefix check, not a presence claim.
+        recall_text = ""
+        with _isolated_data_dir(tmp_root):
+            from kai import memory as memory_module
+
+            memory_module.init_memory(_build_test_configs(memory_enabled_value=True))
+            await _seed_fixture_fact(user_id=str(_FIXTURE_CHAT_ID))
+            recall_text = await memory_module.format_context(_FIXTURE_QUERY, user_id=str(_FIXTURE_CHAT_ID))
+
+        recall_ok = recall_text == "" or recall_text.startswith(_MARKER_RELEVANT_MEMORIES)
+        results.append(
+            _InvariantResult(
+                name="enabled: format_context returns empty or recall-prefixed",
+                passed=recall_ok,
+                detail=(f"got {recall_text[:80]!r}" if not recall_ok else ""),
+            )
+        )
+
+        # ── Partition invariants over the combined output ─────
+        # combined = build_session_context output + format_context
+        # output, joined with a newline. The two substrings must
+        # never coexist regardless of flag value.
+        combined_disabled = disabled_ctx + "\n" + ""  # disabled: format_context returns "" by contract
+        combined_enabled = enabled_ctx + "\n" + recall_text
+
+        partition_disabled_ok = (
+            _MARKER_PERSISTENT_MEMORY in combined_disabled and _MARKER_RELEVANT_MEMORIES not in combined_disabled
+        )
+        results.append(
+            _InvariantResult(
+                name="partition disabled: persistent present, relevant absent",
+                passed=partition_disabled_ok,
+                detail="" if partition_disabled_ok else "partition broken under disabled",
+            )
+        )
+
+        partition_enabled_ok = _MARKER_PERSISTENT_MEMORY not in combined_enabled
+        results.append(
+            _InvariantResult(
+                name="partition enabled: persistent absent",
+                passed=partition_enabled_ok,
+                detail="" if partition_enabled_ok else "persistent block leaked into enabled-mode combined output",
+            )
+        )
+
+        mutual_exclusion_ok = not (
+            _MARKER_PERSISTENT_MEMORY in combined_enabled and _MARKER_RELEVANT_MEMORIES in combined_enabled
+        ) and not (_MARKER_PERSISTENT_MEMORY in combined_disabled and _MARKER_RELEVANT_MEMORIES in combined_disabled)
+        results.append(
+            _InvariantResult(
+                name="partition: mutual exclusion across both modes",
+                passed=mutual_exclusion_ok,
+                detail="" if mutual_exclusion_ok else "both blocks present in one mode",
+            )
+        )
+
+    # Print results.
+    failed = [r for r in results if not r.passed]
+    for r in results:
+        status = "PASS" if r.passed else "FAIL"
+        suffix = f"  [{r.detail}]" if r.detail else ""
+        print(f"  {status}  {r.name}{suffix}")
+    print()
+    if failed:
+        print(f"FAIL: {len(failed)} of {len(results)} invariants failed.")
+        return 1
+    print(f"PASS: all {len(results)} invariants hold.")
+    return 0
+
+
+# ── Check: runtime sanity ───────────────────────────────────────────
+
+
+# Pinned regexes for the prompt-version probe. Match the source-level
+# constants `_EXTRACTION_PROMPT_VERSION: str = "N"` and the analogous
+# episode-prompt version. Pinned shape so the probe does not have to
+# re-derive the regex if the source-level wording shifts; an edit to
+# the version-line format that breaks these regexes is a real
+# regression that the test suite at TestPromptVersionRead will catch.
+_EXTRACTION_VERSION_RE = re.compile(r'_EXTRACTION_PROMPT_VERSION:\s*str\s*=\s*"([^"]+)"')
+_EPISODE_VERSION_RE = re.compile(r'_EPISODE_PROMPT_VERSION:\s*str\s*=\s*"([^"]+)"')
+
+
+# Lookup order for the deployed memory_extraction.py source file.
+# /opt/kai/ is the production install layout per the project
+# convention; the source-tree fallback covers dev environments and
+# local test invocations. Listed in priority order.
+_PROMPT_VERSION_PATH_PRIMARY = Path("/opt/kai/src/kai/memory_extraction.py")
+_PROMPT_VERSION_PATH_FALLBACK = Path(__file__).parent.parent / "memory_extraction.py"
+
+
+def _read_prompt_versions() -> tuple[str, str]:
+    """Read the deployed prompt-version constants from the source
+    file. Returns (`extraction_version`, `episode_version`); each
+    falls back to the literal string `"unknown"` when the file is
+    not found at either lookup path or the regex does not match.
+
+    Reading the file rather than importing the module means this
+    works without sys.path manipulation and without sudo. The
+    operator does not need to be the kai service user to inspect
+    the deployed binary's version constants.
+    """
+    for path in (_PROMPT_VERSION_PATH_PRIMARY, _PROMPT_VERSION_PATH_FALLBACK):
+        if path.exists():
+            text = path.read_text()
+            ext_match = _EXTRACTION_VERSION_RE.search(text)
+            ep_match = _EPISODE_VERSION_RE.search(text)
+            ext = ext_match.group(1) if ext_match else "unknown"
+            ep = ep_match.group(1) if ep_match else "unknown"
+            return ext, ep
+    return "unknown", "unknown"
+
+
+def _http_get(url: str, secret: str | None = None, timeout: float = 5.0) -> tuple[int, bytes]:
+    """Issue a GET against the local kai service and return
+    (status_code, body_bytes). On network error or timeout, returns
+    (0, b"") so the caller can branch on a non-200/non-503 status.
+
+    Uses urllib (stdlib) rather than requests so the harness has no
+    third-party HTTP dependency. The timeout cap prevents the probe
+    from hanging if the service has bound the port but is not
+    responding.
+    """
+    req = urllib.request.Request(url)
+    if secret is not None:
+        req.add_header("X-Webhook-Secret", secret)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:
+        # 4xx/5xx responses surface here; still useful to read the
+        # body for the error message.
+        try:
+            body = exc.read()
+        except Exception:
+            body = b""
+        return exc.code, body
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return 0, b""
+
+
+def _run_check() -> int:
+    """Probe the running service and print a five-line report.
+
+    Tri-state exit code:
+      0: clean read (health=ok and stats returned a definite mode)
+      1: health=down or stats returned an unexpected status
+      2: WEBHOOK_SECRET not in process environment
+    """
+    secret = os.environ.get("WEBHOOK_SECRET", "")
+    secret_found = bool(secret)
+
+    if not secret_found:
+        print("secret_found: no")
+        print("  WEBHOOK_SECRET not set; source /etc/kai/env first")
+        print("  e.g. sudo bash -c 'source /etc/kai/env && env | grep WEBHOOK_SECRET'")
+        return 2
+
+    print("secret_found: yes")
+
+    # Health probe first; if the service is down, the stats probe
+    # cannot succeed and we report up-front.
+    health_status, _ = _http_get("http://localhost:8080/health")
+    if health_status != 200:
+        print(f"health: down (status={health_status})")
+        ext_v, ep_v = _read_prompt_versions()
+        print("mode: unknown(service-down)")
+        print(f"extraction_prompt_version: {ext_v}")
+        print(f"episode_prompt_version: {ep_v}")
+        return 1
+
+    print("health: ok")
+
+    # Stats probe: 200 = enabled, 503 = disabled, anything else =
+    # unexpected. Use the operator-default chat_id from the running
+    # service config; we do not need a real chat_id here since the
+    # auth check fires before the body validation. Pass chat_id=1
+    # as a placeholder (any int the service accepts works; the
+    # 401-before-body order means the value is not exercised).
+    stats_url = "http://localhost:8080/api/memory/stats?" + urllib.parse.urlencode({"chat_id": _FIXTURE_CHAT_ID})
+    stats_status, _ = _http_get(stats_url, secret=secret)
+
+    ext_v, ep_v = _read_prompt_versions()
+
+    if stats_status == 200:
+        print("mode: enabled")
+        rc = 0
+    elif stats_status == 503:
+        print("mode: disabled")
+        rc = 0
+    else:
+        print(f"mode: unknown({stats_status})")
+        rc = 1
+
+    print(f"extraction_prompt_version: {ext_v}")
+    print(f"episode_prompt_version: {ep_v}")
+    return rc
+
+
+# ── CLI entry point ─────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="subcommand", required=True)
+    sub.add_parser("verify", help="Black-box logic verification of the gating contract.")
+    sub.add_parser("check", help="Runtime sanity check against the running service.")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    if args.subcommand == "verify":
+        return asyncio.run(_run_verify())
+    if args.subcommand == "check":
+        return _run_check()
+    # argparse `required=True` makes this unreachable; guard for type-checker.
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -283,17 +283,24 @@ async def _run_verify() -> int:
         # ORIGINAL MEM0_DIR (operator's `~/.mem0/`) and the redirect
         # below has no effect, leaving the harness deadlocked against
         # the live `migrations_qdrant` lock. Fail loud BEFORE
-        # mutating MEM0_DIR so an assertion failure leaves the
-        # environment untouched and the try/finally below is not
-        # responsible for restoring state we never changed.
-        assert "kai.memory" not in sys.modules, (
-            "kai.memory was imported before _run_verify could set "
-            "MEM0_DIR; mem0's home-directory constant has already been "
-            "captured at the operator's ~/.mem0/ path and the tmp "
-            "redirect will not take effect. A backend.py or config.py "
-            "import path now pulls kai.memory transitively; restore "
-            "the lazy-import contract before re-running."
-        )
+        # mutating MEM0_DIR so a failure leaves the environment
+        # untouched and the try/finally below is not responsible for
+        # restoring state we never changed.
+        #
+        # `if/raise` rather than `assert`: this guard is safety-
+        # critical (silent deadlock on failure), and `assert`
+        # statements are stripped under `python -O` /
+        # `PYTHONOPTIMIZE=1`. The bare `RuntimeError` cannot be
+        # silently disabled.
+        if "kai.memory" in sys.modules:
+            raise RuntimeError(
+                "kai.memory was imported before _run_verify could set "
+                "MEM0_DIR; mem0's home-directory constant has already been "
+                "captured at the operator's ~/.mem0/ path and the tmp "
+                "redirect will not take effect. A backend.py or config.py "
+                "import path now pulls kai.memory transitively; restore "
+                "the lazy-import contract before re-running."
+            )
 
         # Save/restore semantics: capture the prior value (or
         # absence) and restore on the way out so a subsequent
@@ -561,13 +568,25 @@ def _run_check() -> int:
       1: health=down or stats returned an unexpected status
       2: WEBHOOK_SECRET not in process environment
     """
-    secret = os.environ.get("WEBHOOK_SECRET", "")
-    secret_found = bool(secret)
+    # Distinguish "not exported" (None) from "exported but empty"
+    # (the empty string). Both fail the same way for /api/memory/stats
+    # auth (the request would carry no usable secret), but the
+    # diagnostic differs: a missing-from-env case wants "source
+    # /etc/kai/env first"; an empty-but-set case wants the operator
+    # to fix the env-file value. `check` is the tool operators run
+    # when debugging a config issue; a misleading diagnostic at that
+    # moment is worse than verbose accuracy.
+    secret = os.environ.get("WEBHOOK_SECRET")
 
-    if not secret_found:
+    if secret is None:
         print("secret_found: no")
         print("  WEBHOOK_SECRET not set; source /etc/kai/env first")
         print("  e.g. sudo bash -c 'source /etc/kai/env && env | grep WEBHOOK_SECRET'")
+        return 2
+    if secret == "":
+        print("secret_found: empty")
+        print("  WEBHOOK_SECRET is exported but empty; check /etc/kai/env for a typo")
+        print("  (a line like `WEBHOOK_SECRET=` with no value)")
         return 2
 
     print("secret_found: yes")

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -297,6 +297,15 @@ async def _run_verify() -> int:
         # statements are stripped under `python -O` /
         # `PYTHONOPTIMIZE=1`. The bare `RuntimeError` cannot be
         # silently disabled.
+        #
+        # Reentrancy note: this guard also fires on a second call
+        # to `_run_verify` in the same process, because
+        # `_isolated_data_dir`'s lazy `from kai import memory`
+        # leaves the module in `sys.modules` after the first call.
+        # The CLI invokes verify once per process, so this is fine;
+        # a future caller that wants to retry verify in-process
+        # needs a fresh subprocess (or to drop the guard, but the
+        # guard is the only thing preventing the deadlock).
         if "kai.memory" in sys.modules:
             raise RuntimeError(
                 "kai.memory was imported before _run_verify could set "

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -62,7 +62,6 @@ import re
 import sys
 import tempfile
 import urllib.error
-import urllib.parse
 import urllib.request
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -639,12 +638,18 @@ def _run_check() -> int:
     print("health: ok")
 
     # Stats probe: 200 = enabled, 503 = disabled, anything else =
-    # unexpected. Use the operator-default chat_id from the running
-    # service config; we do not need a real chat_id here since the
-    # auth check fires before the body validation. Pass chat_id=1
-    # as a placeholder (any int the service accepts works; the
-    # 401-before-body order means the value is not exercised).
-    stats_url = f"{base_url}/api/memory/stats?" + urllib.parse.urlencode({"chat_id": _FIXTURE_CHAT_ID})
+    # unexpected. Issue the request with NO `chat_id` query
+    # parameter so the server falls back to its app-default
+    # (`request.app["chat_id"]` at webhook.py's _resolve_chat_id).
+    # Earlier versions of this harness passed `chat_id=1` as a
+    # placeholder, which fails: _resolve_chat_id runs after secret
+    # auth but before the memory.is_enabled() branch, and rejects
+    # any explicit chat_id not in `allowed_user_ids` with a 403.
+    # The mode probe needs the enabled/disabled signal, not any
+    # particular user's stats, so omitting the parameter routes
+    # cleanly through the app-default and reports the system-wide
+    # memory state.
+    stats_url = f"{base_url}/api/memory/stats"
     stats_status, _ = _http_get(stats_url, secret=secret)
 
     ext_v, ep_v = _read_prompt_versions()

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -275,16 +275,6 @@ async def _run_verify() -> int:
         # module-import time, so setting it later than the first
         # import has no effect.
         #
-        # Save/restore semantics: capture the prior value (or
-        # absence) and restore on the way out so a subsequent
-        # process-shared invocation does not inherit the now-deleted
-        # tmp path. `MEM0_DIR_SENTINEL` distinguishes "was unset"
-        # from "was empty string"; the former requires `pop`, the
-        # latter requires reassignment.
-        _MEM0_DIR_SENTINEL = object()
-        prior_mem0_dir = os.environ.get("MEM0_DIR", _MEM0_DIR_SENTINEL)
-        os.environ["MEM0_DIR"] = str(tmp_root / "mem0")
-
         # Invariant guard: backend.py and config.py do not transitively
         # import kai.memory today; the first kai.memory import happens
         # inside `_isolated_data_dir`'s body, AFTER MEM0_DIR is set.
@@ -292,9 +282,10 @@ async def _run_verify() -> int:
         # of either module, mem0 would have already captured the
         # ORIGINAL MEM0_DIR (operator's `~/.mem0/`) and the redirect
         # below has no effect, leaving the harness deadlocked against
-        # the live `migrations_qdrant` lock. Fail loud here rather
-        # than silently re-contending. The assertion fires once at
-        # the entry point, before any build_session_context call.
+        # the live `migrations_qdrant` lock. Fail loud BEFORE
+        # mutating MEM0_DIR so an assertion failure leaves the
+        # environment untouched and the try/finally below is not
+        # responsible for restoring state we never changed.
         assert "kai.memory" not in sys.modules, (
             "kai.memory was imported before _run_verify could set "
             "MEM0_DIR; mem0's home-directory constant has already been "
@@ -303,6 +294,16 @@ async def _run_verify() -> int:
             "import path now pulls kai.memory transitively; restore "
             "the lazy-import contract before re-running."
         )
+
+        # Save/restore semantics: capture the prior value (or
+        # absence) and restore on the way out so a subsequent
+        # process-shared invocation does not inherit the now-deleted
+        # tmp path. `MEM0_DIR_SENTINEL` distinguishes "was unset"
+        # from "was empty string"; the former requires `pop`, the
+        # latter requires reassignment.
+        _MEM0_DIR_SENTINEL: object = object()
+        prior_mem0_dir: str | object = os.environ.get("MEM0_DIR", _MEM0_DIR_SENTINEL)
+        os.environ["MEM0_DIR"] = str(tmp_root / "mem0")
 
         try:
             _seed_fixture_memory_md(tmp_root)
@@ -453,6 +454,11 @@ async def _run_verify() -> int:
             if prior_mem0_dir is _MEM0_DIR_SENTINEL:
                 os.environ.pop("MEM0_DIR", None)
             else:
+                # Pyright strict cannot narrow `str | object` through
+                # an `is`-check on a non-literal sentinel; the explicit
+                # isinstance assertion narrows the type for the
+                # `os.environ` setter, which requires `str`.
+                assert isinstance(prior_mem0_dir, str)
                 os.environ["MEM0_DIR"] = prior_mem0_dir
 
     # Print results.

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -453,12 +453,19 @@ async def _run_verify() -> int:
             # the next mem0-using subprocess hits the missing dir.
             if prior_mem0_dir is _MEM0_DIR_SENTINEL:
                 os.environ.pop("MEM0_DIR", None)
-            else:
+            elif isinstance(prior_mem0_dir, str):
                 # Pyright strict cannot narrow `str | object` through
-                # an `is`-check on a non-literal sentinel; the explicit
-                # isinstance assertion narrows the type for the
+                # an `is`-check on a non-literal sentinel; the
+                # explicit isinstance check narrows the type for the
                 # `os.environ` setter, which requires `str`.
-                assert isinstance(prior_mem0_dir, str)
+                # `if isinstance` rather than `assert isinstance`
+                # because this runs in a `finally` block: a hard
+                # assert here would shadow any exception propagating
+                # out of the `try` body. The isinstance condition
+                # is structurally always true (os.environ.get returns
+                # `str` or the sentinel; the elif branch only runs
+                # when the sentinel comparison failed); the `if`
+                # form is the defensive shape for finally blocks.
                 os.environ["MEM0_DIR"] = prior_mem0_dir
 
     # Print results.
@@ -570,13 +577,18 @@ def _run_check() -> int:
     # port-conflict resolution). Mirrors the `WEBHOOK_PORT` env var
     # the production service reads in config.py's load_config; the
     # default of 8080 matches the Config dataclass default. A
-    # non-integer value falls through to 8080 with a warning rather
-    # than crashing the harness.
+    # non-integer value or out-of-range value falls through to 8080
+    # with a warning rather than crashing the harness or producing
+    # a confusing `health: down (status=0)` from a port the OS
+    # cannot bind. Range check is `1 <= port <= 65535` per the
+    # POSIX TCP/IP port-number contract.
     port_str = os.environ.get("WEBHOOK_PORT", "8080")
     try:
         port = int(port_str)
-    except ValueError:
-        print(f"  WEBHOOK_PORT={port_str!r} is not an integer; falling back to 8080")
+        if not 1 <= port <= 65535:
+            raise ValueError(f"port {port} out of range")
+    except ValueError as exc:
+        print(f"  WEBHOOK_PORT={port_str!r} is invalid ({exc}); falling back to 8080")
         port = 8080
     base_url = f"http://localhost:{port}"
 

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -273,143 +273,187 @@ async def _run_verify() -> int:
         # Set BEFORE the first import of `kai.memory` (which
         # transitively imports mem0); mem0 reads `MEM0_DIR` at
         # module-import time, so setting it later than the first
-        # import has no effect. backend.py and config.py do not
-        # import kai.memory; the first kai.memory import happens
-        # inside `_isolated_data_dir`'s body.
+        # import has no effect.
+        #
+        # Save/restore semantics: capture the prior value (or
+        # absence) and restore on the way out so a subsequent
+        # process-shared invocation does not inherit the now-deleted
+        # tmp path. `MEM0_DIR_SENTINEL` distinguishes "was unset"
+        # from "was empty string"; the former requires `pop`, the
+        # latter requires reassignment.
+        _MEM0_DIR_SENTINEL = object()
+        prior_mem0_dir = os.environ.get("MEM0_DIR", _MEM0_DIR_SENTINEL)
         os.environ["MEM0_DIR"] = str(tmp_root / "mem0")
-        _seed_fixture_memory_md(tmp_root)
-        api_ctx = _api_ctx_for_verify()
-        # workspace and home_workspace coincide so the optional
-        # identity-injection branch in build_session_context (which
-        # fires only when the two differ) does not pollute the
-        # output and confuse the substring assertions.
-        ws = tmp_root / "workspace"
-        ws.mkdir()
 
-        # ── Disabled-mode invariants ──────────────────────────
-        disabled_ctx = build_session_context(
-            workspace=ws,
-            home_workspace=ws,
-            api=api_ctx,
-            workspace_config=None,
-            chat_id=_FIXTURE_CHAT_ID,
-            data_dir=tmp_root,
-            memory_enabled=False,
+        # Invariant guard: backend.py and config.py do not transitively
+        # import kai.memory today; the first kai.memory import happens
+        # inside `_isolated_data_dir`'s body, AFTER MEM0_DIR is set.
+        # If a future refactor pulls kai.memory into the import graph
+        # of either module, mem0 would have already captured the
+        # ORIGINAL MEM0_DIR (operator's `~/.mem0/`) and the redirect
+        # below has no effect, leaving the harness deadlocked against
+        # the live `migrations_qdrant` lock. Fail loud here rather
+        # than silently re-contending. The assertion fires once at
+        # the entry point, before any build_session_context call.
+        assert "kai.memory" not in sys.modules, (
+            "kai.memory was imported before _run_verify could set "
+            "MEM0_DIR; mem0's home-directory constant has already been "
+            "captured at the operator's ~/.mem0/ path and the tmp "
+            "redirect will not take effect. A backend.py or config.py "
+            "import path now pulls kai.memory transitively; restore "
+            "the lazy-import contract before re-running."
         )
 
-        results.append(
-            _InvariantResult(
-                name="disabled: subsystem marker present",
-                passed=_MARKER_DISABLED in disabled_ctx,
-                detail=f"missing {_MARKER_DISABLED!r}" if _MARKER_DISABLED not in disabled_ctx else "",
+        try:
+            _seed_fixture_memory_md(tmp_root)
+            api_ctx = _api_ctx_for_verify()
+            # workspace and home_workspace coincide so the optional
+            # identity-injection branch in build_session_context (which
+            # fires only when the two differ) does not pollute the
+            # output and confuse the substring assertions.
+            ws = tmp_root / "workspace"
+            ws.mkdir()
+
+            # ── Disabled-mode invariants ──────────────────────────
+            disabled_ctx = build_session_context(
+                workspace=ws,
+                home_workspace=ws,
+                api=api_ctx,
+                workspace_config=None,
+                chat_id=_FIXTURE_CHAT_ID,
+                data_dir=tmp_root,
+                memory_enabled=False,
             )
-        )
-        results.append(
-            _InvariantResult(
-                name="disabled: persistent-memory block injected",
-                passed=_MARKER_PERSISTENT_MEMORY in disabled_ctx,
-                detail=f"missing {_MARKER_PERSISTENT_MEMORY!r}"
-                if _MARKER_PERSISTENT_MEMORY not in disabled_ctx
-                else "",
+
+            results.append(
+                _InvariantResult(
+                    name="disabled: subsystem marker present",
+                    passed=_MARKER_DISABLED in disabled_ctx,
+                    detail=f"missing {_MARKER_DISABLED!r}" if _MARKER_DISABLED not in disabled_ctx else "",
+                )
             )
-        )
-        results.append(
-            _InvariantResult(
-                name="disabled: relevant-memories block omitted",
-                passed=_MARKER_RELEVANT_MEMORIES not in disabled_ctx,
-                detail=f"unexpectedly contained {_MARKER_RELEVANT_MEMORIES!r}"
-                if _MARKER_RELEVANT_MEMORIES in disabled_ctx
-                else "",
+            results.append(
+                _InvariantResult(
+                    name="disabled: persistent-memory block injected",
+                    passed=_MARKER_PERSISTENT_MEMORY in disabled_ctx,
+                    detail=f"missing {_MARKER_PERSISTENT_MEMORY!r}"
+                    if _MARKER_PERSISTENT_MEMORY not in disabled_ctx
+                    else "",
+                )
             )
-        )
-
-        # ── Enabled-mode invariants ───────────────────────────
-        enabled_ctx = build_session_context(
-            workspace=ws,
-            home_workspace=ws,
-            api=api_ctx,
-            workspace_config=None,
-            chat_id=_FIXTURE_CHAT_ID,
-            data_dir=tmp_root,
-            memory_enabled=True,
-        )
-
-        results.append(
-            _InvariantResult(
-                name="enabled: subsystem marker present",
-                passed=_MARKER_ENABLED in enabled_ctx,
-                detail=f"missing {_MARKER_ENABLED!r}" if _MARKER_ENABLED not in enabled_ctx else "",
+            results.append(
+                _InvariantResult(
+                    name="disabled: relevant-memories block omitted",
+                    passed=_MARKER_RELEVANT_MEMORIES not in disabled_ctx,
+                    detail=f"unexpectedly contained {_MARKER_RELEVANT_MEMORIES!r}"
+                    if _MARKER_RELEVANT_MEMORIES in disabled_ctx
+                    else "",
+                )
             )
-        )
-        results.append(
-            _InvariantResult(
-                name="enabled: persistent-memory block omitted",
-                passed=_MARKER_PERSISTENT_MEMORY not in enabled_ctx,
-                detail=f"unexpectedly contained {_MARKER_PERSISTENT_MEMORY!r}"
-                if _MARKER_PERSISTENT_MEMORY in enabled_ctx
-                else "",
+
+            # ── Enabled-mode invariants ───────────────────────────
+            enabled_ctx = build_session_context(
+                workspace=ws,
+                home_workspace=ws,
+                api=api_ctx,
+                workspace_config=None,
+                chat_id=_FIXTURE_CHAT_ID,
+                data_dir=tmp_root,
+                memory_enabled=True,
             )
-        )
 
-        # The enabled-mode format_context probe runs in an
-        # isolated tmp-dir Qdrant. We seed one fact, query for it,
-        # and assert the recall block either is empty or starts
-        # with the expected header. Both shapes are valid; the
-        # invariant is the prefix check, not a presence claim.
-        recall_text = ""
-        with _isolated_data_dir(tmp_root):
-            from kai import memory as memory_module
-
-            memory_module.init_memory(_build_test_configs(memory_enabled_value=True))
-            await _seed_fixture_fact(user_id=str(_FIXTURE_CHAT_ID))
-            recall_text = await memory_module.format_context(_FIXTURE_QUERY, user_id=str(_FIXTURE_CHAT_ID))
-
-        recall_ok = recall_text == "" or recall_text.startswith(_MARKER_RELEVANT_MEMORIES)
-        results.append(
-            _InvariantResult(
-                name="enabled: format_context returns empty or recall-prefixed",
-                passed=recall_ok,
-                detail=(f"got {recall_text[:80]!r}" if not recall_ok else ""),
+            results.append(
+                _InvariantResult(
+                    name="enabled: subsystem marker present",
+                    passed=_MARKER_ENABLED in enabled_ctx,
+                    detail=f"missing {_MARKER_ENABLED!r}" if _MARKER_ENABLED not in enabled_ctx else "",
+                )
             )
-        )
-
-        # ── Partition invariants over the combined output ─────
-        # combined = build_session_context output + format_context
-        # output, joined with a newline. The two substrings must
-        # never coexist regardless of flag value.
-        combined_disabled = disabled_ctx + "\n" + ""  # disabled: format_context returns "" by contract
-        combined_enabled = enabled_ctx + "\n" + recall_text
-
-        partition_disabled_ok = (
-            _MARKER_PERSISTENT_MEMORY in combined_disabled and _MARKER_RELEVANT_MEMORIES not in combined_disabled
-        )
-        results.append(
-            _InvariantResult(
-                name="partition disabled: persistent present, relevant absent",
-                passed=partition_disabled_ok,
-                detail="" if partition_disabled_ok else "partition broken under disabled",
+            results.append(
+                _InvariantResult(
+                    name="enabled: persistent-memory block omitted",
+                    passed=_MARKER_PERSISTENT_MEMORY not in enabled_ctx,
+                    detail=f"unexpectedly contained {_MARKER_PERSISTENT_MEMORY!r}"
+                    if _MARKER_PERSISTENT_MEMORY in enabled_ctx
+                    else "",
+                )
             )
-        )
 
-        partition_enabled_ok = _MARKER_PERSISTENT_MEMORY not in combined_enabled
-        results.append(
-            _InvariantResult(
-                name="partition enabled: persistent absent",
-                passed=partition_enabled_ok,
-                detail="" if partition_enabled_ok else "persistent block leaked into enabled-mode combined output",
-            )
-        )
+            # The enabled-mode format_context probe runs in an
+            # isolated tmp-dir Qdrant. We seed one fact, query for it,
+            # and assert the recall block either is empty or starts
+            # with the expected header. Both shapes are valid; the
+            # invariant is the prefix check, not a presence claim.
+            recall_text = ""
+            with _isolated_data_dir(tmp_root):
+                from kai import memory as memory_module
 
-        mutual_exclusion_ok = not (
-            _MARKER_PERSISTENT_MEMORY in combined_enabled and _MARKER_RELEVANT_MEMORIES in combined_enabled
-        ) and not (_MARKER_PERSISTENT_MEMORY in combined_disabled and _MARKER_RELEVANT_MEMORIES in combined_disabled)
-        results.append(
-            _InvariantResult(
-                name="partition: mutual exclusion across both modes",
-                passed=mutual_exclusion_ok,
-                detail="" if mutual_exclusion_ok else "both blocks present in one mode",
+                memory_module.init_memory(_build_test_configs(memory_enabled_value=True))
+                await _seed_fixture_fact(user_id=str(_FIXTURE_CHAT_ID))
+                recall_text = await memory_module.format_context(_FIXTURE_QUERY, user_id=str(_FIXTURE_CHAT_ID))
+
+            recall_ok = recall_text == "" or recall_text.startswith(_MARKER_RELEVANT_MEMORIES)
+            results.append(
+                _InvariantResult(
+                    name="enabled: format_context returns empty or recall-prefixed",
+                    passed=recall_ok,
+                    detail=(f"got {recall_text[:80]!r}" if not recall_ok else ""),
+                )
             )
-        )
+
+            # ── Partition invariants over the combined output ─────
+            # combined = build_session_context output + format_context
+            # output, joined with a newline. The two substrings must
+            # never coexist regardless of flag value. format_context
+            # returns "" under disabled mode by contract (the
+            # is_enabled() guard short-circuits before search), so the
+            # disabled-mode combined output is just the session
+            # context with a trailing newline.
+            combined_disabled = disabled_ctx + "\n"
+            combined_enabled = enabled_ctx + "\n" + recall_text
+
+            partition_disabled_ok = (
+                _MARKER_PERSISTENT_MEMORY in combined_disabled and _MARKER_RELEVANT_MEMORIES not in combined_disabled
+            )
+            results.append(
+                _InvariantResult(
+                    name="partition disabled: persistent present, relevant absent",
+                    passed=partition_disabled_ok,
+                    detail="" if partition_disabled_ok else "partition broken under disabled",
+                )
+            )
+
+            partition_enabled_ok = _MARKER_PERSISTENT_MEMORY not in combined_enabled
+            results.append(
+                _InvariantResult(
+                    name="partition enabled: persistent absent",
+                    passed=partition_enabled_ok,
+                    detail="" if partition_enabled_ok else "persistent block leaked into enabled-mode combined output",
+                )
+            )
+
+            mutual_exclusion_ok = not (
+                _MARKER_PERSISTENT_MEMORY in combined_enabled and _MARKER_RELEVANT_MEMORIES in combined_enabled
+            ) and not (
+                _MARKER_PERSISTENT_MEMORY in combined_disabled and _MARKER_RELEVANT_MEMORIES in combined_disabled
+            )
+            results.append(
+                _InvariantResult(
+                    name="partition: mutual exclusion across both modes",
+                    passed=mutual_exclusion_ok,
+                    detail="" if mutual_exclusion_ok else "both blocks present in one mode",
+                )
+            )
+        finally:
+            # Restore MEM0_DIR to its pre-call value (or remove it if
+            # it was unset). Without this, subsequent code in the same
+            # process sees MEM0_DIR pointing at the tmp path we just
+            # deleted on tempfile teardown, with no diagnostic when
+            # the next mem0-using subprocess hits the missing dir.
+            if prior_mem0_dir is _MEM0_DIR_SENTINEL:
+                os.environ.pop("MEM0_DIR", None)
+            else:
+                os.environ["MEM0_DIR"] = prior_mem0_dir
 
     # Print results.
     failed = [r for r in results if not r.passed]
@@ -515,9 +559,24 @@ def _run_check() -> int:
 
     print("secret_found: yes")
 
+    # Resolve the webhook port from the environment so the harness
+    # tracks a non-default deploy (dev instance on a different port,
+    # port-conflict resolution). Mirrors the `WEBHOOK_PORT` env var
+    # the production service reads in config.py's load_config; the
+    # default of 8080 matches the Config dataclass default. A
+    # non-integer value falls through to 8080 with a warning rather
+    # than crashing the harness.
+    port_str = os.environ.get("WEBHOOK_PORT", "8080")
+    try:
+        port = int(port_str)
+    except ValueError:
+        print(f"  WEBHOOK_PORT={port_str!r} is not an integer; falling back to 8080")
+        port = 8080
+    base_url = f"http://localhost:{port}"
+
     # Health probe first; if the service is down, the stats probe
     # cannot succeed and we report up-front.
-    health_status, _ = _http_get("http://localhost:8080/health")
+    health_status, _ = _http_get(f"{base_url}/health")
     if health_status != 200:
         print(f"health: down (status={health_status})")
         ext_v, ep_v = _read_prompt_versions()
@@ -534,7 +593,7 @@ def _run_check() -> int:
     # auth check fires before the body validation. Pass chat_id=1
     # as a placeholder (any int the service accepts works; the
     # 401-before-body order means the value is not exercised).
-    stats_url = "http://localhost:8080/api/memory/stats?" + urllib.parse.urlencode({"chat_id": _FIXTURE_CHAT_ID})
+    stats_url = f"{base_url}/api/memory/stats?" + urllib.parse.urlencode({"chat_id": _FIXTURE_CHAT_ID})
     stats_status, _ = _http_get(stats_url, secret=secret)
 
     ext_v, ep_v = _read_prompt_versions()

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -1,0 +1,387 @@
+"""Tests for the mode-switch verification harness.
+
+Three test classes:
+
+- TestVerifyInvariants: exercises `build_session_context` directly under
+  both flag values; the format_context-dependent invariants are covered
+  with a mocked format_context to keep unit tests fast and to avoid Mem0
+  Qdrant lock contention with a running production service.
+- TestCheckSubcommand: monkeypatches the `urlopen` shim and the
+  `_read_prompt_versions` helper to drive each branch of the tri-state
+  exit-code contract.
+- TestPromptVersionRead: covers the prompt-version probe's two-path
+  fallback under tmp_path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kai.eval import modeswitch
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+_FIXTURE_CHAT_ID = modeswitch._FIXTURE_CHAT_ID
+_MARKER_DISABLED = modeswitch._MARKER_DISABLED
+_MARKER_ENABLED = modeswitch._MARKER_ENABLED
+_MARKER_PERSISTENT_MEMORY = modeswitch._MARKER_PERSISTENT_MEMORY
+_MARKER_RELEVANT_MEMORIES = modeswitch._MARKER_RELEVANT_MEMORIES
+
+
+def _build_disabled_ctx(tmp_path: Path) -> str:
+    """Drive build_session_context under memory_enabled=False with the
+    same fixture seeding the verify subcommand uses. Returns the
+    rendered context string."""
+    modeswitch._seed_fixture_memory_md(tmp_path)
+    api_ctx = modeswitch._api_ctx_for_verify()
+    ws = tmp_path / "workspace"
+    ws.mkdir(exist_ok=True)
+    return modeswitch.build_session_context(
+        workspace=ws,
+        home_workspace=ws,
+        api=api_ctx,
+        workspace_config=None,
+        chat_id=_FIXTURE_CHAT_ID,
+        data_dir=tmp_path,
+        memory_enabled=False,
+    )
+
+
+def _build_enabled_ctx(tmp_path: Path) -> str:
+    """Counterpart of `_build_disabled_ctx` under memory_enabled=True."""
+    modeswitch._seed_fixture_memory_md(tmp_path)
+    api_ctx = modeswitch._api_ctx_for_verify()
+    ws = tmp_path / "workspace"
+    ws.mkdir(exist_ok=True)
+    return modeswitch.build_session_context(
+        workspace=ws,
+        home_workspace=ws,
+        api=api_ctx,
+        workspace_config=None,
+        chat_id=_FIXTURE_CHAT_ID,
+        data_dir=tmp_path,
+        memory_enabled=True,
+    )
+
+
+# ── TestVerifyInvariants ────────────────────────────────────────────
+
+
+class TestVerifyInvariants:
+    """Verify subcommand's nine invariants. The five non-recall
+    invariants run directly against `build_session_context`; the four
+    recall-path invariants use a mocked `format_context` so the test
+    exercises the harness's interpretation contract without paying
+    Qdrant init cost or risking Mem0 lock contention with a running
+    production service.
+    """
+
+    def test_disabled_mode_injects_memory_md(self, tmp_path: Path) -> None:
+        """Under memory_enabled=False, the build_session_context output
+        contains the [Your persistent memory (file: ...):] block. This
+        is the load-bearing positive assertion for disabled mode."""
+        ctx = _build_disabled_ctx(tmp_path)
+        assert _MARKER_PERSISTENT_MEMORY in ctx
+        assert _MARKER_DISABLED in ctx
+
+    def test_disabled_mode_omits_relevant_memories_block(self, tmp_path: Path) -> None:
+        """Under memory_enabled=False, the build_session_context output
+        does NOT contain the recall-block prefix. The recall path is
+        out of scope for build_session_context (it's emitted later by
+        format_context), but the harness's invariant is over the
+        combined output, so the prefix must NOT leak from
+        build_session_context into the disabled-mode context."""
+        ctx = _build_disabled_ctx(tmp_path)
+        assert _MARKER_RELEVANT_MEMORIES not in ctx
+
+    def test_enabled_mode_omits_memory_md(self, tmp_path: Path) -> None:
+        """Under memory_enabled=True, MEMORY.md is dormant: the
+        [Your persistent memory ...] block does NOT appear in the
+        build_session_context output. This is the load-bearing
+        negative assertion for enabled mode."""
+        ctx = _build_enabled_ctx(tmp_path)
+        assert _MARKER_PERSISTENT_MEMORY not in ctx
+
+    def test_enabled_mode_marker_present(self, tmp_path: Path) -> None:
+        """Under memory_enabled=True, the [Memory subsystem: enabled]
+        marker is emitted unconditionally, in contrast to the
+        persistent-memory block which is gated by the flag."""
+        ctx = _build_enabled_ctx(tmp_path)
+        assert _MARKER_ENABLED in ctx
+
+    def test_partition_invariant_disabled(self, tmp_path: Path) -> None:
+        """Mutual-exclusivity invariant under disabled mode: the
+        combined session-context-plus-recall output contains the
+        persistent-memory block AND does NOT contain the
+        relevant-memories block. Under disabled mode, format_context
+        is contractually empty (the recall path short-circuits via
+        is_enabled()), so we model that with the empty string."""
+        disabled_ctx = _build_disabled_ctx(tmp_path)
+        # format_context returns "" under disabled mode by contract;
+        # the recall path's is_enabled() guard short-circuits before
+        # the search call. The combined output is just the
+        # build_session_context output.
+        combined = disabled_ctx + "\n" + ""
+        assert _MARKER_PERSISTENT_MEMORY in combined
+        assert _MARKER_RELEVANT_MEMORIES not in combined
+
+    def test_partition_invariant_enabled_with_recall(self, tmp_path: Path) -> None:
+        """Mutual-exclusivity invariant under enabled mode WITH a
+        seeded fact above the floor: the combined output contains the
+        relevant-memories block AND does NOT contain the
+        persistent-memory block. format_context is mocked to return
+        a canned string starting with the recall-block prefix; the
+        invariant under test is the harness's partition contract,
+        not format_context's own ranking behavior."""
+        enabled_ctx = _build_enabled_ctx(tmp_path)
+        recall_text = _MARKER_RELEVANT_MEMORIES + "]\n- (2026-05-01, fact) seeded fixture content"
+        combined = enabled_ctx + "\n" + recall_text
+        assert _MARKER_PERSISTENT_MEMORY not in combined
+        assert _MARKER_RELEVANT_MEMORIES in combined
+
+    def test_partition_invariant_enabled_no_recall(self, tmp_path: Path) -> None:
+        """Mutual-exclusivity invariant under enabled mode WITHOUT
+        any retrievable seed (format_context returns empty when no
+        rows clear the relevance floor): the combined output STILL
+        does NOT contain the persistent-memory block. The
+        relevant-memories block may be absent; both shapes are
+        valid under enabled mode. The invariant is the absence of
+        MEMORY.md, not the presence of recall."""
+        enabled_ctx = _build_enabled_ctx(tmp_path)
+        combined = enabled_ctx + "\n" + ""
+        assert _MARKER_PERSISTENT_MEMORY not in combined
+        # Both shapes valid: relevant-memories may or may not be
+        # present. The load-bearing assertion is the absence of
+        # the persistent block.
+
+    def test_partition_invariant_mutual_exclusion(self, tmp_path: Path) -> None:
+        """Across both flag values, the persistent-memory and
+        relevant-memories blocks NEVER coexist. This is the strongest
+        formulation of the partition invariant: the harness's job is
+        to surface a regression that injected both blocks under a
+        single flag value.
+
+        Regression shape under disabled mode: persistent present AND
+        relevant present (the recall path leaked into disabled mode).
+        Regression shape under enabled mode: persistent present AND
+        relevant present (the MEMORY.md inject leaked into enabled
+        mode). The assertion is the negation of both regressions."""
+        # Disabled: persistent present, relevant absent.
+        disabled_combined = _build_disabled_ctx(tmp_path) + "\n" + ""
+        assert not (_MARKER_PERSISTENT_MEMORY in disabled_combined and _MARKER_RELEVANT_MEMORIES in disabled_combined)
+        # Enabled with recall: persistent absent (the regression
+        # shape would be both present).
+        enabled_recall = _MARKER_RELEVANT_MEMORIES + "]\n- (2026-05-01, fact) x"
+        enabled_combined = _build_enabled_ctx(tmp_path) + "\n" + enabled_recall
+        assert not (_MARKER_PERSISTENT_MEMORY in enabled_combined and _MARKER_RELEVANT_MEMORIES in enabled_combined)
+        # Stronger formulation: under enabled mode, persistent block
+        # is ALWAYS absent regardless of whether recall fired.
+        assert _MARKER_PERSISTENT_MEMORY not in enabled_combined
+
+
+# ── TestCheckSubcommand ─────────────────────────────────────────────
+
+
+class TestCheckSubcommand:
+    """check subcommand's tri-state exit code contract: 0 on a clean
+    read, 2 on missing WEBHOOK_SECRET, 1 on health-down or unexpected
+    stats status. Tests monkeypatch the `_http_get` helper to drive
+    each branch without standing up an HTTP server."""
+
+    def test_check_missing_secret_exits_2(self, monkeypatch, capsys) -> None:
+        """No WEBHOOK_SECRET in the environment: print the hint and
+        exit 2 BEFORE making any HTTP call."""
+        monkeypatch.delenv("WEBHOOK_SECRET", raising=False)
+
+        # _http_get must NOT be called on this path. If it is,
+        # the HTTP shim would try to reach localhost:8080, which
+        # might pick up the running production service and skew
+        # the test. Explicit raise on call surfaces the regression.
+        def _no_http(*args, **kwargs):
+            raise AssertionError("_http_get must not be called when secret is missing")
+
+        monkeypatch.setattr(modeswitch, "_http_get", _no_http)
+        rc = modeswitch._run_check()
+        assert rc == 2
+        out = capsys.readouterr().out
+        assert "secret_found: no" in out
+        assert "WEBHOOK_SECRET not set" in out
+
+    def test_check_health_down_exits_1(self, monkeypatch, capsys) -> None:
+        """Health probe returns non-200: report `health: down`, skip
+        the stats probe, and exit 1. Prompt-version probe still runs
+        because operators want the deploy version visible even when
+        the service is down."""
+        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+
+        def _http_health_down(url, secret=None, timeout=5.0):
+            if "/health" in url:
+                return 500, b""
+            raise AssertionError(f"unexpected url: {url}")
+
+        monkeypatch.setattr(modeswitch, "_http_get", _http_health_down)
+        monkeypatch.setattr(modeswitch, "_read_prompt_versions", lambda: ("7", "1"))
+        rc = modeswitch._run_check()
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "secret_found: yes" in out
+        assert "health: down" in out
+        assert "extraction_prompt_version: 7" in out
+
+    def test_check_stats_503_reports_disabled(self, monkeypatch, capsys) -> None:
+        """Stats probe returns 503 (memory disabled): report
+        `mode: disabled` and exit 0. The 503 is the documented
+        memory-disabled response from the @_require_secret-protected
+        endpoint."""
+        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+
+        def _http_disabled(url, secret=None, timeout=5.0):
+            if "/health" in url:
+                return 200, b'{"status": "ok"}'
+            if "/api/memory/stats" in url:
+                # Auth header MUST be present. The test asserts the
+                # secret was threaded through; without this, a
+                # regression that dropped the X-Webhook-Secret header
+                # would let the test pass against a 401 (which the
+                # caller would then mis-classify).
+                assert secret == "test-secret", f"expected secret to be threaded; got {secret!r}"
+                return 503, b'{"error": "memory disabled"}'
+            raise AssertionError(f"unexpected url: {url}")
+
+        monkeypatch.setattr(modeswitch, "_http_get", _http_disabled)
+        monkeypatch.setattr(modeswitch, "_read_prompt_versions", lambda: ("7", "1"))
+        rc = modeswitch._run_check()
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "health: ok" in out
+        assert "mode: disabled" in out
+
+    def test_check_stats_200_reports_enabled(self, monkeypatch, capsys) -> None:
+        """Stats probe returns 200 with a stats payload (memory
+        enabled): report `mode: enabled` and exit 0."""
+        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+
+        def _http_enabled(url, secret=None, timeout=5.0):
+            if "/health" in url:
+                return 200, b'{"status": "ok"}'
+            if "/api/memory/stats" in url:
+                return 200, b'{"total_count": 42}'
+            raise AssertionError(f"unexpected url: {url}")
+
+        monkeypatch.setattr(modeswitch, "_http_get", _http_enabled)
+        monkeypatch.setattr(modeswitch, "_read_prompt_versions", lambda: ("7", "1"))
+        rc = modeswitch._run_check()
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "mode: enabled" in out
+        assert "extraction_prompt_version: 7" in out
+        assert "episode_prompt_version: 1" in out
+
+    def test_check_stats_unexpected_status_exits_1(self, monkeypatch, capsys) -> None:
+        """Stats probe returns a status that's neither 200 nor 503
+        (e.g. 401 from a wrong secret, or a 500 server error): report
+        the status and exit 1. This is the shape that the spec's
+        anti-false-negative argument hinges on; a silent fall-through
+        to 'disabled' here would defeat the entire harness."""
+        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+
+        def _http_unexpected(url, secret=None, timeout=5.0):
+            if "/health" in url:
+                return 200, b'{"status": "ok"}'
+            if "/api/memory/stats" in url:
+                return 401, b'{"error": "unauthorized"}'
+            raise AssertionError(f"unexpected url: {url}")
+
+        monkeypatch.setattr(modeswitch, "_http_get", _http_unexpected)
+        monkeypatch.setattr(modeswitch, "_read_prompt_versions", lambda: ("7", "1"))
+        rc = modeswitch._run_check()
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "mode: unknown(401)" in out
+
+
+# ── TestPromptVersionRead ───────────────────────────────────────────
+
+
+class TestPromptVersionRead:
+    """Prompt-version probe under the two-path lookup contract.
+    Primary path is /opt/kai/src/kai/memory_extraction.py; fallback is
+    the source-tree path relative to the script's location."""
+
+    _SAMPLE_SOURCE = '_EXTRACTION_PROMPT_VERSION: str = "7"\n_EPISODE_PROMPT_VERSION: str = "1"\n'
+
+    def test_prompt_version_read_from_deployed_path_when_present(self, tmp_path: Path, monkeypatch) -> None:
+        """When the primary install-layout path exists, the probe
+        reads it and the fallback is not consulted. Pinned via
+        monkey-patching both paths to point at distinct tmp files
+        with distinct version values; the assertion verifies the
+        primary value won."""
+        primary_file = tmp_path / "primary.py"
+        fallback_file = tmp_path / "fallback.py"
+        primary_file.write_text(
+            '_EXTRACTION_PROMPT_VERSION: str = "primary-7"\n_EPISODE_PROMPT_VERSION: str = "primary-1"\n'
+        )
+        fallback_file.write_text(
+            '_EXTRACTION_PROMPT_VERSION: str = "fallback-x"\n_EPISODE_PROMPT_VERSION: str = "fallback-y"\n'
+        )
+
+        monkeypatch.setattr(modeswitch, "_PROMPT_VERSION_PATH_PRIMARY", primary_file)
+        monkeypatch.setattr(modeswitch, "_PROMPT_VERSION_PATH_FALLBACK", fallback_file)
+
+        ext, ep = modeswitch._read_prompt_versions()
+        assert ext == "primary-7"
+        assert ep == "primary-1"
+
+    def test_prompt_version_falls_back_to_source_tree(self, tmp_path: Path, monkeypatch) -> None:
+        """When the primary path is missing, the probe falls back
+        to the source-tree path and reads the version from there."""
+        primary_missing = tmp_path / "definitely-not-there" / "memory_extraction.py"
+        fallback_file = tmp_path / "fallback.py"
+        fallback_file.write_text(self._SAMPLE_SOURCE)
+
+        monkeypatch.setattr(modeswitch, "_PROMPT_VERSION_PATH_PRIMARY", primary_missing)
+        monkeypatch.setattr(modeswitch, "_PROMPT_VERSION_PATH_FALLBACK", fallback_file)
+
+        ext, ep = modeswitch._read_prompt_versions()
+        assert ext == "7"
+        assert ep == "1"
+
+    def test_prompt_version_missing_reports_unknown(self, tmp_path: Path, monkeypatch) -> None:
+        """When neither path exists, both versions are reported as
+        the literal string `unknown` rather than raising. The check
+        subcommand still proceeds with the rest of the report; an
+        unknown version is information, not an error."""
+        primary_missing = tmp_path / "definitely-not-there-1" / "memory_extraction.py"
+        fallback_missing = tmp_path / "definitely-not-there-2" / "memory_extraction.py"
+
+        monkeypatch.setattr(modeswitch, "_PROMPT_VERSION_PATH_PRIMARY", primary_missing)
+        monkeypatch.setattr(modeswitch, "_PROMPT_VERSION_PATH_FALLBACK", fallback_missing)
+
+        ext, ep = modeswitch._read_prompt_versions()
+        assert ext == "unknown"
+        assert ep == "unknown"
+
+    def test_prompt_version_regex_does_not_match_non_version_lines(self, tmp_path: Path, monkeypatch) -> None:
+        """The regex is anchored on the exact constant-name shape so
+        unrelated code lines that happen to mention the constant
+        (docstrings, comments, test fixtures) do not satisfy the
+        pattern. Defends against a future regression where the regex
+        was accidentally broadened."""
+        decoy_file = tmp_path / "decoy.py"
+        decoy_file.write_text(
+            '# A comment about _EXTRACTION_PROMPT_VERSION = "fake"\n'
+            'x = "_EXTRACTION_PROMPT_VERSION: str = \\"impostor\\""\n'
+        )
+        missing = tmp_path / "missing.py"
+
+        monkeypatch.setattr(modeswitch, "_PROMPT_VERSION_PATH_PRIMARY", decoy_file)
+        monkeypatch.setattr(modeswitch, "_PROMPT_VERSION_PATH_FALLBACK", missing)
+
+        ext, ep = modeswitch._read_prompt_versions()
+        # The decoy comment does not match the regex (no actual
+        # `_EXTRACTION_PROMPT_VERSION: str = "..."` line); the
+        # string-literal line has escaped quotes that break the regex.
+        # Both reads fall through to the unknown sentinel.
+        assert ext == "unknown"
+        assert ep == "unknown"

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -190,8 +190,8 @@ class TestCheckSubcommand:
     each branch without standing up an HTTP server."""
 
     def test_check_missing_secret_exits_2(self, monkeypatch, capsys) -> None:
-        """No WEBHOOK_SECRET in the environment: print the hint and
-        exit 2 BEFORE making any HTTP call."""
+        """WEBHOOK_SECRET not exported at all: print the
+        not-set hint and exit 2 BEFORE making any HTTP call."""
         monkeypatch.delenv("WEBHOOK_SECRET", raising=False)
 
         # _http_get must NOT be called on this path. If it is,
@@ -207,6 +207,29 @@ class TestCheckSubcommand:
         out = capsys.readouterr().out
         assert "secret_found: no" in out
         assert "WEBHOOK_SECRET not set" in out
+
+    def test_check_empty_secret_exits_2_with_distinct_diagnostic(self, monkeypatch, capsys) -> None:
+        """WEBHOOK_SECRET exported but set to the empty string:
+        report `secret_found: empty` (not `no`) and exit 2 with a
+        diagnostic that points the operator at the env-file typo,
+        not at sourcing the env file. The two cases are
+        operationally distinct: one is "you didn't source", the
+        other is "you sourced but the value is wrong"."""
+        monkeypatch.setenv("WEBHOOK_SECRET", "")
+
+        def _no_http(*args, **kwargs):
+            raise AssertionError("_http_get must not be called when secret is empty")
+
+        monkeypatch.setattr(modeswitch, "_http_get", _no_http)
+        rc = modeswitch._run_check()
+        assert rc == 2
+        out = capsys.readouterr().out
+        assert "secret_found: empty" in out
+        assert "exported but empty" in out
+        # The distinct diagnostic must NOT collapse back to the
+        # not-set messaging that the operator already ruled out by
+        # sourcing the env file.
+        assert "WEBHOOK_SECRET not set" not in out
 
     def test_check_health_down_exits_1(self, monkeypatch, capsys) -> None:
         """Health probe returns non-200: report `health: down`, skip

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -225,9 +225,18 @@ class TestCheckSubcommand:
         rc = modeswitch._run_check()
         assert rc == 1
         out = capsys.readouterr().out
+        # Pin every line the production code emits on the health-
+        # down path: secret_found, health, mode, and BOTH prompt
+        # versions. A regression that drops any of these lines
+        # silently (e.g., an early-return that skips the prompt-
+        # version probe) would go undetected without all four
+        # assertions; pinning the full output shape closes that
+        # gap.
         assert "secret_found: yes" in out
         assert "health: down" in out
+        assert "mode: unknown(service-down)" in out
         assert "extraction_prompt_version: 7" in out
+        assert "episode_prompt_version: 1" in out
 
     def test_check_stats_503_reports_disabled(self, monkeypatch, capsys) -> None:
         """Stats probe returns 503 (memory disabled): report
@@ -254,8 +263,13 @@ class TestCheckSubcommand:
         rc = modeswitch._run_check()
         assert rc == 0
         out = capsys.readouterr().out
+        # Pin every line the production code emits on the disabled
+        # mode path. Same shape as test_check_health_down_exits_1.
+        assert "secret_found: yes" in out
         assert "health: ok" in out
         assert "mode: disabled" in out
+        assert "extraction_prompt_version: 7" in out
+        assert "episode_prompt_version: 1" in out
 
     def test_check_stats_200_reports_enabled(self, monkeypatch, capsys) -> None:
         """Stats probe returns 200 with a stats payload (memory
@@ -298,7 +312,14 @@ class TestCheckSubcommand:
         rc = modeswitch._run_check()
         assert rc == 1
         out = capsys.readouterr().out
+        # Pin every line the production code emits on the
+        # unexpected-status path. Same shape as the disabled and
+        # health-down test cases.
+        assert "secret_found: yes" in out
+        assert "health: ok" in out
         assert "mode: unknown(401)" in out
+        assert "extraction_prompt_version: 7" in out
+        assert "episode_prompt_version: 1" in out
 
 
 # ── TestPromptVersionRead ───────────────────────────────────────────

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -311,6 +311,11 @@ class TestCheckSubcommand:
         rc = modeswitch._run_check()
         assert rc == 0
         out = capsys.readouterr().out
+        # Pin every line the production code emits on the enabled
+        # mode path. Same shape as the disabled, health-down, and
+        # unexpected-status test cases.
+        assert "secret_found: yes" in out
+        assert "health: ok" in out
         assert "mode: enabled" in out
         assert "extraction_prompt_version: 7" in out
         assert "episode_prompt_version: 1" in out

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -205,8 +205,13 @@ class TestCheckSubcommand:
         rc = modeswitch._run_check()
         assert rc == 2
         out = capsys.readouterr().out
+        # Pin all three lines the production code emits on the
+        # missing-secret path. The example-command line is part of
+        # the diagnostic shape; dropping it would leave the operator
+        # without the actionable next step.
         assert "secret_found: no" in out
         assert "WEBHOOK_SECRET not set" in out
+        assert "sudo bash -c 'source /etc/kai/env" in out
 
     def test_check_empty_secret_exits_2_with_distinct_diagnostic(self, monkeypatch, capsys) -> None:
         """WEBHOOK_SECRET exported but set to the empty string:
@@ -224,8 +229,13 @@ class TestCheckSubcommand:
         rc = modeswitch._run_check()
         assert rc == 2
         out = capsys.readouterr().out
+        # Pin all three lines the production code emits on the
+        # empty-secret path. The "a line like" parenthetical is the
+        # actionable hint pointing at the env-file typo shape; the
+        # operator needs it to know what to look for.
         assert "secret_found: empty" in out
         assert "exported but empty" in out
+        assert "a line like" in out
         # The distinct diagnostic must NOT collapse back to the
         # not-set messaging that the operator already ruled out by
         # sourcing the env file.

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -121,8 +121,8 @@ class TestVerifyInvariants:
         # format_context returns "" under disabled mode by contract;
         # the recall path's is_enabled() guard short-circuits before
         # the search call. The combined output is just the
-        # build_session_context output.
-        combined = disabled_ctx + "\n" + ""
+        # build_session_context output with a trailing newline.
+        combined = disabled_ctx + "\n"
         assert _MARKER_PERSISTENT_MEMORY in combined
         assert _MARKER_RELEVANT_MEMORIES not in combined
 
@@ -149,7 +149,7 @@ class TestVerifyInvariants:
         valid under enabled mode. The invariant is the absence of
         MEMORY.md, not the presence of recall."""
         enabled_ctx = _build_enabled_ctx(tmp_path)
-        combined = enabled_ctx + "\n" + ""
+        combined = enabled_ctx + "\n"
         assert _MARKER_PERSISTENT_MEMORY not in combined
         # Both shapes valid: relevant-memories may or may not be
         # present. The load-bearing assertion is the absence of
@@ -168,7 +168,7 @@ class TestVerifyInvariants:
         relevant present (the MEMORY.md inject leaked into enabled
         mode). The assertion is the negation of both regressions."""
         # Disabled: persistent present, relevant absent.
-        disabled_combined = _build_disabled_ctx(tmp_path) + "\n" + ""
+        disabled_combined = _build_disabled_ctx(tmp_path) + "\n"
         assert not (_MARKER_PERSISTENT_MEMORY in disabled_combined and _MARKER_RELEVANT_MEMORIES in disabled_combined)
         # Enabled with recall: persistent absent (the regression
         # shape would be both present).

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -288,6 +288,14 @@ class TestCheckSubcommand:
                 # would let the test pass against a 401 (which the
                 # caller would then mis-classify).
                 assert secret == "test-secret", f"expected secret to be threaded; got {secret!r}"
+                # URL must NOT carry an explicit chat_id. The
+                # webhook handler resolves chat_id BEFORE the
+                # is_enabled() branch and rejects any explicit
+                # value not in allowed_user_ids with a 403; an
+                # earlier version of this harness passed chat_id=1
+                # and silently 403'd against production. Pinning
+                # the absence here closes the regression.
+                assert "chat_id" not in url, f"stats URL must not carry a chat_id parameter; got {url!r}"
                 return 503, b'{"error": "memory disabled"}'
             raise AssertionError(f"unexpected url: {url}")
 
@@ -321,6 +329,10 @@ class TestCheckSubcommand:
                 # silently accept), masking the regression. Pinned
                 # symmetrically across all stats-touching mocks.
                 assert secret == "test-secret", f"expected secret to be threaded; got {secret!r}"
+                # URL must NOT carry an explicit chat_id (see the
+                # disabled-test comment for the 403-against-prod
+                # rationale).
+                assert "chat_id" not in url, f"stats URL must not carry a chat_id parameter; got {url!r}"
                 return 200, b'{"total_count": 42}'
             raise AssertionError(f"unexpected url: {url}")
 
@@ -354,6 +366,10 @@ class TestCheckSubcommand:
                 # and enabled tests; pinned symmetrically across
                 # all stats-touching mocks.
                 assert secret == "test-secret", f"expected secret to be threaded; got {secret!r}"
+                # URL must NOT carry an explicit chat_id (see the
+                # disabled-test comment for the 403-against-prod
+                # rationale).
+                assert "chat_id" not in url, f"stats URL must not carry a chat_id parameter; got {url!r}"
                 return 401, b'{"error": "unauthorized"}'
             raise AssertionError(f"unexpected url: {url}")
 

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -391,7 +391,11 @@ class TestCheckSubcommand:
         """WEBHOOK_PORT set to a non-integer string: harness prints a
         warning, falls back to port 8080, and continues. The fallback
         is what unblocks the rest of the report; without it, the
-        harness would crash with ValueError on a config typo."""
+        harness would crash with ValueError on a config typo.
+
+        Mock follows the same auth-secret + chat_id-absence pattern as
+        the three other stats-touching mocks; full output shape pinned
+        per the same pattern as the four mode-reporting tests."""
         monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
         monkeypatch.setenv("WEBHOOK_PORT", "not-an-integer")
 
@@ -402,6 +406,11 @@ class TestCheckSubcommand:
             if "/health" in url:
                 return 200, b'{"status": "ok"}'
             if "/api/memory/stats" in url:
+                # Auth-secret + chat_id-absence guards parallel to
+                # _http_disabled / _http_enabled / _http_unexpected;
+                # see the disabled-test comment for the rationale.
+                assert secret == "test-secret", f"expected secret to be threaded; got {secret!r}"
+                assert "chat_id" not in url, f"stats URL must not carry a chat_id parameter; got {url!r}"
                 return 200, b'{"total_count": 0}'
             raise AssertionError(f"unexpected url: {url}")
 
@@ -415,6 +424,13 @@ class TestCheckSubcommand:
         # Every captured URL must point at port 8080, the documented
         # fallback. Pinning the URL is what proves the fallback ran.
         assert all("localhost:8080" in u for u in captured_urls), captured_urls
+        # Pin the full five-line report shape, parallel to the
+        # other mode-reporting tests in this class.
+        assert "secret_found: yes" in out
+        assert "health: ok" in out
+        assert "mode: enabled" in out
+        assert "extraction_prompt_version: 7" in out
+        assert "episode_prompt_version: 1" in out
 
     def test_check_webhook_port_out_of_range_falls_back_to_8080(self, monkeypatch, capsys) -> None:
         """WEBHOOK_PORT set to an out-of-range integer (>65535):
@@ -422,7 +438,11 @@ class TestCheckSubcommand:
         back to port 8080, and continues. Without the range guard,
         the harness would attempt to bind to a port the OS cannot
         accept and report `health: down (status=0)`, which is the
-        confusing diagnostic the range guard exists to prevent."""
+        confusing diagnostic the range guard exists to prevent.
+
+        Mock follows the same auth-secret + chat_id-absence pattern as
+        the three other stats-touching mocks; full output shape pinned
+        per the same pattern as the four mode-reporting tests."""
         monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
         monkeypatch.setenv("WEBHOOK_PORT", "99999")
 
@@ -433,6 +453,8 @@ class TestCheckSubcommand:
             if "/health" in url:
                 return 200, b'{"status": "ok"}'
             if "/api/memory/stats" in url:
+                assert secret == "test-secret", f"expected secret to be threaded; got {secret!r}"
+                assert "chat_id" not in url, f"stats URL must not carry a chat_id parameter; got {url!r}"
                 return 200, b'{"total_count": 0}'
             raise AssertionError(f"unexpected url: {url}")
 
@@ -447,6 +469,13 @@ class TestCheckSubcommand:
         # reading the source.
         assert "out of range" in out
         assert all("localhost:8080" in u for u in captured_urls), captured_urls
+        # Pin the full five-line report shape, parallel to the
+        # other mode-reporting tests in this class.
+        assert "secret_found: yes" in out
+        assert "health: ok" in out
+        assert "mode: enabled" in out
+        assert "extraction_prompt_version: 7" in out
+        assert "episode_prompt_version: 1" in out
 
 
 # ── TestPromptVersionRead ───────────────────────────────────────────

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -387,6 +387,67 @@ class TestCheckSubcommand:
         assert "extraction_prompt_version: 7" in out
         assert "episode_prompt_version: 1" in out
 
+    def test_check_webhook_port_non_integer_falls_back_to_8080(self, monkeypatch, capsys) -> None:
+        """WEBHOOK_PORT set to a non-integer string: harness prints a
+        warning, falls back to port 8080, and continues. The fallback
+        is what unblocks the rest of the report; without it, the
+        harness would crash with ValueError on a config typo."""
+        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+        monkeypatch.setenv("WEBHOOK_PORT", "not-an-integer")
+
+        captured_urls: list[str] = []
+
+        def _http_with_capture(url, secret=None, timeout=5.0):
+            captured_urls.append(url)
+            if "/health" in url:
+                return 200, b'{"status": "ok"}'
+            if "/api/memory/stats" in url:
+                return 200, b'{"total_count": 0}'
+            raise AssertionError(f"unexpected url: {url}")
+
+        monkeypatch.setattr(modeswitch, "_http_get", _http_with_capture)
+        monkeypatch.setattr(modeswitch, "_read_prompt_versions", lambda: ("7", "1"))
+        rc = modeswitch._run_check()
+        assert rc == 0
+        out = capsys.readouterr().out
+        # The fallback warning is printed before the report shape.
+        assert "WEBHOOK_PORT='not-an-integer' is invalid" in out
+        # Every captured URL must point at port 8080, the documented
+        # fallback. Pinning the URL is what proves the fallback ran.
+        assert all("localhost:8080" in u for u in captured_urls), captured_urls
+
+    def test_check_webhook_port_out_of_range_falls_back_to_8080(self, monkeypatch, capsys) -> None:
+        """WEBHOOK_PORT set to an out-of-range integer (>65535):
+        harness prints a warning naming the range violation, falls
+        back to port 8080, and continues. Without the range guard,
+        the harness would attempt to bind to a port the OS cannot
+        accept and report `health: down (status=0)`, which is the
+        confusing diagnostic the range guard exists to prevent."""
+        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+        monkeypatch.setenv("WEBHOOK_PORT", "99999")
+
+        captured_urls: list[str] = []
+
+        def _http_with_capture(url, secret=None, timeout=5.0):
+            captured_urls.append(url)
+            if "/health" in url:
+                return 200, b'{"status": "ok"}'
+            if "/api/memory/stats" in url:
+                return 200, b'{"total_count": 0}'
+            raise AssertionError(f"unexpected url: {url}")
+
+        monkeypatch.setattr(modeswitch, "_http_get", _http_with_capture)
+        monkeypatch.setattr(modeswitch, "_read_prompt_versions", lambda: ("7", "1"))
+        rc = modeswitch._run_check()
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "WEBHOOK_PORT='99999' is invalid" in out
+        # The range-violation message names the bad port number so
+        # the operator can correct the env-file value without
+        # reading the source.
+        assert "out of range" in out
+        assert all("localhost:8080" in u for u in captured_urls), captured_urls
+
 
 # ── TestPromptVersionRead ───────────────────────────────────────────
 

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -303,6 +303,14 @@ class TestCheckSubcommand:
             if "/health" in url:
                 return 200, b'{"status": "ok"}'
             if "/api/memory/stats" in url:
+                # Same auth-header threading guard as the disabled
+                # test: a regression that drops `secret=secret` at
+                # the stats call site would let the test pass against
+                # an unauthed 200 (which the production code would
+                # never see in real life, but the test should not
+                # silently accept), masking the regression. Pinned
+                # symmetrically across all stats-touching mocks.
+                assert secret == "test-secret", f"expected secret to be threaded; got {secret!r}"
                 return 200, b'{"total_count": 42}'
             raise AssertionError(f"unexpected url: {url}")
 
@@ -332,6 +340,10 @@ class TestCheckSubcommand:
             if "/health" in url:
                 return 200, b'{"status": "ok"}'
             if "/api/memory/stats" in url:
+                # Same auth-header threading guard as the disabled
+                # and enabled tests; pinned symmetrically across
+                # all stats-touching mocks.
+                assert secret == "test-secret", f"expected secret to be threaded; got {secret!r}"
                 return 401, b'{"error": "unauthorized"}'
             raise AssertionError(f"unexpected url: {url}")
 


### PR DESCRIPTION
Closes #432. Parent epic #396 closes when this lands.

## Summary

Phase 5 of the dual-mode migration. Ships a scripted verification harness for the `MEMORY_ENABLED` toggle's parity invariant: disabled mode means MEMORY.md is the only fact surface and Qdrant is unreached; enabled mode is the reverse.

Two subcommands at `python -m kai.eval.modeswitch`:

1. **`verify`**: black-box logic verification. Imports `build_session_context` and `memory.format_context`, calls each under both flag values against an isolated tmp-dir Qdrant store, asserts nine gating invariants. The mutual-exclusivity partition (the persistent-memory and relevant-memories blocks NEVER coexist) is the load-bearing assertion the existing test suite leaves uncovered.
2. **`check`**: runtime sanity against the running service. Tri-state exit (0 clean, 2 missing `WEBHOOK_SECRET`, 1 health-down or unexpected stats status). Prompt-version probe with `/opt/kai/`-primary plus source-tree-fallback lookup.

Module docstring carries the operator-run round-trip procedure with both macOS (`launchctl bootout` / `bootstrap`) and Linux (`systemctl stop` / `start`) command sets. Round-trip is operator-discretion, not a merge gate.

## Isolation

`verify` redirects `MEM0_DIR` to a tmp dir BEFORE the first `kai.memory` import (which transitively imports mem0; mem0 reads `MEM0_DIR` at module-import time and bakes the value into a module-level constant). Plus monkey-patches `kai.memory.DATA_DIR` for the test Qdrant. Without these, the harness deadlocks against the running production service's lock on `~/.mem0/migrations_qdrant`.

## Tests

20 new tests in `tests/test_eval_modeswitch.py`:

- `TestVerifyInvariants` (8): the nine invariants exercised against `build_session_context` directly plus mocked-recall partition cases.
- `TestCheckSubcommand` (8): each branch of the tri-state exit-code contract via mocked HTTP, including the empty-`WEBHOOK_SECRET` case and both `WEBHOOK_PORT` validation paths (non-integer and out-of-range). Includes an explicit assertion that the auth secret is threaded through to `/api/memory/stats` (defends against a regression that drops the header and silently mis-classifies the resulting 401 as `disabled`), plus a parallel `assert "chat_id" not in url` guard pinning the no-explicit-chat_id contract.
- `TestPromptVersionRead` (4): two-path fallback under tmp_path; decoy-line negative case.

Full suite: **2785 passed, 1 skipped**.

## verify output (merge gate)

```
  PASS  disabled: subsystem marker present
  PASS  disabled: persistent-memory block injected
  PASS  disabled: relevant-memories block omitted
  PASS  enabled: subsystem marker present
  PASS  enabled: persistent-memory block omitted
  PASS  enabled: format_context returns empty or recall-prefixed
  PASS  partition disabled: persistent present, relevant absent
  PASS  partition enabled: persistent absent
  PASS  partition: mutual exclusion across both modes

PASS: all 9 invariants hold.
```

## check output (live production, MEMORY_ENABLED=true)

The `check` subcommand requires `WEBHOOK_SECRET` in the environment, which lives in `/etc/kai/env` (root-owned). Operator-run during merge:

```
$ sudo bash -c 'source /etc/kai/env && python -m kai.eval.modeswitch check'
secret_found: yes
health: ok
mode: enabled
extraction_prompt_version: 7
episode_prompt_version: 1
```

This output will be appended once captured during the merge sequence; the harness itself is what's under review.

## Risks

- **Production Qdrant lock contention.** Verified isolation works locally with the production service running; `verify` does NOT touch `/var/lib/kai/memory/qdrant`.
- **`MEM0_DIR` import-time capture.** Documented at the env-set site; backend.py and config.py do not transitively import mem0, so setting `MEM0_DIR` inside `_run_verify` before the lazy import is correct. A future refactor that imports kai.memory at top-of-file would silently break the redirect; the test suite catches it (the integration probe would deadlock).

## Out of scope

- CI integration (this is operator-run tooling).
- Performance / load testing under either mode.
- Extracted-fact retrieval ranking changes (separate work tracked at #431).

