### PR TITLE
fix(tests): isolate kai.backend.DATA_DIR per test (#438)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,3 +79,25 @@ def _isolate_history_dir(tmp_path):
     """
     with patch("kai.history._LOG_DIR", tmp_path):
         yield
+
+
+@pytest.fixture(autouse=True)
+def _isolate_backend_data_dir(tmp_path):
+    """Redirect kai.backend.DATA_DIR to tmp_path for ALL tests.
+
+    Mirrors _isolate_history_dir in shape (autouse, redirects a
+    module-level path constant via unittest.mock.patch) and in
+    intent (prevent test runs from writing into the real DATA_DIR).
+    Without this guarantee, any test that exercises
+    resolve_home_workspace or ensure_user_home without explicitly
+    redirecting backend.DATA_DIR creates a per-user home directory
+    under the real DATA_DIR. In dev DATA_DIR equals PROJECT_ROOT,
+    so leaked chat_ids from test fixtures (e.g. 111, 222, 12345)
+    materialize as empty directories in the working tree.
+
+    Tests that need a specific DATA_DIR can still override with
+    their own patch / monkeypatch; the autouse fixture only sets
+    the safe default.
+    """
+    with patch("kai.backend.DATA_DIR", tmp_path):
+        yield


### PR DESCRIPTION
Closes #438.

## Summary

Adds an autouse pytest fixture in `tests/conftest.py` that patches `kai.backend.DATA_DIR` to `tmp_path` for every test. Mirrors the existing `_isolate_history_dir` fixture in shape and mechanism (autouse, redirects a module-level path constant via `unittest.mock.patch`); the two safety nets sit adjacent in the conftest as a single coherent block.

## Why

Without this guarantee, any test that exercises `resolve_home_workspace` or `ensure_user_home` without explicitly redirecting `backend.DATA_DIR` creates a per-user home directory under the real `DATA_DIR`. In dev `DATA_DIR == PROJECT_ROOT`, so leaked chat_ids from test fixtures (111, 222, 12345) materialized as empty directories in the working tree. The `resolve_home_workspace` docstring already documents this failure mode; the fixture closes it permanently.

## Mechanism

`kai.backend` imports `DATA_DIR` from `kai.config`, and `resolve_home_workspace` reads it at CALL time when its `data_dir` argument is `None`. Patching `kai.backend.DATA_DIR` therefore redirects the live read; patching `kai.config.DATA_DIR` would NOT propagate into the backend module's already-bound name and is NOT what the fixture targets.

Three existing tests already redirect this same attribute via `monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)`: two in `tests/test_pool.py` and one in `tests/test_bot.py::test_per_user_home_directory_used`. Both `monkeypatch.setattr` and `with patch(...)` set the same attribute on the same module; the autouse redirect is overridden cleanly by either, so no existing test needs modification.

`tests/test_backend.py::TestResolveHomeWorkspace` tests pass `data_dir=tmp_path` explicitly, bypassing the module-level read entirely; the autouse fixture is a no-op for those tests.

## Test plan

- [x] `make check` clean
- [x] `make test` passes (2791 passed, 1 skipped) on a fresh clone with the fixture in place
- [x] No `home/<digits>/` directories appear under `home/` after a full test run from a clean tree
- [x] Tests that already redirect `kai.backend.DATA_DIR` (in `test_bot.py` and `test_pool.py`) pass unchanged
- [x] Diff is `tests/conftest.py` only (22 insertions, 0 deletions)
