### PR TITLE
fix(codex): honor users.yaml os_user via sudo -H -u wrap

### DIFF
--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -34,6 +34,8 @@ import asyncio
 import json
 import logging
 import os
+import signal
+import subprocess
 import time
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -157,6 +159,19 @@ class CodexBackend(AgentBackend):
         self._fresh_session: bool = True  # True until the first message is sent
         self._stderr_task: asyncio.Task | None = None  # Background stderr drain
 
+        # Cross-user teardown apparatus (#456-equivalent for codex).
+        # When effective_codex_user is set in _ensure_started, the
+        # subprocess is the sudo wrapper, not codex itself; signalling
+        # only the wrapper orphans the codex grandchild because POSIX
+        # signal permission rules forbid a service-user-owned killpg
+        # from reaching a target-user grandchild. The escalation path
+        # uses `sudo -n -u <target> /bin/kill ...` against the cached
+        # inner-codex PID. See _send_signal for the full rationale and
+        # claude.py for the original implementation this mirrors.
+        self._pgid: int | None = None
+        self._inner_codex_pid: int | None = None
+        self._effective_codex_user: str | None = None
+
     @property
     def is_alive(self) -> bool:
         """True if the codex subprocess is running and hasn't exited."""
@@ -246,14 +261,36 @@ class CodexBackend(AgentBackend):
             stderr=asyncio.subprocess.PIPE,
             cwd=str(self.workspace),
             env=env,
-            # Cross-user mode: new session group so the entire tree
-            # (sudo + codex) can be killed via SIGKILL. Without this,
-            # killing sudo orphans the codex grandchild. Same shape
-            # claude.py uses.
+            # Cross-user mode: new session group so the sudo wrapper
+            # is the session leader (PGID == PID). os.killpg later
+            # reaps the wrapper after the inner-codex sudo escalation
+            # in _send_signal / _async_send_signal_for_close has
+            # signalled the grandchild directly. Without the
+            # escalation, killpg alone would orphan the codex
+            # grandchild (POSIX permission rules: service user
+            # cannot signal a process whose UIDs are all the
+            # target user). See _send_signal for the full chain.
             start_new_session=bool(effective_codex_user),
             limit=1024 * 1024,  # 1MB per-line buffer
         )
         self._stderr_task = asyncio.create_task(self._drain_stderr())
+
+        # Save the process group ID for reliable signal delivery.
+        # When effective_codex_user is set, start_new_session=True
+        # made the wrapper a session leader so PGID == PID. We save
+        # it now because os.getpgid() fails after the process exits,
+        # but os.killpg() works as long as any group member survives.
+        if effective_codex_user:
+            self._pgid = self._proc.pid
+        else:
+            self._pgid = None
+
+        # Remember the resolved sudo target for the #456-equivalent
+        # cross-user signal escalation. _inner_codex_pid is reset to
+        # None here so a recycled instance does not carry a stale
+        # PID from a previous spawn into the fresh tree.
+        self._effective_codex_user = effective_codex_user
+        self._inner_codex_pid = None
 
         # Step 1: initialize - establish protocol version
         self._next_id = 1
@@ -638,19 +675,256 @@ class CodexBackend(AgentBackend):
 
     # ── Kill / restart / shutdown ──────────────────────────────────
 
+    def _lookup_inner_codex_pid(self) -> int | None:
+        """
+        Find the inner codex subprocess PID in cross-user mode.
+
+        In cross-user mode the bot spawns `sudo -u <target> -- codex
+        app-server` and self._proc tracks the sudo wrapper. sudo
+        fork+exec's codex as its sole child, so pgrep -P <sudo_pid>
+        returns the codex PID. Returns None when no sudo wrapper is
+        alive, sudo has not yet forked, or pgrep fails. The result
+        is cached on self._inner_codex_pid; callers that need to
+        signal after sudo has been killed must rely on the cache.
+        Synchronous variant used by the sync force_kill path.
+        Mirrors claude.py's _lookup_inner_claude_pid (#456/#459).
+        """
+        if self._proc is None:
+            return None
+        try:
+            result = subprocess.run(
+                ["pgrep", "-P", str(self._proc.pid)],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            return None
+        if result.returncode != 0:
+            return None
+        first_line = result.stdout.strip().split("\n", 1)[0] if result.stdout.strip() else ""
+        if not first_line:
+            return None
+        try:
+            return int(first_line)
+        except ValueError:
+            return None
+
+    async def _async_lookup_inner_codex_pid(self) -> int | None:
+        """
+        Async pgrep equivalent of `_lookup_inner_codex_pid`.
+
+        Same semantics, but uses asyncio.create_subprocess_exec so
+        the event loop is not blocked while pgrep runs. Called from
+        the async _kill / shutdown paths; the sync variant remains
+        for force_kill. 2s ceiling matches the sync version. Mirrors
+        claude.py's _async_lookup_inner_claude_pid (#459).
+        """
+        if self._proc is None:
+            return None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "pgrep",
+                "-P",
+                str(self._proc.pid),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+        except (OSError, FileNotFoundError):
+            return None
+        try:
+            stdout_bytes, _ = await asyncio.wait_for(proc.communicate(), timeout=2)
+        except TimeoutError:
+            # pgrep hung; reap it so we do not leak a child. The
+            # kill() guard handles the race where pgrep exited
+            # between wait_for timing out and the kill() call:
+            # ProcessLookupError is a benign already-dead signal.
+            try:
+                proc.kill()
+            except OSError:
+                pass
+            try:
+                await proc.wait()
+            except OSError:
+                pass
+            return None
+        if proc.returncode != 0:
+            return None
+        first_line = stdout_bytes.decode(errors="replace").strip().split("\n", 1)[0]
+        if not first_line:
+            return None
+        try:
+            return int(first_line)
+        except ValueError:
+            return None
+
+    async def _async_sudo_kill(self, target_user: str, pid: int, sig: int) -> None:
+        """
+        Run `sudo -n -u <target> /bin/kill -<sig> <pid>` without blocking.
+
+        Equivalent to the synchronous subprocess.run inside _send_signal,
+        but uses asyncio.create_subprocess_exec so a hung sudo or kill
+        does not stall other coroutines. Logs at WARNING on non-zero
+        exit and on timeout so a missing sudoers rule or other failure
+        mode surfaces in the operator log instead of silently leaking
+        an orphan. Mirrors claude.py's _async_sudo_kill (#459).
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "sudo",
+                "-n",
+                "-u",
+                target_user,
+                "/bin/kill",
+                f"-{int(sig)}",
+                str(pid),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except (OSError, FileNotFoundError):
+            return
+        try:
+            _, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=5)
+        except TimeoutError:
+            try:
+                proc.kill()
+            except OSError:
+                pass
+            try:
+                await proc.wait()
+            except OSError:
+                pass
+            log.warning(
+                "async sudo kill timed out after 5s (target=%s, pid=%d, sig=%d); inner codex may orphan",
+                target_user,
+                pid,
+                int(sig),
+            )
+            return
+        if proc.returncode != 0:
+            log.warning(
+                "sudo kill escalation failed (rc=%d, stderr=%r); inner codex pid=%d may orphan",
+                proc.returncode,
+                stderr_bytes[:200].decode(errors="replace") if stderr_bytes else "",
+                pid,
+            )
+
+    def _send_signal(self, sig: int) -> None:
+        """
+        Send a signal to the codex process (or process group + sudo
+        escalation when running cross-user).
+
+        Cross-user mode: os.killpg from the service user cannot signal
+        a target-user codex grandchild because POSIX signal permission
+        rules require real or effective UID to match real or saved
+        set-user-ID of the target. killpg succeeds for the sudo
+        wrapper (real UID is the service user) but the inner codex
+        (UIDs = target) survives and gets orphaned to init. We
+        escalate via `sudo -n -u <target> /bin/kill -<sig> <pid>` for
+        the inner codex BEFORE killpg reaps the sudo wrapper.
+        install.py's _generate_sudoers emits a per-target
+        NOPASSWD: /bin/kill rule for this path.
+
+        Mirrors claude.py's _send_signal (#456/#458). Deliberately
+        does NOT check self._proc.returncode: when codex_user is set
+        self._proc tracks the sudo wrapper, not codex, and checking
+        returncode would skip delivery if sudo exited first.
+        """
+        if self._pgid is not None:
+            if self._effective_codex_user is not None:
+                if self._inner_codex_pid is None:
+                    self._inner_codex_pid = self._lookup_inner_codex_pid()
+                if self._inner_codex_pid is not None:
+                    try:
+                        # Absolute /bin/kill path so sudo's secure_path
+                        # resolution cannot silently pick a different
+                        # binary than the sudoers rule names. The
+                        # install.py rule also pins /bin/kill; the two
+                        # must match exactly. int(sig) explicit because
+                        # IntEnum f-string behavior changed in 3.11;
+                        # cast is the contract regardless of version.
+                        result = subprocess.run(
+                            [
+                                "sudo",
+                                "-n",
+                                "-u",
+                                self._effective_codex_user,
+                                "/bin/kill",
+                                f"-{int(sig)}",
+                                str(self._inner_codex_pid),
+                            ],
+                            capture_output=True,
+                            timeout=5,
+                            check=False,
+                        )
+                        if result.returncode != 0:
+                            log.warning(
+                                "sudo kill escalation failed (rc=%d, stderr=%r); inner codex may orphan",
+                                result.returncode,
+                                result.stderr[:200].decode(errors="replace") if result.stderr else "",
+                            )
+                    except (subprocess.TimeoutExpired, OSError):
+                        # Inner codex already dead, sudoers rule
+                        # missing on an old install, or kill timed
+                        # out. Fall through to killpg; the wrapper
+                        # still needs reaping.
+                        pass
+            try:
+                os.killpg(self._pgid, sig)
+            except OSError:
+                pass
+        elif self._proc is not None:
+            try:
+                self._proc.send_signal(sig)
+            except OSError:
+                pass
+
+    async def _async_send_signal_for_close(self, sig: int) -> None:
+        """
+        Async equivalent of `_send_signal` used by `_kill` and `shutdown`.
+
+        Same three-step structure as the sync version: prime the
+        inner-codex-PID cache (async pgrep), signal the inner codex
+        through sudo (async subprocess), then reap the wrapper via
+        os.killpg (a non-blocking syscall, sync is fine). The
+        single-user fallback uses _proc.send_signal (also non-
+        blocking). Mirrors claude.py's _async_send_signal_for_close.
+        """
+        if self._pgid is not None:
+            if self._effective_codex_user is not None:
+                if self._inner_codex_pid is None:
+                    self._inner_codex_pid = await self._async_lookup_inner_codex_pid()
+                if self._inner_codex_pid is not None:
+                    await self._async_sudo_kill(
+                        self._effective_codex_user,
+                        self._inner_codex_pid,
+                        int(sig),
+                    )
+            try:
+                os.killpg(self._pgid, sig)
+            except OSError:
+                pass
+        elif self._proc is not None:
+            try:
+                self._proc.send_signal(sig)
+            except OSError:
+                pass
+
     def force_kill(self) -> None:
         """
         Kill the subprocess immediately via SIGKILL.
 
         Safe to call without holding the lock. Called by /stop to abort
-        an in-flight response. Does NOT null _proc - full cleanup
+        an in-flight response. Cross-user mode goes through
+        _send_signal so the codex grandchild is sudo-escalated before
+        the wrapper is killpg'd, avoiding the #456 orphan leak.
+        Single-user mode falls back to _proc.kill() via the
+        _send_signal else-branch. Does NOT null _proc - full cleanup
         happens in _kill() when the read loop detects EOF.
         """
         if self._proc is not None:
-            try:
-                self._proc.kill()
-            except OSError:
-                pass
+            self._send_signal(signal.SIGKILL)
         if self._stderr_task:
             self._stderr_task.cancel()
             self._stderr_task = None
@@ -659,17 +933,25 @@ class CodexBackend(AgentBackend):
         """
         Kill the subprocess and clean up all process state.
 
-        Sends SIGKILL, waits up to 5 seconds for exit, then nulls
-        all process references. Idempotent.
+        Sends SIGKILL via the async escalation path (so cross-user
+        installs do not orphan the codex grandchild), waits up to 5
+        seconds for exit, then nulls all process references.
+        Idempotent.
         """
         if self._proc:
-            self.force_kill()
+            await self._async_send_signal_for_close(signal.SIGKILL)
+            if self._stderr_task:
+                self._stderr_task.cancel()
+                self._stderr_task = None
             try:
                 await asyncio.wait_for(self._proc.wait(), timeout=5)
             except TimeoutError:
                 pass
             self._proc = None
             self._session_id = None
+            self._pgid = None
+            self._inner_codex_pid = None
+            self._effective_codex_user = None
 
     async def restart(self) -> None:
         """
@@ -713,27 +995,27 @@ class CodexBackend(AgentBackend):
         """
         Graceful shutdown. No save prompt - codex CLI has no equivalent.
 
-        Sends SIGTERM first and waits up to 5 seconds for clean exit.
-        Falls back to SIGKILL if the process doesn't terminate in time.
+        Sends SIGTERM first via the async escalation path so the
+        target-user codex grandchild gets sudo-signalled before the
+        wrapper is reaped; waits up to 5 seconds for clean exit.
+        Falls back to SIGKILL (also through the escalation path) if
+        the process doesn't terminate in time.
         """
         if self._proc:
+            await self._async_send_signal_for_close(signal.SIGTERM)
             try:
-                self._proc.terminate()
-            except OSError:
-                # Process already exited between the _proc check and
-                # terminate(). Fall through to cleanup below.
-                pass
-            else:
+                await asyncio.wait_for(self._proc.wait(), timeout=5)
+            except TimeoutError:
+                await self._async_send_signal_for_close(signal.SIGKILL)
                 try:
                     await asyncio.wait_for(self._proc.wait(), timeout=5)
                 except TimeoutError:
-                    self.force_kill()
-                    try:
-                        await asyncio.wait_for(self._proc.wait(), timeout=5)
-                    except TimeoutError:
-                        log.warning("CodexBackend: process did not exit after SIGKILL")
+                    log.warning("CodexBackend: process did not exit after SIGKILL")
         if self._stderr_task:
             self._stderr_task.cancel()
             self._stderr_task = None
         self._proc = None
         self._session_id = None
+        self._pgid = None
+        self._inner_codex_pid = None
+        self._effective_codex_user = None

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -50,7 +50,7 @@ from kai.backend import (
     ensure_user_preferences,
     prepend_to_prompt,
 )
-from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file
+from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
 
 log = logging.getLogger(__name__)
 
@@ -96,6 +96,17 @@ class CodexBackend(AgentBackend):
         workspace_config: WorkspaceConfig | None = None,
         max_context_window: int = 0,
         provider: str = "openai",
+        # Optional OS user to run codex as via `sudo -H -u <user>`. When
+        # set, the codex subprocess runs as <codex_user> and reads its
+        # auth token from ~<codex_user>/.codex/auth.json, NOT the kai
+        # service user's home. This is the multi-user OAuth-isolation
+        # lever: a kai install that runs as service user "kai" but has
+        # users.yaml entries with os_user="daniel" / os_user="scott"
+        # spawns a codex subprocess as the per-user os_user, picking
+        # up that user's own codex login. Mirrors ClaudeCodeBackend's
+        # claude_user kwarg. Default None means "run as the service
+        # user" (single-user install or test fixture).
+        codex_user: str | None = None,
         # Operator-intent flag for the memory subsystem (Config.
         # memory_enabled). Drives the [Memory subsystem: ...] marker
         # emission and gates MEMORY.md inject in build_session_context.
@@ -115,6 +126,7 @@ class CodexBackend(AgentBackend):
         self.workspace_config = workspace_config
         self.max_context_window = max_context_window
         self.provider = provider  # ABC-mandated; bot.py reads this
+        self.codex_user = codex_user
         self.memory_enabled = memory_enabled
 
         # API context for session injection (passed to build_session_context)
@@ -193,20 +205,52 @@ class CodexBackend(AgentBackend):
         if self._api_context.webhook_secret:
             env["KAI_WEBHOOK_SECRET"] = self._api_context.webhook_secret
 
+        # Build the argv. Codex runs either as the bot's process user
+        # (single-user install or self-sudo) or as a per-user os_user
+        # (multi-user install where each users.yaml entry has its own
+        # ~/.codex/auth.json). resolve_claude_user is named claude-
+        # historically but its body is backend-agnostic: it returns
+        # None when codex_user matches the bot's own user (skipping
+        # an unnecessary self-sudo) and the value unchanged otherwise.
+        effective_codex_user = resolve_claude_user(self.codex_user)
+
+        codex_argv = ["codex", "app-server"]
+        if effective_codex_user:
+            # -H sets HOME to <codex_user>'s pw entry so codex reads
+            # auth from ~<codex_user>/.codex/auth.json, not the bot's
+            # home. --preserve-env passes KAI_WEBHOOK_SECRET and
+            # TMPDIR through sudo's env_reset (the SETENV: sudoers
+            # rule allows this). Mirrors claude.py's sudo construction.
+            argv: list[str] = [
+                "sudo",
+                "-H",
+                "-u",
+                effective_codex_user,
+                "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR",
+                "--",
+            ] + codex_argv
+        else:
+            argv = codex_argv
+
         log.info(
-            "Starting persistent Codex app-server process (model=%s, provider=%s)",
+            "Starting persistent Codex app-server process (model=%s, provider=%s, user=%s)",
             self.model,
             self.provider,
+            effective_codex_user or "(same as bot)",
         )
 
         self._proc = await asyncio.create_subprocess_exec(
-            "codex",
-            "app-server",
+            *argv,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=str(self.workspace),
             env=env,
+            # Cross-user mode: new session group so the entire tree
+            # (sudo + codex) can be killed via SIGKILL. Without this,
+            # killing sudo orphans the codex grandchild. Same shape
+            # claude.py uses.
+            start_new_session=bool(effective_codex_user),
             limit=1024 * 1024,  # 1MB per-line buffer
         )
         self._stderr_task = asyncio.create_task(self._drain_stderr())

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1859,6 +1859,14 @@ def _generate_sudoers(
         # rule and breaking the bot's sudo dispatch.
         svc_home = _user_home(service_user)
         claude_bin = f"{svc_home}/.local/bin/claude"
+        # Codex binary path: resolved against the service user's PATH
+        # (the same PATH sudo will use when dispatching the rule).
+        # Falls back to a likely Homebrew location so the install
+        # doesn't break when codex isn't on root's PATH at apply time.
+        # Operators who installed codex via npm or to a non-standard
+        # path may need to edit /etc/sudoers.d/kai post-install; the
+        # smoke-test phase reveals this.
+        codex_bin = shutil.which("codex") or "/opt/homebrew/bin/codex"
         # kill(1) for the cross-user kill escalation (#456). The bot
         # runs `sudo -n -u <target> /bin/kill -<sig> <pid>` against
         # the inner claude grandchild because POSIX signal permissions
@@ -1906,6 +1914,7 @@ def _generate_sudoers(
         """)
         for target in target_users:
             rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {claude_bin}\n"
+            rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {codex_bin}\n"
             rules += f"{service_user} ALL=({target}) NOPASSWD: {kill_bin}\n"
 
     return rules

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1792,10 +1792,14 @@ def _generate_sudoers(
     Falls back to /bin/cat and /usr/bin/tee if the binaries aren't found
     in the current PATH (e.g., when running in a minimal environment).
 
-    Per-user `(target_user) SETENV: NOPASSWD:` rules for the claude binary are
-    emitted for every distinct user in `os_users` and `claude_user` combined.
-    Users matching `service_user` are skipped (the runtime detects self-sudo
-    via resolve_claude_user() and spawns claude directly without sudo).
+    Per-user `(target_user) SETENV: NOPASSWD:` rules for the claude and codex
+    binaries (plus a `NOPASSWD: /bin/kill` rule for the cross-user kill
+    escalation) are emitted for every distinct user in `os_users` and
+    `claude_user` combined. Users matching `service_user` are skipped (the
+    runtime detects self-sudo via resolve_claude_user() and spawns the agent
+    directly without sudo). The codex binary path defaults to
+    /opt/homebrew/bin/codex; Linux installs override with the CODEX_BIN env
+    var at install time.
 
     Args:
         service_user: The OS username that runs the Kai service.

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1859,14 +1859,24 @@ def _generate_sudoers(
         # rule and breaking the bot's sudo dispatch.
         svc_home = _user_home(service_user)
         claude_bin = f"{svc_home}/.local/bin/claude"
-        # Codex binary path: resolved against the service user's PATH
-        # (the same PATH sudo will use when dispatching the rule).
-        # Falls back to a likely Homebrew location so the install
-        # doesn't break when codex isn't on root's PATH at apply time.
-        # Operators who installed codex via npm or to a non-standard
-        # path may need to edit /etc/sudoers.d/kai post-install; the
-        # smoke-test phase reveals this.
-        codex_bin = shutil.which("codex") or "/opt/homebrew/bin/codex"
+        # Codex binary path: anchored deterministically to the same
+        # location codex installs to under the operator's account
+        # (npm's global prefix on macOS is /opt/homebrew, on Linux
+        # is usually /usr/local). We pick the Homebrew prefix as the
+        # default because the smoke-test target is an Apple-Silicon
+        # Mac mini; Linux operators get an override via the
+        # CODEX_BIN env var read at install time. We deliberately
+        # do NOT call shutil.which("codex"): _generate_sudoers runs
+        # under `sudo make install` (root context), and shutil.which
+        # would resolve against root's install-time PATH, exactly
+        # the failure mode PR #455 removed for claude_bin (any
+        # user's ~/.local/bin/codex on root's PATH would bake the
+        # wrong path into the rule). The runtime invocation in
+        # codex.py / triage.py runs bare `codex`; sudo resolves it
+        # against the service user's secure_path, which must
+        # therefore include the directory naming this rule's
+        # binary. The smoke test reveals path mismatches.
+        codex_bin = os.environ.get("CODEX_BIN") or "/opt/homebrew/bin/codex"
         # kill(1) for the cross-user kill escalation (#456). The bot
         # runs `sudo -n -u <target> /bin/kill -<sig> <pid>` against
         # the inner claude grandchild because POSIX signal permissions
@@ -1882,10 +1892,10 @@ def _generate_sudoers(
         # rationale as the claude_bin fix in PR #455.
         kill_bin = "/bin/kill"
         # SETENV: allows the service user to pass env vars (e.g.,
-        # KAI_WEBHOOK_SECRET) through sudo to the claude process.
-        # Scoped to the claude rule only; the kill rule does not
-        # need SETENV (kill ignores env entirely), and the cat/tee
-        # config-read rules above remain locked down.
+        # KAI_WEBHOOK_SECRET) through sudo to claude and codex.
+        # Scoped to the claude and codex rules; the kill rule does
+        # not need SETENV (kill ignores env entirely), and the
+        # cat/tee config-read rules above remain locked down.
         #
         # Scope note for the generated rules below (also surfaced
         # as an inline comment in /etc/sudoers.d/kai itself so
@@ -1893,24 +1903,24 @@ def _generate_sudoers(
         # the kill rule allows the service user to run /bin/kill
         # as <target> with ANY arguments, which means it can
         # signal any <target>-owned process - not just the inner
-        # claude grandchild. A PID-locked rule would be tighter
-        # but sudoers argument matching is not safe per the
-        # sudo(8) manual (Defaults entries warn against it; a
+        # claude/codex grandchild. A PID-locked rule would be
+        # tighter but sudoers argument matching is not safe per
+        # the sudo(8) manual (Defaults entries warn against it; a
         # crafted argument can bypass the pattern). In practice
-        # the scope delta is zero: the claude rule above already
-        # grants arbitrary code execution as <target>, so an
-        # attacker with the service user can already `claude
-        # bash -c "kill -9 -1"`. The kill rule just adds a faster
-        # path for the bot's normal cleanup flow.
+        # the scope delta is zero: the claude/codex rules above
+        # already grant arbitrary code execution as <target>, so
+        # an attacker with the service user can already
+        # `claude bash -c "kill -9 -1"`. The kill rule just adds
+        # a faster path for the bot's normal cleanup flow.
         rules += textwrap.dedent("""\
 
-            # Per-target sudoers rules for the cross-os-user inner Claude spawn.
-            # The claude rule grants arbitrary code execution as <target> (claude has
-            # Bash/Read/Write tools); the kill rule grants signal delivery to any
-            # <target>-owned process. The kill rule's scope is broader than a
-            # PID-locked rule because sudoers argument matching is not safe per
-            # sudo(8). The kill rule is a strict subset of capabilities the claude
-            # rule already provides; the practical delta is zero. See PR #458.
+            # Per-target sudoers rules for the cross-os-user inner agent spawn.
+            # The claude and codex rules grant arbitrary code execution as <target>
+            # (both agents have Bash/Read/Write tools); the kill rule grants signal
+            # delivery to any <target>-owned process. The kill rule's scope is
+            # broader than a PID-locked rule because sudoers argument matching is
+            # not safe per sudo(8). The kill rule is a strict subset of capabilities
+            # the agent rules already provide; the practical delta is zero. See PR #458.
         """)
         for target in target_users:
             rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {claude_bin}\n"

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -199,6 +199,14 @@ class SubprocessPool:
                 memory_enabled=self._config.memory_enabled,
             )
 
+        # os_user for sudo -u isolation. None = run as bot user.
+        # Resolved here (rather than inside each branch) because both
+        # ClaudeCodeBackend and CodexBackend consume it for per-user
+        # subprocess isolation. Goose is the only backend that does
+        # not: goose runs as the service user and bills against a
+        # single GOOSE_PROVIDER auth set in /etc/kai/env.
+        os_user = user.os_user if user else self._config.claude_user
+
         if backend == "codex":
             # Import locally so codex.py is only imported on a
             # codex-active install. Mirrors the goose pattern above
@@ -218,12 +226,9 @@ class SubprocessPool:
                 workspace_config=ws_config,
                 max_context_window=context_window,
                 provider="openai",
+                codex_user=os_user,
                 memory_enabled=self._config.memory_enabled,
             )
-
-        # os_user for sudo -u isolation. None = run as bot user.
-        # Only relevant for ClaudeCodeBackend (Goose / Codex don't use sudo).
-        os_user = user.os_user if user else self._config.claude_user
 
         return ClaudeCodeBackend(
             model=model,

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -419,9 +419,12 @@ async def run_triage(
         # The final agent message text is recovered by walking the
         # events and accumulating any text content; see
         # _extract_codex_text() below for the schema-defensive parser.
-        # No sudo: codex on subscription auth uses the service user's
-        # own ~/.codex/auth.json; per-user OAuth isolation is the
-        # os_user lever in users.yaml (post-#353), not a sudo wrap.
+        # Per-user OAuth isolation: when claude_user is set (the
+        # webhook handler passes the same os_user value to both
+        # backends through this parameter), wrap the codex argv in
+        # `sudo -H -u <user>` so codex reads ~<user>/.codex/auth.json
+        # instead of the service user's home. The parameter name is
+        # claude-historical; rename is out of scope for this fix.
         # No --max-budget-usd: codex on subscription auth has no
         # per-call billing; runaway protection comes from
         # _TRIAGE_TIMEOUT at the asyncio.wait_for below.
@@ -430,7 +433,7 @@ async def run_triage(
             agent_backend,
             override=os.environ.get("ISSUE_TRIAGE_MODEL_CODEX", ""),
         )
-        cmd = [
+        codex_cmd = [
             "codex",
             "exec",
             "--json",
@@ -438,11 +441,33 @@ async def run_triage(
             triage_model,
         ]
 
+        # Resolve self-sudo: skip the sudo wrap when claude_user matches
+        # the bot process user. Mirrors the claude branch's pattern.
+        effective_user = resolve_claude_user(claude_user)
+        if effective_user:
+            # -H sets HOME to <effective_user>'s pw entry so codex
+            # reads auth from the right home. --preserve-env passes
+            # KAI_WEBHOOK_SECRET through sudo's env_reset (the SETENV:
+            # sudoers rule allows this). Same shape claude uses.
+            cmd = [
+                "sudo",
+                "-H",
+                "-u",
+                effective_user,
+                "--preserve-env=KAI_WEBHOOK_SECRET",
+                "--",
+            ] + codex_cmd
+        else:
+            cmd = codex_cmd
+
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            # New session group in cross-user mode so killing sudo
+            # also kills the codex grandchild (mirrors claude branch).
+            start_new_session=bool(effective_user),
         )
 
         try:
@@ -451,7 +476,17 @@ async def run_triage(
                 timeout=_TRIAGE_TIMEOUT,
             )
         except TimeoutError:
-            proc.kill()
+            # Kill the subprocess tree if it exceeds the timeout. In
+            # cross-user mode (effective_user set) the process is in
+            # a new group (PGID == PID); kill the group so both sudo
+            # and the codex grandchild die, preventing orphans.
+            if effective_user:
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass  # Already dead
+            else:
+                proc.kill()
             await proc.wait()
             raise RuntimeError(f"Triage subprocess timed out after {_TRIAGE_TIMEOUT}s") from None
 

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -23,6 +23,7 @@ import asyncio
 import inspect
 import json
 import os
+import signal
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -859,7 +860,7 @@ class TestForceKill:
         """force_kill cancels and nulls the stderr drain task."""
         c = _make_codex()
         proc = MagicMock()
-        proc.kill = MagicMock()
+        proc.send_signal = MagicMock()
         task = MagicMock()
         task.cancel = MagicMock()
         c._proc = proc
@@ -867,9 +868,10 @@ class TestForceKill:
 
         c.force_kill()
 
-        # _stderr_task is nulled by force_kill, so assert against the
-        # captured reference rather than the attribute.
-        proc.kill.assert_called_once()
+        # Single-user mode (no _pgid set) routes through _send_signal's
+        # else-branch -> proc.send_signal(SIGKILL). _stderr_task is
+        # nulled by force_kill, so assert against the captured reference.
+        proc.send_signal.assert_called_once_with(signal.SIGKILL)
         task.cancel.assert_called_once()
         assert c._stderr_task is None
 
@@ -927,17 +929,19 @@ class TestShutdown:
 
     @pytest.mark.asyncio
     async def test_shutdown_sends_sigterm(self):
-        """shutdown() calls terminate() first."""
+        """shutdown() routes SIGTERM through _send_signal."""
         c = _make_codex()
         proc = _make_mock_proc([])
         proc.returncode = None
-        proc.terminate = MagicMock()
+        proc.send_signal = MagicMock()
         c._proc = proc
 
         await c.shutdown()
 
-        # _proc is nulled by shutdown; assert against the captured reference.
-        proc.terminate.assert_called_once()
+        # Single-user mode -> async escalation path falls to
+        # proc.send_signal(SIGTERM). _proc is nulled by shutdown,
+        # so assert against the captured reference.
+        proc.send_signal.assert_called_once_with(signal.SIGTERM)
 
     @pytest.mark.asyncio
     async def test_shutdown_no_proc(self):
@@ -1077,9 +1081,10 @@ class TestCodexUserSudoWrap:
     @pytest.mark.asyncio
     async def test_start_new_session_when_codex_user_set(self):
         """
-        Cross-user mode uses start_new_session=True so killing sudo
-        also kills the codex grandchild (otherwise the codex process
-        orphans when sudo dies).
+        Cross-user mode uses start_new_session=True so the sudo wrapper
+        is a session leader (PGID == PID). os.killpg in
+        _send_signal then reaps the wrapper after the sudo escalation
+        has already signalled the inner codex grandchild directly.
         """
         c = _make_codex(codex_user="ci-fake-user")
         proc = _make_mock_proc(_handshake_lines())
@@ -1095,3 +1100,216 @@ class TestCodexUserSudoWrap:
         with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
             await c._ensure_started()
         assert mock_exec.call_args[1]["start_new_session"] is False
+
+    @pytest.mark.asyncio
+    async def test_pgid_and_user_captured_when_codex_user_set(self):
+        """
+        After _ensure_started in cross-user mode, _pgid equals the
+        sudo wrapper PID and _effective_codex_user holds the resolved
+        target. These drive the teardown escalation.
+        """
+        c = _make_codex(codex_user="ci-fake-user")
+        proc = _make_mock_proc(_handshake_lines())
+        proc.pid = 12345
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            await c._ensure_started()
+        assert c._pgid == 12345
+        assert c._effective_codex_user == "ci-fake-user"
+        # Fresh spawn must reset any stale cached grandchild PID.
+        assert c._inner_codex_pid is None
+
+    @pytest.mark.asyncio
+    async def test_pgid_unset_when_codex_user_unset(self):
+        """Single-user mode leaves _pgid None so _send_signal takes the direct-send branch."""
+        c = _make_codex()
+        proc = _make_mock_proc(_handshake_lines())
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            await c._ensure_started()
+        assert c._pgid is None
+        assert c._effective_codex_user is None
+
+
+class TestCodexCrossUserTeardown:
+    """
+    Verify the #456-equivalent kill-escalation for codex.
+
+    In cross-user mode the codex grandchild runs as the target user
+    while self._proc tracks the service-user-owned sudo wrapper. A
+    plain proc.kill() reaches only the wrapper; the grandchild
+    survives because POSIX signal permission rules forbid killpg from
+    the service user. The escalation calls `sudo -n -u <target>
+    /bin/kill -<sig> <pid>` against the cached inner PID before
+    killpg reaps the wrapper. These tests exercise the sync
+    (force_kill) and async (_kill / shutdown) paths.
+    """
+
+    def test_force_kill_cross_user_escalates_then_killpg(self):
+        """force_kill in cross-user mode looks up the inner codex PID, sudo-kills it, then killpgs the wrapper."""
+        c = _make_codex(codex_user="ci-fake-user")
+        proc = MagicMock()
+        proc.pid = 12345
+        c._proc = proc
+        c._pgid = 12345
+        c._effective_codex_user = "ci-fake-user"
+        c._inner_codex_pid = None  # Force a lookup
+        c._stderr_task = MagicMock()
+
+        # Mock pgrep returning the inner codex PID 67890.
+        pgrep_result = MagicMock()
+        pgrep_result.returncode = 0
+        pgrep_result.stdout = "67890\n"
+        # Mock the sudo /bin/kill returning success.
+        sudo_kill_result = MagicMock()
+        sudo_kill_result.returncode = 0
+        sudo_kill_result.stderr = b""
+
+        with (
+            patch("kai.codex.subprocess.run", side_effect=[pgrep_result, sudo_kill_result]) as mock_run,
+            patch("kai.codex.os.killpg") as mock_killpg,
+        ):
+            c.force_kill()
+
+        # First call: pgrep -P 12345 to find the grandchild.
+        assert mock_run.call_args_list[0][0][0] == ["pgrep", "-P", "12345"]
+        # Second call: sudo -n -u ci-fake-user /bin/kill -9 67890.
+        sudo_argv = mock_run.call_args_list[1][0][0]
+        assert sudo_argv[:5] == ["sudo", "-n", "-u", "ci-fake-user", "/bin/kill"]
+        assert sudo_argv[5] == f"-{int(signal.SIGKILL)}"
+        assert sudo_argv[6] == "67890"
+        # Then killpg reaps the wrapper.
+        mock_killpg.assert_called_once_with(12345, signal.SIGKILL)
+        # Cache primed for any subsequent _send_signal call.
+        assert c._inner_codex_pid == 67890
+
+    def test_force_kill_uses_cached_inner_pid(self):
+        """If _inner_codex_pid is already cached, force_kill skips the pgrep lookup."""
+        c = _make_codex(codex_user="ci-fake-user")
+        c._proc = MagicMock()
+        c._proc.pid = 12345
+        c._pgid = 12345
+        c._effective_codex_user = "ci-fake-user"
+        c._inner_codex_pid = 67890  # Pre-cached
+        c._stderr_task = MagicMock()
+
+        sudo_kill_result = MagicMock()
+        sudo_kill_result.returncode = 0
+        sudo_kill_result.stderr = b""
+
+        with (
+            patch("kai.codex.subprocess.run", return_value=sudo_kill_result) as mock_run,
+            patch("kai.codex.os.killpg"),
+        ):
+            c.force_kill()
+
+        # Only the sudo-kill call - no pgrep.
+        assert mock_run.call_count == 1
+        sudo_argv = mock_run.call_args_list[0][0][0]
+        assert sudo_argv[:5] == ["sudo", "-n", "-u", "ci-fake-user", "/bin/kill"]
+
+    def test_force_kill_single_user_skips_escalation(self):
+        """Single-user mode (no _pgid) takes the direct proc.send_signal branch."""
+        c = _make_codex()
+        proc = MagicMock()
+        proc.send_signal = MagicMock()
+        c._proc = proc
+        c._stderr_task = MagicMock()
+        # _pgid is None, _effective_codex_user is None (default).
+
+        with (
+            patch("kai.codex.subprocess.run") as mock_run,
+            patch("kai.codex.os.killpg") as mock_killpg,
+        ):
+            c.force_kill()
+
+        # Neither escalation nor killpg should run.
+        mock_run.assert_not_called()
+        mock_killpg.assert_not_called()
+        proc.send_signal.assert_called_once_with(signal.SIGKILL)
+
+    def test_force_kill_logs_when_sudo_kill_fails(self, caplog):
+        """A non-zero sudo /bin/kill return logs at WARNING (orphan-leak diagnostic)."""
+        c = _make_codex(codex_user="ci-fake-user")
+        c._proc = MagicMock()
+        c._proc.pid = 12345
+        c._pgid = 12345
+        c._effective_codex_user = "ci-fake-user"
+        c._inner_codex_pid = 67890
+        c._stderr_task = MagicMock()
+
+        sudo_kill_result = MagicMock()
+        sudo_kill_result.returncode = 1
+        sudo_kill_result.stderr = b"a password is required"
+
+        with (
+            patch("kai.codex.subprocess.run", return_value=sudo_kill_result),
+            patch("kai.codex.os.killpg"),
+            caplog.at_level("WARNING", logger="kai.codex"),
+        ):
+            c.force_kill()
+
+        assert any("sudo kill escalation failed" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_async_kill_cross_user_escalates(self):
+        """_kill (async path used by recycle / change_workspace) runs the async escalation."""
+        c = _make_codex(codex_user="ci-fake-user")
+        proc = MagicMock()
+        proc.pid = 12345
+        proc.wait = AsyncMock(return_value=0)
+        c._proc = proc
+        c._pgid = 12345
+        c._effective_codex_user = "ci-fake-user"
+        c._inner_codex_pid = 67890  # Pre-cached -> skip pgrep
+        c._stderr_task = MagicMock()
+
+        sudo_proc = MagicMock()
+        sudo_proc.returncode = 0
+        sudo_proc.communicate = AsyncMock(return_value=(b"", b""))
+
+        with (
+            patch("kai.codex.asyncio.create_subprocess_exec", AsyncMock(return_value=sudo_proc)) as mock_exec,
+            patch("kai.codex.os.killpg") as mock_killpg,
+        ):
+            await c._kill()
+
+        # Async escalation: sudo -n -u ci-fake-user /bin/kill -SIGKILL 67890.
+        sudo_argv = mock_exec.call_args[0]
+        assert sudo_argv[:5] == ("sudo", "-n", "-u", "ci-fake-user", "/bin/kill")
+        assert sudo_argv[5] == f"-{int(signal.SIGKILL)}"
+        assert sudo_argv[6] == "67890"
+        mock_killpg.assert_called_once_with(12345, signal.SIGKILL)
+        # State cleared after _kill.
+        assert c._proc is None
+        assert c._pgid is None
+        assert c._inner_codex_pid is None
+        assert c._effective_codex_user is None
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cross_user_escalates_sigterm_then_sigkill(self):
+        """shutdown() routes SIGTERM through the escalation, falls back to SIGKILL if wait times out."""
+        c = _make_codex(codex_user="ci-fake-user")
+        proc = MagicMock()
+        proc.pid = 12345
+        # First wait times out (forces SIGKILL fallback); second returns 0.
+        proc.wait = AsyncMock(side_effect=[TimeoutError(), 0])
+        c._proc = proc
+        c._pgid = 12345
+        c._effective_codex_user = "ci-fake-user"
+        c._inner_codex_pid = 67890
+        c._stderr_task = MagicMock()
+
+        sudo_proc = MagicMock()
+        sudo_proc.returncode = 0
+        sudo_proc.communicate = AsyncMock(return_value=(b"", b""))
+
+        with (
+            patch("kai.codex.asyncio.create_subprocess_exec", AsyncMock(return_value=sudo_proc)) as mock_exec,
+            patch("kai.codex.os.killpg"),
+        ):
+            await c.shutdown()
+
+        # Two escalations: SIGTERM then SIGKILL.
+        sigterm_call = mock_exec.call_args_list[0][0]
+        sigkill_call = mock_exec.call_args_list[1][0]
+        assert sigterm_call[5] == f"-{int(signal.SIGTERM)}"
+        assert sigkill_call[5] == f"-{int(signal.SIGKILL)}"

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1020,3 +1020,78 @@ class TestSubprocessConstruction:
 
         call_kwargs = mock_exec.call_args[1]
         assert call_kwargs["env"]["KAI_WEBHOOK_SECRET"] == "s3cr3t"
+
+
+# ── Per-user OAuth isolation (codex_user / sudo wrap) ─────────────
+
+
+class TestCodexUserSudoWrap:
+    """
+    Verify the per-user OAuth isolation lever.
+
+    When codex_user is set to a non-self user, the subprocess argv is
+    wrapped in `sudo -H -u <user> --preserve-env=KAI_WEBHOOK_SECRET,TMPDIR --`
+    so codex runs as <codex_user> and reads
+    ~<codex_user>/.codex/auth.json. This is what makes a multi-user
+    install (e.g., users.yaml has os_user=daniel for one chat and
+    os_user=scott for another) actually use each user's own codex
+    login, instead of falling back to the service user's auth.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_sudo_when_codex_user_unset(self):
+        """Default (codex_user=None): argv starts with "codex", no sudo."""
+        c = _make_codex()
+        proc = _make_mock_proc(_handshake_lines())
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await c._ensure_started()
+        argv = mock_exec.call_args[0]
+        assert argv[0] == "codex"
+        assert "sudo" not in argv
+
+    @pytest.mark.asyncio
+    async def test_sudo_wraps_argv_when_codex_user_set(self):
+        """
+        codex_user="ci-fake-user" produces sudo-wrapped argv with the
+        right flags. The implausible username avoids the self-sudo
+        short-circuit in resolve_claude_user (which would skip the
+        wrap if the value matched the test runner's actual user).
+        """
+        c = _make_codex(codex_user="ci-fake-user")
+        proc = _make_mock_proc(_handshake_lines())
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await c._ensure_started()
+        argv = mock_exec.call_args[0]
+        assert argv[0] == "sudo"
+        assert "-H" in argv
+        i = argv.index("-u")
+        assert argv[i + 1] == "ci-fake-user"
+        # KAI_WEBHOOK_SECRET and TMPDIR preserved through sudo's env_reset.
+        assert any(
+            arg.startswith("--preserve-env=") and "KAI_WEBHOOK_SECRET" in arg and "TMPDIR" in arg for arg in argv
+        )
+        # Codex binary follows the sudo prologue.
+        codex_i = argv.index("codex")
+        assert argv[codex_i + 1] == "app-server"
+
+    @pytest.mark.asyncio
+    async def test_start_new_session_when_codex_user_set(self):
+        """
+        Cross-user mode uses start_new_session=True so killing sudo
+        also kills the codex grandchild (otherwise the codex process
+        orphans when sudo dies).
+        """
+        c = _make_codex(codex_user="ci-fake-user")
+        proc = _make_mock_proc(_handshake_lines())
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await c._ensure_started()
+        assert mock_exec.call_args[1]["start_new_session"] is True
+
+    @pytest.mark.asyncio
+    async def test_start_new_session_false_when_codex_user_unset(self):
+        """Single-user mode does not need a new session group."""
+        c = _make_codex()
+        proc = _make_mock_proc(_handshake_lines())
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await c._ensure_started()
+        assert mock_exec.call_args[1]["start_new_session"] is False

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -418,12 +418,15 @@ class TestGenerateSudoers:
         """Acceptance (c, dedupe): repeated os_user values produce one ruleset each."""
         monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
         result = _generate_sudoers("kai", os_users=["sellison", "sellison", "bob"])
-        # Each target gets two rules now (claude + kill, #456). Count
-        # the claude rules specifically to verify dedup at the target
-        # level - the kill rules add their own occurrences of "(name)"
-        # so a bare count("(name)") would double.
-        assert result.count("kai ALL=(sellison) SETENV: NOPASSWD: ") == 1
-        assert result.count("kai ALL=(bob) SETENV: NOPASSWD: ") == 1
+        # Each target gets three rules: claude SETENV (#456), codex
+        # SETENV (per-user codex OAuth isolation), and kill. The
+        # claude rule's binary path uniquely identifies one rule per
+        # target, so counting on the full prefix verifies dedup
+        # without the kill-rule or codex-rule noise inflating the
+        # count.
+        claude_bin = "/home/kai/.local/bin/claude"
+        assert result.count(f"kai ALL=(sellison) SETENV: NOPASSWD: {claude_bin}") == 1
+        assert result.count(f"kai ALL=(bob) SETENV: NOPASSWD: {claude_bin}") == 1
 
     def test_os_user_matching_service_user_skipped(self, monkeypatch):
         """Acceptance (d): os_user == service_user → no rule (self-sudo path)."""
@@ -440,12 +443,42 @@ class TestGenerateSudoers:
         """Legacy CLAUDE_USER and yaml os_users coexist; deduped."""
         monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
         # claude_user and os_users overlap on "alice"; should produce
-        # one ruleset (claude + kill rules, #456) for each distinct
-        # target. Count claude rules specifically to skip kill-rule
-        # noise on the same target name.
+        # one ruleset (claude + codex + kill rules) for each distinct
+        # target. Counting on the full claude-rule prefix verifies
+        # dedup at the target level without the codex-rule or
+        # kill-rule occurrences inflating the count.
         result = _generate_sudoers("kai", claude_user="alice", os_users=["alice", "bob"])
-        assert result.count("kai ALL=(alice) SETENV: NOPASSWD: ") == 1
-        assert result.count("kai ALL=(bob) SETENV: NOPASSWD: ") == 1
+        claude_bin = "/home/kai/.local/bin/claude"
+        assert result.count(f"kai ALL=(alice) SETENV: NOPASSWD: {claude_bin}") == 1
+        assert result.count(f"kai ALL=(bob) SETENV: NOPASSWD: {claude_bin}") == 1
+
+    # -- Codex per-target rule (per-user OAuth isolation) ----------------
+
+    def test_codex_rule_emitted_per_target(self, monkeypatch):
+        """
+        Each per-target ruleset includes a NOPASSWD rule for the codex
+        binary alongside the claude rule. The bot spawns
+        `sudo -H -u <target> -- codex app-server` so codex reads
+        ~<target>/.codex/auth.json instead of the service user's home;
+        without this sudoers rule, the spawn fails with "a password is
+        required" and the codex backend cannot start for any user
+        whose os_user differs from the service user.
+        """
+        monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
+        # shutil.which("codex") may not find codex in the test env; the
+        # function falls back to /opt/homebrew/bin/codex in that case.
+        # Either path is a valid codex location.
+        result = _generate_sudoers("kai", os_users=["alice", "bob"])
+        # Each target gets exactly one codex SETENV rule. The binary
+        # path is not pinned in the assertion (shutil.which is
+        # environment-dependent); match on the rule prefix instead.
+        assert "kai ALL=(alice) SETENV: NOPASSWD: " in result
+        assert "kai ALL=(bob) SETENV: NOPASSWD: " in result
+        # Specifically: a line referencing "codex" appears under each target.
+        alice_lines = [line for line in result.splitlines() if "(alice)" in line and "codex" in line]
+        bob_lines = [line for line in result.splitlines() if "(bob)" in line and "codex" in line]
+        assert len(alice_lines) == 1, alice_lines
+        assert len(bob_lines) == 1, bob_lines
 
     # -- Issue #456: per-target kill rule for cross-user signal escalation ----
 

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -727,16 +727,48 @@ class TestRunTriageCodex:
         assert cmd[i + 1] == "gpt-5.4"
 
     @pytest.mark.asyncio
-    async def test_codex_no_sudo_even_with_claude_user(self):
+    async def test_codex_no_sudo_when_user_unset(self):
         """
-        claude_user is a claude-specific sudo argument. The codex
-        branch ignores it; argv must NOT contain "sudo".
+        With no claude_user passed, codex runs as the bot process user
+        directly: argv begins with "codex", no "sudo" wrap.
         """
         mock_proc = _mock_subprocess(stdout=self._codex_ndjson("{}"))
         with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage("prompt", agent_backend="codex", claude_user="some-user")
+            await run_triage("prompt", agent_backend="codex")
         cmd = mock_exec.call_args[0]
+        assert cmd[0] == "codex"
         assert "sudo" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_codex_wraps_sudo_when_user_set(self):
+        """
+        With claude_user set to a non-self user, codex argv is wrapped
+        in `sudo -H -u <user> --preserve-env=KAI_WEBHOOK_SECRET --`.
+        The per-user os_user lever is what makes a multi-user install
+        spawn codex as each user, reading their per-user ~/.codex/auth.json.
+
+        The current process user is determined at runtime; this test
+        passes a username that cannot match the test runner's user
+        ("ci-fake-user") so resolve_claude_user does NOT short-circuit
+        to no-sudo. If the test runner happens to actually be named
+        "ci-fake-user", the test would self-sudo-skip; that name is
+        chosen to be implausible enough to avoid the collision.
+        """
+        mock_proc = _mock_subprocess(stdout=self._codex_ndjson("{}"))
+        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_triage("prompt", agent_backend="codex", claude_user="ci-fake-user")
+        cmd = mock_exec.call_args[0]
+        # Sudo wrap is present and points at the target user.
+        assert cmd[0] == "sudo"
+        assert "-H" in cmd
+        i = cmd.index("-u")
+        assert cmd[i + 1] == "ci-fake-user"
+        # KAI_WEBHOOK_SECRET preserved through sudo's env_reset.
+        assert any(arg.startswith("--preserve-env=") and "KAI_WEBHOOK_SECRET" in arg for arg in cmd)
+        # Codex binary still gets invoked after the sudo wrap.
+        assert "codex" in cmd
+        codex_i = cmd.index("codex")
+        assert cmd[codex_i + 1] == "exec"
 
     @pytest.mark.asyncio
     async def test_codex_no_max_budget_flag(self):


### PR DESCRIPTION
## Summary

CodexBackend and the codex triage branch were not honoring the per-user `os_user` field in `users.yaml`. This was an oversight in the Phase 2 work for #480: ClaudeCodeBackend has carried a `sudo -H -u <user>` wrap since the multi-user config overhaul, but the codex equivalents were running as the bot's service user regardless. Every chat_id would have read auth from the service user's `~/.codex/auth.json` instead of its own owner's home, breaking OAuth isolation.

This PR closes that gap and ports the #456-equivalent cross-user kill escalation to codex so the persistent backend does not orphan target-user codex grandchildren on teardown.

## Changes

- `src/kai/codex.py`
  - New `codex_user` kwarg; `_ensure_started` builds a `sudo -H -u <user> --preserve-env=KAI_WEBHOOK_SECRET,TMPDIR --` wrap when the resolved user is non-self; `start_new_session=True` in cross-user mode so the sudo wrapper is a session leader (PGID == PID).
  - Full #456-equivalent teardown escalation ported from claude.py: `_pgid` / `_inner_codex_pid` / `_effective_codex_user` state, `_lookup_inner_codex_pid` (sync) + `_async_lookup_inner_codex_pid`, `_async_sudo_kill`, `_send_signal`, `_async_send_signal_for_close`. `force_kill` / `_kill` / `shutdown` route through these so cross-user grandchildren get sudo-signalled before the wrapper is reaped. WARNING-level diagnostics on every escalation failure mode.
- `src/kai/pool.py` - resolves `os_user` before backend dispatch and passes it to `CodexBackend(codex_user=...)`. ClaudeCodeBackend dispatch unchanged.
- `src/kai/triage.py` - codex branch wraps argv in sudo when `claude_user` resolves to a non-self user; uses `killpg` on timeout in cross-user mode to avoid orphaning the codex grandchild.
- `src/kai/install.py`
  - `_generate_sudoers` emits a per-target `SETENV: NOPASSWD` rule for the codex binary alongside the existing claude rule. Codex binary path is anchored deterministically to `/opt/homebrew/bin/codex` with a `CODEX_BIN` env var override for Linux installs (no `shutil.which` - that would resolve against root's install-time PATH, the failure mode PR #455 removed for claude).
  - Inline sudoers comments and the operator-facing generated header updated to cover both claude and codex.

## Tests

- `tests/test_codex.py`
  - New `TestCodexUserSudoWrap` class - covers no-sudo when unset, sudo wrap shape when set, `start_new_session` True/False, and `_pgid` / `_effective_codex_user` capture.
  - New `TestCodexCrossUserTeardown` class - six tests covering force_kill / _kill / shutdown escalation paths, pgrep cache reuse, sudo-kill WARNING diagnostics, and the single-user fallback branch.
  - Existing teardown tests updated to assert routing through the new `_send_signal` path.
- `tests/test_triage.py` - replaces `test_codex_no_sudo_even_with_claude_user` with two corrected tests covering both branches.
- `tests/test_install.py` - adjusts two pre-existing tests that counted the generic SETENV prefix to count on the claude binary path specifically; adds `test_codex_rule_emitted_per_target`.

## Test plan

- [x] `pytest` full suite - 3088 passed, 1 skipped
- [x] `make check` - clean
- [ ] Smoke test on Mac mini once merged: codex backend with a `users.yaml` entry whose `os_user` is the host user that ran `codex login`; verify the codex subprocess opens `~<os_user>/.codex/auth.json` and not the kai service user's home.
- [ ] Linux install path: `CODEX_BIN=/usr/local/bin/codex sudo make install` and confirm the generated `/etc/sudoers.d/kai` names the right path.

Refs #480.
