### PR TITLE
fix: unstick inner Claude spawn when target os_user differs from service user

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -621,8 +621,20 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
     # instead of 0o755. That blocks group traversal and can break the
     # inner subprocess when sudo -u targets a different identity. Force
     # the intended bits explicitly - this is the same pattern install.py
-    # `_apply_migrate` uses after its mkdir calls. Idempotent on reuse.
-    os.chmod(path, 0o755)
+    # `_apply_migrate` uses after its mkdir calls.
+    #
+    # Swallow OSError because in a multi-user install the directory has
+    # already been chowned to the user's os_user (different from the
+    # service user) by install.py `_apply_migrate`, and macOS chmod(2)
+    # returns EPERM for any non-owner non-root caller even when the
+    # target mode equals the current mode. The umask defense only
+    # matters when *this* call creates the directory; a pre-existing
+    # dir is the install's responsibility to set perms on, and the
+    # sibling bootstraps below already use the same swallow pattern.
+    try:
+        os.chmod(path, 0o755)
+    except OSError:
+        pass
 
     # Lazy bootstrap of `<home>/.claude/CLAUDE.md`. Parallel to
     # ensure_user_memory and ensure_user_preferences: stat, possible

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -623,17 +623,18 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
     # the intended bits explicitly - this is the same pattern install.py
     # `_apply_migrate` uses after its mkdir calls.
     #
-    # Swallow OSError because in a multi-user install the directory has
-    # already been chowned to the user's os_user (different from the
-    # service user) by install.py `_apply_migrate`, and macOS chmod(2)
-    # returns EPERM for any non-owner non-root caller even when the
-    # target mode equals the current mode. The umask defense only
-    # matters when *this* call creates the directory; a pre-existing
-    # dir is the install's responsibility to set perms on, and the
-    # sibling bootstraps below already use the same swallow pattern.
+    # Swallow PermissionError because in a multi-user install the
+    # directory has already been chowned to the user's os_user
+    # (different from the service user) by install.py `_apply_migrate`,
+    # and macOS chmod(2) returns EPERM for any non-owner non-root caller
+    # even when the target mode equals the current mode. The umask
+    # defense only matters when *this* call creates the directory; a
+    # pre-existing dir is the install's responsibility to set perms on.
+    # Narrow to PermissionError rather than bare OSError so unrelated
+    # failure modes (ENOENT, ENOTDIR, EIO) still propagate.
     try:
         os.chmod(path, 0o755)
-    except OSError:
+    except PermissionError:
         pass
 
     # Lazy bootstrap of `<home>/.claude/CLAUDE.md`. Parallel to

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1657,11 +1657,18 @@ def _generate_sudoers(
         target_users.append(candidate)
 
     if target_users:
-        # Resolve the actual binary location; fall back to the native installer's
-        # default path under the service user's home if claude is not on PATH
-        # (e.g., when running under sudo with a stripped environment).
+        # Anchor the rule path to the SERVICE user's claude install. The
+        # bot spawns `sudo -u <target> -- claude` and sudo resolves the
+        # bare `claude` against the caller's PATH (the service user's,
+        # not the target's), so the rule must reference the service
+        # user's binary. shutil.which("claude") used to be the first
+        # half of this expression but resolved against whatever PATH
+        # root happened to have when `sudo make install` ran - which
+        # picked up any user's `~/.local/bin/claude` that happened to
+        # be on PATH at install time, baking the wrong path into the
+        # rule and breaking the bot's sudo dispatch.
         svc_home = _user_home(service_user)
-        claude_bin = shutil.which("claude") or f"{svc_home}/.local/bin/claude"
+        claude_bin = f"{svc_home}/.local/bin/claude"
         # SETENV: allows the service user to pass env vars (e.g.,
         # KAI_WEBHOOK_SECRET) through sudo to the claude process.
         # Scoped to per-user rules only; cat/tee rules remain locked down.

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -3395,6 +3395,28 @@ def _apply_sudoers(
     os_users = _collect_os_users_from_yaml(users_yaml_path)
     sudoers_content = _generate_sudoers(service_user, claude_user, os_users)
 
+    # Backstop check: the per-user rules pin the claude binary to
+    # {service_user_home}/.local/bin/claude (the native-installer
+    # location and where the bot's runtime PATH resolves `claude`).
+    # If the service user installed claude somewhere else (Homebrew,
+    # npm global, pipx), the rule will point at a nonexistent or
+    # mismatched binary and the bot's sudo dispatch will fail at
+    # runtime with no obvious cause. Warn loudly but do not abort -
+    # the warning catches the simple "wrong path" case; the operator
+    # still owns the symlink or reinstall to make the paths agree.
+    has_target_users = bool(claude_user) or bool(os_users)
+    if has_target_users:
+        expected_bin = Path(f"{_user_home(service_user)}/.local/bin/claude")
+        if not expected_bin.exists():
+            print(
+                f"Warning: {expected_bin} not found; sudoers rule may point at "
+                "a nonexistent binary. The bot's runtime spawn resolves bare "
+                "`claude` against the service user's PATH - install claude via "
+                "the native installer (`~/.local/bin/claude`) or symlink your "
+                "existing install there to keep the rule and runtime in sync.",
+                file=sys.stderr,
+            )
+
     if dry_run:
         print(f"[DRY RUN] Would write: {sudoers_path} (mode 0440)")
         print("[DRY RUN] Would validate with visudo -cf")

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -8,6 +8,7 @@ and the ApiContext/AgentResponse/StreamEvent data types. These functions are pur
 """
 
 import logging
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -803,6 +804,46 @@ class TestEnsureUserHome:
         assert claude_dst.is_file()
         # Placeholder mirrors the MEMORY.md / PREFERENCES.md precedent.
         assert claude_dst.read_text() == "# Identity\n"
+
+    def test_chmod_eperm_does_not_crash(self, tmp_path):
+        """
+        Regression for issue #454-adjacent install bug: when the per-user
+        home directory already exists owned by a different OS user
+        (because install.py `_apply_migrate` chowned it to the user's
+        `os_user`), the chmod call must NOT propagate EPERM. macOS
+        chmod(2) returns EPERM for any non-owner non-root caller, even
+        when the target mode equals the current mode, so the chmod-as-
+        no-op trick is not safe in a multi-user install.
+
+        Without the swallow, `pool.get` → `_create_instance` →
+        `resolve_home_workspace` → `ensure_user_home` raises, the bot
+        cannot create the per-user backend, and every Telegram message
+        for that chat fails with "Claude process died" with no further
+        diagnostic.
+        """
+        # The directory exists when ensure_user_home is called (parents=
+        # True + exist_ok=True mirrors that path). chmod then raises.
+        target = tmp_path / "home" / "12345"
+        target.mkdir(parents=True)
+
+        real_chmod = os.chmod
+
+        def chmod_eperm(path, mode, **kwargs):
+            # Match the production failure shape: EPERM only on the
+            # per-user dir we are trying to harden; let any other chmod
+            # call (e.g. inside the .claude/ seed branch via shutil.copy2)
+            # fall through to the real implementation. The **kwargs catch
+            # is needed because shutil.copy2 passes follow_symlinks=True.
+            if str(path) == str(target):
+                raise PermissionError(1, "Operation not permitted", str(path))
+            real_chmod(path, mode, **kwargs)
+
+        with patch("kai.backend.os.chmod", side_effect=chmod_eperm):
+            # Must not raise. The caller depends on this returning the
+            # path so the session context build can proceed.
+            result = ensure_user_home(12345, tmp_path)
+
+        assert result == target
 
     def test_seed_swallows_oserror(self, tmp_path):
         """

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -4582,6 +4582,49 @@ class TestApplySudoersDryRun:
         assert "DRY RUN" in output
         assert "sudoers" in output.lower() or "visudo" in output.lower()
 
+    def test_warns_when_claude_bin_missing(self, tmp_path, capsys, monkeypatch):
+        """Warning printed when the rule's claude binary path doesn't exist."""
+        svc_home = tmp_path / "home" / "kai"
+        svc_home.mkdir(parents=True)
+        # Intentionally do NOT create svc_home/.local/bin/claude.
+        monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
+
+        _apply_sudoers("kai", dry_run=True, users_yaml_path=users_yaml)
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert str(svc_home / ".local" / "bin" / "claude") in captured.err
+
+    def test_no_warning_when_no_target_users(self, tmp_path, capsys, monkeypatch):
+        """No warning when there are no per-user rules to emit."""
+        svc_home = tmp_path / "home" / "kai"
+        svc_home.mkdir(parents=True)
+        monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users: []\n")
+
+        _apply_sudoers("kai", dry_run=True, users_yaml_path=users_yaml)
+
+        captured = capsys.readouterr()
+        assert "Warning" not in captured.err
+
+    def test_no_warning_when_claude_bin_exists(self, tmp_path, capsys, monkeypatch):
+        """Path exists -> silent."""
+        svc_home = tmp_path / "home" / "kai"
+        bin_dir = svc_home / ".local" / "bin"
+        bin_dir.mkdir(parents=True)
+        (bin_dir / "claude").write_text("#!/bin/sh\n")
+        monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
+
+        _apply_sudoers("kai", dry_run=True, users_yaml_path=users_yaml)
+
+        captured = capsys.readouterr()
+        assert "Warning" not in captured.err
+
 
 # ── _apply_service dry run ───────────────────────────────────────────
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -348,20 +348,43 @@ class TestGenerateSudoers:
         result = _generate_sudoers("kai")
         assert "claude" not in result
 
-    def test_claude_user_rule_with_which(self, monkeypatch):
-        """Uses shutil.which to resolve the claude binary location."""
-        real_which = shutil.which
-        monkeypatch.setattr(shutil, "which", lambda n: "/usr/local/bin/claude" if n == "claude" else real_which(n))
-        result = _generate_sudoers("kai", claude_user="alice")
-        assert "kai ALL=(alice) SETENV: NOPASSWD: /usr/local/bin/claude" in result
-
-    def test_claude_user_rule_fallback(self, monkeypatch):
-        """Falls back to service user home when claude is not on PATH."""
+    def test_claude_user_rule_anchored_to_service_user_home(self, monkeypatch):
+        """
+        The rule's claude binary path is anchored to the SERVICE user's
+        home (~/.local/bin/claude under the service user, NOT the target
+        user), because the bot's runtime spawn is `sudo -u <target> --
+        claude` and sudo resolves the bare `claude` against the caller's
+        (service user's) PATH. The rule path must match what sudo will
+        actually try to execute.
+        """
         monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
-        real_which = shutil.which
-        monkeypatch.setattr(shutil, "which", lambda n: None if n == "claude" else real_which(n))
         result = _generate_sudoers("kai", claude_user="alice")
         assert "kai ALL=(alice) SETENV: NOPASSWD: /home/kai/.local/bin/claude" in result
+
+    def test_claude_bin_ignores_caller_path(self, monkeypatch):
+        """
+        Regression for issue #454-adjacent install bug: the rule's claude
+        binary path must NOT depend on whatever PATH the install caller
+        happens to have. Pre-fix, `shutil.which("claude")` resolved
+        against root's PATH at install time and silently baked a
+        non-service-user binary path into the rule (e.g. when `sudo make
+        install` was launched from a shell with another user's
+        `~/.local/bin` on PATH), breaking the bot's sudo dispatch on
+        every subsequent message.
+        """
+        monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
+        # Caller's PATH would resolve `claude` to a completely different
+        # location; the generator must ignore this and anchor on the
+        # service user's home.
+        real_which = shutil.which
+        monkeypatch.setattr(
+            shutil,
+            "which",
+            lambda n: "/some/other/users/local/bin/claude" if n == "claude" else real_which(n),
+        )
+        result = _generate_sudoers("kai", claude_user="alice")
+        assert "/home/kai/.local/bin/claude" in result
+        assert "/some/other/users/local/bin/claude" not in result
 
     # -- Issue #341: per-user rules from users.yaml -----------------------
 
@@ -375,28 +398,23 @@ class TestGenerateSudoers:
     def test_one_os_user_emits_one_rule(self, monkeypatch):
         """Acceptance (b): one os_user → one matching rule."""
         monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
-        real_which = shutil.which
-        monkeypatch.setattr(shutil, "which", lambda n: "/usr/bin/claude" if n == "claude" else real_which(n))
         result = _generate_sudoers("kai", os_users=["sellison"])
-        assert result.count("SETENV: NOPASSWD: /usr/bin/claude") == 1
-        assert "kai ALL=(sellison) SETENV: NOPASSWD: /usr/bin/claude" in result
+        assert result.count("SETENV: NOPASSWD: /home/kai/.local/bin/claude") == 1
+        assert "kai ALL=(sellison) SETENV: NOPASSWD: /home/kai/.local/bin/claude" in result
 
     def test_multiple_os_users_emit_one_rule_each(self, monkeypatch):
         """Acceptance (c): multiple distinct os_users → one rule each."""
         monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
-        real_which = shutil.which
-        monkeypatch.setattr(shutil, "which", lambda n: "/usr/bin/claude" if n == "claude" else real_which(n))
         result = _generate_sudoers("kai", os_users=["sellison", "bob", "carol"])
-        assert "kai ALL=(sellison) SETENV: NOPASSWD: /usr/bin/claude" in result
-        assert "kai ALL=(bob) SETENV: NOPASSWD: /usr/bin/claude" in result
-        assert "kai ALL=(carol) SETENV: NOPASSWD: /usr/bin/claude" in result
-        assert result.count("SETENV: NOPASSWD: /usr/bin/claude") == 3
+        bin_path = "/home/kai/.local/bin/claude"
+        assert f"kai ALL=(sellison) SETENV: NOPASSWD: {bin_path}" in result
+        assert f"kai ALL=(bob) SETENV: NOPASSWD: {bin_path}" in result
+        assert f"kai ALL=(carol) SETENV: NOPASSWD: {bin_path}" in result
+        assert result.count(f"SETENV: NOPASSWD: {bin_path}") == 3
 
     def test_duplicate_os_users_deduped(self, monkeypatch):
         """Acceptance (c, dedupe): repeated os_user values produce one rule."""
         monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
-        real_which = shutil.which
-        monkeypatch.setattr(shutil, "which", lambda n: "/usr/bin/claude" if n == "claude" else real_which(n))
         result = _generate_sudoers("kai", os_users=["sellison", "sellison", "bob"])
         assert result.count("(sellison)") == 1
         assert result.count("(bob)") == 1
@@ -404,20 +422,17 @@ class TestGenerateSudoers:
     def test_os_user_matching_service_user_skipped(self, monkeypatch):
         """Acceptance (d): os_user == service_user → no rule (self-sudo path)."""
         monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
-        real_which = shutil.which
-        monkeypatch.setattr(shutil, "which", lambda n: "/usr/bin/claude" if n == "claude" else real_which(n))
         result = _generate_sudoers("kai", os_users=["kai", "sellison"])
         # No self-sudo rule: kai ALL=(kai) would be a dead rule, since
         # resolve_claude_user() short-circuits the sudo wrapper at runtime.
         assert "kai ALL=(kai)" not in result
-        assert "kai ALL=(sellison) SETENV: NOPASSWD: /usr/bin/claude" in result
-        assert result.count("SETENV: NOPASSWD: /usr/bin/claude") == 1
+        bin_path = "/home/kai/.local/bin/claude"
+        assert f"kai ALL=(sellison) SETENV: NOPASSWD: {bin_path}" in result
+        assert result.count(f"SETENV: NOPASSWD: {bin_path}") == 1
 
     def test_legacy_claude_user_combined_with_os_users(self, monkeypatch):
         """Legacy CLAUDE_USER and yaml os_users coexist; deduped."""
         monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
-        real_which = shutil.which
-        monkeypatch.setattr(shutil, "which", lambda n: "/usr/bin/claude" if n == "claude" else real_which(n))
         # claude_user and os_users overlap on "alice"; should produce one rule.
         result = _generate_sudoers("kai", claude_user="alice", os_users=["alice", "bob"])
         assert result.count("(alice)") == 1


### PR DESCRIPTION
## Summary

Two install-introduced bugs that together blocked the inner Claude subprocess from spawning when a chat's `os_user` in users.yaml is a different OS user than the bot's service user. Surfaced today on a fresh install configured with a non-service `os_user`.

1. **`install.py:_generate_sudoers`** pinned the rule's `claude` binary path via `shutil.which("claude")`, which resolved against whatever PATH root happened to have at install time. When `sudo make install` was launched from a shell with another user's `~/.local/bin` on PATH, the wrong binary path got baked into the sudoers rule. The bot's runtime call is `sudo -u <target> -- claude`, which sudo resolves against the caller's (service user's) PATH; the resolved path did not match the rule's path, sudo demanded a password, and every message failed with `Failed to write to Claude process: Connection lost`.

   **Fix:** always anchor `claude_bin` to `{service_user_home}/.local/bin/claude`. Drop the `shutil.which` short-circuit. The bot's runtime spawn always resolves bare `claude` from the service user's PATH, so the rule must reference the service user's binary regardless of what was on PATH at install time.

2. **`backend.ensure_user_home`** chmod'd the per-user home directory to `0o755` on every instance creation. After `install.py _apply_migrate` chowned that directory to the user's `os_user`, the bot (running as the service user) hit `EPERM` on chmod -- macOS denies chmod by non-owner non-root callers even when the target mode equals the current mode, so the chmod-as-idempotent-no-op trick is not safe in a multi-user install. The exception propagated up through `pool.get` -> `_create_instance`, so the bot could not even reach the spawn for that chat and every message died at instance creation.

   **Fix:** wrap the chmod in `try/except OSError`. The umask defense (force `0o755` even under a hostile `umask 0o027`) only matters when *this* call creates the directory; a pre-existing dir with install-time per-user ownership is the install's responsibility to set the mode on. The sibling bootstraps (`ensure_user_memory`, `ensure_user_preferences`) already use the same `OSError`-swallow pattern.

Related: #454 (`/tmp/claude-settings-<hex>.json` collision across OS users sharing the same `--settings` JSON) is the third leg of today's failure chain and needs its own design pass; not in scope here.

## Changes

- `src/kai/install.py` -- drop `shutil.which("claude")`; anchor `claude_bin` to `{service_user_home}/.local/bin/claude`.
- `src/kai/backend.py` -- wrap `ensure_user_home`'s `os.chmod` in `try/except OSError` with a comment explaining the multi-user-install rationale.
- `tests/test_install.py::TestGenerateSudoers` -- existing tests that monkeypatched `shutil.which("claude")` updated to drop the patch and assert the service-user-home-anchored path. New regression test `test_claude_bin_ignores_caller_path` pins the new behavior: even when `shutil.which` returns a non-service-user path, the rule must NOT use it.
- `tests/test_backend.py::TestEnsureUserHome::test_chmod_eperm_does_not_crash` -- new regression test patching `os.chmod` to raise `PermissionError` only on the per-user dir. Without the swallow, the test fails with `PermissionError` escaping `ensure_user_home`.

## Test plan

- [x] `make check` clean.
- [x] `make test` passes (2834 tests, 1 skipped; +1 net new vs main).
- [x] Live verified end-to-end: bot spawns inner Claude as the operator's distinct `os_user`, Telegram message round-trips successfully.

## Diagnostic note (out of scope, captured for follow-up)

The original investigation was blocked by the inner Claude's stderr being drained at `DEBUG`, below the default `INFO` threshold. A separate follow-up to surface that drain at `WARNING` (or rate-limited `INFO`) would make the next class of crash-on-spawn self-diagnosing without needing a temporary code patch + reinstall to see the cause.
