### PR TITLE
fix(codex): kill Rust binary under node wrapper (closes #487)

### DIFF
--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -177,11 +177,22 @@ class CodexBackend(AgentBackend):
         # only the wrapper orphans the codex grandchild because POSIX
         # signal permission rules forbid a service-user-owned killpg
         # from reaching a target-user grandchild. The escalation path
-        # uses `sudo -n -u <target> /bin/kill ...` against the cached
-        # inner-codex PID. See _send_signal for the full rationale and
-        # claude.py for the original implementation this mirrors.
+        # uses `sudo -n -u <target> /bin/kill ...` against each cached
+        # codex descendant PID. See _send_signal for the full rationale
+        # and claude.py for the original implementation this mirrors.
+        #
+        # The cache is a LIST, ordered innermost-first, because codex's
+        # npm-global packaging interposes a node wrapper between sudo
+        # and the Rust binary. Killing only the wrapper leaves the Rust
+        # binary orphaned to init; signalling the leaf without the
+        # wrapper leaves node as a thin shell that normally exits via
+        # SIGCHLD but is worth killing explicitly. Both PIDs are owned
+        # by the target user; the sudoers rule covers either. A future
+        # codex release that drops the node wrapper collapses naturally
+        # to a single-PID list with no test-side changes needed beyond
+        # the pgrep mocks.
         self._pgid: int | None = None
-        self._inner_codex_pid: int | None = None
+        self._inner_codex_pids: list[int] = []
         self._effective_codex_user: str | None = None
 
     @property
@@ -320,11 +331,11 @@ class CodexBackend(AgentBackend):
             self._pgid = None
 
         # Remember the resolved sudo target for the #456-equivalent
-        # cross-user signal escalation. _inner_codex_pid is reset to
-        # None here so a recycled instance does not carry a stale
-        # PID from a previous spawn into the fresh tree.
+        # cross-user signal escalation. _inner_codex_pids is reset to
+        # an empty list here so a recycled instance does not carry
+        # stale PIDs from a previous spawn into the fresh tree.
         self._effective_codex_user = effective_codex_user
-        self._inner_codex_pid = None
+        self._inner_codex_pids = []
 
         # Handshake per the codex app-server protocol:
         #   1. Client `initialize` request (clientInfo + optional
@@ -928,25 +939,61 @@ class CodexBackend(AgentBackend):
 
     # ── Kill / restart / shutdown ──────────────────────────────────
 
-    def _lookup_inner_codex_pid(self) -> int | None:
+    def _lookup_inner_codex_pids(self) -> list[int]:
         """
-        Find the inner codex subprocess PID in cross-user mode.
+        Find the codex descendant PIDs in cross-user mode.
 
         In cross-user mode the bot spawns `sudo -u <target> -- codex
-        app-server` and self._proc tracks the sudo wrapper. sudo
-        fork+exec's codex as its sole child, so pgrep -P <sudo_pid>
-        returns the codex PID. Returns None when no sudo wrapper is
-        alive, sudo has not yet forked, or pgrep fails. The result
-        is cached on self._inner_codex_pid; callers that need to
-        signal after sudo has been killed must rely on the cache.
+        app-server` and self._proc tracks the sudo wrapper. Codex's
+        npm-global packaging interposes a node wrapper between sudo
+        and the actual Rust binary, so the process tree is:
+
+            sudo (service user)
+              └── node /path/to/codex app-server  (target user)
+                    └── /path/.../codex/codex app-server  (target user)
+
+        `pgrep -P <sudo_pid>` returns the node PID. We then `pgrep -P`
+        against that to find the Rust binary. Returns the descendant
+        PIDs in inner-to-outer order: `[rust_pid, node_pid]`. When
+        a future codex release drops the node wrapper (single-binary
+        install), the second pgrep returns nothing and the result
+        collapses to `[node_pid]` (which IS the Rust binary in that
+        case). Returns an empty list when no sudo wrapper is alive,
+        sudo has not yet forked, or pgrep fails outright.
+
+        Innermost-first ordering matters: _send_signal iterates the
+        list in order so the Rust binary dies before the node wrapper
+        gets killpg'd (the wrapper would otherwise exit via SIGCHLD
+        regardless, but signalling the Rust binary first is the
+        defensive shape that catches the original #487 orphan).
+
         Synchronous variant used by the sync force_kill path.
-        Mirrors claude.py's _lookup_inner_claude_pid (#456/#459).
+        Mirrors claude.py's _lookup_inner_claude_pid (#456/#459), with
+        the extra level for codex's npm packaging that #487 surfaced.
         """
         if self._proc is None:
-            return None
+            return []
+        first_pid = self._pgrep_first_child(self._proc.pid)
+        if first_pid is None:
+            return []
+        # Second level: pgrep the first child to find its child (the
+        # Rust binary under the node wrapper). If pgrep returns
+        # nothing the install has no wrapper layer; the first PID is
+        # itself the leaf.
+        second_pid = self._pgrep_first_child(first_pid)
+        if second_pid is None:
+            return [first_pid]
+        return [second_pid, first_pid]
+
+    @staticmethod
+    def _pgrep_first_child(parent_pid: int) -> int | None:
+        """Run pgrep -P <parent_pid> and return the first child PID,
+        or None if pgrep fails / returns no children. Extracted so
+        the two-level walk in _lookup_inner_codex_pids reads as one
+        idea per line."""
         try:
             result = subprocess.run(
-                ["pgrep", "-P", str(self._proc.pid)],
+                ["pgrep", "-P", str(parent_pid)],
                 capture_output=True,
                 text=True,
                 timeout=2,
@@ -964,23 +1011,37 @@ class CodexBackend(AgentBackend):
         except ValueError:
             return None
 
-    async def _async_lookup_inner_codex_pid(self) -> int | None:
+    async def _async_lookup_inner_codex_pids(self) -> list[int]:
         """
-        Async pgrep equivalent of `_lookup_inner_codex_pid`.
+        Async pgrep equivalent of `_lookup_inner_codex_pids`.
 
-        Same semantics, but uses asyncio.create_subprocess_exec so
-        the event loop is not blocked while pgrep runs. Called from
-        the async _kill / shutdown paths; the sync variant remains
-        for force_kill. 2s ceiling matches the sync version. Mirrors
-        claude.py's _async_lookup_inner_claude_pid (#459).
+        Same semantics and two-level walk, but uses
+        asyncio.create_subprocess_exec so the event loop is not
+        blocked while pgrep runs. Called from the async _kill /
+        shutdown paths; the sync variant remains for force_kill.
+        2s ceiling matches the sync version. Mirrors claude.py's
+        _async_lookup_inner_claude_pid (#459), extended to walk
+        the extra level for codex's npm packaging (#487).
         """
         if self._proc is None:
-            return None
+            return []
+        first_pid = await self._async_pgrep_first_child(self._proc.pid)
+        if first_pid is None:
+            return []
+        second_pid = await self._async_pgrep_first_child(first_pid)
+        if second_pid is None:
+            return [first_pid]
+        return [second_pid, first_pid]
+
+    @staticmethod
+    async def _async_pgrep_first_child(parent_pid: int) -> int | None:
+        """Async pgrep -P <parent_pid>, returning the first child PID
+        or None. Companion to _pgrep_first_child; same contract."""
         try:
             proc = await asyncio.create_subprocess_exec(
                 "pgrep",
                 "-P",
-                str(self._proc.pid),
+                str(parent_pid),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.DEVNULL,
             )
@@ -1086,9 +1147,17 @@ class CodexBackend(AgentBackend):
         """
         if self._pgid is not None:
             if self._effective_codex_user is not None:
-                if self._inner_codex_pid is None:
-                    self._inner_codex_pid = self._lookup_inner_codex_pid()
-                if self._inner_codex_pid is not None:
+                if not self._inner_codex_pids:
+                    self._inner_codex_pids = self._lookup_inner_codex_pids()
+                # Innermost-first: kill the Rust binary before the
+                # node wrapper so the wrapper does not get a chance
+                # to spawn a fresh leaf, and so the failure-to-orphan
+                # diagnostic in the warning identifies the load-bearing
+                # PID. A future codex release that drops the wrapper
+                # collapses to a single-element list and the loop
+                # body runs exactly once. _inner_codex_pids is set up
+                # in inner-to-outer order by _lookup_inner_codex_pids.
+                for pid in self._inner_codex_pids:
                     try:
                         # Absolute /bin/kill path so sudo's secure_path
                         # resolution cannot silently pick a different
@@ -1105,7 +1174,7 @@ class CodexBackend(AgentBackend):
                                 self._effective_codex_user,
                                 "/bin/kill",
                                 f"-{int(sig)}",
-                                str(self._inner_codex_pid),
+                                str(pid),
                             ],
                             capture_output=True,
                             timeout=5,
@@ -1113,16 +1182,17 @@ class CodexBackend(AgentBackend):
                         )
                         if result.returncode != 0:
                             log.warning(
-                                "sudo kill escalation failed (rc=%d, stderr=%r); inner codex may orphan",
+                                "sudo kill escalation failed (rc=%d, stderr=%r); codex pid=%d may orphan",
                                 result.returncode,
                                 result.stderr[:200].decode(errors="replace") if result.stderr else "",
+                                pid,
                             )
                     except (subprocess.TimeoutExpired, OSError):
                         # Inner codex already dead, sudoers rule
                         # missing on an old install, or kill timed
-                        # out. Fall through to killpg; the wrapper
-                        # still needs reaping.
-                        pass
+                        # out. Continue to the next PID and then to
+                        # killpg; the wrapper still needs reaping.
+                        continue
             try:
                 os.killpg(self._pgid, sig)
             except OSError:
@@ -1146,12 +1216,15 @@ class CodexBackend(AgentBackend):
         """
         if self._pgid is not None:
             if self._effective_codex_user is not None:
-                if self._inner_codex_pid is None:
-                    self._inner_codex_pid = await self._async_lookup_inner_codex_pid()
-                if self._inner_codex_pid is not None:
+                if not self._inner_codex_pids:
+                    self._inner_codex_pids = await self._async_lookup_inner_codex_pids()
+                # Innermost-first; see _send_signal for the full
+                # rationale on ordering and the npm-wrapper failure
+                # mode this guards against.
+                for pid in self._inner_codex_pids:
                     await self._async_sudo_kill(
                         self._effective_codex_user,
-                        self._inner_codex_pid,
+                        pid,
                         int(sig),
                     )
             try:
@@ -1203,7 +1276,7 @@ class CodexBackend(AgentBackend):
             self._proc = None
             self._session_id = None
             self._pgid = None
-            self._inner_codex_pid = None
+            self._inner_codex_pids = []
             self._effective_codex_user = None
 
     async def restart(self) -> None:

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -1343,5 +1343,5 @@ class CodexBackend(AgentBackend):
         self._proc = None
         self._session_id = None
         self._pgid = None
-        self._inner_codex_pid = None
+        self._inner_codex_pids = []
         self._effective_codex_user = None

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1261,8 +1261,8 @@ class TestCodexUserSudoWrap:
             await c._ensure_started()
         assert c._pgid == 12345
         assert c._effective_codex_user == "ci-fake-user"
-        # Fresh spawn must reset any stale cached grandchild PID.
-        assert c._inner_codex_pid is None
+        # Fresh spawn must reset any stale cached descendant PIDs.
+        assert c._inner_codex_pids == []
 
     @pytest.mark.asyncio
     async def test_pgid_unset_when_codex_user_unset(self):
@@ -1290,51 +1290,67 @@ class TestCodexCrossUserTeardown:
     """
 
     def test_force_kill_cross_user_escalates_then_killpg(self):
-        """force_kill in cross-user mode looks up the inner codex PID, sudo-kills it, then killpgs the wrapper."""
+        """
+        force_kill in cross-user mode walks two pgrep levels under the
+        sudo wrapper, sudo-kills each descendant innermost-first, then
+        killpgs the wrapper. This single-leaf scenario (no node
+        wrapper) collapses the second pgrep to empty so the cache
+        ends up as [67890].
+        """
         c = _make_codex(codex_user="ci-fake-user")
         proc = MagicMock()
         proc.pid = 12345
         c._proc = proc
         c._pgid = 12345
         c._effective_codex_user = "ci-fake-user"
-        c._inner_codex_pid = None  # Force a lookup
+        c._inner_codex_pids = []  # Force a lookup
         c._stderr_task = MagicMock()
 
-        # Mock pgrep returning the inner codex PID 67890.
-        pgrep_result = MagicMock()
-        pgrep_result.returncode = 0
-        pgrep_result.stdout = "67890\n"
+        # First pgrep -P 12345 -> 67890 (the only child).
+        pgrep_first = MagicMock()
+        pgrep_first.returncode = 0
+        pgrep_first.stdout = "67890\n"
+        # Second pgrep -P 67890 -> empty (no grandchild). Lookup
+        # collapses to [67890] (single-binary install).
+        pgrep_second = MagicMock()
+        pgrep_second.returncode = 1
+        pgrep_second.stdout = ""
         # Mock the sudo /bin/kill returning success.
         sudo_kill_result = MagicMock()
         sudo_kill_result.returncode = 0
         sudo_kill_result.stderr = b""
 
         with (
-            patch("kai.codex.subprocess.run", side_effect=[pgrep_result, sudo_kill_result]) as mock_run,
+            patch(
+                "kai.codex.subprocess.run",
+                side_effect=[pgrep_first, pgrep_second, sudo_kill_result],
+            ) as mock_run,
             patch("kai.codex.os.killpg") as mock_killpg,
         ):
             c.force_kill()
 
-        # First call: pgrep -P 12345 to find the grandchild.
+        # First call: pgrep -P 12345 (level 1, sudo's child).
         assert mock_run.call_args_list[0][0][0] == ["pgrep", "-P", "12345"]
-        # Second call: sudo -n -u ci-fake-user /bin/kill -9 67890.
-        sudo_argv = mock_run.call_args_list[1][0][0]
+        # Second call: pgrep -P 67890 (level 2 walk).
+        assert mock_run.call_args_list[1][0][0] == ["pgrep", "-P", "67890"]
+        # Third call: sudo -n -u ci-fake-user /bin/kill -9 67890.
+        sudo_argv = mock_run.call_args_list[2][0][0]
         assert sudo_argv[:5] == ["sudo", "-n", "-u", "ci-fake-user", "/bin/kill"]
         assert sudo_argv[5] == f"-{int(signal.SIGKILL)}"
         assert sudo_argv[6] == "67890"
         # Then killpg reaps the wrapper.
         mock_killpg.assert_called_once_with(12345, signal.SIGKILL)
         # Cache primed for any subsequent _send_signal call.
-        assert c._inner_codex_pid == 67890
+        assert c._inner_codex_pids == [67890]
 
-    def test_force_kill_uses_cached_inner_pid(self):
-        """If _inner_codex_pid is already cached, force_kill skips the pgrep lookup."""
+    def test_force_kill_uses_cached_inner_pids(self):
+        """If _inner_codex_pids is already populated, force_kill skips the pgrep lookup."""
         c = _make_codex(codex_user="ci-fake-user")
         c._proc = MagicMock()
         c._proc.pid = 12345
         c._pgid = 12345
         c._effective_codex_user = "ci-fake-user"
-        c._inner_codex_pid = 67890  # Pre-cached
+        c._inner_codex_pids = [67890]  # Pre-cached
         c._stderr_task = MagicMock()
 
         sudo_kill_result = MagicMock()
@@ -1379,7 +1395,7 @@ class TestCodexCrossUserTeardown:
         c._proc.pid = 12345
         c._pgid = 12345
         c._effective_codex_user = "ci-fake-user"
-        c._inner_codex_pid = 67890
+        c._inner_codex_pids = [67890]
         c._stderr_task = MagicMock()
 
         sudo_kill_result = MagicMock()
@@ -1405,7 +1421,7 @@ class TestCodexCrossUserTeardown:
         c._proc = proc
         c._pgid = 12345
         c._effective_codex_user = "ci-fake-user"
-        c._inner_codex_pid = 67890  # Pre-cached -> skip pgrep
+        c._inner_codex_pids = [67890]  # Pre-cached -> skip pgrep
         c._stderr_task = MagicMock()
 
         sudo_proc = MagicMock()
@@ -1427,7 +1443,7 @@ class TestCodexCrossUserTeardown:
         # State cleared after _kill.
         assert c._proc is None
         assert c._pgid is None
-        assert c._inner_codex_pid is None
+        assert c._inner_codex_pids == []
         assert c._effective_codex_user is None
 
     @pytest.mark.asyncio
@@ -1441,7 +1457,7 @@ class TestCodexCrossUserTeardown:
         c._proc = proc
         c._pgid = 12345
         c._effective_codex_user = "ci-fake-user"
-        c._inner_codex_pid = 67890
+        c._inner_codex_pids = [67890]
         c._stderr_task = MagicMock()
 
         sudo_proc = MagicMock()
@@ -1459,3 +1475,155 @@ class TestCodexCrossUserTeardown:
         sigkill_call = mock_exec.call_args_list[1][0]
         assert sigterm_call[5] == f"-{int(signal.SIGTERM)}"
         assert sigkill_call[5] == f"-{int(signal.SIGKILL)}"
+
+
+class TestCodexGrandchildEscalation:
+    """
+    Codex's npm-global packaging interposes a `node` wrapper between
+    the sudo wrapper and the Rust binary that actually holds the
+    session:
+
+        sudo (service user)
+          -> node /Users/.../bin/codex app-server  (target user)
+              -> /Users/.../codex/codex app-server  (target user)
+
+    A one-level pgrep returns the node PID; killing only that PID
+    leaves the Rust binary reparented to init and accumulating sessions
+    across recycles. _lookup_inner_codex_pids walks two levels and
+    returns [rust_pid, node_pid] (innermost-first); _send_signal
+    iterates and sudo-kills each in order before killpg reaps the
+    sudo wrapper.
+    """
+
+    def test_lookup_walks_two_pgrep_levels(self):
+        """Two-level walk: pgrep -P sudo_pid -> node, pgrep -P node -> rust."""
+        c = _make_codex(codex_user="ci-fake-user")
+        c._proc = MagicMock()
+        c._proc.pid = 12345
+
+        pgrep_level1 = MagicMock()
+        pgrep_level1.returncode = 0
+        pgrep_level1.stdout = "22222\n"  # node wrapper PID
+        pgrep_level2 = MagicMock()
+        pgrep_level2.returncode = 0
+        pgrep_level2.stdout = "33333\n"  # Rust binary PID
+
+        with patch("kai.codex.subprocess.run", side_effect=[pgrep_level1, pgrep_level2]) as mock_run:
+            pids = c._lookup_inner_codex_pids()
+
+        assert mock_run.call_args_list[0][0][0] == ["pgrep", "-P", "12345"]
+        assert mock_run.call_args_list[1][0][0] == ["pgrep", "-P", "22222"]
+        # Innermost-first: Rust first, then node.
+        assert pids == [33333, 22222]
+
+    def test_lookup_collapses_to_single_pid_when_no_grandchild(self):
+        """Single-binary install (no node wrapper): level-2 pgrep returns
+        empty, lookup falls back to the level-1 PID alone."""
+        c = _make_codex(codex_user="ci-fake-user")
+        c._proc = MagicMock()
+        c._proc.pid = 12345
+
+        pgrep_level1 = MagicMock()
+        pgrep_level1.returncode = 0
+        pgrep_level1.stdout = "22222\n"
+        pgrep_level2 = MagicMock()
+        pgrep_level2.returncode = 1
+        pgrep_level2.stdout = ""
+
+        with patch("kai.codex.subprocess.run", side_effect=[pgrep_level1, pgrep_level2]):
+            pids = c._lookup_inner_codex_pids()
+
+        assert pids == [22222]
+
+    def test_lookup_returns_empty_when_pgrep_fails(self):
+        """pgrep failure at level 1 returns an empty list, not a partial
+        chain. The escalation path treats empty as "no escalation possible"
+        and falls through to killpg alone."""
+        c = _make_codex(codex_user="ci-fake-user")
+        c._proc = MagicMock()
+        c._proc.pid = 12345
+
+        pgrep_fail = MagicMock()
+        pgrep_fail.returncode = 1
+        pgrep_fail.stdout = ""
+
+        with patch("kai.codex.subprocess.run", return_value=pgrep_fail):
+            pids = c._lookup_inner_codex_pids()
+
+        assert pids == []
+
+    def test_force_kill_signals_both_descendants_innermost_first(self):
+        """
+        With the npm-wrapper tree (sudo -> node -> rust), force_kill
+        sudo-kills the Rust binary FIRST, then the node wrapper, then
+        killpgs the sudo wrapper. The order matters: signalling the
+        leaf first prevents node from spawning a fresh leaf in the
+        race window before killpg arrives.
+        """
+        c = _make_codex(codex_user="ci-fake-user")
+        proc = MagicMock()
+        proc.pid = 12345
+        c._proc = proc
+        c._pgid = 12345
+        c._effective_codex_user = "ci-fake-user"
+        c._inner_codex_pids = []  # Force lookup
+        c._stderr_task = MagicMock()
+
+        pgrep_level1 = MagicMock()
+        pgrep_level1.returncode = 0
+        pgrep_level1.stdout = "22222\n"
+        pgrep_level2 = MagicMock()
+        pgrep_level2.returncode = 0
+        pgrep_level2.stdout = "33333\n"
+        sudo_kill_ok = MagicMock()
+        sudo_kill_ok.returncode = 0
+        sudo_kill_ok.stderr = b""
+
+        with (
+            patch(
+                "kai.codex.subprocess.run",
+                side_effect=[pgrep_level1, pgrep_level2, sudo_kill_ok, sudo_kill_ok],
+            ) as mock_run,
+            patch("kai.codex.os.killpg") as mock_killpg,
+        ):
+            c.force_kill()
+
+        # call 0: pgrep level 1; call 1: pgrep level 2;
+        # call 2: sudo kill 33333 (Rust, innermost); call 3: sudo kill 22222 (node)
+        rust_kill_argv = mock_run.call_args_list[2][0][0]
+        node_kill_argv = mock_run.call_args_list[3][0][0]
+        assert rust_kill_argv[6] == "33333"
+        assert node_kill_argv[6] == "22222"
+        # Cache reflects the chain in inner-to-outer order.
+        assert c._inner_codex_pids == [33333, 22222]
+        mock_killpg.assert_called_once_with(12345, signal.SIGKILL)
+
+    @pytest.mark.asyncio
+    async def test_async_kill_signals_both_descendants_innermost_first(self):
+        """Async path mirror of the sync force_kill chain test."""
+        c = _make_codex(codex_user="ci-fake-user")
+        proc = MagicMock()
+        proc.pid = 12345
+        proc.wait = AsyncMock(return_value=0)
+        c._proc = proc
+        c._pgid = 12345
+        c._effective_codex_user = "ci-fake-user"
+        c._inner_codex_pids = [33333, 22222]  # Pre-cached - skip pgrep
+        c._stderr_task = MagicMock()
+
+        sudo_proc = MagicMock()
+        sudo_proc.returncode = 0
+        sudo_proc.communicate = AsyncMock(return_value=(b"", b""))
+
+        with (
+            patch("kai.codex.asyncio.create_subprocess_exec", AsyncMock(return_value=sudo_proc)) as mock_exec,
+            patch("kai.codex.os.killpg") as mock_killpg,
+        ):
+            await c._kill()
+
+        # Two sudo kill calls in innermost-first order.
+        first_kill_argv = mock_exec.call_args_list[0][0]
+        second_kill_argv = mock_exec.call_args_list[1][0]
+        assert first_kill_argv[6] == "33333"
+        assert second_kill_argv[6] == "22222"
+        mock_killpg.assert_called_once_with(12345, signal.SIGKILL)

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1475,6 +1475,11 @@ class TestCodexCrossUserTeardown:
         sigkill_call = mock_exec.call_args_list[1][0]
         assert sigterm_call[5] == f"-{int(signal.SIGTERM)}"
         assert sigkill_call[5] == f"-{int(signal.SIGKILL)}"
+        # Post-shutdown state cleared. Mirrors the _kill cleanup
+        # assertion; without the matching clear in shutdown(), the
+        # legacy singular field would be created dynamically and the
+        # plural cache would silently retain stale PIDs.
+        assert c._inner_codex_pids == []
 
 
 class TestCodexGrandchildEscalation:


### PR DESCRIPTION
Closes #487.

## Summary

Codex's npm-global packaging interposes a `node` wrapper between the sudo wrapper and the actual Rust binary:

```
sudo (service user)
  └── node /<os_user>/.npm-global/bin/codex app-server  (target user)
        └── /<os_user>/.npm-global/lib/.../codex/codex app-server  (target user)
```

The `#456`-equivalent escalation that PR #484 ported to `codex.py` did `pgrep -P <sudo_pid>` and sudo-killed the result. For codex that resolved to the `node` PID; the Rust binary reparented to init and survived every `_kill`, `shutdown`, `/new`, and recycle. Each turn accumulated an orphan.

Fix:
- `_lookup_inner_codex_pids` (renamed, plural) walks two pgrep levels under the sudo wrapper and returns the descendant chain in inner-to-outer order: `[rust_pid, node_pid]`. Same for the async variant.
- `_send_signal` and `_async_send_signal_for_close` iterate the cache and `sudo -n -u <target> /bin/kill -<sig> <pid>` each descendant innermost-first, before `os.killpg` reaps the sudo wrapper.
- Cache field renamed from `_inner_codex_pid: int | None` to `_inner_codex_pids: list[int]`. A future codex release that drops the node wrapper collapses to a single-element list with no API change.

The claude backend's escalation does not need this because `claude --print` has no node-wrapper layer; the same logic ported verbatim to codex assumed a single-level child that does not hold for npm packaging.

## Test plan

- [x] `make test` (3155 passed, 1 skipped; +5 new in `TestCodexGrandchildEscalation`)
- [x] `make check` (ruff check + ruff format)
- [x] Pre-push grep gate clean
- [x] New tests cover: the two-level pgrep walk, the single-binary fallback when level-2 pgrep returns empty, the all-empty case when level-1 pgrep fails, the sync `force_kill` chain in innermost-first order, and the async `_kill` chain in the same order.
- [ ] End-to-end smoke after merge: reinstall, recycle a codex backend on the production install, confirm `pgrep -u <os_user> codex` returns no results (the `#487` acceptance criterion).
