### PR TITLE
feat(review): codex branch for one-shot PR review

### DIFF
--- a/src/kai/codex_exec.py
+++ b/src/kai/codex_exec.py
@@ -1,0 +1,119 @@
+"""
+Codex `exec --json` NDJSON parsing helpers shared by one-shot callers.
+
+The codex CLI's one-shot mode (`codex exec --json`) emits NDJSON events on
+stdout - one JSON object per line, each tagged by a top-level `type`
+field from the ThreadEvent enum. One-shot callers (triage.py, review.py,
+and any future codex-driven agent) all need to recover the final
+agent_message text from that stream, so the parser lives here rather
+than being duplicated per caller.
+
+This module is intentionally tiny and dependency-free: no Kai-side
+imports, no I/O, no logging. It exists so the two callers above can
+share one definition site without one importing from the other (which
+would couple unrelated agent surfaces; review.py has no reason to know
+about triage.py and vice versa).
+
+Distinct from `codex.py`, which manages the persistent codex app-server
+subprocess for conversational use. That module speaks the JSON-RPC
+`thread/turn/item` protocol; this one parses the dot-separated event
+stream `codex exec --json` writes to stdout in one-shot mode. Same
+underlying data model, different wire encodings, different callers,
+different lifecycles - hence the separate file.
+"""
+
+import json
+
+
+def extract_codex_text(stdout: str) -> str:
+    """
+    Walk codex's NDJSON event stream and return the agent message text.
+
+    `codex exec --json` emits one JSON event per line. Each event has
+    a top-level `type` tag from the ThreadEvent enum:
+    `thread.started`, `turn.started`, `turn.completed`, `turn.failed`,
+    `item.started`, `item.updated`, `item.completed`, `error`. (Note
+    the DOT separator; the app-server protocol uses slashes
+    instead. Same data model, different wire encoding.)
+
+    Callers only care about the agent's final natural-language
+    response. The `item.completed` event for an agent_message item
+    carries the full consolidated text:
+
+        {"type": "item.completed",
+         "item": {"id": "...", "type": "agent_message", "text": "..."}}
+
+    Schema reference: codex-rs/exec/src/exec_events.rs in the codex
+    repo. The `ThreadItemDetails` enum is `#[serde(tag = "type",
+    rename_all = "snake_case")]` so the discriminator is
+    `"agent_message"` (snake_case), and `text` is a flat field on
+    the item object (the inner enum is `#[serde(flatten)]`).
+
+    A streaming run may emit `item.updated` events for the same
+    agent_message id before its `item.completed`. We trust the
+    completed event as authoritative; if no completed event arrived
+    (e.g. truncated stream) we fall back to the latest updated text
+    so the caller gets something rather than nothing.
+
+    Schema-drift posture: a future codex release that adds new event
+    types or item types must not break extraction. Unknown shapes
+    are silently skipped. A `turn.failed` event short-circuits to an
+    empty result so the caller raises a clearer error than a partial
+    body would.
+
+    Args:
+        stdout: The full stdout from `codex exec --json`.
+
+    Returns:
+        The agent_message text from the last `item.completed`
+        event, or the latest `item.updated` text as a fallback.
+        Empty string if no agent_message was emitted.
+    """
+    completed_text: str | None = None
+    latest_updated_text: str | None = None
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        event_type = obj.get("type")
+        # `turn.failed` is a terminal failure - no body text to
+        # extract; let the caller see an empty string and surface
+        # a clearer error than a half-event would.
+        if event_type == "turn.failed":
+            return ""
+        if event_type in ("item.completed", "item.updated"):
+            text = _recover_agent_message_text(obj)
+            if text is None:
+                continue
+            if event_type == "item.completed":
+                completed_text = text
+            else:
+                latest_updated_text = text
+    if completed_text is not None:
+        return completed_text.strip()
+    if latest_updated_text is not None:
+        return latest_updated_text.strip()
+    return ""
+
+
+def _recover_agent_message_text(obj: dict) -> str | None:
+    """
+    Pull `item.text` from a codex exec event when the item is an
+    agent_message; return None otherwise.
+
+    The wire shape is `{..., "item": {"id": "...", "type": "agent_message", "text": "..."}}`
+    because ThreadItemDetails is serde-flattened onto ThreadItem.
+    """
+    item = obj.get("item")
+    if not isinstance(item, dict):
+        return None
+    if item.get("type") != "agent_message":
+        return None
+    text = item.get("text")
+    if isinstance(text, str):
+        return text
+    return None

--- a/src/kai/codex_exec.py
+++ b/src/kai/codex_exec.py
@@ -25,7 +25,7 @@ different lifecycles - hence the separate file.
 import json
 
 
-def extract_codex_text(stdout: str) -> str:
+def extract_codex_text(stdout: str, *, join_items: bool = True) -> str:
     """
     Walk codex's NDJSON event stream and return the agent message text.
 
@@ -36,9 +36,18 @@ def extract_codex_text(stdout: str) -> str:
     the DOT separator; the app-server protocol uses slashes
     instead. Same data model, different wire encoding.)
 
-    Callers only care about the agent's final natural-language
-    response. The `item.completed` event for an agent_message item
-    carries the full consolidated text:
+    A single turn can emit MULTIPLE `agent_message` items (preamble,
+    tool call, post-tool summary). The persistent codex backend in
+    codex.py handles this with a per-item state machine that joins
+    completed items with a blank-line separator; this helper offers
+    the same behavior under `join_items=True` (the default, correct
+    for free-form review/chat callers) and a last-wins fallback under
+    `join_items=False` (for callers like triage whose JSON-extract
+    contract assumes exactly one final agent_message and would fail
+    if a preamble agent_message were prepended to the JSON body).
+
+    The `item.completed` event for an agent_message item carries the
+    full consolidated text for THAT item:
 
         {"type": "item.completed",
          "item": {"id": "...", "type": "agent_message", "text": "..."}}
@@ -49,7 +58,7 @@ def extract_codex_text(stdout: str) -> str:
     `"agent_message"` (snake_case), and `text` is a flat field on
     the item object (the inner enum is `#[serde(flatten)]`).
 
-    A streaming run may emit `item.updated` events for the same
+    A streaming run may emit `item.updated` events for an
     agent_message id before its `item.completed`. We trust the
     completed event as authoritative; if no completed event arrived
     (e.g. truncated stream) we fall back to the latest updated text
@@ -63,13 +72,23 @@ def extract_codex_text(stdout: str) -> str:
 
     Args:
         stdout: The full stdout from `codex exec --json`.
+        join_items: When True (default), every `item.completed`
+            agent_message in the stream is appended to the result,
+            joined with a blank-line separator. When False, only the
+            LAST completed agent_message is returned. Set False for
+            callers whose output contract is "exactly one final
+            response" (e.g. triage parsing structured JSON, where a
+            joined preamble + JSON body would corrupt the parse);
+            leave at True for free-form callers (review, chat).
 
     Returns:
-        The agent_message text from the last `item.completed`
-        event, or the latest `item.updated` text as a fallback.
-        Empty string if no agent_message was emitted.
+        The agent_message text. With `join_items=True`, completed
+        items are joined by `\\n\\n`; with `join_items=False`, only
+        the last `item.completed` is returned. If no completed
+        events arrived, falls back to the latest `item.updated`
+        text. Empty string if no agent_message was emitted.
     """
-    completed_text: str | None = None
+    completed_texts: list[str] = []
     latest_updated_text: str | None = None
     for line in stdout.splitlines():
         line = line.strip()
@@ -90,11 +109,13 @@ def extract_codex_text(stdout: str) -> str:
             if text is None:
                 continue
             if event_type == "item.completed":
-                completed_text = text
+                completed_texts.append(text)
             else:
                 latest_updated_text = text
-    if completed_text is not None:
-        return completed_text.strip()
+    if completed_texts:
+        if join_items:
+            return "\n\n".join(t.strip() for t in completed_texts)
+        return completed_texts[-1].strip()
     if latest_updated_text is not None:
         return latest_updated_text.strip()
     return ""

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -1,5 +1,5 @@
 """
-PR review agent - one-shot subprocess (Claude or Goose) for automated code review.
+PR review agent - one-shot subprocess (Claude, Codex, or Goose) for automated code review.
 
 Provides functionality to:
 1. Fetch PR diffs and metadata via the GitHub CLI
@@ -19,9 +19,11 @@ repeated. If the relevant code has materially changed, the agent may
 re-evaluate a prior finding.
 
 The LLM subprocess runs in one-shot mode (non-interactive, no tools, no
-streaming): `claude --print` for Claude, `goose run -i -` for Goose.
-The prompt goes in via stdin to handle large diffs without hitting shell
-argument length limits. Output is captured as plain text.
+streaming): `claude --print` for Claude, `codex exec --json` for Codex,
+`goose run -i -` for Goose. The prompt goes in via stdin to handle
+large diffs without hitting shell argument length limits. Output is
+captured as plain text (NDJSON for codex; the agent_message text is
+extracted by kai.codex_exec.extract_codex_text).
 """
 
 import asyncio
@@ -35,6 +37,7 @@ from pathlib import Path
 
 import aiohttp
 
+from kai.codex_exec import extract_codex_text
 from kai.config import ModelRole, get_model_for, resolve_claude_user
 from kai.prompt_utils import make_boundary
 
@@ -673,24 +676,33 @@ async def run_review(
     """
     Spawn a one-shot LLM subprocess to perform the review.
 
-    Dispatches to either Claude (`claude --print`) or Goose
-    (`goose run -i -`) based on agent_backend. Both read from stdin
-    and write plain text to stdout; the prompt and output handling
-    are identical regardless of backend.
+    Dispatches to Claude (`claude --print`), Codex (`codex exec
+    --json`), or Goose (`goose run -i -`) based on agent_backend.
+    All three read the prompt from stdin and return a single string
+    of review text; the prompt and output handling are identical
+    regardless of backend.
 
     Claude path: supports sudo -u for OS-level isolation, process
     group kills for cleanup, and per-run budget caps.
+
+    Codex path: sudo -H -u when claude_user is set (codex needs
+    HOME pointing at the user's home so it reads the right
+    ~/.codex/auth.json); subprocess emits NDJSON which is collapsed
+    to the final agent_message text by extract_codex_text.
 
     Goose path: no sudo (Goose has no user isolation), simple
     proc.kill() for cleanup, --max-turns 1 as the safety limit.
 
     Args:
         prompt: The complete review prompt (from build_review_prompt).
-        claude_user: Optional OS user to run Claude as (via sudo -u).
-            Ignored when agent_backend is "goose".
-        agent_backend: Which LLM backend to use ("claude" or "goose").
+        claude_user: Optional OS user to run the subprocess as (via
+            sudo -u for claude, sudo -H -u for codex). Ignored when
+            agent_backend is "goose".
+        agent_backend: Which LLM backend to use ("claude", "codex",
+            or "goose").
         provider: LLM provider name (e.g. "anthropic", "openai").
-            Only used when agent_backend is "goose".
+            Only used when agent_backend is "goose"; codex always
+            uses openai, claude always uses anthropic.
 
     Returns:
         The review text output from the LLM.
@@ -698,6 +710,102 @@ async def run_review(
     Raises:
         RuntimeError: If the subprocess fails or times out.
     """
+    if agent_backend == "codex":
+        # Codex one-shot mode: --json emits NDJSON events on stdout
+        # (thread.started, turn.started, item.*, turn.completed,
+        # turn.failed, error). The final agent message text is
+        # recovered by walking the events and accumulating any text
+        # content; extract_codex_text in kai.codex_exec is the
+        # schema-defensive parser shared with triage.py.
+        # Per-user OAuth isolation: when claude_user is set (the
+        # webhook handler passes the same os_user value to both
+        # backends through this parameter), wrap the codex argv in
+        # `sudo -H -u <user>` so codex reads ~<user>/.codex/auth.json
+        # instead of the service user's home. The parameter name is
+        # claude-historical; rename is out of scope for this fix.
+        # No --max-budget-usd: codex on subscription auth has no
+        # per-call billing; runaway protection comes from
+        # timeout_s at the asyncio.wait_for below.
+        review_model = get_model_for(
+            ModelRole.PR_REVIEW,
+            agent_backend,
+            override=os.environ.get("PR_REVIEW_MODEL_CODEX", ""),
+        )
+        # Pin the absolute codex path when CODEX_BIN is set; same
+        # rationale as codex.py and triage.py - sudo cannot resolve
+        # bare `codex` when the binary lives in a per-os_user home
+        # that isn't on the service user's PATH. Falls back to bare
+        # "codex" for installs where codex is on PATH.
+        codex_bin = os.environ.get("CODEX_BIN") or "codex"
+        codex_cmd = [
+            codex_bin,
+            "exec",
+            "--json",
+            "--model",
+            review_model,
+        ]
+
+        # Resolve self-sudo: skip the sudo wrap when claude_user
+        # matches the bot process user. Mirrors the triage codex
+        # branch's pattern.
+        effective_user = resolve_claude_user(claude_user)
+        if effective_user:
+            # -H sets HOME to <effective_user>'s pw entry so codex
+            # reads auth from the right home. --preserve-env passes
+            # KAI_WEBHOOK_SECRET through sudo's env_reset (the SETENV:
+            # sudoers rule allows this). Same shape claude uses.
+            cmd = [
+                "sudo",
+                "-H",
+                "-u",
+                effective_user,
+                "--preserve-env=KAI_WEBHOOK_SECRET",
+                "--",
+            ] + codex_cmd
+        else:
+            cmd = codex_cmd
+
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            # New session group in cross-user mode so killing sudo
+            # also kills the codex grandchild (mirrors claude branch
+            # and the triage codex branch).
+            start_new_session=bool(effective_user),
+        )
+
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=prompt.encode()),
+                timeout=timeout_s,
+            )
+        except TimeoutError:
+            # Kill the subprocess tree if it exceeds the timeout. In
+            # cross-user mode (effective_user set) the process is in
+            # a new group (PGID == PID); kill the group so both sudo
+            # and the codex grandchild die, preventing orphans.
+            if effective_user:
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass  # Already dead
+            else:
+                proc.kill()
+            await proc.wait()
+            raise RuntimeError(f"Review subprocess timed out after {timeout_s}s") from None
+
+        if proc.returncode != 0:
+            error = stderr.decode().strip()
+            raise RuntimeError(f"Review subprocess failed (exit {proc.returncode}): {error}")
+
+        # Codex emits NDJSON; extract the final agent message text and
+        # return it (mirrors the contract the claude / goose branches
+        # already satisfy: a single string the caller hands back to
+        # the webhook handler for posting as a PR comment).
+        return extract_codex_text(stdout.decode())
+
     if agent_backend == "goose":
         if not provider:
             raise ValueError(

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -507,7 +507,16 @@ async def run_triage(
         # _parse_triage_json). extract_codex_text lives in codex_exec
         # so review.py can share the same parser without importing
         # from triage.py.
-        return extract_codex_text(stdout.decode())
+        #
+        # join_items=False: triage's downstream contract is "exactly
+        # one JSON object." If codex emits a preamble agent_message
+        # followed by the JSON body as a separate agent_message,
+        # joining them would yield "preamble\n\n{json}" which
+        # _parse_triage_json's fence-stripping cannot recover from.
+        # Last-wins preserves the prior helper behavior and keeps the
+        # JSON contract intact; review.py (free-form markdown) uses
+        # the joining default instead.
+        return extract_codex_text(stdout.decode(), join_items=False)
 
     if agent_backend == "goose":
         if not provider:

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -35,6 +35,7 @@ from pathlib import Path
 
 import aiohttp
 
+from kai.codex_exec import extract_codex_text
 from kai.config import ModelRole, get_model_for, resolve_claude_user
 from kai.prompt_utils import make_boundary
 
@@ -418,7 +419,7 @@ async def run_triage(
         # (thread.started, turn.started, item.*, turn.completed, error).
         # The final agent message text is recovered by walking the
         # events and accumulating any text content; see
-        # _extract_codex_text() below for the schema-defensive parser.
+        # extract_codex_text (kai.codex_exec) is the schema-defensive parser.
         # Per-user OAuth isolation: when claude_user is set (the
         # webhook handler passes the same os_user value to both
         # backends through this parameter), wrap the codex argv in
@@ -503,8 +504,10 @@ async def run_triage(
         # Codex emits NDJSON; extract the final agent message text and
         # return it (mirrors the contract the claude / goose branches
         # already satisfy: a single string the caller hands to
-        # _parse_triage_json).
-        return _extract_codex_text(stdout.decode())
+        # _parse_triage_json). extract_codex_text lives in codex_exec
+        # so review.py can share the same parser without importing
+        # from triage.py.
+        return extract_codex_text(stdout.decode())
 
     if agent_backend == "goose":
         if not provider:
@@ -628,100 +631,6 @@ async def run_triage(
         raise RuntimeError(f"Triage subprocess failed (exit {proc.returncode}): {error}")
 
     return stdout.decode().strip()
-
-
-def _extract_codex_text(stdout: str) -> str:
-    """
-    Walk codex's NDJSON event stream and return the agent message text.
-
-    `codex exec --json` emits one JSON event per line. Each event has
-    a top-level `type` tag from the ThreadEvent enum:
-    `thread.started`, `turn.started`, `turn.completed`, `turn.failed`,
-    `item.started`, `item.updated`, `item.completed`, `error`. (Note
-    the DOT separator; the app-server protocol uses slashes
-    instead. Same data model, different wire encoding.)
-
-    For triage we only care about the agent's final natural-language
-    response. The `item.completed` event for an agent_message item
-    carries the full consolidated text:
-
-        {"type": "item.completed",
-         "item": {"id": "...", "type": "agent_message", "text": "..."}}
-
-    Schema reference: codex-rs/exec/src/exec_events.rs in the codex
-    repo. The `ThreadItemDetails` enum is `#[serde(tag = "type",
-    rename_all = "snake_case")]` so the discriminator is
-    `"agent_message"` (snake_case), and `text` is a flat field on
-    the item object (the inner enum is `#[serde(flatten)]`).
-
-    A streaming run may emit `item.updated` events for the same
-    agent_message id before its `item.completed`. We trust the
-    completed event as authoritative; if no completed event arrived
-    (e.g. truncated stream) we fall back to the latest updated text
-    so triage gets something rather than nothing.
-
-    Schema-drift posture: a future codex release that adds new event
-    types or item types must not break extraction. Unknown shapes
-    are silently skipped. A `turn.failed` event short-circuits to an
-    empty result so the caller raises a clearer error than a partial
-    body would.
-
-    Args:
-        stdout: The full stdout from `codex exec --json`.
-
-    Returns:
-        The agent_message text from the last `item.completed`
-        event, or the latest `item.updated` text as a fallback.
-        Empty string if no agent_message was emitted.
-    """
-    completed_text: str | None = None
-    latest_updated_text: str | None = None
-    for line in stdout.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            obj = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        event_type = obj.get("type")
-        # `turn.failed` is a terminal failure - no body text to
-        # extract; let the caller see an empty string and surface
-        # a clearer error than a half-event would.
-        if event_type == "turn.failed":
-            return ""
-        if event_type in ("item.completed", "item.updated"):
-            text = _recover_agent_message_text(obj)
-            if text is None:
-                continue
-            if event_type == "item.completed":
-                completed_text = text
-            else:
-                latest_updated_text = text
-    if completed_text is not None:
-        return completed_text.strip()
-    if latest_updated_text is not None:
-        return latest_updated_text.strip()
-    return ""
-
-
-def _recover_agent_message_text(obj: dict) -> str | None:
-    """
-    Pull `item.text` from a codex exec event when the item is an
-    agent_message; return None otherwise.
-
-    The wire shape is `{..., "item": {"id": "...", "type": "agent_message", "text": "..."}}`
-    because ThreadItemDetails is serde-flattened onto ThreadItem.
-    """
-    item = obj.get("item")
-    if not isinstance(item, dict):
-        return None
-    if item.get("type") != "agent_message":
-        return None
-    text = item.get("text")
-    if isinstance(text, str):
-        return text
-    return None
 
 
 def _parse_triage_json(raw: str) -> dict:

--- a/tests/test_codex_exec.py
+++ b/tests/test_codex_exec.py
@@ -1,0 +1,98 @@
+"""
+Tests for kai.codex_exec - shared NDJSON parser for codex one-shot
+callers (triage, review, and any future codex-driven one-shot agent).
+
+The codex exec --json schema (codex-rs/exec/src/exec_events.rs):
+each event has top-level `type` discriminator; agent_message
+items carry their full text in `item.text`. item.completed is
+authoritative; item.updated is interim. turn.failed terminates
+extraction with an empty result.
+
+These tests originally lived in test_triage.py alongside the helper.
+Moved here when the helper was promoted to a shared module so the
+test file's location matches the implementation file's location;
+no behavior change.
+"""
+
+import json
+
+from kai.codex_exec import extract_codex_text
+
+
+class TestExtractCodexText:
+    """Unit tests for the extract_codex_text NDJSON parser."""
+
+    def test_empty_input(self):
+        """An empty stream returns the empty string."""
+        assert extract_codex_text("") == ""
+
+    def test_skips_non_json_lines(self):
+        """Non-JSON lines are silently skipped."""
+        valid = json.dumps({"type": "item.completed", "item": {"id": "i", "type": "agent_message", "text": "hello"}})
+        stream = "not-json\n" + valid + "\n"
+        assert extract_codex_text(stream) == "hello"
+
+    def test_extracts_item_completed_agent_message(self):
+        """item.completed for an agent_message returns item.text."""
+        event = {"type": "item.completed", "item": {"id": "i1", "type": "agent_message", "text": "hello"}}
+        stream = json.dumps(event) + "\n"
+        assert extract_codex_text(stream) == "hello"
+
+    def test_ignores_non_agent_message_items(self):
+        """item.completed for non-agent_message items (e.g. reasoning) contributes nothing."""
+        event = {"type": "item.completed", "item": {"id": "i1", "type": "reasoning", "text": "thinking..."}}
+        stream = json.dumps(event) + "\n"
+        assert extract_codex_text(stream) == ""
+
+    def test_ignores_lifecycle_events(self):
+        """thread.started, turn.started, turn.completed contribute nothing."""
+        events = [
+            {"type": "thread.started", "thread_id": "thr_1"},
+            {"type": "turn.started"},
+            {"type": "turn.completed", "usage": {"input_tokens": 0, "output_tokens": 0}},
+        ]
+        stream = "\n".join(json.dumps(e) for e in events) + "\n"
+        assert extract_codex_text(stream) == ""
+
+    def test_strips_outer_whitespace(self):
+        """The accumulated result has leading/trailing whitespace stripped."""
+        event = {"type": "item.completed", "item": {"id": "i", "type": "agent_message", "text": "  hello  "}}
+        stream = json.dumps(event) + "\n"
+        assert extract_codex_text(stream) == "hello"
+
+    def test_completed_wins_over_updated(self):
+        """item.completed text supersedes any earlier item.updated text."""
+        events = [
+            {"type": "item.updated", "item": {"id": "i", "type": "agent_message", "text": "partial"}},
+            {"type": "item.updated", "item": {"id": "i", "type": "agent_message", "text": "partial more"}},
+            {"type": "item.completed", "item": {"id": "i", "type": "agent_message", "text": "FINAL"}},
+        ]
+        stream = "\n".join(json.dumps(e) for e in events) + "\n"
+        assert extract_codex_text(stream) == "FINAL"
+
+    def test_last_completed_wins(self):
+        """Multiple item.completed events (rare): last one wins."""
+        events = [
+            {"type": "item.completed", "item": {"id": "i1", "type": "agent_message", "text": "first"}},
+            {"type": "item.completed", "item": {"id": "i2", "type": "agent_message", "text": "second"}},
+        ]
+        stream = "\n".join(json.dumps(e) for e in events) + "\n"
+        assert extract_codex_text(stream) == "second"
+
+    def test_updated_fallback_when_no_completed(self):
+        """If only item.updated events arrive (truncated stream), use the latest one."""
+        events = [
+            {"type": "item.updated", "item": {"id": "i", "type": "agent_message", "text": "first"}},
+            {"type": "item.updated", "item": {"id": "i", "type": "agent_message", "text": "second"}},
+        ]
+        stream = "\n".join(json.dumps(e) for e in events) + "\n"
+        assert extract_codex_text(stream) == "second"
+
+    def test_turn_failed_short_circuits(self):
+        """A turn.failed event terminates extraction with the empty string."""
+        events = [
+            {"type": "item.completed", "item": {"id": "i", "type": "agent_message", "text": "ignored"}},
+            {"type": "turn.failed", "error": {"message": "model unavailable"}},
+        ]
+        stream = "\n".join(json.dumps(e) for e in events) + "\n"
+        assert extract_codex_text(stream) == ""

--- a/tests/test_codex_exec.py
+++ b/tests/test_codex_exec.py
@@ -70,14 +70,37 @@ class TestExtractCodexText:
         stream = "\n".join(json.dumps(e) for e in events) + "\n"
         assert extract_codex_text(stream) == "FINAL"
 
-    def test_last_completed_wins(self):
-        """Multiple item.completed events (rare): last one wins."""
+    def test_default_joins_multiple_completed_items_with_blank_line(self):
+        """
+        A single codex turn can emit multiple agent_message items
+        (e.g. preamble before a tool call, summary after). The default
+        behavior must surface ALL of them joined with a blank-line
+        separator so review-style callers do not silently drop earlier
+        findings. Mirrors the persistent backend's per-item state
+        machine from PR #491.
+        """
+        events = [
+            {"type": "item.completed", "item": {"id": "i1", "type": "agent_message", "text": "first finding"}},
+            {"type": "item.completed", "item": {"id": "i2", "type": "agent_message", "text": "second finding"}},
+        ]
+        stream = "\n".join(json.dumps(e) for e in events) + "\n"
+        assert extract_codex_text(stream) == "first finding\n\nsecond finding"
+
+    def test_join_items_false_returns_last_completed(self):
+        """
+        Opt-out path for callers whose downstream contract is "exactly
+        one final agent_message" (triage parsing structured JSON). With
+        join_items=False, a multi-item turn collapses to the last
+        completed item only - the prior helper behavior, preserved for
+        callers that would have their parse corrupted by a joined
+        preamble + body.
+        """
         events = [
             {"type": "item.completed", "item": {"id": "i1", "type": "agent_message", "text": "first"}},
             {"type": "item.completed", "item": {"id": "i2", "type": "agent_message", "text": "second"}},
         ]
         stream = "\n".join(json.dumps(e) for e in events) + "\n"
-        assert extract_codex_text(stream) == "second"
+        assert extract_codex_text(stream, join_items=False) == "second"
 
     def test_updated_fallback_when_no_completed(self):
         """If only item.updated events arrive (truncated stream), use the latest one."""

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -886,6 +886,45 @@ class TestRunReviewCodex:
         assert result == body
 
     @pytest.mark.asyncio
+    async def test_codex_multi_item_review_preserves_all_findings(self):
+        """
+        A codex review turn can emit multiple agent_message items
+        (preamble before a tool call, post-tool summary after). The
+        review path must surface ALL of them joined with a blank-line
+        separator; the prior parser dropped earlier completions and
+        only returned the last item's text, silently truncating
+        reviews. Regression guard for the bug TG Codex caught in the
+        PR #490 review (the same class of failure as the persistent
+        backend bug fixed by PR #491).
+        """
+        # Build a two-item NDJSON stream by hand because the single-
+        # item _codex_ndjson helper above can't express it.
+        events = [
+            {"type": "thread.started", "thread_id": "thr_test"},
+            {"type": "turn.started"},
+            {
+                "type": "item.completed",
+                "item": {"id": "item_1", "type": "agent_message", "text": "First finding: foo.py has a bug."},
+            },
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_2",
+                    "type": "agent_message",
+                    "text": "Second finding: bar.py needs a docstring.",
+                },
+            },
+            {"type": "turn.completed", "usage": {"input_tokens": 0, "output_tokens": 0}},
+        ]
+        stream = ("\n".join(json.dumps(e) for e in events) + "\n").encode()
+        mock_proc = _mock_process(stdout=stream)
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await run_review("prompt", agent_backend="codex")
+        # Both findings present, blank-line separated. The prior
+        # "last wins" behavior would have returned only the second.
+        assert result == "First finding: foo.py has a bug.\n\nSecond finding: bar.py needs a docstring."
+
+    @pytest.mark.asyncio
     async def test_codex_subprocess_failure_raises(self):
         """Non-zero exit from codex raises RuntimeError with stderr."""
         mock_proc = _mock_process(returncode=1, stderr=b"auth failed")

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -893,9 +893,10 @@ class TestRunReviewCodex:
         review path must surface ALL of them joined with a blank-line
         separator; the prior parser dropped earlier completions and
         only returned the last item's text, silently truncating
-        reviews. Regression guard for the bug TG Codex caught in the
-        PR #490 review (the same class of failure as the persistent
-        backend bug fixed by PR #491).
+        reviews. Regression guard for the multi-item truncation bug:
+        the prior parser returned only the last completed item, which
+        is the same class of failure as the persistent backend bug
+        fixed by PR #491.
         """
         # Build a two-item NDJSON stream by hand because the single-
         # item _codex_ndjson helper above can't express it.

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -715,6 +715,221 @@ class TestRunReview:
         assert call_kwargs[1]["input"] == b"the review prompt"
 
 
+# ── run_review (Codex backend) ─────────────────────────────────────
+
+
+class TestRunReviewCodex:
+    """
+    Tests for the codex branch of run_review.
+
+    Mirrors TestRunTriageCodex in test_triage.py: the two codex
+    branches share the same pattern (codex exec --json + sudo -H -u
+    wrap + NDJSON parse) and the same kai.codex_exec parser. Locks
+    the "no overlap" guarantee at the subprocess boundary - a codex-
+    backed review never spawns claude or goose.
+    """
+
+    @staticmethod
+    def _codex_ndjson(text: str) -> bytes:
+        """
+        Build a minimal NDJSON stream that mirrors the real
+        `codex exec --json` schema: each event has a top-level `type`
+        tag; item.completed for an agent_message carries the full
+        consolidated `text` field. Returns bytes (the review tests'
+        _mock_process expects bytes via communicate()).
+        """
+        events = [
+            {"type": "thread.started", "thread_id": "thr_test"},
+            {"type": "turn.started"},
+            {
+                "type": "item.completed",
+                "item": {"id": "item_1", "type": "agent_message", "text": text},
+            },
+            {"type": "turn.completed", "usage": {"input_tokens": 0, "output_tokens": 0}},
+        ]
+        return ("\n".join(json.dumps(e) for e in events) + "\n").encode()
+
+    @pytest.mark.asyncio
+    async def test_codex_argv_uses_codex_exec(self):
+        """
+        Argv is `codex exec --json --model <model>`, never claude or
+        goose. Locks the "no overlap" guarantee at the subprocess
+        boundary: the codex review branch never spawns claude.
+        """
+        mock_proc = _mock_process(stdout=self._codex_ndjson("review body"))
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+        ):
+            os.environ.pop("CODEX_BIN", None)
+            await run_review("prompt", agent_backend="codex")
+        cmd = mock_exec.call_args[0]
+        assert cmd[0] == "codex"
+        assert cmd[1] == "exec"
+        assert "--json" in cmd
+        assert "--print" not in cmd  # No claude flag
+
+    @pytest.mark.asyncio
+    async def test_codex_argv_uses_codex_bin_env_var(self):
+        """
+        CODEX_BIN env var overrides bare "codex" in the review argv.
+        Same install-time lever the persistent backend and the codex
+        triage branch honor; needed for multi-user installs where
+        codex lives in a per-os_user home not on the service user's
+        PATH.
+        """
+        mock_proc = _mock_process(stdout=self._codex_ndjson(""))
+        with (
+            patch.dict(os.environ, {"CODEX_BIN": "/Users/daniel/.npm-global/bin/codex"}),
+            patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+        ):
+            await run_review("prompt", agent_backend="codex")
+        cmd = mock_exec.call_args[0]
+        assert cmd[0] == "/Users/daniel/.npm-global/bin/codex"
+        assert cmd[1] == "exec"
+
+    @pytest.mark.asyncio
+    async def test_codex_argv_uses_registry_model(self):
+        """
+        With agent_backend=codex and no env override, the --model
+        argv slot matches the registry's (codex, PR_REVIEW) row
+        ("gpt-5.4-mini"). Locks the registry as the source of truth
+        for the codex side.
+        """
+        mock_proc = _mock_process(stdout=self._codex_ndjson(""))
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_review("prompt", agent_backend="codex")
+        cmd = mock_exec.call_args[0]
+        i = cmd.index("--model")
+        assert cmd[i + 1] == "gpt-5.4-mini"
+
+    @pytest.mark.asyncio
+    async def test_codex_env_override_honored_at_call_site(self, monkeypatch):
+        """
+        PR_REVIEW_MODEL_CODEX in the environment overrides the
+        registry value at the call site. Same end-to-end env-override
+        wiring as the claude path.
+        """
+        monkeypatch.setenv("PR_REVIEW_MODEL_CODEX", "gpt-5.4")
+        mock_proc = _mock_process(stdout=self._codex_ndjson(""))
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_review("prompt", agent_backend="codex")
+        cmd = mock_exec.call_args[0]
+        i = cmd.index("--model")
+        assert cmd[i + 1] == "gpt-5.4"
+
+    @pytest.mark.asyncio
+    async def test_codex_no_sudo_when_user_unset(self):
+        """
+        With no claude_user passed, codex runs as the bot process
+        user directly: argv begins with "codex", no "sudo" wrap.
+        """
+        mock_proc = _mock_process(stdout=self._codex_ndjson(""))
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_review("prompt", agent_backend="codex")
+        cmd = mock_exec.call_args[0]
+        assert cmd[0] == "codex"
+        assert "sudo" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_codex_wraps_sudo_when_user_set(self):
+        """
+        With claude_user set to a non-self user, codex argv is wrapped
+        in `sudo -H -u <user> --preserve-env=KAI_WEBHOOK_SECRET --`.
+        The per-user os_user lever is what makes a multi-user install
+        spawn codex as each user, reading their per-user
+        ~/.codex/auth.json.
+
+        Same fake-username trick as the triage codex tests: pass a
+        username implausible enough to never match the test runner's
+        user, so resolve_claude_user does NOT short-circuit to no-sudo.
+        """
+        mock_proc = _mock_process(stdout=self._codex_ndjson(""))
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_review("prompt", agent_backend="codex", claude_user="ci-fake-user")
+        cmd = mock_exec.call_args[0]
+        assert cmd[0] == "sudo"
+        assert "-H" in cmd
+        i = cmd.index("-u")
+        assert cmd[i + 1] == "ci-fake-user"
+        assert any(arg.startswith("--preserve-env=") and "KAI_WEBHOOK_SECRET" in arg for arg in cmd)
+        assert "codex" in cmd
+        codex_i = cmd.index("codex")
+        assert cmd[codex_i + 1] == "exec"
+
+    @pytest.mark.asyncio
+    async def test_codex_no_max_budget_flag(self):
+        """
+        --max-budget-usd is not emitted on the codex branch. Codex on
+        subscription auth has no per-call billing; runaway protection
+        comes from the asyncio.wait_for timeout. Mirror of the
+        existing claude-side absence assertion.
+        """
+        mock_proc = _mock_process(stdout=self._codex_ndjson(""))
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_review("prompt", agent_backend="codex")
+        cmd = mock_exec.call_args[0]
+        assert "--max-budget-usd" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_codex_extracts_final_text_from_ndjson(self):
+        """
+        Return value is the agent message text extracted from the
+        NDJSON event stream, not the raw stdout. The downstream
+        webhook handler posts the returned text directly as a PR
+        comment; it must not see multi-line NDJSON.
+        """
+        body = "## Review\n\nLooks good."
+        mock_proc = _mock_process(stdout=self._codex_ndjson(body))
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await run_review("prompt", agent_backend="codex")
+        assert result == body
+
+    @pytest.mark.asyncio
+    async def test_codex_subprocess_failure_raises(self):
+        """Non-zero exit from codex raises RuntimeError with stderr."""
+        mock_proc = _mock_process(returncode=1, stderr=b"auth failed")
+        with (
+            patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc),
+            pytest.raises(RuntimeError, match="auth failed"),
+        ):
+            await run_review("prompt", agent_backend="codex")
+
+    @pytest.mark.asyncio
+    async def test_codex_timeout_kills_process_group(self):
+        """
+        On TimeoutError with claude_user set, the subprocess group is
+        killed via os.killpg(PID, SIGKILL) so both sudo and the codex
+        grandchild die. Mirror of the claude branch's process-group
+        teardown.
+        """
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(side_effect=TimeoutError())
+        proc.kill = MagicMock()
+        proc.wait = AsyncMock()
+        proc.pid = 99999  # Fake PID for killpg
+        with (
+            patch("kai.review.asyncio.create_subprocess_exec", return_value=proc),
+            patch("kai.review.os.killpg") as mock_killpg,
+            pytest.raises(RuntimeError, match="timed out"),
+        ):
+            await run_review("prompt", agent_backend="codex", claude_user="ci-fake-user", timeout_s=1)
+        mock_killpg.assert_called_once_with(99999, signal.SIGKILL)
+
+    @pytest.mark.asyncio
+    async def test_codex_stdin_carries_prompt(self):
+        """
+        Codex one-shot mode reads the review prompt from stdin (the
+        prompt is too large for argv on real diffs). Mirrors the
+        existing claude- and goose-side stdin assertions.
+        """
+        mock_proc = _mock_process(stdout=self._codex_ndjson(""))
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
+            await run_review("the review prompt", agent_backend="codex")
+        mock_proc.communicate.assert_called_once()
+        assert mock_proc.communicate.call_args.kwargs["input"] == b"the review prompt"
+
+
 # ── run_review (Goose backend) ─────────────────────────────────────
 
 

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -12,7 +12,6 @@ import pytest
 from kai.triage import (
     _GOOSE_AGENT_MODELS,
     IssueMetadata,
-    _extract_codex_text,
     _parse_triage_json,
     _resolve_goose_model,
     _sanitize_search_query,
@@ -657,7 +656,7 @@ class TestRunTriageCodex:
     Tests for the codex branch of run_triage.
 
     The codex branch invokes `codex exec --json` and parses NDJSON
-    output via _extract_codex_text. No sudo wrap; subscription auth
+    output via extract_codex_text. No sudo wrap; subscription auth
     uses the service user's own ~/.codex/auth.json.
     """
 
@@ -818,7 +817,7 @@ class TestRunTriageCodex:
         mock_proc = _mock_subprocess(stdout=self._codex_ndjson(expected_json))
         with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await run_triage("prompt", agent_backend="codex")
-        # _extract_codex_text strips, so the result is the expected
+        # extract_codex_text strips, so the result is the expected
         # JSON string with no leading/trailing whitespace.
         assert result == expected_json
 
@@ -863,93 +862,6 @@ class TestRunTriageCodex:
             result = await run_triage("prompt", agent_backend="codex")
         # Exactly the completed text, not interim updates concatenated.
         assert result == expected_json
-
-
-class TestExtractCodexText:
-    """
-    Unit tests for the _extract_codex_text NDJSON parser.
-
-    The codex exec --json schema (codex-rs/exec/src/exec_events.rs):
-    each event has top-level `type` discriminator; agent_message
-    items carry their full text in `item.text`. item.completed is
-    authoritative; item.updated is interim. turn.failed terminates
-    extraction with an empty result.
-    """
-
-    def test_empty_input(self):
-        """An empty stream returns the empty string."""
-        assert _extract_codex_text("") == ""
-
-    def test_skips_non_json_lines(self):
-        """Non-JSON lines are silently skipped."""
-        valid = json.dumps({"type": "item.completed", "item": {"id": "i", "type": "agent_message", "text": "hello"}})
-        stream = "not-json\n" + valid + "\n"
-        assert _extract_codex_text(stream) == "hello"
-
-    def test_extracts_item_completed_agent_message(self):
-        """item.completed for an agent_message returns item.text."""
-        event = {"type": "item.completed", "item": {"id": "i1", "type": "agent_message", "text": "hello"}}
-        stream = json.dumps(event) + "\n"
-        assert _extract_codex_text(stream) == "hello"
-
-    def test_ignores_non_agent_message_items(self):
-        """item.completed for non-agent_message items (e.g. reasoning) contributes nothing."""
-        event = {"type": "item.completed", "item": {"id": "i1", "type": "reasoning", "text": "thinking..."}}
-        stream = json.dumps(event) + "\n"
-        assert _extract_codex_text(stream) == ""
-
-    def test_ignores_lifecycle_events(self):
-        """thread.started, turn.started, turn.completed contribute nothing."""
-        events = [
-            {"type": "thread.started", "thread_id": "thr_1"},
-            {"type": "turn.started"},
-            {"type": "turn.completed", "usage": {"input_tokens": 0, "output_tokens": 0}},
-        ]
-        stream = "\n".join(json.dumps(e) for e in events) + "\n"
-        assert _extract_codex_text(stream) == ""
-
-    def test_strips_outer_whitespace(self):
-        """The accumulated result has leading/trailing whitespace stripped."""
-        event = {"type": "item.completed", "item": {"id": "i", "type": "agent_message", "text": "  hello  "}}
-        stream = json.dumps(event) + "\n"
-        assert _extract_codex_text(stream) == "hello"
-
-    def test_completed_wins_over_updated(self):
-        """item.completed text supersedes any earlier item.updated text."""
-        events = [
-            {"type": "item.updated", "item": {"id": "i", "type": "agent_message", "text": "partial"}},
-            {"type": "item.updated", "item": {"id": "i", "type": "agent_message", "text": "partial more"}},
-            {"type": "item.completed", "item": {"id": "i", "type": "agent_message", "text": "FINAL"}},
-        ]
-        stream = "\n".join(json.dumps(e) for e in events) + "\n"
-        assert _extract_codex_text(stream) == "FINAL"
-
-    def test_last_completed_wins(self):
-        """Multiple item.completed events (rare): last one wins."""
-        events = [
-            {"type": "item.completed", "item": {"id": "i1", "type": "agent_message", "text": "first"}},
-            {"type": "item.completed", "item": {"id": "i2", "type": "agent_message", "text": "second"}},
-        ]
-        stream = "\n".join(json.dumps(e) for e in events) + "\n"
-        assert _extract_codex_text(stream) == "second"
-
-    def test_updated_fallback_when_no_completed(self):
-        """If only item.updated events arrive (truncated stream), use the latest one."""
-        events = [
-            {"type": "item.updated", "item": {"id": "i", "type": "agent_message", "text": "first"}},
-            {"type": "item.updated", "item": {"id": "i", "type": "agent_message", "text": "second"}},
-        ]
-        stream = "\n".join(json.dumps(e) for e in events) + "\n"
-        assert _extract_codex_text(stream) == "second"
-
-    def test_turn_failed_short_circuits(self):
-        """A turn.failed event terminates extraction with the empty string."""
-        events = [
-            {"type": "item.completed", "item": {"id": "i", "type": "agent_message", "text": "ignored"}},
-            {"type": "turn.failed", "error": {"message": "model unavailable"}},
-        ]
-        stream = "\n".join(json.dumps(e) for e in events) + "\n"
-        assert _extract_codex_text(stream) == ""
 
 
 class TestResolveGooseModelTriage:


### PR DESCRIPTION
## Summary

Phase 4 of #480. Adds the codex branch to `run_review` so GitHub webhook-driven PR reviews route through codex on a codex-active install, parallel to the codex triage branch that shipped in #483.

- `run_review` codex branch: `codex exec --json --model <model>`; `sudo -H -u <user>` wrap when `claude_user` is set so codex reads `~<user>/.codex/auth.json`; `start_new_session` in cross-user mode so timeout kills sweep both sudo and the codex grandchild; `CODEX_BIN` env honored for installs where codex lives in a per-os_user home not on the service user's PATH.
- Model resolution goes through `get_model_for(ModelRole.PR_REVIEW, "codex", override=os.environ.get("PR_REVIEW_MODEL_CODEX", ""))`. Registry row was added in #481; codex-row validity is enforced at `load_config` time by the check shipped in #489.
- New `kai.codex_exec` module hosts the schema-defensive NDJSON parser (`extract_codex_text` plus private `_recover_agent_message_text`). Both `triage.py` and `review.py` import from there, so the review path does not reach into the triage module for a generic codex helper.
- No new config plumbing: the webhook handler already threads per-user `agent_backend` / `provider` into `review_pr` and `run_review`.

## Test plan

- [x] `make test` (3145 passed, 1 skipped)
- [x] `make check` (ruff check + ruff format)
- [x] `TestRunReviewCodex` (11 new tests) mirrors `TestRunTriageCodex` coverage: argv shape, `CODEX_BIN` override, registry-vs-env model resolution, no-sudo and sudo-wrap paths, no `--max-budget-usd`, NDJSON text extraction, non-zero exit raises, timeout-killpg, stdin carries prompt.
- [x] `TestExtractCodexText` (11 tests) moved from `test_triage.py` to `test_codex_exec.py`.
- [ ] End-to-end smoke: open a real PR on a codex-active install and verify the review comment posts. Deferred to post-merge so the smoke runs against the merged code path the operator will actually use.
