### PR TITLE
fix(install): exclude PREFERENCES.md from global copy, clean up strays

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -88,6 +88,23 @@ _SOURCE_EXCLUDES = {"__pycache__", "*.pyc", "*.egg-info", ".git", ".venv", ".env
 #                 install/home/.claude/MEMORY.md, which would resurrect
 #                 the pre-#347 global layout and shadow the per-user
 #                 reads on every session.
+#   PREFERENCES.md - same shape as MEMORY.md per #400/#401. Read
+#                 directly by _apply_migrate and
+#                 backend.ensure_user_preferences from
+#                 templates/.claude/PREFERENCES.md, written to
+#                 DATA_DIR/preferences/<chat_id>/PREFERENCES.md. The
+#                 exclude prevents _copy_tree from depositing a global
+#                 copy at install/home/.claude/PREFERENCES.md, which
+#                 (while not currently read by any code path) creates
+#                 a name collision that misleads anyone inspecting the
+#                 install layout and would silently shadow per-user
+#                 reads if a future runtime path ever resolves through
+#                 that location. Missed in #442 because the pre-rename
+#                 file was named PREFERENCES.md.example, which had no
+#                 collision with the per-user PREFERENCES.md path; the
+#                 suffix drop turned the install copy into the same
+#                 global-layout artifact MEMORY.md had been protected
+#                 against since #347.
 #   CLAUDE.md   - per-operator regular file (gitignored); created on
 #                 first install by copying templates/.claude/CLAUDE.md
 #                 into the install tree. The exclude prevents the
@@ -95,7 +112,7 @@ _SOURCE_EXCLUDES = {"__pycache__", "*.pyc", "*.egg-info", ".git", ".venv", ".env
 #                 customized destination copy on reinstall.
 #   skills/     - downloaded skills, environment-specific.
 #   __pycache__ - byte-compile artifacts; never tracked.
-_HOME_CLAUDE_EXCLUDES = {"history", "MEMORY.md", "CLAUDE.md", "skills", "__pycache__"}
+_HOME_CLAUDE_EXCLUDES = {"history", "MEMORY.md", "PREFERENCES.md", "CLAUDE.md", "skills", "__pycache__"}
 
 
 # ── Input helpers ────────────────────────────────────────────────────
@@ -2859,6 +2876,13 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
         post_migration_claude_md_exists = claude_pre_is_regular or identity_pre_exists
         if claude_md_src.is_file() and not post_migration_claude_md_exists:
             print(f"[DRY RUN] Would seed {claude_md_src} -> {claude_md_dst}")
+        # Stray-PREFERENCES.md cleanup preview, mirroring the live path
+        # below. Only fires on hosts that ran the brief #442/PR #445
+        # window where the rename created a global stray; future installs
+        # never produce one (PREFERENCES.md is now in _HOME_CLAUDE_EXCLUDES).
+        stray_preferences = ws_claude_dst / "PREFERENCES.md"
+        if stray_preferences.is_file() and not stray_preferences.is_symlink():
+            print(f"[DRY RUN] Would remove stray {stray_preferences}")
         return
 
     _copy_tree(src_src, src_dst, _SOURCE_EXCLUDES)
@@ -2897,6 +2921,23 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
         _copy_tree(config_src, config_dst)
         _set_ownership(config_dst, 0, 0, recursive=True)
         print(f"  Copied config templates to {config_dst}")
+
+    # One-shot cleanup: remove any stray install/home/.claude/PREFERENCES.md
+    # left behind by an install that ran between #442/PR #445 (which renamed
+    # the source from PREFERENCES.md.example to PREFERENCES.md but did not
+    # add the new name to _HOME_CLAUDE_EXCLUDES) and this fix. The file is
+    # never read - per-user PREFERENCES.md lives at
+    # DATA_DIR/preferences/<chat_id>/PREFERENCES.md - so deletion is safe.
+    # Removed unconditionally rather than guarded by an owner check because
+    # nothing reads the path; an operator who manually placed content here
+    # was already getting no behavior from it. Future installs will not
+    # re-create the file thanks to the excludes-set entry above.
+    # Live path: dry_run already returned above. The dry-run preview lives
+    # in the dry_run block earlier in this function.
+    stray_preferences = ws_claude_dst / "PREFERENCES.md"
+    if stray_preferences.is_file() and not stray_preferences.is_symlink():
+        stray_preferences.unlink()
+        print(f"  Removed stray {stray_preferences} (per-user PREFERENCES.md lives in DATA_DIR)")
 
     # Conditional seed: the recursive copy above excluded CLAUDE.md so an
     # operator-customized destination is never overwritten. On first

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3375,20 +3375,34 @@ class TestApplyMigratePerUserPreferences:
         assert all(uid == 501 and gid == 20 for _, uid, gid in stray_calls)
 
 
-class TestPreferencesTemplateShipsViaCopyTree:
+class TestPreferencesTemplateExcludedFromGlobalCopy:
     """
-    The PREFERENCES.md template under templates/.claude/ ships into the
-    install tree as part of `_copy_tree(templates/.claude/, ...)` in
-    `_apply_source`. This test pins the contract that
-    `_HOME_CLAUDE_EXCLUDES` does NOT list the template name, so a future
-    excludes change cannot silently strip it.
+    The PREFERENCES.md template at templates/.claude/PREFERENCES.md is
+    NOT a global file; per #400/#401 the per-user PREFERENCES.md lives
+    at DATA_DIR/preferences/<chat_id>/PREFERENCES.md and is seeded by
+    _apply_migrate / backend.ensure_user_preferences directly from the
+    template path. The recursive _copy_tree(templates/.claude/, ...)
+    in _apply_source must NOT also deposit a copy at
+    install/home/.claude/PREFERENCES.md - that creates a name collision
+    that misleads anyone reading the layout and would silently shadow
+    per-user reads if a future runtime path ever resolves through it.
+
+    This test inverts the prior contract (which treated
+    `PREFERENCES.md.example` as something to ship into the install
+    tree). The rename in #442 dropped the .example suffix and turned
+    the pre-existing copy into the same global-layout artifact MEMORY.md
+    had been excluded against since #347.
     """
 
-    def test_excludes_does_not_drop_preferences_template(self):
+    def test_excludes_includes_preferences_md(self):
         from kai.install import _HOME_CLAUDE_EXCLUDES
 
-        assert "PREFERENCES.md" not in _HOME_CLAUDE_EXCLUDES, (
-            "PREFERENCES.md must ship into the install tree; adding it to _HOME_CLAUDE_EXCLUDES would silently drop it."
+        assert "PREFERENCES.md" in _HOME_CLAUDE_EXCLUDES, (
+            "PREFERENCES.md must NOT ship into the install tree as a "
+            "global file. Per-user PREFERENCES.md lives at "
+            "DATA_DIR/preferences/<chat_id>/PREFERENCES.md and is seeded "
+            "by _apply_migrate / backend.ensure_user_preferences directly "
+            "from templates/.claude/PREFERENCES.md."
         )
 
 
@@ -3986,6 +4000,99 @@ class TestApplySource:
             f"Last chown on {claude_md} was ({last_uid}, {last_gid}); expected (1000, 1000). "
             f"All chown calls in order: {chown_calls}"
         )
+
+    def test_strips_stray_global_preferences_md(self, tmp_path, capsys):
+        """
+        One-shot cleanup: hosts that ran the brief #442/PR #445 window where
+        PREFERENCES.md was missing from _HOME_CLAUDE_EXCLUDES end up with a
+        stray /opt/kai/home/.claude/PREFERENCES.md (root-owned, never read).
+        _apply_source removes it on the next install run so the layout
+        converges on the per-user-only state defined by #400/#401.
+        """
+        src = tmp_path / "source"
+        (src / "src").mkdir(parents=True)
+        (src / "src" / "module.py").write_text("code")
+        (src / "pyproject.toml").write_text("[project]")
+        ws_claude_src = src / "templates" / ".claude"
+        ws_claude_src.mkdir(parents=True)
+        (ws_claude_src / "PREFERENCES.md").write_text("# Preferences template\n")
+        (ws_claude_src / "CLAUDE.md").write_text("# Kai\n")
+
+        install = tmp_path / "install"
+        ws_claude_dst = install / "home" / ".claude"
+        ws_claude_dst.mkdir(parents=True)
+        # Pre-state: stray global PREFERENCES.md left behind by an older install.
+        stray = ws_claude_dst / "PREFERENCES.md"
+        stray.write_text("# Stray global from old install\n")
+        # Pre-existing CLAUDE.md so the seed step skips and we isolate the
+        # PREFERENCES.md cleanup.
+        (ws_claude_dst / "CLAUDE.md").write_text("# Operator content\n")
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install._copy_tree"),
+            patch("kai.install._set_ownership"),
+            patch("os.chown"),
+        ):
+            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
+
+        # Stray is gone, log line emitted.
+        assert not stray.exists()
+        out = capsys.readouterr().out
+        assert "Removed stray" in out
+        assert "PREFERENCES.md" in out
+        # CLAUDE.md untouched.
+        assert (ws_claude_dst / "CLAUDE.md").read_text() == "# Operator content\n"
+
+    def test_dry_run_predicts_stray_preferences_cleanup(self, tmp_path, capsys):
+        """Dry-run preview matches the live cleanup behavior."""
+        src = tmp_path / "source"
+        ws_claude_src = src / "templates" / ".claude"
+        ws_claude_src.mkdir(parents=True)
+        (ws_claude_src / "CLAUDE.md").write_text("# Kai\n")
+
+        install = tmp_path / "install"
+        ws_claude_dst = install / "home" / ".claude"
+        ws_claude_dst.mkdir(parents=True)
+        stray = ws_claude_dst / "PREFERENCES.md"
+        stray.write_text("stray\n")
+        (ws_claude_dst / "CLAUDE.md").write_text("# Operator content\n")
+
+        with patch("kai.install.PROJECT_ROOT", src):
+            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=True)
+
+        out = capsys.readouterr().out
+        assert "[DRY RUN] Would remove stray" in out
+        assert "PREFERENCES.md" in out
+        # Stray still exists; dry-run never touches disk.
+        assert stray.exists()
+
+    def test_no_stray_preferences_no_cleanup_message(self, tmp_path, capsys):
+        """When no stray is present, the cleanup is silent (no false-positive log)."""
+        src = tmp_path / "source"
+        (src / "src").mkdir(parents=True)
+        (src / "src" / "module.py").write_text("code")
+        (src / "pyproject.toml").write_text("[project]")
+        ws_claude_src = src / "templates" / ".claude"
+        ws_claude_src.mkdir(parents=True)
+        (ws_claude_src / "CLAUDE.md").write_text("# Kai\n")
+
+        install = tmp_path / "install"
+        ws_claude_dst = install / "home" / ".claude"
+        ws_claude_dst.mkdir(parents=True)
+        (ws_claude_dst / "CLAUDE.md").write_text("# Operator content\n")
+        # Deliberately no PREFERENCES.md at the destination.
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install._copy_tree"),
+            patch("kai.install._set_ownership"),
+            patch("os.chown"),
+        ):
+            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
+
+        out = capsys.readouterr().out
+        assert "Removed stray" not in out
 
     def test_dry_run_predicts_seed_for_fresh_install(self, tmp_path, capsys):
         """Dry-run prediction matches the live behavior for a fresh install."""


### PR DESCRIPTION
## Summary

Follow-up to #442/PR #445. System check on the operator's machine after the merge install surfaced a fresh `/opt/kai/home/.claude/PREFERENCES.md` (root:wheel) that should not exist. Per #400/#401 the per-user PREFERENCES.md lives at `DATA_DIR/preferences/<chat_id>/PREFERENCES.md`; the install path is the same global-layout artifact MEMORY.md had been excluded against since #347.

- Add `"PREFERENCES.md"` to `_HOME_CLAUDE_EXCLUDES` with a parallel rationale paragraph mirroring the MEMORY.md entry.
- One-shot cleanup in `_apply_source` deletes any stray `install/home/.claude/PREFERENCES.md` left by the brief #442-without-this-fix window. Unconditional delete since nothing reads the path.
- Dry-run preview line matches the live cleanup.

## Why missed in #442

Three reinforcing causes, all repaired in this PR:

1. `_HOME_CLAUDE_EXCLUDES` was preserved "unchanged in shape" through spec v1->v4. The exclude set was treated as untouchable; no agent re-derived membership given the rename.
2. The round-5 review prompted a rewrite of the per-entry rationale that articulated EXACTLY why MEMORY.md is excluded ("would resurrect the pre-#347 global layout and shadow per-user reads"). The same reasoning applies to PREFERENCES.md (added by #400/#401 in the same per-user-data wave). The author of the rationale missed the symmetry.
3. The acceptance grep `grep -rn '\.md\.example'` checked for surviving old-suffix references, not for newly-suffix-stripped collisions at the install destination. The test direction was inverted.

## Test plan

- [x] `make check` passes.
- [x] `pytest -q` passes (2821 tests, 1 skipped; +4 from this PR).
- [x] `TestPreferencesTemplateExcludedFromGlobalCopy` replaces the prior class that pinned the inverse-of-correct contract.
- [x] `test_strips_stray_global_preferences_md` integration test exercises the cleanup against the exact pre-state observed on the operator's machine (root-owned 1026-byte file at `install/home/.claude/PREFERENCES.md`).
- [x] `test_dry_run_predicts_stray_preferences_cleanup` matches dry-run preview to live behavior.
- [x] `test_no_stray_preferences_no_cleanup_message` guards against false-positive log line when no stray is present.
- [ ] Reviewer to spot-check that the new rationale paragraph in `_HOME_CLAUDE_EXCLUDES` matches the MEMORY.md entry's structure.
- [ ] Post-merge: install on the operator's machine, confirm "Removed stray ..." log line fires once and the stray PREFERENCES.md is gone.
