### PR TITLE
fix: set GOOSE_PROVIDER on goose subprocess

### DIFF
--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -164,9 +164,10 @@ class GooseBackend(AgentBackend):
         # Build the subprocess environment. Merge order:
         # 1. Base environment (inherited from parent process)
         # 2. GOOSE_MODEL (translated from self.model)
-        # 3. Per-workspace env_file values
-        # 4. Per-workspace inline env values (override env_file)
-        # 5. Webhook secret (LAST - workspace env can't override it)
+        # 3. GOOSE_PROVIDER (mirrors self.provider)
+        # 4. Per-workspace env_file values
+        # 5. Per-workspace inline env values (override env_file)
+        # 6. Webhook secret (LAST - workspace env can't override it)
         env = os.environ.copy()
         # Kai's logical model names ("sonnet", "opus", "haiku") only apply
         # to the Anthropic provider. Other providers require full model IDs
@@ -177,6 +178,20 @@ class GooseBackend(AgentBackend):
             mapped = self.model
         if mapped:
             env["GOOSE_MODEL"] = mapped
+        # GOOSE_PROVIDER tells the goose binary which provider backend to
+        # talk to (openai, anthropic, google, etc.). Without it, session/new
+        # fails with "Internal error" against a binary that has no default
+        # provider configured. Kai's wizard writes LLM_PROVIDER to
+        # /etc/kai/env for its own bookkeeping, but the goose binary reads
+        # the GOOSE_-prefixed name; the translation happens here so the
+        # two layers stay decoupled. Guarded on truthiness because
+        # self.provider can be the empty-string default for the claude
+        # backend pre-wiring path, and exporting GOOSE_PROVIDER="" would
+        # confuse goose more than omitting it. Placed before the
+        # workspace_config merge so a per-workspace env_file or inline env
+        # can override it, matching GOOSE_MODEL's override semantics.
+        if self.provider:
+            env["GOOSE_PROVIDER"] = self.provider
         if self.workspace_config:
             if self.workspace_config.env_file:
                 env.update(parse_env_file(self.workspace_config.env_file))

--- a/templates/config/goose-config.yaml
+++ b/templates/config/goose-config.yaml
@@ -4,10 +4,11 @@
 # AGENT_BACKEND=goose. Controls which Goose extensions are loaded
 # in ACP mode (`goose acp`).
 #
-# GOOSE_MODEL and GOOSE_PROVIDER are intentionally omitted here -
-# both are set at runtime via environment variables. GOOSE_MODEL is
-# managed by Kai's model switching (/model command). GOOSE_PROVIDER
-# is set during `make config` and written to /etc/kai/env.
+# GOOSE_MODEL and GOOSE_PROVIDER are intentionally omitted here;
+# both are set at runtime by GooseBackend when launching `goose acp`,
+# translated from the effective per-user model and llm_provider.
+# Workspace config (workspaces.yaml env / env_file) can override
+# either one for per-workspace provider or model pinning.
 
 extensions:
   developer:

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -13,6 +13,7 @@ Covers:
 """
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -366,6 +367,54 @@ class TestHandshake:
         call_kwargs = mock_exec.call_args[1]
         # "sonnet" passed through as-is, not mapped to "claude-sonnet-4-6"
         assert call_kwargs["env"]["GOOSE_MODEL"] == "sonnet"
+
+    @pytest.mark.asyncio
+    async def test_provider_env_var_set(self):
+        """
+        GOOSE_PROVIDER env var is set during startup.
+
+        The goose binary reads GOOSE_PROVIDER to pick which provider API
+        to call; without it, session/new fails with "Internal error" on
+        any fresh install that has no provider configured in
+        ~/.config/goose/config.yaml. This test guards the translation
+        from Kai's self.provider field to the goose-prefixed env var.
+        """
+        g = _make_goose(model="gpt-5.4-mini", provider="openai")
+        proc = _make_mock_proc(_handshake_lines())
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await g._ensure_started()
+
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["env"]["GOOSE_PROVIDER"] == "openai"
+
+    @pytest.mark.asyncio
+    async def test_provider_env_var_omitted_when_empty(self):
+        """
+        GOOSE_PROVIDER is not exported when self.provider is empty.
+
+        Exporting GOOSE_PROVIDER="" would confuse the goose binary more
+        than omitting it; the empty default exists for the claude backend
+        pre-wiring path and any test fixtures that do not specify a
+        provider. The guard mirrors GOOSE_MODEL's truthiness check.
+        """
+        g = _make_goose(model="sonnet", provider="")
+        proc = _make_mock_proc(_handshake_lines())
+
+        # Scrub GOOSE_PROVIDER from the inherited parent environment so the
+        # absence is attributable to the truthiness guard, not to the host
+        # shell. Without this scrub the test would silently pass on hosts
+        # that happen to export GOOSE_PROVIDER and silently fail on hosts
+        # that do not, making the regression invisible to local runs.
+        with (
+            patch.dict(os.environ, {}, clear=False) as _env,
+            patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec,
+        ):
+            os.environ.pop("GOOSE_PROVIDER", None)
+            await g._ensure_started()
+
+        call_kwargs = mock_exec.call_args[1]
+        assert "GOOSE_PROVIDER" not in call_kwargs["env"]
 
 
 # ── Stream parsing ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Sets `GOOSE_PROVIDER` on the goose subprocess from `self.provider`, alongside the existing `GOOSE_MODEL` assignment. Without this, `session/new` returns "Internal error" against any goose install that has no provider configured in `~/.config/goose/config.yaml`.
- Refreshes the stale comment block in `templates/config/goose-config.yaml`; the wizard has not written `GOOSE_PROVIDER` to `/etc/kai/env` since the `LLM_PROVIDER` rename.
- Adds two `test_goose.py` cases covering both the set and omit-on-empty paths.

Fixes #473.

## Test plan

- [x] `make check` (ruff)
- [x] Full pytest suite (2963 passed, 1 skipped)
- [x] Targeted `test_goose.py` (46 passed)
- [ ] Manual: after merge, the temporary `GOOSE_PROVIDER="..."` line in operator's `/etc/kai/env` can be removed and goose+openai still works end-to-end.
