### PR TITLE
fix(codex): pass --skip-git-repo-check on every codex exec

### DIFF
--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -513,6 +513,15 @@ def _build_judge_cmd_codex(config: BehavioralConfig) -> list[str]:
         codex_bin,
         "exec",
         "--json",
+        # `codex exec` refuses to spawn unless the cwd is on the user's
+        # trusted-directories list OR this flag is passed. The eval
+        # cwd is wherever the operator invoked the harness from, which
+        # is not necessarily a trusted dir. Passing the flag mirrors
+        # what an interactive `codex exec` user would do for any
+        # non-workspace invocation; the safety check is meant for the
+        # interactive code-modifying path, not a one-shot
+        # structured-output classification call.
+        "--skip-git-repo-check",
         "--model",
         config.judge_model,
     ]
@@ -534,6 +543,9 @@ def _build_gen_cmd_codex(config: BehavioralConfig) -> list[str]:
         codex_bin,
         "exec",
         "--json",
+        # Same `codex exec` trusted-dir gate as the judge builder; see
+        # _build_judge_cmd_codex for the full rationale.
+        "--skip-git-repo-check",
         "--model",
         config.gen_model,
     ]

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -741,6 +741,14 @@ async def run_review(
             codex_bin,
             "exec",
             "--json",
+            # `codex exec` refuses to spawn unless the cwd is on the
+            # user's trusted-directories list OR this flag is passed.
+            # Production review has worked only because the bot's cwd
+            # happened to be trusted; one-shot callers from any other
+            # cwd hit "Not inside a trusted directory" and rc=1. The
+            # safety check is meant for the interactive code-modifying
+            # path, not a non-interactive triage / review / eval call.
+            "--skip-git-repo-check",
             "--model",
             review_model,
         ]

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -444,6 +444,14 @@ async def run_triage(
             codex_bin,
             "exec",
             "--json",
+            # `codex exec` refuses to spawn unless the cwd is on the
+            # user's trusted-directories list OR this flag is passed.
+            # Production worked at first only because the bot's cwd
+            # happened to be trusted; one-shot callers from any other
+            # cwd hit "Not inside a trusted directory" and rc=1. The
+            # safety check is meant for the interactive code-modifying
+            # path, not a non-interactive triage / review / eval call.
+            "--skip-git-repo-check",
             "--model",
             triage_model,
         ]

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -1470,6 +1470,11 @@ class TestBuildJudgeCmdCodex:
         assert cmd[0] == "codex"
         assert cmd[1] == "exec"
         assert "--json" in cmd
+        # `--skip-git-repo-check` is load-bearing: codex exec refuses
+        # to spawn unless the cwd is on the user's trusted-directories
+        # list or this flag is passed. Without it the eval bucketed
+        # every probe as generation_error.
+        assert "--skip-git-repo-check" in cmd
         i = cmd.index("--model")
         assert cmd[i + 1] == "gpt-5.4-mini"
         # No claude flags.
@@ -1497,6 +1502,9 @@ class TestBuildGenCmdCodex:
         assert cmd[0] == "codex"
         assert cmd[1] == "exec"
         assert "--json" in cmd
+        # Same `--skip-git-repo-check` invariant as the judge builder;
+        # see TestBuildJudgeCmdCodex.test_argv_shape for the rationale.
+        assert "--skip-git-repo-check" in cmd
         i = cmd.index("--model")
         assert cmd[i + 1] == "gpt-5.4-mini"
         assert "--system-prompt" not in cmd

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -767,6 +767,11 @@ class TestRunReviewCodex:
         assert cmd[0] == "codex"
         assert cmd[1] == "exec"
         assert "--json" in cmd
+        # `--skip-git-repo-check` is load-bearing: codex exec refuses
+        # to spawn unless the cwd is on the user's trusted-directories
+        # list or this flag is passed. Production-only initial success
+        # was due to the bot's cwd happening to be trusted.
+        assert "--skip-git-repo-check" in cmd
         assert "--print" not in cmd  # No claude flag
 
     @pytest.mark.asyncio

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -697,6 +697,11 @@ class TestRunTriageCodex:
         assert cmd[0] == "codex"
         assert cmd[1] == "exec"
         assert "--json" in cmd
+        # `--skip-git-repo-check` is load-bearing: codex exec refuses
+        # to spawn unless the cwd is on the user's trusted-directories
+        # list or this flag is passed. Production-only initial success
+        # was due to the bot's cwd happening to be trusted.
+        assert "--skip-git-repo-check" in cmd
         assert "--print" not in cmd  # No claude flag
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Codex `exec` refuses to spawn unless the cwd is on the user's trusted-directories list, or `--skip-git-repo-check` is passed. The stderr is `Not inside a trusted directory and --skip-git-repo-check was not specified` and the subprocess exits `rc=1`.

The codex triage / review paths happened to work in production because the bot service runs from a cwd the operator had previously trusted, so the safety check was a no-op there. The codex behavioral eval (just merged in #493) runs from wherever the operator invokes the harness, which is not a trusted directory by default; a wire-check smoke surfaced this immediately with all probes bucketed as `generation_error`.

The R1 open-verification on the behavioral-eval spec explicitly flagged this class of issue: "`codex exec --help` must confirm there is no `--tools` or `--permission-mode` equivalent that needs explicit suppression." The trusted-dir gate was the missed item.

## Summary

Adds `--skip-git-repo-check` to every one-shot `codex exec --json` argv:

- `src/kai/eval/behavioral.py` — `_build_judge_cmd_codex`, `_build_gen_cmd_codex`
- `src/kai/triage.py` — `run_triage` codex branch
- `src/kai/review.py` — `run_review` codex branch

The flag's safety check is meant for the interactive code-modifying path, not non-interactive structured-output classification / triage / review / eval calls. The harness has its own subprocess timeout, env allow-list, and stdin-only prompt delivery, so the git-repo guard adds no safety on top of what's already enforced.

## Test plan

- [x] `make test` (3189 passed)
- [x] `make check` (ruff check + ruff format)
- [x] Pre-push grep gate clean
- [x] Existing `TestRunTriageCodex` / `TestRunReviewCodex` / `TestBuildJudgeCmdCodex` / `TestBuildGenCmdCodex` argv-shape asserts extended to lock the flag in
- [x] Live smoke: re-ran the codex behavioral eval on the 2-probe set after the fix; 2/2 `memory_wins`, 0 `generation_error`, 0 `judge_error`, `codex_cli_version: codex-cli 0.130.0` written to the run JSON, summary rendered the `Codex CLI:` line without KeyError. The wire-check confirms the just-merged codex eval path works end-to-end against the production Qdrant store.
