### PR TITLE
feat: env-tunable paraphrase-dedup gate (#465)

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -537,7 +537,7 @@ class Config:
     # omitted from the Haiku payload, and the extractor falls back to
     # always emitting intent="new" (anchored by the CONSOLIDATION
     # prompt section, which is retained even when the data block is
-    # empty). Storage then uses the existing _is_duplicate semantics.
+    # empty). Storage then uses the existing _paraphrase_neighbor semantics.
     # Tradeoff: each candidate adds ~50-100 chars to the Haiku payload
     # and contributes to per-call cache-creation tokens. Default 8 is
     # 2x the per-call fact cap (5), which gives the model enough to
@@ -594,6 +594,20 @@ class Config:
     # divergence between "what the user sees in /memory search" and
     # "what Kai pulls into context" after a config change.
     memory_search_floor: float = 0.3
+
+    # Write-time semantic-similarity dedup threshold. The extractor's
+    # `_paraphrase_neighbor` helper compares each `intent="new"`
+    # candidate against the top-1 nearest existing fact (per user) and
+    # drops the candidate when the cosine score meets or exceeds this
+    # value. Lowering the threshold catches more paraphrase clusters at
+    # the cost of more false merges; raising it preserves more facts at
+    # the cost of duplicate accumulation. Range [0.3, 1.01]: the lower
+    # bound matches `memory_search_floor`'s operator floor; 1.0 fires
+    # only on exact-cosine matches (effectively disabled), and 1.01 is
+    # the unambiguous-disable sentinel. The dataclass default is the
+    # operator-validated production value; upgraders inherit it
+    # without re-running `make config`.
+    memory_duplicate_threshold: float = 0.9
 
     def get_workspace_config(self, workspace: Path) -> WorkspaceConfig | None:
         """
@@ -1677,6 +1691,23 @@ def load_config() -> Config:
     except ValueError:
         raise SystemExit("MEMORY_SEARCH_FLOOR must be a number") from None
 
+    # Write-time paraphrase-dedup threshold. Range [0.3, 1.01]: the
+    # lower bound matches the existing `memory_search_floor` operator
+    # floor (a threshold below 0.3 produces near-everything-is-a-dup
+    # behavior under cosine similarity), and the upper bound permits
+    # 1.01 as the unambiguous-disable sentinel (since `score == 1.0`
+    # can rarely fire on non-identical text under the embedding model,
+    # 1.0 alone is "effectively disabled" but not "guaranteed
+    # disabled"). Same try/except shape as the other memory_* numeric
+    # vars so a bad env value fails fast at startup rather than
+    # surfacing later as silent dedup misbehavior.
+    try:
+        memory_duplicate_threshold = float(os.environ.get("MEMORY_DUPLICATE_THRESHOLD", "0.9"))
+        if memory_duplicate_threshold < 0.3 or memory_duplicate_threshold > 1.01:
+            raise SystemExit("MEMORY_DUPLICATE_THRESHOLD must be between 0.3 and 1.01")
+    except ValueError:
+        raise SystemExit("MEMORY_DUPLICATE_THRESHOLD must be a number") from None
+
     # Per-workspace configuration. Loaded after ALLOWED_WORKSPACES so
     # YAML-defined workspaces can be merged into the allowed set.
     workspace_configs = _load_workspace_configs()
@@ -1841,4 +1872,5 @@ def load_config() -> Config:
         memory_episode_budget_usd=memory_episode_budget_usd,
         memory_episode_timeout_s=memory_episode_timeout_s,
         memory_search_floor=memory_search_floor,
+        memory_duplicate_threshold=memory_duplicate_threshold,
     )

--- a/src/kai/eval/replay.py
+++ b/src/kai/eval/replay.py
@@ -153,6 +153,20 @@ def _build_parser() -> argparse.ArgumentParser:
             "the store."
         ),
     )
+    parser.add_argument(
+        "--log-file",
+        type=Path,
+        default=None,
+        help=(
+            "If set, attach an INFO-level FileHandler to the root logger "
+            "so structured Kai log lines (memory.consolidate.intent, "
+            "memory.extract:, etc.) are captured. Without this flag the "
+            "replay only writes its preamble and summary to stderr; the "
+            "per-fact intent log (dropped_duplicate fires, update_of "
+            "decisions, store outcomes) is silently dropped. Set this "
+            "for any run whose results need to be analyzed downstream."
+        ),
+    )
     return parser
 
 
@@ -356,6 +370,35 @@ async def _run_replay(
     return counters, dry_run_samples
 
 
+def _attach_log_file(path: Path) -> None:
+    """Attach an INFO-level FileHandler to the root logger.
+
+    Mirrors `kai.main.setup_logging`'s formatter and level so log lines
+    from a replay are byte-shape-compatible with production kai.log
+    lines: same `%(asctime)s %(name)s %(levelname)s %(message)s` shape,
+    same INFO threshold. Downstream parsers that already chew
+    production logs (grep for `memory.consolidate.intent`, jq the JSON
+    payload) work unmodified on a replay log.
+
+    Parent directory is created if missing. Append mode so a re-run of
+    the replay with the same `--log-file` accumulates rather than
+    clobbers; operators who want a clean file should delete it first
+    (the same posture as the production logger's daily-rotation file).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    formatter = logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
+    handler = logging.FileHandler(path, mode="a", encoding="utf-8")
+    handler.setFormatter(formatter)
+    handler.setLevel(logging.INFO)
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(handler)
+    # Match `setup_logging`'s noise suppression so a replay file does
+    # not balloon with per-request HTTP and APScheduler tick chatter.
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("apscheduler.executors.default").setLevel(logging.WARNING)
+
+
 async def _reset_sandbox(user_id: str) -> None:
     """Delete all facts for the sandbox `user_id`. No-op safe."""
     # Late import to keep replay-module import cheap and to let tests
@@ -451,6 +494,17 @@ async def _async_main(argv: list[str] | None = None) -> int:
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
+
+    # Wire structured logs to a file when --log-file is set. Without
+    # this, `_emit_intent_log` (INFO level) and the per-extraction
+    # summary line both vanish because the replay module never calls
+    # the bot's `setup_logging`, and Python's default last-resort
+    # handler suppresses anything below WARNING. The cost of dropping
+    # those signals is invisible until an operator tries to count
+    # gate-fires or correlate outcomes across a sweep - so the gate
+    # must be explicit: pass --log-file to capture, omit to skip.
+    if args.log_file is not None:
+        _attach_log_file(args.log_file)
 
     # Resolve history_dir and config_turns from production config when
     # not supplied. Loaded here (not at top) so a test can run without

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -804,6 +804,13 @@ def _cmd_config() -> None:
     memory_episode_timeout_s = "120"
     memory_token_budget = "2000"
     memory_search_limit = "10"
+    # Pre-init for the extraction-time paraphrase-dedup threshold.
+    # Mirrors the other extraction tunables above: the value is set
+    # only when the wizard reaches the prompt (claude backend AND
+    # extraction enabled). Non-claude installs keep the dataclass
+    # default at runtime via load_config, so the env entry stays
+    # suppressed by the delta-from-default check below.
+    memory_duplicate_threshold = "0.9"
     if memory_enabled:
         # Haiku extraction only fires when the active backend is Claude
         # (bot.py:3609 silently skips it otherwise - no startup error,
@@ -932,6 +939,28 @@ def _cmd_config() -> None:
                     except ValueError:
                         pass
                     print("  Must be an integer of at least 10.")
+                # Write-time paraphrase-dedup threshold. Sits inside
+                # the extraction-enabled guard because the gate only
+                # fires in `_store_facts` on the extraction write
+                # path. Inline range check rather than a dedicated
+                # helper: the [0.3, 1.01] band is unique to this
+                # field (lower bound = operator floor for cosine
+                # similarity, upper bound permits 1.01 as an
+                # unambiguous disable sentinel). The same bound is
+                # re-validated in load_config so a hand-edited
+                # install.conf still fails fast at next daemon start.
+                while True:
+                    memory_duplicate_threshold = _prompt(
+                        "Paraphrase-dedup threshold (cosine; 1.0 effectively disables, 1.01 unambiguously)",
+                        existing_env.get("MEMORY_DUPLICATE_THRESHOLD", "0.9"),
+                    )
+                    try:
+                        val = float(memory_duplicate_threshold)
+                        if 0.3 <= val <= 1.01:
+                            break
+                    except ValueError:
+                        pass
+                    print("  Must be a number between 0.3 and 1.01.")
         while True:
             memory_token_budget = _prompt(
                 "Memory context token budget per turn",
@@ -1125,6 +1154,12 @@ def _cmd_config() -> None:
                 env["MEMORY_EPISODE_BUDGET_USD"] = memory_episode_budget_usd
             if int(memory_episode_timeout_s) != 120:
                 env["MEMORY_EPISODE_TIMEOUT_S"] = memory_episode_timeout_s
+            # Paraphrase-dedup threshold. Same delta-from-default gate
+            # as the other extraction tunables; numeric compare so
+            # "0.90" or "0.9 " do not produce a spurious entry equal
+            # to the dataclass default.
+            if float(memory_duplicate_threshold) != 0.9:
+                env["MEMORY_DUPLICATE_THRESHOLD"] = memory_duplicate_threshold
         if int(memory_token_budget) != 2000:
             env["MEMORY_TOKEN_BUDGET"] = memory_token_budget
         # Search limit applies to retrieval (read path), not extraction
@@ -1156,6 +1191,12 @@ def _cmd_config() -> None:
         env.pop("MEMORY_EPISODE_MODEL", None)
         env.pop("MEMORY_EPISODE_BUDGET_USD", None)
         env.pop("MEMORY_EPISODE_TIMEOUT_S", None)
+        # Paraphrase-dedup threshold is consulted by `_store_facts`,
+        # which only runs under the Haiku extraction path. Same
+        # lifecycle as the other extraction keys: dropped on a
+        # claude→non-claude backend flip so a stale value does not
+        # mislead an operator after the flip.
+        env.pop("MEMORY_DUPLICATE_THRESHOLD", None)
 
     # Build and write install.conf
     conf = {

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -907,6 +907,12 @@ def _emit_intent_log(
     new_id: str | None,
     replaced_id: str | None,
     outcome: str,
+    # Populated by the dedup gate fire path. Other outcomes
+    # (stored, skipped, dropped_backend, the update_of family)
+    # pass None and the payload dict elides the keys, so existing
+    # emit sites produce byte-identical log lines.
+    cosine: float | None = None,
+    content_preview: str | None = None,
     level: int = logging.INFO,
 ) -> None:
     """
@@ -921,11 +927,17 @@ def _emit_intent_log(
     is WARNING for the `add_failed_after_delete` outcome, where the old
     fact was deleted but the new one never landed.
 
+    `cosine` and `content_preview` carry audit detail on the dedup
+    fire path (the surviving neighbor's score and the dropped
+    candidate's content). Both default to None and are conditionally
+    elided from the JSON payload so the four other emit sites stay
+    byte-identical with the pre-extension wire format.
+
     JSON compact separators (`,:`) match the `_emit_recall_log` convention
     so downstream parsers see the same wire format across every
     structured log line in the memory subsystem.
     """
-    payload = {
+    payload: dict = {
         "user_id": user_id,
         "intent": intent,
         "original_intent": original_intent,
@@ -933,6 +945,16 @@ def _emit_intent_log(
         "replaced_id": replaced_id,
         "outcome": outcome,
     }
+    # Conditional-elide invariant: keys are added ONLY when the
+    # caller passed a non-None value. The dedup-fire path is the
+    # only current caller that supplies these; every other emit
+    # site omits the kwargs and the payload stays at the original
+    # six keys, preserving the pre-extension JSON wire format for
+    # downstream parsers and dashboards.
+    if cosine is not None:
+        payload["cosine"] = cosine
+    if content_preview is not None:
+        payload["content_preview"] = content_preview
     log.log(level, "memory.consolidate.intent %s", json.dumps(payload, separators=(",", ":")))
 
 
@@ -1606,25 +1628,37 @@ def _validate_facts(
     return validated
 
 
-def _is_duplicate(content: str, user_id: str, threshold: float = 0.9) -> bool:
+def _paraphrase_neighbor(content: str, user_id: str, threshold: float) -> MemoryResult | None:
     """
-    Top-1 semantic-search dedup.
+    Top-1 semantic-search dedup gate.
 
-    Returns True if the nearest existing user-scoped memory scores at
-    or above `threshold` against `content`. Used at write time before
-    each add_structured() call so the store does not accumulate ten
-    near-identical "User prefers Celsius" facts when a user repeats
-    a preference across conversations.
+    Returns the nearest existing user-scoped memory when its cosine
+    score meets or exceeds `threshold` against `content`. Returns None
+    when no neighbor reaches the threshold, when the store is empty,
+    when memory is disabled, or when the search call raises.
 
-    Dedup-at-write is strictly cheaper than dedup-at-read: it pays once
-    at extraction time rather than on every retrieval. Restored from
-    the seed machinery removed in #321 (originally from #317).
+    Returning the matched `MemoryResult` (vs the prior `bool`) lets the
+    caller log the neighbor's id and cosine score on a fire without
+    running a second `memory.search` against the same content. The
+    strict-greater-or-equal boundary (`score >= threshold`) is
+    preserved from the prior boolean form so the threshold's
+    documented meaning (the lowest score that still counts as a
+    duplicate) is unchanged.
 
-    Returns False on any failure (memory disabled, search error) so
-    extraction continues to succeed on a store with broken search.
+    Used at write time inside `_store_facts`, before each
+    `add_structured()` call on the `intent="new"` branch, so the store
+    does not accumulate ten near-identical "User prefers Celsius"
+    facts when a user repeats a preference across conversations.
+    Dedup-at-write is strictly cheaper than dedup-at-read: it pays
+    once at extraction time rather than on every retrieval.
+
+    The None-on-failure posture (vs raising) means a broken store does
+    not strand extraction; the candidate falls through to
+    `add_structured` and the operator sees the `dropped_backend`
+    outcome instead if Mem0 is the actual problem.
     """
     if not memory.is_enabled():
-        return False
+        return None
     try:
         # memory.search is sync (Mem0 is sync). Called in an executor
         # at the public-API layer; this helper is called from inside
@@ -1632,11 +1666,13 @@ def _is_duplicate(content: str, user_id: str, threshold: float = 0.9) -> bool:
         # runs off the hot path, so a direct sync call is fine here.
         results = memory.search(content, user_id=user_id, limit=1)
     except Exception:
-        log.debug("_is_duplicate: search failed; treating as non-duplicate", exc_info=True)
-        return False
+        log.debug("_paraphrase_neighbor: search failed; treating as non-duplicate", exc_info=True)
+        return None
     if not results:
-        return False
-    return results[0].score >= threshold
+        return None
+    if results[0].score >= threshold:
+        return results[0]
+    return None
 
 
 # ── Subprocess wiring ───────────────────────────────────────────────
@@ -2187,6 +2223,7 @@ def _store_facts(
     *,
     user_id: str,
     session_id: str | None,
+    config: Config,
 ) -> tuple[int, int, int]:
     """
     Persist validated facts via memory.add_structured, branching on intent.
@@ -2203,13 +2240,20 @@ def _store_facts(
     - `skipped`: facts the extractor classified as `skip_redundant`.
       No storage call, but we record the decision for the summary log.
 
+    `config` carries the runtime threshold for the dedup gate
+    (`memory_duplicate_threshold`). Threaded in from `extract_and_store`
+    rather than re-loaded here so a test or a per-call override can
+    flow through the same code path; also avoids an in-loop
+    `load_config()` cost.
+
     Each intent branch emits exactly one `memory.consolidate.intent`
     line via `_emit_intent_log`. The `intent="new"` branch keeps the
-    existing `_is_duplicate` defense-in-depth gate against the case
-    where the extractor returns `new` for a near-verbatim duplicate
-    (the candidate set is capped at N=8, so the extractor may not see
-    the duplicating fact). `update_of` skips `_is_duplicate` because
-    consolidation already happened upstream at the extractor layer.
+    existing `_paraphrase_neighbor` defense-in-depth gate against the
+    case where the extractor returns `new` for a near-verbatim
+    duplicate (the candidate set is capped at N=8, so the extractor
+    may not see the duplicating fact). `update_of` skips
+    `_paraphrase_neighbor` because consolidation already happened
+    upstream at the extractor layer.
 
     Mem0 exposes no atomic replace primitive: `update_of` is implemented
     as `delete_by_id` followed by `add_structured`. The race window is
@@ -2269,16 +2313,16 @@ def _store_facts(
             # `stored` to `delete_failed_added_anyway` so the log carries
             # the operational signal.
             #
-            # We deliberately do NOT run `_is_duplicate` against the new
-            # content here. Reasoning: the extractor already decided this
-            # is a consolidation-of-existing, having seen the top-N
-            # candidate window. If the new content happens to near-match
-            # a *different* fact outside that window, it can land
-            # un-deduped. At N=8 (2x the per-call fact cap) the case is
-            # vanishingly rare; if a duplicate spike appears in
+            # We deliberately do NOT run `_paraphrase_neighbor` against
+            # the new content here. Reasoning: the extractor already
+            # decided this is a consolidation-of-existing, having seen
+            # the top-N candidate window. If the new content happens to
+            # near-match a *different* fact outside that window, it can
+            # land un-deduped. At N=8 (2x the per-call fact cap) the
+            # case is vanishingly rare; if a duplicate spike appears in
             # production, raise N rather than re-introducing the
-            # _is_duplicate gate here (which would silently drop the
-            # consolidation and leave the stale fact in place).
+            # _paraphrase_neighbor gate here (which would silently drop
+            # the consolidation and leave the stale fact in place).
             delete_ok = memory.delete_by_id(user_id=user_id, memory_id=existing_id)
             memory_id = memory.add_structured(
                 content,
@@ -2323,19 +2367,31 @@ def _store_facts(
         if intent != "new":
             continue
 
-        if _is_duplicate(content, user_id):
+        neighbor = _paraphrase_neighbor(
+            content,
+            user_id,
+            threshold=config.memory_duplicate_threshold,
+        )
+        if neighbor is not None:
             log.debug("_store_facts: skipping duplicate %r", content[:80])
             # `dropped_duplicate`: dedup gate fired correctly. Healthy
             # signal at volume - distinguished from `dropped_backend`
             # (below) so a dashboard alert on backend failure does not
-            # also fire on benign deduplication.
+            # also fire on benign deduplication. The extended payload
+            # (replaced_id, cosine, content_preview) carries the
+            # surviving neighbor's id, the rounded cosine score, and
+            # the dropped candidate's text so an operator scanning the
+            # log can audit the gate's behavior without re-running a
+            # search by hand.
             _emit_intent_log(
                 user_id=user_id,
                 intent="new",
                 original_intent=None,
                 new_id=None,
-                replaced_id=None,
+                replaced_id=neighbor.id,
                 outcome="dropped_duplicate",
+                cosine=round(neighbor.score, 3),
+                content_preview=content[:100],
             )
             continue
 
@@ -2469,7 +2525,7 @@ async def extract_and_store(
                         ),
                     )
                 except Exception:
-                    # Match `_is_duplicate`'s search-failure posture: a
+                    # Match `_paraphrase_neighbor`'s search-failure posture: a
                     # broken store does not strand extraction. The
                     # candidate list stays empty and the extractor
                     # falls back to the all-`new` branch via the
@@ -2550,7 +2606,12 @@ async def extract_and_store(
                 # embeds each fact.
                 stored, replaced, skipped = await loop.run_in_executor(
                     None,
-                    lambda: _store_facts(result.facts, user_id=user_id, session_id=session_id),
+                    lambda: _store_facts(
+                        result.facts,
+                        user_id=user_id,
+                        session_id=session_id,
+                        config=config,
+                    ),
                 )
             else:
                 stored = replaced = skipped = 0
@@ -2647,7 +2708,7 @@ __all__ = [
     "_capped_assistant",
     "_emit_intent_log",
     "_get_semaphore",
-    "_is_duplicate",
+    "_paraphrase_neighbor",
     "_per_user_semaphores",
     "_render_candidate_line",
     "_render_candidate_source",

--- a/templates/.env
+++ b/templates/.env
@@ -161,6 +161,16 @@ MEMORY_ENABLED=false
 # at runtime by editing this file and restarting the service.
 #MEMORY_SEARCH_FLOOR=0.3
 
+# Write-time paraphrase-dedup threshold for the extractor. Float in
+# [0.3, 1.01]. Each `intent="new"` fact is compared (cosine) against
+# its top-1 nearest existing fact for the same user; if the score
+# meets or exceeds this value, the candidate is dropped as a paraphrase
+# duplicate. Lower values catch more paraphrase clusters at the cost
+# of more false merges; raise toward 0.95 if Kai feels too aggressive
+# about dropping facts. 1.0 fires only on exact cosine matches
+# (effectively disabled); 1.01 unambiguously disables the gate.
+#MEMORY_DUPLICATE_THRESHOLD=0.9
+
 # Track 2 Haiku extraction. Requires MEMORY_ENABLED=true and a Claude
 # backend. Off by default at Phase 2 ship (self-reinforcing loop needs
 # real-world observation time before the default flips). Kill switch

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,6 +63,7 @@ _CONFIG_ENV_VARS = [
     "MEMORY_EPISODE_BUDGET_USD",
     "MEMORY_EPISODE_TIMEOUT_S",
     "MEMORY_SEARCH_FLOOR",
+    "MEMORY_DUPLICATE_THRESHOLD",
     "KAI_DATA_DIR",
     "KAI_INSTALL_DIR",
 ]
@@ -1633,6 +1634,69 @@ class TestMemorySearchFloor:
     def test_rejects_non_number(self, monkeypatch):
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_SEARCH_FLOOR", "high")
+        with pytest.raises(SystemExit, match="must be a number"):
+            load_config()
+
+
+# ── Memory duplicate threshold ───────────────────────────────────────
+
+
+class TestMemoryDuplicateThreshold:
+    """The MEMORY_DUPLICATE_THRESHOLD env var: cosine threshold for the
+    write-time paraphrase-dedup gate in `_store_facts`. Range [0.3,
+    1.01]: the lower bound matches `memory_search_floor`'s operator
+    floor (cosine below 0.3 is near-everything-is-a-dup territory),
+    and 1.01 is the unambiguous-disable sentinel since a literal
+    `score == 1.0` can rarely fire on non-identical text under the
+    embedding model."""
+
+    def test_default_is_0_9(self, monkeypatch):
+        """Default preserves the prior hard-coded constant from the
+        boolean `_is_duplicate` era. The dataclass default IS the
+        operator-validated production value; upgraders not setting
+        this env var inherit the production default."""
+        _set_required(monkeypatch)
+        config = load_config()
+        assert config.memory_duplicate_threshold == 0.9
+
+    def test_override(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_DUPLICATE_THRESHOLD", "0.85")
+        config = load_config()
+        assert config.memory_duplicate_threshold == 0.85
+
+    def test_accepts_lower_bound(self, monkeypatch):
+        """0.3 is the floor (matches memory_search_floor's operator
+        recommendation). Accepted but pathologically aggressive."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_DUPLICATE_THRESHOLD", "0.3")
+        config = load_config()
+        assert config.memory_duplicate_threshold == 0.3
+
+    def test_accepts_upper_bound(self, monkeypatch):
+        """1.01 is the unambiguous-disable sentinel: at this value
+        even a perfect-cosine 1.0 neighbor fails the strict-ge check,
+        guaranteeing no fires regardless of the embedding model."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_DUPLICATE_THRESHOLD", "1.01")
+        config = load_config()
+        assert config.memory_duplicate_threshold == 1.01
+
+    def test_rejects_below_lower_bound(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_DUPLICATE_THRESHOLD", "0.2")
+        with pytest.raises(SystemExit, match=r"between 0\.3 and 1\.01"):
+            load_config()
+
+    def test_rejects_above_upper_bound(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_DUPLICATE_THRESHOLD", "1.5")
+        with pytest.raises(SystemExit, match=r"between 0\.3 and 1\.01"):
+            load_config()
+
+    def test_rejects_non_number(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_DUPLICATE_THRESHOLD", "tight")
         with pytest.raises(SystemExit, match="must be a number"):
             load_config()
 

--- a/tests/test_eval_replay.py
+++ b/tests/test_eval_replay.py
@@ -415,6 +415,145 @@ class TestInitMemory:
         init_mock.assert_called_once_with(config_mock)
 
 
+# ── --log-file structured-log capture ───────────────────────────────
+
+
+class TestLogFileCapture:
+    """`--log-file` MUST attach an INFO-level FileHandler to the root
+    logger so structured Kai log lines (`memory.consolidate.intent`,
+    `memory.extract:`, etc.) land in a file instead of being dropped
+    by Python's WARNING-only last-resort handler.
+
+    This test exists because that bug actually shipped: the #465
+    five-T sweep ran ~6 hours of compute and produced zero
+    gate-fire-count data because the replay module never configured
+    logging. The deterministic gate-fire signal the spec named as
+    PR-body evidence was silently dropped at the logger boundary. The
+    fix is the `--log-file` flag; this test pins the contract."""
+
+    def _make_history(self, tmp_path: Path) -> Path:
+        """One-pair synthetic history so the replay walks but the
+        extractor and store are stubbed before any subprocess fires."""
+        history_dir = tmp_path / "history" / str(_CHAT_ID)
+        history_dir.mkdir(parents=True)
+        _write_jsonl(
+            history_dir / "2026-05-12.jsonl",
+            [_rec("user", "hi"), _rec("assistant", "hello")],
+        )
+        return history_dir
+
+    @pytest.mark.asyncio
+    async def test_log_file_flag_captures_intent_log_lines(self, tmp_path):
+        """End-to-end: an INFO-level `memory.consolidate.intent` line
+        emitted via the production `_emit_intent_log` helper must
+        appear in the file the operator named. The replay loop is
+        short-circuited (no real extraction) and we directly emit a
+        synthetic intent log from inside the patched extract path so
+        the test is fast and deterministic."""
+        history_dir = self._make_history(tmp_path)
+        log_path = tmp_path / "replay-with-logs.log"
+
+        # Drive a synthetic intent log line from inside the patched
+        # extract path. _emit_intent_log is the production helper that
+        # `_store_facts` calls on every branch; emitting through it
+        # verifies the same call shape production uses, not a stub.
+        async def _fake_extract(*args, **kwargs):
+            from kai.memory_extraction import _emit_intent_log
+
+            _emit_intent_log(
+                user_id=kwargs["user_id"],
+                intent="new",
+                original_intent=None,
+                new_id="test-id",
+                replaced_id=None,
+                outcome="stored",
+            )
+            return 1
+
+        config_mock = MagicMock()
+        config_mock.episode_classifier_context_turns = 3
+
+        with (
+            patch("kai.config.load_config", return_value=config_mock),
+            patch("kai.memory.init_memory"),
+            patch("kai.memory.delete_all"),
+            patch("kai.memory.get_all_facts", return_value=[]),
+            patch("kai.memory_extraction.extract_and_store", side_effect=_fake_extract),
+        ):
+            rc = await replay._async_main(
+                [
+                    "--chat-id",
+                    str(_CHAT_ID),
+                    "--user-id",
+                    "sandbox-log-test",
+                    "--history-dir",
+                    str(history_dir),
+                    "--log-file",
+                    str(log_path),
+                ]
+            )
+
+        assert rc == 0
+        assert log_path.exists(), "log file was not created"
+        captured = log_path.read_text(encoding="utf-8")
+        # The intent log line carries the literal marker the spec
+        # documents as the wire format. Asserting the substring (not
+        # the exact line) keeps the test resilient to formatter
+        # adjustments while pinning the load-bearing tag.
+        assert "memory.consolidate.intent" in captured
+        # The JSON payload's outcome field MUST be preserved verbatim
+        # so a downstream `jq '.outcome'` parse over a real sweep log
+        # produces usable counts. This is the assertion that prevents
+        # a future "summarize before write" refactor from breaking
+        # gate-fire analysis.
+        assert '"outcome":"stored"' in captured
+
+    def _root_handler_count(self) -> int:
+        """Snapshot of the root logger's handler count so the
+        no-flag test can assert no permanent global mutation."""
+        import logging
+
+        return len(logging.getLogger().handlers)
+
+    @pytest.mark.asyncio
+    async def test_log_file_default_attaches_no_handler(self, tmp_path):
+        """Regression guard: without `--log-file` the replay must NOT
+        attach a handler to the root logger. The previous behavior
+        (no logging) was a bug, but the FIX must be explicit (the
+        flag), not silent. A future refactor that auto-enables logging
+        could leak handlers across test runs or surprise an operator
+        whose terminal session was previously quiet."""
+        history_dir = self._make_history(tmp_path)
+        before = self._root_handler_count()
+
+        config_mock = MagicMock()
+        config_mock.episode_classifier_context_turns = 3
+
+        with (
+            patch("kai.config.load_config", return_value=config_mock),
+            patch("kai.memory.init_memory"),
+            patch("kai.memory.delete_all"),
+            patch("kai.memory.get_all_facts", return_value=[]),
+            patch("kai.memory_extraction.extract_and_store", AsyncMock(return_value=0)),
+        ):
+            rc = await replay._async_main(
+                [
+                    "--chat-id",
+                    str(_CHAT_ID),
+                    "--user-id",
+                    "sandbox-no-log-test",
+                    "--history-dir",
+                    str(history_dir),
+                ]
+            )
+
+        assert rc == 0
+        # Handler count unchanged: the replay did not silently attach
+        # logging machinery. Operators who omit --log-file get the
+        # same (broken-but-documented) behavior as before the fix.
+        assert self._root_handler_count() == before
+
+
 # ── PRIOR CONTEXT truncation deferred to extract_and_store ──────────
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1552,6 +1552,7 @@ class TestCmdConfig:
             # branch, type a different model literal here.
             "claude-haiku-4-5-20251001",  # episode model (explicit override)
             "60",  # episode timeout seconds (non-default)
+            "0.85",  # paraphrase-dedup threshold (non-default, exercises emission)
             "3000",  # token budget
             "20",  # search limit (#345)
         ]
@@ -1580,6 +1581,9 @@ class TestCmdConfig:
         assert env["MEMORY_EPISODE_MODEL"] == "claude-haiku-4-5-20251001"
         assert "MEMORY_EPISODE_BUDGET_USD" not in env
         assert env["MEMORY_EPISODE_TIMEOUT_S"] == "60"
+        # Paraphrase-dedup threshold: operator picked 0.85 (non-default),
+        # so the emission gate fires and the env entry is written.
+        assert env["MEMORY_DUPLICATE_THRESHOLD"] == "0.85"
         assert env["MEMORY_TOKEN_BUDGET"] == "3000"
         assert env["MEMORY_SEARCH_LIMIT"] == "20"
 
@@ -1613,6 +1617,7 @@ class TestCmdConfig:
             "3",  # episode classifier context turns (#392, dataclass default; suppressed)
             "",  # episode model: accept wizard default = claude-sonnet-4-6
             "120",  # episode timeout (dataclass default; suppressed)
+            "0.9",  # paraphrase-dedup threshold (dataclass default; suppressed)
             "2000",  # token budget (dataclass default; suppressed)
             "10",  # search limit (dataclass default; suppressed)
         ]
@@ -1636,6 +1641,8 @@ class TestCmdConfig:
         # Episode-classifier context window (#392) at default 3 is
         # also suppressed by the emission gate.
         assert "EPISODE_CLASSIFIER_CONTEXT_TURNS" not in env
+        # Paraphrase-dedup threshold at default 0.9 is also suppressed.
+        assert "MEMORY_DUPLICATE_THRESHOLD" not in env
 
     def test_memory_round_trip_through_env_file(self, tmp_path, monkeypatch):
         """Wizard-captured memory vars survive _generate_env_file()."""
@@ -1655,6 +1662,7 @@ class TestCmdConfig:
             "7",  # episode classifier context turns (#392, non-default)
             "claude-haiku-4-5-future",
             "90",
+            "0.8",  # paraphrase-dedup threshold (non-default)
             "2500",
             "15",
         ]
@@ -1907,6 +1915,7 @@ class TestCmdConfig:
             "5",  # episode classifier context turns (#392, non-default)
             "",  # episode model (accept Sonnet wizard default)
             "120",  # episode timeout (default; suppressed)
+            "0.9",  # paraphrase-dedup threshold (default; suppressed)
             "2000",  # token budget (default; suppressed)
             "10",  # search limit (default; suppressed)
         ]
@@ -1936,6 +1945,7 @@ class TestCmdConfig:
             "3",  # episode classifier context turns (#392, dataclass default)
             "",  # episode model (Sonnet default)
             "120",  # episode timeout (default)
+            "0.9",  # paraphrase-dedup threshold (default)
             "2000",  # token budget (default)
             "10",  # search limit (default)
         ]

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -394,7 +394,7 @@ class TestStage2Trigger:
         causal correlation in logs."""
         order: list[str] = []
 
-        def _store_recorder(facts, *, user_id, session_id):
+        def _store_recorder(facts, *, user_id, session_id, config):
             order.append("store_facts")
             return (len(facts), 0, 0)
 

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -37,7 +37,7 @@ from kai.memory_extraction import (
     _capped_assistant,
     _emit_intent_log,
     _get_semaphore,
-    _is_duplicate,
+    _paraphrase_neighbor,
     _render_candidate_line,
     _render_candidate_source,
     _store_facts,
@@ -506,55 +506,195 @@ class TestValidateFacts:
         assert result == [good]
 
 
-# ── _is_duplicate ───────────────────────────────────────────────────
+# ── _paraphrase_neighbor ────────────────────────────────────────────
 
 
-class TestIsDuplicate:
-    """Spec §13.1: threshold-based dedup. Score >= 0.9 is duplicate;
-    strictly below is not. Tested on the boundary because off-by-one
-    here causes either silent duplicate accumulation (too lax) or
-    silent fact drops (too strict)."""
+class TestParaphraseGate:
+    """Threshold-based dedup gate. Score >= threshold returns the
+    neighbor (the candidate is dropped at the call site); strictly
+    below returns None (candidate lands). The strict-ge boundary is
+    load-bearing: off-by-one here causes either silent duplicate
+    accumulation (too lax) or silent fact drops (too strict). Replaces
+    the prior `_is_duplicate` boolean form; the richer return lets
+    `_store_facts` log the surviving neighbor's id and cosine without
+    a second search call."""
 
-    def test_returns_false_when_memory_disabled(self, monkeypatch):
-        monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: False)
-        assert not _is_duplicate("anything", "user-1")
+    def test_gate_does_not_fire_on_empty_store(self, monkeypatch):
+        """Empty `memory.search` result means there's nothing to merge
+        against; the candidate must pass through to add_structured."""
+        monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
+        monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [])
+        assert _paraphrase_neighbor("x", "user-1", threshold=0.9) is None
 
-    def test_above_threshold_is_duplicate(self, monkeypatch):
+    def test_gate_does_not_fire_below_threshold(self, monkeypatch):
+        """A near-but-not-paraphrase neighbor (score = T - 0.05) is
+        evidence of similarity but NOT enough to collapse the
+        candidate. The strict-ge boundary says "below means land."
+        """
         monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
         fake = MagicMock()
-        fake.score = 0.95
+        fake.score = 0.85
         monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [fake])
-        assert _is_duplicate("x", "user-1")
+        assert _paraphrase_neighbor("x", "user-1", threshold=0.9) is None
 
-    def test_at_threshold_is_duplicate(self, monkeypatch):
+    def test_gate_fires_at_threshold(self, monkeypatch):
+        """Boundary case: score exactly equal to threshold fires the
+        gate (strict-ge preserved from the prior bool form). The
+        returned neighbor is the same object the search call produced,
+        so `replaced_id` carries the right Mem0 id downstream."""
         monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
         fake = MagicMock()
         fake.score = 0.9
+        fake.id = "neighbor-id"
         monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [fake])
-        assert _is_duplicate("x", "user-1")
+        result = _paraphrase_neighbor("x", "user-1", threshold=0.9)
+        assert result is fake
 
-    def test_below_threshold_is_not_duplicate(self, monkeypatch):
+    def test_gate_fires_above_threshold(self, monkeypatch):
+        """Score comfortably above threshold (T + 0.05) is the expected
+        fire path. Returns the neighbor (not just True) so the caller
+        can extract id + score for the audit log."""
         monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
         fake = MagicMock()
-        fake.score = 0.89
+        fake.score = 0.95
+        fake.id = "neighbor-id"
         monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [fake])
-        assert not _is_duplicate("x", "user-1")
+        result = _paraphrase_neighbor("x", "user-1", threshold=0.9)
+        assert result is fake
 
-    def test_empty_results_not_duplicate(self, monkeypatch):
+    def test_gate_skipped_on_update_of_intent(self, monkeypatch):
+        """`update_of` facts bypass the gate entirely (consolidation
+        already happened at the extractor layer). The gate function
+        itself doesn't know about intent; `_store_facts`'s branch
+        table is what enforces the skip. This test pins the branch
+        contract by failing if is_enabled runs on an update_of fact."""
+        monkeypatch.setattr(
+            "kai.memory_extraction.memory.is_enabled",
+            lambda: pytest.fail("_paraphrase_neighbor must not run on update_of"),
+        )
+        monkeypatch.setattr(
+            "kai.memory_extraction.memory.delete_by_id",
+            lambda *, user_id, memory_id: True,
+        )
+        monkeypatch.setattr(
+            "kai.memory_extraction.memory.add_structured",
+            lambda content, **kw: "new-id",
+        )
+        facts = [
+            {
+                "content": "User prefers Earl Grey",
+                "tags": ["preference"],
+                "confidence": 0.9,
+                "intent": "update_of",
+                "existing_id": "old-id",
+            }
+        ]
+        stored, replaced, _ = _store_facts(facts, user_id="u1", session_id="s1", config=_cfg())
+        assert (stored, replaced) == (1, 1)
+
+    def test_gate_skipped_on_skip_redundant_intent(self, monkeypatch):
+        """`skip_redundant` facts also bypass the gate. The extractor
+        cited an existing fact; no storage call should run AT ALL, so
+        is_enabled must NOT be consulted on this path."""
+        monkeypatch.setattr(
+            "kai.memory_extraction.memory.is_enabled",
+            lambda: pytest.fail("_paraphrase_neighbor must not run on skip_redundant"),
+        )
+        monkeypatch.setattr(
+            "kai.memory_extraction.memory.add_structured",
+            lambda *a, **kw: pytest.fail("add_structured must not run on skip_redundant"),
+        )
+        facts = [
+            {
+                "content": "User prefers Earl Grey",
+                "tags": ["preference"],
+                "confidence": 0.9,
+                "intent": "skip_redundant",
+                "existing_id": "old-id",
+            }
+        ]
+        stored, _, skipped = _store_facts(facts, user_id="u1", session_id="s1", config=_cfg())
+        assert (stored, skipped) == (0, 1)
+
+    def test_gate_threshold_from_config(self, monkeypatch, caplog):
+        """The threshold flows from `config.memory_duplicate_threshold`
+        through `_store_facts` into the gate. A neighbor scored just
+        below the config'd threshold must NOT fire the gate; a stub
+        memory.search returning that score plus `add_structured`
+        succeeding is the load-bearing assertion - if the threshold
+        was hard-coded inside _paraphrase_neighbor, the gate would
+        misfire."""
         monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
-        monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [])
-        assert not _is_duplicate("x", "user-1")
+        fake = MagicMock()
+        fake.score = 0.79  # 0.01 below the cfg'd threshold of 0.80
+        fake.id = "neighbor"
+        monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [fake])
+        add_calls: list = []
+        monkeypatch.setattr(
+            "kai.memory_extraction.memory.add_structured",
+            lambda content, **kw: add_calls.append(content) or "new-id",
+        )
+        facts = [{"content": "x", "tags": ["fact"], "confidence": 0.9, "intent": "new"}]
+        cfg = _cfg(memory_duplicate_threshold=0.80)
+        stored, _, _ = _store_facts(facts, user_id="u1", session_id="s1", config=cfg)
+        assert stored == 1
+        assert add_calls == ["x"]
 
-    def test_search_exception_not_duplicate(self, monkeypatch):
+    def test_gate_disabled_at_threshold_1_01(self, monkeypatch):
+        """At T=1.01 (the unambiguous-disable sentinel) even a perfect
+        cosine match of 1.0 must NOT fire the gate, because 1.0 <
+        1.01. This is the contract operators rely on when they need a
+        "gate is OFF" guarantee."""
+        monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
+        fake = MagicMock()
+        fake.score = 1.0
+        monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [fake])
+        assert _paraphrase_neighbor("x", "user-1", threshold=1.01) is None
+
+    def test_gate_search_failure_returns_none(self, monkeypatch):
         """A broken search layer must not block extraction. Treat
-        errors as 'no duplicate found' so new facts still land."""
+        errors as 'no neighbor found' so new facts still land. Pre-
+        rename this was the documented `_is_duplicate` posture; the
+        rename preserves it."""
         monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
 
         def _boom(*a, **kw):
             raise RuntimeError("qdrant down")
 
         monkeypatch.setattr("kai.memory_extraction.memory.search", _boom)
-        assert not _is_duplicate("x", "user-1")
+        assert _paraphrase_neighbor("x", "user-1", threshold=0.9) is None
+
+    def test_gate_log_shape(self, monkeypatch, caplog):
+        """When the gate fires inside `_store_facts`, the intent log
+        line MUST carry the surviving neighbor's id, the rounded
+        cosine score, and a content_preview of the dropped candidate.
+        These three fields are what makes the audit procedure tractable
+        without rerunning a search by hand on every drop."""
+        monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
+        fake = MagicMock()
+        fake.score = 0.9234567
+        fake.id = "surviving-neighbor"
+        monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [fake])
+        monkeypatch.setattr(
+            "kai.memory_extraction.memory.add_structured",
+            lambda *a, **kw: pytest.fail("add_structured must not run on gate fire"),
+        )
+        facts = [
+            {
+                "content": "A" * 150,  # Exceeds the 100-char preview cap.
+                "tags": ["fact"],
+                "confidence": 0.9,
+                "intent": "new",
+            }
+        ]
+        with caplog.at_level("INFO", logger="kai.memory_extraction"):
+            _store_facts(facts, user_id="u1", session_id="s1", config=_cfg())
+        record = next(r for r in caplog.records if "memory.consolidate.intent" in r.getMessage())
+        payload = json.loads(record.getMessage().split("memory.consolidate.intent ", 1)[1])
+        assert payload["outcome"] == "dropped_duplicate"
+        assert payload["replaced_id"] == "surviving-neighbor"
+        assert payload["cosine"] == 0.923
+        assert payload["content_preview"] == "A" * 100
 
 
 # ── _get_semaphore (LRU) ────────────────────────────────────────────
@@ -1078,9 +1218,9 @@ class TestPerUserSemaphore:
 
 
 class TestStoreFactsDedup:
-    """Dedup at write time uses _is_duplicate (top-1, threshold=0.9).
-    A duplicate must NOT be stored, and must NOT abort the rest of the
-    batch."""
+    """Dedup at write time uses _paraphrase_neighbor (top-1, threshold
+    from config.memory_duplicate_threshold). A duplicate must NOT be
+    stored, and must NOT abort the rest of the batch."""
 
     @pytest.mark.asyncio
     async def test_duplicate_fact_skipped(self, monkeypatch):
@@ -1109,6 +1249,10 @@ class TestStoreFactsDedup:
         def _fake_search(query, *, user_id, limit):
             fake = MagicMock()
             fake.score = 0.95 if "Celsius" in query else 0.3
+            # The dedup gate's log emit reads neighbor.id, which the
+            # JSON encoder must serialize; an auto-generated MagicMock
+            # attribute is not serializable, so pin a real string here.
+            fake.id = "neighbor-id"
             return [fake]
 
         monkeypatch.setattr("kai.memory_extraction.memory.search", _fake_search)
@@ -1635,7 +1779,7 @@ class TestStoreFactsIntent:
         )
         facts = [{"content": "x", "tags": ["fact"], "confidence": 0.9, "intent": "new"}]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            stored, replaced, skipped = _store_facts(facts, user_id="u1", session_id="s1")
+            stored, replaced, skipped = _store_facts(facts, user_id="u1", session_id="s1", config=_cfg())
         assert (stored, replaced, skipped) == (1, 0, 0)
         record = next(r for r in caplog.records if "memory.consolidate.intent" in r.getMessage())
         payload = json.loads(record.getMessage().split("memory.consolidate.intent ", 1)[1])
@@ -1646,9 +1790,12 @@ class TestStoreFactsIntent:
 
     def test_new_with_duplicate_dropped(self, monkeypatch, caplog):
         monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
-        # _is_duplicate path: search returns a high-score hit.
+        # _paraphrase_neighbor path: search returns a high-score hit.
         fake = MagicMock()
         fake.score = 0.95
+        # JSON-serializable id - the dedup-fire log line carries
+        # neighbor.id verbatim and chokes on a default MagicMock.
+        fake.id = "neighbor-id"
         monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [fake])
         # add_structured must NOT be called.
         monkeypatch.setattr(
@@ -1657,7 +1804,7 @@ class TestStoreFactsIntent:
         )
         facts = [{"content": "x", "tags": ["fact"], "confidence": 0.9, "intent": "new"}]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            stored, _, _ = _store_facts(facts, user_id="u1", session_id="s1")
+            stored, _, _ = _store_facts(facts, user_id="u1", session_id="s1", config=_cfg())
         assert stored == 0
         record = next(r for r in caplog.records if "memory.consolidate.intent" in r.getMessage())
         payload = json.loads(record.getMessage().split("memory.consolidate.intent ", 1)[1])
@@ -1675,7 +1822,7 @@ class TestStoreFactsIntent:
         a dashboard alert on store-health actionable - bare `dropped` would
         aggregate healthy dedup with sick-backend signals."""
         monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
-        # _is_duplicate's search returns no hits; we proceed to add_structured.
+        # _paraphrase_neighbor's search returns no hits; we proceed to add_structured.
         monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [])
         # add_structured returns None - the documented "storage disabled
         # OR Mem0's internal try/except swallowed an exception" outcome.
@@ -1685,7 +1832,7 @@ class TestStoreFactsIntent:
         )
         facts = [{"content": "x", "tags": ["fact"], "confidence": 0.9, "intent": "new"}]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            stored, replaced, skipped = _store_facts(facts, user_id="u1", session_id="s1")
+            stored, replaced, skipped = _store_facts(facts, user_id="u1", session_id="s1", config=_cfg())
         # Nothing actually landed - all three counters must be zero.
         assert (stored, replaced, skipped) == (0, 0, 0)
         record = next(r for r in caplog.records if "memory.consolidate.intent" in r.getMessage())
@@ -1695,11 +1842,12 @@ class TestStoreFactsIntent:
         assert payload["new_id"] is None
 
     def test_update_of_happy_path(self, monkeypatch, caplog):
-        """Delete-then-add both succeed. _is_duplicate must NOT run for
-        the update_of branch (consolidation already happened upstream)."""
+        """Delete-then-add both succeed. _paraphrase_neighbor must NOT
+        run for the update_of branch (consolidation already happened
+        upstream)."""
         monkeypatch.setattr(
             "kai.memory_extraction.memory.is_enabled",
-            lambda: pytest.fail("is_duplicate must not run on update_of"),
+            lambda: pytest.fail("_paraphrase_neighbor must not run on update_of"),
         )
         delete_calls: list = []
         monkeypatch.setattr(
@@ -1721,7 +1869,7 @@ class TestStoreFactsIntent:
             }
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            stored, replaced, skipped = _store_facts(facts, user_id="u1", session_id="s1")
+            stored, replaced, skipped = _store_facts(facts, user_id="u1", session_id="s1", config=_cfg())
         # Delete and add both ran; outcome is `stored`.
         assert delete_calls == [("u1", "old-id")]
         assert len(add_calls) == 1
@@ -1752,7 +1900,7 @@ class TestStoreFactsIntent:
             }
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            stored, replaced, _ = _store_facts(facts, user_id="u1", session_id="s1")
+            stored, replaced, _ = _store_facts(facts, user_id="u1", session_id="s1", config=_cfg())
         # The new fact landed; replaced is still incremented because the
         # update_of intent succeeded structurally.
         assert (stored, replaced) == (1, 1)
@@ -1779,7 +1927,7 @@ class TestStoreFactsIntent:
             }
         ]
         with caplog.at_level("DEBUG", logger="kai.memory_extraction"):
-            stored, replaced, _ = _store_facts(facts, user_id="u1", session_id="s1")
+            stored, replaced, _ = _store_facts(facts, user_id="u1", session_id="s1", config=_cfg())
         assert (stored, replaced) == (0, 0)
         record = next(r for r in caplog.records if "memory.consolidate.intent" in r.getMessage())
         assert record.levelname == "WARNING"
@@ -1807,7 +1955,7 @@ class TestStoreFactsIntent:
             }
         ]
         with caplog.at_level("INFO", logger="kai.memory_extraction"):
-            stored, replaced, skipped = _store_facts(facts, user_id="u1", session_id="s1")
+            stored, replaced, skipped = _store_facts(facts, user_id="u1", session_id="s1", config=_cfg())
         assert (stored, replaced, skipped) == (0, 0, 1)
         record = next(r for r in caplog.records if "memory.consolidate.intent" in r.getMessage())
         payload = json.loads(record.getMessage().split("memory.consolidate.intent ", 1)[1])
@@ -1994,8 +2142,8 @@ class TestExtractAndStoreConsolidation:
 
     @pytest.mark.asyncio
     async def test_search_failure_falls_back_to_empty_candidates(self, monkeypatch, caplog):
-        """Match `_is_duplicate`'s search-failure posture: a broken
-        store does not strand extraction."""
+        """Match `_paraphrase_neighbor`'s search-failure posture: a
+        broken store does not strand extraction."""
 
         def _boom(*a, **kw):
             raise RuntimeError("qdrant down")


### PR DESCRIPTION
## Summary

Make the write-time paraphrase-dedup gate env-tunable and observable, **without changing the production default**. The dataclass default stays at 0.9. Operators whose chat-history corpus produces a different cluster-density shape can override via `MEMORY_DUPLICATE_THRESHOLD` env var or the `make config` wizard.

This PR reshapes the work originally framed as "lower the threshold to catch more paraphrases." The threshold sweep and cluster-density analysis below establish that the current 0.9 default is already correct for Kai's corpus; lowering would have caused false merges, not real ones.

## Why

The original premise: paraphrases in the 0.75-0.88 cosine band slip past the hardcoded 0.9 gate and accumulate as near-duplicate clusters. Lowering the threshold would catch them.

Empirical result (see Eval below): paraphrase clusters in that band do not exist in measurable quantity. Every fact pair above cosine 0.85 in the production store (337 facts) was either a workflow-state pair carrying real version differences or a structurally-similar-but-semantically-different pair. Zero true paraphrases. Lowering the threshold would have caused six false merges.

The implementation work remains valuable as **observability and tunability infrastructure**:

- Renaming `_is_duplicate` -> `_paraphrase_neighbor` lets the call site log the surviving neighbor's id and cosine without a second `memory.search`.
- The `dropped_duplicate` log line gains `cosine` and `content_preview` fields so a future operator can audit gate behavior from the logs alone.
- The `MEMORY_DUPLICATE_THRESHOLD` env var lets a deployment whose data shape differs from Kai's tune without a code change.
- The replay harness gains a `--log-file` flag (fixes a silent log-drop that erased gate-fire data from the original sweep run).

## What changed

- `Config.memory_duplicate_threshold: float = 0.9` (new field; **default preserves current behavior**).
- `load_config()` parses `MEMORY_DUPLICATE_THRESHOLD` with `[0.3, 1.01]` validator.
- `install.py` wizard prompt + delta-from-default emission gate.
- `templates/.env` documents the new var.
- `_is_duplicate` renamed to `_paraphrase_neighbor`; return type `bool` -> `MemoryResult | None`; strict-ge boundary preserved.
- `_emit_intent_log` gains `cosine` and `content_preview` kwargs (conditional-elide so the four existing emit sites stay byte-identical).
- `_store_facts` gains `config` parameter threaded through `extract_and_store`.
- New `--log-file` flag on `kai.eval.replay` so structured logs land in a file. The harness was silently dropping `memory.consolidate.intent` lines from sweep runs; without this flag a future operator's sweep would have the same problem the original #465 sweep hit.

## What did NOT change

- The production threshold. Default stays at 0.9.
- Existing log-line wire format on all non-fire emit paths (asserted byte-identical via test).
- `update_of` / `skip_redundant` branches (the gate only fires on `intent="new"`).

## Eval evidence

Sweep over five thresholds, 7-day window (2026-05-06 to 2026-05-12), 114 pairs/run:

| | T=0.9 | T=0.88 | T=0.85 | T=0.80 | T=0.75 |
|---|---|---|---|---|---|
| Facts stored | 97 | 72 | 79 | 92 | 78 |
| Net Qdrant points | 95 | 70 | 78 | 89 | 80 |

The fact-count metric is **non-monotone** across thresholds (97 -> 72 -> 79 -> 92 -> 78), which is impossible if the gate were the dominant signal. The shape is dominated by Haiku extraction non-determinism plus order-of-operations cascades. Fact count is not a reliable signal for tuning at this dataset size.

Cluster-density per sandbox (pairs above cosine 0.85, full enumeration):

| Sandbox | Facts | Pairs > 0.85 | Pairs/fact |
|---|---|---|---|
| t90 | 93 | 1 | 0.011 |
| t88 | 67 | 0 | 0.000 |
| t85 | 75 | 0 | 0.000 |
| t80 | 85 | 1 | 0.012 |
| t75 | 74 | 0 | 0.000 |
| **production** | **337** | **6** | **0.018** |

Strong null result: paraphrase clusters above 0.85 are not a measurable problem in this corpus at any scale we measured (67 to 337 facts).

Operator audit of the six production pairs above 0.85: zero are genuine paraphrases. Four are workflow-version pairs where the version difference is real and load-bearing; merging would destroy version provenance. One is overlapping-vocabulary between different concerns about the same flag. One is structural template match between distinct artifacts. Dropping the threshold to 0.85 would have caused six false merges and zero useful collapses.

A separate observation surfaced during the audit (workflow-state facts persisting past the extraction quality test) is filed as a follow-up issue rather than addressed here.

## Test plan

- Full pytest suite: 2961 passing (was 2953 pre-PR).
- New tests: `TestParaphraseGate` (10 tests pinning the rename, return type, threshold-from-config, kill-switch sentinel, search-failure posture, log shape).
- `TestMemoryDuplicateThreshold` parse/validate edges (lower bound, upper sentinel, non-number, out-of-range).
- `TestLogFileCapture` regression guard on the replay harness (intent log lines land in the file; default attaches no handler).
- Install-wizard fixtures updated with the new prompt value (default suppression + non-default emission).

## Acceptance

- Production behavior on merge day identical to pre-merge (default unchanged).
- Gate-fire log lines now carry `cosine` + `content_preview` + `replaced_id` for any operator auditing live behavior from logs.
- Tunability surface available via env var + wizard for any operator whose corpus shape differs from Kai's.

Closes #465.
