### PR TITLE
docs(template): concrete don't-save examples for proactive memory writes

### DIFF
--- a/templates/.claude/CLAUDE.md
+++ b/templates/.claude/CLAUDE.md
@@ -46,7 +46,7 @@ Specifically do NOT save these classes:
 - In-progress task state ("user is evaluating specification X", "user is working on file Y v4").
 - Workflow blocker counts or review-round status ("v2 has three nits", "all four findings resolved", "three blocker fixes applied").
 
-The artifact itself (the spec, the PR, the issue) is durable on its own; status notes about it lose meaning the moment the next version ships, the next review round runs, or the artifact merges. Apply the same counterfactual the extractor's QUALITY TEST applies: would this fact help a future conversation that does not include the current turn? If no, do not save it.
+The artifact itself (the spec, the PR, the issue) is durable on its own; status notes about it lose meaning the moment the next version ships, the next review round runs, or the artifact merges. Apply this counterfactual: would this fact help a future conversation that does not include the current turn? If no, do not save it.
 
 ### Rules go to PREFERENCES.md, but only on explicit instruction
 

--- a/templates/.claude/CLAUDE.md
+++ b/templates/.claude/CLAUDE.md
@@ -39,6 +39,15 @@ Never write to MEMORY.md and Qdrant in the same turn.
 
 **Proactive fact saves (authorized exception to the explicit-instruction rule):** periodically update fact memory on your own when you notice information worth persisting (operator personal facts, corrections, decisions, recurring interests). Do this quietly without announcing it. Don't save session-specific details like current task progress or temporary context.
 
+Specifically do NOT save these classes:
+
+- PR status, review verdicts, or merge state ("PR #N maintains default X", "PR #N implements the feature", "v3 evaluation closed cleanly").
+- Version pointers to specification or design artifacts ("specification X v3 is located at...", "the evaluation is at /tmp/...").
+- In-progress task state ("user is evaluating specification X", "user is working on file Y v4").
+- Workflow blocker counts or review-round status ("v2 has three nits", "all four findings resolved", "three blocker fixes applied").
+
+The artifact itself (the spec, the PR, the issue) is durable on its own; status notes about it lose meaning the moment the next version ships, the next review round runs, or the artifact merges. Apply the same counterfactual the extractor's QUALITY TEST applies: would this fact help a future conversation that does not include the current turn? If no, do not save it.
+
 ### Rules go to PREFERENCES.md, but only on explicit instruction
 
 The `[Your personal preferences (file: ...):]` block injects PREFERENCES.md, the curated always-on rule layer. It is NOT a target for proactive saves. Treat it like CLAUDE.md: read every turn, edited deliberately, never silently appended.


### PR DESCRIPTION
## Summary

Add a worked-example don't-save list to the proactive-saves guidance in `templates/.claude/CLAUDE.md`. Concrete classes (PR status, version pointers, in-progress task state, blocker counts) replace the prior generic phrasing.

## Why

The cleanup audit on #470 enumerated 339 facts in the production fact store and found 42 workflow-version-pair facts that should not have been saved. The #470 probe experiment confirmed the v9 extractor (positive-criterion prompt from #467) correctly rejects this class at the extraction boundary. But three of the 42 production facts were created AFTER #467 shipped, which means they reached the store via a different write path: Kai's proactive `/api/memory/add` calls.

The proactive-save path is documented in the deployed CLAUDE.md template and is intentionally not gated by the extractor's QUALITY TEST. Kai uses its own judgment to decide what is worth saving. That judgment was relying on the generic instruction "Don't save session-specific details like current task progress or temporary context," and in practice that phrasing was too abstract to recognize PR-status notes ("PR #N maintains default X") or spec-pointer facts ("specification X v3 is located at...") as the very class it forbids.

## What changed

Eight lines added to `templates/.claude/CLAUDE.md`, immediately after the existing "Don't save session-specific details..." sentence. The addition enumerates four concrete don't-save classes with worked-example phrasings drawn from the production audit:

- PR status, review verdicts, merge state.
- Version pointers to specification or design artifacts.
- In-progress task state.
- Workflow blocker counts or review-round status.

The block closes with the same counterfactual the extractor's QUALITY TEST uses ("would this fact help a future conversation that does not include the current turn?"). Paralleling the extractor prompt's structure is deliberate: the same shape that proved effective at the extractor layer should be effective at the proactive-save layer.

## What did NOT change

- The proactive-save authorization itself. Kai still maintains memory autonomously.
- The auto-extractor prompt (v9 already rejects this class, confirmed by #470's probe experiment).
- The HTTP API. No structural enforcement at the `/api/memory/add` boundary; this PR is documentation-only. A structural fix (apply QUALITY TEST to the API path) was discussed as a heavier follow-up and is not in scope here.

## Deployment

`templates/.claude/CLAUDE.md` ships to every user's home tree on next install via `make install`, and to new users via `backend.ensure_user_home` on first message. Existing operators get the tightened wording on next install pass.

## Test plan

- Documentation-only change. No code paths affected.
- Full pytest suite: 2961 passing (no regression).
- `make check`: clean.

## Acceptance

- Future cleanup audits run against the production store should not find new workflow-version-pair facts after the next deployment. If they do, the wording needs further tightening, or the heavier follow-up (apply QUALITY TEST to the API path) becomes necessary.

Related: #470 (workflow-fact leak observation, closed), #467 (positive-criterion extraction prompt), #469 (the threshold-gate PR whose audit surfaced this).
