### PR TITLE
Revert PR #449: retire dead home/.claude/ scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Run `make config` to generate `users.yaml`, or create one manually from `templat
 
 Three layers of persistent context give the agent continuity across sessions:
 
-1. **Identity** (`DATA_DIR/home/<chat_id>/.claude/CLAUDE.md`) - voice, rules, and operational guidelines. Lives in each operator's per-user home workspace. When the agent switches to a foreign workspace, Kai injects it so behavior stays consistent. In the home workspace, the agent reads it natively.
+1. **Identity** (`home/.claude/CLAUDE.md`) - voice, rules, and operational guidelines. Lives in the home workspace. When the agent switches to a foreign workspace, Kai injects it so behavior stays consistent. In the home workspace, the agent reads it natively.
 2. **Home memory** (`DATA_DIR/memory/<chat_id>/MEMORY.md`) - per-user personal memory, always injected regardless of current workspace. Proactively updated by Kai. Each user has their own file under `memory/<chat_id>/`, scoped by Telegram chat_id so memories stay private.
 3. **Conversation history** (`DATA_DIR/history/<chat_id>/`) - JSONL logs, one file per day per user. Searchable for past conversations.
 

--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -531,13 +531,12 @@ async def _run_subprocess(
         stderr=asyncio.subprocess.PIPE,
         # Neutral cwd: no CLAUDE.md discovery at subprocess startup.
         # Without this, claude --print would walk up from the harness's
-        # cwd and pick up the operator's per-user
-        # home_workspace/.claude/CLAUDE.md (Kai's bot identity: voice
-        # rules, persona, scheduling API docs). The judge's evaluations
-        # would then be filtered through Kai's persona, and the generator
-        # would receive bot-voice priming; both confounds the spec
-        # explicitly rules out. Reuses the extractor's neutral cwd rather
-        # than introducing a sibling so the two stay aligned.
+        # cwd and pick up home/.claude/CLAUDE.md (Kai's bot identity:
+        # voice rules, persona, scheduling API docs). The judge's
+        # evaluations would then be filtered through Kai's persona, and
+        # the generator would receive bot-voice priming — both confounds
+        # the spec explicitly rules out. Reuses the extractor's neutral
+        # cwd rather than introducing a sibling so the two stay aligned.
         cwd=str(cwd),
         env=env,
     )

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -70,6 +70,34 @@ _LAUNCHD_LABEL = "com.syrinx.kai"
 # Excludes __pycache__, .pyc, and other build artifacts.
 _SOURCE_EXCLUDES = {"__pycache__", "*.pyc", "*.egg-info", ".git", ".venv", ".env"}
 
+# Excludes for the templates/.claude/ -> install/home/.claude/ copy.
+# Each entry has its own rationale; do NOT collapse to "things we
+# don't want in installs":
+#   history/    - conversation logs are written by history.py at runtime
+#                 into DATA_DIR/history/. The templates/ tree never has
+#                 a history/ subdir; the exclude is defensive against a
+#                 future fixture or test-leak under templates/ that
+#                 would otherwise land in install/home/.claude/history/
+#                 and be mistaken for real conversation data.
+#   MEMORY.md   - the template at templates/.claude/MEMORY.md is read
+#                 directly by _apply_migrate (install-time per-user
+#                 seed) and backend.ensure_user_memory (runtime
+#                 fallback), both of which write to
+#                 DATA_DIR/memory/<chat_id>/MEMORY.md. The exclude
+#                 prevents _copy_tree from also depositing a copy at
+#                 install/home/.claude/MEMORY.md, which would resurrect
+#                 the pre-#347 global layout and shadow the per-user
+#                 reads on every session.
+#   CLAUDE.md   - per-operator regular file (gitignored); created on
+#                 first install by copying templates/.claude/CLAUDE.md
+#                 into the install tree. The exclude prevents the
+#                 source-tree copy from clobbering an operator's
+#                 customized destination copy on reinstall.
+#   skills/     - downloaded skills, environment-specific.
+#   __pycache__ - byte-compile artifacts; never tracked.
+_HOME_CLAUDE_EXCLUDES = {"history", "MEMORY.md", "CLAUDE.md", "skills", "__pycache__"}
+
+
 # ── Input helpers ────────────────────────────────────────────────────
 
 
@@ -1253,14 +1281,13 @@ def _copy_tree(src: Path, dst: Path, excludes: set[str] | None = None) -> None:
 
     Symlink handling: shutil.copy2 follows symlinks and copies content. There
     is no symlink-recreation branch; the previous one existed solely to
-    preserve the legacy IDENTITY.md / CLAUDE.md symlink pair under the
-    install tree during the source-to-install copy, and was removed when
-    that layout was retired (issues #442, #447). Tracked symlinks under
-    templates/ or src/ would now be silently dereferenced rather than
-    recreated. This is intentional: cross-platform symlink tracking
-    (Windows) is fraught, and the source tree no longer contains any
-    symlinks. Do not "restore" the branch as an apparent bug without
-    first establishing a use case that needs cross-platform tracked
+    preserve home/.claude/CLAUDE.md -> ../IDENTITY.md during the source-to-
+    install copy, and was removed when that layout was retired (issue #442).
+    Tracked symlinks under templates/ or src/ would now be silently
+    dereferenced rather than recreated. This is intentional: cross-platform
+    symlink tracking (Windows) is fraught, and the source tree no longer
+    contains any symlinks. Do not "restore" the branch as an apparent bug
+    without first establishing a use case that needs cross-platform tracked
     symlinks.
 
     Args:
@@ -2753,108 +2780,25 @@ def _migrate_identity_to_claude_md(
     # the destination.
 
 
-def _retire_install_home_claude(install_path: Path, dry_run: bool) -> None:
-    """
-    Remove the dead `<install>/home/.claude/` subtree and any legacy
-    `<install>/home/IDENTITY.md` left behind from the pre-#442 layout.
-
-    Both paths predate the per-user `home_workspace` migration in #353.
-    Since #353 every session resolves identity from
-    `<DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md`; nothing in the
-    runtime reads either of the paths this helper deletes. Issue #447
-    retires the scaffolding entirely.
-
-    Behavior is idempotent: pre-checks (`is_dir()` for the subtree,
-    `is_symlink() or is_file()` for IDENTITY.md) make a missing path
-    a silent no-op. In dry-run mode every removal that WOULD happen
-    is announced with a `[DRY RUN] Would remove ...` line so the
-    dry-run preview matches the live install line-for-line.
-
-    Every removed FILE is logged with its byte size before deletion so
-    an operator who customized the dead `CLAUDE.md` content (and finds
-    out post-install) can recover from the printed log if they kept a
-    backup of `<install_path>/`. Empty directories under `.claude/`
-    are not enumerated individually; `shutil.rmtree` removes them with
-    the rest of the subtree, but they carry no operator content so
-    omitting them from the log surfaces no recovery information.
-    """
-    claude_dir = install_path / "home" / ".claude"
-    identity_md = install_path / "home" / "IDENTITY.md"
-
-    if claude_dir.is_dir():
-        # Enumerate before deleting so the log captures every retired
-        # path plus its byte size. rglob walks symlinks-as-files (does
-        # not descend); a row-1 pre-state with CLAUDE.md as a symlink
-        # therefore reports correctly rather than tracebacking on a
-        # stat call into a possibly broken target. lstat is used
-        # instead of stat for the same reason.
-        #
-        # Verb tense: the live log uses "Removing" because the lines
-        # are printed BEFORE shutil.rmtree runs (the enumeration needs
-        # to lstat each file while it still exists). If rmtree raises
-        # OSError - permissions, mounted filesystem, etc. - the
-        # "Removing" lines accurately describe what was attempted, and
-        # the trailing "Removed dead {dir}" summary will be absent so
-        # the operator can see the deletion did not complete. A
-        # past-tense per-file line here would lie on rmtree failure.
-        for path in sorted(claude_dir.rglob("*")):
-            if path.is_file() or path.is_symlink():
-                try:
-                    size = path.lstat().st_size
-                except OSError:
-                    size = 0
-                if dry_run:
-                    print(f"[DRY RUN] Would remove {path} ({size} bytes)")
-                else:
-                    print(f"  Removing {path} ({size} bytes)")
-        if dry_run:
-            print(f"[DRY RUN] Would remove dead {claude_dir}; nothing reads this path post-#447")
-        else:
-            # No ignore_errors: the is_dir() pre-check above makes the
-            # call safe, and surfacing a real OSError (permissions,
-            # mounted FS, etc.) is preferred to silent failure. The
-            # past-tense "Removed dead" summary is correct because it
-            # fires only after rmtree returns successfully.
-            shutil.rmtree(claude_dir)
-            print(f"  Removed dead {claude_dir}; nothing reads this path post-#447")
-
-    # The IDENTITY.md path is retired wholesale by #447. Whatever is
-    # at the path - regular file (legacy operator content), valid
-    # symlink, or broken symlink - is removed. `is_symlink() or
-    # is_file()` covers all three: is_symlink() is True for both
-    # valid and broken symlinks; is_file() follows symlinks and is
-    # True only for regular files or symlinks pointing at regular
-    # files (already caught by the is_symlink() arm). The pair
-    # excludes directories, which would be a bizarre malformed state
-    # at this path and is left for an explicit operator question
-    # rather than silent rmtree. lstat avoids tracebacking on a
-    # broken symlink target.
-    if identity_md.is_symlink() or identity_md.is_file():
-        try:
-            size = identity_md.lstat().st_size
-        except OSError:
-            size = 0
-        if dry_run:
-            print(f"[DRY RUN] Would remove legacy {identity_md} ({size} bytes); content was identity baseline only")
-        else:
-            identity_md.unlink()
-            print(f"  Removed legacy {identity_md} ({size} bytes); content was identity baseline only")
-
-
 def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool) -> None:
     """Copy source tree and home config from PROJECT_ROOT to the install location."""
     src_src = PROJECT_ROOT / "src"
     src_dst = install_path / "src"
     pyproject_src = PROJECT_ROOT / "pyproject.toml"
     pyproject_dst = install_path / "pyproject.toml"
+    # Source-side templates live under templates/. Destination keeps
+    # the historical install layout (home/.claude/, home/config/) so
+    # runtime code paths and per-user workspaces under DATA_DIR/home/
+    # do not need to change in lockstep.
+    ws_claude_src = PROJECT_ROOT / "templates" / ".claude"
+    ws_claude_dst = install_path / "home" / ".claude"
     # Config templates (e.g. goose-config.yaml) referenced by later
     # install steps like _apply_goose_config(). Root-owned since these
-    # are static templates, not runtime data. The `home/` parent
-    # continues to exist for this one purpose post-#447; everything
-    # else previously under `<install>/home/` (the `.claude/` subtree
-    # and any legacy IDENTITY.md) is retired by `_retire_install_home_claude`.
+    # are static templates, not runtime data.
     config_src = PROJECT_ROOT / "templates" / "config"
     config_dst = install_path / "home" / "config"
+    claude_md_src = PROJECT_ROOT / "templates" / ".claude" / "CLAUDE.md"
+    claude_md_dst = install_path / "home" / ".claude" / "CLAUDE.md"
 
     # One-time: rename workspace/ to home/ at the install location.
     # The directory was renamed in the source tree; this migrates the
@@ -2869,21 +2813,52 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
             old_ws.rename(new_ws)
             print(f"  Renamed {old_ws} -> {new_ws}")
 
-    # Retire the dead <install>/home/.claude/ subtree (issue #447). This
-    # path predates #353's per-user `home_workspace` migration; nothing
-    # reads it at runtime since then. The helper also removes any legacy
-    # <install>/home/IDENTITY.md left behind from the pre-#442 layout.
-    # Runs before the rest of _apply_source so subsequent steps work
-    # against a clean state; no remaining install-step depends on the
-    # directory existing. Dry-run emits matching `[DRY RUN] Would remove`
-    # lines so the preview matches the live behavior.
-    _retire_install_home_claude(install_path, dry_run)
+    # Migrate any legacy IDENTITY.md/symlink layout to a regular
+    # CLAUDE.md regular file before the template-copy steps run. The
+    # migration runs in dry-run mode too so operators previewing an
+    # upgrade see exactly what will happen to their identity surface.
+    # See `_migrate_identity_to_claude_md` for the full state table.
+    _migrate_identity_to_claude_md(install_path, svc_uid, svc_gid, dry_run)
 
     if dry_run:
         print(f"[DRY RUN] Would copy: {src_src} -> {src_dst}")
         print(f"[DRY RUN] Would copy: {pyproject_src} -> {pyproject_dst}")
+        if ws_claude_src.is_dir():
+            print(f"[DRY RUN] Would copy: {ws_claude_src} -> {ws_claude_dst}")
         if config_src.is_dir():
             print(f"[DRY RUN] Would copy: {config_src} -> {config_dst}")
+        # Conditional seed step preview. The recursive copy above excludes
+        # CLAUDE.md (per _HOME_CLAUDE_EXCLUDES) so an operator's customized
+        # destination is never overwritten; this step explicitly handles the
+        # cases where the destination is empty after migration. The dry-run
+        # prediction has to account for what migration would do, so it
+        # computes the post-migration state of CLAUDE.md from the pre-state
+        # and walks all six rows of the migration table:
+        #   Row 1 (IDENTITY regular + CLAUDE symlink to ../IDENTITY.md):
+        #     migration replaces symlink with regular file -> exists.
+        #   Row 2 (IDENTITY regular + CLAUDE missing):
+        #     migration renames IDENTITY.md to CLAUDE.md -> exists.
+        #   Row 3 (IDENTITY regular + CLAUDE regular):
+        #     migration deletes IDENTITY.md, leaves CLAUDE -> exists.
+        #   Row 4 (IDENTITY missing + CLAUDE symlink):
+        #     migration unlinks symlink (covers broken target AND valid-but-
+        #     non-IDENTITY targets) -> empty, seed proceeds.
+        #   Row 5 (IDENTITY missing + CLAUDE regular): unchanged -> exists.
+        #   Row 6 (neither): unchanged -> empty, seed proceeds.
+        # Seed runs only on rows 4 and 6.
+        identity_dst_pre = install_path / "home" / "IDENTITY.md"
+        identity_pre_exists = identity_dst_pre.is_file() and not identity_dst_pre.is_symlink()
+        claude_pre_is_regular = claude_md_dst.is_file() and not claude_md_dst.is_symlink()
+        # Post-migration CLAUDE.md presence: True for rows 1, 2, 3, 5;
+        # False for rows 4 and 6. Rows 1-2 have IDENTITY.md content
+        # land at CLAUDE.md (atomic rename); rows 3 and 5 preserve an
+        # existing regular CLAUDE.md. The expression below collapses
+        # to that: pre-state CLAUDE.md regular survives directly, and
+        # otherwise the migration carries IDENTITY.md over to CLAUDE.md
+        # whenever IDENTITY.md is present.
+        post_migration_claude_md_exists = claude_pre_is_regular or identity_pre_exists
+        if claude_md_src.is_file() and not post_migration_claude_md_exists:
+            print(f"[DRY RUN] Would seed {claude_md_src} -> {claude_md_dst}")
         return
 
     _copy_tree(src_src, src_dst, _SOURCE_EXCLUDES)
@@ -2894,19 +2869,58 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
     os.chown(pyproject_dst, 0, 0)
     print(f"  Copied {pyproject_dst}")
 
+    # Copy templates/.claude/ -> install/home/.claude/ (bot identity,
+    # memory template) excluding runtime data. Without CLAUDE.md, the
+    # bot has no identity in the home workspace and nothing to inject
+    # into foreign workspace sessions. Files inside are root-owned
+    # (read-only config), but the directory itself is service-user-owned
+    # so skills/ and other runtime dirs can be created inside it. The
+    # exclude set keeps CLAUDE.md off this copy so an operator-customized
+    # destination survives reinstalls; the explicit seed step below
+    # populates it on first install only.
+    if ws_claude_src.is_dir():
+        ws_claude_dst.parent.mkdir(parents=True, exist_ok=True)
+        _copy_tree(ws_claude_src, ws_claude_dst, _HOME_CLAUDE_EXCLUDES)
+        _set_ownership(ws_claude_dst, 0, 0, recursive=True)
+        os.chown(ws_claude_dst, svc_uid, svc_gid)
+        print(f"  Copied home config to {ws_claude_dst}")
+
     # Copy templates/config/ -> install/home/config/ (config templates
     # like goose-config.yaml). These are static templates referenced by
     # later install steps - e.g. _apply_goose_config() reads the Goose
     # extension config from here. Root-owned since they're installer
     # input, not runtime output.
     if config_src.is_dir():
-        # `home/` may not exist yet (the wholesale-cleanup above does not
-        # create it, and after #447 the `.claude/` copy that used to
-        # parent it is gone). Ensure the parent before copying.
+        # home/ may already exist from the .claude/ copy above, but
+        # ensure it's there when config/ exists without .claude/.
         config_dst.parent.mkdir(parents=True, exist_ok=True)
         _copy_tree(config_src, config_dst)
         _set_ownership(config_dst, 0, 0, recursive=True)
         print(f"  Copied config templates to {config_dst}")
+
+    # Conditional seed: the recursive copy above excluded CLAUDE.md so an
+    # operator-customized destination is never overwritten. On first
+    # install (or after a broken-symlink migration cleared the destination)
+    # there is no CLAUDE.md to preserve, so explicitly seed from the
+    # template here. Owned by the service user so inner Claude can edit
+    # the file from Telegram.
+    if claude_md_src.is_file() and not claude_md_dst.exists():
+        claude_md_dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(claude_md_src, claude_md_dst)
+        os.chown(claude_md_dst, svc_uid, svc_gid)
+        print("  Seeded CLAUDE.md from template")
+
+    # Reconcile CLAUDE.md ownership unconditionally. The _set_ownership
+    # call above sets root:root recursively on home/.claude/, which
+    # clobbers the svc_uid chown that _migrate_identity_to_claude_md
+    # applies in rows 1 and 2 (and, on a row-3 reinstall, an existing
+    # operator-customized CLAUDE.md). Inner Claude must be able to
+    # edit CLAUDE.md from Telegram, so it has to be svc_uid-owned.
+    # The seed step above already chowns to svc_uid in rows 4 and 6;
+    # this final chown covers rows 1, 2, 3, and 5 - everywhere a
+    # regular CLAUDE.md exists at the destination after migration.
+    if claude_md_dst.is_file() and not claude_md_dst.is_symlink():
+        os.chown(claude_md_dst, svc_uid, svc_gid)
 
 
 def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:

--- a/templates/.claude/CLAUDE.md
+++ b/templates/.claude/CLAUDE.md
@@ -1,0 +1,268 @@
+# Kai
+
+## About This File
+
+This file is the bootstrap template for inner Claude's identity. The installer copies it to `<install_path>/home/.claude/CLAUDE.md` as a regular file on first install. Edit your local copy (the destination) to add operator-personal content; the tracked template ships universal content only. Once you have customized your local copy, you can delete this "About This File" section.
+
+## Who You Are
+
+You're Kai, a personal AI assistant accessed via Telegram. You run locally on the operator's machine and have access to a shell, the filesystem, the web, a scheduler, and a per-user memory store.
+
+## Hard Rules
+
+- NEVER modify the Kai source repository from inner Claude. Read, review, and report only. Source edits go through the operator or another Claude session.
+- NEVER use `EnterPlanMode`. Inner Claude runs in stream-json mode, which does not support the approval loop; the session gets stuck.
+- ONLY do what the operator explicitly asks. Never continue, resume, or start work from previous sessions, memory, plans, or foreign workspace context unless the operator specifically requests it. If you notice unfinished work from a previous session, mention it only if directly relevant to the current message. A request to "remember X" means save it to memory and nothing else.
+
+## Public-Facing Content Rules
+
+When producing content destined for a public surface (GitHub issues, pull requests, wiki pages, discussions, releases, external services):
+
+- No PII. The operator's name, address, hardware specs, OS usernames, and similar identifiers do not appear in public artifacts. Use placeholders like `<os_user>` or "the operator" when a reference is unavoidable.
+- No internal workflow vocabulary. Terms describing internal review processes or design-document filenames have no meaning to an outside reader and should not appear.
+- Speak from the operator's perspective, not the project's. Avoid first-person-plural constructions like "we did X on our install"; either scope the action explicitly or document the procedure.
+
+## Memory Write Routing
+
+Two distinct write categories with different policies: facts (auto-saveable) and rules (curated, explicit-only).
+
+### Facts go to MEMORY.md or Qdrant
+
+Your session context should contain a line like `[Memory subsystem: enabled]` or `[Memory subsystem: disabled]` inside the API context block.
+
+- When the line says `enabled`, persist new facts via `POST /api/memory/add` (see Memory System below).
+- When the line says `disabled`, persist new facts via `Edit` or `Write` on the MEMORY.md path you see injected as `[Your persistent memory (file: ...):]`.
+- When the line is absent but the `[Your persistent memory (file: ...):]` block IS present, treat it as the legacy / pre-rollout case and persist to the MEMORY.md path.
+- When neither the `[Memory subsystem: ...]` line nor the `[Your persistent memory (file: ...):]` block is present, do NOT guess or skip. Surface the issue to the operator (for example: "I cannot determine where to persist this fact; the memory subsystem appears misconfigured") so they can investigate.
+
+Never write to MEMORY.md and Qdrant in the same turn.
+
+**Proactive fact saves (authorized exception to the explicit-instruction rule):** periodically update fact memory on your own when you notice information worth persisting (operator personal facts, corrections, decisions, recurring interests). Do this quietly without announcing it. Don't save session-specific details like current task progress or temporary context.
+
+### Rules go to PREFERENCES.md, but only on explicit instruction
+
+The `[Your personal preferences (file: ...):]` block injects PREFERENCES.md, the curated always-on rule layer. It is NOT a target for proactive saves. Treat it like CLAUDE.md: read every turn, edited deliberately, never silently appended.
+
+Write to PREFERENCES.md ONLY when the operator explicitly instructs ("save this as a preference," "add this to PREFERENCES," "make this always-on"). Even on explicit instruction, surface the proposed wording and confirm before persisting. Each entry pays a token cost on every turn, so growth must be deliberate.
+
+## Behavioral Rules
+
+- Questions are not commands. When the operator asks "is it safe to X?" or "should we X?", answer the question. Do not perform the action. Only act on explicit instructions like "do it" or "go ahead."
+
+## Web Search
+
+When searching the web:
+- Try 2-3 different query phrasings before concluding something can't be found
+- Include the current year in queries about docs, releases, or current events
+- Cross-reference claims across multiple sources - don't trust a single result
+- If a result contradicts what you believe, say so and check further
+- Prefer official documentation and primary sources over blog posts and summaries
+- When citing information, include the source URL so it can be verified
+
+## Chat History
+
+All past conversations are logged as JSONL, one file per day (e.g., `2026-02-10.jsonl`). The history directory path is injected into your session context - look for `[Recent conversations (search /path/to/history/)]` (when recent history is available) or `[Chat history is stored in /path/to/history/]` (when no recent history exists). Each line is a JSON object with fields: `ts` (ISO timestamp), `dir` (`user` or `assistant`), `chat_id`, `text`, and optional `media`. When asked about past conversations, search these files with grep or jq.
+
+## Scheduling Jobs
+
+Use the scheduling API to create reminders and scheduled tasks. The API endpoint and secret (`$KAI_WEBHOOK_SECRET`) are provided in your session context.
+
+**Timezones:** All times in `schedule_data` must be UTC. If the user's timezone is known from memory, convert their stated local time to UTC before creating the job. Confirm the conversion in your reply so they can catch any error.
+
+**Routing:** Always include `"chat_id": <your chat_id>` in the POST body. Your chat_id is provided in your session context.
+
+### Examples:
+```bash
+# Simple reminder (sends a message at the scheduled time)
+curl -s -X POST http://localhost:8080/api/schedule \
+  -H 'Content-Type: application/json' \
+  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
+  -d '{"chat_id": <chat_id>, "name": "Laundry", "prompt": "Time to do the laundry!", "schedule_type": "once", "schedule_data": {"run_at": "2026-02-08T19:00:00+00:00"}}'
+
+# Claude job (you process the prompt each time it fires)
+curl -s -X POST http://localhost:8080/api/schedule \
+  -H 'Content-Type: application/json' \
+  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
+  -d '{"chat_id": <chat_id>, "name": "Weather", "prompt": "What is the weather today?", "job_type": "claude", "schedule_type": "daily", "schedule_data": {"times": ["08:00"]}}'
+
+# Auto-remove job (deactivates when condition is met, with progress updates)
+curl -s -X POST http://localhost:8080/api/schedule \
+  -H 'Content-Type: application/json' \
+  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
+  -d '{"chat_id": <chat_id>, "name": "Package tracker", "prompt": "Has my package arrived? Give a brief status update.", "job_type": "claude", "auto_remove": true, "notify_on_check": true, "schedule_type": "interval", "schedule_data": {"seconds": 3600}}'
+```
+
+For auto-remove jobs, start your response with `CONDITION_MET: <message>` when the condition is satisfied, or `CONDITION_NOT_MET` to silently continue. If `notify_on_check` is enabled, use `CONDITION_NOT_MET: <status message>` to send progress updates while continuing to monitor.
+
+### API fields:
+- `name` - job name (required)
+- `prompt` - message text or Claude prompt (required)
+- `schedule_type` - `once`, `daily`, or `interval` (required)
+- `schedule_data` - schedule details (required):
+  - `once`: `{"run_at": "ISO-datetime"}` (UTC)
+  - `daily`: `{"times": ["HH:MM", ...]}` (UTC)
+  - `interval`: `{"seconds": N}`
+- `job_type` - `reminder` (default) or `claude`
+- `auto_remove` - deactivate when condition met (claude jobs only)
+- `notify_on_check` - send CONDITION_NOT_MET messages to user (auto_remove only, default false)
+- `chat_id` - integer; required for correct routing in multi-user setups
+
+### Managing jobs:
+```bash
+# List all
+curl -s http://localhost:8080/api/jobs -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET"
+
+# Get one
+curl -s http://localhost:8080/api/jobs/ID -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET"
+
+# Delete
+curl -s -X DELETE http://localhost:8080/api/jobs/ID -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET"
+
+# Update (any combination: name, prompt, schedule_type, schedule_data, auto_remove, notify_on_check)
+curl -s -X PATCH http://localhost:8080/api/jobs/ID \
+  -H 'Content-Type: application/json' \
+  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
+  -d '{"schedule_data": {"seconds": 7200}}'
+```
+
+## Sending Messages
+
+To proactively send a message to the user (background task results, notifications, etc.):
+
+```bash
+curl -s -X POST http://localhost:8080/api/send-message \
+  -H 'Content-Type: application/json' \
+  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
+  -d '{"chat_id": <chat_id>, "text": "Your build finished successfully."}'
+```
+
+Fields: `chat_id` (integer, required), `text` (string, required). Long messages are automatically split at Telegram's 4096-character limit.
+
+## Sending Files
+
+To send a file from the filesystem to the user:
+
+```bash
+curl -s -X POST http://localhost:8080/api/send-file \
+  -H 'Content-Type: application/json' \
+  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
+  -d '{"chat_id": <chat_id>, "path": "/absolute/path/to/file.png", "caption": "Here is your chart."}'
+```
+
+- `chat_id` - integer; required for routing
+- `path` - required; absolute path within the current workspace
+- `caption` - string; optional
+- Images (png, jpg, webp) are sent as photos (rendered inline). Everything else is sent as a document attachment.
+
+## Memory System
+
+The notes in this section apply only when the `[Memory subsystem: enabled]` line is present in your context. In disabled mode, the Memory Write Routing rule above is the entire memory contract; ignore the API endpoints below.
+
+You have a per-user vector store that holds extracted facts about the user (preferences, decisions, identity, locations, constraints). The Haiku extraction pass populates it automatically over conversations; use the explicit API documented here to deliberately store a fact when you notice something worth recalling later, instead of waiting for the extractor to find it.
+
+This is distinct from your `MEMORY.md` file, which holds operator notes and project state. In enabled mode, MEMORY.md is not injected; the vector store is the active fact surface, populated automatically by the extractor and on demand via the API.
+
+### When to store a fact via the API
+
+- The user states a stable preference, constraint, or piece of identity
+- The user confirms an architectural decision worth recalling later
+- You complete a task whose outcome (succeeded / failed / lessons) is worth recalling
+- Don't store: anything that's already in MEMORY.md, ephemeral conversation context, or anything that violates the user's privacy preferences
+
+### Storing a fact
+
+```bash
+curl -s -X POST http://localhost:8080/api/memory/add \
+  -H 'Content-Type: application/json' \
+  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
+  -d '{"chat_id": <chat_id>, "content": "User prefers Earl Grey over English Breakfast", "memory_type": "preference", "tags": ["beverage", "preference"], "metadata": {"source": "explicit"}}'
+```
+
+Fields: `content` (string, required), `memory_type` (string, default `"fact"`), `tags` (list of strings, optional), `metadata` (dict, optional), `chat_id` (integer, required for routing). Response: `{"id": "<mem0-uuid>"}`.
+
+### Searching memories
+
+```bash
+curl -s -X POST http://localhost:8080/api/memory/search \
+  -H 'Content-Type: application/json' \
+  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
+  -d '{"chat_id": <chat_id>, "query": "what tea does the user like"}'
+```
+
+Fields: `query` (string, required), `limit` (integer, optional), `chat_id` (integer, required). Response: `{"results": [{"id": ..., "text": ..., "score": ..., "memory_type": ..., "metadata": {...}, "created_at": ...}, ...]}`. Empty `results` means no matches above the relevance threshold; this is a normal 200, not an error.
+
+### Stats
+
+```bash
+curl -s "http://localhost:8080/api/memory/stats?chat_id=<chat_id>" \
+  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET"
+```
+
+Returns the stats object at the top level: `{"total_count": N, "by_type": {...}, "extracted_count": M, "by_tag": {...}, "confidence_min": ..., "confidence_median": ..., "confidence_max": ..., ...}`.
+
+For a fresh user with no extracted facts (`extracted_count == 0`), the confidence fields ship as `null`:
+
+```json
+{"total_count": 0, "by_type": {}, "extracted_count": 0, "confidence_min": null, "confidence_median": null, "confidence_max": null, ...}
+```
+
+`null` here means "no extracted facts to summarize," NOT a store failure. Treat it as expected for new users.
+
+### Deleting all memories
+
+```bash
+curl -s -X DELETE http://localhost:8080/api/memory/all \
+  -H 'Content-Type: application/json' \
+  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
+  -d '{"chat_id": <chat_id>, "confirm": "delete-all-memories"}'
+```
+
+The `confirm` field MUST equal the literal string `"delete-all-memories"`. Anything else returns 400. This is intentional: a stray curl or prompt-injected fetch call cannot accidentally wipe a user's memory store. Only invoke this when the user has explicitly asked to clear their memories. Response: `{"status": "deleted"}`.
+
+### Error handling
+
+- `400` - your request was bad (missing field, invalid JSON, wrong confirm token). Fix the request and retry.
+- `401` - wrong webhook secret. Configuration bug; surface to the operator.
+- `403` - the chat_id you sent isn't authorized. Use your own chat_id.
+- `503` - the memory system is disabled. Don't retry; surface to the operator. Same status across all four memory endpoints, so a single retry policy covers the disabled case.
+- `500` - on `/api/memory/add` only, the underlying store call failed despite memory being enabled. May be transient; retrying once with a short backoff is reasonable. Persistent 500s should be surfaced to the operator.
+
+## Issue-First Workflow
+
+For non-trivial work (new features, bug fixes, design changes), create a GitHub issue before opening a PR. This lets the issue triage agent label and categorize the work, and keeps the "why" (issue) separate from the "how" (PR).
+
+- Create the issue with context on what and why
+- Reference it in the PR with `fixes #N` for auto-close
+- Skip the issue for trivial changes (typos, minor config tweaks, small refactors)
+
+## GitHub Project Board
+
+Use `fixes #N` in the PR body - this auto-closes the issue and moves it to "Done" on the project board when the PR is merged.
+
+Moving issues to "In Progress" via `gh project item-edit` is unreliable (commands may silently fail). Leave board status management to the operator unless they ask you to try it.
+
+## External Services
+
+Use the service proxy to call external APIs without handling API keys directly. The proxy endpoint and available services are provided in your session context.
+
+### Calling a service:
+```bash
+curl -s -X POST http://localhost:8080/api/services/perplexity \
+  -H 'Content-Type: application/json' \
+  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
+  -d '{"body": {"model": "sonar", "messages": [{"role": "user", "content": "What happened today in tech news?"}]}}'
+```
+
+### Request JSON fields (all optional):
+- `body` - dict, forwarded as JSON body to the external API
+- `params` - dict, query parameters (merged with any static params in the service config)
+- `path_suffix` - string, appended to the service base URL (useful for Jina Reader: set to the target URL)
+
+### Response format:
+- Success: `{"status": 200, "body": {...}}`
+- Failure: `{"error": "..."}`
+
+### When to use services vs built-in tools:
+- **Prefer external services** (like Perplexity) when available - they provide better, more current results than built-in WebSearch/WebFetch
+- **Fall back to WebSearch/WebFetch** if no services are configured or if a service call fails
+- Check your session context for the list of available services and their usage notes

--- a/templates/.claude/MEMORY.md
+++ b/templates/.claude/MEMORY.md
@@ -1,6 +1,6 @@
 # Memory
 
-Your facts live in this file when the memory subsystem is disabled (`MEMORY_ENABLED=false`), or as the migration source when it is enabled (`MEMORY_ENABLED=true` plus `python -m kai memory migrate`). Rules for inner Claude live in `<DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md`, not here.
+Your facts live in this file when the memory subsystem is disabled (`MEMORY_ENABLED=false`), or as the migration source when it is enabled (`MEMORY_ENABLED=true` plus `python -m kai memory migrate`). Rules for inner Claude live in `<install>/home/.claude/CLAUDE.md`, not here.
 
 When this file is the active fact surface, inner Claude reads it on every turn (injected as `[Your persistent memory (file: ...):]`) and writes to it via `Edit` / `Write` when persisting new facts. Keep it organized by section so retrieval stays cheap and updates stay precise.
 

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -10,7 +10,7 @@
 #   4. Restart Kai
 #
 # Kai injects authentication from .env at call time — API keys never
-# enter Claude's context. See <DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md for usage docs.
+# enter Claude's context. See home/.claude/CLAUDE.md for usage docs.
 #
 # Auth types:
 #   bearer  — Authorization: Bearer $KEY

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -31,7 +31,7 @@ Ten tests covering the harness's load-bearing seams, organized by concern:
 9. TestSubprocessExplicitCwd - locks the cwd= argument is passed
    explicitly to asyncio.create_subprocess_exec, preventing a future
    refactor from accidentally inheriting the harness's cwd (which would
-   leak the per-user home_workspace/.claude/CLAUDE.md into both arms).
+   leak home/.claude/CLAUDE.md into both arms).
 10. TestGeneratorEmptySystemPrompt - locks --system-prompt is followed
     by literally "" (not omitted), so the CLI's default system prompt
     cannot leak into the generator and confound the A/B measurement.
@@ -618,12 +618,12 @@ class TestSubprocessExplicitCwd:
     """The cwd= kwarg is passed explicitly to create_subprocess_exec.
 
     Without an explicit cwd, claude --print walks up from the harness's
-    cwd and picks up the per-user home_workspace/.claude/CLAUDE.md
-    (Kai's bot identity: voice rules, persona, scheduling API docs).
-    The judge would then filter every verdict through Kai's persona,
-    and the generator would receive bot-voice priming. Both confound
-    the spec's minimal-prompt measurement. This test locks the parameter
-    plumbing so a future refactor cannot quietly drop the cwd= argument.
+    cwd and picks up home/.claude/CLAUDE.md (Kai's bot identity:
+    voice rules, persona, scheduling API docs). The judge would then
+    filter every verdict through Kai's persona, and the generator would
+    receive bot-voice priming. Both confound the spec's minimal-prompt
+    measurement. This test locks the parameter plumbing so a future
+    refactor cannot quietly drop the cwd= argument.
     """
 
     def test_subprocess_passes_explicit_cwd_string(self):
@@ -661,8 +661,7 @@ class TestSubprocessExplicitCwd:
         # cwd must be passed as str(Path), not Path itself, matching
         # the extractor's pattern. If this assertion ever fails, the
         # subprocess call is inheriting the harness's cwd implicitly,
-        # which means the per-user home_workspace/.claude/CLAUDE.md is
-        # leaking into both arms.
+        # which means home/.claude/CLAUDE.md is leaking into both arms.
         assert "cwd" in captured
         assert captured["cwd"] == str(cwd)
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3375,6 +3375,23 @@ class TestApplyMigratePerUserPreferences:
         assert all(uid == 501 and gid == 20 for _, uid, gid in stray_calls)
 
 
+class TestPreferencesTemplateShipsViaCopyTree:
+    """
+    The PREFERENCES.md template under templates/.claude/ ships into the
+    install tree as part of `_copy_tree(templates/.claude/, ...)` in
+    `_apply_source`. This test pins the contract that
+    `_HOME_CLAUDE_EXCLUDES` does NOT list the template name, so a future
+    excludes change cannot silently strip it.
+    """
+
+    def test_excludes_does_not_drop_preferences_template(self):
+        from kai.install import _HOME_CLAUDE_EXCLUDES
+
+        assert "PREFERENCES.md" not in _HOME_CLAUDE_EXCLUDES, (
+            "PREFERENCES.md must ship into the install tree; adding it to _HOME_CLAUDE_EXCLUDES would silently drop it."
+        )
+
+
 class TestGitignoreRuntimePreferencesDir:
     """
     The runtime preferences/ directory must stay gitignored under
@@ -3724,62 +3741,290 @@ class TestGenerateLauncherScript:
 
 class TestApplySource:
     """
-    _apply_source copies src/, pyproject.toml, and templates/config/
-    into the install tree, and retires the dead <install>/home/.claude/
-    subtree (and any legacy IDENTITY.md) via _retire_install_home_claude.
-    The retirement helper has its own pinned contracts in
-    TestRetireInstallHomeClaude below; the migration helper that ran
-    before #447 is no longer called from _apply_source but is unit-tested
-    directly in TestMigrateIdentityToClaudeMd. These tests cover only
-    the templates/config/ copy and the negative-shape contract that no
-    templates/.claude/ copy or seed step happens.
+    _apply_source copies templates/.claude/ and templates/config/ into
+    the install tree, calls _migrate_identity_to_claude_md to convert
+    legacy IDENTITY.md/symlink layouts, and explicitly seeds CLAUDE.md
+    from the template on first install. The tests below pin those
+    contracts; the migration helper itself is tested directly in
+    TestMigrateIdentityToClaudeMd below.
     """
 
-    def test_dry_run_does_not_mention_retired_template_paths(self, tmp_path, capsys):
-        """Dry-run output never names the retired template-copy or seed steps."""
+    def test_dry_run_mentions_template_paths(self, tmp_path, capsys):
+        """Dry run prints the templates/ source paths and seeds nothing."""
         src = tmp_path / "source"
         ws_claude = src / "templates" / ".claude"
         ws_claude.mkdir(parents=True)
-        # Even if a stray template CLAUDE.md were to exist (it does not
-        # post-#447), the dry-run path must not preview a copy or seed
-        # from it. The negative-shape pin guards against a regression
-        # that reintroduces the retired blocks.
-        (ws_claude / "CLAUDE.md").write_text("identity")
-        # Pre-existing dead subtree at the install destination. The
-        # cleanup helper should emit a "Would remove dead ..." line.
+        claude_md_src = ws_claude / "CLAUDE.md"
+        claude_md_src.write_text("identity")
         install_path = tmp_path / "install"
-        (install_path / "home" / ".claude").mkdir(parents=True)
-        (install_path / "home" / ".claude" / "stale").write_text("stale")
         with patch("kai.install.PROJECT_ROOT", src):
             _apply_source(install_path, svc_uid=1000, svc_gid=1000, dry_run=True)
         output = capsys.readouterr().out
-        # Negative shape: no copy preview of the templates/.claude
-        # source directory and no "Would seed" line. The retired blocks
-        # would have emitted both; their absence is the contract.
-        assert f"Would copy: {ws_claude}" not in output
-        assert "Would seed" not in output
-        # Negative shape: no IDENTITY.md migration line (the migration
-        # helper is not called from _apply_source post-#447).
-        assert "IDENTITY.md" not in output
-        # Positive shape: the cleanup helper announces the pre-existing
-        # dead subtree.
-        assert "[DRY RUN] Would remove dead" in output
+        assert "DRY RUN" in output
+        # Positive shape checks. Each "Would copy:" / "Would seed" line
+        # is "{src_path} -> {dst_path}"; asserting the exact source
+        # path appears on the left side of the arrow proves the dry-run
+        # is reading from templates/, not the retired home/.claude
+        # location. Avoids the prior double-negative replace pattern,
+        # which depended on the install dir being named exactly
+        # "install" and would silently invert if a tmp_path component
+        # ever contained "home/.claude" as a substring.
+        assert f"Would copy: {ws_claude} ->" in output
+        assert f"Would seed {claude_md_src} ->" in output
+        # Negative shape checks. No source-tree reference under
+        # PROJECT_ROOT/home/ should appear (the install destination
+        # under install_path/home/ is unchanged per spec §3.1; that is
+        # a different path and is allowed). And no template should be
+        # named with the retired .example suffix.
+        retired_src = src / "home" / ".claude"
+        assert str(retired_src) not in output
+        assert ".example" not in output
         # Dry run never touches disk.
-        assert (install_path / "home" / ".claude").exists()
+        assert not (install_path / "home" / ".claude").exists()
 
-    def test_dry_run_no_templates_or_config_dir_skips_both(self, tmp_path, capsys):
-        """Dry run with empty source: no template-copy lines for either subtree."""
+    def test_dry_run_no_templates_dir_skips_copy(self, tmp_path, capsys):
+        """Dry run with empty source: no template-copy lines."""
         with patch("kai.install.PROJECT_ROOT", tmp_path):
             _apply_source(tmp_path / "install", svc_uid=1000, svc_gid=1000, dry_run=True)
         output = capsys.readouterr().out
         assert "DRY RUN" in output
-        # Both subtree preview lines must be absent. The templates/.claude
-        # half is structural post-#447 (no copy step exists at all, so
-        # the preview cannot fire). The templates/config half is
-        # conditional on the source dir existing; with tmp_path as
-        # PROJECT_ROOT, neither subtree exists.
+        # Without templates/.claude/, the copy line should not appear.
+        # The migration helper still runs (its row-6 fresh-install path
+        # is silent), so the only printed line is whatever workspace
+        # rename / src copy / pyproject copy preview emits.
         assert "templates/.claude" not in output
         assert "templates/config" not in output
+
+    def test_actual_copies_templates_and_seeds_claude_md(self, tmp_path):
+        """
+        Fresh install path: copies src/, pyproject.toml, templates/.claude/,
+        and seeds <install>/home/.claude/CLAUDE.md from the template.
+        """
+        src = tmp_path / "source"
+        (src / "src").mkdir(parents=True)
+        (src / "src" / "module.py").write_text("code")
+        (src / "pyproject.toml").write_text("[project]")
+        ws_claude = src / "templates" / ".claude"
+        ws_claude.mkdir(parents=True)
+        (ws_claude / "CLAUDE.md").write_text("# Kai\n")
+        install = tmp_path / "install"
+        install.mkdir()
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install._copy_tree") as mock_copy,
+            patch("kai.install._set_ownership"),
+            patch("shutil.copy2") as mock_cp,
+            patch("os.chown") as mock_chown,
+        ):
+            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
+
+        # _copy_tree fires twice: once for src/, once for templates/.claude/.
+        # The mock prevents the seed step from finding the destination
+        # CLAUDE.md, so the explicit seed at the end of _apply_source
+        # also fires (visible via shutil.copy2 below).
+        assert mock_copy.call_count == 2
+        # shutil.copy2 fires for pyproject.toml AND for the seed step
+        # copying templates/.claude/CLAUDE.md -> install/home/.claude/CLAUDE.md.
+        assert mock_cp.call_count == 2
+        claude_md_dst = install / "home" / ".claude" / "CLAUDE.md"
+        chown_calls = mock_chown.call_args_list
+        assert any(c.args == (claude_md_dst, 1000, 1000) for c in chown_calls), (
+            f"Expected os.chown({claude_md_dst}, 1000, 1000); got {chown_calls}"
+        )
+
+    def test_actual_no_templates_dir(self, tmp_path):
+        """No templates/: copies source only, no error."""
+        src = tmp_path / "source"
+        (src / "src").mkdir(parents=True)
+        (src / "src" / "module.py").write_text("code")
+        (src / "pyproject.toml").write_text("[project]")
+        install = tmp_path / "install"
+        install.mkdir()
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install._copy_tree") as mock_copy,
+            patch("kai.install._set_ownership") as mock_own,
+            patch("shutil.copy2") as mock_cp,
+            patch("os.chown"),
+        ):
+            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
+
+        # Only one _copy_tree call (src/), no template copies.
+        mock_copy.assert_called_once()
+        mock_own.assert_called_once()
+        # pyproject.toml only; the seed step skips (no template source).
+        mock_cp.assert_called_once()
+
+    def test_templates_claude_uses_excludes(self, tmp_path):
+        """templates/.claude/ -> install copy uses _HOME_CLAUDE_EXCLUDES."""
+        from kai.install import _HOME_CLAUDE_EXCLUDES
+
+        src = tmp_path / "source"
+        (src / "src").mkdir(parents=True)
+        (src / "src" / "module.py").write_text("code")
+        (src / "pyproject.toml").write_text("[project]")
+        ws_claude = src / "templates" / ".claude"
+        ws_claude.mkdir(parents=True)
+        (ws_claude / "CLAUDE.md").write_text("identity")
+        install = tmp_path / "install"
+        install.mkdir()
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install._copy_tree") as mock_copy,
+            patch("kai.install._set_ownership"),
+            patch("shutil.copy2"),
+            patch("os.chown"),
+        ):
+            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
+
+        # Second _copy_tree call is for templates/.claude/ -> install/home/.claude/.
+        ws_call = mock_copy.call_args_list[1]
+        assert ws_call[0][2] == _HOME_CLAUDE_EXCLUDES
+
+    def test_existing_install_preserves_customized_claude_md(self, tmp_path):
+        """
+        Reinstall path: an operator-customized CLAUDE.md survives.
+        _HOME_CLAUDE_EXCLUDES skips it during the recursive copy and the
+        explicit seed step's `not exists()` guard skips it again.
+        """
+        src = tmp_path / "source"
+        (src / "src").mkdir(parents=True)
+        (src / "src" / "module.py").write_text("code")
+        (src / "pyproject.toml").write_text("[project]")
+        ws_claude_src = src / "templates" / ".claude"
+        ws_claude_src.mkdir(parents=True)
+        (ws_claude_src / "CLAUDE.md").write_text("TEMPLATE")
+
+        # Pre-existing operator-customized destination.
+        install = tmp_path / "install"
+        ws_claude_dst = install / "home" / ".claude"
+        ws_claude_dst.mkdir(parents=True)
+        (ws_claude_dst / "CLAUDE.md").write_text("OPERATOR EDIT")
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install._copy_tree"),
+            patch("kai.install._set_ownership"),
+            patch("os.chown"),
+        ):
+            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
+
+        # The operator-customized destination is unchanged.
+        assert (ws_claude_dst / "CLAUDE.md").read_text() == "OPERATOR EDIT"
+
+    def test_claude_md_owned_by_svc_after_row1_migration(self, tmp_path):
+        """
+        Regression guard for the order-of-operations bug in _apply_source:
+        _migrate_identity_to_claude_md (row 1) chowns CLAUDE.md to svc_uid;
+        the subsequent `_set_ownership(ws_claude_dst, 0, 0, recursive=True)`
+        clobbers that with root:root; the seed step's chown only fires
+        when the dst is missing, so without the trailing reconcile chown
+        CLAUDE.md ends up root-owned and inner Claude cannot edit it.
+
+        This test pins that the LAST chown call on CLAUDE.md is svc_uid,
+        regardless of the row-1 migration writing first and the recursive
+        ownership pass writing second. We do NOT mock _set_ownership so
+        its real implementation (which calls os.chown internally) is
+        captured by the chown spy - that's what makes the bug visible:
+        without the reconcile chown, the recursive root pass leaves the
+        last chown on CLAUDE.md as (0, 0).
+
+        Setup mirrors the production upgrade pre-state: existing
+        IDENTITY.md plus symlink, fresh source templates/ tree.
+        """
+        src = tmp_path / "source"
+        (src / "src").mkdir(parents=True)
+        (src / "src" / "module.py").write_text("code")
+        (src / "pyproject.toml").write_text("[project]")
+        ws_claude_src = src / "templates" / ".claude"
+        ws_claude_src.mkdir(parents=True)
+        (ws_claude_src / "CLAUDE.md").write_text("# Kai\n")
+
+        # Row-1 pre-state.
+        install = tmp_path / "install"
+        ws_claude_dst = install / "home" / ".claude"
+        ws_claude_dst.mkdir(parents=True)
+        identity = install / "home" / "IDENTITY.md"
+        identity.write_text("# Operator content\n")
+        claude_md = ws_claude_dst / "CLAUDE.md"
+        claude_md.symlink_to("../IDENTITY.md")
+
+        # Capture every os.chown call. Real _set_ownership (unmocked)
+        # calls os.chown internally, so the recursive (0, 0) clobbering
+        # pass shows up here in order.
+        chown_calls: list[tuple[str, int, int]] = []
+
+        def record_chown(path, uid, gid):
+            chown_calls.append((str(path), uid, gid))
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install._copy_tree"),
+            patch("os.chown", side_effect=record_chown),
+        ):
+            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
+
+        # Sanity: the recursive root pass on home/.claude/ MUST have
+        # happened (otherwise the test would silently pass even if the
+        # bug were re-introduced). Look for any (path, 0, 0) chown
+        # under ws_claude_dst.
+        recursive_root_pass = any(c[0].startswith(str(ws_claude_dst)) and (c[1], c[2]) == (0, 0) for c in chown_calls)
+        assert recursive_root_pass, (
+            f"Expected _set_ownership to chown some path under {ws_claude_dst} to (0, 0); got {chown_calls}"
+        )
+
+        claude_md_chown_calls = [c for c in chown_calls if c[0] == str(claude_md)]
+        assert claude_md_chown_calls, f"Expected at least one os.chown call on {claude_md}; got {chown_calls}"
+        # The LAST chown wins on the filesystem; pin it explicitly so a
+        # future refactor that reorders steps trips this assertion before
+        # production hits it.
+        _, last_uid, last_gid = claude_md_chown_calls[-1]
+        assert (last_uid, last_gid) == (1000, 1000), (
+            f"Last chown on {claude_md} was ({last_uid}, {last_gid}); expected (1000, 1000). "
+            f"All chown calls in order: {chown_calls}"
+        )
+
+    def test_dry_run_predicts_seed_for_fresh_install(self, tmp_path, capsys):
+        """Dry-run prediction matches the live behavior for a fresh install."""
+        src = tmp_path / "source"
+        ws_claude = src / "templates" / ".claude"
+        ws_claude.mkdir(parents=True)
+        (ws_claude / "CLAUDE.md").write_text("# Kai\n")
+        with patch("kai.install.PROJECT_ROOT", src):
+            _apply_source(tmp_path / "install", svc_uid=1000, svc_gid=1000, dry_run=True)
+        output = capsys.readouterr().out
+        # Dry-run never writes IDENTITY.md or names the .example suffix
+        # (the migration helper has not seen any pre-state to migrate).
+        assert "IDENTITY.md" not in output
+        assert ".example" not in output
+        # The seed-step preview line names the source template path.
+        assert "Would seed" in output
+        assert "templates/.claude/CLAUDE.md" in output
+
+    def test_dry_run_predicts_no_seed_when_identity_md_will_move(self, tmp_path, capsys):
+        """
+        Row 2 of the migration table: IDENTITY.md regular file exists with
+        no CLAUDE.md sibling. The migration moves IDENTITY.md to CLAUDE.md,
+        so the seed step has no work to do. Dry-run reflects that.
+        """
+        src = tmp_path / "source"
+        ws_claude = src / "templates" / ".claude"
+        ws_claude.mkdir(parents=True)
+        (ws_claude / "CLAUDE.md").write_text("# Kai\n")
+        install = tmp_path / "install"
+        (install / "home").mkdir(parents=True)
+        (install / "home" / "IDENTITY.md").write_text("# Operator content")
+
+        with patch("kai.install.PROJECT_ROOT", src):
+            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=True)
+        output = capsys.readouterr().out
+        # Migration row 2 dry-run line.
+        assert "Would move" in output
+        # No seed prediction; the rename will populate CLAUDE.md.
+        assert "Would seed" not in output
 
     def test_copies_templates_config(self, tmp_path):
         """templates/config/ is copied to install/home/config/."""
@@ -3826,262 +4071,6 @@ class TestApplySource:
         assert "templates/config" in output
         # Should not create the directory during dry run
         assert not (tmp_path / "install" / "home" / "config").exists()
-
-
-# ── _retire_install_home_claude ──────────────────────────────────────
-
-
-class TestRetireInstallHomeClaude:
-    """
-    Pins the wholesale-directory cleanup of <install>/home/.claude/ and
-    the legacy <install>/home/IDENTITY.md. Both paths predate the
-    per-user home_workspace migration in #353; nothing in the runtime
-    reads either path. Issue #447 retires both. Each test below pins
-    one row of the cleanup helper's behavior table.
-    """
-
-    def test_fresh_install_no_install_home_claude_dir(self, tmp_path):
-        """
-        Fresh install: no pre-existing <install>/home/.claude/ and no
-        IDENTITY.md. After _apply_source the directory must still not
-        exist - the helper does not create empty scaffolding.
-        """
-        src = tmp_path / "source"
-        (src / "src").mkdir(parents=True)
-        (src / "src" / "module.py").write_text("code")
-        (src / "pyproject.toml").write_text("[project]")
-        install = tmp_path / "install"
-        install.mkdir()
-
-        with (
-            patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install._copy_tree"),
-            patch("kai.install._set_ownership"),
-            patch("shutil.copy2"),
-            patch("os.chown"),
-        ):
-            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
-
-        assert not (install / "home" / ".claude").exists()
-
-    def test_existing_install_home_claude_dir_is_removed(self, tmp_path, capsys):
-        """
-        An existing <install>/home/.claude/ with operator content, plus
-        an excluded MEMORY.md, plus a nested skills/ subdir, is removed
-        wholesale. Every removed file is named in the install log
-        alongside its byte size so the destruction is recoverable from
-        the printed output.
-        """
-        src = tmp_path / "source"
-        (src / "src").mkdir(parents=True)
-        (src / "src" / "module.py").write_text("code")
-        (src / "pyproject.toml").write_text("[project]")
-        install = tmp_path / "install"
-        ws_claude = install / "home" / ".claude"
-        ws_claude.mkdir(parents=True)
-        (ws_claude / "CLAUDE.md").write_text("# Operator content\n")
-        (ws_claude / "MEMORY.md").write_text("# Memory\n")
-        (ws_claude / "skills").mkdir()
-        (ws_claude / "skills" / "example.md").write_text("# skill")
-
-        with (
-            patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install._copy_tree"),
-            patch("kai.install._set_ownership"),
-            patch("shutil.copy2"),
-            patch("os.chown"),
-        ):
-            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
-
-        # The whole subtree is gone.
-        assert not ws_claude.exists()
-        # Each removed file appears in the install log with its byte
-        # size. The exact line format is `  Removed {path} ({size} bytes)`
-        # for files, plus a `  Removed dead {dir}; nothing reads ...`
-        # summary. Operators reading install output can identify what
-        # was deleted.
-        output = capsys.readouterr().out
-        assert "CLAUDE.md" in output
-        assert "MEMORY.md" in output
-        assert "example.md" in output
-        assert "Removed dead" in output
-        assert "nothing reads this path post-#447" in output
-
-    def test_legacy_identity_md_is_removed(self, tmp_path, capsys):
-        """
-        A bare <install>/home/IDENTITY.md (no .claude/ subtree) is
-        removed by the helper's IDENTITY.md branch. This catches the
-        case where #442's migration never ran because the pre-state
-        had no symlink to migrate.
-        """
-        src = tmp_path / "source"
-        (src / "src").mkdir(parents=True)
-        (src / "src" / "module.py").write_text("code")
-        (src / "pyproject.toml").write_text("[project]")
-        install = tmp_path / "install"
-        (install / "home").mkdir(parents=True)
-        identity = install / "home" / "IDENTITY.md"
-        identity.write_text("# Operator content\n")
-
-        with (
-            patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install._copy_tree"),
-            patch("kai.install._set_ownership"),
-            patch("shutil.copy2"),
-            patch("os.chown"),
-        ):
-            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
-
-        assert not identity.exists()
-        output = capsys.readouterr().out
-        assert "Removed legacy" in output
-        assert "IDENTITY.md" in output
-
-    def test_symlink_at_identity_md_is_removed(self, tmp_path):
-        """
-        A symlink at <install>/home/IDENTITY.md is also removed. The
-        path is retired wholesale by #447; the helper does not preserve
-        any shape at this location. Covers both valid and broken
-        symlinks: a broken symlink at the path would lstat as size=0
-        and unlink cleanly.
-        """
-        src = tmp_path / "source"
-        (src / "src").mkdir(parents=True)
-        (src / "src" / "module.py").write_text("code")
-        (src / "pyproject.toml").write_text("[project]")
-        install = tmp_path / "install"
-        (install / "home").mkdir(parents=True)
-        identity = install / "home" / "IDENTITY.md"
-        identity.symlink_to("/nonexistent/broken/target")
-
-        with (
-            patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install._copy_tree"),
-            patch("kai.install._set_ownership"),
-            patch("shutil.copy2"),
-            patch("os.chown"),
-        ):
-            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
-
-        # The symlink itself is gone (lexists test - regular exists()
-        # would follow the symlink to a non-existent target and return
-        # False even if the symlink were still in place).
-        assert not identity.is_symlink()
-        assert not identity.exists()
-
-    def test_dry_run_predicts_cleanup_matches_live(self, tmp_path, capsys):
-        """
-        Dry-run / live parity guard. Each `[DRY RUN] Would remove ...`
-        line in the dry-run output corresponds 1:1 (after the prefix
-        swap) to a `Removed ...` line in the live output. Filtering on
-        the prefix is necessary because capsys captures all stdout
-        from _apply_source (src copy, pyproject copy, etc.) and only
-        the removal lines belong to the cleanup helper.
-        """
-        src = tmp_path / "source"
-        (src / "src").mkdir(parents=True)
-        (src / "src" / "module.py").write_text("code")
-        (src / "pyproject.toml").write_text("[project]")
-
-        # Build identical pre-states under two separate install dirs
-        # so the dry-run pass cannot mutate the live pass's input.
-        def seed_install_state(install_root: Path) -> None:
-            ws_claude = install_root / "home" / ".claude"
-            ws_claude.mkdir(parents=True)
-            (ws_claude / "CLAUDE.md").write_text("# content\n")
-            (ws_claude / "MEMORY.md").write_text("# memory\n")
-            (install_root / "home" / "IDENTITY.md").write_text("# operator\n")
-
-        install_dry = tmp_path / "install_dry"
-        install_live = tmp_path / "install_live"
-        seed_install_state(install_dry)
-        seed_install_state(install_live)
-
-        # Both passes use the same patch set even though `dry_run=True`
-        # returns from `_apply_source` before any of the patched helpers
-        # (`_copy_tree`, `_set_ownership`, `shutil.copy2`, `os.chown`)
-        # are reached. The symmetry is defensive: it keeps a future
-        # refactor that extends the dry-run branch from accidentally
-        # mutating the filesystem via an unpatched production helper,
-        # and it makes the two passes structurally identical so the
-        # only meaningful diff between them is the `dry_run` flag.
-        with (
-            patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install._copy_tree"),
-            patch("kai.install._set_ownership"),
-            patch("shutil.copy2"),
-            patch("os.chown"),
-        ):
-            _apply_source(install_dry, svc_uid=1000, svc_gid=1000, dry_run=True)
-        dry_output = capsys.readouterr().out
-
-        with (
-            patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install._copy_tree"),
-            patch("kai.install._set_ownership"),
-            patch("shutil.copy2"),
-            patch("os.chown"),
-        ):
-            _apply_source(install_live, svc_uid=1000, svc_gid=1000, dry_run=False)
-        live_output = capsys.readouterr().out
-
-        # Filter to the removal-related lines only and strip the
-        # tense-marker prefix so the comparison runs on the action body.
-        # Live uses three prefixes by phase: "Removing " for the
-        # pre-rmtree per-file enumeration (so a rmtree OSError does not
-        # leave a past-tense lie in stdout), "Removed " for the
-        # post-rmtree summary and the post-unlink IDENTITY.md line.
-        # Dry-run uses one prefix ("[DRY RUN] Would remove ") for all
-        # three phases. After prefix strip the bodies must match
-        # 1:1 (path + size, or the "dead ..." / "legacy ..." trailers).
-        def removal_lines(text: str, prefixes: tuple[str, ...], install_path: Path) -> list[str]:
-            placeholder = "<install>"
-            stripped: list[str] = []
-            for line in text.splitlines():
-                line = line.strip()
-                for prefix in prefixes:
-                    if line.startswith(prefix):
-                        body = line[len(prefix) :].lstrip()
-                        body = body.replace(str(install_path), placeholder)
-                        stripped.append(body)
-                        break
-            return stripped
-
-        dry_lines = removal_lines(dry_output, ("[DRY RUN] Would remove ",), install_dry)
-        live_lines = removal_lines(live_output, ("Removing ", "Removed "), install_live)
-        assert dry_lines, f"Dry-run produced no removal previews; got: {dry_output!r}"
-        assert dry_lines == live_lines, f"Dry-run / live parity broken.\n  Dry:  {dry_lines}\n  Live: {live_lines}"
-
-    def test_idempotent_on_repeated_install(self, tmp_path, capsys):
-        """
-        Running _apply_source twice over a fresh install_path leaves the
-        same final state; the second run emits no removal lines for the
-        already-absent directory. The helper's is_dir() guard makes the
-        call a silent no-op when nothing is there.
-        """
-        src = tmp_path / "source"
-        (src / "src").mkdir(parents=True)
-        (src / "src" / "module.py").write_text("code")
-        (src / "pyproject.toml").write_text("[project]")
-        install = tmp_path / "install"
-        install.mkdir()
-
-        with (
-            patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install._copy_tree"),
-            patch("kai.install._set_ownership"),
-            patch("shutil.copy2"),
-            patch("os.chown"),
-        ):
-            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
-            capsys.readouterr()  # discard first run's output
-            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
-
-        second_output = capsys.readouterr().out
-        assert not (install / "home" / ".claude").exists()
-        assert "Removed dead" not in second_output
-        assert "Would remove dead" not in second_output
-        assert "Removed legacy" not in second_output
 
 
 # ── _migrate_identity_to_claude_md ───────────────────────────────────

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1271,11 +1271,9 @@ class TestTriageErrorContent:
             labels=[],
         )
 
-        # Substituted post-#353 because <install>/home/.claude/CLAUDE.md
+        # Substituted post-#353 because /opt/kai/home/.claude/CLAUDE.md
         # no longer exists on production installs (the shared home was
-        # removed; CLAUDE.md is per-user under
-        # <DATA_DIR>/home/<chat_id>/.claude/, and after #447 the install
-        # tree no longer holds any CLAUDE.md at all).
+        # removed; CLAUDE.md is per-user under DATA_DIR/memory/).
         # /etc/kai/env is the production secrets file - if its path ever
         # leaked into a user-facing error notification it would expose
         # the location of TELEGRAM_BOT_TOKEN and other secrets, which


### PR DESCRIPTION
Reverts #449.

## Why

#449 deleted `templates/.claude/CLAUDE.md` on the spec's premise that the file was orphaned: no install-time code consumed it after the wholesale retirement of `<install>/home/.claude/`. The premise was wrong. The template was the SOURCE of any baseline identity for new per-user homes; deleting it left no way for a new user to receive a baseline `<DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md`.

The spec verified the docstring claim that `ensure_user_home` does not seed a template and stopped there. The next question — *if nothing seeds it, where does a new user's CLAUDE.md come from?* — was never asked. Answer: nowhere. No production code path has ever seeded per-user `.claude/CLAUDE.md`. The original operator's runtime copy was placed there manually; secondary users in `users.yaml` have been running with no baseline identity since #353.

Five bot review rounds plus TG Kai's review missed it. So did my eval. The right fix is restore the template AND add a per-user seed step parallel to MEMORY.md/PREFERENCES.md, in a corrected redo of #447.

## What this PR does

- Restores `templates/.claude/CLAUDE.md` from git history.
- Restores the install-time `_copy_tree(templates/.claude/, ...)` step, the `_HOME_CLAUDE_EXCLUDES` constant, the seed step, the reconcile chown, and the `_migrate_identity_to_claude_md` call site.
- Restores the eight `TestApplySource` tests and `TestPreferencesTemplateShipsViaCopyTree` that #449 deleted.
- Restores doc references to `home/.claude/CLAUDE.md` in README, templates, eval/behavioral.py, and three test files.

This puts main back to the state right after #448 (`e6e31d6`).

## What stays broken until the redo

- The PREFERENCES.md root-owned stray at `<install>/home/.claude/PREFERENCES.md` (the bug PR #446 was targeting) returns on next install. Will be fixed in the redo or by reopening #446.
- Per-user new-user identity seeding is still missing — this is the pre-existing gap #449 inadvertently exposed. Will be fixed in the redo.

## Test plan

- [x] `make check` passes.
- [x] `make test` passes (2818 tests, 1 skipped — back to pre-#449 count).
- [x] `templates/.claude/CLAUDE.md` exists and matches the pre-#449 content (16206 bytes, 268 lines).
- [x] `git diff main^^..HEAD` reverses `fa61211` cleanly with no remaining markers.

## Next step

File a new issue to redo #447 with the corrected scope:
1. Retire the dead `<install>/home/.claude/` install-tree scaffolding (the #447 goal — this part was correct).
2. Add per-user seed step in `_apply_migrate` that copies `templates/.claude/CLAUDE.md` to `<DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md` for every user in `users.yaml`, parallel to the MEMORY.md/PREFERENCES.md seed pattern.
3. Add lazy bootstrap in `ensure_user_home` (or a sibling helper) for users added post-install, matching the tier model the docstring already describes.
4. Keep `templates/.claude/CLAUDE.md` in the source tree as the load-bearing source-of-truth template.
