### PR TITLE
docs: remove local-path spec references from source docstrings

### DIFF
--- a/scripts/migrate-memory-md-to-qdrant.py
+++ b/scripts/migrate-memory-md-to-qdrant.py
@@ -27,9 +27,6 @@ Usage:
 
     # Rollback (deletes all migration-source rows for the user):
     python scripts/migrate-memory-md-to-qdrant.py --user-id 123 --rollback
-
-See home/specs/406-memory-md-qdrant-migration-v3.md for the full
-design rationale and acceptance criteria.
 """
 
 from __future__ import annotations

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -48,9 +48,6 @@ their purpose is enumeration, not multi-source admission. The
 duplication of source literals is deliberate so that a future
 change to the shared admit list cannot silently broaden either
 enumeration.
-
-See `home/specs/310-memory-command.md` for the canonical UX flows
-and design rationale.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Two source module docstrings carried trailing pointers to operator-personal spec drafts at local paths (under the operator's home tree). These paths do not exist for anyone who clones the repo, and they bind source code to a personal directory layout that operators must be free to reorganize.

Drop the offending lines. The rest of each docstring stands on its own.

## Why

- The references point at files that ship only on one machine. Cloned copies of the repo have nothing at those paths.
- Tracked source code should not carry pointers into untracked operator-personal organizational structure. Operators get to reorganize their working trees without source-code dependencies tying them down.
- Spec references in tracked code are forbidden by project convention. The "see spec X for design rationale" pattern belongs in PR descriptions or wiki pages, not in module docstrings that ship to every clone.

## What changed

- `src/kai/memory_command.py` module docstring: dropped the trailing "See ... for the canonical UX flows and design rationale" block.
- `scripts/migrate-memory-md-to-qdrant.py` module docstring: dropped the trailing "See ... for the full design rationale and acceptance criteria" block.

Six lines deleted total. The deleted blocks were each a trailing two-line sentence at the end of a multi-paragraph module docstring; the surrounding docstring content was already self-contained.

## What did NOT change

- The `SPEC_DIR` env var defaults to `"specs"` (relative to repo root) and is consumed by the PR-review agent's `resolve_spec_from_branch`. That path is unrelated to operator-personal layout and is left alone.
- Test fixtures in `test_review.py` and `test_config.py` use a hardcoded `spec_dir` value as a config-plumbing fixture; they are testing whether `SPEC_DIR` overrides flow correctly, not asserting an operator layout. Left alone.

## Test plan

- Documentation-only change. No code paths affected.
- Full pytest suite: 2961 passing.
- `make check` clean.
