### PR TITLE
feat: anti-fabrication rule in tracked CLAUDE.md template

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -3099,8 +3099,8 @@ def _migrate_recalled_memory_section(
             install's migration run.
         dry_run: If True, return the would-be modification status
             without writing anything; the caller's dry-run preview
-            branch consumes the bool to print the appropriate preview
-            line.
+            branch consumes the three-state return to print the
+            appropriate preview line.
     """
     # Skip if the per-user copy does not exist. The seed step earlier
     # in the loop just wrote a fresh copy from the current template if

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2456,6 +2456,31 @@ def _apply_migrate(
                     print(f"[DRY RUN] Would seed {claude_dst} from {home_template}")
                 else:
                     print(f"[DRY RUN] Would seed {claude_dst} with placeholder (template missing)")
+            else:
+                # Migration preview for an existing per-user copy. The
+                # seed branch above only fires when claude_dst is
+                # missing; the migration branch fires when claude_dst
+                # exists and the sentinel header may or may not be in
+                # place. Three sub-cases (sentinel missing -> would
+                # append; sentinel present -> already-migrated message;
+                # claude_dst unreadable -> warning handled inside the
+                # helper). Inspecting claude_dst here, before the
+                # `continue` below, ensures the dry-run preview reaches
+                # parity with what the live branch will do; without
+                # this branch, the dry-run output would silently omit
+                # the migration step the live install would execute.
+                if home_template_exists and _migrate_recalled_memory_section(claude_dst, home_template, dry_run=True):
+                    print(f"[DRY RUN] Would append Reading Recalled Memory section to {claude_dst}")
+                elif home_template_exists:
+                    # The helper returned False with sentinel present;
+                    # surface the no-op explicitly so the operator sees
+                    # the migration was considered and skipped, not
+                    # silently omitted.
+                    print(
+                        f"[DRY RUN] {claude_dst}: Reading Recalled Memory section already present, no migration needed"
+                    )
+                # else: template missing; the helper already printed a
+                # warning. No additional preview line needed.
             continue
 
         # Idempotent: never overwrite an operator-customized destination.
@@ -2491,6 +2516,19 @@ def _apply_migrate(
             except OSError as exc:
                 print(f"  ERROR: could not seed {claude_dst}: {exc}")
                 raise
+
+        # Append the Reading Recalled Memory section to pre-existing
+        # per-user CLAUDE.md copies that predate the section. Lands
+        # AFTER the seed step (so a fresh-seeded file from the current
+        # template carries the section already, and the helper's
+        # sentinel check is a clean no-op) and BEFORE the
+        # `_set_ownership` chown step below (so the migration's
+        # atomic `Path.replace`, which produces a new inode owned by
+        # the install runner, gets reconciled back to the per-user
+        # `os_user` in the same iteration; the chown comment block
+        # below names the #347 regression shape this prevents).
+        if home_template_exists and _migrate_recalled_memory_section(claude_dst, home_template, dry_run=False):
+            print(f"  Appended Reading Recalled Memory section to {claude_dst}")
 
         # Recursive chown over the .claude/ subdir so both the
         # directory and the freshly-seeded CLAUDE.md land on the
@@ -2958,6 +2996,188 @@ def _migrate_identity_to_claude_md(
     # this step; the conditional seed at the end of _apply_source emits
     # "Seeded CLAUDE.md from template" when it copies the template into
     # the destination.
+
+
+# Sentinel header used by `_migrate_recalled_memory_section` to detect
+# whether a per-user CLAUDE.md already carries the Reading Recalled
+# Memory section. Module-level constant so the migration helper, the
+# dry-run preview branch in the per-user CLAUDE.md seed loop, and the
+# unit tests in test_install.py all read the same literal. A drift in
+# this string would let the migration re-append on every install
+# (sentinel always missing) and silently double-write the section.
+_RECALLED_MEMORY_SECTION_HEADER = "## Reading Recalled Memory"
+
+
+def _migrate_recalled_memory_section(
+    claude_dst: Path,
+    template_path: Path,
+    *,
+    dry_run: bool,
+) -> bool:
+    """
+    Idempotently append the Reading Recalled Memory section from the
+    tracked CLAUDE.md template to an existing per-user CLAUDE.md copy.
+
+    Returns True when the file was modified (or would be in dry-run),
+    False when the section was already present, the destination is
+    missing, or the template is unreadable / missing the section header.
+
+    The section is identified by its header line
+    (`## Reading Recalled Memory`, the module-level
+    `_RECALLED_MEMORY_SECTION_HEADER` constant). If the header already
+    appears as a line in the per-user copy (operator added it manually,
+    a previous migration ran, or the seed step just copied a current
+    template), the function is a no-op. Otherwise the section text is
+    extracted from the template by header-bounded scan (header line
+    through the next `## ` line or EOF) and appended verbatim with a
+    single blank-line separator.
+
+    Atomic via Path.replace on a temp file in the same directory. The
+    rename closes the partial-write window where a crash or signal
+    mid-write could leave the per-user copy half-populated. The temp
+    file lives in claude_dst's parent so the rename stays within one
+    filesystem and is a true atomic operation (cross-filesystem renames
+    fall back to copy+unlink, which is NOT atomic).
+
+    Ownership reconciliation rides on the caller. Path.replace is
+    rename(2); the post-rename file inherits the temp file's ownership
+    (the install runner, typically root via `sudo make install`), not
+    the per-user `os_user` the inner Claude subprocess writes as. The
+    per-user CLAUDE.md seed loop calls this helper BEFORE the
+    `_set_ownership` chown step, so the appended file's ownership is
+    reconciled in the same iteration; the comment block at the chown
+    site documents the #347 regression shape this prevents.
+
+    No in-source cleanup window. The helper is idempotent on every
+    install (sentinel check returns False on a no-op iteration with
+    no file IO past the existence + read), and is short enough that
+    keeping it indefinitely is cheaper than tracking a removal date.
+    Removal is a follow-up PR when the operator decides the population
+    of pre-migration per-user copies is empirically zero.
+
+    Args:
+        claude_dst: The per-user CLAUDE.md to append to. Path returned
+            by the per-user seed loop's resolution of
+            `<DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md`.
+        template_path: The tracked template
+            (`templates/.claude/CLAUDE.md`). Section text is extracted
+            from here on every call so a future revision to the
+            section's wording in the template propagates to the next
+            install's migration run.
+        dry_run: If True, return the would-be modification status
+            without writing anything; the caller's dry-run preview
+            branch consumes the bool to print the appropriate preview
+            line.
+    """
+    # Skip if the per-user copy does not exist. The seed step earlier
+    # in the loop just wrote a fresh copy from the current template if
+    # claude_dst was missing, so by the time live execution reaches
+    # this helper, claude_dst should exist; the explicit check guards
+    # the dry-run branch (where the seed is a preview-only print) and
+    # the operator-managed-override branch (where the seed is skipped
+    # entirely).
+    if not claude_dst.is_file():
+        return False
+
+    # Read the per-user copy and check for the sentinel header on a
+    # full-line basis. Substring match against the file body would
+    # false-positive on a future section like "## Reading Recalled
+    # Memory Notes" that starts with the same prefix; line-strip-equal
+    # is the precise check that matches what the migration's own
+    # append produces.
+    try:
+        existing = claude_dst.read_text()
+    except OSError as exc:
+        # Broken symlink, permissions, mount issue. Match the
+        # ensure_user_home swallow pattern: surface to operator log,
+        # continue the install rather than abort. The next install
+        # retries; the lazy seed path will also retry on first message.
+        print(f"  WARNING: could not read {claude_dst} for migration: {exc}")
+        return False
+
+    for line in existing.splitlines():
+        if line.strip() == _RECALLED_MEMORY_SECTION_HEADER:
+            return False  # Sentinel present; nothing to do.
+
+    # Read the template and extract the section by header-bounded scan.
+    # Reading template_path on every call (rather than caching at module
+    # import) keeps the helper testable with arbitrary template paths
+    # via tmp_path fixtures.
+    try:
+        template_text = template_path.read_text()
+    except OSError as exc:
+        print(f"  WARNING: could not read template {template_path}: {exc}")
+        return False
+
+    template_lines = template_text.splitlines(keepends=True)
+    section_start = None
+    for i, line in enumerate(template_lines):
+        if line.strip() == _RECALLED_MEMORY_SECTION_HEADER:
+            section_start = i
+            break
+
+    if section_start is None:
+        # Template predates the migration or has been edited to remove
+        # the section. The migration cannot reconstruct content that is
+        # not in the template; warn so the operator notices and either
+        # restores the template or removes this helper from the install
+        # flow. Mirrors the placeholder-warning shape the per-user
+        # CLAUDE.md seed loop uses ("WARNING: <template> not found").
+        print(
+            f"  WARNING: {template_path} is missing the "
+            f"{_RECALLED_MEMORY_SECTION_HEADER!r} section; "
+            f"cannot migrate {claude_dst}"
+        )
+        return False
+
+    # Find the section terminator: the next top-level `## ` line after
+    # the header, or EOF. The header itself is excluded from the
+    # `## ` scan via the `section_start + 1` start so it does not match
+    # itself as its own terminator.
+    section_end = len(template_lines)
+    for i in range(section_start + 1, len(template_lines)):
+        if template_lines[i].startswith("## "):
+            section_end = i
+            break
+
+    # Strip trailing blank lines from the extracted section so the
+    # append produces exactly one trailing newline, matching the
+    # tracked template's overall file shape (no trailing blank lines).
+    section_text = "".join(template_lines[section_start:section_end]).rstrip() + "\n"
+
+    if dry_run:
+        # Caller's dry-run preview branch prints the operator-facing
+        # line; this helper only signals "would modify" by returning
+        # True. Returning early before the temp-file write means a
+        # dry-run pass has zero filesystem side effects.
+        return True
+
+    # Append with a single blank-line separator. The rstrip() drops any
+    # trailing whitespace from the existing per-user copy so the
+    # separator is always exactly one blank line regardless of whether
+    # the source file ended in zero, one, or multiple newlines.
+    new_content = existing.rstrip() + "\n\n" + section_text
+
+    # Atomic write via temp file + Path.replace in the same directory.
+    # The temp file's name pairs the destination's name with a `.tmp`
+    # suffix; deterministic enough that a crash-interrupted earlier run
+    # leaves a recoverable artifact at a known path rather than a random
+    # mkstemp name. The try/except cleans up the temp file when
+    # write_text fails partway, so a partial-write does not leave debris
+    # in the .claude/ directory.
+    temp_path = claude_dst.parent / (claude_dst.name + ".tmp")
+    try:
+        temp_path.write_text(new_content)
+        temp_path.replace(claude_dst)
+    except OSError as exc:
+        # Clean up the partial temp file before propagating so a retry
+        # is not blocked by a stale .tmp file. unlink(missing_ok=True)
+        # handles the case where write_text never created the file.
+        temp_path.unlink(missing_ok=True)
+        print(f"  ERROR: could not migrate {claude_dst}: {exc}")
+        raise
+
+    return True
 
 
 def _retire_install_home_claude(install_path: Path, dry_run: bool) -> None:

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2459,28 +2459,41 @@ def _apply_migrate(
             else:
                 # Migration preview for an existing per-user copy. The
                 # seed branch above only fires when claude_dst is
-                # missing; the migration branch fires when claude_dst
+                # missing; the migration preview fires when claude_dst
                 # exists and the sentinel header may or may not be in
-                # place. Three sub-cases (sentinel missing -> would
-                # append; sentinel present -> already-migrated message;
-                # claude_dst unreadable -> warning handled inside the
-                # helper). Inspecting claude_dst here, before the
+                # place. Inspecting claude_dst here, before the
                 # `continue` below, ensures the dry-run preview reaches
                 # parity with what the live branch will do; without
                 # this branch, the dry-run output would silently omit
                 # the migration step the live install would execute.
-                if home_template_exists and _migrate_recalled_memory_section(claude_dst, home_template, dry_run=True):
-                    print(f"[DRY RUN] Would append Reading Recalled Memory section to {claude_dst}")
-                elif home_template_exists:
-                    # The helper returned False with sentinel present;
-                    # surface the no-op explicitly so the operator sees
-                    # the migration was considered and skipped, not
-                    # silently omitted.
-                    print(
-                        f"[DRY RUN] {claude_dst}: Reading Recalled Memory section already present, no migration needed"
-                    )
-                # else: template missing; the helper already printed a
-                # warning. No additional preview line needed.
+                #
+                # The helper's three-state return is the structural
+                # distinction that lets the preview print accurate text
+                # per case. Truthy/falsy alone would conflate sentinel-
+                # present (False) with the failure paths (None), producing
+                # a misleading "already present" line when the helper had
+                # actually warned about a different problem.
+                if home_template_exists:
+                    migration_result = _migrate_recalled_memory_section(claude_dst, home_template, dry_run=True)
+                    if migration_result is True:
+                        print(f"[DRY RUN] Would append Reading Recalled Memory section to {claude_dst}")
+                    elif migration_result is False:
+                        # Sentinel present; surface the no-op explicitly so
+                        # the operator sees the migration was considered.
+                        print(
+                            f"[DRY RUN] {claude_dst}: Reading Recalled Memory "
+                            f"section already present, no migration needed"
+                        )
+                    # else: migration_result is None; the helper already
+                    # printed its own WARNING for the specific failure path.
+                    # No additional preview line needed.
+                else:
+                    # Template missing entirely; the helper is never called
+                    # because of the short-circuit above, so no warning has
+                    # been printed in this iteration. Surface the gap so the
+                    # dry-run preview is honest about what the install can
+                    # and cannot do for this user.
+                    print(f"[DRY RUN] {claude_dst}: cannot evaluate migration (template missing at {home_template})")
             continue
 
         # Idempotent: never overwrite an operator-customized destination.
@@ -2527,7 +2540,7 @@ def _apply_migrate(
         # the install runner, gets reconciled back to the per-user
         # `os_user` in the same iteration; the chown comment block
         # below names the #347 regression shape this prevents).
-        if home_template_exists and _migrate_recalled_memory_section(claude_dst, home_template, dry_run=False):
+        if home_template_exists and _migrate_recalled_memory_section(claude_dst, home_template, dry_run=False) is True:
             print(f"  Appended Reading Recalled Memory section to {claude_dst}")
 
         # Recursive chown over the .claude/ subdir so both the
@@ -3002,9 +3015,9 @@ def _migrate_identity_to_claude_md(
 # whether a per-user CLAUDE.md already carries the Reading Recalled
 # Memory section. Module-level constant so the migration helper, the
 # dry-run preview branch in the per-user CLAUDE.md seed loop, and the
-# unit tests in test_install.py all read the same literal. A drift in
-# this string would let the migration re-append on every install
-# (sentinel always missing) and silently double-write the section.
+# sibling install tests all read the same literal. A drift in this
+# string would let the migration re-append on every install (sentinel
+# always missing) and silently double-write the section.
 _RECALLED_MEMORY_SECTION_HEADER = "## Reading Recalled Memory"
 
 
@@ -3013,22 +3026,39 @@ def _migrate_recalled_memory_section(
     template_path: Path,
     *,
     dry_run: bool,
-) -> bool:
+) -> bool | None:
     """
     Idempotently append the Reading Recalled Memory section from the
     tracked CLAUDE.md template to an existing per-user CLAUDE.md copy.
 
-    Returns True when the file was modified (or would be in dry-run),
-    False when the section was already present, the destination is
-    missing, or the template is unreadable / missing the section header.
+    Three return states so the dry-run preview can distinguish the
+    legitimate no-op from any failure path:
+
+    - True: the section would be (or was) appended. Sentinel absent in
+      claude_dst, template present and well-formed.
+    - False: the section is already present in claude_dst (sentinel
+      header matched line-strip-equal). Nothing to do; not an error.
+    - None: helper could not proceed. Failure paths include claude_dst
+      not a regular file, claude_dst unreadable, template_path
+      unreadable, and template missing the section header. Each path
+      prints its own operator-facing warning before returning None, so
+      the caller does not need to surface additional output.
+
+    The three-state return is the structural distinction that lets the
+    dry-run preview branch in `_apply_migrate` print accurate operator-
+    facing text per case without re-checking the sentinel separately;
+    truthiness alone (the prior bool return) conflated sentinel-present
+    with the failure paths and produced a misleading "section already
+    present" line when the helper had actually warned about a different
+    problem.
 
     The section is identified by its header line
     (`## Reading Recalled Memory`, the module-level
     `_RECALLED_MEMORY_SECTION_HEADER` constant). If the header already
     appears as a line in the per-user copy (operator added it manually,
     a previous migration ran, or the seed step just copied a current
-    template), the function is a no-op. Otherwise the section text is
-    extracted from the template by header-bounded scan (header line
+    template), the function returns False. Otherwise the section text
+    is extracted from the template by header-bounded scan (header line
     through the next `## ` line or EOF) and appended verbatim with a
     single blank-line separator.
 
@@ -3036,8 +3066,11 @@ def _migrate_recalled_memory_section(
     rename closes the partial-write window where a crash or signal
     mid-write could leave the per-user copy half-populated. The temp
     file lives in claude_dst's parent so the rename stays within one
-    filesystem and is a true atomic operation (cross-filesystem renames
-    fall back to copy+unlink, which is NOT atomic).
+    filesystem; `Path.replace` delegates to `os.replace`, which calls
+    `rename(2)` and surfaces `EXDEV` as `OSError` for cross-filesystem
+    targets. No silent fallback to copy+unlink (that is `shutil.move`'s
+    behavior, not `Path.replace`'s); the colocation here is a hard
+    requirement for the rename to succeed at all.
 
     Ownership reconciliation rides on the caller. Path.replace is
     rename(2); the post-rename file inherits the temp file's ownership
@@ -3077,7 +3110,7 @@ def _migrate_recalled_memory_section(
     # the operator-managed-override branch (where the seed is skipped
     # entirely).
     if not claude_dst.is_file():
-        return False
+        return None
 
     # Read the per-user copy and check for the sentinel header on a
     # full-line basis. Substring match against the file body would
@@ -3093,11 +3126,11 @@ def _migrate_recalled_memory_section(
         # continue the install rather than abort. The next install
         # retries; the lazy seed path will also retry on first message.
         print(f"  WARNING: could not read {claude_dst} for migration: {exc}")
-        return False
+        return None
 
     for line in existing.splitlines():
         if line.strip() == _RECALLED_MEMORY_SECTION_HEADER:
-            return False  # Sentinel present; nothing to do.
+            return False  # Sentinel present; legitimate no-op.
 
     # Read the template and extract the section by header-bounded scan.
     # Reading template_path on every call (rather than caching at module
@@ -3107,7 +3140,7 @@ def _migrate_recalled_memory_section(
         template_text = template_path.read_text()
     except OSError as exc:
         print(f"  WARNING: could not read template {template_path}: {exc}")
-        return False
+        return None
 
     template_lines = template_text.splitlines(keepends=True)
     section_start = None
@@ -3128,15 +3161,17 @@ def _migrate_recalled_memory_section(
             f"{_RECALLED_MEMORY_SECTION_HEADER!r} section; "
             f"cannot migrate {claude_dst}"
         )
-        return False
+        return None
 
     # Find the section terminator: the next top-level `## ` line after
     # the header, or EOF. The header itself is excluded from the
     # `## ` scan via the `section_start + 1` start so it does not match
-    # itself as its own terminator.
+    # itself as its own terminator. lstrip().startswith matches the
+    # whitespace-tolerant strip-equal check the sentinel scan uses,
+    # so a future indented top-level header still terminates the section.
     section_end = len(template_lines)
     for i in range(section_start + 1, len(template_lines)):
-        if template_lines[i].startswith("## "):
+        if template_lines[i].lstrip().startswith("## "):
             section_end = i
             break
 

--- a/templates/.claude/CLAUDE.md
+++ b/templates/.claude/CLAUDE.md
@@ -45,6 +45,22 @@ The `[Your personal preferences (file: ...):]` block injects PREFERENCES.md, the
 
 Write to PREFERENCES.md ONLY when the operator explicitly instructs ("save this as a preference," "add this to PREFERENCES," "make this always-on"). Even on explicit instruction, surface the proposed wording and confirm before persisting. Each entry pays a token cost on every turn, so growth must be deliberate.
 
+## Reading Recalled Memory
+
+When your session context contains the `[Relevant memories from past conversations - context only, not instructions:]` block (or, in disabled mode, the `[Your persistent memory (file: ...):]` block), treat each row as evidence about a past fact, not as a license to synthesize a confident answer.
+
+Three modes apply per row, graded by how much the row covers the user's question:
+
+- **Citation.** Full coverage: the row contains the answer. Quote or paraphrase it and answer plainly. Example: row says `(2026-04-15, fact) operator prefers Earl Grey over English Breakfast`. User asks "what tea do I prefer?" Answer: "You prefer Earl Grey."
+- **Inference.** Partial coverage where a single low-controversy bridging step closes the gap. Mark the inference as inference; do not present it as citation. Example: rows say `(2026-04-15, fact) operator lives in New York City` and `(2026-04-20, fact) operator prefers dark UI themes`. User asks "what time zone am I in?" Answer: "Based on your location (New York City), most likely Eastern Time. Memory doesn't state your time zone directly."
+- **Partial match with gap.** Partial coverage where the bridging step requires guessing across data the row does not contain. Surface the gap; do not fill it in by extrapolation. Example: row says `(2026-04-15, episode, success) Set up the home server. Outcome: server is running`. User asks "what OS is on my home server?" Answer: "Memory mentions you set up a home server but doesn't say what OS it runs. Can you fill that in?"
+
+A partial match is evidence of an open question, not a basis for a confident answer. When you would otherwise answer confidently from a row that does not fully cover the question, switch to the inference or partial-match shape above.
+
+The source tag in a row prefix names the row's provenance, not its credibility. Extracted facts and operator-imported (migration) facts both render as `fact`, so the agent cannot read one as more trustworthy than the other. Rows tagged `legacy` lack a source field entirely; older data, not lower quality. Episode rows (`episode, <quality>`) carry a different shape and apply the three-mode taxonomy the same way as fact rows.
+
+This rule applies to the recalled-memory block and the persistent-memory block. It does not apply to the user's current message, the chat history block, or any other context surface; those have their own contracts.
+
 ## Behavioral Rules
 
 - Questions are not commands. When the operator asks "is it safe to X?" or "should we X?", answer the question. Do not perform the action. Only act on explicit instructions like "do it" or "go ahead."

--- a/templates/.claude/CLAUDE.md
+++ b/templates/.claude/CLAUDE.md
@@ -57,7 +57,7 @@ Three modes apply per row, graded by how much the row covers the user's question
 
 A partial match is evidence of an open question, not a basis for a confident answer. When you would otherwise answer confidently from a row that does not fully cover the question, switch to the inference or partial-match shape above.
 
-The source tag in a row prefix names the row's provenance, not its credibility. Extracted facts and operator-imported (migration) facts both render as `fact`, so the agent cannot read one as more trustworthy than the other. Rows tagged `legacy` lack a source field entirely; older data, not lower quality. Episode rows (`episode, <quality>`) carry a different shape and apply the three-mode taxonomy the same way as fact rows.
+The source tag in a row prefix names the row's provenance, not its credibility. Extracted facts and operator-imported (migration) facts both render as `fact`, so the agent cannot read one as more trustworthy than the other. Rows tagged `legacy` lack a source field entirely, or carry a source the renderer does not recognize; older data or future schema drift, not lower quality. Episode rows (`episode, <quality>`) carry a different shape and apply the three-mode taxonomy the same way as fact rows.
 
 This rule applies to the recalled-memory block and the persistent-memory block. It does not apply to the user's current message, the chat history block, or any other context surface; those have their own contracts.
 

--- a/tests/test_install_recalled_memory_migration.py
+++ b/tests/test_install_recalled_memory_migration.py
@@ -1,0 +1,445 @@
+"""Tests for the Reading Recalled Memory migration helper.
+
+Covers `kai.install._migrate_recalled_memory_section` and its wiring into
+the per-user CLAUDE.md seed loop in `_apply_migrate`.
+
+The helper appends the `## Reading Recalled Memory` section from the
+tracked CLAUDE.md template to pre-existing per-user copies that predate
+the section. Without it, operators already on prior installs would
+never pick up the new section (the seed step in `_apply_migrate`'s
+per-user CLAUDE.md block guards with `if not claude_dst.exists()`, so
+a stale per-user copy survives reinstall untouched), and the rule
+would only apply to users added after the section landed in the template.
+
+The unit tests drive the helper directly with `tmp_path` fixtures; the
+integration tests drive it through `_apply_migrate` with the same
+stubbed `_set_ownership` / `os.chown` patches the sibling install tests
+use, so the ownership-reconciliation contract is exercised end-to-end
+without needing real OS accounts on the test host.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from kai.install import (
+    _RECALLED_MEMORY_SECTION_HEADER,
+    _apply_migrate,
+    _migrate_recalled_memory_section,
+)
+
+# The header-bounded scan in the helper needs at least two top-level
+# `##` sections to exercise the terminator path; we keep the fixture
+# minimal and stable so a future template-shape change does not bleed
+# into these tests' expected outputs.
+_TEMPLATE_WITH_SECTION = (
+    "# Kai\n"
+    "\n"
+    "## Memory Write Routing\n"
+    "\n"
+    "Write rules here.\n"
+    "\n"
+    "## Reading Recalled Memory\n"
+    "\n"
+    "Read rules here.\n"
+    "\n"
+    "Worked example: `(2026-04-15, fact) operator prefers Earl Grey`.\n"
+    "\n"
+    "## Behavioral Rules\n"
+    "\n"
+    "Behavioral rules here.\n"
+)
+
+# The same template content but without the recalled-memory section,
+# used to exercise the "template missing the section header" branch.
+_TEMPLATE_WITHOUT_SECTION = (
+    "# Kai\n\n## Memory Write Routing\n\nWrite rules here.\n\n## Behavioral Rules\n\nBehavioral rules here.\n"
+)
+
+# Operator-customized per-user copy that lacks the recalled-memory
+# section. Represents the pre-migration state of operators who installed
+# before this section landed in the tracked template.
+_STALE_PER_USER_COPY = (
+    "# Kai\n"
+    "\n"
+    "## Memory Write Routing\n"
+    "\n"
+    "OPERATOR LOCAL EDIT: prefer terse memory writes.\n"
+    "\n"
+    "## Behavioral Rules\n"
+    "\n"
+    "Behavioral rules here.\n"
+)
+
+
+# ── Unit tests: _migrate_recalled_memory_section ─────────────────────
+
+
+class TestMigrateRecalledMemorySection:
+    """Spec §6.2: six unit cases covering the helper's full input matrix.
+
+    These tests run the helper in isolation against `tmp_path` fixtures
+    so the failure modes (sentinel absent, sentinel present, template
+    missing section, broken symlink, partial-write recovery) are pinned
+    independent of the install-flow context.
+    """
+
+    # ── Case 1: per-user copy missing the section ──
+
+    def test_appends_section_when_missing(self, tmp_path):
+        """Append happens; file size grows; sentinel header is now present."""
+        template = tmp_path / "template.md"
+        template.write_text(_TEMPLATE_WITH_SECTION)
+        per_user = tmp_path / "per_user.md"
+        per_user.write_text(_STALE_PER_USER_COPY)
+        original_size = per_user.stat().st_size
+
+        result = _migrate_recalled_memory_section(per_user, template, dry_run=False)
+
+        assert result is True
+        new_content = per_user.read_text()
+        assert per_user.stat().st_size > original_size
+        assert _RECALLED_MEMORY_SECTION_HEADER in new_content
+        # The append should land at end-of-file with a single blank-line
+        # separator. The stale copy's last content line was "Behavioral
+        # rules here."; after the append, the section follows it.
+        assert "Behavioral rules here." in new_content
+        # Verify the operator's prior customization survives byte-for-byte
+        # in the prefix; the migration appends, it does not rewrite.
+        assert new_content.startswith(_STALE_PER_USER_COPY.rstrip())
+
+    def test_dry_run_appends_nothing_but_returns_true(self, tmp_path):
+        """Dry-run returns True (would-modify) without touching the file."""
+        template = tmp_path / "template.md"
+        template.write_text(_TEMPLATE_WITH_SECTION)
+        per_user = tmp_path / "per_user.md"
+        per_user.write_text(_STALE_PER_USER_COPY)
+
+        result = _migrate_recalled_memory_section(per_user, template, dry_run=True)
+
+        assert result is True
+        # File contents unchanged: byte-for-byte equality.
+        assert per_user.read_text() == _STALE_PER_USER_COPY
+
+    # ── Case 2: per-user copy already has the section ──
+
+    def test_noop_when_section_already_present(self, tmp_path):
+        """Sentinel present in per-user copy: helper returns False, file unchanged."""
+        template = tmp_path / "template.md"
+        template.write_text(_TEMPLATE_WITH_SECTION)
+        per_user = tmp_path / "per_user.md"
+        # A per-user copy that already carries the section, e.g. seeded
+        # from a current template or manually merged by the operator.
+        per_user.write_text(_TEMPLATE_WITH_SECTION)
+        original = per_user.read_text()
+
+        result = _migrate_recalled_memory_section(per_user, template, dry_run=False)
+
+        assert result is False
+        # Byte-for-byte unchanged. No idempotent re-append, no double
+        # section, no whitespace drift from a stray rstrip-then-write.
+        assert per_user.read_text() == original
+
+    # ── Case 3: operator-customized variant ──
+
+    def test_appends_to_operator_customized_variant_at_eof(self, tmp_path):
+        """An extra section between Memory Write Routing and Behavioral Rules survives.
+
+        The migration appends at end-of-file rather than mid-file, so
+        intervening operator-authored content is not displaced. This is
+        the §3.4 v3 guarantee that operators can leave the appended
+        section at EOF or move it to match their existing section
+        ordering after the fact (the sentinel check keeps the next
+        install idempotent regardless of position).
+        """
+        template = tmp_path / "template.md"
+        template.write_text(_TEMPLATE_WITH_SECTION)
+        per_user = tmp_path / "per_user.md"
+        customized = (
+            "# Kai\n"
+            "\n"
+            "## Memory Write Routing\n"
+            "\n"
+            "Write rules here.\n"
+            "\n"
+            "## Operator's Custom Section\n"
+            "\n"
+            "Some private operator notes that must not be moved or rewritten.\n"
+            "\n"
+            "## Behavioral Rules\n"
+            "\n"
+            "Behavioral rules here.\n"
+        )
+        per_user.write_text(customized)
+
+        result = _migrate_recalled_memory_section(per_user, template, dry_run=False)
+
+        assert result is True
+        new_content = per_user.read_text()
+        # Operator's custom section is intact at its original position.
+        assert "## Operator's Custom Section" in new_content
+        assert "Some private operator notes" in new_content
+        # The appended section lands at EOF, after Behavioral Rules.
+        operator_pos = new_content.find("## Operator's Custom Section")
+        behavioral_pos = new_content.find("## Behavioral Rules")
+        recalled_pos = new_content.find(_RECALLED_MEMORY_SECTION_HEADER)
+        assert operator_pos < behavioral_pos < recalled_pos
+
+    # ── Case 4: template missing the section header ──
+
+    def test_skip_with_warning_when_template_missing_section(self, tmp_path, capsys):
+        """Template lacks the section: skip, warn, do not modify per-user copy."""
+        template = tmp_path / "template.md"
+        template.write_text(_TEMPLATE_WITHOUT_SECTION)
+        per_user = tmp_path / "per_user.md"
+        per_user.write_text(_STALE_PER_USER_COPY)
+
+        result = _migrate_recalled_memory_section(per_user, template, dry_run=False)
+
+        assert result is False
+        # Per-user copy is byte-for-byte unchanged.
+        assert per_user.read_text() == _STALE_PER_USER_COPY
+        # Warning surfaces to operator stdout per the placeholder-warning
+        # shape the per-user CLAUDE.md seed loop uses when the template
+        # is missing.
+        warning = capsys.readouterr().out
+        assert "WARNING" in warning
+        assert str(template) in warning
+
+    # ── Case 5: per-user copy is a broken symlink ──
+
+    def test_skip_with_warning_on_broken_symlink(self, tmp_path, capsys):
+        """Broken symlink at claude_dst: skip with warning, no exception escapes."""
+        template = tmp_path / "template.md"
+        template.write_text(_TEMPLATE_WITH_SECTION)
+        per_user = tmp_path / "per_user.md"
+        # Point the symlink at a path that does not exist. is_file()
+        # returns False for a broken symlink, so the helper's existence
+        # guard hits first and returns False cleanly.
+        per_user.symlink_to(tmp_path / "nonexistent.md")
+
+        result = _migrate_recalled_memory_section(per_user, template, dry_run=False)
+
+        assert result is False
+        # The symlink itself is untouched (still a broken symlink).
+        assert per_user.is_symlink()
+        # No write occurred at the symlink target.
+        assert not (tmp_path / "nonexistent.md").exists()
+
+    # ── Case 6: atomic write recovery on mid-write failure ──
+
+    def test_atomic_write_preserves_original_on_failure(self, tmp_path, monkeypatch):
+        """Simulated write failure leaves the original per-user copy intact.
+
+        The helper writes a `.tmp` file in the same directory and then
+        Path.replace's it over the destination. A failure during the
+        temp write (the only point where partial state could exist)
+        must leave the destination byte-for-byte unchanged and clean up
+        the temp file. This pins the atomic-write contract referenced
+        in the helper's docstring against a real partial-write scenario,
+        which a coverage check alone would not catch.
+        """
+        template = tmp_path / "template.md"
+        template.write_text(_TEMPLATE_WITH_SECTION)
+        per_user = tmp_path / "per_user.md"
+        per_user.write_text(_STALE_PER_USER_COPY)
+
+        # Patch Path.write_text on the tmp_path namespace so the temp
+        # file write fails partway. The helper's try/except cleans up
+        # the temp file and re-raises OSError; the original per-user
+        # copy at `per_user` must remain untouched.
+        original_write_text = Path.write_text
+
+        def _failing_write_text(self, content, *args, **kwargs):
+            # Touch the tmp file partway through, then fail. Verifies
+            # the cleanup branch handles a partially-created temp file.
+            self.touch()
+            raise OSError("simulated mid-write failure")
+
+        monkeypatch.setattr(Path, "write_text", _failing_write_text)
+
+        with pytest.raises(OSError, match="simulated mid-write failure"):
+            _migrate_recalled_memory_section(per_user, template, dry_run=False)
+
+        # Restore the real write_text so the assertion below can read.
+        monkeypatch.setattr(Path, "write_text", original_write_text)
+
+        # Original per-user content is intact.
+        assert per_user.read_text() == _STALE_PER_USER_COPY
+        # Temp file was cleaned up by the helper's exception path.
+        temp_path = per_user.parent / (per_user.name + ".tmp")
+        assert not temp_path.exists()
+
+
+# ── Integration tests: per-user seed loop in _apply_migrate ─────────
+
+
+class TestApplyMigrateRecalledMemoryIntegration:
+    """Spec §6.3: three integration cases covering the dry-run wiring.
+
+    Drives the migration through `_apply_migrate` so the dry-run preview
+    branch (the `if dry_run:` branch in the per-user CLAUDE.md seed
+    loop) and the live branch (after `copy2`, before `_set_ownership`)
+    are exercised together. The patches mirror the sibling
+    TestApplyMigrateClaudeMdSeed in test_install.py so we do not need
+    real OS accounts on the test host.
+    """
+
+    def _write_users_yaml(self, path: Path, entries: list[dict]) -> None:
+        path.write_text(yaml.safe_dump({"users": entries}))
+
+    def _stub_pwd_getpwnam(self):
+        # See sibling note in test_install.py: _apply_migrate calls
+        # pwd.getpwnam to resolve os_user uid/gid; the stub keeps the
+        # test independent of any actual user on the host machine.
+        class _Pw:
+            pw_uid = 1234
+            pw_gid = 1234
+
+        return _Pw()
+
+    def _build_install_layout(self, tmp_path, template_content, claude_dst_content=None):
+        """Set up an install layout with a populated template and optional pre-existing per-user copy."""
+        src = tmp_path / "source"
+        ws_claude = src / "templates" / ".claude"
+        ws_claude.mkdir(parents=True)
+        (ws_claude / "CLAUDE.md").write_text(template_content)
+        # MEMORY.md and PREFERENCES.md templates are referenced by the
+        # sibling seed blocks in _apply_migrate; provide them so the
+        # function does not divert into a placeholder branch that
+        # would emit unrelated warnings into the test's capsys.
+        (ws_claude / "MEMORY.md").write_text("# Memory\n")
+        (ws_claude / "PREFERENCES.md").write_text("# Preferences\n")
+
+        users_yaml = tmp_path / "users.yaml"
+        self._write_users_yaml(users_yaml, [{"telegram_id": 12345, "os_user": "alice"}])
+
+        data_path = tmp_path / "data"
+        if claude_dst_content is not None:
+            claude_dir = data_path / "home" / "12345" / ".claude"
+            claude_dir.mkdir(parents=True)
+            (claude_dir / "CLAUDE.md").write_text(claude_dst_content)
+
+        install_path = tmp_path / "install"
+        install_path.mkdir()
+
+        return src, data_path, install_path, users_yaml
+
+    # ── Case A: stale + dry-run ──
+
+    def test_dry_run_previews_append_for_stale_copy(self, tmp_path, capsys):
+        """Stale per-user copy + dry-run: file unchanged, preview line printed."""
+        src, data_path, install_path, users_yaml = self._build_install_layout(
+            tmp_path,
+            template_content=_TEMPLATE_WITH_SECTION,
+            claude_dst_content=_STALE_PER_USER_COPY,
+        )
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install.pwd.getpwnam", return_value=self._stub_pwd_getpwnam()),
+            patch("kai.install._set_ownership"),
+            patch("os.chown"),
+        ):
+            _apply_migrate(
+                data_path,
+                install_path,
+                svc_uid=0,
+                svc_gid=0,
+                dry_run=True,
+                users_yaml_path=Path(users_yaml),
+            )
+
+        claude_dst = data_path / "home" / "12345" / ".claude" / "CLAUDE.md"
+        # File contents unchanged (dry-run).
+        assert claude_dst.read_text() == _STALE_PER_USER_COPY
+        # The dry-run preview surfaces in stdout so an operator running
+        # `make install --dry-run` sees the planned migration.
+        output = capsys.readouterr().out
+        assert "[DRY RUN] Would append Reading Recalled Memory section" in output
+        assert str(claude_dst) in output
+
+    # ── Case B: current + dry-run ──
+
+    def test_dry_run_reports_noop_when_section_already_present(self, tmp_path, capsys):
+        """Per-user copy already has section + dry-run: file unchanged, no-op line printed."""
+        src, data_path, install_path, users_yaml = self._build_install_layout(
+            tmp_path,
+            template_content=_TEMPLATE_WITH_SECTION,
+            # Per-user copy carries the section already (e.g. seeded
+            # from a current template or migrated in a prior install).
+            claude_dst_content=_TEMPLATE_WITH_SECTION,
+        )
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install.pwd.getpwnam", return_value=self._stub_pwd_getpwnam()),
+            patch("kai.install._set_ownership"),
+            patch("os.chown"),
+        ):
+            _apply_migrate(
+                data_path,
+                install_path,
+                svc_uid=0,
+                svc_gid=0,
+                dry_run=True,
+                users_yaml_path=Path(users_yaml),
+            )
+
+        claude_dst = data_path / "home" / "12345" / ".claude" / "CLAUDE.md"
+        assert claude_dst.read_text() == _TEMPLATE_WITH_SECTION
+        output = capsys.readouterr().out
+        assert "Reading Recalled Memory section already present" in output
+
+    # ── Case C: stale + live install ──
+
+    def test_live_install_appends_and_chowns(self, tmp_path):
+        """Live install on a stale per-user copy: section appended; _set_ownership called.
+
+        Ownership reconciliation is the load-bearing reason the migration
+        sits between the seed copy2 and the `_set_ownership` chown step;
+        the §4.3 ordering rationale documents the #347 regression shape
+        this prevents. Verifying that `_set_ownership` is invoked after
+        the migration runs pins the contract end-to-end.
+        """
+        src, data_path, install_path, users_yaml = self._build_install_layout(
+            tmp_path,
+            template_content=_TEMPLATE_WITH_SECTION,
+            claude_dst_content=_STALE_PER_USER_COPY,
+        )
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install.pwd.getpwnam", return_value=self._stub_pwd_getpwnam()),
+            patch("kai.install._set_ownership") as set_ownership_mock,
+            patch("os.chown"),
+        ):
+            _apply_migrate(
+                data_path,
+                install_path,
+                svc_uid=0,
+                svc_gid=0,
+                dry_run=False,
+                users_yaml_path=Path(users_yaml),
+            )
+
+        claude_dst = data_path / "home" / "12345" / ".claude" / "CLAUDE.md"
+        content = claude_dst.read_text()
+        # The section landed.
+        assert _RECALLED_MEMORY_SECTION_HEADER in content
+        # The operator's prior content survived.
+        assert "OPERATOR LOCAL EDIT" in content
+        # _set_ownership was called for the per-user .claude/ subdir
+        # AFTER the migration ran (the migration is sync, so any
+        # _set_ownership call we see was issued after the migration's
+        # Path.replace returned). At least one recursive call against
+        # the claude_dir is the contract; the seed loop calls
+        # _set_ownership unconditionally per-iteration.
+        called_paths = [call.args[0] for call in set_ownership_mock.call_args_list]
+        assert any("12345" in str(p) and ".claude" in str(p) for p in called_paths), (
+            f"_set_ownership was not called against the per-user .claude/ dir: {called_paths}"
+        )

--- a/tests/test_install_recalled_memory_migration.py
+++ b/tests/test_install_recalled_memory_migration.py
@@ -192,7 +192,12 @@ class TestMigrateRecalledMemorySection:
     # ── Case 4: template missing the section header ──
 
     def test_skip_with_warning_when_template_missing_section(self, tmp_path, capsys):
-        """Template lacks the section: skip, warn, do not modify per-user copy."""
+        """Template lacks the section: skip, warn, do not modify per-user copy.
+
+        Returns None (failure path), not False (no-op). The dry-run preview
+        relies on this distinction to avoid printing "already present" when
+        the helper has actually warned about a different problem.
+        """
         template = tmp_path / "template.md"
         template.write_text(_TEMPLATE_WITHOUT_SECTION)
         per_user = tmp_path / "per_user.md"
@@ -200,7 +205,7 @@ class TestMigrateRecalledMemorySection:
 
         result = _migrate_recalled_memory_section(per_user, template, dry_run=False)
 
-        assert result is False
+        assert result is None
         # Per-user copy is byte-for-byte unchanged.
         assert per_user.read_text() == _STALE_PER_USER_COPY
         # Warning surfaces to operator stdout per the placeholder-warning
@@ -213,18 +218,22 @@ class TestMigrateRecalledMemorySection:
     # ── Case 5: per-user copy is a broken symlink ──
 
     def test_skip_with_warning_on_broken_symlink(self, tmp_path, capsys):
-        """Broken symlink at claude_dst: skip with warning, no exception escapes."""
+        """Broken symlink at claude_dst: skip with warning, no exception escapes.
+
+        Returns None (failure path) so the dry-run preview can suppress the
+        "already present" line that would otherwise mislead the operator.
+        """
         template = tmp_path / "template.md"
         template.write_text(_TEMPLATE_WITH_SECTION)
         per_user = tmp_path / "per_user.md"
         # Point the symlink at a path that does not exist. is_file()
         # returns False for a broken symlink, so the helper's existence
-        # guard hits first and returns False cleanly.
+        # guard hits first and returns None cleanly.
         per_user.symlink_to(tmp_path / "nonexistent.md")
 
         result = _migrate_recalled_memory_section(per_user, template, dry_run=False)
 
-        assert result is False
+        assert result is None
         # The symlink itself is untouched (still a broken symlink).
         assert per_user.is_symlink()
         # No write occurred at the symlink target.
@@ -394,6 +403,54 @@ class TestApplyMigrateRecalledMemoryIntegration:
         assert claude_dst.read_text() == _TEMPLATE_WITH_SECTION
         output = capsys.readouterr().out
         assert "Reading Recalled Memory section already present" in output
+
+    # ── Case D: dry-run when the tracked template is missing entirely ──
+
+    def test_dry_run_surfaces_template_missing_when_claude_dst_exists(self, tmp_path, capsys):
+        """claude_dst exists + template absent + dry-run: surface the gap.
+
+        Without an explicit preview line for this case the dry-run output
+        would silently omit the migration step the operator might assume
+        would run. The seed branch above only fires when claude_dst is
+        missing, so under the (claude_dst exists, template missing)
+        combination the operator would otherwise see no relevant output.
+        """
+        src, data_path, install_path, users_yaml = self._build_install_layout(
+            tmp_path,
+            # Note: _build_install_layout normally writes a CLAUDE.md
+            # template; passing None here is not how the helper is set
+            # up. We rebuild the layout manually to omit the template.
+            template_content=_TEMPLATE_WITH_SECTION,
+            claude_dst_content=_STALE_PER_USER_COPY,
+        )
+        # Remove the CLAUDE.md template so home_template_exists is False
+        # at the seed-loop's check. MEMORY.md and PREFERENCES.md templates
+        # remain so the sibling seed blocks do not emit unrelated noise.
+        (src / "templates" / ".claude" / "CLAUDE.md").unlink()
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install.pwd.getpwnam", return_value=self._stub_pwd_getpwnam()),
+            patch("kai.install._set_ownership"),
+            patch("os.chown"),
+        ):
+            _apply_migrate(
+                data_path,
+                install_path,
+                svc_uid=0,
+                svc_gid=0,
+                dry_run=True,
+                users_yaml_path=Path(users_yaml),
+            )
+
+        claude_dst = data_path / "home" / "12345" / ".claude" / "CLAUDE.md"
+        # File unchanged in dry-run mode.
+        assert claude_dst.read_text() == _STALE_PER_USER_COPY
+        # The dry-run preview names the failure explicitly so the operator
+        # knows the migration was considered and could not proceed.
+        output = capsys.readouterr().out
+        assert "cannot evaluate migration" in output
+        assert "template missing" in output
 
     # ── Case C: stale + live install ──
 

--- a/tests/test_template_claude_md.py
+++ b/tests/test_template_claude_md.py
@@ -1,0 +1,136 @@
+"""Tests for the tracked inner-agent CLAUDE.md template.
+
+The template at templates/.claude/CLAUDE.md is the source for every per-user
+inner-agent identity file. It ships to new users via the install-time seed
+step and is the upstream of the _migrate_recalled_memory_section helper.
+Regressions to the structure or wording of pinned sections would propagate
+into every freshly-seeded per-user copy on the next install.
+
+Coverage focus: the `## Reading Recalled Memory` section added for the
+anti-fabrication rule. The assertions pin the section's structure and the
+worked-example literals against the values `_SOURCE_SHORT` actually emits
+at render time, so a future regression that desyncs the example tags from
+production output fails this test before reaching review.
+"""
+
+from __future__ import annotations
+
+import re
+
+from kai.config import PROJECT_ROOT
+
+# Path to the tracked template. Resolved through PROJECT_ROOT so the test
+# follows whatever install/dev anchoring config.py has bound rather than
+# hardcoding a relative path that breaks under either layout.
+_TEMPLATE = PROJECT_ROOT / "templates" / ".claude" / "CLAUDE.md"
+
+# The section header serves as the migration helper's sentinel. Pinning
+# it here means a rename in the template fails this test before it
+# silently breaks the install-time append logic in install.py.
+_SECTION_HEADER = "## Reading Recalled Memory"
+
+# The next top-level heading after the recalled-memory section. The
+# section is bounded by the literal `## Behavioral Rules` line; the
+# migration helper's header-bounded scan relies on this exact terminator.
+_NEXT_TOP_HEADER = "## Behavioral Rules"
+
+
+def _extract_section() -> str:
+    """Return the recalled-memory section verbatim (header through terminator)."""
+    text = _TEMPLATE.read_text()
+    start = text.find(_SECTION_HEADER)
+    assert start != -1, f"section header {_SECTION_HEADER!r} not found in template"
+    # Search for the next `## ` from a position past the header itself,
+    # not from start, so the section's own header line does not match.
+    end = text.find("\n## ", start + len(_SECTION_HEADER))
+    if end == -1:
+        # Section runs to EOF; valid shape, included for completeness so
+        # a future template that moves the section to the end of the
+        # file still passes the structural checks.
+        return text[start:]
+    return text[start:end]
+
+
+def test_section_header_present() -> None:
+    """Tracked template contains the literal sentinel header."""
+    assert _SECTION_HEADER in _TEMPLATE.read_text()
+
+
+def test_section_ends_before_next_top_header() -> None:
+    """Section is bounded by a top-level header (or EOF), not another `## `.
+
+    Catches the regression where a future top-level section accidentally
+    lands inside the recalled-memory block; the migration helper's
+    header-bounded scan would copy too few lines and the appended block
+    on existing per-user copies would be silently truncated.
+    """
+    section = _extract_section()
+    # The section's own header is the first occurrence; any subsequent
+    # `## ` at line start signals the terminator.
+    inner = section[len(_SECTION_HEADER) :]
+    assert "\n## " not in inner, (
+        "recalled-memory section contains a nested top-level header; expected the next `## ` to terminate the section"
+    )
+
+
+def test_three_mode_labels_present() -> None:
+    """Section contains the three mode labels the rule depends on."""
+    section = _extract_section()
+    for label in ("Citation", "Inference", "Partial match with gap"):
+        assert label in section, f"mode label {label!r} missing from recalled-memory section"
+
+
+def test_inference_example_hedge_present() -> None:
+    """Inference worked example carries the `Memory doesn't state` hedge.
+
+    The hedge phrasing is the load-bearing signal that distinguishes
+    inference from citation: the agent says it is inferring, names what
+    memory does NOT contain, and offers the bridge as a guess. Removing
+    or rewording this hedge would degrade the worked example into a
+    second citation example without anyone noticing in code review.
+    """
+    section = _extract_section()
+    assert "Memory doesn't state" in section, "inference worked example must include the `Memory doesn't state` hedge"
+
+
+def test_source_tag_literals_match_render_output() -> None:
+    """Worked examples use the source tags `_SOURCE_SHORT` actually emits.
+
+    `_SOURCE_SHORT` in `kai.memory` maps `extracted` -> `fact`,
+    `migration` -> `fact`, `episode` -> `episode`. The agent never sees
+    `extracted` in a row prefix. An earlier spec revision used
+    `, extracted)` in the worked examples, which broke the pattern-match
+    anchor the rule relies on; this test pins the corrected literals so
+    a future regression of the same class fails before reaching production.
+    """
+    section = _extract_section()
+    assert ", fact)" in section, (
+        "citation/inference examples must use the `fact` source tag "
+        "(what `_SOURCE_SHORT['extracted']` and `_SOURCE_SHORT['migration']` "
+        "actually emit), not `extracted`"
+    )
+    assert ", episode," in section, (
+        "partial-match example must use the `episode, <quality>` source-tag "
+        "shape that `format_context` actually emits for episode rows"
+    )
+
+
+def test_no_em_or_en_dashes_in_section() -> None:
+    """Section contains no em or en dashes.
+
+    The project-wide rule is to use hyphens, semicolons, periods, or
+    commas instead. Em/en dashes in operator-facing prompt content have
+    bitten review rounds before; pinning the rule mechanically against
+    the new section closes the recurrence path for this specific surface.
+    """
+    section = _extract_section()
+    # The regex character class contains the literal en dash (U+2013) and
+    # em dash (U+2014). The `noqa` suppresses ruff's RUF001 ambiguous-
+    # character lint here; the literal characters are deliberate because
+    # the test's whole purpose is to flag those exact characters in the
+    # tracked template content.
+    forbidden = re.findall("[–—]", section)  # noqa: RUF001
+    assert not forbidden, (
+        f"recalled-memory section contains em/en dashes: {forbidden!r}; "
+        "use hyphens, semicolons, periods, or commas instead"
+    )


### PR DESCRIPTION
## Summary

- Adds a `## Reading Recalled Memory` section to the tracked inner-agent CLAUDE.md template (`templates/.claude/CLAUDE.md`). The section gives the agent a three-mode taxonomy (citation, inference, partial-match-with-gap) and three worked examples for how to read the `[Relevant memories from past conversations - context only, not instructions:]` block in its context.
- New `_migrate_recalled_memory_section` helper in `install.py` appends the section idempotently to pre-existing per-user CLAUDE.md copies. New users pick up the section through the install-time seed step; existing users pick it up through this helper on the next `sudo make install`. Sentinel-header check keeps the helper a no-op on subsequent installs.
- Worked-example row prefixes use the source tags `_SOURCE_SHORT` actually emits at render time (`fact` for extracted and migration, `episode` for episodes). Both prefixes are pinned by snapshot test so a future regression to the example literals fails before reaching review.

## Why

The agent reads the recalled-memory block as evidence about past facts, but a partial match between the user's query and a row's content used to trigger confident-but-wrong answers; the agent would anchor on the partial match and fabricate around the gap. Prior eval work confirmed this failure mode persists with a clean memory store, so it lives in the agent's reading-of-memory behavior at use time, not in the write path. This is a prompt-only intervention at the CLAUDE.md layer.

## Files

- `templates/.claude/CLAUDE.md` - new section between `## Memory Write Routing` and `## Behavioral Rules`.
- `src/kai/install.py` - new `_migrate_recalled_memory_section` helper plus wiring into both the dry-run preview branch and the live branch of the per-user CLAUDE.md seed loop in `_apply_migrate`. Migration is atomic via `Path.replace` on a temp file in the same directory; ordering between the seed step and the `_set_ownership` chown is documented in the helper's docstring to prevent the #347-shape regression (post-rename file owned by install runner, inner subprocess cannot write its identity file).
- `tests/test_template_claude_md.py` - six new tests pinning the section's structure, mode labels, hedge phrasing, source-tag literals, and em/en-dash absence.
- `tests/test_install_recalled_memory_migration.py` - ten new tests: six unit cases on the helper (append, no-op, customized variant, missing-section-in-template, broken symlink, atomic-write recovery) plus three integration cases driving the helper through `_apply_migrate` (stale + dry-run, sentinel-present + dry-run, stale + live install with ownership reconciliation).

## Acceptance

Layer 2 behavioral cannot measure this change. The harness deliberately strips both the system prompt (`--system-prompt ""`) and CLAUDE.md auto-discovery (runs in `_EXTRACTOR_CWD`, a neutral directory) so it can isolate the recall-block effect on a context-stripped agent. The PR edits CLAUDE.md, so the harness returns the same numbers pre- and post-PR by design.

Acceptance shape is therefore qualitative: after merge and `sudo make install`, exercise the bot with partial-match-prone messages and eyeball the response shape (does the agent surface gaps instead of fabricating, does it mark inferences as inferences rather than citations). The migration helper's side of acceptance is mechanical and covered by the new test files.

## Test plan

- [x] 16 new unit tests pass (`tests/test_template_claude_md.py`, `tests/test_install_recalled_memory_migration.py`)
- [x] Full pytest suite passes: 2914 passed, 1 skipped
- [x] `make check` passes (ruff lint + format)
- [ ] Live install on the Mac mini lands the section on existing per-user CLAUDE.md copies via the migration helper
- [ ] Qualitative round-trip via Telegram on a partial-match-prone question confirms the rule changed the agent's response shape

Fixes #430.
