### PR TITLE
refactor(install): relocate goose-config.yaml out of <install>/home/, retire the parent (#452)

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -3073,7 +3073,7 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
         # live cleanup at the end of this function so the operator
         # sees what would happen on an existing-install upgrade
         # where `<install>/home/config/` still exists.
-        _retire_install_home_dir(install_path, dry_run=True)
+        _retire_install_home_dir(install_path, dry_run=dry_run)
         return
 
     _copy_tree(src_src, src_dst, _SOURCE_EXCLUDES)
@@ -3101,8 +3101,10 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
     # install nothing under it exists; on an existing-install upgrade
     # the cleanup above has already removed `.claude/` and `IDENTITY.md`,
     # and the goose-config relocation left an orphan `home/config/`.
-    # The helper handles both end states.
-    _retire_install_home_dir(install_path, dry_run=False)
+    # The helper handles both end states. `dry_run` is propagated
+    # rather than hardcoded so a future restructure of the early
+    # return above cannot silently suppress dry-run output here.
+    _retire_install_home_dir(install_path, dry_run=dry_run)
 
 
 def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2973,6 +2973,65 @@ def _retire_install_home_claude(install_path: Path, dry_run: bool) -> None:
             print(f"  Removed legacy {identity_md} ({size} bytes); content was identity baseline only")
 
 
+def _retire_install_home_dir(install_path: Path, dry_run: bool) -> None:
+    """
+    Remove the `<install>/home/` directory after its contents are gone.
+
+    Pre-#452 this directory held three things:
+      - `home/.claude/` (retired by `_retire_install_home_claude` per #447)
+      - `home/IDENTITY.md` (also retired by `_retire_install_home_claude`)
+      - `home/config/goose-config.yaml` (relocated to `<install>/config/` by #452)
+
+    With all three retired/relocated, `<install>/home/` is vestigial and
+    can be removed. The cleanup catches both end states:
+      - On a clean install: the directory never existed; silent no-op.
+      - On an existing-install upgrade: the `_apply_source` flow above
+        has already retired `.claude/`/`IDENTITY.md` and copied the
+        new `<install>/config/`, leaving an orphan `home/config/`
+        whose only file is `goose-config.yaml`. Remove that orphan
+        and the empty `home/` parent.
+
+    `home/config/goose-config.yaml` is install-time scaffolding (input
+    to `_apply_goose_config`, which writes the runtime config to
+    `~/.config/goose/config.yaml`); operators do not edit it. Logging
+    the removal with byte size is symmetric with
+    `_retire_install_home_claude` and consistent with the established
+    install-time loud-removal contract.
+    """
+    home_dir = install_path / "home"
+    if not home_dir.exists():
+        return
+
+    # Enumerate any surviving files first so the log captures byte
+    # sizes before rmtree runs. The only thing we expect to find is
+    # `home/config/goose-config.yaml` on the existing-install upgrade
+    # path; rglob handles arbitrary content defensively in case a
+    # future code change leaves something else behind.
+    for path in sorted(home_dir.rglob("*")):
+        if path.is_file() or path.is_symlink():
+            try:
+                size = path.lstat().st_size
+            except OSError:
+                size = 0
+            if dry_run:
+                print(f"[DRY RUN] Would remove {path} ({size} bytes)")
+            else:
+                print(f"  Removing {path} ({size} bytes)")
+
+    if dry_run:
+        print(f"[DRY RUN] Would remove retired {home_dir}; <install>/config/ holds the relocated content post-#452")
+    else:
+        # Same try/except discipline as the rmtree in
+        # `_retire_install_home_claude`: surface an operator-readable
+        # error line BEFORE the traceback aborts the install.
+        try:
+            shutil.rmtree(home_dir)
+        except OSError as exc:
+            print(f"  ERROR: could not remove {home_dir}: {exc}")
+            raise
+        print(f"  Removed retired {home_dir}; <install>/config/ holds the relocated content post-#452")
+
+
 def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool) -> None:
     """Copy source tree and home config from PROJECT_ROOT to the install location."""
     src_src = PROJECT_ROOT / "src"
@@ -2981,15 +3040,16 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
     pyproject_dst = install_path / "pyproject.toml"
     # Config templates (e.g. goose-config.yaml) referenced by later
     # install steps like _apply_goose_config(). Root-owned since these
-    # are static templates, not runtime data. The `home/` parent
-    # continues to exist for this one purpose post-#447; everything
-    # else previously under `<install>/home/` (the `.claude/` subtree
-    # and any legacy IDENTITY.md) is retired by `_retire_install_home_claude`.
-    # The per-user `<DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md` is
-    # seeded by `_apply_migrate`'s home block (eager) and
-    # `backend.ensure_user_home` (lazy, first-message fallback).
+    # are static templates, not runtime data. Issue #452 relocated
+    # this destination from `<install>/home/config/` to
+    # `<install>/config/`; the old `home/` parent is fully retired by
+    # `_retire_install_home_dir` below now that no install step
+    # writes under it. Per-user runtime CLAUDE.md is seeded by
+    # `_apply_migrate`'s home block (eager) and
+    # `backend.ensure_user_home` (lazy, first-message fallback);
+    # neither touches the install tree.
     config_src = PROJECT_ROOT / "templates" / "config"
-    config_dst = install_path / "home" / "config"
+    config_dst = install_path / "config"
 
     # One-time: rename workspace/ to home/ at the install location.
     # The directory was renamed in the source tree; this migrates the
@@ -3019,6 +3079,11 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
         print(f"[DRY RUN] Would copy: {pyproject_src} -> {pyproject_dst}")
         if config_src.is_dir():
             print(f"[DRY RUN] Would copy: {config_src} -> {config_dst}")
+        # Issue #452: dry-run preview for the empty-home cleanup.
+        # Matches the live cleanup at the end of this function so the
+        # operator sees what would happen on an existing-install
+        # upgrade where `<install>/home/config/` still exists.
+        _retire_install_home_dir(install_path, dry_run=True)
         return
 
     _copy_tree(src_src, src_dst, _SOURCE_EXCLUDES)
@@ -3029,19 +3094,28 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
     os.chown(pyproject_dst, 0, 0)
     print(f"  Copied {pyproject_dst}")
 
-    # Copy templates/config/ -> install/home/config/ (config templates
-    # like goose-config.yaml). These are static templates referenced by
+    # Copy templates/config/ -> install/config/ (config templates like
+    # goose-config.yaml). These are static templates referenced by
     # later install steps - e.g. _apply_goose_config() reads the Goose
     # extension config from here. Root-owned since they're installer
     # input, not runtime output.
     if config_src.is_dir():
-        # `home/` may not exist yet (the retirement step above does not
-        # create it, and after #447 the `.claude/` copy that used to
-        # parent it is gone). Ensure the parent before copying.
+        # `<install>/config/` may not exist yet on a fresh install.
+        # Pre-#452 this lived under `<install>/home/config/`; the
+        # parent mkdir below creates the new top-level location.
         config_dst.parent.mkdir(parents=True, exist_ok=True)
         _copy_tree(config_src, config_dst)
         _set_ownership(config_dst, 0, 0, recursive=True)
         print(f"  Copied config templates to {config_dst}")
+
+    # Issue #452: retire the now-empty `<install>/home/` directory.
+    # Pre-#452 it held `home/.claude/` (retired by #447), `home/IDENTITY.md`
+    # (retired by #447), and `home/config/` (relocated to `<install>/config/`
+    # by this change). On a clean install nothing under `<install>/home/`
+    # exists; on an existing-install upgrade the migration above has
+    # already removed `.claude/` and `IDENTITY.md`, and the relocation
+    # left an orphan `home/config/`. Cleanup catches both end states.
+    _retire_install_home_dir(install_path, dry_run=False)
 
 
 def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:
@@ -3213,15 +3287,15 @@ def _apply_goose_config(
     """
     Deploy the Goose extension config to the service user's home.
 
-    Copies home/config/goose-config.yaml from the install tree to
-    ~/.config/goose/config.yaml so that `goose acp` picks up the
+    Copies config/goose-config.yaml from the install tree to
+    `~/.config/goose/config.yaml` so that `goose acp` picks up the
     right extension settings. The directory is created if it does
     not exist. Only called when AGENT_BACKEND=goose.
     """
     svc_home = Path(_user_home(service_user))
     goose_dir = svc_home / ".config" / "goose"
     dst = goose_dir / "config.yaml"
-    src = install_path / "home" / "config" / "goose-config.yaml"
+    src = install_path / "config" / "goose-config.yaml"
 
     # Check before dry_run so a missing template is caught during
     # pre-validation, not only on the real install run.

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2975,19 +2975,33 @@ def _retire_install_home_claude(install_path: Path, dry_run: bool) -> None:
 
 def _retire_install_home_dir(install_path: Path, dry_run: bool) -> None:
     """
-    Remove the `<install>/home/` directory after its contents are gone.
+    Remove the `<install>/home/` directory if (and only if) it contains
+    nothing more than an orphan `config/goose-config.yaml`.
 
-    The directory previously held the `.claude/` subtree, a legacy
-    `IDENTITY.md`, and a `config/goose-config.yaml` template.
+    `<install>/home/` previously held the `.claude/` subtree, a legacy
+    `IDENTITY.md`, a `config/goose-config.yaml` template, and a
+    `files/` tree used by the pre-DATA_DIR uploaded-files migration.
     `_retire_install_home_claude` (called earlier in `_apply_source`)
     removes the first two; the goose-config template now lives at
-    `<install>/config/goose-config.yaml`. With nothing remaining,
-    `<install>/home/` is vestigial.
+    `<install>/config/goose-config.yaml`. The `files/` tree is still
+    read by `_apply_migrate`'s legacy uploaded-files block as a
+    backup source on hosts that have not yet migrated.
 
-    The cleanup catches both end states:
+    The helper enforces the conservative guardrail from the originating
+    issue: remove only when the directory contains nothing more than
+    the orphan `config/` subdir (which may hold at most
+    `goose-config.yaml`). If anything else is present - a leftover
+    `files/` backup tree, an operator-placed file, a future code
+    change leaving fresh content - the helper logs the unexpected
+    paths and refuses to remove. The dir persists, the operator can
+    investigate, and no data is destroyed.
+
+    The cleanup catches three end states:
       - Clean install: the directory never existed; silent no-op.
-      - Existing-install upgrade: an orphan `home/config/goose-config.yaml`
-        remains; remove that orphan and the empty `home/` parent.
+      - Existing-install upgrade with only orphan `home/config/goose-config.yaml`:
+        remove the orphan and the empty `home/` parent.
+      - Existing-install upgrade with extra content (e.g., un-migrated
+        `home/files/`): refuse, log the unexpected paths, return.
 
     Logging every removed file with its byte size before rmtree is
     symmetric with `_retire_install_home_claude` and matches the
@@ -2997,10 +3011,34 @@ def _retire_install_home_dir(install_path: Path, dry_run: bool) -> None:
     if not home_dir.exists():
         return
 
-    # Enumerate surviving files first so the log captures byte sizes
-    # before rmtree runs. rglob handles arbitrary content defensively
-    # in case a future code change leaves something other than the
-    # expected orphan behind.
+    # Per the issue contract: only `config/` is an allowed top-level
+    # entry, and only `goose-config.yaml` is allowed inside it.
+    # Anything else means refuse-and-log; do not destroy.
+    top_unexpected = sorted(entry.name for entry in home_dir.iterdir() if entry.name != "config")
+    config_subdir = home_dir / "config"
+    config_unexpected: list[str] = []
+    if config_subdir.is_dir():
+        config_unexpected = sorted(entry.name for entry in config_subdir.iterdir() if entry.name != "goose-config.yaml")
+
+    if top_unexpected or config_unexpected:
+        # Single refusal line names everything unexpected so the
+        # operator can locate it without re-running the install with
+        # extra logging. Dry-run and live both emit the same message
+        # because no deletion happens either way.
+        prefix = "[DRY RUN] " if dry_run else "  "
+        unexpected_paths: list[str] = []
+        unexpected_paths.extend(str(home_dir / name) for name in top_unexpected)
+        unexpected_paths.extend(str(config_subdir / name) for name in config_unexpected)
+        print(
+            f"{prefix}Refusing to remove {home_dir}: unexpected content present "
+            f"({', '.join(unexpected_paths)}). Investigate and remove manually if intended."
+        )
+        return
+
+    # Safe to remove: directory is either empty or contains exactly
+    # `config/[goose-config.yaml]`. Enumerate any surviving file (the
+    # orphan goose-config) first so the log captures its byte size
+    # before rmtree runs.
     for path in sorted(home_dir.rglob("*")):
         if path.is_file() or path.is_symlink():
             try:

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2977,36 +2977,30 @@ def _retire_install_home_dir(install_path: Path, dry_run: bool) -> None:
     """
     Remove the `<install>/home/` directory after its contents are gone.
 
-    Pre-#452 this directory held three things:
-      - `home/.claude/` (retired by `_retire_install_home_claude` per #447)
-      - `home/IDENTITY.md` (also retired by `_retire_install_home_claude`)
-      - `home/config/goose-config.yaml` (relocated to `<install>/config/` by #452)
+    The directory previously held the `.claude/` subtree, a legacy
+    `IDENTITY.md`, and a `config/goose-config.yaml` template.
+    `_retire_install_home_claude` (called earlier in `_apply_source`)
+    removes the first two; the goose-config template now lives at
+    `<install>/config/goose-config.yaml`. With nothing remaining,
+    `<install>/home/` is vestigial.
 
-    With all three retired/relocated, `<install>/home/` is vestigial and
-    can be removed. The cleanup catches both end states:
-      - On a clean install: the directory never existed; silent no-op.
-      - On an existing-install upgrade: the `_apply_source` flow above
-        has already retired `.claude/`/`IDENTITY.md` and copied the
-        new `<install>/config/`, leaving an orphan `home/config/`
-        whose only file is `goose-config.yaml`. Remove that orphan
-        and the empty `home/` parent.
+    The cleanup catches both end states:
+      - Clean install: the directory never existed; silent no-op.
+      - Existing-install upgrade: an orphan `home/config/goose-config.yaml`
+        remains; remove that orphan and the empty `home/` parent.
 
-    `home/config/goose-config.yaml` is install-time scaffolding (input
-    to `_apply_goose_config`, which writes the runtime config to
-    `~/.config/goose/config.yaml`); operators do not edit it. Logging
-    the removal with byte size is symmetric with
-    `_retire_install_home_claude` and consistent with the established
+    Logging every removed file with its byte size before rmtree is
+    symmetric with `_retire_install_home_claude` and matches the
     install-time loud-removal contract.
     """
     home_dir = install_path / "home"
     if not home_dir.exists():
         return
 
-    # Enumerate any surviving files first so the log captures byte
-    # sizes before rmtree runs. The only thing we expect to find is
-    # `home/config/goose-config.yaml` on the existing-install upgrade
-    # path; rglob handles arbitrary content defensively in case a
-    # future code change leaves something else behind.
+    # Enumerate surviving files first so the log captures byte sizes
+    # before rmtree runs. rglob handles arbitrary content defensively
+    # in case a future code change leaves something other than the
+    # expected orphan behind.
     for path in sorted(home_dir.rglob("*")):
         if path.is_file() or path.is_symlink():
             try:
@@ -3019,7 +3013,7 @@ def _retire_install_home_dir(install_path: Path, dry_run: bool) -> None:
                 print(f"  Removing {path} ({size} bytes)")
 
     if dry_run:
-        print(f"[DRY RUN] Would remove retired {home_dir}; <install>/config/ holds the relocated content post-#452")
+        print(f"[DRY RUN] Would remove retired {home_dir}")
     else:
         # Same try/except discipline as the rmtree in
         # `_retire_install_home_claude`: surface an operator-readable
@@ -3029,7 +3023,7 @@ def _retire_install_home_dir(install_path: Path, dry_run: bool) -> None:
         except OSError as exc:
             print(f"  ERROR: could not remove {home_dir}: {exc}")
             raise
-        print(f"  Removed retired {home_dir}; <install>/config/ holds the relocated content post-#452")
+        print(f"  Removed retired {home_dir}")
 
 
 def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool) -> None:
@@ -3039,14 +3033,10 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
     pyproject_src = PROJECT_ROOT / "pyproject.toml"
     pyproject_dst = install_path / "pyproject.toml"
     # Config templates (e.g. goose-config.yaml) referenced by later
-    # install steps like _apply_goose_config(). Root-owned since these
-    # are static templates, not runtime data. Issue #452 relocated
-    # this destination from `<install>/home/config/` to
-    # `<install>/config/`; the old `home/` parent is fully retired by
-    # `_retire_install_home_dir` below now that no install step
-    # writes under it. Per-user runtime CLAUDE.md is seeded by
-    # `_apply_migrate`'s home block (eager) and
-    # `backend.ensure_user_home` (lazy, first-message fallback);
+    # install steps like _apply_goose_config(). Root-owned since
+    # these are static templates, not runtime data. Per-user runtime
+    # CLAUDE.md is seeded by `_apply_migrate`'s home block (eager)
+    # and `backend.ensure_user_home` (lazy, first-message fallback);
     # neither touches the install tree.
     config_src = PROJECT_ROOT / "templates" / "config"
     config_dst = install_path / "config"
@@ -3079,10 +3069,10 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
         print(f"[DRY RUN] Would copy: {pyproject_src} -> {pyproject_dst}")
         if config_src.is_dir():
             print(f"[DRY RUN] Would copy: {config_src} -> {config_dst}")
-        # Issue #452: dry-run preview for the empty-home cleanup.
-        # Matches the live cleanup at the end of this function so the
-        # operator sees what would happen on an existing-install
-        # upgrade where `<install>/home/config/` still exists.
+        # Dry-run preview for the empty-home cleanup. Matches the
+        # live cleanup at the end of this function so the operator
+        # sees what would happen on an existing-install upgrade
+        # where `<install>/home/config/` still exists.
         _retire_install_home_dir(install_path, dry_run=True)
         return
 
@@ -3100,21 +3090,18 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
     # extension config from here. Root-owned since they're installer
     # input, not runtime output.
     if config_src.is_dir():
-        # `<install>/config/` may not exist yet on a fresh install.
-        # Pre-#452 this lived under `<install>/home/config/`; the
-        # parent mkdir below creates the new top-level location.
-        config_dst.parent.mkdir(parents=True, exist_ok=True)
+        # `_copy_tree` creates `config_dst` itself (`install_path` is
+        # guaranteed to exist by this point in the install flow, so
+        # no parent-creation step is needed here).
         _copy_tree(config_src, config_dst)
         _set_ownership(config_dst, 0, 0, recursive=True)
         print(f"  Copied config templates to {config_dst}")
 
-    # Issue #452: retire the now-empty `<install>/home/` directory.
-    # Pre-#452 it held `home/.claude/` (retired by #447), `home/IDENTITY.md`
-    # (retired by #447), and `home/config/` (relocated to `<install>/config/`
-    # by this change). On a clean install nothing under `<install>/home/`
-    # exists; on an existing-install upgrade the migration above has
-    # already removed `.claude/` and `IDENTITY.md`, and the relocation
-    # left an orphan `home/config/`. Cleanup catches both end states.
+    # Retire the now-vestigial `<install>/home/` directory. On a clean
+    # install nothing under it exists; on an existing-install upgrade
+    # the cleanup above has already removed `.claude/` and `IDENTITY.md`,
+    # and the goose-config relocation left an orphan `home/config/`.
+    # The helper handles both end states.
     _retire_install_home_dir(install_path, dry_run=False)
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -4027,8 +4027,8 @@ class TestRetireInstallHomeDir:
         assert "goose-config.yaml" in output
         assert "[DRY RUN] Would remove retired" in output
 
-    def test_idempotent_on_repeated_install(self, tmp_path, capsys):
-        """Second call over the cleaned state is a silent no-op."""
+    def test_silent_on_second_call(self, tmp_path, capsys):
+        """After a successful removal, the second call's no-op path is silent."""
         install = tmp_path / "install"
         (install / "home").mkdir(parents=True)
         _retire_install_home_dir(install, dry_run=False)
@@ -4037,6 +4037,86 @@ class TestRetireInstallHomeDir:
         assert not (install / "home").exists()
         second_output = capsys.readouterr().out
         assert "Removed retired" not in second_output
+
+    def test_refuses_when_files_subdir_present(self, tmp_path, capsys):
+        """
+        Existing-install upgrade with an un-migrated `home/files/` backup
+        tree: the helper must refuse to remove (the pre-DATA_DIR
+        uploaded-files migration in `_apply_migrate` still reads from
+        this path; destroying it before that migration runs would be
+        data loss). The directory is preserved and the operator sees
+        a clear refusal log naming the unexpected path.
+        """
+        install = tmp_path / "install"
+        files_dir = install / "home" / "files"
+        files_dir.mkdir(parents=True)
+        (files_dir / "uploaded.png").write_bytes(b"\x89PNG")
+        # Coexisting orphan goose-config does not change the outcome -
+        # the unexpected files/ subdir is the blocker.
+        (install / "home" / "config").mkdir()
+        (install / "home" / "config" / "goose-config.yaml").write_text("extensions: {}\n")
+
+        _retire_install_home_dir(install, dry_run=False)
+
+        # Directory and its contents are intact.
+        assert files_dir.is_dir()
+        assert (files_dir / "uploaded.png").is_file()
+        output = capsys.readouterr().out
+        assert "Refusing to remove" in output
+        assert "files" in output
+
+    def test_refuses_when_unexpected_top_level_entry(self, tmp_path, capsys):
+        """
+        Any top-level entry other than `config/` blocks removal. Covers
+        the future-code-change case where a new install step deposits
+        something under `<install>/home/`.
+        """
+        install = tmp_path / "install"
+        home_dir = install / "home"
+        home_dir.mkdir(parents=True)
+        (home_dir / "skills").mkdir()
+        (home_dir / "skills" / "example.md").write_text("# skill\n")
+
+        _retire_install_home_dir(install, dry_run=False)
+
+        assert (home_dir / "skills").is_dir()
+        output = capsys.readouterr().out
+        assert "Refusing to remove" in output
+        assert "skills" in output
+
+    def test_refuses_when_unexpected_file_in_config(self, tmp_path, capsys):
+        """
+        `home/config/` is allowed to contain only `goose-config.yaml`.
+        An extra file here also triggers refusal (an operator-placed
+        config override, a future template that should land under
+        `<install>/config/` instead, etc.).
+        """
+        install = tmp_path / "install"
+        config_dir = install / "home" / "config"
+        config_dir.mkdir(parents=True)
+        (config_dir / "goose-config.yaml").write_text("extensions: {}\n")
+        (config_dir / "claude-config.yaml").write_text("model: opus\n")
+
+        _retire_install_home_dir(install, dry_run=False)
+
+        assert (config_dir / "goose-config.yaml").is_file()
+        assert (config_dir / "claude-config.yaml").is_file()
+        output = capsys.readouterr().out
+        assert "Refusing to remove" in output
+        assert "claude-config.yaml" in output
+
+    def test_dry_run_predicts_refusal(self, tmp_path, capsys):
+        """Dry-run on a refusal pre-state emits the same message; no disk mutation."""
+        install = tmp_path / "install"
+        files_dir = install / "home" / "files"
+        files_dir.mkdir(parents=True)
+        (files_dir / "uploaded.png").write_bytes(b"\x89PNG")
+
+        _retire_install_home_dir(install, dry_run=True)
+
+        assert files_dir.is_dir()
+        output = capsys.readouterr().out
+        assert "[DRY RUN] Refusing to remove" in output
 
 
 # ── Per-user CLAUDE.md seed (in _apply_migrate's home block) ─────────

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3789,7 +3789,7 @@ class TestApplySource:
         assert "templates/config" not in output
 
     def test_copies_templates_config(self, tmp_path):
-        """templates/config/ is copied to <install>/config/ (post-#452)."""
+        """templates/config/ is copied to <install>/config/."""
         src = tmp_path / "source"
         (src / "src").mkdir(parents=True)
         (src / "src" / "module.py").write_text("code")
@@ -3967,11 +3967,11 @@ class TestRetireInstallHomeClaude:
 
 class TestRetireInstallHomeDir:
     """
-    Pins the wholesale retirement of `<install>/home/` (issue #452)
-    after the `<install>/home/config/` relocation to `<install>/config/`.
-    Three cases: directory missing (no-op), empty parent (clean
-    removal), and the existing-install upgrade where only the
-    orphaned `home/config/goose-config.yaml` remains.
+    Pins the wholesale retirement of `<install>/home/` after the
+    `<install>/home/config/` relocation to `<install>/config/`. Three
+    cases: directory missing (no-op), empty parent (clean removal),
+    and the existing-install upgrade where only the orphaned
+    `home/config/goose-config.yaml` remains.
     """
 
     def test_no_op_when_home_dir_missing(self, tmp_path):
@@ -3989,13 +3989,13 @@ class TestRetireInstallHomeDir:
         assert not (install / "home").exists()
         output = capsys.readouterr().out
         assert "Removed retired" in output
-        assert "<install>/config/" in output
+        assert str(install / "home") in output
 
     def test_removes_orphan_goose_config(self, tmp_path, capsys):
         """
         Existing-install upgrade: `<install>/home/config/goose-config.yaml`
-        still exists (from a pre-#452 install). The helper removes the
-        orphan file and the empty home/ parent, logging the file's
+        still exists (from before the relocation). The helper removes
+        the orphan file and the empty home/ parent, logging the file's
         byte size before deletion.
         """
         install = tmp_path / "install"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -39,6 +39,7 @@ from kai.install import (
     _generate_users_yaml,
     _migrate_identity_to_claude_md,
     _retire_install_home_claude,
+    _retire_install_home_dir,
     _set_ownership,
     _src_checksum,
     _start_service,
@@ -3788,7 +3789,7 @@ class TestApplySource:
         assert "templates/config" not in output
 
     def test_copies_templates_config(self, tmp_path):
-        """templates/config/ is copied to install/home/config/."""
+        """templates/config/ is copied to <install>/config/ (post-#452)."""
         src = tmp_path / "source"
         (src / "src").mkdir(parents=True)
         (src / "src" / "module.py").write_text("code")
@@ -3812,11 +3813,11 @@ class TestApplySource:
 
         # Verify the specific templates/config/ copy call rather than relying
         # on total call count (which depends on fixture state).
-        config_dst = install / "home" / "config"
+        config_dst = install / "config"
         config_calls = [c for c in mock_copy.call_args_list if c[0][0] == config_dir and c[0][1] == config_dst]
         assert len(config_calls) == 1
 
-        # home/config/ should be root-owned (static template, not runtime data)
+        # <install>/config/ should be root-owned (static template, not runtime data)
         own_calls = [c for c in mock_own.call_args_list if c[0] == (config_dst, 0, 0) and c[1].get("recursive") is True]
         assert len(own_calls) == 1
 
@@ -3830,7 +3831,8 @@ class TestApplySource:
             _apply_source(tmp_path / "install", svc_uid=1000, svc_gid=1000, dry_run=True)
         output = capsys.readouterr().out
         assert "templates/config" in output
-        # Should not create the directory during dry run
+        # Should not create the destination during dry run.
+        assert not (tmp_path / "install" / "config").exists()
         assert not (tmp_path / "install" / "home" / "config").exists()
 
 
@@ -3958,6 +3960,83 @@ class TestRetireInstallHomeClaude:
         assert not (install / "home" / ".claude").exists()
         assert "Removed dead" not in second_output
         assert "Removed legacy" not in second_output
+
+
+# ── _retire_install_home_dir ─────────────────────────────────────────
+
+
+class TestRetireInstallHomeDir:
+    """
+    Pins the wholesale retirement of `<install>/home/` (issue #452)
+    after the `<install>/home/config/` relocation to `<install>/config/`.
+    Three cases: directory missing (no-op), empty parent (clean
+    removal), and the existing-install upgrade where only the
+    orphaned `home/config/goose-config.yaml` remains.
+    """
+
+    def test_no_op_when_home_dir_missing(self, tmp_path):
+        """Fresh install: no <install>/home/, helper is a silent no-op."""
+        install = tmp_path / "install"
+        install.mkdir()
+        _retire_install_home_dir(install, dry_run=False)
+        assert not (install / "home").exists()
+
+    def test_removes_empty_home_dir(self, tmp_path, capsys):
+        """Empty <install>/home/ is removed cleanly with a summary line."""
+        install = tmp_path / "install"
+        (install / "home").mkdir(parents=True)
+        _retire_install_home_dir(install, dry_run=False)
+        assert not (install / "home").exists()
+        output = capsys.readouterr().out
+        assert "Removed retired" in output
+        assert "<install>/config/" in output
+
+    def test_removes_orphan_goose_config(self, tmp_path, capsys):
+        """
+        Existing-install upgrade: `<install>/home/config/goose-config.yaml`
+        still exists (from a pre-#452 install). The helper removes the
+        orphan file and the empty home/ parent, logging the file's
+        byte size before deletion.
+        """
+        install = tmp_path / "install"
+        old_config = install / "home" / "config" / "goose-config.yaml"
+        old_config.parent.mkdir(parents=True)
+        old_config.write_text("extensions: {}\n")
+
+        _retire_install_home_dir(install, dry_run=False)
+
+        assert not (install / "home").exists()
+        output = capsys.readouterr().out
+        assert "goose-config.yaml" in output
+        assert "Removing" in output  # per-file pre-rmtree line
+        assert "Removed retired" in output  # post-rmtree summary
+
+    def test_dry_run_predicts_orphan_cleanup(self, tmp_path, capsys):
+        """Dry-run preview names the file and the directory it would remove."""
+        install = tmp_path / "install"
+        old_config = install / "home" / "config" / "goose-config.yaml"
+        old_config.parent.mkdir(parents=True)
+        old_config.write_text("extensions: {}\n")
+
+        _retire_install_home_dir(install, dry_run=True)
+
+        # Dry run does not touch disk.
+        assert old_config.exists()
+        output = capsys.readouterr().out
+        assert "[DRY RUN] Would remove" in output
+        assert "goose-config.yaml" in output
+        assert "[DRY RUN] Would remove retired" in output
+
+    def test_idempotent_on_repeated_install(self, tmp_path, capsys):
+        """Second call over the cleaned state is a silent no-op."""
+        install = tmp_path / "install"
+        (install / "home").mkdir(parents=True)
+        _retire_install_home_dir(install, dry_run=False)
+        capsys.readouterr()  # discard first run
+        _retire_install_home_dir(install, dry_run=False)
+        assert not (install / "home").exists()
+        second_output = capsys.readouterr().out
+        assert "Removed retired" not in second_output
 
 
 # ── Per-user CLAUDE.md seed (in _apply_migrate's home block) ─────────
@@ -4434,7 +4513,7 @@ class TestApplyGooseConfig:
     def _setup(self, tmp_path):
         """Create a minimal install tree with the goose config template."""
         install_path = tmp_path / "opt" / "kai"
-        config_dir = install_path / "home" / "config"
+        config_dir = install_path / "config"
         config_dir.mkdir(parents=True)
         (config_dir / "goose-config.yaml").write_text("extensions: {}\n")
         return install_path


### PR DESCRIPTION
Closes #452. Follow-up to #447.

## Summary

After #447 retired `<install>/home/.claude/` and the legacy `IDENTITY.md`, `<install>/home/` existed for one purpose only: hosting `<install>/home/config/goose-config.yaml`. This PR relocates that file to `<install>/config/` and retires the vestigial parent.

- `_apply_source`'s `config_dst` -> `install_path / "config"`. Source side (`templates/config/`) unchanged.
- `_apply_goose_config` reads from the new path.
- New `_retire_install_home_dir(install_path, dry_run)` helper next to `_retire_install_home_claude`. Idempotent, dry-run parity, OSError surfaces with a clear line before re-raise. Catches three end states: fresh install (silent no-op), existing-install upgrade with orphan `home/config/goose-config.yaml` (logs file removal + summary), post-cleanup reinstall (silent no-op).

## Test plan

- [x] `make check` passes; lint clean.
- [x] `make test` passes (2829 tests, 1 skipped; +5 from main).
- [x] `TestRetireInstallHomeDir` (5 cases): missing-dir, empty-dir, orphan-goose-config-removal, dry-run preview, idempotency.
- [x] Updated `TestApplySource.test_copies_templates_config` and `test_dry_run_includes_templates_config` to assert the new destination.
- [x] Updated `TestApplyGooseConfig._setup` to seed the new path.
- [x] `grep -rn 'home/config' src/ tests/` returns only hits inside `_retire_install_home_dir`'s own docstring/comments (describing the retired path) and the new test class's narrative — no live path references.

## Operator cleanup note

On the next `make install` after this lands, install output will name `<install>/home/config/goose-config.yaml` removal plus `Removed retired <install>/home/; <install>/config/ holds the relocated content post-#452`. After the install completes, `<install>/home/` is gone for good.
