### PR TITLE
feat(codex): CodexBackend core, wizard wiring, and pool dispatch

### DIFF
--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -1,0 +1,682 @@
+"""
+OpenAI Codex CLI subprocess backend.
+
+Implements the AgentBackend ABC for Codex's JSON-RPC 2.0 protocol over
+a persistent `codex app-server` subprocess. Structurally equivalent to
+GooseBackend: one subprocess per user, kept alive across messages,
+restarted on /new or workspace switch. The wire protocol is JSON-RPC
+2.0 (same family as goose's ACP), but the message types and event
+vocabulary are codex-specific.
+
+The codex protocol (per pinned codex CLI version):
+    Startup:  initialize -> session/new (handshake)
+    Input:    session/prompt (JSON-RPC request with sessionId + prompt)
+    Output:   session/update (streaming notifications, no id field)
+    Finish:   JSON-RPC result with matching id
+
+Schema-drift posture: the documented codex event names are known to be
+out of sync with actual CLI output (openai/codex#4776). This module
+matches the goose ACP envelope (session/update notifications carrying
+an agent_message_chunk payload) because that envelope is what JSON-RPC
+2.0 servers conventionally emit; the first smoke test against a real
+codex binary will reveal whatever variations exist for the pinned
+version, and the unknown-event branches log at DEBUG and skip rather
+than aborting. The codex CLI version is captured in install metadata
+so a future bump triggers a re-pin pass.
+
+This module does NOT take a dependency on OpenAI's Codex Python SDK.
+The decision matches goose.py: keeping the wire protocol in our own
+code keeps Kai's release schedule decoupled from a vendor SDK's
+versioning and avoids inheriting transitive dependencies.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import time
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import kai
+from kai.backend import (
+    AgentBackend,
+    AgentResponse,
+    ApiContext,
+    StreamEvent,
+    build_foreign_workspace_reminder,
+    build_session_context,
+    ensure_user_memory,
+    ensure_user_preferences,
+    prepend_to_prompt,
+)
+from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file
+
+log = logging.getLogger(__name__)
+
+
+# Codex is openai-only in v1. Pool.py resolves self.model via
+# PROVIDER_DEFAULTS["openai"] (currently "gpt-5.4") for codex-backed
+# users, so the value is already in OpenAI's native form ("gpt-5.4",
+# "gpt-5.4-mini", "gpt-5.4-nano"). No logical-name remapping is
+# needed at this layer, unlike goose.py which translates "sonnet" /
+# "opus" / "haiku" to claude-sonnet-4-6 etc for the Anthropic case.
+# If a future codex version accepts a Kai-internal alias, add a map
+# here and apply it before setting CODEX_MODEL on the subprocess env.
+
+
+# ── Codex CLI backend ─────────────────────────────────────────────
+
+
+class CodexBackend(AgentBackend):
+    """
+    AgentBackend implementation for OpenAI Codex CLI's JSON-RPC protocol.
+
+    Manages the lifecycle of a persistent `codex app-server` subprocess:
+    starting with a two-step handshake (initialize + session/new),
+    sending prompts via session/prompt, streaming responses from
+    session/update notifications, and killing/restarting on demand.
+
+    All message sends are serialized via an internal asyncio lock to
+    prevent interleaving. Tool auto-approval is handled by codex's own
+    config; this backend does not inject permission decisions.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str = "gpt-5.4",
+        workspace: Path = Path("home"),
+        home_workspace: Path | None = None,
+        webhook_port: int = 8080,
+        webhook_secret: str = "",
+        max_budget_usd: float = 1.0,
+        timeout_seconds: int = 120,
+        services_info: list[dict] | None = None,
+        workspace_config: WorkspaceConfig | None = None,
+        max_context_window: int = 0,
+        provider: str = "openai",
+        # Operator-intent flag for the memory subsystem (Config.
+        # memory_enabled). Drives the [Memory subsystem: ...] marker
+        # emission and gates MEMORY.md inject in build_session_context.
+        # Default False so direct test instantiations need not plumb
+        # the kwarg; production callers (pool.py) always pass an
+        # explicit value. Codex installs run with memory disabled
+        # (the install wizard's guard forces MEMORY_ENABLED=false on
+        # codex), so this flag is effectively always False in v1.
+        memory_enabled: bool = False,
+    ):
+        # ABC-required attributes (pool.py reads/writes these)
+        self.model = model
+        self.workspace = workspace
+        self.home_workspace = home_workspace or workspace
+        self.max_budget_usd = max_budget_usd
+        self.timeout_seconds = timeout_seconds
+        self.workspace_config = workspace_config
+        self.max_context_window = max_context_window
+        self.provider = provider  # ABC-mandated; bot.py reads this
+        self.memory_enabled = memory_enabled
+
+        # API context for session injection (passed to build_session_context)
+        self._api_context = ApiContext(
+            webhook_port=webhook_port,
+            webhook_secret=webhook_secret,
+            services_info=services_info or [],
+        )
+
+        # Global defaults, preserved so we can restore them when
+        # switching away from a configured workspace.
+        self._default_model = model
+        self._default_timeout = timeout_seconds
+
+        # Apply per-workspace overrides (if configured). These become
+        # the "effective" values for this workspace.
+        if workspace_config:
+            if workspace_config.model:
+                self.model = workspace_config.model
+            if workspace_config.timeout is not None:
+                self.timeout_seconds = workspace_config.timeout
+
+        # Subprocess and session state
+        self._proc: asyncio.subprocess.Process | None = None
+        self._session_id: str | None = None
+        self._next_id: int = 1  # Monotonically increasing JSON-RPC request ID
+        self._lock = asyncio.Lock()  # Serializes all message sends
+        self._fresh_session: bool = True  # True until the first message is sent
+        self._stderr_task: asyncio.Task | None = None  # Background stderr drain
+
+    @property
+    def is_alive(self) -> bool:
+        """True if the codex subprocess is running and hasn't exited."""
+        return self._proc is not None and self._proc.returncode is None
+
+    @property
+    def session_id(self) -> str | None:
+        """The current codex session ID, or None if no session is active."""
+        return self._session_id
+
+    # ── Process lifecycle ──────────────────────────────────────────
+
+    async def _ensure_started(self) -> None:
+        """
+        Start the codex app-server subprocess if not already running.
+
+        Launches `codex app-server` and runs the two-step JSON-RPC
+        handshake:
+        1. initialize - establishes protocol version and capabilities
+        2. session/new - creates a session with cwd
+
+        The process persists across prompts. Model selection happens
+        via the CODEX_MODEL environment variable (a passthrough of
+        self.model; no logical-alias mapping needed at this layer).
+        """
+        if self.is_alive:
+            return
+
+        # Build the subprocess environment. Merge order:
+        # 1. Base environment (inherited from parent process)
+        # 2. CODEX_MODEL (mirrors self.model)
+        # 3. CODEX_PROVIDER (forward-compat placeholder; "openai" today)
+        # 4. Per-workspace env_file values
+        # 5. Per-workspace inline env values (override env_file)
+        # 6. Webhook secret (LAST - workspace env can't override it)
+        env = os.environ.copy()
+        if self.model:
+            env["CODEX_MODEL"] = self.model
+        if self.provider:
+            env["CODEX_PROVIDER"] = self.provider
+        if self.workspace_config:
+            if self.workspace_config.env_file:
+                env.update(parse_env_file(self.workspace_config.env_file))
+            if self.workspace_config.env:
+                env.update(self.workspace_config.env)
+        if self._api_context.webhook_secret:
+            env["KAI_WEBHOOK_SECRET"] = self._api_context.webhook_secret
+
+        log.info(
+            "Starting persistent Codex app-server process (model=%s, provider=%s)",
+            self.model,
+            self.provider,
+        )
+
+        self._proc = await asyncio.create_subprocess_exec(
+            "codex",
+            "app-server",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(self.workspace),
+            env=env,
+            limit=1024 * 1024,  # 1MB per-line buffer
+        )
+        self._stderr_task = asyncio.create_task(self._drain_stderr())
+
+        # Step 1: initialize - establish protocol version
+        self._next_id = 1
+        await self._write_rpc(
+            "initialize",
+            {
+                "protocolVersion": "v1",
+                "clientInfo": {"name": "kai", "version": kai.__version__},
+            },
+        )
+        await self._read_result(expected_id=1)
+
+        # Step 2: session/new - create a session with workspace cwd.
+        # Field shape mirrors the goose ACP convention; if the pinned
+        # codex version's actual schema differs, the smoke test will
+        # surface the error and this call needs adjustment.
+        await self._write_rpc(
+            "session/new",
+            {
+                "cwd": str(self.workspace),
+            },
+        )
+        result = await self._read_result(expected_id=2)
+        self._session_id = result.get("sessionId") or result.get("session_id")
+        self._fresh_session = True
+
+    async def _drain_stderr(self) -> None:
+        """
+        Continuously read and discard stderr from the codex process.
+
+        Without this, the stderr pipe buffer fills up and the process
+        deadlocks. Lines are logged at DEBUG level for diagnostics.
+        """
+        while self._proc and self._proc.stderr:
+            try:
+                line = await self._proc.stderr.readline()
+                if not line:
+                    break
+                text = line.decode().strip()
+                if text:
+                    log.debug("Codex stderr: %s", text[:200])
+            except Exception:
+                log.warning("Unexpected error in Codex stderr drain", exc_info=True)
+                break
+
+    # ── JSON-RPC helpers ───────────────────────────────────────────
+
+    async def _write_rpc(self, method: str, params: dict) -> None:
+        """
+        Write a JSON-RPC 2.0 request to the subprocess stdin.
+
+        Increments the monotonic request ID, serializes the message
+        with a trailing newline, and flushes. Raises RuntimeError if
+        the process or its stdin pipe is gone.
+        """
+        assert self._proc is not None and self._proc.stdin is not None
+        request_id = self._next_id
+        self._next_id += 1
+        msg = (
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "method": method,
+                    "id": request_id,
+                    "params": params,
+                }
+            )
+            + "\n"
+        )
+        self._proc.stdin.write(msg.encode())
+        await self._proc.stdin.drain()
+
+    async def _read_result(self, expected_id: int) -> dict:
+        """
+        Read stdout lines until a JSON-RPC result with the expected id appears.
+
+        Discards session/update notifications that codex may emit
+        during startup. Raises on JSON-RPC error responses or timeout.
+        """
+        assert self._proc is not None and self._proc.stdout is not None
+        while True:
+            try:
+                line = await asyncio.wait_for(
+                    self._proc.stdout.readline(),
+                    timeout=self.timeout_seconds,
+                )
+            except TimeoutError as exc:
+                raise TimeoutError(f"Codex handshake timed out waiting for response id={expected_id}") from exc
+
+            if not line:
+                raise RuntimeError("Codex process exited during handshake")
+
+            try:
+                msg = json.loads(line.decode())
+            except json.JSONDecodeError:
+                # Non-JSON output during startup (e.g., progress bars)
+                continue
+
+            # Check for matching response
+            if msg.get("id") == expected_id:
+                if "error" in msg:
+                    err = msg["error"]
+                    raise RuntimeError(f"Codex error (id={expected_id}): {err.get('message', 'unknown error')}")
+                return msg.get("result", {})
+
+            # Discard notifications during handshake
+
+    # ── Sending prompts ────────────────────────────────────────────
+
+    async def send(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
+        """
+        Send a message to codex and yield streaming events.
+
+        Serialized via an internal lock so concurrent callers queue
+        rather than interleave. Context injection (identity, memory,
+        history, API docs) is prepended on the first message of each
+        session, identical to ClaudeCodeBackend and GooseBackend.
+
+        Args:
+            prompt: Either a text string or a list of content blocks.
+            chat_id: Optional Telegram chat ID for history scoping
+                and API routing.
+
+        Yields:
+            StreamEvent objects with accumulated text. The final event
+            has done=True and includes the complete AgentResponse.
+        """
+        async with self._lock:
+            async for event in self._send_locked(prompt, chat_id):
+                yield event
+
+    async def _send_locked(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
+        """
+        Core send logic (must be called while holding self._lock).
+
+        Handles context injection, prompt coercion to the JSON-RPC
+        content-block format, session/prompt dispatch, and streaming
+        response accumulation from session/update notifications.
+        """
+        try:
+            await self._ensure_started()
+        except (OSError, RuntimeError, TimeoutError) as exc:
+            yield StreamEvent(
+                text_so_far="",
+                done=True,
+                response=AgentResponse(success=False, text="", error=f"Codex startup failed: {exc}"),
+            )
+            return
+
+        # Inject identity, memory, history, and API context on the
+        # first message of a new session. Context injection logic
+        # lives in backend.py as shared functions.
+        if self._fresh_session:
+            self._fresh_session = False
+            # Mirror the ClaudeCodeBackend / GooseBackend send() path:
+            # ensure the per-user MEMORY.md and PREFERENCES.md surfaces
+            # exist before building the session context. The codex
+            # backend ships with memory_enabled=False by default, so
+            # the MEMORY.md path is created but the subsystem marker
+            # in the injected context is "disabled" until backend-
+            # agnostic semantic memory lands.
+            ensure_user_memory(chat_id, DATA_DIR)
+            ensure_user_preferences(chat_id, DATA_DIR)
+            session_ctx = build_session_context(
+                workspace=self.workspace,
+                home_workspace=self.home_workspace,
+                api=self._api_context,
+                workspace_config=self.workspace_config,
+                chat_id=chat_id,
+                data_dir=DATA_DIR,
+                memory_enabled=self.memory_enabled,
+            )
+            prompt = prepend_to_prompt(prompt, session_ctx)
+
+        # When in a foreign workspace, remind on every message to only
+        # respond to what the user asks.
+        reminder = build_foreign_workspace_reminder(self.workspace, self.home_workspace)
+        if reminder:
+            prompt = prepend_to_prompt(prompt, reminder)
+
+        # Coerce prompt to the JSON-RPC content-block format.
+        # The codex CLI accepts text content blocks; image / audio
+        # support is deferred until the smoke test confirms which
+        # block types the pinned version handles.
+        rpc_prompt: list[dict] = []
+        if isinstance(prompt, str):
+            rpc_prompt = [{"type": "text", "text": prompt}]
+        else:
+            for block in prompt:
+                if block.get("type") == "text":
+                    rpc_prompt.append({"type": "text", "text": block["text"]})
+                else:
+                    log.warning(
+                        "CodexBackend: dropping non-text content block type=%s",
+                        block.get("type"),
+                    )
+            if not rpc_prompt:
+                rpc_prompt = [{"type": "text", "text": "(empty prompt)"}]
+
+        # Send the session/prompt request
+        assert self._proc is not None
+        assert self._proc.stdin is not None
+        assert self._proc.stdout is not None
+
+        try:
+            prompt_id = self._next_id
+            await self._write_rpc(
+                "session/prompt",
+                {
+                    "sessionId": self._session_id,
+                    "prompt": rpc_prompt,
+                },
+            )
+        except OSError as e:
+            log.error("Failed to write to Codex process: %s", e)
+            await self._kill()
+            yield StreamEvent(
+                text_so_far="",
+                done=True,
+                response=AgentResponse(
+                    success=False,
+                    text="",
+                    error="Codex process died, restarting on next message",
+                ),
+            )
+            return
+
+        # Stream response: read stdout lines, accumulate text chunks,
+        # and yield StreamEvents. Unknown event types are logged at
+        # DEBUG and skipped (schema-drift defense). The smoke test
+        # against a real codex binary will reveal which event names
+        # the pinned version actually emits; this loop tolerates
+        # variation by only acting on events it recognizes.
+        accumulated = ""
+        last_activity = time.monotonic()
+        max_idle_seconds = self.timeout_seconds * 5
+
+        try:
+            while True:
+                # Check idle timeout before each readline
+                idle = time.monotonic() - last_activity
+                if idle > max_idle_seconds:
+                    log.error(
+                        "Codex idle timeout (%.0fs with no output, limit %ds)",
+                        idle,
+                        max_idle_seconds,
+                    )
+                    await self._kill()
+                    yield StreamEvent(
+                        text_so_far=accumulated,
+                        done=True,
+                        response=AgentResponse(
+                            success=False,
+                            text=accumulated,
+                            error="Codex interaction timed out (no output)",
+                        ),
+                    )
+                    return
+
+                try:
+                    line = await asyncio.wait_for(
+                        self._proc.stdout.readline(),
+                        timeout=self.timeout_seconds * 3,
+                    )
+                except TimeoutError:
+                    log.error("Codex response timed out")
+                    await self._kill()
+                    yield StreamEvent(
+                        text_so_far=accumulated,
+                        done=True,
+                        response=AgentResponse(
+                            success=False,
+                            text=accumulated,
+                            error="Codex timed out",
+                        ),
+                    )
+                    return
+
+                # Reset idle timer on non-empty output
+                if line:
+                    last_activity = time.monotonic()
+                else:
+                    # EOF - process died
+                    log.error("Codex process EOF")
+                    await self._kill()
+                    yield StreamEvent(
+                        text_so_far=accumulated,
+                        done=True,
+                        response=AgentResponse(
+                            success=bool(accumulated),
+                            text=accumulated,
+                            error=None if accumulated else "Codex process ended unexpectedly",
+                        ),
+                    )
+                    return
+
+                try:
+                    msg = json.loads(line.decode())
+                except json.JSONDecodeError:
+                    log.debug("Skipping non-JSON line: %s", line[:200])
+                    continue
+
+                # Streaming notifications (no id field) - accumulate
+                # message chunks; log everything else at DEBUG and
+                # skip. The agent_message_chunk envelope mirrors goose
+                # ACP; the smoke test confirms or corrects this name.
+                if msg.get("method") == "session/update":
+                    update = msg.get("params", {}).get("update", {})
+                    event_type = update.get("sessionUpdate") or update.get("event") or update.get("type")
+                    if event_type == "agent_message_chunk":
+                        text = update.get("content", {}).get("text", "")
+                        if text:
+                            accumulated += text
+                            yield StreamEvent(text_so_far=accumulated)
+                    else:
+                        # Unknown event - log and skip. Schema-drift
+                        # defense: a future codex version emitting a
+                        # new event type (e.g. tool_call_update) does
+                        # not break the conversational stream.
+                        log.debug("Codex: skipping session/update event=%s", event_type)
+
+                # Final result for our prompt (has matching id)
+                elif msg.get("id") == prompt_id and "result" in msg:
+                    response = AgentResponse(
+                        success=True,
+                        text=accumulated,
+                        session_id=self._session_id,
+                        cost_usd=0.0,  # subscription auth; codex reports no per-call cost
+                        duration_ms=0,
+                    )
+                    yield StreamEvent(
+                        text_so_far=accumulated,
+                        done=True,
+                        response=response,
+                    )
+                    return
+
+                # JSON-RPC error for our prompt
+                elif msg.get("id") == prompt_id and "error" in msg:
+                    err = msg["error"].get("message", "unknown codex error")
+                    yield StreamEvent(
+                        text_so_far=accumulated,
+                        done=True,
+                        response=AgentResponse(
+                            success=False,
+                            text=accumulated,
+                            error=err,
+                        ),
+                    )
+                    return
+
+                else:
+                    # Unknown top-level message shape. Schema-drift
+                    # defense: log and skip rather than abort.
+                    log.debug("Codex: skipping unrecognized message id=%s method=%s", msg.get("id"), msg.get("method"))
+
+        except Exception as e:
+            log.exception("Unexpected error reading Codex stream")
+            await self._kill()
+            yield StreamEvent(
+                text_so_far=accumulated,
+                done=True,
+                response=AgentResponse(
+                    success=False,
+                    text=accumulated,
+                    error=str(e),
+                ),
+            )
+
+    # ── Kill / restart / shutdown ──────────────────────────────────
+
+    def force_kill(self) -> None:
+        """
+        Kill the subprocess immediately via SIGKILL.
+
+        Safe to call without holding the lock. Called by /stop to abort
+        an in-flight response. Does NOT null _proc - full cleanup
+        happens in _kill() when the read loop detects EOF.
+        """
+        if self._proc is not None:
+            try:
+                self._proc.kill()
+            except OSError:
+                pass
+        if self._stderr_task:
+            self._stderr_task.cancel()
+            self._stderr_task = None
+
+    async def _kill(self) -> None:
+        """
+        Kill the subprocess and clean up all process state.
+
+        Sends SIGKILL, waits up to 5 seconds for exit, then nulls
+        all process references. Idempotent.
+        """
+        if self._proc:
+            self.force_kill()
+            try:
+                await asyncio.wait_for(self._proc.wait(), timeout=5)
+            except TimeoutError:
+                pass
+            self._proc = None
+            self._session_id = None
+
+    async def restart(self) -> None:
+        """
+        Kill the current process so the next send() starts fresh.
+
+        Called by /new command and model switches. The next send()
+        calls _ensure_started() which re-runs the full handshake
+        with a new session.
+        """
+        await self._kill()
+        self._fresh_session = True
+
+    async def change_workspace(
+        self,
+        new_workspace: Path,
+        workspace_config: WorkspaceConfig | None = None,
+    ) -> None:
+        """
+        Switch to a new workspace directory and apply its config.
+
+        Kills the current subprocess. The next send() restarts codex
+        in the new directory with the new config applied.
+        """
+        await self._kill()
+        self.workspace = new_workspace
+        self.workspace_config = workspace_config
+
+        # Revert to global defaults, then apply overrides. Prevents
+        # stale values when switching from a fully-configured workspace
+        # to a partially-configured one.
+        self.model = self._default_model
+        self.timeout_seconds = self._default_timeout
+        if workspace_config:
+            if workspace_config.model:
+                self.model = workspace_config.model
+            if workspace_config.timeout is not None:
+                self.timeout_seconds = workspace_config.timeout
+        # _fresh_session is set True by _ensure_started() on next send()
+
+    async def shutdown(self) -> None:
+        """
+        Graceful shutdown. No save prompt - codex CLI has no equivalent.
+
+        Sends SIGTERM first and waits up to 5 seconds for clean exit.
+        Falls back to SIGKILL if the process doesn't terminate in time.
+        """
+        if self._proc:
+            try:
+                self._proc.terminate()
+            except OSError:
+                # Process already exited between the _proc check and
+                # terminate(). Fall through to cleanup below.
+                pass
+            else:
+                try:
+                    await asyncio.wait_for(self._proc.wait(), timeout=5)
+                except TimeoutError:
+                    self.force_kill()
+                    try:
+                        await asyncio.wait_for(self._proc.wait(), timeout=5)
+                    except TimeoutError:
+                        log.warning("CodexBackend: process did not exit after SIGKILL")
+        if self._stderr_task:
+            self._stderr_task.cancel()
+            self._stderr_task = None
+        self._proc = None
+        self._session_id = None

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -233,7 +233,20 @@ class CodexBackend(AgentBackend):
             },
         )
         result = await self._read_result(expected_id=2)
-        self._session_id = result.get("sessionId") or result.get("session_id")
+        # Accept either camelCase or snake_case to tolerate codex CLI
+        # schema variants observed across versions. Both absent is a
+        # loud failure: a None session_id would otherwise flow into
+        # the next session/prompt as "sessionId": None and surface as
+        # a confusing downstream prompt error rather than a clear
+        # handshake mismatch. Fail at the boundary instead.
+        session_id = result.get("sessionId") or result.get("session_id")
+        if not session_id:
+            raise RuntimeError(
+                "Codex session/new returned no session id "
+                "(expected 'sessionId' or 'session_id' in result); "
+                "pinned codex CLI schema may differ from this build."
+            )
+        self._session_id = session_id
         self._fresh_session = True
 
     async def _drain_stderr(self) -> None:

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -41,8 +41,9 @@ PROJECT_ROOT = Path(os.environ.get("KAI_INSTALL_DIR") or str(_FILE_ROOT))
 DATA_DIR = Path(os.environ.get("KAI_DATA_DIR") or str(PROJECT_ROOT))
 
 # Valid agent backend choices. "claude" uses Claude Code CLI,
-# "goose" uses Goose ACP. Shared between load_config() and install.py.
-VALID_BACKENDS = {"claude", "goose"}
+# "goose" uses Goose ACP, "codex" uses OpenAI Codex CLI's app-server
+# JSON-RPC protocol. Shared between load_config() and install.py.
+VALID_BACKENDS = {"claude", "goose", "codex"}
 
 # Valid LLM providers per backend. Claude always uses Anthropic
 # (hardcoded in get_effective_provider), so it has no entry here.
@@ -506,6 +507,13 @@ class Config:
     # _VALID_EFFORT_LEVELS so a typo fails fast rather than at the
     # subprocess startup of the next chat session.
     claude_effort_level: str = "high"
+
+    # Codex backend auth mode. "subscription" (default): the codex CLI
+    # uses ~/.codex/auth.json populated by an interactive `codex login`.
+    # "api_key": codex reads OPENAI_API_KEY from the environment, the
+    # same way goose+openai does. Only consulted when AGENT_BACKEND=codex;
+    # ignored on every other backend.
+    codex_auth_mode: str = "subscription"
 
     # Database - uses DATA_DIR so the db lands in the writable data directory
     session_db_path: Path = field(default_factory=lambda: DATA_DIR / "kai.db")
@@ -1620,6 +1628,12 @@ def load_config() -> Config:
     # way to fail. SystemExit on bad input mirrors how the surrounding
     # CLAUDE_* parsing blocks signal config-load failure, keeping the
     # operator-visible behavior consistent across the cluster.
+    # Codex auth mode validation: "subscription" (default) or "api_key".
+    # An unknown value is a typo in /etc/kai/env; fail fast at startup.
+    codex_auth_mode = os.environ.get("CODEX_AUTH_MODE", "subscription").strip().lower() or "subscription"
+    if codex_auth_mode not in ("subscription", "api_key"):
+        raise SystemExit(f"CODEX_AUTH_MODE must be 'subscription' or 'api_key', got {codex_auth_mode!r}")
+
     claude_effort_level = os.environ.get("CLAUDE_EFFORT_LEVEL", "high").strip().lower() or "high"
     if claude_effort_level not in _VALID_EFFORT_LEVELS:
         # Use the ordered tuple, not sorted(_VALID_EFFORT_LEVELS) - the
@@ -1958,6 +1972,7 @@ def load_config() -> Config:
         claude_max_context_window=claude_max_context_window,
         claude_autocompact_pct=claude_autocompact_pct,
         claude_effort_level=claude_effort_level,
+        codex_auth_mode=codex_auth_mode,
         webhook_port=webhook_port,
         webhook_secret=os.environ.get("WEBHOOK_SECRET", ""),
         voice_enabled=os.environ.get("VOICE_ENABLED", "").lower() in ("1", "true", "yes"),

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -895,6 +895,14 @@ def _cmd_config() -> None:
         print("  Semantic memory currently requires the claude backend.")
         print("  Disabling semantic memory for this codex install.")
         memory_enabled = False
+        # Zero memory_extraction_enabled explicitly here too. The
+        # unconditional `memory_extraction_enabled = False` a few lines
+        # down also covers this case, but a future refactor that moves
+        # or reorders the extraction prompt could silently reintroduce
+        # the exact bug the spec hardened against over multiple review
+        # rounds. The explicit assignment makes the guard refactor-safe
+        # and matches the comment's "force both flags off" claim.
+        memory_extraction_enabled = False
     # Defaults match the dataclass values in config.py. Only non-defaults
     # (or memory_enabled=true itself) are written to the env dict below.
     memory_extraction_enabled = False

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -497,8 +497,33 @@ def _cmd_config() -> None:
         existing_env.get("AGENT_BACKEND", "claude"),
     )
 
+    # Codex auth handling runs BEFORE the legacy provider/key block so
+    # subscription mode is not gated on an OPENAI_API_KEY the operator
+    # does not need. VALID_PROVIDERS["codex"] is intentionally unset
+    # (codex is openai-only and has its own auth model), so the
+    # legacy block below skips codex entirely - same path claude
+    # follows today.
+    codex_auth_mode = ""
+    codex_api_key = ""
+    if agent_backend == "codex":
+        codex_auth_mode = _prompt_choice(
+            "Codex auth mode",
+            ["subscription", "api_key"],
+            existing_env.get("CODEX_AUTH_MODE", "subscription"),
+        )
+        if codex_auth_mode == "subscription":
+            print("  After install, run 'codex login' as the service user.")
+        else:
+            codex_api_key = _prompt(
+                "OPENAI_API_KEY",
+                existing_env.get("OPENAI_API_KEY", ""),
+                required=True,
+            )
+
     # Non-Claude backends: provider and API key. The provider choice
     # determines which env var to prompt for (or none for ollama).
+    # Codex is intentionally absent from VALID_PROVIDERS, so this block
+    # only fires for goose; codex is handled in the dedicated branch above.
     llm_provider = ""
     llm_api_key_var = ""
     llm_api_key = ""
@@ -849,6 +874,27 @@ def _cmd_config() -> None:
         "Enable semantic memory (Mem0 + Qdrant)",
         existing_env.get("MEMORY_ENABLED", "false").lower() in ("1", "true", "yes"),
     )
+    # Codex backend cannot use semantic memory in v1 - the Haiku
+    # extraction pipeline shells out to `claude --print` and lives in
+    # the claude vertical. bot.py's effective_backend == "claude" gate
+    # already prevents extraction from running on a codex install, but
+    # the wizard zeroes both flags here as defense in depth: a
+    # MEMORY_ENABLED=true env var on a codex install would still
+    # inject the [Memory subsystem: enabled] marker into the inner
+    # codex agent's session context (build_session_context reads
+    # memory_enabled, not effective_backend) and trigger inner-agent
+    # behavior that has nowhere to land. Force both flags off so the
+    # codex agent never advertises a memory subsystem that cannot
+    # service its requests.
+    memory_extraction_enabled_pre_guard = existing_env.get("MEMORY_EXTRACTION_ENABLED", "false").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    if agent_backend == "codex" and (memory_enabled or memory_extraction_enabled_pre_guard):
+        print("  Semantic memory currently requires the claude backend.")
+        print("  Disabling semantic memory for this codex install.")
+        memory_enabled = False
     # Defaults match the dataclass values in config.py. Only non-defaults
     # (or memory_enabled=true itself) are written to the env dict below.
     memory_extraction_enabled = False
@@ -1087,6 +1133,17 @@ def _cmd_config() -> None:
         env["LLM_PROVIDER"] = llm_provider
     if llm_api_key_var and llm_api_key:
         env[llm_api_key_var] = llm_api_key
+
+    # Codex auth mode + optional api_key. Only written on codex
+    # installs; the load_config default ("subscription") fires
+    # otherwise. OPENAI_API_KEY is emitted only in api_key mode and
+    # only if the operator supplied one, mirroring the
+    # llm_api_key_var emission above for goose.
+    if agent_backend == "codex":
+        if codex_auth_mode and codex_auth_mode != "subscription":
+            env["CODEX_AUTH_MODE"] = codex_auth_mode
+        if codex_api_key:
+            env["OPENAI_API_KEY"] = codex_api_key
 
     # Remove stale renamed keys if present - leaving both the old and
     # new key causes silent confusion (the deprecation warning is
@@ -2942,6 +2999,16 @@ def _cmd_apply() -> None:
                 "\nYou can safely delete it now that secrets are in /etc/kai/env."
                 "\nTo reconfigure later, re-run: python -m kai install config"
             )
+
+        # Codex subscription auth requires an interactive `codex login`
+        # run AS the service user (so the token lands in the service
+        # user's ~/.codex/auth.json, not the operator's). Surface this
+        # explicitly so the operator does not start the service and
+        # then chase silent auth failures on the first message.
+        if env.get("AGENT_BACKEND") == "codex" and env.get("CODEX_AUTH_MODE", "subscription") == "subscription":
+            print("\nCodex subscription auth required:")
+            print(f"  sudo -u {service_user} codex login")
+            print("Run this before the service starts handling messages.")
 
 
 def _apply_directories(

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -180,8 +180,9 @@ class SubprocessPool:
         # clarity of two separate resolution calls is worth it.
         home_ws = resolve_home_workspace(chat_id, self._config)
 
-        # Backend selection: "goose" uses Goose ACP, anything else
-        # (including the default "claude") uses Claude Code CLI.
+        # Backend selection: "goose" uses Goose ACP, "codex" uses
+        # OpenAI Codex CLI's app-server JSON-RPC protocol, anything
+        # else (including the default "claude") uses Claude Code CLI.
         if backend == "goose":
             return GooseBackend(
                 model=model,
@@ -198,8 +199,30 @@ class SubprocessPool:
                 memory_enabled=self._config.memory_enabled,
             )
 
+        if backend == "codex":
+            # Import locally so codex.py is only imported on a
+            # codex-active install. Mirrors the goose pattern above
+            # (imported at module top) but keeps the import optional
+            # for installs where codex CLI is not available.
+            from kai.codex import CodexBackend
+
+            return CodexBackend(
+                model=model,
+                workspace=workspace,
+                home_workspace=home_ws,
+                webhook_port=self._config.webhook_port,
+                webhook_secret=self._config.webhook_secret,
+                max_budget_usd=budget,
+                timeout_seconds=timeout,
+                services_info=self._services_info,
+                workspace_config=ws_config,
+                max_context_window=context_window,
+                provider="openai",
+                memory_enabled=self._config.memory_enabled,
+            )
+
         # os_user for sudo -u isolation. None = run as bot user.
-        # Only relevant for ClaudeCodeBackend (Goose doesn't use sudo).
+        # Only relevant for ClaudeCodeBackend (Goose / Codex don't use sudo).
         os_user = user.os_user if user else self._config.claude_user
 
         return ClaudeCodeBackend(

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1,0 +1,973 @@
+"""
+Tests for codex.py OpenAI Codex CLI subprocess backend.
+
+Covers:
+1. Constructor and ABC signature compliance (force_kill sync, send/_send_locked
+   accept chat_id, change_workspace accepts workspace_config).
+2. Startup handshake sequence (initialize + session/new) including env var
+   injection (CODEX_MODEL, CODEX_PROVIDER) and the no-API-key path under
+   subscription auth.
+3. Stream parsing: agent_message_chunk accumulation, unknown event types
+   skipped (schema-drift defense), non-JSON lines tolerated.
+4. Completion result yields done StreamEvent with AgentResponse.
+5. EOF, timeout, and JSON-RPC error response handling.
+6. restart() triggers new handshake on next send; force_kill is synchronous;
+   change_workspace honors workspace_config overrides; shutdown sends SIGTERM
+   then SIGKILL with timeout.
+7. Send serialization via the internal lock (concurrent sends queue).
+8. Prompt coercion: string -> single text block, list-of-blocks dropping
+   non-text content.
+"""
+
+import asyncio
+import inspect
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kai.backend import StreamEvent
+from kai.codex import CodexBackend
+from kai.config import WorkspaceConfig
+
+# ── Shared helpers ──────────────────────────────────────────────────
+
+
+def _make_codex(**kwargs) -> CodexBackend:
+    """Create a CodexBackend with sensible defaults for testing."""
+    defaults = {
+        "model": "gpt-5.4",
+        "workspace": Path("/tmp/test-workspace"),
+        "timeout_seconds": 30,
+    }
+    defaults.update(kwargs)
+    return CodexBackend(**defaults)
+
+
+def _json_line(obj: dict) -> bytes:
+    """Encode a dict as a JSON line (bytes with trailing newline)."""
+    return json.dumps(obj).encode() + b"\n"
+
+
+def _initialize_result() -> bytes:
+    """Build the server's response to an initialize request."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "protocolVersion": "v1",
+                "agentCapabilities": {},
+            },
+        }
+    )
+
+
+def _session_new_result(session_id: str = "codex-session-1") -> bytes:
+    """Build the server's response to a session/new request."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {"sessionId": session_id},
+        }
+    )
+
+
+def _agent_message_chunk(text: str, session_id: str = "codex-session-1") -> bytes:
+    """
+    Build a session/update notification carrying an agent_message_chunk.
+
+    Schema mirrors goose ACP. The pinned codex CLI version's actual
+    event names may differ; the schema-drift defense in the parser
+    treats unknown event types as skip-and-log, not as errors.
+    """
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": session_id,
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": text},
+                },
+            },
+        }
+    )
+
+
+def _unknown_event(event_name: str, session_id: str = "codex-session-1") -> bytes:
+    """Build a session/update with a deliberately unrecognized event type."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": session_id,
+                "update": {
+                    "sessionUpdate": event_name,
+                    "content": {"type": "text", "text": "should be ignored"},
+                },
+            },
+        }
+    )
+
+
+def _completion_result(prompt_id: int = 3) -> bytes:
+    """Build a completion result for the given prompt id."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "id": prompt_id,
+            "result": {"stopReason": "end_turn"},
+        }
+    )
+
+
+def _error_result(prompt_id: int = 3, message: str = "something broke") -> bytes:
+    """Build a JSON-RPC error response for the given prompt id."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "id": prompt_id,
+            "error": {"code": -32000, "message": message},
+        }
+    )
+
+
+def _make_mock_proc(stdout_lines: list[bytes]) -> MagicMock:
+    """Build a mock subprocess that yields predefined stdout lines."""
+    proc = MagicMock()
+    proc.returncode = None
+    proc.pid = 12345
+    proc.stdin = MagicMock()
+    proc.stdin.write = MagicMock()
+    proc.stdin.drain = AsyncMock()
+    proc.stdout = MagicMock()
+    proc.stdout.readline = AsyncMock(side_effect=stdout_lines)
+    proc.stderr = MagicMock()
+    proc.stderr.readline = AsyncMock(return_value=b"")
+    proc.wait = AsyncMock()
+    proc.kill = MagicMock()
+    proc.terminate = MagicMock()
+    return proc
+
+
+def _handshake_lines(session_id: str = "codex-session-1") -> list[bytes]:
+    """Return the two stdout lines for a successful handshake."""
+    return [_initialize_result(), _session_new_result(session_id)]
+
+
+async def _collect_events(c: CodexBackend, prompt: str | list = "test") -> list[StreamEvent]:
+    """Send a prompt and collect all yielded StreamEvents."""
+    events = []
+    async for event in c._send_locked(prompt):
+        events.append(event)
+    return events
+
+
+# ── ABC signature compliance ────────────────────────────────────────
+
+
+class TestAbcSignatures:
+    """
+    Lock the AgentBackend ABC compliance for CodexBackend.
+
+    pool.py calls instance.force_kill() with no await, instance.send(prompt,
+    chat_id=chat_id), and instance.change_workspace(new_workspace,
+    workspace_config=ws_config). A signature drift on any of these
+    surfaces a TypeError at runtime; these tests catch the drift at
+    import time instead.
+    """
+
+    def test_force_kill_is_sync(self):
+        """force_kill must NOT be async; pool.py calls it without await."""
+        assert not inspect.iscoroutinefunction(CodexBackend.force_kill)
+
+    def test_send_accepts_chat_id(self):
+        """send signature must accept chat_id (pool.py passes it by name)."""
+        sig = inspect.signature(CodexBackend.send)
+        assert "chat_id" in sig.parameters
+
+    def test_send_locked_accepts_chat_id(self):
+        """_send_locked must accept chat_id; it powers per-user context injection."""
+        sig = inspect.signature(CodexBackend._send_locked)
+        assert "chat_id" in sig.parameters
+
+    def test_change_workspace_accepts_workspace_config(self):
+        """change_workspace signature must accept workspace_config (pool.py passes it)."""
+        sig = inspect.signature(CodexBackend.change_workspace)
+        assert "workspace_config" in sig.parameters
+
+
+# ── Constructor ─────────────────────────────────────────────────────
+
+
+class TestConstructor:
+    """Verify CodexBackend initializes attributes correctly."""
+
+    def test_defaults(self):
+        """Constructor sets ABC-required attributes from kwargs."""
+        c = _make_codex()
+        assert c.model == "gpt-5.4"
+        assert c.workspace == Path("/tmp/test-workspace")
+        assert c.timeout_seconds == 30
+        assert c.provider == "openai"
+        assert c._proc is None
+        assert c._session_id is None
+        assert c._fresh_session is True
+
+    def test_workspace_config_overrides(self):
+        """Per-workspace config overrides model and timeout."""
+        ws = WorkspaceConfig(path=Path("/tmp/ws"), model="gpt-5.4-mini", timeout=60)
+        c = _make_codex(workspace_config=ws)
+        assert c.model == "gpt-5.4-mini"
+        assert c.timeout_seconds == 60
+        # Defaults preserved for restore on workspace switch
+        assert c._default_model == "gpt-5.4"
+        assert c._default_timeout == 30
+
+    def test_home_workspace_defaults_to_workspace(self):
+        """home_workspace falls back to workspace when not provided."""
+        c = _make_codex(workspace=Path("/some/path"))
+        assert c.home_workspace == Path("/some/path")
+
+    def test_memory_enabled_default_false(self):
+        """Codex installs disable memory; the default reflects that."""
+        c = _make_codex()
+        assert c.memory_enabled is False
+
+
+# ── Properties ──────────────────────────────────────────────────────
+
+
+class TestProperties:
+    """Verify is_alive and session_id properties."""
+
+    def test_is_alive_no_proc(self):
+        """is_alive returns False when no subprocess exists."""
+        c = _make_codex()
+        assert c.is_alive is False
+
+    def test_is_alive_running(self):
+        """is_alive returns True when subprocess has no returncode."""
+        c = _make_codex()
+        c._proc = MagicMock()
+        c._proc.returncode = None
+        assert c.is_alive is True
+
+    def test_is_alive_exited(self):
+        """is_alive returns False when subprocess has exited."""
+        c = _make_codex()
+        c._proc = MagicMock()
+        c._proc.returncode = 0
+        assert c.is_alive is False
+
+    def test_session_id_none(self):
+        """session_id is None before handshake."""
+        c = _make_codex()
+        assert c.session_id is None
+
+
+# ── Handshake ──────────────────────────────────────────────────────
+
+
+class TestHandshake:
+    """Verify _ensure_started() runs the initialize + session/new handshake."""
+
+    @pytest.mark.asyncio
+    async def test_successful_handshake(self):
+        """Handshake sets _session_id from session/new result."""
+        c = _make_codex()
+        proc = _make_mock_proc(_handshake_lines("test-codex-42"))
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            await c._ensure_started()
+
+        assert c._session_id == "test-codex-42"
+        assert c._fresh_session is True
+        assert c.is_alive is True
+
+        # Verify the two handshake messages were written
+        writes = proc.stdin.write.call_args_list
+        assert len(writes) == 2
+
+        init_msg = json.loads(writes[0][0][0].decode())
+        assert init_msg["method"] == "initialize"
+        assert init_msg["id"] == 1
+        assert init_msg["params"]["clientInfo"]["name"] == "kai"
+
+        session_msg = json.loads(writes[1][0][0].decode())
+        assert session_msg["method"] == "session/new"
+        assert session_msg["id"] == 2
+        assert session_msg["params"]["cwd"] == "/tmp/test-workspace"
+
+    @pytest.mark.asyncio
+    async def test_argv_invokes_codex_app_server(self):
+        """
+        The subprocess argv must begin with ("codex", "app-server"), not
+        any other binary. Locks the "no overlap" guarantee at the
+        subprocess boundary: the codex vertical never spawns claude.
+        """
+        c = _make_codex()
+        proc = _make_mock_proc(_handshake_lines())
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await c._ensure_started()
+
+        argv = mock_exec.call_args[0]
+        assert argv[0] == "codex"
+        assert argv[1] == "app-server"
+
+    @pytest.mark.asyncio
+    async def test_skips_when_alive(self):
+        """_ensure_started() is a no-op when the process is already running."""
+        c = _make_codex()
+        c._proc = MagicMock()
+        c._proc.returncode = None
+
+        await c._ensure_started()
+        # No new process created
+        assert c._proc.returncode is None
+
+    @pytest.mark.asyncio
+    async def test_handshake_error_raises(self):
+        """A JSON-RPC error during handshake raises RuntimeError."""
+        error_line = _json_line(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"code": -32600, "message": "bad request"},
+            }
+        )
+        proc = _make_mock_proc([error_line])
+        c = _make_codex()
+
+        with (
+            patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(RuntimeError, match="bad request"),
+        ):
+            await c._ensure_started()
+
+    @pytest.mark.asyncio
+    async def test_handshake_eof_raises(self):
+        """EOF during handshake raises RuntimeError."""
+        proc = _make_mock_proc([b""])  # Immediate EOF
+        c = _make_codex()
+
+        with (
+            patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(RuntimeError, match="exited during handshake"),
+        ):
+            await c._ensure_started()
+
+    @pytest.mark.asyncio
+    async def test_model_env_var_set(self):
+        """CODEX_MODEL env var is set during startup."""
+        c = _make_codex(model="gpt-5.4-mini")
+        proc = _make_mock_proc(_handshake_lines())
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await c._ensure_started()
+
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["env"]["CODEX_MODEL"] == "gpt-5.4-mini"
+
+    @pytest.mark.asyncio
+    async def test_provider_env_var_set(self):
+        """
+        CODEX_PROVIDER env var is set during startup.
+
+        Forward-compat placeholder: codex is openai-only today, but the
+        envelope follows goose's GOOSE_PROVIDER pattern so a future
+        codex with multi-provider support can pick the right backend
+        without a backend re-wire.
+        """
+        c = _make_codex(provider="openai")
+        proc = _make_mock_proc(_handshake_lines())
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await c._ensure_started()
+
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["env"]["CODEX_PROVIDER"] == "openai"
+
+    @pytest.mark.asyncio
+    async def test_provider_env_var_omitted_when_empty(self):
+        """An empty provider is not exported as CODEX_PROVIDER=''."""
+        c = _make_codex(model="gpt-5.4", provider="")
+        proc = _make_mock_proc(_handshake_lines())
+
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec,
+        ):
+            os.environ.pop("CODEX_PROVIDER", None)
+            await c._ensure_started()
+
+        call_kwargs = mock_exec.call_args[1]
+        assert "CODEX_PROVIDER" not in call_kwargs["env"]
+
+
+# ── Stream parsing ─────────────────────────────────────────────────
+
+
+class TestStreamParsing:
+    """Verify _send_locked() correctly parses streaming responses."""
+
+    @pytest.mark.asyncio
+    async def test_agent_message_chunk_accumulation(self):
+        """agent_message_chunk events accumulate text and yield StreamEvents."""
+        c = _make_codex()
+        c._proc = _make_mock_proc(
+            [
+                _agent_message_chunk("Hello"),
+                _agent_message_chunk(" world"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+
+        assert len(events) == 3
+        assert events[0].text_so_far == "Hello"
+        assert events[1].text_so_far == "Hello world"
+        assert events[2].done is True
+        assert events[2].text_so_far == "Hello world"
+        assert events[2].response is not None
+        assert events[2].response.success is True
+        assert events[2].response.text == "Hello world"
+        assert events[2].response.cost_usd == 0.0
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_type_skipped(self):
+        """
+        Schema-drift defense: an unrecognized sessionUpdate event type
+        is logged at DEBUG and skipped. The stream continues parsing
+        subsequent events instead of aborting.
+        """
+        c = _make_codex()
+        c._proc = _make_mock_proc(
+            [
+                _unknown_event("future.unknown.thing"),
+                _agent_message_chunk("real text"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+
+        # The unknown event produced no StreamEvent; only the real
+        # message and the completion show up.
+        assert len(events) == 2
+        assert events[0].text_so_far == "real text"
+        assert events[1].done is True
+
+    @pytest.mark.asyncio
+    async def test_non_json_lines_skipped(self):
+        """Non-JSON stdout lines are silently skipped (defensive parsing)."""
+        c = _make_codex()
+        c._proc = _make_mock_proc(
+            [
+                b"some random output\n",
+                _agent_message_chunk("hello"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+
+        assert len(events) == 2
+        assert events[0].text_so_far == "hello"
+
+    @pytest.mark.asyncio
+    async def test_alternate_event_field_names_skipped(self):
+        """
+        Codex's actual event name may live under "event" or "type"
+        rather than "sessionUpdate" (the goose ACP key). The parser
+        already accepts any of those three keys; an unrecognized
+        value still skips, but the field-name flexibility is
+        deliberate. This test pins that an event with sessionUpdate
+        missing but event present does NOT crash; it simply skips
+        when the resolved event type is unrecognized.
+        """
+        c = _make_codex()
+        # event under "event" key, unrecognized name -> skip
+        weird_event = _json_line(
+            {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "sessionId": "test-session",
+                    "update": {"event": "weird_thing", "content": {"text": "x"}},
+                },
+            }
+        )
+        c._proc = _make_mock_proc(
+            [
+                weird_event,
+                _agent_message_chunk("real"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+        assert len(events) == 2
+        assert events[0].text_so_far == "real"
+
+
+# ── Completion ─────────────────────────────────────────────────────
+
+
+class TestCompletion:
+    """Verify final result handling."""
+
+    @pytest.mark.asyncio
+    async def test_completion_yields_done_event(self):
+        """A result with matching id yields a done StreamEvent."""
+        c = _make_codex()
+        c._proc = _make_mock_proc(
+            [
+                _agent_message_chunk("answer"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+        final = events[-1]
+
+        assert final.done is True
+        assert final.response is not None
+        assert final.response.success is True
+        assert final.response.text == "answer"
+        assert final.response.session_id == "test-session"
+        assert final.response.cost_usd == 0.0
+
+    @pytest.mark.asyncio
+    async def test_eof_with_accumulated_text(self):
+        """EOF after some text yields a success response with the text."""
+        c = _make_codex()
+        c._proc = _make_mock_proc(
+            [
+                _agent_message_chunk("partial"),
+                b"",  # EOF
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+        final = events[-1]
+
+        assert final.done is True
+        assert final.response.success is True
+        assert final.response.text == "partial"
+
+    @pytest.mark.asyncio
+    async def test_eof_without_text(self):
+        """EOF with no accumulated text yields an error response."""
+        c = _make_codex()
+        c._proc = _make_mock_proc([b""])
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+        final = events[-1]
+
+        assert final.done is True
+        assert final.response.success is False
+        assert "unexpectedly" in final.response.error
+
+
+# ── JSON-RPC error response ────────────────────────────────────────
+
+
+class TestRpcError:
+    """Verify JSON-RPC error responses yield a done event with the error."""
+
+    @pytest.mark.asyncio
+    async def test_error_yields_failed_response(self):
+        """An error with matching id yields done with success=False."""
+        c = _make_codex()
+        c._proc = _make_mock_proc([_error_result(prompt_id=3, message="model not authorized")])
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+        final = events[-1]
+
+        assert final.done is True
+        assert final.response.success is False
+        assert "model not authorized" in final.response.error
+
+    @pytest.mark.asyncio
+    async def test_error_after_partial_text(self):
+        """An error after some streamed text preserves the partial accumulator."""
+        c = _make_codex()
+        c._proc = _make_mock_proc(
+            [
+                _agent_message_chunk("partial"),
+                _error_result(prompt_id=3, message="cut off"),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+        final = events[-1]
+
+        assert final.done is True
+        assert final.response.success is False
+        assert final.response.text == "partial"
+        assert "cut off" in final.response.error
+
+
+# ── Context injection ──────────────────────────────────────────────
+
+
+class TestContextInjection:
+    """Verify session context is prepended on first send only."""
+
+    @pytest.mark.asyncio
+    async def test_fresh_session_injects_context(self):
+        """First send prepends session context to the prompt."""
+        c = _make_codex(
+            workspace=Path("/tmp/ws"),
+            home_workspace=Path("/tmp/ws"),
+            webhook_secret="test-secret",
+        )
+        c._proc = _make_mock_proc(
+            [
+                _agent_message_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = True
+        c._next_id = 3
+
+        with patch("kai.codex.build_session_context", return_value="[CONTEXT]"):
+            await _collect_events(c, prompt="hello")
+
+        write_calls = c._proc.stdin.write.call_args_list
+        prompt_msg = json.loads(write_calls[-1][0][0].decode())
+        prompt_text = prompt_msg["params"]["prompt"][0]["text"]
+        assert prompt_text.startswith("[CONTEXT]")
+        assert "hello" in prompt_text
+
+    @pytest.mark.asyncio
+    async def test_second_send_no_context(self):
+        """Second send does NOT prepend session context."""
+        c = _make_codex(workspace=Path("/tmp/ws"), home_workspace=Path("/tmp/ws"))
+        c._proc = _make_mock_proc(
+            [
+                _agent_message_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        with patch("kai.codex.build_session_context") as mock_ctx:
+            await _collect_events(c, prompt="second")
+
+        mock_ctx.assert_not_called()
+
+
+# ── Prompt coercion ────────────────────────────────────────────────
+
+
+class TestPromptCoercion:
+    """Verify string and list prompts are normalized to content-block format."""
+
+    @pytest.mark.asyncio
+    async def test_string_prompt(self):
+        """A string prompt becomes a single text block."""
+        c = _make_codex()
+        c._proc = _make_mock_proc([_agent_message_chunk("ok"), _completion_result(prompt_id=3)])
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        await _collect_events(c, prompt="hello")
+
+        write_calls = c._proc.stdin.write.call_args_list
+        prompt_msg = json.loads(write_calls[-1][0][0].decode())
+        assert prompt_msg["params"]["prompt"] == [{"type": "text", "text": "hello"}]
+
+    @pytest.mark.asyncio
+    async def test_list_prompt_text_only(self):
+        """A list of text blocks passes through unchanged."""
+        c = _make_codex()
+        c._proc = _make_mock_proc([_agent_message_chunk("ok"), _completion_result(prompt_id=3)])
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        blocks = [{"type": "text", "text": "first"}, {"type": "text", "text": "second"}]
+        await _collect_events(c, prompt=blocks)
+
+        write_calls = c._proc.stdin.write.call_args_list
+        prompt_msg = json.loads(write_calls[-1][0][0].decode())
+        assert prompt_msg["params"]["prompt"] == blocks
+
+    @pytest.mark.asyncio
+    async def test_list_prompt_drops_non_text_blocks(self):
+        """Non-text blocks are dropped with a warning; text blocks preserved."""
+        c = _make_codex()
+        c._proc = _make_mock_proc([_agent_message_chunk("ok"), _completion_result(prompt_id=3)])
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        blocks = [
+            {"type": "text", "text": "keep"},
+            {"type": "image", "data": "..."},
+        ]
+        await _collect_events(c, prompt=blocks)
+
+        write_calls = c._proc.stdin.write.call_args_list
+        prompt_msg = json.loads(write_calls[-1][0][0].decode())
+        # Image block dropped; text block kept
+        assert prompt_msg["params"]["prompt"] == [{"type": "text", "text": "keep"}]
+
+    @pytest.mark.asyncio
+    async def test_empty_list_prompt_synthesizes_placeholder(self):
+        """An all-non-text list yields a single placeholder text block."""
+        c = _make_codex()
+        c._proc = _make_mock_proc([_agent_message_chunk("ok"), _completion_result(prompt_id=3)])
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        blocks = [{"type": "image", "data": "..."}]
+        await _collect_events(c, prompt=blocks)
+
+        write_calls = c._proc.stdin.write.call_args_list
+        prompt_msg = json.loads(write_calls[-1][0][0].decode())
+        assert prompt_msg["params"]["prompt"] == [{"type": "text", "text": "(empty prompt)"}]
+
+
+# ── Restart / force_kill / shutdown / change_workspace ────────────
+
+
+class TestRestart:
+    """Verify restart() kills the subprocess and resets session state."""
+
+    @pytest.mark.asyncio
+    async def test_restart_clears_proc_and_session(self):
+        """restart() nulls _proc and _session_id, sets _fresh_session."""
+        c = _make_codex()
+        c._proc = _make_mock_proc([])
+        c._session_id = "old-session"
+        c._fresh_session = False
+
+        await c.restart()
+
+        assert c._proc is None
+        assert c._session_id is None
+        assert c._fresh_session is True
+
+    @pytest.mark.asyncio
+    async def test_restart_no_proc(self):
+        """restart() on a never-started backend is a no-op (no crash)."""
+        c = _make_codex()
+        await c.restart()
+        assert c._proc is None
+
+
+class TestForceKill:
+    """Verify force_kill() is synchronous and cancels the stderr task."""
+
+    def test_force_kill_is_sync(self):
+        """force_kill must not be a coroutine (pool.py calls it without await)."""
+        assert not inspect.iscoroutinefunction(CodexBackend.force_kill)
+
+    def test_force_kill_cancels_stderr_task(self):
+        """force_kill cancels and nulls the stderr drain task."""
+        c = _make_codex()
+        proc = MagicMock()
+        proc.kill = MagicMock()
+        task = MagicMock()
+        task.cancel = MagicMock()
+        c._proc = proc
+        c._stderr_task = task
+
+        c.force_kill()
+
+        # _stderr_task is nulled by force_kill, so assert against the
+        # captured reference rather than the attribute.
+        proc.kill.assert_called_once()
+        task.cancel.assert_called_once()
+        assert c._stderr_task is None
+
+    def test_force_kill_no_proc(self):
+        """force_kill on a never-started backend is a no-op (no crash)."""
+        c = _make_codex()
+        c.force_kill()  # Should not raise
+
+
+class TestChangeWorkspace:
+    """Verify change_workspace() applies new workspace and config."""
+
+    @pytest.mark.asyncio
+    async def test_change_workspace_kills_proc(self):
+        """change_workspace kills the current subprocess."""
+        c = _make_codex()
+        c._proc = _make_mock_proc([])
+        c._proc.returncode = None
+
+        new_ws = Path("/tmp/new-ws")
+        await c.change_workspace(new_ws)
+
+        assert c._proc is None
+        assert c.workspace == new_ws
+
+    @pytest.mark.asyncio
+    async def test_change_workspace_applies_config(self):
+        """A workspace_config override updates model and timeout."""
+        c = _make_codex(model="gpt-5.4", timeout_seconds=30)
+        ws_cfg = WorkspaceConfig(path=Path("/tmp/ws"), model="gpt-5.4-mini", timeout=120)
+
+        await c.change_workspace(Path("/tmp/ws"), workspace_config=ws_cfg)
+
+        assert c.model == "gpt-5.4-mini"
+        assert c.timeout_seconds == 120
+        assert c.workspace_config == ws_cfg
+
+    @pytest.mark.asyncio
+    async def test_change_workspace_reverts_to_defaults(self):
+        """Switching away from a configured workspace restores defaults."""
+        ws_cfg = WorkspaceConfig(path=Path("/tmp/ws"), model="gpt-5.4-mini", timeout=120)
+        c = _make_codex(model="gpt-5.4", timeout_seconds=30, workspace_config=ws_cfg)
+        # Confirm constructor applied the override
+        assert c.model == "gpt-5.4-mini"
+
+        # Switch to a workspace with no config
+        await c.change_workspace(Path("/tmp/other-ws"))
+
+        assert c.model == "gpt-5.4"  # back to default
+        assert c.timeout_seconds == 30
+
+
+class TestShutdown:
+    """Verify shutdown() sends SIGTERM with fallback to SIGKILL."""
+
+    @pytest.mark.asyncio
+    async def test_shutdown_sends_sigterm(self):
+        """shutdown() calls terminate() first."""
+        c = _make_codex()
+        proc = _make_mock_proc([])
+        proc.returncode = None
+        proc.terminate = MagicMock()
+        c._proc = proc
+
+        await c.shutdown()
+
+        # _proc is nulled by shutdown; assert against the captured reference.
+        proc.terminate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_no_proc(self):
+        """shutdown() on a never-started backend is a no-op (no crash)."""
+        c = _make_codex()
+        await c.shutdown()
+
+
+# ── Send lock ──────────────────────────────────────────────────────
+
+
+class TestSendLock:
+    """Verify send() serializes via the internal lock."""
+
+    @pytest.mark.asyncio
+    async def test_lock_serializes_sends(self):
+        """The lock is held across the entire send() generator."""
+        c = _make_codex()
+        c._proc = _make_mock_proc([_agent_message_chunk("first"), _completion_result(prompt_id=3)])
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        # Iterate send() under the lock; if the lock were not held,
+        # this second acquire would succeed immediately. With the lock
+        # held, locked() returns True while the generator is being
+        # consumed.
+        gen = c.send("hello")
+        # Consume one event to enter the locked section
+        first = await gen.__anext__()
+        assert first is not None
+        assert c._lock.locked() is True
+        # Drain the rest so the lock releases
+        async for _ in gen:
+            pass
+        # After the generator returns, the async-with in send() releases
+        assert c._lock.locked() is False
+
+
+# ── Subprocess construction kwargs ─────────────────────────────────
+
+
+class TestSubprocessConstruction:
+    """Verify create_subprocess_exec is called with the right cwd and stream config."""
+
+    @pytest.mark.asyncio
+    async def test_cwd_passed_explicitly(self):
+        """The subprocess cwd is set to self.workspace."""
+        c = _make_codex(workspace=Path("/tmp/explicit-cwd"))
+        proc = _make_mock_proc(_handshake_lines())
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await c._ensure_started()
+
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["cwd"] == "/tmp/explicit-cwd"
+
+    @pytest.mark.asyncio
+    async def test_pipes_attached(self):
+        """stdin / stdout / stderr are attached as pipes."""
+        c = _make_codex()
+        proc = _make_mock_proc(_handshake_lines())
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await c._ensure_started()
+
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["stdin"] == asyncio.subprocess.PIPE
+        assert call_kwargs["stdout"] == asyncio.subprocess.PIPE
+        assert call_kwargs["stderr"] == asyncio.subprocess.PIPE
+
+    @pytest.mark.asyncio
+    async def test_webhook_secret_injected(self):
+        """KAI_WEBHOOK_SECRET is set in the subprocess env when configured."""
+        c = _make_codex(webhook_secret="s3cr3t")
+        proc = _make_mock_proc(_handshake_lines())
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await c._ensure_started()
+
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["env"]["KAI_WEBHOOK_SECRET"] == "s3cr3t"

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -365,6 +365,55 @@ class TestHandshake:
             await c._ensure_started()
 
     @pytest.mark.asyncio
+    async def test_handshake_missing_session_id_raises(self):
+        """
+        session/new without a recognizable session-id key raises
+        RuntimeError at the handshake boundary.
+
+        A silent None session_id would otherwise flow into the next
+        session/prompt as `"sessionId": None`, producing a confusing
+        downstream prompt error instead of a clear handshake mismatch.
+        Fail loudly at the schema boundary.
+        """
+        bad_session_result = _json_line(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "result": {"someOtherKey": "value"},
+            }
+        )
+        proc = _make_mock_proc([_initialize_result(), bad_session_result])
+        c = _make_codex()
+
+        with (
+            patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(RuntimeError, match="no session id"),
+        ):
+            await c._ensure_started()
+
+    @pytest.mark.asyncio
+    async def test_handshake_accepts_snake_case_session_id(self):
+        """
+        session/new result with `session_id` (snake_case) is accepted
+        alongside camelCase `sessionId`. Tolerates codex CLI schema
+        variants observed across versions.
+        """
+        snake_case_result = _json_line(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "result": {"session_id": "snake-case-session"},
+            }
+        )
+        proc = _make_mock_proc([_initialize_result(), snake_case_result])
+        c = _make_codex()
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            await c._ensure_started()
+
+        assert c._session_id == "snake-case-session"
+
+    @pytest.mark.asyncio
     async def test_model_env_var_set(self):
         """CODEX_MODEL env var is set during startup."""
         c = _make_codex(model="gpt-5.4-mini")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2281,6 +2281,39 @@ class TestCmdConfigDefaultModelDispatch:
         ]
 
     @staticmethod
+    def _inputs_for_codex_subscription(memory_enabled: str = "false") -> list[str]:
+        """
+        Input chain for the users_yaml_exists=True + codex+subscription path.
+
+        Codex bypasses the legacy provider/key block (VALID_PROVIDERS["codex"]
+        is intentionally absent), so no llm_provider or API key prompts fire.
+        autocompact_pct and effort_level are claude-only and suppressed.
+        The codex auth-mode prompt is the new line vs the goose chain.
+        """
+        return [
+            "/opt/kai",  # install dir
+            "/var/lib/kai",  # data dir
+            "kai",  # service user
+            "darwin",  # platform
+            "fake-token",  # bot token
+            "polling",  # transport
+            "codex",  # agent backend
+            "subscription",  # codex auth mode
+            # No OPENAI_API_KEY prompt in subscription mode
+            # No llm_provider prompt (VALID_PROVIDERS["codex"] is None)
+            # No autocompact_pct / effort_level prompts (claude-only)
+            # Model prompt handled by the _prompt_default_model mock
+            "8080",  # webhook port
+            "test-secret",  # webhook secret
+            "900",  # pr review subprocess timeout
+            "1.0",  # pr review subprocess budget (non-claude only)
+            "false",  # voice
+            "false",  # tts
+            memory_enabled,  # memory enabled
+            "",  # perplexity key
+        ]
+
+    @staticmethod
     def _inputs_for_goose_openai() -> list[str]:
         """Input chain for the users_yaml_exists=True + goose+openai path."""
         return [
@@ -2416,6 +2449,50 @@ class TestCmdConfigDefaultModelDispatch:
         assert helper.call_args.args[1] == "gpt-5.4"
         assert helper.call_args.args[1] != "opus"
         assert env["DEFAULT_MODEL"] == "gpt-5.4-mini"
+
+    def test_codex_install_zeroes_both_memory_flags(self, tmp_path, monkeypatch):
+        """
+        Codex installs must force MEMORY_ENABLED=false AND
+        MEMORY_EXTRACTION_ENABLED=false. The Haiku extraction pipeline
+        bypasses the agent backend abstraction and shells out to
+        claude directly; running it on a codex-backed install would
+        either inject a [Memory subsystem: enabled] marker into the
+        inner codex agent's session context against a subsystem that
+        cannot service its requests, or attempt to spawn a claude
+        binary that may not be installed.
+
+        The operator says yes to "Enable semantic memory" at the
+        prompt; the guard catches it. Neither flag should appear in
+        the resulting install.conf env (codex emits memory keys only
+        when they are non-default, and both default to false).
+        """
+        # Seed install.conf with existing_env that has BOTH memory flags
+        # set to true. The guard's pre-check reads MEMORY_EXTRACTION_ENABLED
+        # before it can be zeroed by the unconditional reset later in the
+        # function, so the guard message fires.
+        self._setup(
+            monkeypatch,
+            tmp_path,
+            existing_env={
+                "DEFAULT_MODEL": "gpt-5.4",
+                "MEMORY_ENABLED": "true",
+                "MEMORY_EXTRACTION_ENABLED": "true",
+            },
+        )
+        _, env = self._run(
+            monkeypatch,
+            tmp_path,
+            # Operator answers "true" at the memory_enabled prompt; the
+            # guard overrides it. Without the guard, MEMORY_ENABLED=true
+            # would land in the resulting install.conf.
+            self._inputs_for_codex_subscription(memory_enabled="true"),
+            helper_return="gpt-5.4",
+        )
+        # Both memory keys must be absent from the emitted env (the
+        # emission code only writes them when true; the guard forced
+        # both flags false).
+        assert "MEMORY_ENABLED" not in env
+        assert "MEMORY_EXTRACTION_ENABLED" not in env
 
 
 class TestCmdApplyDefaultModelGate:


### PR DESCRIPTION
## Summary

Phase 2 of the codex backend epic. Lands the conversational backend end-to-end:

- **`src/kai/codex.py`** — `CodexBackend(AgentBackend)` modeled on `goose.py`. Persistent `codex app-server` subprocess, JSON-RPC 2.0 over stdin/stdout, two-step handshake (`initialize` + `session/new`), streaming `session/update` notifications. No vendor SDK dependency; wire protocol spoken directly via `asyncio.create_subprocess_exec`. Defensive parsing on unrecognized events (DEBUG log + skip) per the schema-drift discipline.
- **`src/kai/config.py`** — `codex` in `VALID_BACKENDS`; `VALID_PROVIDERS["codex"]` intentionally absent (codex is openai-only and has its own auth model, same pattern claude follows). New `CODEX_AUTH_MODE` env var (subscription | api_key, default subscription) with startup validation.
- **`src/kai/pool.py`** — third branch in `_create_instance` for `backend == "codex"`. Mirrors the goose branch kwarg-for-kwarg with `provider="openai"` pinned. Local import of `kai.codex` keeps the module optional on claude-only installs.
- **`src/kai/install.py`** — codex auth-mode prompt runs **before** the legacy provider/key block so subscription mode is not gated on an `OPENAI_API_KEY` the operator does not need. Memory disable guard forces both `MEMORY_ENABLED=false` and `MEMORY_EXTRACTION_ENABLED=false` on codex installs. `_cmd_apply` prints a `codex login` reminder on subscription-mode codex installs.
- **`tests/test_codex.py`** — 49 new tests covering ABC compliance, handshake, env injection (`CODEX_MODEL` / `CODEX_PROVIDER`), stream parsing including the schema-drift regression guard, completion / EOF / error paths, prompt coercion, lifecycle (restart / force_kill / change_workspace / shutdown), send-lock serialization, and subprocess construction.

Refs #480.

## Smoke test plan (post-merge)

The codex CLI is not installed on the dev host. Validation requires:

1. Install codex (Homebrew or npm).
2. `make config` -> select `codex` backend; pick subscription auth mode.
3. `sudo make install`.
4. `sudo -u <service_user> codex login` (interactive browser).
5. Restart the kai service.
6. Send a Telegram message.

The first message will exercise the full handshake plus a prompt round-trip. If the codex CLI's actual event vocabulary differs from the goose-ACP-shaped envelope assumed in `_send_locked`, the parser's defensive DEBUG logs will surface what to adjust. Same pattern that surfaced PR #475's missing `GOOSE_PROVIDER` during the goose smoke test.

PR review / issue triage / behavioral eval do not yet have codex branches; on a codex install those paths skip until subsequent phase PRs (#3-5 of the epic) land. This is intentional per the spec's phase boundary.

## Test plan

- [x] `make check` (ruff + format)
- [x] Full pytest suite (3050 passed, 1 skipped)
- [x] Targeted: `test_codex.py` (49 tests) covers every public surface of `CodexBackend` plus subprocess argv assertions
- [x] Existing `test_config.py`, `test_pool.py`, `test_install.py` (525 tests) all pass against the config / pool / wizard changes
- [x] Pre-push grep gate clean

## Out of scope

- Codex branches in `triage.py`, `review.py`, `eval/behavioral.py`, `memory_extraction.py`. Phases 3-6 of the epic.
- Codex SDK adoption. Spec-decided: direct JSON-RPC, no vendor SDK.
- Per-user codex login (operators needing distinct OpenAI accounts use the `os_user` per-user lever post-#353).
- Backend-agnostic semantic memory. Codex installs run with memory disabled; the future memory epic addresses cross-backend extraction together with the `bot.py:3706` dispatcher relaxation.
