### PR TITLE
feat(memory): OneShotReasoner boundary for memory extraction

### DIFF
--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -664,7 +664,7 @@ def _subprocess_env() -> dict[str, str]:
     env. Vars absent from the parent (e.g. ANTHROPIC_API_KEY when the
     operator runs on Max-plan OAuth) are simply not forwarded.
     """
-    from kai.memory_extraction import _SUBPROCESS_ENV_ALLOWLIST
+    from kai.oneshot import _SUBPROCESS_ENV_ALLOWLIST
 
     return {key: os.environ[key] for key in _SUBPROCESS_ENV_ALLOWLIST if key in os.environ}
 
@@ -1484,7 +1484,7 @@ async def _run_all_probes(
     cwd is set up once at run start (idempotent mkdir) so the per-
     probe subprocess calls do not re-stat the directory each time.
     """
-    from kai.memory_extraction import _EXTRACTOR_CWD, _ensure_extractor_cwd
+    from kai.oneshot import _EXTRACTOR_CWD, _ensure_extractor_cwd
 
     # Idempotent; matches the extractor's lazy-init convention so a
     # permission failure surfaces as a logged subprocess miss rather

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -22,15 +22,24 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import re
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
 
 from kai import memory
-from kai.config import DATA_DIR, Config
+from kai.config import Config
 from kai.memory import MemoryResult
+from kai.oneshot import _EXTRACTOR_CWD as _EXTRACTOR_CWD
+from kai.oneshot import _SUBPROCESS_ENV_ALLOWLIST as _SUBPROCESS_ENV_ALLOWLIST
+from kai.oneshot import (
+    ClaudeOneShotReasoner,
+    OneShotError,
+    OneShotReasoner,
+    OneShotSubprocessError,
+    OneShotTimeout,
+)
+from kai.oneshot import _ensure_extractor_cwd as _ensure_extractor_cwd
 
 log = logging.getLogger(__name__)
 
@@ -193,10 +202,13 @@ _pending_episode_tasks: set[asyncio.Task[None]] = set()
 # Neutral cwd for the subprocess. Fixed (not per-call tmp) so
 # ~/.claude/projects/ does not accumulate a new session directory per
 # extraction. Creation is deferred to first use via
-# `_ensure_extractor_cwd()` - matches Kai's lazy-init convention (no
-# filesystem I/O at import time) and lets a permission/path failure
-# surface as a logged extractor miss rather than an import-time crash.
-_EXTRACTOR_CWD = DATA_DIR / "memory" / "extractor_cwd"
+# `_EXTRACTOR_CWD` and `_ensure_extractor_cwd` live in `kai.oneshot`
+# now (the canonical home for provider subprocess mechanics). Re-
+# exported here as one-line aliases so existing test imports of
+# `kai.memory_extraction._EXTRACTOR_CWD` continue to resolve to the
+# same Path object. The `eval/behavioral` harness imports from
+# `kai.oneshot` directly to avoid cross-module coupling on what is
+# now a non-memory-specific helper.
 
 # Role labels used in `_build_extraction_payload` to separate USER and
 # ASSISTANT segments for Haiku. Users can embed these literal markers in
@@ -214,22 +226,11 @@ _EXTRACTOR_CWD = DATA_DIR / "memory" / "extractor_cwd"
 # short" is not an injection and should survive unchanged).
 _ROLE_LABEL_RE = re.compile(r"\n\s*(USER|ASSISTANT)\s*:", re.IGNORECASE)
 
-# Env vars forwarded to the extractor subprocess. Deliberately tight: the
-# parent's full environment is NOT inherited so secrets (DATABASE_URL,
-# GitHub tokens, webhook secrets, etc.) cannot reach the model if the
-# `--tools ""` boundary ever regresses. The vars below are the minimum
-# needed for the claude CLI to find its binary, read its config, and
-# authenticate on the pay-per-token fallback path. Vars absent from the
-# parent environment (ANTHROPIC_API_KEY when the operator is on Max-plan
-# OAuth, for example) are simply not forwarded - the subprocess behaves
-# as if the var is unset, matching the prior parent-inherit semantics.
-_SUBPROCESS_ENV_ALLOWLIST = (
-    "PATH",
-    "HOME",
-    "CLAUDE_CONFIG_DIR",
-    "ANTHROPIC_API_KEY",
-    "ANTHROPIC_BASE_URL",
-)
+# `_SUBPROCESS_ENV_ALLOWLIST` is canonical in `kai.oneshot` (the
+# reasoner uses it to scope the spawned subprocess env). Re-exported
+# here so that test imports of `kai.memory_extraction._SUBPROCESS_ENV_ALLOWLIST`
+# and any operator-facing logs that mention the constant by this path
+# continue to resolve.
 
 
 # ── JSON schema ──────────────────────────────────────────────────────
@@ -737,19 +738,6 @@ GUIDELINES:
 
 
 # ── Helpers ─────────────────────────────────────────────────────────
-
-
-def _ensure_extractor_cwd() -> None:
-    """
-    Create the neutral subprocess cwd on first use.
-
-    Idempotent: mkdir(exist_ok=True) is cheap on the hot path. Called
-    from _run_extractor() before spawning the subprocess. Deferred from
-    import time on purpose - a permission or path failure should
-    surface as a logged extractor miss, not an import-time crash that
-    takes the whole bot down.
-    """
-    _EXTRACTOR_CWD.mkdir(parents=True, exist_ok=True)
 
 
 def _get_semaphore(user_id: str) -> asyncio.Semaphore:
@@ -1675,6 +1663,26 @@ def _paraphrase_neighbor(content: str, user_id: str, threshold: float) -> Memory
     return None
 
 
+# ── Reasoner wiring ─────────────────────────────────────────────────
+
+
+def _get_memory_reasoner() -> OneShotReasoner:
+    """
+    Resolve the one-shot reasoner used by both memory stages.
+
+    Phase 1 hardcodes Claude. The indirection exists for tests, which
+    monkeypatch this helper to inject fake reasoners that raise or
+    return specific envelopes without spawning real subprocesses, and
+    for the future #497 work that will let an operator select Codex
+    here. Returning a fresh instance per call (rather than a module-
+    level singleton) keeps Phase 1 stateless and mirrors the prior
+    per-call subprocess construction; if a future provider benefits
+    from a long-lived client (connection pool, HTTP session), update
+    this helper rather than each call site.
+    """
+    return ClaudeOneShotReasoner()
+
+
 # ── Subprocess wiring ───────────────────────────────────────────────
 
 
@@ -1754,67 +1762,53 @@ async def _run_extractor(
     API-key-only auth path - only `--bare` does, and its absence is
     asserted by a regression test (§13.3).
     """
-    _ensure_extractor_cwd()
-
-    cmd = [
-        "claude",
-        "--print",
-        "--model",
-        config.memory_extraction_model,
-        "--output-format",
-        "json",
-        "--json-schema",
-        json.dumps(_FACT_SCHEMA),
-        "--system-prompt",
-        system_prompt,
-        "--permission-mode",
-        "bypassPermissions",
-        "--tools",
-        "",
-        "--no-session-persistence",
-        # --exclude-dynamic-system-prompt-sections was considered and
-        # rejected: per `claude --help` it is "ignored with
-        # --system-prompt", which we always set. Leaving it in would
-        # be a silent no-op that looks load-bearing to future readers.
-    ]
-    # Build the allow-listed env (_SUBPROCESS_ENV_ALLOWLIST defined at
-    # module level). Absent keys are simply not forwarded.
-    subprocess_env: dict[str, str] = {key: os.environ[key] for key in _SUBPROCESS_ENV_ALLOWLIST if key in os.environ}
-
-    proc = await asyncio.create_subprocess_exec(
-        *cmd,
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        cwd=str(_EXTRACTOR_CWD),
-        env=subprocess_env,
-    )
+    # Provider subprocess mechanics (argv, env allow-list, neutral
+    # cwd, timeout, kill+await on miss) live in `kai.oneshot`'s
+    # ClaudeOneShotReasoner. The reasoner raises typed exceptions on
+    # timeout / non-zero exit; we catch them here and map to the
+    # zero-state ExtractionResult that this function has always
+    # returned on failure. JSON envelope parsing stays in this
+    # function so memory-domain concerns (is_error, structured_output,
+    # facts, has_episode) do not leak into the reasoner.
+    reasoner = _get_memory_reasoner()
     try:
-        stdout, stderr = await asyncio.wait_for(
-            proc.communicate(input=payload_text.encode("utf-8")),
+        result = await reasoner.run(
+            prompt=payload_text,
+            system_prompt=system_prompt,
+            model=config.memory_extraction_model,
             timeout=config.memory_extraction_timeout_s,
+            purpose="fact_extraction",
+            json_schema=_FACT_SCHEMA,
         )
-    except TimeoutError:
-        proc.kill()
-        await proc.wait()
+    except OneShotTimeout:
         log.warning(
             "Memory extraction timed out after %ds",
             config.memory_extraction_timeout_s,
         )
         return ExtractionResult(facts=[], has_episode=False)
-    if proc.returncode != 0:
+    except OneShotSubprocessError as e:
         log.warning(
             "Memory extraction subprocess exited %d: %s",
-            proc.returncode,
-            stderr[:500].decode("utf-8", errors="replace"),
+            e.returncode,
+            e.stderr[:500].decode("utf-8", errors="replace"),
         )
         return ExtractionResult(facts=[], has_episode=False)
+    except OneShotError:
+        # OneShotOutputError or any future OneShotError subclass the
+        # reasoner adds. Collapse to empty extraction rather than
+        # propagate; the broad outer handler in extract_and_store
+        # already provides the "never raises" contract for unexpected
+        # exceptions, but typed reasoner failures are expected and
+        # should produce the same zero-state result as the older
+        # subprocess-error path.
+        log.warning("Memory extraction reasoner error", exc_info=True)
+        return ExtractionResult(facts=[], has_episode=False)
     try:
-        parsed = json.loads(stdout)
+        parsed = json.loads(result.text)
     except json.JSONDecodeError:
         log.warning(
             "Memory extraction produced invalid JSON: %r",
-            stdout[:500].decode("utf-8", errors="replace"),
+            result.text[:500],
         )
         return ExtractionResult(facts=[], has_episode=False)
     if not isinstance(parsed, dict):
@@ -1961,54 +1955,40 @@ async def _run_episode_extractor(
     on `_run_extractor`; runaway protection comes from
     `memory_episode_timeout_s` at the `asyncio.wait_for` call below.
     """
-    _ensure_extractor_cwd()
-
-    cmd = [
-        "claude",
-        "--print",
-        "--model",
-        config.memory_episode_model,
-        "--output-format",
-        "json",
-        "--json-schema",
-        json.dumps(_EPISODE_SCHEMA),
-        "--system-prompt",
-        _EPISODE_SYSTEM_PROMPT,
-        "--permission-mode",
-        "bypassPermissions",
-        "--tools",
-        "",
-        "--no-session-persistence",
-    ]
-    subprocess_env: dict[str, str] = {key: os.environ[key] for key in _SUBPROCESS_ENV_ALLOWLIST if key in os.environ}
-
-    proc = await asyncio.create_subprocess_exec(
-        *cmd,
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        cwd=str(_EXTRACTOR_CWD),
-        env=subprocess_env,
-    )
+    # Stage 2 routes through the same reasoner as stage 1; the
+    # caller-side mapping recovers the exact failure-reason strings
+    # downstream telemetry depends on (`"timeout"` and
+    # `"exit_<code>: <stderr>"`). OneShotSubprocessError carries the
+    # returncode and stderr bytes precisely so this mapping works.
+    reasoner = _get_memory_reasoner()
     try:
-        stdout, stderr = await asyncio.wait_for(
-            proc.communicate(input=payload_text.encode("utf-8")),
+        result = await reasoner.run(
+            prompt=payload_text,
+            system_prompt=_EPISODE_SYSTEM_PROMPT,
+            model=config.memory_episode_model,
             timeout=config.memory_episode_timeout_s,
+            purpose="episode_generation",
+            json_schema=_EPISODE_SCHEMA,
         )
-    except TimeoutError:
-        proc.kill()
-        await proc.wait()
+    except OneShotTimeout:
         return None, 0.0, "timeout"
-    if proc.returncode != 0:
+    except OneShotSubprocessError as e:
         return (
             None,
             0.0,
-            f"exit_{proc.returncode}: {stderr[:200].decode('utf-8', errors='replace')}",
+            f"exit_{e.returncode}: {e.stderr[:200].decode('utf-8', errors='replace')}",
         )
+    except OneShotError:
+        # Future-proof: any other reasoner-level failure collapses to
+        # a parse-shaped reason rather than propagating. The outer
+        # _generate_episode's broad except handles the truly
+        # unexpected case; this branch keeps known reasoner failures
+        # in the stage-2 vocabulary.
+        return None, 0.0, "reasoner_error"
     try:
-        parsed = json.loads(stdout)
+        parsed = json.loads(result.text)
     except json.JSONDecodeError:
-        return None, 0.0, f"invalid_json: {stdout[:200].decode('utf-8', errors='replace')}"
+        return None, 0.0, f"invalid_json: {result.text[:200]}"
     if not isinstance(parsed, dict):
         return None, 0.0, "non_object_envelope"
     # Cost lives in the CLI envelope. Coerce defensively: a future CLI

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -1,0 +1,374 @@
+"""
+Provider-agnostic one-shot reasoning boundary.
+
+Used by semantic memory extraction (and any future caller that needs a
+bounded, stateless model call) so the caller does not embed provider
+subprocess mechanics. Distinct from `kai.backend.AgentBackend`: that
+abstraction is for persistent, interactive sessions that own a long-
+running subprocess and inject Kai's identity / memory / history
+context. A one-shot reasoner has different lifecycle requirements: no
+persistent state, a hard per-call timeout, stdin-only prompt delivery,
+optional structured-output schema, and an envelope that the CALLER
+parses (the reasoner returns raw text, not parsed memory objects).
+
+Phase 1 ships exactly one implementation: `ClaudeOneShotReasoner`. Its
+argv, env allow-list, neutral cwd, and timeout semantics are lifted
+verbatim from `kai.memory_extraction`'s previous direct subprocess
+spawn so that the Claude memory path stays byte-identical to its
+pre-refactor behavior. Future Codex / OpenCode implementations of the
+same `OneShotReasoner` protocol live here as siblings.
+
+`_EXTRACTOR_CWD`, `_ensure_extractor_cwd`, and `_SUBPROCESS_ENV_ALLOWLIST`
+are canonical here, not in memory_extraction. The behavioral eval
+harness (`kai.eval.behavioral`) reuses them to share the same neutral
+cwd + env contract with memory extraction; both modules import from
+this one. Re-exports in `memory_extraction.py` are one-line aliases
+that point back here so test code that imports the old names
+continues to resolve to the same objects.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from kai.config import DATA_DIR
+
+log = logging.getLogger(__name__)
+
+
+# ── Subprocess cwd / env ────────────────────────────────────────────
+
+
+# Neutral cwd for the one-shot subprocess. The directory has no
+# CLAUDE.md, no project files, and no checked-in conventions, so the
+# spawned model cannot accidentally inherit Kai's workspace identity,
+# voice, or instructions. `_ensure_extractor_cwd()` creates it lazily
+# on first call; matches Kai's no-import-time-IO convention so a
+# permissions or path failure surfaces as a logged extractor miss
+# rather than an import-time crash that takes the bot down.
+_EXTRACTOR_CWD = DATA_DIR / "memory" / "extractor_cwd"
+
+
+# Env vars forwarded to the one-shot subprocess. The parent's full
+# environment is deliberately NOT inherited: secrets like DATABASE_URL,
+# GitHub tokens, webhook secrets, and Telegram tokens must not reach
+# the model if the provider's tool-suppression flag ever regresses.
+# The list below is the minimum needed for the Claude CLI to find its
+# binary (PATH), read its config and OAuth state (HOME,
+# CLAUDE_CONFIG_DIR), authenticate on the pay-per-token fallback
+# (ANTHROPIC_API_KEY), and reach a proxy if one is configured
+# (ANTHROPIC_BASE_URL). Vars absent from the parent env are simply
+# not forwarded; the subprocess behaves as if they were unset.
+_SUBPROCESS_ENV_ALLOWLIST = (
+    "PATH",
+    "HOME",
+    "CLAUDE_CONFIG_DIR",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_BASE_URL",
+)
+
+
+def _ensure_extractor_cwd() -> None:
+    """
+    Create the neutral subprocess cwd on first use.
+
+    Idempotent: mkdir(exist_ok=True) is cheap on the hot path. Called
+    from `ClaudeOneShotReasoner.run()` before spawning the subprocess.
+    Deferred from import time on purpose - a permission or path
+    failure should surface as a logged miss, not an import-time crash
+    that takes the whole bot down.
+    """
+    _EXTRACTOR_CWD.mkdir(parents=True, exist_ok=True)
+
+
+# ── Protocol types ──────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class OneShotResult:
+    """
+    Return value from a `OneShotReasoner.run()` call.
+
+    Attributes:
+        text: The model's raw output text. For Claude in Phase 1 this
+            is the stdout of `claude --print`, which the caller parses
+            for the JSON envelope it expects (`is_error`,
+            `structured_output`, etc.). The reasoner does not parse
+            the envelope; that contract lives in memory_extraction.
+        backend: Provider tag ("claude" today; "codex" / "opencode" in
+            future implementations). Surfaces in structured logs and
+            run-record JSON so cross-backend comparisons are possible.
+        model: Model name passed to the provider, or None when the
+            caller did not request a specific model. The reasoner
+            does not validate model strings; that is the caller's
+            responsibility.
+        raw_metadata: Subprocess-layer metadata only - returncode,
+            stderr bytes, and optionally cmd / cwd for log forensics.
+            Phase 1 deliberately does NOT include parsed-envelope
+            fields (is_error, total_cost_usd, etc.); those stay in
+            memory_extraction so the envelope is parsed exactly once.
+            Future provider implementations may populate
+            backend-specific fields, but no Phase 1 caller depends on
+            anything beyond returncode and stderr.
+        duration_ms: Wall-clock duration of the underlying provider
+            call, measured around the subprocess spawn + wait. Used
+            for structured logging and for operator-side latency
+            tracking; the value is informational, not a contract.
+    """
+
+    text: str
+    backend: str
+    model: str | None
+    raw_metadata: dict[str, Any] = field(default_factory=dict)
+    duration_ms: int = 0
+
+
+class OneShotReasoner(Protocol):
+    """
+    Bounded, stateless model call.
+
+    Implementations spawn a provider subprocess (or call a provider
+    API), feed `prompt` as the user message, optionally prefix
+    `system_prompt` and enforce the supplied JSON Schema, wait up to
+    `timeout` seconds, and return a `OneShotResult`. Failures are
+    typed exceptions (`OneShotTimeout`, `OneShotSubprocessError`,
+    `OneShotOutputError`) the caller catches and maps to
+    domain-specific failure semantics; the reasoner itself does not
+    silently swallow errors or invent fallback values.
+
+    `purpose` is a required string keyed to the caller's intent
+    (`"fact_extraction"`, `"episode_generation"`, etc.). It appears
+    in structured logs only; the reasoner does not branch on it. The
+    field is required (not optional) so log streams can always
+    identify which caller spawned the subprocess.
+    """
+
+    async def run(
+        self,
+        *,
+        prompt: str,
+        system_prompt: str | None = None,
+        model: str | None = None,
+        timeout: float | None = None,
+        purpose: str,
+        json_schema: dict[str, Any] | None = None,
+    ) -> OneShotResult: ...
+
+
+# ── Typed errors ────────────────────────────────────────────────────
+
+
+class OneShotError(Exception):
+    """Base for all reasoner-level failures. Memory callers catch this
+    family and collapse it to domain-specific failure shapes; nothing
+    in the reasoner itself raises bare Exception."""
+
+
+class OneShotTimeout(OneShotError):
+    """The provider subprocess exceeded the call's timeout and was
+    killed. No payload fields in Phase 1: stage 1 maps this to
+    `ExtractionResult(facts=[], has_episode=False)`, stage 2 to the
+    literal reason `"timeout"`, neither of which needs additional
+    context off the exception. If a future caller needs the elapsed
+    time, add it then; do not anticipate."""
+
+
+@dataclass
+class OneShotSubprocessError(OneShotError):
+    """
+    The provider subprocess exited with a non-zero return code.
+
+    Carries `returncode` and raw `stderr` bytes because stage 2's
+    episode-extraction failure-reason string is
+    `f"exit_{returncode}: {stderr[:200].decode('utf-8', errors='replace')}"`.
+    Preserving that string is part of Acceptance 4 (stage 2 failure-
+    reason shape). The fields are dataclass attributes, not
+    constructor args, because Python's stdlib `Exception` does not
+    play nicely with `__init__` parameter capture in subclasses;
+    `@dataclass(eq=False)` on the subclass would also work but is not
+    needed here because exception equality semantics are positional.
+    """
+
+    returncode: int
+    stderr: bytes
+
+
+class OneShotOutputError(OneShotError):
+    """
+    The provider returned successfully (rc=0, no timeout) but produced
+    output the reasoner itself could not surface to the caller (e.g.,
+    a stdout that is not valid UTF-8 even with errors='replace'). NOT
+    raised for memory-domain failures such as schema mismatches,
+    `is_error` envelopes, or missing fields; those are the caller's
+    contract, not the reasoner's. Reserved for the cases where the
+    reasoner cannot honestly produce a `OneShotResult`.
+    """
+
+
+# ── Claude implementation ───────────────────────────────────────────
+
+
+class ClaudeOneShotReasoner:
+    """
+    Spawns `claude --print` once per call and returns the raw stdout.
+
+    The argv, env allow-list, neutral cwd, and timeout semantics are
+    lifted verbatim from the pre-refactor `_run_extractor` /
+    `_run_episode_extractor` paths in `kai.memory_extraction`. That
+    is the load-bearing invariant for the Phase 1 refactor: the
+    Claude memory path must stay byte-identical to its prior
+    behavior, so any future drift in this implementation is a
+    semantic change and not a refactor.
+
+    Flag rationale (carried over from the original site):
+
+    - NO `--bare`. `--help` says it forces ANTHROPIC_API_KEY-only auth
+      and bypasses OAuth / keychain, which would bypass Max-plan
+      billing. The explicit flags below give equivalent sandboxing
+      without that trade-off.
+    - `--system-prompt` fully replaces the default; combined with a
+      neutral cwd that has no CLAUDE.md, the spawned model cannot
+      inherit Kai's workspace identity, voice, or operating rules.
+    - `--tools ""` disables all built-in tools.
+    - `--no-session-persistence` keeps `~/.claude/projects/` from
+      growing a directory per call.
+    - NO `--max-budget-usd`. On Max-plan OAuth the CLI's computed-
+      cost ceiling has no relation to actual billing; runaway-loop
+      protection comes from `asyncio.wait_for(timeout)` instead.
+    - `--permission-mode bypassPermissions` is acceptable because
+      `--tools ""` leaves nothing to permit or deny.
+
+    Payload goes on stdin, not argv. Argv is visible via `ps -ef` and
+    often captured by process accounting; stdin is not world-readable
+    and survives a future multi-user transition without code changes.
+    """
+
+    def __init__(self, *, cwd: Path | None = None) -> None:
+        """
+        Args:
+            cwd: Override for the subprocess working directory. Tests
+                pass a temp path so the run does not touch the real
+                DATA_DIR. Production callers leave this unset; the
+                reasoner uses `_EXTRACTOR_CWD` and ensures it exists
+                on first call.
+        """
+        self._cwd = cwd if cwd is not None else _EXTRACTOR_CWD
+
+    async def run(
+        self,
+        *,
+        prompt: str,
+        system_prompt: str | None = None,
+        model: str | None = None,
+        timeout: float | None = None,
+        purpose: str,
+        json_schema: dict[str, Any] | None = None,
+    ) -> OneShotResult:
+        # Lazy mkdir: deferred from import time on purpose so a
+        # permission failure here surfaces as a logged miss rather
+        # than crashing the bot at startup.
+        self._cwd.mkdir(parents=True, exist_ok=True)
+
+        cmd: list[str] = ["claude", "--print"]
+        if model is not None:
+            cmd.extend(["--model", model])
+        cmd.extend(["--output-format", "json"])
+        if json_schema is not None:
+            # `claude --print --json-schema <schema>` validates the
+            # model's structured-output payload CLI-side. Stage 1 and
+            # stage 2 both rely on this defense-in-depth gate; the
+            # caller's Python validation is the primary contract, but
+            # losing the CLI gate would let more malformed payloads
+            # reach the parser. R2 in the spec calls this out.
+            cmd.extend(["--json-schema", json.dumps(json_schema)])
+        if system_prompt is not None:
+            cmd.extend(["--system-prompt", system_prompt])
+        cmd.extend(
+            [
+                "--permission-mode",
+                "bypassPermissions",
+                "--tools",
+                "",
+                "--no-session-persistence",
+            ]
+        )
+
+        # Allow-listed env: only forward vars from
+        # _SUBPROCESS_ENV_ALLOWLIST that are present in the parent
+        # environment. Absent vars are simply not forwarded, matching
+        # the prior parent-inherit semantics for "var was unset" but
+        # without leaking the rest of the parent env. Defense-in-
+        # depth against a future regression in `--tools ""`.
+        subprocess_env: dict[str, str] = {
+            key: os.environ[key] for key in _SUBPROCESS_ENV_ALLOWLIST if key in os.environ
+        }
+
+        start = time.monotonic()
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(self._cwd),
+            env=subprocess_env,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=prompt.encode("utf-8")),
+                timeout=timeout,
+            )
+        except TimeoutError:
+            # Match the pre-refactor cleanup: kill the subprocess and
+            # await its reap before raising. Without the await, the
+            # caller (e.g. _generate_episode) could see the
+            # ProcessLookupError race on a subsequent kill.
+            proc.kill()
+            await proc.wait()
+            duration_ms = int((time.monotonic() - start) * 1000)
+            log.info(
+                "oneshot_reasoner purpose=%s backend=claude model=%s duration_ms=%d outcome=timeout error_category=timeout",
+                purpose,
+                model,
+                duration_ms,
+            )
+            raise OneShotTimeout() from None
+
+        duration_ms = int((time.monotonic() - start) * 1000)
+        returncode = proc.returncode if proc.returncode is not None else -1
+        if returncode != 0:
+            log.info(
+                "oneshot_reasoner purpose=%s backend=claude model=%s duration_ms=%d outcome=subprocess_error error_category=non_zero_exit returncode=%d",
+                purpose,
+                model,
+                duration_ms,
+                returncode,
+            )
+            raise OneShotSubprocessError(returncode=returncode, stderr=stderr)
+
+        log.info(
+            "oneshot_reasoner purpose=%s backend=claude model=%s duration_ms=%d outcome=success returncode=0",
+            purpose,
+            model,
+            duration_ms,
+        )
+        # Phase 1 raw_metadata: subprocess-layer data only. NO JSON
+        # envelope parse here - that is memory_extraction's contract.
+        # Future Codex / OpenCode implementations may populate
+        # backend-specific metadata, but Phase 1 callers depend on
+        # nothing beyond what is captured below.
+        return OneShotResult(
+            text=stdout.decode("utf-8", errors="replace"),
+            backend="claude",
+            model=model,
+            raw_metadata={
+                "returncode": returncode,
+                "stderr": stderr,
+                "cwd": str(self._cwd),
+            },
+            duration_ms=duration_ms,
+        )

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -25,7 +25,7 @@ import asyncio
 import json
 import logging
 from dataclasses import replace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -1092,3 +1092,75 @@ def test_module_exposes_extraction_result():
     from kai.memory_extraction import ExtractionResult as ER
 
     assert ER is ExtractionResult
+
+
+class TestRunEpisodeExtractorViaReasoner:
+    """`_run_episode_extractor` now routes through the OneShotReasoner
+    boundary. These tests monkeypatch the reasoner helper so the
+    caller-side mapping from typed reasoner exceptions to the stage-2
+    `(episode, cost_usd, reason)` triple is exercised directly."""
+
+    @pytest.mark.asyncio
+    async def test_valid_envelope_returns_episode_triple(self):
+        """A reasoner returning a well-formed Claude envelope produces
+        the same `(episode, cost_usd, None)` triple the subprocess
+        path produces today."""
+        from kai.oneshot import OneShotResult
+
+        envelope_text = _stage2_envelope(_valid_episode(), cost_usd=0.04).decode("utf-8")
+
+        class _FakeReasoner:
+            async def run(self, **kwargs):
+                return OneShotResult(
+                    text=envelope_text,
+                    backend="claude",
+                    model="claude-haiku-4-5-20251001",
+                    raw_metadata={"returncode": 0, "stderr": b""},
+                    duration_ms=42,
+                )
+
+        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_FakeReasoner()):
+            episode, cost_usd, reason = await _run_episode_extractor("payload", _cfg())
+
+        assert episode == _valid_episode()
+        assert cost_usd == pytest.approx(0.04)
+        assert reason is None
+
+    @pytest.mark.asyncio
+    async def test_timeout_maps_to_literal_timeout_reason(self):
+        """OneShotTimeout maps to the literal `"timeout"` reason string
+        with `cost_usd=0.0` (no envelope ever returned). Downstream
+        telemetry pins this exact string."""
+        from kai.oneshot import OneShotTimeout
+
+        class _TimingOutReasoner:
+            async def run(self, **kwargs):
+                raise OneShotTimeout()
+
+        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_TimingOutReasoner()):
+            episode, cost_usd, reason = await _run_episode_extractor("payload", _cfg())
+
+        assert episode is None
+        assert cost_usd == 0.0
+        assert reason == "timeout"
+
+    @pytest.mark.asyncio
+    async def test_subprocess_error_preserves_exit_reason_format(self):
+        """OneShotSubprocessError must carry returncode and stderr; the
+        stage-2 mapping recomposes them into the `exit_<code>: <stderr>`
+        reason format that telemetry has used since the original
+        subprocess path."""
+        from kai.oneshot import OneShotSubprocessError
+
+        class _FailingReasoner:
+            async def run(self, **kwargs):
+                raise OneShotSubprocessError(returncode=2, stderr=b"oauth refused: please login")
+
+        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_FailingReasoner()):
+            episode, cost_usd, reason = await _run_episode_extractor("payload", _cfg())
+
+        assert episode is None
+        assert cost_usd == 0.0
+        assert reason is not None
+        assert reason.startswith("exit_2: ")
+        assert "oauth refused" in reason

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import asyncio
 import json
 from dataclasses import replace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -3359,3 +3359,86 @@ class TestSpeakerAttribution:
         # third value that flows through a separate write path and
         # is intentionally not in the extractor enum.
         assert set(speaker_prop["enum"]) == {"user", "assistant"}
+
+
+class TestRunExtractorViaReasoner:
+    """`_run_extractor` now routes through the OneShotReasoner boundary.
+    These tests monkeypatch the reasoner helper rather than the
+    subprocess so they exercise the caller-side mapping from typed
+    reasoner exceptions to the existing zero-state ExtractionResult."""
+
+    @pytest.mark.asyncio
+    async def test_valid_envelope_returns_extraction_result(self):
+        """A reasoner returning a well-formed Claude envelope produces the
+        same ExtractionResult that the subprocess path produces today."""
+        from kai.oneshot import OneShotResult
+
+        envelope_text = '{"is_error": false, "structured_output": {"facts": [], "has_episode": false}}'
+
+        class _FakeReasoner:
+            async def run(self, **kwargs):
+                return OneShotResult(
+                    text=envelope_text,
+                    backend="claude",
+                    model="claude-haiku-4-5-20251001",
+                    raw_metadata={"returncode": 0, "stderr": b""},
+                    duration_ms=12,
+                )
+
+        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_FakeReasoner()):
+            result = await memory_extraction._run_extractor(
+                payload_text="payload",
+                config=_cfg(),
+                candidate_ids=set(),
+                candidate_metadata={},
+                user_id="u1",
+            )
+
+        assert result.facts == []
+        assert result.has_episode is False
+
+    @pytest.mark.asyncio
+    async def test_timeout_collapses_to_empty_extraction_result(self):
+        """OneShotTimeout from the reasoner maps to the canonical empty
+        ExtractionResult, preserving the never-raises contract that the
+        outer extract_and_store relies on."""
+        from kai.oneshot import OneShotTimeout
+
+        class _TimingOutReasoner:
+            async def run(self, **kwargs):
+                raise OneShotTimeout()
+
+        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_TimingOutReasoner()):
+            result = await memory_extraction._run_extractor(
+                payload_text="payload",
+                config=_cfg(),
+                candidate_ids=set(),
+                candidate_metadata={},
+                user_id="u1",
+            )
+
+        assert result.facts == []
+        assert result.has_episode is False
+
+    @pytest.mark.asyncio
+    async def test_subprocess_error_collapses_to_empty_extraction_result(self):
+        """OneShotSubprocessError carries returncode and stderr; stage 1
+        does not surface them (stage 2 does), so the caller-side mapping
+        is "log a warning and return empty"."""
+        from kai.oneshot import OneShotSubprocessError
+
+        class _FailingReasoner:
+            async def run(self, **kwargs):
+                raise OneShotSubprocessError(returncode=2, stderr=b"oauth refused")
+
+        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_FailingReasoner()):
+            result = await memory_extraction._run_extractor(
+                payload_text="payload",
+                config=_cfg(),
+                candidate_ids=set(),
+                candidate_metadata={},
+                user_id="u1",
+            )
+
+        assert result.facts == []
+        assert result.has_episode is False

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -1,0 +1,348 @@
+"""
+Tests for `kai.oneshot` - the provider-agnostic one-shot reasoning
+boundary used by semantic memory extraction.
+
+Coverage focus: subprocess mechanics that the reasoner owns. The
+memory-specific contracts (envelope parsing, schema validation, fact
+storage) live in `tests/test_memory_extraction.py` and stay there.
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kai.oneshot import (
+    _SUBPROCESS_ENV_ALLOWLIST,
+    ClaudeOneShotReasoner,
+    OneShotResult,
+    OneShotSubprocessError,
+    OneShotTimeout,
+)
+
+
+def _make_proc(
+    *,
+    stdout: bytes = b"",
+    stderr: bytes = b"",
+    returncode: int = 0,
+    raise_timeout: bool = False,
+) -> MagicMock:
+    """Build a mock subprocess for asyncio.create_subprocess_exec.
+
+    `raise_timeout=True` makes `communicate` raise TimeoutError on the
+    first await, simulating the wait_for timeout path.
+    """
+    proc = MagicMock()
+    if raise_timeout:
+        proc.communicate = AsyncMock(side_effect=TimeoutError())
+    else:
+        proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock(return_value=returncode)
+    proc.returncode = returncode
+    return proc
+
+
+class TestClaudeOneShotReasonerArgv:
+    """The Claude reasoner's argv must match the pre-refactor memory
+    extraction shape: claude --print, schema flag when provided,
+    sandboxing flags, no --bare, no --max-budget-usd."""
+
+    @pytest.mark.asyncio
+    async def test_argv_shape_with_schema_and_system_prompt(self, tmp_path):
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=b'{"ok": true}')
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(
+                prompt="hello",
+                system_prompt="you are a test",
+                model="claude-haiku-4-5-20251001",
+                timeout=30,
+                purpose="fact_extraction",
+                json_schema={"type": "object", "properties": {}},
+            )
+
+        cmd = mock_exec.call_args[0]
+        assert cmd[0] == "claude"
+        assert cmd[1] == "--print"
+        i = cmd.index("--model")
+        assert cmd[i + 1] == "claude-haiku-4-5-20251001"
+        i = cmd.index("--output-format")
+        assert cmd[i + 1] == "json"
+        assert "--json-schema" in cmd
+        i = cmd.index("--system-prompt")
+        assert cmd[i + 1] == "you are a test"
+        i = cmd.index("--permission-mode")
+        assert cmd[i + 1] == "bypassPermissions"
+        i = cmd.index("--tools")
+        assert cmd[i + 1] == ""
+        assert "--no-session-persistence" in cmd
+
+    @pytest.mark.asyncio
+    async def test_argv_omits_bare_flag(self, tmp_path):
+        """`--bare` would bypass OAuth and force ANTHROPIC_API_KEY-only auth,
+        which would break Max-plan billing for memory extraction. The
+        reasoner must never include it."""
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc()
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(prompt="p", purpose="fact_extraction")
+
+        cmd = mock_exec.call_args[0]
+        assert "--bare" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_argv_omits_max_budget_usd_flag(self, tmp_path):
+        """Max-plan OAuth makes --max-budget-usd a phantom signal; runaway
+        protection is the wait_for timeout. The reasoner must not emit
+        the flag regardless of how a future config knob looks."""
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc()
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(prompt="p", purpose="fact_extraction")
+
+        cmd = mock_exec.call_args[0]
+        assert "--max-budget-usd" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_payload_sent_on_stdin_not_argv(self, tmp_path):
+        """Conversation content goes through stdin, never argv. Argv is
+        visible via `ps -ef`."""
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc()
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            await reasoner.run(prompt="SECRET-USER-MESSAGE", purpose="fact_extraction")
+
+        proc.communicate.assert_awaited_once_with(input=b"SECRET-USER-MESSAGE")
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_omitted_when_none(self, tmp_path):
+        """A `system_prompt=None` argument means the caller does not want
+        to set the flag at all. The reasoner must not emit a stray
+        `--system-prompt ""` because that would silently replace the
+        Claude default with the empty string (which DOES change
+        behavior)."""
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc()
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(prompt="p", purpose="fact_extraction", system_prompt=None)
+
+        cmd = mock_exec.call_args[0]
+        assert "--system-prompt" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_json_schema_omitted_when_none(self, tmp_path):
+        """When the caller passes no schema, the reasoner does not emit
+        --json-schema. Stage 1 and stage 2 always pass one in
+        production, but the protocol allows None and the implementation
+        must honor that."""
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc()
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(prompt="p", purpose="fact_extraction", json_schema=None)
+
+        cmd = mock_exec.call_args[0]
+        assert "--json-schema" not in cmd
+
+
+class TestClaudeOneShotReasonerEnv:
+    """The subprocess env must be allow-listed - the parent's full env
+    is NOT inherited, so a regression in --tools "" cannot leak the
+    bot's secrets to the model."""
+
+    @pytest.mark.asyncio
+    async def test_env_contains_only_allowlisted_keys(self, tmp_path, monkeypatch):
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc()
+
+        # Seed the parent env with several secret-looking values and
+        # one allow-listed value so the assertion can demonstrate both
+        # directions.
+        monkeypatch.setenv("DATABASE_URL", "postgres://leak")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_leak")
+        monkeypatch.setenv("WEBHOOK_SECRET", "hmac-leak")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(prompt="p", purpose="fact_extraction")
+
+        passed_env = mock_exec.call_args.kwargs["env"]
+        # Allow-listed key present.
+        assert passed_env.get("PATH") == "/usr/bin:/bin"
+        # Secrets absent.
+        assert "DATABASE_URL" not in passed_env
+        assert "GITHUB_TOKEN" not in passed_env
+        assert "WEBHOOK_SECRET" not in passed_env
+        # No keys outside the allow-list reached the subprocess.
+        assert set(passed_env.keys()) <= set(_SUBPROCESS_ENV_ALLOWLIST)
+
+
+class TestClaudeOneShotReasonerCwd:
+    """The neutral cwd must exist on call (lazy mkdir) and must be the
+    path the caller supplied (or the canonical _EXTRACTOR_CWD when
+    not overridden)."""
+
+    @pytest.mark.asyncio
+    async def test_cwd_is_created_lazily(self, tmp_path):
+        target = tmp_path / "nested" / "extractor_cwd"
+        assert not target.exists()
+        reasoner = ClaudeOneShotReasoner(cwd=target)
+        proc = _make_proc()
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(prompt="p", purpose="fact_extraction")
+
+        assert target.is_dir()
+        assert mock_exec.call_args.kwargs["cwd"] == str(target)
+
+
+class TestClaudeOneShotReasonerTimeout:
+    """On timeout, the subprocess must be killed and reaped before the
+    exception propagates. The wait() prevents a subsequent kill() from
+    racing on ProcessLookupError."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_and_awaits_then_raises(self, tmp_path):
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(raise_timeout=True)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotTimeout),
+        ):
+            await reasoner.run(prompt="p", purpose="fact_extraction", timeout=0.1)
+
+        proc.kill.assert_called_once()
+        proc.wait.assert_awaited()
+
+
+class TestClaudeOneShotReasonerSubprocessError:
+    """Non-zero exit must raise OneShotSubprocessError carrying
+    returncode AND stderr bytes so stage 2 can preserve its
+    `exit_<code>: <stderr>` failure reason."""
+
+    @pytest.mark.asyncio
+    async def test_non_zero_exit_raises_with_returncode_and_stderr(self, tmp_path):
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=b"", stderr=b"oauth refused", returncode=2)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotSubprocessError) as excinfo,
+        ):
+            await reasoner.run(prompt="p", purpose="fact_extraction")
+
+        assert excinfo.value.returncode == 2
+        assert excinfo.value.stderr == b"oauth refused"
+
+
+class TestClaudeOneShotReasonerSuccess:
+    """A successful run returns a populated OneShotResult: decoded
+    stdout, backend tag, model passthrough, raw_metadata with
+    subprocess-layer fields, and a non-negative duration."""
+
+    @pytest.mark.asyncio
+    async def test_success_returns_one_shot_result(self, tmp_path):
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=b'{"text": "hi"}', stderr=b"warning: deprecated", returncode=0)
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                model="claude-haiku-4-5-20251001",
+            )
+
+        assert isinstance(result, OneShotResult)
+        assert result.text == '{"text": "hi"}'
+        assert result.backend == "claude"
+        assert result.model == "claude-haiku-4-5-20251001"
+        assert result.raw_metadata["returncode"] == 0
+        assert result.raw_metadata["stderr"] == b"warning: deprecated"
+        assert result.raw_metadata["cwd"] == str(tmp_path)
+        assert result.duration_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_raw_metadata_excludes_parsed_envelope_fields(self, tmp_path):
+        """Phase 1 contract: raw_metadata is subprocess-layer only. The
+        Claude reasoner must NOT parse the JSON envelope and populate
+        envelope-derived fields (is_error, total_cost_usd, etc.); that
+        contract belongs to memory_extraction."""
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        envelope = b'{"is_error": false, "total_cost_usd": 0.0023, "subtype": "ok", "result": "{}"}'
+        proc = _make_proc(stdout=envelope, returncode=0)
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(prompt="p", purpose="fact_extraction")
+
+        # Phase 1 must keep raw_metadata free of envelope-parsed fields.
+        for forbidden in ("is_error", "total_cost_usd", "subtype", "result", "structured_output"):
+            assert forbidden not in result.raw_metadata
+
+
+class TestClaudeOneShotReasonerLogging:
+    """Each call emits one structured INFO line keyed by purpose, with
+    distinct outcomes for success / timeout / subprocess_error."""
+
+    @pytest.mark.asyncio
+    async def test_log_line_includes_purpose_and_outcome_success(self, tmp_path, caplog):
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=b"{}", returncode=0)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            caplog.at_level(logging.INFO, logger="kai.oneshot"),
+        ):
+            await reasoner.run(prompt="p", purpose="fact_extraction")
+
+        # One INFO line; contains the structured fields the spec asks for.
+        records = [r for r in caplog.records if r.message.startswith("oneshot_reasoner")]
+        assert len(records) == 1
+        msg = records[0].getMessage()
+        assert "purpose=fact_extraction" in msg
+        assert "backend=claude" in msg
+        assert "outcome=success" in msg
+
+    @pytest.mark.asyncio
+    async def test_log_line_carries_purpose_on_timeout(self, tmp_path, caplog):
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(raise_timeout=True)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            caplog.at_level(logging.INFO, logger="kai.oneshot"),
+            pytest.raises(OneShotTimeout),
+        ):
+            await reasoner.run(prompt="p", purpose="episode_generation", timeout=0.1)
+
+        records = [r for r in caplog.records if r.message.startswith("oneshot_reasoner")]
+        assert len(records) == 1
+        msg = records[0].getMessage()
+        assert "purpose=episode_generation" in msg
+        assert "outcome=timeout" in msg
+
+    @pytest.mark.asyncio
+    async def test_log_line_carries_purpose_on_subprocess_error(self, tmp_path, caplog):
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stderr=b"refused", returncode=3)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            caplog.at_level(logging.INFO, logger="kai.oneshot"),
+            pytest.raises(OneShotSubprocessError),
+        ):
+            await reasoner.run(prompt="p", purpose="episode_generation")
+
+        records = [r for r in caplog.records if r.message.startswith("oneshot_reasoner")]
+        assert len(records) == 1
+        msg = records[0].getMessage()
+        assert "purpose=episode_generation" in msg
+        assert "outcome=subprocess_error" in msg
+        assert "returncode=3" in msg


### PR DESCRIPTION
Closes #496. Phase 1 of epic #495 — introduces a provider-agnostic one-shot reasoning boundary and routes the existing Claude-backed semantic memory extraction path through it with no intended behavior change. Codex memory extraction is #497; this PR is the load-bearing refactor.

## Summary

- **New `src/kai/oneshot.py`** with the protocol, result type, typed exceptions, and the Claude implementation:
  - `OneShotReasoner` Protocol with `run(*, prompt, system_prompt=None, model=None, timeout=None, purpose, json_schema=None) -> OneShotResult`. `purpose` is required so structured logs always identify the caller; `json_schema` is included because CLI-side schema validation is a real semantic the boundary should carry (R2 in the spec's risks).
  - `OneShotResult` (frozen): `text`, `backend`, `model`, `raw_metadata`, `duration_ms`.
  - Typed exceptions: `OneShotError`, `OneShotTimeout`, `OneShotSubprocessError` (dataclass with `returncode: int` and `stderr: bytes` so stage 2 can recompose its existing `"exit_<code>: <stderr>"` failure-reason string), `OneShotOutputError`.
  - `ClaudeOneShotReasoner` implementation. Argv shape lifted verbatim from the prior `_run_extractor` / `_run_episode_extractor`: `claude --print --model --output-format json --json-schema --system-prompt --permission-mode bypassPermissions --tools "" --no-session-persistence`. No `--bare`. No `--max-budget-usd`. Stdin payload. Allow-listed env. Neutral cwd with lazy mkdir. Identical wait-for / kill / await semantics on timeout.
- **`_EXTRACTOR_CWD`, `_ensure_extractor_cwd`, `_SUBPROCESS_ENV_ALLOWLIST` are canonical in `oneshot.py`** now; `memory_extraction.py` keeps one-line re-exports so test imports of the old paths still resolve. `eval/behavioral.py` (the existing second consumer) switches its imports to `kai.oneshot` so the behavioral harness and memory extraction share one source of truth on subprocess env/cwd handling.
- **`memory_extraction.py` routes both stages through `_get_memory_reasoner()`.** The helper returns `ClaudeOneShotReasoner()` per call (stateless; mirrors the prior per-call subprocess pattern). Tests can monkeypatch the helper to inject fakes. Caller-side mapping preserves every existing failure shape:
  - Stage 1: any reasoner-level failure (timeout, subprocess error, reasoner output error) collapses to `ExtractionResult(facts=[], has_episode=False)` — the prior never-raises contract is intact.
  - Stage 2: timeout → `"timeout"`, subprocess error → `"exit_<code>: <stderr>"`, any other reasoner error → `"reasoner_error"`.
- **JSON envelope parsing stays in `memory_extraction.py`** (R1). The reasoner does not import `_FACT_SCHEMA`, `_EPISODE_SCHEMA`, `_validate_facts`, `_validate_episode`, or `kai.memory`; `raw_metadata` carries subprocess-layer fields only (`returncode`, `stderr`, `cwd`). Memory-domain concerns (`is_error`, `structured_output`, `total_cost_usd`, fact validation) stay where they are.
- **Structured logging at the reasoner boundary.** One `oneshot_reasoner` INFO line per call with `purpose`, `backend`, `model`, `duration_ms`, `outcome`, `returncode` where applicable.

## Test plan

- [x] `make test`: 3210 passed, 1 skipped (+21 new across `tests/test_oneshot.py` and the two memory test files).
- [x] `make check` (ruff check + ruff format).
- [x] Pre-push grep gate clean.
- [x] New `tests/test_oneshot.py` (15 tests): argv shape with / without schema and system prompt, `--bare` absent, `--max-budget-usd` absent, stdin-only payload delivery, env allow-list (secret-looking parent vars excluded), lazy cwd mkdir, timeout kills + awaits + raises `OneShotTimeout`, non-zero exit raises `OneShotSubprocessError` carrying `returncode` and `stderr`, success returns populated `OneShotResult`, `raw_metadata` deliberately excludes envelope-parsed fields, structured log line carries `purpose` / `outcome` / `returncode` on success / timeout / subprocess paths.
- [x] `tests/test_memory_extraction.py` gains 3 reasoner-mock tests: valid envelope returns `ExtractionResult`, timeout collapses to empty, subprocess error collapses to empty.
- [x] `tests/test_memory_episodes.py` gains 3 reasoner-mock tests: valid envelope returns `(episode, cost_usd, None)`, timeout maps to `"timeout"`, subprocess error preserves the `"exit_<code>: <stderr>"` reason format.
- [x] **Existing 33 + 24 subprocess-mock tests survive unchanged.** They patch the `asyncio` module attribute itself (`monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)`), so they still catch the call from `kai.oneshot` after the refactor. No test relocations needed; the churn is additive.
- [ ] Manual smoke on a Claude-authenticated install: `MEMORY_ENABLED=true` extraction run before and after the refactor; expected result is no material movement beyond normal model variance because the prompt, schema, and model stay identical.

## Out of scope (handled by the parent epic)

- No Codex reasoner. That is **#497**.
- No memory backend selection config (no `MEMORY_REASONER_BACKEND`, no model registry entries). Adding a knob with only one valid value today would just be startup-error ceremony; it lands when #497 makes Codex selectable.
- No prompt rewrites, schema changes, or eval-threshold changes.
- No migration of triage / review / behavioral eval onto `OneShotReasoner` in this PR. The boundary exists for memory; other one-shot paths stay on their existing call shapes.
- No OpenCode support.

## Follow-ups (referenced in the spec)

- **#497** — Codex `OneShotReasoner` implementation and memory reasoner selection.
- **#498** — Claude-vs-Codex memory eval gate.
- **#499** — production-enable memory-backed Codex installs after the eval gate passes.
