### PR TITLE
fix(tests): pre-set KAI_DATA_DIR at conftest module-top to stop leaks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,46 @@ def _cleanup_mem0_test_dir() -> None:
     shutil.rmtree(_MEM0_TEST_DIR, ignore_errors=True)
 
 
+# ── Session-wide DATA_DIR isolation ─────────────────────────────────
+#
+# `kai.config:40` resolves DATA_DIR at module-import time: it falls
+# back to PROJECT_ROOT when KAI_DATA_DIR is unset. In dev that means
+# DATA_DIR == PROJECT_ROOT, so any code path that writes to
+# `DATA_DIR / "files"`, `DATA_DIR / "memory"`, etc. lands inside the
+# repo working tree. The per-test autouse `_isolate_backend_data_dir`
+# fixture (below) patches `kai.backend.DATA_DIR`, but `from kai.config
+# import DATA_DIR` creates a per-module binding in every importer
+# (`kai.bot`, `kai.memory`, `kai.memory_extraction`, etc.), and some
+# of those bindings are frozen further into module-level constants
+# (e.g. `kai.memory_extraction._EXTRACTOR_CWD = DATA_DIR / "memory" /
+# "extractor_cwd"` at line 188, evaluated once at import). Patching
+# `kai.backend.DATA_DIR` after the fact does not reach those.
+#
+# Setting KAI_DATA_DIR in os.environ BEFORE any kai module is
+# imported makes the import-time fallback resolve to a per-session
+# tempdir for every importer at once, which is the only mechanism
+# that catches the frozen snapshots. The autouse fixtures below stay
+# as defense-in-depth and give per-test isolation on top.
+#
+# The shape (mkdtemp + hard override + atexit) mirrors the MEM0_DIR
+# block above; the same conftest-module-top ordering guarantee
+# applies (conftest runs before pytest collects test modules, which
+# is when their `from kai.config import ...` would otherwise fire).
+_KAI_DATA_TEST_DIR = tempfile.mkdtemp(prefix="kai-test-data-")
+os.environ["KAI_DATA_DIR"] = _KAI_DATA_TEST_DIR
+
+
+@atexit.register
+def _cleanup_kai_data_test_dir() -> None:
+    """Best-effort removal of the per-run KAI_DATA_DIR.
+
+    Mirrors `_cleanup_mem0_test_dir`. Errors are swallowed so a stray
+    open file handle from a crashed worker cannot mask a real test
+    failure with a secondary traceback at interpreter shutdown.
+    """
+    shutil.rmtree(_KAI_DATA_TEST_DIR, ignore_errors=True)
+
+
 # ── Per-test history isolation ──────────────────────────────────────
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,13 @@ def _cleanup_mem0_test_dir() -> None:
 # block above; the same conftest-module-top ordering guarantee
 # applies (conftest runs before pytest collects test modules, which
 # is when their `from kai.config import ...` would otherwise fire).
+#
+# Interaction with `tests/test_config.py:_clean_env`: that autouse
+# fixture does `monkeypatch.delenv("KAI_DATA_DIR")` per test, which
+# pytest auto-restores at fixture teardown. The session-wide value
+# set here therefore persists across test boundaries; only the test
+# body itself sees the env var as absent, which is what the
+# `TestDataDir` cases rely on to exercise the PROJECT_ROOT fallback.
 _KAI_DATA_TEST_DIR = tempfile.mkdtemp(prefix="kai-test-data-")
 os.environ["KAI_DATA_DIR"] = _KAI_DATA_TEST_DIR
 


### PR DESCRIPTION
Closes #444.

## Summary

`make test` was leaking artifacts into the repo working tree because `kai.config:40` resolves `DATA_DIR` at module-import time and falls back to `PROJECT_ROOT` when `KAI_DATA_DIR` is unset (the dev default). PR #438 closed `kai.backend.DATA_DIR` per-test; this PR closes the remaining surface (eight other module bindings plus the import-time-snapshot constants `_EXTRACTOR_CWD`, `_RESPONDING_DIR`, `_LOG_DIR`) by setting `KAI_DATA_DIR` to a session-scoped tempdir at `tests/conftest.py` module-top, BEFORE any `kai.*` module is imported.

Mirrors the existing `MEM0_DIR` block in the same file. Single-file change. Both existing autouse fixtures stay as per-test scoping on top.

## Test plan

- [x] `make check` passes.
- [x] `make test` passes (2818 tests, 1 skipped).
- [x] After `rm -rf files/ memory/ home/ history/ logs/ preferences/ models/ .responding/ .responding_to kai.db` and a fresh `make test`, none of those paths reappear at the repo root.
- [x] `git status -uall` clean (excepting an unrelated untracked `.claude/CLAUDE.md`).
- [x] `TestDataDir` cases in `tests/test_config.py:428-457` still pass without modification (they re-derive via `os.environ.get(...) or str(PROJECT_ROOT)` after `_clean_env`'s `delenv`).

## Operator cleanup (one-time)

After pulling this branch, run the following at the repo root to remove any test residue accumulated from prior runs:

```
rm -rf files/ memory/ home/ history/ logs/ preferences/ models/ .responding/ .responding_to kai.db
```

These paths are `.gitignore`d, so the cleanup cannot ride the diff. Errors for paths that do not exist on a given checkout can be ignored.

**Caveat:** back up `kai.db` first if you've been running Kai locally in dev mode (`python -m kai` from the repo root, with `KAI_DATA_DIR` unset). The dev fallback puts `kai.db` under `PROJECT_ROOT`, and the cleanup command will destroy any conversation history stored there. Production installs are unaffected (their data lives under `/var/lib/kai/`).
