### PR TITLE
fix: _prompt_choice rejects out-of-list default

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -106,22 +106,42 @@ def _prompt_choice(label: str, choices: list[str], default: str = "") -> str:
     """
     Prompt the user to pick from a list of valid choices.
 
-    Rejects input not in the choices list and re-prompts.
+    Rejects input not in the choices list and re-prompts. If the caller
+    supplies a `default` that is not in `choices`, the function behaves
+    as if no default were supplied: the suffix is not shown, and empty
+    input re-prompts rather than returning the invalid value. This guards
+    against call sites that read `default` from operator-facing state
+    (existing_env, install.conf) whose values can drift out of `choices`
+    when a sibling setting changes.
+
+    Membership is case-sensitive against `choices`. A `default` whose
+    case or whitespace does not match a canonical entry is treated as
+    out-of-list and re-prompted. This is consistent with the apply-time
+    normalization in load_config and stops a hand-edited install.conf
+    from re-selecting a near-miss value on Enter.
 
     Args:
         label: The prompt text shown to the user.
         choices: List of valid string values.
-        default: Default value if the user presses Enter.
+        default: Default value if the user presses Enter. Ignored if not
+            in `choices`.
 
     Returns:
-        The chosen value (guaranteed to be in choices).
+        The chosen value, guaranteed to be in `choices`.
     """
     choices_str = "/".join(choices)
-    suffix = f" [{default}]" if default else ""
+    # An out-of-list default is treated as no default. The empty-input
+    # path previously returned the value unchecked, violating the
+    # function's "Returns a value in choices" contract. Recomputing here
+    # keeps the suffix display and the empty-input branch consistent so
+    # the prompt never advertises an option the function would not accept
+    # via typed input.
+    effective_default = default if default in choices else ""
+    suffix = f" [{effective_default}]" if effective_default else ""
     while True:
         value = input(f"{label} ({choices_str}){suffix}: ").strip().lower()
-        if not value and default:
-            return default
+        if not value and effective_default:
+            return effective_default
         if value in choices:
             return value
         print(f"  Please choose one of: {choices_str}")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -884,7 +884,10 @@ class TestPromptChoice:
         assert "[xyz]" not in recorded_prompts[0]
 
     def test_suffix_present_when_default_in_choices(self, monkeypatch):
-        """Pairs with test 3 to lock both directions of the suffix display."""
+        """
+        Pairs with `test_suffix_omitted_when_default_not_in_choices` to
+        lock both directions of the suffix display.
+        """
         recorded_prompts: list[str] = []
         inputs = iter([""])
 
@@ -908,6 +911,21 @@ class TestPromptChoice:
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
         result = _prompt_choice("Pick", ["a", "b"], default="")
         assert result == "a"
+
+    def test_empty_default_with_empty_input_reprompts(self, monkeypatch):
+        """
+        Locks the unset-default row of the behavior matrix: empty input
+        with no default re-prompts rather than returning a falsy value.
+        The single-Enter iterator runs the loop once; the second input()
+        call exhausts the iterator and raises StopIteration, which proves
+        the loop is iterating (it would return without a second read if
+        the empty-input branch were incorrectly returning the empty
+        default).
+        """
+        inputs = iter([""])
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        with pytest.raises(StopIteration):
+            _prompt_choice("Pick", ["a", "b"], default="")
 
     def test_lowercases_and_strips_input(self, monkeypatch):
         """

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -39,6 +39,7 @@ from kai.install import (
     _generate_systemd_unit,
     _generate_users_yaml,
     _migrate_identity_to_claude_md,
+    _prompt_choice,
     _retire_install_home_claude,
     _retire_install_home_dir,
     _set_ownership,
@@ -818,6 +819,120 @@ class TestGenerateSystemdUnit:
     def test_network_dependency(self):
         result = _generate_systemd_unit("/opt/kai", "/var/lib/kai", "kai")
         assert "network-online.target" in result
+
+
+# ── Prompt helpers ───────────────────────────────────────────────────
+
+
+class TestPromptChoice:
+    """
+    `_prompt_choice` defends its "returns a value in `choices`" contract.
+
+    The empty-input branch previously returned the caller's `default`
+    without checking membership; an out-of-list default could leak back
+    to the caller on Enter. The helper now treats an out-of-list default
+    as if no default were supplied: the suffix is omitted and empty input
+    re-prompts.
+    """
+
+    def test_returns_default_when_in_choices(self, monkeypatch):
+        """Regression guard for the no-behavior-change case."""
+        # Empty input simulates the operator pressing Enter at the prompt.
+        inputs = iter([""])
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        result = _prompt_choice("Pick", ["a", "b"], default="a")
+        assert result == "a"
+
+    def test_rejects_empty_input_when_default_not_in_choices(self, monkeypatch, capsys):
+        """
+        With a default that is not in choices, pressing Enter re-prompts
+        rather than returning the invalid value. The "Please choose one
+        of" notice is printed to stdout (via print(), captured by capsys).
+        """
+        # First Enter triggers the re-prompt; the second response ("a")
+        # is in choices so the function returns it. Pre-fix behavior
+        # would have returned "xyz" on the first Enter without re-prompting.
+        inputs = iter(["", "a"])
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        result = _prompt_choice("Pick", ["a", "b"], default="xyz")
+        assert result == "a"
+        captured = capsys.readouterr().out
+        assert "Please choose one of: a/b" in captured
+
+    def test_suffix_omitted_when_default_not_in_choices(self, monkeypatch):
+        """
+        The `[default]` suffix in the prompt string is dropped when the
+        default is out-of-list, so the function does not advertise a
+        value it will not accept on Enter. Couples the suffix display to
+        the empty-input branch via the shared `effective_default` variable.
+        """
+        # Record the exact string passed to input() so we can assert on
+        # the suffix. The bare lambda used in test_returns_default does
+        # not preserve the prompt argument; capsys also will not catch
+        # it because the mock replaces input() entirely and never writes
+        # to stdout. A side-effecting list is the structural analog of
+        # MagicMock.call_args_list for this case.
+        recorded_prompts: list[str] = []
+        inputs = iter(["a"])
+
+        def mock_input(prompt: str) -> str:
+            recorded_prompts.append(prompt)
+            return next(inputs)
+
+        monkeypatch.setattr("builtins.input", mock_input)
+        _prompt_choice("Pick", ["a", "b"], default="xyz")
+        assert "[xyz]" not in recorded_prompts[0]
+
+    def test_suffix_present_when_default_in_choices(self, monkeypatch):
+        """Pairs with test 3 to lock both directions of the suffix display."""
+        recorded_prompts: list[str] = []
+        inputs = iter([""])
+
+        def mock_input(prompt: str) -> str:
+            recorded_prompts.append(prompt)
+            return next(inputs)
+
+        monkeypatch.setattr("builtins.input", mock_input)
+        _prompt_choice("Pick", ["a", "b"], default="a")
+        assert "[a]" in recorded_prompts[0]
+
+    def test_empty_default_with_invalid_input_reprompts(self, monkeypatch):
+        """
+        Regression guard for the empty-default case: invalid typed input
+        re-prompts (not the empty-input path), valid typed input is
+        accepted on the second iteration.
+        """
+        # "bad" is not in choices; "a" is. The function should loop until
+        # it gets a value in choices.
+        inputs = iter(["bad", "a"])
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        result = _prompt_choice("Pick", ["a", "b"], default="")
+        assert result == "a"
+
+    def test_lowercases_and_strips_input(self, monkeypatch):
+        """
+        Existing behavior, kept as a load-bearing regression guard since
+        callers depend on the .strip().lower() normalization to accept
+        operator input in any case.
+        """
+        inputs = iter([" A "])
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        result = _prompt_choice("Pick", ["a", "b"], default="")
+        assert result == "a"
+
+    def test_rejects_case_mismatched_default(self, monkeypatch):
+        """
+        Direct regression test for the case-sensitivity claim in the
+        docstring. "A" is not byte-identical to any entry in ["a", "b"],
+        so the default is treated as out-of-list; the typed "a" is
+        accepted on the next iteration. If a future change relaxes the
+        membership check to be case-insensitive, this test will fail and
+        the docstring claim should be revisited.
+        """
+        inputs = iter(["", "a"])
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        result = _prompt_choice("Pick", ["a", "b"], default="A")
+        assert result == "a"
 
 
 # ── Config subcommand ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `_prompt_choice` no longer returns its `default` argument on empty input without checking membership in `choices`. An out-of-list default is treated as if no default were supplied: the `[default]` suffix is dropped from the prompt, and pressing Enter re-prompts instead of leaking the invalid value back to the caller.
- Implementation: a single `effective_default = default if default in choices else ""` keys the suffix display, the empty-input branch, and the re-prompt loop off the same computed value. No call site changes; behavior is identical on every existing site that passes an in-choices default.
- Membership is case-sensitive, matching the apply-time normalization PR #477 added on the `load_config` side. A hand-edited `install.conf` carrying a mixed-case value (e.g. `"Claude"`) is now treated as out-of-list rather than silently re-selected on Enter.

Fixes #478.

## Test plan

- [x] `make check` (ruff + format)
- [x] Full pytest suite (2981 passed, 1 skipped)
- [x] Targeted: `TestPromptChoice` (7 tests) covering in-choices default, out-of-list default empty-input, suffix display both directions, empty default with invalid input, lowercase/strip, and case-mismatch
- [x] Pre-push grep gate clean

## Out of scope

- Auditing every existing `_prompt_choice` call site to confirm its `default` is always in `choices`. The fix is at the helper precisely because caller-side discipline is fragile; if a future call site passes a stale default, the helper now degrades gracefully instead of leaking it back.
- A separate strict / fail-fast variant. Considered in the spec and rejected; no current call site articulates the need.
