### PR TITLE
refactor: async cross-user kill helpers to unblock event loop (closes #459)

### DIFF
--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -402,6 +402,12 @@ class ClaudeCodeBackend(AgentBackend):
         need to signal after sudo has been killed must rely on the
         cache (pgrep returns nothing on a reaped sudo). _kill primes
         the cache before its first signal for this reason.
+
+        Synchronous variant used by the sync `_send_signal` path
+        (which is called from `force_kill`, also sync). The async
+        sites (`_kill`, `shutdown`) call `_async_lookup_inner_claude_pid`
+        instead so they do not block the event loop on the pgrep
+        invocation. See #459.
         """
         if self._proc is None:
             return None
@@ -424,6 +430,146 @@ class ClaudeCodeBackend(AgentBackend):
             return int(first_line)
         except ValueError:
             return None
+
+    async def _async_lookup_inner_claude_pid(self) -> int | None:
+        """
+        Async pgrep equivalent of `_lookup_inner_claude_pid` (#459).
+
+        Same semantics as the synchronous version - returns the inner
+        claude PID by querying pgrep against the sudo wrapper's PID -
+        but uses `asyncio.create_subprocess_exec` so the event loop
+        is not blocked while pgrep runs. Called from `_kill` and
+        `shutdown`; the sync variant remains for the `force_kill`
+        path. The 2s ceiling matches the sync version's timeout.
+        """
+        if self._proc is None:
+            return None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "pgrep",
+                "-P",
+                str(self._proc.pid),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+        except (OSError, FileNotFoundError):
+            return None
+        try:
+            stdout_bytes, _ = await asyncio.wait_for(proc.communicate(), timeout=2)
+        except TimeoutError:
+            # pgrep is hung; reap it so we do not leak a child and
+            # return None as if no PID was found.
+            proc.kill()
+            try:
+                await proc.wait()
+            except OSError:
+                pass
+            return None
+        if proc.returncode != 0:
+            return None
+        first_line = stdout_bytes.decode(errors="replace").strip().split("\n", 1)[0]
+        if not first_line:
+            return None
+        try:
+            return int(first_line)
+        except ValueError:
+            return None
+
+    async def _async_send_signal_for_close(self, sig: int) -> None:
+        """
+        Async equivalent of `_send_signal` used by `_kill` and
+        `shutdown` (#459).
+
+        Same three-step structure as the sync version:
+        1. Cross-user mode: prime the inner-claude-PID cache (async
+           pgrep) and signal the inner claude through `sudo -n -u
+           <target> /bin/kill` (async subprocess).
+        2. Wrapper reap via `os.killpg` (non-blocking syscall, sync
+           is fine).
+        3. Single-user mode: `_proc.send_signal` (also non-blocking).
+
+        Steps 1's blocking surface is moved off the event loop; the
+        sync `_send_signal` remains for `force_kill` (which is sync
+        by public-API contract).
+        """
+        if self._pgid is not None:
+            if self._effective_claude_user is not None:
+                if self._inner_claude_pid is None:
+                    self._inner_claude_pid = await self._async_lookup_inner_claude_pid()
+                if self._inner_claude_pid is not None:
+                    await self._async_sudo_kill(
+                        self._effective_claude_user,
+                        self._inner_claude_pid,
+                        int(sig),
+                    )
+            try:
+                os.killpg(self._pgid, sig)
+            except OSError:
+                pass
+        elif self._proc is not None:
+            try:
+                self._proc.send_signal(sig)
+            except OSError:
+                pass
+
+    async def _async_sudo_kill(self, target_user: str, pid: int, sig: int) -> None:
+        """
+        Run `sudo -n -u <target> /bin/kill -<sig> <pid>` without blocking
+        the event loop (#459).
+
+        Equivalent to the synchronous `subprocess.run` call inside
+        `_send_signal` and the final-cleanup blocks of `_kill`/
+        `shutdown`, but uses `asyncio.create_subprocess_exec` so a
+        long-running sudo or kill (system pathology) does not stall
+        other coroutines. The 5s ceiling matches the sync ceiling.
+
+        Logs at WARNING when sudo returns non-zero so a missing
+        sudoers rule, an ESRCH on a double-kill, or any other
+        failure mode surfaces in the operator-facing log instead
+        of silently leaking an orphan (same diagnostic contract
+        the sync path adopts in #458/M1).
+
+        Silent on TimeoutError and OSError: same failure-mode
+        swallow as the sync path. The caller has no remedy for
+        a hung sudo or a missing /bin/kill; logging the timeout
+        once at WARNING is the best we can do.
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "sudo",
+                "-n",
+                "-u",
+                target_user,
+                "/bin/kill",
+                f"-{int(sig)}",
+                str(pid),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except (OSError, FileNotFoundError):
+            return
+        try:
+            _, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=5)
+        except TimeoutError:
+            proc.kill()
+            try:
+                await proc.wait()
+            except OSError:
+                pass
+            log.warning(
+                "async sudo kill timed out after 5s (target=%s, pid=%d, sig=%d); inner claude may orphan",
+                target_user,
+                pid,
+                int(sig),
+            )
+            return
+        if proc.returncode != 0:
+            log.warning(
+                "sudo kill escalation failed (rc=%d, stderr=%r); inner claude pid=%d may orphan",
+                proc.returncode,
+                stderr_bytes[:200].decode(errors="replace") if stderr_bytes else "",
+                pid,
+            )
 
     def _send_signal(self, sig: int) -> None:
         """
@@ -1085,17 +1231,25 @@ class ClaudeCodeBackend(AgentBackend):
             # out. Once the killpg below reaps the sudo wrapper,
             # pgrep -P <dead_sudo_pid> returns nothing and we lose
             # the only handle on the orphaned grandchild. The cache
-            # survives the _send_signal->killpg sequence so the
-            # final-cleanup sudo-kill below can still reach the
-            # inner claude. See issue #456. Only attempt when we
-            # actually have a sudo target to escalate to; without
+            # survives the per-signal escalation + killpg sequence
+            # so the final-cleanup sudo-kill below can still reach
+            # the inner claude. See issue #456. Only attempt when
+            # we actually have a sudo target to escalate to; without
             # _effective_claude_user the lookup result is useless.
+            #
+            # Async pgrep variant so the event loop is not blocked
+            # waiting for the lookup. See #459.
             saved_user = self._effective_claude_user
             if saved_user is not None and self._inner_claude_pid is None:
-                self._inner_claude_pid = self._lookup_inner_claude_pid()
+                self._inner_claude_pid = await self._async_lookup_inner_claude_pid()
             saved_inner_pid = self._inner_claude_pid
 
-            self._send_signal(signal.SIGKILL)
+            # Cross-user escalation (#456) + wrapper killpg / single-
+            # user direct signal. Routed through the async helper so
+            # the event loop stays responsive while sudo + kill
+            # complete. See #459.
+            await self._async_send_signal_for_close(signal.SIGKILL)
+
             try:
                 await asyncio.wait_for(self._proc.wait(), timeout=5)
             except TimeoutError:
@@ -1138,35 +1292,13 @@ class ClaudeCodeBackend(AgentBackend):
             # - pgrep failed to find a child PID at any point
             #   (sudo never forked, or sudo died with no child),
             # - the inner claude is already dead (sudo kill returns
-            #   ESRCH; sudo exits 1; we ignore via check=False).
+            #   ESRCH; sudo exits 1; logged at WARNING by
+            #   _async_sudo_kill).
+            #
+            # Async sudo-kill so the event loop is not blocked on the
+            # 5s ceiling. See #459.
             if saved_user is not None and saved_inner_pid is not None:
-                try:
-                    # /bin/kill (not bare "kill") so sudo cannot
-                    # resolve to a different binary than the
-                    # sudoers rule names. See #458 review.
-                    result = subprocess.run(
-                        [
-                            "sudo",
-                            "-n",
-                            "-u",
-                            saved_user,
-                            "/bin/kill",
-                            "-9",
-                            str(saved_inner_pid),
-                        ],
-                        capture_output=True,
-                        timeout=5,
-                        check=False,
-                    )
-                    if result.returncode != 0:
-                        log.warning(
-                            "final-cleanup sudo kill -9 failed (rc=%d, stderr=%r); inner claude pid=%d may orphan",
-                            result.returncode,
-                            result.stderr[:200].decode(errors="replace") if result.stderr else "",
-                            saved_inner_pid,
-                        )
-                except (subprocess.TimeoutExpired, OSError):
-                    pass
+                await self._async_sudo_kill(saved_user, saved_inner_pid, int(signal.SIGKILL))
 
     async def shutdown(self) -> None:
         """
@@ -1210,16 +1342,24 @@ class ClaudeCodeBackend(AgentBackend):
                 # rationale as _kill; see issue #456. Gated on
                 # _effective_claude_user because without a sudo
                 # target the lookup result is useless.
+                #
+                # Async pgrep variant so the event loop stays
+                # responsive while pgrep runs. See #459.
                 saved_user = self._effective_claude_user
                 if saved_user is not None and self._inner_claude_pid is None:
-                    self._inner_claude_pid = self._lookup_inner_claude_pid()
+                    self._inner_claude_pid = await self._async_lookup_inner_claude_pid()
                 saved_inner_pid = self._inner_claude_pid
 
-                self._send_signal(signal.SIGTERM)
+                # Per-signal cross-user escalation runs ASYNC here so
+                # the event loop is not stalled while sudo + kill
+                # complete. killpg is a non-blocking syscall and
+                # stays sync; single-user fallback uses _proc.
+                # send_signal (also non-blocking). See #459.
+                await self._async_send_signal_for_close(signal.SIGTERM)
                 try:
                     await asyncio.wait_for(self._proc.wait(), timeout=5)
                 except TimeoutError:
-                    self._send_signal(signal.SIGKILL)
+                    await self._async_send_signal_for_close(signal.SIGKILL)
                     try:
                         await asyncio.wait_for(self._proc.wait(), timeout=5)
                     except TimeoutError:
@@ -1257,31 +1397,8 @@ class ClaudeCodeBackend(AgentBackend):
         # process directly, so killpg above can leave the inner
         # claude orphaned to init. Skipped silently when the spawn
         # was not in cross-user mode or pgrep never found a child.
+        #
+        # Async sudo-kill so the event loop is not blocked on the
+        # 5s ceiling. See #459.
         if saved_user is not None and saved_inner_pid is not None:
-            try:
-                # /bin/kill absolute path so sudo's secure_path
-                # resolution matches the sudoers rule exactly.
-                # See #458 review.
-                result = subprocess.run(
-                    [
-                        "sudo",
-                        "-n",
-                        "-u",
-                        saved_user,
-                        "/bin/kill",
-                        "-9",
-                        str(saved_inner_pid),
-                    ],
-                    capture_output=True,
-                    timeout=5,
-                    check=False,
-                )
-                if result.returncode != 0:
-                    log.warning(
-                        "shutdown sudo kill -9 failed (rc=%d, stderr=%r); inner claude pid=%d may orphan",
-                        result.returncode,
-                        result.stderr[:200].decode(errors="replace") if result.stderr else "",
-                        saved_inner_pid,
-                    )
-            except (subprocess.TimeoutExpired, OSError):
-                pass
+            await self._async_sudo_kill(saved_user, saved_inner_pid, int(signal.SIGKILL))

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -459,7 +459,18 @@ class ClaudeCodeBackend(AgentBackend):
         except TimeoutError:
             # pgrep is hung; reap it so we do not leak a child and
             # return None as if no PID was found.
-            proc.kill()
+            #
+            # Guard proc.kill() against the race where pgrep exits
+            # between wait_for timing out and the kill() call:
+            # asyncio.subprocess.Process.kill() delegates to
+            # os.kill(pid, SIGKILL), which raises
+            # ProcessLookupError (an OSError subclass) on an
+            # already-dead PID. Swallow because the outcome we
+            # wanted (process gone) is already true.
+            try:
+                proc.kill()
+            except OSError:
+                pass
             try:
                 await proc.wait()
             except OSError:
@@ -488,7 +499,7 @@ class ClaudeCodeBackend(AgentBackend):
            is fine).
         3. Single-user mode: `_proc.send_signal` (also non-blocking).
 
-        Steps 1's blocking surface is moved off the event loop; the
+        Step 1's blocking surface is moved off the event loop; the
         sync `_send_signal` remains for `force_kill` (which is sync
         by public-API contract).
         """
@@ -551,7 +562,15 @@ class ClaudeCodeBackend(AgentBackend):
         try:
             _, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=5)
         except TimeoutError:
-            proc.kill()
+            # Same race guard as _async_lookup_inner_claude_pid:
+            # proc.kill() can raise ProcessLookupError if sudo
+            # exited between wait_for timing out and the kill()
+            # call. Swallow because the outcome we wanted
+            # (process gone) is already true.
+            try:
+                proc.kill()
+            except OSError:
+                pass
             try:
                 await proc.wait()
             except OSError:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -2383,9 +2383,10 @@ class TestLookupInnerClaudePid:
 def _fake_async_proc(returncode: int, stdout: bytes = b"", stderr: bytes = b""):
     """
     Build a fake asyncio.subprocess.Process for tests that patch
-    asyncio.create_subprocess_exec. Returns a MagicMock with the
-    methods _async_lookup_inner_claude_pid / _async_sudo_kill
-    actually call: communicate(), wait(), kill().
+    asyncio.create_subprocess_exec. Returns a MagicMock that surfaces
+    the communicate(), wait(), and kill() interface that
+    _async_lookup_inner_claude_pid and _async_sudo_kill actually
+    invoke.
     """
     proc = MagicMock()
     proc.returncode = returncode
@@ -2458,6 +2459,30 @@ class TestAsyncLookupInnerClaudePid:
             assert await claude._async_lookup_inner_claude_pid() is None
         # Hung pgrep must be reaped, not leaked.
         fake.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_timeout_handler_swallows_process_lookup_error_on_kill(self):
+        """
+        Regression for PR #461 review M-1: if pgrep exits between
+        wait_for timing out and the proc.kill() call,
+        asyncio.subprocess.Process.kill() raises ProcessLookupError
+        (via os.kill on a dead PID). The handler must swallow
+        because the outcome we wanted (process gone) is already
+        true; otherwise the exception propagates out of _kill /
+        shutdown and crashes the caller.
+        """
+        claude = _make_claude(claude_user="daniel")
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        claude._proc = mock_proc
+
+        fake = MagicMock()
+        fake.communicate = AsyncMock(side_effect=TimeoutError)
+        fake.kill = MagicMock(side_effect=ProcessLookupError)
+        fake.wait = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=fake)):
+            # Must NOT raise. Returns None like any other failure mode.
+            assert await claude._async_lookup_inner_claude_pid() is None
 
     @pytest.mark.asyncio
     async def test_handles_oserror_on_spawn(self):
@@ -2547,6 +2572,25 @@ class TestAsyncSudoKill:
 
         assert "timed out" in caplog.text
         fake.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_timeout_handler_swallows_process_lookup_error_on_kill(self):
+        """
+        Regression for PR #461 review M-1: if sudo exits between
+        wait_for timing out and proc.kill(), kill() raises
+        ProcessLookupError. The handler must swallow because the
+        outcome we wanted (process gone) is already true; otherwise
+        the exception propagates out of _kill / shutdown and crashes
+        the caller.
+        """
+        claude = _make_claude(claude_user="daniel")
+        fake = MagicMock()
+        fake.communicate = AsyncMock(side_effect=TimeoutError)
+        fake.kill = MagicMock(side_effect=ProcessLookupError)
+        fake.wait = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=fake)):
+            # Must NOT raise.
+            await claude._async_sudo_kill("daniel", 99999, int(signal.SIGKILL))
 
     @pytest.mark.asyncio
     async def test_swallows_oserror_on_spawn(self):

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -2106,23 +2106,22 @@ class TestKill:
         claude._pgid = 12345
         claude._effective_claude_user = "daniel"
 
-        # Track the order: lookup must come before send_signal/killpg.
+        # Track the order: lookup must come before sudo_kill/killpg.
+        # #459 routed _kill through the async helpers, so we patch
+        # the async versions (and _async_sudo_kill so the final-
+        # cleanup pass is recorded too).
         call_order: list[str] = []
 
-        def lookup_records():
+        async def lookup_records():
             call_order.append("lookup")
             return 99999
 
-        # Return a returncode=0 mock from subprocess.run so the new
-        # diagnostic-log check in production code does not trip on
-        # MagicMock's default truthiness for an unset attribute.
-        def run_records(*_a, **_k):
+        async def sudo_kill_records(*_a, **_k):
             call_order.append("sudo_kill")
-            return MagicMock(returncode=0)
 
         with (
-            patch.object(claude, "_lookup_inner_claude_pid", side_effect=lookup_records),
-            patch("kai.claude.subprocess.run", side_effect=run_records),
+            patch.object(claude, "_async_lookup_inner_claude_pid", side_effect=lookup_records),
+            patch.object(claude, "_async_sudo_kill", side_effect=sudo_kill_records),
             patch("os.killpg") as mock_killpg,
         ):
             mock_killpg.side_effect = lambda *_a, **_k: call_order.append("killpg")
@@ -2136,11 +2135,13 @@ class TestKill:
     @pytest.mark.asyncio
     async def test_kill_final_cleanup_escalates_via_sudo(self):
         """
-        After the main _send_signal/wait/killpg sequence finishes,
-        _kill issues a final `sudo -n -u <target> kill -9 <pid>`
-        for the cached inner claude PID. This is the belt-and-
-        suspenders pass that catches a daniel-owned grandchild that
-        survived the killpg above (POSIX signal-permission gap).
+        After the main signal/wait/killpg sequence finishes, _kill
+        issues a final `sudo -n -u <target> /bin/kill -9 <pid>` for
+        the cached inner claude PID. This is the belt-and-
+        suspenders pass that catches a daniel-owned grandchild
+        that survived the killpg above (POSIX signal-permission
+        gap). #459 moved this off the event loop; we assert the
+        async helper is invoked with the right args.
         """
         claude = _make_claude(claude_user="daniel")
         mock_proc = MagicMock()
@@ -2150,31 +2151,33 @@ class TestKill:
         claude._pgid = 12345
         claude._effective_claude_user = "daniel"
 
+        mock_sudo_kill = AsyncMock()
         with (
-            patch.object(claude, "_lookup_inner_claude_pid", return_value=99999),
-            patch("kai.claude.subprocess.run") as mock_run,
+            patch.object(claude, "_async_lookup_inner_claude_pid", new=AsyncMock(return_value=99999)),
+            patch.object(claude, "_async_sudo_kill", new=mock_sudo_kill),
             patch("os.killpg"),
         ):
             await claude._kill()
 
-        # subprocess.run called at least twice: once during
-        # _send_signal's per-signal escalation, once at the final
-        # cleanup. The final-cleanup invocation uses SIGKILL (-9).
-        cmds = [call.args[0] for call in mock_run.call_args_list]
-        final_cleanup = [c for c in cmds if c[-2] == "-9" and c[-1] == "99999"]
-        assert final_cleanup, f"no final sudo kill -9 99999 in calls: {cmds}"
-        # Every call must target the saved sudo user with the
-        # absolute /bin/kill path.
-        for cmd in cmds:
-            assert cmd[:5] == ["sudo", "-n", "-u", "daniel", "/bin/kill"]
+        # _async_sudo_kill called at least twice: once during the
+        # per-signal escalation (in _async_send_signal_for_close)
+        # and once at the final cleanup. Both go to daniel with
+        # SIGKILL and PID 99999.
+        calls = mock_sudo_kill.await_args_list
+        assert len(calls) >= 2, f"expected >= 2 sudo-kill calls, got {len(calls)}: {calls}"
+        for call in calls:
+            args = call.args
+            assert args[0] == "daniel"
+            assert args[1] == 99999
+            assert args[2] == int(signal.SIGKILL)
 
     @pytest.mark.asyncio
     async def test_kill_skips_sudo_when_inner_pid_unknown(self):
         """
-        If _lookup_inner_claude_pid never returns a PID (sudo died
-        before forking, or pgrep failed every time), the final
-        cleanup must not call sudo - there is no target PID to
-        pass. killpg still fires as a best-effort wrapper reap.
+        If _async_lookup_inner_claude_pid never returns a PID (sudo
+        died before forking, or pgrep failed every time), neither
+        the per-signal escalation nor the final cleanup call sudo.
+        killpg still fires as a best-effort wrapper reap.
         """
         claude = _make_claude(claude_user="daniel")
         mock_proc = MagicMock()
@@ -2184,24 +2187,82 @@ class TestKill:
         claude._pgid = 12345
         claude._effective_claude_user = "daniel"
 
+        mock_sudo_kill = AsyncMock()
         with (
-            patch.object(claude, "_lookup_inner_claude_pid", return_value=None),
-            patch("kai.claude.subprocess.run") as mock_run,
+            patch.object(claude, "_async_lookup_inner_claude_pid", new=AsyncMock(return_value=None)),
+            patch.object(claude, "_async_sudo_kill", new=mock_sudo_kill),
             patch("os.killpg") as mock_killpg,
         ):
             await claude._kill()
 
-        mock_run.assert_not_called()
+        mock_sudo_kill.assert_not_called()
         # killpg still fires (initial + final) so any signalable
         # process in the group (the sudo wrapper) gets reaped.
         assert mock_killpg.called
 
     @pytest.mark.asyncio
+    async def test_kill_does_not_block_event_loop_on_slow_pgrep(self):
+        """
+        Acceptance test for #459: _kill awaits the async pgrep
+        helper so the event loop is not stalled while pgrep runs.
+        We verify by running a parallel coroutine that increments
+        a counter every 10ms; if _kill held the loop for the full
+        pgrep duration, the counter would not advance.
+
+        Pre-#459, _lookup_inner_claude_pid used synchronous
+        subprocess.run which DID block the event loop. This test
+        would have failed on that implementation - the counter
+        would be 0 after _kill completed.
+        """
+        claude = _make_claude(claude_user="daniel")
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        mock_proc.wait = AsyncMock()
+        claude._proc = mock_proc
+        claude._pgid = 12345
+        claude._effective_claude_user = "daniel"
+
+        # Slow pgrep mock: takes ~150ms to return, simulating a
+        # pathological host where pgrep is sluggish but not hung.
+        async def slow_lookup():
+            await asyncio.sleep(0.15)
+            return 99999
+
+        counter = 0
+
+        async def ticker():
+            nonlocal counter
+            while True:
+                counter += 1
+                await asyncio.sleep(0.01)
+
+        ticker_task = asyncio.create_task(ticker())
+        try:
+            with (
+                patch.object(claude, "_async_lookup_inner_claude_pid", side_effect=slow_lookup),
+                patch.object(claude, "_async_sudo_kill", new=AsyncMock()),
+                patch("os.killpg"),
+            ):
+                await claude._kill()
+        finally:
+            ticker_task.cancel()
+            try:
+                await ticker_task
+            except asyncio.CancelledError:
+                pass
+
+        # In 150ms with a 10ms tick interval, the ticker should
+        # have run ~15 times. Use a conservative lower bound (8)
+        # to absorb scheduler jitter on a loaded test host. A
+        # blocking implementation would yield 0 - 1.
+        assert counter >= 8, f"event loop appears blocked: ticker only reached {counter}"
+
+    @pytest.mark.asyncio
     async def test_kill_skips_sudo_in_single_user_mode(self):
         """
         Single-user mode (no _effective_claude_user) takes the
-        non-sudo path entirely. The whole _send_signal cross-user
-        branch is bypassed and no subprocess.run is issued.
+        non-sudo path entirely. The whole cross-user branch is
+        bypassed - no pgrep lookup, no sudo kill.
         """
         claude = _make_claude(claude_user="daniel")
         mock_proc = MagicMock()
@@ -2215,15 +2276,17 @@ class TestKill:
         # short-circuited the sudo wrapper.
         claude._effective_claude_user = None
 
+        mock_lookup = AsyncMock()
+        mock_sudo_kill = AsyncMock()
         with (
-            patch.object(claude, "_lookup_inner_claude_pid") as mock_lookup,
-            patch("kai.claude.subprocess.run") as mock_run,
+            patch.object(claude, "_async_lookup_inner_claude_pid", new=mock_lookup),
+            patch.object(claude, "_async_sudo_kill", new=mock_sudo_kill),
             patch("os.killpg"),
         ):
             await claude._kill()
 
         mock_lookup.assert_not_called()
-        mock_run.assert_not_called()
+        mock_sudo_kill.assert_not_called()
 
 
 # ── _lookup_inner_claude_pid ─────────────────────────────────────────
@@ -2312,6 +2375,186 @@ class TestLookupInnerClaudePid:
         completed = MagicMock(returncode=0, stdout="99999\n11111\n")
         with patch("kai.claude.subprocess.run", return_value=completed):
             assert claude._lookup_inner_claude_pid() == 99999
+
+
+# ── async helpers introduced by #459 ─────────────────────────────────
+
+
+def _fake_async_proc(returncode: int, stdout: bytes = b"", stderr: bytes = b""):
+    """
+    Build a fake asyncio.subprocess.Process for tests that patch
+    asyncio.create_subprocess_exec. Returns a MagicMock with the
+    methods _async_lookup_inner_claude_pid / _async_sudo_kill
+    actually call: communicate(), wait(), kill().
+    """
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.wait = AsyncMock(return_value=returncode)
+    proc.kill = MagicMock()
+    return proc
+
+
+class TestAsyncLookupInnerClaudePid:
+    """
+    Async pgrep equivalent of TestLookupInnerClaudePid. Verifies
+    `_async_lookup_inner_claude_pid` (#459) returns the same set
+    of values as its sync sibling across the same edge cases,
+    without blocking the event loop on the underlying pgrep call.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_proc_is_none(self):
+        claude = _make_claude(claude_user="daniel")
+        assert await claude._async_lookup_inner_claude_pid() is None
+
+    @pytest.mark.asyncio
+    async def test_parses_pgrep_stdout(self):
+        claude = _make_claude(claude_user="daniel")
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        claude._proc = mock_proc
+
+        fake = _fake_async_proc(returncode=0, stdout=b"99999\n")
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=fake)):
+            assert await claude._async_lookup_inner_claude_pid() == 99999
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_nonzero_exit(self):
+        claude = _make_claude(claude_user="daniel")
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        claude._proc = mock_proc
+
+        fake = _fake_async_proc(returncode=1, stdout=b"")
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=fake)):
+            assert await claude._async_lookup_inner_claude_pid() is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_empty_stdout(self):
+        """pgrep success but no output (race: sudo not yet forked)."""
+        claude = _make_claude(claude_user="daniel")
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        claude._proc = mock_proc
+
+        fake = _fake_async_proc(returncode=0, stdout=b"   \n")
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=fake)):
+            assert await claude._async_lookup_inner_claude_pid() is None
+
+    @pytest.mark.asyncio
+    async def test_handles_pgrep_timeout(self):
+        """A hung pgrep must not propagate; reaped via proc.kill()."""
+        claude = _make_claude(claude_user="daniel")
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        claude._proc = mock_proc
+
+        fake = MagicMock()
+        fake.communicate = AsyncMock(side_effect=TimeoutError)
+        fake.kill = MagicMock()
+        fake.wait = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=fake)):
+            assert await claude._async_lookup_inner_claude_pid() is None
+        # Hung pgrep must be reaped, not leaked.
+        fake.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handles_oserror_on_spawn(self):
+        """OSError (e.g., pgrep binary missing) returns None silently."""
+        claude = _make_claude(claude_user="daniel")
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        claude._proc = mock_proc
+
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(side_effect=OSError("no pgrep"))):
+            assert await claude._async_lookup_inner_claude_pid() is None
+
+    @pytest.mark.asyncio
+    async def test_first_line_when_pgrep_returns_multiple(self):
+        """Defensive: take the first line if multiple come back."""
+        claude = _make_claude(claude_user="daniel")
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        claude._proc = mock_proc
+
+        fake = _fake_async_proc(returncode=0, stdout=b"99999\n11111\n")
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=fake)):
+            assert await claude._async_lookup_inner_claude_pid() == 99999
+
+
+class TestAsyncSudoKill:
+    """
+    Async sudo-kill helper (#459). Verifies command shape,
+    diagnostic-log behavior on non-zero exit, and timeout/OSError
+    handling parallel to the sync subprocess.run-based equivalent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_calls_sudo_with_bin_kill_and_int_sig(self):
+        """Argument order, /bin/kill anchor, and int(sig) all correct."""
+        claude = _make_claude(claude_user="daniel")
+        fake = _fake_async_proc(returncode=0)
+        spawn = AsyncMock(return_value=fake)
+        with patch("asyncio.create_subprocess_exec", new=spawn):
+            await claude._async_sudo_kill("daniel", 99999, int(signal.SIGKILL))
+
+        args = spawn.call_args.args
+        assert args[:5] == ("sudo", "-n", "-u", "daniel", "/bin/kill")
+        assert args[5] == f"-{int(signal.SIGKILL)}"
+        assert args[6] == "99999"
+
+    @pytest.mark.asyncio
+    async def test_logs_warning_on_nonzero_exit(self, caplog):
+        """ESRCH, missing sudoers rule, etc. surface at WARNING."""
+        claude = _make_claude(claude_user="daniel")
+        fake = _fake_async_proc(returncode=1, stderr=b"sudo: a password is required")
+        with (
+            patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=fake)),
+            caplog.at_level("WARNING", logger="kai.claude"),
+        ):
+            await claude._async_sudo_kill("daniel", 99999, int(signal.SIGKILL))
+
+        assert "sudo kill escalation failed" in caplog.text
+        assert "99999" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_silent_on_zero_exit(self, caplog):
+        """Happy path: no log noise."""
+        claude = _make_claude(claude_user="daniel")
+        fake = _fake_async_proc(returncode=0)
+        with (
+            patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=fake)),
+            caplog.at_level("WARNING", logger="kai.claude"),
+        ):
+            await claude._async_sudo_kill("daniel", 99999, int(signal.SIGKILL))
+
+        assert "escalation failed" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_logs_warning_on_timeout(self, caplog):
+        """Hung sudo logs a timeout warning and reaps the subprocess."""
+        claude = _make_claude(claude_user="daniel")
+        fake = MagicMock()
+        fake.communicate = AsyncMock(side_effect=TimeoutError)
+        fake.kill = MagicMock()
+        fake.wait = AsyncMock()
+        with (
+            patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=fake)),
+            caplog.at_level("WARNING", logger="kai.claude"),
+        ):
+            await claude._async_sudo_kill("daniel", 99999, int(signal.SIGKILL))
+
+        assert "timed out" in caplog.text
+        fake.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_swallows_oserror_on_spawn(self):
+        """Missing sudo binary -> silent return; no propagation."""
+        claude = _make_claude(claude_user="daniel")
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(side_effect=OSError("no sudo"))):
+            # Must not raise.
+            await claude._async_sudo_kill("daniel", 99999, int(signal.SIGKILL))
 
 
 # ── shutdown ─────────────────────────────────────────────────────────
@@ -2519,22 +2762,21 @@ class TestShutdown:
         claude._pgid = 12345
         claude._effective_claude_user = "daniel"
 
+        # #459: shutdown now routes through the async helpers, so the
+        # patches target the async variants. Same ordering invariant
+        # as the _kill version of this test.
         call_order: list[str] = []
 
-        def lookup_records():
+        async def lookup_records():
             call_order.append("lookup")
             return 99999
 
-        # Return a returncode=0 mock so the new diagnostic-log
-        # check in production does not trip on MagicMock's default
-        # truthiness for an unset attribute.
-        def run_records(*_a, **_k):
+        async def sudo_kill_records(*_a, **_k):
             call_order.append("sudo_kill")
-            return MagicMock(returncode=0)
 
         with (
-            patch.object(claude, "_lookup_inner_claude_pid", side_effect=lookup_records),
-            patch("kai.claude.subprocess.run", side_effect=run_records),
+            patch.object(claude, "_async_lookup_inner_claude_pid", side_effect=lookup_records),
+            patch.object(claude, "_async_sudo_kill", side_effect=sudo_kill_records),
             patch("os.killpg") as mock_killpg,
         ):
             mock_killpg.side_effect = lambda *_a, **_k: call_order.append("killpg")
@@ -2548,10 +2790,12 @@ class TestShutdown:
     async def test_shutdown_final_cleanup_escalates_via_sudo(self):
         """
         After the main shutdown signal/wait sequence, the final
-        cleanup issues `sudo -n -u <target> /bin/kill -9 <pid>` for
-        the cached inner claude PID. This catches the daniel-owned
-        grandchild that survived the killpg (POSIX signal-permission
-        gap on cross-user spawn).
+        cleanup invokes the async sudo-kill helper with SIGKILL
+        for the cached inner claude PID. This catches the daniel-
+        owned grandchild that survived the killpg (POSIX signal-
+        permission gap on cross-user spawn). #459 moved this off
+        the event loop; we assert the async helper is invoked with
+        the right args.
         """
         claude = _make_claude(claude_user="daniel")
         mock_proc = MagicMock()
@@ -2561,28 +2805,34 @@ class TestShutdown:
         claude._pgid = 12345
         claude._effective_claude_user = "daniel"
 
+        mock_sudo_kill = AsyncMock()
         with (
-            patch.object(claude, "_lookup_inner_claude_pid", return_value=99999),
-            patch("kai.claude.subprocess.run") as mock_run,
+            patch.object(claude, "_async_lookup_inner_claude_pid", new=AsyncMock(return_value=99999)),
+            patch.object(claude, "_async_sudo_kill", new=mock_sudo_kill),
             patch("os.killpg"),
         ):
             await claude.shutdown()
 
-        cmds = [call.args[0] for call in mock_run.call_args_list]
-        final_cleanup = [c for c in cmds if c[-2] == "-9" and c[-1] == "99999"]
-        assert final_cleanup, f"no final sudo /bin/kill -9 99999 in calls: {cmds}"
-        # Every call must use the absolute /bin/kill path so the
-        # sudoers rule match cannot be evaded by PATH manipulation.
-        for cmd in cmds:
-            assert cmd[:5] == ["sudo", "-n", "-u", "daniel", "/bin/kill"]
+        # _async_sudo_kill called at least twice: once during the
+        # per-signal escalation (in _async_send_signal_for_close)
+        # and once at the final cleanup. The final-cleanup pass
+        # uses SIGKILL even when the initial signal was SIGTERM.
+        calls = mock_sudo_kill.await_args_list
+        assert len(calls) >= 2, f"expected >= 2 sudo-kill calls, got {len(calls)}: {calls}"
+        sigs_seen = {call.args[2] for call in calls}
+        assert int(signal.SIGKILL) in sigs_seen, f"no SIGKILL final cleanup in: {calls}"
+        for call in calls:
+            args = call.args
+            assert args[0] == "daniel"
+            assert args[1] == 99999
 
     @pytest.mark.asyncio
     async def test_shutdown_skips_sudo_when_inner_pid_unknown(self):
         """
-        If _lookup_inner_claude_pid never returns a PID (sudo died
-        before forking, or pgrep failed every time), the final
-        cleanup must not call sudo. killpg still fires as a best-
-        effort wrapper reap.
+        If _async_lookup_inner_claude_pid never returns a PID (sudo
+        died before forking, or pgrep failed every time), neither
+        the per-signal escalation nor the final cleanup calls sudo.
+        killpg still fires as a best-effort wrapper reap.
         """
         claude = _make_claude(claude_user="daniel")
         mock_proc = MagicMock()
@@ -2592,14 +2842,15 @@ class TestShutdown:
         claude._pgid = 12345
         claude._effective_claude_user = "daniel"
 
+        mock_sudo_kill = AsyncMock()
         with (
-            patch.object(claude, "_lookup_inner_claude_pid", return_value=None),
-            patch("kai.claude.subprocess.run") as mock_run,
+            patch.object(claude, "_async_lookup_inner_claude_pid", new=AsyncMock(return_value=None)),
+            patch.object(claude, "_async_sudo_kill", new=mock_sudo_kill),
             patch("os.killpg") as mock_killpg,
         ):
             await claude.shutdown()
 
-        mock_run.assert_not_called()
+        mock_sudo_kill.assert_not_called()
         assert mock_killpg.called
 
     @pytest.mark.asyncio
@@ -2618,15 +2869,17 @@ class TestShutdown:
         # mode where resolve_claude_user() short-circuits sudo.
         claude._effective_claude_user = None
 
+        mock_lookup = AsyncMock()
+        mock_sudo_kill = AsyncMock()
         with (
-            patch.object(claude, "_lookup_inner_claude_pid") as mock_lookup,
-            patch("kai.claude.subprocess.run") as mock_run,
+            patch.object(claude, "_async_lookup_inner_claude_pid", new=mock_lookup),
+            patch.object(claude, "_async_sudo_kill", new=mock_sudo_kill),
             patch("os.killpg"),
         ):
             await claude.shutdown()
 
         mock_lookup.assert_not_called()
-        mock_run.assert_not_called()
+        mock_sudo_kill.assert_not_called()
 
 
 # ── _save_prompt ─────────────────────────────────────────────────────
@@ -2847,9 +3100,15 @@ class TestSavePrompt:
         async def tracking_save():
             call_order.append("save_prompt")
 
+        async def tracking_send(sig):
+            call_order.append(f"signal_{int(sig)}")
+
+        # #459 routes shutdown's per-signal dispatch through the
+        # async helper rather than the sync _send_signal; patch the
+        # async variant to record SIGTERM/SIGKILL order.
         with (
             patch.object(claude, "_save_prompt", side_effect=tracking_save),
-            patch.object(claude, "_send_signal", side_effect=lambda s: call_order.append(f"signal_{s}")),
+            patch.object(claude, "_async_send_signal_for_close", side_effect=tracking_send),
         ):
             await claude.shutdown()
 


### PR DESCRIPTION
Closes #459.

## Summary

`ClaudeCodeBackend._kill()` and `.shutdown()` are async methods, but their cross-user signal-escalation path called `subprocess.run` synchronously for both the pgrep PID lookup and the `sudo -n -u <target> /bin/kill ...` invocations. In the worst case a single kill or shutdown could stall the asyncio event loop for ~22s before all timeouts fired:

| Site | Timeout |
|---|---|
| `_lookup_inner_claude_pid` (pgrep) | 2s |
| `_send_signal` sudo-kill (per signal) | 5s |
| `_kill` final-cleanup sudo-kill | 5s |
| `_send_signal` SIGKILL retry in shutdown's TimeoutError branch | 5s |
| `shutdown` final-cleanup sudo-kill | 5s |

`pool.force_kill`'s 5s `asyncio.wait_for` could not interrupt a stalled `subprocess.run` because the event loop itself was blocked.

Per #459's recommended option (option 1): convert the async sites in place; leave the synchronous `_send_signal` for the sync `force_kill` caller.

## Changes

Three new private helpers on `ClaudeCodeBackend`:

- **`_async_lookup_inner_claude_pid`** -- pgrep equivalent using `asyncio.create_subprocess_exec` + `asyncio.wait_for(communicate(), timeout=2)`. Reaps a hung pgrep via `proc.kill()` so the helper does not leak a zombie. Same return contract as the sync variant.
- **`_async_sudo_kill`** -- `sudo -n -u <target> /bin/kill -<int(sig)> <pid>` via `asyncio.create_subprocess_exec` + `wait_for(..., timeout=5)`. Logs at WARNING on non-zero exit (same diagnostic contract PR #458 adopted in M1) and on timeout (new visibility for the hung-sudo case). Silent on OSError during spawn.
- **`_async_send_signal_for_close`** -- async equivalent of `_send_signal` used by `_kill` and `shutdown`. Same three-step structure (cross-user sudo-kill → wrapper killpg → single-user `send_signal` fallback), but the sudo-kill step is awaited via `_async_sudo_kill`. `killpg` and `_proc.send_signal` are non-blocking syscalls; they stay synchronous.

`_kill` and `shutdown` rewired:

- Cache-priming `_lookup_inner_claude_pid()` → `await _async_lookup_inner_claude_pid()`.
- `_send_signal(...)` → `await _async_send_signal_for_close(...)`.
- Final-cleanup `subprocess.run(["sudo", "-n", ...])` → `await _async_sudo_kill(...)`.

Sync `_send_signal` and `_lookup_inner_claude_pid` are **unchanged**. `force_kill` (sync public API, called by `/stop` and pool eviction) still uses them; no cascading API change.

## Tests

- 8 existing `TestKill` / `TestShutdown` tests updated: patches now target `_async_lookup_inner_claude_pid` and `_async_sudo_kill` (via `patch.object(claude, ...)`) instead of the sync `subprocess.run`, matching the new dispatch surface. `TestSavePrompt::test_shutdown_calls_save_prompt` updated to patch `_async_send_signal_for_close` (was `_send_signal`).

- New **`test_kill_does_not_block_event_loop_on_slow_pgrep`** -- direct acceptance test for #459. Patches `_async_lookup_inner_claude_pid` to sleep 150ms, runs a parallel 10ms-tick coroutine, asserts the ticker advances ≥ 8 times during `_kill`. A blocking implementation would yield 0-1 ticks; the async version yields ~15. This test would have failed against the pre-#459 sync implementation.

- New **`TestAsyncLookupInnerClaudePid`** (7 tests) -- parallel to the existing sync `TestLookupInnerClaudePid`: parses pgrep stdout, nonzero exit, empty stdout, `TimeoutError` reaps via `kill()`, `OSError` on spawn, multi-line first-line defense, None when `_proc` is None.

- New **`TestAsyncSudoKill`** (5 tests) -- cmd shape (`/bin/kill` anchor, `int(sig)` cast, arg order), WARNING log on nonzero exit, silent on zero exit, WARNING log on timeout + `kill()` reap, swallows `OSError` on spawn.

- New `_fake_async_proc` test helper builds a `MagicMock` with the `communicate`/`wait`/`kill` surface the helpers actually use, parallel to how the sync tests mock `subprocess.run`'s `CompletedProcess`.

## Test plan

- [x] `make check` clean.
- [x] `make test` passes (2882 tests, 1 skipped; +13 net new vs main).
- [x] `test_kill_does_not_block_event_loop_on_slow_pgrep` verifies the event loop stays responsive under a slow pgrep -- the specific failure mode #459 cited.
- [ ] Live verification post-merge: cross-user spawn turnaround under heavy parallel webhook load no longer shows event-loop stalls correlated with timeouts.

## Out of scope

- Converting `_send_signal` to async would cascade through `force_kill` (currently sync, called by `/stop`, pool eviction, bot shutdown). The blocking risk on those paths is much smaller (no async caller waiting on them) and the conversion's surface is larger. #459 explicitly recommended deferring that to option 2 if ever needed; this PR sticks to option 1.
