### PR TITLE
refactor(install): retire dead home/.claude/, seed per-user CLAUDE.md (#447 redo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Run `make config` to generate `users.yaml`, or create one manually from `templat
 
 Three layers of persistent context give the agent continuity across sessions:
 
-1. **Identity** (`home/.claude/CLAUDE.md`) - voice, rules, and operational guidelines. Lives in the home workspace. When the agent switches to a foreign workspace, Kai injects it so behavior stays consistent. In the home workspace, the agent reads it natively.
+1. **Identity** (`DATA_DIR/home/<chat_id>/.claude/CLAUDE.md`) - voice, rules, and operational guidelines. Lives in each operator's per-user home workspace, seeded from `templates/.claude/CLAUDE.md` at install time and lazily on first message for users added later. When the agent switches to a foreign workspace, Kai injects it so behavior stays consistent. In the home workspace, the agent reads it natively.
 2. **Home memory** (`DATA_DIR/memory/<chat_id>/MEMORY.md`) - per-user personal memory, always injected regardless of current workspace. Proactively updated by Kai. Each user has their own file under `memory/<chat_id>/`, scoped by Telegram chat_id so memories stay private.
 3. **Conversation history** (`DATA_DIR/history/<chat_id>/`) - JSONL logs, one file per day per user. Searchable for past conversations.
 

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -637,6 +637,16 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
         claude_dst = claude_dir / "CLAUDE.md"
         if not claude_dst.exists():
             claude_dir.mkdir(parents=True, exist_ok=True)
+            # mkdir's mode= is masked by umask; force the bits to 0o755
+            # explicitly the same way the parent `path` does above.
+            # Without this, a service running under umask 0o027 lands
+            # the .claude/ subdir at 0o750, which blocks group-traverse
+            # for distinct-os_user subprocesses (sudo -H -u <os_user>)
+            # and silently breaks identity reads. ensure_user_memory and
+            # ensure_user_preferences have the same pre-existing gap on
+            # their seeded subdirs; addressing those is out of scope for
+            # this PR but worth a follow-up.
+            os.chmod(claude_dir, 0o755)
             template = PROJECT_ROOT / "templates" / ".claude" / "CLAUDE.md"
             if template.is_file():
                 shutil.copy2(template, claude_dst)

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -589,9 +589,17 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
     `_apply_migrate` uses the same ownership rules). Isolation comes
     from ownership, not mode bits.
 
-    Unlike ensure_user_memory this does NOT seed a template file. The
-    home workspace is an empty directory that the user populates
-    themselves (cloning a repo, dropping notes, etc.).
+    Like ensure_user_memory and ensure_user_preferences, this seeds
+    `<home>/.claude/CLAUDE.md` from `templates/.claude/CLAUDE.md` when
+    the file is absent. Without that seed, a user added to users.yaml
+    AFTER install (or any dev / single-user path without an install
+    pass) gets an empty home workspace and the bot's identity-injection
+    path in `build_session_context` silently fails on the missing file -
+    the gap PR #449 inadvertently exposed and #450 reverted. The
+    install-time eager pass in `install.py:_apply_migrate` covers
+    users present in users.yaml at install time so their CLAUDE.md
+    lands with the right per-user ownership; this lazy fallback
+    bootstraps anyone else on their first message.
     """
     # chat_id of None means we have no real Telegram session to key on
     # (test runs, health checks, smoke runs without users.yaml). Use a
@@ -615,6 +623,36 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
     # the intended bits explicitly - this is the same pattern install.py
     # `_apply_migrate` uses after its mkdir calls. Idempotent on reuse.
     os.chmod(path, 0o755)
+
+    # Lazy bootstrap of `<home>/.claude/CLAUDE.md`. Parallel to
+    # ensure_user_memory and ensure_user_preferences: stat, possible
+    # mkdir, possible copy2. The OSError swallow matches the sibling
+    # bootstraps - a permissions issue here must not prevent the bot
+    # from answering a message. The read path in
+    # build_session_context already handles missing files gracefully,
+    # so a failed seed degrades to the silent-no-identity behavior we
+    # had before #447 rather than crashing the session.
+    try:
+        claude_dir = path / ".claude"
+        claude_dst = claude_dir / "CLAUDE.md"
+        if not claude_dst.exists():
+            claude_dir.mkdir(parents=True, exist_ok=True)
+            template = PROJECT_ROOT / "templates" / ".claude" / "CLAUDE.md"
+            if template.is_file():
+                shutil.copy2(template, claude_dst)
+            else:
+                # No template on this host (incomplete install tree).
+                # Match ensure_user_memory's `# Memory\n` /
+                # ensure_user_preferences' `# Preferences\n` last-resort
+                # placeholder so the inner Claude has a writable file.
+                claude_dst.write_text("# Identity\n")
+    except OSError:
+        log.warning(
+            "ensure_user_home: could not seed CLAUDE.md at %s",
+            path,
+            exc_info=True,
+        )
+
     return path
 
 

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -642,10 +642,15 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
             # Without this, a service running under umask 0o027 lands
             # the .claude/ subdir at 0o750, which blocks group-traverse
             # for distinct-os_user subprocesses (sudo -H -u <os_user>)
-            # and silently breaks identity reads. ensure_user_memory and
-            # ensure_user_preferences have the same pre-existing gap on
-            # their seeded subdirs; addressing those is out of scope for
-            # this PR but worth a follow-up.
+            # and silently breaks identity reads. ensure_user_memory
+            # and ensure_user_preferences create their per-user parent
+            # dirs without an explicit chmod and so have the same
+            # pre-existing umask gap on `data_dir/memory/<chat_id>/`
+            # and `data_dir/preferences/<chat_id>/`. ensure_user_home
+            # already chmods its own per-user parent at line 617; the
+            # call here closes the matching gap on the .claude/ subdir
+            # it creates. Closing the sibling-function gaps is out of
+            # scope for this PR but worth a follow-up.
             os.chmod(claude_dir, 0o755)
             template = PROJECT_ROOT / "templates" / ".claude" / "CLAUDE.md"
             if template.is_file():

--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -531,12 +531,13 @@ async def _run_subprocess(
         stderr=asyncio.subprocess.PIPE,
         # Neutral cwd: no CLAUDE.md discovery at subprocess startup.
         # Without this, claude --print would walk up from the harness's
-        # cwd and pick up home/.claude/CLAUDE.md (Kai's bot identity:
-        # voice rules, persona, scheduling API docs). The judge's
-        # evaluations would then be filtered through Kai's persona, and
-        # the generator would receive bot-voice priming — both confounds
-        # the spec explicitly rules out. Reuses the extractor's neutral
-        # cwd rather than introducing a sibling so the two stay aligned.
+        # cwd and pick up the operator's per-user
+        # home_workspace/.claude/CLAUDE.md (Kai's bot identity: voice
+        # rules, persona, scheduling API docs). The judge's evaluations
+        # would then be filtered through Kai's persona, and the generator
+        # would receive bot-voice priming; both confounds the spec
+        # explicitly rules out. Reuses the extractor's neutral cwd rather
+        # than introducing a sibling so the two stay aligned.
         cwd=str(cwd),
         env=env,
     )

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -70,34 +70,6 @@ _LAUNCHD_LABEL = "com.syrinx.kai"
 # Excludes __pycache__, .pyc, and other build artifacts.
 _SOURCE_EXCLUDES = {"__pycache__", "*.pyc", "*.egg-info", ".git", ".venv", ".env"}
 
-# Excludes for the templates/.claude/ -> install/home/.claude/ copy.
-# Each entry has its own rationale; do NOT collapse to "things we
-# don't want in installs":
-#   history/    - conversation logs are written by history.py at runtime
-#                 into DATA_DIR/history/. The templates/ tree never has
-#                 a history/ subdir; the exclude is defensive against a
-#                 future fixture or test-leak under templates/ that
-#                 would otherwise land in install/home/.claude/history/
-#                 and be mistaken for real conversation data.
-#   MEMORY.md   - the template at templates/.claude/MEMORY.md is read
-#                 directly by _apply_migrate (install-time per-user
-#                 seed) and backend.ensure_user_memory (runtime
-#                 fallback), both of which write to
-#                 DATA_DIR/memory/<chat_id>/MEMORY.md. The exclude
-#                 prevents _copy_tree from also depositing a copy at
-#                 install/home/.claude/MEMORY.md, which would resurrect
-#                 the pre-#347 global layout and shadow the per-user
-#                 reads on every session.
-#   CLAUDE.md   - per-operator regular file (gitignored); created on
-#                 first install by copying templates/.claude/CLAUDE.md
-#                 into the install tree. The exclude prevents the
-#                 source-tree copy from clobbering an operator's
-#                 customized destination copy on reinstall.
-#   skills/     - downloaded skills, environment-specific.
-#   __pycache__ - byte-compile artifacts; never tracked.
-_HOME_CLAUDE_EXCLUDES = {"history", "MEMORY.md", "CLAUDE.md", "skills", "__pycache__"}
-
-
 # ── Input helpers ────────────────────────────────────────────────────
 
 
@@ -1281,13 +1253,14 @@ def _copy_tree(src: Path, dst: Path, excludes: set[str] | None = None) -> None:
 
     Symlink handling: shutil.copy2 follows symlinks and copies content. There
     is no symlink-recreation branch; the previous one existed solely to
-    preserve home/.claude/CLAUDE.md -> ../IDENTITY.md during the source-to-
-    install copy, and was removed when that layout was retired (issue #442).
-    Tracked symlinks under templates/ or src/ would now be silently
-    dereferenced rather than recreated. This is intentional: cross-platform
-    symlink tracking (Windows) is fraught, and the source tree no longer
-    contains any symlinks. Do not "restore" the branch as an apparent bug
-    without first establishing a use case that needs cross-platform tracked
+    preserve the legacy IDENTITY.md / CLAUDE.md symlink pair under the
+    install tree during the source-to-install copy, and was removed when
+    that layout was retired (issues #442, #447). Tracked symlinks under
+    templates/ or src/ would now be silently dereferenced rather than
+    recreated. This is intentional: cross-platform symlink tracking
+    (Windows) is fraught, and the source tree no longer contains any
+    symlinks. Do not "restore" the branch as an apparent bug without
+    first establishing a use case that needs cross-platform tracked
     symlinks.
 
     Args:
@@ -2391,6 +2364,75 @@ def _apply_migrate(
             _set_ownership(user_dir, svc_uid, svc_gid, recursive=False)
         print(f"  Created {user_dir}")
 
+    # -- CLAUDE.md per-user pre-creation --
+    # Mirror the MEMORY.md / PREFERENCES.md per-user pattern above. For
+    # every users.yaml entry we pre-create
+    # <DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md from the template, so
+    # `backend.build_session_context`'s identity-injection path and
+    # the inner Claude's native CLAUDE.md discovery in the home
+    # workspace both have a real file to read. Without this seed, a
+    # new user's home workspace is an empty directory and the bot
+    # runs with no baseline identity for that chat_id - the gap that
+    # PR #449 inadvertently exposed and #450 reverted.
+    #
+    # Lazy bootstrap at runtime (backend.ensure_user_home) is the
+    # fallback for chat_ids added between installs; this eager pass
+    # is for users present in users.yaml at install time so they get
+    # the right ownership (chowned to their os_user via the
+    # _set_ownership call) instead of service-owned-via-mkdir.
+    home_template = PROJECT_ROOT / "templates" / ".claude" / "CLAUDE.md"
+
+    for chat_id, _os_user in memory_owners:
+        if chat_id is None:
+            continue
+        override = home_overrides.get(chat_id)
+        # Case 3: override outside DATA_DIR is operator-managed; the
+        # home-creation loop above skipped it for the same reason and
+        # we follow suit here. Touching it from the installer would
+        # write under a path the operator owns.
+        if override is not None and not override.is_relative_to(data_path_resolved):
+            continue
+        user_home = override if override is not None else home_root / str(chat_id)
+        claude_dir = user_home / ".claude"
+        claude_dst = claude_dir / "CLAUDE.md"
+
+        if dry_run:
+            if not claude_dst.exists():
+                if home_template.is_file():
+                    print(f"[DRY RUN] Would seed {claude_dst} from {home_template}")
+                else:
+                    print(f"[DRY RUN] Would seed {claude_dst} with placeholder (template missing)")
+            continue
+
+        # Idempotent: never overwrite an operator-customized destination.
+        # `not exists()` is the same guard ensure_user_memory and
+        # ensure_user_preferences use; matches the seed-step contract.
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        if not claude_dst.exists():
+            if home_template.is_file():
+                shutil.copy2(home_template, claude_dst)
+                print(f"  Seeded {claude_dst} from CLAUDE.md template")
+            else:
+                # Last-resort placeholder so the inner Claude has
+                # something to read. Mirrors MEMORY.md / PREFERENCES.md
+                # missing-template precedent above.
+                claude_dst.write_text("# Identity\n")
+                print(f"  WARNING: {home_template} not found; wrote placeholder to {claude_dst}")
+
+        # Recursive chown over the .claude/ subdir so both the
+        # directory and the freshly-seeded CLAUDE.md land on the
+        # per-user os_user. The home-creation loop above only chowns
+        # user_dir non-recursively, so without this pass the .claude/
+        # tree would inherit service-user ownership from mkdir and
+        # the inner subprocess (sudo -H -u <os_user>) could read but
+        # not write CLAUDE.md - the same #347 regression the per-user
+        # memory pattern fixed.
+        if str(chat_id) in per_user_ids:
+            uid, gid = per_user_ids[str(chat_id)]
+            _set_ownership(claude_dir, uid, gid, recursive=True)
+        else:
+            _set_ownership(claude_dir, svc_uid, svc_gid, recursive=True)
+
 
 def _cmd_apply() -> None:
     """
@@ -2780,25 +2822,114 @@ def _migrate_identity_to_claude_md(
     # the destination.
 
 
+def _retire_install_home_claude(install_path: Path, dry_run: bool) -> None:
+    """
+    Remove the dead `<install>/home/.claude/` subtree and any legacy
+    `<install>/home/IDENTITY.md` left behind from the pre-#442 layout.
+
+    Both paths predate the per-user `home_workspace` migration in #353.
+    Since #353 every session resolves identity from the per-user
+    `<DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md`; nothing in the
+    runtime reads either of the paths this helper deletes. Issue #447
+    retires the install-tree scaffolding entirely. The per-user
+    `CLAUDE.md` is seeded by `_apply_migrate`'s home block (eager,
+    install-time) and `backend.ensure_user_home` (lazy, first-message
+    fallback) from the still-tracked `templates/.claude/CLAUDE.md`.
+
+    Behavior is idempotent: pre-checks (`is_dir()` for the subtree,
+    `is_symlink() or is_file()` for IDENTITY.md) make a missing path
+    a silent no-op. In dry-run mode every removal that WOULD happen
+    is announced with a `[DRY RUN] Would remove ...` line so the
+    dry-run preview matches the live install line-for-line.
+
+    Every removed FILE is logged with its byte size before deletion so
+    an operator who customized the dead `CLAUDE.md` content (and finds
+    out post-install) can recover from the printed log if they kept a
+    backup of `<install_path>/`. Empty directories under `.claude/`
+    are not enumerated individually; `shutil.rmtree` removes them with
+    the rest of the subtree, but they carry no operator content so
+    omitting them from the log surfaces no recovery information.
+    """
+    claude_dir = install_path / "home" / ".claude"
+    identity_md = install_path / "home" / "IDENTITY.md"
+
+    if claude_dir.is_dir():
+        # Enumerate before deleting so the log captures every retired
+        # path plus its byte size. rglob walks symlinks-as-files (does
+        # not descend); a row-1 pre-state with CLAUDE.md as a symlink
+        # therefore reports correctly rather than tracebacking on a
+        # stat call into a possibly broken target. lstat is used
+        # instead of stat for the same reason.
+        #
+        # Verb tense: the live log uses "Removing" because the lines
+        # are printed BEFORE shutil.rmtree runs (the enumeration needs
+        # to lstat each file while it still exists). If rmtree raises
+        # OSError - permissions, mounted filesystem, etc. - the
+        # "Removing" lines accurately describe what was attempted, and
+        # the trailing "Removed dead {dir}" summary will be absent so
+        # the operator can see the deletion did not complete. A
+        # past-tense per-file line here would lie on rmtree failure.
+        for path in sorted(claude_dir.rglob("*")):
+            if path.is_file() or path.is_symlink():
+                try:
+                    size = path.lstat().st_size
+                except OSError:
+                    size = 0
+                if dry_run:
+                    print(f"[DRY RUN] Would remove {path} ({size} bytes)")
+                else:
+                    print(f"  Removing {path} ({size} bytes)")
+        if dry_run:
+            print(f"[DRY RUN] Would remove dead {claude_dir}; nothing reads this path post-#447")
+        else:
+            # No ignore_errors: the is_dir() pre-check above makes the
+            # call safe, and surfacing a real OSError (permissions,
+            # mounted FS, etc.) is preferred to silent failure. The
+            # past-tense "Removed dead" summary is correct because it
+            # fires only after rmtree returns successfully.
+            shutil.rmtree(claude_dir)
+            print(f"  Removed dead {claude_dir}; nothing reads this path post-#447")
+
+    # The IDENTITY.md path is retired wholesale by #447. Whatever is
+    # at the path - regular file (legacy operator content), valid
+    # symlink, or broken symlink - is removed. `is_symlink() or
+    # is_file()` covers all three: is_symlink() is True for both
+    # valid and broken symlinks; is_file() follows symlinks and is
+    # True only for regular files or symlinks pointing at regular
+    # files (already caught by the is_symlink() arm). The pair
+    # excludes directories, which would be a bizarre malformed state
+    # at this path and is left for an explicit operator question
+    # rather than silent rmtree. lstat avoids tracebacking on a
+    # broken symlink target.
+    if identity_md.is_symlink() or identity_md.is_file():
+        try:
+            size = identity_md.lstat().st_size
+        except OSError:
+            size = 0
+        if dry_run:
+            print(f"[DRY RUN] Would remove legacy {identity_md} ({size} bytes); content was identity baseline only")
+        else:
+            identity_md.unlink()
+            print(f"  Removed legacy {identity_md} ({size} bytes); content was identity baseline only")
+
+
 def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool) -> None:
     """Copy source tree and home config from PROJECT_ROOT to the install location."""
     src_src = PROJECT_ROOT / "src"
     src_dst = install_path / "src"
     pyproject_src = PROJECT_ROOT / "pyproject.toml"
     pyproject_dst = install_path / "pyproject.toml"
-    # Source-side templates live under templates/. Destination keeps
-    # the historical install layout (home/.claude/, home/config/) so
-    # runtime code paths and per-user workspaces under DATA_DIR/home/
-    # do not need to change in lockstep.
-    ws_claude_src = PROJECT_ROOT / "templates" / ".claude"
-    ws_claude_dst = install_path / "home" / ".claude"
     # Config templates (e.g. goose-config.yaml) referenced by later
     # install steps like _apply_goose_config(). Root-owned since these
-    # are static templates, not runtime data.
+    # are static templates, not runtime data. The `home/` parent
+    # continues to exist for this one purpose post-#447; everything
+    # else previously under `<install>/home/` (the `.claude/` subtree
+    # and any legacy IDENTITY.md) is retired by `_retire_install_home_claude`.
+    # The per-user `<DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md` is
+    # seeded by `_apply_migrate`'s home block (eager) and
+    # `backend.ensure_user_home` (lazy, first-message fallback).
     config_src = PROJECT_ROOT / "templates" / "config"
     config_dst = install_path / "home" / "config"
-    claude_md_src = PROJECT_ROOT / "templates" / ".claude" / "CLAUDE.md"
-    claude_md_dst = install_path / "home" / ".claude" / "CLAUDE.md"
 
     # One-time: rename workspace/ to home/ at the install location.
     # The directory was renamed in the source tree; this migrates the
@@ -2813,52 +2944,21 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
             old_ws.rename(new_ws)
             print(f"  Renamed {old_ws} -> {new_ws}")
 
-    # Migrate any legacy IDENTITY.md/symlink layout to a regular
-    # CLAUDE.md regular file before the template-copy steps run. The
-    # migration runs in dry-run mode too so operators previewing an
-    # upgrade see exactly what will happen to their identity surface.
-    # See `_migrate_identity_to_claude_md` for the full state table.
-    _migrate_identity_to_claude_md(install_path, svc_uid, svc_gid, dry_run)
+    # Retire the dead <install>/home/.claude/ subtree (issue #447). This
+    # path predates #353's per-user `home_workspace` migration; nothing
+    # reads it at runtime since then. The helper also removes any legacy
+    # <install>/home/IDENTITY.md left behind from the pre-#442 layout.
+    # Runs before the rest of _apply_source so subsequent steps work
+    # against a clean state; no remaining install-step depends on the
+    # directory existing. Dry-run emits matching `[DRY RUN] Would remove`
+    # lines so the preview matches the live behavior.
+    _retire_install_home_claude(install_path, dry_run)
 
     if dry_run:
         print(f"[DRY RUN] Would copy: {src_src} -> {src_dst}")
         print(f"[DRY RUN] Would copy: {pyproject_src} -> {pyproject_dst}")
-        if ws_claude_src.is_dir():
-            print(f"[DRY RUN] Would copy: {ws_claude_src} -> {ws_claude_dst}")
         if config_src.is_dir():
             print(f"[DRY RUN] Would copy: {config_src} -> {config_dst}")
-        # Conditional seed step preview. The recursive copy above excludes
-        # CLAUDE.md (per _HOME_CLAUDE_EXCLUDES) so an operator's customized
-        # destination is never overwritten; this step explicitly handles the
-        # cases where the destination is empty after migration. The dry-run
-        # prediction has to account for what migration would do, so it
-        # computes the post-migration state of CLAUDE.md from the pre-state
-        # and walks all six rows of the migration table:
-        #   Row 1 (IDENTITY regular + CLAUDE symlink to ../IDENTITY.md):
-        #     migration replaces symlink with regular file -> exists.
-        #   Row 2 (IDENTITY regular + CLAUDE missing):
-        #     migration renames IDENTITY.md to CLAUDE.md -> exists.
-        #   Row 3 (IDENTITY regular + CLAUDE regular):
-        #     migration deletes IDENTITY.md, leaves CLAUDE -> exists.
-        #   Row 4 (IDENTITY missing + CLAUDE symlink):
-        #     migration unlinks symlink (covers broken target AND valid-but-
-        #     non-IDENTITY targets) -> empty, seed proceeds.
-        #   Row 5 (IDENTITY missing + CLAUDE regular): unchanged -> exists.
-        #   Row 6 (neither): unchanged -> empty, seed proceeds.
-        # Seed runs only on rows 4 and 6.
-        identity_dst_pre = install_path / "home" / "IDENTITY.md"
-        identity_pre_exists = identity_dst_pre.is_file() and not identity_dst_pre.is_symlink()
-        claude_pre_is_regular = claude_md_dst.is_file() and not claude_md_dst.is_symlink()
-        # Post-migration CLAUDE.md presence: True for rows 1, 2, 3, 5;
-        # False for rows 4 and 6. Rows 1-2 have IDENTITY.md content
-        # land at CLAUDE.md (atomic rename); rows 3 and 5 preserve an
-        # existing regular CLAUDE.md. The expression below collapses
-        # to that: pre-state CLAUDE.md regular survives directly, and
-        # otherwise the migration carries IDENTITY.md over to CLAUDE.md
-        # whenever IDENTITY.md is present.
-        post_migration_claude_md_exists = claude_pre_is_regular or identity_pre_exists
-        if claude_md_src.is_file() and not post_migration_claude_md_exists:
-            print(f"[DRY RUN] Would seed {claude_md_src} -> {claude_md_dst}")
         return
 
     _copy_tree(src_src, src_dst, _SOURCE_EXCLUDES)
@@ -2869,58 +2969,19 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
     os.chown(pyproject_dst, 0, 0)
     print(f"  Copied {pyproject_dst}")
 
-    # Copy templates/.claude/ -> install/home/.claude/ (bot identity,
-    # memory template) excluding runtime data. Without CLAUDE.md, the
-    # bot has no identity in the home workspace and nothing to inject
-    # into foreign workspace sessions. Files inside are root-owned
-    # (read-only config), but the directory itself is service-user-owned
-    # so skills/ and other runtime dirs can be created inside it. The
-    # exclude set keeps CLAUDE.md off this copy so an operator-customized
-    # destination survives reinstalls; the explicit seed step below
-    # populates it on first install only.
-    if ws_claude_src.is_dir():
-        ws_claude_dst.parent.mkdir(parents=True, exist_ok=True)
-        _copy_tree(ws_claude_src, ws_claude_dst, _HOME_CLAUDE_EXCLUDES)
-        _set_ownership(ws_claude_dst, 0, 0, recursive=True)
-        os.chown(ws_claude_dst, svc_uid, svc_gid)
-        print(f"  Copied home config to {ws_claude_dst}")
-
     # Copy templates/config/ -> install/home/config/ (config templates
     # like goose-config.yaml). These are static templates referenced by
     # later install steps - e.g. _apply_goose_config() reads the Goose
     # extension config from here. Root-owned since they're installer
     # input, not runtime output.
     if config_src.is_dir():
-        # home/ may already exist from the .claude/ copy above, but
-        # ensure it's there when config/ exists without .claude/.
+        # `home/` may not exist yet (the retirement step above does not
+        # create it, and after #447 the `.claude/` copy that used to
+        # parent it is gone). Ensure the parent before copying.
         config_dst.parent.mkdir(parents=True, exist_ok=True)
         _copy_tree(config_src, config_dst)
         _set_ownership(config_dst, 0, 0, recursive=True)
         print(f"  Copied config templates to {config_dst}")
-
-    # Conditional seed: the recursive copy above excluded CLAUDE.md so an
-    # operator-customized destination is never overwritten. On first
-    # install (or after a broken-symlink migration cleared the destination)
-    # there is no CLAUDE.md to preserve, so explicitly seed from the
-    # template here. Owned by the service user so inner Claude can edit
-    # the file from Telegram.
-    if claude_md_src.is_file() and not claude_md_dst.exists():
-        claude_md_dst.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(claude_md_src, claude_md_dst)
-        os.chown(claude_md_dst, svc_uid, svc_gid)
-        print("  Seeded CLAUDE.md from template")
-
-    # Reconcile CLAUDE.md ownership unconditionally. The _set_ownership
-    # call above sets root:root recursively on home/.claude/, which
-    # clobbers the svc_uid chown that _migrate_identity_to_claude_md
-    # applies in rows 1 and 2 (and, on a row-3 reinstall, an existing
-    # operator-customized CLAUDE.md). Inner Claude must be able to
-    # edit CLAUDE.md from Telegram, so it has to be svc_uid-owned.
-    # The seed step above already chowns to svc_uid in rows 4 and 6;
-    # this final chown covers rows 1, 2, 3, and 5 - everywhere a
-    # regular CLAUDE.md exists at the destination after migration.
-    if claude_md_dst.is_file() and not claude_md_dst.is_symlink():
-        os.chown(claude_md_dst, svc_uid, svc_gid)
 
 
 def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2381,6 +2381,10 @@ def _apply_migrate(
     # the right ownership (chowned to their os_user via the
     # _set_ownership call) instead of service-owned-via-mkdir.
     home_template = PROJECT_ROOT / "templates" / ".claude" / "CLAUDE.md"
+    # Cache the template existence check once; the path is fixed for
+    # the duration of the loop and is_file() would otherwise stat the
+    # same inode N times for N users.
+    home_template_exists = home_template.is_file()
 
     for chat_id, _os_user in memory_owners:
         if chat_id is None:
@@ -2398,7 +2402,7 @@ def _apply_migrate(
 
         if dry_run:
             if not claude_dst.exists():
-                if home_template.is_file():
+                if home_template_exists:
                     print(f"[DRY RUN] Would seed {claude_dst} from {home_template}")
                 else:
                     print(f"[DRY RUN] Would seed {claude_dst} with placeholder (template missing)")
@@ -2416,15 +2420,27 @@ def _apply_migrate(
         # parent-dir chmod in the home-creation loop above.
         os.chmod(claude_dir, 0o755)
         if not claude_dst.exists():
-            if home_template.is_file():
-                shutil.copy2(home_template, claude_dst)
-                print(f"  Seeded {claude_dst} from CLAUDE.md template")
-            else:
-                # Last-resort placeholder so the inner Claude has
-                # something to read. Mirrors MEMORY.md / PREFERENCES.md
-                # missing-template precedent above.
-                claude_dst.write_text("# Identity\n")
-                print(f"  WARNING: {home_template} not found; wrote placeholder to {claude_dst}")
+            # Wrap the actual file write in try/except so an OSError
+            # (broken symlink at claude_dst, mounted FS, permissions)
+            # surfaces with a clear operator-readable line BEFORE the
+            # traceback aborts the install. Matches the rmtree wrap
+            # in `_retire_install_home_claude`; install-time policy
+            # is to abort loudly on a real error, not log-and-continue
+            # (that swallow is `backend.ensure_user_home`'s contract
+            # for the runtime path where session-init cannot crash).
+            try:
+                if home_template_exists:
+                    shutil.copy2(home_template, claude_dst)
+                    print(f"  Seeded {claude_dst} from CLAUDE.md template")
+                else:
+                    # Last-resort placeholder so the inner Claude has
+                    # something to read. Mirrors MEMORY.md / PREFERENCES.md
+                    # missing-template precedent above.
+                    claude_dst.write_text("# Identity\n")
+                    print(f"  WARNING: {home_template} not found; wrote placeholder to {claude_dst}")
+            except OSError as exc:
+                print(f"  ERROR: could not seed {claude_dst}: {exc}")
+                raise
 
         # Recursive chown over the .claude/ subdir so both the
         # directory and the freshly-seeded CLAUDE.md land on the

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2408,6 +2408,13 @@ def _apply_migrate(
         # `not exists()` is the same guard ensure_user_memory and
         # ensure_user_preferences use; matches the seed-step contract.
         claude_dir.mkdir(parents=True, exist_ok=True)
+        # mkdir's mode= is masked by umask; force 0o755 explicitly so a
+        # service running under umask 0o027 does not land the subdir at
+        # 0o750 (which would block group-traverse for distinct-os_user
+        # subprocesses). Mirrors the chmod in
+        # `backend.ensure_user_home`'s lazy seed branch and the
+        # parent-dir chmod in the home-creation loop above.
+        os.chmod(claude_dir, 0o755)
         if not claude_dst.exists():
             if home_template.is_file():
                 shutil.copy2(home_template, claude_dst)
@@ -2866,11 +2873,18 @@ def _retire_install_home_claude(install_path: Path, dry_run: bool) -> None:
 
     if claude_dir.is_dir():
         # Enumerate before deleting so the log captures every retired
-        # path plus its byte size. rglob walks symlinks-as-files (does
-        # not descend); a row-1 pre-state with CLAUDE.md as a symlink
-        # therefore reports correctly rather than tracebacking on a
-        # stat call into a possibly broken target. lstat is used
-        # instead of stat for the same reason.
+        # path plus its byte size. The lstat() (not stat()) below avoids
+        # tracebacking on a broken file-symlink target - the row-1
+        # pre-state has CLAUDE.md as a symlink that may point at a
+        # removed IDENTITY.md. The contents of <install>/home/.claude/
+        # in any pre-state we expect (regular files, file symlinks,
+        # `skills/` and `history/` subdirs) do not include directory
+        # symlinks, so rglob's directory-symlink-following behavior
+        # (which varies across Python versions) does not affect this
+        # helper in practice; if a future operator drops a directory
+        # symlink under .claude/ they will see its target's files in
+        # the log but `shutil.rmtree` removes the symlink itself
+        # without descending, so the target is left intact.
         #
         # Verb tense: the live log uses "Removing" because the lines
         # are printed BEFORE shutil.rmtree runs (the enumeration needs

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2960,7 +2960,16 @@ def _retire_install_home_claude(install_path: Path, dry_run: bool) -> None:
         if dry_run:
             print(f"[DRY RUN] Would remove legacy {identity_md} ({size} bytes); content was identity baseline only")
         else:
-            identity_md.unlink()
+            # Same try/except surface as the rmtree above: surface an
+            # operator-readable error line BEFORE the traceback aborts
+            # the install. Likelihood is low (install runs as root and
+            # the pre-check is a short window), but the asymmetry would
+            # be surprising given rmtree's wrap.
+            try:
+                identity_md.unlink()
+            except OSError as exc:
+                print(f"  ERROR: could not remove {identity_md}: {exc}")
+                raise
             print(f"  Removed legacy {identity_md} ({size} bytes); content was identity baseline only")
 
 

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2437,13 +2437,15 @@ def _apply_migrate(
         #
         # The chown runs UNCONDITIONALLY on every install, even when
         # the seed step skipped because CLAUDE.md already existed.
-        # This matches the established MEMORY.md / PREFERENCES.md
-        # ownership-pass pattern at the bottom of those seed blocks:
-        # the seed half is idempotent (never overwrites operator
-        # content), but the ownership half corrects drift when an
-        # operator changes os_user in users.yaml between installs.
-        # Without the unconditional reset, a chat_id whose os_user
-        # changed would keep its old ownership and the new subprocess
+        # Functionally mirrors the MEMORY.md / PREFERENCES.md
+        # ownership reconciliation: idempotent per-install reset
+        # corrects os_user drift. (Structurally those blocks use a
+        # separate iterdir-based pass over the whole tree; this block
+        # inlines the chown into the per-user seed loop because the
+        # tree we care about is one .claude/ subdir per chat_id,
+        # which iterdir would walk anyway.) Without the unconditional
+        # reset, a chat_id whose os_user changed in users.yaml between
+        # installs would keep its old ownership and the new subprocess
         # could not write the identity file.
         if str(chat_id) in per_user_ids:
             uid, gid = per_user_ids[str(chat_id)]

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2427,6 +2427,17 @@ def _apply_migrate(
         # the inner subprocess (sudo -H -u <os_user>) could read but
         # not write CLAUDE.md - the same #347 regression the per-user
         # memory pattern fixed.
+        #
+        # The chown runs UNCONDITIONALLY on every install, even when
+        # the seed step skipped because CLAUDE.md already existed.
+        # This matches the established MEMORY.md / PREFERENCES.md
+        # ownership-pass pattern at the bottom of those seed blocks:
+        # the seed half is idempotent (never overwrites operator
+        # content), but the ownership half corrects drift when an
+        # operator changes os_user in users.yaml between installs.
+        # Without the unconditional reset, a chat_id whose os_user
+        # changed would keep its old ownership and the new subprocess
+        # could not write the identity file.
         if str(chat_id) in per_user_ids:
             uid, gid = per_user_ids[str(chat_id)]
             _set_ownership(claude_dir, uid, gid, recursive=True)
@@ -2886,8 +2897,16 @@ def _retire_install_home_claude(install_path: Path, dry_run: bool) -> None:
             # call safe, and surfacing a real OSError (permissions,
             # mounted FS, etc.) is preferred to silent failure. The
             # past-tense "Removed dead" summary is correct because it
-            # fires only after rmtree returns successfully.
-            shutil.rmtree(claude_dir)
+            # fires only after rmtree returns successfully. Catch the
+            # OSError just long enough to print a clear operator-readable
+            # error line so the traceback is not the first signal, then
+            # re-raise to abort the install (a partial cleanup that
+            # leaves stale content visible is worse than aborting).
+            try:
+                shutil.rmtree(claude_dir)
+            except OSError as exc:
+                print(f"  ERROR: could not remove {claude_dir}: {exc}")
+                raise
             print(f"  Removed dead {claude_dir}; nothing reads this path post-#447")
 
     # The IDENTITY.md path is retired wholesale by #447. Whatever is

--- a/templates/.claude/CLAUDE.md
+++ b/templates/.claude/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## About This File
 
-This file is the bootstrap template for inner Claude's identity. The installer copies it to `<install_path>/home/.claude/CLAUDE.md` as a regular file on first install. Edit your local copy (the destination) to add operator-personal content; the tracked template ships universal content only. Once you have customized your local copy, you can delete this "About This File" section.
+This file is the bootstrap template for inner Claude's identity. The installer copies it to `<DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md` for every user in `users.yaml` at install time; `backend.ensure_user_home` lazily seeds it for users added later on first message. Edit your per-user copy (the destination) to add operator-personal content; the tracked template ships universal content only. Once you have customized your per-user copy, you can delete this "About This File" section there.
 
 ## Who You Are
 

--- a/templates/.claude/MEMORY.md
+++ b/templates/.claude/MEMORY.md
@@ -1,6 +1,6 @@
 # Memory
 
-Your facts live in this file when the memory subsystem is disabled (`MEMORY_ENABLED=false`), or as the migration source when it is enabled (`MEMORY_ENABLED=true` plus `python -m kai memory migrate`). Rules for inner Claude live in `<install>/home/.claude/CLAUDE.md`, not here.
+Your facts live in this file when the memory subsystem is disabled (`MEMORY_ENABLED=false`), or as the migration source when it is enabled (`MEMORY_ENABLED=true` plus `python -m kai memory migrate`). Rules for inner Claude live in `<DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md`, not here.
 
 When this file is the active fact surface, inner Claude reads it on every turn (injected as `[Your persistent memory (file: ...):]`) and writes to it via `Edit` / `Write` when persisting new facts. Keep it organized by section so retrieval stays cheap and updates stay precise.
 

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -10,7 +10,7 @@
 #   4. Restart Kai
 #
 # Kai injects authentication from .env at call time — API keys never
-# enter Claude's context. See home/.claude/CLAUDE.md for usage docs.
+# enter Claude's context. See <DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md for usage docs.
 #
 # Auth types:
 #   bearer  — Authorization: Bearer $KEY

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -741,6 +741,103 @@ class TestEnsureUserHome:
         mode = stat.S_IMODE(result.stat().st_mode)
         assert mode == 0o755, f"expected 0o755, got {oct(mode)}"
 
+    def test_seeds_claude_md_from_template(self, tmp_path):
+        """
+        Lazy bootstrap: ensure_user_home seeds <home>/.claude/CLAUDE.md
+        from templates/.claude/CLAUDE.md when absent. Without this seed,
+        a user added to users.yaml AFTER install (or any dev path
+        without an install pass) gets an empty home workspace and the
+        bot's identity-injection path silently fails on the missing
+        file. Parallel to ensure_user_memory's MEMORY.md seed.
+        """
+        # Build a fake source tree under tmp_path so we can patch
+        # PROJECT_ROOT to it. The real PROJECT_ROOT has a template, but
+        # using the real path would make this test order-dependent on
+        # whether the template currently exists in the working tree.
+        fake_root = tmp_path / "src_root"
+        template_dir = fake_root / "templates" / ".claude"
+        template_dir.mkdir(parents=True)
+        template = template_dir / "CLAUDE.md"
+        template.write_text("# Kai template\n")
+
+        data_dir = tmp_path / "data"
+        with patch("kai.backend.PROJECT_ROOT", fake_root):
+            home = ensure_user_home(99, data_dir)
+
+        claude_dst = home / ".claude" / "CLAUDE.md"
+        assert claude_dst.is_file(), f"Expected lazy seed at {claude_dst}"
+        assert claude_dst.read_text() == "# Kai template\n"
+
+    def test_seed_is_idempotent(self, tmp_path):
+        """An existing per-user CLAUDE.md is never overwritten on later calls."""
+        fake_root = tmp_path / "src_root"
+        template_dir = fake_root / "templates" / ".claude"
+        template_dir.mkdir(parents=True)
+        (template_dir / "CLAUDE.md").write_text("# UPSTREAM\n")
+
+        data_dir = tmp_path / "data"
+        with patch("kai.backend.PROJECT_ROOT", fake_root):
+            home = ensure_user_home(99, data_dir)
+
+        # Operator customizes after first seed.
+        claude_dst = home / ".claude" / "CLAUDE.md"
+        claude_dst.write_text("# OPERATOR CUSTOMIZED\n")
+
+        # Second call must leave the customized content alone.
+        with patch("kai.backend.PROJECT_ROOT", fake_root):
+            ensure_user_home(99, data_dir)
+
+        assert claude_dst.read_text() == "# OPERATOR CUSTOMIZED\n"
+
+    def test_seed_writes_placeholder_when_template_missing(self, tmp_path):
+        """Missing template: last-resort placeholder so the file is writable."""
+        fake_root = tmp_path / "src_root"
+        # Intentionally do not create templates/.claude/CLAUDE.md.
+        (fake_root / "templates" / ".claude").mkdir(parents=True)
+
+        data_dir = tmp_path / "data"
+        with patch("kai.backend.PROJECT_ROOT", fake_root):
+            home = ensure_user_home(99, data_dir)
+
+        claude_dst = home / ".claude" / "CLAUDE.md"
+        assert claude_dst.is_file()
+        # Placeholder mirrors the MEMORY.md / PREFERENCES.md precedent.
+        assert claude_dst.read_text() == "# Identity\n"
+
+    def test_seed_swallows_oserror(self, tmp_path):
+        """
+        A permissions issue creating the seed must not crash the session
+        init - the read path in build_session_context already handles
+        missing files gracefully. Matches ensure_user_memory's OSError
+        swallow contract.
+        """
+        # Build the source tree before patching so the setup mkdirs do
+        # not hit the patched failure.
+        fake_root = tmp_path / "src_root"
+        (fake_root / "templates" / ".claude").mkdir(parents=True)
+        (fake_root / "templates" / ".claude" / "CLAUDE.md").write_text("# Kai\n")
+
+        def boom(*_args, **_kwargs) -> None:
+            raise OSError("simulated permission denied")
+
+        data_dir = tmp_path / "data"
+        # Patch the seed step's copy2 to raise. The outer path.mkdir
+        # for data_dir/home/<chat_id>/ runs cleanly (the function-
+        # under-test handles its own dir creation before reaching the
+        # seed branch); only the seed copy fails. Must not raise: the
+        # function returns the path even when the seed fails, and the
+        # caller may still write into the directory later.
+        with (
+            patch("kai.backend.PROJECT_ROOT", fake_root),
+            patch("kai.backend.shutil.copy2", side_effect=boom),
+        ):
+            result = ensure_user_home(99, data_dir)
+
+        assert result == data_dir / "home" / "99"
+        # The seed file should NOT have been written; the OSError
+        # handler should have logged and continued silently.
+        assert not (result / ".claude" / "CLAUDE.md").exists()
+
 
 class TestResolveHomeWorkspace:
     """

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -31,7 +31,7 @@ Ten tests covering the harness's load-bearing seams, organized by concern:
 9. TestSubprocessExplicitCwd - locks the cwd= argument is passed
    explicitly to asyncio.create_subprocess_exec, preventing a future
    refactor from accidentally inheriting the harness's cwd (which would
-   leak home/.claude/CLAUDE.md into both arms).
+   leak the per-user home_workspace/.claude/CLAUDE.md into both arms).
 10. TestGeneratorEmptySystemPrompt - locks --system-prompt is followed
     by literally "" (not omitted), so the CLI's default system prompt
     cannot leak into the generator and confound the A/B measurement.
@@ -618,12 +618,12 @@ class TestSubprocessExplicitCwd:
     """The cwd= kwarg is passed explicitly to create_subprocess_exec.
 
     Without an explicit cwd, claude --print walks up from the harness's
-    cwd and picks up home/.claude/CLAUDE.md (Kai's bot identity:
-    voice rules, persona, scheduling API docs). The judge would then
-    filter every verdict through Kai's persona, and the generator would
-    receive bot-voice priming. Both confound the spec's minimal-prompt
-    measurement. This test locks the parameter plumbing so a future
-    refactor cannot quietly drop the cwd= argument.
+    cwd and picks up the per-user home_workspace/.claude/CLAUDE.md
+    (Kai's bot identity: voice rules, persona, scheduling API docs).
+    The judge would then filter every verdict through Kai's persona,
+    and the generator would receive bot-voice priming. Both confound
+    the spec's minimal-prompt measurement. This test locks the parameter
+    plumbing so a future refactor cannot quietly drop the cwd= argument.
     """
 
     def test_subprocess_passes_explicit_cwd_string(self):
@@ -661,7 +661,8 @@ class TestSubprocessExplicitCwd:
         # cwd must be passed as str(Path), not Path itself, matching
         # the extractor's pattern. If this assertion ever fails, the
         # subprocess call is inheriting the harness's cwd implicitly,
-        # which means home/.claude/CLAUDE.md is leaking into both arms.
+        # which means the per-user home_workspace/.claude/CLAUDE.md is
+        # leaking into both arms.
         assert "cwd" in captured
         assert captured["cwd"] == str(cwd)
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -38,6 +38,7 @@ from kai.install import (
     _generate_systemd_unit,
     _generate_users_yaml,
     _migrate_identity_to_claude_md,
+    _retire_install_home_claude,
     _set_ownership,
     _src_checksum,
     _start_service,
@@ -3375,23 +3376,6 @@ class TestApplyMigratePerUserPreferences:
         assert all(uid == 501 and gid == 20 for _, uid, gid in stray_calls)
 
 
-class TestPreferencesTemplateShipsViaCopyTree:
-    """
-    The PREFERENCES.md template under templates/.claude/ ships into the
-    install tree as part of `_copy_tree(templates/.claude/, ...)` in
-    `_apply_source`. This test pins the contract that
-    `_HOME_CLAUDE_EXCLUDES` does NOT list the template name, so a future
-    excludes change cannot silently strip it.
-    """
-
-    def test_excludes_does_not_drop_preferences_template(self):
-        from kai.install import _HOME_CLAUDE_EXCLUDES
-
-        assert "PREFERENCES.md" not in _HOME_CLAUDE_EXCLUDES, (
-            "PREFERENCES.md must ship into the install tree; adding it to _HOME_CLAUDE_EXCLUDES would silently drop it."
-        )
-
-
 class TestGitignoreRuntimePreferencesDir:
     """
     The runtime preferences/ directory must stay gitignored under
@@ -3741,290 +3725,67 @@ class TestGenerateLauncherScript:
 
 class TestApplySource:
     """
-    _apply_source copies templates/.claude/ and templates/config/ into
-    the install tree, calls _migrate_identity_to_claude_md to convert
-    legacy IDENTITY.md/symlink layouts, and explicitly seeds CLAUDE.md
-    from the template on first install. The tests below pin those
-    contracts; the migration helper itself is tested directly in
-    TestMigrateIdentityToClaudeMd below.
+    _apply_source copies src/, pyproject.toml, and templates/config/
+    into the install tree, and retires the dead <install>/home/.claude/
+    subtree (and any legacy IDENTITY.md) via _retire_install_home_claude.
+    Post-#447 the install tree carries no CLAUDE.md; the per-user
+    runtime <DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md is seeded by
+    _apply_migrate (eager, install-time) and backend.ensure_user_home
+    (lazy, first-message fallback). The retirement helper has its own
+    pinned contracts in TestRetireInstallHomeClaude below; the
+    migration helper that ran before #447 is no longer called from
+    _apply_source but is unit-tested directly in
+    TestMigrateIdentityToClaudeMd.
     """
 
-    def test_dry_run_mentions_template_paths(self, tmp_path, capsys):
-        """Dry run prints the templates/ source paths and seeds nothing."""
+    def test_dry_run_does_not_mention_retired_template_paths(self, tmp_path, capsys):
+        """Dry-run output never names the retired template-copy or seed steps."""
         src = tmp_path / "source"
         ws_claude = src / "templates" / ".claude"
         ws_claude.mkdir(parents=True)
-        claude_md_src = ws_claude / "CLAUDE.md"
-        claude_md_src.write_text("identity")
+        # Even if a stray template CLAUDE.md were to exist (it does post-
+        # this PR's redo: the template is the source-of-truth for per-user
+        # seeding via _apply_migrate, NOT for any install-tree copy),
+        # the dry-run path must not preview an install-tree copy or seed
+        # from it. The negative-shape pin guards against a regression
+        # that reintroduces the retired blocks.
+        (ws_claude / "CLAUDE.md").write_text("identity")
+        # Pre-existing dead subtree at the install destination. The
+        # cleanup helper should emit a "Would remove dead ..." line.
         install_path = tmp_path / "install"
+        (install_path / "home" / ".claude").mkdir(parents=True)
+        (install_path / "home" / ".claude" / "stale").write_text("stale")
         with patch("kai.install.PROJECT_ROOT", src):
             _apply_source(install_path, svc_uid=1000, svc_gid=1000, dry_run=True)
         output = capsys.readouterr().out
-        assert "DRY RUN" in output
-        # Positive shape checks. Each "Would copy:" / "Would seed" line
-        # is "{src_path} -> {dst_path}"; asserting the exact source
-        # path appears on the left side of the arrow proves the dry-run
-        # is reading from templates/, not the retired home/.claude
-        # location. Avoids the prior double-negative replace pattern,
-        # which depended on the install dir being named exactly
-        # "install" and would silently invert if a tmp_path component
-        # ever contained "home/.claude" as a substring.
-        assert f"Would copy: {ws_claude} ->" in output
-        assert f"Would seed {claude_md_src} ->" in output
-        # Negative shape checks. No source-tree reference under
-        # PROJECT_ROOT/home/ should appear (the install destination
-        # under install_path/home/ is unchanged per spec §3.1; that is
-        # a different path and is allowed). And no template should be
-        # named with the retired .example suffix.
-        retired_src = src / "home" / ".claude"
-        assert str(retired_src) not in output
-        assert ".example" not in output
+        # Negative shape: no install-tree copy preview of the
+        # templates/.claude source directory and no "Would seed" line
+        # for an install-tree destination. The retired blocks would
+        # have emitted both; their absence is the contract.
+        assert f"Would copy: {ws_claude}" not in output
+        assert "Would seed" not in output
+        # Negative shape: no IDENTITY.md migration line (the migration
+        # helper is not called from _apply_source post-#447).
+        assert "IDENTITY.md" not in output
+        # Positive shape: the cleanup helper announces the pre-existing
+        # dead subtree.
+        assert "[DRY RUN] Would remove dead" in output
         # Dry run never touches disk.
-        assert not (install_path / "home" / ".claude").exists()
+        assert (install_path / "home" / ".claude").exists()
 
-    def test_dry_run_no_templates_dir_skips_copy(self, tmp_path, capsys):
-        """Dry run with empty source: no template-copy lines."""
+    def test_dry_run_no_templates_or_config_dir_skips_both(self, tmp_path, capsys):
+        """Dry run with empty source: no template-copy lines for either subtree."""
         with patch("kai.install.PROJECT_ROOT", tmp_path):
             _apply_source(tmp_path / "install", svc_uid=1000, svc_gid=1000, dry_run=True)
         output = capsys.readouterr().out
         assert "DRY RUN" in output
-        # Without templates/.claude/, the copy line should not appear.
-        # The migration helper still runs (its row-6 fresh-install path
-        # is silent), so the only printed line is whatever workspace
-        # rename / src copy / pyproject copy preview emits.
+        # Both subtree preview lines must be absent. The templates/.claude
+        # half is structural post-#447 (no install-tree copy step exists
+        # at all, so the preview cannot fire). The templates/config half
+        # is conditional on the source dir existing; with tmp_path as
+        # PROJECT_ROOT, neither subtree exists.
         assert "templates/.claude" not in output
         assert "templates/config" not in output
-
-    def test_actual_copies_templates_and_seeds_claude_md(self, tmp_path):
-        """
-        Fresh install path: copies src/, pyproject.toml, templates/.claude/,
-        and seeds <install>/home/.claude/CLAUDE.md from the template.
-        """
-        src = tmp_path / "source"
-        (src / "src").mkdir(parents=True)
-        (src / "src" / "module.py").write_text("code")
-        (src / "pyproject.toml").write_text("[project]")
-        ws_claude = src / "templates" / ".claude"
-        ws_claude.mkdir(parents=True)
-        (ws_claude / "CLAUDE.md").write_text("# Kai\n")
-        install = tmp_path / "install"
-        install.mkdir()
-
-        with (
-            patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install._copy_tree") as mock_copy,
-            patch("kai.install._set_ownership"),
-            patch("shutil.copy2") as mock_cp,
-            patch("os.chown") as mock_chown,
-        ):
-            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
-
-        # _copy_tree fires twice: once for src/, once for templates/.claude/.
-        # The mock prevents the seed step from finding the destination
-        # CLAUDE.md, so the explicit seed at the end of _apply_source
-        # also fires (visible via shutil.copy2 below).
-        assert mock_copy.call_count == 2
-        # shutil.copy2 fires for pyproject.toml AND for the seed step
-        # copying templates/.claude/CLAUDE.md -> install/home/.claude/CLAUDE.md.
-        assert mock_cp.call_count == 2
-        claude_md_dst = install / "home" / ".claude" / "CLAUDE.md"
-        chown_calls = mock_chown.call_args_list
-        assert any(c.args == (claude_md_dst, 1000, 1000) for c in chown_calls), (
-            f"Expected os.chown({claude_md_dst}, 1000, 1000); got {chown_calls}"
-        )
-
-    def test_actual_no_templates_dir(self, tmp_path):
-        """No templates/: copies source only, no error."""
-        src = tmp_path / "source"
-        (src / "src").mkdir(parents=True)
-        (src / "src" / "module.py").write_text("code")
-        (src / "pyproject.toml").write_text("[project]")
-        install = tmp_path / "install"
-        install.mkdir()
-
-        with (
-            patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install._copy_tree") as mock_copy,
-            patch("kai.install._set_ownership") as mock_own,
-            patch("shutil.copy2") as mock_cp,
-            patch("os.chown"),
-        ):
-            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
-
-        # Only one _copy_tree call (src/), no template copies.
-        mock_copy.assert_called_once()
-        mock_own.assert_called_once()
-        # pyproject.toml only; the seed step skips (no template source).
-        mock_cp.assert_called_once()
-
-    def test_templates_claude_uses_excludes(self, tmp_path):
-        """templates/.claude/ -> install copy uses _HOME_CLAUDE_EXCLUDES."""
-        from kai.install import _HOME_CLAUDE_EXCLUDES
-
-        src = tmp_path / "source"
-        (src / "src").mkdir(parents=True)
-        (src / "src" / "module.py").write_text("code")
-        (src / "pyproject.toml").write_text("[project]")
-        ws_claude = src / "templates" / ".claude"
-        ws_claude.mkdir(parents=True)
-        (ws_claude / "CLAUDE.md").write_text("identity")
-        install = tmp_path / "install"
-        install.mkdir()
-
-        with (
-            patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install._copy_tree") as mock_copy,
-            patch("kai.install._set_ownership"),
-            patch("shutil.copy2"),
-            patch("os.chown"),
-        ):
-            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
-
-        # Second _copy_tree call is for templates/.claude/ -> install/home/.claude/.
-        ws_call = mock_copy.call_args_list[1]
-        assert ws_call[0][2] == _HOME_CLAUDE_EXCLUDES
-
-    def test_existing_install_preserves_customized_claude_md(self, tmp_path):
-        """
-        Reinstall path: an operator-customized CLAUDE.md survives.
-        _HOME_CLAUDE_EXCLUDES skips it during the recursive copy and the
-        explicit seed step's `not exists()` guard skips it again.
-        """
-        src = tmp_path / "source"
-        (src / "src").mkdir(parents=True)
-        (src / "src" / "module.py").write_text("code")
-        (src / "pyproject.toml").write_text("[project]")
-        ws_claude_src = src / "templates" / ".claude"
-        ws_claude_src.mkdir(parents=True)
-        (ws_claude_src / "CLAUDE.md").write_text("TEMPLATE")
-
-        # Pre-existing operator-customized destination.
-        install = tmp_path / "install"
-        ws_claude_dst = install / "home" / ".claude"
-        ws_claude_dst.mkdir(parents=True)
-        (ws_claude_dst / "CLAUDE.md").write_text("OPERATOR EDIT")
-
-        with (
-            patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install._copy_tree"),
-            patch("kai.install._set_ownership"),
-            patch("os.chown"),
-        ):
-            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
-
-        # The operator-customized destination is unchanged.
-        assert (ws_claude_dst / "CLAUDE.md").read_text() == "OPERATOR EDIT"
-
-    def test_claude_md_owned_by_svc_after_row1_migration(self, tmp_path):
-        """
-        Regression guard for the order-of-operations bug in _apply_source:
-        _migrate_identity_to_claude_md (row 1) chowns CLAUDE.md to svc_uid;
-        the subsequent `_set_ownership(ws_claude_dst, 0, 0, recursive=True)`
-        clobbers that with root:root; the seed step's chown only fires
-        when the dst is missing, so without the trailing reconcile chown
-        CLAUDE.md ends up root-owned and inner Claude cannot edit it.
-
-        This test pins that the LAST chown call on CLAUDE.md is svc_uid,
-        regardless of the row-1 migration writing first and the recursive
-        ownership pass writing second. We do NOT mock _set_ownership so
-        its real implementation (which calls os.chown internally) is
-        captured by the chown spy - that's what makes the bug visible:
-        without the reconcile chown, the recursive root pass leaves the
-        last chown on CLAUDE.md as (0, 0).
-
-        Setup mirrors the production upgrade pre-state: existing
-        IDENTITY.md plus symlink, fresh source templates/ tree.
-        """
-        src = tmp_path / "source"
-        (src / "src").mkdir(parents=True)
-        (src / "src" / "module.py").write_text("code")
-        (src / "pyproject.toml").write_text("[project]")
-        ws_claude_src = src / "templates" / ".claude"
-        ws_claude_src.mkdir(parents=True)
-        (ws_claude_src / "CLAUDE.md").write_text("# Kai\n")
-
-        # Row-1 pre-state.
-        install = tmp_path / "install"
-        ws_claude_dst = install / "home" / ".claude"
-        ws_claude_dst.mkdir(parents=True)
-        identity = install / "home" / "IDENTITY.md"
-        identity.write_text("# Operator content\n")
-        claude_md = ws_claude_dst / "CLAUDE.md"
-        claude_md.symlink_to("../IDENTITY.md")
-
-        # Capture every os.chown call. Real _set_ownership (unmocked)
-        # calls os.chown internally, so the recursive (0, 0) clobbering
-        # pass shows up here in order.
-        chown_calls: list[tuple[str, int, int]] = []
-
-        def record_chown(path, uid, gid):
-            chown_calls.append((str(path), uid, gid))
-
-        with (
-            patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install._copy_tree"),
-            patch("os.chown", side_effect=record_chown),
-        ):
-            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
-
-        # Sanity: the recursive root pass on home/.claude/ MUST have
-        # happened (otherwise the test would silently pass even if the
-        # bug were re-introduced). Look for any (path, 0, 0) chown
-        # under ws_claude_dst.
-        recursive_root_pass = any(c[0].startswith(str(ws_claude_dst)) and (c[1], c[2]) == (0, 0) for c in chown_calls)
-        assert recursive_root_pass, (
-            f"Expected _set_ownership to chown some path under {ws_claude_dst} to (0, 0); got {chown_calls}"
-        )
-
-        claude_md_chown_calls = [c for c in chown_calls if c[0] == str(claude_md)]
-        assert claude_md_chown_calls, f"Expected at least one os.chown call on {claude_md}; got {chown_calls}"
-        # The LAST chown wins on the filesystem; pin it explicitly so a
-        # future refactor that reorders steps trips this assertion before
-        # production hits it.
-        _, last_uid, last_gid = claude_md_chown_calls[-1]
-        assert (last_uid, last_gid) == (1000, 1000), (
-            f"Last chown on {claude_md} was ({last_uid}, {last_gid}); expected (1000, 1000). "
-            f"All chown calls in order: {chown_calls}"
-        )
-
-    def test_dry_run_predicts_seed_for_fresh_install(self, tmp_path, capsys):
-        """Dry-run prediction matches the live behavior for a fresh install."""
-        src = tmp_path / "source"
-        ws_claude = src / "templates" / ".claude"
-        ws_claude.mkdir(parents=True)
-        (ws_claude / "CLAUDE.md").write_text("# Kai\n")
-        with patch("kai.install.PROJECT_ROOT", src):
-            _apply_source(tmp_path / "install", svc_uid=1000, svc_gid=1000, dry_run=True)
-        output = capsys.readouterr().out
-        # Dry-run never writes IDENTITY.md or names the .example suffix
-        # (the migration helper has not seen any pre-state to migrate).
-        assert "IDENTITY.md" not in output
-        assert ".example" not in output
-        # The seed-step preview line names the source template path.
-        assert "Would seed" in output
-        assert "templates/.claude/CLAUDE.md" in output
-
-    def test_dry_run_predicts_no_seed_when_identity_md_will_move(self, tmp_path, capsys):
-        """
-        Row 2 of the migration table: IDENTITY.md regular file exists with
-        no CLAUDE.md sibling. The migration moves IDENTITY.md to CLAUDE.md,
-        so the seed step has no work to do. Dry-run reflects that.
-        """
-        src = tmp_path / "source"
-        ws_claude = src / "templates" / ".claude"
-        ws_claude.mkdir(parents=True)
-        (ws_claude / "CLAUDE.md").write_text("# Kai\n")
-        install = tmp_path / "install"
-        (install / "home").mkdir(parents=True)
-        (install / "home" / "IDENTITY.md").write_text("# Operator content")
-
-        with patch("kai.install.PROJECT_ROOT", src):
-            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=True)
-        output = capsys.readouterr().out
-        # Migration row 2 dry-run line.
-        assert "Would move" in output
-        # No seed prediction; the rename will populate CLAUDE.md.
-        assert "Would seed" not in output
 
     def test_copies_templates_config(self, tmp_path):
         """templates/config/ is copied to install/home/config/."""
@@ -4071,6 +3832,311 @@ class TestApplySource:
         assert "templates/config" in output
         # Should not create the directory during dry run
         assert not (tmp_path / "install" / "home" / "config").exists()
+
+
+# ── _retire_install_home_claude ──────────────────────────────────────
+
+
+class TestRetireInstallHomeClaude:
+    """
+    Pins the wholesale-directory cleanup of <install>/home/.claude/ and
+    the legacy <install>/home/IDENTITY.md. Both paths predate the
+    per-user home_workspace migration in #353; nothing in the runtime
+    reads either path. Issue #447 retires both.
+    """
+
+    def test_fresh_install_no_install_home_claude_dir(self, tmp_path):
+        """Fresh install: no pre-existing dirs, helper is a no-op."""
+        install = tmp_path / "install"
+        install.mkdir()
+        _retire_install_home_claude(install, dry_run=False)
+        assert not (install / "home" / ".claude").exists()
+        assert not (install / "home" / "IDENTITY.md").exists()
+
+    def test_existing_install_home_claude_dir_is_removed(self, tmp_path, capsys):
+        """Existing <install>/home/.claude/ with content is removed wholesale."""
+        install = tmp_path / "install"
+        ws_claude = install / "home" / ".claude"
+        ws_claude.mkdir(parents=True)
+        (ws_claude / "CLAUDE.md").write_text("# Operator content\n")
+        (ws_claude / "MEMORY.md").write_text("# Memory\n")
+        (ws_claude / "skills").mkdir()
+        (ws_claude / "skills" / "example.md").write_text("# skill")
+
+        _retire_install_home_claude(install, dry_run=False)
+
+        assert not ws_claude.exists()
+        output = capsys.readouterr().out
+        assert "CLAUDE.md" in output
+        assert "MEMORY.md" in output
+        assert "example.md" in output
+        assert "Removed dead" in output
+        assert "nothing reads this path post-#447" in output
+
+    def test_legacy_identity_md_regular_file_is_removed(self, tmp_path, capsys):
+        """A bare regular-file <install>/home/IDENTITY.md is removed."""
+        install = tmp_path / "install"
+        (install / "home").mkdir(parents=True)
+        identity = install / "home" / "IDENTITY.md"
+        identity.write_text("# Operator content\n")
+
+        _retire_install_home_claude(install, dry_run=False)
+
+        assert not identity.exists()
+        output = capsys.readouterr().out
+        assert "Removed legacy" in output
+        assert "IDENTITY.md" in output
+
+    def test_symlink_at_identity_md_is_removed(self, tmp_path):
+        """A broken or valid symlink at IDENTITY.md is removed too."""
+        install = tmp_path / "install"
+        (install / "home").mkdir(parents=True)
+        identity = install / "home" / "IDENTITY.md"
+        identity.symlink_to("/nonexistent/broken/target")
+
+        _retire_install_home_claude(install, dry_run=False)
+
+        assert not identity.is_symlink()
+        assert not identity.exists()
+
+    def test_dry_run_predicts_cleanup_matches_live(self, tmp_path, capsys):
+        """Dry-run / live parity: each removal line corresponds 1:1."""
+
+        def seed_install_state(install_root: Path) -> None:
+            ws_claude = install_root / "home" / ".claude"
+            ws_claude.mkdir(parents=True)
+            (ws_claude / "CLAUDE.md").write_text("# content\n")
+            (ws_claude / "MEMORY.md").write_text("# memory\n")
+            (install_root / "home" / "IDENTITY.md").write_text("# operator\n")
+
+        install_dry = tmp_path / "install_dry"
+        install_live = tmp_path / "install_live"
+        seed_install_state(install_dry)
+        seed_install_state(install_live)
+
+        _retire_install_home_claude(install_dry, dry_run=True)
+        dry_output = capsys.readouterr().out
+
+        _retire_install_home_claude(install_live, dry_run=False)
+        live_output = capsys.readouterr().out
+
+        # Filter to the removal-related lines and strip the tense-marker
+        # prefix so the comparison runs on the action body. Live uses
+        # "Removing " for per-file (before rmtree, so a rmtree OSError
+        # does not leave a past-tense lie in stdout) and "Removed " for
+        # the post-rmtree summary and post-unlink IDENTITY.md line.
+        # Dry-run uses a single "[DRY RUN] Would remove " prefix for
+        # all three phases.
+        def removal_lines(text: str, prefixes: tuple[str, ...], install_path: Path) -> list[str]:
+            placeholder = "<install>"
+            stripped: list[str] = []
+            for line in text.splitlines():
+                line = line.strip()
+                for prefix in prefixes:
+                    if line.startswith(prefix):
+                        body = line[len(prefix) :].lstrip()
+                        body = body.replace(str(install_path), placeholder)
+                        stripped.append(body)
+                        break
+            return stripped
+
+        dry_lines = removal_lines(dry_output, ("[DRY RUN] Would remove ",), install_dry)
+        live_lines = removal_lines(live_output, ("Removing ", "Removed "), install_live)
+        assert dry_lines, f"Dry-run produced no removal previews; got: {dry_output!r}"
+        assert dry_lines == live_lines, f"Dry-run / live parity broken.\n  Dry:  {dry_lines}\n  Live: {live_lines}"
+
+    def test_idempotent_on_repeated_install(self, tmp_path, capsys):
+        """Second call over the cleaned state is a silent no-op."""
+        install = tmp_path / "install"
+        install.mkdir()
+
+        _retire_install_home_claude(install, dry_run=False)
+        capsys.readouterr()  # discard first run
+        _retire_install_home_claude(install, dry_run=False)
+
+        second_output = capsys.readouterr().out
+        assert not (install / "home" / ".claude").exists()
+        assert "Removed dead" not in second_output
+        assert "Removed legacy" not in second_output
+
+
+# ── Per-user CLAUDE.md seed (in _apply_migrate's home block) ─────────
+
+
+class TestApplyMigrateClaudeMdSeed:
+    """
+    _apply_migrate's home block seeds <DATA_DIR>/home/<chat_id>/.claude/
+    CLAUDE.md from templates/.claude/CLAUDE.md for every users.yaml
+    entry. Without this seed, a new user's home workspace is an empty
+    directory and the bot has no baseline identity to read. The pattern
+    mirrors the MEMORY.md / PREFERENCES.md seed blocks above this one
+    in the same function. Lazy bootstrap (backend.ensure_user_home) is
+    the fallback for chat_ids added between installs and is covered by
+    its own test module.
+    """
+
+    def _write_users_yaml(self, path: Path, entries: list[dict]) -> None:
+        path.write_text(yaml.safe_dump({"users": entries}))
+
+    def _stub_pwd_getpwnam(self):
+        # Map any os_user to a fixed uid/gid pair. _apply_migrate
+        # validates os_user existence up front via pwd.getpwnam; in
+        # tests we redirect to a stub so we do not need real OS
+        # accounts on the test host. The chown calls inside the
+        # function are themselves stubbed out via patch("os.chown")
+        # in each test, so the uid/gid values here are placeholders.
+        class _Pw:
+            pw_uid = 1234
+            pw_gid = 1234
+
+        return _Pw()
+
+    def test_fresh_install_seeds_per_user_claude_md(self, tmp_path):
+        """A users.yaml entry produces a populated CLAUDE.md at the per-user path."""
+        src = tmp_path / "source"
+        ws_claude = src / "templates" / ".claude"
+        ws_claude.mkdir(parents=True)
+        (ws_claude / "CLAUDE.md").write_text("# Kai template\n")
+        # The seed loop is shared with MEMORY.md / PREFERENCES.md; supply
+        # those templates too so the rest of _apply_migrate does not
+        # diverge into placeholder branches.
+        (ws_claude / "MEMORY.md").write_text("# Memory\n")
+        (ws_claude / "PREFERENCES.md").write_text("# Preferences\n")
+        users_yaml = tmp_path / "users.yaml"
+        self._write_users_yaml(users_yaml, [{"telegram_id": 12345, "os_user": "alice"}])
+
+        data_path = tmp_path / "data"
+        install_path = tmp_path / "install"
+        install_path.mkdir()
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install.pwd.getpwnam", return_value=self._stub_pwd_getpwnam()),
+            patch("kai.install._set_ownership"),
+            patch("os.chown"),
+        ):
+            _apply_migrate(
+                data_path,
+                install_path,
+                svc_uid=0,
+                svc_gid=0,
+                dry_run=False,
+                users_yaml_path=Path(users_yaml),
+            )
+
+        claude_dst = data_path / "home" / "12345" / ".claude" / "CLAUDE.md"
+        assert claude_dst.is_file(), f"Expected seed at {claude_dst}"
+        assert claude_dst.read_text() == "# Kai template\n"
+
+    def test_existing_per_user_claude_md_survives_reinstall(self, tmp_path):
+        """Idempotent: an operator-customized destination is never overwritten."""
+        src = tmp_path / "source"
+        ws_claude = src / "templates" / ".claude"
+        ws_claude.mkdir(parents=True)
+        (ws_claude / "CLAUDE.md").write_text("# Kai template\n")
+        (ws_claude / "MEMORY.md").write_text("# Memory\n")
+        (ws_claude / "PREFERENCES.md").write_text("# Preferences\n")
+        users_yaml = tmp_path / "users.yaml"
+        self._write_users_yaml(users_yaml, [{"telegram_id": 12345, "os_user": "alice"}])
+
+        data_path = tmp_path / "data"
+        claude_dir = data_path / "home" / "12345" / ".claude"
+        claude_dir.mkdir(parents=True)
+        claude_dst = claude_dir / "CLAUDE.md"
+        claude_dst.write_text("# OPERATOR CUSTOMIZED\n")
+
+        install_path = tmp_path / "install"
+        install_path.mkdir()
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install.pwd.getpwnam", return_value=self._stub_pwd_getpwnam()),
+            patch("kai.install._set_ownership"),
+            patch("os.chown"),
+        ):
+            _apply_migrate(
+                data_path,
+                install_path,
+                svc_uid=0,
+                svc_gid=0,
+                dry_run=False,
+                users_yaml_path=Path(users_yaml),
+            )
+
+        # Customized content survives.
+        assert claude_dst.read_text() == "# OPERATOR CUSTOMIZED\n"
+
+    def test_missing_template_writes_placeholder(self, tmp_path):
+        """Missing template: last-resort placeholder so the file is writable."""
+        src = tmp_path / "source"
+        ws_claude = src / "templates" / ".claude"
+        ws_claude.mkdir(parents=True)
+        # CLAUDE.md template intentionally absent; MEMORY.md / PREFERENCES.md
+        # present so the rest of _apply_migrate runs normally.
+        (ws_claude / "MEMORY.md").write_text("# Memory\n")
+        (ws_claude / "PREFERENCES.md").write_text("# Preferences\n")
+        users_yaml = tmp_path / "users.yaml"
+        self._write_users_yaml(users_yaml, [{"telegram_id": 12345, "os_user": "alice"}])
+
+        data_path = tmp_path / "data"
+        install_path = tmp_path / "install"
+        install_path.mkdir()
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install.pwd.getpwnam", return_value=self._stub_pwd_getpwnam()),
+            patch("kai.install._set_ownership"),
+            patch("os.chown"),
+        ):
+            _apply_migrate(
+                data_path,
+                install_path,
+                svc_uid=0,
+                svc_gid=0,
+                dry_run=False,
+                users_yaml_path=Path(users_yaml),
+            )
+
+        claude_dst = data_path / "home" / "12345" / ".claude" / "CLAUDE.md"
+        assert claude_dst.is_file()
+        assert claude_dst.read_text() == "# Identity\n"
+
+    def test_dry_run_predicts_seed(self, tmp_path, capsys):
+        """Dry-run names the source and destination for the seed it would write."""
+        src = tmp_path / "source"
+        ws_claude = src / "templates" / ".claude"
+        ws_claude.mkdir(parents=True)
+        (ws_claude / "CLAUDE.md").write_text("# Kai template\n")
+        (ws_claude / "MEMORY.md").write_text("# Memory\n")
+        (ws_claude / "PREFERENCES.md").write_text("# Preferences\n")
+        users_yaml = tmp_path / "users.yaml"
+        self._write_users_yaml(users_yaml, [{"telegram_id": 12345, "os_user": "alice"}])
+
+        data_path = tmp_path / "data"
+        install_path = tmp_path / "install"
+        install_path.mkdir()
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install.pwd.getpwnam", return_value=self._stub_pwd_getpwnam()),
+        ):
+            _apply_migrate(
+                data_path,
+                install_path,
+                svc_uid=0,
+                svc_gid=0,
+                dry_run=True,
+                users_yaml_path=Path(users_yaml),
+            )
+
+        output = capsys.readouterr().out
+        expected_dst = data_path / "home" / "12345" / ".claude" / "CLAUDE.md"
+        # Dry-run preview names the per-user destination path. The
+        # template source path is in the same line; pin one substring
+        # so a path-format change does not flake the test.
+        assert f"Would seed {expected_dst}" in output
+        # Dry run never touches disk.
+        assert not expected_dst.exists()
 
 
 # ── _migrate_identity_to_claude_md ───────────────────────────────────

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1271,9 +1271,12 @@ class TestTriageErrorContent:
             labels=[],
         )
 
-        # Substituted post-#353 because /opt/kai/home/.claude/CLAUDE.md
+        # Substituted post-#353 because <install>/home/.claude/CLAUDE.md
         # no longer exists on production installs (the shared home was
-        # removed; CLAUDE.md is per-user under DATA_DIR/memory/).
+        # removed; CLAUDE.md is per-user under
+        # <DATA_DIR>/home/<chat_id>/.claude/, seeded by _apply_migrate
+        # eagerly and ensure_user_home lazily, and after #447 the
+        # install tree no longer holds any CLAUDE.md at all).
         # /etc/kai/env is the production secrets file - if its path ever
         # leaked into a user-facing error notification it would expose
         # the location of TELEGRAM_BOT_TOKEN and other secrets, which


### PR DESCRIPTION
Closes #447. Corrected redo of PR #449 (reverted via #450).

## What's different from #449

Where #449 deleted `templates/.claude/CLAUDE.md` on the spec's "no current consumer" classification, this PR keeps the template and **adds the consumer that was missing all along**.

Pre-existing bug exposed by #449: no production code seeded per-user `<DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md`. The bot's identity-injection at `backend.build_session_context:223` silently fails on missing files (`except OSError: pass`), so new users (any chat_id added to users.yaml after install, including the operator's secondary user) ran with no baseline identity. The operator's own runtime CLAUDE.md was placed there manually because no code did it for them. This PR closes the gap.

## Summary

- **Retire the dead `<install>/home/.claude/` install-tree scaffolding** via `_retire_install_home_claude(install_path, dry_run)`. Idempotent (`is_dir()` / `is_symlink() or is_file()` pre-checks), dry-run/live parity, every removed file logged with byte size. Removes both `<install>/home/.claude/` and any legacy `<install>/home/IDENTITY.md` (regular file or symlink).
- **`_apply_source` rewritten.** Cleanup helper runs first, then unchanged src / pyproject / templates/config copy. `_migrate_identity_to_claude_md` call removed (helper body stays for its separately-scheduled retirement).
- **`_HOME_CLAUDE_EXCLUDES` removed.** Its only consumer was the deleted `_copy_tree` call.
- **`templates/.claude/CLAUDE.md` STAYS.** Reclassified as the source-of-truth baseline identity template. "About This File" rewritten to describe its actual purpose.
- **NEW: per-user CLAUDE.md seed in `_apply_migrate`.** Parallel to MEMORY.md / PREFERENCES.md per-user seed blocks: for every users.yaml entry, seed `<DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md` if missing. Recursive chown to the per-user `os_user` so inner Claude can edit it. Last-resort `# Identity\n` placeholder if template missing.
- **NEW: lazy bootstrap in `backend.ensure_user_home`.** Runtime fallback for users added between installs. Same shape as `ensure_user_memory` / `ensure_user_preferences`.
- Doc fix-ups across README, two templates, eval/behavioral.py, three test files, and `_copy_tree`'s symlink docstring.

## Test plan

- [x] `make check` passes; lint clean.
- [x] `make test` passes (2824 tests, 1 skipped; +6 from main, reflecting test churn).
- [x] `TestRetireInstallHomeClaude` (6 tests): fresh, existing dir with log, IDENTITY.md regular, IDENTITY.md symlink, dry-run/live parity, idempotency.
- [x] `TestApplyMigrateClaudeMdSeed` (4 tests): fresh seeds, reinstall preserves operator content, missing template writes placeholder, dry-run preview.
- [x] `TestEnsureUserHome` (4 new tests + 4 pre-existing): seeds from template, idempotent, placeholder on missing template, swallows OSError.
- [x] Acceptance greps:
  - `grep -rn '_HOME_CLAUDE_EXCLUDES' src/ tests/` -> nothing.
  - `grep -rn 'home/\.claude' src/ templates/ README.md` -> only hits inside `_migrate_identity_to_claude_md` and `_retire_install_home_claude` docstrings/comments.
  - `git ls-files templates/.claude/` -> CLAUDE.md, MEMORY.md, PREFERENCES.md (all three kept).

## Operator cleanup note

On the next `make install` after this lands, install output names every file being removed from `<install>/home/.claude/` plus a `Removed dead <install>/home/.claude/; nothing reads this path post-#447` summary. If you customized the install-tree CLAUDE.md believing it was load-bearing, the printed log is the recovery surface. Production impact: the path has not been read by any code since #353. **Your secondary user (and any future user in users.yaml) will get their per-user `.claude/CLAUDE.md` seeded on first install** or first message, whichever comes first.

If you have been running Kai locally in dev mode (`python -m kai` from the repo with `KAI_DATA_DIR` unset) and edited a dev CLAUDE.md under the repo's `home/` tree (pre-#353 layout), back it up first; the cleanup helper runs against your dev install tree too.

## Wiki

Out of repo per issue bullet 5. Pages referencing `<install_path>/home/.claude/` as load-bearing need a refresh post-merge.

