### PR TITLE
fix(memory): sanitize codex --output-schema for OpenAI strict mode

### DIFF
--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -633,6 +633,150 @@ _CODEX_ENV_ALLOWLIST = (
 )
 
 
+# JSON Schema keywords OpenAI's strict structured-outputs rejects.
+# Codex `exec --output-schema <FILE>` forwards the schema verbatim to
+# the Chat Completions endpoint in strict mode, so any of these in the
+# schema produce a 400 `invalid_json_schema` and the codex subprocess
+# exits non-zero. The list is what OpenAI's strict-mode docs disallow
+# as of the codex CLI version verified during the #498 eval-gate work
+# on 2026-05-19; future loosening on the OpenAI side would only mean
+# this strip becomes redundant, never that it does the wrong thing.
+_STRICT_MODE_DISALLOWED_KEYS: frozenset[str] = frozenset(
+    {
+        "minLength",
+        "maxLength",
+        "pattern",
+        "format",
+        "minimum",
+        "maximum",
+        "multipleOf",
+        "minItems",
+        "maxItems",
+        "uniqueItems",
+        "default",
+    }
+)
+
+
+def _sanitize_for_codex(schema: dict[str, Any]) -> dict[str, Any]:
+    """
+    Transform a JSON Schema into OpenAI strict structured-outputs form.
+
+    OpenAI strict mode is a tighter subset of JSON Schema than what
+    Claude's `--json-schema` accepts. Three rules apply, derived from
+    the API's error responses against the production memory schemas:
+
+    1. `additionalProperties: false` on every object node. The kai
+       schemas already set this; the sanitizer is defensive in case a
+       future schema author forgets.
+    2. `required` must include every key in `properties`. Truly
+       optional properties (e.g., `confirmation_quote` on confirmed-
+       action facts, `existing_id` on consolidation intents, `lessons`
+       on episodes) violate this. The sanitizer adds every property
+       to `required` and widens the `type` of the previously-optional
+       properties to include `"null"`, so the model can emit `null`
+       when the field does not apply.
+    3. Many validators are disallowed: `minLength`, `maxLength`,
+       `pattern`, `format`, `minimum`, `maximum`, `multipleOf`,
+       `minItems`, `maxItems`, `uniqueItems`, `default`. The
+       sanitizer strips these recursively from every node.
+
+    Allowed keywords are preserved: `type`, `properties`, `required`,
+    `items`, `enum`, `additionalProperties`, `description`, `oneOf`,
+    `anyOf`, `not`.
+
+    Why sanitize rather than maintain a parallel codex-only schema:
+    the bound constraints (string lengths, value ranges, array sizes)
+    are already enforced post-extraction by the Python validators in
+    `kai.memory_extraction` (`_validate_facts`, `_validate_episode`).
+    Dropping them from the schema does not widen the production
+    contract; it only relaxes what the model is INSTRUCTED to produce.
+    The caller's bound checks continue to gate storage.
+
+    Pure function. The input schema is not mutated; the output is a
+    fresh dict tree the caller can write to disk and discard.
+    """
+    return _strict_node(schema)
+
+
+def _strict_node(node: Any) -> Any:
+    """Recursive worker for `_sanitize_for_codex`.
+
+    Returns a sanitized copy of `node`. Lists and dicts are walked
+    structurally; scalars round-trip unchanged. Object nodes (those
+    with `type == "object"`, or with a `properties` field at the
+    top level when `type` is absent) get the strict-mode treatment;
+    other dicts (e.g., the `properties` mapping itself, which has
+    property-name keys rather than schema keywords) are walked
+    transparently.
+    """
+    if isinstance(node, dict):
+        out: dict[str, Any] = {}
+        for key, value in node.items():
+            if key in _STRICT_MODE_DISALLOWED_KEYS:
+                continue
+            out[key] = _strict_node(value)
+        node_type = out.get("type")
+        # An object node carries `type: "object"` AND a `properties`
+        # mapping. The schema's top-level `properties` value is itself
+        # a dict whose keys are property names; we recurse into each
+        # property value (which IS a schema) but do not treat the
+        # outer `properties` mapping as an object node.
+        if node_type == "object" and isinstance(out.get("properties"), dict):
+            properties: dict[str, Any] = out["properties"]
+            if "additionalProperties" not in out:
+                out["additionalProperties"] = False
+            existing_required = list(out.get("required") or [])
+            required_set = set(existing_required)
+            for prop_name in properties:
+                if prop_name in required_set:
+                    continue
+                # Previously-optional property: widen its type to
+                # include `null` so the model can emit `null` for
+                # absent values, then add it to required.
+                properties[prop_name] = _widen_nullable(properties[prop_name])
+                existing_required.append(prop_name)
+                required_set.add(prop_name)
+            out["required"] = existing_required
+        return out
+    if isinstance(node, list):
+        return [_strict_node(item) for item in node]
+    return node
+
+
+def _widen_nullable(prop_schema: Any) -> Any:
+    """Add `null` to the property's `type` so the model can emit null.
+
+    Three cases the production schemas exercise:
+
+    - `type: "string"` -> `type: ["string", "null"]`.
+    - `type: ["string", "integer"]` (already a list) -> append "null"
+      if not already present.
+    - No `type` at all (e.g., a property whose schema is just an
+      `enum` or an `oneOf`): leave unchanged. OpenAI strict mode may
+      or may not accept this shape in the optional-via-required-and-
+      null form; in practice the production schemas do not use it,
+      and forcing `type: "null"` onto an enum-only property would be
+      a guess about intent. If a future schema hits this, the API
+      will return a 400 and the operator-side log review will surface
+      the property name.
+    """
+    if not isinstance(prop_schema, dict):
+        return prop_schema
+    out = dict(prop_schema)
+    existing_type = out.get("type")
+    if existing_type is None:
+        return out
+    if isinstance(existing_type, list):
+        if "null" not in existing_type:
+            out["type"] = [*existing_type, "null"]
+        return out
+    if existing_type == "null":
+        return out
+    out["type"] = [existing_type, "null"]
+    return out
+
+
 def _render_codex_stdin(system_prompt: str | None, prompt: str) -> str:
     """
     Build a boundary-delimited stdin payload for a codex one-shot call.
@@ -833,6 +977,17 @@ class CodexOneShotReasoner:
         # form (not secret).
         schema_path: Path | None = None
         if json_schema is not None:
+            # Sanitize before writing. Codex forwards the schema to
+            # OpenAI's Chat Completions endpoint in strict structured-
+            # outputs mode, which has tighter requirements than the
+            # JSON Schema subset claude's `--json-schema` accepts.
+            # See `_sanitize_for_codex` for the transformation rules.
+            # The original `json_schema` reference is preserved for
+            # the downstream required-fields check on the model's
+            # response, which uses the caller's TRULY required list
+            # (not the widened all-properties list the sanitizer
+            # produces).
+            sanitized_schema = _sanitize_for_codex(json_schema)
             with tempfile.NamedTemporaryFile(
                 mode="w",
                 suffix=".json",
@@ -841,7 +996,7 @@ class CodexOneShotReasoner:
                 delete=False,
                 encoding="utf-8",
             ) as fh:
-                json.dump(json_schema, fh)
+                json.dump(sanitized_schema, fh)
                 schema_path = Path(fh.name)
             schema_path.chmod(0o644)
             cmd.extend(["--output-schema", str(schema_path)])

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -654,6 +654,12 @@ _STRICT_MODE_DISALLOWED_KEYS: frozenset[str] = frozenset(
         "maxItems",
         "uniqueItems",
         "default",
+        # `not` composition is currently unsupported by OpenAI strict
+        # structured outputs even though plain JSON Schema allows it.
+        # The production memory schemas never use `not`; stripping it
+        # is forward-protection against a future schema author adding
+        # it without knowing the codex CLI would 400 on it.
+        "not",
     }
 )
 
@@ -683,7 +689,8 @@ def _sanitize_for_codex(schema: dict[str, Any]) -> dict[str, Any]:
 
     Allowed keywords are preserved: `type`, `properties`, `required`,
     `items`, `enum`, `additionalProperties`, `description`, `oneOf`,
-    `anyOf`, `not`.
+    `anyOf`. `not` is NOT preserved; OpenAI strict structured outputs
+    currently rejects it even though plain JSON Schema accepts it.
 
     Why sanitize rather than maintain a parallel codex-only schema:
     the bound constraints (string lengths, value ranges, array sizes)

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -586,8 +586,13 @@ class TestCodexOneShotReasonerSchemaFile:
 
     @pytest.mark.asyncio
     async def test_schema_file_written_with_supplied_schema(self, tmp_path):
-        """The path passed via --output-schema must point at a file
-        whose contents are the JSON-serialized schema dict."""
+        """The path passed via --output-schema points at a file
+        whose contents are the SANITIZED form of the schema dict
+        (per the OpenAI strict-mode boundary transform). The
+        sanitizer adds `additionalProperties: false` and lists the
+        property in `required`; the on-disk JSON reflects that."""
+        from kai.oneshot import _sanitize_for_codex
+
         reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user=_current_user())
         captured: dict = {}
 
@@ -605,7 +610,7 @@ class TestCodexOneShotReasonerSchemaFile:
                 json_schema=schema,
             )
 
-        assert json.loads(captured["body"]) == schema
+        assert json.loads(captured["body"]) == _sanitize_for_codex(schema)
         # Cleanup ran in the finally block.
         assert not captured["path"].exists()
 
@@ -1457,3 +1462,350 @@ class TestRoutingLogField:
             await reasoner.run(prompt="p", purpose="fact_extraction")
         msg = next(r.getMessage() for r in caplog.records if r.message.startswith("oneshot_reasoner"))
         assert "os_user=self" in msg
+
+
+# ── _sanitize_for_codex (issue #505) ────────────────────────────────
+
+
+class TestSanitizeForCodexDisallowedKeys:
+    """OpenAI strict structured-outputs rejects many JSON Schema
+    keywords claude accepts (`minLength`, `maxLength`, `pattern`,
+    `format`, `minimum`, `maximum`, `multipleOf`, `minItems`,
+    `maxItems`, `uniqueItems`, `default`). The sanitizer strips
+    them recursively before the schema reaches codex's
+    `--output-schema` flag."""
+
+    def test_strips_string_length_bounds(self):
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {"type": "string", "minLength": 1, "maxLength": 500}
+        out = _sanitize_for_codex(schema)
+        assert out == {"type": "string"}
+
+    def test_strips_number_bounds(self):
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {"type": "number", "minimum": 0.5, "maximum": 1.0}
+        out = _sanitize_for_codex(schema)
+        assert out == {"type": "number"}
+
+    def test_strips_array_bounds(self):
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1,
+            "maxItems": 5,
+            "uniqueItems": True,
+        }
+        out = _sanitize_for_codex(schema)
+        assert out == {"type": "array", "items": {"type": "string"}}
+
+    def test_strips_pattern_and_format(self):
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {"type": "string", "pattern": "^x+$", "format": "email"}
+        out = _sanitize_for_codex(schema)
+        assert out == {"type": "string"}
+
+    def test_strips_default(self):
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {"type": "string", "default": "foo"}
+        out = _sanitize_for_codex(schema)
+        assert out == {"type": "string"}
+
+    def test_preserves_enum(self):
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {"type": "string", "enum": ["a", "b", "c"]}
+        out = _sanitize_for_codex(schema)
+        assert out == {"type": "string", "enum": ["a", "b", "c"]}
+
+    def test_preserves_description(self):
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {"type": "string", "description": "a label"}
+        out = _sanitize_for_codex(schema)
+        assert out == {"type": "string", "description": "a label"}
+
+
+class TestSanitizeForCodexRequiredExpansion:
+    """Strict mode requires `required` to list every key in
+    `properties`. Truly optional properties get added to required
+    AND have their `type` widened to include `"null"` so the model
+    can emit null for absent values."""
+
+    def test_optional_property_added_to_required(self):
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "nickname": {"type": "string"},
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        }
+        out = _sanitize_for_codex(schema)
+        assert set(out["required"]) == {"name", "nickname"}
+
+    def test_optional_type_widened_to_nullable(self):
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "nickname": {"type": "string"},
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        }
+        out = _sanitize_for_codex(schema)
+        assert out["properties"]["nickname"]["type"] == ["string", "null"]
+        assert out["properties"]["name"]["type"] == "string"
+
+    def test_optional_list_type_appends_null(self):
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "field": {"type": ["string", "integer"]},
+            },
+            "required": [],
+            "additionalProperties": False,
+        }
+        out = _sanitize_for_codex(schema)
+        assert out["properties"]["field"]["type"] == ["string", "integer", "null"]
+
+    def test_already_nullable_type_not_double_appended(self):
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {
+            "type": "object",
+            "properties": {"field": {"type": ["string", "null"]}},
+            "required": [],
+            "additionalProperties": False,
+        }
+        out = _sanitize_for_codex(schema)
+        # Property is added to required AND keeps its type list as-is.
+        assert out["required"] == ["field"]
+        assert out["properties"]["field"]["type"] == ["string", "null"]
+
+    def test_property_without_type_left_alone(self):
+        """A property whose schema is just an enum (no explicit
+        `type`) is added to required but cannot be safely widened.
+        Leaving the type absent is the documented posture; if a
+        future schema hits this and codex 400s on it, the
+        operator-side log review will surface the property name."""
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {
+            "type": "object",
+            "properties": {"mode": {"enum": ["a", "b"]}},
+            "required": [],
+            "additionalProperties": False,
+        }
+        out = _sanitize_for_codex(schema)
+        assert out["required"] == ["mode"]
+        assert "type" not in out["properties"]["mode"]
+
+
+class TestSanitizeForCodexAdditionalProperties:
+    """Every object node must have `additionalProperties: false`."""
+
+    def test_adds_when_missing(self):
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+            "required": ["x"],
+        }
+        out = _sanitize_for_codex(schema)
+        assert out["additionalProperties"] is False
+
+    def test_preserves_when_already_set(self):
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+            "required": ["x"],
+            "additionalProperties": False,
+        }
+        out = _sanitize_for_codex(schema)
+        assert out["additionalProperties"] is False
+
+    def test_non_object_node_does_not_gain_additional_properties(self):
+        """Arrays and scalar types must NOT get an
+        `additionalProperties` injected; that would be a schema
+        error of its own."""
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {"type": "array", "items": {"type": "string"}}
+        out = _sanitize_for_codex(schema)
+        assert "additionalProperties" not in out
+
+
+class TestSanitizeForCodexRecursion:
+    """The sanitizer recurses into nested objects and array items."""
+
+    def test_recurses_into_array_items(self):
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "minLength": 1},
+                    "tag": {"type": "string"},
+                },
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+        }
+        out = _sanitize_for_codex(schema)
+        item = out["items"]
+        assert "minLength" not in item["properties"]["name"]
+        assert set(item["required"]) == {"name", "tag"}
+
+    def test_recurses_into_nested_objects(self):
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "inner": {
+                    "type": "object",
+                    "properties": {
+                        "deep": {"type": "string", "maxLength": 10},
+                    },
+                    "required": ["deep"],
+                    "additionalProperties": False,
+                },
+            },
+            "required": ["inner"],
+            "additionalProperties": False,
+        }
+        out = _sanitize_for_codex(schema)
+        assert "maxLength" not in out["properties"]["inner"]["properties"]["deep"]
+
+
+class TestSanitizeForCodexProductionSchemas:
+    """The real `_FACT_SCHEMA` and `_EPISODE_SCHEMA` must come out
+    strict-mode-valid after sanitization. Regression test for the
+    specific failure mode caught running the eval gate on
+    2026-05-19: the API rejected the production schemas for
+    `required` not covering `confirmation_quote` (FACT) and
+    `lessons` (EPISODE)."""
+
+    def _assert_strict_mode_valid(self, node):
+        if isinstance(node, dict):
+            if node.get("type") == "object":
+                assert node.get("additionalProperties") is False, "object missing additionalProperties: false"
+                properties = set((node.get("properties") or {}).keys())
+                required = set(node.get("required") or [])
+                assert properties == required or properties.issubset(required), (
+                    f"required {required} does not cover properties {properties}"
+                )
+            for k, v in node.items():
+                assert k not in (
+                    "minLength",
+                    "maxLength",
+                    "pattern",
+                    "format",
+                    "minimum",
+                    "maximum",
+                    "multipleOf",
+                    "minItems",
+                    "maxItems",
+                    "uniqueItems",
+                    "default",
+                ), f"disallowed key survived: {k}"
+                self._assert_strict_mode_valid(v)
+        elif isinstance(node, list):
+            for item in node:
+                self._assert_strict_mode_valid(item)
+
+    def test_fact_schema_round_trips_strict_mode_valid(self):
+        from kai.memory_extraction import _FACT_SCHEMA
+        from kai.oneshot import _sanitize_for_codex
+
+        sanitized = _sanitize_for_codex(_FACT_SCHEMA)
+        self._assert_strict_mode_valid(sanitized)
+        # The two known-optional fact item properties are now in
+        # required AND widened to nullable.
+        item = sanitized["properties"]["facts"]["items"]
+        for optional in ("confirmation_quote", "existing_id"):
+            assert optional in item["required"]
+            assert item["properties"][optional]["type"] == ["string", "null"]
+
+    def test_episode_schema_round_trips_strict_mode_valid(self):
+        from kai.memory_extraction import _EPISODE_SCHEMA
+        from kai.oneshot import _sanitize_for_codex
+
+        sanitized = _sanitize_for_codex(_EPISODE_SCHEMA)
+        self._assert_strict_mode_valid(sanitized)
+        # `lessons` was the previously-optional field; should now be
+        # required + nullable.
+        episode = sanitized["properties"]["episode"]
+        assert "lessons" in episode["required"]
+        assert episode["properties"]["lessons"]["type"] == ["string", "null"]
+
+    def test_input_schema_not_mutated(self):
+        """The sanitizer must not mutate the caller's schema. Both
+        production memory stages read from module-level constants;
+        an in-place mutation would corrupt subsequent calls."""
+        from kai.memory_extraction import _FACT_SCHEMA
+        from kai.oneshot import _sanitize_for_codex
+
+        before = json.dumps(_FACT_SCHEMA, sort_keys=True)
+        _sanitize_for_codex(_FACT_SCHEMA)
+        after = json.dumps(_FACT_SCHEMA, sort_keys=True)
+        assert before == after
+
+
+class TestCodexReasonerWritesSanitizedSchema:
+    """`CodexOneShotReasoner.run()` calls the sanitizer before
+    writing the temp file, so the disk contents codex actually reads
+    have no strict-mode-disallowed keywords."""
+
+    @pytest.mark.asyncio
+    async def test_disk_schema_is_sanitized(self, tmp_path):
+        from kai.memory_extraction import _FACT_SCHEMA
+
+        reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user=_current_user())
+        captured: dict = {}
+
+        def _capture(*args, **kwargs):
+            i = args.index("--output-schema")
+            captured["path"] = Path(args[i + 1])
+            captured["body"] = json.loads(captured["path"].read_text(encoding="utf-8"))
+            return _make_proc(stdout=b"")
+
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(side_effect=_capture)),
+            pytest.raises(OneShotOutputError),
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema=_FACT_SCHEMA,
+            )
+
+        # The on-disk schema reflects the sanitizer's transform, not
+        # the input. Spot-check the known previously-optional fields
+        # are now required with nullable types.
+        disk = captured["body"]
+        item = disk["properties"]["facts"]["items"]
+        assert "confirmation_quote" in item["required"]
+        assert item["properties"]["confirmation_quote"]["type"] == ["string", "null"]
+        # And the disallowed keys are absent.
+        assert "minLength" not in item["properties"]["content"]
+        assert "maxItems" not in disk["properties"]["facts"]

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -1516,6 +1516,18 @@ class TestSanitizeForCodexDisallowedKeys:
         out = _sanitize_for_codex(schema)
         assert out == {"type": "string"}
 
+    def test_strips_not_composition(self):
+        """`not` is currently rejected by OpenAI strict structured
+        outputs even though plain JSON Schema accepts it. Stripping
+        is forward-protection against a future schema author who
+        adds a `not` branch without knowing the codex CLI would 400
+        on it."""
+        from kai.oneshot import _sanitize_for_codex
+
+        schema = {"type": "string", "not": {"enum": ["forbidden"]}}
+        out = _sanitize_for_codex(schema)
+        assert out == {"type": "string"}
+
     def test_preserves_enum(self):
         from kai.oneshot import _sanitize_for_codex
 
@@ -1727,6 +1739,7 @@ class TestSanitizeForCodexProductionSchemas:
                     "maxItems",
                     "uniqueItems",
                     "default",
+                    "not",
                 ), f"disallowed key survived: {k}"
                 self._assert_strict_mode_valid(v)
         elif isinstance(node, list):


### PR DESCRIPTION
Closes #505.

## Summary

- Adds `_sanitize_for_codex(schema)` in `kai.oneshot`. Pure, recursive, no side effects.
- `CodexOneShotReasoner.run()` calls it before writing the `--output-schema` temp file.
- 21 unit tests covering each transformation rule, the non-mutation invariant, recursion into nested objects and array items, and end-to-end strict-mode validation of the real `_FACT_SCHEMA` and `_EPISODE_SCHEMA`.

## Why

Captured against a real codex run on 2026-05-19 while attempting the memory eval gate (#498):

```
Invalid schema for response_format 'codex_output_schema': In
context=('properties', 'facts', 'items'), 'required' is required to
be supplied and to be an array including every key in properties.
Missing 'confirmation_quote'.
```

OpenAI strict structured-outputs has three constraints `_FACT_SCHEMA` and `_EPISODE_SCHEMA` violate:

1. `additionalProperties: false` on every object node (production schemas satisfy this; sanitizer is defensive).
2. `required` must include every key in `properties`. Truly optional fields (`confirmation_quote`, `existing_id`, `lessons`) violate this.
3. Many validators are disallowed: `minLength`, `maxLength`, `pattern`, `format`, `minimum`, `maximum`, `multipleOf`, `minItems`, `maxItems`, `uniqueItems`, `default`. Production schemas use most of these.

## Transformation rules

- Object nodes get `additionalProperties: false` if missing.
- For each key in `properties` not in `required`, the property is added to `required` AND its `type` is widened to include `"null"` (string → `["string", "null"]`, list types append `"null"`). Properties with no explicit `type` are left alone — rare in production schemas; the operator-side log review would surface the property name if a future schema ever trips OpenAI's validation.
- Disallowed validators are stripped recursively.
- Allowed keywords are preserved: `type`, `properties`, `required`, `items`, `enum`, `additionalProperties`, `description`, `oneOf`, `anyOf`, `not`.
- The caller's schema is not mutated; the output is a fresh dict tree.

## Design notes

**Why not a parallel codex-only schema**: the bound constraints (string lengths, value ranges, array sizes) are already enforced post-extraction by `_validate_facts` and `_validate_episode`. Dropping them from the schema does not widen the production contract; it only relaxes what the model is INSTRUCTED to produce. The caller's bound checks continue to gate storage.

**Why the downstream required-fields check still uses the original schema**: `CodexOneShotReasoner.run()` calls `_sanitize_for_codex(json_schema)` and writes the sanitized copy to disk, but the post-response "missing required fields" check (the wrong-shape-object guard from PR #501) continues to use `json_schema.get("required")` — the caller's TRULY required fields, not the widened all-properties list. That keeps the validation aligned with what the caller actually needs back.

## Test plan

- [x] `pytest tests/test_oneshot.py` — 88 passing (67 before + 21 new).
- [x] `make test` — 3355 passing, 1 skipped.
- [x] `make check` — clean.
- [x] Pre-push hard-rule grep — clean.

## What this unblocks

- **#498 memory eval gate, codex arm**: codex's `--output-schema` no longer 400s. The gate run is one `make install` away from a real verdict on the operator's side.
- **The production-enable issue that follows the gate**: same dependency chain.

## Notes for operator

- The Claude memory timeout you saw separately (26/28 timeouts on the gate's Claude arm) is unrelated to this PR. The default `MEMORY_EXTRACTION_TIMEOUT_S=10` is too tight; the production-tuned value is 60. Bump `MEMORY_EXTRACTION_TIMEOUT_S=60` and `MEMORY_EPISODE_TIMEOUT_S=120` in the gate's env before the next attempt.
- This PR alone is enough to unblock the codex arm. Combined with the timeout bump, both arms should complete cleanly.
