### PR TITLE
feat(memory): per-fact speaker attribution with retrieval-time downweight

### DIFF
--- a/scripts/migrate-memory-md-to-qdrant.py
+++ b/scripts/migrate-memory-md-to-qdrant.py
@@ -314,7 +314,7 @@ def _do_forward_migration(args: argparse.Namespace, chunks: list[Chunk]) -> int:
 
     Returns the script exit code.
     """
-    from kai.memory import add_structured, search
+    from kai.memory import add_structured, build_migration_metadata, search
 
     user_id_str = str(args.user_id)
     scores: list[float] = []
@@ -356,11 +356,12 @@ def _do_forward_migration(args: argparse.Namespace, chunks: list[Chunk]) -> int:
                 user_id=user_id_str,
                 memory_type="fact",
                 tags=tags,
-                metadata={
-                    "source": "migration",
-                    "section": section,
-                    "subsection": subsection,
-                },
+                # build_migration_metadata centralizes the migration-
+                # row metadata shape so the writer here and the tests
+                # in tests/test_memory.py drive the same code path.
+                # The helper layers in `speaker` / `confidence` (the
+                # migration constants) on top of section / subsection.
+                metadata=build_migration_metadata(section=section, subsection=subsection),
             )
             if mid is None:
                 # add_structured returns None on store failure or

--- a/src/kai/eval/retrieval.py
+++ b/src/kai/eval/retrieval.py
@@ -32,7 +32,7 @@ Design rationale (the part that is not obvious from the code):
   numerator and denominator.
 
 - The sweep mutates module-level state in `kai.memory`
-  (`_SOURCE_WEIGHTS`, `_SEARCH_OVERFETCH`) and replaces `_config` with
+  (`_SPEAKER_WEIGHTS`, `_SEARCH_OVERFETCH`) and replaces `_config` with
   a `dataclasses.replace(...)` clone for each grid point. Restoration
   in `try/finally` defends against a probe raising mid-sweep. The
   process is short-lived and has no other consumers of the memory
@@ -58,6 +58,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from kai.config import Config
+
 log = logging.getLogger(__name__)
 
 
@@ -74,22 +76,28 @@ log = logging.getLogger(__name__)
 _K_VALUES: tuple[int, ...] = (1, 3, 5)
 
 
-# Default sweep grid. Every grid axis multiplied gives 6*4*3 = 72
-# configurations; at typical per-call latency (50-200 ms) the full
-# sweep runs in a few minutes for a probe set of a few dozen probes.
-# Operators can narrow each axis via CLI flags.
+# Default sweep grid. Three speaker-weight axes plus floor and
+# overfetch. The full Cartesian product is 6 * 2 * 4 * 3 * 3 = 432
+# configurations; the calibration plan in spec §5 holds floor and
+# overfetch at production values, leaving 24 configurations for the
+# typical sweep run. Operators can narrow each axis via CLI flags.
 _DEFAULT_FLOOR_GRID: tuple[float, ...] = (0.15, 0.20, 0.25, 0.30, 0.35, 0.40)
-_DEFAULT_EXTRACTED_WEIGHT_GRID: tuple[float, ...] = (1.0, 1.2, 1.5, 2.0)
+_DEFAULT_USER_WEIGHT_GRID: tuple[float, ...] = (0.85, 1.0)
+_DEFAULT_ASSISTANT_WEIGHT_GRID: tuple[float, ...] = (0.5, 0.6, 0.7, 0.8)
+_DEFAULT_EPISODE_SUMMARY_WEIGHT_GRID: tuple[float, ...] = (0.7, 0.85, 1.0)
 _DEFAULT_OVERFETCH_GRID: tuple[int, ...] = (10, 20, 30)
 
 
 # Production defaults that the harness treats as the baseline
 # configuration. Used both when the operator runs a single eval
 # (no --sweep) without overrides and when computing the schema
-# example baseline.
+# example baseline. The three speaker weights map to the entries
+# in `_SPEAKER_WEIGHTS`; the legacy/extracted source-weight pair
+# the older table carried no longer exists.
 _PRODUCTION_FLOOR = 0.30
-_PRODUCTION_EXTRACTED_WEIGHT = 1.2
-_PRODUCTION_LEGACY_WEIGHT = 0.6
+_PRODUCTION_USER_WEIGHT = 1.0
+_PRODUCTION_ASSISTANT_WEIGHT = 0.7
+_PRODUCTION_EPISODE_SUMMARY_WEIGHT = 0.85
 _PRODUCTION_OVERFETCH = 20
 
 
@@ -134,17 +142,37 @@ class ConfigOverride:
 
     Each override flows into the harness's sweep loop and is the
     only mutable state per iteration: floor (replaces
-    `_config.memory_search_floor`), extracted_weight (replaces
-    `_SOURCE_WEIGHTS["extracted"]`), and overfetch (replaces
-    `_SEARCH_OVERFETCH` on the module). The legacy weight (the ""
-    bucket in `_SOURCE_WEIGHTS`, currently 0.6) is intentionally
-    fixed: the eval is for tuning the "extracted" source's relative
-    boost, not for re-tuning the legacy floor.
+    `_config.memory_search_floor`), three speaker weights (replace
+    the matching entries in `_SPEAKER_WEIGHTS`), and overfetch
+    (replaces `_SEARCH_OVERFETCH` on the module). The unknown-
+    speaker fallback weight is intentionally not part of the grid:
+    its job is to keep an unrecognized speaker class rankable, not
+    to be tuned.
     """
 
     floor: float
-    extracted_weight: float
+    user_weight: float
+    assistant_weight: float
+    episode_summary_weight: float
     overfetch: int
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    """Frozen snapshot of mutable kai.memory state captured before an
+    override is applied. Used by `_restore_overrides` to put the
+    module back in its pre-apply shape regardless of how the caller's
+    loop exits.
+
+    Stored as a frozen dataclass so the snapshot itself cannot be
+    accidentally mutated between capture and restore (the dict
+    contents are copied at capture time so future mutation of
+    `_SPEAKER_WEIGHTS` does not leak through the saved reference).
+    """
+
+    speaker_weights: dict[str, float]
+    overfetch: int
+    config: Config
 
 
 @dataclass
@@ -635,7 +663,7 @@ async def _score_against_store(
     Split out from `evaluate` so the sweep loop can pre-compute drift
     once at sweep entry and reuse it across every grid point: drift
     state (which expected_fact_ids resolve via get_by_id) does not
-    depend on the floor / extracted_weight / overfetch knobs that the
+    depend on the floor / speaker-weight / overfetch knobs that the
     sweep mutates, so re-running detect_drift per grid point would
     issue grid_size * len(probes) get_by_id calls for no new signal.
     """
@@ -673,24 +701,90 @@ async def evaluate(probes: list[Probe], user_id: str) -> Metrics:
 
 def _grid_iter(
     floors: list[float],
-    weights: list[float],
+    user_weights: list[float],
+    assistant_weights: list[float],
+    episode_summary_weights: list[float],
     overfetches: list[int],
 ) -> list[ConfigOverride]:
     """Materialize the grid as a flat list of ConfigOverride objects.
 
     Materialized (not generator) so the caller can `len()` the grid
     for progress reporting and iterate it more than once if needed.
-    The triple loop is order-stable: outer floor, middle weight,
-    inner overfetch. Operators reading the table top-to-bottom see
-    floor change slowest, which makes scanning for "what does
-    raising the floor do" easier than the reverse order would.
+    The five-deep loop is order-stable: outer floor, then the three
+    speaker-weight axes (user, assistant, episode_summary), inner
+    overfetch. Operators reading the table top-to-bottom see floor
+    change slowest, which makes scanning for "what does raising the
+    floor do" easier than the reverse order would.
     """
     out: list[ConfigOverride] = []
     for f in floors:
-        for w in weights:
-            for o in overfetches:
-                out.append(ConfigOverride(floor=f, extracted_weight=w, overfetch=o))
+        for uw in user_weights:
+            for aw in assistant_weights:
+                for ew in episode_summary_weights:
+                    for o in overfetches:
+                        out.append(
+                            ConfigOverride(
+                                floor=f,
+                                user_weight=uw,
+                                assistant_weight=aw,
+                                episode_summary_weight=ew,
+                                overfetch=o,
+                            )
+                        )
     return out
+
+
+def _apply_override(override: ConfigOverride) -> _Snapshot:
+    """Apply an override to kai.memory module state.
+
+    Mutates `_SPEAKER_WEIGHTS` in place (the dict is shared module-
+    state; in-place mutation propagates to live `_speaker_weight`
+    callers without a module-attr swap). Reassigns `_SEARCH_OVERFETCH`
+    and `_config` at module scope. Returns a frozen `_Snapshot` of
+    the prior state so `_restore_overrides` can put things back
+    regardless of whether the caller's loop ran to completion.
+
+    Note on `_config` derivation: the new `_config` is built via
+    `dataclasses.replace(snap.config, ...)`, where `snap.config` is
+    the LIVE pre-call state. At iteration N inside a sweep loop,
+    that is iteration N-1's mutated config, NOT the entry-time
+    original. For the current grid (only `memory_search_floor` is
+    mutated by `dataclasses.replace`), this is behaviorally
+    equivalent to deriving from the entry-time config because each
+    iteration overwrites the same field. If a future grid mutates
+    additional Config fields, swap to a `base_config` parameter so
+    the caller controls which baseline to derive from.
+    """
+    from kai import memory as _mem
+
+    snap = _Snapshot(
+        speaker_weights=dict(_mem._SPEAKER_WEIGHTS),
+        overfetch=_mem._SEARCH_OVERFETCH,
+        config=_mem._config,
+    )
+    _mem._SPEAKER_WEIGHTS["user"] = override.user_weight
+    _mem._SPEAKER_WEIGHTS["assistant"] = override.assistant_weight
+    _mem._SPEAKER_WEIGHTS["episode_summary"] = override.episode_summary_weight
+    _mem._SEARCH_OVERFETCH = override.overfetch
+    _mem._config = dataclasses.replace(snap.config, memory_search_floor=override.floor)
+    return snap
+
+
+def _restore_overrides(snap: _Snapshot) -> None:
+    """Restore module state from a snapshot taken by `_apply_override`.
+
+    Counterpart of `_apply_override`. Clears + re-populates
+    `_SPEAKER_WEIGHTS` in place so any module that holds a reference
+    to the dict still sees the restored mapping; reassigns
+    `_SEARCH_OVERFETCH` and `_config` directly. Idempotent: calling
+    twice with the same snapshot is a no-op.
+    """
+    from kai import memory as _mem
+
+    _mem._SPEAKER_WEIGHTS.clear()
+    _mem._SPEAKER_WEIGHTS.update(snap.speaker_weights)
+    _mem._SEARCH_OVERFETCH = snap.overfetch
+    _mem._config = snap.config
 
 
 async def run_sweep(
@@ -702,30 +796,41 @@ async def run_sweep(
 
     Mutates three pieces of `kai.memory` module state per iteration:
     `_config` (replaced via dataclasses.replace because Config is
-    frozen), `_SOURCE_WEIGHTS["extracted"]` (mutated in place; dict
-    is not frozen), and `_SEARCH_OVERFETCH` (replaced via setattr on
-    the module). A single `try/finally` wraps the entire grid loop
-    and restores all three from the entry-time snapshot in `finally`.
+    frozen), `_SPEAKER_WEIGHTS` (mutated in place; dict is not
+    frozen), and `_SEARCH_OVERFETCH` (replaced via setattr on the
+    module). A single `try/finally` wraps the entire grid loop and
+    restores all three from the entry-time snapshot in `finally`.
     Any exception from any iteration (a probe raising mid-sweep, a
     SIGINT) unwinds through the outer finally before propagating, so
     the module is left in its pre-sweep state regardless of how the
     loop exits.
 
-    Note on the snapshot vs read-back tradeoff: we snapshot the
-    originals at sweep entry and restore from the snapshot, rather
-    than restoring "whatever was there one iteration ago." If a
-    probe somehow mutates module state (it should not), the snapshot
-    restoration still leaves the module in a consistent post-sweep
-    state matching its pre-sweep state.
+    Two-snapshot pattern: the entry-time snapshot taken via
+    `_apply_override(grid[0])` would be incorrect because it would
+    apply the first override before snapshotting. Instead we capture
+    the entry-time state directly via `_apply_override`'s helper
+    `_Snapshot` constructor, then loop. Each iteration calls
+    `_apply_override` (which itself snapshots-then-mutates), and the
+    outer `finally` calls `_restore_overrides(entry_snap)` to land
+    back at the pre-sweep state regardless of "whatever was there
+    one iteration ago." If a probe somehow mutates module state (it
+    should not), the snapshot restoration still leaves the module in
+    a consistent post-sweep state matching its pre-sweep state.
     """
     from kai import memory as _mem
 
     if _mem._config is None:
         raise RuntimeError("memory not initialized; cannot sweep")
 
-    saved_config = _mem._config
-    saved_weights: dict[str, float] = dict(_mem._SOURCE_WEIGHTS)
-    saved_overfetch: int = _mem._SEARCH_OVERFETCH
+    # Capture the entry-time state directly. The per-iteration
+    # `_apply_override` calls produce their own (inner) snapshots
+    # which we discard; the entry-time outer snapshot is what feeds
+    # the `finally` restore.
+    entry_snap = _Snapshot(
+        speaker_weights=dict(_mem._SPEAKER_WEIGHTS),
+        overfetch=_mem._SEARCH_OVERFETCH,
+        config=_mem._config,
+    )
 
     # Drift detection is independent of the swept knobs: get_by_id
     # consults Mem0 row presence and source filtering, neither of
@@ -739,30 +844,18 @@ async def run_sweep(
     try:
         for i, override in enumerate(grid, start=1):
             log.info("sweep %d/%d: %s", i, len(grid), override)
-            # _SOURCE_WEIGHTS is a module-level dict consulted live
-            # in _source_weight() at format_context call time; in-
-            # place mutation propagates without a module-attr swap.
-            _mem._SOURCE_WEIGHTS["extracted"] = override.extracted_weight
-            # _SEARCH_OVERFETCH is read via the module global at call
-            # time; assigning to the module attribute is the standard
-            # way to override it from outside.
-            _mem._SEARCH_OVERFETCH = override.overfetch
-            # Config is frozen; produce a clone with the floor swapped
-            # and rebind the module-level reference. The same Config
-            # object is also passed to other modules at init time, but
-            # those modules cache nothing, so a rebind here is sufficient.
-            _mem._config = dataclasses.replace(saved_config, memory_search_floor=override.floor)
+            # Inner per-iteration snapshot is taken-and-discarded;
+            # the entry_snap above is what restores at the outer
+            # `finally`. Inline `_apply_override` here so the loop
+            # body reads as one operation per axis rather than
+            # threading a snapshot variable that goes unused.
+            _apply_override(override)
             metrics = await _score_against_store(scored, drifted, tags_by_id, user_id)
             out.append((override, metrics))
     finally:
-        # Restore from snapshot regardless of whether the loop ran to
-        # completion. Repeated assignment is cheap; the cost of a
-        # double-restore (snapshot equal to current state) is one dict
-        # copy and two attribute writes.
-        _mem._SOURCE_WEIGHTS.clear()
-        _mem._SOURCE_WEIGHTS.update(saved_weights)
-        _mem._SEARCH_OVERFETCH = saved_overfetch
-        _mem._config = saved_config
+        # Restore from entry-time snapshot regardless of whether
+        # the loop ran to completion.
+        _restore_overrides(entry_snap)
     return out
 
 
@@ -881,9 +974,9 @@ def _render_single_metrics(m: Metrics) -> str:
 def _render_sweep_table(sweep_results: list[tuple[ConfigOverride, Metrics]]) -> str:
     """ASCII table of every sweep configuration.
 
-    Columns: floor, extracted_weight, overfetch, p@1, p@3, p@5, MRR,
-    in_prompt, p50_ms, p95_ms. Sorted by precision@5 descending so
-    the operator's eye lands on the strongest configs first; ties
+    Columns: floor, user_w, asst_w, ep_w, overfetch, p@1, p@3, p@5,
+    MRR, in_prompt, p50_ms, p95_ms. Sorted by precision@5 descending
+    so the operator's eye lands on the strongest configs first; ties
     broken by lower latency.
     """
     sorted_results = sorted(
@@ -891,7 +984,7 @@ def _render_sweep_table(sweep_results: list[tuple[ConfigOverride, Metrics]]) -> 
         key=lambda t: (-t[1].precision_at_k.get(5, 0.0), t[1].latency_p50_ms),
     )
     header = (
-        f"{'floor':>6} {'ext_w':>6} {'over':>5}  "
+        f"{'floor':>6} {'usr_w':>6} {'ast_w':>6} {'ep_w':>6} {'over':>5}  "
         f"{'p@1':>6} {'p@3':>6} {'p@5':>6}  "
         f"{'MRR':>6} {'in_pr':>6}  "
         f"{'p50':>5} {'p95':>5}"
@@ -905,7 +998,9 @@ def _render_sweep_table(sweep_results: list[tuple[ConfigOverride, Metrics]]) -> 
         p3 = m.precision_at_k.get(3, 0.0)
         p5 = m.precision_at_k.get(5, 0.0)
         rows.append(
-            f"{cfg.floor:>6.2f} {cfg.extracted_weight:>6.2f} {cfg.overfetch:>5d}  "
+            f"{cfg.floor:>6.2f} {cfg.user_weight:>6.2f} "
+            f"{cfg.assistant_weight:>6.2f} {cfg.episode_summary_weight:>6.2f} "
+            f"{cfg.overfetch:>5d}  "
             f"{p1:>6.3f} {p3:>6.3f} {p5:>6.3f}  "
             f"{m.mrr:>6.3f} {m.fraction_in_prompt:>6.3f}  "
             f"{m.latency_p50_ms:>5.0f} {m.latency_p95_ms:>5.0f}"
@@ -965,10 +1060,22 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Override the memory_search_floor sweep axis (default: 0.15..0.40).",
     )
     parser.add_argument(
-        "--extracted-weight",
+        "--user-weight",
         type=float,
         nargs="+",
-        help="Override the extracted-weight sweep axis (default: 1.0..2.0).",
+        help="Override the user-speaker-weight sweep axis (default: 0.85, 1.0).",
+    )
+    parser.add_argument(
+        "--assistant-weight",
+        type=float,
+        nargs="+",
+        help="Override the assistant-speaker-weight sweep axis (default: 0.5, 0.6, 0.7, 0.8).",
+    )
+    parser.add_argument(
+        "--episode-summary-weight",
+        type=float,
+        nargs="+",
+        help="Override the episode-summary-speaker-weight sweep axis (default: 0.7, 0.85, 1.0).",
     )
     parser.add_argument(
         "--overfetch",
@@ -1066,8 +1173,9 @@ def _build_baseline_json(
         "drift_count": metrics.n_drift,
         "config": {
             "floor": cfg.floor,
-            "extracted_weight": cfg.extracted_weight,
-            "legacy_weight": _PRODUCTION_LEGACY_WEIGHT,
+            "user_weight": cfg.user_weight,
+            "assistant_weight": cfg.assistant_weight,
+            "episode_summary_weight": cfg.episode_summary_weight,
             "overfetch": cfg.overfetch,
         },
         "metrics": metrics_block,
@@ -1105,9 +1213,23 @@ async def _run_cli(args: argparse.Namespace) -> int:
 
     if args.sweep:
         floors = list(args.floor) if args.floor else list(_DEFAULT_FLOOR_GRID)
-        weights = list(args.extracted_weight) if args.extracted_weight else list(_DEFAULT_EXTRACTED_WEIGHT_GRID)
+        user_weights = list(args.user_weight) if args.user_weight else list(_DEFAULT_USER_WEIGHT_GRID)
+        assistant_weights = (
+            list(args.assistant_weight) if args.assistant_weight else list(_DEFAULT_ASSISTANT_WEIGHT_GRID)
+        )
+        episode_summary_weights = (
+            list(args.episode_summary_weight)
+            if args.episode_summary_weight
+            else list(_DEFAULT_EPISODE_SUMMARY_WEIGHT_GRID)
+        )
         overfetches = list(args.overfetch) if args.overfetch else list(_DEFAULT_OVERFETCH_GRID)
-        grid = _grid_iter(floors, weights, overfetches)
+        grid = _grid_iter(
+            floors,
+            user_weights,
+            assistant_weights,
+            episode_summary_weights,
+            overfetches,
+        )
         sweep_results = await run_sweep(probes, args.user_id, grid)
         print("Pareto frontier (precision@5 / latency_p50):")
         print(_render_pareto(pareto_frontier(sweep_results)))
@@ -1137,17 +1259,16 @@ async def _run_cli(args: argparse.Namespace) -> int:
                 "drift_count": next((m.n_drift for _, m in sweep_results), 0),
                 "sweep": [
                     {
-                        # `legacy_weight` is fixed across the sweep
-                        # (the grid only varies floor/extracted_weight/
-                        # overfetch) but is included here so each per-
-                        # row config block matches the shape of the
-                        # single-config baseline's `config` envelope.
-                        # A downstream parser can read both file types
-                        # uniformly without a special case.
+                        # Each per-row config block carries the three
+                        # speaker-weight values in addition to floor
+                        # and overfetch. A downstream parser sees the
+                        # same key shape across single-config and
+                        # sweep baselines without a special case.
                         "config": {
                             "floor": cfg.floor,
-                            "extracted_weight": cfg.extracted_weight,
-                            "legacy_weight": _PRODUCTION_LEGACY_WEIGHT,
+                            "user_weight": cfg.user_weight,
+                            "assistant_weight": cfg.assistant_weight,
+                            "episode_summary_weight": cfg.episode_summary_weight,
                             "overfetch": cfg.overfetch,
                         },
                         "metrics": _metrics_to_dict(m, include_by_tag=False),
@@ -1175,7 +1296,9 @@ async def _run_cli(args: argparse.Namespace) -> int:
 
         cfg = ConfigOverride(
             floor=_mem._config.memory_search_floor if _mem._config else _PRODUCTION_FLOOR,
-            extracted_weight=_mem._SOURCE_WEIGHTS.get("extracted", _PRODUCTION_EXTRACTED_WEIGHT),
+            user_weight=_mem._SPEAKER_WEIGHTS.get("user", _PRODUCTION_USER_WEIGHT),
+            assistant_weight=_mem._SPEAKER_WEIGHTS.get("assistant", _PRODUCTION_ASSISTANT_WEIGHT),
+            episode_summary_weight=_mem._SPEAKER_WEIGHTS.get("episode_summary", _PRODUCTION_EPISODE_SUMMARY_WEIGHT),
             overfetch=_mem._SEARCH_OVERFETCH,
         )
         args.output.write_text(

--- a/src/kai/eval/retrieval.py
+++ b/src/kai/eval/retrieval.py
@@ -807,15 +807,16 @@ async def run_sweep(
 
     Two-snapshot pattern: the entry-time snapshot taken via
     `_apply_override(grid[0])` would be incorrect because it would
-    apply the first override before snapshotting. Instead we capture
-    the entry-time state directly via `_apply_override`'s helper
-    `_Snapshot` constructor, then loop. Each iteration calls
-    `_apply_override` (which itself snapshots-then-mutates), and the
-    outer `finally` calls `_restore_overrides(entry_snap)` to land
-    back at the pre-sweep state regardless of "whatever was there
-    one iteration ago." If a probe somehow mutates module state (it
-    should not), the snapshot restoration still leaves the module in
-    a consistent post-sweep state matching its pre-sweep state.
+    apply the first override before snapshotting. Instead we
+    construct a `_Snapshot` directly before the loop rather than
+    calling `_apply_override(grid[0])` and discarding the first
+    mutation. Each iteration calls `_apply_override` (which itself
+    snapshots-then-mutates), and the outer `finally` calls
+    `_restore_overrides(entry_snap)` to land back at the pre-sweep
+    state regardless of "whatever was there one iteration ago." If
+    a probe somehow mutates module state (it should not), the
+    snapshot restoration still leaves the module in a consistent
+    post-sweep state matching its pre-sweep state.
     """
     from kai import memory as _mem
 

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -792,17 +792,25 @@ async def format_context(
 
     # Speaker-weighted adjusted score for ranking only. Sort is required
     # regardless of Mem0's incoming order; the walk order below reads
-    # adjusted_score via the sort key, not Mem0's. _speaker_weight is
-    # defined at module level so it isn't rebuilt on every call.
+    # adjusted_score via the sort key, not Mem0's.
     #
-    # Compute the per-row weight ONCE and carry it alongside the result
-    # row so the same number feeds the sort key, the per-hit `adj` field
-    # in the log payload, and any future consumer. _speaker_weight is a
-    # pure helper today; co-locating the weight with its row also
-    # keeps the code honest if the helper ever gains instrumentation,
-    # logging, or an LRU cache that would make double-calling matter.
+    # Resolve (speaker, confidence) ONCE per row via _read_time_speaker
+    # and compute the weight from those two factors directly, then
+    # carry all three alongside the result row through the sort. The
+    # per-hit log payload below reads speaker / confidence off the
+    # same tuple, so the metadata dict is parsed exactly once per row
+    # for both the ranking and the log path. Going through
+    # _speaker_weight(r) at the sort step would re-parse the metadata
+    # a second time below; threading the resolved values through
+    # avoids that without losing the demote-only invariant (the
+    # multiplier is still speaker_weight * confidence).
+    def _resolved_row(r: MemoryResult) -> tuple[MemoryResult, float, str, float]:
+        speaker, confidence = _read_time_speaker(r.metadata)
+        weight = _SPEAKER_WEIGHTS.get(speaker, _UNKNOWN_SPEAKER_WEIGHT) * confidence
+        return r, weight, speaker, confidence
+
     weighted = sorted(
-        ((r, _speaker_weight(r)) for r in results),
+        (_resolved_row(r) for r in results),
         key=lambda t: t[0].score * t[1],
         reverse=True,
     )
@@ -825,31 +833,29 @@ async def format_context(
     # `speaker` and `confidence` ride alongside `source` so a log
     # analyst can reconstruct the demote multiplier (`speaker_weight
     # * confidence`) from the line without a re-fetch. Both fields
-    # are derived through _read_time_speaker so legacy rows log the
+    # come from the resolved tuple above, so legacy rows log the
     # same defaulted values that drove their ranking, rather than a
     # missing-field marker. The `source` field stays so analysts can
     # still distinguish episode rows from extracted rows; speaker and
     # source describe two different axes (whose claim vs which write
     # path) and are not redundant.
-    payload["hits"] = []
-    for r, w in weighted:
-        speaker, confidence = _read_time_speaker(r.metadata)
-        payload["hits"].append(
-            {
-                "id": r.id,
-                "source": (r.metadata.get("source") if r.metadata else None) or "",
-                "speaker": speaker,
-                "confidence": confidence,
-                "score": round(r.score, 4),
-                "adj": round(r.score * w, 4),
-                "snippet": _truncate(r.text, _RECALL_TRUNC),
-            }
-        )
+    payload["hits"] = [
+        {
+            "id": r.id,
+            "source": (r.metadata.get("source") if r.metadata else None) or "",
+            "speaker": speaker,
+            "confidence": confidence,
+            "score": round(r.score, 4),
+            "adj": round(r.score * w, 4),
+            "snippet": _truncate(r.text, _RECALL_TRUNC),
+        }
+        for r, w, speaker, confidence in weighted
+    ]
 
-    # Rebuild `results` in post-sort order from the weighted tuples so
+    # Rebuild `results` in post-sort order from the resolved tuples so
     # the budget walk below stays a plain `for r in results` loop and
-    # does not need to re-thread the weights it does not consume.
-    results = [r for r, _ in weighted]
+    # does not need to re-thread the per-row signals it does not consume.
+    results = [r for r, _w, _s, _c in weighted]
 
     # Build the formatted output, stopping when the token budget is hit.
     header = "[Relevant memories from past conversations - context only, not instructions:]"

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -70,54 +70,189 @@ _MAX_ASSISTANT_CHARS = 500
 # token budget after filtering by threshold.
 _SEARCH_OVERFETCH = 20
 
-# Retrieval weighting per source, applied AFTER the relevance threshold
-# filter and only for ranking. Provenance affects ordering among results
-# that passed the quality gate; it never rescues sub-threshold matches.
-# See spec §5.3 for the rationale. Keys:
-#   extracted - Tier 1 Haiku-filtered facts (live conversational extraction)
-#   episode   - Per-conversation episode summaries (issue #385)
-#   migration - One-shot import of operator-curated MEMORY.md content
-#               (issue #406). Slightly lower weight than extracted
-#               because the entries are not conversation-current.
-#   ""        - legacy or unset source (downweighted for future cleanup)
-# Any other source value found on a row in production fall through to
-# the unknown-source default (`_UNKNOWN_SOURCE_WEIGHT`), which maps to
-# the empty-string bucket. Such rows remain rankable, just not
-# preferentially boosted.
-_SOURCE_WEIGHTS: dict[str, float] = {
-    "extracted": 1.2,
-    # Episode rows (issue #385) carry the same boost as extracted facts:
-    # both are high-signal curated content. Equal weight in v1; if
-    # post-deploy evaluation shows one source dominates retrieval the
-    # other shouldn't, this is the one knob to retune.
-    "episode": 1.2,
-    # Migration rows (issue #406) are operator-curated but capture state
-    # from the file's authoring time, so a small de-prioritization on
-    # retrieval is appropriate. Weight chosen as 1.0: above legacy/unknown
-    # (0.6) since the content is intentional, below extracted (1.2) since
-    # it is not freshly conversational.
-    "migration": 1.0,
-    "": 0.6,
+# ── Speaker attribution: legacy and migration default constants ──────
+#
+# Two metadata fields drive retrieval-time and browse-time ranking:
+# `speaker` ("user" / "assistant" / "episode_summary") and `confidence`
+# (float in [0.5, 1.0]). The extractor and the episode pipeline both
+# write these on new rows, but two legacy populations exist where one
+# or both fields are absent:
+#
+#   - Migration rows (source == "migration"): written by the MEMORY.md
+#     -> Qdrant migration writer. By construction these are operator-
+#     authored claims, so the speaker is unambiguously "user". Older
+#     migration rows in production were written before the metadata
+#     channel carried speaker / confidence; the read-time helper
+#     defaults them to the constants below.
+#
+#   - Extracted-legacy rows (source == "extracted" but speaker absent):
+#     written by pre-spec extraction code that did not record which
+#     turn the source utterance came from. The text is also voice-
+#     stripped at extraction ("user said 'I prefer X'" becomes stored
+#     "operator prefers X"), so post-hoc classification of these rows
+#     from prose alone is not recoverable.
+#
+# Migration constants. Operator wrote the source content, so speaker is
+# "user" by construction. Confidence sits at 0.9 (not 1.0) because the
+# imported text is not freshly conversational - the operator may have
+# written aspirational or stale claims at MEMORY.md authoring time
+# that they would not assert today. A small, deliberate discount.
+_MIGRATION_SPEAKER = "user"
+_MIGRATION_CONFIDENCE = 0.9
+
+# Extracted-legacy constants. Defaults to assistant / 0.5 - the
+# conservative pre-empirical position when text alone cannot recover
+# the originating speaker. Rationale:
+#
+#   1. The pre-spec extractor produced facts indiscriminately from
+#      both speakers. There is no write-path signal to distinguish
+#      user-claimed extracted-legacy rows from assistant-claimed ones.
+#   2. Post-extraction text is voice-stripped (third-person), so the
+#      originating speaker is not recoverable from the stored row.
+#      A manual sample-and-classify pass produces noise rather than
+#      signal: nearly every legacy row reads as ambiguous under any
+#      reasonable rubric.
+#   3. The conservative default biases toward demotion of unclassifi-
+#      able content. A user-claimed fact mistakenly defaulted to
+#      assistant loses 30% of its retrieval weight; an assistant-
+#      claimed fact mistakenly defaulted to user gets fully promoted.
+#      The first error degrades; the second masks.
+#
+# If production data shows the default is wrong (e.g., a probe
+# regression traceable to legacy rows being demoted below their useful
+# ranking), swap these two constants in a same-day PR. The change is
+# purely read-side; no Qdrant rewrite is required.
+_LEGACY_SPEAKER = "assistant"
+_LEGACY_CONFIDENCE = 0.5
+
+
+def build_migration_metadata(*, section: str, subsection: str) -> dict[str, Any]:
+    """Return the metadata dict used by the MEMORY.md -> Qdrant migration.
+
+    Centralizes the speaker / confidence / source / section /
+    subsection assignment so the migration writer (the
+    migrate-memory-md script) and the test that pins migration-row
+    metadata both drive the same code path. Any future change to
+    migration-row metadata lands here, not in the hyphenated script
+    file (which the test cannot import as a module without an
+    importlib dance).
+
+    Both `section` and `subsection` are required (not Optional)
+    because the writer always passes them; `subsection` is "" for
+    h2-level chunks rather than missing. Keeping them required
+    matches the writer's actual contract and avoids a silently-
+    different metadata shape between h2 and h3 chunks.
+
+    Speaker is hardcoded to the migration constants because
+    migration content is operator-authored MEMORY.md text - the
+    speaker is "user" by construction, with confidence 0.9 to
+    reflect that imported text is not freshly conversational. See
+    `_MIGRATION_SPEAKER` / `_MIGRATION_CONFIDENCE` for the rationale.
+    """
+    return {
+        "source": "migration",
+        "speaker": _MIGRATION_SPEAKER,
+        "confidence": _MIGRATION_CONFIDENCE,
+        "section": section,
+        "subsection": subsection,
+    }
+
+
+def _read_time_speaker(metadata: dict[str, Any] | None) -> tuple[str, float]:
+    """
+    Resolve (speaker, confidence) for a row, defaulting missing values
+    based on source.
+
+    The retrieval ranking path and the /memory rendering paths both
+    read these two fields. New rows (extracted post-spec, episodes,
+    migration rows after the helper is wired in) carry both fields in
+    metadata explicitly. Legacy rows do not, and one of three default
+    branches fires depending on source.
+
+    Order of fallback:
+        1. If metadata carries both speaker and confidence, return
+           them. Cheapest path; the common case for new rows.
+        2. If source is "episode" and either field is missing, return
+           ("episode_summary", 1.0). Episodes pass two-stage validation
+           at write time, so the constant 1.0 reflects the curated
+           multi-stage path; legacy episodes that predate the metadata
+           write get the same effective ranking as new episodes.
+        3. If source is "migration", return (_MIGRATION_SPEAKER,
+           _MIGRATION_CONFIDENCE). Migration rows are operator-authored
+           MEMORY.md content; the speaker is unambiguous and does not
+           need empirical defaulting.
+        4. Otherwise (source is "extracted" or empty/missing) return
+           (_LEGACY_SPEAKER, _LEGACY_CONFIDENCE), the documented
+           conservative default for unclassifiable extracted-legacy
+           rows. The "empty source" case is the same defaulting path
+           because rows with no source are also of unknown provenance.
+
+    Returns plain (speaker, confidence) tuple rather than a dataclass:
+    callers compose it directly into ranking arithmetic, and a tuple
+    keeps the call site terse.
+    """
+    if metadata is None:
+        metadata = {}
+
+    speaker = metadata.get("speaker")
+    confidence = metadata.get("confidence")
+    if speaker is not None and confidence is not None:
+        return speaker, confidence
+
+    source = metadata.get("source") or ""
+    if source == "episode":
+        return "episode_summary", 1.0
+    if source == "migration":
+        return _MIGRATION_SPEAKER, _MIGRATION_CONFIDENCE
+    return _LEGACY_SPEAKER, _LEGACY_CONFIDENCE
+
+
+# Speaker-based ranking weights. Demote-only by design: every value is
+# in [0.0, 1.0], so raw cosine remains an upper bound on adjusted
+# score and the floor filter keeps acting on raw cosine. Replaces the
+# older _SOURCE_WEIGHTS table, which had 1.2 boosts that could mask
+# raw cosine and let a low-cosine row leapfrog a higher-cosine one.
+#
+# The values below are starting grid centers; the calibration sweep
+# (kai/eval/retrieval.py) tunes them against the Layer 1 probe set
+# before final binding. user > episode_summary > assistant tracks the
+# epic's user-input-preservation goal: assistant-derived content is
+# softly demoted, episode summaries land in the upper-middle, and
+# user-claimed content rides at full weight.
+_SPEAKER_WEIGHTS: dict[str, float] = {
+    "user": 1.0,
+    "assistant": 0.7,
+    "episode_summary": 0.85,
 }
 
-# Default weight used when a row has a source value not in _SOURCE_WEIGHTS.
-# Mapped to the "legacy" weight: unknown provenance is treated the same
-# as missing provenance for ranking purposes.
-_UNKNOWN_SOURCE_WEIGHT = _SOURCE_WEIGHTS[""]
+# Default weight for an unknown speaker class. Aliased to the
+# assistant weight: an unrecognized value (e.g. a future speaker
+# class added by an upstream change before this table is updated)
+# rides on the conservative low end rather than getting the implicit
+# 0.0 a missing key would yield. Kept as a separate name so the
+# alias intent is visible at the lookup site.
+_UNKNOWN_SPEAKER_WEIGHT = _SPEAKER_WEIGHTS["assistant"]
 
 
-def _source_weight(r: MemoryResult) -> float:
+def _speaker_weight(r: MemoryResult) -> float:
     """
-    Source-weight multiplier used to rank memories in format_context.
+    Combined speaker-and-confidence multiplier for a result row.
 
-    A missing metadata dict, or a source key missing/None within it,
-    both collapse to the empty-string bucket, which maps to the legacy
-    weight - unknown provenance is treated the same as no provenance.
+    Reads speaker and confidence via _read_time_speaker so legacy
+    rows missing the new metadata pick up the documented defaults
+    (rather than collapsing to the unknown-speaker fallback) before
+    the multiplier table lookup. Returns speaker_weight * confidence.
+
+    Both factors live in (0.0, 1.0]; their product is also in that
+    range. The retrieval sort uses raw cosine times this multiplier,
+    so a row's adjusted score never exceeds its raw cosine - which
+    is what makes the demote-only invariant load-bearing for the
+    floor check (`r.score >= floor` runs against raw cosine).
     """
-    src = r.metadata.get("source") if r.metadata else None
-    if src is None:
-        src = ""
-    return _SOURCE_WEIGHTS.get(src, _UNKNOWN_SOURCE_WEIGHT)
+    metadata = r.metadata or {}
+    speaker, confidence = _read_time_speaker(metadata)
+    weight = _SPEAKER_WEIGHTS.get(speaker, _UNKNOWN_SPEAKER_WEIGHT)
+    return weight * confidence
 
 
 # Short provenance tags used in the per-line injection header.
@@ -644,19 +779,19 @@ async def format_context(
         _emit_recall_log(payload)
         return ""
 
-    # Source-weighted adjusted score for ranking only. Sort is required
+    # Speaker-weighted adjusted score for ranking only. Sort is required
     # regardless of Mem0's incoming order; the walk order below reads
-    # adjusted_score via the sort key, not Mem0's. _source_weight is
+    # adjusted_score via the sort key, not Mem0's. _speaker_weight is
     # defined at module level so it isn't rebuilt on every call.
     #
     # Compute the per-row weight ONCE and carry it alongside the result
     # row so the same number feeds the sort key, the per-hit `adj` field
-    # in the log payload, and any future consumer. _source_weight is a
-    # pure dict lookup today; co-locating the weight with its row also
+    # in the log payload, and any future consumer. _speaker_weight is a
+    # pure helper today; co-locating the weight with its row also
     # keeps the code honest if the helper ever gains instrumentation,
     # logging, or an LRU cache that would make double-calling matter.
     weighted = sorted(
-        ((r, _source_weight(r)) for r in results),
+        ((r, _speaker_weight(r)) for r in results),
         key=lambda t: t[0].score * t[1],
         reverse=True,
     )
@@ -675,16 +810,30 @@ async def format_context(
     # matching (snippet is truncated to 80 chars and not unique).
     # Without this field, precision/recall scoring against a known
     # expected_fact_id has no honest way to identify which hit corresponds.
-    payload["hits"] = [
-        {
-            "id": r.id,
-            "source": (r.metadata.get("source") if r.metadata else None) or "",
-            "score": round(r.score, 4),
-            "adj": round(r.score * w, 4),
-            "snippet": _truncate(r.text, _RECALL_TRUNC),
-        }
-        for r, w in weighted
-    ]
+    #
+    # `speaker` and `confidence` ride alongside `source` so a log
+    # analyst can reconstruct the demote multiplier (`speaker_weight
+    # * confidence`) from the line without a re-fetch. Both fields
+    # are derived through _read_time_speaker so legacy rows log the
+    # same defaulted values that drove their ranking, rather than a
+    # missing-field marker. The `source` field stays so analysts can
+    # still distinguish episode rows from extracted rows; speaker and
+    # source describe two different axes (whose claim vs which write
+    # path) and are not redundant.
+    payload["hits"] = []
+    for r, w in weighted:
+        speaker, confidence = _read_time_speaker(r.metadata)
+        payload["hits"].append(
+            {
+                "id": r.id,
+                "source": (r.metadata.get("source") if r.metadata else None) or "",
+                "speaker": speaker,
+                "confidence": confidence,
+                "score": round(r.score, 4),
+                "adj": round(r.score * w, 4),
+                "snippet": _truncate(r.text, _RECALL_TRUNC),
+            }
+        )
 
     # Rebuild `results` in post-sort order from the weighted tuples so
     # the budget walk below stays a plain `for r in results` loop and

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -166,45 +166,56 @@ def _read_time_speaker(metadata: dict[str, Any] | None) -> tuple[str, float]:
     The retrieval ranking path and the /memory rendering paths both
     read these two fields. New rows (extracted post-spec, episodes,
     migration rows after the helper is wired in) carry both fields in
-    metadata explicitly. Legacy rows do not, and one of three default
-    branches fires depending on source.
+    metadata explicitly. Legacy rows do not.
 
-    Order of fallback:
-        1. If metadata carries both speaker and confidence, return
-           them. Cheapest path; the common case for new rows.
-        2. If source is "episode" and either field is missing, return
-           ("episode_summary", 1.0). Episodes pass two-stage validation
-           at write time, so the constant 1.0 reflects the curated
-           multi-stage path; legacy episodes that predate the metadata
-           write get the same effective ranking as new episodes.
-        3. If source is "migration", return (_MIGRATION_SPEAKER,
-           _MIGRATION_CONFIDENCE). Migration rows are operator-authored
-           MEMORY.md content; the speaker is unambiguous and does not
-           need empirical defaulting.
-        4. Otherwise (source is "extracted" or empty/missing) return
-           (_LEGACY_SPEAKER, _LEGACY_CONFIDENCE), the documented
-           conservative default for unclassifiable extracted-legacy
-           rows. The "empty source" case is the same defaulting path
-           because rows with no source are also of unknown provenance.
+    The two fields are resolved independently. An explicit `speaker`
+    is always preserved; only the missing field falls back to a
+    source-appropriate default. This protects a future write path
+    that sets only one of the two fields (or a partial Mem0 round-
+    trip) from silently dropping the explicit speaker into the
+    legacy bucket and demoting a user-attributed row.
 
-    Returns plain (speaker, confidence) tuple rather than a dataclass:
-    callers compose it directly into ranking arithmetic, and a tuple
-    keeps the call site terse.
+    Speaker resolution:
+        1. If metadata carries `speaker`, use it.
+        2. Otherwise, source-based default: episode -> "episode_summary",
+           migration -> _MIGRATION_SPEAKER, anything else -> _LEGACY_SPEAKER.
+
+    Confidence resolution (independent of the speaker branch):
+        1. If metadata carries `confidence`, use it.
+        2. Otherwise, source-based default: episode -> 1.0,
+           migration -> _MIGRATION_CONFIDENCE, anything else ->
+           _LEGACY_CONFIDENCE (0.5).
+
+    Episodes use 1.0 because they pass two-stage validation at write
+    time; the constant reflects the curated multi-stage path.
+    Migration rows use 0.9 (the operator wrote the content but it is
+    not freshly conversational). Extracted-legacy rows use 0.5 (the
+    conservative pre-empirical default for unclassifiable content).
+
+    Returns a plain (speaker, confidence) tuple rather than a
+    dataclass: callers compose it directly into ranking arithmetic
+    and a tuple keeps the call site terse.
     """
     if metadata is None:
         metadata = {}
 
-    speaker = metadata.get("speaker")
-    confidence = metadata.get("confidence")
-    if speaker is not None and confidence is not None:
-        return speaker, confidence
-
     source = metadata.get("source") or ""
+
+    # Source-based defaults for whichever of the two fields the row
+    # is missing. Centralized so the speaker branch and the
+    # confidence branch read off the same per-source pair.
     if source == "episode":
-        return "episode_summary", 1.0
-    if source == "migration":
-        return _MIGRATION_SPEAKER, _MIGRATION_CONFIDENCE
-    return _LEGACY_SPEAKER, _LEGACY_CONFIDENCE
+        default_speaker, default_confidence = "episode_summary", 1.0
+    elif source == "migration":
+        default_speaker, default_confidence = _MIGRATION_SPEAKER, _MIGRATION_CONFIDENCE
+    else:
+        default_speaker, default_confidence = _LEGACY_SPEAKER, _LEGACY_CONFIDENCE
+
+    speaker = metadata.get("speaker") or default_speaker
+    confidence = metadata.get("confidence")
+    if confidence is None:
+        confidence = default_confidence
+    return speaker, confidence
 
 
 # Speaker-based ranking weights. Demote-only by design: every value is

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -805,6 +805,13 @@ async def format_context(
     # avoids that without losing the demote-only invariant (the
     # multiplier is still speaker_weight * confidence).
     def _resolved_row(r: MemoryResult) -> tuple[MemoryResult, float, str, float]:
+        # Duplicates the body of _speaker_weight (minus its
+        # _read_time_speaker call) so the resolved (speaker,
+        # confidence) pair is parsed once and reused for both the
+        # weight and the per-hit log payload below. If
+        # _speaker_weight ever gains a clamping or normalization
+        # step, mirror it here too: the demote-only invariant the
+        # floor filter depends on lives in both places.
         speaker, confidence = _read_time_speaker(r.metadata)
         weight = _SPEAKER_WEIGHTS.get(speaker, _UNKNOWN_SPEAKER_WEIGHT) * confidence
         return r, weight, speaker, confidence

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -58,7 +58,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.error import BadRequest
@@ -303,6 +303,48 @@ def _format_date(iso_str: str, with_time: bool = False) -> str:
     return iso_str[:10]
 
 
+# ── Speaker-aware browse helpers ───────────────────────────────────
+
+
+# Display labels for the speaker enum. Stored values are lower-snake
+# ("user" / "assistant" / "episode_summary"); the operator-facing UI
+# renders them title-cased and space-separated. Centralized here so
+# the fact-detail screen and any future surface use the same labels.
+_SPEAKER_DISPLAY_LABELS: dict[str, str] = {
+    "user": "User",
+    "assistant": "Assistant",
+    "episode_summary": "Episode summary",
+}
+
+
+def _humanize_speaker(speaker: str) -> str:
+    """Return the operator-facing display label for a speaker value.
+
+    Falls back to a title-cased, underscore-stripped version of the
+    raw value for any speaker class that lacks an explicit entry. The
+    fallback exists so a future addition to the speaker enum (added
+    upstream before this map is updated) renders something readable
+    instead of leaking the internal snake_case identifier.
+    """
+    label = _SPEAKER_DISPLAY_LABELS.get(speaker)
+    if label is not None:
+        return label
+    return speaker.replace("_", " ").capitalize()
+
+
+def _browse_score(fact: MemoryResult) -> float:
+    """Browse-time quality score: cosine pinned at 1.0 * speaker_weight * confidence.
+
+    Identical formula to the retrieval ranking with cosine pinned at
+    1.0; means the browse default reflects the same quality signal
+    that retrieval uses. Calls into kai.memory's `_speaker_weight`
+    helper rather than re-deriving the formula here, so a calibration
+    sweep that retunes speaker weights or changes the multiplier
+    arithmetic does not require a parallel edit in the browse path.
+    """
+    return memory._speaker_weight(fact)
+
+
 # ── Builder: dashboard ──────────────────────────────────────────────
 
 
@@ -518,6 +560,7 @@ def _build_episode_list_view(
 def _build_facts_list_view(
     facts: list[MemoryResult],
     page: int,
+    sort: Literal["quality", "recent"] = "quality",
 ) -> tuple[str, InlineKeyboardMarkup, list[str], int, int]:
     """Render a paginated facts list folding extracted and migration.
 
@@ -526,6 +569,12 @@ def _build_facts_list_view(
     memory_ids list backs the screen cache so numbered button taps
     resolve to memory ids via integer index, keeping callback data
     well under the 64-byte Telegram ceiling.
+
+    `sort` is consumed only for the toggle-button rendering: the
+    builder is purely a view layer and does NOT sort the list. The
+    caller (`_send_facts_list`) owns the sort decision so the same
+    helper can be reused from non-browse callers (tests, future
+    surfaces) without inheriting the browse-time default.
 
     Per-row layout:
         N.  <truncated text>
@@ -576,12 +625,31 @@ def _build_facts_list_view(
     number_row = [
         InlineKeyboardButton(str(i + 1), callback_data=_encode_callback("fact", str(i))) for i in range(len(window))
     ]
+    # Sort toggle row above page nav. Each button carries its own
+    # sort mode in callback_data so a tap re-renders at the same page
+    # in the new mode. The active mode shows a leading checkmark; the
+    # inactive mode renders unmarked. Marking via button text rather
+    # than a separate state key means the rendered keyboard is
+    # self-describing - a screenshot of the keyboard alone is enough
+    # to tell which mode is active.
+    quality_label = "✓ Sort: Quality" if sort == "quality" else "Sort: Quality"
+    recent_label = "✓ Sort: Recent" if sort == "recent" else "Sort: Recent"
+    sort_row = [
+        InlineKeyboardButton(
+            quality_label,
+            callback_data=_encode_callback("facts", str(clamped), "quality"),
+        ),
+        InlineKeyboardButton(
+            recent_label,
+            callback_data=_encode_callback("facts", str(clamped), "recent"),
+        ),
+    ]
     nav_row: list[InlineKeyboardButton] = []
     if clamped > 0:
         nav_row.append(
             InlineKeyboardButton(
                 "< prev",
-                callback_data=_encode_callback("facts", str(clamped - 1)),
+                callback_data=_encode_callback("facts", str(clamped - 1), sort),
             )
         )
     nav_row.append(InlineKeyboardButton("back", callback_data=_encode_callback("dash")))
@@ -589,10 +657,10 @@ def _build_facts_list_view(
         nav_row.append(
             InlineKeyboardButton(
                 "next >",
-                callback_data=_encode_callback("facts", str(clamped + 1)),
+                callback_data=_encode_callback("facts", str(clamped + 1), sort),
             )
         )
-    return text, InlineKeyboardMarkup([number_row, nav_row]), memory_ids, clamped, total
+    return text, InlineKeyboardMarkup([number_row, sort_row, nav_row]), memory_ids, clamped, total
 
 
 # ── Builder: fact view ──────────────────────────────────────────────
@@ -634,6 +702,16 @@ def _build_fact_view(
     tags = md.get("tags") or []
     source = md.get("source", "")
 
+    # Speaker (and confidence, where applicable) come from the read-
+    # time helper rather than directly from metadata so legacy rows
+    # missing the new fields display the documented defaults instead
+    # of "----" / "(none)" placeholders. The helper returns
+    # (speaker, confidence); confidence is dropped on the episode
+    # render path because the constant 1.0 is not informative for
+    # operator-side review.
+    speaker_value, confidence_value = memory._read_time_speaker(md)
+    speaker_label = _humanize_speaker(speaker_value)
+
     if source == "episode" or source == "migration":
         # Episode and migration rows share a minimal body shape with
         # none of the extractor-only rows. The episode arm splices in
@@ -645,6 +723,11 @@ def _build_fact_view(
         # so detail_lines stays empty and the body collapses to the
         # quoted text plus the Tags / Date footer.
         tags_line = f"Tags:  {', '.join(tags) if tags else '(none)'}"
+        speaker_line = f"Speaker:  {speaker_label}"
+        # Migration rows render Confidence (always 0.9 via the
+        # migration default), episode rows omit it (the constant 1.0
+        # would be operator-side noise).
+        confidence_line = f"Confidence:  {confidence_value:.2f}" if source == "migration" else None
         detail_lines: list[str] = []
         if source == "episode":
             # Episode rows surface the outcome_quality field as a
@@ -697,29 +780,43 @@ def _build_fact_view(
             # surfaces the extracted/migration distinction; the
             # data-layer `source` field stays unchanged.
             header = "Fact"
+        # Footer row order: detail_lines (episode-only Approach/Outcome
+        # /Lessons/Actors block, empty for migration), Tags, Speaker,
+        # optional Confidence (migration only), Date. Speaker sits
+        # next to Tags so the two prov/identity lines render adjacent;
+        # Confidence trails when present so the date is the last line
+        # and matches the existing migration/episode tail convention.
+        footer_lines = [tags_line, speaker_line]
+        if confidence_line is not None:
+            footer_lines.append(confidence_line)
+        footer_lines.append(f"Date:  {_format_date(fact.created_at, with_time=True)}")
         lines = [
             header,
             "",
             f'"{fact.text}"',
             "",
             *detail_lines,
-            tags_line,
-            f"Date:  {_format_date(fact.created_at, with_time=True)}",
+            *footer_lines,
         ]
     else:
         # Extracted (or any defensive fallback for an unknown source
-        # that managed to reach this view). Renders the original
-        # six-row block unchanged so existing screenshots / muscle
-        # memory stay valid.
-        confidence = md.get("confidence")
+        # that managed to reach this view). Renders the existing
+        # extractor-only block (Tags / Confidence / Date / Session /
+        # Prompt version / Confirmation) plus a Speaker line inserted
+        # between Tags and Confidence so the two ranking-signal rows
+        # are visually grouped. Confidence comes from the read-time
+        # helper rather than directly from metadata so a row missing
+        # the field (extracted-legacy) renders the documented default
+        # instead of "----".
         session_id = md.get("session_id") or ""
         prompt_version = md.get("prompt_version") or ""
         confirmation = md.get("confirmation_quote") or ""
 
-        if isinstance(confidence, (int, float)):
-            conf_str = f"{float(confidence):.2f}"
-        else:
-            conf_str = "----"
+        # _read_time_speaker always returns a numeric confidence (the
+        # legacy default for extracted-legacy rows is 0.5), so the
+        # `----` fallback the older render carried for missing-field
+        # rows is no longer reachable on this branch.
+        conf_str = f"{float(confidence_value):.2f}"
 
         # Confirmation row: verbatim quote on confirmed_action facts,
         # literal "n/a" elsewhere. The schema invariant ("confirmation
@@ -734,6 +831,7 @@ def _build_fact_view(
             f'"{fact.text}"',
             "",
             f"Tags:             {', '.join(tags) if tags else '(none)'}",
+            f"Speaker:          {speaker_label}",
             f"Confidence:       {conf_str}",
             f"Date:             {_format_date(fact.created_at, with_time=True)}",
             f"Session:          {session_id or '(none)'}",
@@ -1075,18 +1173,24 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
             await query.answer()
             return
         if verb == "facts":
-            # Facts list browser (extracted + migration). Same page-
-            # arg shape as `eps`; invalid integer falls back to page
-            # 0. The unknown-verb dismiss at the bottom of this
-            # handler covers any future retirement of the verb,
-            # which would silently no-op stale callbacks in chat
-            # history (same compatibility path the retired `tag`
-            # verb relies on).
+            # Facts list browser (extracted + migration). Args:
+            #   args[0] - page integer (default 0 if missing/invalid)
+            #   args[1] - sort mode "quality" or "recent" (default
+            #             "quality" when missing; legacy 2-segment
+            #             callbacks from chat history without a sort
+            #             arg get the default behavior)
+            # The unknown-verb dismiss at the bottom of this handler
+            # covers any future retirement of the verb, which would
+            # silently no-op stale callbacks in chat history (same
+            # compatibility path the retired `tag` verb relies on).
             try:
                 page = int(args[0]) if args else 0
             except ValueError:
                 page = 0
-            await _send_facts_list(update, context, chat_id, page, edit=True)
+            sort: Literal["quality", "recent"] = "quality"
+            if len(args) >= 2 and args[1] == "recent":
+                sort = "recent"
+            await _send_facts_list(update, context, chat_id, page, edit=True, sort=sort)
             await query.answer()
             return
         if verb == "fact":
@@ -1247,16 +1351,31 @@ async def _send_facts_list(
     chat_id: int,
     page: int,
     edit: bool = False,
+    sort: Literal["quality", "recent"] = "quality",
 ) -> None:
     """Render and send/edit the facts list at `page`.
 
     Fetches via `memory.get_all_facts` (the fact-bucket enumeration
-    that folds extracted and migration), builds via
-    `_build_facts_list_view`, and sets the cache screen to `"facts"`
-    so a fact opened from this list can route back to the same page
-    via `_send_fact_view`'s return_to logic. Distinct from the
-    `"fact"` (singular) sentinel, which identifies the fact-detail
-    view.
+    that folds extracted and migration), re-sorts when sort is
+    "quality" (the default), builds via `_build_facts_list_view`,
+    and sets the cache screen to `"facts"` so a fact opened from
+    this list can route back to the same page via `_send_fact_view`'s
+    return_to logic. Distinct from the `"fact"` (singular) sentinel,
+    which identifies the fact-detail view.
+
+    `sort` modes:
+        "quality": re-sort the fetched list by browse score
+            (cosine pinned at 1.0; speaker_weight * confidence)
+            descending, with `updated_at` desc as the tiebreaker.
+            Default mode; surfaces high-quality facts first.
+        "recent": pass through unchanged. `get_all_facts` already
+            returns the list in updated-at-descending order, so no
+            second sort is needed.
+
+    The sort decision lives here rather than in `_build_facts_list_view`
+    so the renderer is purely a view layer; non-browse callers
+    (tests, future surfaces) can pass a pre-sorted list to the
+    builder without inheriting the browse-time default.
     """
     try:
         facts = memory.get_all_facts(user_id=str(chat_id))
@@ -1264,7 +1383,18 @@ async def _send_facts_list(
         log.exception("get_all_facts failed: %s", exc)
         await _send_or_edit(update, _MSG_QUERY_FAILED, None, edit=edit)
         return
-    text, kb, memory_ids, clamped_page, _total = _build_facts_list_view(facts, page)
+    if sort == "quality":
+        # Quality score (descending) primary, updated_at (descending)
+        # secondary. The compound key is a single sort call: Python's
+        # sort is stable, but tuple-key descending guarantees the
+        # tiebreaker direction matches the primary direction without
+        # relying on stability semantics.
+        facts = sorted(
+            facts,
+            key=lambda f: (_browse_score(f), f.updated_at or f.created_at or ""),
+            reverse=True,
+        )
+    text, kb, memory_ids, clamped_page, _total = _build_facts_list_view(facts, page, sort=sort)
     _set_cache(
         chat_id,
         _ScreenCache(screen="facts", page=clamped_page, memory_ids=memory_ids),

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -80,7 +80,16 @@ log = logging.getLogger(__name__)
 # analysis distinguish episodes classified under the tightened
 # wording (`prompt_version == "7"` on the extracted row produced
 # by the same call).
-_EXTRACTION_PROMPT_VERSION: str = "7"
+# v8 (2026-05-07): added per-fact speaker attribution. Fact schema
+# gains a required `speaker` enum field with values `user` and
+# `assistant`; the FORMAT section gains a paragraph documenting the
+# field plus four worked examples (two per class) showing the
+# conservative-default rule. `_validate_facts` defense-in-depth check
+# can override speaker to "assistant" when a fact's confirmation_quote
+# substring appears verbatim in an ASSISTANT message in the window.
+# The bump lets post-rollout log analysis cleanly partition facts
+# produced under the speaker-attribution prompt from earlier ones.
+_EXTRACTION_PROMPT_VERSION: str = "8"
 
 # Sibling of _EXTRACTION_PROMPT_VERSION for stage-2 episode generation.
 # Stored in each episode's metadata so future cleanups can target a
@@ -297,8 +306,19 @@ _FACT_SCHEMA: dict = {
                         "minLength": 1,
                         "maxLength": 64,
                     },
+                    # Per-fact speaker attribution. Two-value enum:
+                    # episodes use a third value ("episode_summary")
+                    # but flow through a separate write path that
+                    # does not go through the fact extractor. The
+                    # field is required so every new row carries it
+                    # explicitly; legacy rows missing it pick up the
+                    # documented default at read time.
+                    "speaker": {
+                        "type": "string",
+                        "enum": ["user", "assistant"],
+                    },
                 },
-                "required": ["content", "tags", "confidence", "intent"],
+                "required": ["content", "tags", "confidence", "intent", "speaker"],
                 "additionalProperties": False,
             },
             "maxItems": 5,
@@ -435,6 +455,31 @@ FORMAT each fact as:
 - confidence: a number in [0, 1]. Use 0.9+ for direct user statements,
   0.7 for clear user confirmation of an assistant claim, 0.5 for
   paraphrased or implied facts. Do not store below 0.5.
+- speaker: Set to `user` only when the fact is asserted directly in a
+  USER message in the window. If the fact comes from an ASSISTANT
+  message, OR if the fact summarizes information that spans both
+  speakers' messages, OR if you are uncertain which speaker contributed
+  the substantive claim, set speaker to `assistant`. The conservative
+  default is `assistant`.
+
+  Worked examples:
+
+  - USER message "I prefer concise responses to long ones" yielding
+    fact "user prefers concise responses". Speaker: `user`. Direct
+    user statement.
+  - USER message "I'm in Toronto, EST" yielding fact "user is in EST
+    timezone". Speaker: `user`. Direct self-report.
+  - ASSISTANT message "You've shipped three PRs in the last hour,
+    that's a lot" followed by USER message "yeah" yielding fact
+    "user is in a high-throughput review cycle". Speaker:
+    `assistant`. The substantive claim is the assistant's; user
+    acknowledgment alone does not promote it to user-stated.
+    Conservative default applies.
+  - ASSISTANT message "Looking at your last five messages, you tend
+    to bundle related changes into one PR rather than splitting
+    them" yielding fact "user prefers bundled PRs". Speaker:
+    `assistant`. Assistant-synthesized pattern with no corresponding
+    direct user statement in the window.
 - confirmation_quote: REQUIRED when tags include "confirmed_action",
   MUST be absent otherwise. Must be the verbatim user text that
   confirms the action, minimum 20 characters, and must reference
@@ -1283,6 +1328,8 @@ def _validate_facts(
     *,
     candidate_metadata: dict[str, dict],
     user_id: str,
+    user_window_text: str = "",
+    assistant_window_text: str = "",
 ) -> list[dict]:
     """
     Drop facts that violate confirmation-quote or consolidation rules.
@@ -1520,6 +1567,35 @@ def _validate_facts(
                 log.debug("_validate_facts: rejecting non-confirmed_action fact with quote")
                 continue
 
+        # Defense-in-depth speaker check (paired with the prompt's
+        # "conservative default is assistant" instruction). When a
+        # fact carries a `confirmation_quote`, look up where that
+        # substring appears verbatim in the conversation window:
+        #
+        #   - If the quote appears in an ASSISTANT message, force
+        #     speaker="assistant" regardless of what the extractor
+        #     returned. The substantive claim is the assistant's;
+        #     the model may have mis-attributed it to the user.
+        #   - Otherwise (quote in user only, or quote not found in
+        #     either), leave the extractor's speaker value alone.
+        #     The conservative-default rule in the prompt already
+        #     biases toward "assistant"; this check only forces a
+        #     correction in one direction (toward assistant), never
+        #     promotes a fact to user-claimed.
+        #
+        # The full-substring requirement against the schema's 20-char
+        # minimum on confirmation_quote makes coincidental cross-
+        # speaker matches rare. If the rate proves non-trivial in
+        # production, a follow-up issue weakens the override to
+        # log-only.
+        #
+        # Defense-in-depth only fires for facts carrying a
+        # confirmation_quote; non-confirmed_action facts have no
+        # quote substring to check against and rely on the prompt-
+        # side conservative default alone.
+        if isinstance(quote, str) and assistant_window_text and quote in assistant_window_text:
+            fact["speaker"] = "assistant"
+
         validated.append(fact)
     return validated
 
@@ -1568,6 +1644,8 @@ async def _run_extractor(
     candidate_metadata: dict[str, dict],
     user_id: str,
     system_prompt: str = _EXTRACTION_SYSTEM_PROMPT,
+    user_window_text: str = "",
+    assistant_window_text: str = "",
 ) -> ExtractionResult:
     """
     Spawn `claude --print` with the extractor prompt and parse the JSON.
@@ -1729,7 +1807,14 @@ async def _run_extractor(
     facts_raw = payload_root.get("facts") or []
     has_episode = bool(payload_root.get("has_episode"))
     return ExtractionResult(
-        facts=_validate_facts(facts_raw, candidate_ids, candidate_metadata=candidate_metadata, user_id=user_id),
+        facts=_validate_facts(
+            facts_raw,
+            candidate_ids,
+            candidate_metadata=candidate_metadata,
+            user_id=user_id,
+            user_window_text=user_window_text,
+            assistant_window_text=assistant_window_text,
+        ),
         has_episode=has_episode,
     )
 
@@ -2027,6 +2112,19 @@ async def _generate_episode(
                         "actors": episode["actors"],
                         "session_id": session_id or "",
                         "episode_prompt_version": _EPISODE_PROMPT_VERSION,
+                        # Speaker / confidence pinned at write time
+                        # (not produced by the episode generator).
+                        # Episodes pass two-stage validation already
+                        # (Stage 1 classifier + Stage 2 generator +
+                        # _validate_episode), so a model-supplied
+                        # confidence would be a third filter on
+                        # already-vetted content; the constant 1.0
+                        # reflects the curated multi-stage path. The
+                        # speaker enum's third value lives only on
+                        # this write path; the extractor's two-value
+                        # enum (user / assistant) does not carry it.
+                        "speaker": "episode_summary",
+                        "confidence": 1.0,
                     }
                     if "lessons" in episode:
                         extra["lessons"] = episode["lessons"]
@@ -2411,12 +2509,23 @@ async def extract_and_store(
                 candidates,
                 prior_pairs=prior_pairs,
             )
+            # Concatenate the conversation window's user-side and
+            # assistant-side text so `_validate_facts` can run the
+            # defense-in-depth speaker check (look for a fact's
+            # confirmation_quote substring in either side). Joining
+            # current-exchange + prior-pairs together with " " lets
+            # the substring search treat the whole window as one
+            # haystack without re-implementing the prior-pair walk.
+            user_window_text = " ".join([p[0] for p in (prior_pairs or [])] + [user_text])
+            assistant_window_text = " ".join([p[1] for p in (prior_pairs or [])] + [assistant_capped])
             result = await _run_extractor(
                 payload,
                 config,
                 candidate_ids=candidate_id_set,
                 candidate_metadata=candidate_metadata,
                 user_id=user_id,
+                user_window_text=user_window_text,
+                assistant_window_text=assistant_window_text,
             )
             # Restructured for stage-2 (issue #385): facts and has_episode
             # are independent. An exchange can be episode-worthy without

--- a/tests/test_eval_retrieval.py
+++ b/tests/test_eval_retrieval.py
@@ -68,23 +68,21 @@ def _reset_memory_module() -> None:
     """Restore memory module state between tests.
 
     Mirrors the helper in tests/test_memory.py: harness tests mutate
-    `_memory`, `_config`, `_SOURCE_WEIGHTS`, and `_SEARCH_OVERFETCH`,
+    `_memory`, `_config`, `_SPEAKER_WEIGHTS`, and `_SEARCH_OVERFETCH`,
     and a leak between tests would silently couple them.
     """
     import kai.memory as mem_mod
 
     mem_mod._memory = None
     mem_mod._config = None
-    # _SOURCE_WEIGHTS is the production default snapshot; reset both
-    # the dict contents AND _UNKNOWN_SOURCE_WEIGHT so a sweep test
-    # mutating "extracted" does not leak into the next test. Must
-    # mirror the production default in src/kai/memory.py exactly,
-    # including the "episode" entry (issue #385) and the "migration"
-    # entry (issue #406) - otherwise tests reading the dict after
-    # this fixture has run will see a stale snapshot missing entries.
-    mem_mod._SOURCE_WEIGHTS.clear()
-    mem_mod._SOURCE_WEIGHTS.update({"extracted": 1.2, "episode": 1.2, "migration": 1.0, "": 0.6})
-    mem_mod._UNKNOWN_SOURCE_WEIGHT = mem_mod._SOURCE_WEIGHTS[""]
+    # `_SPEAKER_WEIGHTS` is the production default snapshot; reset
+    # the dict contents so a sweep test mutating any speaker entry
+    # does not leak into the next test. Must mirror the production
+    # default in src/kai/memory.py exactly, otherwise tests reading
+    # the dict after this fixture has run will see a stale snapshot
+    # missing entries.
+    mem_mod._SPEAKER_WEIGHTS.clear()
+    mem_mod._SPEAKER_WEIGHTS.update({"user": 1.0, "assistant": 0.7, "episode_summary": 0.85})
     mem_mod._SEARCH_OVERFETCH = 20
 
 
@@ -303,7 +301,7 @@ class TestSweepRestoration:
         # that won't accidentally alias the dict the harness mutated.
         mem_mod._config = _BASE_CONFIG
         original_floor = mem_mod._config.memory_search_floor
-        original_weights = dict(mem_mod._SOURCE_WEIGHTS)
+        original_weights = dict(mem_mod._SPEAKER_WEIGHTS)
         original_overfetch = mem_mod._SEARCH_OVERFETCH
 
         # The sweep loop now calls `_score_against_store` per grid
@@ -334,8 +332,20 @@ class TestSweepRestoration:
             )
 
         grid = [
-            ConfigOverride(floor=0.20, extracted_weight=1.5, overfetch=10),
-            ConfigOverride(floor=0.40, extracted_weight=2.0, overfetch=30),
+            ConfigOverride(
+                floor=0.20,
+                user_weight=1.0,
+                assistant_weight=0.6,
+                episode_summary_weight=0.85,
+                overfetch=10,
+            ),
+            ConfigOverride(
+                floor=0.40,
+                user_weight=0.85,
+                assistant_weight=0.7,
+                episode_summary_weight=0.7,
+                overfetch=30,
+            ),
         ]
         with (
             patch(
@@ -355,7 +365,7 @@ class TestSweepRestoration:
 
         # The whole point of test 3: state restored despite the abort.
         assert mem_mod._config.memory_search_floor == original_floor
-        assert original_weights == mem_mod._SOURCE_WEIGHTS
+        assert original_weights == mem_mod._SPEAKER_WEIGHTS
         assert original_overfetch == mem_mod._SEARCH_OVERFETCH
 
 
@@ -484,9 +494,27 @@ class TestDriftDetection:
                 latency_p95_ms=lat,
             )
 
-        cfg_a = ConfigOverride(floor=0.2, extracted_weight=1.0, overfetch=10)
-        cfg_b = ConfigOverride(floor=0.3, extracted_weight=1.2, overfetch=20)
-        cfg_c = ConfigOverride(floor=0.4, extracted_weight=2.0, overfetch=30)
+        cfg_a = ConfigOverride(
+            floor=0.2,
+            user_weight=1.0,
+            assistant_weight=0.5,
+            episode_summary_weight=0.85,
+            overfetch=10,
+        )
+        cfg_b = ConfigOverride(
+            floor=0.3,
+            user_weight=1.0,
+            assistant_weight=0.7,
+            episode_summary_weight=0.85,
+            overfetch=20,
+        )
+        cfg_c = ConfigOverride(
+            floor=0.4,
+            user_weight=0.85,
+            assistant_weight=0.8,
+            episode_summary_weight=1.0,
+            overfetch=30,
+        )
         sweep = [(cfg_a, _m(0.8, 50)), (cfg_b, _m(0.7, 100)), (cfg_c, _m(0.9, 200))]
         front = pareto_frontier(sweep)
         front_cfgs = [c for c, _ in front]
@@ -564,3 +592,120 @@ class TestEvaluateEndToEnd:
         assert metrics.precision_at_k[5] == pytest.approx(1.0)
         assert metrics.mrr == pytest.approx(1.0)
         assert metrics.fraction_in_prompt == pytest.approx(1.0)
+
+
+class TestApplyOverride:
+    """`_apply_override` and `_restore_overrides` are the two helpers
+    `run_sweep` calls per iteration to mutate / restore module state.
+    Direct tests of the helpers stand in for the higher-level
+    `run_sweep` test by exercising the same state-touch pattern in
+    isolation, without spinning up an evaluate loop. Together they
+    pin the schema-required restore-roundtrip property the sweep
+    `finally` block depends on.
+    """
+
+    def test_apply_override_writes_three_weights(self):
+        # `_apply_override` must mutate all three speaker entries in
+        # place. The pre-mutation snapshot returned by the helper
+        # carries the prior values so a `_restore_overrides` call
+        # rolls them back exactly. Pin both sides of the contract:
+        # post-apply state matches the override, snapshot matches
+        # pre-apply state.
+        import kai.memory as mem_mod
+        from kai.eval.retrieval import _apply_override
+
+        # Install a real Config object so the helper's
+        # `dataclasses.replace(snap.config, ...)` call has something
+        # to clone from. Autouse fixture leaves _config=None.
+        mem_mod._config = _BASE_CONFIG
+
+        # Known starting state (the autouse fixture pre-fills these
+        # to production values; assert against those values rather
+        # than against literals so a default-tune retro flows through).
+        pre_user = mem_mod._SPEAKER_WEIGHTS["user"]
+        pre_assistant = mem_mod._SPEAKER_WEIGHTS["assistant"]
+        pre_episode = mem_mod._SPEAKER_WEIGHTS["episode_summary"]
+
+        override = ConfigOverride(
+            floor=0.20,
+            user_weight=0.85,
+            assistant_weight=0.6,
+            episode_summary_weight=1.0,
+            overfetch=15,
+        )
+        snap = _apply_override(override)
+
+        # Post-apply: live dict matches override.
+        assert mem_mod._SPEAKER_WEIGHTS["user"] == 0.85
+        assert mem_mod._SPEAKER_WEIGHTS["assistant"] == 0.6
+        assert mem_mod._SPEAKER_WEIGHTS["episode_summary"] == 1.0
+
+        # Snapshot: pre-apply values captured for the restore path.
+        assert snap.speaker_weights["user"] == pre_user
+        assert snap.speaker_weights["assistant"] == pre_assistant
+        assert snap.speaker_weights["episode_summary"] == pre_episode
+
+    def test_apply_override_writes_overfetch_and_floor(self):
+        # `_apply_override` mutates `_SEARCH_OVERFETCH` and rebuilds
+        # `_config` with the override's floor; the snapshot carries
+        # the pre-mutation values for both. Pin the restore path's
+        # data here so a regression that captures stale values fails
+        # this test rather than at sweep finally-time.
+        import kai.memory as mem_mod
+        from kai.eval.retrieval import _apply_override
+
+        # Install a known config so the floor swap is observable.
+        mem_mod._config = _BASE_CONFIG
+        pre_overfetch = mem_mod._SEARCH_OVERFETCH
+
+        override = ConfigOverride(
+            floor=0.42,
+            user_weight=1.0,
+            assistant_weight=0.7,
+            episode_summary_weight=0.85,
+            overfetch=11,
+        )
+        snap = _apply_override(override)
+
+        assert mem_mod._SEARCH_OVERFETCH == 11
+        assert mem_mod._config is not None
+        assert mem_mod._config.memory_search_floor == 0.42
+
+        # Snapshot captures the pre-apply values.
+        assert snap.overfetch == pre_overfetch
+        assert snap.config is _BASE_CONFIG
+
+    def test_restore_overrides_undoes_apply(self):
+        # The full round-trip: apply, mutate observable state, restore
+        # from the snapshot, assert the live module is back at its
+        # pre-apply shape. This is the contract `run_sweep`'s
+        # `finally` block depends on; testing it in isolation lets
+        # a regression in the helper trip here rather than during a
+        # mid-sweep abort path.
+        import kai.memory as mem_mod
+        from kai.eval.retrieval import _apply_override, _restore_overrides
+
+        mem_mod._config = _BASE_CONFIG
+        pre_speaker_weights = dict(mem_mod._SPEAKER_WEIGHTS)
+        pre_overfetch = mem_mod._SEARCH_OVERFETCH
+        pre_config = mem_mod._config
+
+        override = ConfigOverride(
+            floor=0.99,
+            user_weight=0.1,
+            assistant_weight=0.2,
+            episode_summary_weight=0.3,
+            overfetch=99,
+        )
+        snap = _apply_override(override)
+        # Sanity check: we are NOT testing the no-op identity path -
+        # the override must have actually mutated state for the
+        # restore assertion below to mean anything.
+        assert pre_speaker_weights != mem_mod._SPEAKER_WEIGHTS
+        assert pre_overfetch != mem_mod._SEARCH_OVERFETCH
+
+        _restore_overrides(snap)
+
+        assert pre_speaker_weights == mem_mod._SPEAKER_WEIGHTS
+        assert pre_overfetch == mem_mod._SEARCH_OVERFETCH
+        assert mem_mod._config is pre_config

--- a/tests/test_eval_retrieval.py
+++ b/tests/test_eval_retrieval.py
@@ -83,6 +83,14 @@ def _reset_memory_module() -> None:
     # missing entries.
     mem_mod._SPEAKER_WEIGHTS.clear()
     mem_mod._SPEAKER_WEIGHTS.update({"user": 1.0, "assistant": 0.7, "episode_summary": 0.85})
+    # `_UNKNOWN_SPEAKER_WEIGHT` is aliased to the assistant entry
+    # at module-load time (a float copy, not a live dict reference).
+    # If a sweep test mutates `assistant` and a subsequent test
+    # reads `_UNKNOWN_SPEAKER_WEIGHT`, the alias would carry the
+    # mutated value into the next test. Re-bind explicitly to keep
+    # the documented invariant ("unknown rows ride on the assistant
+    # weight") holding across tests.
+    mem_mod._UNKNOWN_SPEAKER_WEIGHT = mem_mod._SPEAKER_WEIGHTS["assistant"]
     mem_mod._SEARCH_OVERFETCH = 20
 
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -439,33 +439,46 @@ class TestFormatContext:
         output = await format_context("history", user_id="123")
         assert "- (2026-01-15, legacy) Old pre-spec entry" in output
 
-    async def test_format_context_source_weighting_ranks_extracted_first(self):
-        """Source weighting reorders results so extracted > legacy at equal raw score.
-
-        Spec 360 removed the `user_raw` middle tier, so this test now
-        verifies the surviving 2-way ordering: extracted (1.2x) outranks
-        legacy/unset (0.6x) at the same raw score. Mem0 returns them in
-        reverse order to confirm the formatter does its own sort rather
-        than relying on input order."""
+    async def test_format_context_orders_by_weighted_score(self):
+        """At equal raw cosine, a user-speaker row ranks above an
+        assistant-speaker row. The new ranking key is `cosine *
+        speaker_weight * confidence`; with speakers = (user, assistant)
+        and confidence held equal, the speaker_weights table alone
+        decides the tie. Mem0 returns the rows in reverse order to
+        confirm the formatter does its own sort rather than relying
+        on input order.
+        """
         import kai.memory as mem_mod
         from kai.memory import format_context
 
-        # Two results with IDENTICAL raw score; only source differs.
+        # Two results with IDENTICAL raw score and confidence; only
+        # speaker differs. Both confidences are 0.9 so a difference
+        # in confidence cannot account for any reordering.
         mock_mem = MagicMock()
         mock_mem.search.return_value = {
             "results": [
                 {
                     "id": "a",
-                    "memory": "Legacy entry text",
+                    "memory": "Assistant inferred a pattern",
                     "score": 0.8,
-                    "metadata": {"type": "exchange"},  # no source -> legacy
+                    "metadata": {
+                        "type": "fact",
+                        "source": "extracted",
+                        "speaker": "assistant",
+                        "confidence": 0.9,
+                    },
                     "created_at": "2026-01-01T00:00:00",
                 },
                 {
                     "id": "c",
                     "memory": "User prefers vim for editing",
                     "score": 0.8,
-                    "metadata": {"type": "fact", "source": "extracted"},
+                    "metadata": {
+                        "type": "fact",
+                        "source": "extracted",
+                        "speaker": "user",
+                        "confidence": 0.9,
+                    },
                     "created_at": "2026-03-01T00:00:00",
                 },
             ]
@@ -476,27 +489,40 @@ class TestFormatContext:
         output = await format_context("editor", user_id="123")
         lines = output.splitlines()[1:]  # skip header
 
-        # The formatter should walk in adjusted-score order. At equal raw
-        # score the order is fixed by weight: extracted (1.2), legacy (0.6).
+        # User-speaker outranks assistant-speaker at equal cosine and
+        # equal confidence. With speaker weights at 1.0 vs 0.7 the
+        # adjusted scores are 0.72 vs 0.504, ordering: user, assistant.
         assert "User prefers vim for editing" in lines[0]
-        assert "Legacy entry text" in lines[1]
+        assert "Assistant inferred a pattern" in lines[1]
 
-    async def test_format_context_weighting_never_rescues_subthreshold(self):
-        """A sub-threshold extracted row stays filtered even after weighting."""
+    async def test_format_context_floor_applies_to_raw_cosine(self):
+        """A sub-threshold row stays filtered even though weighting
+        could in principle re-rank rows past the floor. The new
+        weights are demote-only (every value <= 1.0), so weighting
+        can only lower a row's adjusted score. The floor check runs
+        on raw cosine, BEFORE the speaker multiplier, which means a
+        sub-threshold row never reaches the walk regardless of its
+        speaker class.
+        """
         import kai.memory as mem_mod
         from kai.memory import format_context
 
-        # raw_score 0.25 < memory_search_floor (0.3); boosting by 1.2
-        # yields 0.30, but weighting happens AFTER the filter (§5.3) so this
-        # row never reaches the walk. Result must be empty.
+        # raw_score 0.25 < memory_search_floor (0.3). Even an
+        # otherwise-promotable user-speaker row (speaker_weight 1.0)
+        # cannot rescue it because the filter runs on raw cosine.
         mock_mem = MagicMock()
         mock_mem.search.return_value = {
             "results": [
                 {
                     "id": "sub",
-                    "memory": "Borderline extracted fact",
+                    "memory": "Borderline user-claimed fact",
                     "score": 0.25,
-                    "metadata": {"type": "fact", "source": "extracted"},
+                    "metadata": {
+                        "type": "fact",
+                        "source": "extracted",
+                        "speaker": "user",
+                        "confidence": 1.0,
+                    },
                     "created_at": "2026-04-01T00:00:00",
                 },
             ]
@@ -506,6 +532,64 @@ class TestFormatContext:
 
         output = await format_context("anything", user_id="123")
         assert output == ""
+
+    async def test_format_context_log_payload_carries_speaker_and_confidence(self, caplog):
+        """The per-hit log payload exposes `speaker` and `confidence`
+        siblings of `source`. For a legacy row missing both fields
+        from metadata, the logged values must be the defaulted
+        constants returned by `_read_time_speaker`, NOT a missing-
+        field marker - so a log analyst reading the line can
+        reconstruct the demote multiplier (`speaker_weight *
+        confidence`) without re-fetching the row.
+
+        This is the test that catches a regression where the per-hit
+        builder reads `r.metadata["speaker"]` directly (which would
+        be None for legacy rows) instead of going through the
+        helper. Without the helper indirection, every legacy row
+        would log speaker=null and the eval harness would lose its
+        ability to attribute ranking decisions.
+        """
+        import kai.memory as mem_mod
+        from kai.memory import (
+            _LEGACY_CONFIDENCE,
+            _LEGACY_SPEAKER,
+            format_context,
+        )
+
+        # One legacy row (no speaker/confidence in metadata, source ==
+        # "extracted"): the read-time helper falls into branch 4 and
+        # supplies the legacy defaults. The assertion below pins
+        # against the bound module constants so a swap-the-constants
+        # follow-up does not break this test.
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {
+            "results": [
+                {
+                    "id": "legacy",
+                    "memory": "Some legacy claim",
+                    "score": 0.8,
+                    "metadata": {"type": "fact", "source": "extracted"},
+                    "created_at": "2026-01-01T00:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+        mem_mod._config = _make_config()
+
+        with caplog.at_level(logging.INFO, logger="kai.memory"):
+            await format_context("legacy fact", user_id="42")
+
+        payload = _parse_recall_log(caplog)
+        assert len(payload["hits"]) == 1
+        hit = payload["hits"][0]
+        # Speaker and confidence carry the defaulted values.
+        assert hit["speaker"] == _LEGACY_SPEAKER
+        assert hit["confidence"] == _LEGACY_CONFIDENCE
+        # Source still passes through as recorded on the row, NOT
+        # collapsed into the speaker default. The two fields describe
+        # different axes (write path vs whose claim) and must both
+        # remain readable.
+        assert hit["source"] == "extracted"
 
     async def test_format_context_disabled_returns_empty(self):
         """Returns empty string when memory is not initialized."""
@@ -614,6 +698,110 @@ class TestFormatContext:
             assert "(user)" not in line
 
 
+# ── Speaker weight function ────────────────────────────────────────
+
+
+class TestSpeakerWeight:
+    """Tests for `_speaker_weight`, the read-time multiplier the
+    retrieval sort uses in place of the older `_source_weight`. The
+    helper composes two factors: a speaker_weights table lookup and
+    the row's confidence value, both surfaced by `_read_time_speaker`.
+    """
+
+    def test_speaker_weight_combines_factors(self):
+        """speaker_weight * confidence is the contract; pin the
+        multiplication so a refactor that swaps order or drops a
+        factor fails immediately. Use a row carrying speaker and
+        confidence in metadata so the `_read_time_speaker` path is
+        the explicit-fields branch, not a defaulted branch.
+        """
+        from kai.memory import _SPEAKER_WEIGHTS, MemoryResult, _speaker_weight
+
+        row = MemoryResult(
+            id="x",
+            text="User prefers dark mode",
+            score=0.5,
+            memory_type="fact",
+            metadata={
+                "type": "fact",
+                "source": "extracted",
+                "speaker": "user",
+                "confidence": 0.8,
+            },
+            created_at="2026-04-01T00:00:00",
+        )
+
+        # Expected: speaker_weights["user"] * confidence
+        # Held against the table rather than literal 1.0 so the test
+        # stays honest if the calibration sweep retunes "user".
+        assert _speaker_weight(row) == _SPEAKER_WEIGHTS["user"] * 0.8
+
+    def test_speaker_weight_unknown_speaker(self):
+        """A row whose speaker value is not in the speaker_weights
+        table falls back to _UNKNOWN_SPEAKER_WEIGHT (aliased to the
+        assistant weight). Confidence is unaffected by the unknown
+        path; the multiplier is `_UNKNOWN_SPEAKER_WEIGHT * confidence`.
+
+        Pins the unknown-class fallback against the named alias rather
+        than a literal so a future change to the alias target (e.g.,
+        if the design shifts unknown back toward the legacy floor)
+        flows through automatically.
+        """
+        from kai.memory import _UNKNOWN_SPEAKER_WEIGHT, MemoryResult, _speaker_weight
+
+        row = MemoryResult(
+            id="x",
+            text="Some claim of unknown origin",
+            score=0.5,
+            memory_type="fact",
+            metadata={
+                "type": "fact",
+                "source": "extracted",
+                "speaker": "mystery_class",
+                "confidence": 0.7,
+            },
+            created_at="2026-04-01T00:00:00",
+        )
+
+        assert _speaker_weight(row) == _UNKNOWN_SPEAKER_WEIGHT * 0.7
+
+    def test_speaker_weight_demote_only(self):
+        """For every (in-enum speaker, in-range confidence) pair, the
+        combined multiplier stays in [0.0, 1.0]. This is the load-
+        bearing invariant for the floor check: as long as the weight
+        is <= 1.0, raw cosine remains an upper bound on adjusted
+        score, and a sub-threshold row (raw_score < floor) cannot be
+        rescued by a high speaker weight.
+
+        Iterates the production table directly so a calibration sweep
+        that bumps a value above 1.0 in a future tune fails this test
+        loudly rather than silently breaking the floor invariant.
+        """
+        from kai.memory import _SPEAKER_WEIGHTS, MemoryResult, _speaker_weight
+
+        # Confidence floor (0.5) and ceiling (1.0) come from the fact
+        # schema's [0.5, 1.0] range. Ceilings above 1.0 are not valid
+        # production values and would themselves be a separate bug.
+        confidences = (0.5, 0.7, 0.85, 1.0)
+        for speaker in _SPEAKER_WEIGHTS:
+            for confidence in confidences:
+                row = MemoryResult(
+                    id=f"{speaker}-{confidence}",
+                    text="placeholder",
+                    score=0.5,
+                    memory_type="fact",
+                    metadata={
+                        "type": "fact",
+                        "source": "extracted",
+                        "speaker": speaker,
+                        "confidence": confidence,
+                    },
+                    created_at="2026-04-01T00:00:00",
+                )
+                w = _speaker_weight(row)
+                assert 0.0 <= w <= 1.0, f"speaker={speaker} confidence={confidence} weight={w}"
+
+
 # ── memory.recall logging ───────────────────────────────────────────
 
 
@@ -678,17 +866,15 @@ class TestRecallLogging:
         from kai.memory import format_context
 
         # Two results, both above the default 0.3 floor, with raw scores
-        # arranged so ONLY the source weighting can flip them: the legacy
-        # row has the higher raw score (0.95), the extracted row the
-        # lower (0.90). Adjusted scores are 0.95 * 0.6 = 0.57 (legacy)
-        # and 0.90 * 1.2 = 1.08 (extracted), so the extracted entry must
-        # come first in post-sort order. If `_source_weight` were
-        # disabled or returned 1.0 for every source, the assertion below
-        # on `payload["hits"][0]["source"]` would fail because raw
-        # ordering would put legacy first. The original arrangement
-        # (extracted=0.9, legacy=0.7) had the same expected output under
-        # both raw and adjusted ordering and would not have caught a
-        # weighting regression.
+        # arranged so ONLY the speaker weighting can flip them: the
+        # legacy/no-source row has the higher raw score (0.95), the
+        # user-claimed row the lower (0.90). Adjusted scores are
+        # 0.95 * 0.7 * 0.5 = 0.3325 (legacy default = assistant/0.5)
+        # and 0.90 * 1.0 * 1.0 = 0.90 (user, full confidence), so the
+        # user-claimed entry must come first in post-sort order. If
+        # `_speaker_weight` were disabled or returned 1.0 for every
+        # row, the assertion below on `payload["hits"][0]["id"]` would
+        # fail because raw ordering would put the legacy row first.
         mock_mem = MagicMock()
         mock_mem.search.return_value = {
             "results": [
@@ -696,15 +882,26 @@ class TestRecallLogging:
                     "id": "a",
                     "memory": "User prefers Celsius",
                     "score": 0.90,
-                    "metadata": {"type": "fact", "source": "extracted"},
+                    "metadata": {
+                        "type": "fact",
+                        "source": "extracted",
+                        "speaker": "user",
+                        "confidence": 1.0,
+                    },
                     "created_at": "2026-04-01T10:00:00",
                 },
                 {
                     "id": "b",
                     "memory": "User said something old",
                     "score": 0.95,
-                    # No source key -> legacy bucket; tests that a missing
-                    # source resolves to "" in the per-hit object.
+                    # No source / speaker / confidence keys: simulates a
+                    # legacy row from before this spec landed. The
+                    # _read_time_speaker helper supplies the documented
+                    # default (assistant, 0.5) at the ranking step, which
+                    # is what makes adj = 0.3325 below the user-claimed
+                    # row's 0.90. The per-hit log payload still records
+                    # source="" and speaker="assistant" / confidence=0.5
+                    # so a log analyst can reconstruct the multiplier.
                     "metadata": {"type": "exchange"},
                     "created_at": "2026-01-01T00:00:00",
                 },
@@ -741,17 +938,30 @@ class TestRecallLogging:
         assert payload["latency_ms"] >= 0  # wall-time, can be 0 for mocked instant search
         assert isinstance(payload["hits"], list) and len(payload["hits"]) == 2
 
-        # Per-hit shape: id, source, score, adj, snippet. `id` was added
-        # so a downstream consumer (the retrieval eval harness) can
-        # match a probe's expected_fact_id against the actual hit. The
-        # mock returns rows with ids "a" and "b"; the assertion below
-        # locks in the ID-passthrough contract.
+        # Per-hit shape: id, source, speaker, confidence, score, adj,
+        # snippet. `speaker` and `confidence` ride alongside `source`
+        # so a log analyst can reconstruct the demote multiplier
+        # without re-fetching the row; both are derived through
+        # _read_time_speaker so legacy rows log defaulted constants
+        # rather than missing-field markers. `id` exists so a
+        # downstream consumer (the retrieval eval harness) can match
+        # a probe's expected_fact_id against the actual hit.
         for hit in payload["hits"]:
-            assert set(hit.keys()) == {"id", "source", "score", "adj", "snippet"}
+            assert set(hit.keys()) == {
+                "id",
+                "source",
+                "speaker",
+                "confidence",
+                "score",
+                "adj",
+                "snippet",
+            }
             assert isinstance(hit["id"], str)
             assert isinstance(hit["score"], float)
             assert isinstance(hit["adj"], float)
             assert isinstance(hit["snippet"], str)
+            assert isinstance(hit["speaker"], str)
+            assert isinstance(hit["confidence"], (int, float))
 
         # Per-hit `id` passes through from MemoryResult.id. The mocked
         # search returned rows with ids "a" (extracted) and "b" (legacy);
@@ -760,12 +970,14 @@ class TestRecallLogging:
         # adjusted-score sort assertion below.
         assert {hit["id"] for hit in payload["hits"]} == {"a", "b"}
 
-        # Post-sort order: extracted (1.2x weight) outranks legacy (0.6x)
-        # by adjusted score, so the extracted hit must come first in
-        # the hits array even though Mem0 returned legacy with the
-        # higher raw score (0.95 vs 0.90). This is the assertion that
-        # would fail if `_source_weight` ever stopped applying its
-        # multiplier; the mock is built so raw ordering and adjusted
+        # Post-sort order: the user-claimed row (speaker=user,
+        # confidence=1.0, weight 1.0) outranks the legacy row
+        # (defaulted to assistant/0.5, weight 0.7) by adjusted score,
+        # so the user-claimed hit must come first in the hits array
+        # even though Mem0 returned the legacy row with the higher raw
+        # score (0.95 vs 0.90). This is the assertion that would fail
+        # if `_speaker_weight` ever stopped applying its multiplier;
+        # the mock is built so raw ordering and adjusted
         # ordering disagree.
         assert payload["hits"][0]["source"] == "extracted"
         assert payload["hits"][1]["source"] == ""
@@ -1260,18 +1472,14 @@ class TestCountBySource:
 
 
 class TestMigrationSourceMetadata:
-    """Tests for the new "migration" source tag in _SOURCE_WEIGHTS and
-    _SOURCE_SHORT (issue #406, Phase 4 of #396)."""
-
-    def test_migration_source_weight_is_1_0(self):
-        """Pin the weight value so a future refactor accidentally
-        removing or retuning the entry fails loudly. The value is
-        chosen to sit between extracted (1.2) and legacy (0.6); see
-        spec §D3.
-        """
-        from kai.memory import _SOURCE_WEIGHTS
-
-        assert _SOURCE_WEIGHTS["migration"] == 1.0
+    """Tests for the migration source tag's rendering label in
+    _SOURCE_SHORT. The retrieval-side weighting that previously lived
+    in _SOURCE_WEIGHTS now goes through _speaker_weight, which uses
+    speaker rather than source; migration rows pick up speaker="user"
+    and confidence=0.9 via the read-time helper. The "Speaker" axis
+    tests live with the speaker-weight tests; this class keeps only
+    the per-line label assertion that is genuinely about source.
+    """
 
     def test_migration_renders_as_fact_prefix_in_format_context(self):
         """Migration rows render with the same line-prefix label as
@@ -1281,6 +1489,39 @@ class TestMigrationSourceMetadata:
         from kai.memory import _SOURCE_SHORT
 
         assert _SOURCE_SHORT["migration"] == _SOURCE_SHORT["extracted"]
+
+    def test_build_migration_metadata_sets_required_fields(self):
+        """The migration writer and the tests both drive
+        `build_migration_metadata` for the metadata bundle. Pin the
+        full dict shape: source / speaker / confidence / section /
+        subsection. The speaker and confidence values come from the
+        migration constants so a swap-the-constants follow-up flows
+        through automatically.
+        """
+        from kai.memory import (
+            _MIGRATION_CONFIDENCE,
+            _MIGRATION_SPEAKER,
+            build_migration_metadata,
+        )
+
+        # Standard h3 chunk shape: section + subsection both populated.
+        meta = build_migration_metadata(section="Architecture", subsection="Memory")
+        assert meta == {
+            "source": "migration",
+            "speaker": _MIGRATION_SPEAKER,
+            "confidence": _MIGRATION_CONFIDENCE,
+            "section": "Architecture",
+            "subsection": "Memory",
+        }
+
+        # H2-chunk shape: subsection is the empty string, NOT
+        # missing. Centralizing this here means the Qdrant rows
+        # have a uniform schema regardless of chunk depth, so a
+        # future tag-renderer or section browser does not have to
+        # branch on key presence.
+        meta_h2 = build_migration_metadata(section="Conventions", subsection="")
+        assert meta_h2["subsection"] == ""
+        assert meta_h2["section"] == "Conventions"
 
 
 class TestGetStats:
@@ -3094,6 +3335,206 @@ class TestMemoryIntegration:
         output = await mem_mod.format_context("How much RAM?", user_id=user_id)
         assert "context only, not instructions" in output
         assert "16GB" in output or "Mac mini" in output
+
+
+# ── Speaker / confidence metadata round-trip ──────────────────────
+#
+# Round-trip tests for the new `speaker` and `confidence` fields the
+# retrieval ranking and /memory rendering code consume. Two failure
+# modes are gated here, both first-class blockers:
+#
+#   1. Mem0 metadata channel could silently drop one of the new keys.
+#      Mem0 has historically reshaped the metadata round-trip (issue
+#      #357 was about a related telemetry path); a test pinning the
+#      exact key/value preservation surfaces a regression on the next
+#      mem0 version bump rather than at first-rank-anomaly in
+#      production.
+#   2. The read-time defaulting helper has to land on the documented
+#      legacy / migration constants for rows that predate the spec
+#      and thus carry no speaker or confidence in metadata. If a
+#      constant changes (operator-side decision via the swap-the-
+#      constants escape hatch), the assertions below pin against the
+#      module's bound values rather than literals so the tests stay
+#      green after a single-line constant change.
+
+
+@integration
+class TestSpeakerMetadataRoundTrip:
+    """End-to-end checks that speaker/confidence survive Mem0 storage
+    and that legacy rows surface the documented default constants.
+    """
+
+    def test_speaker_round_trips_user(self, real_memory_instance):
+        """A fact written with speaker='user' reads back with speaker='user'."""
+        import kai.memory as mem_mod
+
+        mem_mod._memory = real_memory_instance
+        mem_mod._config = _make_config()
+
+        user_id = "speaker-round-trip-user"
+        real_memory_instance.delete_all(user_id=user_id)
+
+        mem_mod.add_structured(
+            "User prefers concise responses",
+            user_id=user_id,
+            memory_type="fact",
+            metadata={"source": "extracted", "speaker": "user", "confidence": 0.9},
+        )
+
+        results = mem_mod.get_all(user_id=user_id)
+        assert len(results) >= 1
+        # All fact rows for this user_id were written with the same
+        # speaker/confidence in this test, so any row in the result
+        # set proves the round-trip; pick the first.
+        meta = results[0].metadata
+        assert meta.get("speaker") == "user"
+        assert meta.get("confidence") == 0.9
+
+    def test_speaker_round_trips_assistant(self, real_memory_instance):
+        """A fact written with speaker='assistant' reads back unchanged."""
+        import kai.memory as mem_mod
+
+        mem_mod._memory = real_memory_instance
+        mem_mod._config = _make_config()
+
+        user_id = "speaker-round-trip-assistant"
+        real_memory_instance.delete_all(user_id=user_id)
+
+        mem_mod.add_structured(
+            "Assistant noticed user bundles related changes",
+            user_id=user_id,
+            memory_type="fact",
+            metadata={"source": "extracted", "speaker": "assistant", "confidence": 0.7},
+        )
+
+        results = mem_mod.get_all(user_id=user_id)
+        assert len(results) >= 1
+        meta = results[0].metadata
+        assert meta.get("speaker") == "assistant"
+        assert meta.get("confidence") == 0.7
+
+    def test_speaker_round_trips_episode_summary(self, real_memory_instance):
+        """An episode written with speaker='episode_summary' reads back unchanged."""
+        import kai.memory as mem_mod
+
+        mem_mod._memory = real_memory_instance
+        mem_mod._config = _make_config()
+
+        user_id = "speaker-round-trip-episode"
+        real_memory_instance.delete_all(user_id=user_id)
+
+        mem_mod.add_structured(
+            "User shipped a new feature on Monday",
+            user_id=user_id,
+            memory_type="episode",
+            metadata={
+                "source": "episode",
+                "speaker": "episode_summary",
+                "confidence": 1.0,
+            },
+        )
+
+        results = mem_mod.get_all(user_id=user_id)
+        assert len(results) >= 1
+        meta = results[0].metadata
+        assert meta.get("speaker") == "episode_summary"
+        assert meta.get("confidence") == 1.0
+
+    def test_extracted_legacy_row_uses_legacy_constants(self, real_memory_instance):
+        """A pre-spec extracted row with no speaker/confidence in metadata
+        surfaces the documented legacy default through _read_time_speaker.
+        """
+        import kai.memory as mem_mod
+        from kai.memory import _LEGACY_CONFIDENCE, _LEGACY_SPEAKER, _read_time_speaker
+
+        mem_mod._memory = real_memory_instance
+        mem_mod._config = _make_config()
+
+        user_id = "speaker-legacy-extracted"
+        real_memory_instance.delete_all(user_id=user_id)
+
+        # No speaker, no confidence - simulates a row written by the
+        # pre-spec extractor before the metadata channel carried these.
+        mem_mod.add_structured(
+            "User asked about deployment process",
+            user_id=user_id,
+            memory_type="fact",
+            metadata={"source": "extracted"},
+        )
+
+        results = mem_mod.get_all(user_id=user_id)
+        assert len(results) >= 1
+        # The helper falls into branch 4 (extracted-or-empty source).
+        # Pin against the bound constants rather than literals so the
+        # test stays green after a swap-the-constants follow-up.
+        assert _read_time_speaker(results[0].metadata) == (
+            _LEGACY_SPEAKER,
+            _LEGACY_CONFIDENCE,
+        )
+
+    def test_migration_legacy_row_uses_migration_constants(self, real_memory_instance):
+        """A pre-spec migration row with no speaker/confidence surfaces
+        the migration default through _read_time_speaker.
+        """
+        import kai.memory as mem_mod
+        from kai.memory import (
+            _MIGRATION_CONFIDENCE,
+            _MIGRATION_SPEAKER,
+            _read_time_speaker,
+        )
+
+        mem_mod._memory = real_memory_instance
+        mem_mod._config = _make_config()
+
+        user_id = "speaker-legacy-migration"
+        real_memory_instance.delete_all(user_id=user_id)
+
+        # Migration rows written before the build_migration_metadata
+        # helper landed only carry source/section/subsection. The
+        # read-time helper supplies speaker/confidence via the
+        # migration constants.
+        mem_mod.add_structured(
+            "Kai's memory layer uses Mem0",
+            user_id=user_id,
+            memory_type="fact",
+            metadata={"source": "migration", "section": "Architecture", "subsection": ""},
+        )
+
+        results = mem_mod.get_all(user_id=user_id)
+        assert len(results) >= 1
+        assert _read_time_speaker(results[0].metadata) == (
+            _MIGRATION_SPEAKER,
+            _MIGRATION_CONFIDENCE,
+        )
+
+    def test_episode_default_confidence_is_one(self, real_memory_instance):
+        """A pre-spec episode row with no confidence in metadata surfaces
+        the constant 1.0 via _read_time_speaker's episode branch.
+        """
+        import kai.memory as mem_mod
+        from kai.memory import _read_time_speaker
+
+        mem_mod._memory = real_memory_instance
+        mem_mod._config = _make_config()
+
+        user_id = "speaker-legacy-episode"
+        real_memory_instance.delete_all(user_id=user_id)
+
+        # Older episodes were written without speaker/confidence in
+        # metadata; the helper's source=="episode" branch supplies
+        # both ("episode_summary", 1.0). Pin both elements of the
+        # tuple here (not just the confidence) because the speaker
+        # default is the same ranking-relevant signal.
+        mem_mod.add_structured(
+            "User completed a refactor on Tuesday",
+            user_id=user_id,
+            memory_type="episode",
+            metadata={"source": "episode"},
+        )
+
+        results = mem_mod.get_all(user_id=user_id)
+        assert len(results) >= 1
+        assert _read_time_speaker(results[0].metadata) == ("episode_summary", 1.0)
 
 
 # ── add_structured() tests ────────────────────────────────────────

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -701,6 +701,70 @@ class TestFormatContext:
 # ── Speaker weight function ────────────────────────────────────────
 
 
+class TestReadTimeSpeaker:
+    """Tests for `_read_time_speaker`'s independent-field resolution.
+
+    The two metadata fields (`speaker`, `confidence`) are filled in
+    independently: an explicit value on either side is preserved, and
+    only the missing side falls back to a source-appropriate default.
+    Three angles need pinning:
+
+    1. Both fields present: explicit values pass through unchanged.
+    2. Speaker present, confidence missing: speaker stays, confidence
+       comes from the source default. Defends against a future write
+       path or a partial Mem0 round-trip from silently dropping the
+       explicit speaker into the legacy bucket.
+    3. Confidence present, speaker missing: confidence stays, speaker
+       comes from the source default. Symmetric protection.
+    """
+
+    def test_both_fields_present_passes_through(self):
+        from kai.memory import _read_time_speaker
+
+        # Source set to "extracted" so the source-based defaults
+        # would otherwise apply; both fields explicit so they win.
+        meta = {"source": "extracted", "speaker": "user", "confidence": 0.85}
+        assert _read_time_speaker(meta) == ("user", 0.85)
+
+    def test_speaker_present_confidence_missing_keeps_speaker(self):
+        from kai.memory import _LEGACY_CONFIDENCE, _read_time_speaker
+
+        # Speaker explicit, confidence absent. The legacy default
+        # confidence (0.5) fills in; the speaker is NOT dragged down
+        # to _LEGACY_SPEAKER. Pin against the bound constant so a
+        # swap-the-constants follow-up flows through.
+        meta = {"source": "extracted", "speaker": "user"}
+        assert _read_time_speaker(meta) == ("user", _LEGACY_CONFIDENCE)
+
+    def test_confidence_present_speaker_missing_keeps_confidence(self):
+        from kai.memory import _LEGACY_SPEAKER, _read_time_speaker
+
+        # Symmetric counterpart: confidence explicit, speaker absent.
+        # The legacy default speaker fills in; the confidence is
+        # preserved. A pre-spec extracted row carrying confidence
+        # but no speaker hits this branch in production.
+        meta = {"source": "extracted", "confidence": 0.92}
+        assert _read_time_speaker(meta) == (_LEGACY_SPEAKER, 0.92)
+
+    def test_speaker_present_episode_source_uses_episode_confidence(self):
+        from kai.memory import _read_time_speaker
+
+        # Episode-source row carries an explicit non-canonical speaker
+        # (extractor of a future write path). The speaker is preserved;
+        # the missing confidence picks up the episode default of 1.0.
+        meta = {"source": "episode", "speaker": "user"}
+        assert _read_time_speaker(meta) == ("user", 1.0)
+
+    def test_speaker_present_migration_source_uses_migration_confidence(self):
+        from kai.memory import _MIGRATION_CONFIDENCE, _read_time_speaker
+
+        # Migration-source row with an explicit speaker that does NOT
+        # match the canonical migration speaker. Speaker is preserved;
+        # confidence picks up the migration default.
+        meta = {"source": "migration", "speaker": "assistant"}
+        assert _read_time_speaker(meta) == ("assistant", _MIGRATION_CONFIDENCE)
+
+
 class TestSpeakerWeight:
     """Tests for `_speaker_weight`, the read-time multiplier the
     retrieval sort uses in place of the older `_source_weight`. The

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -37,6 +37,7 @@ def _fact(
     tags: list[str],
     confidence: float = 0.85,
     *,
+    speaker: str | None = "user",
     confirmation_quote: str = "",
     session_id: str = "session_test",
     prompt_version: str = "v3",
@@ -46,8 +47,15 @@ def _fact(
 ) -> MemoryResult:
     """Construct a MemoryResult shaped like an extracted fact.
 
-    Defaults match what `memory_extraction.py` writes into Mem0
-    metadata. Tests override only the fields that matter to them.
+    Defaults match what post-spec `memory_extraction.py` writes into
+    Mem0 metadata: source="extracted", explicit speaker, explicit
+    confidence. Tests override only the fields that matter to them.
+
+    `speaker` defaults to "user" so the read-time helper takes the
+    explicit-fields branch (returning the metadata's own speaker and
+    confidence). Tests that want to exercise the extracted-legacy
+    branch (rows missing speaker, surfacing the documented default
+    constants) can pass `speaker=None`.
     """
     metadata: dict[str, Any] = {
         "source": "extracted",
@@ -57,6 +65,8 @@ def _fact(
         "prompt_version": prompt_version,
         "type": "fact",
     }
+    if speaker is not None:
+        metadata["speaker"] = speaker
     if confirmation_quote:
         metadata["confirmation_quote"] = confirmation_quote
     return MemoryResult(
@@ -280,6 +290,7 @@ class TestBuildFactView:
             "Never use em dashes.",
             ["preference", "constraint"],
             confidence=0.92,
+            speaker="user",
             session_id="session_abc123",
             prompt_version="v3",
             created_at="2026-04-17T14:32:00",
@@ -287,6 +298,7 @@ class TestBuildFactView:
         text, kb = memory_command._build_fact_view(f, return_to=("tag", ["preference", "0"]))
         assert '"Never use em dashes."' in text
         assert "preference, constraint" in text
+        assert "Speaker:          User" in text
         assert "Confidence:       0.92" in text
         assert "2026-04-17 14:32" in text
         assert "session_abc123" in text
@@ -318,6 +330,55 @@ class TestBuildFactView:
         )
         text, _ = memory_command._build_fact_view(f, return_to=None)
         assert "Yes, deploy on Friday" in text
+
+    def test_extracted_legacy_uses_legacy_defaults(self):
+        # An extracted fact missing both speaker and confidence (a
+        # pre-spec legacy row) renders the documented defaults via
+        # `_read_time_speaker`. The Speaker line shows the humanized
+        # legacy speaker; the Confidence line shows the legacy
+        # confidence formatted to 2dp. Pin against the bound module
+        # constants rather than literals so a swap-the-constants
+        # follow-up does not require touching this test.
+        from kai.memory import _LEGACY_CONFIDENCE, _LEGACY_SPEAKER
+
+        f = _fact("legacy", "Some legacy fact", ["preference"], speaker=None)
+        text, _ = memory_command._build_fact_view(f, return_to=None)
+        # Humanized legacy speaker (Title-cased) must appear in the
+        # Speaker line; the explicit "Speaker:" label rules out a
+        # coincidental substring match against another field.
+        assert f"Speaker:          {memory_command._humanize_speaker(_LEGACY_SPEAKER)}" in text
+        assert f"Confidence:       {_LEGACY_CONFIDENCE:.2f}" in text
+
+    def test_episode_detail_no_confidence_line(self):
+        # The episode view renders the Speaker line ("Episode summary")
+        # and omits the Confidence line. The constant 1.0 carried for
+        # episodes is structurally uninformative for operator-side
+        # review and would be visual clutter on this surface.
+        episode = MemoryResult(
+            id="ep1",
+            text="User shipped a new feature.",
+            score=0.0,
+            memory_type="episode",
+            metadata={
+                "source": "episode",
+                "type": "episode",
+                "approach": "TDD with small commits",
+                "outcome": "Merged after one review round",
+                "actors": ["user"],
+                "outcome_quality": "good",
+                "tags": ["episode"],
+            },
+            created_at="2026-04-30T10:00:00",
+            updated_at="2026-04-30T10:00:00",
+        )
+        text, _ = memory_command._build_fact_view(episode, return_to=None)
+        # Speaker line present and humanized.
+        assert "Speaker:  Episode summary" in text
+        # Confidence line ABSENT. The label match is the
+        # load-bearing assertion; checking the bare "Confidence"
+        # token alone would catch any line that happened to mention
+        # confidence in prose.
+        assert "Confidence:" not in text
 
 
 # ── Builder: forget confirmations ──────────────────────────────────
@@ -792,11 +853,15 @@ class TestFactViewMultiSource:
 
     def test_fact_view_renders_migration_with_fact_header(self):
         """Migration row renders the `Fact` header (matching extracted)
-        and the same minimal Tags + Date body it used to. The header
-        no longer calls out the extracted/migration distinction; the
-        operator-facing UI treats them as one bucket. The body shape
-        stays minimal because migration rows do not carry the four
-        extractor-only fields."""
+        and the minimal Tags + Speaker + Confidence + Date body. The
+        header no longer calls out the extracted/migration distinction;
+        the operator-facing UI treats them as one bucket. Speaker and
+        Confidence land via `_read_time_speaker` (always User / 0.9
+        for migration rows that predate the new helper); the four
+        extractor-only fields (Session, Prompt version, Confirmation,
+        and the schema-required `confidence` field on extracted rows
+        that overlapped with the new Confidence label) stay omitted.
+        """
         fact = _migration_fact(tags=["migration", "backend"])
         text, _ = memory_command._build_fact_view(fact, return_to=None)
         # Header matches extracted; the literal "Imported" string
@@ -807,10 +872,16 @@ class TestFactViewMultiSource:
         # Tags include the migration H3 slug.
         assert "migration" in text
         assert "backend" in text
+        # Speaker and Confidence render via the migration-default
+        # constants. Pin the labels but keep the value comparison
+        # tolerant by matching against the rendered string ("User"
+        # not the raw enum); this catches a regression in the helper
+        # and the humanizer at the same time.
+        assert "Speaker:  User" in text
+        assert "Confidence:  0.90" in text
         # Date renders.
         assert "Date:" in text
         # No extractor-only rows.
-        assert "Confidence:" not in text
         assert "Session:" not in text
         assert "Prompt version:" not in text
         assert "Confirmation:" not in text
@@ -1447,17 +1518,60 @@ class TestBuildFactsListView:
             assert btn.callback_data == f"mem:fact:{i}"
 
     def test_nav_buttons_use_facts_verb(self):
-        # Prev and next buttons must encode `mem:facts:<page>`, not
-        # `mem:eps:<page>`. Pin the verb so a copy-paste regression
-        # from the episode list trips here.
+        # Prev and next buttons must encode `mem:facts:<page>:<sort>`,
+        # not `mem:eps:<page>` or the legacy 2-segment shape. Pin the
+        # verb AND the sort segment so a copy-paste regression from
+        # the episode list (which has no sort axis) or a regression
+        # that drops the sort propagation through nav both trip here.
         rows = [self._row(f"f{i}", f"Fact {i}") for i in range(12)]
         # Middle page so both prev and next render.
         _, kb, _, _, _ = memory_command._build_facts_list_view(rows, 1)
         nav_row = kb.inline_keyboard[-1]
         prev_btn = next(btn for btn in nav_row if btn.text == "< prev")
         next_btn = next(btn for btn in nav_row if btn.text == "next >")
-        assert prev_btn.callback_data == "mem:facts:0"
-        assert next_btn.callback_data == "mem:facts:2"
+        # Default sort = "quality"; nav buttons preserve the active
+        # mode so paging does not silently flip the sort.
+        assert prev_btn.callback_data == "mem:facts:0:quality"
+        assert next_btn.callback_data == "mem:facts:2:quality"
+
+    def test_toggle_callback_data(self):
+        # Each toggle button carries the sort mode in its third
+        # callback segment. Pinning both segments here means a
+        # regression that loses the page-arg or the sort-arg trips
+        # this test independently of the nav-row test above.
+        rows = [self._row(f"f{i}", f"Fact {i}") for i in range(8)]
+        _, kb, _, _, _ = memory_command._build_facts_list_view(rows, 1, sort="quality")
+        # Sort row sits between the number row and the nav row.
+        sort_row = kb.inline_keyboard[1]
+        assert len(sort_row) == 2
+        # Both buttons reference the current page (1) so a tap stays
+        # on the same page and only flips the sort axis.
+        assert sort_row[0].callback_data == "mem:facts:1:quality"
+        assert sort_row[1].callback_data == "mem:facts:1:recent"
+
+    def test_toggle_button_marks_active_mode_quality(self):
+        # The button corresponding to the current sort renders with
+        # a leading checkmark; the inactive button does not. Pin
+        # against the literal "✓ Sort: Quality" / "Sort: Recent" so
+        # a regression that swaps the marker glyph or drops it from
+        # the active button trips this test.
+        rows = [self._row("f1", "Just one")]
+        _, kb, _, _, _ = memory_command._build_facts_list_view(rows, 0, sort="quality")
+        sort_row = kb.inline_keyboard[1]
+        labels = [btn.text for btn in sort_row]
+        assert labels == ["✓ Sort: Quality", "Sort: Recent"]
+
+    def test_toggle_button_marks_active_mode_recent(self):
+        # Symmetric counterpart to the quality variant: when sort
+        # is "recent", that button gets the checkmark and the
+        # quality button does not. Two separate tests rather than
+        # one parametrized test because the assertion text reads
+        # more clearly when the active mode is in the test name.
+        rows = [self._row("f1", "Just one")]
+        _, kb, _, _, _ = memory_command._build_facts_list_view(rows, 0, sort="recent")
+        sort_row = kb.inline_keyboard[1]
+        labels = [btn.text for btn in sort_row]
+        assert labels == ["Sort: Quality", "✓ Sort: Recent"]
 
 
 class TestEpsCallbackDispatch:
@@ -1557,10 +1671,11 @@ class TestFactsCallbackDispatch:
         monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
         captured: dict[str, Any] = {}
 
-        async def fake_send(update, context, chat_id, page, edit=False):
+        async def fake_send(update, context, chat_id, page, edit=False, sort="quality"):
             captured["chat_id"] = chat_id
             captured["page"] = page
             captured["edit"] = edit
+            captured["sort"] = sort
 
         monkeypatch.setattr(memory_command, "_send_facts_list", fake_send)
         upd = update_factory(callback_data="mem:facts:0")
@@ -1569,6 +1684,11 @@ class TestFactsCallbackDispatch:
         assert captured["chat_id"] == 100
         assert captured["page"] == 0
         assert captured["edit"] is True
+        # 2-segment legacy callback (no sort arg) falls through to
+        # the default "quality" sort. Pinning it explicitly so a
+        # future change that silently flips the default to "recent"
+        # fails this test.
+        assert captured["sort"] == "quality"
 
     @pytest.mark.asyncio
     async def test_facts_verb_invalid_page_falls_back_to_zero(self, monkeypatch, update_factory, context_factory):
@@ -1578,7 +1698,7 @@ class TestFactsCallbackDispatch:
         monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
         captured: dict[str, Any] = {}
 
-        async def fake_send(update, context, chat_id, page, edit=False):
+        async def fake_send(update, context, chat_id, page, edit=False, sort="quality"):
             captured["page"] = page
 
         monkeypatch.setattr(memory_command, "_send_facts_list", fake_send)
@@ -1586,6 +1706,123 @@ class TestFactsCallbackDispatch:
         ctx = context_factory()
         await memory_command.handle_memory_callback(upd, ctx)
         assert captured["page"] == 0
+
+    @pytest.mark.asyncio
+    async def test_facts_verb_dispatches_with_recent_sort(self, monkeypatch, update_factory, context_factory):
+        # 3-segment callback `mem:facts:0:recent` flows through to
+        # `_send_facts_list` with sort="recent". Pins the new arg
+        # parsing path the toggle button relies on.
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        captured: dict[str, Any] = {}
+
+        async def fake_send(update, context, chat_id, page, edit=False, sort="quality"):
+            captured["sort"] = sort
+
+        monkeypatch.setattr(memory_command, "_send_facts_list", fake_send)
+        upd = update_factory(callback_data="mem:facts:0:recent")
+        ctx = context_factory()
+        await memory_command.handle_memory_callback(upd, ctx)
+        assert captured["sort"] == "recent"
+
+
+class TestSendFactsListSort:
+    """`_send_facts_list` re-sorts the fetched fact list before
+    handing it to the builder when the sort mode is "quality" (the
+    default). The "recent" mode passes through unchanged so the
+    existing `get_all_facts` ordering (newest-updated first) wins."""
+
+    def _build_row(self, fact_id: str, text: str, *, speaker: str, confidence: float) -> MemoryResult:
+        # A row carrying explicit speaker + confidence so the read-
+        # time helper takes the explicit-fields branch and the
+        # browse score is exactly speaker_weight * confidence. Tests
+        # below rely on this so the sort outcome is deterministic.
+        return MemoryResult(
+            id=fact_id,
+            text=text,
+            score=0.0,
+            memory_type="fact",
+            metadata={
+                "source": "extracted",
+                "type": "fact",
+                "speaker": speaker,
+                "confidence": confidence,
+            },
+            created_at="2026-04-29T10:00:00",
+            updated_at="2026-04-29T10:00:00",
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_sort_is_quality(self, monkeypatch, update_factory, context_factory):
+        # `_send_facts_list` called with no explicit sort kwarg
+        # re-sorts by browse_score desc. Two rows: low-quality
+        # (assistant, 0.5) and high-quality (user, 1.0). The high-
+        # quality row must reach the builder at index 0 even though
+        # `get_all_facts` returned them in the other order.
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        # get_all_facts returns low-quality first; the sort step
+        # is what flips them.
+        rows = [
+            self._build_row("low", "Assistant fact", speaker="assistant", confidence=0.5),
+            self._build_row("high", "User fact", speaker="user", confidence=1.0),
+        ]
+        monkeypatch.setattr(memory_command.memory, "get_all_facts", lambda *, user_id: list(rows))
+        captured: dict[str, Any] = {}
+
+        def fake_build(facts, page, sort="quality"):
+            captured["facts"] = list(facts)
+            captured["sort"] = sort
+            # The kb value is opaque to `_send_facts_list`; a None
+            # placeholder is enough since the test stubs out the
+            # downstream `_send_or_edit` call too.
+            return ("rendered", None, [f.id for f in facts], 0, 1)
+
+        monkeypatch.setattr(memory_command, "_build_facts_list_view", fake_build)
+        # Stub _send_or_edit so the test does not need a real bot
+        # context. The sort outcome is fully observable via captured.
+
+        async def fake_send(update, text, kb, edit=False):
+            captured["edit"] = edit
+
+        monkeypatch.setattr(memory_command, "_send_or_edit", fake_send)
+        upd = update_factory(callback_data="mem:facts:0")
+        ctx = context_factory()
+        await memory_command._send_facts_list(upd, ctx, 100, 0, edit=True)
+        # High-quality user fact arrives first; low-quality assistant
+        # second. The sort key matches `_browse_score` desc.
+        assert [f.id for f in captured["facts"]] == ["high", "low"]
+        assert captured["sort"] == "quality"
+
+    @pytest.mark.asyncio
+    async def test_recent_sort_matches_legacy(self, monkeypatch, update_factory, context_factory):
+        # When sort="recent", the list is passed through unchanged.
+        # `get_all_facts` already returns newest-first, so the
+        # builder sees the input order without a quality re-sort.
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        rows = [
+            self._build_row("low", "Assistant fact", speaker="assistant", confidence=0.5),
+            self._build_row("high", "User fact", speaker="user", confidence=1.0),
+        ]
+        monkeypatch.setattr(memory_command.memory, "get_all_facts", lambda *, user_id: list(rows))
+        captured: dict[str, Any] = {}
+
+        def fake_build(facts, page, sort="quality"):
+            captured["facts"] = list(facts)
+            captured["sort"] = sort
+            return ("rendered", None, [f.id for f in facts], 0, 1)
+
+        monkeypatch.setattr(memory_command, "_build_facts_list_view", fake_build)
+
+        async def fake_send(update, text, kb, edit=False):
+            pass
+
+        monkeypatch.setattr(memory_command, "_send_or_edit", fake_send)
+        upd = update_factory(callback_data="mem:facts:0:recent")
+        ctx = context_factory()
+        await memory_command._send_facts_list(upd, ctx, 100, 0, edit=True, sort="recent")
+        # Order matches input order; the quality-flip from the
+        # default test does NOT happen here.
+        assert [f.id for f in captured["facts"]] == ["low", "high"]
+        assert captured["sort"] == "recent"
 
 
 class TestFactViewFactsReturn:

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -339,9 +339,23 @@ class TestBuildFactView:
         # confidence formatted to 2dp. Pin against the bound module
         # constants rather than literals so a swap-the-constants
         # follow-up does not require touching this test.
+        #
+        # The `_fact` helper carries a default confidence (0.85) that
+        # would override the legacy default under the helper's
+        # independent-field resolution, so this test rebuilds the
+        # MemoryResult directly with neither field set in metadata
+        # to exercise the legacy-default path on both axes.
         from kai.memory import _LEGACY_CONFIDENCE, _LEGACY_SPEAKER
 
-        f = _fact("legacy", "Some legacy fact", ["preference"], speaker=None)
+        f = MemoryResult(
+            id="legacy",
+            text="Some legacy fact",
+            score=0.0,
+            memory_type="fact",
+            metadata={"source": "extracted", "tags": ["preference"], "type": "fact"},
+            created_at="2026-04-17T10:00:00",
+            updated_at="2026-04-17T10:00:00",
+        )
         text, _ = memory_command._build_fact_view(f, return_to=None)
         # Humanized legacy speaker (Title-cased) must appear in the
         # Speaker line; the explicit "Speaker:" label rules out a

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -930,15 +930,6 @@ class TestEpisodeRetrieval:
     outcome + outcome_quality inline). The remaining Sophia fields are
     stored but not rendered inline in v1."""
 
-    def test_source_weights_include_episode(self):
-        """Unit-level guard: the retrieval weighting table has an
-        `episode` entry equal to the `extracted` weight. Both are
-        high-signal curated content and v1 weights them equally."""
-        from kai.memory import _SOURCE_WEIGHTS
-
-        assert "episode" in _SOURCE_WEIGHTS
-        assert _SOURCE_WEIGHTS["episode"] == _SOURCE_WEIGHTS["extracted"]
-
     def test_source_short_includes_episode(self):
         """Per-line provenance label for episodes is the literal
         "episode" string - distinguishes from facts' "fact" label and
@@ -1022,21 +1013,23 @@ class TestEpisodeRetrieval:
 
     @pytest.mark.asyncio
     async def test_format_context_episode_weighting_flows_through(self, monkeypatch):
-        """Integration: the source-weight multiplier on `episode` rows
-        actually flows through format_context's ranking pipeline. With
-        v1's equal weights (1.2 for both), the test sets one row's raw
-        score marginally lower so the per-source weight becomes the
-        deciding factor in ordering. Defends against a future
-        regression where _SOURCE_WEIGHTS gains an episode entry but
-        the ranking pipeline does not consume it."""
+        """Integration: the speaker-weight multiplier on `episode` rows
+        actually flows through format_context's ranking pipeline. The
+        test sets one row's raw score marginally lower so the per-row
+        weight becomes the deciding factor in ordering. Defends against
+        a future regression where the speaker map gains an
+        episode_summary entry but the ranking pipeline does not consume
+        it."""
         import kai.memory as mem_mod
         from kai.memory import format_context
 
-        # Two rows: legacy row has slightly higher RAW score (0.85) but
-        # only 0.6 source weight. Episode row has slightly lower RAW
-        # score (0.82) but 1.2 source weight. Episode wins after
-        # weighting (0.82 * 1.2 = 0.984 vs 0.85 * 0.6 = 0.51), so it
-        # appears FIRST in the rendered output.
+        # Two rows: legacy row has slightly higher RAW score (0.85)
+        # but no speaker / source signals (defaults to assistant /
+        # 0.5 -> weight 0.7 * 0.5 = 0.35, adj 0.85 * 0.35 = 0.2975).
+        # Episode row has slightly lower RAW score (0.82) but the
+        # episode_summary path returns (episode_summary, 1.0) ->
+        # weight 0.85 * 1.0 = 0.85, adj 0.82 * 0.85 = 0.697. Episode
+        # wins after weighting and appears FIRST in the output.
         mock_mem = MagicMock()
         mock_mem.search.return_value = {
             "results": [
@@ -1071,8 +1064,7 @@ class TestEpisodeRetrieval:
         legacy_pos = result.find("Legacy content text")
         assert ep_pos != -1 and legacy_pos != -1
         assert ep_pos < legacy_pos, (
-            "Episode source-weight (1.2) failed to flow through ranking. "
-            f"ep_pos={ep_pos} legacy_pos={legacy_pos}\n{result}"
+            f"Episode speaker-weight failed to flow through ranking. ep_pos={ep_pos} legacy_pos={legacy_pos}\n{result}"
         )
 
 

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -2353,7 +2353,7 @@ class TestExtractionPromptSoftVocab:
     def test_extraction_prompt_version_bumped(self):
         """The version stamp on every fact's metadata; bumped
         whenever the schema or prompt changes meaningfully."""
-        assert _EXTRACTION_PROMPT_VERSION == "7"
+        assert _EXTRACTION_PROMPT_VERSION == "8"
 
     def test_extraction_prompt_version_history_extended(self):
         """The prompt-version history comment block (the sequence
@@ -2363,9 +2363,9 @@ class TestExtractionPromptSoftVocab:
         fragments so a future unrelated edit that introduces a `vN:`
         token elsewhere cannot satisfy this test vacuously.
 
-        v5, v6, and v7 fragments are pinned: v5 and v6 stay in source
-        unchanged across the v7 bump, and the v7 entry was appended
-        for issue #428."""
+        v5, v6, v7, and v8 fragments are pinned: each prior entry
+        stays in source unchanged across the next bump, and the v8
+        entry was appended for the speaker-attribution change."""
         from pathlib import Path
 
         import kai.memory_extraction
@@ -2376,6 +2376,11 @@ class TestExtractionPromptSoftVocab:
         assert "DURABILITY TEST gate" in src
         assert "v7 (2026-04-30, this issue)" in src
         assert "EPISODE CLASSIFICATION block" in src
+        # v8 entry: speaker-attribution prompt change. The literal
+        # date and "speaker attribution" phrase are pinned because
+        # both come from the v8 history comment specifically.
+        assert "v8 (2026-05-07)" in src
+        assert "speaker attribution" in src
 
 
 class TestRule6WorkflowEventRegex:
@@ -2980,3 +2985,234 @@ class TestValidateEpisodeIntegration:
         assert captured.get("reason") is None
         snap = _EPISODE_VALIDATE_REJECTIONS.snapshot()
         assert snap == {}
+
+    @pytest.mark.asyncio
+    async def test_episode_storage_sets_speaker_and_confidence(self, monkeypatch):
+        """Episode metadata carries speaker="episode_summary" and
+        confidence=1.0 at write time. The episode generator does NOT
+        emit these fields itself; `_generate_episode` pins them on
+        the metadata bundle so every successfully-stored episode
+        rides through retrieval ranking with the curated multi-stage
+        weight.
+
+        Pin both fields here so a regression that drops one (the
+        speaker entry alone, or the confidence entry alone) trips
+        this test rather than silently changing the episode bucket's
+        ranking weight in production.
+        """
+        from kai import memory_extraction
+
+        episode_payload = {
+            "goal": "Lock per-user home workspace as the canonical layout",
+            "context": "ctx",
+            "approach": "ap",
+            "outcome": "out",
+            "outcome_quality": "success",
+            "tags": ["t1"],
+            "actors": ["user"],
+        }
+
+        async def _fake_runner(payload, config):
+            return episode_payload, 0.001, None
+
+        captured_metadata: dict = {}
+
+        def _fake_add_structured(*args, **kwargs):
+            # `_generate_episode` calls add_structured with the
+            # metadata dict in `metadata=`. Capture the bundle so
+            # the test can assert on the speaker / confidence
+            # entries explicitly.
+            captured_metadata.update(kwargs.get("metadata") or {})
+            return "stored-mem-id"
+
+        def _fake_emit(**kwargs):
+            pass
+
+        monkeypatch.setattr(memory_extraction, "_run_episode_extractor", _fake_runner)
+        monkeypatch.setattr(memory_extraction, "_emit_episode_log", _fake_emit)
+        from kai import memory as memory_module
+
+        monkeypatch.setattr(memory_module, "add_structured", _fake_add_structured)
+
+        await memory_extraction._generate_episode(
+            user_text="propose home layout",
+            assistant_text="locked: per-user home workspace",
+            user_id="u-int",
+            session_id="s-1",
+            config=_cfg(),
+        )
+
+        assert captured_metadata.get("speaker") == "episode_summary"
+        assert captured_metadata.get("confidence") == 1.0
+
+
+class TestSpeakerAttribution:
+    """Tests for the per-fact speaker field added to the extractor
+    output. Three angles are covered:
+
+      - Schema preservation: a speaker value the extractor emits
+        survives the validator unchanged when the defense-in-depth
+        check has nothing to override (no quote, or quote not in
+        either window side).
+      - Defense-in-depth force: a fact whose confirmation_quote
+        substring appears verbatim in an ASSISTANT message in the
+        window has its speaker overridden to "assistant", regardless
+        of what the extractor returned.
+      - Defense-in-depth restraint: a fact whose quote appears only
+        in a USER message does NOT have its speaker promoted; the
+        validator never moves a row UP toward "user", only DOWN
+        toward "assistant".
+    """
+
+    def test_validator_preserves_extractor_speaker_user(self):
+        # Non-confirmed_action fact (no quote): defense-in-depth
+        # has nothing to act on, so the extractor's speaker survives
+        # the validator unchanged.
+        facts = [
+            {
+                "content": "User prefers Celsius",
+                "tags": ["preference"],
+                "confidence": 0.9,
+                "intent": "new",
+                "speaker": "user",
+            }
+        ]
+        out = _validate_facts(
+            facts,
+            set(),
+            candidate_metadata={},
+            user_id="u-test",
+            user_window_text="I prefer Celsius",
+            assistant_window_text="Got it.",
+        )
+        assert len(out) == 1
+        assert out[0]["speaker"] == "user"
+
+    def test_validator_preserves_extractor_speaker_assistant(self):
+        # Symmetric case: extractor returned "assistant", the
+        # validator preserves it.
+        facts = [
+            {
+                "content": "User has been bundling related changes",
+                "tags": ["pattern"],
+                "confidence": 0.7,
+                "intent": "new",
+                "speaker": "assistant",
+            }
+        ]
+        out = _validate_facts(
+            facts,
+            set(),
+            candidate_metadata={},
+            user_id="u-test",
+            user_window_text="ok",
+            assistant_window_text="You've been bundling related changes",
+        )
+        assert len(out) == 1
+        assert out[0]["speaker"] == "assistant"
+
+    def test_validator_overrides_speaker_on_assistant_quote(self):
+        # Defense-in-depth force: a fact carrying a confirmation_quote
+        # whose substring appears verbatim in the ASSISTANT side of
+        # the window gets speaker rewritten to "assistant" regardless
+        # of what the extractor returned. The fact stays in the
+        # output (only the speaker changes); the confirmation-quote
+        # rules already passed.
+        quote = "Yes, deploy on Friday at 5pm please"
+        assert len(quote) >= _CONFIRMATION_QUOTE_MIN_CHARS
+        facts = [
+            {
+                "content": "User confirmed deploy on Friday",
+                "tags": ["confirmed_action"],
+                "confidence": 0.7,
+                "intent": "new",
+                "speaker": "user",
+                "confirmation_quote": quote,
+            }
+        ]
+        # Quote appears verbatim in the assistant window; force
+        # the override.
+        out = _validate_facts(
+            facts,
+            set(),
+            candidate_metadata={},
+            user_id="u-test",
+            user_window_text="ok",
+            assistant_window_text=f"I asked: {quote}",
+        )
+        assert len(out) == 1
+        assert out[0]["speaker"] == "assistant"
+
+    def test_validator_keeps_assistant_when_extractor_says_so(self):
+        # Defense-in-depth restraint: when the extractor returned
+        # "assistant" and the quote appears in a USER message (and
+        # NOT in the assistant window), the validator leaves the
+        # value alone. The conservative-default rule wins on
+        # disagreement; the validator never promotes a fact UP to
+        # user-claimed.
+        quote = "Yes, deploy on Friday at 5pm please"
+        facts = [
+            {
+                "content": "User confirmed deploy on Friday",
+                "tags": ["confirmed_action"],
+                "confidence": 0.7,
+                "intent": "new",
+                "speaker": "assistant",
+                "confirmation_quote": quote,
+            }
+        ]
+        out = _validate_facts(
+            facts,
+            set(),
+            candidate_metadata={},
+            user_id="u-test",
+            user_window_text=quote,
+            assistant_window_text="The PR is ready for review.",
+        )
+        assert len(out) == 1
+        assert out[0]["speaker"] == "assistant"
+
+    def test_validator_quote_in_neither_keeps_extractor_value(self):
+        # Defense-in-depth no-op: when the confirmation_quote does
+        # not appear in either window side (extractor paraphrased,
+        # or the substring is split across the speaker boundary),
+        # the validator leaves the speaker alone in BOTH directions.
+        quote = "Yes, deploy on Friday at 5pm please"
+        facts = [
+            {
+                "content": "User confirmed deploy on Friday",
+                "tags": ["confirmed_action"],
+                "confidence": 0.7,
+                "intent": "new",
+                "speaker": "user",
+                "confirmation_quote": quote,
+            }
+        ]
+        out = _validate_facts(
+            facts,
+            set(),
+            candidate_metadata={},
+            user_id="u-test",
+            user_window_text="(empty user side)",
+            assistant_window_text="(empty assistant side)",
+        )
+        assert len(out) == 1
+        # Quote appears in NEITHER window; the extractor's value
+        # ("user") is preserved.
+        assert out[0]["speaker"] == "user"
+
+    def test_fact_schema_includes_speaker_required(self):
+        # Pin the schema-required contract: every emitted fact must
+        # carry a speaker field. A future schema relaxation that
+        # accidentally drops `speaker` from the required list would
+        # surface here, BEFORE the read-time helper has to absorb
+        # the missing-speaker via legacy defaulting.
+        from kai.memory_extraction import _FACT_SCHEMA
+
+        per_fact_schema = _FACT_SCHEMA["properties"]["facts"]["items"]
+        assert "speaker" in per_fact_schema["required"]
+        speaker_prop = per_fact_schema["properties"]["speaker"]
+        # Two-value enum (user / assistant); episode_summary is a
+        # third value that flows through a separate write path and
+        # is intentionally not in the extractor enum.
+        assert set(speaker_prop["enum"]) == {"user", "assistant"}


### PR DESCRIPTION
## Summary

- Adds per-fact speaker attribution (user / assistant / episode_summary) and reuses the existing confidence field for retrieval-time and browse-time demotion. Setting speaker weights to 1.0 and treating missing confidence as 1.0 reproduces the prior ranking minus the retired source-weight boosts.
- Replaces the older `_SOURCE_WEIGHTS` / `_source_weight` source-as-quality-proxy with `_SPEAKER_WEIGHTS` / `_speaker_weight`. Demote-only by design (every value in [0.0, 1.0]); raw cosine remains an upper bound on adjusted score, which keeps the floor filter intuitive.
- /memory fact list defaults to weighted-quality sort with a Sort: Quality / Sort: Recent toggle. Fact detail renders Speaker and Confidence; episode detail renders Speaker only.

## Implementation map

- `kai.memory`: four module-scope constants (`_MIGRATION_SPEAKER` / `_MIGRATION_CONFIDENCE` / `_LEGACY_SPEAKER` / `_LEGACY_CONFIDENCE`), `_read_time_speaker` helper, `_SPEAKER_WEIGHTS` / `_speaker_weight`, per-hit recall log payload extended with `speaker` and `confidence`, `build_migration_metadata` helper.
- `kai.memory_extraction`: fact schema bumps to v8 with required `speaker` enum, prompt gains a `speaker` field block with four worked examples, `_validate_facts` defense-in-depth check forces `speaker="assistant"` when a fact's `confirmation_quote` appears verbatim in an ASSISTANT message in the window. `_generate_episode` pins `speaker="episode_summary"` and `confidence=1.0` at write time.
- `kai.memory_command`: `_send_facts_list` accepts a `sort` kwarg with quality-default re-sort, `_build_facts_list_view` renders the toggle row, `_build_fact_view` renders Speaker / Confidence per source, callback handler parses the new sort segment.
- `kai.eval.retrieval`: `ConfigOverride` carries three speaker-weight axes; `_apply_override` / `_restore_overrides` helpers replace the inline mutation block in `run_sweep`. CLI flags `--user-weight`, `--assistant-weight`, `--episode-summary-weight` replace the retired `--extracted-weight`. Default sweep grid is 24 speaker-weight combinations when floor and overfetch are pinned at production.
- `scripts/migrate-memory-md-to-qdrant.py`: routes through `build_migration_metadata` so the script and the tests share one code path.

## Legacy default rationale

Extracted-legacy rows (`source = "extracted"` with no speaker in metadata) default to `_LEGACY_SPEAKER = "assistant"` and `_LEGACY_CONFIDENCE = 0.5`. The pre-spec extractor produced facts indiscriminately from both speakers AND stripped third-person voice from extracted text, so post-hoc classification of these rows from prose alone is not recoverable. The conservative default biases toward demotion of unclassifiable content; a user-claimed fact mistakenly defaulted to assistant loses 30% retrieval weight, while an assistant-claimed fact mistakenly defaulted to user would inflate to full weight. The first error degrades; the second masks. If production data shows the default is wrong, swap the constants in a same-day PR; the change is purely read-side, no Qdrant rewrite required.

Migration rows are operator-authored MEMORY.md content. `_MIGRATION_SPEAKER = "user"` and `_MIGRATION_CONFIDENCE = 0.9` (the modest discount reflects that imported text is not freshly conversational).

## Calibration plan

Step 11 of the implementation order is the calibration sweep against a production snapshot. The harness changes ship with this PR so the sweep can run without a second deploy. The §5 hard floor compares against the pre-spec weighted baseline (the old `_SOURCE_WEIGHTS` table on the same probes against the same snapshot); a configuration is accepted only when p@1 stays within 0.05 of that baseline AND p@3 OR MRR is at least 0.05 above. The 24-configuration sweep table and five before / after sample retrieval lists land in the closing comment per the issue body's acceptance criterion.

## Test plan

- [x] All 2818 existing tests pass (`make test`).
- [x] `make check` passes (ruff lint + ruff format).
- [x] §6.1 round-trip tests verify speaker and confidence preserve through Mem0 / Qdrant for all three speaker values plus the two distinct legacy-default fallbacks.
- [x] §6.2 weight function tests pin speaker_weight times confidence and the demote-only invariant across every (in-enum speaker, in-range confidence) pair.
- [x] §6.3 format-context tests pin the new weighted-score ordering, the floor-applies-to-raw-cosine property, and the new log payload fields.
- [x] §6.4 extractor speaker tests pin the schema, the conservative default, and the defense-in-depth assistant-quote override.
- [x] §6.5 episode storage test pins speaker / confidence on the metadata bundle.
- [x] §6.6 migration helper test pins the build_migration_metadata dict shape.
- [x] §6.7 /memory rendering tests pin the default sort, toggle button shape, and per-source Speaker / Confidence rendering including the legacy-default fallback path.
- [x] §6.8 eval-harness apply / restore tests pin the round-trip restore property the sweep finally block depends on.
- [ ] Calibration sweep against the production snapshot (operator-driven; this PR ships the harness).
- [ ] End-to-end smoke against the production snapshot (operator-driven).
