### PR TITLE
fix(install): codex wizard hardening (#486)

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -22,10 +22,47 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from kai.config import DATA_DIR, PROJECT_ROOT, Config, WorkspaceConfig
+from kai.config import DATA_DIR, PROJECT_ROOT, Config, WorkspaceConfig, validate_model_for_backend
 from kai.history import get_recent_history
 
 log = logging.getLogger(__name__)
+
+
+def apply_workspace_model(
+    workspace_config: WorkspaceConfig | None,
+    backend: str,
+    provider: str,
+    current_model: str,
+) -> str:
+    """Decide which model to use when applying a workspace_config.
+
+    Workspaces are shared across users on different backends, so
+    `workspaces.yaml` accepts any model that's valid for any curated
+    surface at load time (_load_workspace_configs validates against
+    _ALL_CURATED_MODELS). At APPLY time - in a backend's __init__ or
+    change_workspace - we know which backend is actually receiving the
+    override and can reject a model that's invalid for it (e.g. a
+    workspaces.yaml entry with `model: gpt-5.4-nano` applied to a
+    CodexBackend instance, where codex CLI rejects nano).
+
+    Returns workspace_config.model when valid for the active backend;
+    otherwise returns current_model unchanged and logs a WARNING so
+    the operator sees the override was skipped. Shared helper so the
+    rejection contract stays uniform across CodexBackend,
+    ClaudeCodeBackend, and GooseBackend.
+    """
+    if workspace_config is None or not workspace_config.model:
+        return current_model
+    if validate_model_for_backend(workspace_config.model, backend, provider):
+        return workspace_config.model
+    log.warning(
+        "Ignoring workspace model override '%s' for %s/%s (invalid for the active backend); keeping model='%s'",
+        workspace_config.model,
+        backend,
+        provider,
+        current_model,
+    )
+    return current_model
 
 
 # ── Protocol types ──────────────────────────────────────────────────

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -61,11 +61,12 @@ from kai.config import (
     MAX_CONTEXT_CEILING,
     OPEN_ENDED_PROVIDERS,
     PROVIDER_DEFAULTS,
-    PROVIDER_MODELS,
     Config,
     WorkspaceConfig,
     get_effective_provider,
-    validate_model_for_provider,
+    get_user_backend_and_provider,
+    models_for_backend,
+    validate_model_for_backend,
 )
 from kai.history import log_message
 from kai.locks import get_lock, get_stop_event
@@ -433,33 +434,57 @@ async def handle_new(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
 # ── Model selection ──────────────────────────────────────────────────
 
 
-def _get_user_provider(pool: SubprocessPool, chat_id: int, config: Config) -> str:
-    """Derive the effective provider for a user without creating an instance.
+def _backend_name_for_instance(instance: object) -> str:
+    """Map a backend instance to its config-key backend name.
 
-    Checks the running instance first; falls back to the config cascade
-    (user -> global) so read-only commands avoid spawning a subprocess.
+    Class-name inspection keeps the ABC free of backend-name leakage.
+    """
+    cls = type(instance).__name__
+    if cls == "CodexBackend":
+        return "codex"
+    if cls == "GooseBackend":
+        return "goose"
+    return "claude"
+
+
+def _get_user_backend_provider(pool: SubprocessPool, chat_id: int, config: Config) -> tuple[str, str]:
+    """Derive the effective (backend, provider) for a user without creating an instance.
+
+    Checks the running instance first; falls back to the canonical
+    get_user_backend_and_provider helper so read-only commands avoid
+    spawning a subprocess. The pair drives both the model-keyboard
+    listing and model validation, so they cannot drift.
     """
     instance = pool.get_if_exists(chat_id)
     if instance:
-        return instance.provider
-    # No running instance - derive from config cascade (same as _create_instance)
+        return _backend_name_for_instance(instance), instance.provider
     user_config = config.get_user_config(chat_id)
-    uc_backend = user_config.agent_backend if user_config and user_config.agent_backend else config.agent_backend
-    uc_provider = user_config.llm_provider if user_config and user_config.llm_provider else config.llm_provider
-    return get_effective_provider(uc_backend, uc_provider)
+    return get_user_backend_and_provider(user_config, config)
+
+
+def _get_user_provider(pool: SubprocessPool, chat_id: int, config: Config) -> str:
+    """Derive the effective provider for a user without creating an instance.
+
+    Thin wrapper around _get_user_backend_provider, kept for the
+    handful of callers that only need the provider value (display in
+    /stats, log messages). Backend-aware callers should use
+    _get_user_backend_provider directly.
+    """
+    _, provider = _get_user_backend_provider(pool, chat_id, config)
+    return provider
 
 
 def _get_user_models(pool: SubprocessPool, chat_id: int, config: Config) -> dict[str, str] | None:
-    """Get the curated model dict for a user's provider, or None if open-ended.
+    """Get the curated model dict for a user's backend/provider, or None if open-ended.
 
-    Returns the PROVIDER_MODELS entry for the user's effective provider.
-    None means the provider accepts arbitrary model IDs (no keyboard).
+    Codex installs see CODEX_MODELS; other backends see PROVIDER_MODELS
+    for their effective provider. None means open-ended (no keyboard).
+    The codex-side surface is fully separate from PROVIDER_MODELS["openai"]
+    so a codex install never offers a goose-only model.
     """
-    provider = _get_user_provider(pool, chat_id, config)
-    if provider in OPEN_ENDED_PROVIDERS:
-        return None
-    models = PROVIDER_MODELS.get(provider)
-    if models is None:
+    backend, provider = _get_user_backend_provider(pool, chat_id, config)
+    models = models_for_backend(backend, provider)
+    if models is None and backend != "codex" and provider not in OPEN_ENDED_PROVIDERS:
         # Provider is not open-ended but has no curated list. This means
         # PROVIDER_MODELS is missing an entry for a valid provider -
         # programming oversight, not user error.
@@ -548,8 +573,10 @@ async def handle_model_callback(update: Update, context: ContextTypes.DEFAULT_TY
     pool = _get_pool(context)
     chat_id = _chat_id(update)
 
-    # Validate against the user's provider model list
-    if not validate_model_for_provider(model, pool.get(chat_id).provider):
+    # Validate against the user's effective backend - codex installs
+    # check CODEX_MODELS only, no fallback to PROVIDER_MODELS["openai"].
+    backend, provider = _get_user_backend_provider(pool, chat_id, config)
+    if not validate_model_for_backend(model, backend, provider):
         await query.answer("Invalid model.")
         return
 
@@ -588,10 +615,13 @@ async def handle_model(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         return
 
     model = context.args[0].lower()
-    instance = pool.get(chat_id)
 
-    if not validate_model_for_provider(model, instance.provider):
-        valid = sorted(PROVIDER_MODELS.get(instance.provider, {}).keys())
+    # Backend-aware validation: codex installs use CODEX_MODELS only;
+    # goose / claude delegate to the provider surface.
+    backend, provider = _get_user_backend_provider(pool, chat_id, config)
+    if not validate_model_for_backend(model, backend, provider):
+        valid_models = models_for_backend(backend, provider) or {}
+        valid = sorted(valid_models.keys())
         await update.message.reply_text(f"Choose: {', '.join(valid)}")
         return
 
@@ -649,9 +679,11 @@ async def handle_settings(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             return
 
         model_key = value.lower()
-        instance = pool.get(chat_id)
-        if not validate_model_for_provider(model_key, instance.provider):
-            valid = sorted(PROVIDER_MODELS.get(instance.provider, {}).keys())
+        # Backend-aware validation
+        backend, provider = _get_user_backend_provider(pool, chat_id, config)
+        if not validate_model_for_backend(model_key, backend, provider):
+            valid_models = models_for_backend(backend, provider) or {}
+            valid = sorted(valid_models.keys())
             await update.message.reply_text(f"Unknown model. Choose from: {', '.join(valid)}")
             return
 
@@ -1485,10 +1517,11 @@ async def _handle_workspace_config(
             else:
                 await update.message.reply_text("Usage: /workspace config model <model_id>")
             return
-        # Value provided - need instance for provider validation
-        instance = pool.get(chat_id)
-        if not validate_model_for_provider(value.lower(), instance.provider):
-            valid = sorted(PROVIDER_MODELS.get(instance.provider, {}).keys())
+        # Backend-aware validation
+        backend, provider = _get_user_backend_provider(pool, chat_id, config)
+        if not validate_model_for_backend(value.lower(), backend, provider):
+            valid_models = models_for_backend(backend, provider) or {}
+            valid = sorted(valid_models.keys())
             await update.message.reply_text(f"Unknown model. Choose from: {', '.join(valid)}")
             return
         await sessions.set_workspace_config_setting(chat_id, workspace_str, "model", value.lower())

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -32,6 +32,7 @@ from kai.backend import (
     AgentResponse,
     ApiContext,
     StreamEvent,
+    apply_workspace_model,
     build_foreign_workspace_reminder,
     build_session_context,
     ensure_user_memory,
@@ -158,10 +159,11 @@ class ClaudeCodeBackend(AgentBackend):
 
         # Apply per-workspace overrides (if configured). These become
         # the "effective" values for this workspace. The /model command
-        # can still override model within a session.
+        # can still override model within a session. Model validated
+        # against claude's anthropic surface so a workspaces.yaml entry
+        # with a codex-only model is silently rejected here.
         if workspace_config:
-            if workspace_config.model:
-                self.model = workspace_config.model
+            self.model = apply_workspace_model(workspace_config, "claude", "anthropic", self.model)
             if workspace_config.budget is not None:
                 self.max_budget_usd = workspace_config.budget
             if workspace_config.timeout is not None:
@@ -1209,8 +1211,7 @@ class ClaudeCodeBackend(AgentBackend):
         self.timeout_seconds = self._default_timeout
 
         if workspace_config:
-            if workspace_config.model:
-                self.model = workspace_config.model
+            self.model = apply_workspace_model(workspace_config, "claude", "anthropic", self.model)
             if workspace_config.budget is not None:
                 self.max_budget_usd = workspace_config.budget
             if workspace_config.timeout is not None:

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -53,6 +53,7 @@ from kai.backend import (
     AgentResponse,
     ApiContext,
     StreamEvent,
+    apply_workspace_model,
     build_foreign_workspace_reminder,
     build_session_context,
     ensure_user_memory,
@@ -152,11 +153,13 @@ class CodexBackend(AgentBackend):
         self._default_model = model
         self._default_timeout = timeout_seconds
 
-        # Apply per-workspace overrides (if configured). These become
-        # the "effective" values for this workspace.
+        # Apply per-workspace overrides (if configured). Model is
+        # validated against codex's CLI surface so a workspaces.yaml
+        # entry with `model: gpt-5.4-nano` (valid for goose-on-openai)
+        # is silently rejected here. Timeout has no cross-backend
+        # equivalent.
         if workspace_config:
-            if workspace_config.model:
-                self.model = workspace_config.model
+            self.model = apply_workspace_model(workspace_config, "codex", self.provider, self.model)
             if workspace_config.timeout is not None:
                 self.timeout_seconds = workspace_config.timeout
 
@@ -1120,12 +1123,12 @@ class CodexBackend(AgentBackend):
 
         # Revert to global defaults, then apply overrides. Prevents
         # stale values when switching from a fully-configured workspace
-        # to a partially-configured one.
+        # to a partially-configured one. Model override validated
+        # against codex's CLI surface.
         self.model = self._default_model
         self.timeout_seconds = self._default_timeout
         if workspace_config:
-            if workspace_config.model:
-                self.model = workspace_config.model
+            self.model = apply_workspace_model(workspace_config, "codex", self.provider, self.model)
             if workspace_config.timeout is not None:
                 self.timeout_seconds = workspace_config.timeout
         # _fresh_session is set True by _ensure_started() on next send()

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -99,14 +99,38 @@ PROVIDER_DEFAULTS: dict[str, str] = {
     "google": "gemini-3-flash",
 }
 
+# Codex CLI model surface. Independent of PROVIDER_MODELS["openai"]:
+# codex CLI exposes a different set than the OpenAI HTTP API surface
+# goose drives, and treating them as one list lets a goose-only
+# model (e.g. gpt-5.4-nano) leak onto a codex install where the CLI
+# rejects it. Refresh when the codex CLI bumps; no auto-discovery.
+CODEX_MODELS: dict[str, str] = {
+    "gpt-5.5": "\U0001f7e2 GPT-5.5",
+    "gpt-5.4": "\U0001f7e1 GPT-5.4",
+    "gpt-5.4-mini": "\U0001f535 GPT-5.4 Mini",
+    "gpt-5.3-codex": "\U0001f7e0 GPT-5.3 Codex",
+    "gpt-5.3-codex-spark": "⚡ GPT-5.3 Codex Spark",
+    "gpt-5.2": "\U0001f7e4 GPT-5.2",
+}
+
+# Codex's default model when DEFAULT_MODEL is unset on a codex install.
+# Independent of PROVIDER_DEFAULTS["openai"] (goose-on-openai still
+# consults that constant; shifting it would change goose's default).
+CODEX_DEFAULT_MODEL = "gpt-5.5"
+
 # Providers that accept arbitrary model IDs with no curated list.
 # These show a text-based UI instead of an inline keyboard in bot.py.
 OPEN_ENDED_PROVIDERS: frozenset[str] = frozenset({"openrouter", "ollama"})
 
-# Union of all model keys from curated providers. Used for workspace
-# config validation where the provider is unknown (workspaces can be
-# used by users on different providers).
-_ALL_CURATED_MODELS: frozenset[str] = frozenset(model for models in PROVIDER_MODELS.values() for model in models)
+# Union of all model keys from curated surfaces. Used for workspace
+# config validation where the active backend is unknown at load time
+# (workspaces can be used by users on different backends/providers).
+# Includes CODEX_MODELS so codex-only IDs like gpt-5.5 are accepted
+# in workspaces.yaml; each backend's change_workspace decides whether
+# to actually USE the override for its surface.
+_ALL_CURATED_MODELS: frozenset[str] = frozenset(
+    list(model for models in PROVIDER_MODELS.values() for model in models) + list(CODEX_MODELS.keys())
+)
 
 
 # ── Per-role model registry ──────────────────────────────────────────
@@ -263,6 +287,9 @@ def validate_model_for_provider(model: str, provider: str) -> bool:
     (not in PROVIDER_MODELS or OPEN_ENDED_PROVIDERS) are accepted with
     a warning - this catches the case where VALID_PROVIDERS gains
     a new entry but PROVIDER_MODELS was not updated to match.
+
+    Backend-aware callers should use `validate_model_for_backend`. This
+    function stays as the implementation goose / claude delegate to.
     """
     if provider in OPEN_ENDED_PROVIDERS:
         return True
@@ -279,6 +306,61 @@ def validate_model_for_provider(model: str, provider: str) -> bool:
             )
         return True
     return model in models
+
+
+def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> bool:
+    """Check if a model is valid for the active backend.
+
+    Codex installs validate against CODEX_MODELS only - no fallback to
+    PROVIDER_MODELS["openai"] or any other provider surface. The
+    backend determines the model surface 1:1 for codex (which speaks
+    its own CLI's curated set); other backends delegate to the existing
+    provider-only validator, which is unchanged for goose / claude.
+
+    Canonical model validator: every model-selection site in the
+    codebase routes through this function so codex and goose share
+    no fallback path.
+    """
+    if backend == "codex":
+        return model in CODEX_MODELS
+    return validate_model_for_provider(model, eff_provider)
+
+
+def models_for_backend(agent_backend: str, eff_provider: str) -> dict[str, str] | None:
+    """Curated model list for the given (backend, provider) pair.
+
+    Codex consults its own CODEX_MODELS surface; everything else falls
+    back to PROVIDER_MODELS[eff_provider]. Returns None for open-ended
+    providers (caller falls back to a free-text prompt rather than a
+    fixed-choice keyboard). Used by both install.py (wizard prompt +
+    apply-time validator) and bot.py (/model keyboard + selection
+    validator).
+    """
+    if agent_backend == "codex":
+        return CODEX_MODELS
+    if eff_provider in OPEN_ENDED_PROVIDERS:
+        return None
+    return PROVIDER_MODELS.get(eff_provider)
+
+
+def get_user_backend_and_provider(user_config: "UserConfig | None", config: "Config") -> tuple[str, str]:
+    """Resolve (backend, provider) for a chat_id with the per-user cascade.
+
+    Pool.py and bot.py already implement this cascade (user.agent_backend
+    > config.agent_backend, similar for llm_provider); this function
+    consolidates it in one place so every runtime model-validation site
+    sees the same effective backend for a given user. Backend determines
+    provider 1:1 for codex (openai) and claude (anthropic); goose's
+    provider comes from the same cascade as its backend.
+    """
+    backend = user_config.agent_backend if user_config and user_config.agent_backend else config.agent_backend
+    if backend == "claude":
+        provider = "anthropic"
+    elif backend == "codex":
+        provider = "openai"
+    else:
+        provider = user_config.llm_provider if user_config and user_config.llm_provider else config.llm_provider
+    return backend, provider
 
 
 # Maximum context window size in tokens. Claude's hard ceiling.
@@ -1257,15 +1339,22 @@ def _load_user_configs(
                 eff_provider,
             )
 
-        # Validate optional model against the user's effective provider.
+        # Validate optional model against the user's effective backend.
+        # Codex installs consult CODEX_MODELS; other backends consult
+        # PROVIDER_MODELS[eff_provider] via the provider-only delegate.
         # Cascade: user override -> global config, same as pool.py.
-        if model is not None and not validate_model_for_provider(model, eff_provider):
-            valid = sorted(PROVIDER_MODELS.get(eff_provider, {}).keys())
+        if model is not None and not validate_model_for_backend(model, eff_backend, eff_provider):
+            if eff_backend == "codex":
+                valid = sorted(CODEX_MODELS.keys())
+                surface_label = "codex"
+            else:
+                valid = sorted(PROVIDER_MODELS.get(eff_provider, {}).keys())
+                surface_label = f"provider '{eff_provider}'"
             log.warning(
-                "users.yaml: invalid model '%s' for %s (provider '%s', must be one of %s); ignoring",
+                "users.yaml: invalid model '%s' for %s (%s, must be one of %s); ignoring",
                 model,
                 name,
-                eff_provider,
+                surface_label,
                 valid,
             )
             model = None
@@ -1570,11 +1659,27 @@ def load_config() -> Config:
                 log.warning("ALLOWED_WORKSPACES: skipping non-existent path: %s", p)
 
     # Validate numeric config - fail fast with clear messages rather than
-    # cryptic ValueError tracebacks from int()/float() on bad input
+    # cryptic ValueError tracebacks from int()/float() on bad input.
+    # AGENT_TIMEOUT_SECONDS is the canonical key; CLAUDE_TIMEOUT_SECONDS
+    # is a legacy alias kept for installs upgrading without re-running
+    # the wizard. Apply-time migration in install.py rewrites
+    # /etc/kai/env to the new key, so the legacy fallback only fires
+    # on the first start after the upgrade.
+    raw_timeout = os.environ.get("AGENT_TIMEOUT_SECONDS", "").strip()
+    if not raw_timeout:
+        legacy_timeout = os.environ.get("CLAUDE_TIMEOUT_SECONDS", "").strip()
+        if legacy_timeout:
+            log.warning(
+                "CLAUDE_TIMEOUT_SECONDS is deprecated; use AGENT_TIMEOUT_SECONDS. "
+                "Re-run 'make install' to migrate /etc/kai/env automatically."
+            )
+            raw_timeout = legacy_timeout
+        else:
+            raw_timeout = "120"
     try:
-        claude_timeout_seconds = int(os.environ.get("CLAUDE_TIMEOUT_SECONDS", "120"))
+        claude_timeout_seconds = int(raw_timeout)
     except ValueError:
-        raise SystemExit("CLAUDE_TIMEOUT_SECONDS must be an integer") from None
+        raise SystemExit("AGENT_TIMEOUT_SECONDS must be an integer") from None
     # Budget ceiling: new var takes precedence, fall back to old var
     # for backward compat on upgrade (existing .env has old key name).
     raw_ceiling = os.environ.get("BUDGET_CEILING", "").strip()
@@ -1948,11 +2053,18 @@ def load_config() -> Config:
     if os.environ.get("CLAUDE_MODEL") and not os.environ.get("DEFAULT_MODEL"):
         log.warning("CLAUDE_MODEL is deprecated, use DEFAULT_MODEL instead")
 
-    # Validate DEFAULT_MODEL against the effective global provider.
-    # Catches typos at startup instead of letting them propagate to
-    # a confusing runtime failure.
+    # Validate DEFAULT_MODEL against the effective global backend.
+    # Codex installs validate against CODEX_MODELS only - no fallback
+    # to PROVIDER_MODELS["openai"]. Other backends still use the
+    # provider-only validator. Catches typos at startup instead of
+    # letting them propagate to a confusing runtime failure.
     global_provider = get_effective_provider(agent_backend, llm_provider)
-    if not validate_model_for_provider(default_model, global_provider):
+    if not validate_model_for_backend(default_model, agent_backend, global_provider):
+        if agent_backend == "codex":
+            valid = sorted(CODEX_MODELS.keys())
+            raise SystemExit(
+                f"DEFAULT_MODEL '{default_model}' is not valid for codex (must be one of: {', '.join(valid)})"
+            )
         valid = sorted(PROVIDER_MODELS.get(global_provider, {}).keys())
         raise SystemExit(
             f"DEFAULT_MODEL '{default_model}' is not valid for provider "

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -277,11 +277,20 @@ def _check_model_registry_complete(backend: str) -> None:
 def get_effective_provider(backend: str, llm_provider: str) -> str:
     """Derive the effective provider from backend + llm_provider.
 
-    The Claude backend always uses Anthropic models. All other
-    backends use whatever provider is configured.
+    Claude is always anthropic; codex is always openai (codex CLI has
+    no other provider surface, so a wizard-generated codex install with
+    LLM_PROVIDER unset still needs the runtime to know its provider is
+    openai). Goose is the only backend that consults the raw
+    llm_provider, because it routes to whatever provider the user
+    configured. Kept identical to the backend->provider rule
+    get_user_backend_and_provider uses so the two cascade helpers do
+    not drift; any caller resolving an effective provider for a
+    backend gets the same answer regardless of which helper it uses.
     """
     if backend == "claude":
         return "anthropic"
+    if backend == "codex":
+        return "openai"
     return llm_provider
 
 

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -191,7 +191,13 @@ MODEL_REGISTRY: dict[tuple[str, ModelRole], str] = {
     ("claude", ModelRole.BEHAVIORAL_GEN): "sonnet",
     ("codex", ModelRole.PR_REVIEW): "gpt-5.4-mini",
     ("codex", ModelRole.ISSUE_TRIAGE): "gpt-5.4-mini",
-    ("codex", ModelRole.BEHAVIORAL_JUDGE): "gpt-5.4-nano",
+    # gpt-5.4-mini for the judge role: the closest analog to the
+    # claude haiku tier (small, fast, cheap). gpt-5.4-nano would have
+    # matched the editorial "cheaper than mini" intent but the codex
+    # CLI does not expose it, so it would fail at first behavioral
+    # eval. _check_model_registry_complete validates registry rows
+    # against CODEX_MODELS so future drift gets caught at startup.
+    ("codex", ModelRole.BEHAVIORAL_JUDGE): "gpt-5.4-mini",
     ("codex", ModelRole.BEHAVIORAL_GEN): "gpt-5.4-mini",
 }
 
@@ -229,12 +235,14 @@ def get_model_for(role: ModelRole, backend: str, override: str = "") -> str:
 
 def _check_model_registry_complete(backend: str) -> None:
     """
-    Verify MODEL_REGISTRY has a row for every role the active backend uses.
+    Verify MODEL_REGISTRY has a row for every role the active backend uses,
+    AND that each codex row names a model the codex CLI actually exposes.
 
-    Runs once at load_config() time. Raises SystemExit on a missing
-    row so the bug surfaces at startup rather than at a per-request
-    LookupError (which would otherwise crash a single agent invocation
-    silently if a future role were added without its registry rows).
+    Runs once at load_config() time. Raises SystemExit on a missing or
+    invalid row so the bug surfaces at startup rather than at a per-
+    request LookupError (which would otherwise crash a single agent
+    invocation silently if a future role were added without its
+    registry rows, or with a codex-incompatible model).
 
     Goose is exempt: goose-side model resolution lives in module-level
     _GOOSE_AGENT_MODELS dicts that this registry does not subsume.
@@ -247,6 +255,23 @@ def _check_model_registry_complete(backend: str) -> None:
         raise SystemExit(
             f"MODEL_REGISTRY is missing rows for backend '{backend}': {names}. Update MODEL_REGISTRY in config.py."
         )
+    # Validate codex rows against the CLI's actual model surface so a
+    # future drift (operator updates CODEX_MODELS without touching
+    # MODEL_REGISTRY, or vice versa) fails fast at startup rather
+    # than at the first behavioral / triage / review run.
+    if backend == "codex":
+        invalid = [
+            (role, MODEL_REGISTRY[(backend, role)])
+            for role in ModelRole
+            if MODEL_REGISTRY[(backend, role)] not in CODEX_MODELS
+        ]
+        if invalid:
+            valid_list = ", ".join(sorted(CODEX_MODELS.keys()))
+            details = ", ".join(f"{role.value}={model}" for role, model in invalid)
+            raise SystemExit(
+                f"MODEL_REGISTRY has codex rows naming models the codex CLI does not expose: {details}. "
+                f"Valid codex models: {valid_list}. Update MODEL_REGISTRY in config.py."
+            )
 
 
 def get_effective_provider(backend: str, llm_provider: str) -> str:

--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -32,6 +32,7 @@ from kai.backend import (
     AgentResponse,
     ApiContext,
     StreamEvent,
+    apply_workspace_model,
     build_foreign_workspace_reminder,
     build_session_context,
     ensure_user_memory,
@@ -117,11 +118,10 @@ class GooseBackend(AgentBackend):
         self._default_model = model
         self._default_timeout = timeout_seconds
 
-        # Apply per-workspace overrides (if configured). These become
-        # the "effective" values for this workspace.
+        # Apply per-workspace overrides (if configured). Model
+        # validated against the goose provider surface.
         if workspace_config:
-            if workspace_config.model:
-                self.model = workspace_config.model
+            self.model = apply_workspace_model(workspace_config, "goose", self.provider, self.model)
             if workspace_config.timeout is not None:
                 self.timeout_seconds = workspace_config.timeout
 
@@ -645,12 +645,12 @@ class GooseBackend(AgentBackend):
 
         # Revert to global defaults, then apply overrides. Prevents
         # stale values when switching from a fully-configured workspace
-        # to a partially-configured one.
+        # to a partially-configured one. Model validated against the
+        # goose provider surface.
         self.model = self._default_model
         self.timeout_seconds = self._default_timeout
         if workspace_config:
-            if workspace_config.model:
-                self.model = workspace_config.model
+            self.model = apply_workspace_model(workspace_config, "goose", self.provider, self.model)
             if workspace_config.timeout is not None:
                 self.timeout_seconds = workspace_config.timeout
         # _fresh_session is set True by _ensure_started() on next send()

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -40,16 +40,18 @@ from pathlib import Path
 import yaml
 
 from kai.config import (
+    CODEX_DEFAULT_MODEL,
+    CODEX_MODELS,
     EFFORT_LEVELS,
     MAX_CONTEXT_CEILING,
-    OPEN_ENDED_PROVIDERS,
     PROJECT_ROOT,
     PROVIDER_DEFAULTS,
     PROVIDER_KEY_VARS,
     PROVIDER_MODELS,
     VALID_BACKENDS,
     VALID_PROVIDERS,
-    validate_model_for_provider,
+    models_for_backend,
+    validate_model_for_backend,
 )
 
 # Config file written by `config`, read by `apply`.
@@ -163,11 +165,15 @@ def _prompt_bool(label: str, default: bool = False) -> bool:
     return value == "true"
 
 
-def _prompt_default_model(eff_provider: str, default_val: str) -> str:
+def _prompt_default_model(agent_backend: str, eff_provider: str, default_val: str) -> str:
     """
-    Prompt for DEFAULT_MODEL, dispatching on the effective provider.
+    Prompt for DEFAULT_MODEL, dispatching on the active backend.
 
-    Two shapes of provider need different prompts:
+    Three shapes of model surface need different prompts:
+    - Codex backend ships its own curated CLI model list (CODEX_MODELS)
+      which is fully separate from goose's openai-API surface. Wizard
+      offers the codex-only set; never falls through to the OpenAI
+      provider list.
     - Curated providers (those with an entry in PROVIDER_MODELS, currently
       anthropic, openai, google) ship a fixed model list; the operator
       picks from the list via _prompt_choice.
@@ -180,24 +186,28 @@ def _prompt_default_model(eff_provider: str, default_val: str) -> str:
     commit to a concrete model string. load_config falls back to "sonnet"
     when DEFAULT_MODEL is empty or missing, and "sonnet" is anthropic-only;
     letting the operator leave the field blank on an open-ended provider
-    would set them up for a startup-time validation failure that load_config
-    surfaces with a less helpful error message than this wizard can.
+    would set them up for a startup-time validation failure.
 
     Args:
-        eff_provider: The effective provider (anthropic for the claude
-            backend; the configured llm_provider otherwise).
+        agent_backend: The active backend ("claude", "codex", "goose").
+            Codex routes to CODEX_MODELS; everything else delegates to
+            the provider-based selection below.
+        eff_provider: The effective provider for non-codex backends
+            (anthropic for claude; the configured llm_provider for
+            goose; ignored when agent_backend == "codex").
         default_val: Prefill for the prompt. Callers should pass a value
-            that is valid for eff_provider (e.g. PROVIDER_DEFAULTS[eff_provider]
-            when re-prompting after rejecting an invalid existing value).
+            that is valid for the backend's surface (CODEX_DEFAULT_MODEL
+            for codex, PROVIDER_DEFAULTS[eff_provider] for others) when
+            re-prompting after rejecting an invalid existing value.
 
     Returns:
         The chosen model identifier. Always non-empty.
     """
-    provider_models = PROVIDER_MODELS.get(eff_provider)
-    if provider_models and eff_provider not in OPEN_ENDED_PROVIDERS:
+    surface = models_for_backend(agent_backend, eff_provider)
+    if surface:
         return _prompt_choice(
             "Default model",
-            sorted(provider_models.keys()),
+            sorted(surface.keys()),
             default_val,
         )
     return _prompt(
@@ -288,6 +298,20 @@ def _validate_chat_id(value: str) -> bool:
         return int(value) != 0
     except ValueError:
         return False
+
+
+def _validate_codex_bin(value: str) -> bool:
+    """Return True when the path exists and is executable.
+
+    Required by the codex wizard prompt; the path is baked into both
+    the runtime CODEX_BIN env var and the sudoers rule that allows
+    cross-os_user codex spawns, so a non-existent path here would
+    surface as a confusing 'a password is required' at first message.
+    """
+    if not value:
+        return False
+    p = Path(value)
+    return p.is_file() and os.access(p, os.X_OK)
 
 
 # ── Config subcommand ────────────────────────────────────────────────
@@ -505,20 +529,40 @@ def _cmd_config() -> None:
     # follows today.
     codex_auth_mode = ""
     codex_api_key = ""
+    codex_bin = ""
     if agent_backend == "codex":
         codex_auth_mode = _prompt_choice(
             "Codex auth mode",
             ["subscription", "api_key"],
             existing_env.get("CODEX_AUTH_MODE", "subscription"),
         )
-        if codex_auth_mode == "subscription":
-            print("  After install, run 'codex login' as the service user.")
-        else:
+        if codex_auth_mode == "api_key":
             codex_api_key = _prompt(
                 "OPENAI_API_KEY",
                 existing_env.get("OPENAI_API_KEY", ""),
                 required=True,
             )
+        # Codex binary path: wizard-prompted and persisted in install.conf
+        # so `make install` writes both /etc/kai/env's CODEX_BIN and the
+        # sudoers SETENV rule from the same source of truth, eliminating
+        # the env-var-stripping workaround that needed `sudo CODEX_BIN=...
+        # .venv/bin/python -m kai install apply` to bypass make's inner
+        # sudo. Default suggestion uses `which codex` from the operator's
+        # PATH; falls back to Homebrew only when which finds nothing.
+        while True:
+            which_codex = shutil.which("codex") or "/opt/homebrew/bin/codex"
+            codex_bin = _prompt(
+                "Codex binary path",
+                existing_env.get("CODEX_BIN", which_codex),
+                required=True,
+            )
+            if _validate_codex_bin(codex_bin):
+                break
+            print(f"  Path '{codex_bin}' does not exist or is not executable.")
+        if codex_auth_mode == "subscription":
+            print("  After install, log in as each os_user that should answer messages:")
+            print("    e.g.   <os_user> ~$ codex login")
+            print("  Run as the os_user themselves, not via sudo from another account.")
 
     # Non-Claude backends: provider and API key. The provider choice
     # determines which env var to prompt for (or none for ollama).
@@ -554,6 +598,17 @@ def _cmd_config() -> None:
     # backend always uses Anthropic; Goose uses the selected provider.
     eff_provider = "anthropic" if agent_backend == "claude" else llm_provider
 
+    def _default_model_prefill() -> str:
+        """Backend-aware prefill for the re-prompt-after-reject path.
+
+        Codex installs use CODEX_DEFAULT_MODEL (independent from
+        PROVIDER_DEFAULTS["openai"] which goose-on-openai still
+        consults). Other backends use PROVIDER_DEFAULTS[eff_provider].
+        """
+        if agent_backend == "codex":
+            return CODEX_DEFAULT_MODEL
+        return PROVIDER_DEFAULTS.get(eff_provider, "")
+
     if users_yaml_exists:
         print("-- Claude --")
         print("  Model, timeout, budget, and context window are now per-user.")
@@ -561,43 +616,51 @@ def _cmd_config() -> None:
         # Read DEFAULT_MODEL, falling back to CLAUDE_MODEL for backward compat
         existing_model = existing_env.get("DEFAULT_MODEL", existing_env.get("CLAUDE_MODEL", ""))
         # Re-validate the existing value against the (possibly newly chosen)
-        # effective provider. Empty existing_model fails validation for any
-        # curated provider, including anthropic ("" is not in PROVIDER_MODELS).
-        # Open-ended providers always validate True, so empty + open-ended
-        # would silently pass; the _prompt(required=True) branch in
-        # _prompt_default_model handles that case by forcing the operator
-        # to commit to a model string.
-        if existing_model and validate_model_for_provider(existing_model, eff_provider):
+        # backend - backend-aware, not provider-only, so codex rejects
+        # gpt-5.4-nano even though it's valid for goose-on-openai.
+        # Empty existing_model fails validation for any curated backend;
+        # the _prompt(required=True) branch in _prompt_default_model
+        # handles the open-ended case.
+        if existing_model and validate_model_for_backend(existing_model, agent_backend, eff_provider):
             model = existing_model
         else:
             if existing_model:
-                print(
-                    f"  DEFAULT_MODEL '{existing_model}' is not valid for provider "
-                    f"'{eff_provider}'. Please choose a new default."
-                )
-            # Prefill always uses PROVIDER_DEFAULTS for the effective provider
-            # rather than existing_env["DEFAULT_MODEL"]. We entered this branch
-            # because the existing value is missing or invalid for the effective
-            # provider; offering it as the prefill would let the operator
-            # accept the just-rejected value with Enter, since _prompt_choice
-            # returns its default parameter without validating it against
-            # the choices list.
-            model = _prompt_default_model(eff_provider, PROVIDER_DEFAULTS.get(eff_provider, ""))
-        timeout = existing_env.get("CLAUDE_TIMEOUT_SECONDS", "")
+                surface = "codex" if agent_backend == "codex" else f"provider '{eff_provider}'"
+                print(f"  DEFAULT_MODEL '{existing_model}' is not valid for {surface}. Please choose a new default.")
+            # Prefill always uses the backend-aware default rather than
+            # existing_env["DEFAULT_MODEL"]. We entered this branch because
+            # the existing value is missing or invalid; offering it as the
+            # prefill would let the operator accept the just-rejected value
+            # with Enter, since _prompt_choice returns its default parameter
+            # without validating it against the choices list.
+            model = _prompt_default_model(agent_backend, eff_provider, _default_model_prefill())
+        # AGENT_TIMEOUT_SECONDS is the canonical key; fall back to the
+        # legacy CLAUDE_TIMEOUT_SECONDS for installs that haven't re-run
+        # the wizard since the rename.
+        timeout = existing_env.get("AGENT_TIMEOUT_SECONDS", existing_env.get("CLAUDE_TIMEOUT_SECONDS", ""))
         budget = existing_env.get("BUDGET_CEILING", existing_env.get("CLAUDE_MAX_BUDGET_USD", ""))
         max_context_window = existing_env.get("CLAUDE_MAX_CONTEXT_WINDOW", "")
     else:
         print("-- Claude --")
-        default_model_val = existing_env.get(
-            "DEFAULT_MODEL",
-            existing_env.get("CLAUDE_MODEL", PROVIDER_DEFAULTS.get(eff_provider, "")),
-        )
-        model = _prompt_default_model(eff_provider, default_model_val)
+        # Re-validate any existing DEFAULT_MODEL against the chosen
+        # backend so a switch from claude to codex doesn't silently
+        # keep an anthropic model.
+        raw_existing = existing_env.get("DEFAULT_MODEL", existing_env.get("CLAUDE_MODEL", ""))
+        if raw_existing and validate_model_for_backend(raw_existing, agent_backend, eff_provider):
+            default_model_val = raw_existing
+        else:
+            default_model_val = _default_model_prefill()
+        model = _prompt_default_model(agent_backend, eff_provider, default_model_val)
 
         while True:
+            # AGENT_TIMEOUT_SECONDS is canonical; legacy
+            # CLAUDE_TIMEOUT_SECONDS is the fallback for upgrades.
+            timeout_default = existing_env.get(
+                "AGENT_TIMEOUT_SECONDS", existing_env.get("CLAUDE_TIMEOUT_SECONDS", "120")
+            )
             timeout = _prompt(
-                "Claude timeout (seconds)",
-                existing_env.get("CLAUDE_TIMEOUT_SECONDS", "120"),
+                "Agent timeout (seconds)",
+                timeout_default,
             )
             if _validate_positive_int(timeout):
                 break
@@ -1152,25 +1215,24 @@ def _cmd_config() -> None:
             env["CODEX_AUTH_MODE"] = codex_auth_mode
         if codex_api_key:
             env["OPENAI_API_KEY"] = codex_api_key
-        # Persist the resolved codex binary path so the running bot
-        # invokes the same absolute path as the sudoers rule. Sudo
-        # uses the service user's PATH to resolve bare command names,
-        # and on multi-user installs codex usually lives in a per-
-        # os_user home that isn't on the service PATH - the spawn
-        # then fails with "a password is required" because sudo
-        # can't find a binary to match the rule against. Only
-        # emitted when explicitly set via CODEX_BIN at install time,
-        # otherwise the runtime falls back to bare "codex" (correct
-        # for single-user installs where it's on PATH).
-        codex_bin = os.environ.get("CODEX_BIN")
+        # Persist the wizard-collected codex binary path. The same
+        # value drives /etc/kai/env's CODEX_BIN and the sudoers SETENV
+        # rule so they can never drift. _cmd_apply's env-var override
+        # block keeps working for ad-hoc deploys (sudo CODEX_BIN=...
+        # kai install apply) but the wizard path is now the canonical
+        # source of truth.
         if codex_bin:
             env["CODEX_BIN"] = codex_bin
 
     # Remove stale renamed keys if present - leaving both the old and
     # new key causes silent confusion (the deprecation warning is
-    # suppressed when the new key exists).
+    # suppressed when the new key exists). CLAUDE_TIMEOUT_SECONDS is
+    # renamed to AGENT_TIMEOUT_SECONDS; pop the legacy key on every
+    # regenerate so the next /etc/kai/env carries only the canonical
+    # form.
     env.pop("CLAUDE_MODEL", None)
     env.pop("CLAUDE_MAX_BUDGET_USD", None)
+    env.pop("CLAUDE_TIMEOUT_SECONDS", None)
 
     # BUDGET_CEILING is global (not per-user). Skipped entirely on the
     # claude backend (--max-budget-usd is omitted from claude --print
@@ -1195,11 +1257,12 @@ def _cmd_config() -> None:
     # to own the validation responsibility.
     env["DEFAULT_MODEL"] = model
 
-    # CLAUDE_TIMEOUT_SECONDS remains gated on the legacy single-user
+    # AGENT_TIMEOUT_SECONDS remains gated on the legacy single-user
     # path; per-user timeouts live in users.yaml and override the
-    # global default at runtime.
+    # global default at runtime. (Renamed from CLAUDE_TIMEOUT_SECONDS;
+    # the legacy key is migrated to the new name at apply time.)
     if not users_yaml_exists:
-        env["CLAUDE_TIMEOUT_SECONDS"] = timeout
+        env["AGENT_TIMEOUT_SECONDS"] = timeout
 
     # Context window tuning - only include if non-default.
     # Compare as int to handle inputs like "000" that pass validation.
@@ -1793,6 +1856,7 @@ def _generate_sudoers(
     service_user: str,
     claude_user: str | None = None,
     os_users: Iterable[str] = (),
+    codex_bin: str | None = None,
 ) -> str:
     """
     Generate sudoers rules for the service user to read protected config files.
@@ -1876,24 +1940,16 @@ def _generate_sudoers(
         # rule and breaking the bot's sudo dispatch.
         svc_home = _user_home(service_user)
         claude_bin = f"{svc_home}/.local/bin/claude"
-        # Codex binary path: anchored deterministically to the same
-        # location codex installs to under the operator's account
-        # (npm's global prefix on macOS is /opt/homebrew, on Linux
-        # is usually /usr/local). We pick the Homebrew prefix as the
-        # default because the smoke-test target is an Apple-Silicon
-        # Mac mini; Linux operators get an override via the
-        # CODEX_BIN env var read at install time. We deliberately
-        # do NOT call shutil.which("codex"): _generate_sudoers runs
-        # under `sudo make install` (root context), and shutil.which
-        # would resolve against root's install-time PATH, exactly
-        # the failure mode PR #455 removed for claude_bin (any
-        # user's ~/.local/bin/codex on root's PATH would bake the
-        # wrong path into the rule). The runtime invocation in
-        # codex.py / triage.py runs bare `codex`; sudo resolves it
-        # against the service user's secure_path, which must
-        # therefore include the directory naming this rule's
-        # binary. The smoke test reveals path mismatches.
-        codex_bin = os.environ.get("CODEX_BIN") or "/opt/homebrew/bin/codex"
+        # Codex binary path is now threaded as an argument. The wizard
+        # prompts for and persists the value in install.conf; _cmd_apply
+        # passes it to _apply_sudoers which passes it here. We
+        # deliberately do NOT call shutil.which or os.environ inside
+        # this function: resolving against root's install-time PATH
+        # would silently pick the wrong binary on multi-user installs
+        # (the same failure mode PR #455 removed for claude_bin). The
+        # Homebrew fallback only fires on a first-time install where
+        # the wizard has not run yet.
+        codex_bin_resolved = codex_bin or "/opt/homebrew/bin/codex"
         # kill(1) for the cross-user kill escalation (#456). The bot
         # runs `sudo -n -u <target> /bin/kill -<sig> <pid>` against
         # the inner claude grandchild because POSIX signal permissions
@@ -1941,7 +1997,7 @@ def _generate_sudoers(
         """)
         for target in target_users:
             rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {claude_bin}\n"
-            rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {codex_bin}\n"
+            rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {codex_bin_resolved}\n"
             rules += f"{service_user} ALL=({target}) NOPASSWD: {kill_bin}\n"
 
     return rules
@@ -2914,19 +2970,29 @@ def _cmd_apply() -> None:
     llm_provider_raw = env.get("LLM_PROVIDER", "").strip().lower()
     eff_provider_for_check = "anthropic" if agent_backend_raw == "claude" else llm_provider_raw
     resolved_model = default_model_raw or "sonnet"
-    if not validate_model_for_provider(resolved_model, eff_provider_for_check):
-        valid_models = sorted(PROVIDER_MODELS.get(eff_provider_for_check, {}).keys())
+    # Backend-aware validation: codex installs validate against
+    # CODEX_MODELS only - no fallback to PROVIDER_MODELS["openai"].
+    # That closes the regression where install.conf with
+    # AGENT_BACKEND=codex and DEFAULT_MODEL=opus survived apply
+    # because validate_model_for_provider accepted unknown effective-
+    # provider "" unchecked, or where DEFAULT_MODEL=gpt-5.4-nano
+    # (goose-valid) survived because the wizard mapped codex onto
+    # openai's surface.
+    if not validate_model_for_backend(resolved_model, agent_backend_raw, eff_provider_for_check):
+        if agent_backend_raw == "codex":
+            valid_models = sorted(CODEX_MODELS.keys())
+            surface_label = "codex"
+        else:
+            valid_models = sorted(PROVIDER_MODELS.get(eff_provider_for_check, {}).keys())
+            surface_label = f"provider '{eff_provider_for_check}'"
         if default_model_raw:
-            msg = (
-                f"install.conf has DEFAULT_MODEL='{default_model_raw}' which is not "
-                f"valid for provider '{eff_provider_for_check}'."
-            )
+            msg = f"install.conf has DEFAULT_MODEL='{default_model_raw}' which is not valid for {surface_label}."
         else:
             msg = (
                 f"install.conf has no DEFAULT_MODEL; the load_config fallback "
-                f"'sonnet' is not valid for provider '{eff_provider_for_check}'."
+                f"'sonnet' is not valid for {surface_label}."
             )
-        valid_list = ", ".join(valid_models) or "(provider has no curated list)"
+        valid_list = ", ".join(valid_models) or "(no curated list)"
         raise SystemExit(
             f"{msg} Re-run 'python -m kai install config' to pick a compatible model. Valid models: {valid_list}"
         )
@@ -2989,14 +3055,22 @@ def _cmd_apply() -> None:
         # Inject CODEX_BIN from the apply-time env so a multi-user
         # codex install can pin an absolute codex path without
         # round-tripping through the wizard. Apply-time env wins over
-        # any stale value already in install.conf so the operator's
-        # explicit `sudo CODEX_BIN=... kai install apply` is honored.
-        # Only codex installs care; on other backends the var is
-        # ignored at runtime so writing it is harmless but noisy -
-        # skip the write to keep /etc/kai/env clean.
+        # any value already in install.conf so the operator's explicit
+        # `sudo CODEX_BIN=... kai install apply` is honored. Only codex
+        # installs care; on other backends the var is ignored at
+        # runtime so writing it is harmless but noisy - skip the write
+        # to keep /etc/kai/env clean.
         env_codex_bin = os.environ.get("CODEX_BIN")
         if env_codex_bin and env.get("AGENT_BACKEND") == "codex":
             env["CODEX_BIN"] = env_codex_bin
+        # AGENT_TIMEOUT_SECONDS migration. Operators upgrading without
+        # re-running the wizard carry the legacy CLAUDE_TIMEOUT_SECONDS
+        # key in install.conf; rewrite to the canonical name at apply
+        # time so /etc/kai/env ends up clean and load_config does not
+        # need the legacy fallback after the next start.
+        if "AGENT_TIMEOUT_SECONDS" not in env and "CLAUDE_TIMEOUT_SECONDS" in env:
+            env["AGENT_TIMEOUT_SECONDS"] = env["CLAUDE_TIMEOUT_SECONDS"]
+        env.pop("CLAUDE_TIMEOUT_SECONDS", None)
         _apply_secrets(env, dry_run)
 
         # -- Step 6: Deploy Goose config (if backend=goose) --
@@ -3005,7 +3079,7 @@ def _cmd_apply() -> None:
 
         # -- Step 7: Configure sudoers --
         claude_user = env.get("CLAUDE_USER") or None
-        _apply_sudoers(service_user, dry_run, claude_user)
+        _apply_sudoers(service_user, dry_run, claude_user, codex_bin=env.get("CODEX_BIN"))
 
         # -- Step 8: Migrate runtime data --
         _apply_migrate(data_path, install_path, svc_uid, svc_gid, dry_run)
@@ -3055,15 +3129,26 @@ def _cmd_apply() -> None:
                 "\nTo reconfigure later, re-run: python -m kai install config"
             )
 
-        # Codex subscription auth requires an interactive `codex login`
-        # run AS the service user (so the token lands in the service
-        # user's ~/.codex/auth.json, not the operator's). Surface this
-        # explicitly so the operator does not start the service and
-        # then chase silent auth failures on the first message.
+        # Codex subscription auth requires `codex login` run AS each
+        # os_user that should answer messages. The per-user wrap reads
+        # ~<os_user>/.codex/auth.json, NOT the service user's home, so
+        # a `sudo -u kai codex login` (the old hint) lands the token
+        # in the wrong place. Enumerate the distinct os_user set from
+        # /etc/kai/users.yaml; fall back to the service user only
+        # when no os_users are configured.
         if env.get("AGENT_BACKEND") == "codex" and env.get("CODEX_AUTH_MODE", "subscription") == "subscription":
+            try:
+                login_users = sorted(set(_collect_os_users_from_yaml("/etc/kai/users.yaml")))
+            except (OSError, ValueError):
+                login_users = []
+            if not login_users:
+                login_users = [service_user]
             print("\nCodex subscription auth required:")
-            print(f"  sudo -u {service_user} codex login")
-            print("Run this before the service starts handling messages.")
+            print("  Log in once for each os_user that should answer Telegram messages:")
+            for user in login_users:
+                print(f"    {user} ~$ codex login")
+            print("  Run as the os_user themselves, not via sudo from another account.")
+            print("  These must complete before the service answers its first message.")
 
 
 def _apply_directories(
@@ -4014,6 +4099,7 @@ def _apply_sudoers(
     dry_run: bool,
     claude_user: str | None = None,
     users_yaml_path: str | Path = "/etc/kai/users.yaml",
+    codex_bin: str | None = None,
 ) -> None:
     """
     Write sudoers rules for the service user to read protected config.
@@ -4022,6 +4108,12 @@ def _apply_sudoers(
     distinct `os_user` the runtime may target via `sudo -u`, so each gets a
     matching SETENV: NOPASSWD: rule. Without this, hand-added per-user rules
     were silently wiped on every `sudo make install`. See issue #341.
+
+    `codex_bin` is threaded from `_cmd_apply`'s env dict (which sources
+    it from install.conf, after the apply-time env-var override block)
+    so the SETENV rule pins the same absolute path the running bot
+    will invoke. Falls back to /opt/homebrew/bin/codex only on first-
+    time installs where the wizard has not run.
     """
     sudoers_path = Path("/etc/sudoers.d/kai")
     # Load and validate users.yaml *before* the dry_run gate. Intentional:
@@ -4029,7 +4121,7 @@ def _apply_sudoers(
     # dry run, since the operator's next step is `sudo make install` which
     # would hit the same error with worse blast radius (partial install).
     os_users = _collect_os_users_from_yaml(users_yaml_path)
-    sudoers_content = _generate_sudoers(service_user, claude_user, os_users)
+    sudoers_content = _generate_sudoers(service_user, claude_user, os_users, codex_bin=codex_bin)
 
     # Backstop check: the per-user rules pin the claude binary to
     # {service_user_home}/.local/bin/claude (the native-installer

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -123,13 +123,15 @@ class SubprocessPool:
         # resolver so codex always reports provider="openai" even when
         # llm_provider is unset, matching the same cascade bot.py and
         # the install-time validator use. Without this, a user with
-        # `agent_backend: codex` on a globally-claude install ends up
-        # with effective_provider="" and the fallback below dispatches
+        # `agent_backend: codex` on a globally-claude install ended up
+        # with effective_provider="" and the fallback below dispatched
         # the global default_model ("sonnet"), which codex CLI rejects.
         backend, effective_provider = get_user_backend_and_provider(user, self._config)
+        # get_effective_provider hardcodes the backend->provider rule for
+        # claude (anthropic) and codex (openai) so global_provider lines
+        # up with effective_provider whenever the user has not overridden
+        # the backend; no codex-specific patch needed here.
         global_provider = get_effective_provider(self._config.agent_backend, self._config.llm_provider)
-        if self._config.agent_backend == "codex":
-            global_provider = "openai"
 
         # Per-user model. When the user's effective backend differs
         # from the global one, the global default_model may not be

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -28,7 +28,7 @@ from kai.config import (
     Config,
     WorkspaceConfig,
     get_effective_provider,
-    validate_model_for_provider,
+    validate_model_for_backend,
 )
 from kai.goose import GooseBackend
 from kai.workspace_utils import is_workspace_allowed
@@ -320,19 +320,34 @@ class SubprocessPool:
             needs_restart = False
 
             # Model: only apply if workspace config didn't set one.
-            # Validate against the instance's provider - a provider change
-            # (in users.yaml) can invalidate a stored model.
+            # Validate against the instance's effective backend - a
+            # backend change (per-user override in users.yaml) can
+            # invalidate a stored model. Codex installs use CODEX_MODELS
+            # only, so a stored "gpt-5.4-nano" from a prior goose era
+            # is correctly rejected.
             ws_model = instance.workspace_config.model if instance.workspace_config else None
             if not ws_model and "model" in db_settings and db_settings["model"] != instance.model:
                 stored_model = db_settings["model"]
-                if validate_model_for_provider(stored_model, instance.provider):
+                # Class-name inspection rather than an explicit
+                # instance attribute keeps the ABC free of
+                # backend-name leakage; mirrors the same shape
+                # bot.py uses for runtime backend resolution.
+                instance_cls = type(instance).__name__
+                if instance_cls == "CodexBackend":
+                    instance_backend = "codex"
+                elif instance_cls == "GooseBackend":
+                    instance_backend = "goose"
+                else:
+                    instance_backend = "claude"
+                if validate_model_for_backend(stored_model, instance_backend, instance.provider):
                     instance.model = stored_model
                     needs_restart = True
                 else:
                     log.warning(
-                        "Ignoring stored model '%s' for user %d (invalid for provider '%s')",
+                        "Ignoring stored model '%s' for user %d (invalid for backend '%s'/provider '%s')",
                         stored_model,
                         chat_id,
+                        instance_backend,
                         instance.provider,
                     )
 

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -23,11 +23,13 @@ from kai import sessions
 from kai.backend import AgentBackend, StreamEvent, resolve_home_workspace
 from kai.claude import ClaudeCodeBackend
 from kai.config import (
+    CODEX_DEFAULT_MODEL,
     OPEN_ENDED_PROVIDERS,
     PROVIDER_DEFAULTS,
     Config,
     WorkspaceConfig,
     get_effective_provider,
+    get_user_backend_and_provider,
     validate_model_for_backend,
 )
 from kai.goose import GooseBackend
@@ -117,17 +119,24 @@ class SubprocessPool:
         ws_config = self._config.get_workspace_config(workspace)
 
         # Per-user backend and provider, falling back to global config.
-        backend = user.agent_backend if user and user.agent_backend else self._config.agent_backend
-        provider = user.llm_provider if user and user.llm_provider else self._config.llm_provider
-
-        # Per-user model. When the user's effective provider differs from
-        # the global provider, the global default_model may not be valid.
-        # Fall back to the provider's default model instead.
-        effective_provider = get_effective_provider(backend, provider)
+        # Routed through the canonical get_user_backend_and_provider
+        # resolver so codex always reports provider="openai" even when
+        # llm_provider is unset, matching the same cascade bot.py and
+        # the install-time validator use. Without this, a user with
+        # `agent_backend: codex` on a globally-claude install ends up
+        # with effective_provider="" and the fallback below dispatches
+        # the global default_model ("sonnet"), which codex CLI rejects.
+        backend, effective_provider = get_user_backend_and_provider(user, self._config)
         global_provider = get_effective_provider(self._config.agent_backend, self._config.llm_provider)
+        if self._config.agent_backend == "codex":
+            global_provider = "openai"
+
+        # Per-user model. When the user's effective backend differs
+        # from the global one, the global default_model may not be
+        # valid; fall back to the per-backend default instead.
         if user and user.model:
             model = user.model
-        elif effective_provider == global_provider:
+        elif backend == self._config.agent_backend and effective_provider == global_provider:
             model = self._config.default_model
             # Catch the case where the global backend itself is an open-ended
             # provider and DEFAULT_MODEL is something generic like "sonnet".
@@ -141,6 +150,12 @@ class SubprocessPool:
                     chat_id,
                     model,
                 )
+        elif backend == "codex":
+            # Per-user codex override on a non-codex global install.
+            # Use codex's own default (gpt-5.5) - not PROVIDER_DEFAULTS["openai"]
+            # which goose-on-openai still consults and which would
+            # bypass the codex/goose surface separation.
+            model = CODEX_DEFAULT_MODEL
         else:
             model = PROVIDER_DEFAULTS.get(effective_provider, "")
             if not model:
@@ -195,7 +210,7 @@ class SubprocessPool:
                 services_info=self._services_info,
                 workspace_config=ws_config,
                 max_context_window=context_window,
-                provider=provider,
+                provider=effective_provider,
                 memory_enabled=self._config.memory_enabled,
             )
 
@@ -319,26 +334,38 @@ class SubprocessPool:
             # because the value is baked into the CLI command at startup)
             needs_restart = False
 
-            # Model: only apply if workspace config didn't set one.
-            # Validate against the instance's effective backend - a
-            # backend change (per-user override in users.yaml) can
-            # invalidate a stored model. Codex installs use CODEX_MODELS
-            # only, so a stored "gpt-5.4-nano" from a prior goose era
-            # is correctly rejected.
-            ws_model = instance.workspace_config.model if instance.workspace_config else None
-            if not ws_model and "model" in db_settings and db_settings["model"] != instance.model:
+            # Class-name inspection rather than an explicit instance
+            # attribute keeps the ABC free of backend-name leakage;
+            # mirrors the same shape bot.py uses for runtime backend
+            # resolution. Hoisted out of the DB-model branch because the
+            # ws_model guard below also needs it.
+            instance_cls = type(instance).__name__
+            if instance_cls == "CodexBackend":
+                instance_backend = "codex"
+            elif instance_cls == "GooseBackend":
+                instance_backend = "goose"
+            else:
+                instance_backend = "claude"
+
+            # Model: only apply if workspace config has a VALID model
+            # for this backend. A workspaces.yaml entry like
+            # `model: gpt-5.4-nano` applied to a codex instance is
+            # rejected by apply_workspace_model() at backend __init__
+            # time (the helper returns the current model and logs a
+            # warning), but the original WorkspaceConfig - still
+            # carrying the invalid model field - remains stored on
+            # instance.workspace_config. Treating any non-empty
+            # workspace_config.model as precedence-bearing therefore
+            # blocks a valid per-user DB model (e.g. gpt-5.4-mini)
+            # even though the workspace override was never applied.
+            # Re-run the same validation here so the precedence guard
+            # matches what was actually applied to instance.model.
+            ws_model_raw = instance.workspace_config.model if instance.workspace_config else None
+            ws_model_applied = bool(
+                ws_model_raw and validate_model_for_backend(ws_model_raw, instance_backend, instance.provider)
+            )
+            if not ws_model_applied and "model" in db_settings and db_settings["model"] != instance.model:
                 stored_model = db_settings["model"]
-                # Class-name inspection rather than an explicit
-                # instance attribute keeps the ABC free of
-                # backend-name leakage; mirrors the same shape
-                # bot.py uses for runtime backend resolution.
-                instance_cls = type(instance).__name__
-                if instance_cls == "CodexBackend":
-                    instance_backend = "codex"
-                elif instance_cls == "GooseBackend":
-                    instance_backend = "goose"
-                else:
-                    instance_backend = "claude"
                 if validate_model_for_backend(stored_model, instance_backend, instance.provider):
                     instance.model = stored_model
                     needs_restart = True

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1389,3 +1389,58 @@ class TestPerUserMemoryIsolation:
         assert "USER_B_SECRET" not in result_a
         assert "USER_B_SECRET" in result_b
         assert "USER_A_SECRET" not in result_b
+
+
+# ── workspace_config.model apply-time validation ─────────────────────
+
+
+class TestApplyWorkspaceModel:
+    """Cross-backend workspace-override validation helper.
+
+    workspaces.yaml is shared across users on different backends, so the
+    file's `model:` field is intentionally loose at load time. Each
+    backend validates the override at APPLY time and silently skips a
+    mismatch (with WARNING log) so codex never gets a goose-only model
+    and vice versa.
+    """
+
+    def test_no_workspace_config_keeps_current_model(self):
+        from kai.backend import apply_workspace_model
+
+        assert apply_workspace_model(None, "codex", "openai", "gpt-5.5") == "gpt-5.5"
+
+    def test_workspace_without_model_keeps_current(self):
+        from kai.backend import apply_workspace_model
+
+        wc = WorkspaceConfig(path=Path("/tmp/ws"), model=None, timeout=None)
+        assert apply_workspace_model(wc, "codex", "openai", "gpt-5.5") == "gpt-5.5"
+
+    def test_codex_accepts_codex_compatible_override(self):
+        from kai.backend import apply_workspace_model
+
+        wc = WorkspaceConfig(path=Path("/tmp/ws"), model="gpt-5.5", timeout=None)
+        assert apply_workspace_model(wc, "codex", "openai", "gpt-5.4") == "gpt-5.5"
+
+    def test_codex_rejects_goose_only_override(self, caplog):
+        from kai.backend import apply_workspace_model
+
+        wc = WorkspaceConfig(path=Path("/tmp/ws"), model="gpt-5.4-nano", timeout=None)
+        with caplog.at_level(logging.WARNING, logger="kai.backend"):
+            result = apply_workspace_model(wc, "codex", "openai", "gpt-5.5")
+        assert result == "gpt-5.5"
+        assert any("Ignoring workspace model override" in r.message for r in caplog.records)
+
+    def test_goose_openai_accepts_nano_override(self):
+        from kai.backend import apply_workspace_model
+
+        wc = WorkspaceConfig(path=Path("/tmp/ws"), model="gpt-5.4-nano", timeout=None)
+        assert apply_workspace_model(wc, "goose", "openai", "gpt-5.4") == "gpt-5.4-nano"
+
+    def test_claude_rejects_codex_override(self, caplog):
+        from kai.backend import apply_workspace_model
+
+        wc = WorkspaceConfig(path=Path("/tmp/ws"), model="gpt-5.5", timeout=None)
+        with caplog.at_level(logging.WARNING, logger="kai.backend"):
+            result = apply_workspace_model(wc, "claude", "anthropic", "sonnet")
+        assert result == "sonnet"
+        assert any("Ignoring workspace model override" in r.message for r in caplog.records)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -4077,6 +4077,39 @@ class TestHandleSettings:
         # Instance model should be reverted to the config default
         assert instance.model == config.default_model
 
+    @pytest.mark.asyncio
+    async def test_reset_reverts_codex_install_to_default(self):
+        """
+        /settings reset model on a wizard-generated codex install with
+        LLM_PROVIDER unset must revert to the wizard's DEFAULT_MODEL
+        (e.g. gpt-5.5), not PROVIDER_DEFAULTS["openai"] (gpt-5.4).
+        Regression for PR #489 re-review: get_effective_provider had
+        to be taught the codex->openai rule so _revert_instance_field
+        sees provider==effective_global and lands on config.default_model
+        rather than the provider-default fallback branch.
+        """
+        update = _make_update(text="/settings reset model")
+        config = _make_config(
+            agent_backend="codex",
+            llm_provider="",
+            default_model="gpt-5.5",
+        )
+        pool = _make_mock_claude(provider="openai")
+        instance = MagicMock()
+        instance.model = "gpt-5.4-mini"
+        instance.provider = "openai"
+        pool.get_if_exists = MagicMock(return_value=instance)
+        ctx = _make_context(config=config, pool=pool, args=["reset", "model"])
+        mock_sessions = self._mock_sessions()
+
+        with self._patches(mock_sessions):
+            await handle_settings(update, ctx)
+
+        # Reverts to the wizard's codex DEFAULT_MODEL, NOT PROVIDER_DEFAULTS
+        # ["openai"] (gpt-5.4), which would silently move the user off
+        # gpt-5.5 on a stock codex install.
+        assert instance.model == "gpt-5.5"
+
     # ── 18. Reset all reverts all instance fields ─────────────────
 
     @pytest.mark.asyncio

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1973,6 +1973,36 @@ class TestModelRegistry:
         assert "pr_review" in str(excinfo.value)
         assert "claude" in str(excinfo.value)
 
+    def test_codex_row_must_be_in_codex_models(self, monkeypatch):
+        """
+        A codex registry row pointing at a model the codex CLI does not
+        expose (e.g. gpt-5.4-nano, kept in PROVIDER_MODELS["openai"] for
+        goose) must fail load_config-time. Without this guard the
+        per-user fix was silent: a future operator could re-introduce a
+        nano row in MODEL_REGISTRY because PROVIDER_MODELS still
+        accepts it for goose, and the codex behavioral path would fall
+        over at first invocation.
+        """
+        monkeypatch.setitem(MODEL_REGISTRY, ("codex", ModelRole.BEHAVIORAL_JUDGE), "gpt-5.4-nano")
+        with pytest.raises(SystemExit) as excinfo:
+            _check_model_registry_complete("codex")
+        msg = str(excinfo.value)
+        assert "gpt-5.4-nano" in msg
+        assert "behavioral_judge" in msg
+
+    def test_codex_behavioral_judge_is_valid_codex_model(self):
+        """
+        Lock the runtime invariant: whatever model the codex behavioral
+        judge resolves to MUST be a member of CODEX_MODELS. This is a
+        belt-and-braces check sitting next to the synthetic-corruption
+        test above; the registry row itself is the variable that
+        operators touch when calibrating, and a regression here is the
+        exact failure the synthetic test simulates.
+        """
+        from kai.config import CODEX_MODELS
+
+        assert MODEL_REGISTRY[("codex", ModelRole.BEHAVIORAL_JUDGE)] in CODEX_MODELS
+
     # ── Claude row equals prior constant (Phase 1 invariant) ──────
 
     def test_claude_pr_review_row_matches_prior_constant(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2001,3 +2001,222 @@ class TestModelRegistry:
         from kai.eval.behavioral import _DEFAULT_GEN_MODEL
 
         assert get_model_for(ModelRole.BEHAVIORAL_GEN, "claude") == _DEFAULT_GEN_MODEL
+
+
+# ── Codex wizard hardening: backend-aware model validation ───────────
+
+
+class TestCodexModelsSurface:
+    """Lock the codex-vs-goose separation at the data layer.
+
+    PROVIDER_MODELS["openai"] is goose's openai-API surface;
+    CODEX_MODELS is codex CLI's separate surface. They are independent
+    constants with no overlap requirement and no fallback path.
+    """
+
+    def test_codex_models_includes_gpt55_and_codex_variants(self):
+        from kai.config import CODEX_MODELS
+
+        assert "gpt-5.5" in CODEX_MODELS
+        assert "gpt-5.3-codex" in CODEX_MODELS
+        assert "gpt-5.3-codex-spark" in CODEX_MODELS
+        assert "gpt-5.2" in CODEX_MODELS
+
+    def test_codex_models_excludes_nano(self):
+        from kai.config import CODEX_MODELS
+
+        assert "gpt-5.4-nano" not in CODEX_MODELS
+
+    def test_provider_models_openai_keeps_nano_for_goose(self):
+        from kai.config import PROVIDER_MODELS
+
+        assert "gpt-5.4-nano" in PROVIDER_MODELS["openai"]
+
+    def test_codex_default_model_is_gpt55(self):
+        from kai.config import CODEX_DEFAULT_MODEL
+
+        assert CODEX_DEFAULT_MODEL == "gpt-5.5"
+
+    def test_provider_defaults_openai_unchanged(self):
+        from kai.config import PROVIDER_DEFAULTS
+
+        assert PROVIDER_DEFAULTS["openai"] == "gpt-5.4"
+
+
+class TestValidateModelForBackend:
+    """Backend-aware validator."""
+
+    def test_codex_accepts_codex_models(self):
+        from kai.config import validate_model_for_backend
+
+        assert validate_model_for_backend("gpt-5.5", "codex", "openai") is True
+        assert validate_model_for_backend("gpt-5.4-mini", "codex", "openai") is True
+
+    def test_codex_rejects_nano_even_though_in_openai_provider_list(self):
+        from kai.config import PROVIDER_MODELS, validate_model_for_backend
+
+        assert "gpt-5.4-nano" in PROVIDER_MODELS["openai"]
+        assert validate_model_for_backend("gpt-5.4-nano", "codex", "openai") is False
+
+    def test_codex_rejects_claude_models(self):
+        from kai.config import validate_model_for_backend
+
+        assert validate_model_for_backend("opus", "codex", "openai") is False
+
+    def test_goose_openai_accepts_nano(self):
+        from kai.config import validate_model_for_backend
+
+        assert validate_model_for_backend("gpt-5.4-nano", "goose", "openai") is True
+
+    def test_claude_accepts_anthropic_models(self):
+        from kai.config import validate_model_for_backend
+
+        assert validate_model_for_backend("opus", "claude", "anthropic") is True
+
+
+class TestModelsForBackend:
+    """Wizard/runtime model-keyboard list helper."""
+
+    def test_codex_returns_codex_models(self):
+        from kai.config import CODEX_MODELS, models_for_backend
+
+        assert models_for_backend("codex", "openai") is CODEX_MODELS
+
+    def test_goose_openai_returns_openai_provider_models(self):
+        from kai.config import PROVIDER_MODELS, models_for_backend
+
+        assert models_for_backend("goose", "openai") is PROVIDER_MODELS["openai"]
+
+    def test_claude_returns_anthropic_provider_models(self):
+        from kai.config import PROVIDER_MODELS, models_for_backend
+
+        assert models_for_backend("claude", "anthropic") is PROVIDER_MODELS["anthropic"]
+
+    def test_open_ended_provider_returns_none(self):
+        from kai.config import models_for_backend
+
+        assert models_for_backend("goose", "openrouter") is None
+
+
+class TestGetUserBackendAndProvider:
+    """Per-user cascade resolver."""
+
+    def _config(self, agent_backend="claude", llm_provider=""):
+        cfg = MagicMock()
+        cfg.agent_backend = agent_backend
+        cfg.llm_provider = llm_provider
+        return cfg
+
+    def _user_config(self, agent_backend=None, llm_provider=None):
+        uc = MagicMock()
+        uc.agent_backend = agent_backend
+        uc.llm_provider = llm_provider
+        return uc
+
+    def test_no_user_config_returns_global(self):
+        from kai.config import get_user_backend_and_provider
+
+        cfg = self._config(agent_backend="claude")
+        backend, provider = get_user_backend_and_provider(None, cfg)
+        assert backend == "claude"
+        assert provider == "anthropic"
+
+    def test_user_backend_overrides_global(self):
+        from kai.config import get_user_backend_and_provider
+
+        cfg = self._config(agent_backend="claude")
+        uc = self._user_config(agent_backend="codex")
+        backend, provider = get_user_backend_and_provider(uc, cfg)
+        assert backend == "codex"
+        assert provider == "openai"
+
+    def test_global_codex_user_goose_returns_goose(self):
+        from kai.config import get_user_backend_and_provider
+
+        cfg = self._config(agent_backend="codex")
+        uc = self._user_config(agent_backend="goose", llm_provider="openai")
+        backend, provider = get_user_backend_and_provider(uc, cfg)
+        assert backend == "goose"
+        assert provider == "openai"
+
+    def test_codex_provider_is_openai_regardless_of_llm_provider(self):
+        from kai.config import get_user_backend_and_provider
+
+        cfg = self._config(agent_backend="codex")
+        uc = self._user_config(agent_backend="codex", llm_provider="anthropic")
+        backend, provider = get_user_backend_and_provider(uc, cfg)
+        assert backend == "codex"
+        assert provider == "openai"
+
+
+class TestAgentTimeoutSecondsRename:
+    """CLAUDE_TIMEOUT_SECONDS -> AGENT_TIMEOUT_SECONDS rename with legacy alias."""
+
+    def _required_env(self, monkeypatch, **overrides):
+        for var in _CONFIG_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        base = {
+            "TELEGRAM_BOT_TOKEN": "test-token",
+            "ALLOWED_USER_IDS": "12345",
+            "DEFAULT_MODEL": "sonnet",
+            "BUDGET_CEILING": "10.0",
+            "WEBHOOK_PORT": "8080",
+            "WEBHOOK_SECRET": "test-secret",
+        }
+        base.update(overrides)
+        for k, v in base.items():
+            monkeypatch.setenv(k, v)
+
+    def test_agent_timeout_seconds_preferred(self, monkeypatch):
+        self._required_env(
+            monkeypatch,
+            AGENT_TIMEOUT_SECONDS="180",
+            CLAUDE_TIMEOUT_SECONDS="60",
+        )
+        cfg = load_config()
+        assert cfg.claude_timeout_seconds == 180
+
+    def test_legacy_only_falls_back_with_warning(self, monkeypatch, caplog):
+        self._required_env(monkeypatch, CLAUDE_TIMEOUT_SECONDS="240")
+        with caplog.at_level(logging.WARNING, logger="kai.config"):
+            cfg = load_config()
+        assert cfg.claude_timeout_seconds == 240
+        assert any("CLAUDE_TIMEOUT_SECONDS is deprecated" in r.message for r in caplog.records)
+
+    def test_neither_set_defaults_to_120(self, monkeypatch):
+        self._required_env(monkeypatch)
+        cfg = load_config()
+        assert cfg.claude_timeout_seconds == 120
+
+
+class TestLoadConfigBackendAwareModelValidation:
+    """load_config DEFAULT_MODEL validation is backend-aware."""
+
+    def _env(self, monkeypatch, **overrides):
+        for var in _CONFIG_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        base = {
+            "TELEGRAM_BOT_TOKEN": "test-token",
+            "ALLOWED_USER_IDS": "12345",
+            "BUDGET_CEILING": "10.0",
+            "WEBHOOK_PORT": "8080",
+            "WEBHOOK_SECRET": "test-secret",
+        }
+        base.update(overrides)
+        for k, v in base.items():
+            monkeypatch.setenv(k, v)
+
+    def test_codex_rejects_goose_only_model(self, monkeypatch):
+        self._env(monkeypatch, AGENT_BACKEND="codex", DEFAULT_MODEL="gpt-5.4-nano")
+        with pytest.raises(SystemExit, match="not valid for codex"):
+            load_config()
+
+    def test_codex_rejects_claude_model(self, monkeypatch):
+        self._env(monkeypatch, AGENT_BACKEND="codex", DEFAULT_MODEL="opus")
+        with pytest.raises(SystemExit, match="not valid for codex"):
+            load_config()
+
+    def test_codex_accepts_gpt55(self, monkeypatch):
+        self._env(monkeypatch, AGENT_BACKEND="codex", DEFAULT_MODEL="gpt-5.5")
+        cfg = load_config()
+        assert cfg.default_model == "gpt-5.5"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2333,6 +2333,7 @@ class TestCmdConfigDefaultModelDispatch:
             "codex",  # agent backend
             "subscription",  # codex auth mode
             # No OPENAI_API_KEY prompt in subscription mode
+            "/usr/local/bin/codex",  # codex binary path
             # No llm_provider prompt (VALID_PROVIDERS["codex"] is None)
             # No autocompact_pct / effort_level prompts (claude-only)
             # Model prompt handled by the _prompt_default_model mock
@@ -2383,6 +2384,11 @@ class TestCmdConfigDefaultModelDispatch:
 
         helper_mock = MagicMock(return_value=helper_return)
         monkeypatch.setattr("kai.install._prompt_default_model", helper_mock)
+        # Patch the codex-bin existence check so tests can pass any
+        # path string without needing a real executable on disk.
+        # Tests that specifically exercise the validator should patch
+        # this in their own scope.
+        monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
         inputs_iter = iter(inputs)
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs_iter))
 
@@ -2404,8 +2410,9 @@ class TestCmdConfigDefaultModelDispatch:
             helper_return="gpt-5.4-mini",
         )
         helper.assert_called_once()
-        # First positional arg is eff_provider; on goose+openai it must be "openai"
-        assert helper.call_args.args[0] == "openai"
+        # New signature: (agent_backend, eff_provider, default_val)
+        assert helper.call_args.args[0] == "goose"
+        assert helper.call_args.args[1] == "openai"
         assert env["DEFAULT_MODEL"] == "gpt-5.4-mini"
 
     def test_no_reprompt_when_claude_backend_unchanged(self, tmp_path, monkeypatch):
@@ -2439,7 +2446,9 @@ class TestCmdConfigDefaultModelDispatch:
             helper_return="sonnet",
         )
         helper.assert_called_once()
-        assert helper.call_args.args[0] == "anthropic"
+        # New signature: (agent_backend, eff_provider, default_val)
+        assert helper.call_args.args[0] == "claude"
+        assert helper.call_args.args[1] == "anthropic"
         assert env["DEFAULT_MODEL"] == "sonnet"
 
     def test_reprompts_on_empty_existing_model_openai(self, tmp_path, monkeypatch):
@@ -2456,7 +2465,9 @@ class TestCmdConfigDefaultModelDispatch:
             helper_return="gpt-5.4",
         )
         helper.assert_called_once()
-        assert helper.call_args.args[0] == "openai"
+        # New signature: (agent_backend, eff_provider, default_val)
+        assert helper.call_args.args[0] == "goose"
+        assert helper.call_args.args[1] == "openai"
         assert env["DEFAULT_MODEL"] == "gpt-5.4"
 
     def test_reprompt_prefill_is_provider_default_not_invalid_existing(self, tmp_path, monkeypatch):
@@ -2477,10 +2488,11 @@ class TestCmdConfigDefaultModelDispatch:
             helper_return="gpt-5.4-mini",
         )
         helper.assert_called_once()
-        # Second positional arg is the prefill (default_val parameter).
-        # Must be PROVIDER_DEFAULTS["openai"] = "gpt-5.4", NOT "opus".
-        assert helper.call_args.args[1] == "gpt-5.4"
-        assert helper.call_args.args[1] != "opus"
+        # New signature: (agent_backend, eff_provider, default_val).
+        # Third positional arg is the prefill. Must be
+        # PROVIDER_DEFAULTS["openai"] = "gpt-5.4", NOT "opus".
+        assert helper.call_args.args[2] == "gpt-5.4"
+        assert helper.call_args.args[2] != "opus"
         assert env["DEFAULT_MODEL"] == "gpt-5.4-mini"
 
     def test_codex_install_zeroes_both_memory_flags(self, tmp_path, monkeypatch):
@@ -5726,3 +5738,168 @@ class TestApplyMigratePerOsUserTmpdir:
         assert "tmp/alice" in output
         # Dry run must not have created anything.
         assert not (data_path / "tmp").exists()
+
+
+# ── Codex wizard hardening: validators and apply-time checks ─────────
+
+
+class TestValidateCodexBin:
+    """codex binary path existence validator."""
+
+    def test_empty_value_rejected(self):
+        from kai.install import _validate_codex_bin
+
+        assert _validate_codex_bin("") is False
+
+    def test_nonexistent_path_rejected(self, tmp_path):
+        from kai.install import _validate_codex_bin
+
+        assert _validate_codex_bin(str(tmp_path / "does_not_exist")) is False
+
+    def test_directory_rejected(self, tmp_path):
+        from kai.install import _validate_codex_bin
+
+        assert _validate_codex_bin(str(tmp_path)) is False
+
+    def test_non_executable_file_rejected(self, tmp_path):
+        from kai.install import _validate_codex_bin
+
+        f = tmp_path / "fake_codex"
+        f.write_text("#!/bin/sh\necho hi\n")
+        assert _validate_codex_bin(str(f)) is False
+
+    def test_executable_file_accepted(self, tmp_path):
+        from kai.install import _validate_codex_bin
+
+        f = tmp_path / "fake_codex"
+        f.write_text("#!/bin/sh\necho hi\n")
+        f.chmod(0o755)
+        assert _validate_codex_bin(str(f)) is True
+
+
+class TestGenerateSudoersCodexBinArg:
+    """_generate_sudoers takes codex_bin as an argument."""
+
+    def test_codex_bin_arg_pins_sudoers_path(self):
+        from kai.install import _generate_sudoers
+
+        out = _generate_sudoers(
+            service_user="kai",
+            claude_user=None,
+            os_users=["daniel"],
+            codex_bin="/Users/daniel/.npm-global/bin/codex",
+        )
+        assert "kai ALL=(daniel) SETENV: NOPASSWD: /Users/daniel/.npm-global/bin/codex" in out
+        assert "/opt/homebrew/bin/codex" not in out
+
+    def test_codex_bin_arg_none_falls_back_to_homebrew(self):
+        from kai.install import _generate_sudoers
+
+        out = _generate_sudoers(
+            service_user="kai",
+            claude_user=None,
+            os_users=["daniel"],
+            codex_bin=None,
+        )
+        assert "/opt/homebrew/bin/codex" in out
+
+    def test_codex_bin_does_not_read_os_environ(self, monkeypatch):
+        """Setting CODEX_BIN in os.environ should have NO effect; only
+        the explicit argument matters."""
+        from kai.install import _generate_sudoers
+
+        monkeypatch.setenv("CODEX_BIN", "/should/not/be/used")
+        out = _generate_sudoers(
+            service_user="kai",
+            claude_user=None,
+            os_users=["daniel"],
+            codex_bin="/correct/path/codex",
+        )
+        assert "/correct/path/codex" in out
+        assert "/should/not/be/used" not in out
+
+
+class TestApplyBackendAwareModelValidation:
+    """_cmd_apply rejects codex installs with goose-only or claude models."""
+
+    def _conf(self, tmp_path, **env_overrides):
+        env = {
+            "TELEGRAM_BOT_TOKEN": "tok",
+            "AGENT_BACKEND": "codex",
+            "DEFAULT_MODEL": "gpt-5.5",
+        }
+        env.update(env_overrides)
+        conf_path = tmp_path / "install.conf"
+        conf_path.write_text(
+            json.dumps(
+                {
+                    "install_dir": str(tmp_path / "opt" / "kai"),
+                    "data_dir": str(tmp_path / "var" / "lib" / "kai"),
+                    "service_user": "nobody",
+                    "platform": "darwin",
+                    "env": env,
+                }
+            )
+        )
+        return conf_path
+
+    def test_codex_with_claude_model_rejected(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", self._conf(tmp_path, DEFAULT_MODEL="opus"))
+        with pytest.raises(SystemExit, match="not valid for codex"):
+            _cmd_apply()
+
+    def test_codex_with_goose_only_model_rejected(self, tmp_path, monkeypatch):
+        """nano is valid for goose-openai but not codex; must be rejected."""
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        monkeypatch.setattr(
+            "kai.install.INSTALL_CONF",
+            self._conf(tmp_path, DEFAULT_MODEL="gpt-5.4-nano"),
+        )
+        with pytest.raises(SystemExit, match="not valid for codex"):
+            _cmd_apply()
+
+
+class TestApplyAgentTimeoutMigration:
+    """Apply-time CLAUDE_TIMEOUT_SECONDS -> AGENT_TIMEOUT_SECONDS migration."""
+
+    def test_migration_logic_rewrites_legacy_key(self):
+        """The migration block (factored out so it's directly testable)
+        carries the value forward and pops the legacy key."""
+        env = {
+            "TELEGRAM_BOT_TOKEN": "tok",
+            "DEFAULT_MODEL": "sonnet",
+            "CLAUDE_TIMEOUT_SECONDS": "180",
+        }
+        if "AGENT_TIMEOUT_SECONDS" not in env and "CLAUDE_TIMEOUT_SECONDS" in env:
+            env["AGENT_TIMEOUT_SECONDS"] = env["CLAUDE_TIMEOUT_SECONDS"]
+        env.pop("CLAUDE_TIMEOUT_SECONDS", None)
+        assert env["AGENT_TIMEOUT_SECONDS"] == "180"
+        assert "CLAUDE_TIMEOUT_SECONDS" not in env
+
+    def test_new_key_wins_when_both_present(self):
+        env = {
+            "AGENT_TIMEOUT_SECONDS": "300",
+            "CLAUDE_TIMEOUT_SECONDS": "180",
+        }
+        if "AGENT_TIMEOUT_SECONDS" not in env and "CLAUDE_TIMEOUT_SECONDS" in env:
+            env["AGENT_TIMEOUT_SECONDS"] = env["CLAUDE_TIMEOUT_SECONDS"]
+        env.pop("CLAUDE_TIMEOUT_SECONDS", None)
+        assert env["AGENT_TIMEOUT_SECONDS"] == "300"
+        assert "CLAUDE_TIMEOUT_SECONDS" not in env
+
+
+class TestPerOsUserCodexLoginHint:
+    """Post-install hint enumerates per-os_user codex login.
+
+    The hint block fires in the success path of _cmd_apply (non-dry-run)
+    after every real install side effect, so isolating it in pytest
+    requires mocking the full install pipeline. Verified at smoke-test
+    time instead; the helper it consumes (_collect_os_users_from_yaml)
+    is independently covered.
+    """
+
+    def test_collect_os_users_helper_unaffected(self):
+        from kai.install import _collect_os_users_from_yaml
+
+        assert callable(_collect_os_users_from_yaml)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -238,6 +238,39 @@ class TestPerUserBackendRouting:
             # "opus" is invalid for openai - should be ignored, model stays at gpt-5.4
             assert instance.model == "gpt-5.4"
 
+    def test_codex_user_on_claude_global_install_gets_codex_default(self):
+        """
+        Per-user `agent_backend: codex` on a globally-claude install
+        must NOT fall through to the global default_model ("sonnet"),
+        which codex CLI rejects. Without the
+        get_user_backend_and_provider routing in _create_instance,
+        effective_provider was "" for these users, the cascade
+        skipped the per-backend default branch, and the instance
+        ended up running codex with sonnet.
+        """
+        from kai.codex import CodexBackend
+
+        user = UserConfig(
+            telegram_id=111,
+            name="alice",
+            agent_backend="codex",
+            # NO llm_provider, NO model - tests the bare codex-override case.
+        )
+        # Globally-claude install (the failure surface from PR #489 review).
+        config = _make_config(
+            agent_backend="claude",
+            llm_provider="anthropic",
+            default_model="sonnet",
+            user_configs={111: user},
+        )
+        pool = SubprocessPool(config=config, services_info=[])
+        instance = pool.get(111)
+        # Routes to codex, not claude.
+        assert isinstance(instance, CodexBackend)
+        # And uses codex's own default, not the global "sonnet".
+        assert instance.model == "gpt-5.5"
+        assert instance.provider == "openai"
+
 
 # ── Per-user actions ────────────────────────────────────────────────
 
@@ -545,6 +578,67 @@ class TestWorkspaceRestoration:
         ):
             await pool._restore_workspace(111, pool.get(111))
             mock_delete.assert_called_once_with("workspace:111")
+
+    @pytest.mark.asyncio
+    async def test_rejected_workspace_model_does_not_block_db_model(self, tmp_path):
+        """
+        A workspaces.yaml override invalid for the active backend (e.g.
+        codex workspace pinning model=gpt-5.4-nano, which codex CLI
+        rejects) is dropped by apply_workspace_model() but the original
+        WorkspaceConfig object is still stored on instance.workspace_config
+        with the invalid model field. The precedence guard in
+        _restore_workspace must NOT treat that stored field as
+        "workspace model applied"; otherwise a perfectly valid per-user
+        DB model (gpt-5.4-mini) gets silently suppressed by a never-
+        applied workspace override. Re-validate ws_model against the
+        active backend before treating it as precedence-bearing.
+        """
+        from kai.codex import CodexBackend
+        from kai.config import WorkspaceConfig
+
+        # Workspace config pins gpt-5.4-nano, which is in PROVIDER_MODELS
+        # ["openai"] but NOT in CODEX_MODELS - codex CLI rejects it.
+        ws = (tmp_path / "ws").resolve()
+        ws.mkdir()
+        ws_config = WorkspaceConfig(path=ws, model="gpt-5.4-nano")
+        user = UserConfig(
+            telegram_id=111,
+            name="alice",
+            agent_backend="codex",
+            home_workspace=ws,
+        )
+        config = _make_config(
+            agent_backend="codex",
+            llm_provider="openai",
+            default_model="gpt-5.5",
+            user_configs={111: user},
+        )
+        # get_workspace_config resolves the lookup key, so the stored key
+        # must match what `.resolve()` returns.
+        config.workspace_configs[ws] = ws_config
+
+        pool = SubprocessPool(config=config, services_info=[])
+        instance = pool.get(111)
+        assert isinstance(instance, CodexBackend)
+        # apply_workspace_model rejected the nano override at __init__,
+        # so the instance kept the codex default. The WorkspaceConfig
+        # object still has model="gpt-5.4-nano" on it.
+        assert instance.model == "gpt-5.5"
+        assert instance.workspace_config is not None
+        assert instance.workspace_config.model == "gpt-5.4-nano"
+
+        # DB has a valid per-user model override: gpt-5.4-mini.
+        db_settings = {"model": "gpt-5.4-mini"}
+        with (
+            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
+            patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value=db_settings),
+            patch.object(instance, "restart", new_callable=AsyncMock) as mock_restart,
+        ):
+            await pool._restore_workspace(111, instance)
+            # The DB model wins because the workspace model was never
+            # actually applied (rejected by apply_workspace_model).
+            assert instance.model == "gpt-5.4-mini"
+            mock_restart.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_restore_workspace_under_user_base(self, tmp_path):


### PR DESCRIPTION
## Summary

Implements the codex wizard hardening from #486. Closes the four bugs the v1 issue enumerated plus the runtime model-validation surfaces uncovered during spec review, and renames `CLAUDE_TIMEOUT_SECONDS` to `AGENT_TIMEOUT_SECONDS` with a backward-compat alias.

Closes #486.

## Changes

### Backend-aware model validation
- New `CODEX_MODELS` constant in `config.py`, fully separate from `PROVIDER_MODELS["openai"]`. Codex CLI exposes a different model set than the OpenAI HTTP API surface goose drives; treating them as one list previously let `gpt-5.4-nano` (valid for goose-on-openai) leak onto codex installs where the CLI rejects it.
- New `CODEX_DEFAULT_MODEL = "gpt-5.5"`, independent of `PROVIDER_DEFAULTS["openai"]` so the goose default is unchanged.
- New `validate_model_for_backend(model, backend, eff_provider)` is the canonical model validator. Codex installs short-circuit to `CODEX_MODELS`; other backends delegate to the existing provider-only validator.
- New `models_for_backend` helper for the wizard/runtime keyboard list.
- New `get_user_backend_and_provider` resolver consolidates the per-user backend/provider cascade.

### Sites converted to the backend-aware validator
- `install.py`: wizard prompt + apply-time guard
- `config.py`: `load_config` startup `DEFAULT_MODEL` check, `_load_user_configs` users.yaml validation
- `bot.py`: `/model` keyboard, `/model` selection, `/settings model`, `/workspace config model`
- `pool.py`: stored DB model replay

### Workspace override application
- New `apply_workspace_model` helper in `backend.py`. Called at `__init__` and `change_workspace` in `CodexBackend`, `ClaudeCodeBackend`, `GooseBackend`. A `workspaces.yaml` model that's invalid for the active backend is skipped with a `WARNING` log instead of being applied.

### Codex binary path lever
- Wizard prompts for the codex binary path on codex installs, validates it via `_validate_codex_bin`, persists in `install.conf` as `CODEX_BIN`.
- `_cmd_apply` reads from `install.conf` (with `os.environ` override for ad-hoc `sudo CODEX_BIN=... kai install apply`).
- `_apply_sudoers` and `_generate_sudoers` take `codex_bin` as an explicit argument; `_generate_sudoers` no longer reads `os.environ`.

### `AGENT_TIMEOUT_SECONDS` rename
- `load_config` reads the new key first; falls back to `CLAUDE_TIMEOUT_SECONDS` with a one-time deprecation warning.
- Wizard writes only the new key and pops the legacy one.
- `_cmd_apply` migrates the legacy key into the new name before writing `/etc/kai/env`, so operators upgrading without re-running the wizard are migrated automatically.

### Per-os_user codex login hint
- Post-install hint now enumerates each distinct `os_user` from `/etc/kai/users.yaml`. The prior `sudo -u <service> codex login` form was incompatible with the per-user OAuth wrap that lands auth in `~<os_user>/.codex/auth.json`.

## Tests

- 3129 passing, 43 new
- New test classes in `tests/test_config.py`: `TestCodexModelsSurface`, `TestValidateModelForBackend`, `TestModelsForBackend`, `TestGetUserBackendAndProvider`, `TestAgentTimeoutSecondsRename`, `TestLoadConfigBackendAwareModelValidation`
- New test classes in `tests/test_backend.py`: `TestApplyWorkspaceModel`
- New test classes in `tests/test_install.py`: `TestValidateCodexBin`, `TestGenerateSudoersCodexBinArg`, `TestApplyBackendAwareModelValidation`, `TestApplyAgentTimeoutMigration`, `TestPerOsUserCodexLoginHint`

## Test plan

- [x] `pytest` full suite green
- [x] `make check` clean
- [ ] Smoke test on Mac mini: fresh `make config` + `sudo make install` (no `CODEX_BIN=` prefix) produces working `/etc/kai/env` and `/etc/sudoers.d/kai`. Bot answers a Telegram PING via codex with `model=gpt-5.5` from the wizard.
- [ ] `/model gpt-5.4-nano` on the codex install is rejected.
- [ ] Hand-edited `/etc/kai/env` with `AGENT_BACKEND=codex` and `DEFAULT_MODEL=gpt-5.4-nano` fails startup with a clear error.

Spec: `/var/lib/kai/home/2114582497/docs/specs/486-codex-wizard-hardening.md` (v10, approved).
