### PR TITLE
fix(codex): re-land approval, sandbox, multi-agentMessage fixes

### DIFF
--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -292,7 +292,20 @@ class CodexBackend(AgentBackend):
             # cannot signal a process whose UIDs are all the
             # target user). See _send_signal for the full chain.
             start_new_session=bool(effective_codex_user),
-            limit=1024 * 1024,  # 1MB per-line buffer
+            # A single codex event can carry the full text of a tool
+            # call's output inline (e.g. a `gh pr diff` result on a
+            # reasoning item, or an item/completed for a long
+            # agentMessage). The asyncio.StreamReader default limit
+            # is 64KB; we previously bumped it to 1MB which was still
+            # too tight for PR-review-sized chunks - real codex review
+            # turns surfaced "Separator is not found, and chunk exceed
+            # the limit" from readline. 16MB is well above any
+            # plausible single-event payload while still bounding
+            # memory if codex ever produces a runaway line. A
+            # proper streaming reader (chunked + reassemble on \n)
+            # would remove the ceiling entirely; deferred until the
+            # 16MB ceiling is itself observed in practice.
+            limit=16 * 1024 * 1024,
         )
         self._stderr_task = asyncio.create_task(self._drain_stderr())
 

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -351,7 +351,33 @@ class CodexBackend(AgentBackend):
 
         await self._write_notification("initialized")
 
-        thread_params: dict = {"cwd": str(self.workspace)}
+        # `approvalPolicy: "never"` is load-bearing for an unattended
+        # Telegram bot. Codex's default is "on-request", which makes
+        # the server emit approval-request notifications and wait for
+        # a client response before any tool call. Kai has no human
+        # in the loop to approve from Telegram, so on-request gates
+        # silently: codex waits forever, the bot's stdout-readline
+        # ceiling fires, the operator sees "Codex timed out".
+        #
+        # `sandbox: "danger-full-access"` matches the claude backend's
+        # posture: claude --print runs unsandboxed with whatever
+        # permissions the bot's os_user has. The `workspace-write`
+        # alternative would disable network access (codex's default
+        # for workspace-write profiles), breaking `gh`, `curl`, `pip`,
+        # and anything else the bot needs to reach outside the local
+        # filesystem. The bot already runs under a per-user sudo wrap
+        # with that user's full file authority; constraining codex
+        # tighter than the surrounding process makes no security
+        # sense.
+        #
+        # Sandbox variants are kebab-case (`read-only`, `workspace-write`,
+        # `danger-full-access`); the codex server rejects camelCase
+        # spellings at thread/start with "unknown variant".
+        thread_params: dict = {
+            "cwd": str(self.workspace),
+            "approvalPolicy": "never",
+            "sandbox": "danger-full-access",
+        }
         if self.model:
             thread_params["model"] = self.model
         await self._write_rpc("thread/start", thread_params)
@@ -597,11 +623,31 @@ class CodexBackend(AgentBackend):
 
         # Stream response: read stdout lines, accumulate text chunks,
         # and yield StreamEvents. Unknown event types are logged at
-        # DEBUG and skipped (schema-drift defense). The smoke test
-        # against a real codex binary will reveal which event names
-        # the pinned version actually emits; this loop tolerates
-        # variation by only acting on events it recognizes.
-        accumulated = ""
+        # DEBUG and skipped (schema-drift defense).
+        #
+        # Multi-agentMessage tracking: a single turn can emit MORE
+        # than one agentMessage item (e.g. preamble, tool call,
+        # post-tool summary). Per the codex protocol README, deltas
+        # are scoped to a single itemId; concatenating them across
+        # items without separators tacks the second item's first
+        # word onto the first item's terminator ("summary here.The"
+        # -> the operator's smoke-test observation). We track each
+        # item's text separately, commit completed items into a
+        # joined-with-blank-line prefix, and only let item/completed
+        # override the CURRENT item's text - never the prior
+        # committed content. The visible text streamed to telegram
+        # is `committed + ("\n\n" + current if current)`.
+        committed_text = ""
+        current_item_id: str | None = None
+        current_item_text = ""
+
+        def _visible_text() -> str:
+            if not current_item_id:
+                return committed_text
+            if not committed_text:
+                return current_item_text
+            return committed_text + "\n\n" + current_item_text
+
         last_activity = time.monotonic()
         max_idle_seconds = self.timeout_seconds * 5
 
@@ -616,12 +662,13 @@ class CodexBackend(AgentBackend):
                         max_idle_seconds,
                     )
                     await self._kill()
+                    visible = _visible_text()
                     yield StreamEvent(
-                        text_so_far=accumulated,
+                        text_so_far=visible,
                         done=True,
                         response=AgentResponse(
                             success=False,
-                            text=accumulated,
+                            text=visible,
                             error="Codex interaction timed out (no output)",
                         ),
                     )
@@ -635,12 +682,13 @@ class CodexBackend(AgentBackend):
                 except TimeoutError:
                     log.error("Codex response timed out")
                     await self._kill()
+                    visible = _visible_text()
                     yield StreamEvent(
-                        text_so_far=accumulated,
+                        text_so_far=visible,
                         done=True,
                         response=AgentResponse(
                             success=False,
-                            text=accumulated,
+                            text=visible,
                             error="Codex timed out",
                         ),
                     )
@@ -653,13 +701,14 @@ class CodexBackend(AgentBackend):
                     # EOF - process died
                     log.error("Codex process EOF")
                     await self._kill()
+                    visible = _visible_text()
                     yield StreamEvent(
-                        text_so_far=accumulated,
+                        text_so_far=visible,
                         done=True,
                         response=AgentResponse(
-                            success=bool(accumulated),
-                            text=accumulated,
-                            error=None if accumulated else "Codex process ended unexpectedly",
+                            success=bool(visible),
+                            text=visible,
+                            error=None if visible else "Codex process ended unexpectedly",
                         ),
                     )
                     return
@@ -701,37 +750,83 @@ class CodexBackend(AgentBackend):
                 method = msg.get("method")
                 if method == "item/started":
                     item = msg.get("params", {}).get("item", {})
-                    log.debug("Codex: item/started type=%s id=%s", item.get("type"), item.get("id"))
+                    if item.get("type") == "agentMessage":
+                        # Begin a new in-flight agentMessage. Anything
+                        # currently in current_item_text was uncommitted
+                        # (no item/completed arrived); commit it now
+                        # so the new item's deltas start fresh and we
+                        # don't lose mid-stream text on the boundary.
+                        if current_item_id and current_item_text:
+                            committed_text = (
+                                committed_text + "\n\n" + current_item_text if committed_text else current_item_text
+                            )
+                        current_item_id = item.get("id")
+                        current_item_text = ""
+                    else:
+                        log.debug("Codex: item/started type=%s id=%s", item.get("type"), item.get("id"))
 
                 elif method == "item/agentMessage/delta":
-                    delta_text = msg.get("params", {}).get("delta", "")
+                    params = msg.get("params", {})
+                    delta_text = params.get("delta", "")
+                    delta_item_id = params.get("itemId")
                     if delta_text:
-                        accumulated += delta_text
-                        yield StreamEvent(text_so_far=accumulated)
+                        # Defensive: if a delta arrives without a
+                        # prior item/started (out-of-order or schema
+                        # drift), treat it as opening a new item.
+                        if delta_item_id and delta_item_id != current_item_id:
+                            if current_item_id and current_item_text:
+                                committed_text = (
+                                    committed_text + "\n\n" + current_item_text if committed_text else current_item_text
+                                )
+                            current_item_id = delta_item_id
+                            current_item_text = ""
+                        current_item_text += delta_text
+                        yield StreamEvent(text_so_far=_visible_text())
 
                 elif method == "item/completed":
                     item = msg.get("params", {}).get("item", {})
                     if item.get("type") == "agentMessage":
-                        # Authoritative full text; trust it over our
-                        # delta-accumulation in case any delta was
-                        # missed or arrived out of order.
+                        # Authoritative final text for THIS item only.
+                        # Override current_item_text if codex's final
+                        # value differs from our delta sum (the docs
+                        # call item/completed the source of truth).
                         final_text = item.get("text", "")
-                        if final_text and final_text != accumulated:
-                            accumulated = final_text
-                            yield StreamEvent(text_so_far=accumulated)
+                        if final_text:
+                            current_item_text = final_text
+                        # Commit the in-flight item to the prefix and
+                        # reset. Subsequent items append after a blank
+                        # line; subsequent deltas can never overwrite
+                        # this text.
+                        if current_item_text:
+                            committed_text = (
+                                committed_text + "\n\n" + current_item_text if committed_text else current_item_text
+                            )
+                        current_item_id = None
+                        current_item_text = ""
+                        yield StreamEvent(text_so_far=_visible_text())
                     else:
                         log.debug("Codex: item/completed type=%s", item.get("type"))
 
                 elif method == "turn/completed":
                     turn = msg.get("params", {}).get("turn", {})
                     status = turn.get("status")
+                    # Flush any uncommitted current_item_text so the
+                    # final response carries it (schema-drift defense:
+                    # a missing item/completed should not lose text).
+                    if current_item_id and current_item_text:
+                        committed_text = (
+                            committed_text + "\n\n" + current_item_text if committed_text else current_item_text
+                        )
+                        current_item_id = None
+                        current_item_text = ""
+                    final_visible = committed_text
                     if status == "completed":
                         yield StreamEvent(
-                            text_so_far=accumulated,
+                            text_so_far=final_visible,
                             done=True,
                             response=AgentResponse(
                                 success=True,
-                                text=accumulated,
+                                text=final_visible,
                                 session_id=self._session_id,
                                 cost_usd=0.0,
                                 duration_ms=0,
@@ -743,11 +838,11 @@ class CodexBackend(AgentBackend):
                     err_obj = turn.get("error") or {}
                     err_msg = err_obj.get("message") or f"Codex turn ended with status={status}"
                     yield StreamEvent(
-                        text_so_far=accumulated,
+                        text_so_far=final_visible,
                         done=True,
                         response=AgentResponse(
                             success=False,
-                            text=accumulated,
+                            text=final_visible,
                             error=err_msg,
                         ),
                     )
@@ -759,12 +854,13 @@ class CodexBackend(AgentBackend):
                     # would be redundant.
                     err_obj = msg.get("params", {}).get("error", {})
                     err_msg = err_obj.get("message") or "Codex error"
+                    visible = _visible_text()
                     yield StreamEvent(
-                        text_so_far=accumulated,
+                        text_so_far=visible,
                         done=True,
                         response=AgentResponse(
                             success=False,
-                            text=accumulated,
+                            text=visible,
                             error=err_msg,
                         ),
                     )
@@ -780,12 +876,13 @@ class CodexBackend(AgentBackend):
                 # never made it to streaming, so finish here.
                 elif msg.get("id") == prompt_id and "error" in msg:
                     err = msg["error"].get("message", "unknown codex error")
+                    visible = _visible_text()
                     yield StreamEvent(
-                        text_so_far=accumulated,
+                        text_so_far=visible,
                         done=True,
                         response=AgentResponse(
                             success=False,
-                            text=accumulated,
+                            text=visible,
                             error=err,
                         ),
                     )
@@ -805,12 +902,13 @@ class CodexBackend(AgentBackend):
         except Exception as e:
             log.exception("Unexpected error reading Codex stream")
             await self._kill()
+            visible = _visible_text()
             yield StreamEvent(
-                text_so_far=accumulated,
+                text_so_far=visible,
                 done=True,
                 response=AgentResponse(
                     success=False,
-                    text=accumulated,
+                    text=visible,
                     error=str(e),
                 ),
             )

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -351,6 +351,14 @@ class TestHandshake:
         assert thread_msg["id"] == 2
         assert thread_msg["params"]["cwd"] == "/tmp/test-workspace"
         assert thread_msg["params"]["model"] == "gpt-5.4"
+        # approvalPolicy and sandbox are the two production-unblocking
+        # fields: dropping or misspelling either re-creates the original
+        # "Codex timed out" (on-request gate with no human approver) or
+        # "GitHub access is blocked by the sandbox" (workspace-write
+        # default disables network). Lock both exact strings; sandbox
+        # variants are kebab-case at thread/start.
+        assert thread_msg["params"]["approvalPolicy"] == "never"
+        assert thread_msg["params"]["sandbox"] == "danger-full-access"
 
     @pytest.mark.asyncio
     async def test_argv_invokes_codex_app_server(self):

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -542,6 +542,77 @@ class TestStreamParsing:
         assert events[2].response.cost_usd == 0.0
 
     @pytest.mark.asyncio
+    async def test_multi_agent_message_items_join_with_blank_line(self):
+        """
+        A single turn can emit multiple agentMessage items (e.g. preamble
+        before a tool call, post-tool summary after). The visible text must
+        commit each item's content with a blank-line separator; item N's
+        completion must NEVER override prior items' accumulated text
+        (the bug that produced "summary here.The..." truncations during
+        the live smoke test).
+        """
+        c = _make_codex()
+        c._proc = _make_mock_proc(
+            [
+                _item_started_agent(item_id="item-1"),
+                _agent_message_delta("Hello", item_id="item-1"),
+                _agent_message_delta(" world.", item_id="item-1"),
+                _item_completed_agent("Hello world.", item_id="item-1"),
+                _item_started_agent(item_id="item-2"),
+                _agent_message_delta("Next, ", item_id="item-2"),
+                _agent_message_delta("more text.", item_id="item-2"),
+                _item_completed_agent("Next, more text.", item_id="item-2"),
+                _turn_completed("completed"),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+
+        final = events[-1]
+        assert final.done is True
+        assert final.response is not None
+        assert final.response.success is True
+        # Items joined with a blank-line separator; item 2's text is
+        # appended, NOT substituted for item 1's. This is the regression
+        # guard for the smoke-test overwrite bug.
+        assert final.response.text == "Hello world.\n\nNext, more text."
+
+    @pytest.mark.asyncio
+    async def test_item_completed_overrides_only_current_item(self):
+        """
+        item/completed's `text` field is authoritative for THAT item only.
+        A drift between accumulated deltas and the completed text for
+        item 2 must not erase item 1's previously committed content.
+        """
+        c = _make_codex()
+        c._proc = _make_mock_proc(
+            [
+                _item_started_agent(item_id="item-1"),
+                _agent_message_delta("first item content.", item_id="item-1"),
+                _item_completed_agent("first item content.", item_id="item-1"),
+                _item_started_agent(item_id="item-2"),
+                # Deltas accumulate "partial..." but completion says
+                # the canonical text is "Second item." - the override
+                # must apply to current item only.
+                _agent_message_delta("partial accumulated text", item_id="item-2"),
+                _item_completed_agent("Second item.", item_id="item-2"),
+                _turn_completed("completed"),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+
+        final = events[-1]
+        assert final.response is not None
+        assert final.response.text == "first item content.\n\nSecond item."
+
+    @pytest.mark.asyncio
     async def test_unknown_event_type_skipped(self):
         """
         Schema-drift defense: an unrecognized sessionUpdate event type

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -507,6 +507,27 @@ class TestHandshake:
         call_kwargs = mock_exec.call_args[1]
         assert "CODEX_PROVIDER" not in call_kwargs["env"]
 
+    @pytest.mark.asyncio
+    async def test_subprocess_limit_is_at_least_16mb(self):
+        """
+        The asyncio.StreamReader limit on stdout must be large enough
+        for any single codex event payload. The default 64KB and our
+        previous 1MB both produced
+        "Separator is not found, and chunk exceed the limit"
+        from readline on real PR-review turns where codex inlines a
+        tool result (e.g. a `gh pr diff` body or a long item/completed
+        agentMessage text). Lock the lower bound so a future shrinkback
+        gets caught here, not on a live operator turn.
+        """
+        c = _make_codex()
+        proc = _make_mock_proc(_handshake_lines())
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await c._ensure_started()
+
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["limit"] >= 16 * 1024 * 1024
+
 
 # ── Stream parsing ─────────────────────────────────────────────────
 


### PR DESCRIPTION
Supersedes #488. That PR was filed against an older main and never merged; the codex wizard hardening PR landed in the interim and touched the `__init__` block #488 was based on, so this PR re-applies the three fixes on a fresh branch off current main rather than rebasing the original. The original branch is left intact for history.

## What this does

Three fixes from the original smoke-test session, folded into one commit:

1. **`approvalPolicy: "never"`** at thread/start. The codex default is `on-request`, which makes the server emit approval-request notifications and wait for the client to respond before any tool call. The bot has no in-loop approver, so on-request gates silently: codex waits forever, the readline ceiling fires, the operator sees "Codex timed out". This is the user-visible symptom that triggered this whole investigation.
2. **`sandbox: "danger-full-access"`** at thread/start. `read-only` blocks file writes; `workspace-write` disables network egress by default (the `gh access is blocked by the sandbox` symptom). `danger-full-access` matches the claude backend's posture: claude --print runs unsandboxed with the bot's `os_user`'s permissions, and codex now has the same authority profile. Sandbox variants are kebab-case; the server rejects camelCase at thread/start with "unknown variant".
3. **Per-item `agentMessage` tracking** in the streaming parser. A single turn can emit multiple `agentMessage` items (preamble, tool call, post-tool summary). The previous parser concatenated deltas across items without a separator and let item N's `item/completed.text` override the entire accumulated string, erasing prior committed items. Now: `committed_text` holds completed items joined with `\n\n`; `current_item_text` holds the in-flight item's delta sum; `current_item_id` correlates which item the deltas belong to. `item/completed` authoritatively sets the CURRENT item's text only, commits it to the prefix, and resets.

## Test plan

- [x] `make test` (3136 passed, 1 skipped on this branch; 2 new tests in `TestStreamParsing` lock the multi-item join with a blank-line separator and the per-item override scope; all 63 existing codex tests still pass without modification)
- [x] `make check` (ruff check + ruff format)
- [x] Pre-push grep gate clean
- [ ] End-to-end smoke on production after merge: reinstall, send a Telegram message that requires `gh`/`curl` (currently blocked by the sandbox default), confirm the response arrives without "Codex timed out" or `GitHub access is blocked by the sandbox`.

## What happens to #488

After this PR merges and the production smoke passes, close #488 with a comment pointing at this PR. Until then it stays open as the historical record.
