### PR TITLE
refactor(backend): extract per-turn memory context assembly

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -810,6 +810,160 @@ def prepend_to_prompt(prompt: str | list, prefix: str) -> str | list:
     return [{"type": "text", "text": prefix}] + prompt
 
 
+# Persistent structural delimiter for the current user message. When
+# retrieval blocks contain quote-shaped lines that mimic real user
+# input (legacy `User said:` rows or sufficiently user-voiced extracted
+# facts), the inner agent can fail to recognize the trailing user text
+# as the actual message. This marker is the one structural signal that
+# says "the message below this line is the real one; respond to it."
+# Module-level so tests can import and assert against it without
+# string duplication.
+#
+# Bracket-label format chosen to match the visual shape of the other
+# context blocks (`[Recent conversations ...]`, `[Your persistent
+# memory ...]`, `[Relevant memories ...]`) without colliding with any
+# of them; a retrieval row could in principle contain any of those
+# header strings verbatim, but cannot accidentally produce this exact
+# label. NOT gated by a feature flag: the marker must be a permanent
+# fixture so prompt shape is consistent session-to-session.
+#
+# Lives in backend.py rather than claude.py because the per-turn
+# context-assembly contract (capture query before pollution, prepend
+# marker, prepend session/memory/reminder above it) is backend-neutral
+# and is consumed by `assemble_turn_context` below. Importing
+# backends should reference `kai.backend.USER_MESSAGE_MARKER`.
+USER_MESSAGE_MARKER = "[User's current message - respond to this:]"
+
+
+def extract_text_query(prompt: str | list) -> str:
+    """
+    Extract the user's original text from a prompt, before any context injection.
+
+    The memory retrieval query MUST come from the raw user message, not
+    from the prompt after session context, memory recall, or reminder
+    blocks have been prepended. On a fresh session the prepended
+    CLAUDE.md, MEMORY.md, history, and API docs reach ~10-20KB; if any
+    of that ends up in the embedding query, the first message's memory
+    retrieval is essentially random and the user-visible behavior is
+    "Kai never remembers anything on the first turn of a new session."
+
+    For string prompts the raw text is the prompt itself. For list
+    prompts (mixed-modal content blocks), return the first text block's
+    body. Defensive shape checks (`isinstance(block, dict)`,
+    `isinstance(block.get("text"), str)`) guard against malformed list
+    entries from older callers or future backends that may grow new
+    block shapes; an unexpected entry is skipped rather than crashing
+    the assembly path. Returns "" when no text block exists, which the
+    caller (`assemble_turn_context`) treats as "skip recall."
+    """
+    if isinstance(prompt, str):
+        return prompt
+    for block in prompt:
+        if isinstance(block, dict) and block.get("type") == "text" and isinstance(block.get("text"), str):
+            return block["text"]
+    return ""
+
+
+async def assemble_turn_context(
+    prompt: str | list,
+    *,
+    chat_id: int | None,
+    session_context: str = "",
+    workspace_reminder: str = "",
+) -> str | list:
+    """
+    Assemble the per-turn prompt context for an interactive backend.
+
+    Backend-neutral assembly of the per-turn prompt around a single
+    user message. Captures the original user text as the memory
+    search query BEFORE any context is prepended (so the embedding
+    vector is not polluted by injected CLAUDE.md / history / API docs
+    on fresh sessions), then layers prefixes in an order whose
+    inverse is the final reading order:
+
+        workspace_reminder    (topmost)
+        semantic memory block
+        session_context
+        USER_MESSAGE_MARKER
+        user prompt           (bottom; the real message)
+
+    `prepend_to_prompt` stacks each prefix ABOVE the existing prompt,
+    so the implementation order below is the REVERSE of the reading
+    order: marker first (so it lands closest to the user text),
+    session_context second, memory third, reminder last (topmost).
+    This is load-bearing and the single most common way to break the
+    invariant; the regression test
+    `tests/test_claude.py::test_delimiter_is_closest_prefix_to_user_text`
+    catches an inverted call order, but a backend that re-implements
+    this logic locally can drift silently.
+
+    Semantic recall is gated on both `chat_id is not None` (an empty
+    or fake user id risks cross-user behavior in any future memory
+    implementation that changes filtering semantics) AND a non-
+    whitespace search query (empty embeddings produce arbitrary
+    false-positive hits). `format_context` has its own empty-query
+    guard but skipping the call entirely keeps the "at most one
+    `memory.recall` log line per eligible turn" contract clear.
+
+    The `kai.memory` import is function-local because `kai.backend`
+    is imported from low-level entry points (config, install) that
+    must not pull the memory subsystem at module-load time, and
+    function-local import preserves the existing lazy-import shape
+    in claude.py so tests can patch `kai.memory.format_context`
+    without import-order surprises.
+
+    The helper does NOT call `build_session_context` or
+    `build_foreign_workspace_reminder`; those have backend-specific
+    inputs (fresh-session detection, workspace state, API context)
+    and stay backend-owned. The backend builds those strings and
+    passes them in. The helper owns only the ordering invariant.
+
+    Returns the assembled prompt in the same type family as the
+    input (`str | list`). Backends do their own protocol-specific
+    coercion afterwards (Claude stream-json content blocks, Codex
+    JSON-RPC text blocks, ACP content shape).
+    """
+    # Capture the raw user text before any prepend. Empty result is
+    # treated as "skip retrieval" by the guard below.
+    search_query = extract_text_query(prompt)
+
+    # Marker first so subsequent prepends stack ABOVE it. Always
+    # applied, even when memory is disabled or no recall fires:
+    # the marker protects the current user message from injected
+    # context, not just from recalled memories, so it must be a
+    # permanent prompt-shape fixture for interactive backends.
+    prompt = prepend_to_prompt(prompt, USER_MESSAGE_MARKER)
+
+    # First-session context (CLAUDE.md + PREFERENCES.md + recent
+    # history + API context) is built by the caller because the
+    # fresh-session lifecycle is backend-owned. Empty string is the
+    # normal non-fresh-session value.
+    if session_context:
+        prompt = prepend_to_prompt(prompt, session_context)
+
+    # Semantic recall on every eligible turn (~50-100ms via the
+    # executor inside format_context). Skip entirely when chat_id
+    # is None (cross-user leakage risk) or the query is whitespace-
+    # only (random embedding hits). The function-local import
+    # mirrors the claude.py shape pre-extraction so test patching
+    # of kai.memory.format_context stays valid.
+    if chat_id is not None and search_query.strip():
+        from kai.memory import format_context as memory_format_context
+
+        memory_ctx = await memory_format_context(search_query, user_id=str(chat_id))
+        if memory_ctx:
+            prompt = prepend_to_prompt(prompt, memory_ctx)
+
+    # Foreign-workspace reminder is built fresh by the caller on
+    # every turn (it depends on the workspace state at call time).
+    # Prepended last so it lands topmost in the final reading order,
+    # matching the pre-extraction Claude behavior.
+    if workspace_reminder:
+        prompt = prepend_to_prompt(prompt, workspace_reminder)
+
+    return prompt
+
+
 def get_workspace_system_prompt(
     workspace_config: WorkspaceConfig | None,
 ) -> str | None:

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -33,35 +33,15 @@ from kai.backend import (
     ApiContext,
     StreamEvent,
     apply_workspace_model,
+    assemble_turn_context,
     build_foreign_workspace_reminder,
     build_session_context,
     ensure_user_memory,
     ensure_user_preferences,
-    prepend_to_prompt,
 )
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
 
 log = logging.getLogger(__name__)
-
-
-# Persistent structural delimiter for the current user message. Spec
-# 360 §1.2 / §3.3: when retrieval blocks contain quote-shaped lines
-# that mimic real user input (legacy `User said:` rows or sufficiently
-# user-voiced extracted facts), the inner agent can fail to recognize
-# the trailing user text as the actual message. This marker is the
-# one structural signal that says "the message below this line is
-# the real one — respond to it." Module-level so tests can import
-# and assert against it without string duplication.
-#
-# Bracket-label format chosen to match the visual shape of the other
-# context blocks (`[Recent conversations ...]`, `[Your persistent
-# memory ...]`, `[Relevant memories ...]`) without colliding with any
-# of them — a retrieval row could in principle contain any of those
-# header strings verbatim, but cannot accidentally produce this exact
-# label. NOT gated by a feature flag: spec §5.1 requires the marker
-# to be a permanent fixture so prompt shape is consistent
-# session-to-session.
-USER_MESSAGE_MARKER = "[User's current message - respond to this:]"
 
 
 # ── Claude Code backend ─────────────────────────────────────────────
@@ -770,65 +750,36 @@ class ClaudeCodeBackend(AgentBackend):
             )
             return
 
-        # Capture the user's original message text for memory search
-        # BEFORE session context is prepended. On fresh sessions,
-        # prepend_to_prompt adds CLAUDE.md + MEMORY.md + history + API
-        # docs (~10-20KB) which would dominate the embedding vector and
-        # make the first message's memory retrieval essentially random.
-        if isinstance(prompt, str):
-            search_query = prompt
-        else:
-            search_query = next(
-                (block["text"] for block in prompt if block.get("type") == "text"),
-                "",
-            )
-
-        # Persistent structural delimiter for the current user message.
-        # Prepended FIRST in the chain so subsequent prepends (session,
-        # memory, reminder) stack ABOVE it in the assembled prompt,
-        # leaving the marker as the closest prefix to the user's
-        # actual text.
+        # Per-turn prompt context. Build the fresh-session bootstrap
+        # (MEMORY.md / PREFERENCES.md seed + session_context block)
+        # and the foreign-workspace reminder LOCALLY, then hand both
+        # to `assemble_turn_context` so the shared helper owns the
+        # ordering invariant (marker closest to user text, session/
+        # memory/reminder stacked above in that order).
         #
-        # This ordering is load-bearing and the most common way to
-        # break the spec 360 fix: `prepend_to_prompt` is a pure
-        # prefix-prepend, so calling it for the marker LAST in the
-        # chain would put the marker at the TOP of the assembled
-        # prompt — the exact opposite of the invariant. The order of
-        # the prepends below is the inverse of the final reading
-        # order. See spec 360 §3.3 and `tests/test_claude.py::
-        # test_delimiter_is_closest_prefix_to_user_text` for the
-        # regression test that catches the inverted form.
-        prompt = prepend_to_prompt(prompt, USER_MESSAGE_MARKER)
-
-        # Inject identity, memory, history, and API context on the
-        # first message of a new session. Context injection logic lives
-        # in backend.py as shared functions usable by any backend.
+        # Fresh-session lifecycle stays in the backend because the
+        # `_fresh_session` flag, the MEMORY.md/PREFERENCES.md seeding
+        # (and its swallowed-OSError contract), and the
+        # `build_session_context` inputs (workspace, home_workspace,
+        # API context, workspace_config) are all backend-owned state.
+        # The shared helper handles only string composition; pulling
+        # the lifecycle into it would couple the helper to per-
+        # backend internals it has no other reason to know about.
+        #
+        # The single-call MEMORY.md/PREFERENCES.md bootstrap retry
+        # caveat from before extraction still applies: the seed runs
+        # exactly once per session because `_fresh_session` flips to
+        # False unconditionally; a transient OSError inside
+        # `ensure_user_memory` / `ensure_user_preferences` is logged
+        # as a warning but not retried on subsequent messages of the
+        # same session. Failure modes here are persistent
+        # (permissions, missing parent dir), not transient, so the
+        # one-shot behavior is acceptable; documenting it so future
+        # readers do not assume self-healing.
+        session_ctx = ""
         if self._fresh_session:
             self._fresh_session = False
-            # Ensure this user's MEMORY.md exists before the session
-            # context is built. In production, install.py pre-creates
-            # the per-user directory; this call is a no-op then. For
-            # users added after install (or local dev with no install
-            # at all), it seeds the directory + file so the subprocess
-            # has a writable target and build_session_context reads a
-            # real file rather than falling back to the "not yet
-            # created" placeholder. See backend.ensure_user_memory().
-            #
-            # Retry limitation: this call is gated on _fresh_session,
-            # which the line above flips to False unconditionally. A
-            # transient OSError inside ensure_user_memory (logged as a
-            # warning, not raised) is therefore not retried on
-            # subsequent messages of the same session - the session
-            # would have to be rebuilt for another attempt. In
-            # practice the failure modes are persistent (permissions,
-            # missing parent dir), not transient, so this is
-            # acceptable; documenting it so future readers do not
-            # assume self-healing.
             ensure_user_memory(chat_id, DATA_DIR)
-            # Sibling bootstrap for the per-user PREFERENCES.md surface.
-            # Same scope, same OSError-swallow semantics; see
-            # backend.ensure_user_preferences() for the multi-user
-            # ownership caveats.
             ensure_user_preferences(chat_id, DATA_DIR)
             session_ctx = build_session_context(
                 workspace=self.workspace,
@@ -839,32 +790,22 @@ class ClaudeCodeBackend(AgentBackend):
                 data_dir=DATA_DIR,
                 memory_enabled=self.memory_enabled,
             )
-            prompt = prepend_to_prompt(prompt, session_ctx)
 
-        # Inject semantically relevant memories for this message.
-        # Runs on every message (~50-100ms). Returns empty string
-        # when memory is disabled or no relevant memories found.
-        # Skip entirely when chat_id is None - an empty-string user_id
-        # would search across all users, which is a data isolation risk.
-        if chat_id is not None and search_query:
-            from kai.memory import format_context as memory_format_context
+        # Foreign-workspace reminder is built fresh per turn (its
+        # value depends on the current workspace, which the operator
+        # can change between messages via `/workspace`). `build_
+        # foreign_workspace_reminder` returns None when the workspace
+        # equals home_workspace; `assemble_turn_context` no-ops on an
+        # empty string, so coerce the None to "" rather than threading
+        # the optional through the helper signature.
+        reminder = build_foreign_workspace_reminder(self.workspace, self.home_workspace) or ""
 
-            # token_budget is omitted - format_context uses the value
-            # from the Config stored at init_memory() time. Awaited
-            # because the search runs in an executor to avoid blocking.
-            memory_ctx = await memory_format_context(
-                search_query,
-                user_id=str(chat_id),
-            )
-            if memory_ctx:
-                prompt = prepend_to_prompt(prompt, memory_ctx)
-
-        # When in a foreign workspace, remind on every message to only
-        # respond to what the user asks - workspace context (CLAUDE.md,
-        # git branch, auto-memory) can otherwise trigger autonomous action.
-        reminder = build_foreign_workspace_reminder(self.workspace, self.home_workspace)
-        if reminder:
-            prompt = prepend_to_prompt(prompt, reminder)
+        prompt = await assemble_turn_context(
+            prompt,
+            chat_id=chat_id,
+            session_context=session_ctx,
+            workspace_reminder=reminder,
+        )
 
         content = prompt if isinstance(prompt, list) else [{"type": "text", "text": prompt}]
         msg = (

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1444,3 +1444,288 @@ class TestApplyWorkspaceModel:
             result = apply_workspace_model(wc, "claude", "anthropic", "sonnet")
         assert result == "sonnet"
         assert any("Ignoring workspace model override" in r.message for r in caplog.records)
+
+
+# ── Backend-neutral per-turn context assembly (#516) ────────────────
+
+
+class TestExtractTextQuery:
+    """Tests for the raw user-text extraction used as the memory search query.
+
+    The query must come from the original prompt BEFORE any context is
+    prepended; if the helper saw the post-injection prompt, the embedding
+    would be dominated by CLAUDE.md/MEMORY.md/history/API docs and
+    fresh-session retrieval would be essentially random.
+    """
+
+    def test_string_prompt_returns_full_text(self):
+        from kai.backend import extract_text_query
+
+        assert extract_text_query("Hello there") == "Hello there"
+
+    def test_empty_string_returns_empty(self):
+        from kai.backend import extract_text_query
+
+        assert extract_text_query("") == ""
+
+    def test_list_prompt_returns_first_text_block(self):
+        from kai.backend import extract_text_query
+
+        prompt = [
+            {"type": "image", "path": "/tmp/example.png"},
+            {"type": "text", "text": "Describe this."},
+        ]
+        assert extract_text_query(prompt) == "Describe this."
+
+    def test_list_prompt_no_text_block_returns_empty(self):
+        from kai.backend import extract_text_query
+
+        prompt = [{"type": "image", "path": "/tmp/example.png"}]
+        assert extract_text_query(prompt) == ""
+
+    def test_list_prompt_skips_malformed_entries(self):
+        """A block whose `text` field is not a string (or that is missing
+        the `type` key entirely) must not crash the helper. Pre-fix the
+        loose `next(...)` form would have raised KeyError or returned a
+        non-string; the defensive `isinstance` checks skip the bad entry
+        and fall through to the next candidate.
+        """
+        from kai.backend import extract_text_query
+
+        prompt = [
+            {"type": "text"},  # missing 'text' key
+            {"type": "text", "text": None},  # wrong type
+            {"type": "text", "text": "real text"},
+        ]
+        assert extract_text_query(prompt) == "real text"
+
+
+class TestAssembleTurnContext:
+    """Tests for the composed per-turn prompt assembly contract.
+
+    The ordering invariant is the contract: marker closest to user text,
+    then session_context, then memory, then workspace_reminder, with the
+    inverse of that order applied via repeated prepends. Backends that
+    re-implement this locally are exactly the failure mode the helper
+    exists to prevent; these tests pin the invariant at the helper level
+    so a future backend wire-up has a one-line integration target.
+    """
+
+    async def test_string_prompt_full_ordering(self, monkeypatch):
+        """All four context layers present, string prompt. Final reading
+        order must be reminder, memory, session, marker, user text, with
+        only whitespace separating the marker and the user message.
+        """
+        from kai.backend import USER_MESSAGE_MARKER, assemble_turn_context
+
+        async def fake_format_context(query, *, user_id, **kwargs):
+            return "[Relevant memories]\n- fact one"
+
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        result = await assemble_turn_context(
+            "ACTUAL_USER_TEXT",
+            chat_id=42,
+            session_context="[SESSION]",
+            workspace_reminder="[REMINDER]",
+        )
+        assert isinstance(result, str)
+        assert result.count(USER_MESSAGE_MARKER) == 1
+        # Inverse-prepend ordering: each subsequent layer lands above
+        # the previous one, so the final reading order from top to
+        # bottom is reminder, memory, session, marker, user text.
+        positions = [
+            result.index("[REMINDER]"),
+            result.index("[Relevant memories]"),
+            result.index("[SESSION]"),
+            result.index(USER_MESSAGE_MARKER),
+            result.index("ACTUAL_USER_TEXT"),
+        ]
+        assert positions == sorted(positions), positions
+        # Only whitespace between the marker and the user message.
+        marker_end = result.index(USER_MESSAGE_MARKER) + len(USER_MESSAGE_MARKER)
+        user_start = result.index("ACTUAL_USER_TEXT")
+        assert result[marker_end:user_start].strip() == "", repr(result[marker_end:user_start])
+
+    async def test_format_context_receives_raw_query(self, monkeypatch):
+        """The search query handed to format_context is the original user
+        text, not the post-prepend prompt. Pre-fix-shape regression: if
+        the helper extracted the query after session_context was applied,
+        the embedding would be dominated by CLAUDE.md/history/API docs.
+        """
+        from kai.backend import assemble_turn_context
+
+        captured: dict = {}
+
+        async def fake_format_context(query, *, user_id, **kwargs):
+            captured["query"] = query
+            captured["user_id"] = user_id
+            return ""
+
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        await assemble_turn_context(
+            "ACTUAL_USER_TEXT",
+            chat_id=42,
+            session_context="[10KB of CLAUDE.md and history]",
+            workspace_reminder="",
+        )
+        assert captured["query"] == "ACTUAL_USER_TEXT"
+        assert captured["user_id"] == "42"
+
+    async def test_no_memory_block_still_preserves_marker(self, monkeypatch):
+        """When format_context returns the empty string (memory disabled
+        or no relevant hits), the marker must still appear and remain
+        the closest prefix to the user text.
+        """
+        from kai.backend import USER_MESSAGE_MARKER, assemble_turn_context
+
+        async def fake_format_context(query, *, user_id, **kwargs):
+            return ""
+
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        result = await assemble_turn_context(
+            "user message",
+            chat_id=42,
+            session_context="",
+            workspace_reminder="",
+        )
+        assert isinstance(result, str)
+        assert result.count(USER_MESSAGE_MARKER) == 1
+        marker_end = result.index(USER_MESSAGE_MARKER) + len(USER_MESSAGE_MARKER)
+        user_start = result.index("user message")
+        assert result[marker_end:user_start].strip() == ""
+
+    async def test_chat_id_none_skips_recall(self, monkeypatch):
+        """chat_id=None must NOT call format_context. An empty or fake
+        user_id would search across all users, which is a data isolation
+        risk if a future memory implementation changes filtering
+        semantics. The marker still applies.
+        """
+        from kai.backend import USER_MESSAGE_MARKER, assemble_turn_context
+
+        called = False
+
+        async def fake_format_context(query, *, user_id, **kwargs):
+            nonlocal called
+            called = True
+            return "[Relevant memories]"
+
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        result = await assemble_turn_context(
+            "user message",
+            chat_id=None,
+            session_context="",
+            workspace_reminder="",
+        )
+        assert not called
+        assert USER_MESSAGE_MARKER in result
+
+    async def test_whitespace_query_skips_recall(self, monkeypatch):
+        """An empty or whitespace-only query produces arbitrary
+        embedding hits; the gate must skip the call entirely rather
+        than rely on format_context's own empty-query guard. The
+        marker still applies.
+        """
+        from kai.backend import USER_MESSAGE_MARKER, assemble_turn_context
+
+        called = False
+
+        async def fake_format_context(query, *, user_id, **kwargs):
+            nonlocal called
+            called = True
+            return "[Relevant memories]"
+
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        result = await assemble_turn_context(
+            "   ",
+            chat_id=42,
+            session_context="",
+            workspace_reminder="",
+        )
+        assert not called
+        assert USER_MESSAGE_MARKER in result
+
+    async def test_list_prompt_preserves_original_block_order(self, monkeypatch):
+        """List prompts get text prefixes inserted at the front; original
+        content blocks (e.g. an image followed by a text block) must
+        keep their relative order, and the memory query extraction must
+        find the original text block, not an injected one.
+        """
+        from kai.backend import USER_MESSAGE_MARKER, assemble_turn_context
+
+        captured: dict = {}
+
+        async def fake_format_context(query, *, user_id, **kwargs):
+            captured["query"] = query
+            return ""
+
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        original = [
+            {"type": "image", "path": "/tmp/example.png"},
+            {"type": "text", "text": "Describe this."},
+        ]
+        result = await assemble_turn_context(
+            original,
+            chat_id=42,
+            session_context="",
+            workspace_reminder="",
+        )
+        assert isinstance(result, list)
+        assert captured["query"] == "Describe this."
+        # Injected text-prefix blocks (the marker) come at the front;
+        # original image + text remain in order at the tail.
+        marker_block = next(
+            i for i, b in enumerate(result) if b.get("type") == "text" and b.get("text") == USER_MESSAGE_MARKER
+        )
+        image_block = next(i for i, b in enumerate(result) if b.get("type") == "image")
+        original_text_block = next(
+            i for i, b in enumerate(result) if b.get("type") == "text" and b.get("text") == "Describe this."
+        )
+        assert marker_block < image_block < original_text_block
+
+    async def test_list_prompt_no_text_skips_recall(self, monkeypatch):
+        """An image-only list prompt has no text query, so recall must
+        be skipped. The marker still applies as a text-prefix block.
+        """
+        from kai.backend import USER_MESSAGE_MARKER, assemble_turn_context
+
+        called = False
+
+        async def fake_format_context(query, *, user_id, **kwargs):
+            nonlocal called
+            called = True
+            return ""
+
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        original = [{"type": "image", "path": "/tmp/example.png"}]
+        result = await assemble_turn_context(
+            original,
+            chat_id=42,
+            session_context="",
+            workspace_reminder="",
+        )
+        assert not called
+        # Marker present as a text-prefix block at the front.
+        assert any(b.get("type") == "text" and b.get("text") == USER_MESSAGE_MARKER for b in result)
+
+    async def test_format_context_called_once_per_eligible_turn(self, monkeypatch):
+        """format_context must be called exactly once per eligible turn;
+        the helper does not retry or fan out. The single-call contract
+        keeps the `memory.recall` log line count predictable.
+        """
+        from kai.backend import assemble_turn_context
+
+        call_count = 0
+
+        async def fake_format_context(query, *, user_id, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return "[Relevant memories]"
+
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        await assemble_turn_context(
+            "user message",
+            chat_id=42,
+            session_context="",
+            workspace_reminder="",
+        )
+        assert call_count == 1

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1710,7 +1710,7 @@ class TestContextInjection:
         marker, and the user's actual text must appear after it. Imported
         from the module rather than hard-coded so a future rename of the
         constant fails this test loudly rather than silently drifting."""
-        from kai.claude import USER_MESSAGE_MARKER
+        from kai.backend import USER_MESSAGE_MARKER
 
         proc = _make_mock_proc([_system_event(), _result_event(), b""])
         claude = _make_claude(workspace=home_workspace, home_workspace=home_workspace)
@@ -1747,7 +1747,7 @@ class TestContextInjection:
         to return a non-empty string so the memory_ctx prepend also
         fires. With all three context blocks populated we can assert
         their relative position to the marker."""
-        from kai.claude import USER_MESSAGE_MARKER
+        from kai.backend import USER_MESSAGE_MARKER
 
         proc = _make_mock_proc([_system_event(), _result_event(), b""])
         # Foreign workspace so build_foreign_workspace_reminder returns
@@ -1808,6 +1808,48 @@ class TestContextInjection:
         user_idx = prompt.index("ACTUAL_USER_TEXT")
         between = prompt[marker_idx + len(USER_MESSAGE_MARKER) : user_idx]
         assert between.strip() == "", f"non-whitespace between marker and user text: {between!r}"
+
+    @pytest.mark.asyncio
+    async def test_memory_query_captured_before_session_context_pollution(self, home_workspace, foreign_workspace):
+        """Pin the read-path invariant for the integration: when Claude
+        is on a fresh session (so build_session_context fires and the
+        prompt grows to include CLAUDE.md, recent history, API docs,
+        etc.), format_context must still receive the RAW user text as
+        the embedding query, not the post-prepend prompt. Pre-fix
+        shape was protected inside claude._send_locked by capturing
+        search_query before any prepend; post-extraction the same
+        guarantee comes from `assemble_turn_context` calling
+        `extract_text_query` as its first operation. This test exists
+        at the integration boundary so a future regression where
+        Claude bypasses the helper would be caught here, not only in
+        the helper-level unit tests.
+        """
+        proc = _make_mock_proc([_system_event(), _result_event(), b""])
+        claude = _make_claude(
+            workspace=foreign_workspace,
+            home_workspace=home_workspace,
+            webhook_secret="secret",
+        )
+        claude._proc = proc
+        claude._fresh_session = True
+
+        captured: dict = {}
+
+        async def fake_format_context(query, *, user_id, **kwargs):
+            captured["query"] = query
+            captured["user_id"] = user_id
+            return ""
+
+        with (
+            patch("kai.backend.get_recent_history", return_value="prior turn"),
+            patch("kai.memory.format_context", new=fake_format_context),
+        ):
+            events = []
+            async for event in claude._send_locked("What do I prefer?", chat_id=42):
+                events.append(event)
+
+        assert captured["query"] == "What do I prefer?"
+        assert captured["user_id"] == "42"
 
 
 # ── _send_locked: multi-modal prompt ─────────────────────────────────


### PR DESCRIPTION
## Summary

- Extract Claude's per-turn memory context assembly (query capture, USER_MESSAGE_MARKER, session/memory/reminder layering) into a backend-neutral helper.
- Wire `ClaudeCodeBackend._send_locked` through the helper. No runtime behavior change.
- Sets up Codex and Goose semantic-memory wire-throughs as follow-up PRs that call one obvious function instead of re-implementing the ordering invariant locally.

Closes #516.

## What moved

`src/kai/backend.py` gains:

- `USER_MESSAGE_MARKER` constant (moved from `claude.py`).
- `extract_text_query(prompt)` returns the raw user text BEFORE any context injection. Defensive `isinstance` checks on list-block shape so a malformed or future-extended block does not crash the assembly path.
- `assemble_turn_context(prompt, *, chat_id, session_context, workspace_reminder)` async helper that owns the ordering invariant (marker closest to user text, then session, then memory, then reminder).

`src/kai/claude.py`:

- Imports `USER_MESSAGE_MARKER` and `assemble_turn_context` from `kai.backend`.
- `_send_locked` builds `session_ctx` (only on fresh sessions) and the foreign-workspace reminder, then hands both to `assemble_turn_context`. Inline marker + query-capture + recall blocks removed.

Codex and Goose are intentionally not touched in this PR.

## Ordering invariant (unchanged)

Final reading order, top to bottom:

```
workspace_reminder    (topmost)
semantic memory block
session_context
USER_MESSAGE_MARKER
user prompt           (bottom; the real message)
```

`prepend_to_prompt` stacks each prefix ABOVE the existing prompt, so the implementation order in the helper is the REVERSE of the reading order: marker first, session second, memory third, reminder last. Existing regression `tests/test_claude.py::test_delimiter_is_closest_prefix_to_user_text` pins this.

## Test plan

- [x] `pytest tests/test_backend.py tests/test_claude.py tests/test_memory.py` -> 387 passed
- [x] `pytest tests/test_codex.py tests/test_goose.py` -> 117 passed, runtime unchanged
- [x] Full suite -> 3416 passed, 1 skipped
- [x] `ruff check .` + `ruff format --check .` clean
- [x] 13 new helper-level tests (`TestExtractTextQuery`, `TestAssembleTurnContext`) covering string + list prompts, ordering, chat_id=None / whitespace-query gating, query capture before pollution, single-call contract
- [x] 1 new claude integration test (`test_memory_query_captured_before_session_context_pollution`) asserts `format_context` receives the raw user text on a fresh session
- [x] `USER_MESSAGE_MARKER` import in the two existing claude regression tests updated to `kai.backend`
