### PR TITLE
feat(memory): production-enable codex backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ Three layers of persistent context give the agent continuity across sessions:
 
 Workspaces can also define a system prompt via `workspaces.yaml` for workspace-specific instructions. See [System Architecture](https://github.com/dcellison/kai/wiki/System-Architecture).
 
+#### Memory backend selection
+
+Semantic memory extraction (the subprocess that proactively writes facts and episode summaries) is independent of the agent backend. The reasoner used for extraction is selected by `MEMORY_REASONER_BACKEND` (`claude` or `codex`); each value names the subprocess that runs the extraction call. All four combinations of agent backend and reasoner backend are supported (claude+claude, claude+codex, codex+claude, codex+codex). The wizard defaults to the same-vendor case when extraction is enabled, but the operator can pick either.
+
+The named binary must be reachable at startup when extraction is enabled; the bot exits at config-load otherwise with a message naming the resolution sequence. Retrieval-only memory (`MEMORY_ENABLED=true` with extraction disabled) does not require either binary.
+
+To verify a memory configuration end-to-end without writing to the store, run `python -m kai.smoke.memory` from the install directory. Pass `--os-user <name>` when the configured reasoner is codex; the codex reasoner refuses to spawn without one. The smoke prints the resolved binary, the argv that ran, and any extracted facts.
+
 ### Scheduled jobs
 
 Reminders and recurring agent jobs with one-shot, daily, and interval schedules. Ask naturally ("remind me at 3pm") or use the HTTP API (`POST /api/schedule`). Agent jobs run as full agent sessions - Kai can check conditions, search the web, run commands, and report back on a schedule. Auto-remove jobs support monitoring use cases where the agent watches for a condition and deactivates itself when it's met. See [Scheduling and Conditional Jobs](https://github.com/dcellison/kai/wiki/Scheduling-and-Conditional-Jobs).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,7 @@ known-first-party = ["kai"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+markers = [
+    "integration: marks tests requiring optional dependencies (deselect with -m 'not integration')",
+    "routing_test: codex routing-policy tests that opt out of the test-level same-user bypass",
+]

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -3736,7 +3736,7 @@ async def _handle_response(
                 effective_backend = (
                     user_config.agent_backend if user_config and user_config.agent_backend else config.agent_backend
                 )
-                if config.memory_extraction_enabled and effective_backend == "claude":
+                if config.memory_extraction_enabled and effective_backend in ("claude", "codex"):
                     # Windowed PRIOR CONTEXT for the episode classifier
                     # (issue #392). Fetch one extra pair beyond the
                     # configured window and drop the most recent: the

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -2172,11 +2172,10 @@ def load_config() -> Config:
         # `agent_backend` wins; otherwise the global default applies.
         # Only users whose effective backend is one bot.py would
         # actually run extraction for need an os_user.
-        missing = [
-            uc.telegram_id
-            for uc in user_configs.values()
-            if (uc.agent_backend or agent_backend) in ("claude", "codex") and not uc.os_user
+        extraction_users = [
+            uc for uc in user_configs.values() if (uc.agent_backend or agent_backend) in ("claude", "codex")
         ]
+        missing = [uc.telegram_id for uc in extraction_users if not uc.os_user]
         if missing:
             raise SystemExit(
                 "MEMORY_REASONER_BACKEND='codex' with MEMORY_EXTRACTION_ENABLED=true "
@@ -2186,6 +2185,32 @@ def load_config() -> Config:
                 "the codex subprocess will run as), or set MEMORY_EXTRACTION_ENABLED=false "
                 "to run with retrieval-only memory."
             )
+
+        # Codex must NOT run as the bot user. The codex reasoner
+        # refuses same-user spawn at runtime; surface the same
+        # boundary at config-load so a misconfigured users.yaml does
+        # not silently no-op every extraction. Detect by matching
+        # the configured os_user against the current process user;
+        # mirror the runtime's resolve_claude_user check so the two
+        # gates name the same condition.
+        try:
+            current_user = pwd.getpwuid(os.getuid()).pw_name
+        except KeyError:
+            # No passwd entry for the running UID (e.g., container
+            # with --user <uid>). The runtime resolve_claude_user
+            # falls through to honor the configured os_user in this
+            # case, so config-load does too.
+            current_user = None
+        if current_user is not None:
+            same_user = [uc.telegram_id for uc in extraction_users if uc.os_user == current_user]
+            if same_user:
+                raise SystemExit(
+                    "MEMORY_REASONER_BACKEND='codex' refuses to run codex as the bot user "
+                    f"({current_user!r}). The following users.yaml chat_ids have 'os_user' "
+                    f"set to the bot user: {sorted(same_user)}. Set 'os_user' to a "
+                    "different OS account, or set MEMORY_EXTRACTION_ENABLED=false to "
+                    "run with retrieval-only memory."
+                )
 
     # Deprecation warnings for env vars superseded by users.yaml.
     # The vars still work as global fallbacks, but users.yaml is the

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1947,6 +1947,33 @@ def load_config() -> Config:
             f"(must be one of: {', '.join(_valid_memory_backends)})"
         )
 
+    # Cross-binary validation. When the operator has BOTH MEMORY_ENABLED=true
+    # AND MEMORY_EXTRACTION_ENABLED=true (the composed `memory_extraction_enabled`
+    # value above), the configured reasoner backend's binary must be reachable
+    # at startup; otherwise the first extraction would surface as a runtime
+    # OneShotRoutingError at first user message rather than a clear config-load
+    # failure. Retrieval-only memory (MEMORY_ENABLED=true with extraction
+    # disabled) intentionally does NOT trigger this check because no reasoner
+    # subprocess runs in that mode; gaining a binary prerequisite there would
+    # break the supported retrieval-only configuration.
+    #
+    # Local import avoids any future risk of an import cycle with kai.oneshot
+    # (which itself imports from kai.config). We catch `BinaryResolutionError`,
+    # the leaf module's stdlib-only exception type, NOT `OneShotRoutingError`
+    # (which lives in kai.oneshot and would defeat the cycle-free design).
+    if memory_extraction_enabled:
+        from kai.oneshot_binary import BinaryResolutionError, resolve_oneshot_binary
+
+        try:
+            resolve_oneshot_binary(memory_reasoner_backend)
+        except BinaryResolutionError as e:
+            raise SystemExit(
+                f"MEMORY_REASONER_BACKEND='{memory_reasoner_backend}' requires the binary "
+                f"to be reachable at startup, but {e}. Set CODEX_BIN (for codex) or fix "
+                f"PATH (for either backend); rerun the wizard if you no longer want memory "
+                f"extraction enabled."
+            ) from None
+
     # Memory model resolution. Env override wins; otherwise the role
     # registry resolves to a backend-appropriate default (claude-haiku
     # for backend=claude, gpt-5.4-mini for backend=codex). Sentinel

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -778,14 +778,14 @@ class Config:
     # stays because test fixtures construct Config directly and
     # depend on a usable Claude default without going through env.
     memory_extraction_model: str = "claude-haiku-4-5-20251001"
-    # Per-call budget ceiling. Omitted from claude --print argv on the
-    # claude backend (Max-plan OAuth makes the CLI's computed-cost
-    # ceiling a phantom signal; runaway protection comes from
-    # memory_extraction_timeout_s instead). Field stays defined for
-    # non-claude backends, which run on pay-per-token billing where
-    # the ceiling is a real cost gate, and so operators upgrading a
-    # deployment with MEMORY_EXTRACTION_BUDGET_USD already set in
-    # /etc/kai/env do not see a startup error after upgrade.
+    # Per-call budget ceiling. Retained as inert compatibility config.
+    # Both supported memory reasoners (claude and codex) are
+    # subscription-backed in the operator deployment model and no code
+    # path forwards this value to subprocess argv. Runaway protection
+    # comes from memory_extraction_timeout_s instead. The field stays
+    # in the dataclass so operators upgrading from a deployment with
+    # MEMORY_EXTRACTION_BUDGET_USD already set in /etc/kai/env do not
+    # see a startup error after upgrade.
     memory_extraction_budget_usd: float = 0.01
     # Timeout (seconds) for a single extraction subprocess. Haiku
     # typically finishes in 2-4s; 10s gives headroom without stranding
@@ -841,19 +841,14 @@ class Config:
     # is never the effective value. Test fixtures that construct Config
     # directly should set this explicitly to a real model name.
     memory_episode_model: str = ""
-    # Per-call budget ceiling (USD). Omitted from claude --print argv
-    # on the claude backend (Max-plan OAuth makes the CLI's
-    # computed-cost ceiling a phantom signal; runaway protection comes
-    # from memory_episode_timeout_s instead). Field stays defined for
-    # non-claude backends, which run on pay-per-token billing where
-    # the ceiling is a real cost gate, and so operators upgrading a
-    # deployment with MEMORY_EPISODE_BUDGET_USD already set in
-    # /etc/kai/env do not see a startup error after upgrade. Default
-    # 0.15 is sized for a Sonnet-class model on the FULL uncapped
-    # (user, assistant) pair; stage 2 deliberately bypasses stage-1's
-    # 500-char assistant cap. Operators downgrading memory_episode_model
-    # to Haiku can drop this to 0.05 or lower; the wizard recommends
-    # 0.15 as the default for non-claude backends.
+    # Per-call budget ceiling (USD). Retained as inert compatibility
+    # config. Same rationale as memory_extraction_budget_usd above:
+    # both supported reasoners are subscription-backed and no code
+    # path forwards this value to subprocess argv. Runaway protection
+    # comes from memory_episode_timeout_s instead. The field stays in
+    # the dataclass so operators upgrading from a deployment with
+    # MEMORY_EPISODE_BUDGET_USD already set in /etc/kai/env do not see
+    # a startup error after upgrade.
     memory_episode_budget_usd: float = 0.15
     # Subprocess timeout (seconds). Default 120 - twice the production-
     # tuned stage-1 value (60s) and 12x the stage-1 dataclass default
@@ -2134,6 +2129,46 @@ def load_config() -> Config:
         # ALLOWED_USER_IDS is valid and no users.yaml exists. This works
         # but is the legacy path - nudge toward users.yaml.
         log.info("Using ALLOWED_USER_IDS from env (legacy). Run 'make config' to migrate to users.yaml.")
+
+    # Codex memory routing precondition. The codex reasoner refuses to
+    # spawn without an `os_user` (the security boundary that keeps
+    # codex from running as the bot user). The runtime resolver reads
+    # `os_user` from users.yaml per chat_id; if the entry is missing
+    # or unset, extraction silently collapses to a zero-state miss
+    # every turn. Fail at config-load with a clear remediation hint
+    # so the operator does not discover this through silently empty
+    # memory state.
+    #
+    # Two failure modes covered:
+    #   1. users.yaml missing entirely: codex memory cannot be wired
+    #      because there is no per-user os_user surface.
+    #   2. users.yaml present but at least one entry lacks os_user:
+    #      that user's extraction never runs.
+    #
+    # Claude memory does not need this check: ClaudeOneShotReasoner
+    # supports a None os_user (the historical Max-plan self-sudo-skip
+    # path that spawns claude as the bot user), so claude extraction
+    # still works without per-user OS routing.
+    if memory_extraction_enabled and memory_reasoner_backend == "codex":
+        if user_configs is None:
+            raise SystemExit(
+                "MEMORY_REASONER_BACKEND='codex' with MEMORY_EXTRACTION_ENABLED=true "
+                "requires users.yaml with a per-user 'os_user' entry for every "
+                "authorized chat_id. ALLOWED_USER_IDS alone does not provide the "
+                "OS-user routing the codex reasoner needs. Run 'make config' to "
+                "generate users.yaml, or set MEMORY_EXTRACTION_ENABLED=false to "
+                "run with retrieval-only memory."
+            )
+        missing = [uc.telegram_id for uc in user_configs.values() if not uc.os_user]
+        if missing:
+            raise SystemExit(
+                "MEMORY_REASONER_BACKEND='codex' with MEMORY_EXTRACTION_ENABLED=true "
+                "requires every users.yaml entry to set 'os_user'. The following "
+                f"chat_ids are missing 'os_user': {sorted(missing)}. Edit users.yaml "
+                "to add an 'os_user' field for each entry (the OS user the codex "
+                "subprocess will run as), or set MEMORY_EXTRACTION_ENABLED=false "
+                "to run with retrieval-only memory."
+            )
 
     # Deprecation warnings for env vars superseded by users.yaml.
     # The vars still work as global fallbacks, but users.yaml is the

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -2139,11 +2139,20 @@ def load_config() -> Config:
     # so the operator does not discover this through silently empty
     # memory state.
     #
-    # Two failure modes covered:
+    # The precondition only applies to users whose EFFECTIVE agent
+    # backend is one the runtime would actually invoke extraction
+    # for. `bot.py:3739` gates extraction on
+    # `effective_backend in ("claude", "codex")`; goose users skip
+    # extraction entirely under that gate, so they do not need
+    # `os_user` for codex memory routing. The effective-backend
+    # cascade here mirrors the runtime: the user's per-entry
+    # `agent_backend` wins; otherwise the global default applies.
+    #
+    # Failure modes covered (scoped to extraction-eligible users):
     #   1. users.yaml missing entirely: codex memory cannot be wired
     #      because there is no per-user os_user surface.
-    #   2. users.yaml present but at least one entry lacks os_user:
-    #      that user's extraction never runs.
+    #   2. users.yaml present but at least one extraction-eligible
+    #      entry lacks os_user: that user's extraction never runs.
     #
     # Claude memory does not need this check: ClaudeOneShotReasoner
     # supports a None os_user (the historical Max-plan self-sudo-skip
@@ -2159,14 +2168,22 @@ def load_config() -> Config:
                 "generate users.yaml, or set MEMORY_EXTRACTION_ENABLED=false to "
                 "run with retrieval-only memory."
             )
-        missing = [uc.telegram_id for uc in user_configs.values() if not uc.os_user]
+        # Mirror the runtime's effective-backend cascade: per-user
+        # `agent_backend` wins; otherwise the global default applies.
+        # Only users whose effective backend is one bot.py would
+        # actually run extraction for need an os_user.
+        missing = [
+            uc.telegram_id
+            for uc in user_configs.values()
+            if (uc.agent_backend or agent_backend) in ("claude", "codex") and not uc.os_user
+        ]
         if missing:
             raise SystemExit(
                 "MEMORY_REASONER_BACKEND='codex' with MEMORY_EXTRACTION_ENABLED=true "
-                "requires every users.yaml entry to set 'os_user'. The following "
-                f"chat_ids are missing 'os_user': {sorted(missing)}. Edit users.yaml "
-                "to add an 'os_user' field for each entry (the OS user the codex "
-                "subprocess will run as), or set MEMORY_EXTRACTION_ENABLED=false "
+                "requires every claude/codex users.yaml entry to set 'os_user'. The "
+                f"following chat_ids are missing 'os_user': {sorted(missing)}. Edit "
+                "users.yaml to add an 'os_user' field for each entry (the OS user "
+                "the codex subprocess will run as), or set MEMORY_EXTRACTION_ENABLED=false "
                 "to run with retrieval-only memory."
             )
 

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1089,6 +1089,31 @@ def _cmd_config() -> None:
                         users_yaml_path.write_text(users_yaml_content)
                         os.chmod(users_yaml_path, 0o600)
                         print(f"  Updated {users_yaml_path} with os_user={admin_os_user}")
+                # CODEX_BIN must be collected whenever the codex
+                # reasoner is selected, not only when the agent
+                # backend is codex. The earlier codex agent-backend
+                # block prompts for the binary path only on
+                # `agent_backend == "codex"`, so a claude+codex (or
+                # goose+codex) memory install would otherwise emit no
+                # CODEX_BIN entry. _apply_sudoers then falls back to
+                # /opt/homebrew/bin/codex via _generate_sudoers, while
+                # the runtime CodexOneShotReasoner resolves codex via
+                # PATH; if the two diverge the sudoers SETENV rule no
+                # longer matches the argv the reasoner spawns. Re-
+                # prompt here when the agent block did not already
+                # collect a value so install.conf, /etc/kai/env, and
+                # /etc/kai/sudoers.d cannot drift apart.
+                if memory_reasoner_backend == "codex" and not codex_bin:
+                    while True:
+                        which_codex = shutil.which("codex") or "/opt/homebrew/bin/codex"
+                        codex_bin = _prompt(
+                            "Codex binary path (required by codex memory reasoner)",
+                            existing_env.get("CODEX_BIN", which_codex),
+                            required=True,
+                        )
+                        if _validate_codex_bin(codex_bin):
+                            break
+                        print(f"  Path '{codex_bin}' does not exist or is not executable.")
                 # No MEMORY_EXTRACTION_BUDGET_USD prompt on this branch:
                 # --max-budget-usd is omitted from the stage-1 claude
                 # --print argv (memory_extraction.py:_run_extractor),
@@ -1323,14 +1348,21 @@ def _cmd_config() -> None:
             env["CODEX_AUTH_MODE"] = codex_auth_mode
         if codex_api_key:
             env["OPENAI_API_KEY"] = codex_api_key
-        # Persist the wizard-collected codex binary path. The same
-        # value drives /etc/kai/env's CODEX_BIN and the sudoers SETENV
-        # rule so they can never drift. _cmd_apply's env-var override
-        # block keeps working for ad-hoc deploys (sudo CODEX_BIN=...
-        # kai install apply) but the wizard path is now the canonical
-        # source of truth.
-        if codex_bin:
-            env["CODEX_BIN"] = codex_bin
+
+    # Persist the wizard-collected codex binary path whenever any
+    # codex surface (agent backend or memory reasoner) is in play.
+    # Gating on `codex_bin` rather than `agent_backend == "codex"`
+    # covers the supported claude+codex / goose+codex memory cases
+    # where the codex binary is required solely because the memory
+    # reasoner is codex; the second collection block at the memory
+    # gate above guarantees `codex_bin` is set on those paths. The
+    # same value drives /etc/kai/env's CODEX_BIN and the sudoers
+    # SETENV rule so the two can never drift. _cmd_apply's env-var
+    # override block keeps working for ad-hoc deploys (sudo
+    # CODEX_BIN=... kai install apply) but the wizard path remains
+    # the canonical source of truth.
+    if codex_bin:
+        env["CODEX_BIN"] = codex_bin
 
     # Remove stale renamed keys if present - leaving both the old and
     # new key causes silent confusion (the deprecation warning is
@@ -3174,12 +3206,16 @@ def _cmd_apply() -> None:
         # codex install can pin an absolute codex path without
         # round-tripping through the wizard. Apply-time env wins over
         # any value already in install.conf so the operator's explicit
-        # `sudo CODEX_BIN=... kai install apply` is honored. Only codex
-        # installs care; on other backends the var is ignored at
-        # runtime so writing it is harmless but noisy - skip the write
-        # to keep /etc/kai/env clean.
+        # `sudo CODEX_BIN=... kai install apply` is honored. The gate
+        # accepts either AGENT_BACKEND=codex (the codex agent path) or
+        # MEMORY_REASONER_BACKEND=codex (the claude+codex / goose+codex
+        # memory path); in both cases codex actually runs and the
+        # sudoers SETENV rule needs the same path the runtime resolver
+        # spawns. Skipping the write on truly codex-free installs
+        # keeps /etc/kai/env clean.
         env_codex_bin = os.environ.get("CODEX_BIN")
-        if env_codex_bin and env.get("AGENT_BACKEND") == "codex":
+        codex_needed = env.get("AGENT_BACKEND") == "codex" or env.get("MEMORY_REASONER_BACKEND") == "codex"
+        if env_codex_bin and codex_needed:
             env["CODEX_BIN"] = env_codex_bin
         # AGENT_TIMEOUT_SECONDS migration. Operators upgrading without
         # re-running the wizard carry the legacy CLAUDE_TIMEOUT_SECONDS

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -410,6 +410,15 @@ def _cmd_config() -> None:
     # CLAUDE_USER prompt later (section 8). Needs to be in scope
     # regardless of which branch we take.
     admin_os_user: str | None = None
+    # Admin identity is captured in scope so the codex-memory branch
+    # below can re-prompt for a valid os_user and rewrite the wizard-
+    # owned users.yaml without re-collecting the static fields. Both
+    # stay empty on the existing-users.yaml branch; the codex-memory
+    # validation block is gated on `not users_yaml_exists` so it only
+    # consults these when the wizard actually owns the file.
+    admin_telegram_id: str = ""
+    admin_name: str = ""
+    admin_home_workspace: str | None = None
 
     if users_yaml_exists:
         # Summarize the existing config without modifying it.
@@ -455,14 +464,17 @@ def _cmd_config() -> None:
 
         # Advanced options: os_user and home_workspace.
         advanced = _prompt_bool("Configure advanced user options", False)
-        admin_home_workspace: str | None = None
 
         if advanced:
             # Default os_user to CLAUDE_USER if previously set, else $USER.
-            # Note: on machines where the service user and the current user
-            # are the same (e.g., "kai" on the Mac mini), accepting the
-            # default means os_user matches the bot process user. This is
-            # fine - PR #192 handles the self-sudo skip for this case.
+            # Note: on the claude backend, an os_user that matches the bot
+            # process user is fine; the runtime detects self-sudo via
+            # `resolve_claude_user` and spawns claude in-process (the
+            # Max-plan OAuth path under the bot user's home). The codex
+            # memory branch enforces a separate non-bot-user precondition
+            # further down in the wizard (after the operator picks codex
+            # extraction) so the security boundary that block exists for
+            # is not silently bypassed by accepting the default here.
             default_os_user = existing_env.get("CLAUDE_USER", "") or os.environ.get("USER", "")
             while True:
                 admin_os_user = _prompt("OS user for subprocess isolation", default_os_user).strip() or None
@@ -1021,6 +1033,62 @@ def _cmd_config() -> None:
                         memory_reasoner_backend = candidate
                         break
                     print("  Must be 'claude' or 'codex'.")
+                # Codex extraction requires every extraction-eligible
+                # users.yaml entry to set a non-bot-user `os_user`.
+                # CodexOneShotReasoner.run() refuses the None and the
+                # same-user cases at runtime; load_config() refuses the
+                # same shapes at startup. Without this wizard-time
+                # check, a fresh install that accepted the default
+                # "Configure advanced user options = false" earlier in
+                # the prompt sequence produces a users.yaml with no
+                # `os_user`, and load_config() then SystemExits on the
+                # next daemon start. Re-prompt and rewrite the wizard-
+                # owned users.yaml in-place so the generated config
+                # passes load_config. The check fires only when the
+                # wizard owns the file (`not users_yaml_exists`); when
+                # the operator owns users.yaml, the load_config
+                # SystemExit at next start surfaces the same shape of
+                # error with the same diagnostic.
+                if memory_reasoner_backend == "codex" and not users_yaml_exists:
+                    needs_reprompt = (
+                        not admin_os_user
+                        or admin_os_user == service_user
+                        or not _validate_os_user(admin_os_user)
+                    )
+                    if needs_reprompt:
+                        print()
+                        print("  Codex memory extraction requires the admin user to spawn")
+                        print(f"  under a non-service OS account (service runs as '{service_user}';")
+                        print("  codex must run as a different account so the subprocess")
+                        print("  cannot read bot-user-only files such as /etc/kai/env).")
+                        while True:
+                            admin_os_user = _prompt(
+                                "OS account for codex memory extraction",
+                                "",
+                                required=True,
+                            ).strip()
+                            if not _validate_os_user(admin_os_user):
+                                print(
+                                    "  Username may only contain letters, numbers, "
+                                    "dots, hyphens, and underscores."
+                                )
+                                continue
+                            if admin_os_user == service_user:
+                                print(
+                                    f"  Must not match the service user '{service_user}' "
+                                    "(codex would run as the bot user)."
+                                )
+                                continue
+                            break
+                        users_yaml_content = _generate_users_yaml(
+                            admin_telegram_id,
+                            admin_name,
+                            os_user=admin_os_user,
+                            home_workspace=admin_home_workspace,
+                        )
+                        users_yaml_path.write_text(users_yaml_content)
+                        os.chmod(users_yaml_path, 0o600)
+                        print(f"  Updated {users_yaml_path} with os_user={admin_os_user}")
                 # No MEMORY_EXTRACTION_BUDGET_USD prompt on this branch:
                 # --max-budget-usd is omitted from the stage-1 claude
                 # --print argv (memory_extraction.py:_run_extractor),

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1869,6 +1869,52 @@ def _collect_os_users_from_yaml(users_yaml_path: str | Path) -> list[str]:
     return result
 
 
+def _build_codex_login_reminder(
+    env: dict[str, str],
+    service_user: str,
+    users_yaml_path: str | Path = "/etc/kai/users.yaml",
+) -> str | None:
+    """Compose the post-install codex subscription-auth reminder.
+
+    Codex CLI auth state lives under the spawning user's home directory
+    (~<os_user>/.codex/auth.json). CodexOneShotReasoner spawns codex
+    per-user via `sudo -u <os_user>`, so subscription auth must be
+    completed AS each target user before the first call; a service-
+    user-only login lands the token in the wrong home and every
+    cross-user spawn fails. Returns the reminder text (without a
+    leading blank line) when codex actually runs on this install AND
+    uses subscription auth, else None. The "codex runs anywhere"
+    predicate matches AGENT_BACKEND=codex OR MEMORY_REASONER_BACKEND=
+    codex so claude+codex (or goose+codex) memory installs still get
+    the reminder. Factored out of _cmd_apply so the gate and the
+    per-user enumeration are independently testable.
+    """
+    codex_needed = env.get("AGENT_BACKEND") == "codex" or env.get("MEMORY_REASONER_BACKEND") == "codex"
+    if not codex_needed:
+        return None
+    if env.get("CODEX_AUTH_MODE", "subscription") != "subscription":
+        return None
+    # _collect_os_users_from_yaml raises ValueError on a crafted/
+    # malformed entry (sudoers-injection guard); the apply path
+    # already wrote sudoers from the same file, so a raise here would
+    # be too late. Treat both raise paths as "fall back to service
+    # user" so the operator still sees an actionable hint.
+    try:
+        login_users = sorted(set(_collect_os_users_from_yaml(users_yaml_path)))
+    except (OSError, ValueError):
+        login_users = []
+    if not login_users:
+        login_users = [service_user]
+    user_lines = "\n".join(f"    {u} ~$ codex login" for u in login_users)
+    return (
+        "Codex subscription auth required:\n"
+        "  Log in once for each os_user that should answer Telegram messages:\n"
+        f"{user_lines}\n"
+        "  Run as the os_user themselves, not via sudo from another account.\n"
+        "  These must complete before the service answers its first message."
+    )
+
+
 def _collect_user_memory_owners(users_yaml_path: str | Path) -> list[tuple[int, str | None]]:
     """
     Read users.yaml and return (telegram_id, os_user) tuples.
@@ -3283,26 +3329,14 @@ def _cmd_apply() -> None:
                 "\nTo reconfigure later, re-run: python -m kai install config"
             )
 
-        # Codex subscription auth requires `codex login` run AS each
-        # os_user that should answer messages. The per-user wrap reads
-        # ~<os_user>/.codex/auth.json, NOT the service user's home, so
-        # a `sudo -u kai codex login` (the old hint) lands the token
-        # in the wrong place. Enumerate the distinct os_user set from
-        # /etc/kai/users.yaml; fall back to the service user only
-        # when no os_users are configured.
-        if env.get("AGENT_BACKEND") == "codex" and env.get("CODEX_AUTH_MODE", "subscription") == "subscription":
-            try:
-                login_users = sorted(set(_collect_os_users_from_yaml("/etc/kai/users.yaml")))
-            except (OSError, ValueError):
-                login_users = []
-            if not login_users:
-                login_users = [service_user]
-            print("\nCodex subscription auth required:")
-            print("  Log in once for each os_user that should answer Telegram messages:")
-            for user in login_users:
-                print(f"    {user} ~$ codex login")
-            print("  Run as the os_user themselves, not via sudo from another account.")
-            print("  These must complete before the service answers its first message.")
+        # Codex subscription auth reminder. Factored out so the gate
+        # ("codex runs anywhere": agent backend OR memory reasoner is
+        # codex) and the per-user enumeration can be unit-tested
+        # without mocking the entire apply pipeline. Returns None when
+        # no reminder applies.
+        reminder = _build_codex_login_reminder(env, service_user)
+        if reminder:
+            print("\n" + reminder)
 
 
 def _apply_directories(

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1051,9 +1051,7 @@ def _cmd_config() -> None:
                 # error with the same diagnostic.
                 if memory_reasoner_backend == "codex" and not users_yaml_exists:
                     needs_reprompt = (
-                        not admin_os_user
-                        or admin_os_user == service_user
-                        or not _validate_os_user(admin_os_user)
+                        not admin_os_user or admin_os_user == service_user or not _validate_os_user(admin_os_user)
                     )
                     if needs_reprompt:
                         print()
@@ -1068,10 +1066,7 @@ def _cmd_config() -> None:
                                 required=True,
                             ).strip()
                             if not _validate_os_user(admin_os_user):
-                                print(
-                                    "  Username may only contain letters, numbers, "
-                                    "dots, hyphens, and underscores."
-                                )
+                                print("  Username may only contain letters, numbers, dots, hyphens, and underscores.")
                                 continue
                             if admin_os_user == service_user:
                                 print(

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -937,35 +937,12 @@ def _cmd_config() -> None:
         "Enable semantic memory (Mem0 + Qdrant)",
         existing_env.get("MEMORY_ENABLED", "false").lower() in ("1", "true", "yes"),
     )
-    # Codex backend cannot use semantic memory in v1 - the Haiku
-    # extraction pipeline shells out to `claude --print` and lives in
-    # the claude vertical. bot.py's effective_backend == "claude" gate
-    # already prevents extraction from running on a codex install, but
-    # the wizard zeroes both flags here as defense in depth: a
-    # MEMORY_ENABLED=true env var on a codex install would still
-    # inject the [Memory subsystem: enabled] marker into the inner
-    # codex agent's session context (build_session_context reads
-    # memory_enabled, not effective_backend) and trigger inner-agent
-    # behavior that has nowhere to land. Force both flags off so the
-    # codex agent never advertises a memory subsystem that cannot
-    # service its requests.
-    memory_extraction_enabled_pre_guard = existing_env.get("MEMORY_EXTRACTION_ENABLED", "false").lower() in (
-        "1",
-        "true",
-        "yes",
-    )
-    if agent_backend == "codex" and (memory_enabled or memory_extraction_enabled_pre_guard):
-        print("  Semantic memory currently requires the claude backend.")
-        print("  Disabling semantic memory for this codex install.")
-        memory_enabled = False
-        # Zero memory_extraction_enabled explicitly here too. The
-        # unconditional `memory_extraction_enabled = False` a few lines
-        # down also covers this case, but a future refactor that moves
-        # or reorders the extraction prompt could silently reintroduce
-        # the exact bug the spec hardened against over multiple review
-        # rounds. The explicit assignment makes the guard refactor-safe
-        # and matches the comment's "force both flags off" claim.
-        memory_extraction_enabled = False
+    # Codex memory is supported. Both claude and codex agent backends
+    # can run semantic memory with a backend-matched reasoner; the
+    # reasoner_backend prompt below resolves which subprocess runs
+    # the extraction. The historical "codex disables memory" guard
+    # was removed once OneShotReasoner abstracted away the claude-
+    # only assumption in memory_extraction.
     # Defaults match the dataclass values in config.py. Only non-defaults
     # (or memory_enabled=true itself) are written to the env dict below.
     memory_extraction_enabled = False
@@ -1002,17 +979,48 @@ def _cmd_config() -> None:
     # default at runtime via load_config, so the env entry stays
     # suppressed by the delta-from-default check below.
     memory_duplicate_threshold = "0.9"
+    # Default to claude when the agent backend has no memory reasoner
+    # (goose retrieval-only) so the prompt-and-persist path never lands
+    # an invalid MEMORY_REASONER_BACKEND value. The prompt itself is
+    # gated on extraction being enabled below; for retrieval-only
+    # installs the variable is neither prompted nor persisted, so
+    # load_config falls back to the dataclass default at runtime.
+    memory_reasoner_backend = "claude"
     if memory_enabled:
-        # Haiku extraction only fires when the active backend is Claude
-        # (bot.py:3609 silently skips it otherwise - no startup error,
-        # no log line). Skip the prompt for non-claude backends rather
-        # than offer an option whose effect is invisible at runtime.
-        if agent_backend == "claude":
+        # Memory extraction is supported on agent backends that have a
+        # OneShotReasoner implementation. Today that is claude and
+        # codex; goose retrieval-only installs accept memory_enabled
+        # but skip the extraction prompt because no reasoner exists
+        # for goose. Add to the tuple when a new reasoner ships.
+        if agent_backend in ("claude", "codex"):
             memory_extraction_enabled = _prompt_bool(
-                "Enable Haiku extraction (proactive memory writes)",
+                "Enable memory extraction (proactive memory writes)",
                 existing_env.get("MEMORY_EXTRACTION_ENABLED", "false").lower() in ("1", "true", "yes"),
             )
             if memory_extraction_enabled:
+                # MEMORY_REASONER_BACKEND selects which one-shot
+                # reasoner runs the extraction subprocess. Default
+                # mirrors the install's agent_backend (same vendor
+                # for both surfaces) when the agent has a reasoner;
+                # falls back to "claude" otherwise so the persisted
+                # value is always one config validation accepts.
+                # The prompt sits inside the extraction-enabled
+                # branch because the variable has no runtime effect
+                # when extraction is disabled.
+                reasoner_default = agent_backend if agent_backend in ("claude", "codex") else "claude"
+                while True:
+                    candidate = (
+                        _prompt(
+                            "Memory reasoner backend (claude or codex)",
+                            existing_env.get("MEMORY_REASONER_BACKEND", reasoner_default),
+                        )
+                        .strip()
+                        .lower()
+                    )
+                    if candidate in ("claude", "codex"):
+                        memory_reasoner_backend = candidate
+                        break
+                    print("  Must be 'claude' or 'codex'.")
                 # No MEMORY_EXTRACTION_BUDGET_USD prompt on this branch:
                 # --max-budget-usd is omitted from the stage-1 claude
                 # --print argv (memory_extraction.py:_run_extractor),
@@ -1101,10 +1109,42 @@ def _cmd_config() -> None:
                 # the inheritance fallback continues to work for tests
                 # and for operators who explicitly want to track
                 # whatever extraction model is set.
-                memory_episode_model = _prompt(
-                    "Episode generator model (Sonnet recommended for narrative quality)",
-                    existing_env.get("MEMORY_EPISODE_MODEL", "claude-sonnet-4-6"),
-                )
+                # Episode model default is reasoner-aware. On the codex
+                # reasoner load_config validates this value against
+                # CODEX_MODELS and exits on a non-codex SKU; a
+                # claude-sonnet default would fail config-load. Default
+                # to "" on codex so the inheritance fallback in
+                # load_config picks up the (already validated) codex
+                # extraction model. On claude the historical
+                # claude-sonnet-4-6 recommendation stands.
+                if memory_reasoner_backend == "codex":
+                    episode_default = ""
+                    episode_prompt = "Episode generator model (blank inherits extraction model)"
+                else:
+                    episode_default = "claude-sonnet-4-6"
+                    episode_prompt = "Episode generator model (Sonnet recommended for narrative quality)"
+                while True:
+                    candidate = _prompt(
+                        episode_prompt,
+                        existing_env.get("MEMORY_EPISODE_MODEL", episode_default),
+                    ).strip()
+                    # Validate non-empty entries against CODEX_MODELS on
+                    # the codex branch, matching load_config's fail-fast
+                    # rule. Blank stays blank (inheritance). Claude
+                    # branch accepts any non-empty string (free-form,
+                    # matches the prior behavior).
+                    if memory_reasoner_backend == "codex" and candidate:
+                        from kai.config import CODEX_MODELS
+
+                        if candidate not in CODEX_MODELS:
+                            valid = sorted(CODEX_MODELS.keys())
+                            print(
+                                f"  '{candidate}' is not a valid codex model. "
+                                f"Must be one of: {', '.join(valid)} or blank."
+                            )
+                            continue
+                    memory_episode_model = candidate
+                    break
                 # No MEMORY_EPISODE_BUDGET_USD prompt on this branch:
                 # --max-budget-usd is omitted from the stage-2 claude
                 # --print argv (memory_extraction.py:_run_episode_extractor)
@@ -1332,6 +1372,15 @@ def _cmd_config() -> None:
         env["MEMORY_ENABLED"] = "true"
         if memory_extraction_enabled:
             env["MEMORY_EXTRACTION_ENABLED"] = "true"
+            # Persist MEMORY_REASONER_BACKEND only when non-default.
+            # The dataclass and load_config default is "claude"; an
+            # explicit "claude" selection is suppressed here so the
+            # generated env stays minimal. The prompt itself only
+            # fires when extraction is enabled (above), so a
+            # retrieval-only install never reaches this site and the
+            # key is never written for it.
+            if memory_reasoner_backend != "claude":
+                env["MEMORY_REASONER_BACKEND"] = memory_reasoner_backend
             # Double-gate (agent_backend AND non-default value) is
             # intentionally redundant: the wizard now skips the
             # extraction-budget prompt on claude, so the value is
@@ -1394,25 +1443,26 @@ def _cmd_config() -> None:
         if int(memory_search_limit) != 10:
             env["MEMORY_SEARCH_LIMIT"] = memory_search_limit
 
-    # Drop stale extraction keys when the backend isn't Claude. Mirrors
-    # the CLAUDE_MODEL/CLAUDE_MAX_BUDGET_USD cleanup above: bot.py:3609
-    # silently ignores these on non-claude backends, so leaving them in
-    # /etc/kai/env is misleading without effect. A user who flips backend
-    # from claude to goose should not see lingering extraction config.
-    if agent_backend != "claude":
+    # Drop stale extraction keys when the agent backend has no memory
+    # reasoner. Today that is goose; claude and codex both support
+    # extraction. A user who flips backend from claude/codex to goose
+    # should not see lingering extraction config that would be
+    # silently ignored at runtime.
+    if agent_backend not in ("claude", "codex"):
         env.pop("MEMORY_EXTRACTION_ENABLED", None)
+        env.pop("MEMORY_REASONER_BACKEND", None)
         env.pop("MEMORY_EXTRACTION_BUDGET_USD", None)
         env.pop("MEMORY_EXTRACTION_TIMEOUT_S", None)
         env.pop("MEMORY_CONSOLIDATION_CANDIDATES_N", None)
         # Episode-classifier window key (issue #392). Same lifecycle
         # as the other stage-1 extraction tunables: only consulted on
-        # the claude backend, so leaving a stale value here after a
-        # claude→goose flip would be misleading without effect.
+        # backends with a reasoner, so leaving a stale value here
+        # after a supported→goose flip would be misleading.
         env.pop("EPISODE_CLASSIFIER_CONTEXT_TURNS", None)
         # Episode keys follow the same lifecycle: stage 2 only fires
-        # when stage 1 fires, and stage 1 silently skips on non-claude
-        # backends. Leaving these in the env file would mislead an
-        # operator who flips backend from claude to goose.
+        # when stage 1 fires, and stage 1 silently skips on backends
+        # without a reasoner. Leaving these in the env file would
+        # mislead an operator who flips backend.
         env.pop("MEMORY_EPISODE_MODEL", None)
         env.pop("MEMORY_EPISODE_BUDGET_USD", None)
         env.pop("MEMORY_EPISODE_TIMEOUT_S", None)

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -613,8 +613,70 @@ def init_memory(config: Config) -> None:
     """
     global _memory, _config
 
+    # Structured startup log describing the configured memory state.
+    # Emitted exactly once per init regardless of whether memory is
+    # enabled, so an operator scanning the log after a restart can
+    # confirm the configured state without firing an extraction.
+    # The `extraction_binary` field is populated ONLY when
+    # `memory_extraction_enabled` is true (config-load validation
+    # already proved the binary was reachable at startup); for
+    # retrieval-only installs (MEMORY_ENABLED=true with extraction
+    # disabled) the field is null and the resolver is NOT called,
+    # so a retrieval-only install with no claude/codex binary on
+    # PATH still initializes successfully here.
+    #
+    # The resolver call IS wrapped in try/except as defense against
+    # between-load-and-init drift (PATH change, binary unlinked,
+    # etc.). A miss logs a WARNING and emits `extraction_binary: null`
+    # so memory init still completes; the next actual extraction
+    # would surface the real failure with a typed error.
+    extraction_binary: str | None = None
+    if config.memory_enabled and config.memory_extraction_enabled:
+        from kai.oneshot_binary import BinaryResolutionError, resolve_oneshot_binary
+
+        try:
+            extraction_binary = resolve_oneshot_binary(config.memory_reasoner_backend)
+        except BinaryResolutionError as e:
+            # Defensive: config-load validation already passed, so
+            # this should not happen on a healthy install. If it
+            # does, log loudly and continue with null so init does
+            # not fail on an observability field.
+            log.warning(
+                "memory.config: %s reasoner binary resolution failed at init time (%s); "
+                "extraction_binary will log as null",
+                config.memory_reasoner_backend,
+                e,
+            )
+
     if not config.memory_enabled:
+        log.info(
+            "memory.config %s",
+            json.dumps(
+                {
+                    "enabled": False,
+                    "extraction_enabled": False,
+                    "reasoner_backend": None,
+                    "extraction_model": None,
+                    "episode_model": None,
+                    "extraction_binary": None,
+                }
+            ),
+        )
         return
+
+    log.info(
+        "memory.config %s",
+        json.dumps(
+            {
+                "enabled": True,
+                "extraction_enabled": config.memory_extraction_enabled,
+                "reasoner_backend": config.memory_reasoner_backend,
+                "extraction_model": config.memory_extraction_model or None,
+                "episode_model": config.memory_episode_model or None,
+                "extraction_binary": extraction_binary,
+            }
+        ),
+    )
 
     _config = config
 

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1789,9 +1789,10 @@ async def _run_extractor(
       `asyncio.wait_for` below), which is sufficient: a stuck or
       recursive extractor cannot hold the executor longer than the
       timeout, regardless of how many tokens it has notionally generated.
-      The `memory_extraction_budget_usd` Config field stays defined so
-      non-claude backends - which run on pay-per-token billing and need
-      a real ceiling - can read it through their own dispatch.
+      The `memory_extraction_budget_usd` Config field stays defined as
+      inert compatibility config: both supported reasoners (claude and
+      codex) are subscription-backed in the operator deployment model
+      and no code path forwards the value to subprocess argv.
     - --permission-mode bypassPermissions is acceptable because
       --tools "" leaves nothing to permit or deny.
 

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -935,10 +935,17 @@ class CodexOneShotReasoner:
                 policy says any agent subprocess that inherits the
                 bot's sudoers permissions can be coerced into reading
                 kai-only protected files. `run()` raises
-                `OneShotRoutingError` when `os_user is None`. A
-                supplied `os_user` matching the current process is
-                the legitimate self-sudo-skip case (single-user
-                install), detected by `resolve_claude_user`.
+                `OneShotRoutingError` when `os_user is None`, AND
+                when a supplied `os_user` resolves to the current
+                process user via `resolve_claude_user` (the same-
+                user case). Unlike claude, the self-sudo-skip is
+                NOT a legitimate path here: claude can safely run
+                in-process because Max-plan OAuth state lives under
+                the bot user's home, but codex would gain unintended
+                access to bot-user-only protected files (/etc/kai/
+                env, etc.). load_config() mirrors the refusal at
+                startup so a misconfigured users.yaml fails fast
+                rather than silently no-opping every extraction.
         """
         self._cwd = cwd if cwd is not None else _EXTRACTOR_CWD
         self._os_user = os_user

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -40,6 +40,7 @@ from typing import Any, Protocol
 
 from kai.codex_exec import extract_codex_text
 from kai.config import DATA_DIR, resolve_claude_user
+from kai.oneshot_binary import BinaryResolutionError, resolve_oneshot_binary
 from kai.prompt_utils import make_boundary
 
 log = logging.getLogger(__name__)
@@ -477,7 +478,20 @@ class ClaudeOneShotReasoner:
         self._cwd.mkdir(parents=True, exist_ok=True)
         self._cwd.chmod(0o755)
 
-        cmd: list[str] = ["claude", "--print"]
+        # Resolve the claude binary through the shared resolver so
+        # config validation, this argv, and the smoke output all see
+        # the same resolution result. BinaryResolutionError from the
+        # resolver becomes OneShotRoutingError here so the existing
+        # memory_extraction `except OneShotError` catch surface still
+        # collapses the failure to the zero-state extraction result;
+        # the rewrap preserves the leaf-resolver / reasoner-error
+        # split documented on oneshot_binary.
+        try:
+            resolved_binary = resolve_oneshot_binary("claude")
+        except BinaryResolutionError as e:
+            raise OneShotRoutingError(str(e)) from e
+
+        cmd: list[str] = [resolved_binary, "--print"]
         if model is not None:
             cmd.extend(["--model", model])
         cmd.extend(["--output-format", "json"])
@@ -600,6 +614,14 @@ class ClaudeOneShotReasoner:
                 "returncode": returncode,
                 "stderr": stderr,
                 "cwd": str(self._cwd),
+                # cmd is the post-wrap argv (includes sudo prefix on
+                # cross-user routing); resolved_binary is the pre-wrap
+                # agent path. Smoke prints resolved_binary directly so
+                # the operator-visible "which binary ran" answer does
+                # not regress under the sudo wrap, where cmd[0] is
+                # "sudo" rather than the agent.
+                "cmd": list(cmd),
+                "resolved_binary": resolved_binary,
             },
             duration_ms=duration_ms,
         )
@@ -952,9 +974,21 @@ class CodexOneShotReasoner:
         self._cwd.mkdir(parents=True, exist_ok=True)
         self._cwd.chmod(0o755)
 
-        codex_bin = os.environ.get("CODEX_BIN") or "codex"
+        # Resolve the codex binary through the shared resolver so
+        # config validation, this argv, and the smoke output all see
+        # the same resolution result. Tighter than the previous inline
+        # `os.environ.get("CODEX_BIN") or "codex"` because the resolver
+        # validates an explicit CODEX_BIN override as is-file plus
+        # executable (no PATH fallback for a bad override), matching
+        # config-load validation. BinaryResolutionError becomes
+        # OneShotRoutingError here so the existing memory_extraction
+        # `except OneShotError` catch surface is unchanged.
+        try:
+            resolved_binary = resolve_oneshot_binary("codex")
+        except BinaryResolutionError as e:
+            raise OneShotRoutingError(str(e)) from e
         cmd: list[str] = [
-            codex_bin,
+            resolved_binary,
             "exec",
             "--json",
             "--skip-git-repo-check",
@@ -1115,6 +1149,15 @@ class CodexOneShotReasoner:
                         "returncode": returncode,
                         "stderr": stderr,
                         "cwd": str(self._cwd),
+                        # cmd is post-wrap (includes sudo prefix on
+                        # cross-user routing); resolved_binary is the
+                        # pre-wrap agent path. Smoke prints
+                        # resolved_binary so the operator-visible
+                        # "which binary ran" answer survives the sudo
+                        # wrap, where cmd[0] is "sudo" rather than
+                        # the agent.
+                        "cmd": list(cmd),
+                        "resolved_binary": resolved_binary,
                     },
                     duration_ms=duration_ms,
                 )
@@ -1216,6 +1259,13 @@ class CodexOneShotReasoner:
                     "returncode": returncode,
                     "stderr": stderr,
                     "cwd": str(self._cwd),
+                    # cmd / resolved_binary as documented on the
+                    # free-form return above; same fields populate
+                    # on every codex success branch so the smoke
+                    # output reads the same shape regardless of
+                    # whether json_schema was set.
+                    "cmd": list(cmd),
+                    "resolved_binary": resolved_binary,
                 },
                 duration_ms=duration_ms,
             )

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -1000,6 +1000,32 @@ class CodexOneShotReasoner:
         if model is not None:
             cmd.extend(["--model", model])
 
+        # Per-user OS routing. The construction-level None case was
+        # refused at the top of run(). resolve_claude_user returns
+        # None when the target user matches the current process user
+        # (the historical self-sudo-skip path). For claude, the
+        # self-sudo-skip is legitimate (Max-plan OAuth state lives
+        # under the bot user's home). For codex, it is a security
+        # boundary violation: codex MUST NOT run as the bot user, or
+        # it gains access to /etc/kai/env and other bot-user-only
+        # state. Refuse the same-user case here with the same typed
+        # error as the construction-level None case so the caller's
+        # collapse-to-zero-state path applies uniformly. The refusal
+        # fires BEFORE the schema temp file is written so there is
+        # nothing to clean up on this branch.
+        effective_user = resolve_claude_user(self._os_user)
+        if effective_user is None:
+            log.info(
+                "oneshot_reasoner purpose=%s backend=codex model=%s duration_ms=0 outcome=routing_error error_category=same_user_refused os_user=self",
+                purpose,
+                model,
+            )
+            raise OneShotRoutingError(
+                "codex memory routing refuses same-user spawn; "
+                f"os_user={self._os_user!r} resolves to the bot user. "
+                "Set users.yaml os_user to a different OS account."
+            )
+
         # Schema temp file lifecycle. Written before subprocess spawn
         # so the CLI sees a populated file; removed in `finally` so
         # success, timeout, non-zero exit, and output-parse failures
@@ -1042,15 +1068,10 @@ class CodexOneShotReasoner:
             schema_path.chmod(0o644)
             cmd.extend(["--output-schema", str(schema_path)])
 
-        # Per-user OS routing. The construction-level None case is
-        # already refused above; this branch covers the self-sudo-
-        # skip (target == bot user, where resolve_claude_user returns
-        # None) and the cross-user case (target != bot user, where it
-        # returns the target). Self-sudo-skip spawns directly with no
-        # wrap; cross-user wraps in sudo with the auth preserve list.
-        effective_user = resolve_claude_user(self._os_user)
-        if effective_user is not None:
-            cmd = _wrap_cmd_for_user(cmd, effective_user, "codex")
+        # Wrap codex in `sudo -H -u <target>` with the auth preserve
+        # list. Same-user routing is already refused above; this
+        # branch always wraps.
+        cmd = _wrap_cmd_for_user(cmd, effective_user, "codex")
 
         # Allow-listed env: only forward keys present in the parent
         # env. Defense-in-depth against a future regression that

--- a/src/kai/oneshot_binary.py
+++ b/src/kai/oneshot_binary.py
@@ -1,0 +1,120 @@
+"""
+Shared agent-binary resolver for the one-shot reasoner family.
+
+Single source of truth for "where is the claude/codex binary."
+`kai.config.load_config()` uses this to fail-fast at startup when the
+memory reasoner backend points at an unreachable binary;
+`kai.oneshot.{Claude,Codex}OneShotReasoner` uses it to build argv with
+the resolved absolute path; `kai.smoke.memory` reads the resolved
+binary from `OneShotResult.raw_metadata["resolved_binary"]` to show
+the operator which binary actually ran.
+
+Module is a leaf by design: imports `os`, `shutil`, `pathlib` only.
+Neither `kai.config` nor `kai.oneshot` is imported here. The
+constraint exists because `kai.oneshot` already imports from
+`kai.config`, so putting the resolver in `kai.oneshot` while having
+`kai.config.load_config()` call into it would create a circular
+import. Keeping the resolver leaf-only sidesteps that entirely and
+keeps the dependency direction one-way.
+
+`BinaryResolutionError` is deliberately distinct from
+`kai.oneshot.OneShotRoutingError`. Routing failures (e.g., codex
+refusing to run as the bot user) and binary-resolution failures
+(e.g., codex binary not on PATH) are adjacent but not identical
+conditions with different remediation paths. The reasoner argv
+builders catch `BinaryResolutionError` and convert to
+`OneShotRoutingError` so the existing `memory_extraction.py`
+`except OneShotError` catch surface is unchanged; the new error
+type is what `kai.config` and `kai.smoke.memory` see.
+"""
+
+import os
+import shutil
+from pathlib import Path
+
+
+class BinaryResolutionError(Exception):
+    """
+    Raised when `resolve_oneshot_binary` cannot resolve the named
+    backend's binary. The exception message carries the resolution
+    sequence that was tried (e.g., "CODEX_BIN unset, `codex` not on
+    PATH") so the operator has a concrete remediation pointer
+    without re-deriving the lookup order.
+
+    Distinct from `kai.oneshot.OneShotRoutingError` so the
+    config-validation and smoke call sites can catch this leaf
+    module's exception without depending on `kai.oneshot`. The
+    reasoner argv builders catch and rewrap into
+    `OneShotRoutingError` to preserve the existing reasoner-error
+    hierarchy `memory_extraction` already handles.
+    """
+
+
+def resolve_oneshot_binary(backend: str) -> str:
+    """
+    Return the absolute path of the agent binary the OneShotReasoner
+    of `backend` will invoke.
+
+    `backend == "claude"`: `shutil.which("claude")`. Resolution
+    sequence: claude on PATH only. Failure message names that
+    sequence.
+
+    `backend == "codex"`: branch on `CODEX_BIN`.
+      - Explicit override: when `CODEX_BIN` is set, resolve to that
+        exact path. Validate `Path(p).is_file()` AND
+        `os.access(p, os.X_OK)`. On either check failing, raise
+        `BinaryResolutionError` naming the override path and the
+        specific failure (not-a-file vs not-executable). NO fallback
+        to PATH; a bad explicit override is a configuration error
+        worth surfacing, not silently recovering from.
+      - No override: `shutil.which("codex")`. On no resolution,
+        raise `BinaryResolutionError` naming both candidates
+        (CODEX_BIN unset, codex not on PATH).
+
+    Raises `BinaryResolutionError` with a single-line message
+    describing the resolution sequence that was tried and the
+    specific failure mode that fired. Callers should surface the
+    message verbatim where appropriate; it is designed to be
+    operator-readable.
+
+    Raises `ValueError` on an unknown backend string. That is
+    distinct from a resolution miss: unknown backend means the
+    caller's config validation upstream of this function has a
+    bug, not the operator's PATH.
+    """
+    if backend == "claude":
+        # Resolution: claude on PATH only. No explicit-override
+        # variable for claude (CLAUDE_CONFIG_DIR controls auth state,
+        # not binary discovery). A future CLAUDE_BIN override would
+        # land here as the second branch.
+        resolved = shutil.which("claude")
+        if resolved is None:
+            raise BinaryResolutionError("could not resolve claude binary: `claude` not on PATH")
+        return resolved
+
+    if backend == "codex":
+        override = os.environ.get("CODEX_BIN")
+        if override:
+            # Explicit override: validate as a configuration error,
+            # do not fall back. The two checks fire in order so the
+            # message names the specific failure mode rather than a
+            # composite. Path.is_file resolves symlinks; the
+            # executable check is on the resolved target's stat.
+            override_path = Path(override)
+            if not override_path.is_file():
+                raise BinaryResolutionError(f"could not resolve codex binary: CODEX_BIN={override!r} not-a-file")
+            if not os.access(str(override_path), os.X_OK):
+                raise BinaryResolutionError(f"could not resolve codex binary: CODEX_BIN={override!r} not-executable")
+            return str(override_path)
+        # No override: try PATH. Failure message names both
+        # candidates so the operator does not have to guess which
+        # branch fired.
+        resolved = shutil.which("codex")
+        if resolved is None:
+            raise BinaryResolutionError("could not resolve codex binary: CODEX_BIN unset, `codex` not on PATH")
+        return resolved
+
+    # Unknown backend. Unlike a resolution miss this is a caller bug
+    # (config validation upstream of this function did not catch the
+    # invalid backend string), so the exception type is distinct.
+    raise ValueError(f"unknown backend for binary resolution: {backend!r}")

--- a/src/kai/smoke/__init__.py
+++ b/src/kai/smoke/__init__.py
@@ -1,0 +1,8 @@
+"""Operator-facing smoke commands for verifying a Kai install.
+
+Each smoke command runs a small, idempotent verification of one
+runtime surface; see individual modules for the contract. The
+package layout matches `kai.eval.*`: each smoke is a directly-
+invocable module (`python -m kai.smoke.<name>`), not a subcommand
+dispatched through `kai.smoke.__main__`.
+"""

--- a/src/kai/smoke/memory.py
+++ b/src/kai/smoke/memory.py
@@ -1,0 +1,183 @@
+"""End-to-end smoke for the memory reasoner pipeline.
+
+Runs ONE extraction call against a fixed two-turn conversation and
+prints the resolved backend, model, invoked binary, extracted facts,
+episode-classification result, and total latency. Exit 0 when the
+extraction returns at least one fact whose content references the
+expected anchor; non-zero otherwise.
+
+Does NOT touch the Qdrant store. The reasoner runs against the
+in-memory fact schema and the result is parsed and printed; nothing
+is persisted. Safe to invoke repeatedly without polluting the
+install's memory state.
+
+Invocation: `python -m kai.smoke.memory [--os-user <name>]`.
+
+The `--os-user` flag is required when the configured reasoner is
+codex; the codex reasoner refuses to spawn without an os_user (it
+exists to prevent the bot user from running codex). Pass the per-
+user OS account name from `users.yaml`. The flag is accepted but
+ignored on the claude reasoner branch; the historical Max-plan
+self-sudo-skip path resolves None safely.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+import time
+
+from kai.config import load_config
+from kai.memory_extraction import (
+    _EXTRACTION_SYSTEM_PROMPT,
+    _FACT_SCHEMA,
+    _get_memory_reasoner,
+)
+from kai.oneshot import OneShotError
+
+log = logging.getLogger("kai.smoke.memory")
+
+
+# Fixed two-turn conversation. The user-asserted preference is stable
+# enough that both claude and codex extractors reliably produce a
+# single fact referencing the anchor substring; the assistant turn
+# carries the conventional acknowledgement shape so the prompt's
+# extraction rules fire on familiar ground.
+_SMOKE_USER_TEXT = "Quick note: I take my coffee with oat milk, no sugar."
+_SMOKE_ASSISTANT_TEXT = "Noted, coffee with oat milk and no sugar."
+_SMOKE_ANCHOR_SUBSTRING = "oat milk"
+
+
+def _build_payload() -> str:
+    """Render the smoke conversation as the extractor's expected
+    prompt shape. Same pattern as `_build_extraction_payload`'s output
+    but inline so the smoke does not couple to its internal builders;
+    a future change to the builder should be re-derived rather than
+    silently picked up here."""
+    return f"[CURRENT EXCHANGE]\nUser: {_SMOKE_USER_TEXT}\nAssistant: {_SMOKE_ASSISTANT_TEXT}\n"
+
+
+async def _run(os_user: str | None) -> int:
+    """Execute the smoke and return the desired exit code.
+
+    Returns 0 on success (anchor substring appears in at least one
+    extracted fact), 1 on any failure path (reasoner raises, JSON
+    envelope unparseable, no facts, no anchor hit). Exception
+    messages are logged at WARNING; the operator sees them in the
+    terminal output."""
+    config = load_config()
+    if config.memory_reasoner_backend == "codex" and not os_user:
+        sys.stderr.write(
+            "smoke: --os-user is required when memory_reasoner_backend=codex; "
+            "pass the per-user OS account configured in users.yaml.\n"
+        )
+        return 1
+
+    print(f"backend: {config.memory_reasoner_backend}")
+    print(f"extraction model: {config.memory_extraction_model}")
+    print(f"episode model: {config.memory_episode_model or '(inherits extraction model)'}")
+    print(f"os_user: {os_user or '(none; direct spawn)'}")
+
+    reasoner = _get_memory_reasoner(config, os_user=os_user)
+    timeout = float(config.memory_extraction_timeout_s)
+
+    start = time.monotonic()
+    try:
+        result = await reasoner.run(
+            prompt=_build_payload(),
+            system_prompt=_EXTRACTION_SYSTEM_PROMPT,
+            model=config.memory_extraction_model,
+            timeout=timeout,
+            purpose="smoke_memory",
+            json_schema=_FACT_SCHEMA,
+        )
+    except OneShotError as e:
+        latency_ms = int((time.monotonic() - start) * 1000)
+        log.warning("reasoner failed after %d ms: %s", latency_ms, e)
+        print(f"latency_ms: {latency_ms}")
+        print(f"error: {type(e).__name__}: {e}")
+        return 1
+
+    latency_ms = int((time.monotonic() - start) * 1000)
+
+    # The reasoner records the actually invoked argv plus the
+    # pre-sudo agent binary path in raw_metadata. Print both: cmd
+    # for forensics under cross-user wrapping (where cmd[0] is
+    # "sudo"), resolved_binary for the "which binary actually ran"
+    # answer the operator usually wants.
+    resolved_binary = result.raw_metadata.get("resolved_binary") or "(not recorded)"
+    cmd = result.raw_metadata.get("cmd") or []
+    print(f"resolved_binary: {resolved_binary}")
+    print(f"argv: {' '.join(cmd) if cmd else '(not recorded)'}")
+    print(f"latency_ms: {latency_ms}")
+
+    # Parse the envelope the reasoner returned. Claude returns
+    # `--output-format=json` shape; codex returns the
+    # `{is_error, structured_output}` rewrap.
+    try:
+        envelope = json.loads(result.text)
+    except json.JSONDecodeError as e:
+        log.warning("could not parse reasoner output as JSON: %s", e)
+        print(f"raw_text (first 300 chars): {result.text[:300]!r}")
+        return 1
+
+    structured = envelope.get("structured_output")
+    if not isinstance(structured, dict):
+        log.warning("envelope missing structured_output: keys=%s", sorted(envelope))
+        return 1
+
+    facts = structured.get("facts") or []
+    has_episode = structured.get("has_episode")
+    print(f"has_episode: {has_episode}")
+    print(f"fact_count: {len(facts)}")
+    for i, fact in enumerate(facts):
+        content = fact.get("content", "")
+        tags = fact.get("tags", [])
+        speaker = fact.get("speaker", "")
+        intent = fact.get("intent", "")
+        print(f"  fact[{i}]: speaker={speaker} intent={intent} tags={tags} content={content!r}")
+
+    # Success contract: at least one fact whose content references
+    # the anchor substring. The smoke does NOT enforce a specific
+    # extraction shape beyond that; both backends sometimes
+    # paraphrase the user assertion.
+    anchor_hit = any(_SMOKE_ANCHOR_SUBSTRING.lower() in (f.get("content") or "").lower() for f in facts)
+    if not anchor_hit:
+        log.warning(
+            "no fact referenced the anchor substring %r; extraction succeeded but content did not match.",
+            _SMOKE_ANCHOR_SUBSTRING,
+        )
+        return 1
+    print("verdict: pass")
+    return 0
+
+
+def main() -> int:
+    """Entry point for `python -m kai.smoke.memory`."""
+    parser = argparse.ArgumentParser(
+        prog="python -m kai.smoke.memory",
+        description="Verify the memory reasoner pipeline against a fixed payload.",
+    )
+    parser.add_argument(
+        "--os-user",
+        dest="os_user",
+        default=None,
+        help=(
+            "Per-user OS account for cross-user codex spawning. Required when "
+            "MEMORY_REASONER_BACKEND=codex. Ignored on the claude reasoner branch."
+        ),
+    )
+    args = parser.parse_args()
+
+    # Configure logging at WARNING so the operator sees reasoner-side
+    # failures inline without enabling Mem0 / Qdrant / urllib3 noise.
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
+
+    return asyncio.run(_run(args.os_user))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kai/smoke/memory.py
+++ b/src/kai/smoke/memory.py
@@ -69,6 +69,31 @@ async def _run(os_user: str | None) -> int:
     messages are logged at WARNING; the operator sees them in the
     terminal output."""
     config = load_config()
+
+    # Production-mode precondition. The smoke claims to verify the
+    # memory extraction pipeline end-to-end; running the reasoner
+    # against a fixed payload when production has memory disabled or
+    # extraction disabled produces a false-positive "pass" for a path
+    # that will never fire on real traffic. Refuse to run in those
+    # configurations rather than print a misleading verdict.
+    if not config.memory_enabled:
+        sys.stderr.write(
+            "smoke: MEMORY_ENABLED is false; memory extraction is not configured to run "
+            "in production. The smoke would exercise the reasoner against a fixed payload "
+            "but that result does not reflect production behavior. Enable memory in the "
+            "wizard before running the smoke.\n"
+        )
+        return 1
+    if not config.memory_extraction_enabled:
+        sys.stderr.write(
+            "smoke: MEMORY_EXTRACTION_ENABLED is false (retrieval-only mode); memory "
+            "extraction is not configured to run in production. The smoke verifies the "
+            "extraction pipeline; for retrieval-only installs, exercise retrieval via "
+            "the /memory commands instead. Enable extraction in the wizard to run the "
+            "smoke.\n"
+        )
+        return 1
+
     if config.memory_reasoner_backend == "codex" and not os_user:
         sys.stderr.write(
             "smoke: --os-user is required when memory_reasoner_backend=codex; "

--- a/templates/.env
+++ b/templates/.env
@@ -193,14 +193,11 @@ MEMORY_ENABLED=false
 # supported reasoners.
 #MEMORY_EXTRACTION_ENABLED=false
 #MEMORY_EXTRACTION_MODEL=claude-haiku-4-5-20251001
-# Per-call budget ceiling (USD). Informational only on the claude
-# backend (Max-plan OAuth makes the CLI's computed-cost ceiling a
-# phantom signal; --max-budget-usd is omitted from claude --print
-# argv, and runaway protection comes from MEMORY_EXTRACTION_TIMEOUT_S
-# instead). Enforced on non-claude backends, which run on
-# pay-per-token billing where the ceiling is a real cost gate; raise
-# to 0.05 or higher there because Haiku-rate cache-creation tokens
-# typically dominate per-call cost.
+# Per-call budget ceiling (USD). Retained as inert compatibility
+# config. Both supported memory reasoners (claude and codex) are
+# subscription-backed in the operator deployment model and no
+# code path forwards this value to subprocess argv. Runaway
+# protection comes from MEMORY_EXTRACTION_TIMEOUT_S instead.
 #MEMORY_EXTRACTION_BUDGET_USD=0.01
 # Subprocess timeout (seconds). Haiku typically finishes in 2-4s.
 #MEMORY_EXTRACTION_TIMEOUT_S=10
@@ -229,14 +226,12 @@ MEMORY_ENABLED=false
 # useful for tests or for operators who deliberately want both stages
 # on the same model.
 #MEMORY_EPISODE_MODEL=claude-sonnet-4-6
-# Budget ceiling per episode call (USD). Informational only on the
-# claude backend (Max-plan OAuth makes the CLI's computed-cost
-# ceiling a phantom signal; --max-budget-usd is omitted from claude
-# --print argv, and runaway protection comes from
-# MEMORY_EPISODE_TIMEOUT_S instead). Enforced on non-claude backends
-# where stage 2 reads the FULL uncapped (user, assistant) pair and
-# costs more than stage 1: 0.15 fits Sonnet, drop to 0.05 if you set
-# MEMORY_EPISODE_MODEL to Haiku there.
+# Budget ceiling per episode call (USD). Retained as inert
+# compatibility config. Same rationale as MEMORY_EXTRACTION_BUDGET_USD
+# above: both supported reasoners are subscription-backed in the
+# operator deployment model and no code path forwards this value to
+# subprocess argv. Runaway protection comes from MEMORY_EPISODE_TIMEOUT_S
+# instead.
 #MEMORY_EPISODE_BUDGET_USD=0.15
 # Subprocess timeout (seconds). Default 120 - twice the production
 # stage-1 value. Stage 2 is fire-and-forget off the user turn, so a

--- a/templates/.env
+++ b/templates/.env
@@ -171,10 +171,26 @@ MEMORY_ENABLED=false
 # (effectively disabled); 1.01 unambiguously disables the gate.
 #MEMORY_DUPLICATE_THRESHOLD=0.9
 
-# Track 2 Haiku extraction. Requires MEMORY_ENABLED=true and a Claude
-# backend. Off by default at Phase 2 ship (self-reinforcing loop needs
-# real-world observation time before the default flips). Kill switch
-# is the same flag.
+# Memory reasoner backend. Selects which subprocess runs the
+# extraction and episode-classification calls. Independent of
+# AGENT_BACKEND. Valid values: "claude", "codex".
+#
+# Set to "codex" when running a codex-backed install and you want
+# semantic memory; the install will not invoke the claude binary
+# for memory work in that case. Set to "claude" (default) when
+# running a claude-backed install. Cross-backend combinations are
+# supported but when extraction is enabled, the wizard defaults to
+# the same-vendor case. Retrieval-only memory (MEMORY_ENABLED=true
+# with extraction disabled) does not prompt for or persist this
+# variable.
+#MEMORY_REASONER_BACKEND=claude
+
+# Memory extraction. Requires MEMORY_ENABLED=true. Off by default
+# at Phase 2 ship (self-reinforcing loop needs real-world
+# observation time before the default flips). Kill switch is the
+# same flag. Extraction subprocess routing is controlled by
+# MEMORY_REASONER_BACKEND above; today both claude and codex are
+# supported reasoners.
 #MEMORY_EXTRACTION_ENABLED=false
 #MEMORY_EXTRACTION_MODEL=claude-haiku-4-5-20251001
 # Per-call budget ceiling (USD). Informational only on the claude

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1645,6 +1645,99 @@ class TestMemoryReasonerBinaryValidation:
         assert called == []
 
 
+class TestCodexMemoryRequiresOsUser:
+    """The codex reasoner refuses to spawn without an `os_user` (the
+    security boundary that keeps codex from running as the bot user).
+    Config-load enforces the precondition: a wizard-generated config
+    that enables codex memory without per-user os_user entries fails
+    fast instead of silently no-opping every extraction at runtime."""
+
+    def test_no_users_yaml_raises_systemexit(self, monkeypatch):
+        """ALLOWED_USER_IDS without users.yaml does not expose an
+        os_user surface at all. Codex memory cannot be wired in this
+        configuration; SystemExit at config-load."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        with pytest.raises(SystemExit) as exc:
+            load_config()
+        msg = str(exc.value)
+        assert "users.yaml" in msg
+        assert "os_user" in msg
+        assert "codex" in msg
+
+    def test_users_yaml_with_os_user_passes(self, tmp_path, monkeypatch):
+        """The happy path: users.yaml with a per-user os_user entry
+        for every authorized chat_id. Config-load completes; codex
+        memory is wired."""
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: alice_os\n"
+        )
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        config = load_config()
+        assert config.memory_reasoner_backend == "codex"
+        assert config.user_configs is not None
+        assert config.user_configs[12345].os_user == "alice_os"
+
+    def test_users_yaml_with_missing_os_user_raises_systemexit(self, tmp_path, monkeypatch):
+        """At least one users.yaml entry without os_user must fail
+        config-load. The error names the offending chat_id so the
+        operator can find the entry to fix."""
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            "users:\n"
+            "  - telegram_id: 12345\n"
+            "    name: alice\n"
+            "    role: admin\n"
+            "    os_user: alice_os\n"
+            "  - telegram_id: 67890\n"
+            "    name: bob\n"
+            "    role: user\n"
+        )
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        with pytest.raises(SystemExit) as exc:
+            load_config()
+        msg = str(exc.value)
+        assert "67890" in msg
+        assert "12345" not in msg  # alice has os_user; should not appear
+        assert "os_user" in msg
+
+    def test_claude_memory_does_not_require_os_user(self, monkeypatch):
+        """ClaudeOneShotReasoner accepts os_user=None (Max-plan
+        self-sudo-skip path), so claude memory does NOT require
+        users.yaml. The precondition applies only to codex."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "claude")
+        # No users.yaml; ALLOWED_USER_IDS-only. Claude is fine here.
+        config = load_config()
+        assert config.memory_reasoner_backend == "claude"
+
+    def test_codex_memory_retrieval_only_skips_precondition(self, monkeypatch):
+        """Retrieval-only memory (extraction disabled) does NOT
+        require os_user even on codex; the precondition fires only
+        when extraction is actually enabled."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        # MEMORY_EXTRACTION_ENABLED unset = retrieval-only.
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        # No users.yaml; precondition should not fire.
+        config = load_config()
+        assert config.memory_enabled is True
+        assert config.memory_extraction_enabled is False
+
+
 class TestMemoryReasonerModelResolution:
     """Memory model defaults resolve through the per-backend role
     registry. Claude rows match the existing literal so installs that

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1724,6 +1724,40 @@ class TestCodexMemoryRequiresOsUser:
         config = load_config()
         assert config.memory_reasoner_backend == "claude"
 
+    def test_goose_user_without_os_user_does_not_block_codex_memory(self, tmp_path, monkeypatch):
+        """Mixed-backend deployment: a global codex install where one
+        user has `agent_backend: goose` should not be required to
+        give that goose user an `os_user`. The runtime gate at
+        `bot.py:3739` skips extraction for goose users (effective
+        backend not in claude/codex), so the precondition must
+        mirror the same effective-backend cascade rather than
+        enforce os_user on every entry blindly."""
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            "users:\n"
+            "  - telegram_id: 1\n"
+            "    name: codex_user\n"
+            "    role: admin\n"
+            "    os_user: codex_os\n"
+            "  - telegram_id: 2\n"
+            "    name: goose_user\n"
+            "    role: user\n"
+            "    agent_backend: goose\n"
+            "    llm_provider: openai\n"
+        )
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        # No SystemExit: the goose user is not extraction-eligible.
+        config = load_config()
+        assert config.memory_reasoner_backend == "codex"
+        # Both users load; the precondition skipped chat 2
+        # because its effective backend is goose, not codex.
+        assert 1 in config.user_configs
+        assert 2 in config.user_configs
+
     def test_codex_memory_retrieval_only_skips_precondition(self, monkeypatch):
         """Retrieval-only memory (extraction disabled) does NOT
         require os_user even on codex; the precondition fires only

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1724,6 +1724,31 @@ class TestCodexMemoryRequiresOsUser:
         config = load_config()
         assert config.memory_reasoner_backend == "claude"
 
+    def test_users_yaml_os_user_matches_bot_user_raises_systemexit(self, tmp_path, monkeypatch):
+        """Codex must NOT run as the bot user. The runtime refuses
+        same-user spawn; config-load surfaces the same boundary so
+        a misconfigured users.yaml does not silently no-op every
+        extraction. The check names the bot user and the offending
+        chat_ids so the operator can locate the misconfiguration."""
+        import pwd
+
+        bot_user = pwd.getpwuid(os.getuid()).pw_name
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            f"users:\n  - telegram_id: 12345\n    name: misconfigured\n    role: admin\n    os_user: {bot_user}\n"
+        )
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        with pytest.raises(SystemExit) as exc:
+            load_config()
+        msg = str(exc.value)
+        assert "bot user" in msg
+        assert "12345" in msg
+        assert bot_user in msg
+
     def test_goose_user_without_os_user_does_not_block_codex_memory(self, tmp_path, monkeypatch):
         """Mixed-backend deployment: a global codex install where one
         user has `agent_backend: goose` should not be required to

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,6 +90,23 @@ def _clean_env(monkeypatch):
         monkeypatch.delenv(var, raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _mock_binary_resolver(monkeypatch):
+    """Pin the binary resolver so config-load cross-binary validation
+    passes on any host. Tests in this file exercise the config parser
+    in isolation and do not care whether the local machine actually
+    has claude/codex installed; cross-binary validation tests
+    explicitly override this fixture with their own setUp.
+
+    Without this, tests that set MEMORY_ENABLED=true +
+    MEMORY_EXTRACTION_ENABLED=true would fail on hosts where the
+    configured reasoner's binary is not on PATH."""
+    monkeypatch.setattr(
+        "kai.oneshot_binary.resolve_oneshot_binary",
+        lambda backend: f"/fake/{backend}",
+    )
+
+
 def _set_required(monkeypatch, token="fake-token", user_ids="123"):
     """Set only the truly required env vars (token + user IDs).
 
@@ -1536,6 +1553,96 @@ class TestMemoryReasonerBackend:
         monkeypatch.setenv("MEMORY_REASONER_BACKEND", "CODEX")
         config = load_config()
         assert config.memory_reasoner_backend == "codex"
+
+
+class TestMemoryReasonerBinaryValidation:
+    """Cross-binary validation: when memory extraction is enabled, the
+    configured reasoner backend's binary must be reachable at startup.
+    The check fires only on the composed `memory_extraction_enabled`
+    value (both MEMORY_ENABLED and MEMORY_EXTRACTION_ENABLED true);
+    retrieval-only memory does NOT require a reachable agent binary."""
+
+    def test_claude_binary_missing_raises_systemexit(self, monkeypatch):
+        """MEMORY_REASONER_BACKEND=claude with extraction enabled and
+        no claude on PATH must fail at config-load with a clear
+        message. The composed `memory_extraction_enabled` is what
+        triggers the check; both env vars must be true."""
+        from kai.oneshot_binary import BinaryResolutionError
+
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
+
+        def boom(_backend: str) -> str:
+            raise BinaryResolutionError("could not resolve claude binary: `claude` not on PATH")
+
+        monkeypatch.setattr("kai.oneshot_binary.resolve_oneshot_binary", boom)
+        with pytest.raises(SystemExit) as exc:
+            load_config()
+        assert "MEMORY_REASONER_BACKEND='claude'" in str(exc.value)
+        assert "claude binary" in str(exc.value)
+
+    def test_codex_binary_missing_raises_systemexit(self, monkeypatch):
+        """Same shape for codex; the error mentions the codex backend."""
+        from kai.oneshot_binary import BinaryResolutionError
+
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+
+        def boom(_backend: str) -> str:
+            raise BinaryResolutionError("could not resolve codex binary: CODEX_BIN unset, `codex` not on PATH")
+
+        monkeypatch.setattr("kai.oneshot_binary.resolve_oneshot_binary", boom)
+        with pytest.raises(SystemExit) as exc:
+            load_config()
+        assert "MEMORY_REASONER_BACKEND='codex'" in str(exc.value)
+        assert "codex binary" in str(exc.value)
+
+    def test_retrieval_only_skips_binary_check(self, monkeypatch):
+        """MEMORY_ENABLED=true with MEMORY_EXTRACTION_ENABLED=false
+        (retrieval-only) must NOT require a reachable agent binary.
+        The check is gated on the composed extraction-enabled value,
+        not on memory_enabled alone."""
+        from kai.oneshot_binary import BinaryResolutionError
+
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        # Extraction explicitly disabled; binary should NEVER be looked up.
+        called = []
+
+        def boom(backend: str) -> str:
+            called.append(backend)
+            raise BinaryResolutionError("should not be called")
+
+        monkeypatch.setattr("kai.oneshot_binary.resolve_oneshot_binary", boom)
+        # No SystemExit expected; the load completes successfully.
+        config = load_config()
+        assert config.memory_enabled is True
+        assert config.memory_extraction_enabled is False
+        assert called == [], f"resolver must not run on retrieval-only; got {called}"
+
+    def test_extraction_disabled_without_memory_enabled_skips_check(self, monkeypatch):
+        """The compositional gate also covers `MEMORY_EXTRACTION_ENABLED=true`
+        with `MEMORY_ENABLED=false`. Composed extraction_enabled is
+        False, so the binary check does not fire."""
+        from kai.oneshot_binary import BinaryResolutionError
+
+        _set_required(monkeypatch)
+        # MEMORY_ENABLED unset / false, but EXTRACTION_ENABLED true.
+        # The composed value at config.py:1933 is False; binary check skipped.
+        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
+        called = []
+
+        def boom(backend: str) -> str:
+            called.append(backend)
+            raise BinaryResolutionError("should not be called")
+
+        monkeypatch.setattr("kai.oneshot_binary.resolve_oneshot_binary", boom)
+        config = load_config()
+        assert config.memory_extraction_enabled is False
+        assert called == []
 
 
 class TestMemoryReasonerModelResolution:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2268,9 +2268,7 @@ class TestCmdConfig:
         assert config.memory_extraction_model in CODEX_MODELS
         assert config.memory_episode_model in CODEX_MODELS
 
-    def test_codex_fresh_install_with_memory_extraction_yields_valid_users_yaml(
-        self, tmp_path, monkeypatch
-    ):
+    def test_codex_fresh_install_with_memory_extraction_yields_valid_users_yaml(self, tmp_path, monkeypatch):
         """Fresh-install regression for the codex memory wizard gate.
 
         When the wizard drives the path 'no users.yaml -> codex backend
@@ -2796,9 +2794,7 @@ class TestCmdConfigDefaultModelDispatch:
         assert env.get("MEMORY_EXTRACTION_ENABLED") == "true"
         assert env.get("MEMORY_REASONER_BACKEND") == "codex"
 
-    def test_claude_install_codex_reasoner_emits_codex_bin_and_matches_sudoers(
-        self, tmp_path, monkeypatch
-    ):
+    def test_claude_install_codex_reasoner_emits_codex_bin_and_matches_sudoers(self, tmp_path, monkeypatch):
         """claude+codex memory regression: when AGENT_BACKEND=claude but
         MEMORY_REASONER_BACKEND=codex, the wizard must still collect
         CODEX_BIN (the earlier agent-block prompt is skipped because the
@@ -2862,11 +2858,7 @@ class TestCmdConfigDefaultModelDispatch:
             os_users=["alice"],
             codex_bin=env["CODEX_BIN"],
         )
-        codex_lines = [
-            line
-            for line in sudoers.splitlines()
-            if "(alice)" in line and "/usr/local/bin/codex" in line
-        ]
+        codex_lines = [line for line in sudoers.splitlines() if "(alice)" in line and "/usr/local/bin/codex" in line]
         assert len(codex_lines) == 1, codex_lines
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2796,6 +2796,79 @@ class TestCmdConfigDefaultModelDispatch:
         assert env.get("MEMORY_EXTRACTION_ENABLED") == "true"
         assert env.get("MEMORY_REASONER_BACKEND") == "codex"
 
+    def test_claude_install_codex_reasoner_emits_codex_bin_and_matches_sudoers(
+        self, tmp_path, monkeypatch
+    ):
+        """claude+codex memory regression: when AGENT_BACKEND=claude but
+        MEMORY_REASONER_BACKEND=codex, the wizard must still collect
+        CODEX_BIN (the earlier agent-block prompt is skipped because the
+        agent backend is not codex). install.conf must emit CODEX_BIN,
+        and the sudoers rules _generate_sudoers produces from that env
+        must reference the same path. Without this contract the codex
+        memory reasoner spawns the binary resolved from PATH while the
+        sudoers SETENV rule allows only the wizard's fallback
+        /opt/homebrew/bin/codex; if the two diverge, every cross-user
+        codex call fails with "a password is required" and extraction
+        silently no-ops.
+        """
+        from kai.install import _generate_sudoers
+
+        self._setup(monkeypatch, tmp_path, existing_env={"DEFAULT_MODEL": "sonnet"})
+        # The new claude-with-codex-reasoner memory block. The
+        # CODEX_BIN re-prompt is the load-bearing entry: it only
+        # fires when memory_reasoner_backend == codex AND the earlier
+        # codex agent-block did not collect a path (agent_backend !=
+        # codex). Episode model is left blank to inherit the codex
+        # extraction default in load_config.
+        memory_inputs = [
+            "true",  # MEMORY_ENABLED
+            "true",  # MEMORY_EXTRACTION_ENABLED
+            "codex",  # MEMORY_REASONER_BACKEND (override default = claude)
+            "/usr/local/bin/codex",  # NEW: codex_bin re-prompt at memory gate
+            "10",  # extraction timeout (dataclass default)
+            "8",  # consolidation candidates (dataclass default)
+            "3",  # episode classifier context turns (dataclass default)
+            "",  # episode model (blank inherits extraction model on codex)
+            "120",  # episode timeout (dataclass default)
+            "0.9",  # paraphrase-dedup threshold (dataclass default)
+            "2000",  # token budget (dataclass default)
+            "10",  # search limit (dataclass default)
+        ]
+        # _inputs_for_claude_backend places memory_enabled as the
+        # second-to-last entry. Replace it with "true" and splice the
+        # rest of the memory block immediately after; the trailing
+        # perplexity-key entry stays at the end.
+        base_inputs = self._inputs_for_claude_backend()
+        idx = len(base_inputs) - 2  # memory_enabled position
+        base_inputs = base_inputs[:idx] + ["true"] + base_inputs[idx + 1 :]
+        inputs = base_inputs[: idx + 1] + memory_inputs[1:] + base_inputs[idx + 1 :]
+        _, env = self._run(monkeypatch, tmp_path, inputs, helper_return="sonnet")
+        assert env.get("MEMORY_REASONER_BACKEND") == "codex"
+        # The wizard must emit CODEX_BIN even though AGENT_BACKEND=
+        # claude. Pre-fix this assertion failed because the env-
+        # emission block was gated on agent_backend == codex.
+        assert env.get("CODEX_BIN") == "/usr/local/bin/codex"
+
+        # Sudoers rules generated from env["CODEX_BIN"] must use the
+        # same path. This pins the install-time wiring so the codex
+        # memory reasoner argv (which resolves codex via the same
+        # binary path through resolve_oneshot_binary) and the
+        # sudoers SETENV rule cannot drift apart. _user_home is
+        # patched because the sudoers generator inspects per-target
+        # home directories that do not exist on the test host.
+        monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
+        sudoers = _generate_sudoers(
+            "kai",
+            os_users=["alice"],
+            codex_bin=env["CODEX_BIN"],
+        )
+        codex_lines = [
+            line
+            for line in sudoers.splitlines()
+            if "(alice)" in line and "/usr/local/bin/codex" in line
+        ]
+        assert len(codex_lines) == 1, codex_lines
+
 
 class TestCmdApplyDefaultModelGate:
     """

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2268,6 +2268,132 @@ class TestCmdConfig:
         assert config.memory_extraction_model in CODEX_MODELS
         assert config.memory_episode_model in CODEX_MODELS
 
+    def test_codex_fresh_install_with_memory_extraction_yields_valid_users_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        """Fresh-install regression for the codex memory wizard gate.
+
+        When the wizard drives the path 'no users.yaml -> codex backend
+        -> enable memory -> enable extraction -> codex reasoner' AND the
+        operator accepts the default 'Configure advanced user options =
+        false' earlier in the prompt sequence, the wizard re-prompts for
+        a non-service os_user at the memory-reasoner-backend gate and
+        rewrites users.yaml in place before the env is persisted. The
+        produced env + generated users.yaml together must pass
+        load_config(); without the gate the wizard emits a users.yaml
+        with no os_user and load_config() SystemExits at next daemon
+        start ('chat_ids are missing os_user' on the codex precondition).
+
+        This test pins the full fresh-install integration contract, in
+        contrast to test_codex_install_accept_all_defaults_yields_load_
+        config_compatible_env which hand-seeds users.yaml and only
+        checks the env emission.
+        """
+        from unittest.mock import MagicMock
+
+        from kai.config import load_config
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+        # Pin the model + codex-binary helpers so the test does not
+        # depend on the host having codex installed or a curated
+        # model registry on disk. The mock value below is a real
+        # CODEX_MODELS entry so load_config's model-vs-backend
+        # validation passes.
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            MagicMock(return_value="gpt-5.4"),
+        )
+        monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
+
+        inputs = iter(
+            [
+                "/opt/kai",  # install dir
+                "/var/lib/kai",  # data dir
+                "kai",  # service user
+                "darwin",  # platform
+                "fake-token",  # bot token
+                "12345",  # admin telegram ID
+                "admin",  # admin display name
+                "false",  # advanced user options - the failure-mode entry
+                "polling",  # transport
+                "codex",  # agent backend
+                "subscription",  # codex auth mode
+                "/usr/local/bin/codex",  # codex binary path
+                # model: handled by _prompt_default_model mock
+                "120",  # agent timeout
+                "10.0",  # budget (codex != claude branch)
+                "200000",  # max context window
+                # autocompact + effort skipped on non-claude backend
+                "8080",  # webhook port
+                "test-secret",  # webhook secret
+                "",  # workspace base
+                "",  # allowed workspaces
+                "false",  # pr review enabled
+                "900",  # pr review timeout
+                "1.0",  # pr review budget (non-claude branch)
+                "false",  # issue triage enabled
+                "",  # github notify chat id
+                "false",  # voice
+                "false",  # tts
+                # claude_user skipped on agent_backend != claude
+                "true",  # memory enabled
+                "true",  # memory extraction enabled
+                "codex",  # memory reasoner backend
+                "codex_runner",  # NEW: re-prompted os_user after codex gate
+                "10",  # extraction timeout
+                "8",  # consolidation candidates
+                "3",  # episode classifier context turns
+                "",  # episode model (blank inherits extraction model)
+                "120",  # episode timeout
+                "0.9",  # paraphrase-dedup threshold
+                "2000",  # token budget
+                "10",  # search limit
+                "",  # perplexity key
+            ]
+        )
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        # users.yaml must carry the re-prompted os_user. The wizard
+        # rewrote it in place after the codex memory gate fired; the
+        # pre-fix path left os_user absent here.
+        users_yaml_path = tmp_path / "users.yaml"
+        assert users_yaml_path.exists()
+        data = yaml.safe_load(users_yaml_path.read_text())
+        entry = data["users"][0]
+        assert entry["telegram_id"] == 12345
+        assert entry["os_user"] == "codex_runner"
+
+        # Integration pin: feed the produced env + users.yaml into
+        # load_config and assert it accepts the shape. Neuter the
+        # /etc/kai/ readers and PROJECT_ROOT so load_config consumes
+        # the wizard-generated artifacts under tmp_path. The
+        # oneshot-binary resolver is mocked because the test host
+        # has no codex binary; load_config validates the resolved
+        # path on the codex extraction-eligible branch.
+        env_block = json.loads((tmp_path / "install.conf").read_text())["env"]
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr("kai.config.load_dotenv", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.config._read_protected_file", lambda path: None)
+        monkeypatch.setattr(
+            "kai.oneshot_binary.resolve_oneshot_binary",
+            lambda backend: f"/fake/{backend}",
+        )
+        for key, value in env_block.items():
+            monkeypatch.setenv(key, value)
+
+        config = load_config()
+        assert config.memory_enabled is True
+        assert config.memory_extraction_enabled is True
+        assert config.memory_reasoner_backend == "codex"
+        assert config.user_configs is not None
+        assert 12345 in config.user_configs
+        assert config.user_configs[12345].os_user == "codex_runner"
+
 
 # ── Apply subcommand ─────────────────────────────────────────────────
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -6222,14 +6222,129 @@ class TestApplyAgentTimeoutMigration:
 class TestPerOsUserCodexLoginHint:
     """Post-install hint enumerates per-os_user codex login.
 
-    The hint block fires in the success path of _cmd_apply (non-dry-run)
-    after every real install side effect, so isolating it in pytest
-    requires mocking the full install pipeline. Verified at smoke-test
-    time instead; the helper it consumes (_collect_os_users_from_yaml)
-    is independently covered.
+    The reminder fires when codex actually runs on this install: agent
+    backend = codex OR memory reasoner = codex. Subscription auth lives
+    under each spawning user's home, so the reminder must enumerate
+    every distinct os_user in users.yaml (falling back to the service
+    user only when none are configured). The gate and enumeration are
+    factored into `_build_codex_login_reminder` so this test exercises
+    them directly without driving the full _cmd_apply pipeline.
     """
 
-    def test_collect_os_users_helper_unaffected(self):
-        from kai.install import _collect_os_users_from_yaml
+    @staticmethod
+    def _write_users_yaml(tmp_path, entries: list[dict]) -> Path:
+        path = tmp_path / "users.yaml"
+        path.write_text(yaml.safe_dump({"users": entries}))
+        return path
 
-        assert callable(_collect_os_users_from_yaml)
+    def test_claude_agent_with_codex_memory_reasoner_emits_reminder(self, tmp_path):
+        """The reviewer-flagged regression. With AGENT_BACKEND=claude and
+        MEMORY_REASONER_BACKEND=codex, codex still runs per-user for
+        memory extraction; the operator must run `codex login` as the
+        target os_user or the first extraction fails with no auth.
+        Pre-fix the reminder was suppressed because the gate keyed on
+        AGENT_BACKEND alone.
+        """
+        from kai.install import _build_codex_login_reminder
+
+        users_yaml = self._write_users_yaml(
+            tmp_path,
+            [{"telegram_id": 12345, "name": "alice", "role": "admin", "os_user": "alice"}],
+        )
+        env = {
+            "AGENT_BACKEND": "claude",
+            "MEMORY_REASONER_BACKEND": "codex",
+        }
+        text = _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml)
+        assert text is not None
+        assert "Codex subscription auth required:" in text
+        assert "alice ~$ codex login" in text
+        # service-user fallback must NOT fire when users.yaml has entries.
+        assert "kai ~$ codex login" not in text
+
+    def test_codex_agent_backend_still_emits_reminder(self, tmp_path):
+        """Defense-in-depth for the original gate: AGENT_BACKEND=codex
+        alone (no memory) still produces the reminder.
+        """
+        from kai.install import _build_codex_login_reminder
+
+        users_yaml = self._write_users_yaml(
+            tmp_path,
+            [{"telegram_id": 1, "name": "alice", "role": "admin", "os_user": "alice"}],
+        )
+        env = {"AGENT_BACKEND": "codex"}
+        text = _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml)
+        assert text is not None
+        assert "alice ~$ codex login" in text
+
+    def test_pure_claude_no_codex_anywhere_returns_none(self, tmp_path):
+        """No codex surface, no reminder. Claude memory extraction does
+        not spawn codex; emitting the hint here would be wizard noise.
+        """
+        from kai.install import _build_codex_login_reminder
+
+        users_yaml = self._write_users_yaml(
+            tmp_path,
+            [{"telegram_id": 1, "name": "alice", "role": "admin", "os_user": "alice"}],
+        )
+        env = {"AGENT_BACKEND": "claude"}
+        assert _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml) is None
+
+    def test_codex_api_key_mode_returns_none(self, tmp_path):
+        """API-key auth needs no per-user login; the env var ships the
+        token. The reminder must skip both codex-anywhere cases when
+        CODEX_AUTH_MODE=api_key.
+        """
+        from kai.install import _build_codex_login_reminder
+
+        users_yaml = self._write_users_yaml(
+            tmp_path,
+            [{"telegram_id": 1, "name": "alice", "role": "admin", "os_user": "alice"}],
+        )
+        for env in (
+            {"AGENT_BACKEND": "codex", "CODEX_AUTH_MODE": "api_key"},
+            {
+                "AGENT_BACKEND": "claude",
+                "MEMORY_REASONER_BACKEND": "codex",
+                "CODEX_AUTH_MODE": "api_key",
+            },
+        ):
+            assert _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml) is None, env
+
+    def test_no_os_users_falls_back_to_service_user(self, tmp_path):
+        """When users.yaml has no os_user entries (legacy single-user
+        mode or empty file), the fallback hint names the service user.
+        """
+        from kai.install import _build_codex_login_reminder
+
+        users_yaml = self._write_users_yaml(
+            tmp_path,
+            [{"telegram_id": 1, "name": "alice", "role": "admin"}],
+        )
+        env = {"AGENT_BACKEND": "codex"}
+        text = _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml)
+        assert text is not None
+        assert "kai ~$ codex login" in text
+
+    def test_multiple_os_users_enumerated_and_deduplicated(self, tmp_path):
+        """Each distinct os_user gets one line. Duplicates in users.yaml
+        collapse so the operator does not see redundant hints; order is
+        deterministic (sorted) so the post-install output is stable
+        across runs.
+        """
+        from kai.install import _build_codex_login_reminder
+
+        users_yaml = self._write_users_yaml(
+            tmp_path,
+            [
+                {"telegram_id": 1, "name": "alice", "role": "admin", "os_user": "alice"},
+                {"telegram_id": 2, "name": "bob", "role": "user", "os_user": "bob"},
+                {"telegram_id": 3, "name": "carol", "role": "user", "os_user": "alice"},
+            ],
+        )
+        env = {"AGENT_BACKEND": "codex"}
+        text = _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml)
+        assert text is not None
+        # alice once (dedup), bob once; sorted ordering puts alice first.
+        login_lines = [line for line in text.splitlines() if "~$ codex login" in line]
+        assert login_lines == ["    alice ~$ codex login", "    bob ~$ codex login"]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1709,6 +1709,7 @@ class TestCmdConfig:
         memory_block = [
             "true",  # memory enabled
             "true",  # extraction enabled (claude backend)
+            "claude",  # MEMORY_REASONER_BACKEND (matches install vendor; suppressed at emission as default)
             "60",  # extraction timeout seconds (#345)
             "5",  # consolidation candidates (non-default, exercises emission branch)
             "5",  # episode classifier context turns (#392, non-default exercises emission)
@@ -1731,6 +1732,10 @@ class TestCmdConfig:
         env = conf["env"]
         assert env["MEMORY_ENABLED"] == "true"
         assert env["MEMORY_EXTRACTION_ENABLED"] == "true"
+        # MEMORY_REASONER_BACKEND="claude" is the dataclass default;
+        # the wizard's emission gate suppresses default values, so the
+        # key must NOT appear in the generated env.
+        assert "MEMORY_REASONER_BACKEND" not in env
         # Budget keys absent on claude backend: prompt is skipped, value
         # stays at dataclass default, double-gated emission suppresses.
         assert "MEMORY_EXTRACTION_BUDGET_USD" not in env
@@ -1778,6 +1783,7 @@ class TestCmdConfig:
         memory_block = [
             "true",  # memory enabled
             "true",  # extraction enabled
+            "claude",  # MEMORY_REASONER_BACKEND (default-accept; suppressed at emission)
             "10",  # extraction timeout (dataclass default; suppressed)
             "8",  # consolidation candidates (dataclass default; suppressed)
             "3",  # episode classifier context turns (#392, dataclass default; suppressed)
@@ -1823,6 +1829,7 @@ class TestCmdConfig:
         memory_block = [
             "true",
             "true",
+            "claude",  # MEMORY_REASONER_BACKEND (default-accept; suppressed)
             "45",
             "4",
             "7",  # episode classifier context turns (#392, non-default)
@@ -2076,6 +2083,7 @@ class TestCmdConfig:
         memory_block = [
             "true",  # memory enabled
             "true",  # extraction enabled
+            "claude",  # MEMORY_REASONER_BACKEND (default-accept; suppressed)
             "10",  # extraction timeout (default; suppressed)
             "8",  # consolidation candidates (default; suppressed)
             "5",  # episode classifier context turns (#392, non-default)
@@ -2106,6 +2114,7 @@ class TestCmdConfig:
         memory_block = [
             "true",  # memory enabled
             "true",  # extraction enabled
+            "claude",  # MEMORY_REASONER_BACKEND (default-accept; suppressed)
             "10",  # extraction timeout (default)
             "8",  # consolidation candidates (default)
             "3",  # episode classifier context turns (#392, dataclass default)
@@ -2151,6 +2160,105 @@ class TestCmdConfig:
         # that leaves a stale value in /etc/kai/env after a
         # claude→goose flip surfaces here.
         assert "EPISODE_CLASSIFIER_CONTEXT_TURNS" not in env
+
+    def test_goose_retrieval_only_does_not_persist_invalid_reasoner_backend(self, tmp_path, monkeypatch):
+        """v5 regression: a goose install accepting memory_enabled=true
+        with extraction disabled must NOT write MEMORY_REASONER_BACKEND
+        to the generated env. The wizard gates the prompt on
+        memory_extraction_enabled (the composed value), so on a
+        goose-backed install the prompt never fires and the key never
+        lands. Prevents the prior failure mode where the prompt fired
+        and `agent_backend=goose` as the default would have produced
+        MEMORY_REASONER_BACKEND=goose, failing load_config validation."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+
+        # Goose install: extraction is gated out, so no reasoner prompt.
+        # Inputs match the existing goose-skip test shape (memory_enabled,
+        # token_budget, search_limit).
+        memory_block = ["true", "2000", "10"]
+        inputs = iter(self._base_inputs(memory_block, agent_backend="goose"))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        env = json.loads((tmp_path / "install.conf").read_text())["env"]
+        # The critical assertion: no invalid reasoner-backend value
+        # in the env. The cleanup block also drops it on non-supported
+        # backends as defense-in-depth.
+        assert "MEMORY_REASONER_BACKEND" not in env
+        # Extraction config is also absent on goose retrieval-only.
+        assert "MEMORY_EXTRACTION_ENABLED" not in env
+
+    def test_codex_install_accept_all_defaults_yields_load_config_compatible_env(self, monkeypatch):
+        """v6 catch-all regression: a codex install that accepts every
+        wizard default for memory must produce an env block that
+        load_config accepts without raising. Pins the entire 'wizard
+        default invalid under selected reasoner' bug class so a
+        future default flip lands as a single-test failure rather
+        than a runtime config-load SystemExit.
+
+        Test shape: rather than re-driving the full wizard (covered
+        by surrounding tests), this test pins the integration
+        contract directly: assemble the env block the wizard emits
+        on codex accept-all-defaults and feed it into load_config.
+        The wizard's emission rules are simple enough that the env
+        contents are mechanical: MEMORY_ENABLED=true,
+        MEMORY_EXTRACTION_ENABLED=true, MEMORY_REASONER_BACKEND=codex,
+        and no other memory keys (every other knob accepted the
+        dataclass default and the wizard's delta-from-default
+        emission suppresses them)."""
+        from kai.config import load_config
+
+        # Pin the resolver so this test does not depend on having
+        # codex actually installed on the host.
+        monkeypatch.setattr(
+            "kai.oneshot_binary.resolve_oneshot_binary",
+            lambda backend: f"/fake/{backend}",
+        )
+        # Pin protected-env / dotenv to be inert. Without this,
+        # load_config reads /etc/kai/env (when present on the dev
+        # box) and `os.environ.setdefault` populates the process env
+        # with values that leak into subsequent tests. The /etc/kai/env
+        # on a dev install typically carries `CODEX_BIN=/Users/...`,
+        # which would make later test_review codex tests assert the
+        # absolute path instead of the literal "codex". The autouse
+        # fixture in test_config.py applies the same neutering for
+        # its scope; this test is in test_install.py and has to do
+        # it explicitly.
+        monkeypatch.setattr("kai.config.load_dotenv", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.config._read_protected_file", lambda path: None)
+        # Seed only the env keys the wizard would emit. Everything
+        # else falls back to dataclass defaults via load_config.
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+        monkeypatch.setenv("ALLOWED_USER_IDS", "1")
+        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        # DEFAULT_MODEL validates against the agent backend's model
+        # set; codex requires a CODEX_MODELS entry. The wizard would
+        # have prompted for this; here we set it explicitly to focus
+        # the test on the memory wiring contract.
+        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4")
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        # MEMORY_EPISODE_MODEL is intentionally NOT set; the codex
+        # branch defaults the wizard prompt to blank, which means
+        # load_config inherits from MEMORY_EXTRACTION_MODEL, which
+        # itself defaults to the codex registry SKU. The contract
+        # under test is "blank episode_model under codex resolves to
+        # a CODEX_MODELS-valid SKU."
+        config = load_config()
+        assert config.memory_enabled is True
+        assert config.memory_extraction_enabled is True
+        assert config.memory_reasoner_backend == "codex"
+        # Both models must validate as codex SKUs (load_config
+        # checks against CODEX_MODELS and SystemExits on miss).
+        from kai.config import CODEX_MODELS
+
+        assert config.memory_extraction_model in CODEX_MODELS
+        assert config.memory_episode_model in CODEX_MODELS
 
 
 # ── Apply subcommand ─────────────────────────────────────────────────
@@ -2495,49 +2603,64 @@ class TestCmdConfigDefaultModelDispatch:
         assert helper.call_args.args[2] != "opus"
         assert env["DEFAULT_MODEL"] == "gpt-5.4-mini"
 
-    def test_codex_install_zeroes_both_memory_flags(self, tmp_path, monkeypatch):
+    def test_codex_install_enables_memory_with_codex_reasoner(self, tmp_path, monkeypatch):
         """
-        Codex installs must force MEMORY_ENABLED=false AND
-        MEMORY_EXTRACTION_ENABLED=false. The Haiku extraction pipeline
-        bypasses the agent backend abstraction and shells out to
-        claude directly; running it on a codex-backed install would
-        either inject a [Memory subsystem: enabled] marker into the
-        inner codex agent's session context against a subsystem that
-        cannot service its requests, or attempt to spawn a claude
-        binary that may not be installed.
+        Codex installs CAN enable semantic memory. The reasoner
+        backend defaults to codex (matching the agent backend), the
+        extraction-enabled flag persists, MEMORY_REASONER_BACKEND
+        lands as a non-default value, and the stale-key cleanup at
+        wizard end no longer strips the codex extraction config.
 
-        The operator says yes to "Enable semantic memory" at the
-        prompt; the guard catches it. Neither flag should appear in
-        the resulting install.conf env (codex emits memory keys only
-        when they are non-default, and both default to false).
+        Regression for the prior wizard behavior that forced both
+        memory flags off on codex installs and printed a "currently
+        requires the claude backend" message; that guard came out
+        when the OneShotReasoner abstraction made codex memory
+        reachable end-to-end.
         """
-        # Seed install.conf with existing_env that has BOTH memory flags
-        # set to true. The guard's pre-check reads MEMORY_EXTRACTION_ENABLED
-        # before it can be zeroed by the unconditional reset later in the
-        # function, so the guard message fires.
         self._setup(
             monkeypatch,
             tmp_path,
-            existing_env={
-                "DEFAULT_MODEL": "gpt-5.4",
-                "MEMORY_ENABLED": "true",
-                "MEMORY_EXTRACTION_ENABLED": "true",
-            },
+            existing_env={"DEFAULT_MODEL": "gpt-5.4"},
         )
-        _, env = self._run(
-            monkeypatch,
-            tmp_path,
-            # Operator answers "true" at the memory_enabled prompt; the
-            # guard overrides it. Without the guard, MEMORY_ENABLED=true
-            # would land in the resulting install.conf.
-            self._inputs_for_codex_subscription(memory_enabled="true"),
-            helper_return="gpt-5.4",
-        )
-        # Both memory keys must be absent from the emitted env (the
-        # emission code only writes them when true; the guard forced
-        # both flags false).
-        assert "MEMORY_ENABLED" not in env
-        assert "MEMORY_EXTRACTION_ENABLED" not in env
+        # Feed the wizard codex defaults for every memory prompt. The
+        # reasoner_backend default mirrors agent_backend=codex, so
+        # accepting it via empty string locks in MEMORY_REASONER_BACKEND
+        # =codex. The episode model default is empty (inherit
+        # extraction model) on the codex reasoner branch; accepting
+        # blank exercises that path.
+        memory_inputs = [
+            "true",  # MEMORY_ENABLED
+            "true",  # MEMORY_EXTRACTION_ENABLED
+            "",  # MEMORY_REASONER_BACKEND (accept default = codex)
+            "10",  # extraction timeout (dataclass default)
+            "8",  # consolidation candidates (dataclass default)
+            "3",  # episode classifier context turns (dataclass default)
+            "",  # episode model (blank inherits extraction model on codex)
+            "120",  # episode timeout (dataclass default)
+            "0.9",  # paraphrase-dedup threshold (dataclass default)
+            "2000",  # token budget (dataclass default)
+            "10",  # search limit (dataclass default)
+        ]
+        # Codex-subscription inputs sequence inserts memory_enabled
+        # as the second-to-last entry (before the perplexity key).
+        # Replace memory_enabled with "true" and append the rest of
+        # the memory block in order; the helper currently emits
+        # memory_enabled as the final memory-flag entry, so we splice
+        # the new prompt sequence into the rest of the chain.
+        base_inputs = self._inputs_for_codex_subscription(memory_enabled="true")
+        # Find the memory_enabled slot ("true") and insert the rest
+        # of the memory block immediately after it; the trailing
+        # perplexity key entry stays at the end.
+        idx = len(base_inputs) - 2  # memory_enabled position
+        inputs = base_inputs[: idx + 1] + memory_inputs[1:] + base_inputs[idx + 1 :]
+        _, env = self._run(monkeypatch, tmp_path, inputs, helper_return="gpt-5.4")
+        # Codex install now persists memory extraction config. The
+        # reasoner backend is codex (non-default; emitted), and the
+        # extraction flag survives the cleanup block that previously
+        # stripped it on non-claude installs.
+        assert env.get("MEMORY_ENABLED") == "true"
+        assert env.get("MEMORY_EXTRACTION_ENABLED") == "true"
+        assert env.get("MEMORY_REASONER_BACKEND") == "codex"
 
 
 class TestCmdApplyDefaultModelGate:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2192,7 +2192,7 @@ class TestCmdConfig:
         # Extraction config is also absent on goose retrieval-only.
         assert "MEMORY_EXTRACTION_ENABLED" not in env
 
-    def test_codex_install_accept_all_defaults_yields_load_config_compatible_env(self, monkeypatch):
+    def test_codex_install_accept_all_defaults_yields_load_config_compatible_env(self, tmp_path, monkeypatch):
         """v6 catch-all regression: a codex install that accepts every
         wizard default for memory must produce an env block that
         load_config accepts without raising. Pins the entire 'wizard
@@ -2218,6 +2218,14 @@ class TestCmdConfig:
             "kai.oneshot_binary.resolve_oneshot_binary",
             lambda backend: f"/fake/{backend}",
         )
+        # users.yaml is required for codex memory (config-load
+        # validates the per-user os_user precondition). The wizard
+        # builds this alongside the env block; here we set up a
+        # minimal users.yaml inline so the test focuses on the
+        # memory env contract.
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 1\n    name: tester\n    role: admin\n    os_user: tester_os\n")
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
         # Pin protected-env / dotenv to be inert. Without this,
         # load_config reads /etc/kai/env (when present on the dev
         # box) and `os.environ.setdefault` populates the process env

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -141,6 +141,105 @@ class TestInitMemory:
         init_memory(config)
         assert not is_enabled()
 
+    def test_init_disabled_emits_config_log_with_null_fields(self, caplog):
+        """Even when memory is disabled, init_memory emits exactly
+        one structured `memory.config` log so an operator scanning
+        the log post-restart can confirm the configured state. All
+        non-`enabled` fields elide to null."""
+        import json as json_module
+
+        from kai.memory import init_memory
+
+        config = _make_config(enabled=False)
+        with caplog.at_level(logging.INFO, logger="kai.memory"):
+            init_memory(config)
+        records = [r for r in caplog.records if "memory.config" in r.getMessage()]
+        assert len(records) == 1
+        payload = json_module.loads(records[0].getMessage().split("memory.config ", 1)[1])
+        assert payload == {
+            "enabled": False,
+            "extraction_enabled": False,
+            "reasoner_backend": None,
+            "extraction_model": None,
+            "episode_model": None,
+            "extraction_binary": None,
+        }
+
+    def test_init_retrieval_only_emits_null_extraction_binary(self, caplog, tmp_path, monkeypatch):
+        """Retrieval-only memory (MEMORY_ENABLED=true with extraction
+        disabled) MUST NOT call the resolver: the resolver call is
+        gated on `memory_extraction_enabled`, so an install without a
+        claude or codex binary on PATH still initializes
+        successfully. The resolver mock fires loudly if called."""
+        import json as json_module
+
+        from kai.memory import init_memory
+
+        called = []
+
+        def fake_resolve(backend: str) -> str:
+            called.append(backend)
+            raise RuntimeError("resolver should not run on retrieval-only init")
+
+        monkeypatch.setattr("kai.oneshot_binary.resolve_oneshot_binary", fake_resolve)
+        # Memory enabled but extraction disabled = retrieval-only.
+        config = _make_config(
+            memory_extraction_enabled=False,
+            memory_reasoner_backend="claude",
+            memory_extraction_model="claude-haiku-4-5",
+            memory_episode_model="",
+        )
+        with (
+            caplog.at_level(logging.INFO, logger="kai.memory"),
+            patch("kai.memory.DATA_DIR", tmp_path),
+            patch("mem0.Memory") as mock_mem,
+        ):
+            # Set the embedding model dim to the expected 384 so init
+            # proceeds past the dim-check guard.
+            mock_mem.from_config.return_value.embedding_model.model.get_embedding_dimension.return_value = 384
+            init_memory(config)
+        records = [r for r in caplog.records if "memory.config" in r.getMessage()]
+        assert len(records) == 1
+        payload = json_module.loads(records[0].getMessage().split("memory.config ", 1)[1])
+        assert payload["enabled"] is True
+        assert payload["extraction_enabled"] is False
+        assert payload["extraction_binary"] is None
+        # Critical contract: resolver MUST NOT have been called.
+        assert called == [], f"resolver was invoked on retrieval-only init: {called}"
+
+    def test_init_extraction_enabled_resolves_binary_in_log(self, caplog, tmp_path, monkeypatch):
+        """When extraction is enabled, init_memory calls the resolver
+        and writes the resolved path into the `extraction_binary`
+        field of the structured log."""
+        import json as json_module
+
+        from kai.memory import init_memory
+
+        monkeypatch.setattr(
+            "kai.oneshot_binary.resolve_oneshot_binary",
+            lambda backend: f"/fake/{backend}-binary",
+        )
+        config = _make_config(
+            memory_extraction_enabled=True,
+            memory_reasoner_backend="codex",
+            memory_extraction_model="gpt-5.4-mini",
+            memory_episode_model="",
+        )
+        with (
+            caplog.at_level(logging.INFO, logger="kai.memory"),
+            patch("kai.memory.DATA_DIR", tmp_path),
+            patch("mem0.Memory") as mock_mem,
+        ):
+            mock_mem.from_config.return_value.embedding_model.model.get_embedding_dimension.return_value = 384
+            init_memory(config)
+        records = [r for r in caplog.records if "memory.config" in r.getMessage()]
+        assert len(records) == 1
+        payload = json_module.loads(records[0].getMessage().split("memory.config ", 1)[1])
+        assert payload["enabled"] is True
+        assert payload["extraction_enabled"] is True
+        assert payload["reasoner_backend"] == "codex"
+        assert payload["extraction_binary"] == "/fake/codex-binary"
+
     @integration
     def test_mem0_telemetry_path_is_isolated(self):
         """Mem0's hardcoded telemetry Qdrant path must live under the

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -165,6 +165,7 @@ class TestInitMemory:
             "extraction_binary": None,
         }
 
+    @integration
     def test_init_retrieval_only_emits_null_extraction_binary(self, caplog, tmp_path, monkeypatch):
         """Retrieval-only memory (MEMORY_ENABLED=true with extraction
         disabled) MUST NOT call the resolver: the resolver call is
@@ -207,6 +208,7 @@ class TestInitMemory:
         # Critical contract: resolver MUST NOT have been called.
         assert called == [], f"resolver was invoked on retrieval-only init: {called}"
 
+    @integration
     def test_init_extraction_enabled_resolves_binary_in_log(self, caplog, tmp_path, monkeypatch):
         """When extraction is enabled, init_memory calls the resolver
         and writes the resolved path into the `extraction_binary`

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -1213,8 +1213,8 @@ class TestRunEpisodeExtractorWithCodexEnvelope:
             ep, cost_usd, reason = await _run_episode_extractor("payload", config)
 
         assert ep == episode
-        # No total_cost_usd in the envelope -> 0.0 (matches the codex
-        # subscription-auth posture; pay-per-token codex deployments
-        # will populate this differently if they ever land).
+        # No total_cost_usd in the envelope -> 0.0. Codex runs
+        # subscription-backed in the supported deployment model, so
+        # the cost field is informational and reads as zero.
         assert cost_usd == 0.0
         assert reason is None

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -138,6 +138,20 @@ def _stage2_envelope(episode: dict | None = None, *, cost_usd: float = 0.04) -> 
 
 
 @pytest.fixture(autouse=True)
+def _mock_binary_resolver(monkeypatch):
+    """Pin the binary resolver so the reasoner argv builders do not
+    require claude/codex on PATH at test time. Same pattern as the
+    autouse fixtures in test_memory_extraction.py and test_oneshot.py;
+    the stage-2 tests in this file exercise the reasoner through
+    extract_and_store and rely on the underlying subprocess mock
+    rather than the binary resolution itself."""
+    monkeypatch.setattr(
+        "kai.oneshot.resolve_oneshot_binary",
+        lambda backend: "claude" if backend == "claude" else "codex",
+    )
+
+
+@pytest.fixture(autouse=True)
 def _reset_episode_state():
     """Clear stage-2 module state between tests.
 

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -51,6 +51,27 @@ from kai.memory_extraction import (
 # ── Fixtures ─────────────────────────────────────────────────────────
 
 
+@pytest.fixture(autouse=True)
+def _mock_binary_resolver():
+    """Pin the binary resolver to literal backend names so existing
+    argv assertions (`args[0] == "claude"`) stay valid across host
+    machines. Tests in this file mock subprocess execution end-to-end
+    and do not care which absolute path the resolver would have
+    returned; pinning is the minimal-friction way to keep extraction-
+    pipeline assertions stable while the resolver lives at the
+    reasoner argv boundary."""
+
+    def fake_resolve(backend: str) -> str:
+        if backend == "claude":
+            return "claude"
+        if backend == "codex":
+            return "codex"
+        raise ValueError(f"unknown backend: {backend!r}")
+
+    with patch("kai.oneshot.resolve_oneshot_binary", side_effect=fake_resolve):
+        yield
+
+
 _BASE_CONFIG = Config(
     telegram_bot_token="test-token",
     allowed_user_ids={12345},

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -60,6 +60,39 @@ def _mock_binary_resolver():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _bypass_codex_routing_for_argv_tests(request):
+    """The codex reasoner now refuses to spawn under the bot user
+    (same-user routing rejected on the codex branch). The existing
+    argv/env/schema/output tests in this file use `os_user=_current_user()`
+    so resolve_claude_user short-circuits to None (the historical
+    test-friendly self-sudo-skip path), which is no longer valid for
+    codex.
+
+    To keep the surface those tests check (argv flag layout, env
+    allow-list, stdin payload, JSON parsing) without each test having
+    to wire a sudo-wrap shim, this autouse fixture:
+
+      - makes resolve_claude_user a pass-through (so the same-user
+        refusal does not fire on os_user=_current_user())
+      - makes _wrap_cmd_for_user a no-op (so the argv assertions that
+        expect cmd[0] == "codex" stay valid; the wrap is exercised
+        explicitly by the tests marked `routing_test` below)
+
+    Tests that exercise real routing behavior (the routing classes,
+    the same-user refusal test, etc.) are marked with
+    `@pytest.mark.routing_test` and opt out of this bypass so they
+    can assert against the production wrap shape and refusal."""
+    if request.node.get_closest_marker("routing_test"):
+        yield
+        return
+    with (
+        patch("kai.oneshot.resolve_claude_user", side_effect=lambda u: u if u else None),
+        patch("kai.oneshot._wrap_cmd_for_user", side_effect=lambda cmd, *a, **kw: cmd),
+    ):
+        yield
+
+
 def _make_proc(
     *,
     stdout: bytes = b"",
@@ -654,9 +687,17 @@ class TestCodexOneShotReasonerSchemaFile:
         captured: dict = {}
 
         def _capture(*args, **kwargs):
-            i = args.index("--output-schema")
-            captured["path"] = Path(args[i + 1])
-            return _make_proc(raise_timeout=True)
+            # Multiple subprocess spawns may fire on the timeout
+            # path: the codex run itself, and the cross-user kill
+            # tree. Only the first carries --output-schema; the
+            # kill subprocess's argv is the sudo+kill shape.
+            if "--output-schema" in args:
+                i = args.index("--output-schema")
+                captured["path"] = Path(args[i + 1])
+                return _make_proc(raise_timeout=True)
+            # Kill subprocess: return a noop mock so the kill helper
+            # awaits and returns cleanly.
+            return _make_proc()
 
         with (
             patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(side_effect=_capture)),
@@ -773,9 +814,20 @@ class TestCodexOneShotReasonerTimeout:
     async def test_timeout_kills_and_awaits_then_raises(self, tmp_path):
         reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user=_current_user())
         proc = _make_proc(raise_timeout=True)
+        # The cross-user kill path also spawns a subprocess (sudo
+        # /bin/kill -KILL -<pgid>). Returning the same timing-out
+        # proc for that spawn would have proc.kill called twice.
+        # Differentiate on argv: the kill subprocess starts with
+        # "sudo" + "-n", the reasoner spawn starts differently.
+        kill_proc = _make_proc()
+
+        def _route(*args, **kwargs):
+            if args and args[0] == "sudo" and len(args) > 1 and args[1] == "-n":
+                return kill_proc
+            return proc
 
         with (
-            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(side_effect=_route)),
             pytest.raises(OneShotTimeout),
         ):
             await reasoner.run(
@@ -1136,9 +1188,10 @@ class TestCodexOneShotReasonerLogging:
         # Schema-backed success is the production memory path; the
         # routing log field must be present so operator-side log
         # review can confirm the subprocess ran under the intended
-        # OS user. `os_user=self` here because the direct-spawn
-        # self-sudo-skip case is what `_current_user()` triggers.
-        assert "os_user=self" in msg
+        # OS user. Under the autouse bypass, resolve_claude_user
+        # passes the os_user through unchanged (no longer treated as
+        # self-sudo-skip), so the field carries the actual user name.
+        assert f"os_user={_current_user()}" in msg
 
     @pytest.mark.asyncio
     async def test_log_line_carries_target_os_user_on_wrapped_success(self, tmp_path, caplog):
@@ -1194,6 +1247,7 @@ class TestCodexOneShotReasonerLogging:
 # ── Per-user OS routing (issue #503) ────────────────────────────────
 
 
+@pytest.mark.routing_test
 class TestRoutingArgvAndPreserveEnv:
     """`os_user` constructor argument controls the sudo wrap.
 
@@ -1243,17 +1297,35 @@ class TestRoutingArgvAndPreserveEnv:
         assert mock_exec.call_args.kwargs["start_new_session"] is True
 
     @pytest.mark.asyncio
-    async def test_codex_direct_spawn_when_os_user_is_current(self, tmp_path):
+    async def test_codex_refuses_same_user_spawn(self, tmp_path):
+        """Codex memory MUST NOT run as the bot user. The
+        construction-level None case is already refused; this test
+        pins the same-user case (os_user resolves to the current
+        process user). The refusal fires BEFORE the subprocess
+        spawn so no codex process ever starts under the bot
+        identity.
+
+        Replaces the historical direct-spawn behavior pinned by the
+        prior `test_codex_direct_spawn_when_os_user_is_current`
+        test. The old behavior contradicted the safety claim in
+        CodexOneShotReasoner.run() and the operator's standing
+        kai/daniel separation policy: codex running as the bot
+        user would have access to /etc/kai/env and other bot-only
+        state through sudoers."""
         reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user=_current_user())
-        proc = _make_proc(stdout=b"")
+        spawn_called = []
+
+        async def fail_exec(*args, **kwargs):
+            spawn_called.append(args)
+            raise AssertionError("subprocess must not spawn on the same-user refusal path")
+
         with (
-            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec,
-            pytest.raises(OneShotOutputError),
+            patch("kai.oneshot.asyncio.create_subprocess_exec", side_effect=fail_exec),
+            pytest.raises(OneShotRoutingError) as exc,
         ):
             await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
-        cmd = mock_exec.call_args[0]
-        assert "sudo" not in cmd
-        assert mock_exec.call_args.kwargs["start_new_session"] is False
+        assert "same-user spawn" in str(exc.value)
+        assert spawn_called == []
 
     @pytest.mark.asyncio
     async def test_codex_wraps_with_preserve_env(self, tmp_path):
@@ -1279,6 +1351,7 @@ class TestRoutingArgvAndPreserveEnv:
         assert mock_exec.call_args.kwargs["start_new_session"] is True
 
 
+@pytest.mark.routing_test
 class TestRoutingRefusal:
     """Codex with `os_user=None` refuses to run; Claude does not.
 
@@ -1316,6 +1389,7 @@ class TestRoutingRefusal:
         assert "sudo" not in cmd
 
 
+@pytest.mark.routing_test
 class TestRoutingTimeoutCleanup:
     """On timeout from a wrapped spawn, the cross-user kill goes
     out BEFORE the wrapper reap. Negative-PGID covers the whole
@@ -1469,6 +1543,7 @@ class TestCwdAndSchemaModes:
         assert captured["mode"] == 0o644
 
 
+@pytest.mark.routing_test
 class TestRoutingLogField:
     """Every outcome line carries `os_user=<target>` or `os_user=self`."""
 

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -42,6 +42,24 @@ def _current_user() -> str:
     return pwd.getpwuid(os.getuid()).pw_name
 
 
+@pytest.fixture(autouse=True)
+def _mock_binary_resolver():
+    """Pin the binary resolver to literal backend names so existing
+    argv-shape assertions stay valid across host machines. Tests that
+    care about resolver behavior itself (e.g. CODEX_BIN override
+    validation) patch over this fixture with their own values."""
+
+    def fake_resolve(backend: str) -> str:
+        if backend == "claude":
+            return "claude"
+        if backend == "codex":
+            return "codex"
+        raise ValueError(f"unknown backend: {backend!r}")
+
+    with patch("kai.oneshot.resolve_oneshot_binary", side_effect=fake_resolve):
+        yield
+
+
 def _make_proc(
     *,
     stdout: bytes = b"",
@@ -435,12 +453,28 @@ class TestCodexOneShotReasonerArgv:
     @pytest.mark.asyncio
     async def test_argv_honors_codex_bin_env(self, tmp_path, monkeypatch):
         """CODEX_BIN must override the bare `codex` resolution so
-        per-os_user homebrew installs work without PATH munging."""
-        monkeypatch.setenv("CODEX_BIN", "/custom/path/to/codex")
+        per-os_user homebrew installs work without PATH munging.
+        Bypasses the autouse resolver mock to exercise the real
+        resolver path; the test points CODEX_BIN at an executable
+        file in tmp_path so the resolver's is-file + executable
+        checks pass."""
+        fake_codex = tmp_path / "codex-bin"
+        fake_codex.write_text("#!/bin/sh\nexit 0\n")
+        fake_codex.chmod(0o755)
+        monkeypatch.setenv("CODEX_BIN", str(fake_codex))
+        # Bypass the autouse fixture for this single test by patching
+        # the real resolver back into place. The autouse fixture pins
+        # to literal "codex"; here we want the real CODEX_BIN
+        # honoring behavior to ground the assertion.
+        from kai.oneshot_binary import resolve_oneshot_binary as real_resolver
+
         reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user=_current_user())
         proc = _make_proc(stdout=_codex_envelope_ndjson({"ok": True}))
 
-        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+        with (
+            patch("kai.oneshot.resolve_oneshot_binary", side_effect=real_resolver),
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec,
+        ):
             await reasoner.run(
                 prompt="p",
                 purpose="fact_extraction",
@@ -448,7 +482,7 @@ class TestCodexOneShotReasonerArgv:
             )
 
         cmd = mock_exec.call_args[0]
-        assert cmd[0] == "/custom/path/to/codex"
+        assert cmd[0] == str(fake_codex)
 
     @pytest.mark.asyncio
     async def test_argv_omits_output_schema_without_schema(self, tmp_path):
@@ -1462,6 +1496,93 @@ class TestRoutingLogField:
             await reasoner.run(prompt="p", purpose="fact_extraction")
         msg = next(r.getMessage() for r in caplog.records if r.message.startswith("oneshot_reasoner"))
         assert "os_user=self" in msg
+
+
+# ── Binary resolver integration ─────────────────────────────────────
+
+
+class TestBinaryResolverIntegration:
+    """Both reasoners must convert leaf-module `BinaryResolutionError`
+    into `OneShotRoutingError` so the existing `memory_extraction`
+    catch surface (`except OneShotError`) stays unchanged. Also
+    confirms `OneShotResult.raw_metadata` carries `cmd` plus
+    `resolved_binary` so the smoke command can ground its output in
+    the subprocess boundary rather than re-resolving the binary."""
+
+    @pytest.mark.asyncio
+    async def test_claude_raises_routing_error_on_binary_unreachable(self, tmp_path):
+        """Claude argv builder catches BinaryResolutionError and
+        re-raises as OneShotRoutingError with the leaf-module
+        message preserved. `memory_extraction` already catches
+        OneShotError; the rewrap keeps its catch surface unchanged."""
+        from kai.oneshot_binary import BinaryResolutionError
+
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+
+        def boom(_backend: str) -> str:
+            raise BinaryResolutionError("could not resolve claude binary: `claude` not on PATH")
+
+        with (
+            patch("kai.oneshot.resolve_oneshot_binary", side_effect=boom),
+            pytest.raises(OneShotRoutingError) as exc,
+        ):
+            await reasoner.run(prompt="p", purpose="fact_extraction")
+        assert "claude binary" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_codex_raises_routing_error_on_binary_unreachable(self, tmp_path):
+        """Codex argv builder mirrors the claude branch: catch
+        BinaryResolutionError, re-raise as OneShotRoutingError."""
+        from kai.oneshot_binary import BinaryResolutionError
+
+        reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user=_current_user())
+
+        def boom(_backend: str) -> str:
+            raise BinaryResolutionError("could not resolve codex binary: CODEX_BIN unset, `codex` not on PATH")
+
+        with (
+            patch("kai.oneshot.resolve_oneshot_binary", side_effect=boom),
+            pytest.raises(OneShotRoutingError) as exc,
+        ):
+            await reasoner.run(prompt="p", purpose="fact_extraction")
+        assert "codex binary" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_claude_raw_metadata_carries_cmd_and_resolved_binary(self, tmp_path):
+        """OneShotResult.raw_metadata must carry `cmd` (full argv,
+        including any sudo prefix on cross-user routing) and
+        `resolved_binary` (pre-sudo agent path). Smoke prints
+        resolved_binary so the operator-visible answer is correct
+        under cross-user wrapping."""
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=b'{"ok": true}')
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(
+                prompt="hello",
+                model="claude-haiku-4-5",
+                timeout=30,
+                purpose="fact_extraction",
+            )
+        assert result.raw_metadata["resolved_binary"] == "claude"  # autouse fixture pins to literal
+        assert result.raw_metadata["cmd"][0] == "claude"
+        assert "--print" in result.raw_metadata["cmd"]
+
+    @pytest.mark.asyncio
+    async def test_codex_raw_metadata_carries_cmd_and_resolved_binary(self, tmp_path):
+        """Same shape as the claude case. Tested against the
+        non-schema branch so we exercise the simpler success path."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user=_current_user())
+        proc = _make_proc(stdout=_codex_event("agent_message", "free-form text").encode("utf-8") + b"\n")
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(
+                prompt="hello",
+                timeout=30,
+                purpose="fact_extraction",
+                json_schema=None,
+            )
+        assert result.raw_metadata["resolved_binary"] == "codex"
+        assert result.raw_metadata["cmd"][0] == "codex"
+        assert "exec" in result.raw_metadata["cmd"]
 
 
 # ── _sanitize_for_codex (issue #505) ────────────────────────────────

--- a/tests/test_oneshot_binary.py
+++ b/tests/test_oneshot_binary.py
@@ -1,0 +1,137 @@
+"""Tests for `kai.oneshot_binary` - the leaf binary resolver shared by
+config validation, the OneShotReasoner argv builders, and the smoke
+command.
+
+Resolution rules under test:
+- claude: shutil.which("claude") only.
+- codex: branches on CODEX_BIN. Explicit override validates as
+  is-file plus executable, no PATH fallback. No override falls back
+  to shutil.which.
+- Unknown backend: ValueError (distinct from BinaryResolutionError;
+  unknown backend is a caller bug, not an operator PATH issue).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kai.oneshot_binary import BinaryResolutionError, resolve_oneshot_binary
+
+
+class TestClaudeResolution:
+    def test_resolves_via_path(self, monkeypatch):
+        """shutil.which returning a path means the resolver returns it
+        verbatim. Pinned via monkeypatch so the test does not depend
+        on the host having claude installed."""
+        monkeypatch.setattr(
+            "kai.oneshot_binary.shutil.which", lambda name: "/fake/path/claude" if name == "claude" else None
+        )
+        assert resolve_oneshot_binary("claude") == "/fake/path/claude"
+
+    def test_raises_when_unreachable(self, monkeypatch):
+        """No claude on PATH must raise BinaryResolutionError, NOT
+        return a fallback or empty string. The message names the
+        candidate so the operator can fix it."""
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", lambda name: None)
+        with pytest.raises(BinaryResolutionError) as exc:
+            resolve_oneshot_binary("claude")
+        assert "claude" in str(exc.value)
+        assert "PATH" in str(exc.value)
+
+
+class TestCodexResolution:
+    def test_no_override_resolves_via_path(self, monkeypatch):
+        """CODEX_BIN unset, codex on PATH. Same shape as the claude
+        resolution path; the test is here for parity so a future
+        backend-asymmetric regression surfaces."""
+        monkeypatch.delenv("CODEX_BIN", raising=False)
+        monkeypatch.setattr(
+            "kai.oneshot_binary.shutil.which", lambda name: "/fake/path/codex" if name == "codex" else None
+        )
+        assert resolve_oneshot_binary("codex") == "/fake/path/codex"
+
+    def test_no_override_unreachable_raises_naming_both_candidates(self, monkeypatch):
+        """Without CODEX_BIN and without codex on PATH, the message
+        must name both candidates so the operator does not have to
+        guess which branch fired."""
+        monkeypatch.delenv("CODEX_BIN", raising=False)
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", lambda name: None)
+        with pytest.raises(BinaryResolutionError) as exc:
+            resolve_oneshot_binary("codex")
+        message = str(exc.value)
+        assert "CODEX_BIN" in message
+        assert "PATH" in message
+
+    def test_explicit_override_resolves_to_exact_path(self, tmp_path, monkeypatch):
+        """A real executable file at CODEX_BIN resolves to that exact
+        path, NOT a shutil.which lookup of its name. Tests the
+        is-file plus executable validation."""
+        fake = tmp_path / "codex-binary"
+        fake.write_text("#!/bin/sh\nexit 0\n")
+        fake.chmod(0o755)
+        monkeypatch.setenv("CODEX_BIN", str(fake))
+        # Even if PATH would also resolve codex, the override wins.
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", lambda name: "/other/codex")
+        assert resolve_oneshot_binary("codex") == str(fake)
+
+    def test_explicit_override_not_a_file_raises_not_a_file(self, tmp_path, monkeypatch):
+        """CODEX_BIN pointing at a nonexistent path raises with
+        'not-a-file' in the message. NO PATH fallback fires; a bad
+        explicit override is a configuration error, not a recovery
+        opportunity."""
+        monkeypatch.setenv("CODEX_BIN", str(tmp_path / "does-not-exist"))
+        # Ensure PATH would have resolved had the fallback been used;
+        # the test fails open if the fallback unexpectedly fires.
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", lambda name: "/should/not/be/returned")
+        with pytest.raises(BinaryResolutionError) as exc:
+            resolve_oneshot_binary("codex")
+        message = str(exc.value)
+        assert "not-a-file" in message
+        assert "does-not-exist" in message
+
+    def test_explicit_override_not_executable_raises_not_executable(self, tmp_path, monkeypatch):
+        """CODEX_BIN pointing at a non-executable file raises with
+        'not-executable' in the message. The two error modes (not-a-
+        file vs not-executable) get distinct messages so the operator
+        can resolve the right one."""
+        fake = tmp_path / "codex-not-x"
+        fake.write_text("not-a-script")
+        fake.chmod(0o644)  # no execute bit
+        monkeypatch.setenv("CODEX_BIN", str(fake))
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", lambda name: "/should/not/be/returned")
+        with pytest.raises(BinaryResolutionError) as exc:
+            resolve_oneshot_binary("codex")
+        message = str(exc.value)
+        assert "not-executable" in message
+        assert str(fake) in message
+
+    def test_explicit_override_no_fallback_to_path(self, tmp_path, monkeypatch):
+        """Regression: when CODEX_BIN is set and resolves to a bad
+        path, the resolver MUST NOT silently fall back to
+        shutil.which('codex'). The fallback would hide stale-config
+        bugs from the operator."""
+        monkeypatch.setenv("CODEX_BIN", str(tmp_path / "missing"))
+
+        # Set up shutil.which to fail loudly if called - confirms
+        # the no-fallback contract directly.
+        called = []
+
+        def fake_which(name):
+            called.append(name)
+            return "/some/codex"
+
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", fake_which)
+        with pytest.raises(BinaryResolutionError):
+            resolve_oneshot_binary("codex")
+        assert called == [], f"shutil.which should not be called when CODEX_BIN is set; got {called}"
+
+
+class TestUnknownBackend:
+    def test_unknown_backend_raises_value_error(self):
+        """An unknown backend string is a CALLER bug (config validation
+        upstream should have rejected it), so the exception type is
+        ValueError, NOT BinaryResolutionError. The exception type
+        split lets call sites distinguish 'fix the operator's PATH'
+        from 'fix the code that asked for the wrong backend'."""
+        with pytest.raises(ValueError, match="unknown backend"):
+            resolve_oneshot_binary("opencode")

--- a/tests/test_smoke_memory.py
+++ b/tests/test_smoke_memory.py
@@ -144,6 +144,53 @@ class TestSmokeMemorySuccess:
         assert "verdict: pass" not in out
 
 
+class TestSmokeMemoryProductionMode:
+    """The smoke claims to verify the memory extraction pipeline
+    end-to-end. Running the reasoner against a fixed payload when
+    production has memory disabled or extraction disabled produces a
+    false-positive 'pass' for a path that never fires on real
+    traffic. The smoke refuses to run in those configurations."""
+
+    @pytest.mark.asyncio
+    async def test_memory_disabled_exits_nonzero(self, monkeypatch, capsys):
+        """MEMORY_ENABLED=false: smoke must refuse, name the var, and
+        not invoke the reasoner."""
+        from kai.smoke import memory as smoke_module
+
+        monkeypatch.setattr(smoke_module, "load_config", lambda: _config(memory_enabled=False))
+
+        def fail_factory(*args, **kwargs):
+            pytest.fail("reasoner must not run when memory is disabled")
+
+        monkeypatch.setattr(smoke_module, "_get_memory_reasoner", fail_factory)
+        rc = await smoke_module._run(os_user=None)
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "MEMORY_ENABLED" in captured.err
+
+    @pytest.mark.asyncio
+    async def test_extraction_disabled_exits_nonzero(self, monkeypatch, capsys):
+        """Retrieval-only mode (MEMORY_ENABLED=true with extraction
+        disabled): smoke must refuse rather than print verdict:pass
+        against a path that will never fire on real traffic."""
+        from kai.smoke import memory as smoke_module
+
+        monkeypatch.setattr(
+            smoke_module,
+            "load_config",
+            lambda: _config(memory_extraction_enabled=False),
+        )
+
+        def fail_factory(*args, **kwargs):
+            pytest.fail("reasoner must not run when extraction is disabled")
+
+        monkeypatch.setattr(smoke_module, "_get_memory_reasoner", fail_factory)
+        rc = await smoke_module._run(os_user=None)
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "MEMORY_EXTRACTION_ENABLED" in captured.err
+
+
 class TestSmokeMemoryRoutingPrecondition:
     @pytest.mark.asyncio
     async def test_codex_without_os_user_exits_with_message(self, monkeypatch, capsys):

--- a/tests/test_smoke_memory.py
+++ b/tests/test_smoke_memory.py
@@ -1,0 +1,196 @@
+"""Tests for `kai.smoke.memory` - the operator-facing verification
+command for the memory reasoner pipeline.
+
+Two contracts under test:
+- Success path: reasoner returns at least one fact whose content
+  references the anchor substring; the command prints
+  resolved_binary from raw_metadata, fact rows, and exits 0.
+- Routing-precondition path: when the configured reasoner is codex
+  and `--os-user` is not supplied, exit 1 with a clear message
+  before any subprocess fires.
+
+The tests mock at the OneShotReasoner boundary so neither agent
+binary is actually invoked.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from kai.config import Config
+from kai.oneshot import OneShotResult
+
+_BASE_CONFIG = Config(
+    telegram_bot_token="test",
+    allowed_user_ids={1},
+    webhook_secret="test",
+)
+
+
+def _config(**overrides) -> Config:
+    """Minimal config for smoke testing. Memory must be enabled +
+    extraction-enabled for the smoke to even reach the reasoner;
+    other knobs match the dataclass defaults."""
+    defaults = {
+        "memory_enabled": True,
+        "memory_extraction_enabled": True,
+        "memory_reasoner_backend": "claude",
+        "memory_extraction_model": "claude-haiku-4-5",
+        "memory_episode_model": "",
+        "memory_extraction_timeout_s": 30,
+    }
+    defaults.update(overrides)
+    return replace(_BASE_CONFIG, **defaults)
+
+
+def _success_envelope() -> str:
+    """Envelope shape the smoke parses. Matches what
+    `--output-format=json` produces on the claude branch and what
+    CodexOneShotReasoner rewraps on the codex branch."""
+    import json as json_mod
+
+    return json_mod.dumps(
+        {
+            "structured_output": {
+                "facts": [
+                    {
+                        "content": "User takes coffee with oat milk, no sugar.",
+                        "tags": ["preference", "food"],
+                        "speaker": "user",
+                        "intent": "new",
+                        "confidence": 0.95,
+                    }
+                ],
+                "has_episode": False,
+            }
+        }
+    )
+
+
+class TestSmokeMemorySuccess:
+    @pytest.mark.asyncio
+    async def test_anchor_hit_exits_zero(self, monkeypatch, capsys):
+        """A reasoner result with at least one fact referencing the
+        anchor substring ('oat milk') yields exit 0. The smoke prints
+        the resolved binary and argv from raw_metadata, plus the
+        extracted facts list."""
+        from kai.smoke import memory as smoke_module
+
+        monkeypatch.setattr(smoke_module, "load_config", lambda: _config())
+        fake_run = AsyncMock(
+            return_value=OneShotResult(
+                text=_success_envelope(),
+                backend="claude",
+                model="claude-haiku-4-5",
+                raw_metadata={
+                    "cmd": ["claude", "--print"],
+                    "resolved_binary": "/fake/path/claude",
+                    "returncode": 0,
+                    "stderr": b"",
+                    "cwd": "/tmp",
+                },
+                duration_ms=42,
+            )
+        )
+        with patch.object(smoke_module, "_get_memory_reasoner", return_value=type("R", (), {"run": fake_run})()):
+            rc = await smoke_module._run(os_user=None)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "resolved_binary: /fake/path/claude" in out
+        assert "verdict: pass" in out
+        assert "oat milk" in out
+
+    @pytest.mark.asyncio
+    async def test_no_anchor_hit_exits_nonzero(self, monkeypatch, capsys):
+        """Reasoner succeeded structurally but extracted facts do not
+        reference the anchor substring: smoke treats that as a
+        content-failure and exits non-zero. Distinguishes 'extractor
+        broken' from 'extractor wrong'."""
+        import json as json_mod
+
+        from kai.smoke import memory as smoke_module
+
+        envelope = json_mod.dumps(
+            {
+                "structured_output": {
+                    "facts": [{"content": "User likes tea", "tags": [], "speaker": "user", "intent": "new"}],
+                    "has_episode": False,
+                }
+            }
+        )
+        monkeypatch.setattr(smoke_module, "load_config", lambda: _config())
+        fake_run = AsyncMock(
+            return_value=OneShotResult(
+                text=envelope,
+                backend="claude",
+                model="claude-haiku-4-5",
+                raw_metadata={
+                    "cmd": ["claude"],
+                    "resolved_binary": "/fake/claude",
+                    "returncode": 0,
+                    "stderr": b"",
+                    "cwd": "/tmp",
+                },
+                duration_ms=10,
+            )
+        )
+        with patch.object(smoke_module, "_get_memory_reasoner", return_value=type("R", (), {"run": fake_run})()):
+            rc = await smoke_module._run(os_user=None)
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "verdict: pass" not in out
+
+
+class TestSmokeMemoryRoutingPrecondition:
+    @pytest.mark.asyncio
+    async def test_codex_without_os_user_exits_with_message(self, monkeypatch, capsys):
+        """The codex reasoner refuses to spawn without an os_user.
+        Smoke must surface this requirement explicitly with a clear
+        message rather than fail at the routing layer; exit 1 before
+        any subprocess fires."""
+        from kai.smoke import memory as smoke_module
+
+        monkeypatch.setattr(smoke_module, "load_config", lambda: _config(memory_reasoner_backend="codex"))
+
+        # Reasoner should NEVER be constructed on the os_user-missing
+        # path; the precondition fires before _get_memory_reasoner.
+        def fail_factory(*args, **kwargs):
+            pytest.fail("_get_memory_reasoner must not run when --os-user is missing")
+
+        monkeypatch.setattr(smoke_module, "_get_memory_reasoner", fail_factory)
+
+        rc = await smoke_module._run(os_user=None)
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "--os-user" in captured.err
+        assert "users.yaml" in captured.err
+
+    @pytest.mark.asyncio
+    async def test_claude_without_os_user_proceeds(self, monkeypatch, capsys):
+        """On the claude branch, --os-user is optional. The reasoner
+        is invoked with os_user=None and the historical self-sudo-skip
+        path handles it gracefully."""
+        from kai.smoke import memory as smoke_module
+
+        monkeypatch.setattr(smoke_module, "load_config", lambda: _config())
+        fake_run = AsyncMock(
+            return_value=OneShotResult(
+                text=_success_envelope(),
+                backend="claude",
+                model="claude-haiku-4-5",
+                raw_metadata={
+                    "cmd": ["claude"],
+                    "resolved_binary": "/fake/claude",
+                    "returncode": 0,
+                    "stderr": b"",
+                    "cwd": "/tmp",
+                },
+                duration_ms=10,
+            )
+        )
+        with patch.object(smoke_module, "_get_memory_reasoner", return_value=type("R", (), {"run": fake_run})()):
+            rc = await smoke_module._run(os_user=None)
+        assert rc == 0


### PR DESCRIPTION
Closes #499.

Implements spec v7.1 at `/var/lib/kai/home/2114582497/docs/specs/499-codex-memory-production-enable.md` (operator-private).

## Summary

Codex semantic memory was implemented end-to-end through #495 / #496 / #497 / #501 / #504 / #506 / #508, but four operator-facing gates still forced it off:

- Wizard at three layers: codex-disable guard, claude-only extraction prompt gate, stale-key cleanup that stripped codex extraction config.
- Runtime gate at `bot.py:3739` (`effective_backend == "claude"`) that silently skipped extraction on codex installs even when memory was configured.

This PR removes all four gates, adds the surface an operator needs to verify a codex memory install (config-load validation, structured startup log, smoke command, docs), and keeps the supported retrieval-only mode unchanged.

## Architecture

- `kai.oneshot_binary` is a new stdlib-only leaf module that owns claude/codex binary resolution. `BinaryResolutionError` is distinct from `kai.oneshot.OneShotRoutingError` so the leaf module does not need to import the OneShot* hierarchy; reasoner argv builders catch and rewrap. The split is what lets `kai.config.load_config()` call into the resolver without creating an import cycle with `kai.oneshot` (which already imports from `kai.config`).
- `OneShotResult.raw_metadata` carries both `cmd` (full argv including sudo wrapper) and `resolved_binary` (pre-sudo agent path). Smoke prints `resolved_binary` so the operator-visible "which binary ran" answer is correct under cross-user routing where `cmd[0]` is "sudo".
- Cross-binary config validation fires only on composed `memory_extraction_enabled`; retrieval-only memory (MEMORY_ENABLED=true with extraction disabled) does NOT trigger the check, preserving the supported Mem0/Qdrant-only mode.
- `init_memory()` emits one structured `memory.config` INFO log. `extraction_binary` is populated only when extraction is enabled; retrieval-only emits `null` and never calls the resolver, so a retrieval-only install with no claude/codex on PATH still initializes successfully.

## Wizard

Seven surgical edits in `install.py`:

1. Drop the codex-disable guard (was forcing memory_enabled=false on codex).
2. Allow the extraction-enable prompt on codex installs.
3. New `MEMORY_REASONER_BACKEND` prompt, gated on extraction being enabled (a goose retrieval-only install cannot land an invalid value).
4. Episode model prompt is now reasoner-aware: codex branch defaults to blank (inherit extraction model); claude branch keeps `claude-sonnet-4-6`. Wizard validates explicit codex-branch entries against `CODEX_MODELS`.
5. Stale-key cleanup condition changed from `agent_backend != "claude"` to `not in ("claude", "codex")`. Cleanup still fires on goose retrieval-only.
6. Persist `MEMORY_REASONER_BACKEND` to env only when non-default.
7. Stale "currently requires the claude backend" copy dropped.

## Smoke command

`python -m kai.smoke.memory [--os-user <name>]` runs one extraction call against a fixed two-turn conversation and prints:

- Resolved backend, extraction model, episode model.
- Resolved binary path and full argv.
- Extracted facts list (content, tags, intent, speaker, confidence).
- Episode classification result.
- Total latency.

Exit 0 when at least one fact references the expected anchor substring; non-zero otherwise. Does NOT touch Qdrant. `--os-user` is required when the configured reasoner is codex; the codex reasoner refuses to spawn without one and the smoke surfaces the requirement explicitly rather than failing at the routing layer.

## Test plan

- [x] `pytest tests/`. 3386 passing, 1 skipped.
- [x] `ruff check .`. clean.
- [x] `ruff format --check .`. clean.
- [x] Pre-push hard-rule grep. clean.

New tests:

- `tests/test_oneshot_binary.py` (9 tests): claude / codex resolution success, CODEX_BIN override validation (not-a-file, not-executable, no PATH fallback), unknown-backend `ValueError`.
- `tests/test_smoke_memory.py` (4 tests): anchor-hit success, anchor-miss content failure, codex-without-os_user precondition, claude-without-os_user happy path.
- `TestMemoryReasonerBinaryValidation` in `test_config.py` (4 tests): claude / codex binary missing raises SystemExit; retrieval-only does NOT trigger the check; extraction-enabled-without-memory-enabled skips the check.
- `TestInitMemory` startup-log tests (3 new): disabled, retrieval-only, extraction-enabled.
- `TestBinaryResolverIntegration` in `test_oneshot.py` (4 tests): both reasoners rewrap `BinaryResolutionError` → `OneShotRoutingError`; both populate `cmd` and `resolved_binary` in `raw_metadata`.
- `TestCmdConfig` regression tests in `test_install.py` (3 new): goose retrieval-only does not persist an invalid `MEMORY_REASONER_BACKEND`; codex install enables memory with codex reasoner; codex install accept-all-defaults produces a `load_config`-compatible env (catches the "wizard default invalid under selected reasoner" bug class).

## What this unblocks

- An operator running a codex-backed install can now enable semantic memory through the standard wizard. No hand-editing required.
- `python -m kai.smoke.memory` gives a one-command verification that the configuration is wired correctly end-to-end without writing to the store.
- Issue #495 (backend-agnostic semantic memory epic) can close once this lands.

## Out of scope

- Retuning extraction quality (#511, #512).
- Codex `w-merged` workflow-noise miss (#513).
- OpenCode or other new memory backends.
- Goose-backed memory extraction.
- Wiki updates (separate sweep).
