### PR TITLE
fix(codex): symmetric same-user spawn with claude one-shot reasoner

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -2101,57 +2101,6 @@ def load_config() -> Config:
         agent_backend, user_configs, memory_extraction_enabled
     )
 
-    # Codex extraction requires users.yaml. The codex reasoner
-    # spawns codex under each user's `os_user`; ALLOWED_USER_IDS-only
-    # authorization exposes no per-user os_user surface, so codex
-    # extraction would collapse to a zero-state miss every turn. Fail
-    # fast at config-load with a clear remediation hint.
-    if memory_extraction_enabled and "codex" in extraction_eligible_backends and user_configs is None:
-        raise SystemExit(
-            "Codex memory extraction requires users.yaml with a per-user 'os_user' entry "
-            "for every codex-effective chat_id. ALLOWED_USER_IDS alone does not provide "
-            "the OS-user routing the codex reasoner needs. Run 'make config' to generate "
-            "users.yaml, or set MEMORY_EXTRACTION_ENABLED=false to run with retrieval-only "
-            "memory."
-        )
-
-    # Every codex-effective user must have a non-bot-user os_user.
-    # Claude-effective users are NOT gated on os_user because
-    # ClaudeOneShotReasoner accepts os_user=None (the historical
-    # Max-plan self-sudo-skip path that spawns claude as the bot user).
-    # Codex has no equivalent safe path: spawning codex as the bot
-    # user would give it access to /etc/kai/env and other bot-user-only
-    # state, so the runtime CodexOneShotReasoner refuses; surface the
-    # same boundary at config-load.
-    if memory_extraction_enabled and user_configs is not None and "codex" in extraction_eligible_backends:
-        codex_users = [uc for uc in user_configs.values() if (uc.agent_backend or agent_backend) == "codex"]
-        missing = [uc.telegram_id for uc in codex_users if not uc.os_user]
-        if missing:
-            raise SystemExit(
-                "Codex memory extraction requires every codex-effective users.yaml entry "
-                "to set 'os_user'. The following chat_ids are missing 'os_user': "
-                f"{sorted(missing)}. Edit users.yaml to add an 'os_user' field for each "
-                "entry (the OS user the codex subprocess will run as), or set "
-                "MEMORY_EXTRACTION_ENABLED=false to run with retrieval-only memory."
-            )
-        try:
-            current_user = pwd.getpwuid(os.getuid()).pw_name
-        except KeyError:
-            # No passwd entry for the running UID (e.g., container
-            # with --user <uid>); the runtime falls through to honor
-            # the configured os_user, so config-load does too.
-            current_user = None
-        if current_user is not None:
-            same_user = [uc.telegram_id for uc in codex_users if uc.os_user == current_user]
-            if same_user:
-                raise SystemExit(
-                    "Codex memory extraction refuses to run codex as the bot user "
-                    f"({current_user!r}). The following users.yaml chat_ids have 'os_user' "
-                    f"set to the bot user: {sorted(same_user)}. Set 'os_user' to a "
-                    "different OS account, or set MEMORY_EXTRACTION_ENABLED=false to "
-                    "run with retrieval-only memory."
-                )
-
     # Registry completeness and binary resolution per
     # eligible backend. With model env vars retired, get_model_for()
     # is the only check that a (role, backend) registry row exists;

--- a/src/kai/eval/memory_backend_gate.py
+++ b/src/kai/eval/memory_backend_gate.py
@@ -1906,15 +1906,14 @@ def _build_parser() -> argparse.ArgumentParser:
         "--os-user",
         default=None,
         help=(
-            "OS user to run the memory reasoner as via sudo -H -u. "
-            "REQUIRED when 'codex' is in --backends because the codex "
-            "memory reasoner refuses to spawn as the bot process user. "
-            "The eval gate writes to sandbox user IDs that have no "
-            "users.yaml entry, so the resolution path used in "
-            "production (telegram_id -> users.yaml.os_user) yields "
-            "None and the codex reasoner would refuse. Supply this "
-            "flag to override the resolution and route both arms "
-            "through the same OS target."
+            "Optional OS user override to run the memory reasoner as "
+            "via sudo -H -u. The eval gate writes to sandbox user IDs "
+            "that have no users.yaml entry, so the production "
+            "resolution path (telegram_id -> users.yaml.os_user) "
+            "yields None; both codex and claude follow the same "
+            "self-sudo-skip path on None and spawn in-process as the "
+            "bot user. Supply this flag to force both arms through a "
+            "specific non-bot OS target instead."
         ),
     )
     parser.add_argument(
@@ -1962,20 +1961,6 @@ async def _run_cli(args: argparse.Namespace) -> int:
         validate_fixture_minimums(probes)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
-        return 2
-    # Routing preflight: the codex memory reasoner refuses to run
-    # when its os_user is None. Sandbox user IDs do not resolve to
-    # users.yaml entries, so the gate must supply an --os-user
-    # override whenever the codex arm is in scope. Reject the
-    # missing-flag case before any model call so the operator gets
-    # an immediate exit-2 instead of a per-probe routing_error
-    # cascade in the artifacts.
-    if "codex" in args.backends and not args.os_user:
-        print(
-            "error: --os-user is required when 'codex' is in --backends; "
-            "the codex memory reasoner refuses to run as the bot process user",
-            file=sys.stderr,
-        )
         return 2
     if args.validate_only:
         print(f"fixture ok: {len(probes)} probes, {sum(len(p.retrieval) for p in probes)} retrieval queries")

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1800,12 +1800,12 @@ def _codex_users_from_yaml(users_yaml_path: str | Path, global_agent_backend: st
     `global_agent_backend`. Only entries whose effective backend is
     "codex" appear in the returned list.
 
-    Includes entries with a missing `os_user`. A codex-effective entry
-    without an `os_user` is a configuration error (codex spawning
-    requires a non-bot-user account), but the wizard predicate using
-    this helper must still see the user as "codex" so install plumbing
-    (CODEX_BIN, sudoers, login reminder) fires. The missing os_user
-    surfaces as a `load_config` SystemExit elsewhere.
+    Includes entries with a missing `os_user`. After #522, missing
+    `os_user` is a valid configuration that resolves to same-user
+    in-process spawn at runtime (the self-sudo-skip path). The helper
+    still includes those entries because codex itself runs for them,
+    so install plumbing (CODEX_BIN, sudoers, login reminder) must
+    fire regardless of whether `os_user` is set.
 
     Behavior parallels `_collect_os_users_from_yaml`: missing file or
     empty/non-dict/no-users-key returns []; malformed YAML raises;

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -468,14 +468,15 @@ def _cmd_config() -> None:
 
         if advanced:
             # Default os_user to CLAUDE_USER if previously set, else $USER.
-            # Note: on the claude backend, an os_user that matches the bot
-            # process user is fine; the runtime detects self-sudo via
-            # `resolve_claude_user` and spawns claude in-process (the
-            # Max-plan OAuth path under the bot user's home). The codex
-            # memory branch enforces a separate non-bot-user precondition
-            # further down in the wizard (after the operator picks codex
-            # extraction) so the security boundary that block exists for
-            # is not silently bypassed by accepting the default here.
+            # `os_user` is optional on both backends and follows the same
+            # semantics: an empty value (or a value matching the bot
+            # process user) spawns the agent in-process via the
+            # self-sudo-skip path detected by `resolve_claude_user`;
+            # a different OS account wraps the agent argv in `sudo -H
+            # -u <user>` for cross-user isolation. Operators who run
+            # kai under their own account leave this empty; operators
+            # with a dedicated kai service user and separate per-user
+            # OS accounts set it to those accounts.
             default_os_user = existing_env.get("CLAUDE_USER", "") or os.environ.get("USER", "")
             while True:
                 admin_os_user = _prompt("OS user for subprocess isolation", default_os_user).strip() or None
@@ -534,16 +535,16 @@ def _cmd_config() -> None:
         existing_env.get("AGENT_BACKEND", "claude"),
     )
 
-    # Compute the two codex predicates the wizard branches on. Both
-    # use the authoritative-source rule: when users.yaml exists, the
-    # configured users alone determine whether codex runs; without
-    # users.yaml, the global AGENT_BACKEND is the only signal (every
-    # authorized user inherits it). `codex_runs_anywhere` gates
-    # everything codex needs to run AT ALL (CODEX_BIN, sudoers,
-    # login reminder) regardless of memory state. `codex_extraction_
-    # needed` narrows to memory-specific gates (codex memory os_user
-    # precondition surfaces at load_config; the fresh-install os_user
-    # re-prompt fires here).
+    # Compute the codex predicate the wizard branches on. Uses the
+    # authoritative-source rule: when users.yaml exists, the configured
+    # users alone determine whether codex runs; without users.yaml,
+    # the global AGENT_BACKEND is the only signal (every authorized
+    # user inherits it). `codex_runs_anywhere` gates everything codex
+    # needs (CODEX_BIN collection, sudoers SETENV rule, post-install
+    # `codex login` reminder) regardless of memory state. Memory
+    # extraction has no codex-specific wizard gate of its own; codex
+    # memory follows claude's symmetry now (`os_user` optional,
+    # in-process when unset or matching the bot user).
     #
     # Re-read users.yaml here in case the wizard wrote a fresh
     # admin entry above (lines ~485-493 for the not-users_yaml_exists
@@ -1035,69 +1036,14 @@ def _cmd_config() -> None:
                 # backend). There is no global reasoner or model
                 # config; the wizard prompts that used to ask for both
                 # were retired with the env vars they emitted.
-                codex_extraction_needed = codex_runs_anywhere
-                # Codex extraction requires every codex-effective
-                # users.yaml entry to set a non-bot-user `os_user`.
-                # The runtime CodexOneShotReasoner.run() refuses
-                # missing-os_user and same-user spawning; load_config
-                # refuses the same shapes at startup. Without this
-                # wizard-time check, a fresh install that accepted
-                # the default "Configure advanced user options = false"
-                # earlier in the prompt sequence produces a users.yaml
-                # with no `os_user`, and load_config then SystemExits
-                # on the next daemon start. Re-prompt and rewrite the
-                # wizard-owned users.yaml in-place so the generated
-                # config passes load_config. The check fires only
-                # when the wizard owns the file (`not users_yaml_
-                # exists`); when the operator owns users.yaml, the
-                # load_config SystemExit surfaces the same diagnostic.
-                if codex_extraction_needed and not users_yaml_exists:
-                    needs_reprompt = (
-                        not admin_os_user or admin_os_user == service_user or not _validate_os_user(admin_os_user)
-                    )
-                    if needs_reprompt:
-                        print()
-                        print("  Codex memory extraction requires the admin user to spawn")
-                        print(f"  under a non-service OS account (service runs as '{service_user}';")
-                        print("  codex must run as a different account so the subprocess")
-                        print("  cannot read bot-user-only files such as /etc/kai/env).")
-                        while True:
-                            admin_os_user = _prompt(
-                                "OS account for codex memory extraction",
-                                "",
-                                required=True,
-                            ).strip()
-                            if not _validate_os_user(admin_os_user):
-                                print("  Username may only contain letters, numbers, dots, hyphens, and underscores.")
-                                continue
-                            if admin_os_user == service_user:
-                                print(
-                                    f"  Must not match the service user '{service_user}' "
-                                    "(codex would run as the bot user)."
-                                )
-                                continue
-                            break
-                        users_yaml_content = _generate_users_yaml(
-                            admin_telegram_id,
-                            admin_name,
-                            os_user=admin_os_user,
-                            home_workspace=admin_home_workspace,
-                        )
-                        users_yaml_path.write_text(users_yaml_content)
-                        os.chmod(users_yaml_path, 0o600)
-                        print(f"  Updated {users_yaml_path} with os_user={admin_os_user}")
-                        # users.yaml just gained a codex user; refresh
-                        # the codex_users set so codex_runs_anywhere
-                        # reflects the new state for any downstream
-                        # check that consults it (the env-emission
-                        # block reads codex_runs_anywhere via the
-                        # codex_bin emission gate).
-                        try:
-                            _codex_users_now = _codex_users_from_yaml(users_yaml_path, agent_backend)
-                        except (OSError, ValueError):
-                            _codex_users_now = []
-                        codex_runs_anywhere = _compute_codex_runs_anywhere(agent_backend, True, _codex_users_now)
-                        codex_extraction_needed = codex_runs_anywhere
+                #
+                # No codex-memory-specific os_user gate fires here.
+                # Codex now follows claude's `resolve_claude_user`
+                # symmetry: missing `os_user` spawns codex in-process
+                # as the bot user, the same self-sudo-skip path
+                # claude uses. The earlier `codex_runs_anywhere`
+                # block already collected CODEX_BIN; nothing else
+                # specific to codex memory needs setup at this point.
                 # CODEX_BIN must be collected whenever codex runs
                 # anywhere on the install. The earlier codex agent
                 # block already prompts for the binary path when
@@ -1934,9 +1880,10 @@ def _compute_codex_runs_anywhere(
     "codex"` determines the answer.
 
     The wizard uses this predicate for everything codex needs to run
-    AT ALL (CODEX_BIN collection, sudoers, login reminder); the
-    `codex_extraction_needed` companion narrows to memory-specific
-    sites by AND-ing with `memory_extraction_enabled`.
+    AT ALL (CODEX_BIN collection, sudoers, login reminder). Memory
+    extraction has no codex-specific gate of its own; codex memory
+    spawns in-process when `os_user` is unset or matches the bot
+    user, the same self-sudo-skip path claude uses.
     """
     if users_yaml_exists:
         return bool(codex_users)

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1751,11 +1751,11 @@ def _build_memory_reasoner(effective_backend: str, os_user: str | None = None) -
     failure visible.
 
     `os_user` is resolved once at the top of `extract_and_store` and
-    threaded in. The codex reasoner raises `OneShotRoutingError` from
-    `run()` when `os_user is None`; the claude reasoner spawns
-    directly. Tests monkeypatch this helper to inject fake reasoners;
-    the parameters are accepted but not inspected on the test side
-    because patches use `return_value=`.
+    threaded in. Both reasoners accept `os_user=None` and spawn
+    in-process via the self-sudo-skip path; a non-bot value wraps
+    the argv in `sudo -H -u <user>`. Tests monkeypatch this helper
+    to inject fake reasoners; the parameters are accepted but not
+    inspected on the test side because patches use `return_value=`.
 
     Returning a fresh instance per call (rather than a module-level
     singleton) keeps the memory path stateless and mirrors the

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -930,22 +930,19 @@ class CodexOneShotReasoner:
                 the run does not touch the real DATA_DIR. Production
                 callers leave this unset; the reasoner uses
                 `_EXTRACTOR_CWD` and ensures it exists on first call.
-            os_user: REQUIRED for production routing. Codex memory
-                must NOT run as the bot process user; the boundary
-                policy says any agent subprocess that inherits the
-                bot's sudoers permissions can be coerced into reading
-                kai-only protected files. `run()` raises
-                `OneShotRoutingError` when `os_user is None`, AND
-                when a supplied `os_user` resolves to the current
-                process user via `resolve_claude_user` (the same-
-                user case). Unlike claude, the self-sudo-skip is
-                NOT a legitimate path here: claude can safely run
-                in-process because Max-plan OAuth state lives under
-                the bot user's home, but codex would gain unintended
-                access to bot-user-only protected files (/etc/kai/
-                env, etc.). load_config() mirrors the refusal at
-                startup so a misconfigured users.yaml fails fast
-                rather than silently no-opping every extraction.
+            os_user: Optional target OS user for the codex subprocess,
+                symmetric with claude. `None` (or a value that
+                `resolve_claude_user` collapses to the current process
+                user) spawns codex in-process as the bot user - the
+                self-sudo-skip path. A non-bot username wraps the
+                argv in `sudo -H -u <user>` for cross-user isolation.
+                Operators who want the cross-user separation set
+                `os_user` to a different OS account in users.yaml;
+                operators running kai under their own account leave
+                it unset and codex runs in-process the same way
+                claude does. The persistent codex chat backend in
+                `src/kai/codex.py` already uses this resolution
+                shape; this reasoner now follows it.
         """
         self._cwd = cwd if cwd is not None else _EXTRACTOR_CWD
         self._os_user = os_user
@@ -960,20 +957,6 @@ class CodexOneShotReasoner:
         purpose: str,
         json_schema: dict[str, Any] | None = None,
     ) -> OneShotResult:
-        # Routing refusal. Codex memory must not run as the bot user;
-        # surfaces as a typed error before any subprocess spawn so the
-        # caller (memory_extraction) collapses to the zero-state
-        # extraction result. Claude does NOT raise this for the
-        # corresponding None case because the historical Max-plan
-        # OAuth path already runs claude as the bot user.
-        if self._os_user is None:
-            log.info(
-                "oneshot_reasoner purpose=%s backend=codex model=%s duration_ms=0 outcome=routing_error error_category=missing_os_user os_user=self",
-                purpose,
-                model,
-            )
-            raise OneShotRoutingError("codex memory routing requires os_user; refusing to run as the bot user")
-
         # Lazy mkdir + chmod: deferred from import time so a
         # permission failure surfaces as a logged miss rather than
         # crashing the bot at startup. The unconditional chmod
@@ -1007,31 +990,16 @@ class CodexOneShotReasoner:
         if model is not None:
             cmd.extend(["--model", model])
 
-        # Per-user OS routing. The construction-level None case was
-        # refused at the top of run(). resolve_claude_user returns
-        # None when the target user matches the current process user
-        # (the historical self-sudo-skip path). For claude, the
-        # self-sudo-skip is legitimate (Max-plan OAuth state lives
-        # under the bot user's home). For codex, it is a security
-        # boundary violation: codex MUST NOT run as the bot user, or
-        # it gains access to /etc/kai/env and other bot-user-only
-        # state. Refuse the same-user case here with the same typed
-        # error as the construction-level None case so the caller's
-        # collapse-to-zero-state path applies uniformly. The refusal
-        # fires BEFORE the schema temp file is written so there is
-        # nothing to clean up on this branch.
+        # Per-user OS routing target. resolve_claude_user returns
+        # None when `os_user` is unset OR when it resolves to the
+        # current process user (the self-sudo-skip path). Codex
+        # treats None the same way claude does: spawn in-process as
+        # the bot user, skipping the sudo wrap. A non-None target
+        # produces the sudo-wrapped argv assembled below. Mirrors
+        # the persistent codex chat backend's resolution shape so
+        # both codex spawn paths share the same direct-vs-wrapped
+        # decision logic.
         effective_user = resolve_claude_user(self._os_user)
-        if effective_user is None:
-            log.info(
-                "oneshot_reasoner purpose=%s backend=codex model=%s duration_ms=0 outcome=routing_error error_category=same_user_refused os_user=self",
-                purpose,
-                model,
-            )
-            raise OneShotRoutingError(
-                "codex memory routing refuses same-user spawn; "
-                f"os_user={self._os_user!r} resolves to the bot user. "
-                "Set users.yaml os_user to a different OS account."
-            )
 
         # Schema temp file lifecycle. Written before subprocess spawn
         # so the CLI sees a populated file; removed in `finally` so
@@ -1076,9 +1044,15 @@ class CodexOneShotReasoner:
             cmd.extend(["--output-schema", str(schema_path)])
 
         # Wrap codex in `sudo -H -u <target>` with the auth preserve
-        # list. Same-user routing is already refused above; this
-        # branch always wraps.
-        cmd = _wrap_cmd_for_user(cmd, effective_user, "codex")
+        # list when running cross-user. When `effective_user is None`
+        # (same-user spawn: os_user unset OR matches the bot user),
+        # the argv stays direct - codex runs in-process as the bot
+        # user, the same shape the persistent codex chat backend
+        # uses for self-sudo-skip. The `start_new_session` flag and
+        # the timeout-escalation branch below already gate on the
+        # same predicate so the cross-user path stays unchanged.
+        if effective_user is not None:
+            cmd = _wrap_cmd_for_user(cmd, effective_user, "codex")
 
         # Allow-listed env: only forward keys present in the parent
         # env. Defense-in-depth against a future regression that

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -229,14 +229,14 @@ class OneShotOutputError(OneShotError):
 
 class OneShotRoutingError(OneShotError):
     """
-    Reasoner refused to run because per-user OS routing was required
-    but no `os_user` was resolved. Raised by the codex reasoner when
-    its `os_user` is None; the claude reasoner deliberately does NOT
-    raise this to preserve the historical Max-plan OAuth path that
-    spawns claude as the bot user. Surfaces as a typed error so the
-    caller (memory_extraction) collapses to the zero-state extraction
-    result rather than letting the codex memory path silently run
-    inside the boundary the policy is meant to enforce.
+    Reasoner refused to run for a routing reason that cannot be
+    satisfied at the call site. The only current source is binary
+    resolution failure: `resolve_oneshot_binary` raised
+    `BinaryResolutionError` and the reasoner re-raises as this
+    typed error so the caller's existing `OneShotError` catch
+    surface collapses to the zero-state extraction result. Both
+    backends now accept `os_user=None` (the self-sudo-skip path),
+    so missing-os_user is no longer a refusal source.
     """
 
 

--- a/src/kai/oneshot_binary.py
+++ b/src/kai/oneshot_binary.py
@@ -18,14 +18,13 @@ import. Keeping the resolver leaf-only sidesteps that entirely and
 keeps the dependency direction one-way.
 
 `BinaryResolutionError` is deliberately distinct from
-`kai.oneshot.OneShotRoutingError`. Routing failures (e.g., codex
-refusing to run as the bot user) and binary-resolution failures
-(e.g., codex binary not on PATH) are adjacent but not identical
-conditions with different remediation paths. The reasoner argv
-builders catch `BinaryResolutionError` and convert to
-`OneShotRoutingError` so the existing `memory_extraction.py`
-`except OneShotError` catch surface is unchanged; the new error
-type is what `kai.config` and `kai.smoke.memory` see.
+`kai.oneshot.OneShotRoutingError` so config-load and smoke can
+distinguish "binary not found" from runtime routing errors when
+deciding what to print. The reasoner argv builders catch
+`BinaryResolutionError` and convert to `OneShotRoutingError` so
+the existing `memory_extraction.py` `except OneShotError` catch
+surface is unchanged; the new error type is what `kai.config`
+and `kai.smoke.memory` see directly.
 """
 
 import os

--- a/src/kai/smoke/memory.py
+++ b/src/kai/smoke/memory.py
@@ -116,13 +116,6 @@ async def _run(user_id: str | None, os_user: str | None) -> int:
         )
         return 1
 
-    if effective_backend == "codex" and not os_user:
-        sys.stderr.write(
-            "smoke: --os-user is required when the effective backend is codex; "
-            "pass the per-user OS account configured in users.yaml.\n"
-        )
-        return 1
-
     extraction_model = get_model_for(ModelRole.MEMORY_EXTRACTION, effective_backend)
     episode_model = get_model_for(ModelRole.MEMORY_EPISODE, effective_backend)
     print(f"backend: {effective_backend}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1648,36 +1648,72 @@ class TestMemoryReasonerBinaryValidation:
         assert called == []
 
 
-class TestCodexMemoryRequiresOsUser:
-    """The codex reasoner refuses to spawn without an `os_user` (the
-    security boundary that keeps codex from running as the bot user).
-    Per-user dispatch (issue #515) means codex eligibility is computed
-    from each user's effective `agent_backend`; the precondition is
-    expressed against that effective cascade rather than a single
-    `MEMORY_REASONER_BACKEND` global. Config-load enforces it so a
-    wizard-generated config that enables codex memory without per-user
-    os_user entries fails fast instead of silently no-opping every
-    extraction at runtime."""
+class TestCodexMemorySameUserSymmetry:
+    """Codex memory follows claude's `resolve_claude_user` symmetry
+    (issue #522): `os_user` is optional and same-user spawn is a
+    supported deployment shape. config-load does NOT refuse any of:
+    AGENT_BACKEND=codex without users.yaml, codex-effective user
+    without os_user, or codex-effective user with os_user matching
+    the bot user. Pinning these as starts-cleanly cases guards
+    against a future change that re-introduces the pre-#522
+    deployment-shape assumption."""
 
-    def test_no_users_yaml_raises_systemexit(self, monkeypatch):
-        """AGENT_BACKEND=codex without users.yaml. ALLOWED_USER_IDS
-        exposes no per-user os_user surface, so codex extraction
-        cannot be wired; SystemExit at config-load."""
+    def test_codex_no_users_yaml_starts_cleanly(self, monkeypatch):
+        """AGENT_BACKEND=codex with extraction enabled and no
+        users.yaml loads successfully. Per-user dispatch falls back
+        to the global agent_backend; the spawn target is the bot
+        user via the self-sudo-skip path."""
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
         monkeypatch.setenv("AGENT_BACKEND", "codex")
-        with pytest.raises(SystemExit) as exc:
-            load_config()
-        msg = str(exc.value)
-        assert "users.yaml" in msg
-        assert "os_user" in msg
-        assert "odex" in msg  # 'codex' or 'Codex'
+        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
+        config = load_config()
+        assert config.agent_backend == "codex"
+        assert config.memory_extraction_enabled is True
 
-    def test_users_yaml_with_os_user_passes(self, tmp_path, monkeypatch):
-        """The happy path: users.yaml with a per-user os_user entry
-        for every codex-effective chat_id. Config-load completes;
-        codex memory is wired per user."""
+    def test_codex_users_yaml_missing_os_user_starts_cleanly(self, tmp_path, monkeypatch):
+        """A codex-effective users.yaml entry without `os_user`
+        loads successfully. The runtime treats missing os_user as
+        in-process spawn (claude's existing pattern), so config-load
+        does not refuse the shape."""
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 67890\n    name: bob\n    role: user\n")
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
+        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
+        config = load_config()
+        assert config.user_configs is not None
+        assert config.user_configs[67890].os_user is None
+
+    def test_codex_users_yaml_same_user_as_bot_starts_cleanly(self, tmp_path, monkeypatch):
+        """A codex-effective users.yaml entry with `os_user`
+        matching the bot user loads successfully. The runtime
+        detects same-user via `resolve_claude_user` and spawns
+        codex in-process - the same path claude has always used
+        for same-user."""
+        bot_user = pwd.getpwuid(os.getuid()).pw_name
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            f"users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: {bot_user}\n"
+        )
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
+        _set_required(monkeypatch)
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
+        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
+        config = load_config()
+        assert config.user_configs[12345].os_user == bot_user
+
+    def test_codex_users_yaml_cross_user_os_user_passes(self, tmp_path, monkeypatch):
+        """The cross-user deployment shape still works: an `os_user`
+        set to a non-bot account loads cleanly and is preserved on
+        the UserConfig entry. Regression guard for the multi-user
+        case."""
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text(
             "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: alice_os\n"
@@ -1687,125 +1723,9 @@ class TestCodexMemoryRequiresOsUser:
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
         monkeypatch.setenv("AGENT_BACKEND", "codex")
-        # DEFAULT_MODEL must be a codex-valid SKU when AGENT_BACKEND=codex.
         monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
         config = load_config()
-        assert config.agent_backend == "codex"
-        assert config.user_configs is not None
         assert config.user_configs[12345].os_user == "alice_os"
-
-    def test_users_yaml_with_missing_os_user_raises_systemexit(self, tmp_path, monkeypatch):
-        """At least one codex-effective users.yaml entry without
-        os_user must fail config-load. The error names the
-        offending chat_id so the operator can find the entry to
-        fix."""
-        users_yaml = tmp_path / "users.yaml"
-        users_yaml.write_text(
-            "users:\n"
-            "  - telegram_id: 12345\n"
-            "    name: alice\n"
-            "    role: admin\n"
-            "    os_user: alice_os\n"
-            "  - telegram_id: 67890\n"
-            "    name: bob\n"
-            "    role: user\n"
-        )
-        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_ENABLED", "true")
-        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("AGENT_BACKEND", "codex")
-        with pytest.raises(SystemExit) as exc:
-            load_config()
-        msg = str(exc.value)
-        assert "67890" in msg
-        assert "12345" not in msg  # alice has os_user; should not appear
-        assert "os_user" in msg
-
-    def test_claude_memory_does_not_require_os_user(self, monkeypatch):
-        """ClaudeOneShotReasoner accepts os_user=None (Max-plan
-        self-sudo-skip path), so claude-only installs do NOT require
-        users.yaml. The precondition fires only when codex is in the
-        extraction-eligible set."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_ENABLED", "true")
-        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        # AGENT_BACKEND defaults to claude. No users.yaml.
-        config = load_config()
-        assert config.agent_backend == "claude"
-
-    def test_users_yaml_os_user_matches_bot_user_raises_systemexit(self, tmp_path, monkeypatch):
-        """Codex must NOT run as the bot user. The runtime refuses
-        same-user spawn; config-load surfaces the same boundary so
-        a misconfigured users.yaml does not silently no-op every
-        extraction. The check names the bot user and the offending
-        chat_ids so the operator can locate the misconfiguration."""
-        bot_user = pwd.getpwuid(os.getuid()).pw_name
-        users_yaml = tmp_path / "users.yaml"
-        users_yaml.write_text(
-            f"users:\n  - telegram_id: 12345\n    name: misconfigured\n    role: admin\n    os_user: {bot_user}\n"
-        )
-        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_ENABLED", "true")
-        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("AGENT_BACKEND", "codex")
-        with pytest.raises(SystemExit) as exc:
-            load_config()
-        msg = str(exc.value)
-        assert "bot user" in msg
-        assert "12345" in msg
-        assert bot_user in msg
-
-    def test_goose_user_without_os_user_does_not_block_codex_memory(self, tmp_path, monkeypatch):
-        """Mixed-backend deployment: a global codex install where one
-        user has `agent_backend: goose` should not be required to
-        give that goose user an `os_user`. The runtime gate at
-        `bot.py:3739` skips extraction for goose users (effective
-        backend not in claude/codex), so the precondition must
-        mirror the same effective-backend cascade rather than
-        enforce os_user on every entry blindly."""
-        users_yaml = tmp_path / "users.yaml"
-        users_yaml.write_text(
-            "users:\n"
-            "  - telegram_id: 1\n"
-            "    name: codex_user\n"
-            "    role: admin\n"
-            "    os_user: codex_os\n"
-            "  - telegram_id: 2\n"
-            "    name: goose_user\n"
-            "    role: user\n"
-            "    agent_backend: goose\n"
-            "    llm_provider: openai\n"
-        )
-        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_ENABLED", "true")
-        monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("AGENT_BACKEND", "codex")
-        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
-        # No SystemExit: the goose user is not extraction-eligible.
-        config = load_config()
-        assert config.agent_backend == "codex"
-        # Both users load; the precondition skipped chat 2
-        # because its effective backend is goose, not codex.
-        assert 1 in config.user_configs
-        assert 2 in config.user_configs
-
-    def test_codex_memory_retrieval_only_skips_precondition(self, monkeypatch):
-        """Retrieval-only memory (extraction disabled) does NOT
-        require os_user even on codex; the precondition fires only
-        when extraction is actually enabled (the eligible set is
-        empty when extraction is off)."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_ENABLED", "true")
-        # MEMORY_EXTRACTION_ENABLED unset = retrieval-only.
-        monkeypatch.setenv("AGENT_BACKEND", "codex")
-        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
-        # No users.yaml; precondition should not fire.
-        config = load_config()
-        assert config.memory_enabled is True
-        assert config.memory_extraction_enabled is False
 
 
 class TestMemoryReasonerModelResolution:

--- a/tests/test_eval_memory_backend_gate.py
+++ b/tests/test_eval_memory_backend_gate.py
@@ -1000,16 +1000,15 @@ class TestCLIInitializesMemory:
         assert call_order.index("init_memory") < call_order.index("run_backend")
 
 
-# ── --os-user preflight (issue #503) ────────────────────────────────
+# ── --os-user override threading ────────────────────────────────────
 
 
-class TestOsUserPreflight:
-    """The eval gate's `--os-user` is required when the codex arm is
-    in scope, because sandbox user IDs do not resolve to users.yaml
-    entries and the codex memory reasoner refuses to run with
-    `os_user=None`. The preflight rejects the missing-flag case
-    before any model call so the operator gets exit 2 instead of a
-    per-probe routing_error cascade."""
+class TestOsUserOverride:
+    """The eval gate's `--os-user` is an optional override (issue
+    #522). When supplied, it threads into `run_backend(...,
+    os_user_override=...)` for both arms; when omitted, both arms
+    proceed with `os_user_override=None` and the reasoners follow
+    their self-sudo-skip path (in-process spawn as the bot user)."""
 
     def _valid_fixture(self, tmp_path: Path) -> Path:
         rows = []
@@ -1069,8 +1068,13 @@ class TestOsUserPreflight:
             },
         )()
 
-    def test_codex_without_os_user_exits_2(self, tmp_path, capsys):
+    def test_codex_without_os_user_proceeds(self, tmp_path, monkeypatch):
+        """Issue #522: codex same-user spawn is supported. Running
+        the gate with `--backends codex` and no `--os-user` reaches
+        `run_backend` with `os_user_override=None`; no preflight
+        rejection."""
         import asyncio
+        from unittest.mock import patch
 
         path = self._valid_fixture(tmp_path)
         args = self._args(
@@ -1079,15 +1083,31 @@ class TestOsUserPreflight:
             backends=["claude", "codex"],
             os_user=None,
         )
-        rc = asyncio.run(g._run_cli(args))
-        assert rc == 2
-        err = capsys.readouterr().err
-        assert "--os-user is required" in err
+
+        captured: list[str | None] = []
+
+        async def _fake_run_backend(**kwargs):
+            captured.append(kwargs.get("os_user_override"))
+            return g.BackendRun(
+                backend=kwargs["backend"],
+                sandbox_user_id=kwargs["sandbox_user_id"],
+                model_fact="m",
+                model_episode="m",
+                log_path=kwargs["log_path"],
+            )
+
+        with (
+            patch("kai.eval.memory_backend_gate.memory.init_memory", lambda _c: None),
+            patch("kai.eval.memory_backend_gate.load_config", return_value=_BASE_CONFIG),
+            patch("kai.eval.memory_backend_gate.run_backend", _fake_run_backend),
+        ):
+            rc = asyncio.run(g._run_cli(args))
+        assert rc == 0
+        assert captured == [None, None]
 
     def test_claude_only_does_not_require_os_user(self, tmp_path, monkeypatch):
-        """If the operator runs only the claude arm, `--os-user` is
-        not required (the claude reasoner falls through to direct
-        spawn for the historical Max-plan installs)."""
+        """Single-arm claude run with no `--os-user` proceeds the
+        same way it always has."""
         import asyncio
         from unittest.mock import patch
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2251,23 +2251,20 @@ class TestCmdConfig:
         assert get_model_for(ModelRole.MEMORY_EPISODE, "codex") in CODEX_MODELS
 
     def test_codex_fresh_install_with_memory_extraction_yields_valid_users_yaml(self, tmp_path, monkeypatch):
-        """Fresh-install regression for the codex memory wizard gate.
+        """Fresh-install integration contract for codex memory.
 
         When the wizard drives the path 'no users.yaml -> codex backend
-        -> enable memory -> enable extraction -> codex reasoner' AND the
-        operator accepts the default 'Configure advanced user options =
-        false' earlier in the prompt sequence, the wizard re-prompts for
-        a non-service os_user at the memory-reasoner-backend gate and
-        rewrites users.yaml in place before the env is persisted. The
-        produced env + generated users.yaml together must pass
-        load_config(); without the gate the wizard emits a users.yaml
-        with no os_user and load_config() SystemExits at next daemon
-        start ('chat_ids are missing os_user' on the codex precondition).
+        -> enable memory -> enable extraction' AND the operator accepts
+        the default 'Configure advanced user options = false', the
+        wizard writes users.yaml with NO `os_user`. Issue #522 makes
+        that valid: codex memory follows claude's `resolve_claude_user`
+        symmetry and spawns in-process when os_user is unset. The
+        produced env + users.yaml must pass load_config() without any
+        codex-memory-specific precondition firing.
 
-        This test pins the full fresh-install integration contract, in
-        contrast to test_codex_install_accept_all_defaults_yields_load_
-        config_compatible_env which hand-seeds users.yaml and only
-        checks the env emission.
+        Pre-#522 this same input shape required a separate reprompt
+        for a non-bot os_user; that reprompt is now gone along with
+        the load_config precondition that motivated it.
         """
         from unittest.mock import MagicMock
 
@@ -2297,7 +2294,7 @@ class TestCmdConfig:
                 "fake-token",  # bot token
                 "12345",  # admin telegram ID
                 "admin",  # admin display name
-                "false",  # advanced user options - the failure-mode entry
+                "false",  # advanced user options (no os_user)
                 "polling",  # transport
                 "codex",  # agent backend
                 "subscription",  # codex auth mode
@@ -2321,7 +2318,7 @@ class TestCmdConfig:
                 # claude_user skipped on agent_backend != claude
                 "true",  # memory enabled
                 "true",  # memory extraction enabled
-                "codex_runner",  # re-prompted os_user after codex gate
+                # No codex-memory os_user reprompt (#522 removed it).
                 "10",  # extraction timeout
                 "8",  # consolidation candidates
                 "3",  # episode classifier context turns
@@ -2336,15 +2333,15 @@ class TestCmdConfig:
 
         _cmd_config()
 
-        # users.yaml must carry the re-prompted os_user. The wizard
-        # rewrote it in place after the codex memory gate fired; the
-        # pre-fix path left os_user absent here.
+        # users.yaml is written without os_user; same-user spawn is
+        # the supported deployment shape for an operator who accepts
+        # the default "Configure advanced user options = false".
         users_yaml_path = tmp_path / "users.yaml"
         assert users_yaml_path.exists()
         data = yaml.safe_load(users_yaml_path.read_text())
         entry = data["users"][0]
         assert entry["telegram_id"] == 12345
-        assert entry["os_user"] == "codex_runner"
+        assert entry.get("os_user") is None
 
         # Integration pin: feed the produced env + users.yaml into
         # load_config and assert it accepts the shape. Neuter the
@@ -2370,7 +2367,9 @@ class TestCmdConfig:
         assert config.agent_backend == "codex"
         assert config.user_configs is not None
         assert 12345 in config.user_configs
-        assert config.user_configs[12345].os_user == "codex_runner"
+        # No os_user → in-process spawn at runtime via the
+        # self-sudo-skip path.
+        assert config.user_configs[12345].os_user is None
 
 
 # ── Apply subcommand ─────────────────────────────────────────────────

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -62,27 +62,24 @@ def _mock_binary_resolver():
 
 @pytest.fixture(autouse=True)
 def _bypass_codex_routing_for_argv_tests(request):
-    """The codex reasoner now refuses to spawn under the bot user
-    (same-user routing rejected on the codex branch). The existing
-    argv/env/schema/output tests in this file use `os_user=_current_user()`
-    so resolve_claude_user short-circuits to None (the historical
-    test-friendly self-sudo-skip path), which is no longer valid for
-    codex.
+    """The argv/env/schema/output tests in this file run with
+    `os_user=_current_user()` so `resolve_claude_user` short-circuits
+    to None (the self-sudo-skip path). Codex now treats that the
+    same way claude does: spawn in-process, no sudo wrap. But the
+    pre-#522 surface those tests assert against expects unwrapped
+    argv even on the cross-user path, so this autouse fixture keeps
+    both halves working without per-test shim:
 
-    To keep the surface those tests check (argv flag layout, env
-    allow-list, stdin payload, JSON parsing) without each test having
-    to wire a sudo-wrap shim, this autouse fixture:
+      - makes resolve_claude_user a pass-through (so a non-None
+        `os_user` survives into argv assembly rather than collapsing
+        to the self-sudo-skip None)
+      - makes _wrap_cmd_for_user a no-op (so the argv assertions
+        that expect cmd[0] == "codex" stay valid; the real wrap
+        is exercised explicitly by the tests marked `routing_test`)
 
-      - makes resolve_claude_user a pass-through (so the same-user
-        refusal does not fire on os_user=_current_user())
-      - makes _wrap_cmd_for_user a no-op (so the argv assertions that
-        expect cmd[0] == "codex" stay valid; the wrap is exercised
-        explicitly by the tests marked `routing_test` below)
-
-    Tests that exercise real routing behavior (the routing classes,
-    the same-user refusal test, etc.) are marked with
-    `@pytest.mark.routing_test` and opt out of this bypass so they
-    can assert against the production wrap shape and refusal."""
+    Tests that exercise real routing behavior (the routing classes
+    that assert against the production wrap shape) are marked with
+    `@pytest.mark.routing_test` and opt out of this bypass."""
     if request.node.get_closest_marker("routing_test"):
         yield
         return
@@ -1297,35 +1294,26 @@ class TestRoutingArgvAndPreserveEnv:
         assert mock_exec.call_args.kwargs["start_new_session"] is True
 
     @pytest.mark.asyncio
-    async def test_codex_refuses_same_user_spawn(self, tmp_path):
-        """Codex memory MUST NOT run as the bot user. The
-        construction-level None case is already refused; this test
-        pins the same-user case (os_user resolves to the current
-        process user). The refusal fires BEFORE the subprocess
-        spawn so no codex process ever starts under the bot
-        identity.
-
-        Replaces the historical direct-spawn behavior pinned by the
-        prior `test_codex_direct_spawn_when_os_user_is_current`
-        test. The old behavior contradicted the safety claim in
-        CodexOneShotReasoner.run() and the operator's standing
-        kai/daniel separation policy: codex running as the bot
-        user would have access to /etc/kai/env and other bot-only
-        state through sudoers."""
+    async def test_codex_runs_in_process_when_os_user_matches_bot(self, tmp_path):
+        """Codex follows claude's `resolve_claude_user` symmetry
+        (issue #522): when `os_user` resolves to the current process
+        user, the argv stays direct - no sudo wrap. This is the
+        same self-sudo-skip path claude uses. Pins the matches-bot-
+        user branch so a regression that re-introduces the
+        unconditional `_wrap_cmd_for_user` call fails here."""
         reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user=_current_user())
-        spawn_called = []
-
-        async def fail_exec(*args, **kwargs):
-            spawn_called.append(args)
-            raise AssertionError("subprocess must not spawn on the same-user refusal path")
-
+        proc = _make_proc(stdout=b"")
         with (
-            patch("kai.oneshot.asyncio.create_subprocess_exec", side_effect=fail_exec),
-            pytest.raises(OneShotRoutingError) as exc,
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec,
+            pytest.raises(OneShotOutputError),
         ):
             await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
-        assert "same-user spawn" in str(exc.value)
-        assert spawn_called == []
+        cmd = mock_exec.call_args[0]
+        assert cmd[0] != "sudo"
+        # start_new_session only fires on the wrap path; pin the
+        # in-process default for parity with the persistent codex
+        # chat backend.
+        assert mock_exec.call_args.kwargs["start_new_session"] is False
 
     @pytest.mark.asyncio
     async def test_codex_wraps_with_preserve_env(self, tmp_path):
@@ -1352,30 +1340,30 @@ class TestRoutingArgvAndPreserveEnv:
 
 
 @pytest.mark.routing_test
-class TestRoutingRefusal:
-    """Codex with `os_user=None` refuses to run; Claude does not.
-
-    The asymmetry is deliberate: existing Max-plan Claude installs
-    have always run claude as the bot user, and breaking those
-    installs without an explicit operator opt-in would be hostile.
-    Codex memory is brand new in #497 / PR #501; the refusal is
-    its safe default.
+class TestRoutingSymmetry:
+    """Codex and claude both spawn in-process on the self-sudo-skip
+    path (issue #522). Either `os_user=None` or `os_user` matching
+    the current process user produces a direct argv with no sudo
+    wrap; a non-bot `os_user` wraps via `sudo -H -u <user>` on both
+    backends. Pinning the symmetry guards against a future change
+    that re-introduces an asymmetric refusal on either backend.
     """
 
     @pytest.mark.asyncio
-    async def test_codex_with_no_os_user_raises_routing_error(self, tmp_path, caplog):
+    async def test_codex_with_no_os_user_runs_in_process(self, tmp_path):
+        """`CodexOneShotReasoner(os_user=None).run()` does not raise
+        and produces a direct argv (no sudo prefix). Mirror of the
+        claude self-sudo-skip path."""
         reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user=None)
+        proc = _make_proc(stdout=b"")
         with (
-            caplog.at_level(logging.INFO, logger="kai.oneshot"),
-            pytest.raises(OneShotRoutingError),
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec,
+            pytest.raises(OneShotOutputError),
         ):
             await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
-        records = [r for r in caplog.records if r.message.startswith("oneshot_reasoner")]
-        assert len(records) == 1
-        msg = records[0].getMessage()
-        assert "outcome=routing_error" in msg
-        assert "error_category=missing_os_user" in msg
-        assert "os_user=self" in msg
+        cmd = mock_exec.call_args[0]
+        assert cmd[0] != "sudo"
+        assert mock_exec.call_args.kwargs["start_new_session"] is False
 
     @pytest.mark.asyncio
     async def test_claude_with_no_os_user_still_spawns(self, tmp_path):
@@ -1387,6 +1375,25 @@ class TestRoutingRefusal:
             await reasoner.run(prompt="p", purpose="fact_extraction")
         cmd = mock_exec.call_args[0]
         assert "sudo" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_codex_with_non_bot_user_wraps_in_sudo(self, tmp_path):
+        """The cross-user codex path stays unchanged: a non-bot
+        `os_user` wraps the argv in `sudo -H -u <user>`. Regression
+        guard for the multi-user/service-user deployment shape."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user="other-user")
+        proc = _make_proc(stdout=b"")
+        with (
+            patch("kai.oneshot.resolve_claude_user", return_value="other-user"),
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec,
+            pytest.raises(OneShotOutputError),
+        ):
+            await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
+        cmd = mock_exec.call_args[0]
+        assert cmd[0] == "sudo"
+        assert "-u" in cmd
+        assert "other-user" in cmd
+        assert mock_exec.call_args.kwargs["start_new_session"] is True
 
 
 @pytest.mark.routing_test

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -35,9 +35,10 @@ def _current_user() -> str:
     Tests that exercise the codex reasoner's direct-spawn path use
     this as `os_user` so `resolve_claude_user` self-sudo-skips back
     to None (target matches current process); the reasoner then
-    spawns codex directly with no sudo wrap. Without setting
-    `os_user`, the codex reasoner would raise `OneShotRoutingError`
-    by design.
+    spawns codex directly with no sudo wrap. Both reasoners now
+    accept `os_user=None` and follow the same in-process path,
+    so this helper is a parity convenience rather than a routing
+    requirement.
     """
     return pwd.getpwuid(os.getuid()).pw_name
 

--- a/tests/test_smoke_memory.py
+++ b/tests/test_smoke_memory.py
@@ -191,27 +191,32 @@ class TestSmokeMemoryProductionMode:
 
 class TestSmokeMemoryRoutingPrecondition:
     @pytest.mark.asyncio
-    async def test_codex_without_os_user_exits_with_message(self, monkeypatch, capsys):
-        """The codex reasoner refuses to spawn without an os_user.
-        Smoke must surface this requirement explicitly with a clear
-        message rather than fail at the routing layer; exit 1 before
-        any subprocess fires."""
+    async def test_codex_without_os_user_proceeds(self, monkeypatch, capsys):
+        """Issue #522: codex same-user spawn is supported. Smoke
+        without --os-user against AGENT_BACKEND=codex no longer
+        exits 1 on the precondition; it proceeds to the reasoner
+        call. Pins the symmetry with claude same-user."""
         from kai.smoke import memory as smoke_module
 
         monkeypatch.setattr(smoke_module, "load_config", lambda: _config(agent_backend="codex"))
-
-        # Reasoner should NEVER be constructed on the os_user-missing
-        # path; the precondition fires before _build_memory_reasoner.
-        def fail_factory(*args, **kwargs):
-            pytest.fail("_build_memory_reasoner must not run when --os-user is missing")
-
-        monkeypatch.setattr(smoke_module, "_build_memory_reasoner", fail_factory)
-
-        rc = await smoke_module._run(user_id=None, os_user=None)
-        captured = capsys.readouterr()
-        assert rc == 1
-        assert "--os-user" in captured.err
-        assert "users.yaml" in captured.err
+        fake_run = AsyncMock(
+            return_value=OneShotResult(
+                text=_success_envelope(),
+                backend="codex",
+                model="gpt-5.4-mini",
+                raw_metadata={
+                    "cmd": ["codex"],
+                    "resolved_binary": "/fake/codex",
+                    "returncode": 0,
+                    "stderr": b"",
+                    "cwd": "/tmp",
+                },
+                duration_ms=10,
+            )
+        )
+        with patch.object(smoke_module, "_build_memory_reasoner", return_value=type("R", (), {"run": fake_run})()):
+            rc = await smoke_module._run(user_id=None, os_user=None)
+        assert rc == 0
 
     @pytest.mark.asyncio
     async def test_claude_without_os_user_proceeds(self, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

Closes #522. Drop the codex-specific same-user spawn refusal so the
codex one-shot memory reasoner treats `os_user=None` and `os_user ==
bot_user` the same way the claude one-shot reasoner does: spawn
in-process as the bot user via the self-sudo-skip path.

The cross-vendor security boundary that motivated the refusal
(codex would gain access to `/etc/kai/env` and other bot-user-only
files) assumes a deployment shape where the bot user is distinct
from the operator. For a single-user install where the operator IS
the bot user, the boundary is fictional and turns an explicit
deployment choice into a hard error.

The fix is symmetric, not opt-in. Claude does not require an opt-in
for same-user spawn; codex shouldn't either. Operators who want the
cross-user isolation set `os_user` to a non-bot account in
`users.yaml`, exactly as today.

## Surface changes

- `CodexOneShotReasoner.run()`: delete the construction-level None
  refusal and the same-user-resolves-to-bot-user refusal. Gate the
  existing `_wrap_cmd_for_user(cmd, effective_user, "codex")` call
  on `effective_user is not None` so the in-process path produces
  unwrapped argv. The `start_new_session` flag and timeout-
  escalation branch already gate on the same predicate.
- `config.load_config()`: delete the three codex-effective
  preconditions (codex-without-users.yaml, missing-os_user,
  same-user-as-bot) that mirrored the runtime refusal.
- `install._cmd_config`: delete the codex-memory os_user reprompt
  block and the `codex_extraction_needed` companion variable; both
  existed solely to satisfy the load_config preconditions. Update
  the predicate-introduction comment, `_compute_codex_runs_anywhere`
  docstring, and the advanced-options prompt comment to reflect
  the new symmetry.
- `smoke.memory`: delete the `codex + missing os_user` precondition.

The cross-user spawn path (sudo -u <os_user>) stays unchanged for
multi-user/service-user deployments. Persistent codex chat in
`src/kai/codex.py` already had the correct resolution shape and
needed no change.

## Test plan

- [x] `make test` (3421 passed, 1 skipped)
- [x] `make check` (ruff clean, format clean)
- [x] Pre-push grep for security-boundary phrases (`refusing to run
  as the bot user`, `same.user.refused`, `MUST NOT run as the bot
  user`, `non-service OS account`, `this branch always wraps`,
  `codex_extraction_needed`): zero matches in added lines.
- [x] `rg codex_extraction_needed src/kai/install.py` returns no
  matches.
- [x] New test coverage:
  - `test_oneshot.TestRoutingSymmetry`: codex + claude same-user
    spawn parity, plus the cross-user wrap regression guard.
  - `test_oneshot.test_codex_runs_in_process_when_os_user_matches_bot`:
    replaces the same-user refusal test.
  - `test_config.TestCodexMemorySameUserSymmetry`: four
    starts-cleanly cases (no-users.yaml, missing-os_user,
    same-user-as-bot, cross-user).
  - `test_smoke_memory`: codex-without-os_user now proceeds to
    reasoner call instead of exiting 1.
  - `test_install`: fresh-codex-install no longer reprompts for a
    non-bot os_user; users.yaml is written without os_user and
    load_config accepts it.
- [ ] Manual: on a single-user install (operator IS the bot user),
  set `AGENT_BACKEND=codex` and `MEMORY_EXTRACTION_ENABLED=true`,
  restart the service, send a Telegram message that should trigger
  fact extraction, verify codex actually runs (no
  `OneShotRoutingError` in the log, fact lands in Qdrant).
