### PR TITLE
feat(config): per-role model registry for multi-backend agent calls

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -17,6 +17,7 @@ import os
 import pwd
 import subprocess
 from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
 
 import yaml
@@ -105,6 +106,122 @@ OPEN_ENDED_PROVIDERS: frozenset[str] = frozenset({"openrouter", "ollama"})
 # config validation where the provider is unknown (workspaces can be
 # used by users on different providers).
 _ALL_CURATED_MODELS: frozenset[str] = frozenset(model for models in PROVIDER_MODELS.values() for model in models)
+
+
+# ── Per-role model registry ──────────────────────────────────────────
+#
+# Maps (backend, role) -> the model identifier each backend's CLI
+# accepts as --model for that role. Centralizes per-function defaults
+# so codex and any future backend can declare its mapping in one place
+# instead of scattered _TRIAGE_MODEL / _REVIEW_MODEL / _DEFAULT_*
+# constants across modules.
+#
+# Scope: only the four one-shot agent roles whose model strings move
+# between backends in the codex epic. CONVERSATION is excluded
+# deliberately: conversational model selection is owned by pool.py +
+# DEFAULT_MODEL + PROVIDER_DEFAULTS, and routing it through the
+# registry would collide with the per-user override layer that
+# users.yaml / /settings already provide. FACT_EXTRACTION /
+# EPISODE_EXTRACTION are also excluded; they are owned by
+# config.memory_extraction_model / memory_episode_model with the
+# load_config inheritance sentinel below, and the future
+# backend-agnostic memory epic will introduce them to this enum
+# alongside their codex consumer.
+
+
+class ModelRole(StrEnum):
+    """
+    Logical role tag for a model-selection lookup.
+
+    Each role corresponds to a specific agent-invocation site
+    (triage.py, review.py, eval/behavioral.py) whose model string
+    differs by backend. The registry MODEL_REGISTRY pairs each
+    (backend, role) with the vendor-specific identifier to pass to
+    that backend's CLI as --model.
+    """
+
+    PR_REVIEW = "pr_review"
+    ISSUE_TRIAGE = "issue_triage"
+    BEHAVIORAL_JUDGE = "behavioral_judge"
+    BEHAVIORAL_GEN = "behavioral_gen"
+
+
+# Values are exactly what each backend's CLI accepts as --model.
+# Claude rows match today's inline constants verbatim so the registry
+# migration is no-behavior-change:
+# - triage.py _TRIAGE_MODEL = "sonnet"
+# - review.py _REVIEW_MODEL = "sonnet"
+# - eval/behavioral.py _DEFAULT_JUDGE_MODEL = "claude-haiku-4-5-20251001"
+# - eval/behavioral.py _DEFAULT_GEN_MODEL = "sonnet"
+# Codex rows reflect editorial tier mapping: nano for cheap high-volume
+# work (judge), mini for balanced default generation (gen, triage, review).
+# Goose entries are intentionally absent: goose's model identifier
+# depends on llm_provider (the _GOOSE_AGENT_MODELS dicts in triage.py /
+# review.py already encode that per-provider resolution), which would
+# need a third axis the registry does not carry today.
+MODEL_REGISTRY: dict[tuple[str, ModelRole], str] = {
+    ("claude", ModelRole.PR_REVIEW): "sonnet",
+    ("claude", ModelRole.ISSUE_TRIAGE): "sonnet",
+    ("claude", ModelRole.BEHAVIORAL_JUDGE): "claude-haiku-4-5-20251001",
+    ("claude", ModelRole.BEHAVIORAL_GEN): "sonnet",
+    ("codex", ModelRole.PR_REVIEW): "gpt-5.4-mini",
+    ("codex", ModelRole.ISSUE_TRIAGE): "gpt-5.4-mini",
+    ("codex", ModelRole.BEHAVIORAL_JUDGE): "gpt-5.4-nano",
+    ("codex", ModelRole.BEHAVIORAL_GEN): "gpt-5.4-mini",
+}
+
+
+def get_model_for(role: ModelRole, backend: str, override: str = "") -> str:
+    """
+    Resolve the model identifier for a (role, backend) pair.
+
+    Override precedence: if `override` is truthy, it wins (used by
+    per-role env vars like ISSUE_TRIAGE_MODEL_CODEX or by CLI flags
+    like --judge-model). Otherwise the registry value is returned.
+
+    Raises LookupError on a missing (backend, role) row. Total in the
+    steady state because _check_model_registry_complete() runs at
+    startup and fails fast (SystemExit) if any role is missing for
+    the active backend. The runtime LookupError exists for defensive
+    parsing: a request-path bug should surface as a 5xx, not a
+    process-wide SystemExit.
+
+    Args:
+        role: The ModelRole the caller wants a model for.
+        backend: The active backend string ("claude" or "codex").
+        override: Caller-supplied override string. Empty disables.
+
+    Returns:
+        The model identifier to pass to the backend's CLI.
+    """
+    if override:
+        return override
+    try:
+        return MODEL_REGISTRY[(backend, role)]
+    except KeyError:
+        raise LookupError(f"No registry entry for (backend={backend}, role={role.value})") from None
+
+
+def _check_model_registry_complete(backend: str) -> None:
+    """
+    Verify MODEL_REGISTRY has a row for every role the active backend uses.
+
+    Runs once at load_config() time. Raises SystemExit on a missing
+    row so the bug surfaces at startup rather than at a per-request
+    LookupError (which would otherwise crash a single agent invocation
+    silently if a future role were added without its registry rows).
+
+    Goose is exempt: goose-side model resolution lives in module-level
+    _GOOSE_AGENT_MODELS dicts that this registry does not subsume.
+    """
+    if backend not in ("claude", "codex"):
+        return
+    missing = [role for role in ModelRole if (backend, role) not in MODEL_REGISTRY]
+    if missing:
+        names = ", ".join(role.value for role in missing)
+        raise SystemExit(
+            f"MODEL_REGISTRY is missing rows for backend '{backend}': {names}. Update MODEL_REGISTRY in config.py."
+        )
 
 
 def get_effective_provider(backend: str, llm_provider: str) -> str:
@@ -1569,6 +1686,13 @@ def load_config() -> Config:
         raise SystemExit(
             f"AGENT_BACKEND '{agent_backend}' is not valid (must be one of: {', '.join(sorted(VALID_BACKENDS))})"
         )
+
+    # Verify the per-role model registry has rows for every role the
+    # active backend will look up. Goose is exempt (its model resolution
+    # uses _GOOSE_AGENT_MODELS dicts, not the registry). Raises
+    # SystemExit on a missing row so the bug surfaces at startup rather
+    # than as a per-request LookupError.
+    _check_model_registry_complete(agent_backend)
 
     # LLM provider - validated against the backend's supported set.
     # Only required for non-Claude backends.

--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -94,6 +94,7 @@ from typing import Any
 # Import from the Layer 1 sibling module so the two layers stay aligned
 # on probe schema, drift detection, and probe-set-hash semantics. If
 # Layer 1's drift bucketing changes, Layer 2 follows automatically.
+from kai.config import ModelRole, get_model_for
 from kai.eval.retrieval import (
     Probe,
     detect_drift,
@@ -1818,8 +1819,15 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--judge-model",
-        default=_DEFAULT_JUDGE_MODEL,
-        help=f"Model for the judge call (default: {_DEFAULT_JUDGE_MODEL}).",
+        # default=None so an unset flag is distinguishable from an
+        # explicit pass; the BehavioralConfig construction below uses
+        # this distinction to fall through to MODEL_REGISTRY's
+        # BEHAVIORAL_JUDGE row for the active backend. With argparse
+        # carrying _DEFAULT_JUDGE_MODEL as the default, every unset
+        # invocation against the codex backend would hand the codex
+        # CLI a Claude alias.
+        default=None,
+        help=f"Model for the judge call (default for claude: {_DEFAULT_JUDGE_MODEL}; codex uses MODEL_REGISTRY's BEHAVIORAL_JUDGE row).",
     )
     parser.add_argument(
         "--judge-budget-usd",
@@ -1835,8 +1843,9 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--gen-model",
-        default=_DEFAULT_GEN_MODEL,
-        help=f"Model for the generation arms (default: {_DEFAULT_GEN_MODEL}).",
+        # See --judge-model above for the rationale on default=None.
+        default=None,
+        help=f"Model for the generation arms (default for claude: {_DEFAULT_GEN_MODEL}; codex uses MODEL_REGISTRY's BEHAVIORAL_GEN row).",
     )
     parser.add_argument(
         "--gen-budget-usd",
@@ -2017,11 +2026,32 @@ async def _run_cli(args: argparse.Namespace) -> int:
 
     # Materialize the per-run config from CLI args. Done here (not in
     # _build_parser) because _resolve_seed needs the loaded probes.
+    #
+    # Resolve judge_model and gen_model against the per-role registry.
+    # argparse default=None for --judge-model / --gen-model (see
+    # _build_parser) means an unset flag yields override="" and the
+    # registry value is returned. An explicit --judge-model claude_haiku
+    # invocation still wins via the override. This indirection prevents
+    # the codex backend from receiving Claude aliases when no flag is
+    # passed; on the claude backend the registry row is byte-identical
+    # to _DEFAULT_JUDGE_MODEL / _DEFAULT_GEN_MODEL so behavior is
+    # unchanged.
+    eval_backend = os.environ.get("AGENT_BACKEND", "claude").strip().lower()
+    resolved_judge_model = get_model_for(
+        ModelRole.BEHAVIORAL_JUDGE,
+        eval_backend,
+        override=args.judge_model or "",
+    )
+    resolved_gen_model = get_model_for(
+        ModelRole.BEHAVIORAL_GEN,
+        eval_backend,
+        override=args.gen_model or "",
+    )
     config = BehavioralConfig(
-        judge_model=args.judge_model,
+        judge_model=resolved_judge_model,
         judge_budget_usd=args.judge_budget_usd,
         judge_timeout_s=args.judge_timeout_s,
-        gen_model=args.gen_model,
+        gen_model=resolved_gen_model,
         gen_budget_usd=args.gen_budget_usd,
         gen_timeout_s=args.gen_timeout_s,
         seed=_resolve_seed(cli_seed=args.seed, probes=probes, user_id=args.user_id),

--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -2027,26 +2027,38 @@ async def _run_cli(args: argparse.Namespace) -> int:
     # Materialize the per-run config from CLI args. Done here (not in
     # _build_parser) because _resolve_seed needs the loaded probes.
     #
-    # Resolve judge_model and gen_model against the per-role registry.
+    # Resolve judge_model and gen_model with backend-aware dispatch.
     # argparse default=None for --judge-model / --gen-model (see
-    # _build_parser) means an unset flag yields override="" and the
-    # registry value is returned. An explicit --judge-model claude_haiku
-    # invocation still wins via the override. This indirection prevents
-    # the codex backend from receiving Claude aliases when no flag is
-    # passed; on the claude backend the registry row is byte-identical
-    # to _DEFAULT_JUDGE_MODEL / _DEFAULT_GEN_MODEL so behavior is
-    # unchanged.
+    # _build_parser) means an unset flag yields override="" so the
+    # branch below picks the right backend-appropriate default.
+    #
+    # The registry only covers claude and codex; goose's model
+    # resolution lives in _GOOSE_AGENT_MODELS dicts inside triage.py
+    # and review.py, not in MODEL_REGISTRY. For goose (and any future
+    # non-registry backend) we preserve the pre-Phase-1 behavior:
+    # explicit --judge-model / --gen-model wins, otherwise the legacy
+    # _DEFAULT_JUDGE_MODEL / _DEFAULT_GEN_MODEL constants are used.
+    # This keeps the goose path byte-identical to today rather than
+    # crashing with a LookupError on an unset flag.
     eval_backend = os.environ.get("AGENT_BACKEND", "claude").strip().lower()
-    resolved_judge_model = get_model_for(
-        ModelRole.BEHAVIORAL_JUDGE,
-        eval_backend,
-        override=args.judge_model or "",
-    )
-    resolved_gen_model = get_model_for(
-        ModelRole.BEHAVIORAL_GEN,
-        eval_backend,
-        override=args.gen_model or "",
-    )
+    if eval_backend in ("claude", "codex"):
+        resolved_judge_model = get_model_for(
+            ModelRole.BEHAVIORAL_JUDGE,
+            eval_backend,
+            override=args.judge_model or "",
+        )
+        resolved_gen_model = get_model_for(
+            ModelRole.BEHAVIORAL_GEN,
+            eval_backend,
+            override=args.gen_model or "",
+        )
+    else:
+        # Non-registry backend (goose). Preserve pre-Phase-1 behavior:
+        # explicit flag wins, otherwise the legacy _DEFAULT_* constant
+        # is used. Codex-aware behavioral wiring on non-registry
+        # backends is Phase 5 scope.
+        resolved_judge_model = args.judge_model or _DEFAULT_JUDGE_MODEL
+        resolved_gen_model = args.gen_model or _DEFAULT_GEN_MODEL
     config = BehavioralConfig(
         judge_model=resolved_judge_model,
         judge_budget_usd=args.judge_budget_usd,

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -35,7 +35,7 @@ from pathlib import Path
 
 import aiohttp
 
-from kai.config import resolve_claude_user
+from kai.config import ModelRole, get_model_for, resolve_claude_user
 from kai.prompt_utils import make_boundary
 
 log = logging.getLogger(__name__)
@@ -45,11 +45,6 @@ log = logging.getLogger(__name__)
 # a note so Claude knows the review is partial. 100K chars is well within
 # Claude's context window while leaving room for the prompt frame.
 _MAX_DIFF_CHARS = 100_000
-
-# Review model - hardcoded to Sonnet per design decision #10 in the PR
-# review discussion. Reviews are a background task; no reason to burn
-# Opus tokens. Sonnet is more than capable for code review.
-_REVIEW_MODEL = "sonnet"
 
 # Default per-review budget cap in USD. Vestigial after #390:
 # --max-budget-usd is no longer emitted to claude --print argv on the
@@ -758,11 +753,24 @@ async def run_review(
         # signature is unused on every currently-exercised path - see the
         # comment on the parameter declaration above for the full rationale
         # and why cleanup is deferred to a separate refactor.
+        # Model identifier comes from the per-role registry so the
+        # codex backend (and any future backend) can override the
+        # mid-tier "sonnet" default without modifying this branch.
+        # The override env var PR_REVIEW_MODEL_<BACKEND> is read here
+        # rather than in load_config because the override surface
+        # grows with ModelRole; threading every entry through Config
+        # would inflate the dataclass for a passthrough to a typed
+        # lookup.
+        review_model = get_model_for(
+            ModelRole.PR_REVIEW,
+            agent_backend,
+            override=os.environ.get(f"PR_REVIEW_MODEL_{agent_backend.upper()}", ""),
+        )
         cmd = [
             "claude",
             "--print",
             "--model",
-            _REVIEW_MODEL,
+            review_model,
         ]
 
         # Resolve self-sudo: skip sudo when claude_user matches the bot

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -35,15 +35,11 @@ from pathlib import Path
 
 import aiohttp
 
-from kai.config import resolve_claude_user
+from kai.config import ModelRole, get_model_for, resolve_claude_user
 from kai.prompt_utils import make_boundary
 
 log = logging.getLogger(__name__)
 
-
-# Triage model - Sonnet, same reasoning as PR review. Background task,
-# no need for Opus tokens. Sonnet handles classification and analysis well.
-_TRIAGE_MODEL = "sonnet"
 
 # Per-triage budget cap in USD. Vestigial after #390: --max-budget-usd
 # is no longer emitted to claude --print argv on the claude branch
@@ -473,11 +469,23 @@ async def run_triage(
         # it has notionally produced. _TRIAGE_BUDGET_USD stays defined for
         # symmetry with the other budget defaults in this codebase; cleanup
         # is deferred to a separate refactor.
+        # Model identifier comes from the per-role registry so the
+        # codex backend (and any future backend) can override the
+        # mid-tier "sonnet" default without modifying this branch.
+        # The override env var ISSUE_TRIAGE_MODEL_<BACKEND> is read here
+        # rather than in load_config because the override surface grows
+        # with ModelRole; threading every entry through Config would
+        # inflate the dataclass for a passthrough to a typed lookup.
+        triage_model = get_model_for(
+            ModelRole.ISSUE_TRIAGE,
+            agent_backend,
+            override=os.environ.get(f"ISSUE_TRIAGE_MODEL_{agent_backend.upper()}", ""),
+        )
         cmd = [
             "claude",
             "--print",
             "--model",
-            _TRIAGE_MODEL,
+            triage_model,
         ]
 
         # Resolve self-sudo: skip sudo when claude_user matches the bot

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,17 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from kai.config import Config, UserConfig, _read_protected_file, load_config, resolve_claude_user
+from kai.config import (
+    MODEL_REGISTRY,
+    Config,
+    ModelRole,
+    UserConfig,
+    _check_model_registry_complete,
+    _read_protected_file,
+    get_model_for,
+    load_config,
+    resolve_claude_user,
+)
 
 # All env vars that load_config reads
 _CONFIG_ENV_VARS = [
@@ -1883,3 +1893,108 @@ class TestPerUserAllowedWorkspacesYaml:
         configs = self._load_with_yaml(monkeypatch, users_data)
         assert configs is not None
         assert configs[123].allowed_workspaces == [ws.resolve()]
+
+
+# ── Per-role model registry ─────────────────────────────────────────
+
+
+class TestModelRegistry:
+    """
+    Verify get_model_for and the MODEL_REGISTRY shape.
+
+    The registry centralizes per-function model defaults so codex (and
+    future backends) can declare their mapping in one place. These tests
+    cover the lookup contract (override precedence, missing-row error,
+    startup completeness check) and the claude-row-equals-prior-constant
+    invariant that makes the Phase 1 migration no-behavior-change.
+    """
+
+    def test_lookup_returns_registry_value_when_no_override(self):
+        """Default path: empty override returns the registry value."""
+        result = get_model_for(ModelRole.PR_REVIEW, "claude")
+        assert result == "sonnet"
+
+    def test_override_wins_over_registry(self):
+        """A truthy override short-circuits the registry lookup."""
+        result = get_model_for(ModelRole.PR_REVIEW, "claude", override="opus")
+        assert result == "opus"
+
+    def test_empty_override_falls_through(self):
+        """
+        Empty-string override is treated as no override.
+
+        This is the contract eval/behavioral.py relies on:
+        `args.judge_model or ""` yields "" when the flag is unset, and
+        the registry takes over. If empty short-circuited the registry,
+        the codex behavioral path would never reach the gpt-5.4-nano row.
+        """
+        result = get_model_for(ModelRole.PR_REVIEW, "claude", override="")
+        assert result == "sonnet"
+
+    def test_missing_row_raises_lookup_error(self):
+        """
+        Per-request handler safety: a missing registry row raises
+        LookupError (5xx-shape) rather than SystemExit (process-wide
+        teardown). The startup completeness check is supposed to
+        prevent this from ever firing in production; the runtime guard
+        exists so a packaging bug surfaces as a contained per-request
+        failure if it does.
+        """
+        with pytest.raises(LookupError, match="No registry entry"):
+            get_model_for(ModelRole.PR_REVIEW, "no-such-backend")
+
+    def test_completeness_check_passes_for_claude(self):
+        """Claude has rows for every role; no exception."""
+        _check_model_registry_complete("claude")  # no raise
+
+    def test_completeness_check_passes_for_codex(self):
+        """Codex has rows for every role; no exception."""
+        _check_model_registry_complete("codex")  # no raise
+
+    def test_completeness_check_skips_goose(self):
+        """
+        Goose model resolution lives in _GOOSE_AGENT_MODELS dicts inside
+        triage.py / review.py, not in MODEL_REGISTRY. The completeness
+        check skips goose explicitly so a goose-backed install does
+        not fail at startup just because the registry has no goose rows.
+        """
+        _check_model_registry_complete("goose")  # no raise
+
+    def test_completeness_check_raises_on_missing_row(self, monkeypatch):
+        """
+        Synthetic missing-row case: remove a registry entry for the
+        active backend and assert load_config-time SystemExit fires
+        with a clear message. Uses monkeypatch.delitem so the change
+        is reverted between tests.
+        """
+        monkeypatch.delitem(MODEL_REGISTRY, ("claude", ModelRole.PR_REVIEW))
+        with pytest.raises(SystemExit) as excinfo:
+            _check_model_registry_complete("claude")
+        assert "pr_review" in str(excinfo.value)
+        assert "claude" in str(excinfo.value)
+
+    # ── Claude row equals prior constant (Phase 1 invariant) ──────
+
+    def test_claude_pr_review_row_matches_prior_constant(self):
+        """review.py used _REVIEW_MODEL = "sonnet" pre-Phase-1."""
+        assert get_model_for(ModelRole.PR_REVIEW, "claude") == "sonnet"
+
+    def test_claude_issue_triage_row_matches_prior_constant(self):
+        """triage.py used _TRIAGE_MODEL = "sonnet" pre-Phase-1."""
+        assert get_model_for(ModelRole.ISSUE_TRIAGE, "claude") == "sonnet"
+
+    def test_claude_behavioral_judge_row_matches_prior_constant(self):
+        """
+        eval/behavioral.py used _DEFAULT_JUDGE_MODEL =
+        "claude-haiku-4-5-20251001" pre-Phase-1. Locks the byte-identical
+        invariant the M1 fix from the v4 review depends on.
+        """
+        from kai.eval.behavioral import _DEFAULT_JUDGE_MODEL
+
+        assert get_model_for(ModelRole.BEHAVIORAL_JUDGE, "claude") == _DEFAULT_JUDGE_MODEL
+
+    def test_claude_behavioral_gen_row_matches_prior_constant(self):
+        """eval/behavioral.py used _DEFAULT_GEN_MODEL = "sonnet" pre-Phase-1."""
+        from kai.eval.behavioral import _DEFAULT_GEN_MODEL
+
+        assert get_model_for(ModelRole.BEHAVIORAL_GEN, "claude") == _DEFAULT_GEN_MODEL

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1987,7 +1987,10 @@ class TestModelRegistry:
         """
         eval/behavioral.py used _DEFAULT_JUDGE_MODEL =
         "claude-haiku-4-5-20251001" pre-Phase-1. Locks the byte-identical
-        invariant the M1 fix from the v4 review depends on.
+        invariant the behavioral codex path depends on: the claude
+        BEHAVIORAL_JUDGE row must equal _DEFAULT_JUDGE_MODEL so an
+        unset --judge-model on claude resolves to the same string the
+        pre-Phase-1 argparse default emitted.
         """
         from kai.eval.behavioral import _DEFAULT_JUDGE_MODEL
 

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -929,10 +929,14 @@ class TestBackendAwareModelResolution:
         return args
 
     @staticmethod
-    def _run_with_captured_config(args, monkeypatch):
+    def _run_with_captured_config(args):
         """
         Invoke _run_cli with heavyweight machinery mocked, capturing
         the BehavioralConfig that gets handed to _run_all_probes.
+
+        Callers apply monkeypatch.setenv("AGENT_BACKEND", ...) before
+        calling this helper; the env is already set by the time
+        _run_cli reads it.
         """
         captured: dict[str, BehavioralConfig] = {}
 
@@ -963,7 +967,7 @@ class TestBackendAwareModelResolution:
         """
         monkeypatch.setenv("AGENT_BACKEND", "goose")
         args = self._make_args(tmp_path)  # judge_model=None, gen_model=None
-        config = self._run_with_captured_config(args, monkeypatch)
+        config = self._run_with_captured_config(args)
         assert config.judge_model == behavioral._DEFAULT_JUDGE_MODEL
         assert config.gen_model == behavioral._DEFAULT_GEN_MODEL
 
@@ -974,7 +978,7 @@ class TestBackendAwareModelResolution:
         """
         monkeypatch.setenv("AGENT_BACKEND", "goose")
         args = self._make_args(tmp_path, judge_model="opus", gen_model="haiku")
-        config = self._run_with_captured_config(args, monkeypatch)
+        config = self._run_with_captured_config(args)
         assert config.judge_model == "opus"
         assert config.gen_model == "haiku"
 
@@ -988,7 +992,7 @@ class TestBackendAwareModelResolution:
         """
         monkeypatch.setenv("AGENT_BACKEND", "claude")
         args = self._make_args(tmp_path)
-        config = self._run_with_captured_config(args, monkeypatch)
+        config = self._run_with_captured_config(args)
         assert config.judge_model == behavioral._DEFAULT_JUDGE_MODEL
         assert config.gen_model == behavioral._DEFAULT_GEN_MODEL
 
@@ -996,7 +1000,7 @@ class TestBackendAwareModelResolution:
         """Explicit flag wins on claude too, exercising the override path."""
         monkeypatch.setenv("AGENT_BACKEND", "claude")
         args = self._make_args(tmp_path, judge_model="opus", gen_model="sonnet")
-        config = self._run_with_captured_config(args, monkeypatch)
+        config = self._run_with_captured_config(args)
         assert config.judge_model == "opus"
         assert config.gen_model == "sonnet"
 

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -890,6 +890,117 @@ class TestOutputWriteFailure:
         assert exit_code == 1
 
 
+class TestBackendAwareModelResolution:
+    """
+    Verify the backend-aware dispatch in _run_cli for judge/gen models.
+
+    The resolution shape:
+    - On claude / codex, get_model_for(role, backend, override=args.x or "")
+      handles the lookup. Unset flag yields the registry default;
+      explicit flag wins via override.
+    - On goose (and any future non-registry backend), the legacy
+      _DEFAULT_JUDGE_MODEL / _DEFAULT_GEN_MODEL constants are used
+      when the flag is unset, mirroring pre-Phase-1 behavior. Without
+      this fallback, get_model_for would raise LookupError on the
+      missing (goose, BEHAVIORAL_*) row and crash the eval CLI.
+    """
+
+    @staticmethod
+    def _make_args(tmp_path: Path, *, judge_model=None, gen_model=None):
+        """Minimal args.Namespace mock for _run_cli."""
+        probes_file = tmp_path / "probes.jsonl"
+        probes_file.write_text(
+            json.dumps({"question": "q1", "expected_fact_id": "f1"}) + "\n",
+            encoding="utf-8",
+        )
+        args = MagicMock()
+        args.probes = probes_file
+        args.user_id = "user-1"
+        args.output = None
+        args.judge_model = judge_model
+        args.judge_budget_usd = 0.05
+        args.judge_timeout_s = 60
+        args.gen_model = gen_model
+        args.gen_budget_usd = 0.10
+        args.gen_timeout_s = 120
+        args.seed = None
+        args.max_concurrency = 1
+        args.pollution_lines = 0
+        return args
+
+    @staticmethod
+    def _run_with_captured_config(args, monkeypatch):
+        """
+        Invoke _run_cli with heavyweight machinery mocked, capturing
+        the BehavioralConfig that gets handed to _run_all_probes.
+        """
+        captured: dict[str, BehavioralConfig] = {}
+
+        async def fake_run_all_probes(**kwargs):
+            captured["config"] = kwargs["config"]
+            return []
+
+        with (
+            patch.object(behavioral, "_initialize_memory", return_value=Path("/tmp")),
+            patch.object(
+                behavioral,
+                "detect_drift",
+                return_value=([Probe(question="q1", expected_fact_id="f1")], [], {"f1": ()}),
+            ),
+            patch.object(behavioral, "_run_all_probes", new=fake_run_all_probes),
+            patch.object(behavioral, "_resolve_ground_truth", return_value={"f1": "gold"}),
+            patch.object(behavioral, "_capture_claude_cli_version", return_value="2.1.118"),
+        ):
+            asyncio.run(behavioral._run_cli(args))
+        return captured["config"]
+
+    def test_goose_unset_flag_falls_back_to_legacy_constant(self, tmp_path, monkeypatch):
+        """
+        On a goose-backed install, an unset --judge-model must NOT trigger
+        get_model_for("goose", BEHAVIORAL_JUDGE) (no registry row, would
+        raise LookupError). The fallback path uses _DEFAULT_JUDGE_MODEL,
+        matching pre-Phase-1 behavior.
+        """
+        monkeypatch.setenv("AGENT_BACKEND", "goose")
+        args = self._make_args(tmp_path)  # judge_model=None, gen_model=None
+        config = self._run_with_captured_config(args, monkeypatch)
+        assert config.judge_model == behavioral._DEFAULT_JUDGE_MODEL
+        assert config.gen_model == behavioral._DEFAULT_GEN_MODEL
+
+    def test_goose_explicit_flag_wins(self, tmp_path, monkeypatch):
+        """
+        Explicit --judge-model still wins on goose. The fallback only
+        kicks in for an unset (None) flag value.
+        """
+        monkeypatch.setenv("AGENT_BACKEND", "goose")
+        args = self._make_args(tmp_path, judge_model="opus", gen_model="haiku")
+        config = self._run_with_captured_config(args, monkeypatch)
+        assert config.judge_model == "opus"
+        assert config.gen_model == "haiku"
+
+    def test_claude_unset_flag_uses_registry(self, tmp_path, monkeypatch):
+        """
+        On the claude backend, an unset flag resolves through the
+        registry to the BEHAVIORAL_JUDGE / BEHAVIORAL_GEN row. The
+        registry rows are byte-identical to the legacy constants by
+        Phase 1's no-behavior-change invariant, so the resolved values
+        must equal the pre-Phase-1 defaults.
+        """
+        monkeypatch.setenv("AGENT_BACKEND", "claude")
+        args = self._make_args(tmp_path)
+        config = self._run_with_captured_config(args, monkeypatch)
+        assert config.judge_model == behavioral._DEFAULT_JUDGE_MODEL
+        assert config.gen_model == behavioral._DEFAULT_GEN_MODEL
+
+    def test_claude_explicit_flag_wins(self, tmp_path, monkeypatch):
+        """Explicit flag wins on claude too, exercising the override path."""
+        monkeypatch.setenv("AGENT_BACKEND", "claude")
+        args = self._make_args(tmp_path, judge_model="opus", gen_model="sonnet")
+        config = self._run_with_captured_config(args, monkeypatch)
+        assert config.judge_model == "opus"
+        assert config.gen_model == "sonnet"
+
+
 class TestProbeIdMatchesSourcePosition:
     """per_probe[].probe_id reflects position in the source probes file,
     not position in the (scored + drift) concatenated outcomes list.

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -518,6 +518,21 @@ class TestRunReview:
         assert "sonnet" in cmd
 
     @pytest.mark.asyncio
+    async def test_claude_env_override_honored_at_call_site(self, monkeypatch):
+        """
+        PR_REVIEW_MODEL_CLAUDE in the environment overrides the registry
+        value at the call site. The override env var is read here rather
+        than in load_config; this test verifies the wiring end-to-end.
+        """
+        monkeypatch.setenv("PR_REVIEW_MODEL_CLAUDE", "opus")
+        mock_proc = _mock_process(stdout=b"ok")
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_review("prompt")
+        cmd = mock_exec.call_args[0]
+        i = cmd.index("--model")
+        assert cmd[i + 1] == "opus"
+
+    @pytest.mark.asyncio
     async def test_max_budget_usd_flag_absent_on_claude_backend(self):
         """
         --max-budget-usd must NOT be emitted to claude --print argv

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -316,6 +316,40 @@ class TestRunTriage:
         assert result == expected
 
     @pytest.mark.asyncio
+    async def test_claude_argv_uses_registry_model(self):
+        """
+        With agent_backend=claude and no env override, the --model
+        argv slot matches the registry's (claude, ISSUE_TRIAGE) row.
+        Locks the Phase 1 byte-identical invariant at the call site:
+        Phase 1 removed the _TRIAGE_MODEL constant, so this test is
+        the place the resolved string is observable.
+        """
+        mock_proc = _mock_subprocess(returncode=0, stdout='{"labels": []}')
+        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_triage("prompt", agent_backend="claude")
+        cmd = mock_exec.call_args[0]
+        # --model is followed immediately by the model identifier in
+        # the argv vector; index +1 gives the actual model string.
+        i = cmd.index("--model")
+        assert cmd[i + 1] == "sonnet"
+
+    @pytest.mark.asyncio
+    async def test_claude_env_override_honored_at_call_site(self, monkeypatch):
+        """
+        ISSUE_TRIAGE_MODEL_CLAUDE in the environment overrides the
+        registry value at the call site. The override env var is
+        read here rather than in load_config; this test verifies the
+        wiring end-to-end.
+        """
+        monkeypatch.setenv("ISSUE_TRIAGE_MODEL_CLAUDE", "opus")
+        mock_proc = _mock_subprocess(returncode=0, stdout='{"labels": []}')
+        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_triage("prompt", agent_backend="claude")
+        cmd = mock_exec.call_args[0]
+        i = cmd.index("--model")
+        assert cmd[i + 1] == "opus"
+
+    @pytest.mark.asyncio
     async def test_max_budget_usd_flag_absent_on_claude_backend(self):
         """
         --max-budget-usd must NOT be emitted to claude --print argv on


### PR DESCRIPTION
## Summary

- Adds `ModelRole` enum and `MODEL_REGISTRY` to `config.py`. Pairs `(backend, role)` with the vendor-specific model identifier each backend's CLI accepts as `--model`.
- Adds `get_model_for(role, backend, override="")` for runtime lookup and `_check_model_registry_complete(backend)` for load-time completeness validation.
- Migrates four model-string sites to read from the registry: `_TRIAGE_MODEL` and `_REVIEW_MODEL` constants are removed; `_DEFAULT_JUDGE_MODEL` and `_DEFAULT_GEN_MODEL` stay as constants referenced from help strings, with their argparse `default=` changed to `None` so an unset flag falls through to the registry instead of forcing a Claude alias onto a future codex run.
- Claude-row-equals-prior-constant invariant locked by four dedicated tests; ensures Phase 1 is no-behavior-change.

Phase 1 of the codex backend epic (#480). No `CodexBackend` yet; later phases add it plus the codex branches in each agent module.

## Test plan

- [x] `make check` (ruff + format)
- [x] Full pytest suite (2994 passed, 1 skipped)
- [x] Targeted: `TestModelRegistry` (12 tests) covering lookup, override precedence, missing-row `LookupError`, completeness check on claude / codex / goose paths, and byte-identical claude rows for every migrated role
- [x] Pre-push grep gate clean

## Refs

Refs #480.

## Out of scope

- `CodexBackend` itself and the codex branches in `triage.py` / `review.py` / `eval/behavioral.py`. Following phases.
- Memory extraction migration. Tied to the backend-agnostic semantic memory epic; the registry intentionally omits `FACT_EXTRACTION` / `EPISODE_EXTRACTION` until that epic introduces both the roles and the consumer.
- Goose registry rows. Goose's model identifier depends on `llm_provider`; the existing `_GOOSE_AGENT_MODELS` dicts in `triage.py` / `review.py` retain that resolution path.
