### PR TITLE
fix(install): read /etc/kai/users.yaml via sudo when project root is empty

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -315,6 +315,38 @@ def _validate_codex_bin(value: str) -> bool:
     return p.is_file() and os.access(p, os.X_OK)
 
 
+def _read_users_yaml_text(path: Path) -> str | None:
+    """Return the contents of a users.yaml file, falling back to sudo
+    for root-owned protected copies.
+
+    The wizard reads users.yaml as the operator account, not as root.
+    `/etc/kai/users.yaml` is installed mode 0600 root-owned, so a
+    direct `read_text()` raises `PermissionError`. The fallback uses
+    interactive `sudo cat` (no `-n` flag) because the operator is at
+    the terminal during `make config`; a password prompt mid-wizard
+    is acceptable UX. Returns the file content on success, None on
+    missing file, no sudo rights, or unreadable content.
+    """
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except PermissionError:
+        pass
+    try:
+        result = subprocess.run(
+            ["sudo", "cat", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
 # ── Config subcommand ────────────────────────────────────────────────
 
 
@@ -398,14 +430,14 @@ def _cmd_config() -> None:
     users_yaml_exists = users_yaml_path.exists()
 
     if not users_yaml_exists:
-        # /etc/kai/users.yaml is mode 0600 owned by root. Whether
-        # Path.exists() works depends on the parent directory permissions;
-        # it may return True even if the file isn't readable. Either way,
-        # the worst case is re-prompting and the next 'make install'
-        # overwrites the deployed copy with the new one.
+        # `/etc/kai/users.yaml` is mode 0600 owned by root.
+        # `Path.exists()` works as long as the parent directory is
+        # listable; downstream reads from `users_yaml_path` go through
+        # `_read_users_yaml_text` which sudo-cats protected copies.
         etc_users = Path("/etc/kai/users.yaml")
         if etc_users.exists():
             users_yaml_exists = True
+            users_yaml_path = etc_users
 
     # Track whether advanced mode set os_user, so we can skip the
     # CLAUDE_USER prompt later (section 8). Needs to be in scope
@@ -422,27 +454,25 @@ def _cmd_config() -> None:
     admin_home_workspace: str | None = None
 
     if users_yaml_exists:
-        # Summarize the existing config without modifying it.
-        # Note: if only the /etc/kai/ copy exists (not the local one),
-        # users_yaml_path still points to PROJECT_ROOT / "users.yaml"
-        # which doesn't exist. Guard with .exists() so we skip the
-        # summary gracefully rather than relying on the bare except.
+        # Summarize the existing config without modifying it. Reads
+        # go through `_read_users_yaml_text` so the protected
+        # `/etc/kai/users.yaml` path works via sudo cat. Empty
+        # summary on unreadable / malformed - the summary is
+        # cosmetic, the downstream codex predicate is what matters.
         summary = ""
-        if users_yaml_path.exists():
+        raw_yaml = _read_users_yaml_text(users_yaml_path)
+        if raw_yaml is not None:
             try:
-                data = yaml.safe_load(users_yaml_path.read_text())
-                if isinstance(data, dict) and isinstance(data.get("users"), list):
-                    entries = data["users"]
-                    n_users = len(entries)
-                    n_admins = sum(
-                        1 for e in entries if isinstance(e, dict) and str(e.get("role", "")).lower() == "admin"
-                    )
-                    summary = (
-                        f" ({n_users} user{'s' if n_users != 1 else ''}, "
-                        f"{n_admins} admin{'s' if n_admins != 1 else ''})"
-                    )
-            except Exception:
-                pass  # Malformed YAML - skip the summary
+                data = yaml.safe_load(raw_yaml)
+            except yaml.YAMLError:
+                data = None
+            if isinstance(data, dict) and isinstance(data.get("users"), list):
+                entries = data["users"]
+                n_users = len(entries)
+                n_admins = sum(1 for e in entries if isinstance(e, dict) and str(e.get("role", "")).lower() == "admin")
+                summary = (
+                    f" ({n_users} user{'s' if n_users != 1 else ''}, {n_admins} admin{'s' if n_admins != 1 else ''})"
+                )
         print(f"  users.yaml already configured{summary}.")
         print("  To modify users, edit users.yaml directly or use Telegram commands.")
     else:
@@ -1812,11 +1842,14 @@ def _codex_users_from_yaml(users_yaml_path: str | Path, global_agent_backend: st
     non-dict entries are skipped. Telegram IDs that do not parse as
     int are skipped (the entry is invalid and the same logic exists
     in `_load_user_configs`).
+
+    The read path goes through `_read_users_yaml_text` so the
+    protected `/etc/kai/users.yaml` file (mode 0600 root-owned) is
+    reachable via sudo cat when the wizard runs as the operator.
     """
     path = Path(users_yaml_path)
-    try:
-        text = path.read_text(encoding="utf-8")
-    except FileNotFoundError:
+    text = _read_users_yaml_text(path)
+    if text is None:
         return []
 
     if not text.strip():

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -28,6 +28,7 @@ from kai.install import (
     _cmd_apply,
     _cmd_config,
     _cmd_status,
+    _codex_users_from_yaml,
     _collect_os_users_from_yaml,
     _collect_user_memory_owners,
     _copy_tree,
@@ -40,6 +41,7 @@ from kai.install import (
     _generate_users_yaml,
     _migrate_identity_to_claude_md,
     _prompt_choice,
+    _read_users_yaml_text,
     _retire_install_home_claude,
     _retire_install_home_dir,
     _set_ownership,
@@ -712,6 +714,107 @@ class TestCollectOsUsersFromYaml:
         )
         with pytest.raises(ValueError, match=str(path)):
             _collect_os_users_from_yaml(path)
+
+
+class TestReadUsersYamlText:
+    """The wizard reads users.yaml as the operator account. The
+    deployed `/etc/kai/users.yaml` is mode 0600 root-owned, so a
+    direct `read_text()` raises `PermissionError`; `_read_users_yaml_text`
+    falls back to `sudo cat`. Both branches plus the missing-file
+    and unreadable-via-sudo cases are pinned here so a future
+    refactor of the helper does not regress the protected path."""
+
+    def test_local_readable_path_returns_content(self, tmp_path):
+        """Direct read works when the file is operator-readable."""
+        path = tmp_path / "users.yaml"
+        path.write_text("users: []\n", encoding="utf-8")
+        assert _read_users_yaml_text(path) == "users: []\n"
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert _read_users_yaml_text(tmp_path / "absent.yaml") is None
+
+    def test_permission_error_falls_back_to_sudo_cat(self, monkeypatch, tmp_path):
+        """The protected `/etc/kai/users.yaml` path: direct read
+        raises PermissionError, the fallback shells out to `sudo cat`
+        and returns its stdout."""
+        path = tmp_path / "protected.yaml"
+
+        def _raise_perm(self, encoding="utf-8"):
+            raise PermissionError(13, "Permission denied", str(self))
+
+        monkeypatch.setattr(Path, "read_text", _raise_perm)
+
+        captured: dict = {}
+
+        def _fake_subprocess_run(argv, capture_output, text, timeout):
+            captured["argv"] = argv
+
+            class _R:
+                returncode = 0
+                stdout = "users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n"
+
+            return _R()
+
+        monkeypatch.setattr("kai.install.subprocess.run", _fake_subprocess_run)
+        out = _read_users_yaml_text(path)
+        assert captured["argv"] == ["sudo", "cat", str(path)]
+        assert "alice" in out
+
+    def test_sudo_failure_returns_none(self, monkeypatch, tmp_path):
+        """When sudo refuses (no password, no rule, timeout, etc.)
+        the helper returns None so the caller's missing-content
+        branch fires."""
+        path = tmp_path / "protected.yaml"
+
+        def _raise_perm(self, encoding="utf-8"):
+            raise PermissionError(13, "Permission denied", str(self))
+
+        monkeypatch.setattr(Path, "read_text", _raise_perm)
+
+        def _fake_subprocess_run(argv, capture_output, text, timeout):
+            class _R:
+                returncode = 1
+                stdout = ""
+
+            return _R()
+
+        monkeypatch.setattr("kai.install.subprocess.run", _fake_subprocess_run)
+        assert _read_users_yaml_text(path) is None
+
+
+class TestCodexUsersFromYamlProtectedFallback:
+    """Regression for the failure mode where the wizard skipped the
+    entire codex setup block because it read users.yaml from the
+    project-root path while only `/etc/kai/users.yaml` existed. The
+    fix routes `_codex_users_from_yaml` through `_read_users_yaml_text`
+    so the protected-path fallback works."""
+
+    def test_protected_path_yields_codex_users(self, monkeypatch, tmp_path):
+        """When the path raises PermissionError on direct read, the
+        helper sudo-cats the file and returns the codex-effective
+        users. Without this, the wizard predicate `codex_runs_anywhere`
+        evaluates False on installs with only `/etc/kai/users.yaml`
+        present, and the codex setup block silently skips - the
+        symptom the operator hit on a real deployment."""
+        path = Path("/etc/kai/users.yaml")
+
+        def _raise_perm(self, encoding="utf-8"):
+            raise PermissionError(13, "Permission denied", str(self))
+
+        monkeypatch.setattr(Path, "read_text", _raise_perm)
+
+        def _fake_subprocess_run(argv, capture_output, text, timeout):
+            class _R:
+                returncode = 0
+                stdout = "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: alice_os\n"
+
+            return _R()
+
+        monkeypatch.setattr("kai.install.subprocess.run", _fake_subprocess_run)
+        refs = _codex_users_from_yaml(path, "codex")
+        assert len(refs) == 1
+        assert refs[0].telegram_id == 12345
+        assert refs[0].os_user == "alice_os"
 
 
 class TestCollectUserMemoryOwners:


### PR DESCRIPTION
## Summary

Closes #528. When `make config` runs against a deployment with only `/etc/kai/users.yaml` present (no local `users.yaml`), the wizard's `users_yaml_path` continued to point at the absent project-root file. `_codex_users_from_yaml` then returned `[]`, `_compute_codex_runs_anywhere` returned `False`, and the entire codex setup block (auth mode, `CODEX_BIN` collection, login reminder) was silently skipped. The generated `/etc/kai/env` ended up with `AGENT_BACKEND=codex` but no `CODEX_BIN`, and the daemon `SystemExit`ed at the codex binary resolution step on next start. Because there is no `StandardErrorPath` in the launchd plist and the bash wrapper does not capture Python's stderr, the failure was invisible.

## Surface changes

- New `_read_users_yaml_text` helper in `src/kai/install.py`. Reads the file directly; falls back to `sudo cat` on `PermissionError`. Sudo runs interactively (no `-n`) because the wizard runs under the operator at the terminal, where a password prompt mid-`make config` is acceptable UX. Returns `None` on missing file or sudo failure.
- Wizard fallback now updates `users_yaml_path` to `/etc/kai/users.yaml` when that is the source. Downstream reads (`_codex_users_from_yaml` and the wizard summary) go through the new helper.
- `_codex_users_from_yaml` swaps its inline `path.read_text()` for `_read_users_yaml_text` so both read sites share the protected-path handling.

## Test plan

- [x] `make test` (3433 passed, 1 skipped)
- [x] `make check` (ruff clean, format clean)
- [x] New regression coverage:
  - `TestReadUsersYamlText`: direct read, missing file, PermissionError → sudo cat fallback (asserts argv shape), sudo failure → None.
  - `TestCodexUsersFromYamlProtectedFallback`: pins the bug - PermissionError on the path triggers the sudo fallback and the helper returns the codex-effective entries instead of empty.
- [ ] Manual: on a deployment with only `/etc/kai/users.yaml`, run `make config`, choose `AGENT_BACKEND=codex`, confirm the wizard prompts for `CODEX_BIN`, run `sudo make install`, confirm the daemon starts and emits `memory.config`.

## Out of scope

- The launchd plist lacks `StandardErrorPath`, so Python's startup tracebacks land in `/dev/null`. That is what made this bug invisible. Worth a separate follow-up to add `StandardErrorPath = ${KAI_DATA_DIR}/logs/kai-stderr.log` (or similar) so future early-init crashes are recoverable from logs.
