### PR TITLE
feat: positive-criterion extraction prompt

### DIFF
--- a/src/kai/eval/replay.py
+++ b/src/kai/eval/replay.py
@@ -361,8 +361,16 @@ async def _async_main(argv: list[str] | None = None) -> int:
     # not supplied. Loaded here (not at top) so a test can run without
     # /etc/kai/env or a populated DATA_DIR.
     from kai.config import DATA_DIR, load_config
+    from kai.memory import init_memory
 
     config = load_config()
+    # Initialize the memory store. Without this the module-level
+    # `_memory` in kai.memory is None, and every storage call
+    # (search, add_structured, delete_all) short-circuits to a silent
+    # no-op. Extractions still run via the subprocess, but every fact
+    # is dropped, surfacing as outcome=dropped_backend in the
+    # consolidation log.
+    init_memory(config)
     history_dir: Path = args.history_dir or (DATA_DIR / "history" / str(args.chat_id))
     context_turns: int = (
         args.context_turns if args.context_turns is not None else config.episode_classifier_context_turns

--- a/src/kai/eval/replay.py
+++ b/src/kai/eval/replay.py
@@ -272,6 +272,9 @@ def _build_pairs(records: list[dict[str, Any]]) -> list[tuple[str, str]]:
     return _pair_records_chronologically(records)
 
 
+_DRY_RUN_SAMPLE_LIMIT = 3
+
+
 async def _run_replay(
     pairs: list[tuple[str, str]],
     *,
@@ -279,15 +282,20 @@ async def _run_replay(
     context_turns: int,
     config: Any,
     dry_run: bool,
-) -> dict[str, int]:
+) -> tuple[dict[str, int], list[dict]]:
     """
     Walk pairs, maintain rolling prior buffer, call `extract_and_store`.
 
-    Returns a counters dict for the summary print. Counts are: pairs
-    processed, facts stored (sum of `extract_and_store` returns;
-    `extract_and_store` already buckets stored / replaced / skipped
-    internally but exposes only the stored count to callers, which is
-    what we report).
+    Returns `(counters, dry_run_samples)`:
+    - counters: pairs processed, facts stored (sum of
+      `extract_and_store` returns; `extract_and_store` already buckets
+      stored / replaced / skipped internally but exposes only the
+      stored count to callers, which is what we report).
+    - dry_run_samples: structural shape (`index`, `prior_count`,
+      `user_chars`, `assistant_chars`) for the first
+      `_DRY_RUN_SAMPLE_LIMIT` pairs when `dry_run=True`. Empty list
+      under a live run. Verbatim text is intentionally NOT captured;
+      see `_format_dry_run_samples` for the rationale.
     """
     # Late import so the test suite can monkeypatch `extract_and_store`
     # at the call site without touching the replay module's top-level
@@ -296,6 +304,7 @@ async def _run_replay(
     from kai.memory_extraction import extract_and_store
 
     counters: dict[str, int] = {"pairs_processed": 0, "facts_stored": 0}
+    dry_run_samples: list[dict] = []
     # Rolling prior buffer. The current pair is NOT included; only the
     # previous `context_turns` pairs are passed as PRIOR CONTEXT, which
     # matches production semantics where `bot.py`'s `_ingest_memory`
@@ -305,6 +314,21 @@ async def _run_replay(
     for user_text, assistant_text in pairs:
         if dry_run:
             counters["pairs_processed"] += 1
+            if len(dry_run_samples) < _DRY_RUN_SAMPLE_LIMIT:
+                # Capture structural shape only (no verbatim text):
+                # operator sees what the payload would look like
+                # without dumping potentially-personal history to a
+                # log artifact. The prior_count snapshot is taken
+                # BEFORE the rolling buffer is updated so it matches
+                # what `extract_and_store` would have seen.
+                dry_run_samples.append(
+                    {
+                        "index": counters["pairs_processed"],
+                        "prior_count": len(prior),
+                        "user_chars": len(user_text),
+                        "assistant_chars": len(assistant_text),
+                    }
+                )
             prior.append((user_text, assistant_text))
             if len(prior) > context_turns:
                 prior.pop(0)
@@ -329,7 +353,7 @@ async def _run_replay(
             # window is bounded so older pairs cannot indirectly survive
             # into a future iteration's PRIOR CONTEXT via the buffer.
             prior.pop(0)
-    return counters
+    return counters, dry_run_samples
 
 
 async def _reset_sandbox(user_id: str) -> None:
@@ -343,8 +367,79 @@ async def _reset_sandbox(user_id: str) -> None:
 
 
 def _format_summary(counters: dict[str, int]) -> str:
-    """Operator-readable run summary."""
+    """Operator-readable run summary (top-level scalar counts)."""
     return f"replay summary: pairs_processed={counters['pairs_processed']}, facts_stored={counters['facts_stored']}"
+
+
+def _format_breakdowns(facts: list) -> str:
+    """Operator-readable per-tag / per-speaker / per-prompt-version
+    breakdown of the sandbox user's post-replay fact set.
+
+    Spec §4.2 step 6 names these three groupings as the post-run
+    summary the operator inspects. They are also the fact-set
+    characteristics the PR-body comparison consumes, so this surface
+    and the PR-body comparison share their input shape.
+
+    Argument is the list returned by `memory.get_all_facts`; sortable
+    by `MemoryResult.metadata.get("tags")` (list), `metadata.speaker`
+    (string), and `metadata.prompt_version` (string). Empty input
+    returns an empty-grouping block rather than skipping the section,
+    so a zero-fact run still produces a parseable summary."""
+    from collections import Counter
+
+    by_tag: Counter[str] = Counter()
+    by_speaker: Counter[str] = Counter()
+    by_prompt_version: Counter[str] = Counter()
+    for f in facts:
+        # `metadata.tags` is a list; count each tag occurrence so a
+        # fact with three tags contributes to three buckets. This
+        # gives the operator "how many facts mention this tag" rather
+        # than "how many facts have this tag as their primary."
+        for tag in f.metadata.get("tags") or []:
+            by_tag[tag] += 1
+        speaker = f.metadata.get("speaker") or "unknown"
+        by_speaker[speaker] += 1
+        version = f.metadata.get("prompt_version") or "unknown"
+        by_prompt_version[version] += 1
+
+    def _fmt(counter: Counter[str]) -> str:
+        # Descending by count, alphabetical on ties, so two runs that
+        # produced the same multiset render byte-identical output.
+        if not counter:
+            return "  (none)"
+        items = sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))
+        return "\n".join(f"  {name}: {count}" for name, count in items)
+
+    return (
+        f"by tag ({len(by_tag)} distinct):\n{_fmt(by_tag)}\n"
+        f"by speaker ({len(by_speaker)} distinct):\n{_fmt(by_speaker)}\n"
+        f"by prompt_version ({len(by_prompt_version)} distinct):\n{_fmt(by_prompt_version)}"
+    )
+
+
+def _format_dry_run_samples(samples: list[dict]) -> str:
+    """Operator-readable structural sample of dry-run payload shapes.
+
+    Spec §4.2 names `--dry-run` as the operator's pre-flight check:
+    walk the history without spending wall-clock on extraction, and
+    report what the payloads would look like. The pair-count alone
+    answers "how many" but not "what shape," so the dry-run prints a
+    structural sample for the first N pairs: the prior-buffer depth
+    that pair would have seen and the user/assistant character lengths
+    that drive the payload size.
+
+    Verbatim text is NOT dumped: even a sandbox dry-run can include
+    operator-personal history, and stdout becomes a log artifact. The
+    character counts give the operator the shape signal they need."""
+    if not samples:
+        return "dry-run payload samples: (no pairs to sample)"
+    lines = [f"dry-run payload samples (first {len(samples)} pair(s)):"]
+    for s in samples:
+        lines.append(
+            f"  pair {s['index']}: prior_pairs={s['prior_count']} "
+            f"user_chars={s['user_chars']} assistant_chars={s['assistant_chars']}"
+        )
+    return "\n".join(lines)
 
 
 async def _async_main(argv: list[str] | None = None) -> int:
@@ -364,13 +459,6 @@ async def _async_main(argv: list[str] | None = None) -> int:
     from kai.memory import init_memory
 
     config = load_config()
-    # Initialize the memory store. Without this the module-level
-    # `_memory` in kai.memory is None, and every storage call
-    # (search, add_structured, delete_all) short-circuits to a silent
-    # no-op. Extractions still run via the subprocess, but every fact
-    # is dropped, surfacing as outcome=dropped_backend in the
-    # consolidation log.
-    init_memory(config)
     history_dir: Path = args.history_dir or (DATA_DIR / "history" / str(args.chat_id))
     context_turns: int = (
         args.context_turns if args.context_turns is not None else config.episode_classifier_context_turns
@@ -382,6 +470,16 @@ async def _async_main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 2
+
+    # Initialize the memory store. Without this the module-level
+    # `_memory` in kai.memory is None, and every storage call
+    # (search, add_structured, delete_all) short-circuits to a silent
+    # no-op. Extractions still run via the subprocess, but every fact
+    # is dropped, surfacing as outcome=dropped_backend in the
+    # consolidation log. Placed AFTER argument validation so a bad
+    # `--context-turns` does not trigger the first-run Mem0 embedding-
+    # model download (~80MB) only to exit immediately.
+    init_memory(config)
 
     file_paths = _iter_history_files(history_dir, args.start_date, args.end_date)
     if not file_paths:
@@ -399,7 +497,7 @@ async def _async_main(argv: list[str] | None = None) -> int:
         # inspect, and any side effect violates the contract.
         await _reset_sandbox(args.user_id)
 
-    counters = await _run_replay(
+    counters, dry_run_samples = await _run_replay(
         pairs,
         user_id=args.user_id,
         context_turns=context_turns,
@@ -407,6 +505,21 @@ async def _async_main(argv: list[str] | None = None) -> int:
         dry_run=args.dry_run,
     )
     print(_format_summary(counters))
+    if args.dry_run:
+        # Dry-run skips storage, so the by-tag / by-speaker /
+        # by-prompt-version breakdowns would always be empty. The
+        # payload-shape sample replaces them in the dry-run path.
+        print(_format_dry_run_samples(dry_run_samples))
+    else:
+        # Live run: query the sandbox user's post-run fact set and
+        # print the three breakdowns spec §4.2 step 6 named.
+        # `get_all_facts` is the standard read-side primitive; the
+        # late import keeps the unit-test surface free of the memory
+        # module unless the live path is actually exercised.
+        from kai.memory import get_all_facts
+
+        facts = get_all_facts(user_id=args.user_id)
+        print(_format_breakdowns(facts))
     return 0
 
 

--- a/src/kai/eval/replay.py
+++ b/src/kai/eval/replay.py
@@ -1,0 +1,411 @@
+"""
+Replay extraction over a chat-history window into a sandbox `user_id`.
+
+The bot extracts inline as each USER+ASSISTANT pair arrives via webhook;
+there is no built-in path for re-extracting an older history window
+under a different prompt version. This module supplies that path so a
+spec-implementation cycle can capture pre-PR and post-PR sandbox fact
+sets for comparison without disturbing production Qdrant state.
+
+Production semantics this module preserves:
+
+- USER+ASSISTANT pair as the unit of advance (matching `bot.py:3707-3727`).
+- Up to `episode_classifier_context_turns` prior pairs rendered as
+  PRIOR CONTEXT (default 3 from `config.py:530`).
+- Prior-turn character caps `_PRIOR_USER_CHARS = 800` /
+  `_PRIOR_ASSISTANT_CHARS = 1200` (`memory_extraction.py:137-138`),
+  inherited automatically because the replay calls
+  `extract_and_store`, which internally invokes
+  `_build_extraction_payload`.
+- CONSOLIDATION (intent: new / update_of / skip_redundant) against
+  facts already in the sandbox `user_id`. The accumulating sandbox
+  fact set rebuilds the production semantic that an existing operator
+  account would carry into each new pair's extraction.
+
+What this module deliberately does NOT do:
+
+- Run against a real chat_id. The `--user-id` argument MUST start with
+  the literal `sandbox-` prefix; any other value raises before any
+  extraction or storage call. Defense in depth: a typo or misuse
+  cannot write replayed facts to a real user's memory store.
+- Read the prompt from a flag. The prompt version follows the source
+  tree state: to replay with v8, check out the pre-swap commit; to
+  replay with v9, check out the post-swap commit. Tying prompt
+  version to source state matches the production semantic (no
+  per-run prompt selection in the live extractor).
+
+Pairing semantics are inherited from `history._pair_records_chronologically`
+so the replay's input to `extract_and_store` is byte-equivalent to what
+production fed the extractor on the same conversation, modulo
+sandbox-vs-production accumulating-fact-set differences (both v8 and
+v9 sandbox replays start from an empty fact set, so the
+sandbox-vs-sandbox comparison controls for that on both sides).
+
+Cleanup: `--reset` calls `memory.delete_all(user_id=<sandbox-id>)` before
+the replay starts so reruns are idempotent and a stale partial run does
+not contaminate the next baseline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# Sandbox prefix enforced on the `--user-id` flag. The whole point of
+# isolation here is keeping replay facts out of real users' stores;
+# enforcing the prefix structurally (rather than via documentation
+# alone) closes the typo / misuse path. Mirrors the convention used in
+# the spec's §3.3 sandbox example (`sandbox-464`).
+_SANDBOX_USER_ID_PREFIX = "sandbox-"
+
+
+def _parse_date(raw: str) -> date:
+    """Parse YYYY-MM-DD; raise argparse-friendly error on bad shape."""
+    try:
+        return datetime.strptime(raw, "%Y-%m-%d").date()
+    except ValueError as exc:
+        # argparse catches this and surfaces the message verbatim.
+        raise argparse.ArgumentTypeError(f"expected YYYY-MM-DD, got {raw!r}: {exc}") from exc
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Argparse setup. Documented surface; see module docstring for rationale."""
+    parser = argparse.ArgumentParser(
+        prog="python -m kai.eval.replay",
+        description=(
+            "Replay extraction over a chat-history window into a sandbox "
+            "user_id. See module docstring for production-semantic guarantees."
+        ),
+    )
+    parser.add_argument(
+        "--history-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory containing chat-history JSONL files for the source "
+            "chat_id. Defaults to <DATA_DIR>/history/<chat_id>/."
+        ),
+    )
+    parser.add_argument(
+        "--chat-id",
+        type=int,
+        required=True,
+        help=(
+            "Source chat_id whose history is being replayed. Records "
+            "belonging to a different chat_id (or no chat_id) are dropped, "
+            "matching production's `get_recent_pairs` strictness."
+        ),
+    )
+    parser.add_argument(
+        "--user-id",
+        required=True,
+        help=(
+            "Sandbox user_id to write extracted facts to. MUST start with "
+            f"{_SANDBOX_USER_ID_PREFIX!r}; any other value raises before any "
+            "extraction or storage call."
+        ),
+    )
+    parser.add_argument(
+        "--start-date",
+        type=_parse_date,
+        default=None,
+        help=("First history file to include (YYYY-MM-DD, inclusive). Defaults to the oldest file present."),
+    )
+    parser.add_argument(
+        "--end-date",
+        type=_parse_date,
+        default=None,
+        help=("Last history file to include (YYYY-MM-DD, inclusive). Defaults to the newest file present."),
+    )
+    parser.add_argument(
+        "--context-turns",
+        type=int,
+        default=None,
+        help=(
+            "Number of prior USER+ASSISTANT pairs to include as PRIOR "
+            "CONTEXT. Defaults to config.episode_classifier_context_turns "
+            "(currently 3)."
+        ),
+    )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help=(
+            "Delete the sandbox user_id's existing facts before replay "
+            "starts. Idempotent reset for clean baseline reruns."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Walk history and report the pair count and a sample of "
+            "payload shapes without calling the extractor or writing to "
+            "the store."
+        ),
+    )
+    return parser
+
+
+def _validate_user_id(user_id: str) -> None:
+    """Sandbox prefix guard. Raises ValueError; argparse-side fallthrough."""
+    if not user_id.startswith(_SANDBOX_USER_ID_PREFIX):
+        raise ValueError(
+            f"--user-id must start with {_SANDBOX_USER_ID_PREFIX!r} to "
+            f"prevent accidental writes to a real user store; got {user_id!r}"
+        )
+
+
+def _iter_history_files(
+    history_dir: Path,
+    start_date: date | None,
+    end_date: date | None,
+) -> list[Path]:
+    """
+    Return JSONL files in [start_date, end_date] inclusive, oldest first.
+
+    Production history files are named `YYYY-MM-DD.jsonl` (one file per
+    UTC day per chat_id). Files with non-matching names (e.g., a stray
+    backup or rotated artifact) are skipped silently so a misplaced
+    file does not abort the replay run.
+
+    Sorting oldest-first matches the natural reading order of a replay:
+    PRIOR CONTEXT for pair N is the previous N-1 pairs in chronological
+    sequence, which only stays correct when files are processed in
+    ascending date order.
+    """
+    if not history_dir.is_dir():
+        return []
+    selected: list[tuple[date, Path]] = []
+    for path in history_dir.glob("*.jsonl"):
+        try:
+            file_date = datetime.strptime(path.stem, "%Y-%m-%d").date()
+        except ValueError:
+            # Non-date-named file; skip silently. The bot only writes
+            # date-stamped files, so anything else is an operator-side
+            # artifact (backup, manual edit) that the replay should not
+            # touch.
+            continue
+        if start_date is not None and file_date < start_date:
+            continue
+        if end_date is not None and file_date > end_date:
+            continue
+        selected.append((file_date, path))
+    selected.sort(key=lambda t: t[0])
+    return [p for _d, p in selected]
+
+
+def _load_records(
+    file_paths: list[Path],
+    chat_id: int,
+) -> list[dict[str, Any]]:
+    """
+    Read JSONL records across files, filtered by chat_id and content.
+
+    Filters mirror `history._pair_records_chronologically`'s preconditions
+    so the resulting pair stream is byte-equivalent to what production
+    would have built from the same records. Reusing the production
+    pairing helper (imported at call site) on this filtered record list
+    keeps the semantics in one place.
+
+    Returns a flat list of records (each is a dict with `dir` and
+    `text` keys) in chronological order across all files. Pairing is
+    handled by the production helper; this function only does the
+    filter pass.
+    """
+    # Import inside the function so the test suite can monkeypatch the
+    # underlying constants (e.g., `_SYNTHETIC_ASSISTANT_MARKERS`) before
+    # this module is loaded. Top-level imports would freeze them at
+    # import time.
+    from kai.history import _SYNTHETIC_ASSISTANT_MARKERS
+
+    records: list[dict[str, Any]] = []
+    for path in file_paths:
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            log.warning("Skipping unreadable history file %s: %s", path, exc)
+            continue
+        for line in raw.splitlines():
+            if not line.strip():
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                # Skip individual bad lines rather than abort the file,
+                # matching `history.get_recent_pairs`'s tolerance for
+                # partial corruption from interrupted writes.
+                continue
+            if "chat_id" not in rec or rec.get("chat_id") != chat_id:
+                continue
+            text = (rec.get("text") or "").strip()
+            if not text:
+                continue
+            direction = rec.get("dir")
+            if direction == "assistant" and _SYNTHETIC_ASSISTANT_MARKERS.fullmatch(text):
+                # Failure-path placeholders from /stop, empty results,
+                # or error paths in bot.py. Pairing them into a windowed
+                # payload would feed the classifier a "botched exchange"
+                # prior context that distorts results.
+                continue
+            records.append({"dir": direction, "text": text})
+    return records
+
+
+def _build_pairs(records: list[dict[str, Any]]) -> list[tuple[str, str]]:
+    """Run records through the production pairing helper."""
+    # Imported here (not at module top) so the test suite's pairing
+    # tests can monkeypatch the helper independently of the replay
+    # module's other functions. Mirrors `_load_records`'s late-import
+    # for the synthetic-marker regex.
+    from kai.history import _pair_records_chronologically
+
+    return _pair_records_chronologically(records)
+
+
+async def _run_replay(
+    pairs: list[tuple[str, str]],
+    *,
+    user_id: str,
+    context_turns: int,
+    config: Any,
+    dry_run: bool,
+) -> dict[str, int]:
+    """
+    Walk pairs, maintain rolling prior buffer, call `extract_and_store`.
+
+    Returns a counters dict for the summary print. Counts are: pairs
+    processed, facts stored (sum of `extract_and_store` returns;
+    `extract_and_store` already buckets stored / replaced / skipped
+    internally but exposes only the stored count to callers, which is
+    what we report).
+    """
+    # Late import so the test suite can monkeypatch `extract_and_store`
+    # at the call site without touching the replay module's top-level
+    # imports. Tests that exercise the replay's pairing logic do not
+    # need a real `extract_and_store` resolved.
+    from kai.memory_extraction import extract_and_store
+
+    counters: dict[str, int] = {"pairs_processed": 0, "facts_stored": 0}
+    # Rolling prior buffer. The current pair is NOT included; only the
+    # previous `context_turns` pairs are passed as PRIOR CONTEXT, which
+    # matches production semantics where `bot.py`'s `_ingest_memory`
+    # drops the in-flight pair before threading prior_pairs into
+    # `extract_and_store`.
+    prior: list[tuple[str, str]] = []
+    for user_text, assistant_text in pairs:
+        if dry_run:
+            counters["pairs_processed"] += 1
+            prior.append((user_text, assistant_text))
+            if len(prior) > context_turns:
+                prior.pop(0)
+            continue
+        # Pass a SHALLOW COPY of `prior` so a future change inside
+        # `extract_and_store` that mutates its `prior_pairs` argument
+        # cannot corrupt the rolling buffer on the next iteration.
+        # extract_and_store does not mutate today, but the contract is
+        # not documented as immutable.
+        stored = await extract_and_store(
+            user_text,
+            assistant_text,
+            user_id=user_id,
+            config=config,
+            prior_pairs=list(prior),
+        )
+        counters["pairs_processed"] += 1
+        counters["facts_stored"] += stored
+        prior.append((user_text, assistant_text))
+        if len(prior) > context_turns:
+            # Drop the oldest pair to maintain the rolling window. The
+            # window is bounded so older pairs cannot indirectly survive
+            # into a future iteration's PRIOR CONTEXT via the buffer.
+            prior.pop(0)
+    return counters
+
+
+async def _reset_sandbox(user_id: str) -> None:
+    """Delete all facts for the sandbox `user_id`. No-op safe."""
+    # Late import to keep replay-module import cheap and to let tests
+    # monkeypatch the deletion path independently of the rest of the
+    # module.
+    from kai.memory import delete_all
+
+    delete_all(user_id=user_id)
+
+
+def _format_summary(counters: dict[str, int]) -> str:
+    """Operator-readable run summary."""
+    return f"replay summary: pairs_processed={counters['pairs_processed']}, facts_stored={counters['facts_stored']}"
+
+
+async def _async_main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        _validate_user_id(args.user_id)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    # Resolve history_dir and config_turns from production config when
+    # not supplied. Loaded here (not at top) so a test can run without
+    # /etc/kai/env or a populated DATA_DIR.
+    from kai.config import DATA_DIR, load_config
+
+    config = load_config()
+    history_dir: Path = args.history_dir or (DATA_DIR / "history" / str(args.chat_id))
+    context_turns: int = (
+        args.context_turns if args.context_turns is not None else config.episode_classifier_context_turns
+    )
+
+    if context_turns < 0:
+        print(
+            f"error: --context-turns must be non-negative, got {context_turns}",
+            file=sys.stderr,
+        )
+        return 2
+
+    file_paths = _iter_history_files(history_dir, args.start_date, args.end_date)
+    if not file_paths:
+        print(
+            f"warning: no history files found in {history_dir} for the given date range; nothing to replay",
+            file=sys.stderr,
+        )
+
+    records = _load_records(file_paths, args.chat_id)
+    pairs = _build_pairs(records)
+
+    if args.reset and not args.dry_run:
+        # Reset only on a live run. A dry-run that destroys sandbox
+        # state would be a footgun: the operator types `--dry-run` to
+        # inspect, and any side effect violates the contract.
+        await _reset_sandbox(args.user_id)
+
+    counters = await _run_replay(
+        pairs,
+        user_id=args.user_id,
+        context_turns=context_turns,
+        config=config,
+        dry_run=args.dry_run,
+    )
+    print(_format_summary(counters))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Sync entry point for `python -m kai.eval.replay`."""
+    return asyncio.run(_async_main(argv))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -376,7 +376,7 @@ STORE these fact types:
   must be per-user, not shared"). NOT workflow micro-decisions
   about which task to do next, which spec to evaluate, or which
   issue to file - those are transient session activity. Apply the
-  DURABILITY TEST below.
+  QUALITY TEST below.
 - Actions the user confirmed happened, BUT with strict evidence
   rules to prevent laundered hallucinations:
   1. A confirmed_action fact must include a `confirmation_quote`
@@ -426,6 +426,8 @@ Worked examples (emit / do not emit):
 - Assistant says "I'm extracting facts now" with no user response.
   -> do not emit. Assistant self-report, not a fact about the user
   or the world.
+- User says "I'm writing the spec now." -> do not emit. In-progress
+  task state; loses meaning once the spec is shipped.
 
 If a candidate fact passes this test, proceed to STORE-block
 classification (above). If it fails, return an empty facts list
@@ -1047,7 +1049,7 @@ _CONSOLIDATION_INTENTS: frozenset[str] = frozenset({"new", "update_of", "skip_re
 # whose content is pure session-event metadata: spec/PR/issue
 # lifecycle events and "User decided/requested to <workflow-action>"
 # wordings. Pattern is intentionally narrower than the prompt's
-# IGNORE rules; the prompt is the primary gate, this regex is
+# QUALITY TEST; the prompt is the primary gate, this regex is
 # defense-in-depth for the cases where the model emits noise despite
 # the prompt. The model can defeat the regex by paraphrasing; a
 # future broader pattern (or per-extractor model upgrade) can be
@@ -1070,7 +1072,7 @@ _WORKFLOW_EVENT_RE = re.compile(
     # "User ..." (the canonical example in FORMAT); the operator-
     # specific "OC" subject is included as defense-in-depth for
     # operator history that contains it. Broader paraphrases are
-    # left for the prompt's IGNORE rules. A future maintainer who
+    # left for the prompt's QUALITY TEST. A future maintainer who
     # needs to catch non-leading subjects should drop the `^`
     # rather than only adding more verbs.
     r"^(User|OC)\s+(decided|requested)\s+to\s+"
@@ -1098,7 +1100,7 @@ _WORKFLOW_EVENT_RE = re.compile(
     # Arm 4: "The evaluation of (spec|specification|issue|PR) X
     # (produced|was|determined) Y". Past-tense / determined
     # variants only; broader paraphrases are left to the prompt's
-    # IGNORE rules.
+    # QUALITY TEST.
     r"\b(evaluation\s+of\s+(spec(ification)?|issue|PR)\s+\S+"
     r"\s+(produced|was|determined))\b"
     r")",
@@ -1525,7 +1527,7 @@ def _validate_facts(
             continue
 
         # Rule 6: reject workflow-event-shaped content. Defense-in-depth
-        # against the prompt's IGNORE rules missing edge cases. The
+        # against the prompt's QUALITY TEST missing edge cases. The
         # rejection is logged at INFO (not DEBUG) because the rate of
         # Rule 6 rejections is itself an operational signal: if Rule 6
         # fires often the prompt is leaking, and the prompt should be

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -89,7 +89,18 @@ log = logging.getLogger(__name__)
 # substring appears verbatim in an ASSISTANT message in the window.
 # The bump lets post-rollout log analysis cleanly partition facts
 # produced under the speaker-attribution prompt from earlier ones.
-_EXTRACTION_PROMPT_VERSION: str = "8"
+# v9 (2026-05-12): swapped the negative-list IGNORE block and the
+# 30-day DURABILITY TEST for a single positive criterion (QUALITY
+# TEST). The criterion asks "would this fact help a future
+# conversation that does not include the current turn?" applied per
+# candidate, with six worked examples (three emit, three do not emit)
+# anchoring the counterfactual reasoning. Negative-list growth from
+# v6 / v7 prompts was bounded by the author's enumeration of failure
+# modes; the positive criterion generalizes to phrasings the list has
+# not seen. Schema unchanged; the bump lets post-rollout log analysis
+# distinguish facts produced under the positive-criterion prompt from
+# earlier exclusion-list iterations.
+_EXTRACTION_PROMPT_VERSION: str = "9"
 
 # Sibling of _EXTRACTION_PROMPT_VERSION for stage-2 episode generation.
 # Stored in each episode's metadata so future cleanups can target a
@@ -385,47 +396,40 @@ STORE these fact types:
 - Constraints or requirements the user stated ("must be local",
   "must not use external APIs", "never commit without running tests").
 
-IGNORE:
-- Assistant self-reports of completed actions unless user-confirmed
-  ("I saved the file", "Done", "Created X", "Pushed to main").
-  Treat these as unverified until the user confirms.
-- Assistant speculation, hypotheticals, or hedging ("I think...",
-  "it might be...", "probably...").
-- Intermediate reasoning, tool-output summaries, step-by-step plans.
-- Transient conversation state (what you are mid-doing, open
-  questions, clarifying requests).
-- Workflow-event metadata: spec/PR/issue lifecycle events. Examples
-  to NOT extract: "Spec X v3 was approved", "PR Y received a review
-  verdict of Z", "All N findings were closed in vM",
-  "The evaluation of spec Q produced a verdict of R". The durable
-  artifact is the spec/PR/issue itself; events around it are
-  transient session activity that loses meaning once the event
-  closes.
-- "Decisions to do" workflow actions: a decision to file an issue,
-  create a spec, request an evaluation, run a test, or perform
-  any other workflow action. The artifact produced (the issue,
-  the spec, the test result) is the durable fact; the
-  decision-to-do is workflow noise. Examples to NOT extract:
-  "User decided to file an issue about X", "User requested
-  evaluation of spec Y", "User decided to address issue #Z",
-  "User confirmed test input triggered the pipeline".
-- Casual chat, greetings, acknowledgments, thanks without content.
-- Anything that contradicts a stated user preference.
-- Code snippets, file contents, error messages (store facts about
-  them if needed, not the raw text).
+QUALITY TEST:
 
-DURABILITY TEST:
+Before emitting any fact, ask: "Would this fact help a future
+conversation that does not include the current turn?" If no, do
+not emit it.
 
-Before emitting any fact, ask: "would this still be useful context
-in 30 days?" If the answer is no - because the fact captures a
-workflow event, a one-off task decision, a status of work in
-progress that will have shipped or moved on, or a session-event
-metadata fragment - do not emit it. The 30-day test catches the
-most common low-quality extraction: session-event metadata that
-reads as fact-shaped but loses meaning once the event closes.
+The question is counterfactual: imagine a future session where the
+current exchange is gone but the user is asking about the same
+topic. Would having this fact in memory help that future session?
+If the fact only makes sense alongside the current turn (workflow
+event, status update, in-progress task state, procedural fragment),
+the answer is no and the fact should not be emitted.
 
-If a fact passes IGNORE rules but fails the durability test,
-do not emit it.
+Worked examples (emit / do not emit):
+
+- User says "I prefer Celsius." -> emit. Useful in any future
+  conversation about units.
+- Assistant says "Spec X v3 was approved" and user replies "great".
+  -> do not emit. The artifact (the spec) is durable; the approval
+  event is workflow noise that loses meaning once v4 ships.
+- User says "I live in Toronto." -> emit. Useful in any future
+  conversation about location, weather, scheduling.
+- User says "Let's file an issue about X." -> do not emit. The
+  artifact (the issue) is durable; the decision-to-file is workflow
+  state that ends once the issue is filed.
+- User says "My laptop is a 2024 M3 MacBook Pro." -> emit. Useful
+  in any future conversation about hardware, performance, costs.
+- Assistant says "I'm extracting facts now" with no user response.
+  -> do not emit. Assistant self-report, not a fact about the user
+  or the world.
+
+If a candidate fact passes this test, proceed to STORE-block
+classification (above). If it fails, return an empty facts list
+for that candidate slot.
 
 CONFIDENCE:
 - Only store facts you can phrase as a single clear sentence.

--- a/tests/test_eval_replay.py
+++ b/tests/test_eval_replay.py
@@ -309,7 +309,7 @@ class TestDryRun:
         store_mock = AsyncMock(return_value=0)
 
         with patch("kai.memory_extraction.extract_and_store", store_mock):
-            counters = await replay._run_replay(
+            counters, samples = await replay._run_replay(
                 pairs,
                 user_id="sandbox-test",
                 context_turns=3,
@@ -323,6 +323,19 @@ class TestDryRun:
         # run would have processed.
         assert counters["pairs_processed"] == 3
         assert counters["facts_stored"] == 0
+        # Dry-run captures payload-shape samples for the first
+        # `_DRY_RUN_SAMPLE_LIMIT` pairs (3 here, with all 3 pairs
+        # sampled). Verbatim text is not captured; only structural
+        # shape (prior depth + char counts) lands in the sample.
+        assert len(samples) == 3
+        assert samples[0] == {
+            "index": 1,
+            "prior_count": 0,
+            "user_chars": 2,
+            "assistant_chars": 2,
+        }
+        assert samples[1]["prior_count"] == 1
+        assert samples[2]["prior_count"] == 2
 
 
 # ── Reset flag ──────────────────────────────────────────────────────
@@ -384,6 +397,7 @@ class TestInitMemory:
             patch("kai.config.load_config", return_value=config_mock),
             patch("kai.memory.init_memory", init_mock),
             patch("kai.memory.delete_all"),
+            patch("kai.memory.get_all_facts", return_value=[]),
             patch("kai.memory_extraction.extract_and_store", AsyncMock(return_value=0)),
         ):
             rc = await replay._async_main(
@@ -451,3 +465,121 @@ class TestPriorContextTruncationDeferred:
         assert len(captured_prior) == 2
         assert captured_prior[0] == []
         assert captured_prior[1] == [(long_user, long_assistant)]
+
+
+# ── Summary breakdowns (spec §4.2 step 6) ───────────────────────────
+
+
+class TestFormatBreakdowns:
+    """`_format_breakdowns` produces the per-tag / per-speaker /
+    per-prompt-version aggregation of a sandbox user's post-replay
+    fact set. Spec §4.2 step 6 names these three groupings as the
+    summary the operator inspects. The unit test pins the grouping
+    rules (tags fan out, speaker and prompt_version are single-valued)
+    and the deterministic sort order (count desc, name asc) so two
+    runs with the same fact multiset render byte-identical output."""
+
+    def _fact(self, *, tags: list[str], speaker: str, prompt_version: str):
+        # Lightweight stub mirroring `MemoryResult.metadata` access.
+        # The format helper only reads `metadata`, not the other
+        # MemoryResult fields, so a SimpleNamespace suffices here.
+        from types import SimpleNamespace
+
+        return SimpleNamespace(metadata={"tags": tags, "speaker": speaker, "prompt_version": prompt_version})
+
+    def test_groups_by_tag_speaker_and_prompt_version(self):
+        facts = [
+            self._fact(tags=["preference"], speaker="user", prompt_version="9"),
+            self._fact(tags=["preference", "location"], speaker="user", prompt_version="9"),
+            self._fact(tags=["fact"], speaker="assistant", prompt_version="9"),
+        ]
+        out = replay._format_breakdowns(facts)
+        # Tag fan-out: "preference" appears in 2 facts, contributes
+        # twice; "location" appears in 1 fact, once; "fact" in 1, once.
+        assert "preference: 2" in out
+        assert "location: 1" in out
+        assert "fact: 1" in out
+        # Speaker single-valued: 2 user + 1 assistant.
+        assert "user: 2" in out
+        assert "assistant: 1" in out
+        # Prompt-version single-valued: all 3 on v9.
+        assert "9: 3" in out
+
+    def test_empty_facts_renders_none_buckets(self):
+        # A zero-fact run is the normal output of an extraction-
+        # disabled or all-suppressed window. The summary section must
+        # still render (parseable empty block) rather than crash or
+        # skip.
+        out = replay._format_breakdowns([])
+        assert "by tag (0 distinct):" in out
+        assert "by speaker (0 distinct):" in out
+        assert "by prompt_version (0 distinct):" in out
+        assert "(none)" in out
+
+    def test_missing_metadata_fields_default_to_unknown(self):
+        # Older fact rows predating the speaker / prompt_version
+        # fields land in the store with those keys absent. The format
+        # helper should bucket them under "unknown" rather than KeyError.
+        from types import SimpleNamespace
+
+        facts = [SimpleNamespace(metadata={"tags": ["fact"]})]
+        out = replay._format_breakdowns(facts)
+        assert "unknown: 1" in out
+
+    def test_sort_order_is_count_desc_then_name_asc(self):
+        facts = [
+            self._fact(tags=["alpha"], speaker="user", prompt_version="9"),
+            self._fact(tags=["beta"], speaker="user", prompt_version="9"),
+            self._fact(tags=["beta"], speaker="user", prompt_version="9"),
+            self._fact(tags=["gamma"], speaker="user", prompt_version="9"),
+        ]
+        out = replay._format_breakdowns(facts)
+        # beta (count=2) precedes alpha (count=1, comes before gamma
+        # alphabetically). gamma trails alpha.
+        beta_pos = out.index("beta:")
+        alpha_pos = out.index("alpha:")
+        gamma_pos = out.index("gamma:")
+        assert beta_pos < alpha_pos < gamma_pos
+
+
+# ── Dry-run payload-shape sample (spec §4.2) ────────────────────────
+
+
+class TestFormatDryRunSamples:
+    """`_format_dry_run_samples` answers the spec §4.2 `--dry-run`
+    contract: "report the would-be pair count AND a sample of payload
+    shapes." The pair count is in the top-level summary; this helper
+    renders the per-pair structural sample. Verbatim text is NOT in
+    the output (operator-personal history could land in stdout
+    otherwise); only structural shape: prior depth, user/assistant
+    character counts."""
+
+    def test_renders_one_pair(self):
+        samples = [{"index": 1, "prior_count": 0, "user_chars": 12, "assistant_chars": 200}]
+        out = replay._format_dry_run_samples(samples)
+        assert "first 1 pair(s)" in out
+        assert "pair 1: prior_pairs=0 user_chars=12 assistant_chars=200" in out
+
+    def test_renders_three_pairs(self):
+        samples = [
+            {"index": 1, "prior_count": 0, "user_chars": 10, "assistant_chars": 20},
+            {"index": 2, "prior_count": 1, "user_chars": 30, "assistant_chars": 40},
+            {"index": 3, "prior_count": 2, "user_chars": 50, "assistant_chars": 60},
+        ]
+        out = replay._format_dry_run_samples(samples)
+        assert "first 3 pair(s)" in out
+        assert out.count("pair ") == 3
+
+    def test_no_verbatim_text_in_output(self):
+        # The sample dict deliberately carries no verbatim text;
+        # confirm `_format_dry_run_samples` does not introduce any.
+        # The "no operator-personal stdout leak" property is what
+        # the helper's docstring promises.
+        samples = [{"index": 1, "prior_count": 0, "user_chars": 5, "assistant_chars": 5}]
+        out = replay._format_dry_run_samples(samples)
+        for forbidden in ("user_text", "assistant_text", "content="):
+            assert forbidden not in out
+
+    def test_empty_samples_does_not_crash(self):
+        out = replay._format_dry_run_samples([])
+        assert "no pairs to sample" in out

--- a/tests/test_eval_replay.py
+++ b/tests/test_eval_replay.py
@@ -342,6 +342,65 @@ class TestReset:
         delete_mock.assert_called_once_with(user_id="sandbox-test")
 
 
+# ── Memory store initialization ─────────────────────────────────────
+
+
+class TestInitMemory:
+    """`_async_main` MUST initialize the memory store before invoking the
+    replay loop. Without this, the module-level `_memory` handle in
+    `kai.memory` stays None, every storage primitive
+    (`search`, `add_structured`, `delete_all`) short-circuits to a
+    silent no-op, and the replay extracts facts via `claude --print`
+    only to discard them. The failure mode is invisible at the unit
+    level - `extract_and_store` returns 0 stored per pair, the summary
+    line reports `facts_stored=0`, and no exception is raised - so the
+    only place the regression can be caught structurally is here, by
+    asserting the init call happens. This test exists because that bug
+    actually shipped pre-init-fix: a 93-pair sandbox replay produced
+    zero stored facts because `_memory` was None, and the symptom was
+    only diagnosable by reading the `consolidate.intent` log lines for
+    `outcome=dropped_backend`."""
+
+    @pytest.mark.asyncio
+    async def test_async_main_initializes_memory(self, tmp_path):
+        # Create a history file with one valid pair so the replay walks
+        # but does not block on missing files.
+        history_dir = tmp_path / "history" / str(_CHAT_ID)
+        history_dir.mkdir(parents=True)
+        _write_jsonl(
+            history_dir / "2026-05-12.jsonl",
+            [_rec("user", "hi"), _rec("assistant", "hello")],
+        )
+
+        init_mock = MagicMock()
+        config_mock = MagicMock()
+        config_mock.episode_classifier_context_turns = 3
+        # Patch every dependency reached after init_memory so the unit
+        # test cannot reach a real config / store / subprocess. The
+        # only assertion is that init_memory was invoked with the
+        # config object - the call shape protecting against the silent
+        # storage no-op.
+        with (
+            patch("kai.config.load_config", return_value=config_mock),
+            patch("kai.memory.init_memory", init_mock),
+            patch("kai.memory.delete_all"),
+            patch("kai.memory_extraction.extract_and_store", AsyncMock(return_value=0)),
+        ):
+            rc = await replay._async_main(
+                [
+                    "--chat-id",
+                    str(_CHAT_ID),
+                    "--user-id",
+                    "sandbox-init-test",
+                    "--history-dir",
+                    str(history_dir),
+                ]
+            )
+
+        assert rc == 0
+        init_mock.assert_called_once_with(config_mock)
+
+
 # ── PRIOR CONTEXT truncation deferred to extract_and_store ──────────
 
 

--- a/tests/test_eval_replay.py
+++ b/tests/test_eval_replay.py
@@ -1,0 +1,394 @@
+"""Tests for `kai.eval.replay`.
+
+The replay module re-extracts an older history window into a sandbox
+`user_id` so a spec-implementation cycle can compare v8-prompt and
+v9-prompt sandboxes without disturbing production. The unit tests pin
+the safety guards (sandbox-prefix enforcement), the file-selection
+logic (date-range filter), the pairing semantics (which records become
+which pairs), the rolling prior buffer (PRIOR CONTEXT window of N
+pairs), tolerance for partial-corruption (malformed JSONL lines), the
+two side-effect-free dry-run / would-be-modify contracts, and the
+reset path's call to `memory.delete_all`. PRIOR CONTEXT truncation is
+deferred to `_build_extraction_payload`; the replay only feeds raw
+pair strings, so we assert the call shape (replay does not roll its
+own truncation).
+
+PII posture: tests use synthetic JSONL fixtures generated inside
+`tmp_path`; no real operator history files are touched.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kai.eval import replay
+
+# A canonical chat_id used across fixtures; aligns with the production
+# operator id so tests exercise the same shape the real bot writes.
+_CHAT_ID = 12345
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    """Write one record per line; matches the bot's `log_message` shape."""
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+
+
+def _rec(direction: str, text: str, *, chat_id: int = _CHAT_ID, ts: str = "2026-05-12T10:00:00") -> dict:
+    """Build a record dict with the fields production writes."""
+    return {"ts": ts, "dir": direction, "chat_id": chat_id, "text": text}
+
+
+# ── Sandbox-prefix guard ─────────────────────────────────────────────
+
+
+class TestSandboxPrefixGuard:
+    """The `--user-id` prefix check is the structural defense against
+    accidentally writing replay output to a real user_id. The guard
+    raises before any extraction or storage call, which means tests
+    can exercise it without standing up a Mem0 store."""
+
+    def test_real_chat_id_raises(self):
+        with pytest.raises(ValueError, match="must start with"):
+            replay._validate_user_id("2114582497")
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="must start with"):
+            replay._validate_user_id("")
+
+    def test_almost_prefix_raises(self):
+        # Casing matters; an unprefixed value with the right characters
+        # in a different order still fails. The literal prefix is the
+        # check, not a fuzzy match.
+        with pytest.raises(ValueError, match="must start with"):
+            replay._validate_user_id("Sandbox-464")
+
+    def test_correct_prefix_accepted(self):
+        # No exception means the guard passed.
+        replay._validate_user_id("sandbox-464")
+        replay._validate_user_id("sandbox-")
+        replay._validate_user_id("sandbox-anything-else")
+
+
+# ── Date-range filter ────────────────────────────────────────────────
+
+
+class TestDateRangeFilter:
+    """The replay reads JSONL files named `YYYY-MM-DD.jsonl` from a
+    chat-history directory. The date-range filter selects which files
+    enter the replay; non-date-named files are skipped silently so an
+    operator backup or rotated artifact does not abort the run."""
+
+    def test_three_files_pick_middle(self, tmp_path: Path):
+        history = tmp_path / "history"
+        history.mkdir()
+        for d in ("2026-05-10", "2026-05-11", "2026-05-12"):
+            (history / f"{d}.jsonl").write_text("")
+        picked = replay._iter_history_files(history, date(2026, 5, 11), date(2026, 5, 11))
+        assert [p.name for p in picked] == ["2026-05-11.jsonl"]
+
+    def test_no_filter_returns_all_oldest_first(self, tmp_path: Path):
+        history = tmp_path / "history"
+        history.mkdir()
+        for d in ("2026-05-12", "2026-05-10", "2026-05-11"):
+            (history / f"{d}.jsonl").write_text("")
+        picked = replay._iter_history_files(history, None, None)
+        # Oldest first; alphabetical sort happens to match for ISO dates,
+        # but the function sorts by parsed date so the order is correct
+        # even for date-strings that would lex-sort differently.
+        assert [p.name for p in picked] == [
+            "2026-05-10.jsonl",
+            "2026-05-11.jsonl",
+            "2026-05-12.jsonl",
+        ]
+
+    def test_non_date_named_files_skipped(self, tmp_path: Path):
+        history = tmp_path / "history"
+        history.mkdir()
+        (history / "2026-05-12.jsonl").write_text("")
+        (history / "backup.jsonl").write_text("")
+        (history / "rotated-2026-05-12.jsonl").write_text("")
+        picked = replay._iter_history_files(history, None, None)
+        assert [p.name for p in picked] == ["2026-05-12.jsonl"]
+
+    def test_missing_dir_returns_empty(self, tmp_path: Path):
+        picked = replay._iter_history_files(tmp_path / "does-not-exist", None, None)
+        assert picked == []
+
+
+# ── Pairing semantics ───────────────────────────────────────────────
+
+
+class TestPairing:
+    """The replay reuses `history._pair_records_chronologically` so the
+    pair stream fed to `extract_and_store` matches what production
+    builds from the same records. These tests pin the integration: the
+    replay's filter pass drops the right records and hands the right
+    list to the pairing helper."""
+
+    def test_clean_alternating_records(self, tmp_path: Path):
+        history = tmp_path / "history"
+        history.mkdir()
+        _write_jsonl(
+            history / "2026-05-12.jsonl",
+            [
+                _rec("user", "Hi"),
+                _rec("assistant", "Hello"),
+                _rec("user", "What's up?"),
+                _rec("assistant", "Working on the eval."),
+            ],
+        )
+        files = replay._iter_history_files(history, None, None)
+        records = replay._load_records(files, _CHAT_ID)
+        pairs = replay._build_pairs(records)
+        assert pairs == [("Hi", "Hello"), ("What's up?", "Working on the eval.")]
+
+    def test_orphan_assistant_dropped(self, tmp_path: Path):
+        # An assistant record with no pending user is the orphan path
+        # described in history._pair_records_chronologically: drop it.
+        history = tmp_path / "history"
+        history.mkdir()
+        _write_jsonl(
+            history / "2026-05-12.jsonl",
+            [
+                _rec("assistant", "Mystery reply"),
+                _rec("user", "Hi"),
+                _rec("assistant", "Hello"),
+            ],
+        )
+        files = replay._iter_history_files(history, None, None)
+        records = replay._load_records(files, _CHAT_ID)
+        pairs = replay._build_pairs(records)
+        assert pairs == [("Hi", "Hello")]
+
+    def test_other_chat_id_filtered_out(self, tmp_path: Path):
+        history = tmp_path / "history"
+        history.mkdir()
+        _write_jsonl(
+            history / "2026-05-12.jsonl",
+            [
+                _rec("user", "From _CHAT_ID"),
+                _rec("assistant", "Reply", chat_id=99999),
+            ],
+        )
+        files = replay._iter_history_files(history, None, None)
+        records = replay._load_records(files, _CHAT_ID)
+        # Assistant record dropped (wrong chat_id), so the user record
+        # has no partner and the pair list is empty.
+        pairs = replay._build_pairs(records)
+        assert pairs == []
+
+    def test_missing_chat_id_field_dropped(self, tmp_path: Path):
+        # Legacy pre-Phase-2 records have no chat_id field. The replay
+        # is strict (matches history.get_recent_pairs's strictness on
+        # provenance) and drops them.
+        history = tmp_path / "history"
+        history.mkdir()
+        _write_jsonl(
+            history / "2026-05-12.jsonl",
+            [
+                {"ts": "2026-05-12T10:00:00", "dir": "user", "text": "Legacy"},
+                _rec("user", "Modern"),
+                _rec("assistant", "Reply"),
+            ],
+        )
+        records = replay._load_records(replay._iter_history_files(history, None, None), _CHAT_ID)
+        pairs = replay._build_pairs(records)
+        assert pairs == [("Modern", "Reply")]
+
+
+# ── Rolling prior buffer ─────────────────────────────────────────────
+
+
+class TestRollingPriorBuffer:
+    """`_run_replay` maintains a rolling buffer of the previous
+    `context_turns` pairs and passes it as `prior_pairs` to
+    `extract_and_store`. The first pair sees an empty buffer; later
+    pairs see at most `context_turns` predecessors."""
+
+    @pytest.mark.asyncio
+    async def test_buffer_grows_then_caps(self):
+        pairs = [(f"u{i}", f"a{i}") for i in range(5)]
+        captured: list[list[tuple[str, str]]] = []
+
+        async def fake_store(user_text, assistant_text, *, user_id, config, prior_pairs):
+            captured.append(list(prior_pairs))
+            return 0
+
+        with patch("kai.memory_extraction.extract_and_store", side_effect=fake_store):
+            await replay._run_replay(
+                pairs,
+                user_id="sandbox-test",
+                context_turns=2,
+                config=MagicMock(),
+                dry_run=False,
+            )
+
+        # First pair: empty prior. Second pair: one prior. Third pair:
+        # two priors (the cap). Fourth and fifth pairs: still two
+        # priors (the oldest gets dropped each iteration).
+        assert captured[0] == []
+        assert captured[1] == [("u0", "a0")]
+        assert captured[2] == [("u0", "a0"), ("u1", "a1")]
+        assert captured[3] == [("u1", "a1"), ("u2", "a2")]
+        assert captured[4] == [("u2", "a2"), ("u3", "a3")]
+
+    @pytest.mark.asyncio
+    async def test_zero_context_turns_passes_empty_buffer(self):
+        # context_turns=0 disables the prior-context window entirely.
+        # Used by callers that want the pre-#392 single-turn behavior.
+        captured: list[list[tuple[str, str]]] = []
+
+        async def fake_store(user_text, assistant_text, *, user_id, config, prior_pairs):
+            captured.append(list(prior_pairs))
+            return 0
+
+        with patch("kai.memory_extraction.extract_and_store", side_effect=fake_store):
+            await replay._run_replay(
+                [("u0", "a0"), ("u1", "a1")],
+                user_id="sandbox-test",
+                context_turns=0,
+                config=MagicMock(),
+                dry_run=False,
+            )
+
+        # Both calls see empty prior; the buffer collects entries but
+        # gets immediately trimmed to zero by the `if len(prior) >
+        # context_turns: prior.pop(0)` branch.
+        assert captured == [[], []]
+
+
+# ── Malformed-line tolerance ────────────────────────────────────────
+
+
+class TestMalformedTolerance:
+    """The replay tolerates partial-corruption mirroring
+    `history.get_recent_pairs`'s behavior: skip individual bad lines,
+    keep the rest. Catches an interrupted-write or operator-edit
+    scenario without aborting an entire replay run."""
+
+    def test_mixed_malformed_lines_skipped(self, tmp_path: Path):
+        history = tmp_path / "history"
+        history.mkdir()
+        # Build a file with: a valid record, an empty line, a non-JSON
+        # line, a truncated JSON line, and another valid record.
+        raw = "\n".join(
+            [
+                json.dumps(_rec("user", "first")),
+                "",
+                "garbage not json",
+                '{"dir": "assistant", "chat_id": ',  # truncated
+                json.dumps(_rec("assistant", "second")),
+            ]
+        )
+        (history / "2026-05-12.jsonl").write_text(raw, encoding="utf-8")
+
+        files = replay._iter_history_files(history, None, None)
+        records = replay._load_records(files, _CHAT_ID)
+        pairs = replay._build_pairs(records)
+
+        assert pairs == [("first", "second")]
+
+
+# ── Dry-run flag ────────────────────────────────────────────────────
+
+
+class TestDryRun:
+    """Dry-run reports the pair count without calling
+    `extract_and_store` or writing to the store. Operators use it to
+    inspect what a real run would do before spending wall-clock on
+    actual extraction."""
+
+    @pytest.mark.asyncio
+    async def test_dry_run_skips_extract_and_store(self):
+        pairs = [("u0", "a0"), ("u1", "a1"), ("u2", "a2")]
+        store_mock = AsyncMock(return_value=0)
+
+        with patch("kai.memory_extraction.extract_and_store", store_mock):
+            counters = await replay._run_replay(
+                pairs,
+                user_id="sandbox-test",
+                context_turns=3,
+                config=MagicMock(),
+                dry_run=True,
+            )
+
+        # extract_and_store was NEVER called; only the pair walk ran.
+        store_mock.assert_not_called()
+        # Pair count still updates so the operator sees what the real
+        # run would have processed.
+        assert counters["pairs_processed"] == 3
+        assert counters["facts_stored"] == 0
+
+
+# ── Reset flag ──────────────────────────────────────────────────────
+
+
+class TestReset:
+    """`--reset` calls `memory.delete_all(user_id=...)` before the
+    replay loop starts. The unit test mocks the deletion path so a
+    test run does not touch a real Qdrant store; the assertion is that
+    the helper was invoked with the sandbox user_id."""
+
+    @pytest.mark.asyncio
+    async def test_reset_calls_delete_all(self):
+        delete_mock = MagicMock()
+        with patch("kai.memory.delete_all", delete_mock):
+            await replay._reset_sandbox("sandbox-test")
+        delete_mock.assert_called_once_with(user_id="sandbox-test")
+
+
+# ── PRIOR CONTEXT truncation deferred to extract_and_store ──────────
+
+
+class TestPriorContextTruncationDeferred:
+    """The replay does NOT roll its own truncation for prior turns. It
+    passes raw pair strings to `extract_and_store`, which internally
+    invokes `_build_extraction_payload` and applies the production
+    `_PRIOR_USER_CHARS` / `_PRIOR_ASSISTANT_CHARS` caps. The assertion
+    here is on the call shape: the prior_pairs the replay passes are
+    the unmodified raw strings; trusting `_build_extraction_payload`
+    to do the truncation is the contract.
+
+    A regression in which the replay rolled its own (likely diverging)
+    truncation logic would land in this test as an inequality on the
+    captured `prior_pairs`."""
+
+    @pytest.mark.asyncio
+    async def test_replay_passes_untruncated_pairs(self):
+        # Build a pair with a deliberately oversized user-side prior
+        # turn (5000 chars). Production's _PRIOR_USER_CHARS cap (800)
+        # would truncate, but only inside _build_extraction_payload.
+        # The replay must pass the full string through; the truncation
+        # is the downstream's job.
+        long_user = "X" * 5000
+        long_assistant = "Y" * 5000
+        pairs = [
+            (long_user, long_assistant),  # The prior pair.
+            ("current_u", "current_a"),
+        ]
+        captured_prior: list[list[tuple[str, str]]] = []
+
+        async def fake_store(user_text, assistant_text, *, user_id, config, prior_pairs):
+            captured_prior.append(list(prior_pairs))
+            return 0
+
+        with patch("kai.memory_extraction.extract_and_store", side_effect=fake_store):
+            await replay._run_replay(
+                pairs,
+                user_id="sandbox-test",
+                context_turns=1,
+                config=MagicMock(),
+                dry_run=False,
+            )
+
+        # The second call's prior_pairs is the first pair, untruncated.
+        # If the replay had rolled its own truncation, the captured
+        # strings would be shorter than 5000 chars here.
+        assert len(captured_prior) == 2
+        assert captured_prior[0] == []
+        assert captured_prior[1] == [(long_user, long_assistant)]

--- a/tests/test_extraction_prompt.py
+++ b/tests/test_extraction_prompt.py
@@ -76,6 +76,37 @@ def test_durability_test_appears_once():
     assert _EXTRACTION_SYSTEM_PROMPT.count("DURABILITY TEST:") == 1
 
 
+def test_store_block_does_not_reference_durability_test():
+    """The fact-side STORE block must not direct the model to a
+    DURABILITY TEST that no longer exists.
+
+    The colon-suffixed `DURABILITY TEST:` header check above is too
+    narrow: a bare-form `DURABILITY TEST below` inside the STORE block
+    leaves the model pointing at a section that was deleted in the v9
+    swap. The PR #467 review (M-1) flagged exactly this: the STORE
+    block's "Apply the DURABILITY TEST below" reference survived the
+    swap because the spec's deletion range was line-based and the
+    STORE block sat outside it.
+
+    Pinning the absence of any "DURABILITY TEST" substring in the
+    fact-side STORE block - regardless of suffix - closes the
+    recurrence path. The episode-side `EPISODE DURABILITY TEST` is
+    after this block, so a substring search bounded to the fact-side
+    STORE region is safe.
+    """
+    # Bound the search to the fact-side region: from "STORE these
+    # fact types:" through (but not including) "EPISODE
+    # CLASSIFICATION" (the episode-side header that opens the
+    # DURABILITY TEST surface we DO want to keep).
+    store_idx = _EXTRACTION_SYSTEM_PROMPT.index("STORE these fact types:")
+    episode_idx = _EXTRACTION_SYSTEM_PROMPT.index("EPISODE CLASSIFICATION")
+    fact_side = _EXTRACTION_SYSTEM_PROMPT[store_idx:episode_idx]
+    assert "DURABILITY TEST" not in fact_side, (
+        "fact-side STORE/QUALITY TEST region must not reference DURABILITY TEST; "
+        "the section was deleted in v9 and any reference is an orphan pointer"
+    )
+
+
 def test_prompt_version_bumped():
     """Version stamp matches the prompt revision."""
     assert _EXTRACTION_PROMPT_VERSION == "9"
@@ -121,16 +152,21 @@ def test_positive_worked_examples_present():
 
 
 def test_negative_worked_examples_present():
-    """The three negative (do-not-emit) worked examples are in the block.
+    """The four negative (do-not-emit) worked examples are in the block.
 
-    Same pinning rationale as the positive set. The three negatives
-    cover three of the four classes the prior IGNORE list targeted
-    (workflow-event metadata, decision-to-do, assistant self-report).
+    Same pinning rationale as the positive set. The four negatives
+    cover the four classes the prior IGNORE list targeted: workflow-
+    event metadata, decision-to-do, assistant self-report, and
+    in-progress task state ("ephemeral state"). PR #467 review (W-2)
+    added the ephemeral-state example to reconcile the spec prose
+    that named four classes against the original block which only
+    carried three.
     """
     block = _extract_quality_test_block()
     for snippet in (
         '"Spec X v3 was approved"',
         '"Let\'s file an issue about X."',
         '"I\'m extracting facts now"',
+        '"I\'m writing the spec now."',
     ):
         assert snippet in block, f"negative worked example missing: {snippet}"

--- a/tests/test_extraction_prompt.py
+++ b/tests/test_extraction_prompt.py
@@ -1,0 +1,136 @@
+"""Snapshot tests for `_EXTRACTION_SYSTEM_PROMPT` structure.
+
+Pins the boundary properties of the extraction prompt that this
+revision targets: the fact-side IGNORE block and DURABILITY TEST are
+gone, the QUALITY TEST block is in their place, the version stamp has
+bumped, and the worked-example anchors are intact. Pinning these
+structurally (not by exact full-prompt string) keeps the tests stable
+under minor wording edits while still catching the regressions this
+revision is intended to prevent.
+
+The em/en-dash gate matches the project-wide convention and mirrors
+`tests/test_template_claude_md.py::test_no_em_or_en_dashes_in_section`.
+"""
+
+from __future__ import annotations
+
+import re
+
+from kai.memory_extraction import _EXTRACTION_PROMPT_VERSION, _EXTRACTION_SYSTEM_PROMPT
+
+# The new section's header literal. Pinning it here means a rename in
+# the prompt fails this test before it silently breaks the production
+# extractor's reliance on the QUALITY TEST as the upfront-floor gate.
+_QUALITY_TEST_HEADER = "QUALITY TEST:"
+
+
+def _extract_quality_test_block() -> str:
+    """Return the QUALITY TEST section from header through its terminator.
+
+    Terminator is the next ALL-CAPS section header in the prompt
+    (CONFIDENCE, FORMAT, EPISODE CLASSIFICATION, etc.). The block-bounded
+    scan lets the dash-detection test below operate on just the new
+    content rather than the whole prompt (which has unrelated text the
+    project's no-dashes rule does not apply to retroactively).
+    """
+    start = _EXTRACTION_SYSTEM_PROMPT.find(_QUALITY_TEST_HEADER)
+    assert start != -1, f"{_QUALITY_TEST_HEADER!r} missing from prompt"
+    # Terminator: the next ALL-CAPS-line section header. CONFIDENCE
+    # follows QUALITY TEST in the current prompt structure; the scan
+    # tolerates any future intervening ALL-CAPS section by matching
+    # the first all-caps header after QUALITY TEST.
+    tail = _EXTRACTION_SYSTEM_PROMPT[start + len(_QUALITY_TEST_HEADER) :]
+    next_header = re.search(r"\n([A-Z][A-Z _]+):", tail)
+    if next_header is None:
+        # Section runs to end of prompt; valid shape for completeness.
+        return _EXTRACTION_SYSTEM_PROMPT[start:]
+    return _EXTRACTION_SYSTEM_PROMPT[start : start + len(_QUALITY_TEST_HEADER) + next_header.start()]
+
+
+def test_quality_test_header_present():
+    """Section header literal landed in the prompt."""
+    assert _QUALITY_TEST_HEADER in _EXTRACTION_SYSTEM_PROMPT
+
+
+def test_ignore_block_removed():
+    """The fact-side IGNORE: header is gone.
+
+    The episode-side block has its own header (`EPISODE IGNORE rules`)
+    which contains the word IGNORE but is a different literal; that
+    block stays per parent epic scope.
+    """
+    assert "IGNORE:" not in _EXTRACTION_SYSTEM_PROMPT, (
+        "fact-side IGNORE: block should have been replaced by QUALITY TEST"
+    )
+
+
+def test_durability_test_appears_once():
+    """DURABILITY TEST: now appears only on the episode side.
+
+    The fact-side DURABILITY TEST is gone; the episode-side
+    `EPISODE DURABILITY TEST:` (which contains DURABILITY TEST: as a
+    substring) remains. `count == 1` is the formulation that survives
+    the substring-containment trap a `not in` assertion would fall
+    into. Documented in the spec's M-1 v2 review fix.
+    """
+    assert _EXTRACTION_SYSTEM_PROMPT.count("DURABILITY TEST:") == 1
+
+
+def test_prompt_version_bumped():
+    """Version stamp matches the prompt revision."""
+    assert _EXTRACTION_PROMPT_VERSION == "9"
+
+
+def test_no_em_or_en_dashes_in_quality_test_block():
+    """The new section uses hyphens, semicolons, periods, or commas only.
+
+    Em/en dashes have bitten prior review rounds; mechanically pinning
+    the rule against the new section closes the recurrence path for
+    this surface. The block-scoped check (rather than full-prompt)
+    avoids retroactively gating older sections that may contain the
+    characters legitimately.
+
+    Literal characters in the regex are the en dash (U+2013) and em
+    dash (U+2014). The noqa suppresses ruff's RUF001 ambiguous-
+    character lint here; the literals are deliberate because the test's
+    purpose is to flag those exact characters.
+    """
+    block = _extract_quality_test_block()
+    forbidden = re.findall("[–—]", block)  # noqa: RUF001
+    assert not forbidden, (
+        f"QUALITY TEST block contains em/en dashes: {forbidden!r}; use hyphens, semicolons, periods, or commas instead"
+    )
+
+
+def test_positive_worked_examples_present():
+    """The three positive (emit) worked examples are in the block.
+
+    Each example's distinctive opener pins the example against
+    accidental rewording in a future edit. Removing or paraphrasing
+    one of these would fail the test before reaching review, matching
+    the v3 review's hedge-language pinning pattern in the inference
+    example for spec #430.
+    """
+    block = _extract_quality_test_block()
+    for snippet in (
+        '"I prefer Celsius."',
+        '"I live in Toronto."',
+        '"My laptop is a 2024 M3 MacBook Pro."',
+    ):
+        assert snippet in block, f"positive worked example missing: {snippet}"
+
+
+def test_negative_worked_examples_present():
+    """The three negative (do-not-emit) worked examples are in the block.
+
+    Same pinning rationale as the positive set. The three negatives
+    cover three of the four classes the prior IGNORE list targeted
+    (workflow-event metadata, decision-to-do, assistant self-report).
+    """
+    block = _extract_quality_test_block()
+    for snippet in (
+        '"Spec X v3 was approved"',
+        '"Let\'s file an issue about X."',
+        '"I\'m extracting facts now"',
+    ):
+        assert snippet in block, f"negative worked example missing: {snippet}"

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -2353,7 +2353,7 @@ class TestExtractionPromptSoftVocab:
     def test_extraction_prompt_version_bumped(self):
         """The version stamp on every fact's metadata; bumped
         whenever the schema or prompt changes meaningfully."""
-        assert _EXTRACTION_PROMPT_VERSION == "8"
+        assert _EXTRACTION_PROMPT_VERSION == "9"
 
     def test_extraction_prompt_version_history_extended(self):
         """The prompt-version history comment block (the sequence
@@ -2363,9 +2363,10 @@ class TestExtractionPromptSoftVocab:
         fragments so a future unrelated edit that introduces a `vN:`
         token elsewhere cannot satisfy this test vacuously.
 
-        v5, v6, v7, and v8 fragments are pinned: each prior entry
-        stays in source unchanged across the next bump, and the v8
-        entry was appended for the speaker-attribution change."""
+        v5, v6, v7, v8, and v9 fragments are pinned: each prior entry
+        stays in source unchanged across the next bump, and the v9
+        entry was appended for the QUALITY TEST positive-criterion
+        swap."""
         from pathlib import Path
 
         import kai.memory_extraction
@@ -2376,11 +2377,14 @@ class TestExtractionPromptSoftVocab:
         assert "DURABILITY TEST gate" in src
         assert "v7 (2026-04-30, this issue)" in src
         assert "EPISODE CLASSIFICATION block" in src
-        # v8 entry: speaker-attribution prompt change. The literal
-        # date and "speaker attribution" phrase are pinned because
-        # both come from the v8 history comment specifically.
+        # v8 entry: speaker-attribution prompt change.
         assert "v8 (2026-05-07)" in src
         assert "speaker attribution" in src
+        # v9 entry: positive-criterion swap. The literal date and
+        # "QUALITY TEST" phrase are pinned because both come from the
+        # v9 history comment specifically.
+        assert "v9 (2026-05-12)" in src
+        assert "QUALITY TEST" in src
 
 
 class TestRule6WorkflowEventRegex:
@@ -2530,28 +2534,19 @@ class TestRule6WorkflowEventRegex:
 
 
 class TestExtractionPromptDurability:
-    """Pins the v6 prompt content additions: STORE / Decisions
-    refinement, two new IGNORE bullets, and the DURABILITY TEST
-    section header. Substring assertions only; the exact wording
-    is captured byte-for-byte by the source-text history-fragment
-    test in TestExtractionPromptSoftVocab."""
+    """Pins the v6 STORE-decisions refinement that survives the v9
+    swap. The v6 IGNORE bullets and DURABILITY TEST that this class
+    used to pin were retired by the v9 positive-criterion swap; their
+    replacements live in `tests/test_extraction_prompt.py`. The
+    `durable scope` and `NOT workflow micro-decisions` clauses in the
+    STORE block are unchanged across v6 -> v9 and are still pinned
+    here because they remain the only on-prompt distinction between
+    durable design decisions and workflow micro-decisions in the
+    STORE classification path."""
 
     def test_store_decisions_scoped_to_durable(self):
         assert "durable scope" in _EXTRACTION_SYSTEM_PROMPT
         assert "NOT workflow micro-decisions" in _EXTRACTION_SYSTEM_PROMPT
-
-    def test_ignore_bullets_added(self):
-        assert "Workflow-event metadata" in _EXTRACTION_SYSTEM_PROMPT
-        assert "Decisions to do" in _EXTRACTION_SYSTEM_PROMPT
-        # Concrete examples carried in the bullets so the model has
-        # specific noise patterns to match against.
-        assert "Spec X v3 was approved" in _EXTRACTION_SYSTEM_PROMPT
-        assert "User decided to file an issue about X" in _EXTRACTION_SYSTEM_PROMPT
-
-    def test_durability_test_section_present(self):
-        assert "DURABILITY TEST:" in _EXTRACTION_SYSTEM_PROMPT
-        # The 30-day frame is the operationally usable phrasing.
-        assert "30 days" in _EXTRACTION_SYSTEM_PROMPT
 
 
 class TestRunExtractorSystemPromptDefault:


### PR DESCRIPTION
## Summary

- Replace the negative-IGNORE-list extraction prompt (v8) with a positive-criterion QUALITY TEST (v9). The v9 prompt asks "would this fact help a future conversation that does not include the current turn?" with seven worked examples (three emit, four do not emit), and removes the open-ended IGNORE rules + DURABILITY TEST blocks v8 used to suppress workflow-event metadata.
- Add `kai.eval.replay` module: a sandboxed prompt-comparison harness that replays a chat-history window into a `sandbox-` prefixed user_id using production's exact pairing semantics, candidate-fetch path, and `extract_and_store` integration. Supports date-range, dry-run, and reset flags; the live-run summary breaks the resulting sandbox fact set down by tag / speaker / prompt_version; the dry-run prints a structural payload-shape sample for the first three pairs.
- Bug fix in `_async_main`: initialize the memory store before the extract loop. Without `init_memory(config)`, every storage primitive silently no-ops and every extracted fact is discarded (`outcome=dropped_backend` in the per-pair consolidate.intent log).
- 34 new tests: 8 prompt snapshots pinning the v9 QUALITY TEST structure (worked-example coverage, STORE-block coherence, no orphan DURABILITY TEST references); 26 replay unit tests (sandbox-prefix guard, date-range filter, pairing, rolling-prior buffer, malformed-tolerance, dry-run + payload-sample shape, reset, prior-truncation deferral, init_memory regression guard, summary-breakdown grouping and sort, dry-run payload-sample formatting).

## Why

The IGNORE-list pattern in v8 carried two recurring costs:
1. Open-ended maintenance. Every new pattern of workflow-event leakage required adding a bullet, with no closure rule on when the list is "complete."
2. Collateral suppression. Broad IGNORE phrases caught legitimate durable content as a side-effect (multi-user knowledge, system paths, configuration defaults).

The v9 hypothesis was that a single positive criterion ("would a future session benefit from this fact?") could shoulder the suppression work without the IGNORE list's maintenance shape.

## Eval evidence

Three-way sandbox replay over a 7-day chat-history window (114 paired exchanges):

| Prompt | Final Qdrant fact rows |
|--------|------------------------|
| no-coercion baseline (no STORE / no IGNORE / no QUALITY TEST) | 237 |
| positive-criterion v9 (this PR) | 75 |
| negative-IGNORE v8 (prior) | 59 |

v9 suppresses 68% of what no-coercion extraction would produce, achieving 91% of v8's suppression with one prompt block instead of an open-ended IGNORE list. The 16-fact gap between v9 and v8 is mostly durable content v8 collateral-suppressed (multi-user GitHub handles, system paths, configuration defaults) plus a small residual of workflow-event leaks that the planned memory janitor pass (#466) is designed to address downstream.

## Methodology divergence from spec

The spec acceptance procedure (canary recall + stratified 40-60-fact bucket classification) was not run. During implementation the operator rejected manual bucket classification as too ambiguous to produce a measurement: bucketing facts into `should_suppress` / `should_preserve` / `ambiguous` has no stable rubric, so per-bucket retention rates would not have been load-bearing evidence. The same critique applied to the parent epic's prior sub (#430).

The 3-way replay above (no-coercion / v9 / v8) replaces both spec acceptance parts. It directly tests the spec's core hypothesis ("positive criterion = more selective than no guidance") by measuring against the right baseline. Comparing v9 against v8 alone (the spec's intended methodology) had been misleading: v8 is itself a heavily-suppressed prompt, and a v9-vs-v8 delta in the permissive direction looked like a regression until the no-coercion baseline put the gap in context (16 facts vs the 162-fact suppression v9 achieves overall).

Spec amendment to v5 documenting this change is appropriate before merge if the spec needs to remain the authoritative record; flagging here rather than amending unilaterally.

## Canary recall (added per re-review)

Twelve natural-language queries representative of operator follow-ups on the May 6-12 window. Each ran through `memory.search(..., limit=5)` against both sandboxes; "top-1 correct" means the highest-similarity result is the fact the query asks about.

| Canary | v8 top-1 correct? | v9 top-1 correct? |
|--------|-------------------|-------------------|
| What is the user's GitHub username? | yes | yes |
| What is the user's Telegram chat ID? | yes | yes |
| What OS user account does the inner Claude run as? | partial | partial |
| Which chat ID receives GitHub push notifications? | yes | yes |
| How is the GitHub webhook URL derived from the Telegram one? | yes | yes |
| What was set up for the anvil repository? | yes | yes |
| How does GitHub notification routing fall back when no session override is present? | yes | **no** |
| Where is the home workspace located? | partial (Scott's first) | yes |
| What is the data directory path on a normal install? | yes | yes |
| What is Scott's GitHub handle? | **no** | yes |
| Where is outer Claude's configuration directory? | **no** | yes |
| What is the bug in the /github notify command help text? | yes | yes |

**Summary:** v9 regresses on one canary (the conditional-fallback routing fact at c7, which collapsed into adjacent github-notify content under v9's prompt) and gains on three (Scott's handle, outer Claude config path, home workspace location). Net +2 on recall surface, no catastrophic regression. The gains are exactly the multi-user / system-location content v8's IGNORE rules collateral-suppressed; the regression is one specific routing-fallback phrasing v9's QUALITY TEST treated as adjacent-event metadata. The per-canary top-5 result lists are archived in `/tmp/464-canary-results.md` (not in PR body to avoid leaking operator-personal content).

## Files

- `src/kai/memory_extraction.py`: v9 prompt swap (`_EXTRACTION_PROMPT_VERSION` bumped 8 → 9; version-history block extended). STORE rules retained, IGNORE block + DURABILITY TEST removed, new QUALITY TEST block added (seven worked examples). Three comment sites updated from "the prompt's IGNORE rules" to "the prompt's QUALITY TEST" so future readers do not hunt for a removed section.
- `src/kai/eval/replay.py`: new module. Reuses `kai.history._pair_records_chronologically` and `_SYNTHETIC_ASSISTANT_MARKERS` so pairing semantics live in one place; reuses `extract_and_store` so truncation caps and consolidation logic stay byte-equivalent to production. Live-run summary prints by-tag / by-speaker / by-prompt-version breakdowns; dry-run summary prints structural payload samples (prior depth + char counts) without dumping verbatim history text.
- `tests/test_extraction_prompt.py`: 8 snapshot tests on the v9 QUALITY TEST structure.
- `tests/test_eval_replay.py`: 27 unit tests covering replay invariants and format-helper behavior.
- `tests/test_memory_extraction.py`: three existing tests updated for the v9 prompt swap; the `TestExtractionPromptDurability` class trimmed because the v9 prompt no longer carries the structures it pinned. Replacement coverage lives in `test_extraction_prompt.py`.

## Acceptance

Production sampling for two weeks post-merge: fact extraction rate stable, no recurrence of the `dropped_backend` log signal, no regression in the operator-visible /memory dashboard. The eval evidence above is the primary acceptance for the prompt change; the sandbox replay is the methodology.

## Test plan

- [x] 34 new tests pass
- [x] Full pytest suite passes: 2948 passed, 1 skipped
- [x] `make check` passes (ruff lint + format)
- [x] Three-way sandbox replay validates v9's suppression profile against the no-coercion baseline
- [ ] Two-week production sampling post-merge

Fixes #464.
