### PR TITLE
fix(memory): persist fact speaker through _store_facts metadata

### DIFF
--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -2319,8 +2319,25 @@ def _store_facts(
 
         # Build the metadata bundle once; the same shape applies to
         # both the `new` and `update_of` branches that call add_structured.
+        #
+        # `speaker` is required by the fact schema; the structured-output
+        # validator guarantees it is present on any fact that reaches
+        # this function in production, and `_validate_facts` runs a
+        # confirmation_quote-based override that may force it to
+        # "assistant". Persisting it here is what lets downstream
+        # readers distinguish user-asserted from assistant-asserted
+        # facts. Without this copy, the row lands with no
+        # `metadata.speaker` and `_read_time_speaker` silently falls
+        # through to the legacy "assistant" default for every extracted
+        # fact regardless of the model's attribution. That was the
+        # state production was in before this line existed. The `or`
+        # fallback matches that legacy default so a fact dict that
+        # bypassed validation (e.g. in a unit-test shim) lands in the
+        # same state it would have before the fix, rather than
+        # KeyError-ing the storage path.
         extra: dict = {
             "source": "extracted",
+            "speaker": fact.get("speaker") or "assistant",
             "confidence": fact.get("confidence"),
             "session_id": session_id or "",
             "prompt_version": _EXTRACTION_PROMPT_VERSION,

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -2048,9 +2048,7 @@ class TestStoreFactsSpeakerPersistence:
                 "speaker": "user",
             }
         ]
-        stored, replaced, _ = _store_facts(
-            facts, user_id="u1", session_id="s1", config=_cfg()
-        )
+        stored, replaced, _ = _store_facts(facts, user_id="u1", session_id="s1", config=_cfg())
         assert (stored, replaced) == (1, 1)
         assert captured["metadata"]["speaker"] == "user"
 

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -1964,6 +1964,97 @@ class TestStoreFactsIntent:
         assert payload["outcome"] == "skipped"
 
 
+# ── _store_facts: speaker persistence ───────────────────────────────
+
+
+class TestStoreFactsSpeakerPersistence:
+    """Regression: `_store_facts` must copy `fact["speaker"]` into the
+    metadata bundle passed to `add_structured`. Before the fix, the
+    extractor's per-fact speaker attribution was dropped on the floor
+    at storage time; every extracted row landed with no
+    `metadata.speaker`, and the read-time helper masked the bug by
+    falling through to the legacy "assistant" default. The gate's
+    direct `metadata.get("speaker")` read surfaced the gap as a
+    uniformly-zero speaker_accuracy across both backends in #498's
+    first clean run."""
+
+    def test_new_branch_persists_user_speaker(self, monkeypatch):
+        """User-asserted fact lands with metadata.speaker == "user". The
+        new branch passes through _paraphrase_neighbor when memory is
+        enabled, so wire that to "no neighbor found" and capture the
+        metadata kwarg add_structured receives."""
+        monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
+        monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [])
+        captured: dict = {}
+        monkeypatch.setattr(
+            "kai.memory_extraction.memory.add_structured",
+            lambda content, **kw: captured.update(kw) or "new-id",
+        )
+        facts = [
+            {
+                "content": "User prefers black coffee.",
+                "tags": ["preference"],
+                "confidence": 0.9,
+                "intent": "new",
+                "speaker": "user",
+            }
+        ]
+        stored, _, _ = _store_facts(facts, user_id="u1", session_id="s1", config=_cfg())
+        assert stored == 1
+        assert captured["metadata"]["speaker"] == "user"
+
+    def test_new_branch_persists_assistant_speaker(self, monkeypatch):
+        """Assistant-attributed fact lands with metadata.speaker ==
+        "assistant" - the value the confirmation_quote override in
+        _validate_facts may force. Same shape as the user case."""
+        monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
+        monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [])
+        captured: dict = {}
+        monkeypatch.setattr(
+            "kai.memory_extraction.memory.add_structured",
+            lambda content, **kw: captured.update(kw) or "new-id",
+        )
+        facts = [
+            {
+                "content": "Reminder set for Monday.",
+                "tags": ["confirmed_action"],
+                "confidence": 0.9,
+                "intent": "new",
+                "speaker": "assistant",
+            }
+        ]
+        stored, _, _ = _store_facts(facts, user_id="u1", session_id="s1", config=_cfg())
+        assert stored == 1
+        assert captured["metadata"]["speaker"] == "assistant"
+
+    def test_update_of_branch_persists_speaker(self, monkeypatch):
+        """The update_of branch builds the metadata bundle from the same
+        code as the new branch; cover it explicitly so a future
+        refactor that diverges the two branches cannot silently
+        regress speaker persistence on consolidation writes."""
+        monkeypatch.setattr("kai.memory_extraction.memory.delete_by_id", lambda **kw: True)
+        captured: dict = {}
+        monkeypatch.setattr(
+            "kai.memory_extraction.memory.add_structured",
+            lambda content, **kw: captured.update(kw) or "new-id",
+        )
+        facts = [
+            {
+                "content": "User now in Pacific time.",
+                "tags": ["preference", "timezone"],
+                "confidence": 0.9,
+                "intent": "update_of",
+                "existing_id": "old-id",
+                "speaker": "user",
+            }
+        ]
+        stored, replaced, _ = _store_facts(
+            facts, user_id="u1", session_id="s1", config=_cfg()
+        )
+        assert (stored, replaced) == (1, 1)
+        assert captured["metadata"]["speaker"] == "user"
+
+
 # ── extract_and_store: end-to-end consolidation ─────────────────────
 
 


### PR DESCRIPTION
Closes #507 (write-path piece).

## Summary

- `_store_facts` now copies `fact["speaker"]` into the metadata bundle passed to `add_structured`, on both `intent="new"` and `intent="update_of"` branches.
- Three regression tests cover the persistence on each branch (user / assistant / update_of).

## Why

The fact-extraction schema requires `speaker`, the prompt instructs the model to attribute it, `_validate_facts` enforces it, and there is a confirmation-quote-based override that may force `speaker="assistant"` when the citation lives in the assistant turn. After all of that, `_store_facts` was building the `add_structured` metadata dict without copying `speaker` into it. Every extracted fact has been persisted with no `metadata.speaker` since the v8 attribution prompt shipped.

Production has not crashed because every reader funnels through `memory._read_time_speaker`, which falls back to `_LEGACY_SPEAKER = "assistant"` when the field is absent. The cost has been a silent no-op: every extracted fact reads back as `speaker="assistant"` regardless of the model's attribution.

The #498 eval gate surfaced the gap by reading `target_row.metadata.get("speaker")` directly (no fallback). The first clean gate run came back with `speaker_accuracy = 0.000` on both claude and codex arms, which was the diagnostic trail.

## Operator-visible UX change

Once this lands, the `/memory` dashboard will start showing **User** on user-asserted facts that have previously rendered as **Assistant** via the legacy fallback. That is a correction, not a regression, but it will be visible against the existing corpus the next time the dashboard is loaded.

(Legacy migration rows and rows written before the v8 prompt still surface as **Assistant** via the same legacy fallback. Only new extractions land with the real speaker.)

## Fallback choice

The new line is `"speaker": fact.get("speaker") or "assistant"`. Production validators guarantee the key, so the fallback never fires in practice. It exists so unit tests and any future code path that constructs a fact dict outside the validator do not KeyError; the chosen default matches the read-time legacy default so the new code is at worst no-worse-than-before, never worse.

## Test plan

- [x] `pytest tests/test_memory_extraction.py`. 187 passing (184 before + 3 new).
- [x] `pytest tests/test_memory.py tests/test_memory_command.py`. 292 passing.
- [x] `ruff check src/kai/memory_extraction.py tests/test_memory_extraction.py`. clean.
- [x] Pre-push hard-rule grep. clean.

## Companion fixture change

The operator-private eval fixture (`memory-backend-gate-probes.jsonl`) needs its `tags_any` allowlists widened for three anchors (`d-pet`, `d-bday`, `c-new-partner-bday`) where codex's tag vocabulary differs from claude's. That is the other half of #507; the fixture is not in this repo so it lives outside this PR.

## What this unblocks

- #498 eval gate's T4.speaker_accuracy axis will measure real model behavior on the next run rather than uniform 0.
- #499 production-enable can be revisited once the gate passes end-to-end.
