### PR TITLE
feat(memory): write-side mode-switch verification (#434)

### DIFF
--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -271,7 +271,17 @@ def _parse_recall_reason(records: list[logging.LogRecord]) -> str | None:
             # since Python 3.5, so the bare `ValueError` covers
             # both the well-formed-but-invalid-JSON case and the
             # malformed-input case that JSONDecodeError raises.
-            return None
+            #
+            # `continue` rather than `return None` so a single
+            # malformed trailing record does not shadow earlier
+            # well-formed records. Today's callers pass a list with
+            # exactly one `memory.recall` record per capture block,
+            # but a future multi-record caller would silently
+            # observe `None` for "valid records exist but the most
+            # recent is bad," which is the wrong shape. The final
+            # `return None` outside the loop still handles the
+            # no-records case.
+            continue
         reason = payload.get("reason") if isinstance(payload, dict) else None
         return reason if isinstance(reason, str) else None
     return None

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -255,7 +255,11 @@ def _parse_recall_reason(records: list[logging.LogRecord]) -> str | None:
             continue
         try:
             payload = json.loads(msg[len(prefix) :])
-        except (json.JSONDecodeError, ValueError):
+        except ValueError:
+            # `json.JSONDecodeError` is a subclass of `ValueError`
+            # since Python 3.5, so the bare `ValueError` covers
+            # both the well-formed-but-invalid-JSON case and the
+            # malformed-input case that JSONDecodeError raises.
             return None
         reason = payload.get("reason") if isinstance(payload, dict) else None
         return reason if isinstance(reason, str) else None
@@ -470,6 +474,16 @@ async def _run_verify() -> int:
             # log-line contract that downstream eval harnesses depend
             # on (a missing or wrongly-tagged record under disabled
             # mode would silently break those harnesses).
+            #
+            # Deferred import for the same reason `_isolated_data_dir`
+            # imports `kai.memory` lazily: a top-level import would
+            # capture `kai.memory` in `sys.modules` BEFORE the
+            # MEM0_DIR redirect at the start of `_run_verify` could
+            # take effect, deadlocking the harness against the live
+            # `~/.mem0/migrations_qdrant` lock the running service
+            # holds. The `if "kai.memory" in sys.modules:` guard at
+            # the top of `_run_verify` enforces the invariant; this
+            # deferred form preserves it.
             from kai.memory import _RECALL_REASON_DISABLED
 
             with _isolated_data_dir(tmp_root):

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -222,14 +222,25 @@ def _capture_recall_logs() -> Iterator[list[logging.LogRecord]]:
     # CLI's `logging.basicConfig(level=logging.WARNING, ...)` would
     # otherwise filter INFO-level records out before they reach the
     # handler.
+    #
+    # Disable propagation while the handler is attached so the
+    # captured records do not also fan out to the root logger. The
+    # CLI entry point's `basicConfig(level=WARNING)` already filters
+    # them, but during pytest runs the root logger may be configured
+    # at INFO and the records would appear duplicated in console
+    # output. Restored in `finally` so other code paths that rely on
+    # propagation are not affected after the with-block.
     prior_level = logger.level
+    prior_propagate = logger.propagate
     logger.setLevel(logging.INFO)
+    logger.propagate = False
     logger.addHandler(handler)
     try:
         yield records
     finally:
         logger.removeHandler(handler)
         logger.setLevel(prior_level)
+        logger.propagate = prior_propagate
 
 
 def _parse_recall_reason(records: list[logging.LogRecord]) -> str | None:

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -505,15 +505,17 @@ async def _run_verify() -> int:
             # on (a missing or wrongly-tagged record under disabled
             # mode would silently break those harnesses).
             #
-            # Deferred import for the same reason `_isolated_data_dir`
-            # imports `kai.memory` lazily: a top-level import would
-            # capture `kai.memory` in `sys.modules` BEFORE the
-            # MEM0_DIR redirect at the start of `_run_verify` could
-            # take effect, deadlocking the harness against the live
-            # `~/.mem0/migrations_qdrant` lock the running service
-            # holds. The `if "kai.memory" in sys.modules:` guard at
-            # the top of `_run_verify` enforces the invariant; this
-            # deferred form preserves it.
+            # Deferred to preserve the `if "kai.memory" in sys.modules:`
+            # invariant guarded at the top of `_run_verify`. A
+            # top-level `from kai.memory import _RECALL_REASON_DISABLED`
+            # in this module would put `kai.memory` into `sys.modules`
+            # before `_run_verify` runs, tripping the assertion. The
+            # constant itself is a string literal and does not boot
+            # Mem0 or touch the migrations_qdrant lock; the deadlock
+            # concern that motivates `_isolated_data_dir`'s lazy
+            # import does not apply directly to this constant. The
+            # consistency-with-the-guard rationale is what carries
+            # the deferral.
             from kai.memory import _RECALL_REASON_DISABLED
 
             with _isolated_data_dir(tmp_root):

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -245,8 +245,9 @@ def _capture_recall_logs() -> Iterator[list[logging.LogRecord]]:
 
 def _parse_recall_reason(records: list[logging.LogRecord]) -> str | None:
     """Pull the `reason` field from the most-recent `memory.recall`
-    log record in `records`. Returns None if no such record exists
-    or if the record's payload is malformed.
+    log record in `records`. Returns None if no such record exists,
+    if the record's payload is malformed, or if the payload's
+    `reason` field is absent.
 
     The payload format is fixed at the producer
     (`memory._emit_recall_log`): a compact JSON object preceded by
@@ -255,9 +256,17 @@ def _parse_recall_reason(records: list[logging.LogRecord]) -> str | None:
     producer's `log.info("memory.recall %s", json.dumps(payload, ...))`.
 
     Returns the value of the `reason` field cast to `str`, or None
-    on any decode failure or shape mismatch. The harness callers
-    compare against `_RECALL_REASON_DISABLED` (or its absence) and
-    treat None as a separate-and-failing outcome.
+    on any decode failure, shape mismatch, or success-path payload
+    where `reason` is omitted entirely (per `_base_recall_payload`'s
+    docstring: `reason` is set only on short-circuit lines).
+
+    Caller-side interpretation differs by mode. The disabled-mode
+    caller compares `parsed == _RECALL_REASON_DISABLED` and treats
+    None as a failing outcome (it neither equals nor implies the
+    expected reason string). The enabled-mode caller compares
+    `parsed != _RECALL_REASON_DISABLED` and treats None as a
+    PASSING outcome, since the success-path payload omits `reason`
+    entirely and that absence is part of the documented contract.
     """
     prefix = "memory.recall "
     for record in reversed(records):

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
 import os
 import re
@@ -178,6 +179,87 @@ def _isolated_data_dir(tmp_root: Path) -> Iterator[Path]:
             # constructs a fresh client against its own DATA_DIR.
             memory_module._memory = None
             memory_module._config = None
+
+
+@contextmanager
+def _capture_recall_logs() -> Iterator[list[logging.LogRecord]]:
+    """Capture every LogRecord emitted to the `kai.memory` logger
+    during the with-block and yield the (initially empty) list to
+    the caller. The list is populated as records arrive and is
+    safe to inspect after the with-block exits.
+
+    Why a manual `logging.Handler` rather than pytest's `caplog`
+    fixture: the harness runs from a CLI entry point, NOT under
+    pytest, so the fixture is unavailable. The pytest test pair at
+    `tests/test_eval_modeswitch.py::TestRecallReasonField` uses
+    `caplog` (the idiomatic pytest tool); the two surfaces capture
+    the same records via different mechanisms, both correct for
+    their context.
+
+    Records are appended in the order they arrive. The harness's
+    callers only inspect the most-recent record (a single
+    `format_context` call is made per use of this contextmanager),
+    but the list keeps prior records too in case future callers
+    want to assert on multi-call sequences.
+
+    Each fresh use creates a new `_ListHandler` instance and a new
+    list, so a residual handler from a prior run cannot pollute
+    THIS run's records. Removal in the `finally` block guards
+    against handler leaks across calls.
+    """
+    records: list[logging.LogRecord] = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _ListHandler()
+    handler.setLevel(logging.INFO)
+    logger = logging.getLogger("kai.memory")
+    # Save and lower the logger level so the `memory.recall` line
+    # (emitted via `log.info(...)`) is forwarded to our handler
+    # regardless of the harness's outer logging configuration. The
+    # CLI's `logging.basicConfig(level=logging.WARNING, ...)` would
+    # otherwise filter INFO-level records out before they reach the
+    # handler.
+    prior_level = logger.level
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prior_level)
+
+
+def _parse_recall_reason(records: list[logging.LogRecord]) -> str | None:
+    """Pull the `reason` field from the most-recent `memory.recall`
+    log record in `records`. Returns None if no such record exists
+    or if the record's payload is malformed.
+
+    The payload format is fixed at the producer
+    (`memory._emit_recall_log`): a compact JSON object preceded by
+    the literal prefix `"memory.recall "`. Splitting on the first
+    space and `json.loads`-decoding the tail is the inverse of the
+    producer's `log.info("memory.recall %s", json.dumps(payload, ...))`.
+
+    Returns the value of the `reason` field cast to `str`, or None
+    on any decode failure or shape mismatch. The harness callers
+    compare against `_RECALL_REASON_DISABLED` (or its absence) and
+    treat None as a separate-and-failing outcome.
+    """
+    prefix = "memory.recall "
+    for record in reversed(records):
+        msg = record.getMessage()
+        if not msg.startswith(prefix):
+            continue
+        try:
+            payload = json.loads(msg[len(prefix) :])
+        except (json.JSONDecodeError, ValueError):
+            return None
+        reason = payload.get("reason") if isinstance(payload, dict) else None
+        return reason if isinstance(reason, str) else None
+    return None
 
 
 def _build_test_configs(memory_enabled_value: bool) -> Config:
@@ -377,6 +459,40 @@ async def _run_verify() -> int:
                 )
             )
 
+            # Disabled-mode recall-log reason invariant. Drives
+            # `format_context` under a config with memory_enabled=False
+            # so init_memory short-circuits at its
+            # `if not config.memory_enabled: return` guard, leaving
+            # `_memory` and `_config` as None. format_context then
+            # short-circuits via its `if not is_enabled() or _config
+            # is None:` branch and emits a `memory.recall` log line
+            # with `reason: "disabled"`. The invariant verifies the
+            # log-line contract that downstream eval harnesses depend
+            # on (a missing or wrongly-tagged record under disabled
+            # mode would silently break those harnesses).
+            from kai.memory import _RECALL_REASON_DISABLED
+
+            with _isolated_data_dir(tmp_root):
+                from kai import memory as memory_module
+
+                memory_module.init_memory(_build_test_configs(memory_enabled_value=False))
+                with _capture_recall_logs() as disabled_recall_records:
+                    await memory_module.format_context(_FIXTURE_QUERY, user_id=str(_FIXTURE_CHAT_ID))
+
+            disabled_reason = _parse_recall_reason(disabled_recall_records)
+            disabled_reason_ok = disabled_reason == _RECALL_REASON_DISABLED
+            results.append(
+                _InvariantResult(
+                    name="disabled: recall log reason is 'disabled'",
+                    passed=disabled_reason_ok,
+                    detail=(
+                        ""
+                        if disabled_reason_ok
+                        else f"got reason={disabled_reason!r}, expected {_RECALL_REASON_DISABLED!r}"
+                    ),
+                )
+            )
+
             # ── Enabled-mode invariants ───────────────────────────
             enabled_ctx = build_session_context(
                 workspace=ws,
@@ -410,13 +526,22 @@ async def _run_verify() -> int:
             # and assert the recall block either is empty or starts
             # with the expected header. Both shapes are valid; the
             # invariant is the prefix check, not a presence claim.
+            #
+            # The same invocation is wrapped in `_capture_recall_logs`
+            # so we can additionally assert the `memory.recall` log
+            # line carries a non-disabled `reason`. format_context
+            # emits exactly one log line per call (multiple internal
+            # short-circuit branches all funnel through
+            # `_emit_recall_log` once), so the most-recent record
+            # under capture is the one we want.
             recall_text = ""
             with _isolated_data_dir(tmp_root):
                 from kai import memory as memory_module
 
                 memory_module.init_memory(_build_test_configs(memory_enabled_value=True))
                 await _seed_fixture_fact(user_id=str(_FIXTURE_CHAT_ID))
-                recall_text = await memory_module.format_context(_FIXTURE_QUERY, user_id=str(_FIXTURE_CHAT_ID))
+                with _capture_recall_logs() as enabled_recall_records:
+                    recall_text = await memory_module.format_context(_FIXTURE_QUERY, user_id=str(_FIXTURE_CHAT_ID))
 
             recall_ok = recall_text == "" or recall_text.startswith(_MARKER_RELEVANT_MEMORIES)
             results.append(
@@ -424,6 +549,38 @@ async def _run_verify() -> int:
                     name="enabled: format_context returns empty or recall-prefixed",
                     passed=recall_ok,
                     detail=(f"got {recall_text[:80]!r}" if not recall_ok else ""),
+                )
+            )
+
+            # Enabled-mode recall-log reason invariant. Asserts the
+            # negative (reason != "disabled") rather than enumerating
+            # specific allowed values so a future new reason added in
+            # `memory.py`'s `_RECALL_REASON_*` enum does not break
+            # this test. The match-positively-on-disabled / match-
+            # negatively-on-enabled split mirrors the spec contract:
+            # disabled mode MUST emit reason="disabled"; enabled mode
+            # MAY emit any of the non-disabled reasons depending on
+            # whether the seeded fact lands above the relevance floor,
+            # whether the query is empty, etc.
+            #
+            # `_parse_recall_reason` returns None when the payload's
+            # `reason` field is missing, which is the documented
+            # success-path shape (per `_base_recall_payload`'s
+            # docstring: `reason` is omitted on success, present only
+            # on short-circuit lines). Both None and any non-disabled
+            # string satisfy the invariant; only the literal string
+            # equal to `_RECALL_REASON_DISABLED` fails it.
+            enabled_reason = _parse_recall_reason(enabled_recall_records)
+            enabled_reason_ok = enabled_reason != _RECALL_REASON_DISABLED
+            results.append(
+                _InvariantResult(
+                    name="enabled: recall log reason is not 'disabled'",
+                    passed=enabled_reason_ok,
+                    detail=(
+                        ""
+                        if enabled_reason_ok
+                        else f"got reason={enabled_reason!r}, expected anything OTHER than {_RECALL_REASON_DISABLED!r}"
+                    ),
                 )
             )
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2919,6 +2919,13 @@ class TestHandleResponse:
         config = _make_config(memory_extraction_enabled=True)
         ctx = _make_context(config=config, pool=pool)
 
+        # Snapshot the task set BEFORE the call so we can compute the
+        # delta after. A bare `asyncio.all_tasks()` post-call would
+        # also pick up unrelated tasks (pytest-asyncio fixtures,
+        # leftover work from a prior test) and gather them too,
+        # which is fragile even when it does not currently break.
+        tasks_before = asyncio.all_tasks()
+
         with patch.multiple("kai.bot", **self._base_patches()):
             await _handle_response(update, ctx, 12345, "test prompt", pool, "claude-opus")
 
@@ -2927,7 +2934,7 @@ class TestHandleResponse:
         # be a no-op; if a regression spawned a task anyway, the
         # gather lets it run before the assertion, surfacing the bug
         # as a failed call_count check rather than a timing-flake.
-        new_tasks = asyncio.all_tasks() - {asyncio.current_task()}
+        new_tasks = asyncio.all_tasks() - tasks_before - {asyncio.current_task()}
         if new_tasks:
             await asyncio.gather(*new_tasks, return_exceptions=True)
 
@@ -2972,6 +2979,11 @@ class TestHandleResponse:
         )
         ctx = _make_context(config=config, pool=pool)
 
+        # Snapshot pre-call so the post-call delta reflects only the
+        # tasks _handle_response spawned. See the disabled counterpart
+        # for the full rationale.
+        tasks_before = asyncio.all_tasks()
+
         with patch.multiple("kai.bot", **self._base_patches()):
             await _handle_response(update, ctx, 12345, "test prompt", pool, "claude-opus")
 
@@ -2980,7 +2992,7 @@ class TestHandleResponse:
         # the coroutine onto the event loop; the test's coroutine
         # cannot assert until the scheduled task has had a chance to
         # progress past its `await extract_and_store(...)` line.
-        new_tasks = asyncio.all_tasks() - {asyncio.current_task()}
+        new_tasks = asyncio.all_tasks() - tasks_before - {asyncio.current_task()}
         if new_tasks:
             await asyncio.gather(*new_tasks, return_exceptions=True)
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2916,7 +2916,19 @@ class TestHandleResponse:
         # extract_and_store call. The OUTER is_enabled() guard is the
         # contract under test; the inner check would mask its failure
         # if both were False.
-        config = _make_config(memory_extraction_enabled=True)
+        #
+        # episode_classifier_context_turns=0 mirrors the enabled-mode
+        # counterpart's setup so the two tests are structurally
+        # symmetric. Under current behavior the disabled test never
+        # reaches the inner block, so the value is unread; the
+        # symmetry is defense-in-depth: if the monkeypatch ever stops
+        # taking effect or the guard moves, the inner block would
+        # otherwise execute with the default value of 3 and trigger
+        # an unstated `get_recent_pairs(12345, 4)` disk read.
+        config = _make_config(
+            memory_extraction_enabled=True,
+            episode_classifier_context_turns=0,
+        )
         ctx = _make_context(config=config, pool=pool)
 
         # Snapshot the task set BEFORE the call so we can compute the

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2992,9 +2992,18 @@ class TestHandleResponse:
         # the coroutine onto the event loop; the test's coroutine
         # cannot assert until the scheduled task has had a chance to
         # progress past its `await extract_and_store(...)` line.
+        #
+        # NOT `return_exceptions=True`: in the positive test, a task
+        # that crashed BEFORE reaching extract_and_store (e.g., a
+        # config-guard mismatch, a missing attribute) would be
+        # silently swallowed and surface only as "expected called
+        # once, called zero times" - hiding the real cause. The
+        # disabled-mode counterpart uses return_exceptions=True
+        # because there a task appearing at all is the regression
+        # signal; here we want crashes to propagate.
         new_tasks = asyncio.all_tasks() - tasks_before - {asyncio.current_task()}
         if new_tasks:
-            await asyncio.gather(*new_tasks, return_exceptions=True)
+            await asyncio.gather(*new_tasks)
 
         extract_mock.assert_called_once()
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2889,6 +2889,103 @@ class TestHandleResponse:
 
         # If we got here without hanging, the typing task was properly cancelled
 
+    @pytest.mark.asyncio
+    async def test_extraction_skipped_when_memory_disabled(self, monkeypatch):
+        """Switch point 5 (#434): under memory.is_enabled() == False,
+        the post-response ingestion guard short-circuits and
+        extract_and_store is never invoked. The fire-and-forget task
+        is gated, so no _ingest_memory task is even created.
+
+        Pinned regression: a refactor that flips the
+        `if memory_is_enabled() and chat_id is not None:` guard to
+        `if True:` (or removes it entirely) fails this test because
+        extract_and_store would then run under disabled mode and write
+        to Qdrant from a mode that promises never to write.
+        """
+        from kai.bot import _handle_response
+
+        monkeypatch.setattr("kai.memory.is_enabled", lambda: False)
+        extract_mock = AsyncMock()
+        monkeypatch.setattr("kai.memory_extraction.extract_and_store", extract_mock)
+
+        update = _make_update()
+        pool = _make_mock_claude()
+        pool.send = MagicMock(return_value=_fake_stream(_done_event("Hello world")))
+        # memory_extraction_enabled=True ensures the inner config check
+        # in _ingest_memory does NOT short-circuit before reaching the
+        # extract_and_store call. The OUTER is_enabled() guard is the
+        # contract under test; the inner check would mask its failure
+        # if both were False.
+        config = _make_config(memory_extraction_enabled=True)
+        ctx = _make_context(config=config, pool=pool)
+
+        with patch.multiple("kai.bot", **self._base_patches()):
+            await _handle_response(update, ctx, 12345, "test prompt", pool, "claude-opus")
+
+        # Drain any tasks the call may have spawned. The disabled-path
+        # contract is that NO ingest task is created, so this should
+        # be a no-op; if a regression spawned a task anyway, the
+        # gather lets it run before the assertion, surfacing the bug
+        # as a failed call_count check rather than a timing-flake.
+        new_tasks = asyncio.all_tasks() - {asyncio.current_task()}
+        if new_tasks:
+            await asyncio.gather(*new_tasks, return_exceptions=True)
+
+        extract_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_extraction_invoked_when_memory_enabled(self, monkeypatch):
+        """Switch point 5 (#434): under memory.is_enabled() == True
+        plus a successful response, the post-response ingestion path
+        spawns a background _ingest_memory task that calls
+        extract_and_store exactly once.
+
+        Pinned regression: a refactor that flips the guard to
+        `if False:` (or removes the call site from the closure) fails
+        this test because extract_and_store would not run under
+        enabled mode and the Qdrant fact surface would never receive
+        new extractions.
+
+        The fire-and-forget task is awaited explicitly via
+        `asyncio.gather` over the post-call task set so the assertion
+        does not race the create_task'd coroutine.
+        """
+        from kai.bot import _handle_response
+
+        monkeypatch.setattr("kai.memory.is_enabled", lambda: True)
+        extract_mock = AsyncMock()
+        monkeypatch.setattr("kai.memory_extraction.extract_and_store", extract_mock)
+
+        update = _make_update()
+        pool = _make_mock_claude()
+        pool.send = MagicMock(return_value=_fake_stream(_done_event("Hello world", session_id="sess-1")))
+        # episode_classifier_context_turns=0 skips the history fetch
+        # inside _ingest_memory (no get_recent_pairs call needed); the
+        # contract under test is the outer gate plus the inner config
+        # branch, neither of which depends on prior_pairs being
+        # non-empty. memory_extraction_enabled=True so the inner gate
+        # passes; agent_backend defaults to "claude" so the backend
+        # check passes too.
+        config = _make_config(
+            memory_extraction_enabled=True,
+            episode_classifier_context_turns=0,
+        )
+        ctx = _make_context(config=config, pool=pool)
+
+        with patch.multiple("kai.bot", **self._base_patches()):
+            await _handle_response(update, ctx, 12345, "test prompt", pool, "claude-opus")
+
+        # Wait for the fire-and-forget _ingest_memory task to run to
+        # completion. asyncio.create_task at the call site schedules
+        # the coroutine onto the event loop; the test's coroutine
+        # cannot assert until the scheduled task has had a chance to
+        # progress past its `await extract_and_store(...)` line.
+        new_tasks = asyncio.all_tasks() - {asyncio.current_task()}
+        if new_tasks:
+            await asyncio.gather(*new_tasks, return_exceptions=True)
+
+        extract_mock.assert_called_once()
+
 
 # ── _notify_if_queued ────────────────────────────────────────────────
 

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -1,11 +1,15 @@
 """Tests for the mode-switch verification harness.
 
-Three test classes:
+Test classes:
 
 - TestVerifyInvariants: exercises `build_session_context` directly under
   both flag values; the format_context-dependent invariants are covered
   with a mocked format_context to keep unit tests fast and to avoid Mem0
   Qdrant lock contention with a running production service.
+- TestRecallReasonField: switch-point-6 contract; asserts format_context
+  emits a memory.recall log line with reason='disabled' under disabled
+  mode and any non-'disabled' reason (or no reason field at all on the
+  success path) under enabled mode.
 - TestCheckSubcommand: monkeypatches the `urlopen` shim and the
   `_read_prompt_versions` helper to drive each branch of the tri-state
   exit-code contract.
@@ -15,7 +19,11 @@ Three test classes:
 
 from __future__ import annotations
 
+import ast
+import logging
 from pathlib import Path
+
+import pytest
 
 from kai.eval import modeswitch
 
@@ -178,6 +186,291 @@ class TestVerifyInvariants:
         # Stronger formulation: under enabled mode, persistent block
         # is ALWAYS absent regardless of whether recall fired.
         assert _MARKER_PERSISTENT_MEMORY not in enabled_combined
+
+
+# ── TestRecallReasonField ───────────────────────────────────────────
+
+
+class TestRecallReasonField:
+    """Switch-point-6 contract: format_context emits exactly one
+    `memory.recall` log line per call, and the line's `reason` field
+    distinguishes disabled-mode short-circuits ("disabled") from every
+    other outcome. Eval harnesses parse the `reason` field to bucket
+    log lines by short-circuit category; a regression that emitted
+    "disabled" under enabled mode (or omitted the marker under
+    disabled mode) would silently break those harnesses.
+
+    Mirrors the new `_run_verify` invariants the harness runs at the
+    operator-CLI level. The harness drives format_context against a
+    real tmp-dir Mem0 instance; the tests here use mocking to stay
+    fast and to avoid Mem0 lock contention with a running production
+    service. Both surfaces assert the same contract.
+    """
+
+    @pytest.fixture
+    def reset_memory_module(self):
+        """Save and restore `kai.memory`'s module-level singletons
+        (`_memory`, `_config`) around each test. format_context reads
+        these directly; leaving a prior test's setup live would let
+        configuration leak across tests. The teardown is unconditional
+        so a test that mutates state and then fails does not strand
+        junk for the next test.
+        """
+        from kai import memory as memory_module
+
+        prior_memory = memory_module._memory
+        prior_config = memory_module._config
+        memory_module._memory = None
+        memory_module._config = None
+        try:
+            yield
+        finally:
+            memory_module._memory = prior_memory
+            memory_module._config = prior_config
+
+    @pytest.mark.asyncio
+    async def test_recall_reason_is_disabled_under_disabled_mode(self, reset_memory_module, caplog):
+        """memory_enabled=False: init_memory short-circuits and leaves
+        the singletons unset, so format_context's first guard fires
+        (`if not is_enabled() or _config is None`) and emits a
+        memory.recall line with reason='disabled'. The harness's
+        `_parse_recall_reason` is reused so both surfaces interpret
+        the captured payload via the same code.
+        """
+        from kai import memory as memory_module
+
+        # init_memory's "if not config.memory_enabled: return" guard
+        # is the production entry into the disabled state. The fixture
+        # already cleared the singletons, but invoking init_memory
+        # explicitly mirrors the production-path entry the harness
+        # uses, so a regression that moved the guard inside init_memory
+        # would surface here as a state-mutation bug rather than a
+        # silently passing test.
+        memory_module.init_memory(modeswitch._build_test_configs(memory_enabled_value=False))
+
+        with caplog.at_level(logging.INFO, logger="kai.memory"):
+            result = await memory_module.format_context(
+                "test query",
+                user_id=str(_FIXTURE_CHAT_ID),
+            )
+
+        # format_context returns "" on the disabled short-circuit;
+        # paired with the reason assertion below, this pins both
+        # halves of the contract (return shape + log-line shape).
+        assert result == ""
+        # Assert at least one memory.recall record exists. Without
+        # this, a regression that silenced the disabled-mode log line
+        # entirely would let `_parse_recall_reason` return None,
+        # which the reason equality check below would NOT distinguish
+        # from a simple field-rename regression. The two assertions
+        # together pin presence AND correct content.
+        recall_records = [r for r in caplog.records if r.getMessage().startswith("memory.recall ")]
+        assert recall_records, "expected at least one memory.recall log line"
+        reason = modeswitch._parse_recall_reason(caplog.records)
+        assert reason == memory_module._RECALL_REASON_DISABLED, (
+            f"expected reason={memory_module._RECALL_REASON_DISABLED!r}; got {reason!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_recall_reason_is_not_disabled_under_enabled_mode(self, reset_memory_module, monkeypatch, caplog):
+        """memory_enabled=True with a search hit: format_context goes
+        through the recall path and emits a memory.recall line whose
+        `reason` field is anything OTHER than 'disabled'. On the
+        success path the field is omitted entirely (per
+        `_base_recall_payload`'s docstring: `reason` is only set on
+        short-circuit lines), so `_parse_recall_reason` returns None;
+        on the various non-disabled short-circuits (empty_query,
+        no_results, all_below_floor, budget_exhausted) it returns the
+        corresponding string. Both shapes satisfy the contract.
+
+        The test mocks `kai.memory.search` to return one canned
+        MemoryResult above the relevance floor so the recall path
+        completes without spinning up Mem0. The harness's `verify`
+        subcommand exercises the same contract against a real
+        tmp-dir Mem0 instance; the two surfaces are intentionally
+        complementary (this test is the CI gate; the harness is the
+        operator gate).
+        """
+        from kai import memory as memory_module
+
+        # Stand the singletons up by hand. Setting `_memory` to a
+        # truthy sentinel makes is_enabled() return True; `_config`
+        # supplies the budget and floor that the recall path reads.
+        # Bypassing init_memory avoids the Mem0/sentence-transformers
+        # boot cost (~80MB embedding model on first run); the
+        # production path under verification is format_context, not
+        # init_memory.
+        memory_module._memory = object()
+        memory_module._config = modeswitch._build_test_configs(memory_enabled_value=True)
+
+        canned_result = memory_module.MemoryResult(
+            id="test-fact-1",
+            text="Mode-switch test fixture marker phrase.",
+            score=0.95,
+            memory_type="fact",
+            metadata={"source": "extracted"},
+            created_at="2026-05-01T00:00:00Z",
+        )
+        # Mock the synchronous search() helper. format_context dispatches
+        # search() through `loop.run_in_executor`, so a sync mock is the
+        # correct shape; an async mock would break that wrapping.
+        monkeypatch.setattr(memory_module, "search", lambda query, *, user_id, limit=None: [canned_result])
+
+        with caplog.at_level(logging.INFO, logger="kai.memory"):
+            result = await memory_module.format_context(
+                "test fixture query",
+                user_id=str(_FIXTURE_CHAT_ID),
+            )
+
+        # The recall path should have produced a string starting with
+        # the relevant-memories header (the canned result is above the
+        # floor and within budget). This pins the success-path output
+        # shape; the reason assertion below pins the log-line shape.
+        assert result.startswith(_MARKER_RELEVANT_MEMORIES), f"expected recall-prefixed output; got {result[:80]!r}"
+        recall_records = [r for r in caplog.records if r.getMessage().startswith("memory.recall ")]
+        assert recall_records, "expected at least one memory.recall log line"
+        reason = modeswitch._parse_recall_reason(caplog.records)
+        # Negative assertion: anything OTHER than the disabled marker
+        # is acceptable. Includes None (success-path payload omits
+        # `reason`) and any of the other `_RECALL_REASON_*` constants.
+        assert reason != memory_module._RECALL_REASON_DISABLED, (
+            f"expected reason != {memory_module._RECALL_REASON_DISABLED!r}; got {reason!r}"
+        )
+
+
+# ── TestExtractionCallSiteGating ────────────────────────────────────
+
+
+class TestExtractionCallSiteGating:
+    """Switch-point-5 structural backstop (#434): every call site of
+    `memory_extraction.extract_and_store` in `src/kai/bot.py` must
+    sit inside an enclosing `if memory_is_enabled() ...:` guard.
+
+    The behavioral pair in `test_bot.py::TestHandleResponse`
+    exercises the gate with mocks; this test enforces it at the
+    AST level so a refactor that adds a SECOND call site OUTSIDE
+    the guard fails at CI rather than at runtime under disabled
+    mode. Today there is exactly one call site at
+    `bot.py`'s `_handle_response` post-response path; the test
+    asserts the gating property over every Call node, not just
+    "the one Call we know about."
+
+    Predicate shape note: the production guard is
+    `if memory_is_enabled() and chat_id is not None:`, whose
+    `If.test` is a `BoolOp(op=And(), values=[Call, Compare])`.
+    The Call to memory_is_enabled lives nested inside the
+    BoolOp's values, NOT as the direct `If.test`. The predicate
+    therefore walks `if_node.test` recursively via `ast.walk`
+    rather than comparing `if_node.test` to a Call directly.
+    """
+
+    @staticmethod
+    def _attach_parents(tree: ast.AST) -> None:
+        """Attach a `parent` attribute to every node so ancestor
+        traversal works after `ast.walk`. ast.AST does not declare
+        a `parent` field, so the assignment is silently typed as
+        `Any`; pyright tolerates it under the strict-but-permissive
+        attribute model. This is the standard pattern; the
+        alternative (a side-table dict keyed by id(node)) is more
+        verbose with no semantic gain.
+        """
+        for parent in ast.walk(tree):
+            for child in ast.iter_child_nodes(parent):
+                child.parent = parent  # type: ignore[attr-defined]
+
+    @staticmethod
+    def _guard_contains_memory_is_enabled(if_node: ast.If) -> bool:
+        """True iff `if_node.test` contains, somewhere in its
+        expression tree, a `Call` to a name `memory_is_enabled`.
+
+        Recursive-walk via `ast.walk(if_node.test)` so the
+        predicate matches the actual production shape
+        `BoolOp(And, [Call(memory_is_enabled), Compare(...)])` from
+        the `if memory_is_enabled() and chat_id is not None:`
+        guard. A direct-test predicate
+        (`isinstance(if_node.test, ast.Call) and
+        if_node.test.func.id == 'memory_is_enabled'`) would return
+        False on this shape and silently miss the gate.
+        """
+        return any(
+            isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "memory_is_enabled"
+            for n in ast.walk(if_node.test)
+        )
+
+    def test_every_extract_and_store_call_site_is_inside_is_enabled_guard(self) -> None:
+        """Walk `src/kai/bot.py`'s AST. For every `Call` whose `func`
+        is an `Attribute` with `attr == "extract_and_store"`, confirm
+        that at least one ancestor `If` node has a test containing a
+        `Call` to `memory_is_enabled`. Fail with the offending line
+        number if any call site is unguarded.
+
+        `func` is checked as `Attribute` (e.g.
+        `memory_extraction.extract_and_store(...)`) per the production
+        shape; the test deliberately does NOT match `Name`-shaped
+        calls (`extract_and_store(...)` from a `from
+        kai.memory_extraction import extract_and_store`) because the
+        production code uses the module-qualified form. If a future
+        refactor introduces the `from`-import shape, this test should
+        be extended to cover both forms.
+        """
+        # Resolve the bot.py source path relative to the test file's
+        # location so the test runs cleanly under any working
+        # directory (pytest cwd, IDE runner, CI). `Path(__file__)`
+        # is `tests/test_eval_modeswitch.py`; two levels up is the
+        # repo root, then descend into `src/kai/bot.py`.
+        bot_py = Path(__file__).parent.parent / "src" / "kai" / "bot.py"
+        assert bot_py.exists(), f"expected bot.py at {bot_py}"
+
+        tree = ast.parse(bot_py.read_text())
+        self._attach_parents(tree)
+
+        # `ast.walk(tree)` traverses every node, not just top-level
+        # `Module.body`. The actual extract_and_store call site lives
+        # nested at `_handle_response > if memory_is_enabled() >
+        # async def _ingest_memory > await extract_and_store(...)`,
+        # several layers below the module root, so the deep traversal
+        # is required.
+        call_sites: list[ast.Call] = []
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "extract_and_store"
+            ):
+                call_sites.append(node)
+
+        # Fail loud if the production code stops invoking
+        # extract_and_store entirely. A regression that removes the
+        # call site would otherwise leave this test passing
+        # vacuously, masking the absence of the production behavior
+        # the test is meant to backstop.
+        assert call_sites, "expected at least one `extract_and_store` call site in bot.py"
+
+        ungated: list[int] = []
+        for call in call_sites:
+            # Walk the parent chain looking for an `If` whose test
+            # contains a Call to memory_is_enabled. The chain ends
+            # at the Module node which has no `parent` attribute;
+            # the loop terminates by hitting that absence.
+            node: ast.AST = call
+            guarded = False
+            while True:
+                parent = getattr(node, "parent", None)
+                if parent is None:
+                    break
+                if isinstance(parent, ast.If) and self._guard_contains_memory_is_enabled(parent):
+                    guarded = True
+                    break
+                node = parent
+            if not guarded:
+                ungated.append(call.lineno)
+
+        assert not ungated, (
+            f"extract_and_store call site(s) at lines {ungated} are NOT inside an "
+            "`if memory_is_enabled() ...` guard. Switch point 5 (#434) requires "
+            "every extract_and_store call to be gated by memory_is_enabled() so "
+            "the disabled mode does not write to Qdrant."
+        )
 
 
 # ── TestCheckSubcommand ─────────────────────────────────────────────

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -322,11 +322,13 @@ class TestRecallReasonField:
                 user_id=str(_FIXTURE_CHAT_ID),
             )
 
-        # The recall path should have produced a string starting with
-        # the relevant-memories header (the canned result is above the
-        # floor and within budget). This pins the success-path output
-        # shape; the reason assertion below pins the log-line shape.
-        assert result.startswith(_MARKER_RELEVANT_MEMORIES), f"expected recall-prefixed output; got {result[:80]!r}"
+        # Reason assertion FIRST: the log-line `reason` field is the
+        # contract under test. The output-shape assertion below is a
+        # secondary sanity check; if the canned result's score (0.95)
+        # ever stops clearing the configured relevance floor, the
+        # output-shape assertion would fire and mask the actual
+        # contract test. Reason-first keeps the failure message
+        # informative under that regression class.
         recall_records = [r for r in caplog.records if r.getMessage().startswith("memory.recall ")]
         assert recall_records, "expected at least one memory.recall log line"
         reason = modeswitch._parse_recall_reason(caplog.records)
@@ -336,6 +338,12 @@ class TestRecallReasonField:
         assert reason != memory_module._RECALL_REASON_DISABLED, (
             f"expected reason != {memory_module._RECALL_REASON_DISABLED!r}; got {reason!r}"
         )
+        # Output-shape sanity check: the canned result is above the
+        # floor and within budget, so format_context should have
+        # produced the recall-prefixed string. A miss here suggests
+        # the floor was tuned above 0.95 or the budget was tightened
+        # below the single-line cost.
+        assert result.startswith(_MARKER_RELEVANT_MEMORIES), f"expected recall-prefixed output; got {result[:80]!r}"
 
 
 # ── TestExtractionCallSiteGating ────────────────────────────────────
@@ -391,6 +399,16 @@ class TestExtractionCallSiteGating:
         (`isinstance(if_node.test, ast.Call) and
         if_node.test.func.id == 'memory_is_enabled'`) would return
         False on this shape and silently miss the gate.
+
+        Limitation: this is a presence check, not a polarity check.
+        An inverted guard (`if not memory_is_enabled():`) would
+        ALSO satisfy the predicate because the Call lives inside
+        the `UnaryOp(Not, ...)` and `ast.walk` reaches it. A
+        regression that flipped the guard to `not` would have
+        inverted semantics (extract under disabled, skip under
+        enabled) but pass this structural test. The behavioral
+        pair in `test_bot.py::TestHandleResponse` is the polarity
+        check; this test's job is the call-site-existence check.
         """
         return any(
             isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "memory_is_enabled"

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -376,11 +376,11 @@ class TestExtractionCallSiteGating:
     def _attach_parents(tree: ast.AST) -> None:
         """Attach a `parent` attribute to every node so ancestor
         traversal works after `ast.walk`. ast.AST does not declare
-        a `parent` field, so the assignment is silently typed as
-        `Any`; pyright tolerates it under the strict-but-permissive
-        attribute model. This is the standard pattern; the
-        alternative (a side-table dict keyed by id(node)) is more
-        verbose with no semantic gain.
+        a `parent` field, so pyright flags the assignment as an
+        attr-defined error; the `# type: ignore[attr-defined]`
+        below is load-bearing, not cosmetic. The alternative
+        (a side-table dict keyed by id(node)) is more verbose with
+        no semantic gain; this is the standard ast-walking pattern.
         """
         for parent in ast.walk(tree):
             for child in ast.iter_child_nodes(parent):

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -300,6 +300,16 @@ class TestRecallReasonField:
         # boot cost (~80MB embedding model on first run); the
         # production path under verification is format_context, not
         # init_memory.
+        #
+        # `object()` is safe ONLY because format_context never
+        # invokes attributes on `_memory` directly: `is_enabled()`
+        # checks `_memory is not None`, and every search call
+        # routes through the module-level `search()` wrapper, which
+        # is mocked below. A future refactor that called something
+        # like `_memory.client_ready()` from the hot path would
+        # break this test with a confusing `AttributeError` rather
+        # than a clean assertion failure; the sentinel would need
+        # to grow into a proper Mem0 mock at that point.
         memory_module._memory = object()
         memory_module._config = modeswitch._build_test_configs(memory_enabled_value=True)
 

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -430,6 +430,17 @@ class TestExtractionCallSiteGating:
         production code uses the module-qualified form. If a future
         refactor introduces the `from`-import shape, this test should
         be extended to cover both forms.
+
+        Polarity caveat: this test is a presence check, not a
+        polarity check. An inverted guard
+        (`if not memory_is_enabled():`) would satisfy the predicate
+        because `_guard_contains_memory_is_enabled` walks the test
+        expression and finds the Call inside the `UnaryOp(Not, ...)`.
+        The behavioral pair in
+        `test_bot.py::TestHandleResponse::test_extraction_skipped_when_memory_disabled`
+        plus `test_extraction_invoked_when_memory_enabled` covers
+        polarity by asserting the correct `extract_and_store`
+        call_count under each flag value.
         """
         # Resolve the bot.py source path relative to the test file's
         # location so the test runs cleanly under any working

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -473,7 +473,11 @@ class TestExtractionCallSiteGating:
         # call site would otherwise leave this test passing
         # vacuously, masking the absence of the production behavior
         # the test is meant to backstop.
-        assert call_sites, "expected at least one `extract_and_store` call site in bot.py"
+        assert call_sites, (
+            "expected at least one `extract_and_store` call site in bot.py; "
+            "the production path lives in `_handle_response`'s post-response "
+            "ingestion block, gated by `if memory_is_enabled() and chat_id is not None:`"
+        )
 
         ungated: list[int] = []
         for call in call_sites:

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -2384,6 +2384,35 @@ class TestCallbackDispatch:
         toast = upd.callback_query.answer.call_args.args[0]
         assert toast == memory_command._MSG_QUERY_FAILED
 
+    @pytest.mark.asyncio
+    async def test_callback_disabled_short_circuits(self, monkeypatch, update_factory, context_factory):
+        """Switch point 4 (#434): when memory is disabled, the
+        callback handler's `if not memory.is_enabled():` early return
+        fires and the user gets the _MSG_DISABLED toast WITHOUT any
+        edit_message_text dispatch. Mirrors
+        `TestCommandDispatch::test_memory_disabled_short_circuits`
+        which covers the same contract on the slash-command side;
+        without this test, a regression that removed the callback
+        handler's early return would let the dashboard re-render fire
+        under disabled mode and confuse a user who just ran a
+        forget-flow on a now-disabled install.
+        """
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: False)
+        upd = update_factory(callback_data="mem:dash")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+        # The disabled-mode toast is the contract: the operator
+        # tapped a button on a /memory dashboard that is no longer
+        # active, and the only acceptable response is the
+        # disabled-mode reply via query.answer().
+        upd.callback_query.answer.assert_awaited_once_with(memory_command._MSG_DISABLED)
+        # No dashboard re-render: the early return must fire BEFORE
+        # any verb dispatch reaches edit_message_text. A regression
+        # that left the answer call in place but moved it AFTER
+        # dispatch would slip past the answer assertion alone, so
+        # the negative assertion here pins the early-return shape.
+        upd.callback_query.edit_message_text.assert_not_called()
+
 
 # ── Issue #416: tag browse-axis dismantle ──────────────────────────
 


### PR DESCRIPTION
Closes #434.

## Summary

Extends the mode-switch verification harness shipped in PR #433 with regression coverage for the three write-side switch points the issue body flagged as unverified. Switch point 2 (inner-Claude write routing) is intentionally left to the existing read-side partition invariants, which already verify the contract delivered to the inner Claude (the `[Memory subsystem: ...]` marker plus the `[Your persistent memory (file: ...):]` block presence/absence).

## Coverage added

| # | Switch point | Site | New tests |
|---|---|---|---|
| 4 (callback) | `handle_memory_callback` disabled-mode early return | `memory_command.py` | 1 in `test_memory_command.py::TestCallbackDispatch` |
| 5 (behavioral) | extraction-gating guard in `_handle_response` | `bot.py` | 2 in `test_bot.py::TestHandleResponse` |
| 5 (structural) | AST property: every `extract_and_store` call inside `if memory_is_enabled()` | `bot.py` | 1 in `test_eval_modeswitch.py::TestExtractionCallSiteGating` |
| 6 (harness) | `memory.recall` log line `reason` field | `_run_verify` | 2 invariants in `modeswitch.py` |
| 6 (pytest) | same contract via `caplog` | `format_context` | 2 in `test_eval_modeswitch.py::TestRecallReasonField` |

`/memory` slash-command disabled-mode reply was already covered by the pre-existing `tests/test_memory_command.py::TestCommandDispatch::test_memory_disabled_short_circuits`; only the callback handler's parallel early return needed a new test.

## Verify subcommand

`python -m kai.eval.modeswitch verify` now runs 11 invariants (up from 9). The two new ones drive `format_context` against an isolated tmp-dir Mem0 under each flag value, capture `memory.recall` log records via a `logging.Handler` attached to the `kai.memory` logger, and assert the `reason` field of the JSON payload (compares against `_RECALL_REASON_DISABLED` for the disabled mode; asserts the negative for enabled mode so the success-path shape, where the `reason` field is omitted entirely, is also accepted).

Local run output:

```
PASS  disabled: subsystem marker present
PASS  disabled: persistent-memory block injected
PASS  disabled: relevant-memories block omitted
PASS  disabled: recall log reason is 'disabled'
PASS  enabled: subsystem marker present
PASS  enabled: persistent-memory block omitted
PASS  enabled: format_context returns empty or recall-prefixed
PASS  enabled: recall log reason is not 'disabled'
PASS  partition disabled: persistent present, relevant absent
PASS  partition enabled: persistent absent
PASS  partition: mutual exclusion across both modes

PASS: all 11 invariants hold.
```

## Test count

Suite size: 2791 (+6 from the prior baseline).

## Test placement deviation

The implementation plan placed the switch-point-5 behavioral tests in `TestHandleMessage`. The `if memory_is_enabled()` guard is actually in `_handle_response`, not `handle_message`; the existing `TestHandleMessage` tests mock `_handle_response` entirely and never reach the guard. The new behavioral tests live in `TestHandleResponse` (which already has 13 driver-pattern tests using `_make_update`/`_make_context`/`_fake_stream`/`_done_event`). The placement is documented in each test's docstring.

## Regression contracts

- A refactor that flips the `if memory_is_enabled() and chat_id is not None:` guard to `if True:` fails `test_extraction_skipped_when_memory_disabled`.
- A refactor that adds a new ungated `extract_and_store` call site to `bot.py` fails `test_every_extract_and_store_call_site_is_inside_is_enabled_guard`.
- A refactor that removes the early-return in `handle_memory_callback` fails `test_callback_disabled_short_circuits`.
- A refactor that changes `_RECALL_REASON_DISABLED` without updating the emission site fails `test_recall_reason_is_disabled_under_disabled_mode`.

## Test plan

- [x] `make check` clean
- [x] `make test` passes (2791 passed)
- [x] `python -m kai.eval.modeswitch verify` exits 0 with 11 invariants
- [ ] Bot-review pass clean
