### PR TITLE
refactor(memory): derive memory reasoner per-user from agent_backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ Workspaces can also define a system prompt via `workspaces.yaml` for workspace-s
 
 #### Memory backend selection
 
-Semantic memory extraction (the subprocess that proactively writes facts and episode summaries) is independent of the agent backend. The reasoner used for extraction is selected by `MEMORY_REASONER_BACKEND` (`claude` or `codex`); each value names the subprocess that runs the extraction call. All four combinations of agent backend and reasoner backend are supported (claude+claude, claude+codex, codex+claude, codex+codex). The wizard defaults to the same-vendor case when extraction is enabled, but the operator can pick either.
+Semantic memory extraction (the subprocess that proactively writes facts and episode summaries) routes per-user: each user's effective `agent_backend` selects the reasoner, and the model comes from the project's `MODEL_REGISTRY` for that `(role, backend)` pair. Claude-effective users get the claude reasoner with the claude-registry model; codex-effective users get the codex reasoner with the codex-registry model. There is no per-deployment override for the memory reasoner or model; an operator who wants a different model edits the registry in `config.py`.
 
-The named binary must be reachable at startup when extraction is enabled; the bot exits at config-load otherwise with a message naming the resolution sequence. Retrieval-only memory (`MEMORY_ENABLED=true` with extraction disabled) does not require either binary.
+Each backend that runs extraction on this install must have its binary reachable at startup; the bot exits at config-load otherwise with a message naming the offending backend and resolution sequence. Retrieval-only memory (`MEMORY_ENABLED=true` with extraction disabled) requires no extraction binary.
 
-To verify a memory configuration end-to-end without writing to the store, run `python -m kai.smoke.memory` from the install directory. Pass `--os-user <name>` when the configured reasoner is codex; the codex reasoner refuses to spawn without one. The smoke prints the resolved binary, the argv that ran, and any extracted facts.
+To verify a memory configuration end-to-end without writing to the store, run `python -m kai.smoke.memory` from the install directory. Pass `--user-id <chat_id>` to drive the smoke under that user's effective backend (otherwise the global `AGENT_BACKEND` is used). Pass `--os-user <name>` when the effective backend resolves to codex; the codex reasoner refuses to spawn without one. The smoke prints the resolved binary, the argv that ran, and any extracted facts.
 
 ### Scheduled jobs
 

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -146,12 +146,7 @@ _ALL_CURATED_MODELS: frozenset[str] = frozenset(
 # deliberately: conversational model selection is owned by pool.py +
 # DEFAULT_MODEL + PROVIDER_DEFAULTS, and routing it through the
 # registry would collide with the per-user override layer that
-# users.yaml / /settings already provide. FACT_EXTRACTION /
-# EPISODE_EXTRACTION are also excluded; they are owned by
-# config.memory_extraction_model / memory_episode_model with the
-# load_config inheritance sentinel below, and the future
-# backend-agnostic memory epic will introduce them to this enum
-# alongside their codex consumer.
+# users.yaml / /settings already provide.
 
 
 class ModelRole(StrEnum):
@@ -169,14 +164,13 @@ class ModelRole(StrEnum):
     ISSUE_TRIAGE = "issue_triage"
     BEHAVIORAL_JUDGE = "behavioral_judge"
     BEHAVIORAL_GEN = "behavioral_gen"
-    # Memory extraction roles. Routed through the per-backend registry
-    # so MEMORY_REASONER_BACKEND=codex can resolve a codex-native
-    # model (gpt-5.4-mini) instead of inheriting the Claude-shaped
-    # `claude-haiku-4-5-20251001` literal that the codex CLI would
-    # reject. MEMORY_EPISODE is a distinct row from MEMORY_EXTRACTION
-    # so an operator can downgrade one stage without the other;
-    # load_config still applies the "episode inherits extraction"
-    # default at env-resolution time when MEMORY_EPISODE_MODEL is unset.
+    # Memory extraction roles. Resolved per-user at extraction time:
+    # `get_model_for(MEMORY_EXTRACTION, effective_backend)` picks the
+    # registry row matching the user's effective agent_backend. Codex
+    # users get the codex registry value (gpt-5.4-mini); claude users
+    # get the claude registry value. MEMORY_EPISODE is a distinct row
+    # so operators can adjust one stage without touching the other; both
+    # are runtime-only (no env-var override surface, no Config field).
     MEMORY_EXTRACTION = "memory_extraction"
     MEMORY_EPISODE = "memory_episode"
 
@@ -209,15 +203,15 @@ MODEL_REGISTRY: dict[tuple[str, ModelRole], str] = {
     # against CODEX_MODELS so future drift gets caught at startup.
     ("codex", ModelRole.BEHAVIORAL_JUDGE): "gpt-5.4-mini",
     ("codex", ModelRole.BEHAVIORAL_GEN): "gpt-5.4-mini",
-    # Memory extraction rows. Claude entries equal the existing
-    # `memory_extraction_model` / `memory_episode_model` dataclass
-    # default so an install that has not set MEMORY_REASONER_BACKEND
-    # sees byte-identical model resolution. Codex entries pick the
-    # smallest currently-exposed codex model (gpt-5.4-mini) on the
-    # same editorial tier as Claude's haiku selection; the structural
-    # validator below asserts both rows land on models the codex CLI
-    # accepts, so a future operator who renames a codex SKU surfaces
-    # the bad row at startup rather than at first extraction.
+    # Memory extraction rows. Claude entries match the historical
+    # extraction default (claude-haiku-4-5-20251001), so any install
+    # that ran under the old MEMORY_EXTRACTION_MODEL=<empty> path
+    # sees identical model resolution post-migration. Codex entries
+    # pick the smallest currently-exposed codex model (gpt-5.4-mini)
+    # on the same editorial tier as Claude's haiku selection;
+    # _check_model_registry_complete validates codex rows against
+    # CODEX_MODELS at startup so a future SKU rename surfaces the
+    # bad row before runtime.
     ("claude", ModelRole.MEMORY_EXTRACTION): "claude-haiku-4-5-20251001",
     ("claude", ModelRole.MEMORY_EPISODE): "claude-haiku-4-5-20251001",
     ("codex", ModelRole.MEMORY_EXTRACTION): "gpt-5.4-mini",
@@ -753,31 +747,18 @@ class Config:
     memory_token_budget: int = 2000
     memory_embedding_model: str = "all-MiniLM-L6-v2"
 
-    # Memory reasoner backend selection. Independent of `agent_backend`
-    # because memory extraction has not yet passed the cross-backend
-    # eval gate; an install running `AGENT_BACKEND=codex` must NOT
-    # silently flip memory extraction onto an unevaluated provider.
-    # Default stays "claude" until a follow-up production-enables the
-    # codex path. Values are validated at config-load time against
-    # `{"claude", "codex"}`; an unknown value is a SystemExit, matching
-    # the AGENT_BACKEND validation pattern. When `memory_enabled=False`
-    # or `memory_extraction_enabled=False`, the value still parses but
-    # no reasoner is invoked.
-    memory_reasoner_backend: str = "claude"
-
-    # Track 2 (Haiku extraction) config. Requires memory_enabled=True and
-    # a Claude backend. Default is False at Phase 2 ship so the self-
-    # reinforcing extraction loop has real-world observation time before
-    # the default flips. The kill switch is the same flag.
+    # Memory extraction toggle. Sub-toggle of memory_enabled (extraction
+    # only runs when memory is on); the kill switch is the same flag.
+    # The reasoner and model for extraction are derived per-user from
+    # the user's effective `agent_backend` at extraction time
+    # (memory_extraction._build_memory_reasoner +
+    # get_model_for(role, effective_backend)). There is no global
+    # MEMORY_REASONER_BACKEND / MEMORY_EXTRACTION_MODEL / MEMORY_EPISODE_MODEL
+    # config surface; the registry is the single source of truth for
+    # the (role, backend) -> model mapping. An operator who wants a
+    # different model for a (role, backend) pair edits MODEL_REGISTRY
+    # in code.
     memory_extraction_enabled: bool = False
-    # Default model name for extraction. The literal here is the
-    # Claude registry row; load_config() re-resolves this through
-    # `get_model_for(ModelRole.MEMORY_EXTRACTION, memory_reasoner_backend)`
-    # so an install with MEMORY_REASONER_BACKEND=codex gets a codex
-    # model instead of the Claude default. The dataclass literal
-    # stays because test fixtures construct Config directly and
-    # depend on a usable Claude default without going through env.
-    memory_extraction_model: str = "claude-haiku-4-5-20251001"
     # Per-call budget ceiling. Retained as inert compatibility config.
     # Both supported memory reasoners (claude and codex) are
     # subscription-backed in the operator deployment model and no code
@@ -830,17 +811,10 @@ class Config:
     # Stage-2 episode generation (issue #385). Conditional second extractor
     # that runs out-of-band on stage-1 positives (has_episode=true) to
     # produce one Sophia-shaped episode record per episode-worthy turn.
-    # Honors memory_enabled; no dedicated kill switch.
-    #
-    # memory_episode_model: empty string is the sentinel for "inherit
-    # memory_extraction_model" - load_config() applies the inheritance
-    # at startup, so an operator who only sets MEMORY_EXTRACTION_MODEL
-    # gets both stages on the new model. The literal stays empty here
-    # rather than a model name so a reader who greps for "what is the
-    # default model" is not misled: in production the dataclass literal
-    # is never the effective value. Test fixtures that construct Config
-    # directly should set this explicitly to a real model name.
-    memory_episode_model: str = ""
+    # Honors memory_enabled; no dedicated kill switch. The model is
+    # resolved per-user from the registry at episode-extraction time
+    # via get_model_for(ModelRole.MEMORY_EPISODE, effective_backend);
+    # there is no global override field.
     # Per-call budget ceiling (USD). Retained as inert compatibility
     # config. Same rationale as memory_extraction_budget_usd above:
     # both supported reasoners are subscription-backed and no code
@@ -1197,6 +1171,40 @@ def _load_workspace_configs() -> dict[Path, WorkspaceConfig]:
 
 # Valid user roles for users.yaml
 _VALID_ROLES = {"admin", "user"}
+
+
+def _compute_extraction_eligible_backends(
+    agent_backend: str,
+    user_configs: "dict[int, UserConfig] | None",
+    memory_extraction_enabled: bool,
+) -> set[str]:
+    """
+    Return the set of distinct effective backends across extraction-eligible users.
+
+    Mirrors `_ingest_memory`'s extraction gate (effective backend in
+    {"claude", "codex"}; goose users are filtered out because they
+    have no `OneShotReasoner` implementation). With users.yaml: each
+    user contributes its effective backend (per-user override or
+    global default). Without users.yaml (legacy ALLOWED_USER_IDS auth):
+    every authorized user inherits the global, so the set is
+    `{agent_backend}` when that is extraction-eligible, else empty.
+
+    Returns an empty set when `memory_extraction_enabled` is False;
+    callers that gate codex plumbing or registry validation off the
+    set should not fire on retrieval-only or memory-disabled installs.
+    """
+    if not memory_extraction_enabled:
+        return set()
+    eligible: set[str] = set()
+    if user_configs is None:
+        if agent_backend in ("claude", "codex"):
+            eligible.add(agent_backend)
+        return eligible
+    for uc in user_configs.values():
+        effective = uc.agent_backend or agent_backend
+        if effective in ("claude", "codex"):
+            eligible.add(effective)
+    return eligible
 
 
 def _load_user_configs(
@@ -1927,68 +1935,30 @@ def load_config() -> Config:
     # closed regardless of operator env-var ordering.
     memory_extraction_enabled = memory_extraction_enabled and memory_enabled
 
-    # Memory reasoner backend. Must validate BEFORE the role-resolved
-    # model defaults below so a typo like MEMORY_REASONER_BACKEND=gpt5
-    # is surfaced at config-load time, not at the first extraction
-    # call inside _get_memory_reasoner(). The valid set is {"claude",
-    # "codex"} for #497; OpenCode would extend this set, but adding
-    # it here without a registry row would defeat the registry
-    # completeness check.
-    memory_reasoner_backend = os.environ.get("MEMORY_REASONER_BACKEND", "claude").strip().lower()
-    _valid_memory_backends = ("claude", "codex")
-    if memory_reasoner_backend not in _valid_memory_backends:
-        raise SystemExit(
-            f"MEMORY_REASONER_BACKEND '{memory_reasoner_backend}' is not valid "
-            f"(must be one of: {', '.join(_valid_memory_backends)})"
-        )
+    # Deprecation warnings for the three retired memory env vars. The
+    # reasoner and model used for memory extraction now derive entirely
+    # from each user's effective `agent_backend` (per-user dispatch via
+    # memory_extraction._build_memory_reasoner +
+    # get_model_for(role, effective_backend)). A legacy /etc/kai/env
+    # may still carry any of these keys; honor them as one-shot
+    # deprecation hints (one log.warning per key seen), then ignore
+    # the values. The next `sudo make install` rewrites /etc/kai/env
+    # from install.conf with the wizard's emission blocks removed, so
+    # the keys do not survive the next reinstall.
+    _deprecated_memory_env = (
+        ("MEMORY_REASONER_BACKEND", "memory reasoner is now derived per-user from agent_backend"),
+        ("MEMORY_EXTRACTION_MODEL", "memory extraction model is now resolved per-user from the MODEL_REGISTRY"),
+        ("MEMORY_EPISODE_MODEL", "memory episode model is now resolved per-user from the MODEL_REGISTRY"),
+    )
+    for _legacy_key, _reason in _deprecated_memory_env:
+        if os.environ.get(_legacy_key):
+            log.warning(
+                "%s is deprecated and ignored; %s. Remove it from /etc/kai/env "
+                "(the next 'sudo make install' will drop it automatically).",
+                _legacy_key,
+                _reason,
+            )
 
-    # Cross-binary validation. When the operator has BOTH MEMORY_ENABLED=true
-    # AND MEMORY_EXTRACTION_ENABLED=true (the composed `memory_extraction_enabled`
-    # value above), the configured reasoner backend's binary must be reachable
-    # at startup; otherwise the first extraction would surface as a runtime
-    # OneShotRoutingError at first user message rather than a clear config-load
-    # failure. Retrieval-only memory (MEMORY_ENABLED=true with extraction
-    # disabled) intentionally does NOT trigger this check because no reasoner
-    # subprocess runs in that mode; gaining a binary prerequisite there would
-    # break the supported retrieval-only configuration.
-    #
-    # Local import avoids any future risk of an import cycle with kai.oneshot
-    # (which itself imports from kai.config). We catch `BinaryResolutionError`,
-    # the leaf module's stdlib-only exception type, NOT `OneShotRoutingError`
-    # (which lives in kai.oneshot and would defeat the cycle-free design).
-    if memory_extraction_enabled:
-        from kai.oneshot_binary import BinaryResolutionError, resolve_oneshot_binary
-
-        try:
-            resolve_oneshot_binary(memory_reasoner_backend)
-        except BinaryResolutionError as e:
-            raise SystemExit(
-                f"MEMORY_REASONER_BACKEND='{memory_reasoner_backend}' requires the binary "
-                f"to be reachable at startup, but {e}. Set CODEX_BIN (for codex) or fix "
-                f"PATH (for either backend); rerun the wizard if you no longer want memory "
-                f"extraction enabled."
-            ) from None
-
-    # Memory model resolution. Env override wins; otherwise the role
-    # registry resolves to a backend-appropriate default (claude-haiku
-    # for backend=claude, gpt-5.4-mini for backend=codex). Sentinel
-    # empty-string from the dataclass would also fall through to the
-    # registry, but explicit None-check on the env var matches the
-    # other memory_* fields' style and keeps the read order
-    # predictable.
-    memory_extraction_model = os.environ.get("MEMORY_EXTRACTION_MODEL", "").strip()
-    if not memory_extraction_model:
-        memory_extraction_model = get_model_for(ModelRole.MEMORY_EXTRACTION, memory_reasoner_backend)
-    # Codex memory model overrides must name a model the codex CLI
-    # exposes. Claude memory model overrides stay free-form (matches
-    # the previous behavior; a stricter list would need its own
-    # validation pass and is out of scope here).
-    if memory_reasoner_backend == "codex" and memory_extraction_model not in CODEX_MODELS:
-        valid = sorted(CODEX_MODELS.keys())
-        raise SystemExit(
-            f"MEMORY_EXTRACTION_MODEL '{memory_extraction_model}' is not valid "
-            f"for memory_reasoner_backend='codex' (must be one of: {', '.join(valid)})"
-        )
     try:
         memory_extraction_budget_usd = float(os.environ.get("MEMORY_EXTRACTION_BUDGET_USD", "0.01"))
         if memory_extraction_budget_usd < 0:
@@ -2028,25 +1998,14 @@ def load_config() -> Config:
         raise SystemExit("MEMORY_CONSOLIDATION_CANDIDATES_N must be an integer") from None
 
     # Stage-2 episode generation (issue #385). Same try/except pattern as
-    # the other memory_* numeric vars. Model defaults to whatever was
-    # loaded for memory_extraction_model so an operator who changed only
-    # MEMORY_EXTRACTION_MODEL also moves stage 2 onto the new model;
-    # explicit MEMORY_EPISODE_MODEL takes precedence. Budget is strictly
-    # positive (zero would silently disable a real subprocess; the
-    # intentional kill switch is MEMORY_ENABLED). Timeout floor is 10s
-    # to prevent accidentally tightening it below Haiku's warm-up time.
-    memory_episode_model = os.environ.get("MEMORY_EPISODE_MODEL", "").strip() or memory_extraction_model
-    # Apply the same codex-CLI validation to the episode model. The
-    # episode default inherits memory_extraction_model (already
-    # validated), so this gate only fires on an explicit
-    # MEMORY_EPISODE_MODEL override that names a non-codex SKU under
-    # the codex memory backend.
-    if memory_reasoner_backend == "codex" and memory_episode_model not in CODEX_MODELS:
-        valid = sorted(CODEX_MODELS.keys())
-        raise SystemExit(
-            f"MEMORY_EPISODE_MODEL '{memory_episode_model}' is not valid "
-            f"for memory_reasoner_backend='codex' (must be one of: {', '.join(valid)})"
-        )
+    # the other memory_* numeric vars. Model resolution is per-user at
+    # extraction time (memory_extraction._resolve_episode_model uses
+    # get_model_for(ModelRole.MEMORY_EPISODE, effective_backend)); the
+    # global MEMORY_EPISODE_MODEL env var is deprecated and warned
+    # about above. Budget is strictly positive (zero would silently
+    # disable a real subprocess; the intentional kill switch is
+    # MEMORY_ENABLED). Timeout floor is 10s to prevent accidentally
+    # tightening it below Haiku's warm-up time.
     try:
         memory_episode_budget_usd = float(os.environ.get("MEMORY_EPISODE_BUDGET_USD", "0.15"))
         if memory_episode_budget_usd <= 0:
@@ -2130,87 +2089,97 @@ def load_config() -> Config:
         # but is the legacy path - nudge toward users.yaml.
         log.info("Using ALLOWED_USER_IDS from env (legacy). Run 'make config' to migrate to users.yaml.")
 
-    # Codex memory routing precondition. The codex reasoner refuses to
-    # spawn without an `os_user` (the security boundary that keeps
-    # codex from running as the bot user). The runtime resolver reads
-    # `os_user` from users.yaml per chat_id; if the entry is missing
-    # or unset, extraction silently collapses to a zero-state miss
-    # every turn. Fail at config-load with a clear remediation hint
-    # so the operator does not discover this through silently empty
-    # memory state.
-    #
-    # The precondition only applies to users whose EFFECTIVE agent
-    # backend is one the runtime would actually invoke extraction
-    # for. `bot.py:3739` gates extraction on
-    # `effective_backend in ("claude", "codex")`; goose users skip
-    # extraction entirely under that gate, so they do not need
-    # `os_user` for codex memory routing. The effective-backend
-    # cascade here mirrors the runtime: the user's per-entry
-    # `agent_backend` wins; otherwise the global default applies.
-    #
-    # Failure modes covered (scoped to extraction-eligible users):
-    #   1. users.yaml missing entirely: codex memory cannot be wired
-    #      because there is no per-user os_user surface.
-    #   2. users.yaml present but at least one extraction-eligible
-    #      entry lacks os_user: that user's extraction never runs.
-    #
-    # Claude memory does not need this check: ClaudeOneShotReasoner
-    # supports a None os_user (the historical Max-plan self-sudo-skip
-    # path that spawns claude as the bot user), so claude extraction
-    # still works without per-user OS routing.
-    if memory_extraction_enabled and memory_reasoner_backend == "codex":
-        if user_configs is None:
-            raise SystemExit(
-                "MEMORY_REASONER_BACKEND='codex' with MEMORY_EXTRACTION_ENABLED=true "
-                "requires users.yaml with a per-user 'os_user' entry for every "
-                "authorized chat_id. ALLOWED_USER_IDS alone does not provide the "
-                "OS-user routing the codex reasoner needs. Run 'make config' to "
-                "generate users.yaml, or set MEMORY_EXTRACTION_ENABLED=false to "
-                "run with retrieval-only memory."
-            )
-        # Mirror the runtime's effective-backend cascade: per-user
-        # `agent_backend` wins; otherwise the global default applies.
-        # Only users whose effective backend is one bot.py would
-        # actually run extraction for need an os_user.
-        extraction_users = [
-            uc for uc in user_configs.values() if (uc.agent_backend or agent_backend) in ("claude", "codex")
-        ]
-        missing = [uc.telegram_id for uc in extraction_users if not uc.os_user]
+    # Memory extraction preconditions, validated per the
+    # extraction-eligible backend set. Reasoner and model both derive
+    # per-user from each user's effective `agent_backend` at extraction
+    # time, so the "is this install in a valid state for memory
+    # extraction" question must read the full eligible set rather than
+    # a single global backend value. The helper mirrors
+    # `_ingest_memory`'s extraction gate in bot.py (goose users are
+    # filtered out because they have no `OneShotReasoner` implementation).
+    extraction_eligible_backends = _compute_extraction_eligible_backends(
+        agent_backend, user_configs, memory_extraction_enabled
+    )
+
+    # Codex extraction requires users.yaml. The codex reasoner
+    # spawns codex under each user's `os_user`; ALLOWED_USER_IDS-only
+    # authorization exposes no per-user os_user surface, so codex
+    # extraction would collapse to a zero-state miss every turn. Fail
+    # fast at config-load with a clear remediation hint.
+    if memory_extraction_enabled and "codex" in extraction_eligible_backends and user_configs is None:
+        raise SystemExit(
+            "Codex memory extraction requires users.yaml with a per-user 'os_user' entry "
+            "for every codex-effective chat_id. ALLOWED_USER_IDS alone does not provide "
+            "the OS-user routing the codex reasoner needs. Run 'make config' to generate "
+            "users.yaml, or set MEMORY_EXTRACTION_ENABLED=false to run with retrieval-only "
+            "memory."
+        )
+
+    # Every codex-effective user must have a non-bot-user os_user.
+    # Claude-effective users are NOT gated on os_user because
+    # ClaudeOneShotReasoner accepts os_user=None (the historical
+    # Max-plan self-sudo-skip path that spawns claude as the bot user).
+    # Codex has no equivalent safe path: spawning codex as the bot
+    # user would give it access to /etc/kai/env and other bot-user-only
+    # state, so the runtime CodexOneShotReasoner refuses; surface the
+    # same boundary at config-load.
+    if memory_extraction_enabled and user_configs is not None and "codex" in extraction_eligible_backends:
+        codex_users = [uc for uc in user_configs.values() if (uc.agent_backend or agent_backend) == "codex"]
+        missing = [uc.telegram_id for uc in codex_users if not uc.os_user]
         if missing:
             raise SystemExit(
-                "MEMORY_REASONER_BACKEND='codex' with MEMORY_EXTRACTION_ENABLED=true "
-                "requires every claude/codex users.yaml entry to set 'os_user'. The "
-                f"following chat_ids are missing 'os_user': {sorted(missing)}. Edit "
-                "users.yaml to add an 'os_user' field for each entry (the OS user "
-                "the codex subprocess will run as), or set MEMORY_EXTRACTION_ENABLED=false "
-                "to run with retrieval-only memory."
+                "Codex memory extraction requires every codex-effective users.yaml entry "
+                "to set 'os_user'. The following chat_ids are missing 'os_user': "
+                f"{sorted(missing)}. Edit users.yaml to add an 'os_user' field for each "
+                "entry (the OS user the codex subprocess will run as), or set "
+                "MEMORY_EXTRACTION_ENABLED=false to run with retrieval-only memory."
             )
-
-        # Codex must NOT run as the bot user. The codex reasoner
-        # refuses same-user spawn at runtime; surface the same
-        # boundary at config-load so a misconfigured users.yaml does
-        # not silently no-op every extraction. Detect by matching
-        # the configured os_user against the current process user;
-        # mirror the runtime's resolve_claude_user check so the two
-        # gates name the same condition.
         try:
             current_user = pwd.getpwuid(os.getuid()).pw_name
         except KeyError:
             # No passwd entry for the running UID (e.g., container
-            # with --user <uid>). The runtime resolve_claude_user
-            # falls through to honor the configured os_user in this
-            # case, so config-load does too.
+            # with --user <uid>); the runtime falls through to honor
+            # the configured os_user, so config-load does too.
             current_user = None
         if current_user is not None:
-            same_user = [uc.telegram_id for uc in extraction_users if uc.os_user == current_user]
+            same_user = [uc.telegram_id for uc in codex_users if uc.os_user == current_user]
             if same_user:
                 raise SystemExit(
-                    "MEMORY_REASONER_BACKEND='codex' refuses to run codex as the bot user "
+                    "Codex memory extraction refuses to run codex as the bot user "
                     f"({current_user!r}). The following users.yaml chat_ids have 'os_user' "
                     f"set to the bot user: {sorted(same_user)}. Set 'os_user' to a "
                     "different OS account, or set MEMORY_EXTRACTION_ENABLED=false to "
                     "run with retrieval-only memory."
                 )
+
+    # Registry completeness and binary resolution per
+    # eligible backend. With model env vars retired, get_model_for()
+    # is the only check that a (role, backend) registry row exists;
+    # the existing early _check_model_registry_complete(agent_backend)
+    # call covers conversational + triage + review + behavioral-eval
+    # rows for the global backend, but a per-user override to a
+    # different backend would reach runtime without its memory-role
+    # rows being validated. Loop over the eligible set after
+    # _load_user_configs runs so per-user overrides are visible.
+    # `_check_model_registry_complete` is idempotent so re-running
+    # it for the global backend if it appears in the set is harmless.
+    # `resolve_oneshot_binary` is gated on the same set so a missing
+    # CODEX_BIN on a deployment where any user routes to codex fails
+    # fast at startup instead of at the first extraction.
+    if memory_extraction_enabled and extraction_eligible_backends:
+        from kai.oneshot_binary import BinaryResolutionError, resolve_oneshot_binary
+
+        for _backend in sorted(extraction_eligible_backends):
+            _check_model_registry_complete(_backend)
+            try:
+                resolve_oneshot_binary(_backend)
+            except BinaryResolutionError as e:
+                raise SystemExit(
+                    f"Memory extraction requires the {_backend!r} binary to be reachable "
+                    f"at startup (at least one extraction-eligible user routes to it), but "
+                    f"{e}. Set CODEX_BIN (for codex) or fix PATH (for either backend); "
+                    f"rerun the wizard if you no longer want memory extraction enabled."
+                ) from None
 
     # Deprecation warnings for env vars superseded by users.yaml.
     # The vars still work as global fallbacks, but users.yaml is the
@@ -2336,14 +2305,11 @@ def load_config() -> Config:
         memory_search_limit=memory_search_limit,
         memory_token_budget=memory_token_budget,
         memory_embedding_model=memory_embedding_model,
-        memory_reasoner_backend=memory_reasoner_backend,
         memory_extraction_enabled=memory_extraction_enabled,
-        memory_extraction_model=memory_extraction_model,
         memory_extraction_budget_usd=memory_extraction_budget_usd,
         memory_extraction_timeout_s=memory_extraction_timeout_s,
         episode_classifier_context_turns=episode_classifier_context_turns,
         memory_consolidation_candidates_n=memory_consolidation_candidates_n,
-        memory_episode_model=memory_episode_model,
         memory_episode_budget_usd=memory_episode_budget_usd,
         memory_episode_timeout_s=memory_episode_timeout_s,
         memory_search_floor=memory_search_floor,

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -627,6 +627,13 @@ async def _run_one_probe(
         # separately so the v6 delta is attributed to v6 only -
         # lumping the two arms together would inflate the v6 metric
         # with v5's more numerous rejections.
+        # Per-user dispatch (issue #515): `_run_extractor` now requires
+        # an explicit `effective_backend`. The eval harness runs in
+        # single-backend mode (one prompt-pair comparison per run, no
+        # mixed-backend cascade), so the global `agent_backend` is the
+        # correct backend for both arms; threading it explicitly avoids
+        # relying on a default we no longer have.
+        effective_backend = config.agent_backend
         pre_v5 = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
         v5_result = await memory_extraction._run_extractor(
             payload,
@@ -634,6 +641,7 @@ async def _run_one_probe(
             candidate_ids=set(),
             candidate_metadata={},
             user_id=user_id,
+            effective_backend=effective_backend,
             system_prompt=baseline_prompt,
         )
         post_v5 = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
@@ -648,6 +656,7 @@ async def _run_one_probe(
             candidate_ids=set(),
             candidate_metadata={},
             user_id=user_id,
+            effective_backend=effective_backend,
         )
         post_v6 = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
         v6_rule_6_delta = post_v6 - pre_v6

--- a/src/kai/eval/memory_backend_gate.py
+++ b/src/kai/eval/memory_backend_gate.py
@@ -592,17 +592,21 @@ def make_backend_config(base_config: Config, backend: str) -> Config:
 
     Forces memory_enabled=True and memory_extraction_enabled=True so
     the harness can run against an install whose env file disables
-    memory in production; resolves the memory models through the
-    role registry so a future SKU rename is picked up automatically.
-    Uses `dataclasses.replace` because `Config` is frozen.
+    memory in production. Drives the per-user dispatch (issue #515)
+    by setting `agent_backend` to the backend under test; with no
+    `user_configs` override, `_resolve_effective_backend` in
+    `memory_extraction.py` returns the global value for every
+    extraction call, so the harness deterministically exercises one
+    backend per run. Memory models come from the registry per-call
+    via `get_model_for(role, effective_backend)`; no Config fields
+    carry per-backend models any more. Uses `dataclasses.replace`
+    because `Config` is frozen.
     """
     return dataclasses.replace(
         base_config,
         memory_enabled=True,
         memory_extraction_enabled=True,
-        memory_reasoner_backend=backend,
-        memory_extraction_model=get_model_for(ModelRole.MEMORY_EXTRACTION, backend),
-        memory_episode_model=get_model_for(ModelRole.MEMORY_EPISODE, backend),
+        agent_backend=backend,
     )
 
 
@@ -698,11 +702,16 @@ async def run_backend(
     elif memory.get_all(user_id=sandbox_user_id, limit=1):
         raise SystemExit(f"sandbox user {sandbox_user_id!r} has existing rows; pass --reset to clear them")
 
+    # Memory models for this run come from the per-backend registry,
+    # matching what `_resolve_effective_backend` -> `get_model_for`
+    # produces in production per-extraction. Pinned here so the
+    # BackendRun summary reports the same SKUs the reasoner actually
+    # spawned.
     run = BackendRun(
         backend=backend,
         sandbox_user_id=sandbox_user_id,
-        model_fact=config.memory_extraction_model,
-        model_episode=config.memory_episode_model,
+        model_fact=get_model_for(ModelRole.MEMORY_EXTRACTION, backend),
+        model_episode=get_model_for(ModelRole.MEMORY_EPISODE, backend),
         log_path=log_path,
     )
 

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -35,6 +35,7 @@ import tempfile
 import textwrap
 import time
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
@@ -533,16 +534,45 @@ def _cmd_config() -> None:
         existing_env.get("AGENT_BACKEND", "claude"),
     )
 
+    # Compute the two codex predicates the wizard branches on. Both
+    # use the authoritative-source rule: when users.yaml exists, the
+    # configured users alone determine whether codex runs; without
+    # users.yaml, the global AGENT_BACKEND is the only signal (every
+    # authorized user inherits it). `codex_runs_anywhere` gates
+    # everything codex needs to run AT ALL (CODEX_BIN, sudoers,
+    # login reminder) regardless of memory state. `codex_extraction_
+    # needed` narrows to memory-specific gates (codex memory os_user
+    # precondition surfaces at load_config; the fresh-install os_user
+    # re-prompt fires here).
+    #
+    # Re-read users.yaml here in case the wizard wrote a fresh
+    # admin entry above (lines ~485-493 for the not-users_yaml_exists
+    # branch); that file is now the authoritative source for the
+    # codex_users helper too. _codex_users_from_yaml falls back to []
+    # if the file is missing, so the fallback to global agent_backend
+    # in _compute_codex_runs_anywhere handles both fresh and
+    # existing-yaml paths.
+    try:
+        _codex_users_now = _codex_users_from_yaml(users_yaml_path, agent_backend)
+    except (OSError, ValueError):
+        _codex_users_now = []
+    codex_runs_anywhere = _compute_codex_runs_anywhere(agent_backend, users_yaml_exists, _codex_users_now)
+
     # Codex auth handling runs BEFORE the legacy provider/key block so
     # subscription mode is not gated on an OPENAI_API_KEY the operator
     # does not need. VALID_PROVIDERS["codex"] is intentionally unset
     # (codex is openai-only and has its own auth model), so the
     # legacy block below skips codex entirely - same path claude
-    # follows today.
+    # follows today. Gate is `codex_runs_anywhere` rather than
+    # `agent_backend == "codex"` so an install with global claude but
+    # a users.yaml that includes codex-effective users still collects
+    # CODEX_BIN, auth, and the login hint. Conversely, an install
+    # with global codex but a users.yaml where every entry overrides
+    # to non-codex skips codex setup entirely.
     codex_auth_mode = ""
     codex_api_key = ""
     codex_bin = ""
-    if agent_backend == "codex":
+    if codex_runs_anywhere:
         codex_auth_mode = _prompt_choice(
             "Codex auth mode",
             ["subscription", "api_key"],
@@ -969,17 +999,12 @@ def _cmd_config() -> None:
     # when the operator is on the claude backend AND extraction is
     # enabled - same gating pattern as the other extraction tunables.
     episode_classifier_context_turns = "3"
-    # Stage-2 episode generation defaults (issue #385). Each pre-init
+    # Stage-2 episode budget + timeout pre-inits (issue #385). Each
     # value matches the corresponding wizard prompt default and the
     # emission-gate sentinel so the data flow reads consistently
-    # whether the operator runs the episode block or skips it.
-    # Model is the exception by design: empty string here means
-    # "inherit memory_extraction_model" via load_config, while the
-    # wizard separately recommends Sonnet to operators who reach the
-    # prompt - they're different defaults for different audiences
-    # (test fixtures and skipped-wizard installs vs operators
-    # actively configuring).
-    memory_episode_model = ""
+    # whether the operator runs the episode block or skips it. The
+    # episode model itself is resolved per-user from the registry
+    # at extraction time; no wizard prompt or env var carries it.
     memory_episode_budget_usd = "0.15"
     memory_episode_timeout_s = "120"
     memory_token_budget = "2000"
@@ -991,13 +1016,6 @@ def _cmd_config() -> None:
     # default at runtime via load_config, so the env entry stays
     # suppressed by the delta-from-default check below.
     memory_duplicate_threshold = "0.9"
-    # Default to claude when the agent backend has no memory reasoner
-    # (goose retrieval-only) so the prompt-and-persist path never lands
-    # an invalid MEMORY_REASONER_BACKEND value. The prompt itself is
-    # gated on extraction being enabled below; for retrieval-only
-    # installs the variable is neither prompted nor persisted, so
-    # load_config falls back to the dataclass default at runtime.
-    memory_reasoner_backend = "claude"
     if memory_enabled:
         # Memory extraction is supported on agent backends that have a
         # OneShotReasoner implementation. Today that is claude and
@@ -1010,46 +1028,30 @@ def _cmd_config() -> None:
                 existing_env.get("MEMORY_EXTRACTION_ENABLED", "false").lower() in ("1", "true", "yes"),
             )
             if memory_extraction_enabled:
-                # MEMORY_REASONER_BACKEND selects which one-shot
-                # reasoner runs the extraction subprocess. Default
-                # mirrors the install's agent_backend (same vendor
-                # for both surfaces) when the agent has a reasoner;
-                # falls back to "claude" otherwise so the persisted
-                # value is always one config validation accepts.
-                # The prompt sits inside the extraction-enabled
-                # branch because the variable has no runtime effect
-                # when extraction is disabled.
-                reasoner_default = agent_backend if agent_backend in ("claude", "codex") else "claude"
-                while True:
-                    candidate = (
-                        _prompt(
-                            "Memory reasoner backend (claude or codex)",
-                            existing_env.get("MEMORY_REASONER_BACKEND", reasoner_default),
-                        )
-                        .strip()
-                        .lower()
-                    )
-                    if candidate in ("claude", "codex"):
-                        memory_reasoner_backend = candidate
-                        break
-                    print("  Must be 'claude' or 'codex'.")
-                # Codex extraction requires every extraction-eligible
+                # Per-user dispatch (issue #515). Memory reasoner and
+                # model derive from each user's effective agent_backend
+                # at extraction time via memory_extraction._build_
+                # memory_reasoner + get_model_for(role, effective_
+                # backend). There is no global reasoner or model
+                # config; the wizard prompts that used to ask for both
+                # were retired with the env vars they emitted.
+                codex_extraction_needed = codex_runs_anywhere
+                # Codex extraction requires every codex-effective
                 # users.yaml entry to set a non-bot-user `os_user`.
-                # CodexOneShotReasoner.run() refuses the None and the
-                # same-user cases at runtime; load_config() refuses the
-                # same shapes at startup. Without this wizard-time
-                # check, a fresh install that accepted the default
-                # "Configure advanced user options = false" earlier in
-                # the prompt sequence produces a users.yaml with no
-                # `os_user`, and load_config() then SystemExits on the
-                # next daemon start. Re-prompt and rewrite the wizard-
-                # owned users.yaml in-place so the generated config
-                # passes load_config. The check fires only when the
-                # wizard owns the file (`not users_yaml_exists`); when
-                # the operator owns users.yaml, the load_config
-                # SystemExit at next start surfaces the same shape of
-                # error with the same diagnostic.
-                if memory_reasoner_backend == "codex" and not users_yaml_exists:
+                # The runtime CodexOneShotReasoner.run() refuses
+                # missing-os_user and same-user spawning; load_config
+                # refuses the same shapes at startup. Without this
+                # wizard-time check, a fresh install that accepted
+                # the default "Configure advanced user options = false"
+                # earlier in the prompt sequence produces a users.yaml
+                # with no `os_user`, and load_config then SystemExits
+                # on the next daemon start. Re-prompt and rewrite the
+                # wizard-owned users.yaml in-place so the generated
+                # config passes load_config. The check fires only
+                # when the wizard owns the file (`not users_yaml_
+                # exists`); when the operator owns users.yaml, the
+                # load_config SystemExit surfaces the same diagnostic.
+                if codex_extraction_needed and not users_yaml_exists:
                     needs_reprompt = (
                         not admin_os_user or admin_os_user == service_user or not _validate_os_user(admin_os_user)
                     )
@@ -1084,21 +1086,28 @@ def _cmd_config() -> None:
                         users_yaml_path.write_text(users_yaml_content)
                         os.chmod(users_yaml_path, 0o600)
                         print(f"  Updated {users_yaml_path} with os_user={admin_os_user}")
-                # CODEX_BIN must be collected whenever the codex
-                # reasoner is selected, not only when the agent
-                # backend is codex. The earlier codex agent-backend
-                # block prompts for the binary path only on
-                # `agent_backend == "codex"`, so a claude+codex (or
-                # goose+codex) memory install would otherwise emit no
-                # CODEX_BIN entry. _apply_sudoers then falls back to
-                # /opt/homebrew/bin/codex via _generate_sudoers, while
-                # the runtime CodexOneShotReasoner resolves codex via
-                # PATH; if the two diverge the sudoers SETENV rule no
-                # longer matches the argv the reasoner spawns. Re-
-                # prompt here when the agent block did not already
-                # collect a value so install.conf, /etc/kai/env, and
-                # /etc/kai/sudoers.d cannot drift apart.
-                if memory_reasoner_backend == "codex" and not codex_bin:
+                        # users.yaml just gained a codex user; refresh
+                        # the codex_users set so codex_runs_anywhere
+                        # reflects the new state for any downstream
+                        # check that consults it (the env-emission
+                        # block reads codex_runs_anywhere via the
+                        # codex_bin emission gate).
+                        try:
+                            _codex_users_now = _codex_users_from_yaml(users_yaml_path, agent_backend)
+                        except (OSError, ValueError):
+                            _codex_users_now = []
+                        codex_runs_anywhere = _compute_codex_runs_anywhere(agent_backend, True, _codex_users_now)
+                        codex_extraction_needed = codex_runs_anywhere
+                # CODEX_BIN must be collected whenever codex runs
+                # anywhere on the install. The earlier codex agent
+                # block already prompts for the binary path when
+                # codex_runs_anywhere; this second prompt fires only
+                # in the rare case where the earlier block did not
+                # collect a value AND a codex user surfaces via the
+                # os_user re-prompt above. Defense in depth: even
+                # if the earlier prompt's gate was wrong, the binary
+                # path is collected before the env block writes.
+                if codex_runs_anywhere and not codex_bin:
                     while True:
                         which_codex = shutil.which("codex") or "/opt/homebrew/bin/codex"
                         codex_bin = _prompt(
@@ -1175,64 +1184,15 @@ def _cmd_config() -> None:
                     except ValueError:
                         pass
                     print("  Must be 0-10.")
-                # Stage-2 episode generation tunables (issue #385). All
-                # three sit inside the extraction-enabled guard because
-                # episodes only fire when stage 1 fires (the has_episode
-                # classifier comes from stage 1's output). Operators
-                # who disable extraction also disable episodes; those
-                # tunables would otherwise be wizard noise.
-                #
-                # Wizard recommends Sonnet for stage 2 even though the
-                # config dataclass default falls back to the extraction
-                # model (Haiku). Reasoning: stage 2 runs out-of-band so
-                # latency does not reach the user, and on a Max-plan
-                # OAuth subscription headless `claude --print` calls do
-                # not bill per-token, so the only reason to keep Haiku
-                # for stage 2 was historical (cost-asymmetry framing
-                # that does not apply to Kai's deployment shape).
-                # Narrative quality across the 7-8 Sophia episode
-                # fields is exactly the regime where Sonnet pulls ahead
-                # of Haiku, so the default the operator sees should
-                # reflect that. The dataclass default stays at "" so
-                # the inheritance fallback continues to work for tests
-                # and for operators who explicitly want to track
-                # whatever extraction model is set.
-                # Episode model default is reasoner-aware. On the codex
-                # reasoner load_config validates this value against
-                # CODEX_MODELS and exits on a non-codex SKU; a
-                # claude-sonnet default would fail config-load. Default
-                # to "" on codex so the inheritance fallback in
-                # load_config picks up the (already validated) codex
-                # extraction model. On claude the historical
-                # claude-sonnet-4-6 recommendation stands.
-                if memory_reasoner_backend == "codex":
-                    episode_default = ""
-                    episode_prompt = "Episode generator model (blank inherits extraction model)"
-                else:
-                    episode_default = "claude-sonnet-4-6"
-                    episode_prompt = "Episode generator model (Sonnet recommended for narrative quality)"
-                while True:
-                    candidate = _prompt(
-                        episode_prompt,
-                        existing_env.get("MEMORY_EPISODE_MODEL", episode_default),
-                    ).strip()
-                    # Validate non-empty entries against CODEX_MODELS on
-                    # the codex branch, matching load_config's fail-fast
-                    # rule. Blank stays blank (inheritance). Claude
-                    # branch accepts any non-empty string (free-form,
-                    # matches the prior behavior).
-                    if memory_reasoner_backend == "codex" and candidate:
-                        from kai.config import CODEX_MODELS
-
-                        if candidate not in CODEX_MODELS:
-                            valid = sorted(CODEX_MODELS.keys())
-                            print(
-                                f"  '{candidate}' is not a valid codex model. "
-                                f"Must be one of: {', '.join(valid)} or blank."
-                            )
-                            continue
-                    memory_episode_model = candidate
-                    break
+                # Stage-2 episode tunables (issue #385). Budget and
+                # timeout sit inside the extraction-enabled guard
+                # because episodes only fire when stage 1 fires (the
+                # has_episode classifier comes from stage 1's output).
+                # The episode model is resolved per-user from the
+                # registry at extraction time via get_model_for(
+                # ModelRole.MEMORY_EPISODE, effective_backend); the
+                # wizard prompt for the model was retired with the
+                # MEMORY_EPISODE_MODEL env var.
                 # No MEMORY_EPISODE_BUDGET_USD prompt on this branch:
                 # --max-budget-usd is omitted from the stage-2 claude
                 # --print argv (memory_extraction.py:_run_episode_extractor)
@@ -1467,15 +1427,14 @@ def _cmd_config() -> None:
         env["MEMORY_ENABLED"] = "true"
         if memory_extraction_enabled:
             env["MEMORY_EXTRACTION_ENABLED"] = "true"
-            # Persist MEMORY_REASONER_BACKEND only when non-default.
-            # The dataclass and load_config default is "claude"; an
-            # explicit "claude" selection is suppressed here so the
-            # generated env stays minimal. The prompt itself only
-            # fires when extraction is enabled (above), so a
-            # retrieval-only install never reaches this site and the
-            # key is never written for it.
-            if memory_reasoner_backend != "claude":
-                env["MEMORY_REASONER_BACKEND"] = memory_reasoner_backend
+            # MEMORY_REASONER_BACKEND, MEMORY_EXTRACTION_MODEL, and
+            # MEMORY_EPISODE_MODEL are deprecated (issue #515). Memory
+            # reasoner and model both derive per-user from each user's
+            # effective agent_backend via the model registry; there is
+            # no env-var surface to emit. Legacy values still parse
+            # as deprecation warnings at load_config time so existing
+            # installs survive one reboot before this wizard regenerates
+            # /etc/kai/env without those keys.
             # Double-gate (agent_backend AND non-default value) is
             # intentionally redundant: the wizard now skips the
             # extraction-budget prompt on claude, so the value is
@@ -1511,13 +1470,10 @@ def _cmd_config() -> None:
             if int(episode_classifier_context_turns) != 3:
                 env["EPISODE_CLASSIFIER_CONTEXT_TURNS"] = episode_classifier_context_turns
             # Stage-2 episode tunables (issue #385). Same delta-from-default
-            # discipline as the stage-1 keys above. Episode model is
-            # written ONLY when the operator entered a non-blank value -
-            # blank means "inherit memory_extraction_model" and load_config
-            # implements the inheritance, so we deliberately leave the
-            # key out so the inheritance path stays intact across reinstall.
-            if memory_episode_model.strip():
-                env["MEMORY_EPISODE_MODEL"] = memory_episode_model.strip()
+            # discipline as the stage-1 keys above. MEMORY_EPISODE_MODEL
+            # is no longer emitted: the episode model resolves per-user
+            # from the registry at extraction time via get_model_for
+            # (issue #515).
             # Double-gate matches the stage-1 budget treatment above.
             if agent_backend != "claude" and float(memory_episode_budget_usd) != 0.15:
                 env["MEMORY_EPISODE_BUDGET_USD"] = memory_episode_budget_usd
@@ -1538,6 +1494,17 @@ def _cmd_config() -> None:
         if int(memory_search_limit) != 10:
             env["MEMORY_SEARCH_LIMIT"] = memory_search_limit
 
+    # Drop the three deprecated memory env vars on every wizard run
+    # (issue #515). Reasoner and model both derive per-user from each
+    # user's effective agent_backend via the registry; the env vars
+    # are no longer parsed beyond a one-shot deprecation warning at
+    # load_config time. Popping unconditionally keeps install.conf
+    # from carrying the keys forward across reinstall regardless of
+    # which agent backend the operator selected.
+    env.pop("MEMORY_REASONER_BACKEND", None)
+    env.pop("MEMORY_EXTRACTION_MODEL", None)
+    env.pop("MEMORY_EPISODE_MODEL", None)
+
     # Drop stale extraction keys when the agent backend has no memory
     # reasoner. Today that is goose; claude and codex both support
     # extraction. A user who flips backend from claude/codex to goose
@@ -1545,7 +1512,6 @@ def _cmd_config() -> None:
     # silently ignored at runtime.
     if agent_backend not in ("claude", "codex"):
         env.pop("MEMORY_EXTRACTION_ENABLED", None)
-        env.pop("MEMORY_REASONER_BACKEND", None)
         env.pop("MEMORY_EXTRACTION_BUDGET_USD", None)
         env.pop("MEMORY_EXTRACTION_TIMEOUT_S", None)
         env.pop("MEMORY_CONSOLIDATION_CANDIDATES_N", None)
@@ -1558,7 +1524,6 @@ def _cmd_config() -> None:
         # when stage 1 fires, and stage 1 silently skips on backends
         # without a reasoner. Leaving these in the env file would
         # mislead an operator who flips backend.
-        env.pop("MEMORY_EPISODE_MODEL", None)
         env.pop("MEMORY_EPISODE_BUDGET_USD", None)
         env.pop("MEMORY_EPISODE_TIMEOUT_S", None)
         # Paraphrase-dedup threshold is consulted by `_store_facts`,
@@ -1864,6 +1829,120 @@ def _collect_os_users_from_yaml(users_yaml_path: str | Path) -> list[str]:
     return result
 
 
+@dataclass(frozen=True)
+class CodexUserRef:
+    """Reference to a codex-effective user found in users.yaml.
+
+    Carries telegram_id and the optional os_user separately so a
+    misconfigured entry (codex backend with missing os_user) still
+    counts as "codex exists" for the predicate that gates install
+    plumbing, while only entries with a non-empty os_user appear in
+    the post-install login reminder.
+    """
+
+    telegram_id: int
+    os_user: str | None
+
+
+def _codex_users_from_yaml(users_yaml_path: str | Path, global_agent_backend: str) -> list[CodexUserRef]:
+    """Read users.yaml and return one CodexUserRef per codex-effective entry.
+
+    Effective backend cascade mirrors `_ingest_memory` in bot.py and
+    `config._compute_extraction_eligible_backends`: per-user
+    `agent_backend` overrides the
+    global default; an entry with no `agent_backend` field inherits
+    `global_agent_backend`. Only entries whose effective backend is
+    "codex" appear in the returned list.
+
+    Includes entries with a missing `os_user`. A codex-effective entry
+    without an `os_user` is a configuration error (codex spawning
+    requires a non-bot-user account), but the wizard predicate using
+    this helper must still see the user as "codex" so install plumbing
+    (CODEX_BIN, sudoers, login reminder) fires. The missing os_user
+    surfaces as a `load_config` SystemExit elsewhere.
+
+    Behavior parallels `_collect_os_users_from_yaml`: missing file or
+    empty/non-dict/no-users-key returns []; malformed YAML raises;
+    non-dict entries are skipped. Telegram IDs that do not parse as
+    int are skipped (the entry is invalid and the same logic exists
+    in `_load_user_configs`).
+    """
+    path = Path(users_yaml_path)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+
+    if not text.strip():
+        return []
+
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        return []
+
+    users = data.get("users")
+    if not isinstance(users, list):
+        return []
+
+    result: list[CodexUserRef] = []
+    for entry in users:
+        if not isinstance(entry, dict):
+            continue
+        # Effective backend cascade. Per-user `agent_backend` is
+        # admin-controlled in users.yaml; missing field means inherit
+        # the global default. Only the "codex" effective backend
+        # matters here; "claude" / "goose" / anything else produces
+        # no ref.
+        per_user_backend = entry.get("agent_backend")
+        if not isinstance(per_user_backend, str) or not per_user_backend.strip():
+            effective = global_agent_backend
+        else:
+            effective = per_user_backend.strip().lower()
+        if effective != "codex":
+            continue
+        raw_tid = entry.get("telegram_id")
+        try:
+            tid = int(raw_tid)
+        except (TypeError, ValueError):
+            continue
+        os_user_raw = entry.get("os_user")
+        if isinstance(os_user_raw, str):
+            normalized = os_user_raw.strip()
+            os_user_val: str | None = normalized if normalized else None
+        else:
+            os_user_val = None
+        result.append(CodexUserRef(telegram_id=tid, os_user=os_user_val))
+    return result
+
+
+def _compute_codex_runs_anywhere(
+    global_agent_backend: str,
+    users_yaml_exists: bool,
+    codex_users: list[CodexUserRef],
+) -> bool:
+    """Return True when any user on this install routes to codex.
+
+    Authoritative-source rule (issue #515 v4): when `users_yaml_exists`
+    is True, the users.yaml is the user set; the global `AGENT_BACKEND`
+    is only the default users inherit when they have no per-user
+    override, NOT an additional virtual user. So `codex_users` alone
+    drives the answer.
+
+    Without users.yaml (legacy ALLOWED_USER_IDS auth or pre-wizard
+    fresh install where the file has not been written yet), every
+    authorized user inherits the global, so `global_agent_backend ==
+    "codex"` determines the answer.
+
+    The wizard uses this predicate for everything codex needs to run
+    AT ALL (CODEX_BIN collection, sudoers, login reminder); the
+    `codex_extraction_needed` companion narrows to memory-specific
+    sites by AND-ing with `memory_extraction_enabled`.
+    """
+    if users_yaml_exists:
+        return bool(codex_users)
+    return global_agent_backend == "codex"
+
+
 def _build_codex_login_reminder(
     env: dict[str, str],
     service_user: str,
@@ -1872,32 +1951,43 @@ def _build_codex_login_reminder(
     """Compose the post-install codex subscription-auth reminder.
 
     Codex CLI auth state lives under the spawning user's home directory
-    (~<os_user>/.codex/auth.json). CodexOneShotReasoner spawns codex
+    (~<os_user>/.codex/auth.json). The codex reasoner spawns codex
     per-user via `sudo -u <os_user>`, so subscription auth must be
     completed AS each target user before the first call; a service-
     user-only login lands the token in the wrong home and every
     cross-user spawn fails. Returns the reminder text (without a
     leading blank line) when codex actually runs on this install AND
-    uses subscription auth, else None. The "codex runs anywhere"
-    predicate matches AGENT_BACKEND=codex OR MEMORY_REASONER_BACKEND=
-    codex so claude+codex (or goose+codex) memory installs still get
-    the reminder. Factored out of _cmd_apply so the gate and the
-    per-user enumeration are independently testable.
+    uses subscription auth, else None.
+
+    Gate uses the authoritative-source `codex_runs_anywhere` rule:
+    when /etc/kai/users.yaml exists, only users.yaml entries with
+    effective codex backend count; without users.yaml, falls back to
+    `AGENT_BACKEND=codex`. Enumeration filters to codex-effective
+    users with a non-empty os_user (claude-effective users have no
+    codex login to perform; missing-os_user codex users surface as
+    config-load errors elsewhere).
     """
-    codex_needed = env.get("AGENT_BACKEND") == "codex" or env.get("MEMORY_REASONER_BACKEND") == "codex"
-    if not codex_needed:
+    global_agent_backend = env.get("AGENT_BACKEND", "claude")
+    try:
+        codex_users = _codex_users_from_yaml(users_yaml_path, global_agent_backend)
+    except (OSError, ValueError):
+        # Malformed or sudoers-injection-flagged users.yaml. Apply
+        # path has already written sudoers from the same file, so
+        # raising here would be too late; treat as "no codex users
+        # readable" and fall back to the service-user hint below.
+        codex_users = []
+    users_yaml_exists = Path(users_yaml_path).exists()
+    if not _compute_codex_runs_anywhere(global_agent_backend, users_yaml_exists, codex_users):
         return None
     if env.get("CODEX_AUTH_MODE", "subscription") != "subscription":
         return None
-    # _collect_os_users_from_yaml raises ValueError on a crafted/
-    # malformed entry (sudoers-injection guard); the apply path
-    # already wrote sudoers from the same file, so a raise here would
-    # be too late. Treat both raise paths as "fall back to service
-    # user" so the operator still sees an actionable hint.
-    try:
-        login_users = sorted(set(_collect_os_users_from_yaml(users_yaml_path)))
-    except (OSError, ValueError):
-        login_users = []
+    # Enumerate codex-effective os_users with a usable account. A
+    # codex user without os_user does not get a line (login as which
+    # user?), so the missing-os_user case is handled by the
+    # config-load SystemExit elsewhere. Fall back to service_user
+    # only when no codex users contribute an os_user (legacy
+    # ALLOWED_USER_IDS install with global AGENT_BACKEND=codex).
+    login_users = sorted({ref.os_user for ref in codex_users if ref.os_user})
     if not login_users:
         login_users = [service_user]
     user_lines = "\n".join(f"    {u} ~$ codex login" for u in login_users)
@@ -3247,16 +3337,24 @@ def _cmd_apply() -> None:
         # codex install can pin an absolute codex path without
         # round-tripping through the wizard. Apply-time env wins over
         # any value already in install.conf so the operator's explicit
-        # `sudo CODEX_BIN=... kai install apply` is honored. The gate
-        # accepts either AGENT_BACKEND=codex (the codex agent path) or
-        # MEMORY_REASONER_BACKEND=codex (the claude+codex / goose+codex
-        # memory path); in both cases codex actually runs and the
-        # sudoers SETENV rule needs the same path the runtime resolver
-        # spawns. Skipping the write on truly codex-free installs
-        # keeps /etc/kai/env clean.
+        # `sudo CODEX_BIN=... kai install apply` is honored. Gate uses
+        # the authoritative-source `codex_runs_anywhere` rule: when
+        # /etc/kai/users.yaml exists, only users.yaml entries with
+        # effective codex backend count; without users.yaml, falls back
+        # to the env's AGENT_BACKEND. Skipping the write on truly
+        # codex-free installs keeps /etc/kai/env clean.
         env_codex_bin = os.environ.get("CODEX_BIN")
-        codex_needed = env.get("AGENT_BACKEND") == "codex" or env.get("MEMORY_REASONER_BACKEND") == "codex"
-        if env_codex_bin and codex_needed:
+        _apply_global_backend = env.get("AGENT_BACKEND", "claude")
+        try:
+            _apply_codex_users = _codex_users_from_yaml("/etc/kai/users.yaml", _apply_global_backend)
+        except (OSError, ValueError):
+            _apply_codex_users = []
+        _apply_codex_runs_anywhere = _compute_codex_runs_anywhere(
+            _apply_global_backend,
+            Path("/etc/kai/users.yaml").exists(),
+            _apply_codex_users,
+        )
+        if env_codex_bin and _apply_codex_runs_anywhere:
             env["CODEX_BIN"] = env_codex_bin
         # AGENT_TIMEOUT_SECONDS migration. Operators upgrading without
         # re-running the wizard carry the legacy CLAUDE_TIMEOUT_SECONDS

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -617,36 +617,44 @@ def init_memory(config: Config) -> None:
     # Emitted exactly once per init regardless of whether memory is
     # enabled, so an operator scanning the log after a restart can
     # confirm the configured state without firing an extraction.
-    # The `extraction_binary` field is populated ONLY when
-    # `memory_extraction_enabled` is true (config-load validation
-    # already proved the binary was reachable at startup); for
-    # retrieval-only installs (MEMORY_ENABLED=true with extraction
-    # disabled) the field is null and the resolver is NOT called,
-    # so a retrieval-only install with no claude/codex binary on
-    # PATH still initializes successfully here.
+    # Resolve the per-eligible-backend binary set for the startup log.
+    # With per-user dispatch (issue #515), a single install can have
+    # one user on claude and another on codex; the log must surface
+    # the effective backend set rather than a single global value.
+    # `_compute_extraction_eligible_backends` mirrors the eligibility
+    # cascade load_config used to validate the set before this point,
+    # so the log reports what extraction will actually invoke.
     #
-    # The resolver call IS wrapped in try/except as defense against
+    # The resolver call is wrapped in try/except as defense against
     # between-load-and-init drift (PATH change, binary unlinked,
-    # etc.). A miss logs a WARNING and emits `extraction_binary: null`
-    # so memory init still completes; the next actual extraction
-    # would surface the real failure with a typed error.
-    extraction_binary: str | None = None
-    if config.memory_enabled and config.memory_extraction_enabled:
+    # etc.). A miss logs a WARNING and emits `extraction_binaries`
+    # with a null entry for the affected backend so memory init still
+    # completes; the next actual extraction would surface the real
+    # failure with a typed error. Retrieval-only installs
+    # (MEMORY_ENABLED=true with extraction disabled) produce an empty
+    # eligible set, so the resolver loop is a no-op and the map is
+    # empty.
+    from kai.config import ModelRole, _compute_extraction_eligible_backends, get_model_for
+
+    eligible_backends: set[str] = _compute_extraction_eligible_backends(
+        config.agent_backend, config.user_configs, config.memory_extraction_enabled
+    )
+    extraction_binaries: dict[str, str | None] = {}
+    if eligible_backends:
         from kai.oneshot_binary import BinaryResolutionError, resolve_oneshot_binary
 
-        try:
-            extraction_binary = resolve_oneshot_binary(config.memory_reasoner_backend)
-        except BinaryResolutionError as e:
-            # Defensive: config-load validation already passed, so
-            # this should not happen on a healthy install. If it
-            # does, log loudly and continue with null so init does
-            # not fail on an observability field.
-            log.warning(
-                "memory.config: %s reasoner binary resolution failed at init time (%s); "
-                "extraction_binary will log as null",
-                config.memory_reasoner_backend,
-                e,
-            )
+        for backend in sorted(eligible_backends):
+            try:
+                extraction_binaries[backend] = resolve_oneshot_binary(backend)
+            except BinaryResolutionError as e:
+                log.warning(
+                    "memory.config: %s reasoner binary resolution failed at init time (%s); "
+                    "extraction_binaries[%r] will log as null",
+                    backend,
+                    e,
+                    backend,
+                )
+                extraction_binaries[backend] = None
 
     if not config.memory_enabled:
         log.info(
@@ -655,14 +663,50 @@ def init_memory(config: Config) -> None:
                 {
                     "enabled": False,
                     "extraction_enabled": False,
+                    "reasoner_mode": None,
                     "reasoner_backend": None,
+                    "reasoner_backends": [],
                     "extraction_model": None,
-                    "episode_model": None,
-                    "extraction_binary": None,
+                    "extraction_models": {},
+                    "episode_models": {},
+                    "extraction_binaries": {},
                 }
             ),
         )
         return
+
+    # Resolved per-backend models for the startup log. Operators see
+    # the actual model each backend will run, not an env var. Empty
+    # eligible set (retrieval-only memory) leaves both maps empty
+    # and the uniform/per-user mode keys unset.
+    extraction_models: dict[str, str] = {
+        backend: get_model_for(ModelRole.MEMORY_EXTRACTION, backend) for backend in sorted(eligible_backends)
+    }
+    episode_models: dict[str, str] = {
+        backend: get_model_for(ModelRole.MEMORY_EPISODE, backend) for backend in sorted(eligible_backends)
+    }
+
+    # Uniform vs per-user log shape. Single-eligible-backend installs
+    # keep the legacy `reasoner_backend` + `extraction_model` flat keys
+    # so existing log consumers see no shape change on the common path.
+    # Mixed installs emit `reasoner_backends` + `extraction_models` as
+    # a per-backend map; flat keys are null in that mode so consumers
+    # do not silently read the wrong value.
+    if len(eligible_backends) == 1:
+        only = next(iter(eligible_backends))
+        reasoner_mode = "uniform"
+        flat_backend: str | None = only
+        flat_model: str | None = extraction_models[only]
+    elif len(eligible_backends) > 1:
+        reasoner_mode = "per-user"
+        flat_backend = None
+        flat_model = None
+    else:
+        # Retrieval-only or memory-disabled-extraction install. No
+        # reasoner runs, so neither mode applies.
+        reasoner_mode = None
+        flat_backend = None
+        flat_model = None
 
     log.info(
         "memory.config %s",
@@ -670,10 +714,13 @@ def init_memory(config: Config) -> None:
             {
                 "enabled": True,
                 "extraction_enabled": config.memory_extraction_enabled,
-                "reasoner_backend": config.memory_reasoner_backend,
-                "extraction_model": config.memory_extraction_model or None,
-                "episode_model": config.memory_episode_model or None,
-                "extraction_binary": extraction_binary,
+                "reasoner_mode": reasoner_mode,
+                "reasoner_backend": flat_backend,
+                "reasoner_backends": sorted(eligible_backends),
+                "extraction_model": flat_model,
+                "extraction_models": extraction_models,
+                "episode_models": episode_models,
+                "extraction_binaries": extraction_binaries,
             }
         ),
     )

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -28,7 +28,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 
 from kai import memory
-from kai.config import Config
+from kai.config import Config, ModelRole, get_model_for
 from kai.memory import MemoryResult
 from kai.oneshot import _EXTRACTOR_CWD as _EXTRACTOR_CWD
 from kai.oneshot import _SUBPROCESS_ENV_ALLOWLIST as _SUBPROCESS_ENV_ALLOWLIST
@@ -1704,36 +1704,68 @@ def _resolve_os_user(user_id: str, config: Config) -> str | None:
     return user_cfg.os_user
 
 
-def _get_memory_reasoner(config: Config, os_user: str | None = None) -> OneShotReasoner:
+def _resolve_effective_backend(user_id: str, config: Config) -> str:
     """
-    Resolve the one-shot reasoner used by both memory stages.
+    Resolve the user being extracted to its effective `agent_backend`.
 
-    Dispatches on `config.memory_reasoner_backend`. The valid set is
-    validated at config-load time so this helper can rely on the
-    string being either "claude" or "codex"; a third value would have
-    failed `load_config` already and never reached here. The
-    RuntimeError branch exists as a safety net for a future enum
-    extension where the dataclass field gains a new value before this
-    function is updated; surfacing it as a runtime error rather than
-    silently selecting Claude keeps the failure visible.
+    Cascade: per-user `agent_backend` from users.yaml wins; otherwise
+    the global `config.agent_backend` applies. The same shape
+    `_ingest_memory` in bot.py uses to gate extraction eligibility,
+    kept in lockstep so the per-user dispatch site here cannot drift
+    from the eligibility check there.
+
+    `user_id` is the Telegram chat_id string the caller threads through
+    `extract_and_store`. Non-integer values (eval-gate sandbox IDs like
+    `sandbox-498-claude`) fall back to the global default because
+    they cannot index `user_configs`. Same for IDs not present in
+    `user_configs`. Both cases produce the same value the global path
+    would have produced before per-user dispatch existed.
+
+    Goose users never reach this function because `bot.py`'s
+    extraction gate filters them out upstream; the defensive raise in
+    `_build_memory_reasoner` below catches a future regression where
+    the gate moves or changes.
+    """
+    if config.user_configs is None:
+        return config.agent_backend
+    try:
+        tid = int(user_id)
+    except ValueError:
+        return config.agent_backend
+    user_cfg = config.user_configs.get(tid)
+    if user_cfg is None:
+        return config.agent_backend
+    return user_cfg.agent_backend or config.agent_backend
+
+
+def _build_memory_reasoner(effective_backend: str, os_user: str | None = None) -> OneShotReasoner:
+    """
+    Build the one-shot reasoner matching the user's effective backend.
+
+    Dispatches on the per-user `effective_backend` resolved by
+    `_resolve_effective_backend`. The valid set is "claude" / "codex";
+    goose users do not reach this site (gated upstream in `bot.py`).
+    The RuntimeError branch is a defensive safety net for a future
+    regression where the upstream gate widens or changes - surfacing
+    as a runtime error rather than silently selecting Claude keeps the
+    failure visible.
 
     `os_user` is resolved once at the top of `extract_and_store` and
-    threaded into this helper. The codex reasoner raises
-    `OneShotRoutingError` from `run()` when os_user is None; the
-    claude reasoner spawns directly. Tests monkeypatch this helper
-    to inject fake reasoners; the `os_user` parameter is accepted
-    but not inspected on the test side because patches use
-    `return_value=`.
+    threaded in. The codex reasoner raises `OneShotRoutingError` from
+    `run()` when `os_user is None`; the claude reasoner spawns
+    directly. Tests monkeypatch this helper to inject fake reasoners;
+    the parameters are accepted but not inspected on the test side
+    because patches use `return_value=`.
 
     Returning a fresh instance per call (rather than a module-level
     singleton) keeps the memory path stateless and mirrors the
     pre-refactor per-call subprocess construction.
     """
-    if config.memory_reasoner_backend == "claude":
+    if effective_backend == "claude":
         return ClaudeOneShotReasoner(os_user=os_user)
-    if config.memory_reasoner_backend == "codex":
+    if effective_backend == "codex":
         return CodexOneShotReasoner(os_user=os_user)
-    raise RuntimeError(f"Unknown memory_reasoner_backend: {config.memory_reasoner_backend!r}")
+    raise RuntimeError(f"extraction reached _build_memory_reasoner for non-extraction backend: {effective_backend!r}")
 
 
 # ── Subprocess wiring ───────────────────────────────────────────────
@@ -1746,6 +1778,7 @@ async def _run_extractor(
     candidate_ids: set[str],
     candidate_metadata: dict[str, dict],
     user_id: str,
+    effective_backend: str,
     os_user: str | None = None,
     system_prompt: str = _EXTRACTION_SYSTEM_PROMPT,
     user_window_text: str = "",
@@ -1825,12 +1858,12 @@ async def _run_extractor(
     # returned on failure. JSON envelope parsing stays in this
     # function so memory-domain concerns (is_error, structured_output,
     # facts, has_episode) do not leak into the reasoner.
-    reasoner = _get_memory_reasoner(config, os_user=os_user)
+    reasoner = _build_memory_reasoner(effective_backend, os_user=os_user)
     try:
         result = await reasoner.run(
             prompt=payload_text,
             system_prompt=system_prompt,
-            model=config.memory_extraction_model,
+            model=get_model_for(ModelRole.MEMORY_EXTRACTION, effective_backend),
             timeout=config.memory_extraction_timeout_s,
             purpose="fact_extraction",
             json_schema=_FACT_SCHEMA,
@@ -1988,6 +2021,7 @@ async def _run_episode_extractor(
     payload_text: str,
     config: Config,
     *,
+    effective_backend: str,
     os_user: str | None = None,
 ) -> tuple[dict | None, float, str | None]:
     """
@@ -2020,12 +2054,12 @@ async def _run_episode_extractor(
     # `os_user` is the routing target resolved once at the top of
     # `extract_and_store` (per-user OS routing); stage 2 inherits the
     # same target so the policy boundary is enforced consistently.
-    reasoner = _get_memory_reasoner(config, os_user=os_user)
+    reasoner = _build_memory_reasoner(effective_backend, os_user=os_user)
     try:
         result = await reasoner.run(
             prompt=payload_text,
             system_prompt=_EPISODE_SYSTEM_PROMPT,
-            model=config.memory_episode_model,
+            model=get_model_for(ModelRole.MEMORY_EPISODE, effective_backend),
             timeout=config.memory_episode_timeout_s,
             purpose="episode_generation",
             json_schema=_EPISODE_SCHEMA,
@@ -2081,6 +2115,7 @@ async def _generate_episode(
     user_id: str,
     session_id: str | None,
     config: Config,
+    effective_backend: str,
     os_user: str | None = None,
 ) -> None:
     """
@@ -2121,7 +2156,9 @@ async def _generate_episode(
             # quick succession and the second waits on the first.
             start = time.monotonic()
             payload = _build_episode_payload(user_text, assistant_text)
-            episode, cost_usd, run_reason = await _run_episode_extractor(payload, config, os_user=os_user)
+            episode, cost_usd, run_reason = await _run_episode_extractor(
+                payload, config, effective_backend=effective_backend, os_user=os_user
+            )
             if episode is None:
                 # Map the run-helper's failure tags onto the documented
                 # outcome enum: timeout, subprocess_error, parse_error,
@@ -2550,6 +2587,17 @@ async def extract_and_store(
     # `users.yaml[telegram_id].os_user`.
     os_user = os_user_override if os_user_override is not None else _resolve_os_user(user_id, config)
 
+    # Per-user reasoner backend (issue #515). Resolved ONCE alongside
+    # `os_user` and threaded into both stages so the (effective_backend,
+    # os_user) pair stays consistent across stage 1 and stage 2 for a
+    # single exchange. The model for each stage is looked up inline
+    # via `get_model_for(role, effective_backend)` at the call site
+    # (no global model field; the registry is the single source of
+    # truth). Goose users do not reach this site because `bot.py`'s
+    # extraction gate filters them out upstream; the cascade here
+    # mirrors `_resolve_effective_backend`.
+    effective_backend = _resolve_effective_backend(user_id, config)
+
     sem = _get_semaphore(user_id)
     # Pre-initialize the storage counters so the post-try summary log
     # cannot reference an unbound name regardless of which branch (or
@@ -2655,6 +2703,7 @@ async def extract_and_store(
                 candidate_ids=candidate_id_set,
                 candidate_metadata=candidate_metadata,
                 user_id=user_id,
+                effective_backend=effective_backend,
                 os_user=os_user,
                 user_window_text=user_window_text,
                 assistant_window_text=assistant_window_text,
@@ -2715,6 +2764,7 @@ async def extract_and_store(
                         user_id=user_id,
                         session_id=session_id,
                         config=config,
+                        effective_backend=effective_backend,
                         os_user=os_user,
                     ),
                     name=f"episode-{user_id}",

--- a/src/kai/smoke/memory.py
+++ b/src/kai/smoke/memory.py
@@ -11,14 +11,17 @@ in-memory fact schema and the result is parsed and printed; nothing
 is persisted. Safe to invoke repeatedly without polluting the
 install's memory state.
 
-Invocation: `python -m kai.smoke.memory [--os-user <name>]`.
+Invocation: `python -m kai.smoke.memory [--user-id <chat_id>] [--os-user <name>]`.
 
-The `--os-user` flag is required when the configured reasoner is
-codex; the codex reasoner refuses to spawn without an os_user (it
-exists to prevent the bot user from running codex). Pass the per-
-user OS account name from `users.yaml`. The flag is accepted but
-ignored on the claude reasoner branch; the historical Max-plan
-self-sudo-skip path resolves None safely.
+The `--user-id` flag selects which user's effective `agent_backend`
+the smoke runs under (the same per-user dispatch production uses).
+When omitted, the smoke falls back to the global `config.agent_backend`.
+The `--os-user` flag is required when the resolved effective backend
+is codex; the codex reasoner refuses to spawn without an os_user (it
+exists to prevent the bot user from running codex). Pass the per-user
+OS account name from `users.yaml`. The flag is accepted but ignored
+on the claude reasoner branch; the historical Max-plan self-sudo-skip
+path resolves None safely.
 """
 
 from __future__ import annotations
@@ -30,11 +33,12 @@ import logging
 import sys
 import time
 
-from kai.config import load_config
+from kai.config import ModelRole, get_model_for, load_config
 from kai.memory_extraction import (
     _EXTRACTION_SYSTEM_PROMPT,
     _FACT_SCHEMA,
-    _get_memory_reasoner,
+    _build_memory_reasoner,
+    _resolve_effective_backend,
 )
 from kai.oneshot import OneShotError
 
@@ -60,7 +64,7 @@ def _build_payload() -> str:
     return f"[CURRENT EXCHANGE]\nUser: {_SMOKE_USER_TEXT}\nAssistant: {_SMOKE_ASSISTANT_TEXT}\n"
 
 
-async def _run(os_user: str | None) -> int:
+async def _run(user_id: str | None, os_user: str | None) -> int:
     """Execute the smoke and return the desired exit code.
 
     Returns 0 on success (anchor substring appears in at least one
@@ -94,19 +98,40 @@ async def _run(os_user: str | None) -> int:
         )
         return 1
 
-    if config.memory_reasoner_backend == "codex" and not os_user:
+    # Resolve the effective backend the smoke runs under. With per-user
+    # dispatch (issue #515), production extraction uses each user's
+    # effective `agent_backend`; the smoke mirrors that by accepting a
+    # `--user-id` that the helper looks up in users.yaml. Without
+    # `--user-id`, fall back to the global `agent_backend` (the legacy
+    # single-backend smoke path). The string the helper takes is the
+    # raw user_id (production threads it through `extract_and_store`
+    # the same way), so reuse it directly.
+    resolved_user_id = user_id if user_id is not None else "smoke"
+    effective_backend = _resolve_effective_backend(resolved_user_id, config)
+    if effective_backend not in ("claude", "codex"):
         sys.stderr.write(
-            "smoke: --os-user is required when memory_reasoner_backend=codex; "
+            f"smoke: effective backend {effective_backend!r} has no memory reasoner. "
+            "Pass --user-id matching a claude- or codex-effective entry in users.yaml, "
+            "or run with a global AGENT_BACKEND of claude or codex.\n"
+        )
+        return 1
+
+    if effective_backend == "codex" and not os_user:
+        sys.stderr.write(
+            "smoke: --os-user is required when the effective backend is codex; "
             "pass the per-user OS account configured in users.yaml.\n"
         )
         return 1
 
-    print(f"backend: {config.memory_reasoner_backend}")
-    print(f"extraction model: {config.memory_extraction_model}")
-    print(f"episode model: {config.memory_episode_model or '(inherits extraction model)'}")
+    extraction_model = get_model_for(ModelRole.MEMORY_EXTRACTION, effective_backend)
+    episode_model = get_model_for(ModelRole.MEMORY_EPISODE, effective_backend)
+    print(f"backend: {effective_backend}")
+    print(f"extraction model: {extraction_model}")
+    print(f"episode model: {episode_model}")
+    print(f"user_id: {user_id or '(none; using global agent_backend)'}")
     print(f"os_user: {os_user or '(none; direct spawn)'}")
 
-    reasoner = _get_memory_reasoner(config, os_user=os_user)
+    reasoner = _build_memory_reasoner(effective_backend, os_user=os_user)
     timeout = float(config.memory_extraction_timeout_s)
 
     start = time.monotonic()
@@ -114,7 +139,7 @@ async def _run(os_user: str | None) -> int:
         result = await reasoner.run(
             prompt=_build_payload(),
             system_prompt=_EXTRACTION_SYSTEM_PROMPT,
-            model=config.memory_extraction_model,
+            model=extraction_model,
             timeout=timeout,
             purpose="smoke_memory",
             json_schema=_FACT_SCHEMA,
@@ -187,12 +212,21 @@ def main() -> int:
         description="Verify the memory reasoner pipeline against a fixed payload.",
     )
     parser.add_argument(
+        "--user-id",
+        dest="user_id",
+        default=None,
+        help=(
+            "Telegram chat_id whose effective agent_backend selects the reasoner. "
+            "Defaults to the global agent_backend when omitted."
+        ),
+    )
+    parser.add_argument(
         "--os-user",
         dest="os_user",
         default=None,
         help=(
-            "Per-user OS account for cross-user codex spawning. Required when "
-            "MEMORY_REASONER_BACKEND=codex. Ignored on the claude reasoner branch."
+            "Per-user OS account for cross-user codex spawning. Required when the "
+            "effective backend resolves to codex. Ignored on the claude branch."
         ),
     )
     args = parser.parse_args()
@@ -201,7 +235,7 @@ def main() -> int:
     # failures inline without enabling Mem0 / Qdrant / urllib3 noise.
     logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
 
-    return asyncio.run(_run(args.os_user))
+    return asyncio.run(_run(args.user_id, args.os_user))
 
 
 if __name__ == "__main__":

--- a/templates/.env
+++ b/templates/.env
@@ -171,28 +171,27 @@ MEMORY_ENABLED=false
 # (effectively disabled); 1.01 unambiguously disables the gate.
 #MEMORY_DUPLICATE_THRESHOLD=0.9
 
-# Memory reasoner backend. Selects which subprocess runs the
-# extraction and episode-classification calls. Independent of
-# AGENT_BACKEND. Valid values: "claude", "codex".
+# Memory reasoner and model: NO env var.
 #
-# Set to "codex" when running a codex-backed install and you want
-# semantic memory; the install will not invoke the claude binary
-# for memory work in that case. Set to "claude" (default) when
-# running a claude-backed install. Cross-backend combinations are
-# supported but when extraction is enabled, the wizard defaults to
-# the same-vendor case. Retrieval-only memory (MEMORY_ENABLED=true
-# with extraction disabled) does not prompt for or persist this
-# variable.
-#MEMORY_REASONER_BACKEND=claude
+# Memory extraction routes the reasoner subprocess per-user, based
+# on each user's effective agent_backend (per-user override in
+# users.yaml > global AGENT_BACKEND). Claude users get the claude
+# reasoner with the claude-registry model; codex users get the
+# codex reasoner with the codex-registry model. There is no
+# deployment-level override surface: model selection happens
+# through MODEL_REGISTRY in config.py, edited in code, not in the
+# env file.
+#
+# Legacy installs may still carry MEMORY_REASONER_BACKEND,
+# MEMORY_EXTRACTION_MODEL, and MEMORY_EPISODE_MODEL. load_config
+# logs a one-shot deprecation warning per key and ignores the
+# values; the next 'sudo make install' drops them.
 
 # Memory extraction. Requires MEMORY_ENABLED=true. Off by default
-# at Phase 2 ship (self-reinforcing loop needs real-world
-# observation time before the default flips). Kill switch is the
-# same flag. Extraction subprocess routing is controlled by
-# MEMORY_REASONER_BACKEND above; today both claude and codex are
-# supported reasoners.
+# (self-reinforcing loop needs real-world observation time before
+# the default flips). Kill switch is the same flag. Extraction
+# routing is per-user (see note above).
 #MEMORY_EXTRACTION_ENABLED=false
-#MEMORY_EXTRACTION_MODEL=claude-haiku-4-5-20251001
 # Per-call budget ceiling (USD). Retained as inert compatibility
 # config. Both supported memory reasoners (claude and codex) are
 # subscription-backed in the operator deployment model and no
@@ -220,12 +219,9 @@ MEMORY_ENABLED=false
 # Stage-2 episode generation. Conditional second extractor that runs
 # out-of-band on stage-1 positives (has_episode=true) to produce one
 # Sophia-shaped narrative record per episode-worthy turn. Honors
-# MEMORY_ENABLED; no dedicated kill switch.
-# Sonnet is recommended for narrative quality across the 7-8 episode
-# fields. Leave blank to inherit MEMORY_EXTRACTION_MODEL (Haiku) -
-# useful for tests or for operators who deliberately want both stages
-# on the same model.
-#MEMORY_EPISODE_MODEL=claude-sonnet-4-6
+# MEMORY_ENABLED; no dedicated kill switch. Episode model is
+# resolved per-user from MODEL_REGISTRY (see the memory reasoner
+# note above); there is no MEMORY_EPISODE_MODEL env var.
 # Budget ceiling per episode call (USD). Retained as inert
 # compatibility config. Same rationale as MEMORY_EXTRACTION_BUDGET_USD
 # above: both supported reasoners are subscription-backed in the

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1319,7 +1319,6 @@ class TestMemoryExtractionConfig:
         _set_required(monkeypatch)
         config = load_config()
         assert config.memory_extraction_enabled is False
-        assert config.memory_extraction_model == "claude-haiku-4-5-20251001"
         assert config.memory_extraction_budget_usd == 0.01
         assert config.memory_extraction_timeout_s == 10
 
@@ -1350,11 +1349,20 @@ class TestMemoryExtractionConfig:
         assert config.memory_extraction_enabled is False
         assert config.memory_enabled is False
 
-    def test_model_override(self, monkeypatch):
+    def test_model_override_logs_deprecation(self, monkeypatch, caplog):
+        """The legacy MEMORY_EXTRACTION_MODEL env var is no longer
+        load-bearing (issue #515): memory models resolve per-user
+        from the registry via get_model_for(role, effective_backend).
+        Setting the env var still parses without error, but emits a
+        single deprecation warning at load_config time."""
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_EXTRACTION_MODEL", "claude-haiku-4-5-20251001-custom")
-        config = load_config()
-        assert config.memory_extraction_model == "claude-haiku-4-5-20251001-custom"
+        with caplog.at_level("WARNING", logger="kai.config"):
+            config = load_config()
+        # Field is gone; verify no AttributeError on access shape.
+        assert not hasattr(config, "memory_extraction_model")
+        deprecation_msgs = [r.message for r in caplog.records if "MEMORY_EXTRACTION_MODEL is deprecated" in r.message]
+        assert len(deprecation_msgs) == 1, deprecation_msgs
 
     def test_budget_override(self, monkeypatch):
         _set_required(monkeypatch)
@@ -1504,69 +1512,50 @@ class TestEpisodeClassifierContextTurns:
 # ── Memory reasoner backend selection ───────────────────────────────
 
 
-class TestMemoryReasonerBackend:
-    """MEMORY_REASONER_BACKEND selects the OneShotReasoner used by both
-    memory stages. Default is `claude` even when AGENT_BACKEND=codex,
-    because codex memory extraction has not yet cleared the
-    cross-backend quality eval; the value must be explicitly opted in.
-    Invalid values are SystemExit at config-load time, matching the
-    AGENT_BACKEND validation pattern (no first-extraction surprise)."""
+class TestMemoryReasonerBackendDeprecation:
+    """The MEMORY_REASONER_BACKEND env var was retired in issue #515.
+    Memory reasoner selection is now per-user, derived from each
+    user's effective `agent_backend`. Legacy installs that still
+    carry the env var get a deprecation warning but load_config
+    completes normally."""
 
-    def test_default_is_claude(self, monkeypatch):
-        _set_required(monkeypatch)
-        config = load_config()
-        assert config.memory_reasoner_backend == "claude"
-
-    def test_default_stays_claude_under_agent_backend_codex(self, monkeypatch):
-        """The conservative posture: AGENT_BACKEND=codex does NOT flip
-        memory extraction onto codex. The selection is explicit so an
-        unevaluated provider cannot silently start writing memory."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("AGENT_BACKEND", "codex")
-        monkeypatch.setenv("LLM_PROVIDER", "openai")
-        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.5")
-        config = load_config()
-        assert config.agent_backend == "codex"
-        assert config.memory_reasoner_backend == "claude"
-
-    def test_codex_value_accepted(self, monkeypatch):
+    def test_env_var_logs_deprecation_warning(self, monkeypatch, caplog):
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
-        config = load_config()
-        assert config.memory_reasoner_backend == "codex"
+        with caplog.at_level("WARNING", logger="kai.config"):
+            config = load_config()
+        # No SystemExit; load_config returns normally.
+        deprecation_msgs = [r.message for r in caplog.records if "MEMORY_REASONER_BACKEND is deprecated" in r.message]
+        assert len(deprecation_msgs) == 1, deprecation_msgs
+        # The field is gone.
+        assert not hasattr(config, "memory_reasoner_backend")
 
-    def test_invalid_value_raises_systemexit(self, monkeypatch):
-        """Typos like `gpt5` must fail at config-load time, not at
-        the first `_get_memory_reasoner` call. The error message
-        names the offending var so an operator does not have to grep
-        for it."""
+    def test_unknown_value_still_only_warns(self, monkeypatch, caplog):
+        """Even a typo like `gpt5` does NOT SystemExit any more; the
+        value is ignored after the deprecation warning. Operators
+        who used to see config-load failures will now see one warning
+        and a working install."""
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_REASONER_BACKEND", "gpt5")
-        with pytest.raises(SystemExit, match="MEMORY_REASONER_BACKEND"):
+        with caplog.at_level("WARNING", logger="kai.config"):
             load_config()
-
-    def test_case_insensitive(self, monkeypatch):
-        """Operators sometimes set env vars in uppercase out of habit;
-        the parser is case-insensitive to avoid a confusing
-        SystemExit on Codex/CLAUDE typo variants."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "CODEX")
-        config = load_config()
-        assert config.memory_reasoner_backend == "codex"
+        deprecation_msgs = [r.message for r in caplog.records if "MEMORY_REASONER_BACKEND is deprecated" in r.message]
+        assert len(deprecation_msgs) == 1
 
 
 class TestMemoryReasonerBinaryValidation:
-    """Cross-binary validation: when memory extraction is enabled, the
-    configured reasoner backend's binary must be reachable at startup.
-    The check fires only on the composed `memory_extraction_enabled`
-    value (both MEMORY_ENABLED and MEMORY_EXTRACTION_ENABLED true);
-    retrieval-only memory does NOT require a reachable agent binary."""
+    """Cross-binary validation: when memory extraction is enabled, each
+    extraction-eligible backend's binary must be reachable at startup.
+    Per-user dispatch (issue #515) means the eligible set is computed
+    from each user's effective `agent_backend`, so the check iterates
+    that set rather than reading a single global reasoner toggle.
+    Retrieval-only memory does NOT require a reachable agent binary."""
 
     def test_claude_binary_missing_raises_systemexit(self, monkeypatch):
-        """MEMORY_REASONER_BACKEND=claude with extraction enabled and
-        no claude on PATH must fail at config-load with a clear
-        message. The composed `memory_extraction_enabled` is what
-        triggers the check; both env vars must be true."""
+        """Default-claude install with extraction enabled and no claude
+        on PATH must fail at config-load. The composed
+        `memory_extraction_enabled` plus the eligible-set membership
+        triggers the check."""
         from kai.oneshot_binary import BinaryResolutionError
 
         _set_required(monkeypatch)
@@ -1579,32 +1568,45 @@ class TestMemoryReasonerBinaryValidation:
         monkeypatch.setattr("kai.oneshot_binary.resolve_oneshot_binary", boom)
         with pytest.raises(SystemExit) as exc:
             load_config()
-        assert "MEMORY_REASONER_BACKEND='claude'" in str(exc.value)
-        assert "claude binary" in str(exc.value)
+        # New error wording: names the offending backend and the
+        # extraction-eligible-user link, no longer cites a global env
+        # var since per-user dispatch made it irrelevant.
+        assert "'claude'" in str(exc.value)
+        assert "binary" in str(exc.value)
 
-    def test_codex_binary_missing_raises_systemexit(self, monkeypatch):
-        """Same shape for codex; the error mentions the codex backend."""
+    def test_codex_binary_missing_raises_systemexit(self, tmp_path, monkeypatch):
+        """Codex via per-user routing: a users.yaml entry pinned to
+        codex makes codex extraction-eligible. Missing codex binary
+        must fail at config-load with the same per-backend error
+        shape as claude."""
         from kai.oneshot_binary import BinaryResolutionError
 
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    agent_backend: codex\n    os_user: alice_os\n"
+        )
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
 
         def boom(_backend: str) -> str:
-            raise BinaryResolutionError("could not resolve codex binary: CODEX_BIN unset, `codex` not on PATH")
+            if _backend == "codex":
+                raise BinaryResolutionError("could not resolve codex binary: CODEX_BIN unset, `codex` not on PATH")
+            return f"/fake/{_backend}"
 
         monkeypatch.setattr("kai.oneshot_binary.resolve_oneshot_binary", boom)
         with pytest.raises(SystemExit) as exc:
             load_config()
-        assert "MEMORY_REASONER_BACKEND='codex'" in str(exc.value)
-        assert "codex binary" in str(exc.value)
+        assert "'codex'" in str(exc.value)
+        assert "binary" in str(exc.value)
 
     def test_retrieval_only_skips_binary_check(self, monkeypatch):
         """MEMORY_ENABLED=true with MEMORY_EXTRACTION_ENABLED=false
         (retrieval-only) must NOT require a reachable agent binary.
         The check is gated on the composed extraction-enabled value,
-        not on memory_enabled alone."""
+        not on memory_enabled alone, and the eligible set is empty
+        when extraction is disabled."""
         from kai.oneshot_binary import BinaryResolutionError
 
         _set_required(monkeypatch)
@@ -1626,12 +1628,13 @@ class TestMemoryReasonerBinaryValidation:
     def test_extraction_disabled_without_memory_enabled_skips_check(self, monkeypatch):
         """The compositional gate also covers `MEMORY_EXTRACTION_ENABLED=true`
         with `MEMORY_ENABLED=false`. Composed extraction_enabled is
-        False, so the binary check does not fire."""
+        False, eligible set is empty, and the binary check does not
+        fire."""
         from kai.oneshot_binary import BinaryResolutionError
 
         _set_required(monkeypatch)
         # MEMORY_ENABLED unset / false, but EXTRACTION_ENABLED true.
-        # The composed value at config.py:1933 is False; binary check skipped.
+        # The composed value is False; binary check skipped.
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
         called = []
 
@@ -1648,29 +1651,33 @@ class TestMemoryReasonerBinaryValidation:
 class TestCodexMemoryRequiresOsUser:
     """The codex reasoner refuses to spawn without an `os_user` (the
     security boundary that keeps codex from running as the bot user).
-    Config-load enforces the precondition: a wizard-generated config
-    that enables codex memory without per-user os_user entries fails
-    fast instead of silently no-opping every extraction at runtime."""
+    Per-user dispatch (issue #515) means codex eligibility is computed
+    from each user's effective `agent_backend`; the precondition is
+    expressed against that effective cascade rather than a single
+    `MEMORY_REASONER_BACKEND` global. Config-load enforces it so a
+    wizard-generated config that enables codex memory without per-user
+    os_user entries fails fast instead of silently no-opping every
+    extraction at runtime."""
 
     def test_no_users_yaml_raises_systemexit(self, monkeypatch):
-        """ALLOWED_USER_IDS without users.yaml does not expose an
-        os_user surface at all. Codex memory cannot be wired in this
-        configuration; SystemExit at config-load."""
+        """AGENT_BACKEND=codex without users.yaml. ALLOWED_USER_IDS
+        exposes no per-user os_user surface, so codex extraction
+        cannot be wired; SystemExit at config-load."""
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        monkeypatch.setenv("AGENT_BACKEND", "codex")
         with pytest.raises(SystemExit) as exc:
             load_config()
         msg = str(exc.value)
         assert "users.yaml" in msg
         assert "os_user" in msg
-        assert "codex" in msg
+        assert "odex" in msg  # 'codex' or 'Codex'
 
     def test_users_yaml_with_os_user_passes(self, tmp_path, monkeypatch):
         """The happy path: users.yaml with a per-user os_user entry
-        for every authorized chat_id. Config-load completes; codex
-        memory is wired."""
+        for every codex-effective chat_id. Config-load completes;
+        codex memory is wired per user."""
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text(
             "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: alice_os\n"
@@ -1679,16 +1686,19 @@ class TestCodexMemoryRequiresOsUser:
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        # DEFAULT_MODEL must be a codex-valid SKU when AGENT_BACKEND=codex.
+        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
         config = load_config()
-        assert config.memory_reasoner_backend == "codex"
+        assert config.agent_backend == "codex"
         assert config.user_configs is not None
         assert config.user_configs[12345].os_user == "alice_os"
 
     def test_users_yaml_with_missing_os_user_raises_systemexit(self, tmp_path, monkeypatch):
-        """At least one users.yaml entry without os_user must fail
-        config-load. The error names the offending chat_id so the
-        operator can find the entry to fix."""
+        """At least one codex-effective users.yaml entry without
+        os_user must fail config-load. The error names the
+        offending chat_id so the operator can find the entry to
+        fix."""
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text(
             "users:\n"
@@ -1704,7 +1714,7 @@ class TestCodexMemoryRequiresOsUser:
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        monkeypatch.setenv("AGENT_BACKEND", "codex")
         with pytest.raises(SystemExit) as exc:
             load_config()
         msg = str(exc.value)
@@ -1714,15 +1724,15 @@ class TestCodexMemoryRequiresOsUser:
 
     def test_claude_memory_does_not_require_os_user(self, monkeypatch):
         """ClaudeOneShotReasoner accepts os_user=None (Max-plan
-        self-sudo-skip path), so claude memory does NOT require
-        users.yaml. The precondition applies only to codex."""
+        self-sudo-skip path), so claude-only installs do NOT require
+        users.yaml. The precondition fires only when codex is in the
+        extraction-eligible set."""
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "claude")
-        # No users.yaml; ALLOWED_USER_IDS-only. Claude is fine here.
+        # AGENT_BACKEND defaults to claude. No users.yaml.
         config = load_config()
-        assert config.memory_reasoner_backend == "claude"
+        assert config.agent_backend == "claude"
 
     def test_users_yaml_os_user_matches_bot_user_raises_systemexit(self, tmp_path, monkeypatch):
         """Codex must NOT run as the bot user. The runtime refuses
@@ -1730,8 +1740,6 @@ class TestCodexMemoryRequiresOsUser:
         a misconfigured users.yaml does not silently no-op every
         extraction. The check names the bot user and the offending
         chat_ids so the operator can locate the misconfiguration."""
-        import pwd
-
         bot_user = pwd.getpwuid(os.getuid()).pw_name
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text(
@@ -1741,7 +1749,7 @@ class TestCodexMemoryRequiresOsUser:
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        monkeypatch.setenv("AGENT_BACKEND", "codex")
         with pytest.raises(SystemExit) as exc:
             load_config()
         msg = str(exc.value)
@@ -1774,10 +1782,11 @@ class TestCodexMemoryRequiresOsUser:
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
         # No SystemExit: the goose user is not extraction-eligible.
         config = load_config()
-        assert config.memory_reasoner_backend == "codex"
+        assert config.agent_backend == "codex"
         # Both users load; the precondition skipped chat 2
         # because its effective backend is goose, not codex.
         assert 1 in config.user_configs
@@ -1786,11 +1795,13 @@ class TestCodexMemoryRequiresOsUser:
     def test_codex_memory_retrieval_only_skips_precondition(self, monkeypatch):
         """Retrieval-only memory (extraction disabled) does NOT
         require os_user even on codex; the precondition fires only
-        when extraction is actually enabled."""
+        when extraction is actually enabled (the eligible set is
+        empty when extraction is off)."""
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         # MEMORY_EXTRACTION_ENABLED unset = retrieval-only.
-        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
         # No users.yaml; precondition should not fire.
         config = load_config()
         assert config.memory_enabled is True
@@ -1799,74 +1810,181 @@ class TestCodexMemoryRequiresOsUser:
 
 class TestMemoryReasonerModelResolution:
     """Memory model defaults resolve through the per-backend role
-    registry. Claude rows match the existing literal so installs that
-    have not set MEMORY_REASONER_BACKEND see byte-identical model
+    registry via `get_model_for(role, effective_backend)`. There is no
+    longer an env-var override surface for memory models (issue #515
+    retired MEMORY_EXTRACTION_MODEL and MEMORY_EPISODE_MODEL); the
+    registry is the only source. Claude rows must match the prior
+    literal so installs without users.yaml see byte-identical model
     selection. Codex rows pick a codex-CLI-valid SKU."""
 
     def test_claude_default_model_unchanged(self, monkeypatch):
+        """Default (claude) install: registry resolves to the same
+        Haiku SKU that the retired MEMORY_EXTRACTION_MODEL default
+        produced, so production behavior is byte-identical."""
         _set_required(monkeypatch)
-        config = load_config()
-        assert config.memory_reasoner_backend == "claude"
-        assert config.memory_extraction_model == "claude-haiku-4-5-20251001"
-        assert config.memory_episode_model == "claude-haiku-4-5-20251001"
+        # load_config completes; the model selection happens at the
+        # call site (memory_extraction.py), so the test reads the
+        # registry directly to pin the per-backend default.
+        load_config()
+        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "claude") == "claude-haiku-4-5-20251001"
+        assert get_model_for(ModelRole.MEMORY_EPISODE, "claude") == "claude-haiku-4-5-20251001"
 
-    def test_codex_default_resolves_to_codex_model(self, monkeypatch):
+    def test_codex_default_resolves_to_codex_model(self, tmp_path, monkeypatch):
+        """Codex install: registry resolves to a codex-CLI-valid SKU.
+        Test path is the per-user dispatch surface that production
+        will follow: AGENT_BACKEND=codex + users.yaml with os_user."""
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: alice_os\n"
+        )
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
         _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
-        config = load_config()
-        assert config.memory_extraction_model == "gpt-5.4-mini"
-        assert config.memory_episode_model == "gpt-5.4-mini"
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
+        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
+        load_config()
+        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "codex") == "gpt-5.4-mini"
+        assert get_model_for(ModelRole.MEMORY_EPISODE, "codex") == "gpt-5.4-mini"
 
-    def test_explicit_override_wins_for_codex(self, monkeypatch):
-        """An explicit MEMORY_EXTRACTION_MODEL takes precedence over
-        the registry default; the episode model inherits the override
-        when MEMORY_EPISODE_MODEL is unset."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
-        monkeypatch.setenv("MEMORY_EXTRACTION_MODEL", "gpt-5.5")
-        config = load_config()
-        assert config.memory_extraction_model == "gpt-5.5"
-        # Episode inherits extraction when its own var is unset.
-        assert config.memory_episode_model == "gpt-5.5"
-
-    def test_explicit_episode_override_wins(self, monkeypatch):
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
-        monkeypatch.setenv("MEMORY_EPISODE_MODEL", "gpt-5.4")
-        config = load_config()
-        # Extraction got the registry default; episode is the override.
-        assert config.memory_extraction_model == "gpt-5.4-mini"
-        assert config.memory_episode_model == "gpt-5.4"
-
-    def test_codex_extraction_model_rejects_non_codex_value(self, monkeypatch):
-        """A model name the codex CLI does not expose must fail at
-        startup. Without this guard, an operator who sets
-        MEMORY_REASONER_BACKEND=codex but forgets to update
-        MEMORY_EXTRACTION_MODEL (still pointing at a Claude SKU) would
-        see a SubprocessError on every extraction."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
-        monkeypatch.setenv("MEMORY_EXTRACTION_MODEL", "claude-haiku-4-5-20251001")
-        with pytest.raises(SystemExit, match="MEMORY_EXTRACTION_MODEL"):
-            load_config()
-
-    def test_codex_episode_model_rejects_non_codex_value(self, monkeypatch):
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
-        monkeypatch.setenv("MEMORY_EPISODE_MODEL", "claude-haiku-4-5-20251001")
-        with pytest.raises(SystemExit, match="MEMORY_EPISODE_MODEL"):
-            load_config()
-
-    def test_claude_model_override_stays_free_form(self, monkeypatch):
-        """Claude memory-model overrides are intentionally NOT validated
-        against a fixed list; the existing permissive behavior is
-        preserved so an operator running a pinned Claude SKU
-        (`claude-haiku-4-5-20251001-pinned`) does not have a config
-        change rejected by a newly added allowlist."""
+    def test_legacy_extraction_model_env_var_is_ignored(self, monkeypatch, caplog):
+        """The retired MEMORY_EXTRACTION_MODEL env var no longer has
+        a load-bearing effect. Setting it logs a deprecation warning
+        and does not change the registry-resolved model; nor does it
+        raise on a Claude SKU sent to a codex install (since the value
+        is dropped before any validation)."""
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_EXTRACTION_MODEL", "claude-haiku-4-5-20251001-pinned")
-        config = load_config()
-        assert config.memory_extraction_model == "claude-haiku-4-5-20251001-pinned"
+        with caplog.at_level("WARNING", logger="kai.config"):
+            config = load_config()
+        # Field is gone; the value is dropped after the warning.
+        assert not hasattr(config, "memory_extraction_model")
+        # Registry resolution is untouched.
+        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "claude") == "claude-haiku-4-5-20251001"
+        assert any("MEMORY_EXTRACTION_MODEL is deprecated" in r.message for r in caplog.records)
+
+    def test_legacy_episode_model_env_var_is_ignored(self, monkeypatch, caplog):
+        """Same shape for the retired MEMORY_EPISODE_MODEL env var."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_EPISODE_MODEL", "claude-sonnet-4-6")
+        with caplog.at_level("WARNING", logger="kai.config"):
+            config = load_config()
+        assert not hasattr(config, "memory_episode_model")
+        assert get_model_for(ModelRole.MEMORY_EPISODE, "claude") == "claude-haiku-4-5-20251001"
+        assert any("MEMORY_EPISODE_MODEL is deprecated" in r.message for r in caplog.records)
+
+
+class TestExtractionEligibleBackendsHelper:
+    """`_compute_extraction_eligible_backends` is the per-user
+    dispatch cascade in one helper. It feeds the codex
+    precondition checks at config-load and the per-backend binary
+    resolution loop in memory.init_memory."""
+
+    def test_returns_empty_when_memory_extraction_disabled(self):
+        """Retrieval-only and memory-disabled installs do not run any
+        reasoner, so the eligible set is empty regardless of
+        agent_backend and users.yaml."""
+        from kai.config import _compute_extraction_eligible_backends
+
+        assert _compute_extraction_eligible_backends("claude", None, False) == set()
+        assert _compute_extraction_eligible_backends("codex", None, False) == set()
+
+    def test_no_users_yaml_uses_global_backend(self):
+        """ALLOWED_USER_IDS-only authorization (no users.yaml): every
+        authorized user inherits the global agent backend, so the
+        eligible set is `{agent_backend}` when extraction-eligible."""
+        from kai.config import _compute_extraction_eligible_backends
+
+        assert _compute_extraction_eligible_backends("claude", None, True) == {"claude"}
+        assert _compute_extraction_eligible_backends("codex", None, True) == {"codex"}
+
+    def test_goose_global_with_no_users_yaml_returns_empty(self):
+        """Goose is not extraction-eligible (no OneShotReasoner
+        implementation). ALLOWED_USER_IDS install with
+        AGENT_BACKEND=goose produces an empty set; no reasoner
+        plumbing fires."""
+        from kai.config import _compute_extraction_eligible_backends
+
+        assert _compute_extraction_eligible_backends("goose", None, True) == set()
+
+    def test_mixed_users_yaml_contributes_each_effective_backend(self):
+        """users.yaml with both claude and codex users: the eligible
+        set is the union of effective backends, in the same shape
+        bot.py's extraction gate uses."""
+        from kai.config import UserConfig, _compute_extraction_eligible_backends
+
+        configs = {
+            1: UserConfig(telegram_id=1, name="alice", os_user="a"),
+            2: UserConfig(telegram_id=2, name="bob", os_user="b", agent_backend="codex"),
+        }
+        eligible = _compute_extraction_eligible_backends("claude", configs, True)
+        assert eligible == {"claude", "codex"}
+
+    def test_goose_users_filtered_out(self):
+        """A users.yaml entry with `agent_backend: goose` does NOT
+        contribute to the eligible set, mirroring the runtime gate
+        at bot.py that skips extraction for goose users. The
+        precondition/binary checks must not fire on a goose-only
+        user even when extraction is enabled globally."""
+        from kai.config import UserConfig, _compute_extraction_eligible_backends
+
+        configs = {
+            1: UserConfig(telegram_id=1, name="alice", os_user="a"),
+            2: UserConfig(telegram_id=2, name="bob", os_user="b", agent_backend="goose", llm_provider="openai"),
+        }
+        eligible = _compute_extraction_eligible_backends("claude", configs, True)
+        assert eligible == {"claude"}
+
+
+class TestConfigNoMemoryModelFields:
+    """Regression guard for issue #515 field removal. A future
+    change that adds back any of these fields (e.g., as part of a
+    bigger refactor that misses the spec rationale) must surface
+    here rather than at runtime."""
+
+    def test_config_has_no_memory_extraction_model_field(self):
+        # `Config()` cannot be called without required fields, so
+        # inspect the dataclass fields directly.
+        from dataclasses import fields
+
+        from kai.config import Config
+
+        field_names = {f.name for f in fields(Config)}
+        assert "memory_extraction_model" not in field_names
+        assert "memory_episode_model" not in field_names
+        assert "memory_reasoner_backend" not in field_names
+
+
+class TestRegistryValidationPerEligibleBackend:
+    """Per-eligible-backend `_check_model_registry_complete`
+    catches missing memory-role rows at config-load. A per-user
+    codex override on a global-claude install must not reach
+    runtime without its codex memory-role rows being validated."""
+
+    def test_missing_codex_memory_extraction_row_systemexits(self, monkeypatch, tmp_path):
+        """Mixed install: AGENT_BACKEND=claude with one users.yaml
+        entry pinned to `agent_backend: codex`. Patch the registry
+        so the codex MEMORY_EXTRACTION row is missing; load_config
+        SystemExits at startup."""
+        import kai.config as config_mod
+        from kai.config import ModelRole
+
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            "users:\n"
+            "  - telegram_id: 1\n    name: alice\n    role: admin\n"
+            "    agent_backend: codex\n    os_user: alice_os\n"
+        )
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
+        # Patch the registry to drop the codex MEMORY_EXTRACTION row.
+        patched_registry = dict(config_mod.MODEL_REGISTRY)
+        patched_registry.pop(("codex", ModelRole.MEMORY_EXTRACTION), None)
+        monkeypatch.setattr("kai.config.MODEL_REGISTRY", patched_registry)
+        with pytest.raises(SystemExit):
+            load_config()
 
 
 # ── Stage-2 episode generation (issue #385) ───────────────────────────
@@ -1874,44 +1992,19 @@ class TestMemoryReasonerModelResolution:
 
 class TestMemoryEpisode:
     """The MEMORY_EPISODE_* env vars: stage-2 episode generation, which
-    runs out-of-band on stage-1 positives. Bounds differ from stage 1:
-    budget is strictly positive (no zero kill-switch; the master switch
-    is MEMORY_ENABLED) and timeout has a 10s floor (Haiku warm-up time).
-    The model defaults to whatever memory_extraction_model is set to,
-    so an operator who only changed MEMORY_EXTRACTION_MODEL also moves
-    stage 2 onto the new model without a second var."""
+    runs out-of-band on stage-1 positives. Bounds: budget is strictly
+    positive (no zero kill-switch; the master switch is MEMORY_ENABLED)
+    and timeout has a 10s floor (Haiku warm-up time). The model is no
+    longer configurable here (issue #515 retired MEMORY_EPISODE_MODEL);
+    `get_model_for(ModelRole.MEMORY_EPISODE, effective_backend)` is the
+    only source."""
 
     def test_defaults(self, monkeypatch):
-        """Defaults must stay stable so unset = production behavior.
-        Model inheritance from memory_extraction_model is the contract
-        when no env var is set: a fresh install with neither var set
-        ends up with both stages on Haiku (the wizard separately
-        recommends Sonnet for stage 2; the inheritance fallback is
-        the safety floor for tests and operators who skipped wizard).
-        Budget default is 0.15, sized for Sonnet."""
+        """Defaults must stay stable so unset = production behavior."""
         _set_required(monkeypatch)
         config = load_config()
-        assert config.memory_episode_model == "claude-haiku-4-5-20251001"
         assert config.memory_episode_budget_usd == 0.15
         assert config.memory_episode_timeout_s == 120
-
-    def test_model_inherits_extraction_model_when_unset(self, monkeypatch):
-        """Operator changes MEMORY_EXTRACTION_MODEL only - episode
-        follows. Documented in the templates/.env comment."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_EXTRACTION_MODEL", "claude-haiku-4-5-future")
-        config = load_config()
-        assert config.memory_episode_model == "claude-haiku-4-5-future"
-
-    def test_model_override_takes_precedence(self, monkeypatch):
-        """Explicit MEMORY_EPISODE_MODEL beats extraction inheritance.
-        Use case: operator runs Haiku for stage 1 and Sonnet for stage 2
-        narrative quality."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_EXTRACTION_MODEL", "claude-haiku-4-5-20251001")
-        monkeypatch.setenv("MEMORY_EPISODE_MODEL", "claude-sonnet-4-6")
-        config = load_config()
-        assert config.memory_episode_model == "claude-sonnet-4-6"
 
     def test_budget_override(self, monkeypatch):
         """Override path: arbitrary positive value beats the dataclass

--- a/tests/test_episode_classifier_eval.py
+++ b/tests/test_episode_classifier_eval.py
@@ -55,7 +55,6 @@ def _eval_config() -> Config:
         _BASE_CONFIG,
         memory_enabled=True,
         memory_extraction_enabled=True,
-        memory_extraction_model="claude-haiku-4-5-20251001",
         memory_extraction_budget_usd=0.05,
         memory_extraction_timeout_s=60,
         memory_consolidation_candidates_n=0,
@@ -108,7 +107,12 @@ async def test_episode_classifier_precision_recall():
         start = time.monotonic()
         try:
             result = await _run_extractor(
-                payload, config, candidate_ids=set(), candidate_metadata={}, user_id=f"eval-{item_id}"
+                payload,
+                config,
+                candidate_ids=set(),
+                candidate_metadata={},
+                user_id=f"eval-{item_id}",
+                effective_backend="claude",
             )
             predicted: bool = result.has_episode
             error: str | None = None

--- a/tests/test_eval_memory_backend_gate.py
+++ b/tests/test_eval_memory_backend_gate.py
@@ -247,18 +247,29 @@ class TestValidateUserPrefix:
 
 class TestMakeBackendConfig:
     def test_claude_resolves_claude_models(self):
+        """Issue #515 retired the memory reasoner + model env vars;
+        `make_backend_config` now stamps `agent_backend` and the eval
+        harness reads models inline via `get_model_for(role, backend)`
+        at each call site. Pin both the agent_backend selection and
+        the registry-resolved model strings so a future registry
+        change surfaces here."""
+        from kai.config import ModelRole, get_model_for
+
         config = g.make_backend_config(_BASE_CONFIG, "claude")
-        assert config.memory_reasoner_backend == "claude"
-        assert config.memory_extraction_model == "claude-haiku-4-5-20251001"
-        assert config.memory_episode_model == "claude-haiku-4-5-20251001"
+        assert config.agent_backend == "claude"
         assert config.memory_enabled is True
         assert config.memory_extraction_enabled is True
+        # Registry resolution still produces the expected literals.
+        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "claude") == "claude-haiku-4-5-20251001"
+        assert get_model_for(ModelRole.MEMORY_EPISODE, "claude") == "claude-haiku-4-5-20251001"
 
     def test_codex_resolves_codex_models(self):
+        from kai.config import ModelRole, get_model_for
+
         config = g.make_backend_config(_BASE_CONFIG, "codex")
-        assert config.memory_reasoner_backend == "codex"
-        assert config.memory_extraction_model == "gpt-5.4-mini"
-        assert config.memory_episode_model == "gpt-5.4-mini"
+        assert config.agent_backend == "codex"
+        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "codex") == "gpt-5.4-mini"
+        assert get_model_for(ModelRole.MEMORY_EPISODE, "codex") == "gpt-5.4-mini"
 
 
 # ── Anchor matching ─────────────────────────────────────────────────

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1705,19 +1705,15 @@ class TestCmdConfig:
         # Budget prompts (extraction, episode) are skipped on the claude
         # backend per issue #390 - --max-budget-usd is no longer emitted
         # to claude --print argv at either stage, so the wizard does not
-        # ask for a value that would never be enforced.
+        # ask for a value that would never be enforced. The memory
+        # reasoner backend and episode model prompts were retired in
+        # issue #515 (per-user dispatch via agent_backend).
         memory_block = [
             "true",  # memory enabled
             "true",  # extraction enabled (claude backend)
-            "claude",  # MEMORY_REASONER_BACKEND (matches install vendor; suppressed at emission as default)
             "60",  # extraction timeout seconds (#345)
             "5",  # consolidation candidates (non-default, exercises emission branch)
             "5",  # episode classifier context turns (#392, non-default exercises emission)
-            # Episode model: empty input now resolves to the wizard's
-            # default of "claude-sonnet-4-6" rather than the empty
-            # string. To exercise the explicit-override emission
-            # branch, type a different model literal here.
-            "claude-haiku-4-5-20251001",  # episode model (explicit override)
             "60",  # episode timeout seconds (non-default)
             "0.85",  # paraphrase-dedup threshold (non-default, exercises emission)
             "3000",  # token budget
@@ -1732,10 +1728,11 @@ class TestCmdConfig:
         env = conf["env"]
         assert env["MEMORY_ENABLED"] == "true"
         assert env["MEMORY_EXTRACTION_ENABLED"] == "true"
-        # MEMORY_REASONER_BACKEND="claude" is the dataclass default;
-        # the wizard's emission gate suppresses default values, so the
-        # key must NOT appear in the generated env.
+        # The retired memory-reasoner + model env vars are no longer
+        # collected by the wizard; the wizard never writes them.
         assert "MEMORY_REASONER_BACKEND" not in env
+        assert "MEMORY_EXTRACTION_MODEL" not in env
+        assert "MEMORY_EPISODE_MODEL" not in env
         # Budget keys absent on claude backend: prompt is skipped, value
         # stays at dataclass default, double-gated emission suppresses.
         assert "MEMORY_EXTRACTION_BUDGET_USD" not in env
@@ -1745,11 +1742,6 @@ class TestCmdConfig:
         # non-default 5, so the emission gate fires and the env entry
         # is written.
         assert env["EPISODE_CLASSIFIER_CONTEXT_TURNS"] == "5"
-        # Episode model: the wizard's non-blank default means an
-        # operator who hits Enter at the prompt now gets Sonnet
-        # written to the env. This test asserts the explicit-override
-        # path: a model literal typed in the prompt survives to env.
-        assert env["MEMORY_EPISODE_MODEL"] == "claude-haiku-4-5-20251001"
         assert "MEMORY_EPISODE_BUDGET_USD" not in env
         assert env["MEMORY_EPISODE_TIMEOUT_S"] == "60"
         # Paraphrase-dedup threshold: operator picked 0.85 (non-default),
@@ -1758,36 +1750,25 @@ class TestCmdConfig:
         assert env["MEMORY_TOKEN_BUDGET"] == "3000"
         assert env["MEMORY_SEARCH_LIMIT"] == "20"
 
-    def test_memory_episode_wizard_default_writes_sonnet(self, tmp_path, monkeypatch):
-        """Regression for the v1 default-flip: an operator who accepts
-        every wizard default in the episode block should end up with
-        MEMORY_EPISODE_MODEL=claude-sonnet-4-6 written to env, not the
-        empty-inheritance fallback. Pins the recommendation contract so
-        a future "default back to inheritance" change surfaces here.
-
-        Budget default is 0.15 (matches the dataclass default), so the
-        emission gate suppresses the key - asserted absent. Timeout
-        default is 120, also suppressed."""
+    def test_memory_episode_defaults_suppress_emission(self, tmp_path, monkeypatch):
+        """Operator who accepts every wizard default in the episode
+        block produces no episode-specific env entries (the emission
+        gates suppress equal-to-dataclass-default values). The memory
+        reasoner backend and episode model prompts were retired in
+        issue #515; per-user dispatch resolves both at runtime."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
 
-        # Every input below matches the corresponding dataclass
-        # default so the emission gates suppress non-episode keys.
-        # Asserted on the negative side below for the episode keys;
-        # the positive assertion is on the Sonnet model entry.
-        # Budget prompts (extraction, episode) are skipped on the
-        # claude backend per issue #390, so they are absent from
-        # the input list rather than supplying the dataclass default.
+        # Every input matches the corresponding dataclass default so
+        # the emission gates suppress every key in the memory block.
         memory_block = [
             "true",  # memory enabled
             "true",  # extraction enabled
-            "claude",  # MEMORY_REASONER_BACKEND (default-accept; suppressed at emission)
             "10",  # extraction timeout (dataclass default; suppressed)
             "8",  # consolidation candidates (dataclass default; suppressed)
             "3",  # episode classifier context turns (#392, dataclass default; suppressed)
-            "",  # episode model: accept wizard default = claude-sonnet-4-6
             "120",  # episode timeout (dataclass default; suppressed)
             "0.9",  # paraphrase-dedup threshold (dataclass default; suppressed)
             "2000",  # token budget (dataclass default; suppressed)
@@ -1799,21 +1780,19 @@ class TestCmdConfig:
         _cmd_config()
 
         env = json.loads((tmp_path / "install.conf").read_text())["env"]
-        # Sonnet is the recommended default, so empty input → Sonnet.
-        assert env["MEMORY_EPISODE_MODEL"] == "claude-sonnet-4-6"
+        # Retired vars never appear, regardless of input.
+        assert "MEMORY_REASONER_BACKEND" not in env
+        assert "MEMORY_EXTRACTION_MODEL" not in env
+        assert "MEMORY_EPISODE_MODEL" not in env
         # Budget and timeout match dataclass defaults → no emission.
         assert "MEMORY_EPISODE_BUDGET_USD" not in env
         assert "MEMORY_EPISODE_TIMEOUT_S" not in env
         # Stage-1 keys also suppressed because their inputs match
-        # the dataclass defaults too. Assert the suppression so a
-        # future change to the gate semantics surfaces here.
+        # the dataclass defaults too.
         assert "MEMORY_EXTRACTION_BUDGET_USD" not in env
         assert "MEMORY_EXTRACTION_TIMEOUT_S" not in env
         assert "MEMORY_CONSOLIDATION_CANDIDATES_N" not in env
-        # Episode-classifier context window (#392) at default 3 is
-        # also suppressed by the emission gate.
         assert "EPISODE_CLASSIFIER_CONTEXT_TURNS" not in env
-        # Paraphrase-dedup threshold at default 0.9 is also suppressed.
         assert "MEMORY_DUPLICATE_THRESHOLD" not in env
 
     def test_memory_round_trip_through_env_file(self, tmp_path, monkeypatch):
@@ -1823,17 +1802,16 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
 
-        # Inputs in wizard order: enabled, ext enabled, timeout, consolidation, classifier-window, episode model/timeout, token budget, search limit.
+        # Inputs in wizard order: enabled, ext enabled, timeout, consolidation, classifier-window, episode timeout, dedup threshold, token budget, search limit.
         # Budget prompts (extraction, episode) are skipped on the claude
-        # backend per issue #390, so they are absent from this input list.
+        # backend per issue #390. The memory reasoner backend and
+        # episode model prompts were retired in issue #515.
         memory_block = [
             "true",
             "true",
-            "claude",  # MEMORY_REASONER_BACKEND (default-accept; suppressed)
             "45",
             "4",
             "7",  # episode classifier context turns (#392, non-default)
-            "claude-haiku-4-5-future",
             "90",
             "0.8",  # paraphrase-dedup threshold (non-default)
             "2500",
@@ -1856,10 +1834,15 @@ class TestCmdConfig:
         assert 'MEMORY_CONSOLIDATION_CANDIDATES_N="4"' in rendered
         # Episode-classifier context window (#392) round-trip parity.
         assert 'EPISODE_CLASSIFIER_CONTEXT_TURNS="7"' in rendered
-        # Episode tunables: explicit model entry survives, non-default
-        # timeout survives. Round-trip parity with the extraction tunables
-        # above. Budget is suppressed on claude for the same reason.
-        assert 'MEMORY_EPISODE_MODEL="claude-haiku-4-5-future"' in rendered
+        # Retired keys (per issue #515 per-user dispatch) must NOT
+        # round-trip; the wizard no longer collects them, so they
+        # cannot appear in the env file.
+        assert "MEMORY_REASONER_BACKEND" not in rendered
+        assert "MEMORY_EXTRACTION_MODEL" not in rendered
+        assert "MEMORY_EPISODE_MODEL" not in rendered
+        # Episode tunables: non-default timeout survives. Round-trip
+        # parity with the extraction tunables above. Budget is
+        # suppressed on claude for the same reason.
         assert "MEMORY_EPISODE_BUDGET_USD" not in rendered
         assert 'MEMORY_EPISODE_TIMEOUT_S="90"' in rendered
         assert 'MEMORY_TOKEN_BUDGET="2500"' in rendered
@@ -2083,11 +2066,9 @@ class TestCmdConfig:
         memory_block = [
             "true",  # memory enabled
             "true",  # extraction enabled
-            "claude",  # MEMORY_REASONER_BACKEND (default-accept; suppressed)
             "10",  # extraction timeout (default; suppressed)
             "8",  # consolidation candidates (default; suppressed)
             "5",  # episode classifier context turns (#392, non-default)
-            "",  # episode model (accept Sonnet wizard default)
             "120",  # episode timeout (default; suppressed)
             "0.9",  # paraphrase-dedup threshold (default; suppressed)
             "2000",  # token budget (default; suppressed)
@@ -2114,11 +2095,9 @@ class TestCmdConfig:
         memory_block = [
             "true",  # memory enabled
             "true",  # extraction enabled
-            "claude",  # MEMORY_REASONER_BACKEND (default-accept; suppressed)
             "10",  # extraction timeout (default)
             "8",  # consolidation candidates (default)
             "3",  # episode classifier context turns (#392, dataclass default)
-            "",  # episode model (Sonnet default)
             "120",  # episode timeout (default)
             "0.9",  # paraphrase-dedup threshold (default)
             "2000",  # token budget (default)
@@ -2250,7 +2229,9 @@ class TestCmdConfig:
         monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4")
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("MEMORY_REASONER_BACKEND", "codex")
+        # MEMORY_REASONER_BACKEND retired (issue #515); memory reasoner
+        # derives from AGENT_BACKEND per-user. The wizard no longer
+        # emits the key.
         # MEMORY_EPISODE_MODEL is intentionally NOT set; the codex
         # branch defaults the wizard prompt to blank, which means
         # load_config inherits from MEMORY_EXTRACTION_MODEL, which
@@ -2260,13 +2241,14 @@ class TestCmdConfig:
         config = load_config()
         assert config.memory_enabled is True
         assert config.memory_extraction_enabled is True
-        assert config.memory_reasoner_backend == "codex"
-        # Both models must validate as codex SKUs (load_config
-        # checks against CODEX_MODELS and SystemExits on miss).
-        from kai.config import CODEX_MODELS
+        assert config.agent_backend == "codex"
+        # Per-user dispatch (issue #515) resolves the memory model
+        # from the registry at extraction time; verify both stage roles
+        # have a codex-valid row.
+        from kai.config import CODEX_MODELS, ModelRole, get_model_for
 
-        assert config.memory_extraction_model in CODEX_MODELS
-        assert config.memory_episode_model in CODEX_MODELS
+        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "codex") in CODEX_MODELS
+        assert get_model_for(ModelRole.MEMORY_EPISODE, "codex") in CODEX_MODELS
 
     def test_codex_fresh_install_with_memory_extraction_yields_valid_users_yaml(self, tmp_path, monkeypatch):
         """Fresh-install regression for the codex memory wizard gate.
@@ -2339,12 +2321,10 @@ class TestCmdConfig:
                 # claude_user skipped on agent_backend != claude
                 "true",  # memory enabled
                 "true",  # memory extraction enabled
-                "codex",  # memory reasoner backend
-                "codex_runner",  # NEW: re-prompted os_user after codex gate
+                "codex_runner",  # re-prompted os_user after codex gate
                 "10",  # extraction timeout
                 "8",  # consolidation candidates
                 "3",  # episode classifier context turns
-                "",  # episode model (blank inherits extraction model)
                 "120",  # episode timeout
                 "0.9",  # paraphrase-dedup threshold
                 "2000",  # token budget
@@ -2387,7 +2367,7 @@ class TestCmdConfig:
         config = load_config()
         assert config.memory_enabled is True
         assert config.memory_extraction_enabled is True
-        assert config.memory_reasoner_backend == "codex"
+        assert config.agent_backend == "codex"
         assert config.user_configs is not None
         assert 12345 in config.user_configs
         assert config.user_configs[12345].os_user == "codex_runner"
@@ -2737,37 +2717,28 @@ class TestCmdConfigDefaultModelDispatch:
 
     def test_codex_install_enables_memory_with_codex_reasoner(self, tmp_path, monkeypatch):
         """
-        Codex installs CAN enable semantic memory. The reasoner
-        backend defaults to codex (matching the agent backend), the
-        extraction-enabled flag persists, MEMORY_REASONER_BACKEND
-        lands as a non-default value, and the stale-key cleanup at
-        wizard end no longer strips the codex extraction config.
+        Codex installs CAN enable semantic memory. The wizard no
+        longer prompts for MEMORY_REASONER_BACKEND or the episode
+        model (issue #515 retired both); the memory reasoner derives
+        from each user's effective `agent_backend` at extraction time.
+        The extraction-enabled flag persists and the stale-key cleanup
+        at wizard end no longer strips the codex extraction config.
 
         Regression for the prior wizard behavior that forced both
         memory flags off on codex installs and printed a "currently
-        requires the claude backend" message; that guard came out
-        when the OneShotReasoner abstraction made codex memory
-        reachable end-to-end.
+        requires the claude backend" message.
         """
         self._setup(
             monkeypatch,
             tmp_path,
             existing_env={"DEFAULT_MODEL": "gpt-5.4"},
         )
-        # Feed the wizard codex defaults for every memory prompt. The
-        # reasoner_backend default mirrors agent_backend=codex, so
-        # accepting it via empty string locks in MEMORY_REASONER_BACKEND
-        # =codex. The episode model default is empty (inherit
-        # extraction model) on the codex reasoner branch; accepting
-        # blank exercises that path.
         memory_inputs = [
             "true",  # MEMORY_ENABLED
             "true",  # MEMORY_EXTRACTION_ENABLED
-            "",  # MEMORY_REASONER_BACKEND (accept default = codex)
             "10",  # extraction timeout (dataclass default)
             "8",  # consolidation candidates (dataclass default)
             "3",  # episode classifier context turns (dataclass default)
-            "",  # episode model (blank inherits extraction model on codex)
             "120",  # episode timeout (dataclass default)
             "0.9",  # paraphrase-dedup threshold (dataclass default)
             "2000",  # token budget (dataclass default)
@@ -2786,80 +2757,23 @@ class TestCmdConfigDefaultModelDispatch:
         idx = len(base_inputs) - 2  # memory_enabled position
         inputs = base_inputs[: idx + 1] + memory_inputs[1:] + base_inputs[idx + 1 :]
         _, env = self._run(monkeypatch, tmp_path, inputs, helper_return="gpt-5.4")
-        # Codex install now persists memory extraction config. The
-        # reasoner backend is codex (non-default; emitted), and the
-        # extraction flag survives the cleanup block that previously
-        # stripped it on non-claude installs.
+        # Codex install persists memory extraction config; the global
+        # AGENT_BACKEND=codex is what makes codex extraction-eligible.
         assert env.get("MEMORY_ENABLED") == "true"
         assert env.get("MEMORY_EXTRACTION_ENABLED") == "true"
-        assert env.get("MEMORY_REASONER_BACKEND") == "codex"
+        assert env.get("AGENT_BACKEND") == "codex"
+        # MEMORY_REASONER_BACKEND retired; the wizard must not emit it.
+        assert "MEMORY_REASONER_BACKEND" not in env
 
-    def test_claude_install_codex_reasoner_emits_codex_bin_and_matches_sudoers(self, tmp_path, monkeypatch):
-        """claude+codex memory regression: when AGENT_BACKEND=claude but
-        MEMORY_REASONER_BACKEND=codex, the wizard must still collect
-        CODEX_BIN (the earlier agent-block prompt is skipped because the
-        agent backend is not codex). install.conf must emit CODEX_BIN,
-        and the sudoers rules _generate_sudoers produces from that env
-        must reference the same path. Without this contract the codex
-        memory reasoner spawns the binary resolved from PATH while the
-        sudoers SETENV rule allows only the wizard's fallback
-        /opt/homebrew/bin/codex; if the two diverge, every cross-user
-        codex call fails with "a password is required" and extraction
-        silently no-ops.
-        """
-        from kai.install import _generate_sudoers
-
-        self._setup(monkeypatch, tmp_path, existing_env={"DEFAULT_MODEL": "sonnet"})
-        # The new claude-with-codex-reasoner memory block. The
-        # CODEX_BIN re-prompt is the load-bearing entry: it only
-        # fires when memory_reasoner_backend == codex AND the earlier
-        # codex agent-block did not collect a path (agent_backend !=
-        # codex). Episode model is left blank to inherit the codex
-        # extraction default in load_config.
-        memory_inputs = [
-            "true",  # MEMORY_ENABLED
-            "true",  # MEMORY_EXTRACTION_ENABLED
-            "codex",  # MEMORY_REASONER_BACKEND (override default = claude)
-            "/usr/local/bin/codex",  # NEW: codex_bin re-prompt at memory gate
-            "10",  # extraction timeout (dataclass default)
-            "8",  # consolidation candidates (dataclass default)
-            "3",  # episode classifier context turns (dataclass default)
-            "",  # episode model (blank inherits extraction model on codex)
-            "120",  # episode timeout (dataclass default)
-            "0.9",  # paraphrase-dedup threshold (dataclass default)
-            "2000",  # token budget (dataclass default)
-            "10",  # search limit (dataclass default)
-        ]
-        # _inputs_for_claude_backend places memory_enabled as the
-        # second-to-last entry. Replace it with "true" and splice the
-        # rest of the memory block immediately after; the trailing
-        # perplexity-key entry stays at the end.
-        base_inputs = self._inputs_for_claude_backend()
-        idx = len(base_inputs) - 2  # memory_enabled position
-        base_inputs = base_inputs[:idx] + ["true"] + base_inputs[idx + 1 :]
-        inputs = base_inputs[: idx + 1] + memory_inputs[1:] + base_inputs[idx + 1 :]
-        _, env = self._run(monkeypatch, tmp_path, inputs, helper_return="sonnet")
-        assert env.get("MEMORY_REASONER_BACKEND") == "codex"
-        # The wizard must emit CODEX_BIN even though AGENT_BACKEND=
-        # claude. Pre-fix this assertion failed because the env-
-        # emission block was gated on agent_backend == codex.
-        assert env.get("CODEX_BIN") == "/usr/local/bin/codex"
-
-        # Sudoers rules generated from env["CODEX_BIN"] must use the
-        # same path. This pins the install-time wiring so the codex
-        # memory reasoner argv (which resolves codex via the same
-        # binary path through resolve_oneshot_binary) and the
-        # sudoers SETENV rule cannot drift apart. _user_home is
-        # patched because the sudoers generator inspects per-target
-        # home directories that do not exist on the test host.
-        monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
-        sudoers = _generate_sudoers(
-            "kai",
-            os_users=["alice"],
-            codex_bin=env["CODEX_BIN"],
-        )
-        codex_lines = [line for line in sudoers.splitlines() if "(alice)" in line and "/usr/local/bin/codex" in line]
-        assert len(codex_lines) == 1, codex_lines
+    # The old test_claude_install_codex_reasoner_emits_codex_bin_and_matches_sudoers
+    # tested a wizard prompt path that issue #515 retired (global
+    # MEMORY_REASONER_BACKEND=codex with AGENT_BACKEND=claude). The
+    # mixed-backend scenario it covered now requires a users.yaml entry
+    # with per-user `agent_backend: codex`, which the wizard does not
+    # prompt for - operators edit users.yaml directly. The CODEX_BIN
+    # sudoers wiring is covered by other tests in the suite; a
+    # dedicated regression for the codex_runs_anywhere predicate
+    # belongs in the new-tests pass for issue #515.
 
 
 class TestCmdApplyDefaultModelGate:
@@ -6229,24 +6143,30 @@ class TestPerOsUserCodexLoginHint:
         path.write_text(yaml.safe_dump({"users": entries}))
         return path
 
-    def test_claude_agent_with_codex_memory_reasoner_emits_reminder(self, tmp_path):
-        """The reviewer-flagged regression. With AGENT_BACKEND=claude and
-        MEMORY_REASONER_BACKEND=codex, codex still runs per-user for
-        memory extraction; the operator must run `codex login` as the
-        target os_user or the first extraction fails with no auth.
-        Pre-fix the reminder was suppressed because the gate keyed on
-        AGENT_BACKEND alone.
+    def test_claude_agent_with_per_user_codex_emits_reminder(self, tmp_path):
+        """Mixed-backend regression. With AGENT_BACKEND=claude but a
+        users.yaml entry pinned to `agent_backend: codex`, codex still
+        runs per-user; the operator must run `codex login` as the
+        target os_user or the first turn fails with no auth.
+        Pre-#515 fix the reminder was suppressed because the gate
+        keyed on AGENT_BACKEND alone; now the gate honors per-user
+        agent_backend overrides via `_codex_users_from_yaml`.
         """
         from kai.install import _build_codex_login_reminder
 
         users_yaml = self._write_users_yaml(
             tmp_path,
-            [{"telegram_id": 12345, "name": "alice", "role": "admin", "os_user": "alice"}],
+            [
+                {
+                    "telegram_id": 12345,
+                    "name": "alice",
+                    "role": "admin",
+                    "agent_backend": "codex",
+                    "os_user": "alice",
+                }
+            ],
         )
-        env = {
-            "AGENT_BACKEND": "claude",
-            "MEMORY_REASONER_BACKEND": "codex",
-        }
+        env = {"AGENT_BACKEND": "claude"}
         text = _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml)
         assert text is not None
         assert "Codex subscription auth required:" in text
@@ -6293,15 +6213,28 @@ class TestPerOsUserCodexLoginHint:
             tmp_path,
             [{"telegram_id": 1, "name": "alice", "role": "admin", "os_user": "alice"}],
         )
-        for env in (
-            {"AGENT_BACKEND": "codex", "CODEX_AUTH_MODE": "api_key"},
-            {
-                "AGENT_BACKEND": "claude",
-                "MEMORY_REASONER_BACKEND": "codex",
-                "CODEX_AUTH_MODE": "api_key",
-            },
-        ):
-            assert _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml) is None, env
+        # First env: global codex with api_key auth, users.yaml has
+        # alice as a generic claude-effective user (no agent_backend
+        # override). Second env: claude global with per-user codex
+        # override via users.yaml + api_key auth. Both must return None
+        # because api_key auth needs no per-user codex login.
+        env_codex_global = {"AGENT_BACKEND": "codex", "CODEX_AUTH_MODE": "api_key"}
+        assert _build_codex_login_reminder(env_codex_global, "kai", users_yaml_path=users_yaml) is None
+
+        users_yaml_mixed = self._write_users_yaml(
+            tmp_path,
+            [
+                {
+                    "telegram_id": 2,
+                    "name": "alice",
+                    "role": "admin",
+                    "agent_backend": "codex",
+                    "os_user": "alice",
+                }
+            ],
+        )
+        env_mixed = {"AGENT_BACKEND": "claude", "CODEX_AUTH_MODE": "api_key"}
+        assert _build_codex_login_reminder(env_mixed, "kai", users_yaml_path=users_yaml_mixed) is None
 
     def test_no_os_users_falls_back_to_service_user(self, tmp_path):
         """When users.yaml has no os_user entries (legacy single-user

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -145,7 +145,10 @@ class TestInitMemory:
         """Even when memory is disabled, init_memory emits exactly
         one structured `memory.config` log so an operator scanning
         the log post-restart can confirm the configured state. All
-        non-`enabled` fields elide to null."""
+        non-`enabled` fields elide to null/empty. Per-user dispatch
+        (issue #515) added `reasoner_mode`/`reasoner_backends`/
+        `extraction_models`/`episode_models`/`extraction_binaries`
+        beside the legacy flat keys."""
         import json as json_module
 
         from kai.memory import init_memory
@@ -159,10 +162,13 @@ class TestInitMemory:
         assert payload == {
             "enabled": False,
             "extraction_enabled": False,
+            "reasoner_mode": None,
             "reasoner_backend": None,
+            "reasoner_backends": [],
             "extraction_model": None,
-            "episode_model": None,
-            "extraction_binary": None,
+            "extraction_models": {},
+            "episode_models": {},
+            "extraction_binaries": {},
         }
 
     @integration
@@ -184,12 +190,10 @@ class TestInitMemory:
 
         monkeypatch.setattr("kai.oneshot_binary.resolve_oneshot_binary", fake_resolve)
         # Memory enabled but extraction disabled = retrieval-only.
-        config = _make_config(
-            memory_extraction_enabled=False,
-            memory_reasoner_backend="claude",
-            memory_extraction_model="claude-haiku-4-5",
-            memory_episode_model="",
-        )
+        # No reasoner/model fields needed at config level any more
+        # (issue #515 retired them); per-user dispatch resolves at
+        # runtime, and the retrieval-only eligible set is empty.
+        config = _make_config(memory_extraction_enabled=False)
         with (
             caplog.at_level(logging.INFO, logger="kai.memory"),
             patch("kai.memory.DATA_DIR", tmp_path),
@@ -204,7 +208,12 @@ class TestInitMemory:
         payload = json_module.loads(records[0].getMessage().split("memory.config ", 1)[1])
         assert payload["enabled"] is True
         assert payload["extraction_enabled"] is False
-        assert payload["extraction_binary"] is None
+        # Retrieval-only: eligible set is empty so the per-backend
+        # binary map is empty, the flat field is null, and the mode
+        # key is null because no reasoner runs.
+        assert payload["extraction_binaries"] == {}
+        assert payload["reasoner_backend"] is None
+        assert payload["reasoner_mode"] is None
         # Critical contract: resolver MUST NOT have been called.
         assert called == [], f"resolver was invoked on retrieval-only init: {called}"
 
@@ -221,11 +230,14 @@ class TestInitMemory:
             "kai.oneshot_binary.resolve_oneshot_binary",
             lambda backend: f"/fake/{backend}-binary",
         )
+        # Per-user dispatch: the eligible set is computed from
+        # `agent_backend` (legacy ALLOWED_USER_IDS auth has no
+        # users.yaml, so every user inherits the global). A
+        # single-backend install logs the uniform-mode flat keys plus
+        # the per-backend maps.
         config = _make_config(
             memory_extraction_enabled=True,
-            memory_reasoner_backend="codex",
-            memory_extraction_model="gpt-5.4-mini",
-            memory_episode_model="",
+            agent_backend="codex",
         )
         with (
             caplog.at_level(logging.INFO, logger="kai.memory"),
@@ -239,8 +251,67 @@ class TestInitMemory:
         payload = json_module.loads(records[0].getMessage().split("memory.config ", 1)[1])
         assert payload["enabled"] is True
         assert payload["extraction_enabled"] is True
+        assert payload["reasoner_mode"] == "uniform"
         assert payload["reasoner_backend"] == "codex"
-        assert payload["extraction_binary"] == "/fake/codex-binary"
+        assert payload["reasoner_backends"] == ["codex"]
+        assert payload["extraction_binaries"] == {"codex": "/fake/codex-binary"}
+
+    @integration
+    def test_init_per_user_mode_startup_log_shape(self, caplog, tmp_path, monkeypatch):
+        """Mixed-backend install (per-user dispatch active): the
+        startup log emits `reasoner_mode=per-user`, the sorted
+        `reasoner_backends` list, and the per-backend
+        `extraction_models`/`episode_models`/`extraction_binaries`
+        maps. The flat `reasoner_backend`/`extraction_model` keys
+        are null to prevent consumers from silently reading the
+        wrong value on mixed installs."""
+        import json as json_module
+
+        from kai.config import UserConfig
+        from kai.memory import init_memory
+
+        monkeypatch.setattr(
+            "kai.oneshot_binary.resolve_oneshot_binary",
+            lambda backend: f"/fake/{backend}-binary",
+        )
+        config = _make_config(
+            memory_extraction_enabled=True,
+            agent_backend="claude",
+            user_configs={
+                1: UserConfig(telegram_id=1, name="alice", os_user="a"),
+                2: UserConfig(telegram_id=2, name="bob", os_user="b", agent_backend="codex"),
+            },
+        )
+        with (
+            caplog.at_level(logging.INFO, logger="kai.memory"),
+            patch("kai.memory.DATA_DIR", tmp_path),
+            patch("mem0.Memory") as mock_mem,
+        ):
+            mock_mem.from_config.return_value.embedding_model.model.get_embedding_dimension.return_value = 384
+            init_memory(config)
+        records = [r for r in caplog.records if "memory.config" in r.getMessage()]
+        assert len(records) == 1
+        payload = json_module.loads(records[0].getMessage().split("memory.config ", 1)[1])
+        assert payload["reasoner_mode"] == "per-user"
+        # Sorted ordering so consumers see a deterministic list.
+        assert payload["reasoner_backends"] == ["claude", "codex"]
+        # Flat keys null on per-user mode; the per-backend maps
+        # carry the resolved models so consumers must read them
+        # explicitly rather than silently picking one vendor.
+        assert payload["reasoner_backend"] is None
+        assert payload["extraction_model"] is None
+        assert payload["extraction_models"] == {
+            "claude": "claude-haiku-4-5-20251001",
+            "codex": "gpt-5.4-mini",
+        }
+        assert payload["episode_models"] == {
+            "claude": "claude-haiku-4-5-20251001",
+            "codex": "gpt-5.4-mini",
+        }
+        assert payload["extraction_binaries"] == {
+            "claude": "/fake/claude-binary",
+            "codex": "/fake/codex-binary",
+        }
 
     @integration
     def test_mem0_telemetry_path_is_isolated(self):

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -62,11 +62,9 @@ def _cfg(**overrides) -> Config:
     defaults = {
         "memory_enabled": True,
         "memory_extraction_enabled": True,
-        "memory_extraction_model": "claude-haiku-4-5-20251001",
         "memory_extraction_budget_usd": 0.05,
         "memory_extraction_timeout_s": 60,
         "memory_consolidation_candidates_n": 0,
-        "memory_episode_model": "claude-haiku-4-5-20251001",
         "memory_episode_budget_usd": 0.15,
         "memory_episode_timeout_s": 120,
     }
@@ -201,7 +199,14 @@ class TestExtractionResultClassifier:
             return _make_proc(stdout=_stage1_envelope(facts=[], has_episode=True))
 
         monkeypatch.setattr(memory_extraction.asyncio, "create_subprocess_exec", _fake_exec)
-        result = await _run_extractor("payload", _cfg(), candidate_ids=set(), candidate_metadata={}, user_id="u1")
+        result = await _run_extractor(
+            "payload",
+            _cfg(),
+            candidate_ids=set(),
+            candidate_metadata={},
+            user_id="u1",
+            effective_backend="claude",
+        )
         assert isinstance(result, ExtractionResult)
         assert result.has_episode is True
         assert result.facts == []
@@ -216,7 +221,14 @@ class TestExtractionResultClassifier:
             return _make_proc(stdout=_stage1_envelope(facts=[], has_episode=False))
 
         monkeypatch.setattr(memory_extraction.asyncio, "create_subprocess_exec", _fake_exec)
-        result = await _run_extractor("payload", _cfg(), candidate_ids=set(), candidate_metadata={}, user_id="u1")
+        result = await _run_extractor(
+            "payload",
+            _cfg(),
+            candidate_ids=set(),
+            candidate_metadata={},
+            user_id="u1",
+            effective_backend="claude",
+        )
         assert result.has_episode is False
 
     @pytest.mark.asyncio
@@ -242,7 +254,14 @@ class TestExtractionResultClassifier:
             return build_proc()
 
         monkeypatch.setattr(memory_extraction.asyncio, "create_subprocess_exec", _fake_exec)
-        result = await _run_extractor("payload", _cfg(), candidate_ids=set(), candidate_metadata={}, user_id="u1")
+        result = await _run_extractor(
+            "payload",
+            _cfg(),
+            candidate_ids=set(),
+            candidate_metadata={},
+            user_id="u1",
+            effective_backend="claude",
+        )
         assert result.has_episode is False
         assert result.facts == []
 
@@ -496,6 +515,7 @@ class TestStage2Isolation:
                 user_id="u1",
                 session_id=None,
                 config=_cfg(memory_episode_timeout_s=10),
+                effective_backend="claude",
             )
 
         episode_records = [r for r in caplog.records if r.message.startswith("memory.episode ")]
@@ -545,6 +565,7 @@ class TestStage2Isolation:
                 user_id="u1",
                 session_id=None,
                 config=_cfg(),
+                effective_backend="claude",
             )
         await release_task
 
@@ -592,6 +613,7 @@ class TestStage2Isolation:
                 user_id="u1",
                 session_id=None,
                 config=_cfg(),
+                effective_backend="claude",
             )
 
         records = [r for r in caplog.records if r.message.startswith("memory.episode ")]
@@ -628,6 +650,7 @@ class TestStage2Isolation:
                 user_id="u1",
                 session_id=None,
                 config=_cfg(),
+                effective_backend="claude",
             )
 
         episode_records = [r for r in caplog.records if r.message.startswith("memory.episode ")]
@@ -674,6 +697,7 @@ class TestStage2Storage:
             user_id="u1",
             session_id="sess-42",
             config=_cfg(),
+            effective_backend="claude",
         )
 
         assert captured["memory_type"] == "episode"
@@ -713,6 +737,7 @@ class TestStage2Storage:
             user_id="u1",
             session_id=None,
             config=_cfg(),
+            effective_backend="claude",
         )
 
         assert "lessons" not in captured["metadata"]
@@ -744,6 +769,7 @@ class TestStage2Storage:
             user_id="u1",
             session_id=None,
             config=_cfg(),
+            effective_backend="claude",
         )
 
         assert captured["metadata"]["lessons"] == episode_with_lessons["lessons"]
@@ -773,6 +799,7 @@ class TestStage2Storage:
             user_id="u1",
             session_id=None,
             config=_cfg(),
+            effective_backend="claude",
         )
 
         assert captured["content"] == f"{ep['goal']}\n\n{ep['context']}"
@@ -798,6 +825,7 @@ class TestStage2Storage:
                 user_id="u1",
                 session_id=None,
                 config=_cfg(),
+                effective_backend="claude",
             )
 
         records = [r for r in caplog.records if r.message.startswith("memory.episode ")]
@@ -834,6 +862,7 @@ class TestStage2Storage:
                 user_id="u1",
                 session_id=None,
                 config=_cfg(),
+                effective_backend="claude",
             )
 
         records = [r for r in caplog.records if r.message.startswith("memory.episode ")]
@@ -860,11 +889,12 @@ class TestStage2SubprocessAssembly:
 
     @pytest.mark.asyncio
     async def test_stage2_command_uses_episode_config(self, monkeypatch):
-        """Model, budget, timeout, system prompt, and JSON schema all
-        come from the episode-specific config fields, not the stage-1
-        ones. A regression where stage 2 reads memory_extraction_model
-        would silently double the stage-1 cost on every episode-worthy
-        turn."""
+        """Budget, timeout, system prompt, and JSON schema all come
+        from the episode-specific config fields, not the stage-1 ones.
+        The model now resolves through `get_model_for(MEMORY_EPISODE,
+        effective_backend)` (issue #515 retired the per-stage env vars),
+        so the assertion pins the registry-resolved value rather than a
+        config-field override."""
         captured: dict = {}
 
         async def _fake_exec(*args, **kwargs):
@@ -875,14 +905,14 @@ class TestStage2SubprocessAssembly:
         monkeypatch.setattr(memory_extraction.asyncio, "create_subprocess_exec", _fake_exec)
         await _run_episode_extractor(
             "payload",
-            _cfg(
-                memory_episode_model="claude-sonnet-4-6",
-                memory_episode_budget_usd=0.15,
-            ),
+            _cfg(memory_episode_budget_usd=0.15),
+            effective_backend="claude",
         )
 
         args = captured["args"]
-        assert args[args.index("--model") + 1] == "claude-sonnet-4-6"
+        # Registry MEMORY_EPISODE row for claude is the Haiku SKU; same
+        # value the retired `memory_episode_model` default pointed at.
+        assert args[args.index("--model") + 1] == "claude-haiku-4-5-20251001"
         # --max-budget-usd is NOT emitted on the claude backend (issue
         # #390): Max-plan OAuth makes the CLI's computed-cost ceiling a
         # phantom signal. Runaway protection comes from
@@ -906,7 +936,7 @@ class TestStage2SubprocessAssembly:
             return _make_proc(stdout=_stage2_envelope(_valid_episode()))
 
         monkeypatch.setattr(memory_extraction.asyncio, "create_subprocess_exec", _fake_exec)
-        await _run_episode_extractor("payload", _cfg())
+        await _run_episode_extractor("payload", _cfg(), effective_backend="claude")
 
         args = captured["args"]
         assert args[args.index("--tools") + 1] == ""
@@ -1133,8 +1163,8 @@ class TestRunEpisodeExtractorViaReasoner:
                     duration_ms=42,
                 )
 
-        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_FakeReasoner()):
-            episode, cost_usd, reason = await _run_episode_extractor("payload", _cfg())
+        with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FakeReasoner()):
+            episode, cost_usd, reason = await _run_episode_extractor("payload", _cfg(), effective_backend="claude")
 
         assert episode == _valid_episode()
         assert cost_usd == pytest.approx(0.04)
@@ -1151,8 +1181,8 @@ class TestRunEpisodeExtractorViaReasoner:
             async def run(self, **kwargs):
                 raise OneShotTimeout()
 
-        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_TimingOutReasoner()):
-            episode, cost_usd, reason = await _run_episode_extractor("payload", _cfg())
+        with patch("kai.memory_extraction._build_memory_reasoner", return_value=_TimingOutReasoner()):
+            episode, cost_usd, reason = await _run_episode_extractor("payload", _cfg(), effective_backend="claude")
 
         assert episode is None
         assert cost_usd == 0.0
@@ -1170,8 +1200,8 @@ class TestRunEpisodeExtractorViaReasoner:
             async def run(self, **kwargs):
                 raise OneShotSubprocessError(returncode=2, stderr=b"oauth refused: please login")
 
-        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_FailingReasoner()):
-            episode, cost_usd, reason = await _run_episode_extractor("payload", _cfg())
+        with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FailingReasoner()):
+            episode, cost_usd, reason = await _run_episode_extractor("payload", _cfg(), effective_backend="claude")
 
         assert episode is None
         assert cost_usd == 0.0
@@ -1208,9 +1238,9 @@ class TestRunEpisodeExtractorWithCodexEnvelope:
                     duration_ms=33,
                 )
 
-        config = _cfg(memory_reasoner_backend="codex", memory_episode_model="gpt-5.4-mini")
-        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_FakeCodexReasoner()):
-            ep, cost_usd, reason = await _run_episode_extractor("payload", config)
+        config = _cfg()
+        with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FakeCodexReasoner()):
+            ep, cost_usd, reason = await _run_episode_extractor("payload", config, effective_backend="codex")
 
         assert ep == episode
         # No total_cost_usd in the envelope -> 0.0. Codex runs

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -90,7 +90,6 @@ def _cfg(**overrides) -> Config:
     defaults = {
         "memory_enabled": True,
         "memory_extraction_enabled": True,
-        "memory_extraction_model": "claude-haiku-4-5-20251001",
         "memory_extraction_budget_usd": 0.01,
         "memory_extraction_timeout_s": 10,
         "memory_consolidation_candidates_n": 0,
@@ -2856,6 +2855,7 @@ class TestRunExtractorSystemPromptDefault:
                 candidate_ids=set(),
                 candidate_metadata={},
                 user_id="test-user-default-kwarg",
+                effective_backend="claude",
             )
 
         asyncio.run(_run())
@@ -3181,6 +3181,7 @@ class TestValidateEpisodeIntegration:
             user_id="u-int",
             session_id="s-1",
             config=_cfg(),
+            effective_backend="claude",
         )
 
         assert captured["outcome"] == "validate_rejected"
@@ -3231,6 +3232,7 @@ class TestValidateEpisodeIntegration:
             user_id="u-int",
             session_id="s-1",
             config=_cfg(),
+            effective_backend="claude",
         )
 
         assert captured["outcome"] == "stored"
@@ -3293,6 +3295,7 @@ class TestValidateEpisodeIntegration:
             user_id="u-int",
             session_id="s-1",
             config=_cfg(),
+            effective_backend="claude",
         )
 
         assert captured_metadata.get("speaker") == "episode_summary"
@@ -3495,13 +3498,14 @@ class TestRunExtractorViaReasoner:
                     duration_ms=12,
                 )
 
-        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_FakeReasoner()):
+        with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FakeReasoner()):
             result = await memory_extraction._run_extractor(
                 payload_text="payload",
                 config=_cfg(),
                 candidate_ids=set(),
                 candidate_metadata={},
                 user_id="u1",
+                effective_backend="claude",
             )
 
         assert result.facts == []
@@ -3518,13 +3522,14 @@ class TestRunExtractorViaReasoner:
             async def run(self, **kwargs):
                 raise OneShotTimeout()
 
-        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_TimingOutReasoner()):
+        with patch("kai.memory_extraction._build_memory_reasoner", return_value=_TimingOutReasoner()):
             result = await memory_extraction._run_extractor(
                 payload_text="payload",
                 config=_cfg(),
                 candidate_ids=set(),
                 candidate_metadata={},
                 user_id="u1",
+                effective_backend="claude",
             )
 
         assert result.facts == []
@@ -3541,13 +3546,14 @@ class TestRunExtractorViaReasoner:
             async def run(self, **kwargs):
                 raise OneShotSubprocessError(returncode=2, stderr=b"oauth refused")
 
-        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_FailingReasoner()):
+        with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FailingReasoner()):
             result = await memory_extraction._run_extractor(
                 payload_text="payload",
                 config=_cfg(),
                 candidate_ids=set(),
                 candidate_metadata={},
                 user_id="u1",
+                effective_backend="claude",
             )
 
         assert result.facts == []
@@ -3555,24 +3561,23 @@ class TestRunExtractorViaReasoner:
 
 
 class TestMemoryReasonerSelection:
-    """`_get_memory_reasoner(config)` dispatches on
-    `config.memory_reasoner_backend`. The Claude case is the default
-    and proves the helper still returns a Claude reasoner when no env
-    var is set; the Codex case proves the selector wires up the new
-    CodexOneShotReasoner without requiring memory_extraction.py to
-    branch on backend at the call site."""
+    """`_build_memory_reasoner(effective_backend)` dispatches on the
+    per-user effective backend resolved by `_resolve_effective_backend`.
+    The Claude case proves the helper returns a Claude reasoner; the
+    Codex case proves the dispatch wires up CodexOneShotReasoner.
+    Backend selection used to live on `config.memory_reasoner_backend`;
+    with issue #515 it derives from the user being extracted."""
 
-    def test_default_returns_claude_reasoner(self):
+    def test_claude_backend_returns_claude_reasoner(self):
         from kai.oneshot import ClaudeOneShotReasoner
 
-        reasoner = memory_extraction._get_memory_reasoner(_cfg())
+        reasoner = memory_extraction._build_memory_reasoner("claude")
         assert isinstance(reasoner, ClaudeOneShotReasoner)
 
     def test_codex_backend_returns_codex_reasoner(self):
         from kai.oneshot import CodexOneShotReasoner
 
-        config = _cfg(memory_reasoner_backend="codex")
-        reasoner = memory_extraction._get_memory_reasoner(config)
+        reasoner = memory_extraction._build_memory_reasoner("codex")
         assert isinstance(reasoner, CodexOneShotReasoner)
 
 
@@ -3600,14 +3605,15 @@ class TestRunExtractorWithCodexEnvelope:
                     duration_ms=42,
                 )
 
-        config = _cfg(memory_reasoner_backend="codex", memory_extraction_model="gpt-5.4-mini")
-        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_FakeCodexReasoner()):
+        config = _cfg(agent_backend="codex")
+        with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FakeCodexReasoner()):
             result = await memory_extraction._run_extractor(
                 payload_text="payload",
                 config=config,
                 candidate_ids=set(),
                 candidate_metadata={},
                 user_id="u1",
+                effective_backend="codex",
             )
 
         assert result.facts == []
@@ -3628,14 +3634,15 @@ class TestRunExtractorWithCodexEnvelope:
             async def run(self, **kwargs):
                 raise OneShotOutputError("codex final JSON missing required fields: ['facts', 'has_episode']")
 
-        config = _cfg(memory_reasoner_backend="codex", memory_extraction_model="gpt-5.4-mini")
-        with patch("kai.memory_extraction._get_memory_reasoner", return_value=_OutputErrorReasoner()):
+        config = _cfg(agent_backend="codex")
+        with patch("kai.memory_extraction._build_memory_reasoner", return_value=_OutputErrorReasoner()):
             result = await memory_extraction._run_extractor(
                 payload_text="payload",
                 config=config,
                 candidate_ids=set(),
                 candidate_metadata={},
                 user_id="u1",
+                effective_backend="codex",
             )
 
         assert result.facts == []
@@ -3699,18 +3706,16 @@ class TestResolveOsUser:
         assert memory_extraction._resolve_os_user("42", config) is None
 
 
-class TestGetMemoryReasonerWithOsUser:
-    """`_get_memory_reasoner` threads `os_user` into the reasoner
+class TestBuildMemoryReasonerWithOsUser:
+    """`_build_memory_reasoner` threads `os_user` into the reasoner
     constructor so both stages route to the same target."""
 
     def test_claude_reasoner_receives_os_user(self):
-        config = _cfg()
-        reasoner = memory_extraction._get_memory_reasoner(config, os_user="target")
+        reasoner = memory_extraction._build_memory_reasoner("claude", os_user="target")
         assert reasoner._os_user == "target"
 
     def test_codex_reasoner_receives_os_user(self):
-        config = _cfg(memory_reasoner_backend="codex", memory_extraction_model="gpt-5.4-mini")
-        reasoner = memory_extraction._get_memory_reasoner(config, os_user="target")
+        reasoner = memory_extraction._build_memory_reasoner("codex", os_user="target")
         assert reasoner._os_user == "target"
 
 
@@ -3794,3 +3799,252 @@ class TestExtractAndStoreThreadsOsUser:
             config=config,
         )
         assert captured.get("os_user") == "opuser"
+
+
+class TestExtractAndStorePerUserDispatch:
+    """Per-user reasoner dispatch (issue #515): `extract_and_store`
+    resolves the effective backend from the user being extracted and
+    threads that backend into both stages. Mixed-backend deployments
+    (one claude user + one codex user under the same install) must
+    extract via the matching vendor without cross-talk."""
+
+    @pytest.mark.asyncio
+    async def test_dispatches_per_user_to_matching_reasoner(self, monkeypatch):
+        """Two users in users.yaml, one claude-effective (no override,
+        global default) and one codex-effective (per-user override).
+        `extract_and_store` for each user resolves a different
+        effective backend; captured `_build_memory_reasoner` argv
+        proves the dispatch."""
+        from kai import memory as memory_module
+        from kai.config import UserConfig
+
+        captured_backends: list[str] = []
+
+        class _StubReasoner:
+            def __init__(self):
+                self._os_user = None
+
+            async def run(self, **kwargs):
+                from kai.oneshot import OneShotResult
+
+                return OneShotResult(
+                    text='{"is_error": false, "structured_output": {"facts": [], "has_episode": false}}',
+                    backend="stub",
+                    model="stub",
+                    raw_metadata={"returncode": 0, "stderr": b""},
+                    duration_ms=1,
+                )
+
+        def _spy_build(effective_backend, os_user=None):
+            captured_backends.append(effective_backend)
+            return _StubReasoner()
+
+        monkeypatch.setattr(memory_extraction, "_build_memory_reasoner", _spy_build)
+        monkeypatch.setattr(memory_module, "_memory", object())
+
+        config = replace(
+            _cfg(),
+            agent_backend="claude",
+            user_configs={
+                1: UserConfig(telegram_id=1, name="alice", os_user="alice_os"),
+                2: UserConfig(
+                    telegram_id=2,
+                    name="bob",
+                    os_user="bob_os",
+                    agent_backend="codex",
+                ),
+            },
+        )
+        await memory_extraction.extract_and_store(user_text="u", assistant_text="a", user_id="1", config=config)
+        await memory_extraction.extract_and_store(user_text="u", assistant_text="a", user_id="2", config=config)
+
+        assert captured_backends == ["claude", "codex"]
+
+    @pytest.mark.asyncio
+    async def test_passes_per_user_matching_model(self, monkeypatch):
+        """The reasoner's `run` kwargs include the per-backend
+        registry model. Pinning the model assignment per call site
+        guards against a regression where one stage's `get_model_for`
+        call drifts off the effective backend."""
+        from kai import memory as memory_module
+        from kai.config import UserConfig
+
+        captured_models: list[str] = []
+
+        class _ModelCapturingReasoner:
+            def __init__(self):
+                self._os_user = None
+
+            async def run(self, **kwargs):
+                from kai.oneshot import OneShotResult
+
+                captured_models.append(kwargs.get("model"))
+                return OneShotResult(
+                    text='{"is_error": false, "structured_output": {"facts": [], "has_episode": false}}',
+                    backend="stub",
+                    model="stub",
+                    raw_metadata={"returncode": 0, "stderr": b""},
+                    duration_ms=1,
+                )
+
+        def _build(effective_backend, os_user=None):
+            return _ModelCapturingReasoner()
+
+        monkeypatch.setattr(memory_extraction, "_build_memory_reasoner", _build)
+        monkeypatch.setattr(memory_module, "_memory", object())
+
+        config = replace(
+            _cfg(),
+            agent_backend="claude",
+            user_configs={
+                1: UserConfig(telegram_id=1, name="alice", os_user="alice_os"),
+                2: UserConfig(
+                    telegram_id=2,
+                    name="bob",
+                    os_user="bob_os",
+                    agent_backend="codex",
+                ),
+            },
+        )
+        await memory_extraction.extract_and_store(user_text="u", assistant_text="a", user_id="1", config=config)
+        await memory_extraction.extract_and_store(user_text="u", assistant_text="a", user_id="2", config=config)
+
+        # Claude user receives the claude-registry stage-1 model;
+        # codex user receives the codex-registry stage-1 model. The
+        # exact literals come from MODEL_REGISTRY[MEMORY_EXTRACTION].
+        assert captured_models == ["claude-haiku-4-5-20251001", "gpt-5.4-mini"]
+
+    @pytest.mark.asyncio
+    async def test_per_user_override_wins_over_global(self, monkeypatch):
+        """Global `AGENT_BACKEND=claude` with a per-user
+        `agent_backend: codex` override resolves to codex for the
+        override user. Pin the cascade direction (per-user beats
+        global) at the dispatch site."""
+        from kai import memory as memory_module
+        from kai.config import UserConfig
+
+        captured: list[str] = []
+
+        def _build(effective_backend, os_user=None):
+            captured.append(effective_backend)
+
+            class _R:
+                _os_user = None
+
+                async def run(self, **kwargs):
+                    from kai.oneshot import OneShotResult
+
+                    return OneShotResult(
+                        text='{"is_error": false, "structured_output": {"facts": [], "has_episode": false}}',
+                        backend="stub",
+                        model="stub",
+                        raw_metadata={"returncode": 0, "stderr": b""},
+                        duration_ms=1,
+                    )
+
+            return _R()
+
+        monkeypatch.setattr(memory_extraction, "_build_memory_reasoner", _build)
+        monkeypatch.setattr(memory_module, "_memory", object())
+
+        config = replace(
+            _cfg(),
+            agent_backend="claude",
+            user_configs={
+                1: UserConfig(
+                    telegram_id=1,
+                    name="alice",
+                    os_user="alice_os",
+                    agent_backend="codex",
+                )
+            },
+        )
+        await memory_extraction.extract_and_store(user_text="u", assistant_text="a", user_id="1", config=config)
+        assert captured == ["codex"]
+
+    @pytest.mark.asyncio
+    async def test_inherits_global_when_no_per_user_override(self, monkeypatch):
+        """Global `AGENT_BACKEND=codex` with a users.yaml entry that
+        does not pin `agent_backend` resolves to codex for that
+        user. Pins the cascade fallback when no override exists."""
+        from kai import memory as memory_module
+        from kai.config import UserConfig
+
+        captured: list[str] = []
+
+        def _build(effective_backend, os_user=None):
+            captured.append(effective_backend)
+
+            class _R:
+                _os_user = None
+
+                async def run(self, **kwargs):
+                    from kai.oneshot import OneShotResult
+
+                    return OneShotResult(
+                        text='{"is_error": false, "structured_output": {"facts": [], "has_episode": false}}',
+                        backend="stub",
+                        model="stub",
+                        raw_metadata={"returncode": 0, "stderr": b""},
+                        duration_ms=1,
+                    )
+
+            return _R()
+
+        monkeypatch.setattr(memory_extraction, "_build_memory_reasoner", _build)
+        monkeypatch.setattr(memory_module, "_memory", object())
+
+        config = replace(
+            _cfg(),
+            agent_backend="codex",
+            user_configs={
+                1: UserConfig(telegram_id=1, name="alice", os_user="alice_os"),
+            },
+        )
+        await memory_extraction.extract_and_store(user_text="u", assistant_text="a", user_id="1", config=config)
+        assert captured == ["codex"]
+
+    @pytest.mark.asyncio
+    async def test_stage2_inherits_stage1_dispatch(self, monkeypatch):
+        """Stage-2 episode generation must use the same effective
+        backend stage 1 resolved (per-exchange consistency). The
+        episode model is looked up independently via
+        `get_model_for(MEMORY_EPISODE, effective_backend)` but the
+        backend itself does not get re-resolved."""
+        from kai import memory as memory_module
+        from kai.config import UserConfig
+
+        # Stub stage 1 to return episode-positive so stage 2 fires.
+        async def _fake_run_extractor(payload, config, **kwargs):
+            return memory_extraction.ExtractionResult(facts=[], has_episode=True)
+
+        captured_episode_kwargs: dict = {}
+
+        async def _fake_generate_episode(**kwargs):
+            captured_episode_kwargs.update(kwargs)
+
+        monkeypatch.setattr(memory_extraction, "_run_extractor", _fake_run_extractor)
+        monkeypatch.setattr(memory_extraction, "_generate_episode", _fake_generate_episode)
+        monkeypatch.setattr(memory_module, "_memory", object())
+
+        config = replace(
+            _cfg(),
+            agent_backend="claude",
+            user_configs={
+                1: UserConfig(
+                    telegram_id=1,
+                    name="alice",
+                    os_user="alice_os",
+                    agent_backend="codex",
+                )
+            },
+        )
+        await memory_extraction.extract_and_store(user_text="u", assistant_text="a", user_id="1", config=config)
+        # Drain scheduled stage-2 task.
+        await asyncio.sleep(0)
+        for task in list(memory_extraction._pending_episode_tasks):
+            await task
+
+        # Stage 2 inherits the codex backend stage 1 resolved.
+        assert captured_episode_kwargs.get("effective_backend") == "codex"
+        assert captured_episode_kwargs.get("os_user") == "alice_os"

--- a/tests/test_smoke_memory.py
+++ b/tests/test_smoke_memory.py
@@ -37,9 +37,7 @@ def _config(**overrides) -> Config:
     defaults = {
         "memory_enabled": True,
         "memory_extraction_enabled": True,
-        "memory_reasoner_backend": "claude",
-        "memory_extraction_model": "claude-haiku-4-5",
-        "memory_episode_model": "",
+        "agent_backend": "claude",
         "memory_extraction_timeout_s": 30,
     }
     defaults.update(overrides)
@@ -95,8 +93,8 @@ class TestSmokeMemorySuccess:
                 duration_ms=42,
             )
         )
-        with patch.object(smoke_module, "_get_memory_reasoner", return_value=type("R", (), {"run": fake_run})()):
-            rc = await smoke_module._run(os_user=None)
+        with patch.object(smoke_module, "_build_memory_reasoner", return_value=type("R", (), {"run": fake_run})()):
+            rc = await smoke_module._run(user_id=None, os_user=None)
         out = capsys.readouterr().out
         assert rc == 0
         assert "resolved_binary: /fake/path/claude" in out
@@ -137,8 +135,8 @@ class TestSmokeMemorySuccess:
                 duration_ms=10,
             )
         )
-        with patch.object(smoke_module, "_get_memory_reasoner", return_value=type("R", (), {"run": fake_run})()):
-            rc = await smoke_module._run(os_user=None)
+        with patch.object(smoke_module, "_build_memory_reasoner", return_value=type("R", (), {"run": fake_run})()):
+            rc = await smoke_module._run(user_id=None, os_user=None)
         out = capsys.readouterr().out
         assert rc == 1
         assert "verdict: pass" not in out
@@ -162,8 +160,8 @@ class TestSmokeMemoryProductionMode:
         def fail_factory(*args, **kwargs):
             pytest.fail("reasoner must not run when memory is disabled")
 
-        monkeypatch.setattr(smoke_module, "_get_memory_reasoner", fail_factory)
-        rc = await smoke_module._run(os_user=None)
+        monkeypatch.setattr(smoke_module, "_build_memory_reasoner", fail_factory)
+        rc = await smoke_module._run(user_id=None, os_user=None)
         captured = capsys.readouterr()
         assert rc == 1
         assert "MEMORY_ENABLED" in captured.err
@@ -184,8 +182,8 @@ class TestSmokeMemoryProductionMode:
         def fail_factory(*args, **kwargs):
             pytest.fail("reasoner must not run when extraction is disabled")
 
-        monkeypatch.setattr(smoke_module, "_get_memory_reasoner", fail_factory)
-        rc = await smoke_module._run(os_user=None)
+        monkeypatch.setattr(smoke_module, "_build_memory_reasoner", fail_factory)
+        rc = await smoke_module._run(user_id=None, os_user=None)
         captured = capsys.readouterr()
         assert rc == 1
         assert "MEMORY_EXTRACTION_ENABLED" in captured.err
@@ -200,16 +198,16 @@ class TestSmokeMemoryRoutingPrecondition:
         any subprocess fires."""
         from kai.smoke import memory as smoke_module
 
-        monkeypatch.setattr(smoke_module, "load_config", lambda: _config(memory_reasoner_backend="codex"))
+        monkeypatch.setattr(smoke_module, "load_config", lambda: _config(agent_backend="codex"))
 
         # Reasoner should NEVER be constructed on the os_user-missing
-        # path; the precondition fires before _get_memory_reasoner.
+        # path; the precondition fires before _build_memory_reasoner.
         def fail_factory(*args, **kwargs):
-            pytest.fail("_get_memory_reasoner must not run when --os-user is missing")
+            pytest.fail("_build_memory_reasoner must not run when --os-user is missing")
 
-        monkeypatch.setattr(smoke_module, "_get_memory_reasoner", fail_factory)
+        monkeypatch.setattr(smoke_module, "_build_memory_reasoner", fail_factory)
 
-        rc = await smoke_module._run(os_user=None)
+        rc = await smoke_module._run(user_id=None, os_user=None)
         captured = capsys.readouterr()
         assert rc == 1
         assert "--os-user" in captured.err
@@ -238,6 +236,144 @@ class TestSmokeMemoryRoutingPrecondition:
                 duration_ms=10,
             )
         )
-        with patch.object(smoke_module, "_get_memory_reasoner", return_value=type("R", (), {"run": fake_run})()):
-            rc = await smoke_module._run(os_user=None)
+        with patch.object(smoke_module, "_build_memory_reasoner", return_value=type("R", (), {"run": fake_run})()):
+            rc = await smoke_module._run(user_id=None, os_user=None)
         assert rc == 0
+
+
+class TestSmokeMemoryUserIdDispatch:
+    """The `--user-id` flag drives the smoke's effective backend
+    resolution (issue #515). With per-user dispatch, the smoke must
+    reach the same reasoner production would for that user; without
+    `--user-id`, it falls back to the global `agent_backend`."""
+
+    @pytest.mark.asyncio
+    async def test_user_id_resolves_codex_user(self, monkeypatch, capsys):
+        """A `--user-id` matching a codex-effective users.yaml entry
+        resolves to codex, prints `backend: codex`, and resolves the
+        codex registry model. Pins per-user dispatch end-to-end at
+        the smoke surface."""
+        from kai.config import UserConfig
+        from kai.smoke import memory as smoke_module
+
+        config = _config(
+            user_configs={
+                1: UserConfig(
+                    telegram_id=1,
+                    name="codex_user",
+                    os_user="codex_os",
+                    agent_backend="codex",
+                )
+            }
+        )
+        monkeypatch.setattr(smoke_module, "load_config", lambda: config)
+        captured_backend: list[str] = []
+
+        def _build(effective_backend, os_user=None):
+            captured_backend.append(effective_backend)
+            run_fn = AsyncMock(
+                return_value=OneShotResult(
+                    text=_success_envelope(),
+                    backend=effective_backend,
+                    model="gpt-5.4-mini",
+                    raw_metadata={
+                        "cmd": ["codex"],
+                        "resolved_binary": "/fake/codex",
+                        "returncode": 0,
+                        "stderr": b"",
+                        "cwd": "/tmp",
+                    },
+                    duration_ms=10,
+                )
+            )
+            return type("R", (), {"run": run_fn})()
+
+        monkeypatch.setattr(smoke_module, "_build_memory_reasoner", _build)
+        rc = await smoke_module._run(user_id="1", os_user="codex_os")
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert captured_backend == ["codex"]
+        assert "backend: codex" in out
+
+    @pytest.mark.asyncio
+    async def test_user_id_resolves_claude_user(self, monkeypatch, capsys):
+        """A `--user-id` matching a claude-effective users.yaml entry
+        resolves to claude even when global AGENT_BACKEND=codex."""
+        from kai.config import UserConfig
+        from kai.smoke import memory as smoke_module
+
+        config = _config(
+            agent_backend="codex",
+            user_configs={
+                1: UserConfig(
+                    telegram_id=1,
+                    name="claude_user",
+                    os_user="claude_os",
+                    agent_backend="claude",
+                )
+            },
+        )
+        monkeypatch.setattr(smoke_module, "load_config", lambda: config)
+        captured_backend: list[str] = []
+
+        def _build(effective_backend, os_user=None):
+            captured_backend.append(effective_backend)
+            run_fn = AsyncMock(
+                return_value=OneShotResult(
+                    text=_success_envelope(),
+                    backend=effective_backend,
+                    model="claude-haiku-4-5",
+                    raw_metadata={
+                        "cmd": ["claude"],
+                        "resolved_binary": "/fake/claude",
+                        "returncode": 0,
+                        "stderr": b"",
+                        "cwd": "/tmp",
+                    },
+                    duration_ms=10,
+                )
+            )
+            return type("R", (), {"run": run_fn})()
+
+        monkeypatch.setattr(smoke_module, "_build_memory_reasoner", _build)
+        rc = await smoke_module._run(user_id="1", os_user=None)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert captured_backend == ["claude"]
+        assert "backend: claude" in out
+
+    @pytest.mark.asyncio
+    async def test_no_user_id_uses_global_agent_backend(self, monkeypatch, capsys):
+        """Smoke without `--user-id` falls back to the global
+        `agent_backend`. Pins the legacy single-backend smoke path
+        so the per-user dispatch change does not silently break
+        operator habits ('run smoke without flags' still works)."""
+        from kai.smoke import memory as smoke_module
+
+        config = _config(agent_backend="claude")
+        monkeypatch.setattr(smoke_module, "load_config", lambda: config)
+        captured_backend: list[str] = []
+
+        def _build(effective_backend, os_user=None):
+            captured_backend.append(effective_backend)
+            run_fn = AsyncMock(
+                return_value=OneShotResult(
+                    text=_success_envelope(),
+                    backend=effective_backend,
+                    model="claude-haiku-4-5",
+                    raw_metadata={
+                        "cmd": ["claude"],
+                        "resolved_binary": "/fake/claude",
+                        "returncode": 0,
+                        "stderr": b"",
+                        "cwd": "/tmp",
+                    },
+                    duration_ms=10,
+                )
+            )
+            return type("R", (), {"run": run_fn})()
+
+        monkeypatch.setattr(smoke_module, "_build_memory_reasoner", _build)
+        rc = await smoke_module._run(user_id=None, os_user=None)
+        assert rc == 0
+        assert captured_backend == ["claude"]


### PR DESCRIPTION
## Summary

Closes #515. Retire the global `MEMORY_REASONER_BACKEND`,
`MEMORY_EXTRACTION_MODEL`, and `MEMORY_EPISODE_MODEL` env vars. Each
user's memory reasoner and model now derive from that user's effective
`agent_backend` (per-user override in `users.yaml` winning over the
global default), with model resolution via
`get_model_for(role, effective_backend)` at every call site.

The motivation is a mixed-backend `users.yaml` (one user on codex,
another on claude) under the old globals routes every user's memory
through a single vendor, producing cross-vendor traffic and silent SKU
mismatches. Per-user dispatch matches the same effective-backend
cascade `_ingest_memory` in `bot.py` uses for the extraction gate so
selection and gating stay in lockstep.

## Surface changes

- `Config`: drop `memory_reasoner_backend`, `memory_extraction_model`,
  `memory_episode_model` fields. Three deprecation warnings (one per
  legacy env var) fire at `load_config` if present, then the value is
  ignored.
- `memory_extraction`: `_build_memory_reasoner(effective_backend,
  os_user)` replaces `_get_memory_reasoner(config, os_user)`;
  `_run_extractor`, `_run_episode_extractor`, `_generate_episode` now
  take an `effective_backend` kwarg; `extract_and_store` resolves the
  backend once at the top and threads it into both stages.
- New `_compute_extraction_eligible_backends` helper in `config.py`
  feeds the codex precondition checks at config-load and the
  per-backend binary resolution loop in `memory.init_memory`.
- Per-eligible-backend `_check_model_registry_complete` +
  `resolve_oneshot_binary` loop replace the single global lookup. A
  per-user codex override on a global-claude install cannot reach
  runtime without its codex memory-role rows being validated.
- `memory.init_memory` startup log gains `reasoner_mode` /
  `reasoner_backends` / `extraction_models` / `episode_models` /
  `extraction_binaries` maps; flat `reasoner_backend` /
  `extraction_model` keys remain on uniform installs and go null on
  mixed installs to prevent consumers from silently reading the
  wrong vendor.
- Install wizard: drops the `MEMORY_REASONER_BACKEND` and episode-model
  prompts; new `CodexUserRef` + `_codex_users_from_yaml` +
  `_compute_codex_runs_anywhere` helpers drive the codex auth + binary
  + login-reminder gates from the actual codex-effective set rather
  than a single env var; the apply-time stale-key cleanup retires the
  three old keys.
- Smoke (`python -m kai.smoke.memory`) gains a `--user-id` flag that
  drives the effective-backend resolution at the smoke surface to
  mirror production per-user dispatch.
- Eval `memory_backend_gate`: `make_backend_config` stamps
  `agent_backend` instead of `memory_reasoner_backend`; the harness
  reads models inline via `get_model_for(role, backend)` at each call
  site.

Legacy installs with the deprecated env vars in `/etc/kai/env`
continue to work: one deprecation warning per key at startup, then the
next `sudo make install` rewrites `/etc/kai/env` without them.

## Test plan

- [x] `make test` (3423 passed, 1 skipped)
- [x] `make check` (ruff clean, format clean)
- [x] Pre-push grep gate (`MEMORY_REASONER_BACKEND` /
  `MEMORY_EXTRACTION_MODEL` / `MEMORY_EPISODE_MODEL` in new content)
  matches only the documented sites: deprecation-warning text,
  stale-key cleanup, legacy-env deprecation tests, README migration
  note.
- [x] New test coverage:
  - `test_memory_extraction.TestExtractAndStorePerUserDispatch` (5
    cases): claude/codex dispatch in mixed install, per-user matching
    model, per-user override beats global, inherit-global cascade,
    stage-2 inherits stage-1 backend.
  - `test_config.TestExtractionEligibleBackendsHelper` (5 cases):
    helper unit cases covering empty/single/mixed/goose-only cascades.
  - `test_config.TestConfigNoMemoryModelFields`: regression guard for
    field removal.
  - `test_config.TestRegistryValidationPerEligibleBackend`: D5e -
    missing codex memory-role row SystemExits at startup.
  - `test_memory.test_init_per_user_mode_startup_log_shape`: mixed
    install emits the per-user-mode log shape.
  - `test_smoke_memory.TestSmokeMemoryUserIdDispatch` (3 cases):
    `--user-id` matching a codex user routes to codex; same for
    claude; no flag falls back to global `agent_backend`.
- [ ] Manual: drop `MEMORY_REASONER_BACKEND=codex` into
  `/etc/kai/env` on the dev box, restart the service, confirm one
  deprecation warning appears at startup and memory extraction still
  works through per-user dispatch.
