### PR TITLE
fix: per-user allowed_workspaces in users.yaml (closes #460)

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -2023,8 +2023,16 @@ async def _handle_workspace_allowed(
     # would query the DB twice. Only this handler needs attribution.
     db_paths = await sessions.get_allowed_workspaces(chat_id)
     db_path_set = {p.resolve() for p in db_paths}
+    # Per-user yaml allowed_workspaces tier (#460). Tracked
+    # separately from db_path_set so the source attribution
+    # below can distinguish "your yaml" from "your DB entries".
+    yaml_path_set: set[Path] = set()
+    if user_config and user_config.allowed_workspaces:
+        yaml_path_set = {p.resolve() for p in user_config.allowed_workspaces}
 
-    # Combined list: DB first, then global, deduplicated
+    # Combined list: DB > yaml-per-user > global. Same order as
+    # resolve_workspace_access so this view matches what name
+    # resolution actually traverses.
     seen: set[Path] = set()
     allowed: list[Path] = []
     for p in db_paths:
@@ -2032,6 +2040,12 @@ async def _handle_workspace_allowed(
         if resolved not in seen:
             seen.add(resolved)
             allowed.append(resolved)
+    if user_config and user_config.allowed_workspaces:
+        for p in user_config.allowed_workspaces:
+            resolved = p.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                allowed.append(resolved)
     for p in config.allowed_workspaces:
         resolved = p.resolve()
         if resolved not in seen:
@@ -2048,7 +2062,17 @@ async def _handle_workspace_allowed(
         lines.append("")
         lines.append("Allowed workspaces:")
         for p in allowed:
-            source = "you" if p in db_path_set else "global"
+            # Source attribution priority matches the union order:
+            # DB beats yaml beats global. A path could in principle
+            # appear in multiple tiers (operator pinned via
+            # /workspace allow AND listed in users.yaml); the most
+            # specific tier wins the label.
+            if p in db_path_set:
+                source = "you"
+            elif p in yaml_path_set:
+                source = "yaml"
+            else:
+                source = "global"
             lines.append(f"  {p} ({source})")
     elif base:
         lines.append("\nNo additional allowed paths beyond workspace base.")

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -281,6 +281,16 @@ class UserConfig:
     timeout: int | None = None
     context_window: int | None = None
     workspace_base: Path | None = None
+    # Per-user allowed workspaces from users.yaml. Distinct from the
+    # global `Config.allowed_workspaces` (env var / workspaces.yaml)
+    # and from the per-chat DB `allowed_workspaces` table (set via
+    # `/workspace allow`): this list is admin-set in users.yaml for
+    # workspaces a specific user should access by name without having
+    # to run `/workspace allow` first. Resolved at load time
+    # (.expanduser().resolve()); paths that don't exist on the host
+    # are dropped with a warning rather than failing the whole
+    # config load. See issue #460.
+    allowed_workspaces: list[Path] = field(default_factory=list)
     # Per-user backend/provider override. Admin-controlled via users.yaml,
     # not user-configurable via /settings. None = use global config.
     agent_backend: str | None = None
@@ -1171,6 +1181,52 @@ def _load_user_configs(
                     )
                     user_workspace_base = None
 
+        # Parse optional per-user allowed_workspaces (#460). Distinct
+        # from the global `allowed_workspaces` config field (env var
+        # + workspaces.yaml) and from the per-chat DB
+        # `allowed_workspaces` table (set via `/workspace allow`):
+        # this is the admin's per-user yaml grant of additional
+        # paths accessible by name.
+        #
+        # Each entry: strip, expanduser, resolve. Empty strings are
+        # dropped silently. Paths that don't exist are dropped with
+        # a warning - matches the `workspace_base` / `home_workspace`
+        # precedent of "warn but don't fail the load" (a missing
+        # directory may be on an unmounted drive or about to be
+        # created; failing the whole config load would block the
+        # operator from any access). Non-list values produce a
+        # warning and an empty list. The runtime resolver
+        # (`sessions.resolve_workspace_access`) reads this field
+        # and unions it with the DB and global sources.
+        user_allowed_workspaces: list[Path] = []
+        raw_user_allowed = entry.get("allowed_workspaces", [])
+        if isinstance(raw_user_allowed, list):
+            for raw_ws in raw_user_allowed:
+                ws_str = str(raw_ws).strip()
+                if not ws_str:
+                    continue
+                ws_path = Path(ws_str).expanduser().resolve()
+                if not ws_path.is_dir():
+                    log.warning(
+                        "users.yaml: allowed_workspaces entry for %s not found: %s; dropping",
+                        name,
+                        ws_path,
+                    )
+                    continue
+                # Dedup at load time: a user listing the same path
+                # twice is almost certainly a typo, and the union
+                # in resolve_workspace_access dedupes anyway, but
+                # catching it here keeps the per-user list clean
+                # for downstream consumers (e.g., `/workspace allowed`
+                # source attribution).
+                if ws_path not in user_allowed_workspaces:
+                    user_allowed_workspaces.append(ws_path)
+        else:
+            log.warning(
+                "users.yaml: allowed_workspaces for %s must be a list (ignoring)",
+                name,
+            )
+
         # Parse optional github_repos list (list of "owner/repo" strings).
         # Validate format but don't verify repo existence (that would
         # require network calls during config loading).
@@ -1246,6 +1302,7 @@ def _load_user_configs(
             timeout=user_timeout,
             context_window=user_context_window,
             workspace_base=user_workspace_base,
+            allowed_workspaces=user_allowed_workspaces,
             agent_backend=user_backend,
             llm_provider=user_provider,
             github_repos=github_repos,

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -911,25 +911,35 @@ async def resolve_workspace_access(chat_id: int, config: Config) -> tuple[Path |
     Resolve per-user workspace_base and allowed_workspaces.
 
     Returns (workspace_base, allowed_workspaces) with per-user config
-    applied. The allowed list is the union of user-added DB entries and
-    the global ALLOWED_WORKSPACES env var, deduplicated by resolved path.
+    applied. The allowed list is the union of:
+      1. The per-chat DB `allowed_workspaces` table (set via
+         `/workspace allow` from Telegram).
+      2. The per-user `allowed_workspaces` field in users.yaml
+         (admin-set baseline; see issue #460).
+      3. The global `Config.allowed_workspaces` (env var
+         ALLOWED_WORKSPACES + workspaces.yaml entries).
+    Deduplicated by resolved path; earlier tiers win on collision.
 
     Precedence for workspace_base:
         1. users.yaml workspace_base (admin-set per user)
         2. Global WORKSPACE_BASE env var
 
     Precedence for allowed_workspaces:
-        Union of DB entries (user-managed) and global config (admin-set).
-        Deduplicated; DB entries appear first in the list.
+        DB > yaml-per-user > global. DB first so user-added
+        workspaces appear at the top of the /workspaces keyboard
+        and /workspace allowed list; yaml-per-user before global
+        because the user-specific tier is more relevant to the
+        user than the bot-wide tier.
     """
     user_config = config.get_user_config(chat_id)
 
     # workspace_base: users.yaml > env
     base = user_config.workspace_base if user_config and user_config.workspace_base else config.workspace_base
 
-    # allowed_workspaces: union of DB + global, deduplicated.
-    # DB entries first so user-added workspaces appear at the top
-    # of the /workspaces keyboard and /workspace allowed list.
+    # allowed_workspaces: union of DB + yaml-per-user + global,
+    # deduplicated. Resolved paths are the dedup key so the same
+    # directory expressed two different ways (symlink, relative
+    # form) collapses to a single entry.
     db_allowed = await get_allowed_workspaces(chat_id)
     seen: set[Path] = set()
     combined: list[Path] = []
@@ -939,6 +949,18 @@ async def resolve_workspace_access(chat_id: int, config: Config) -> tuple[Path |
         if resolved not in seen:
             seen.add(resolved)
             combined.append(resolved)
+
+    # Per-user yaml allowed_workspaces (#460). The loader already
+    # resolved each path at load time, but re-resolve here for
+    # symmetry with the other tiers - cheap and protects against
+    # a stale Path object if the loader is ever changed to keep
+    # the raw form.
+    if user_config and user_config.allowed_workspaces:
+        for p in user_config.allowed_workspaces:
+            resolved = p.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                combined.append(resolved)
 
     for p in config.allowed_workspaces:
         resolved = p.resolve()

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2012,6 +2012,82 @@ class TestHandleWorkspaceAllowed:
         reply = update.message.reply_text.call_args[0][0]
         assert f"Workspace base: {tmp_path}" in reply
 
+    @pytest.mark.asyncio
+    async def test_shows_yaml_per_user_tier(self, tmp_path):
+        """
+        Per-user yaml `allowed_workspaces:` entries (#460) appear in
+        the listing with a `(yaml)` source label, distinct from the
+        existing `(you)` (DB) and `(global)` tiers. Pre-#460 these
+        entries were silently dropped by the config loader; with the
+        loader fix in place this UI test pins the user-visible
+        result of the change.
+        """
+        from kai.config import UserConfig
+
+        yaml_ws = tmp_path / "yaml-ws"
+        yaml_ws.mkdir()
+        db_ws = tmp_path / "db-ws"
+        db_ws.mkdir()
+        global_ws = tmp_path / "global-ws"
+        global_ws.mkdir()
+
+        uc = UserConfig(
+            telegram_id=123,
+            name="alice",
+            allowed_workspaces=[yaml_ws.resolve()],
+        )
+        config = _make_config(
+            user_configs={123: uc},
+            allowed_workspaces=[global_ws.resolve()],
+        )
+        update = _make_update(chat_id=123)
+        ctx = _make_context(config=config)
+        with patch(
+            "kai.bot.sessions.get_allowed_workspaces",
+            new_callable=AsyncMock,
+            return_value=[db_ws],
+        ):
+            await _handle_workspace_allowed(update, ctx)
+
+        reply = update.message.reply_text.call_args[0][0]
+        # All three source tiers attributed correctly.
+        assert f"{db_ws.resolve()} (you)" in reply
+        assert f"{yaml_ws.resolve()} (yaml)" in reply
+        assert f"{global_ws.resolve()} (global)" in reply
+
+    @pytest.mark.asyncio
+    async def test_yaml_tier_priority_when_in_db_too(self, tmp_path):
+        """
+        A path listed in BOTH the per-user yaml and the DB collapses
+        to a single line; the `(you)` (DB) label wins because the
+        DB tier appears earlier in the union. Same priority order
+        as `resolve_workspace_access`.
+        """
+        from kai.config import UserConfig
+
+        shared = tmp_path / "shared-ws"
+        shared.mkdir()
+        uc = UserConfig(
+            telegram_id=123,
+            name="alice",
+            allowed_workspaces=[shared.resolve()],
+        )
+        config = _make_config(user_configs={123: uc})
+        update = _make_update(chat_id=123)
+        ctx = _make_context(config=config)
+        with patch(
+            "kai.bot.sessions.get_allowed_workspaces",
+            new_callable=AsyncMock,
+            return_value=[shared],
+        ):
+            await _handle_workspace_allowed(update, ctx)
+
+        reply = update.message.reply_text.call_args[0][0]
+        assert f"{shared.resolve()} (you)" in reply
+        # Exactly one occurrence of the path in the output: no
+        # duplicate listing under the yaml tier.
+        assert reply.count(str(shared.resolve())) == 1
+
 
 # ── /workspace allow/deny routing via handle_workspace ──────────────
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1635,3 +1635,187 @@ class TestMemorySearchFloor:
         monkeypatch.setenv("MEMORY_SEARCH_FLOOR", "high")
         with pytest.raises(SystemExit, match="must be a number"):
             load_config()
+
+
+# ── Per-user allowed_workspaces (issue #460) ─────────────────────────
+
+
+class TestPerUserAllowedWorkspacesYaml:
+    """
+    Parse `allowed_workspaces:` from per-user users.yaml entries.
+
+    Pre-#460 the field was silently dropped by the loader (no
+    UserConfig field, no parser branch). These tests pin the
+    happy path, edge cases (missing field, empty list, non-list,
+    nonexistent path, duplicates), and the field's downstream
+    visibility on the resulting UserConfig.
+    """
+
+    def _load_with_yaml(self, monkeypatch, users_data):
+        """
+        Drive _load_user_configs against an in-memory yaml dict.
+        Patches _read_protected_yaml so the loader does not hit
+        /etc/kai or PROJECT_ROOT during the test.
+        """
+        from kai.config import _load_user_configs
+
+        monkeypatch.setattr("kai.config._read_protected_yaml", lambda _name: users_data)
+        return _load_user_configs(global_backend="claude", global_llm_provider="anthropic")
+
+    def test_missing_field_yields_empty_list(self, monkeypatch):
+        """
+        Default: a users.yaml entry without an `allowed_workspaces:`
+        key produces an empty list on the resulting UserConfig.
+        Mirrors the github_repos default behavior.
+        """
+        users_data = {
+            "users": [
+                {"telegram_id": 123, "name": "alice"},
+            ],
+        }
+        configs = self._load_with_yaml(monkeypatch, users_data)
+        assert configs is not None
+        assert configs[123].allowed_workspaces == []
+
+    def test_parses_well_formed_list(self, monkeypatch, tmp_path):
+        """
+        A list of absolute path strings parses into a list of
+        resolved Path objects. The directories must exist on the
+        host (we tmp_path-create them) since the loader drops
+        nonexistent entries.
+        """
+        a = tmp_path / "alpha"
+        a.mkdir()
+        b = tmp_path / "beta"
+        b.mkdir()
+        users_data = {
+            "users": [
+                {
+                    "telegram_id": 123,
+                    "name": "alice",
+                    "allowed_workspaces": [str(a), str(b)],
+                },
+            ],
+        }
+        configs = self._load_with_yaml(monkeypatch, users_data)
+        assert configs is not None
+        assert configs[123].allowed_workspaces == [a.resolve(), b.resolve()]
+
+    def test_drops_nonexistent_paths_with_warning(self, monkeypatch, tmp_path, caplog):
+        """
+        A path that does not exist on the host is dropped from the
+        list with a WARNING log line. Matches the workspace_base /
+        home_workspace precedent: the loader does not fail the
+        whole user entry on a single missing directory (could be
+        on an unmounted drive or about to be created).
+        """
+        real_path = tmp_path / "alpha"
+        real_path.mkdir()
+        users_data = {
+            "users": [
+                {
+                    "telegram_id": 123,
+                    "name": "alice",
+                    "allowed_workspaces": [str(real_path), str(tmp_path / "does-not-exist")],
+                },
+            ],
+        }
+        with caplog.at_level(logging.WARNING, logger="kai.config"):
+            configs = self._load_with_yaml(monkeypatch, users_data)
+
+        assert configs is not None
+        # Only the real path survives.
+        assert configs[123].allowed_workspaces == [real_path.resolve()]
+        assert "allowed_workspaces entry for alice not found" in caplog.text
+
+    def test_non_list_field_yields_empty_with_warning(self, monkeypatch, caplog):
+        """
+        If `allowed_workspaces:` is set to something other than a
+        list (e.g., a string), the loader emits a WARNING and the
+        field falls back to empty. Same pattern as github_repos.
+        """
+        users_data = {
+            "users": [
+                {
+                    "telegram_id": 123,
+                    "name": "alice",
+                    "allowed_workspaces": "/just/one/path",
+                },
+            ],
+        }
+        with caplog.at_level(logging.WARNING, logger="kai.config"):
+            configs = self._load_with_yaml(monkeypatch, users_data)
+
+        assert configs is not None
+        assert configs[123].allowed_workspaces == []
+        assert "allowed_workspaces for alice must be a list" in caplog.text
+
+    def test_empty_strings_dropped_silently(self, monkeypatch, tmp_path):
+        """
+        Empty-string entries (yaml `- ""` or whitespace) are dropped
+        without warning - matches the workspace_base empty-string
+        handling. A user with only whitespace entries gets an
+        empty list, same as if they had no field at all.
+        """
+        real_path = tmp_path / "alpha"
+        real_path.mkdir()
+        users_data = {
+            "users": [
+                {
+                    "telegram_id": 123,
+                    "name": "alice",
+                    "allowed_workspaces": ["", "   ", str(real_path)],
+                },
+            ],
+        }
+        configs = self._load_with_yaml(monkeypatch, users_data)
+        assert configs is not None
+        assert configs[123].allowed_workspaces == [real_path.resolve()]
+
+    def test_duplicates_deduplicated_at_load_time(self, monkeypatch, tmp_path):
+        """
+        A user listing the same path twice is almost certainly a
+        typo. The loader collapses duplicates so the per-user list
+        is clean for downstream consumers (source-attribution
+        listings, the /workspaces keyboard).
+        """
+        real_path = tmp_path / "alpha"
+        real_path.mkdir()
+        users_data = {
+            "users": [
+                {
+                    "telegram_id": 123,
+                    "name": "alice",
+                    "allowed_workspaces": [str(real_path), str(real_path)],
+                },
+            ],
+        }
+        configs = self._load_with_yaml(monkeypatch, users_data)
+        assert configs is not None
+        assert configs[123].allowed_workspaces == [real_path.resolve()]
+
+    def test_expands_user_tilde(self, monkeypatch, tmp_path):
+        """
+        `~/path` style entries get expanded via Path.expanduser().
+        Mirrors workspace_base / home_workspace handling.
+        """
+        # Build a fake HOME under tmp_path so ~ resolves into the
+        # test sandbox rather than the developer's actual home.
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        ws = fake_home / "ws"
+        ws.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        users_data = {
+            "users": [
+                {
+                    "telegram_id": 123,
+                    "name": "alice",
+                    "allowed_workspaces": ["~/ws"],
+                },
+            ],
+        }
+        configs = self._load_with_yaml(monkeypatch, users_data)
+        assert configs is not None
+        assert configs[123].allowed_workspaces == [ws.resolve()]

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -883,6 +883,136 @@ class TestResolveWorkspaceAccess:
         assert allowed[0] == db_path.resolve()
         assert allowed[1] == global_path.resolve()
 
+    # -- Per-user yaml allowed_workspaces (issue #460) -------------------
+
+    async def test_yaml_per_user_allowed_visible(self, db, tmp_path):
+        """
+        A path listed only under per-user `allowed_workspaces:` in
+        users.yaml is in the combined list. Pre-#460, the field
+        was silently dropped by the config loader and this list
+        was always empty.
+        """
+        from kai.config import UserConfig
+
+        yaml_path = tmp_path / "yaml-repo"
+        yaml_path.mkdir()
+        uc = UserConfig(
+            telegram_id=111,
+            name="alice",
+            allowed_workspaces=[yaml_path.resolve()],
+        )
+        config = self._make_config(user_configs={111: uc})
+        _base, allowed = await sessions.resolve_workspace_access(111, config)
+        assert yaml_path.resolve() in allowed
+
+    async def test_yaml_per_user_unioned_with_db_and_global(self, db, tmp_path):
+        """
+        Effective list is the union of all three tiers: DB,
+        yaml-per-user, global. Each path appears exactly once.
+        """
+        from kai.config import UserConfig
+
+        db_path = tmp_path / "db-repo"
+        db_path.mkdir()
+        yaml_path = tmp_path / "yaml-repo"
+        yaml_path.mkdir()
+        global_path = tmp_path / "global-repo"
+        global_path.mkdir()
+
+        await sessions.add_allowed_workspace(111, str(db_path.resolve()))
+        uc = UserConfig(
+            telegram_id=111,
+            name="alice",
+            allowed_workspaces=[yaml_path.resolve()],
+        )
+        config = self._make_config(
+            user_configs={111: uc},
+            allowed_workspaces=[global_path.resolve()],
+        )
+        _base, allowed = await sessions.resolve_workspace_access(111, config)
+        assert len(allowed) == 3
+        assert db_path.resolve() in allowed
+        assert yaml_path.resolve() in allowed
+        assert global_path.resolve() in allowed
+
+    async def test_yaml_per_user_ordering_db_yaml_global(self, db, tmp_path):
+        """
+        The combined list orders entries DB > yaml-per-user > global.
+        The keyboard and the /workspace allowed listing both depend
+        on this ordering for the source-attribution labels.
+        """
+        from kai.config import UserConfig
+
+        db_path = tmp_path / "db-repo"
+        db_path.mkdir()
+        yaml_path = tmp_path / "yaml-repo"
+        yaml_path.mkdir()
+        global_path = tmp_path / "global-repo"
+        global_path.mkdir()
+
+        await sessions.add_allowed_workspace(111, str(db_path.resolve()))
+        uc = UserConfig(
+            telegram_id=111,
+            name="alice",
+            allowed_workspaces=[yaml_path.resolve()],
+        )
+        config = self._make_config(
+            user_configs={111: uc},
+            allowed_workspaces=[global_path.resolve()],
+        )
+        _base, allowed = await sessions.resolve_workspace_access(111, config)
+        assert allowed[0] == db_path.resolve()
+        assert allowed[1] == yaml_path.resolve()
+        assert allowed[2] == global_path.resolve()
+
+    async def test_yaml_per_user_dedup_with_db(self, db, tmp_path):
+        """
+        Same path in both the DB and the per-user yaml list collapses
+        to a single entry; the DB tier wins the slot (earlier in
+        the iteration order).
+        """
+        from kai.config import UserConfig
+
+        shared = tmp_path / "shared-repo"
+        shared.mkdir()
+        resolved = shared.resolve()
+
+        await sessions.add_allowed_workspace(111, str(resolved))
+        uc = UserConfig(
+            telegram_id=111,
+            name="alice",
+            allowed_workspaces=[resolved],
+        )
+        config = self._make_config(user_configs={111: uc})
+        _base, allowed = await sessions.resolve_workspace_access(111, config)
+        assert len(allowed) == 1
+        assert allowed[0] == resolved
+
+    async def test_yaml_per_user_dedup_with_global(self, db, tmp_path):
+        """
+        Same path in both per-user yaml and global config collapses
+        to a single entry; the per-user tier wins the slot
+        (earlier in the iteration order).
+        """
+        from kai.config import UserConfig
+
+        shared = tmp_path / "shared-repo"
+        shared.mkdir()
+        resolved = shared.resolve()
+
+        uc = UserConfig(
+            telegram_id=111,
+            name="alice",
+            allowed_workspaces=[resolved],
+        )
+        config = self._make_config(
+            user_configs={111: uc},
+            allowed_workspaces=[resolved],
+        )
+        _base, allowed = await sessions.resolve_workspace_access(111, config)
+        assert len(allowed) == 1
+        assert allowed[0] == resolved
+
 
 # ── Effective repos ───────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #460.

## Summary

The per-user `allowed_workspaces:` field in `users.yaml` was silently dropped by the config loader. An operator listing workspaces under a user's entry expecting them to be added to that user's accessible set saw no effect; the only effective sources were the global `ALLOWED_WORKSPACES` env var and `workspaces.yaml`.

**Root cause.** `UserConfig` had no `allowed_workspaces` field, so the yaml key was discarded during instantiation. `sessions.resolve_workspace_access` read only `workspace_base` from the user tier, never an allowed-list field.

## Changes

**`UserConfig` (config.py)** -- new `allowed_workspaces: list[Path] = field(default_factory=list)` between `workspace_base` and `agent_backend`. Docstring distinguishes the three tiers (global env/yaml, per-user yaml, per-chat DB) so the reason the field exists alongside `Config.allowed_workspaces` is self-documenting.

**`_load_user_configs` (config.py)** -- parse `allowed_workspaces` from each user entry. Each value is stripped, expanded via `Path.expanduser()`, and resolved via `.resolve()`. Empty strings drop silently. Nonexistent paths drop with a `WARNING` (same precedent as `workspace_base` / `home_workspace` handling). Non-list values produce a warning and yield an empty list. Duplicates dedup at load time.

**`resolve_workspace_access` (sessions.py)** -- union the per-user yaml allowed list between the existing DB and global tiers. Order is **DB > yaml-per-user > global** (more specific to less specific). Resolved paths are the dedup key.

**`_handle_workspace_allowed` (bot.py)** -- `/workspace allowed` listing now distinguishes three tiers in source attribution. New label `(yaml)` for per-user yaml entries, joining `(you)` (DB) and `(global)`. A path appearing in multiple tiers gets the label of the most specific tier (DB beats yaml beats global).

## Tests

`tests/test_config.py::TestPerUserAllowedWorkspacesYaml` (7 tests):

- Missing field defaults to `[]`.
- Well-formed list parses to resolved `Path` objects.
- Nonexistent paths drop with `WARNING`.
- Non-list value warns and yields `[]`.
- Empty strings drop silently.
- Duplicates dedup at load time.
- `~/path` expands via `expanduser()`.

`tests/test_sessions.py::TestResolveWorkspaceAccess` (5 new tests):

- Yaml-only entry visible in combined list.
- All three tiers union; each path appears exactly once.
- Ordering pin: DB > yaml > global.
- Dedup DB + yaml collapses; DB wins the slot.
- Dedup yaml + global collapses; yaml wins the slot.

`tests/test_bot.py::TestHandleWorkspaceAllowed` (2 new tests):

- All three tiers attributed correctly in the listing.
- Path in both DB + yaml shown once with `(you)` label.

## Test plan

- [x] `make check` clean.
- [x] `make test` passes (2898 tests, 1 skipped; +14 net new vs main).
- [ ] Live verification on next `sudo make install`: per-user yaml `allowed_workspaces:` entries become accessible via `/workspace <name>` and visible in the `/workspaces` keyboard.

## Out of scope

The issue body mentioned a "discoverability follow-up" -- warning on unknown user-entry keys during loading -- so silent-drop bugs surface at install time rather than at runtime. Not in this PR. The remediation for #460 specifically is the field addition + resolver wiring; broader strict-key validation across the whole yaml schema is a separate concern.
