### PR TITLE
fix: DEFAULT_MODEL wizard re-prompt with apply-time validation

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -49,6 +49,7 @@ from kai.config import (
     PROVIDER_MODELS,
     VALID_BACKENDS,
     VALID_PROVIDERS,
+    validate_model_for_provider,
 )
 
 # Config file written by `config`, read by `apply`.
@@ -140,6 +141,49 @@ def _prompt_bool(label: str, default: bool = False) -> bool:
     default_str = "true" if default else "false"
     value = _prompt_choice(label, ["true", "false"], default_str)
     return value == "true"
+
+
+def _prompt_default_model(eff_provider: str, default_val: str) -> str:
+    """
+    Prompt for DEFAULT_MODEL, dispatching on the effective provider.
+
+    Two shapes of provider need different prompts:
+    - Curated providers (anthropic, openai, google, copilot, ...) carry a
+      fixed model list in PROVIDER_MODELS; the operator picks from the
+      list via _prompt_choice.
+    - Open-ended providers (openrouter, ollama, and any provider in
+      VALID_PROVIDERS without a PROVIDER_MODELS entry) accept arbitrary
+      model identifiers; the operator types one via _prompt(required=True).
+
+    The required=True on the open-ended branch forces the operator to
+    commit to a concrete model string. load_config falls back to "sonnet"
+    when DEFAULT_MODEL is empty or missing, and "sonnet" is anthropic-only;
+    letting the operator leave the field blank on an open-ended provider
+    would set them up for a startup-time validation failure that load_config
+    surfaces with a less helpful error message than this wizard can.
+
+    Args:
+        eff_provider: The effective provider (anthropic for the claude
+            backend; the configured llm_provider otherwise).
+        default_val: Prefill for the prompt. Callers should pass a value
+            that is valid for eff_provider (e.g. PROVIDER_DEFAULTS[eff_provider]
+            when re-prompting after rejecting an invalid existing value).
+
+    Returns:
+        The chosen model identifier. Always non-empty.
+    """
+    provider_models = PROVIDER_MODELS.get(eff_provider)
+    if provider_models and eff_provider not in OPEN_ENDED_PROVIDERS:
+        return _prompt_choice(
+            "Default model",
+            sorted(provider_models.keys()),
+            default_val,
+        )
+    return _prompt(
+        "Default model ID",
+        default_val,
+        required=True,
+    )
 
 
 def _validate_user_ids(value: str) -> bool:
@@ -469,31 +513,40 @@ def _cmd_config() -> None:
         print("  Model, timeout, budget, and context window are now per-user.")
         print("  Set defaults in users.yaml or let users configure via /settings.")
         # Read DEFAULT_MODEL, falling back to CLAUDE_MODEL for backward compat
-        model = existing_env.get("DEFAULT_MODEL", existing_env.get("CLAUDE_MODEL", ""))
+        existing_model = existing_env.get("DEFAULT_MODEL", existing_env.get("CLAUDE_MODEL", ""))
+        # Re-validate the existing value against the (possibly newly chosen)
+        # effective provider. Empty existing_model fails validation for any
+        # curated provider, including anthropic ("" is not in PROVIDER_MODELS).
+        # Open-ended providers always validate True, so empty + open-ended
+        # would silently pass; the _prompt(required=True) branch in
+        # _prompt_default_model handles that case by forcing the operator
+        # to commit to a model string.
+        if existing_model and validate_model_for_provider(existing_model, eff_provider):
+            model = existing_model
+        else:
+            if existing_model:
+                print(
+                    f"  DEFAULT_MODEL '{existing_model}' is not valid for provider "
+                    f"'{eff_provider}'. Please choose a new default."
+                )
+            # Prefill always uses PROVIDER_DEFAULTS for the effective provider
+            # rather than existing_env["DEFAULT_MODEL"]. We entered this branch
+            # because the existing value is missing or invalid for the effective
+            # provider; offering it as the prefill would let the operator
+            # accept the just-rejected value with Enter, since _prompt_choice
+            # returns its default parameter without validating it against
+            # the choices list.
+            model = _prompt_default_model(eff_provider, PROVIDER_DEFAULTS.get(eff_provider, ""))
         timeout = existing_env.get("CLAUDE_TIMEOUT_SECONDS", "")
         budget = existing_env.get("BUDGET_CEILING", existing_env.get("CLAUDE_MAX_BUDGET_USD", ""))
         max_context_window = existing_env.get("CLAUDE_MAX_CONTEXT_WINDOW", "")
     else:
         print("-- Claude --")
-        # Show provider-aware model choices
-        provider_models = PROVIDER_MODELS.get(eff_provider)
         default_model_val = existing_env.get(
             "DEFAULT_MODEL",
             existing_env.get("CLAUDE_MODEL", PROVIDER_DEFAULTS.get(eff_provider, "")),
         )
-        if provider_models and eff_provider not in OPEN_ENDED_PROVIDERS:
-            model = _prompt_choice(
-                "Default model",
-                sorted(provider_models.keys()),
-                default_model_val,
-            )
-        else:
-            # Open-ended provider - free-text model ID
-            model = _prompt(
-                "Default model ID",
-                default_model_val,
-                required=True,
-            )
+        model = _prompt_default_model(eff_provider, default_model_val)
 
         while True:
             timeout = _prompt(
@@ -1033,10 +1086,20 @@ def _cmd_config() -> None:
     if agent_backend != "claude" and budget:
         env["BUDGET_CEILING"] = budget
 
-    # Deprecated per-user vars: only include without users.yaml
-    # (legacy single-user mode). With users.yaml, these are noise.
+    # DEFAULT_MODEL is always emitted. The model is global (per-user
+    # values in users.yaml are overrides on top of it, not replacements),
+    # and load_config validates DEFAULT_MODEL against the effective
+    # provider at startup. The load_config fallback ("sonnet") is
+    # anthropic-only, so omitting the key on non-anthropic backends
+    # produces a startup-time SystemExit; emitting it unconditionally
+    # makes the env file self-describing and forces the wizard layer
+    # to own the validation responsibility.
+    env["DEFAULT_MODEL"] = model
+
+    # CLAUDE_TIMEOUT_SECONDS remains gated on the legacy single-user
+    # path; per-user timeouts live in users.yaml and override the
+    # global default at runtime.
     if not users_yaml_exists:
-        env["DEFAULT_MODEL"] = model
         env["CLAUDE_TIMEOUT_SECONDS"] = timeout
 
     # Context window tuning - only include if non-default.
@@ -2706,6 +2769,45 @@ def _cmd_apply() -> None:
         svc_gid = user_info.pw_gid
     except KeyError:
         raise SystemExit(f"Service user '{service_user}' does not exist on this system.") from None
+
+    # Defensive validation: refuse to apply an install.conf whose
+    # (DEFAULT_MODEL, effective_provider) pair would fail load_config's
+    # startup check. Without this gate, apply would stop the service,
+    # rewrite /etc/kai/env, then the next service start would crash with
+    # an inscrutable message; the operator would see a partial-state
+    # installation and a dead bot.
+    #
+    # Normalize the same way load_config does (config.py reads both env
+    # vars through .strip().lower() before validating). A hand-edited
+    # install.conf with "AGENT_BACKEND": "Claude" or trailing whitespace
+    # would otherwise compute the wrong effective provider here, pass
+    # the apply gate, and then fail at startup.
+    #
+    # Resolve the same fallback load_config uses ("" -> "sonnet"). An
+    # empty or missing DEFAULT_MODEL is silently promoted at runtime;
+    # if we do not mirror that promotion here, the apply gate misses
+    # the missing-key case that is precisely what this gate exists for.
+    default_model_raw = env.get("DEFAULT_MODEL", "")
+    agent_backend_raw = env.get("AGENT_BACKEND", "claude").strip().lower()
+    llm_provider_raw = env.get("LLM_PROVIDER", "").strip().lower()
+    eff_provider_for_check = "anthropic" if agent_backend_raw == "claude" else llm_provider_raw
+    resolved_model = default_model_raw or "sonnet"
+    if not validate_model_for_provider(resolved_model, eff_provider_for_check):
+        valid_models = sorted(PROVIDER_MODELS.get(eff_provider_for_check, {}).keys())
+        if default_model_raw:
+            msg = (
+                f"install.conf has DEFAULT_MODEL='{default_model_raw}' which is not "
+                f"valid for provider '{eff_provider_for_check}'."
+            )
+        else:
+            msg = (
+                f"install.conf has no DEFAULT_MODEL; the load_config fallback "
+                f"'sonnet' is not valid for provider '{eff_provider_for_check}'."
+            )
+        valid_list = ", ".join(valid_models) or "(provider has no curated list)"
+        raise SystemExit(
+            f"{msg} Re-run 'python -m kai install config' to pick a compatible model. Valid models: {valid_list}"
+        )
 
     dry_run = os.environ.get("DRY_RUN", "").strip() in ("1", "true", "yes")
     if dry_run:

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -148,12 +148,13 @@ def _prompt_default_model(eff_provider: str, default_val: str) -> str:
     Prompt for DEFAULT_MODEL, dispatching on the effective provider.
 
     Two shapes of provider need different prompts:
-    - Curated providers (anthropic, openai, google, copilot, ...) carry a
-      fixed model list in PROVIDER_MODELS; the operator picks from the
-      list via _prompt_choice.
-    - Open-ended providers (openrouter, ollama, and any provider in
-      VALID_PROVIDERS without a PROVIDER_MODELS entry) accept arbitrary
-      model identifiers; the operator types one via _prompt(required=True).
+    - Curated providers (those with an entry in PROVIDER_MODELS, currently
+      anthropic, openai, google) ship a fixed model list; the operator
+      picks from the list via _prompt_choice.
+    - Open-ended providers (those in OPEN_ENDED_PROVIDERS, currently
+      openrouter and ollama; also any provider in VALID_PROVIDERS without
+      a PROVIDER_MODELS entry) accept arbitrary model identifiers; the
+      operator types one via _prompt(required=True).
 
     The required=True on the open-ended branch forces the operator to
     commit to a concrete model string. load_config falls back to "sonnet"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2077,6 +2077,405 @@ class TestCmdApply:
         assert "KAI_DATA_DIR=/var/lib/kai" in unit
 
 
+class TestCmdConfigDefaultModelDispatch:
+    """
+    Wizard dispatch for DEFAULT_MODEL when users.yaml exists.
+
+    Dispatch shape:
+    - if the existing model is non-empty and validates against the effective
+      provider, keep it (no prompt);
+    - otherwise call _prompt_default_model with the provider's curated
+      default as the prefill (never the just-rejected value).
+
+    The wizard has many prompts that fire before and after the model
+    dispatch. The helper below mocks _prompt_default_model to capture
+    its call args and return a fixed value, leaving the other prompts
+    to be driven via an input chain.
+    """
+
+    @staticmethod
+    def _setup(monkeypatch, tmp_path, existing_env: dict[str, str] | None = None) -> None:
+        """
+        Configure the wizard sandbox so users_yaml_exists=True.
+
+        Writes a users.yaml under tmp_path (PROJECT_ROOT) so the wizard
+        takes the per-user branch. Optionally seeds install.conf with the
+        given env so existing_env reflects the desired pre-existing state.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        # Block /etc/kai/users.yaml detection so only tmp_path/users.yaml
+        # determines users_yaml_exists.
+        _real_exists = Path.exists
+
+        def _exists_no_etc(self):
+            if str(self) == "/etc/kai/users.yaml":
+                return False
+            return _real_exists(self)
+
+        monkeypatch.setattr(Path, "exists", _exists_no_etc)
+
+        # Seed users.yaml; content does not matter for this dispatch test,
+        # only its presence (PROJECT_ROOT / "users.yaml").exists() drives
+        # the branch.
+        (tmp_path / "users.yaml").write_text("users: []\n")
+
+        if existing_env is not None:
+            (tmp_path / "install.conf").write_text(json.dumps({"env": existing_env, "version": 1}))
+
+    @staticmethod
+    def _inputs_for_claude_backend() -> list[str]:
+        """Input chain for the users_yaml_exists=True + claude path."""
+        return [
+            "/opt/kai",  # install dir
+            "/var/lib/kai",  # data dir
+            "kai",  # service user
+            "darwin",  # platform
+            "fake-token",  # bot token
+            "polling",  # transport
+            "claude",  # agent backend
+            # model prompt is handled by the _prompt_default_model mock
+            "80",  # autocompact pct
+            "",  # effort level (default)
+            "8080",  # webhook port
+            "test-secret",  # webhook secret
+            "900",  # pr review subprocess timeout
+            "false",  # voice
+            "false",  # tts
+            "false",  # memory enabled
+            "",  # perplexity key
+        ]
+
+    @staticmethod
+    def _inputs_for_goose_openai() -> list[str]:
+        """Input chain for the users_yaml_exists=True + goose+openai path."""
+        return [
+            "/opt/kai",  # install dir
+            "/var/lib/kai",  # data dir
+            "kai",  # service user
+            "darwin",  # platform
+            "fake-token",  # bot token
+            "polling",  # transport
+            "goose",  # agent backend
+            "openai",  # llm provider
+            "openai-key",  # OPENAI_API_KEY
+            # model prompt is handled by the _prompt_default_model mock
+            "80",  # autocompact pct
+            "8080",  # webhook port
+            "test-secret",  # webhook secret
+            "900",  # pr review subprocess timeout
+            "1.0",  # pr review subprocess budget (non-claude only)
+            "false",  # voice
+            "false",  # tts
+            "false",  # memory enabled
+            "",  # perplexity key
+        ]
+
+    def _run(self, monkeypatch, tmp_path, inputs: list[str], helper_return: str):
+        """
+        Run _cmd_config with _prompt_default_model mocked.
+
+        Returns (mock_object, written_env) where mock_object exposes
+        call_args / called for assertion, and written_env is the env
+        dict that the wizard wrote to install.conf.
+        """
+        from unittest.mock import MagicMock
+
+        helper_mock = MagicMock(return_value=helper_return)
+        monkeypatch.setattr("kai.install._prompt_default_model", helper_mock)
+        inputs_iter = iter(inputs)
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs_iter))
+
+        _cmd_config()
+        conf = json.loads((tmp_path / "install.conf").read_text())
+        return helper_mock, conf["env"]
+
+    def test_reprompts_on_provider_flip_with_users_yaml(self, tmp_path, monkeypatch):
+        """
+        Acceptance 1: with users.yaml present and DEFAULT_MODEL=sonnet, flipping
+        to goose+openai prompts for a new model and the chosen value lands in
+        install.conf.
+        """
+        self._setup(monkeypatch, tmp_path, existing_env={"DEFAULT_MODEL": "sonnet"})
+        helper, env = self._run(
+            monkeypatch,
+            tmp_path,
+            self._inputs_for_goose_openai(),
+            helper_return="gpt-5.4-mini",
+        )
+        helper.assert_called_once()
+        # First positional arg is eff_provider; on goose+openai it must be "openai"
+        assert helper.call_args.args[0] == "openai"
+        assert env["DEFAULT_MODEL"] == "gpt-5.4-mini"
+
+    def test_no_reprompt_when_claude_backend_unchanged(self, tmp_path, monkeypatch):
+        """
+        Acceptance 2: with users.yaml present, DEFAULT_MODEL=sonnet, and the
+        wizard kept on claude, no model prompt fires AND install.conf still
+        emits DEFAULT_MODEL=sonnet (the unconditional-emission half of the fix).
+        """
+        self._setup(monkeypatch, tmp_path, existing_env={"DEFAULT_MODEL": "sonnet"})
+        helper, env = self._run(
+            monkeypatch,
+            tmp_path,
+            self._inputs_for_claude_backend(),
+            helper_return="should-not-be-used",
+        )
+        helper.assert_not_called()
+        assert env["DEFAULT_MODEL"] == "sonnet"
+
+    def test_reprompts_on_empty_existing_model_claude(self, tmp_path, monkeypatch):
+        """
+        Acceptance 3 / edge case 5: users.yaml present, no DEFAULT_MODEL in
+        existing env, backend stays claude. Empty existing model fails
+        validate_model_for_provider (empty is not in PROVIDER_MODELS["anthropic"]),
+        so the dispatch re-prompts.
+        """
+        self._setup(monkeypatch, tmp_path, existing_env={})
+        helper, env = self._run(
+            monkeypatch,
+            tmp_path,
+            self._inputs_for_claude_backend(),
+            helper_return="sonnet",
+        )
+        helper.assert_called_once()
+        assert helper.call_args.args[0] == "anthropic"
+        assert env["DEFAULT_MODEL"] == "sonnet"
+
+    def test_reprompts_on_empty_existing_model_openai(self, tmp_path, monkeypatch):
+        """
+        Edge case 5 on a non-anthropic provider. Empty existing model + flip
+        to goose+openai: dispatch re-prompts, helper fires with eff_provider
+        equal to "openai".
+        """
+        self._setup(monkeypatch, tmp_path, existing_env={})
+        helper, env = self._run(
+            monkeypatch,
+            tmp_path,
+            self._inputs_for_goose_openai(),
+            helper_return="gpt-5.4",
+        )
+        helper.assert_called_once()
+        assert helper.call_args.args[0] == "openai"
+        assert env["DEFAULT_MODEL"] == "gpt-5.4"
+
+    def test_reprompt_prefill_is_provider_default_not_invalid_existing(self, tmp_path, monkeypatch):
+        """
+        Acceptance 10: when re-prompting because the existing model is
+        invalid for the new provider, the prefill is PROVIDER_DEFAULTS for
+        the new provider, NOT the just-rejected value. Guards against
+        _prompt_choice's default-passthrough behavior (it returns its
+        `default` parameter on empty input without validating it against
+        the `choices` list); if the dispatch passed the invalid model as
+        the prefill, the operator pressing Enter would re-accept it.
+        """
+        self._setup(monkeypatch, tmp_path, existing_env={"DEFAULT_MODEL": "opus"})
+        helper, env = self._run(
+            monkeypatch,
+            tmp_path,
+            self._inputs_for_goose_openai(),
+            helper_return="gpt-5.4-mini",
+        )
+        helper.assert_called_once()
+        # Second positional arg is the prefill (default_val parameter).
+        # Must be PROVIDER_DEFAULTS["openai"] = "gpt-5.4", NOT "opus".
+        assert helper.call_args.args[1] == "gpt-5.4"
+        assert helper.call_args.args[1] != "opus"
+        assert env["DEFAULT_MODEL"] == "gpt-5.4-mini"
+
+
+class TestCmdApplyDefaultModelGate:
+    """
+    Defensive validation in _cmd_apply for the (DEFAULT_MODEL, provider) pair.
+
+    The gate sits immediately after the service-user check and before
+    the DRY_RUN read, so all side-effect entry points (_stop_service,
+    _apply_directories, _apply_secrets, etc.) are unreachable on a failed
+    validation; each test asserts the gate fires before any of them runs.
+    """
+
+    @staticmethod
+    def _write_install_conf(tmp_path, env: dict[str, str]) -> Path:
+        """Write a minimal install.conf with the given env dict."""
+        conf_path = tmp_path / "install.conf"
+        conf_path.write_text(
+            json.dumps(
+                {
+                    "install_dir": str(tmp_path / "opt" / "kai"),
+                    "data_dir": str(tmp_path / "var" / "lib" / "kai"),
+                    "service_user": "nobody",
+                    "platform": "darwin",
+                    "env": env,
+                }
+            )
+        )
+        return conf_path
+
+    @staticmethod
+    def _patch_side_effects(monkeypatch):
+        """
+        Replace every apply-time side-effect entry point with a tracking mock.
+
+        Returns the mock for _stop_service since that is the canonical
+        "did we reach the body of apply" probe; the other mocks are silenced
+        so tests do not need to know which helpers run on the happy path.
+        """
+        from unittest.mock import MagicMock
+
+        stop_service_mock = MagicMock()
+        for fn_name in (
+            "_stop_service",
+            "_apply_directories",
+            "_apply_source",
+            "_apply_venv",
+            "_apply_models",
+            "_apply_secrets",
+            "_apply_goose_config",
+            "_apply_sudoers",
+            "_apply_migrate",
+            "_apply_service",
+            "_start_service",
+        ):
+            mock = stop_service_mock if fn_name == "_stop_service" else MagicMock()
+            monkeypatch.setattr(f"kai.install.{fn_name}", mock, raising=False)
+        return stop_service_mock
+
+    def test_rejects_incompatible_default_model(self, tmp_path, monkeypatch):
+        """
+        Acceptance 4: model + provider mismatch raises SystemExit before
+        any side effect. Error names both the bad value and the provider.
+        """
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {"DEFAULT_MODEL": "sonnet", "AGENT_BACKEND": "goose", "LLM_PROVIDER": "openai"},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        stop_service = self._patch_side_effects(monkeypatch)
+
+        with pytest.raises(SystemExit) as excinfo:
+            _cmd_apply()
+        msg = str(excinfo.value)
+        assert "sonnet" in msg
+        assert "openai" in msg
+        assert "install config" in msg
+        stop_service.assert_not_called()
+
+    def test_rejects_missing_default_model_on_non_anthropic(self, tmp_path, monkeypatch):
+        """
+        Acceptance 5: missing DEFAULT_MODEL on non-anthropic provider
+        raises SystemExit naming the load_config 'sonnet' fallback so the
+        operator understands why an unset key is a problem.
+        """
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {"AGENT_BACKEND": "goose", "LLM_PROVIDER": "openai"},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        stop_service = self._patch_side_effects(monkeypatch)
+
+        with pytest.raises(SystemExit) as excinfo:
+            _cmd_apply()
+        msg = str(excinfo.value)
+        assert "no DEFAULT_MODEL" in msg
+        assert "sonnet" in msg
+        assert "openai" in msg
+        stop_service.assert_not_called()
+
+    def test_accepts_missing_default_model_on_anthropic(self, tmp_path, monkeypatch):
+        """
+        Edge case 1b on anthropic: a missing DEFAULT_MODEL resolves to
+        'sonnet' via the load_config fallback; sonnet is valid for
+        anthropic so the gate passes and apply proceeds past _stop_service.
+        """
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {"AGENT_BACKEND": "claude"},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        stop_service = self._patch_side_effects(monkeypatch)
+        # DRY_RUN suppresses real filesystem operations on the happy path;
+        # the gate runs before the DRY_RUN read, so this affects only
+        # what happens AFTER the gate accepts the config.
+        monkeypatch.setenv("DRY_RUN", "1")
+
+        _cmd_apply()
+        stop_service.assert_called_once()
+
+    def test_accepts_open_ended_provider(self, tmp_path, monkeypatch):
+        """
+        Edge case 2: open-ended providers (openrouter, ollama) accept any
+        non-empty model. validate_model_for_provider returns True for them,
+        so the gate does not block regardless of the model string.
+        """
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {
+                "DEFAULT_MODEL": "anthropic/claude-sonnet-4-6",
+                "AGENT_BACKEND": "goose",
+                "LLM_PROVIDER": "openrouter",
+            },
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        stop_service = self._patch_side_effects(monkeypatch)
+        monkeypatch.setenv("DRY_RUN", "1")
+
+        _cmd_apply()
+        stop_service.assert_called_once()
+
+    def test_dry_run_still_validates(self, tmp_path, monkeypatch):
+        """
+        Acceptance 7: DRY_RUN=1 does not bypass the gate. Validation runs
+        before the dry-run flag is even read, so a bad config exits with
+        the same SystemExit it would emit on a non-dry-run apply.
+        """
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        monkeypatch.setenv("DRY_RUN", "1")
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {"DEFAULT_MODEL": "sonnet", "AGENT_BACKEND": "goose", "LLM_PROVIDER": "openai"},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        stop_service = self._patch_side_effects(monkeypatch)
+
+        with pytest.raises(SystemExit) as excinfo:
+            _cmd_apply()
+        msg = str(excinfo.value)
+        assert "sonnet" in msg
+        assert "openai" in msg
+        stop_service.assert_not_called()
+
+    def test_normalizes_agent_backend_case_and_whitespace(self, tmp_path, monkeypatch):
+        """
+        Mirrors load_config's .strip().lower() normalization on
+        AGENT_BACKEND and LLM_PROVIDER. A hand-edited install.conf
+        carrying 'Claude ' (mixed case + trailing space) must compute
+        the same effective provider load_config will at startup.
+        """
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {"DEFAULT_MODEL": "opus", "AGENT_BACKEND": "Claude "},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        stop_service = self._patch_side_effects(monkeypatch)
+        monkeypatch.setenv("DRY_RUN", "1")
+
+        # Without normalization the gate would resolve to ("opus", "")
+        # and pass (empty provider triggers the unknown-provider warning
+        # branch in validate_model_for_provider, which returns True).
+        # With normalization the gate resolves to ("opus", "anthropic"),
+        # opus is valid, and the apply proceeds. This indirectly verifies
+        # that both .strip() and .lower() are applied by checking that
+        # the apply reaches _stop_service (i.e. the gate accepted).
+        _cmd_apply()
+        stop_service.assert_called_once()
+
+
 # ── Directory creation ───────────────────────────────────────────────
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2193,9 +2193,9 @@ class TestCmdConfigDefaultModelDispatch:
 
     def test_reprompts_on_provider_flip_with_users_yaml(self, tmp_path, monkeypatch):
         """
-        Acceptance 1: with users.yaml present and DEFAULT_MODEL=sonnet, flipping
-        to goose+openai prompts for a new model and the chosen value lands in
-        install.conf.
+        With users.yaml present and DEFAULT_MODEL=sonnet, flipping to
+        goose+openai prompts for a new model and the chosen value lands
+        in install.conf.
         """
         self._setup(monkeypatch, tmp_path, existing_env={"DEFAULT_MODEL": "sonnet"})
         helper, env = self._run(
@@ -2211,9 +2211,9 @@ class TestCmdConfigDefaultModelDispatch:
 
     def test_no_reprompt_when_claude_backend_unchanged(self, tmp_path, monkeypatch):
         """
-        Acceptance 2: with users.yaml present, DEFAULT_MODEL=sonnet, and the
-        wizard kept on claude, no model prompt fires AND install.conf still
-        emits DEFAULT_MODEL=sonnet (the unconditional-emission half of the fix).
+        With users.yaml present, DEFAULT_MODEL=sonnet, and the wizard kept
+        on claude, no model prompt fires AND install.conf still emits
+        DEFAULT_MODEL=sonnet (the unconditional-emission half of the fix).
         """
         self._setup(monkeypatch, tmp_path, existing_env={"DEFAULT_MODEL": "sonnet"})
         helper, env = self._run(
@@ -2227,10 +2227,10 @@ class TestCmdConfigDefaultModelDispatch:
 
     def test_reprompts_on_empty_existing_model_claude(self, tmp_path, monkeypatch):
         """
-        Acceptance 3 / edge case 5: users.yaml present, no DEFAULT_MODEL in
-        existing env, backend stays claude. Empty existing model fails
-        validate_model_for_provider (empty is not in PROVIDER_MODELS["anthropic"]),
-        so the dispatch re-prompts.
+        users.yaml present, no DEFAULT_MODEL in existing env, backend stays
+        claude. Empty existing model fails validate_model_for_provider
+        (empty is not in PROVIDER_MODELS["anthropic"]), so the dispatch
+        re-prompts.
         """
         self._setup(monkeypatch, tmp_path, existing_env={})
         helper, env = self._run(
@@ -2245,9 +2245,9 @@ class TestCmdConfigDefaultModelDispatch:
 
     def test_reprompts_on_empty_existing_model_openai(self, tmp_path, monkeypatch):
         """
-        Edge case 5 on a non-anthropic provider. Empty existing model + flip
-        to goose+openai: dispatch re-prompts, helper fires with eff_provider
-        equal to "openai".
+        Empty-existing-model path on a non-anthropic provider: flip to
+        goose+openai with no DEFAULT_MODEL in existing env, dispatch
+        re-prompts, helper fires with eff_provider equal to "openai".
         """
         self._setup(monkeypatch, tmp_path, existing_env={})
         helper, env = self._run(
@@ -2262,9 +2262,9 @@ class TestCmdConfigDefaultModelDispatch:
 
     def test_reprompt_prefill_is_provider_default_not_invalid_existing(self, tmp_path, monkeypatch):
         """
-        Acceptance 10: when re-prompting because the existing model is
-        invalid for the new provider, the prefill is PROVIDER_DEFAULTS for
-        the new provider, NOT the just-rejected value. Guards against
+        When re-prompting because the existing model is invalid for the
+        new provider, the prefill is PROVIDER_DEFAULTS for the new
+        provider, NOT the just-rejected value. Guards against
         _prompt_choice's default-passthrough behavior (it returns its
         `default` parameter on empty input without validating it against
         the `choices` list); if the dispatch passed the invalid model as
@@ -2343,8 +2343,8 @@ class TestCmdApplyDefaultModelGate:
 
     def test_rejects_incompatible_default_model(self, tmp_path, monkeypatch):
         """
-        Acceptance 4: model + provider mismatch raises SystemExit before
-        any side effect. Error names both the bad value and the provider.
+        Model + provider mismatch raises SystemExit before any side effect.
+        Error names both the bad value and the provider.
         """
         monkeypatch.setattr("os.geteuid", lambda: 0)
         conf_path = self._write_install_conf(
@@ -2364,8 +2364,8 @@ class TestCmdApplyDefaultModelGate:
 
     def test_rejects_missing_default_model_on_non_anthropic(self, tmp_path, monkeypatch):
         """
-        Acceptance 5: missing DEFAULT_MODEL on non-anthropic provider
-        raises SystemExit naming the load_config 'sonnet' fallback so the
+        Missing DEFAULT_MODEL on a non-anthropic provider raises
+        SystemExit naming the load_config 'sonnet' fallback so the
         operator understands why an unset key is a problem.
         """
         monkeypatch.setattr("os.geteuid", lambda: 0)
@@ -2386,9 +2386,9 @@ class TestCmdApplyDefaultModelGate:
 
     def test_accepts_missing_default_model_on_anthropic(self, tmp_path, monkeypatch):
         """
-        Edge case 1b on anthropic: a missing DEFAULT_MODEL resolves to
-        'sonnet' via the load_config fallback; sonnet is valid for
-        anthropic so the gate passes and apply proceeds past _stop_service.
+        Missing DEFAULT_MODEL on anthropic: resolves to 'sonnet' via the
+        load_config fallback; sonnet is valid for anthropic so the gate
+        passes and apply proceeds past _stop_service.
         """
         monkeypatch.setattr("os.geteuid", lambda: 0)
         conf_path = self._write_install_conf(
@@ -2407,9 +2407,9 @@ class TestCmdApplyDefaultModelGate:
 
     def test_accepts_open_ended_provider(self, tmp_path, monkeypatch):
         """
-        Edge case 2: open-ended providers (openrouter, ollama) accept any
-        non-empty model. validate_model_for_provider returns True for them,
-        so the gate does not block regardless of the model string.
+        Open-ended providers (openrouter, ollama) accept any non-empty
+        model. validate_model_for_provider returns True for them, so the
+        gate does not block regardless of the model string.
         """
         monkeypatch.setattr("os.geteuid", lambda: 0)
         conf_path = self._write_install_conf(
@@ -2429,9 +2429,9 @@ class TestCmdApplyDefaultModelGate:
 
     def test_dry_run_still_validates(self, tmp_path, monkeypatch):
         """
-        Acceptance 7: DRY_RUN=1 does not bypass the gate. Validation runs
-        before the dry-run flag is even read, so a bad config exits with
-        the same SystemExit it would emit on a non-dry-run apply.
+        DRY_RUN=1 does not bypass the gate. Validation runs before the
+        dry-run flag is even read, so a bad config exits with the same
+        SystemExit it would emit on a non-dry-run apply.
         """
         monkeypatch.setattr("os.geteuid", lambda: 0)
         monkeypatch.setenv("DRY_RUN", "1")
@@ -2449,31 +2449,47 @@ class TestCmdApplyDefaultModelGate:
         assert "openai" in msg
         stop_service.assert_not_called()
 
-    def test_normalizes_agent_backend_case_and_whitespace(self, tmp_path, monkeypatch):
+    def test_normalizes_llm_provider_case_and_whitespace(self, tmp_path, monkeypatch):
         """
         Mirrors load_config's .strip().lower() normalization on
-        AGENT_BACKEND and LLM_PROVIDER. A hand-edited install.conf
-        carrying 'Claude ' (mixed case + trailing space) must compute
-        the same effective provider load_config will at startup.
+        AGENT_BACKEND and LLM_PROVIDER. The test relies on a code path
+        where normalized and un-normalized lookups produce DIFFERENT
+        gate outcomes, so that the test fails if either transformation
+        is dropped from the gate.
+
+        Setup: AGENT_BACKEND="goose", LLM_PROVIDER=" OpenAI ", DEFAULT_MODEL="sonnet".
+        - With .strip().lower() applied: eff_provider="openai",
+          validate("sonnet", "openai") returns False (sonnet is not in
+          PROVIDER_MODELS["openai"]) -> SystemExit.
+        - Without .strip().lower(): eff_provider=" OpenAI ", which is
+          not in PROVIDER_MODELS or OPEN_ENDED_PROVIDERS. The validator
+          falls through the unknown-provider branch (which returns True
+          with a warning) and the gate silently accepts.
+
+        Asserting SystemExit therefore captures BOTH transformations:
+        dropping .strip() leaves " OpenAI " unknown; dropping .lower()
+        leaves "OpenAI" unknown; either way the gate would silently
+        accept and the test would fail.
         """
         monkeypatch.setattr("os.geteuid", lambda: 0)
         conf_path = self._write_install_conf(
             tmp_path,
-            {"DEFAULT_MODEL": "opus", "AGENT_BACKEND": "Claude "},
+            {
+                "DEFAULT_MODEL": "sonnet",
+                "AGENT_BACKEND": "goose",
+                "LLM_PROVIDER": " OpenAI ",
+            },
         )
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         stop_service = self._patch_side_effects(monkeypatch)
-        monkeypatch.setenv("DRY_RUN", "1")
 
-        # Without normalization the gate would resolve to ("opus", "")
-        # and pass (empty provider triggers the unknown-provider warning
-        # branch in validate_model_for_provider, which returns True).
-        # With normalization the gate resolves to ("opus", "anthropic"),
-        # opus is valid, and the apply proceeds. This indirectly verifies
-        # that both .strip() and .lower() are applied by checking that
-        # the apply reaches _stop_service (i.e. the gate accepted).
-        _cmd_apply()
-        stop_service.assert_called_once()
+        with pytest.raises(SystemExit) as excinfo:
+            _cmd_apply()
+        # The error message should name the normalized provider, not the
+        # raw input, so operator-facing output stays consistent with the
+        # load_config error wording.
+        assert "openai" in str(excinfo.value).lower()
+        stop_service.assert_not_called()
 
 
 # ── Directory creation ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Wizard:** `_cmd_config` now re-prompts for `DEFAULT_MODEL` whenever the existing value is missing, empty, or invalid for the effective provider, regardless of whether `users.yaml` exists. The provider-aware dispatch is factored into a new `_prompt_default_model` helper shared by both wizard branches. The re-prompt's prefill is always `PROVIDER_DEFAULTS[eff_provider]`, never the just-rejected value (guards against `_prompt_choice`'s empty-input default-passthrough).
- **Wizard emit:** `DEFAULT_MODEL` is now written to `install.conf` unconditionally, not gated on `not users_yaml_exists`. The model is global; per-user values in `users.yaml` override but do not replace it.
- **Apply:** `_cmd_apply` validates the `(DEFAULT_MODEL, effective_provider)` pair before any side effect (`_stop_service` is never reached on the failure path, and `DRY_RUN=1` does not bypass). Normalization mirrors `load_config`'s `.strip().lower()` so hand-edited `install.conf` values are caught here rather than at startup. Empty/missing `DEFAULT_MODEL` is resolved to `"sonnet"` before validation, matching the runtime fallback.

Fixes #474.

## Test plan

- [x] `make check` (ruff + format)
- [x] Full pytest suite (2974 passed, 1 skipped)
- [x] Targeted: `TestCmdConfigDefaultModelDispatch` (5 tests) and `TestCmdApplyDefaultModelGate` (6 tests), 11 passed total
- [ ] Manual: flip a goose-configured `/etc/kai/env` back to claude via `make config` and confirm no validation error at startup. (Sibling validation of the wizard half; operator's earlier smoke test covered the goose direction.)

## Out of scope

- `_prompt_choice`'s un-validated `default` parameter is a latent bug surfaced during review of this change; should be its own follow-up issue rather than bundled here.
- Broader multi-backend wizard reorder is still deferred to a separate effort.
