### PR TITLE
feat(memory): Codex OneShotReasoner + MEMORY_REASONER_BACKEND selector

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -169,6 +169,16 @@ class ModelRole(StrEnum):
     ISSUE_TRIAGE = "issue_triage"
     BEHAVIORAL_JUDGE = "behavioral_judge"
     BEHAVIORAL_GEN = "behavioral_gen"
+    # Memory extraction roles. Routed through the per-backend registry
+    # so MEMORY_REASONER_BACKEND=codex can resolve a codex-native
+    # model (gpt-5.4-mini) instead of inheriting the Claude-shaped
+    # `claude-haiku-4-5-20251001` literal that the codex CLI would
+    # reject. MEMORY_EPISODE is a distinct row from MEMORY_EXTRACTION
+    # so an operator can downgrade one stage without the other;
+    # load_config still applies the "episode inherits extraction"
+    # default at env-resolution time when MEMORY_EPISODE_MODEL is unset.
+    MEMORY_EXTRACTION = "memory_extraction"
+    MEMORY_EPISODE = "memory_episode"
 
 
 # Values are exactly what each backend's CLI accepts as --model.
@@ -199,6 +209,19 @@ MODEL_REGISTRY: dict[tuple[str, ModelRole], str] = {
     # against CODEX_MODELS so future drift gets caught at startup.
     ("codex", ModelRole.BEHAVIORAL_JUDGE): "gpt-5.4-mini",
     ("codex", ModelRole.BEHAVIORAL_GEN): "gpt-5.4-mini",
+    # Memory extraction rows. Claude entries equal the existing
+    # `memory_extraction_model` / `memory_episode_model` dataclass
+    # default so an install that has not set MEMORY_REASONER_BACKEND
+    # sees byte-identical model resolution. Codex entries pick the
+    # smallest currently-exposed codex model (gpt-5.4-mini) on the
+    # same editorial tier as Claude's haiku selection; the structural
+    # validator below asserts both rows land on models the codex CLI
+    # accepts, so a future operator who renames a codex SKU surfaces
+    # the bad row at startup rather than at first extraction.
+    ("claude", ModelRole.MEMORY_EXTRACTION): "claude-haiku-4-5-20251001",
+    ("claude", ModelRole.MEMORY_EPISODE): "claude-haiku-4-5-20251001",
+    ("codex", ModelRole.MEMORY_EXTRACTION): "gpt-5.4-mini",
+    ("codex", ModelRole.MEMORY_EPISODE): "gpt-5.4-mini",
 }
 
 
@@ -730,12 +753,30 @@ class Config:
     memory_token_budget: int = 2000
     memory_embedding_model: str = "all-MiniLM-L6-v2"
 
+    # Memory reasoner backend selection. Independent of `agent_backend`
+    # because memory extraction has not yet passed the cross-backend
+    # eval gate; an install running `AGENT_BACKEND=codex` must NOT
+    # silently flip memory extraction onto an unevaluated provider.
+    # Default stays "claude" until a follow-up production-enables the
+    # codex path. Values are validated at config-load time against
+    # `{"claude", "codex"}`; an unknown value is a SystemExit, matching
+    # the AGENT_BACKEND validation pattern. When `memory_enabled=False`
+    # or `memory_extraction_enabled=False`, the value still parses but
+    # no reasoner is invoked.
+    memory_reasoner_backend: str = "claude"
+
     # Track 2 (Haiku extraction) config. Requires memory_enabled=True and
     # a Claude backend. Default is False at Phase 2 ship so the self-
     # reinforcing extraction loop has real-world observation time before
     # the default flips. The kill switch is the same flag.
     memory_extraction_enabled: bool = False
-    # Claude model name for extraction. Default is Haiku 4.5.
+    # Default model name for extraction. The literal here is the
+    # Claude registry row; load_config() re-resolves this through
+    # `get_model_for(ModelRole.MEMORY_EXTRACTION, memory_reasoner_backend)`
+    # so an install with MEMORY_REASONER_BACKEND=codex gets a codex
+    # model instead of the Claude default. The dataclass literal
+    # stays because test fixtures construct Config directly and
+    # depend on a usable Claude default without going through env.
     memory_extraction_model: str = "claude-haiku-4-5-20251001"
     # Per-call budget ceiling. Omitted from claude --print argv on the
     # claude backend (Max-plan OAuth makes the CLI's computed-cost
@@ -1890,9 +1931,42 @@ def load_config() -> Config:
     # here so the dependency is explicit and the budget-burn hole is
     # closed regardless of operator env-var ordering.
     memory_extraction_enabled = memory_extraction_enabled and memory_enabled
-    memory_extraction_model = (
-        os.environ.get("MEMORY_EXTRACTION_MODEL", "claude-haiku-4-5-20251001").strip() or "claude-haiku-4-5-20251001"
-    )
+
+    # Memory reasoner backend. Must validate BEFORE the role-resolved
+    # model defaults below so a typo like MEMORY_REASONER_BACKEND=gpt5
+    # is surfaced at config-load time, not at the first extraction
+    # call inside _get_memory_reasoner(). The valid set is {"claude",
+    # "codex"} for #497; OpenCode would extend this set, but adding
+    # it here without a registry row would defeat the registry
+    # completeness check.
+    memory_reasoner_backend = os.environ.get("MEMORY_REASONER_BACKEND", "claude").strip().lower()
+    _valid_memory_backends = ("claude", "codex")
+    if memory_reasoner_backend not in _valid_memory_backends:
+        raise SystemExit(
+            f"MEMORY_REASONER_BACKEND '{memory_reasoner_backend}' is not valid "
+            f"(must be one of: {', '.join(_valid_memory_backends)})"
+        )
+
+    # Memory model resolution. Env override wins; otherwise the role
+    # registry resolves to a backend-appropriate default (claude-haiku
+    # for backend=claude, gpt-5.4-mini for backend=codex). Sentinel
+    # empty-string from the dataclass would also fall through to the
+    # registry, but explicit None-check on the env var matches the
+    # other memory_* fields' style and keeps the read order
+    # predictable.
+    memory_extraction_model = os.environ.get("MEMORY_EXTRACTION_MODEL", "").strip()
+    if not memory_extraction_model:
+        memory_extraction_model = get_model_for(ModelRole.MEMORY_EXTRACTION, memory_reasoner_backend)
+    # Codex memory model overrides must name a model the codex CLI
+    # exposes. Claude memory model overrides stay free-form (matches
+    # the previous behavior; a stricter list would need its own
+    # validation pass and is out of scope here).
+    if memory_reasoner_backend == "codex" and memory_extraction_model not in CODEX_MODELS:
+        valid = sorted(CODEX_MODELS.keys())
+        raise SystemExit(
+            f"MEMORY_EXTRACTION_MODEL '{memory_extraction_model}' is not valid "
+            f"for memory_reasoner_backend='codex' (must be one of: {', '.join(valid)})"
+        )
     try:
         memory_extraction_budget_usd = float(os.environ.get("MEMORY_EXTRACTION_BUDGET_USD", "0.01"))
         if memory_extraction_budget_usd < 0:
@@ -1940,6 +2014,17 @@ def load_config() -> Config:
     # intentional kill switch is MEMORY_ENABLED). Timeout floor is 10s
     # to prevent accidentally tightening it below Haiku's warm-up time.
     memory_episode_model = os.environ.get("MEMORY_EPISODE_MODEL", "").strip() or memory_extraction_model
+    # Apply the same codex-CLI validation to the episode model. The
+    # episode default inherits memory_extraction_model (already
+    # validated), so this gate only fires on an explicit
+    # MEMORY_EPISODE_MODEL override that names a non-codex SKU under
+    # the codex memory backend.
+    if memory_reasoner_backend == "codex" and memory_episode_model not in CODEX_MODELS:
+        valid = sorted(CODEX_MODELS.keys())
+        raise SystemExit(
+            f"MEMORY_EPISODE_MODEL '{memory_episode_model}' is not valid "
+            f"for memory_reasoner_backend='codex' (must be one of: {', '.join(valid)})"
+        )
     try:
         memory_episode_budget_usd = float(os.environ.get("MEMORY_EPISODE_BUDGET_USD", "0.15"))
         if memory_episode_budget_usd <= 0:
@@ -2147,6 +2232,7 @@ def load_config() -> Config:
         memory_search_limit=memory_search_limit,
         memory_token_budget=memory_token_budget,
         memory_embedding_model=memory_embedding_model,
+        memory_reasoner_backend=memory_reasoner_backend,
         memory_extraction_enabled=memory_extraction_enabled,
         memory_extraction_model=memory_extraction_model,
         memory_extraction_budget_usd=memory_extraction_budget_usd,

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -34,6 +34,7 @@ from kai.oneshot import _EXTRACTOR_CWD as _EXTRACTOR_CWD
 from kai.oneshot import _SUBPROCESS_ENV_ALLOWLIST as _SUBPROCESS_ENV_ALLOWLIST
 from kai.oneshot import (
     ClaudeOneShotReasoner,
+    CodexOneShotReasoner,
     OneShotError,
     OneShotReasoner,
     OneShotSubprocessError,
@@ -1666,21 +1667,34 @@ def _paraphrase_neighbor(content: str, user_id: str, threshold: float) -> Memory
 # ── Reasoner wiring ─────────────────────────────────────────────────
 
 
-def _get_memory_reasoner() -> OneShotReasoner:
+def _get_memory_reasoner(config: Config) -> OneShotReasoner:
     """
     Resolve the one-shot reasoner used by both memory stages.
 
-    Phase 1 hardcodes Claude. The indirection exists for tests, which
-    monkeypatch this helper to inject fake reasoners that raise or
-    return specific envelopes without spawning real subprocesses, and
-    for the future #497 work that will let an operator select Codex
-    here. Returning a fresh instance per call (rather than a module-
-    level singleton) keeps Phase 1 stateless and mirrors the prior
-    per-call subprocess construction; if a future provider benefits
-    from a long-lived client (connection pool, HTTP session), update
-    this helper rather than each call site.
+    Dispatches on `config.memory_reasoner_backend`. The valid set is
+    validated at config-load time so this helper can rely on the
+    string being either "claude" or "codex"; a third value would have
+    failed `load_config` already and never reached here. The
+    RuntimeError branch exists as a safety net for a future enum
+    extension where the dataclass field gains a new value before this
+    function is updated; surfacing it as a runtime error rather than
+    silently selecting Claude keeps the failure visible.
+
+    Returning a fresh instance per call (rather than a module-level
+    singleton) keeps the memory path stateless and mirrors the
+    pre-refactor per-call subprocess construction. If a future
+    provider benefits from a long-lived client (connection pool,
+    HTTP session), update this helper rather than each call site.
+
+    Tests monkeypatch this helper to inject fake reasoners; the
+    `config` parameter is accepted but not inspected on the test
+    side because patches use `return_value=`.
     """
-    return ClaudeOneShotReasoner()
+    if config.memory_reasoner_backend == "claude":
+        return ClaudeOneShotReasoner()
+    if config.memory_reasoner_backend == "codex":
+        return CodexOneShotReasoner()
+    raise RuntimeError(f"Unknown memory_reasoner_backend: {config.memory_reasoner_backend!r}")
 
 
 # ── Subprocess wiring ───────────────────────────────────────────────
@@ -1770,7 +1784,7 @@ async def _run_extractor(
     # returned on failure. JSON envelope parsing stays in this
     # function so memory-domain concerns (is_error, structured_output,
     # facts, has_episode) do not leak into the reasoner.
-    reasoner = _get_memory_reasoner()
+    reasoner = _get_memory_reasoner(config)
     try:
         result = await reasoner.run(
             prompt=payload_text,
@@ -1960,7 +1974,7 @@ async def _run_episode_extractor(
     # downstream telemetry depends on (`"timeout"` and
     # `"exit_<code>: <stderr>"`). OneShotSubprocessError carries the
     # returncode and stderr bytes precisely so this mapping works.
-    reasoner = _get_memory_reasoner()
+    reasoner = _get_memory_reasoner(config)
     try:
         result = await reasoner.run(
             prompt=payload_text,

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -696,15 +696,28 @@ class CodexOneShotReasoner:
 
             # Codex's `--output-schema` enforcement is best-effort:
             # the CLI does not hard-reject a final message that
-            # parses as JSON but does not match the schema. A bare
-            # string ("not an object"), a list, or a wrong-keyed
-            # object would otherwise wrap into a syntactically
-            # valid `is_error: false` envelope, and memory
-            # extraction's nested-vs-root resolution would silently
-            # treat it as a successful empty extraction. Reject
-            # anything other than a JSON object here so a schema
-            # failure surfaces as `OneShotOutputError` and the
-            # caller's typed-error path takes over instead.
+            # parses as JSON but does not match the schema. Three
+            # distinct shape failures must surface as typed errors,
+            # not as a successful is_error=false envelope that the
+            # caller would treat as "the model found nothing":
+            #
+            #   1. Scalar / list / null payloads (`json.loads` returns
+            #      something that is not a dict).
+            #   2. Object payloads missing required top-level fields
+            #      named by the supplied schema (e.g. an `{"episode":
+            #      ...}` response under the fact schema, which
+            #      requires `facts` and `has_episode`).
+            #
+            # The required-field check intentionally stays minimal:
+            # the reasoner does not import a JSON Schema validator
+            # because the runtime dependency is not worth the cost
+            # for two callers, and a deeper structural check belongs
+            # to the caller's own `_validate_facts` / episode
+            # validators. Only the top-level required list is read
+            # off `json_schema`; anything beyond that (additional
+            # properties, nested required, type enforcement) is left
+            # to the caller's existing validators, same posture as
+            # the Claude path.
             if not isinstance(payload, dict):
                 log.info(
                     "oneshot_reasoner purpose=%s backend=codex model=%s duration_ms=%d outcome=output_error error_category=non_object_json returncode=0",
@@ -713,6 +726,18 @@ class CodexOneShotReasoner:
                     duration_ms,
                 )
                 raise OneShotOutputError("codex final JSON was not an object")
+
+            required_fields = json_schema.get("required")
+            if isinstance(required_fields, list):
+                missing = [field for field in required_fields if field not in payload]
+                if missing:
+                    log.info(
+                        "oneshot_reasoner purpose=%s backend=codex model=%s duration_ms=%d outcome=output_error error_category=missing_required_fields returncode=0",
+                        purpose,
+                        model,
+                        duration_ms,
+                    )
+                    raise OneShotOutputError(f"codex final JSON missing required fields: {missing}")
 
             # Wrap codex's schema-shaped payload in the same envelope
             # claude emits natively. memory_extraction.py already

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -694,6 +694,26 @@ class CodexOneShotReasoner:
                 )
                 raise OneShotOutputError(f"codex final text was not valid JSON: {exc}") from None
 
+            # Codex's `--output-schema` enforcement is best-effort:
+            # the CLI does not hard-reject a final message that
+            # parses as JSON but does not match the schema. A bare
+            # string ("not an object"), a list, or a wrong-keyed
+            # object would otherwise wrap into a syntactically
+            # valid `is_error: false` envelope, and memory
+            # extraction's nested-vs-root resolution would silently
+            # treat it as a successful empty extraction. Reject
+            # anything other than a JSON object here so a schema
+            # failure surfaces as `OneShotOutputError` and the
+            # caller's typed-error path takes over instead.
+            if not isinstance(payload, dict):
+                log.info(
+                    "oneshot_reasoner purpose=%s backend=codex model=%s duration_ms=%d outcome=output_error error_category=non_object_json returncode=0",
+                    purpose,
+                    model,
+                    duration_ms,
+                )
+                raise OneShotOutputError("codex final JSON was not an object")
+
             # Wrap codex's schema-shaped payload in the same envelope
             # claude emits natively. memory_extraction.py already
             # walks the `structured_output` field on a parsed dict;

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -28,15 +28,19 @@ continues to resolve to the same objects.
 """
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
 
+from kai.codex_exec import extract_codex_text
 from kai.config import DATA_DIR
+from kai.prompt_utils import make_boundary
 
 log = logging.getLogger(__name__)
 
@@ -372,3 +376,357 @@ class ClaudeOneShotReasoner:
             },
             duration_ms=duration_ms,
         )
+
+
+# ── Codex implementation ────────────────────────────────────────────
+
+
+# Env vars forwarded to the codex one-shot subprocess. Deliberately
+# separate from `_SUBPROCESS_ENV_ALLOWLIST`: that list carries
+# Anthropic-specific variables (CLAUDE_CONFIG_DIR, ANTHROPIC_API_KEY,
+# ANTHROPIC_BASE_URL) that mean nothing to codex and would only widen
+# blast radius if forwarded. Codex authentication comes from one of
+# two sources, both covered by this list:
+#   - subscription (ChatGPT Pro) OAuth state under ~/.codex, reached
+#     via HOME or the optional CODEX_HOME override.
+#   - pay-per-token via OPENAI_API_KEY, with OPENAI_BASE_URL for
+#     compatible proxies (Azure OpenAI, vLLM, etc.).
+# PATH is required so the codex binary can resolve its own libexec
+# helpers and any subprocesses it spawns. KAI_WEBHOOK_SECRET, GitHub
+# tokens, Telegram tokens, DATABASE_URL, and the rest of the bot
+# parent env are NOT forwarded; a regression that started reaching
+# for them would surface as a logged miss rather than a silent
+# secret-leak to the model.
+_CODEX_ENV_ALLOWLIST = (
+    "PATH",
+    "HOME",
+    "CODEX_HOME",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+)
+
+
+def _render_codex_stdin(system_prompt: str | None, prompt: str) -> str:
+    """
+    Build a boundary-delimited stdin payload for a codex one-shot call.
+
+    Codex `exec` mode has no `--system-prompt` flag. The closest
+    equivalent is prepending the system text inside a randomized
+    boundary block (same scheme `triage.py`, `review.py`, and the
+    behavioral harness use to wrap untrusted prompt sections) and
+    sending the user payload below it. The model treats the boundary
+    block as authoritative context but cannot forge the closing token
+    from inside the user payload because `make_boundary` re-rolls the
+    token per call.
+
+    A None or empty `system_prompt` produces no boundary block at all
+    rather than an empty SYSTEM section. An empty SYSTEM section
+    would emit a free-floating boundary marker that the model could
+    see with no content inside it, which is both confusing and a
+    pointless attack surface; sending the payload unchanged matches
+    the no-system-prompt semantics callers already get from claude's
+    `--system-prompt` flag being omitted.
+
+    The helper lives in oneshot.py (not behavioral.py) deliberately:
+    importing eval-harness code from a provider implementation would
+    couple memory extraction's runtime to the eval module's import
+    graph. The two helpers are intentional duplicates of a small
+    function rather than a shared import, mirroring how `triage.py`
+    and `review.py` each format their own boundary blocks.
+    """
+    if not system_prompt:
+        return prompt
+    begin, end = make_boundary("SYSTEM")
+    return f"{begin}\n{system_prompt}\n{end}\n\n{prompt}"
+
+
+class CodexOneShotReasoner:
+    """
+    Spawns `codex exec --json` once per call and returns either the
+    raw final agent_message text or, when a JSON schema is supplied, a
+    normalized `{"is_error": false, "structured_output": ...}` envelope
+    string that matches the shape memory_extraction.py already parses.
+
+    Codex differs from Claude in three load-bearing ways:
+
+    - No `--system-prompt` flag: the system text is prepended to stdin
+      via `_render_codex_stdin` with a randomized boundary block.
+    - No inline `--json-schema`: codex takes `--output-schema <FILE>`,
+      so this reasoner writes the schema to a per-call temp file and
+      removes it on every exit path (success, timeout, non-zero exit,
+      or output-parse failure).
+    - NDJSON event output instead of a single envelope: stdout is a
+      sequence of `thread.*`, `turn.*`, and `item.*` events. The final
+      `agent_message` text is recovered via `extract_codex_text` with
+      `join_items=False`, which matches triage's "last completed
+      message only" contract for structured-output callers. A
+      preamble agent_message followed by a JSON body would otherwise
+      corrupt the parse.
+
+    The schema-backed call always returns a wrapped envelope so the
+    caller's nested-vs-root resolution path (the one already in
+    `memory_extraction._run_extractor` and `_run_episode_extractor`)
+    sees the same `structured_output` shape it sees from Claude. The
+    reasoner does not inspect fact / episode / tag / confidence
+    fields; that contract stays with the caller. When no schema is
+    supplied (`json_schema is None`), the final agent_message text is
+    returned directly without wrapping; memory extraction always
+    supplies a schema, so the wrap path is the production memory
+    path and the non-schema branch exists only for future free-form
+    callers.
+
+    Flag rationale:
+
+    - `--json` is required for NDJSON event output; without it the
+      CLI emits free-form text that the parser cannot walk.
+    - `--skip-git-repo-check` is required because the neutral
+      extractor cwd is not a Git repository. Codex's trusted-dir
+      gate refuses to spawn otherwise; the lesson from the broader
+      codex one-shot lineage is to pass this on every exec invocation.
+    - `--ephemeral` mirrors Claude's `--no-session-persistence`: no
+      session files written under ~/.codex per call.
+    - `--ignore-rules` keeps user or project execpolicy `.rules`
+      files from influencing memory extraction. The neutral cwd
+      already avoids project rules, but the explicit flag protects
+      the one-shot path from user-level rule drift on the service
+      user's `~/.codex/`.
+    - `--cd <cwd>` tells codex its working root explicitly; the
+      subprocess `cwd` argument keeps the process environment aligned
+      with that root so a future codex release that reads cwd from
+      either source sees the same value.
+    - `--output-schema <file>` is included only when a schema is
+      supplied. Codex's schema enforcement is best-effort (unlike
+      claude's CLI-side `--json-schema` validation); the reasoner
+      parses the final text as JSON and raises `OneShotOutputError`
+      on malformed output so memory storage never sees a half-shaped
+      payload.
+
+    Deliberately NOT passed:
+
+    - `--dangerously-bypass-approvals-and-sandbox`: memory extraction
+      asks for structured output only and does not need tools, shell
+      commands, or filesystem writes. Granting the bypass would widen
+      blast radius if a future codex release tried to invoke tools.
+    - `--sandbox danger-full-access`: same reasoning. If codex
+      attempts tool calls during exec, the call should fail or
+      produce no valid final JSON; the reasoner then raises
+      `OneShotOutputError` and the caller stores nothing.
+
+    The schema temp file lives under `DATA_DIR/memory/extractor_cwd/`
+    on production and the test-supplied cwd otherwise. Storing it
+    next to the run cwd keeps the path predictable in logs and means
+    a crash that leaks the file leaves it inside the memory subtree
+    rather than under /tmp where unrelated tooling might trip on it.
+    Cleanup is wrapped in `contextlib.suppress(FileNotFoundError)` so
+    a process death between write and remove does not leave a stale
+    exception masking the original failure.
+    """
+
+    def __init__(self, *, cwd: Path | None = None) -> None:
+        """
+        Args:
+            cwd: Override for the subprocess working directory and the
+                schema temp file's parent. Tests pass a temp path so
+                the run does not touch the real DATA_DIR. Production
+                callers leave this unset; the reasoner uses
+                `_EXTRACTOR_CWD` and ensures it exists on first call.
+        """
+        self._cwd = cwd if cwd is not None else _EXTRACTOR_CWD
+
+    async def run(
+        self,
+        *,
+        prompt: str,
+        system_prompt: str | None = None,
+        model: str | None = None,
+        timeout: float | None = None,
+        purpose: str,
+        json_schema: dict[str, Any] | None = None,
+    ) -> OneShotResult:
+        # Same lazy-mkdir contract as Claude: deferred from import
+        # time so a permission failure surfaces as a logged miss
+        # rather than crashing the bot at startup.
+        self._cwd.mkdir(parents=True, exist_ok=True)
+
+        codex_bin = os.environ.get("CODEX_BIN") or "codex"
+        cmd: list[str] = [
+            codex_bin,
+            "exec",
+            "--json",
+            "--skip-git-repo-check",
+            "--ephemeral",
+            "--ignore-rules",
+            "--cd",
+            str(self._cwd),
+        ]
+        if model is not None:
+            cmd.extend(["--model", model])
+
+        # Schema temp file lifecycle. Written before subprocess spawn
+        # so the CLI sees a populated file; removed in `finally` so
+        # success, timeout, non-zero exit, and output-parse failures
+        # all clean up. `delete=False` is required because the
+        # subprocess opens the file by path, not by inherited fd;
+        # NamedTemporaryFile's auto-delete on close would yank the
+        # file out from under the running codex process.
+        schema_path: Path | None = None
+        if json_schema is not None:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                suffix=".json",
+                prefix="codex-schema-",
+                dir=str(self._cwd),
+                delete=False,
+                encoding="utf-8",
+            ) as fh:
+                json.dump(json_schema, fh)
+                schema_path = Path(fh.name)
+            cmd.extend(["--output-schema", str(schema_path)])
+
+        # Allow-listed env: only forward keys present in the parent
+        # env. Absent keys are simply not forwarded; the subprocess
+        # behaves as if they were unset. Defense-in-depth against a
+        # future regression that tries to reuse Claude's env list:
+        # the codex list deliberately excludes the Anthropic-specific
+        # variables and keeps the secret surface narrow.
+        subprocess_env: dict[str, str] = {key: os.environ[key] for key in _CODEX_ENV_ALLOWLIST if key in os.environ}
+
+        stdin_payload = _render_codex_stdin(system_prompt, prompt)
+
+        start = time.monotonic()
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(self._cwd),
+                env=subprocess_env,
+            )
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(input=stdin_payload.encode("utf-8")),
+                    timeout=timeout,
+                )
+            except TimeoutError:
+                # Same kill+await pattern as Claude: without the await
+                # a subsequent kill on the reaped pid could race on
+                # ProcessLookupError. The duration is measured around
+                # the wait_for so the log line shows wall-clock
+                # cost-to-timeout, not wall-clock-to-reap.
+                proc.kill()
+                await proc.wait()
+                duration_ms = int((time.monotonic() - start) * 1000)
+                log.info(
+                    "oneshot_reasoner purpose=%s backend=codex model=%s duration_ms=%d outcome=timeout error_category=timeout",
+                    purpose,
+                    model,
+                    duration_ms,
+                )
+                raise OneShotTimeout() from None
+
+            duration_ms = int((time.monotonic() - start) * 1000)
+            returncode = proc.returncode if proc.returncode is not None else -1
+            if returncode != 0:
+                log.info(
+                    "oneshot_reasoner purpose=%s backend=codex model=%s duration_ms=%d outcome=subprocess_error error_category=non_zero_exit returncode=%d",
+                    purpose,
+                    model,
+                    duration_ms,
+                    returncode,
+                )
+                raise OneShotSubprocessError(returncode=returncode, stderr=stderr)
+
+            stdout_text = stdout.decode("utf-8", errors="replace")
+            # Triage's lesson carried over: structured-output callers
+            # want only the LAST completed agent_message so a preamble
+            # message does not get glued ahead of the JSON body. Memory
+            # extraction is the canonical structured caller here; the
+            # `join_items=True` (review/chat) path has no caller in
+            # #497 but the protocol leaves room for one.
+            final_text = extract_codex_text(stdout_text, join_items=False)
+
+            if json_schema is None:
+                # Free-form path: hand the final agent_message text
+                # back unchanged. Memory extraction never takes this
+                # branch in production; it stays here so a future
+                # free-form caller does not need to special-case
+                # codex.
+                log.info(
+                    "oneshot_reasoner purpose=%s backend=codex model=%s duration_ms=%d outcome=success returncode=0",
+                    purpose,
+                    model,
+                    duration_ms,
+                )
+                return OneShotResult(
+                    text=final_text,
+                    backend="codex",
+                    model=model,
+                    raw_metadata={
+                        "returncode": returncode,
+                        "stderr": stderr,
+                        "cwd": str(self._cwd),
+                    },
+                    duration_ms=duration_ms,
+                )
+
+            # Schema-backed path. The final agent_message must parse
+            # as a JSON object; anything else is OneShotOutputError so
+            # memory_extraction's caller-side mapping collapses it to
+            # the zero-state extraction result instead of letting a
+            # malformed payload reach the fact validator.
+            if not final_text:
+                log.info(
+                    "oneshot_reasoner purpose=%s backend=codex model=%s duration_ms=%d outcome=output_error error_category=empty_agent_message returncode=0",
+                    purpose,
+                    model,
+                    duration_ms,
+                )
+                raise OneShotOutputError("codex produced no final agent_message")
+            try:
+                payload = json.loads(final_text)
+            except json.JSONDecodeError as exc:
+                log.info(
+                    "oneshot_reasoner purpose=%s backend=codex model=%s duration_ms=%d outcome=output_error error_category=invalid_json returncode=0",
+                    purpose,
+                    model,
+                    duration_ms,
+                )
+                raise OneShotOutputError(f"codex final text was not valid JSON: {exc}") from None
+
+            # Wrap codex's schema-shaped payload in the same envelope
+            # claude emits natively. memory_extraction.py already
+            # walks the `structured_output` field on a parsed dict;
+            # rewrapping here keeps the parser path provider-neutral.
+            # `is_error: false` is hardcoded because reaching this
+            # branch means rc=0 AND a parseable final JSON; the
+            # caller's is_error guard still fires on a future codex
+            # variant that emits an error envelope as its agent_message.
+            envelope = json.dumps({"is_error": False, "structured_output": payload})
+            log.info(
+                "oneshot_reasoner purpose=%s backend=codex model=%s duration_ms=%d outcome=success returncode=0",
+                purpose,
+                model,
+                duration_ms,
+            )
+            return OneShotResult(
+                text=envelope,
+                backend="codex",
+                model=model,
+                raw_metadata={
+                    "returncode": returncode,
+                    "stderr": stderr,
+                    "cwd": str(self._cwd),
+                },
+                duration_ms=duration_ms,
+            )
+        finally:
+            # Cleanup runs on every exit path: success, timeout,
+            # subprocess error, output error, and any unexpected
+            # exception propagating from the spawn itself. Suppress
+            # FileNotFoundError so a cleanup race (e.g. the OS
+            # already removed the file under a temp sweep) does not
+            # mask the original failure with a secondary one.
+            if schema_path is not None:
+                with contextlib.suppress(FileNotFoundError):
+                    schema_path.unlink()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,6 +63,7 @@ _CONFIG_ENV_VARS = [
     "MEMORY_SEARCH_LIMIT",
     "MEMORY_TOKEN_BUDGET",
     "MEMORY_EMBEDDING_MODEL",
+    "MEMORY_REASONER_BACKEND",
     "MEMORY_EXTRACTION_ENABLED",
     "MEMORY_EXTRACTION_MODEL",
     "MEMORY_EXTRACTION_BUDGET_USD",
@@ -1481,6 +1482,132 @@ class TestEpisodeClassifierContextTurns:
         monkeypatch.setenv("EPISODE_CLASSIFIER_CONTEXT_TURNS", "abc")
         with pytest.raises(SystemExit, match="must be an integer"):
             load_config()
+
+
+# ── Memory reasoner backend selection ───────────────────────────────
+
+
+class TestMemoryReasonerBackend:
+    """MEMORY_REASONER_BACKEND selects the OneShotReasoner used by both
+    memory stages. Default is `claude` even when AGENT_BACKEND=codex,
+    because codex memory extraction has not yet cleared the
+    cross-backend quality eval; the value must be explicitly opted in.
+    Invalid values are SystemExit at config-load time, matching the
+    AGENT_BACKEND validation pattern (no first-extraction surprise)."""
+
+    def test_default_is_claude(self, monkeypatch):
+        _set_required(monkeypatch)
+        config = load_config()
+        assert config.memory_reasoner_backend == "claude"
+
+    def test_default_stays_claude_under_agent_backend_codex(self, monkeypatch):
+        """The conservative posture: AGENT_BACKEND=codex does NOT flip
+        memory extraction onto codex. The selection is explicit so an
+        unevaluated provider cannot silently start writing memory."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        monkeypatch.setenv("LLM_PROVIDER", "openai")
+        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.5")
+        config = load_config()
+        assert config.agent_backend == "codex"
+        assert config.memory_reasoner_backend == "claude"
+
+    def test_codex_value_accepted(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        config = load_config()
+        assert config.memory_reasoner_backend == "codex"
+
+    def test_invalid_value_raises_systemexit(self, monkeypatch):
+        """Typos like `gpt5` must fail at config-load time, not at
+        the first `_get_memory_reasoner` call. The error message
+        names the offending var so an operator does not have to grep
+        for it."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "gpt5")
+        with pytest.raises(SystemExit, match="MEMORY_REASONER_BACKEND"):
+            load_config()
+
+    def test_case_insensitive(self, monkeypatch):
+        """Operators sometimes set env vars in uppercase out of habit;
+        the parser is case-insensitive to avoid a confusing
+        SystemExit on Codex/CLAUDE typo variants."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "CODEX")
+        config = load_config()
+        assert config.memory_reasoner_backend == "codex"
+
+
+class TestMemoryReasonerModelResolution:
+    """Memory model defaults resolve through the per-backend role
+    registry. Claude rows match the existing literal so installs that
+    have not set MEMORY_REASONER_BACKEND see byte-identical model
+    selection. Codex rows pick a codex-CLI-valid SKU."""
+
+    def test_claude_default_model_unchanged(self, monkeypatch):
+        _set_required(monkeypatch)
+        config = load_config()
+        assert config.memory_reasoner_backend == "claude"
+        assert config.memory_extraction_model == "claude-haiku-4-5-20251001"
+        assert config.memory_episode_model == "claude-haiku-4-5-20251001"
+
+    def test_codex_default_resolves_to_codex_model(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        config = load_config()
+        assert config.memory_extraction_model == "gpt-5.4-mini"
+        assert config.memory_episode_model == "gpt-5.4-mini"
+
+    def test_explicit_override_wins_for_codex(self, monkeypatch):
+        """An explicit MEMORY_EXTRACTION_MODEL takes precedence over
+        the registry default; the episode model inherits the override
+        when MEMORY_EPISODE_MODEL is unset."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        monkeypatch.setenv("MEMORY_EXTRACTION_MODEL", "gpt-5.5")
+        config = load_config()
+        assert config.memory_extraction_model == "gpt-5.5"
+        # Episode inherits extraction when its own var is unset.
+        assert config.memory_episode_model == "gpt-5.5"
+
+    def test_explicit_episode_override_wins(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        monkeypatch.setenv("MEMORY_EPISODE_MODEL", "gpt-5.4")
+        config = load_config()
+        # Extraction got the registry default; episode is the override.
+        assert config.memory_extraction_model == "gpt-5.4-mini"
+        assert config.memory_episode_model == "gpt-5.4"
+
+    def test_codex_extraction_model_rejects_non_codex_value(self, monkeypatch):
+        """A model name the codex CLI does not expose must fail at
+        startup. Without this guard, an operator who sets
+        MEMORY_REASONER_BACKEND=codex but forgets to update
+        MEMORY_EXTRACTION_MODEL (still pointing at a Claude SKU) would
+        see a SubprocessError on every extraction."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        monkeypatch.setenv("MEMORY_EXTRACTION_MODEL", "claude-haiku-4-5-20251001")
+        with pytest.raises(SystemExit, match="MEMORY_EXTRACTION_MODEL"):
+            load_config()
+
+    def test_codex_episode_model_rejects_non_codex_value(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        monkeypatch.setenv("MEMORY_EPISODE_MODEL", "claude-haiku-4-5-20251001")
+        with pytest.raises(SystemExit, match="MEMORY_EPISODE_MODEL"):
+            load_config()
+
+    def test_claude_model_override_stays_free_form(self, monkeypatch):
+        """Claude memory-model overrides are intentionally NOT validated
+        against a fixed list; the existing permissive behavior is
+        preserved so an operator running a pinned Claude SKU
+        (`claude-haiku-4-5-20251001-pinned`) does not have a config
+        change rejected by a newly added allowlist."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_EXTRACTION_MODEL", "claude-haiku-4-5-20251001-pinned")
+        config = load_config()
+        assert config.memory_extraction_model == "claude-haiku-4-5-20251001-pinned"
 
 
 # ── Stage-2 episode generation (issue #385) ───────────────────────────

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -1164,3 +1164,43 @@ class TestRunEpisodeExtractorViaReasoner:
         assert reason is not None
         assert reason.startswith("exit_2: ")
         assert "oauth refused" in reason
+
+
+class TestRunEpisodeExtractorWithCodexEnvelope:
+    """A fake Codex reasoner returning a normalized episode envelope
+    must flow through `_run_episode_extractor` unchanged. Stage 2's
+    parser path was already provider-neutral on the `structured_output`
+    field; this test pins that fact so a future refactor cannot
+    re-introduce a backend branch in the episode extractor."""
+
+    @pytest.mark.asyncio
+    async def test_codex_envelope_produces_episode_triple(self):
+        from kai.oneshot import OneShotResult
+
+        episode = _valid_episode()
+        # CodexOneShotReasoner emits exactly this envelope shape (no
+        # total_cost_usd field; codex subscription auth has no
+        # per-call billing surface). The stage-2 cost coercion to 0.0
+        # is the documented behavior for non-claude backends.
+        envelope_text = '{"is_error": false, "structured_output": {"episode": ' + json.dumps(episode) + "}}"
+
+        class _FakeCodexReasoner:
+            async def run(self, **kwargs):
+                return OneShotResult(
+                    text=envelope_text,
+                    backend="codex",
+                    model="gpt-5.4-mini",
+                    raw_metadata={"returncode": 0, "stderr": b""},
+                    duration_ms=33,
+                )
+
+        config = _cfg(memory_reasoner_backend="codex", memory_episode_model="gpt-5.4-mini")
+        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_FakeCodexReasoner()):
+            ep, cost_usd, reason = await _run_episode_extractor("payload", config)
+
+        assert ep == episode
+        # No total_cost_usd in the envelope -> 0.0 (matches the codex
+        # subscription-auth posture; pay-per-token codex deployments
+        # will populate this differently if they ever land).
+        assert cost_usd == 0.0
+        assert reason is None

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -3502,3 +3502,31 @@ class TestRunExtractorWithCodexEnvelope:
 
         assert result.facts == []
         assert result.has_episode is False
+
+    @pytest.mark.asyncio
+    async def test_codex_reasoner_output_error_collapses_to_empty_result(self):
+        """When the Codex reasoner raises OneShotOutputError (e.g.
+        because Codex returned a wrong-shape object that the
+        reasoner rejected at the schema boundary), `_run_extractor`
+        must collapse to the zero-state ExtractionResult rather than
+        propagate. This is the typed-error path that prevents a
+        wrong-shape Codex payload from reaching the fact validator
+        or being silently stored as `the model found nothing`."""
+        from kai.oneshot import OneShotOutputError
+
+        class _OutputErrorReasoner:
+            async def run(self, **kwargs):
+                raise OneShotOutputError("codex final JSON missing required fields: ['facts', 'has_episode']")
+
+        config = _cfg(memory_reasoner_backend="codex", memory_extraction_model="gpt-5.4-mini")
+        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_OutputErrorReasoner()):
+            result = await memory_extraction._run_extractor(
+                payload_text="payload",
+                config=config,
+                candidate_ids=set(),
+                candidate_metadata={},
+                user_id="u1",
+            )
+
+        assert result.facts == []
+        assert result.has_episode is False

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -3442,3 +3442,63 @@ class TestRunExtractorViaReasoner:
 
         assert result.facts == []
         assert result.has_episode is False
+
+
+class TestMemoryReasonerSelection:
+    """`_get_memory_reasoner(config)` dispatches on
+    `config.memory_reasoner_backend`. The Claude case is the default
+    and proves the helper still returns a Claude reasoner when no env
+    var is set; the Codex case proves the selector wires up the new
+    CodexOneShotReasoner without requiring memory_extraction.py to
+    branch on backend at the call site."""
+
+    def test_default_returns_claude_reasoner(self):
+        from kai.oneshot import ClaudeOneShotReasoner
+
+        reasoner = memory_extraction._get_memory_reasoner(_cfg())
+        assert isinstance(reasoner, ClaudeOneShotReasoner)
+
+    def test_codex_backend_returns_codex_reasoner(self):
+        from kai.oneshot import CodexOneShotReasoner
+
+        config = _cfg(memory_reasoner_backend="codex")
+        reasoner = memory_extraction._get_memory_reasoner(config)
+        assert isinstance(reasoner, CodexOneShotReasoner)
+
+
+class TestRunExtractorWithCodexEnvelope:
+    """A fake Codex reasoner returning a normalized envelope
+    (the same `{"is_error": false, "structured_output": ...}` shape
+    `CodexOneShotReasoner` produces) must flow through `_run_extractor`
+    without any backend-specific parsing. This locks in the
+    provider-neutrality contract: the parser path is identical
+    regardless of which backend produced the envelope."""
+
+    @pytest.mark.asyncio
+    async def test_codex_envelope_flows_through_unchanged(self):
+        from kai.oneshot import OneShotResult
+
+        envelope_text = '{"is_error": false, "structured_output": {"facts": [], "has_episode": false}}'
+
+        class _FakeCodexReasoner:
+            async def run(self, **kwargs):
+                return OneShotResult(
+                    text=envelope_text,
+                    backend="codex",
+                    model="gpt-5.4-mini",
+                    raw_metadata={"returncode": 0, "stderr": b""},
+                    duration_ms=42,
+                )
+
+        config = _cfg(memory_reasoner_backend="codex", memory_extraction_model="gpt-5.4-mini")
+        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_FakeCodexReasoner()):
+            result = await memory_extraction._run_extractor(
+                payload_text="payload",
+                config=config,
+                candidate_ids=set(),
+                candidate_metadata={},
+                user_id="u1",
+            )
+
+        assert result.facts == []
+        assert result.has_episode is False

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -7,14 +7,19 @@ memory-specific contracts (envelope parsing, schema validation, fact
 storage) live in `tests/test_memory_extraction.py` and stay there.
 """
 
+import json
 import logging
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from kai.oneshot import (
+    _CODEX_ENV_ALLOWLIST,
     _SUBPROCESS_ENV_ALLOWLIST,
     ClaudeOneShotReasoner,
+    CodexOneShotReasoner,
+    OneShotOutputError,
     OneShotResult,
     OneShotSubprocessError,
     OneShotTimeout,
@@ -344,5 +349,597 @@ class TestClaudeOneShotReasonerLogging:
         assert len(records) == 1
         msg = records[0].getMessage()
         assert "purpose=episode_generation" in msg
+        assert "outcome=subprocess_error" in msg
+        assert "returncode=3" in msg
+
+
+# ── Codex reasoner ──────────────────────────────────────────────────
+
+
+def _codex_event(item_type: str, text: str | None = None) -> str:
+    """Serialize one NDJSON event the way `codex exec --json` emits.
+
+    The reasoner extracts text by walking `item.completed` events;
+    other event types in the stream are silently skipped, so the
+    helper only needs to produce a well-formed agent_message item.
+    """
+    item: dict = {"id": "item-1", "type": item_type}
+    if text is not None:
+        item["text"] = text
+    return json.dumps({"type": "item.completed", "item": item})
+
+
+def _codex_envelope_ndjson(payload: dict) -> bytes:
+    """Helper: one NDJSON line wrapping `payload` as an agent_message."""
+    return _codex_event("agent_message", json.dumps(payload)).encode("utf-8") + b"\n"
+
+
+class TestCodexOneShotReasonerArgv:
+    """The codex argv must reflect the spec's flag set: exec mode,
+    JSON event output, trusted-dir skip, ephemeral session, ignore
+    user/project rules, neutral cwd, model when provided, and
+    --output-schema with a real path only when a schema is supplied."""
+
+    @pytest.mark.asyncio
+    async def test_argv_includes_required_flags(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CODEX_BIN", raising=False)
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=_codex_envelope_ndjson({"ok": True}))
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(
+                prompt="hello",
+                system_prompt="you are a test",
+                model="gpt-5.4-mini",
+                timeout=30,
+                purpose="fact_extraction",
+                json_schema={"type": "object", "properties": {}},
+            )
+
+        cmd = mock_exec.call_args[0]
+        assert cmd[0] == "codex"
+        assert cmd[1] == "exec"
+        assert "--json" in cmd
+        assert "--skip-git-repo-check" in cmd
+        assert "--ephemeral" in cmd
+        assert "--ignore-rules" in cmd
+        i = cmd.index("--cd")
+        assert cmd[i + 1] == str(tmp_path)
+        i = cmd.index("--model")
+        assert cmd[i + 1] == "gpt-5.4-mini"
+        # --output-schema must point at a real file the CLI can open.
+        i = cmd.index("--output-schema")
+        schema_path = Path(cmd[i + 1])
+        # The file is removed in the finally block AFTER the
+        # subprocess exits; this assertion only proves the path
+        # parameter is wired up, not lifecycle - that is covered by
+        # TestCodexOneShotReasonerSchemaFile below.
+        assert schema_path.parent == tmp_path
+
+    @pytest.mark.asyncio
+    async def test_argv_honors_codex_bin_env(self, tmp_path, monkeypatch):
+        """CODEX_BIN must override the bare `codex` resolution so
+        per-os_user homebrew installs work without PATH munging."""
+        monkeypatch.setenv("CODEX_BIN", "/custom/path/to/codex")
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=_codex_envelope_ndjson({"ok": True}))
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+        cmd = mock_exec.call_args[0]
+        assert cmd[0] == "/custom/path/to/codex"
+
+    @pytest.mark.asyncio
+    async def test_argv_omits_output_schema_without_schema(self, tmp_path):
+        """When the caller passes no schema, --output-schema must be
+        absent entirely. The non-schema branch returns raw final text
+        and never writes a temp file."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=_codex_event("agent_message", "free-form text").encode("utf-8") + b"\n")
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(prompt="p", purpose="fact_extraction", json_schema=None)
+
+        cmd = mock_exec.call_args[0]
+        assert "--output-schema" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_argv_omits_model_when_none(self, tmp_path):
+        """A None model means the codex CLI's default; the reasoner
+        must not emit a stray `--model` with an empty string."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=_codex_envelope_ndjson({"ok": True}))
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+        cmd = mock_exec.call_args[0]
+        assert "--model" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_payload_sent_on_stdin_not_argv(self, tmp_path):
+        """User content goes through stdin only. Argv is visible via
+        `ps -ef`; the rendered stdin block carries both the system
+        prompt boundary and the user payload."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=_codex_envelope_ndjson({"ok": True}))
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(
+                prompt="SECRET-USER-MESSAGE",
+                system_prompt="SYSTEM-INSTRUCTIONS",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+        # Argv carries no conversation content.
+        cmd = mock_exec.call_args[0]
+        for arg in cmd:
+            assert "SECRET-USER-MESSAGE" not in arg
+            assert "SYSTEM-INSTRUCTIONS" not in arg
+        # Stdin carries both pieces.
+        stdin_bytes = proc.communicate.call_args.kwargs["input"]
+        decoded = stdin_bytes.decode("utf-8")
+        assert "SECRET-USER-MESSAGE" in decoded
+        assert "SYSTEM-INSTRUCTIONS" in decoded
+
+
+class TestCodexOneShotReasonerStdin:
+    """`_render_codex_stdin` semantics: a non-empty system prompt is
+    wrapped in a randomized boundary; None / empty produces the user
+    payload unchanged so callers do not emit an empty SYSTEM block."""
+
+    @pytest.mark.asyncio
+    async def test_stdin_wraps_system_prompt_in_boundary_when_provided(self, tmp_path):
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=_codex_envelope_ndjson({"ok": True}))
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            await reasoner.run(
+                prompt="USER-PAYLOAD",
+                system_prompt="SYSTEM-INSTRUCTIONS",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+        stdin_bytes = proc.communicate.call_args.kwargs["input"]
+        decoded = stdin_bytes.decode("utf-8")
+        # Boundary markers wrap the system prompt; the user payload
+        # follows after a blank line.
+        assert "--- BEGIN SYSTEM" in decoded
+        assert "--- END SYSTEM" in decoded
+        assert decoded.index("SYSTEM-INSTRUCTIONS") < decoded.index("USER-PAYLOAD")
+
+    @pytest.mark.asyncio
+    async def test_stdin_omits_boundary_when_system_prompt_is_none(self, tmp_path):
+        """No system prompt means no SYSTEM block at all; the user
+        payload reaches codex unchanged, matching how Claude's
+        omitted --system-prompt flag behaves."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=_codex_envelope_ndjson({"ok": True}))
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            await reasoner.run(
+                prompt="USER-PAYLOAD",
+                system_prompt=None,
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+        stdin_bytes = proc.communicate.call_args.kwargs["input"]
+        decoded = stdin_bytes.decode("utf-8")
+        assert "--- BEGIN SYSTEM" not in decoded
+        assert decoded == "USER-PAYLOAD"
+
+    @pytest.mark.asyncio
+    async def test_stdin_omits_boundary_when_system_prompt_is_empty(self, tmp_path):
+        """Empty-string system prompt collapses to the same no-boundary
+        behavior; a free-floating SYSTEM section with empty content
+        would be visible to the model with nothing inside it."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=_codex_envelope_ndjson({"ok": True}))
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            await reasoner.run(
+                prompt="USER-PAYLOAD",
+                system_prompt="",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+        stdin_bytes = proc.communicate.call_args.kwargs["input"]
+        decoded = stdin_bytes.decode("utf-8")
+        assert "--- BEGIN SYSTEM" not in decoded
+        assert decoded == "USER-PAYLOAD"
+
+
+class TestCodexOneShotReasonerSchemaFile:
+    """The schema temp file must exist for the duration of the
+    subprocess call and be removed on every exit path (success,
+    timeout, non-zero exit, output error). A leaked file under the
+    cwd would accumulate across calls."""
+
+    @pytest.mark.asyncio
+    async def test_schema_file_written_with_supplied_schema(self, tmp_path):
+        """The path passed via --output-schema must point at a file
+        whose contents are the JSON-serialized schema dict."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        captured: dict = {}
+
+        def _capture(*args, **kwargs):
+            i = args.index("--output-schema")
+            captured["path"] = Path(args[i + 1])
+            captured["body"] = captured["path"].read_text(encoding="utf-8")
+            return _make_proc(stdout=_codex_envelope_ndjson({"ok": True}))
+
+        schema = {"type": "object", "properties": {"facts": {"type": "array"}}}
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(side_effect=_capture)):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema=schema,
+            )
+
+        assert json.loads(captured["body"]) == schema
+        # Cleanup ran in the finally block.
+        assert not captured["path"].exists()
+
+    @pytest.mark.asyncio
+    async def test_schema_file_removed_on_timeout(self, tmp_path):
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        captured: dict = {}
+
+        def _capture(*args, **kwargs):
+            i = args.index("--output-schema")
+            captured["path"] = Path(args[i + 1])
+            return _make_proc(raise_timeout=True)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(side_effect=_capture)),
+            pytest.raises(OneShotTimeout),
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                timeout=0.1,
+                json_schema={"type": "object"},
+            )
+
+        assert not captured["path"].exists()
+
+    @pytest.mark.asyncio
+    async def test_schema_file_removed_on_subprocess_error(self, tmp_path):
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        captured: dict = {}
+
+        def _capture(*args, **kwargs):
+            i = args.index("--output-schema")
+            captured["path"] = Path(args[i + 1])
+            return _make_proc(stdout=b"", stderr=b"refused", returncode=2)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(side_effect=_capture)),
+            pytest.raises(OneShotSubprocessError),
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+        assert not captured["path"].exists()
+
+    @pytest.mark.asyncio
+    async def test_schema_file_removed_on_output_error(self, tmp_path):
+        """Empty final agent_message under a schema-backed call must
+        raise OneShotOutputError AND remove the temp file. Without
+        the cleanup, repeat failures would leak one file per call."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        captured: dict = {}
+
+        def _capture(*args, **kwargs):
+            i = args.index("--output-schema")
+            captured["path"] = Path(args[i + 1])
+            # No item.completed events at all -> extract_codex_text
+            # returns empty string -> OneShotOutputError fires.
+            return _make_proc(stdout=b"", returncode=0)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(side_effect=_capture)),
+            pytest.raises(OneShotOutputError),
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+        assert not captured["path"].exists()
+
+
+class TestCodexOneShotReasonerEnv:
+    """The codex env allow-list is separate from the Claude one:
+    Anthropic vars are NOT forwarded, and only PATH / HOME /
+    CODEX_HOME / OPENAI_API_KEY / OPENAI_BASE_URL reach the
+    subprocess. A regression that started forwarding the parent's
+    full env would leak the bot's secrets to the model."""
+
+    @pytest.mark.asyncio
+    async def test_env_contains_only_codex_allowlisted_keys(self, tmp_path, monkeypatch):
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=_codex_envelope_ndjson({"ok": True}))
+
+        # Allow-listed keys present in parent env.
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+        monkeypatch.setenv("HOME", "/Users/test")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        # Secret-looking values that MUST NOT reach the subprocess.
+        monkeypatch.setenv("DATABASE_URL", "postgres://leak")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_leak")
+        monkeypatch.setenv("WEBHOOK_SECRET", "hmac-leak")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "ant-leak")
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/tmp/claude-leak")
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+        passed_env = mock_exec.call_args.kwargs["env"]
+        assert passed_env.get("PATH") == "/usr/bin:/bin"
+        assert passed_env.get("HOME") == "/Users/test"
+        assert passed_env.get("OPENAI_API_KEY") == "sk-test"
+        # Claude-only and bot-internal secrets are absent.
+        assert "ANTHROPIC_API_KEY" not in passed_env
+        assert "CLAUDE_CONFIG_DIR" not in passed_env
+        assert "DATABASE_URL" not in passed_env
+        assert "GITHUB_TOKEN" not in passed_env
+        assert "WEBHOOK_SECRET" not in passed_env
+        assert set(passed_env.keys()) <= set(_CODEX_ENV_ALLOWLIST)
+
+
+class TestCodexOneShotReasonerTimeout:
+    """Timeout path mirrors Claude: kill + await + raise OneShotTimeout.
+    The duration measurement is around wait_for so a slow-reap codex
+    process does not inflate the logged duration."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_and_awaits_then_raises(self, tmp_path):
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(raise_timeout=True)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotTimeout),
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                timeout=0.1,
+                json_schema={"type": "object"},
+            )
+
+        proc.kill.assert_called_once()
+        proc.wait.assert_awaited()
+
+
+class TestCodexOneShotReasonerSubprocessError:
+    """Non-zero exit raises OneShotSubprocessError with the returncode
+    AND stderr bytes so stage 2 can reconstruct its
+    `exit_<code>: <stderr>` failure reason format unchanged."""
+
+    @pytest.mark.asyncio
+    async def test_non_zero_exit_raises_with_returncode_and_stderr(self, tmp_path):
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=b"", stderr=b"codex auth failed", returncode=2)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotSubprocessError) as excinfo,
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+        assert excinfo.value.returncode == 2
+        assert excinfo.value.stderr == b"codex auth failed"
+
+
+class TestCodexOneShotReasonerOutputError:
+    """Schema-backed calls require a parseable JSON final message.
+    Empty output, malformed JSON, and turn.failed events all collapse
+    to OneShotOutputError so memory_extraction sees a typed reasoner
+    failure instead of half-shaped data reaching the validator."""
+
+    @pytest.mark.asyncio
+    async def test_empty_final_message_under_schema_raises_output_error(self, tmp_path):
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=b"", returncode=0)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotOutputError),
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_turn_failed_under_schema_raises_output_error(self, tmp_path):
+        """A `turn.failed` event short-circuits extract_codex_text to
+        empty string; the reasoner must then raise OneShotOutputError
+        rather than wrap empty content in the envelope."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        stdout = json.dumps({"type": "turn.failed", "error": "x"}).encode("utf-8") + b"\n"
+        proc = _make_proc(stdout=stdout, returncode=0)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotOutputError),
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_malformed_final_json_under_schema_raises_output_error(self, tmp_path):
+        """A non-JSON agent_message under a schema-backed call cannot
+        be wrapped in `{"is_error": false, "structured_output": ...}`;
+        OneShotOutputError fires so the caller sees a typed failure
+        instead of a downstream parse error on the envelope."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        # agent_message text is "not json at all" - extract_codex_text
+        # returns that string, then the JSON parse raises.
+        stdout = _codex_event("agent_message", "not json at all").encode("utf-8") + b"\n"
+        proc = _make_proc(stdout=stdout, returncode=0)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotOutputError),
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+
+class TestCodexOneShotReasonerSuccess:
+    """Valid schema-backed output: the reasoner returns the normalized
+    envelope as `OneShotResult.text` so memory_extraction's existing
+    `structured_output` parser path works without a codex branch."""
+
+    @pytest.mark.asyncio
+    async def test_schema_backed_success_returns_normalized_envelope(self, tmp_path):
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        payload = {"facts": [{"content": "x"}], "has_episode": False}
+        stdout = _codex_envelope_ndjson(payload)
+        proc = _make_proc(stdout=stdout, stderr=b"", returncode=0)
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                model="gpt-5.4-mini",
+                json_schema={"type": "object"},
+            )
+
+        assert isinstance(result, OneShotResult)
+        assert result.backend == "codex"
+        assert result.model == "gpt-5.4-mini"
+        envelope = json.loads(result.text)
+        assert envelope == {"is_error": False, "structured_output": payload}
+        assert result.raw_metadata["returncode"] == 0
+        assert result.duration_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_multi_item_uses_last_completed(self, tmp_path):
+        """Multi-item streams under schema callers must parse only the
+        LAST `item.completed` agent_message. Joining a preamble with
+        the JSON body (the `join_items=True` path) would produce a
+        non-JSON string and trip the OneShotOutputError branch."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        preamble = _codex_event("agent_message", "preamble text, not JSON")
+        payload = {"facts": []}
+        final = _codex_event("agent_message", json.dumps(payload))
+        stdout = (preamble + "\n" + final + "\n").encode("utf-8")
+        proc = _make_proc(stdout=stdout, returncode=0)
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+        envelope = json.loads(result.text)
+        assert envelope == {"is_error": False, "structured_output": payload}
+
+    @pytest.mark.asyncio
+    async def test_non_schema_success_returns_raw_text(self, tmp_path):
+        """A None schema means the caller wants the free-form
+        agent_message text back unchanged; no envelope wrapping
+        happens. Memory extraction never takes this branch, but the
+        protocol permits it for future callers."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        stdout = _codex_event("agent_message", "free-form reply").encode("utf-8") + b"\n"
+        proc = _make_proc(stdout=stdout, returncode=0)
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema=None,
+            )
+
+        assert result.text == "free-form reply"
+        assert result.backend == "codex"
+
+
+class TestCodexOneShotReasonerLogging:
+    """Each codex call emits one structured INFO line keyed by purpose,
+    with `backend=codex` and distinct outcomes for success / timeout
+    / subprocess_error. Returncode appears on the subprocess_error
+    line so log queries can partition by exit code."""
+
+    @pytest.mark.asyncio
+    async def test_log_line_includes_backend_codex_on_success(self, tmp_path, caplog):
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=_codex_envelope_ndjson({"ok": True}), returncode=0)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            caplog.at_level(logging.INFO, logger="kai.oneshot"),
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+        records = [r for r in caplog.records if r.message.startswith("oneshot_reasoner")]
+        assert len(records) == 1
+        msg = records[0].getMessage()
+        assert "purpose=fact_extraction" in msg
+        assert "backend=codex" in msg
+        assert "outcome=success" in msg
+
+    @pytest.mark.asyncio
+    async def test_log_line_carries_returncode_on_subprocess_error(self, tmp_path, caplog):
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stderr=b"refused", returncode=3)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            caplog.at_level(logging.INFO, logger="kai.oneshot"),
+            pytest.raises(OneShotSubprocessError),
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="episode_generation",
+                json_schema={"type": "object"},
+            )
+
+        records = [r for r in caplog.records if r.message.startswith("oneshot_reasoner")]
+        assert len(records) == 1
+        msg = records[0].getMessage()
+        assert "backend=codex" in msg
         assert "outcome=subprocess_error" in msg
         assert "returncode=3" in msg

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -856,6 +856,102 @@ class TestCodexOneShotReasonerOutputError:
             )
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "wrong_key_object",
+        [
+            {"unexpected": True},
+            {"episode": {"goal": "x"}},
+            {"facts": []},  # missing has_episode
+            {"has_episode": False},  # missing facts
+            {},
+        ],
+    )
+    async def test_object_missing_required_fields_raises_output_error(self, tmp_path, wrong_key_object):
+        """A parseable JSON object that does not satisfy the supplied
+        schema's top-level `required` list must raise
+        OneShotOutputError. Codex's --output-schema enforcement does
+        not hard-reject these payloads, so the reasoner is the last
+        boundary between a model that ignored the schema and the
+        memory extractor treating wrong-shape output as `the model
+        found nothing`. The check reads `required` off the supplied
+        schema rather than embedding fact/episode field names so
+        the reasoner stays domain-neutral."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        # Fact-extraction schema requires facts AND has_episode at root.
+        fact_schema = {
+            "type": "object",
+            "required": ["facts", "has_episode"],
+            "properties": {
+                "facts": {"type": "array"},
+                "has_episode": {"type": "boolean"},
+            },
+        }
+        stdout = _codex_envelope_ndjson(wrong_key_object)
+        proc = _make_proc(stdout=stdout, returncode=0)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotOutputError),
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema=fact_schema,
+            )
+
+    @pytest.mark.asyncio
+    async def test_missing_required_fields_logs_dedicated_category(self, tmp_path, caplog):
+        """Operator dashboards must be able to separate `wrong-shape
+        object` from `bad JSON` and from `non-object scalar`; each
+        gets its own error_category so log queries can partition the
+        failure modes without re-parsing the message body."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        stdout = _codex_envelope_ndjson({"unexpected": True})
+        proc = _make_proc(stdout=stdout, returncode=0)
+        schema = {"type": "object", "required": ["facts", "has_episode"]}
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            caplog.at_level(logging.INFO, logger="kai.oneshot"),
+            pytest.raises(OneShotOutputError),
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema=schema,
+            )
+
+        records = [r for r in caplog.records if r.message.startswith("oneshot_reasoner")]
+        assert len(records) == 1
+        msg = records[0].getMessage()
+        assert "outcome=output_error" in msg
+        assert "error_category=missing_required_fields" in msg
+
+    @pytest.mark.asyncio
+    async def test_schema_without_required_field_does_not_block_success(self, tmp_path):
+        """A schema that omits the top-level `required` list must not
+        force a rejection; the reasoner falls back to its baseline
+        contract (object payload) and accepts the payload. This keeps
+        the guard from over-rejecting schemas that use other JSON
+        Schema constructs (oneOf, allOf, etc.) to express constraints
+        instead of a flat `required` list."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        stdout = _codex_envelope_ndjson({"any": "object", "shape": True})
+        proc = _make_proc(stdout=stdout, returncode=0)
+        schema_without_required = {"type": "object", "properties": {"any": {"type": "string"}}}
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema=schema_without_required,
+            )
+
+        envelope = json.loads(result.text)
+        assert envelope["is_error"] is False
+        assert envelope["structured_output"] == {"any": "object", "shape": True}
+
+    @pytest.mark.asyncio
     async def test_non_object_json_logs_non_object_category(self, tmp_path, caplog):
         """The non-object-JSON path must emit its own log category so
         operator-side dashboards can separate "model returned wrong

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -820,6 +820,68 @@ class TestCodexOneShotReasonerOutputError:
                 json_schema={"type": "object"},
             )
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "non_object_payload",
+        [
+            '"a plain string"',
+            "[]",
+            "[1, 2, 3]",
+            "42",
+            "true",
+            "null",
+        ],
+    )
+    async def test_non_object_json_under_schema_raises_output_error(self, tmp_path, non_object_payload):
+        """A final agent_message that parses as JSON but is not an
+        object must still raise OneShotOutputError. Codex's
+        `--output-schema` enforcement is best-effort; without this
+        guard, a string / list / scalar would wrap into a
+        syntactically valid `is_error: false` envelope and the
+        caller would silently store zero facts as if the model had
+        legitimately found nothing. The schema-failure case must be
+        distinguishable from the empty-extraction case."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        stdout = _codex_event("agent_message", non_object_payload).encode("utf-8") + b"\n"
+        proc = _make_proc(stdout=stdout, returncode=0)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotOutputError),
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_non_object_json_logs_non_object_category(self, tmp_path, caplog):
+        """The non-object-JSON path must emit its own log category so
+        operator-side dashboards can separate "model returned wrong
+        shape" from "model returned malformed JSON" without re-parsing
+        the message body."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path)
+        stdout = _codex_event("agent_message", '"a plain string"').encode("utf-8") + b"\n"
+        proc = _make_proc(stdout=stdout, returncode=0)
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            caplog.at_level(logging.INFO, logger="kai.oneshot"),
+            pytest.raises(OneShotOutputError),
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+        records = [r for r in caplog.records if r.message.startswith("oneshot_reasoner")]
+        assert len(records) == 1
+        msg = records[0].getMessage()
+        assert "outcome=output_error" in msg
+        assert "error_category=non_object_json" in msg
+
 
 class TestCodexOneShotReasonerSuccess:
     """Valid schema-backed output: the reasoner returns the normalized


### PR DESCRIPTION
## Summary

- Add `CodexOneShotReasoner` to `kai.oneshot` alongside the existing Claude implementation.
- Add `MEMORY_REASONER_BACKEND` (default `claude`) so memory extraction can be explicitly selected onto codex without flipping when `AGENT_BACKEND=codex`.
- Resolve memory model defaults through `ModelRole.MEMORY_EXTRACTION` / `MEMORY_EPISODE` registry rows; codex overrides validated against `CODEX_MODELS`.
- Codex schema-backed output is normalized into the same `{"is_error", "structured_output"}` envelope memory extraction already parses, so `memory_extraction.py` has no provider branch.

## Why

Closes #497. Memory extraction was the last one-shot agent surface still tied to Claude on a codex install; this completes the per-backend selectability without changing the production default. Default stays Claude until the cross-backend eval gate (#498) and production-enable (#499) land.

## Design notes

- Selection is decoupled from `AGENT_BACKEND` on purpose. Codex memory extraction has not cleared the eval gate; an `AGENT_BACKEND=codex` install must not start writing codex-generated memory implicitly.
- `CodexOneShotReasoner` uses `codex exec --json --skip-git-repo-check --ephemeral --ignore-rules --cd <cwd>` with `--output-schema <file>` for schema-backed calls. No `--dangerously-bypass-approvals-and-sandbox`; memory only needs structured output, not tool execution.
- System prompt is prepended to stdin inside a `make_boundary("SYSTEM")` block because codex `exec` has no `--system-prompt` flag. Empty/None system prompt omits the block entirely.
- Schema temp file is created in the run cwd and removed in `finally` on every exit path (success, timeout, non-zero exit, output error).
- Codex env allowlist is separate from Claude's: `PATH`, `HOME`, `CODEX_HOME`, `OPENAI_API_KEY`, `OPENAI_BASE_URL`. Anthropic vars are not forwarded.
- Failure mapping mirrors Claude: `OneShotTimeout`, `OneShotSubprocessError(returncode, stderr)`, `OneShotOutputError` for empty / malformed final agent_message.

## Auth note for codex memory smoke

Memory extraction runs as the kai service user, NOT under the conversational backend's per-user sudo wrap. Before exercising `MEMORY_REASONER_BACKEND=codex` end-to-end, either run `sudo -u kai codex login` or set `OPENAI_API_KEY` (and `OPENAI_BASE_URL` if relevant) in the service env. Out of scope for this PR.

## Test plan

- [x] `pytest tests/test_oneshot.py tests/test_memory_extraction.py tests/test_memory_episodes.py tests/test_config.py` (474 passed)
- [x] `make test` full suite (3249 passed, 1 skipped)
- [x] `make check` (ruff check + format)
- [ ] Manual smoke once auth precondition is met (separate go-ahead)
