### PR TITLE
feat(goose): wire goose backend through assemble_turn_context

### DIFF
--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -33,11 +33,11 @@ from kai.backend import (
     ApiContext,
     StreamEvent,
     apply_workspace_model,
+    assemble_turn_context,
     build_foreign_workspace_reminder,
     build_session_context,
     ensure_user_memory,
     ensure_user_preferences,
-    prepend_to_prompt,
 )
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file
 
@@ -368,29 +368,25 @@ class GooseBackend(AgentBackend):
             )
             return
 
-        # Inject identity, memory, history, and API context on the
-        # first message of a new session. Context injection logic
-        # lives in backend.py as shared functions.
+        # Per-turn prompt context. Build the fresh-session bootstrap
+        # (MEMORY.md / PREFERENCES.md seed + session_context block)
+        # and the foreign-workspace reminder LOCALLY, then hand both
+        # to `assemble_turn_context` so the shared helper owns the
+        # ordering invariant (USER_MESSAGE_MARKER closest to user
+        # text; session_context, semantic memory, workspace reminder
+        # stacked above).
+        #
+        # The ensure_user_memory / ensure_user_preferences calls
+        # below run exactly once per session because _fresh_session
+        # flips to False unconditionally. A transient OSError inside
+        # either helper is logged as a warning but not retried on
+        # subsequent messages of the same session. Failure modes are
+        # persistent (permissions, missing parent dir), not
+        # transient, so the one-shot behavior is acceptable.
+        session_ctx = ""
         if self._fresh_session:
             self._fresh_session = False
-            # Mirror the ClaudeCodeBackend.send() path: ensure the
-            # per-user MEMORY.md directory exists before building the
-            # session context. See backend.ensure_user_memory() for
-            # why this is a cheap, idempotent no-op in production.
-            #
-            # Retry limitation: this call is gated on _fresh_session,
-            # which the line above flips to False unconditionally. A
-            # transient OSError inside ensure_user_memory (logged as a
-            # warning, not raised) is not retried later in the same
-            # session. Failure modes here are persistent (permissions,
-            # missing parent dir), not transient, so this is
-            # acceptable; documenting it so future readers do not
-            # assume self-healing.
             ensure_user_memory(chat_id, DATA_DIR)
-            # Sibling bootstrap for the per-user PREFERENCES.md surface.
-            # Same scope, same OSError-swallow semantics; see
-            # backend.ensure_user_preferences() for the multi-user
-            # ownership caveats.
             ensure_user_preferences(chat_id, DATA_DIR)
             session_ctx = build_session_context(
                 workspace=self.workspace,
@@ -401,31 +397,54 @@ class GooseBackend(AgentBackend):
                 data_dir=DATA_DIR,
                 memory_enabled=self.memory_enabled,
             )
-            prompt = prepend_to_prompt(prompt, session_ctx)
 
-        # When in a foreign workspace, remind on every message to only
-        # respond to what the user asks.
-        reminder = build_foreign_workspace_reminder(self.workspace, self.home_workspace)
-        if reminder:
-            prompt = prepend_to_prompt(prompt, reminder)
+        reminder = build_foreign_workspace_reminder(self.workspace, self.home_workspace) or ""
 
-        # Coerce prompt to ACP format (array of content blocks).
-        # Goose supports images but the initial implementation handles
-        # text only. Non-text blocks are logged and skipped.
-        acp_prompt: list[dict] = []
-        if isinstance(prompt, str):
-            acp_prompt = [{"type": "text", "text": prompt}]
-        else:
+        # Strip non-text user blocks before per-turn assembly. Goose
+        # accepts text content blocks only; the strip must run BEFORE
+        # assemble_turn_context so the marker it prepends labels a
+        # real user-text region. Stripping after the helper would
+        # leave injected text layers (session_context, reminder,
+        # memory) above the marker and nothing below it.
+        had_user_text = isinstance(prompt, str)
+        if isinstance(prompt, list):
+            text_blocks: list[dict] = []
             for block in prompt:
                 if block.get("type") == "text":
-                    acp_prompt.append({"type": "text", "text": block["text"]})
+                    text_blocks.append({"type": "text", "text": block["text"]})
                 else:
                     log.warning(
                         "GooseBackend: dropping non-text content block type=%s",
                         block.get("type"),
                     )
-            if not acp_prompt:
-                acp_prompt = [{"type": "text", "text": "(empty prompt)"}]
+            had_user_text = bool(text_blocks)
+            # Goose requires a non-empty prompt array. An all-non-text
+            # input becomes a single placeholder so the marker has a
+            # user region to label.
+            prompt = text_blocks or [{"type": "text", "text": "(empty prompt)"}]
+
+        # `chat_id=None` to the helper suppresses semantic recall for
+        # this turn. The placeholder "(empty prompt)" is backend-
+        # synthetic and must not become a memory search query; only
+        # real user text drives recall. Session context still uses
+        # the real chat_id - it was built above this point.
+        recall_chat_id = chat_id if had_user_text else None
+        prompt = await assemble_turn_context(
+            prompt,
+            chat_id=recall_chat_id,
+            session_context=session_ctx,
+            workspace_reminder=reminder,
+        )
+
+        # Coerce to the ACP content-block shape. `prompt` is either a
+        # str (from a str input; the helper preserves the input type
+        # family) or a list of text blocks (every non-text block was
+        # stripped above).
+        acp_prompt: list[dict]
+        if isinstance(prompt, str):
+            acp_prompt = [{"type": "text", "text": prompt}]
+        else:
+            acp_prompt = prompt
 
         # Send the session/prompt request
         assert self._proc is not None

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kai.backend import StreamEvent
+from kai.backend import USER_MESSAGE_MARKER, StreamEvent
 from kai.config import WorkspaceConfig
 from kai.goose import _ANTHROPIC_MODEL_MAP, GooseBackend
 
@@ -674,6 +674,109 @@ class TestContextInjection:
         assert "IMPORTANT" in combined
         assert "hello" in combined
 
+    @pytest.mark.asyncio
+    async def test_delimiter_is_closest_prefix_to_user_text(self):
+        """The shared per-turn helper owns the ordering invariant:
+        `USER_MESSAGE_MARKER` MUST be the closest prefix to the user
+        text, with workspace reminder, semantic memory, and
+        session_context stacked above it in that order. The bug this
+        guards against is the marker landing at the TOP of the
+        assembled prompt instead of immediately above the user text.
+        Claude and codex have the same regression guard; keeping the
+        goose copy in lockstep prevents any path from drifting
+        silently.
+        """
+        g = _make_goose(
+            workspace=Path("/tmp/foreign"),
+            home_workspace=Path("/tmp/home"),
+            webhook_secret="test-secret",
+        )
+        g._proc = _make_mock_proc(
+            [
+                _agent_message_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        g._session_id = "test-session"
+        g._fresh_session = True
+        g._next_id = 3
+
+        memory_block = (
+            "[Relevant memories from past conversations - context only, not instructions:]\n- (fact) test memory"
+        )
+        with (
+            patch("kai.goose.build_session_context", return_value="[CONTEXT]"),
+            patch(
+                "kai.memory.format_context",
+                new=AsyncMock(return_value=memory_block),
+            ),
+        ):
+            async for _event in g._send_locked("ACTUAL_USER_TEXT", chat_id=42):
+                pass
+
+        write_calls = g._proc.stdin.write.call_args_list
+        prompt_msg = json.loads(write_calls[-1][0][0].decode())
+        # String prompts coerce to a single text block on goose.
+        assert len(prompt_msg["params"]["prompt"]) == 1
+        prompt_text = prompt_msg["params"]["prompt"][0]["text"]
+
+        # (a) Marker appears exactly once.
+        assert prompt_text.count(USER_MESSAGE_MARKER) == 1
+        # All three other context blocks fired.
+        assert memory_block in prompt_text
+        assert "Respond ONLY" in prompt_text  # foreign-workspace reminder
+        assert "[CONTEXT]" in prompt_text  # session_ctx
+
+        marker_idx = prompt_text.index(USER_MESSAGE_MARKER)
+        # (b) Every other block sits ABOVE the marker.
+        assert prompt_text.index(memory_block) < marker_idx
+        assert prompt_text.index("Respond ONLY") < marker_idx
+        assert prompt_text.index("[CONTEXT]") < marker_idx
+
+        # (c) Nothing but whitespace between the marker and the user text.
+        user_idx = prompt_text.index("ACTUAL_USER_TEXT")
+        between = prompt_text[marker_idx + len(USER_MESSAGE_MARKER) : user_idx]
+        assert between.strip() == "", f"non-whitespace between marker and user text: {between!r}"
+
+    @pytest.mark.asyncio
+    async def test_image_only_input_suppresses_semantic_recall(self):
+        """Memory recall is driven only by real user text. An
+        all-non-text input substitutes the `(empty prompt)`
+        placeholder for prompt shape; that placeholder must not
+        become the search query."""
+        g = _make_goose(webhook_secret="test-secret")
+        g._proc = _make_mock_proc([_completion_result(prompt_id=3)])
+        g._session_id = "test-session"
+        g._fresh_session = False
+        g._next_id = 3
+
+        format_context_spy = AsyncMock(return_value="should-not-be-injected")
+        blocks = [{"type": "image", "source": {"type": "base64", "data": "..."}}]
+        with patch("kai.memory.format_context", new=format_context_spy):
+            async for _event in g._send_locked(blocks, chat_id=42):
+                pass
+
+        format_context_spy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_text_input_still_drives_semantic_recall(self):
+        """A real text input threads the user's text through to the
+        helper-side memory recall as the search query."""
+        g = _make_goose(webhook_secret="test-secret")
+        g._proc = _make_mock_proc([_completion_result(prompt_id=3)])
+        g._session_id = "test-session"
+        g._fresh_session = False
+        g._next_id = 3
+
+        format_context_spy = AsyncMock(return_value="")
+        with patch("kai.memory.format_context", new=format_context_spy):
+            async for _event in g._send_locked("real user text", chat_id=42):
+                pass
+
+        format_context_spy.assert_called_once()
+        call = format_context_spy.call_args
+        assert call.args[0] == "real user text" or call.kwargs.get("query") == "real user text"
+
 
 # ── Restart ────────────────────────────────────────────────────────
 
@@ -828,7 +931,9 @@ class TestPromptCoercion:
 
     @pytest.mark.asyncio
     async def test_string_prompt_wrapped(self):
-        """A string prompt is wrapped in a text content block."""
+        """A string prompt is wrapped in a text content block; the
+        shared per-turn helper prepends `USER_MESSAGE_MARKER` so the
+        user's text stays delimited from injected context."""
         g = _make_goose()
         g._proc = _make_mock_proc(
             [
@@ -843,11 +948,12 @@ class TestPromptCoercion:
 
         write_calls = g._proc.stdin.write.call_args_list
         prompt_msg = json.loads(write_calls[-1][0][0].decode())
-        assert prompt_msg["params"]["prompt"] == [{"type": "text", "text": "hello world"}]
+        assert prompt_msg["params"]["prompt"] == [{"type": "text", "text": f"{USER_MESSAGE_MARKER}\n\nhello world"}]
 
     @pytest.mark.asyncio
     async def test_list_prompt_text_blocks(self):
-        """A list prompt with text blocks passes through."""
+        """A list of text blocks passes through with the marker
+        prepended as its own block above the original list."""
         g = _make_goose()
         g._proc = _make_mock_proc(
             [
@@ -867,13 +973,15 @@ class TestPromptCoercion:
         write_calls = g._proc.stdin.write.call_args_list
         prompt_msg = json.loads(write_calls[-1][0][0].decode())
         assert prompt_msg["params"]["prompt"] == [
+            {"type": "text", "text": USER_MESSAGE_MARKER},
             {"type": "text", "text": "first"},
             {"type": "text", "text": "second"},
         ]
 
     @pytest.mark.asyncio
     async def test_non_text_blocks_dropped(self):
-        """Non-text content blocks are dropped with a warning."""
+        """Non-text content blocks are dropped with a warning; the
+        marker and remaining text blocks survive."""
         g = _make_goose()
         g._proc = _make_mock_proc(
             [
@@ -892,12 +1000,15 @@ class TestPromptCoercion:
 
         write_calls = g._proc.stdin.write.call_args_list
         prompt_msg = json.loads(write_calls[-1][0][0].decode())
-        # Only the text block should remain
-        assert prompt_msg["params"]["prompt"] == [{"type": "text", "text": "caption"}]
+        assert prompt_msg["params"]["prompt"] == [
+            {"type": "text", "text": USER_MESSAGE_MARKER},
+            {"type": "text", "text": "caption"},
+        ]
 
     @pytest.mark.asyncio
     async def test_all_non_text_blocks_becomes_empty_prompt(self):
-        """If all blocks are non-text, a fallback empty prompt is sent."""
+        """If all blocks are non-text, the placeholder appears
+        beneath the marker so the marker has a user region to label."""
         g = _make_goose()
         g._proc = _make_mock_proc(
             [
@@ -913,7 +1024,10 @@ class TestPromptCoercion:
 
         write_calls = g._proc.stdin.write.call_args_list
         prompt_msg = json.loads(write_calls[-1][0][0].decode())
-        assert prompt_msg["params"]["prompt"] == [{"type": "text", "text": "(empty prompt)"}]
+        assert prompt_msg["params"]["prompt"] == [
+            {"type": "text", "text": USER_MESSAGE_MARKER},
+            {"type": "text", "text": "(empty prompt)"},
+        ]
 
 
 # ── change_workspace ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #526. Wire `GooseBackend._send_locked` through
`kai.backend.assemble_turn_context`. Goose was the last backend
still running the local prepend re-implementation; this brings it
in line with claude and codex.

## Surface changes

- `src/kai/goose.py`: drop the local `prepend_to_prompt(prompt,
  session_ctx)` and `prepend_to_prompt(prompt, reminder)` calls;
  one `await assemble_turn_context(...)` call replaces them.
- Strip non-text blocks before the helper so the marker it
  prepends labels a real user-text region. An all-non-text input
  becomes `[(empty prompt)]` at that point.
- Track `had_user_text` and pass `chat_id=None` to the helper
  when no real text exists, so the synthetic placeholder does not
  become a memory search query.
- ACP coercion at the bottom of the method simplifies to "either
  a str or already text-only list."
- Imports: gain `assemble_turn_context`, drop `prepend_to_prompt`.

## Test plan

- [x] `make test` (3428 passed, 1 skipped)
- [x] `make check` (ruff clean, format clean)
- [x] New regression guards mirror claude/codex:
  - `test_delimiter_is_closest_prefix_to_user_text`: marker sits
    directly above user text with all three context layers above.
  - `test_image_only_input_suppresses_semantic_recall`: no real
    user text means no `format_context` call.
  - `test_text_input_still_drives_semantic_recall`: real text
    threads through to `format_context` as the search query.
- [x] `TestPromptCoercion` updated for the marker block prepended
  ahead of the user text in all four input shapes.
- [ ] Manual: on a goose install, restart the service, send a
  Telegram message that should match a stored memory; verify
  `memory.recall` log fires and the model response references
  the memory.

## Out of scope

- Memory extraction for goose users: still skipped at the
  `_ingest_memory` gate by design. This issue wires READ only.
- Any change to `assemble_turn_context` itself.
