### PR TITLE
feat(triage): codex branch for one-shot issue triage

### DIFF
--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -593,21 +593,31 @@ def _extract_codex_text(stdout: str) -> str:
     """
     Walk codex's NDJSON event stream and return the agent message text.
 
-    `codex exec --json` emits one JSON event per line. The relevant
-    payload (the agent's final response) lives inside an item event;
-    the exact event name and field path are not yet pinned by smoke
+    `codex exec --json` emits one JSON event per line. A streaming run
+    can produce two representations of the same message: incremental
+    chunks (delta events) and a single terminal/complete event that
+    carries the full consolidated text. Accumulating across both
+    representations would double the message; this parser prefers
+    the terminal text and only falls back to delta accumulation when
+    no terminal event appears in the stream.
+
+    The exact event name and field path are not yet pinned by smoke
     test, so this parser is defensive about field names:
 
     - Each line is attempted as JSON; non-JSON lines are skipped.
-    - Within each parsed object, text content is recovered from any
-      of: top-level "text"; "content" as a string; "content" as a
-      list of {"type": "text", "text": ...} blocks (the JSON-RPC
-      convention used by goose ACP); "delta.text"; "item.content"
-      with the same list shape.
-    - All recovered text is concatenated in order; partial recoveries
-      are returned rather than raising, on the assumption that the
-      caller's JSON parser will surface a clearer error if the
-      result is malformed.
+    - Terminal/complete events are recognized by their FIELD PATH
+      rather than by an event-name string. Any of these signals a
+      complete message: top-level "content" as a string, top-level
+      "content" as a list of {"type":"text", "text":...} blocks, or
+      "item.content" with the same list shape. When multiple
+      terminal events appear, the last one wins (matches the
+      streaming convention that "completed" supersedes prior partials).
+    - Chunk/delta events use "delta.text" or a top-level "text"
+      field. Chunks accumulate in order. Used only when the stream
+      contains no terminal event.
+    - On any genuine schema mismatch the result is the empty string;
+      `_parse_triage_json` then raises a clearer error than a
+      doubled-up partial would.
 
     The smoke test against a real codex CLI will reveal which of
     these field paths actually fire for the pinned version; the
@@ -617,10 +627,12 @@ def _extract_codex_text(stdout: str) -> str:
         stdout: The full stdout from `codex exec --json`.
 
     Returns:
-        The accumulated agent message text. Empty string if no
-        recognizable text content was found in any event.
+        The agent message text. Terminal text if any terminal event
+        was found; otherwise the accumulated delta/chunk text. Empty
+        string if no recognizable text was found in any event.
     """
-    chunks: list[str] = []
+    terminal_text: str | None = None
+    accumulated_chunks: list[str] = []
     for line in stdout.splitlines():
         line = line.strip()
         if not line:
@@ -629,50 +641,83 @@ def _extract_codex_text(stdout: str) -> str:
             obj = json.loads(line)
         except json.JSONDecodeError:
             continue
-        chunks.extend(_recover_text_from_event(obj))
-    return "".join(chunks).strip()
+        # Terminal event wins; the most recent terminal event
+        # supersedes earlier ones (a streaming run that emits
+        # interim consolidated events before the final one ends
+        # up with the latest version).
+        terminal = _recover_terminal_text(obj)
+        if terminal is not None:
+            terminal_text = terminal
+            continue
+        # Delta/chunk events accumulate, but only matter when no
+        # terminal event ever fires.
+        chunk = _recover_chunk_text(obj)
+        if chunk is not None:
+            accumulated_chunks.append(chunk)
+    if terminal_text is not None:
+        return terminal_text.strip()
+    return "".join(accumulated_chunks).strip()
 
 
-def _recover_text_from_event(obj: dict) -> list[str]:
+def _recover_terminal_text(obj: dict) -> str | None:
     """
-    Pull text content out of one codex NDJSON event.
+    Pull a complete/terminal agent message from one codex event.
 
-    Defensive: tries multiple field paths the codex CLI is observed
-    or documented to use, and returns whatever text it finds. An
-    event with no recognizable text payload contributes nothing.
+    Recognized field paths for a complete message:
+    - Top-level "content" as a string (single-block shape).
+    - Top-level "content" as a list of {"type":"text", "text":...} blocks.
+    - "item.content" with the same list-of-blocks shape (events
+      wrapped in an "item" object).
+
+    Returns the consolidated text string, or None if the event has
+    none of these paths (and is therefore either a chunk/delta or
+    pure metadata).
     """
-    out: list[str] = []
-    # Top-level text field (common shape for "delta" events)
-    text = obj.get("text")
-    if isinstance(text, str):
-        out.append(text)
-    # delta.text (alternate streaming shape)
-    delta = obj.get("delta")
-    if isinstance(delta, dict):
-        d_text = delta.get("text")
-        if isinstance(d_text, str):
-            out.append(d_text)
-    # content as a string OR as a list of {type: text, text: ...} blocks
     content = obj.get("content")
     if isinstance(content, str):
-        out.append(content)
-    elif isinstance(content, list):
-        for block in content:
-            if isinstance(block, dict) and block.get("type") == "text":
-                b_text = block.get("text")
-                if isinstance(b_text, str):
-                    out.append(b_text)
-    # item.content for events wrapped in an "item" object
+        return content
+    if isinstance(content, list):
+        parts = [
+            block["text"]
+            for block in content
+            if isinstance(block, dict) and block.get("type") == "text" and isinstance(block.get("text"), str)
+        ]
+        if parts:
+            return "".join(parts)
     item = obj.get("item")
     if isinstance(item, dict):
         i_content = item.get("content")
         if isinstance(i_content, list):
-            for block in i_content:
-                if isinstance(block, dict) and block.get("type") == "text":
-                    b_text = block.get("text")
-                    if isinstance(b_text, str):
-                        out.append(b_text)
-    return out
+            parts = [
+                block["text"]
+                for block in i_content
+                if isinstance(block, dict) and block.get("type") == "text" and isinstance(block.get("text"), str)
+            ]
+            if parts:
+                return "".join(parts)
+    return None
+
+
+def _recover_chunk_text(obj: dict) -> str | None:
+    """
+    Pull a streaming chunk/delta text fragment from one codex event.
+
+    Recognized field paths for an incremental chunk:
+    - "delta.text" (the conventional streaming-delta shape).
+    - Top-level "text" string (an alternate shape some CLI versions emit).
+
+    Returns the fragment text, or None if the event has no chunk-style
+    text field.
+    """
+    delta = obj.get("delta")
+    if isinstance(delta, dict):
+        d_text = delta.get("text")
+        if isinstance(d_text, str):
+            return d_text
+    text = obj.get("text")
+    if isinstance(text, str):
+        return text
+    return None
 
 
 def _parse_triage_json(raw: str) -> dict:

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -413,6 +413,58 @@ async def run_triage(
     Raises:
         RuntimeError: If the subprocess fails or times out.
     """
+    if agent_backend == "codex":
+        # Codex one-shot mode: --json emits NDJSON events on stdout
+        # (thread.started, turn.started, item.*, turn.completed, error).
+        # The final agent message text is recovered by walking the
+        # events and accumulating any text content; see
+        # _extract_codex_text() below for the schema-defensive parser.
+        # No sudo: codex on subscription auth uses the service user's
+        # own ~/.codex/auth.json; per-user OAuth isolation is the
+        # os_user lever in users.yaml (post-#353), not a sudo wrap.
+        # No --max-budget-usd: codex on subscription auth has no
+        # per-call billing; runaway protection comes from
+        # _TRIAGE_TIMEOUT at the asyncio.wait_for below.
+        triage_model = get_model_for(
+            ModelRole.ISSUE_TRIAGE,
+            agent_backend,
+            override=os.environ.get("ISSUE_TRIAGE_MODEL_CODEX", ""),
+        )
+        cmd = [
+            "codex",
+            "exec",
+            "--json",
+            "--model",
+            triage_model,
+        ]
+
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=prompt.encode()),
+                timeout=_TRIAGE_TIMEOUT,
+            )
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise RuntimeError(f"Triage subprocess timed out after {_TRIAGE_TIMEOUT}s") from None
+
+        if proc.returncode != 0:
+            error = stderr.decode().strip()
+            raise RuntimeError(f"Triage subprocess failed (exit {proc.returncode}): {error}")
+
+        # Codex emits NDJSON; extract the final agent message text and
+        # return it (mirrors the contract the claude / goose branches
+        # already satisfy: a single string the caller hands to
+        # _parse_triage_json).
+        return _extract_codex_text(stdout.decode())
+
     if agent_backend == "goose":
         if not provider:
             raise ValueError(
@@ -535,6 +587,92 @@ async def run_triage(
         raise RuntimeError(f"Triage subprocess failed (exit {proc.returncode}): {error}")
 
     return stdout.decode().strip()
+
+
+def _extract_codex_text(stdout: str) -> str:
+    """
+    Walk codex's NDJSON event stream and return the agent message text.
+
+    `codex exec --json` emits one JSON event per line. The relevant
+    payload (the agent's final response) lives inside an item event;
+    the exact event name and field path are not yet pinned by smoke
+    test, so this parser is defensive about field names:
+
+    - Each line is attempted as JSON; non-JSON lines are skipped.
+    - Within each parsed object, text content is recovered from any
+      of: top-level "text"; "content" as a string; "content" as a
+      list of {"type": "text", "text": ...} blocks (the JSON-RPC
+      convention used by goose ACP); "delta.text"; "item.content"
+      with the same list shape.
+    - All recovered text is concatenated in order; partial recoveries
+      are returned rather than raising, on the assumption that the
+      caller's JSON parser will surface a clearer error if the
+      result is malformed.
+
+    The smoke test against a real codex CLI will reveal which of
+    these field paths actually fire for the pinned version; the
+    others remain as fallbacks for schema drift.
+
+    Args:
+        stdout: The full stdout from `codex exec --json`.
+
+    Returns:
+        The accumulated agent message text. Empty string if no
+        recognizable text content was found in any event.
+    """
+    chunks: list[str] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        chunks.extend(_recover_text_from_event(obj))
+    return "".join(chunks).strip()
+
+
+def _recover_text_from_event(obj: dict) -> list[str]:
+    """
+    Pull text content out of one codex NDJSON event.
+
+    Defensive: tries multiple field paths the codex CLI is observed
+    or documented to use, and returns whatever text it finds. An
+    event with no recognizable text payload contributes nothing.
+    """
+    out: list[str] = []
+    # Top-level text field (common shape for "delta" events)
+    text = obj.get("text")
+    if isinstance(text, str):
+        out.append(text)
+    # delta.text (alternate streaming shape)
+    delta = obj.get("delta")
+    if isinstance(delta, dict):
+        d_text = delta.get("text")
+        if isinstance(d_text, str):
+            out.append(d_text)
+    # content as a string OR as a list of {type: text, text: ...} blocks
+    content = obj.get("content")
+    if isinstance(content, str):
+        out.append(content)
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                b_text = block.get("text")
+                if isinstance(b_text, str):
+                    out.append(b_text)
+    # item.content for events wrapped in an "item" object
+    item = obj.get("item")
+    if isinstance(item, dict):
+        i_content = item.get("content")
+        if isinstance(i_content, list):
+            for block in i_content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    b_text = block.get("text")
+                    if isinstance(b_text, str):
+                        out.append(b_text)
+    return out
 
 
 def _parse_triage_json(raw: str) -> dict:

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -778,6 +778,35 @@ class TestRunTriageCodex:
         ):
             await run_triage("prompt", agent_backend="codex")
 
+    @pytest.mark.asyncio
+    async def test_codex_handles_streaming_deltas_plus_terminal(self):
+        """
+        End-to-end through run_triage: a stream that contains both
+        delta chunks AND a terminal consolidated message returns the
+        terminal JSON exactly once, parseable by _parse_triage_json.
+
+        This is the integration counterpart to
+        TestExtractCodexText::test_terminal_text_wins_over_accumulated_deltas.
+        Without the terminal-wins rule, the triage path would return
+        a doubled JSON string (`{"labels":[]}{"labels":[]}`) and the
+        downstream parser would fail on every codex run that streams.
+        """
+        expected_json = '{"labels": ["bug"], "summary": "ok"}'
+        events = [
+            {"event": "delta", "delta": {"text": '{"labels":'}},
+            {"event": "delta", "delta": {"text": ' ["bug"], "summary": "ok"}'}},
+            {
+                "event": "item.message.completed",
+                "item": {"content": [{"type": "text", "text": expected_json}]},
+            },
+        ]
+        stream = "\n".join(json.dumps(e) for e in events) + "\n"
+        mock_proc = _mock_subprocess(stdout=stream)
+        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await run_triage("prompt", agent_backend="codex")
+        # Exactly the terminal JSON, not deltas + terminal concatenated.
+        assert result == expected_json
+
 
 class TestExtractCodexText:
     """
@@ -851,6 +880,55 @@ class TestExtractCodexText:
         """The accumulated result has leading/trailing whitespace stripped."""
         stream = json.dumps({"text": "  hello  "}) + "\n"
         assert _extract_codex_text(stream) == "hello"
+
+    def test_terminal_text_wins_over_accumulated_deltas(self):
+        """
+        A stream with both delta chunks and a terminal consolidated
+        message returns the terminal text exactly once, NOT the
+        deltas concatenated with the terminal.
+
+        Without the terminal-wins rule, the parser would yield
+        `"HelloHello"` for the worked example below: triage's JSON
+        parser then fails because `{"labels":[]}{"labels":[]}` is
+        not a single JSON object, breaking the triage path on
+        every codex run that streams. This regression guard
+        protects against a future refactor that re-introduces
+        accumulate-across-representations.
+        """
+        events = [
+            {"event": "delta", "delta": {"text": "Hel"}},
+            {"event": "delta", "delta": {"text": "lo"}},
+            {"event": "item.message.completed", "item": {"content": [{"type": "text", "text": "Hello"}]}},
+        ]
+        stream = "\n".join(json.dumps(e) for e in events) + "\n"
+        assert _extract_codex_text(stream) == "Hello"
+
+    def test_last_terminal_wins_on_multiple_terminals(self):
+        """
+        When a stream emits more than one terminal/complete event
+        (e.g. an interim consolidated text followed by a final one),
+        the most recent terminal text wins. Mirrors the streaming
+        convention that "completed" supersedes prior partials.
+        """
+        events = [
+            {"item": {"content": [{"type": "text", "text": "first"}]}},
+            {"item": {"content": [{"type": "text", "text": "final"}]}},
+        ]
+        stream = "\n".join(json.dumps(e) for e in events) + "\n"
+        assert _extract_codex_text(stream) == "final"
+
+    def test_deltas_only_when_no_terminal(self):
+        """
+        With no terminal event, delta chunks accumulate as the result.
+        Locks the fallback behavior the terminal-wins rule does not
+        short-circuit when no terminal text was emitted.
+        """
+        events = [
+            {"event": "delta", "delta": {"text": "Hel"}},
+            {"event": "delta", "delta": {"text": "lo"}},
+        ]
+        stream = "\n".join(json.dumps(e) for e in events) + "\n"
+        assert _extract_codex_text(stream) == "Hello"
 
 
 class TestResolveGooseModelTriage:

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -12,6 +12,7 @@ import pytest
 from kai.triage import (
     _GOOSE_AGENT_MODELS,
     IssueMetadata,
+    _extract_codex_text,
     _parse_triage_json,
     _resolve_goose_model,
     _sanitize_search_query,
@@ -649,6 +650,207 @@ class TestRunTriageGoose:
         """Goose backend with empty provider raises ValueError early."""
         with pytest.raises(ValueError, match="provider is empty"):
             await run_triage("prompt", agent_backend="goose", provider="")
+
+
+class TestRunTriageCodex:
+    """
+    Tests for the codex branch of run_triage.
+
+    The codex branch invokes `codex exec --json` and parses NDJSON
+    output via _extract_codex_text. No sudo wrap; subscription auth
+    uses the service user's own ~/.codex/auth.json.
+    """
+
+    @staticmethod
+    def _codex_ndjson(text: str) -> str:
+        """
+        Build a minimal NDJSON stream that _extract_codex_text resolves
+        to the given final text. Uses the "content" list-of-blocks
+        shape (the JSON-RPC convention goose ACP uses) since the
+        actual codex schema is not yet pinned.
+        """
+        events = [
+            {"event": "thread.started"},
+            {"event": "turn.started"},
+            {
+                "event": "item.message.completed",
+                "content": [{"type": "text", "text": text}],
+            },
+            {"event": "turn.completed"},
+        ]
+        return "\n".join(json.dumps(e) for e in events) + "\n"
+
+    @pytest.mark.asyncio
+    async def test_codex_argv_uses_codex_exec(self):
+        """
+        Argv is `codex exec --json --model <model>`, never claude or
+        goose. Locks the "no overlap" guarantee at the subprocess
+        boundary: the codex triage branch never spawns claude.
+        """
+        mock_proc = _mock_subprocess(stdout=self._codex_ndjson('{"labels": []}'))
+        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_triage("prompt", agent_backend="codex")
+        cmd = mock_exec.call_args[0]
+        assert cmd[0] == "codex"
+        assert cmd[1] == "exec"
+        assert "--json" in cmd
+        assert "--print" not in cmd  # No claude flag
+
+    @pytest.mark.asyncio
+    async def test_codex_argv_uses_registry_model(self):
+        """
+        With agent_backend=codex and no env override, the --model argv
+        slot matches the registry's (codex, ISSUE_TRIAGE) row
+        ("gpt-5.4-mini"). Locks the registry as the source of truth
+        for the codex side.
+        """
+        mock_proc = _mock_subprocess(stdout=self._codex_ndjson("{}"))
+        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_triage("prompt", agent_backend="codex")
+        cmd = mock_exec.call_args[0]
+        i = cmd.index("--model")
+        assert cmd[i + 1] == "gpt-5.4-mini"
+
+    @pytest.mark.asyncio
+    async def test_codex_env_override_honored_at_call_site(self, monkeypatch):
+        """
+        ISSUE_TRIAGE_MODEL_CODEX in the environment overrides the
+        registry value at the call site. Same end-to-end env-override
+        wiring as the claude path.
+        """
+        monkeypatch.setenv("ISSUE_TRIAGE_MODEL_CODEX", "gpt-5.4")
+        mock_proc = _mock_subprocess(stdout=self._codex_ndjson("{}"))
+        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_triage("prompt", agent_backend="codex")
+        cmd = mock_exec.call_args[0]
+        i = cmd.index("--model")
+        assert cmd[i + 1] == "gpt-5.4"
+
+    @pytest.mark.asyncio
+    async def test_codex_no_sudo_even_with_claude_user(self):
+        """
+        claude_user is a claude-specific sudo argument. The codex
+        branch ignores it; argv must NOT contain "sudo".
+        """
+        mock_proc = _mock_subprocess(stdout=self._codex_ndjson("{}"))
+        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_triage("prompt", agent_backend="codex", claude_user="some-user")
+        cmd = mock_exec.call_args[0]
+        assert "sudo" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_codex_no_max_budget_flag(self):
+        """
+        --max-budget-usd is not emitted on the codex branch. Codex on
+        subscription auth has no per-call billing; runaway protection
+        comes from the asyncio.wait_for timeout. Mirror of the existing
+        claude-side absence assertion.
+        """
+        mock_proc = _mock_subprocess(stdout=self._codex_ndjson("{}"))
+        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_triage("prompt", agent_backend="codex")
+        cmd = mock_exec.call_args[0]
+        assert "--max-budget-usd" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_codex_extracts_final_text_from_ndjson(self):
+        """
+        Return value is the agent message text extracted from the
+        NDJSON event stream, not the raw stdout. The downstream
+        _parse_triage_json receives a single JSON object, not
+        multi-line NDJSON.
+        """
+        expected_json = '{"labels": ["bug"], "summary": "A bug."}'
+        mock_proc = _mock_subprocess(stdout=self._codex_ndjson(expected_json))
+        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await run_triage("prompt", agent_backend="codex")
+        # _extract_codex_text strips, so the result is the expected
+        # JSON string with no leading/trailing whitespace.
+        assert result == expected_json
+
+    @pytest.mark.asyncio
+    async def test_codex_subprocess_failure_raises(self):
+        """Non-zero exit from codex raises RuntimeError with stderr."""
+        mock_proc = _mock_subprocess(returncode=1, stderr="auth failed")
+        with (
+            patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc),
+            pytest.raises(RuntimeError, match="auth failed"),
+        ):
+            await run_triage("prompt", agent_backend="codex")
+
+
+class TestExtractCodexText:
+    """
+    Unit tests for the _extract_codex_text NDJSON parser.
+
+    The codex CLI schema is not yet pinned by smoke test; the parser
+    accepts multiple field paths (top-level "text"; "content" as
+    string or list-of-blocks; "delta.text"; "item.content") so a
+    schema variant the docs do not describe still yields the agent
+    message. These tests lock each path independently.
+    """
+
+    def test_empty_input(self):
+        """An empty stream returns the empty string."""
+        assert _extract_codex_text("") == ""
+
+    def test_skips_non_json_lines(self):
+        """Non-JSON lines are silently skipped."""
+        stream = "not-json\n" + json.dumps({"text": "hello"}) + "\n"
+        assert _extract_codex_text(stream) == "hello"
+
+    def test_extracts_top_level_text(self):
+        """Events with a top-level 'text' field contribute that string."""
+        stream = json.dumps({"event": "delta", "text": "abc"}) + "\n"
+        assert _extract_codex_text(stream) == "abc"
+
+    def test_extracts_delta_text(self):
+        """Events with 'delta.text' (alternate streaming shape) work."""
+        stream = json.dumps({"event": "delta", "delta": {"text": "abc"}}) + "\n"
+        assert _extract_codex_text(stream) == "abc"
+
+    def test_extracts_content_string(self):
+        """Events with 'content' as a string contribute that string."""
+        stream = json.dumps({"event": "msg", "content": "hello"}) + "\n"
+        assert _extract_codex_text(stream) == "hello"
+
+    def test_extracts_content_list_of_text_blocks(self):
+        """Events with 'content' as a list of {type:text, text:...} blocks work."""
+        event = {
+            "event": "msg",
+            "content": [
+                {"type": "text", "text": "part-A"},
+                {"type": "text", "text": " part-B"},
+            ],
+        }
+        stream = json.dumps(event) + "\n"
+        assert _extract_codex_text(stream) == "part-A part-B"
+
+    def test_extracts_item_content(self):
+        """Events with text inside 'item.content[...]' work."""
+        event = {"event": "item.message.completed", "item": {"content": [{"type": "text", "text": "from item"}]}}
+        stream = json.dumps(event) + "\n"
+        assert _extract_codex_text(stream) == "from item"
+
+    def test_ignores_unknown_event_types(self):
+        """An event with no recognizable text payload contributes nothing."""
+        stream = json.dumps({"event": "thread.started", "metadata": {"foo": "bar"}}) + "\n"
+        assert _extract_codex_text(stream) == ""
+
+    def test_accumulates_across_events(self):
+        """Text from multiple events accumulates in order."""
+        events = [
+            {"event": "delta", "text": "Hello"},
+            {"event": "delta", "text": " "},
+            {"event": "delta", "text": "world"},
+        ]
+        stream = "\n".join(json.dumps(e) for e in events) + "\n"
+        assert _extract_codex_text(stream) == "Hello world"
+
+    def test_strips_outer_whitespace(self):
+        """The accumulated result has leading/trailing whitespace stripped."""
+        stream = json.dumps({"text": "  hello  "}) + "\n"
+        assert _extract_codex_text(stream) == "hello"
 
 
 class TestResolveGooseModelTriage:


### PR DESCRIPTION
## Summary

Phase 3 of the codex backend epic. Adds the codex branch to `run_triage` so GitHub webhook-driven issue triage runs through codex on a codex-active install:

- **`run_triage` codex branch** invokes `codex exec --json --model <model>` with the model from `get_model_for(ModelRole.ISSUE_TRIAGE, "codex", override=os.environ.get("ISSUE_TRIAGE_MODEL_CODEX", ""))`. No sudo wrap (codex uses the service user's own `~/.codex/auth.json`); no `--max-budget-usd` (subscription auth has no per-call billing; `_TRIAGE_TIMEOUT` is the runaway gate).
- **`_extract_codex_text` / `_recover_terminal_text` / `_recover_chunk_text` helpers** parse codex's NDJSON event stream with a terminal-wins discipline: complete-message events (top-level `content` as string or list-of-blocks; `item.content` list-of-blocks) win over streaming chunks (`delta.text` or top-level `text`). Without the discipline, a stream containing both deltas AND a terminal consolidated event would yield the message twice concatenated.

Phases 1 and 2 (registry + `CodexBackend`) are prerequisites and are merged.

Refs #480.

## Smoke checklist (post-merge, requires `codex` CLI installed)

Phase 2's smoke gate validates the `codex app-server` JSON-RPC conversational path. This PR introduces a SECOND codex surface (`codex exec --json` for one-shot triage) with a different event vocabulary and a different stdin/argv contract. The Phase 2 smoke test does NOT validate this surface; the items below need explicit verification:

- [ ] **Stdin contract for `codex exec`.** The branch passes the prompt via `proc.communicate(input=prompt.encode())` with no positional prompt argument and no `-` argv marker. Goose uses `goose run -i -`, claude uses `--print`; codex has no equivalent explicit affordance verified yet. If `codex exec --json --model <m>` requires the prompt as a positional argv (or some other marker), the branch needs the prompt appended to `cmd` rather than written to stdin. Verify by triggering a real GitHub webhook against a codex-active install and inspecting the resulting triage subprocess.
- [ ] **`codex exec --json` event vocabulary.** The parser tolerates several field-path variants (terminal: `content` string/list, `item.content` list; chunk: `delta.text`, top-level `text`). The Phase 2 smoke test exercises `session/update` + `agent_message_chunk` (the conversational ACP-shaped envelope), which is a DIFFERENT vocabulary. Capture a real NDJSON stream from `codex exec --json` against a known prompt, store it as a fixture under `tests/fixtures/codex/`, and reshape `_recover_terminal_text` / `_recover_chunk_text` if the pinned schema lands outside the recognized paths.
- [ ] **Webhook-driven triage path end-to-end.** Trigger a real GitHub issue webhook against a codex-active install and verify the triage comment posts. This exercises the integration of the codex branch with the dispatch logic, NDJSON extraction, and `_parse_triage_json`.

## Test plan (pre-merge)

- [x] `make check` (ruff + format)
- [x] Full pytest suite (3074 passed, 1 skipped)
- [x] Targeted: `TestRunTriageCodex` (8 tests) covering argv asserts (`"codex"` + `"exec"` + `--json`, never claude / sudo / `--max-budget-usd`), registry model selection, `ISSUE_TRIAGE_MODEL_CODEX` env override, no-sudo even with `claude_user` passed, subprocess failure handling, final-text extraction from NDJSON, AND end-to-end through `run_triage` on a deltas+terminal stream
- [x] Targeted: `TestExtractCodexText` (13 tests) — 10 single-path tests plus 3 regression guards for the terminal-wins discipline (deltas+terminal, last-terminal-wins, deltas-only fallback)
- [x] Pre-push grep gate clean

## Out of scope

- Codex branches in `review.py` and `eval/behavioral.py`. Phases 4 and 5 of the epic.
- Codex memory extraction. Phase 6 / future memory epic.
