### PR TITLE
fix(memory): add PR-merge / deploy-status negative to QUALITY TEST

### DIFF
--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -130,7 +130,17 @@ log = logging.getLogger(__name__)
 # updates.
 # Schema unchanged; the bump lets post-rollout log analysis partition
 # episodes classified under the looser criteria from earlier ones.
-_EXTRACTION_PROMPT_VERSION: str = "10"
+# v11 (2026-05-24): added a fifth QUALITY TEST negative worked
+# example covering user-announced completed workflow actions (PR
+# merges, deploys, builds, rollbacks). The four prior negatives
+# covered assistant-spoken approvals, future intent, in-progress
+# task state, and assistant self-report; none of them named the
+# user-announced completed-status shape that the codex extractor
+# was storing at a 100% rate on the merge-PR probe while the claude
+# extractor classified the same probe correctly. Schema unchanged;
+# the bump lets post-rollout log analysis partition facts produced
+# after the merge-PR negative landed from those produced before it.
+_EXTRACTION_PROMPT_VERSION: str = "11"
 
 # Sibling of _EXTRACTION_PROMPT_VERSION for stage-2 episode generation.
 # Stored in each episode's metadata so future cleanups can target a
@@ -450,6 +460,16 @@ Worked examples (emit / do not emit):
   or the world.
 - User says "I'm writing the spec now." -> do not emit. In-progress
   task state; loses meaning once the spec is shipped.
+- User says "Just merged PR #501 finally." -> do not emit. The user
+  announced a completed workflow action; the merge event is
+  workflow status that loses recall value within hours. The
+  artifact (the closed PR, the merged commit) is its own durable
+  record. The same logic applies to deployment-status announcements
+  ("deploy is up", "the build passed", "rolled back the X change").
+  Do not store these as confirmed_action facts either; the
+  confirmed_action machinery exists to prevent laundered assistant
+  claims, not to authorize storing every user-announced workflow
+  event.
 
 If a candidate fact passes this test, proceed to STORE-block
 classification (above). If it fails, return an empty facts list

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1183,6 +1183,38 @@ _WORKFLOW_EVENT_RE = re.compile(
 )
 
 
+# Workflow self-announcement regex (Rule 6 confirmation-quote arm).
+# Matches confirmation_quote strings where the user speaks as the
+# AGENT of a completed workflow action ("Just merged PR #501",
+# "Deployed X", "Shipped Y") rather than as the OBSERVER confirming
+# an assistant-stated claim ("I see PR #299 is merged, thanks", "I
+# noticed the deploy went out"). The discriminator is the leading
+# verb: legitimate confirmation quotes lead with a perceiver
+# pronoun ("I see", "I noticed", "Confirmed -") because the user is
+# positioning themselves as the observer of an event the assistant
+# claimed. Self-announcement quotes lead with the action verb
+# itself, optionally prefixed with "Just".
+#
+# Used to close the confirmed_action route on the user-announces-
+# workflow-status shape that the QUALITY TEST negative example
+# targets at the prompt level. The model can mis-route an
+# announcement into confirmed_action; this regex backstops that
+# routing without rejecting the legitimate confirmation pattern
+# (where the user did not utter the action verb as their leading
+# claim).
+#
+# The verb set covers the canonical software-workflow announcement
+# verbs surfaced in the originating gate runs. It is intentionally
+# narrow: broader paraphrases ("I shipped a new release of X today,
+# thanks for the heads up") are left to the prompt's QUALITY TEST
+# because they pair the action verb with first-person perceiver
+# framing and are a real edge case worth not over-rejecting.
+_WORKFLOW_SELF_ANNOUNCEMENT_QUOTE_RE = re.compile(
+    r"^(Just\s+)?(merged|deployed|shipped|pushed|rolled\s+back|released|landed)\b",
+    re.IGNORECASE,
+)
+
+
 class _Counter:
     """Per-user rejection counter for `_validate_facts` Rule 6.
 
@@ -1609,19 +1641,39 @@ def _validate_facts(
         # `_RULE_6_REJECTIONS` increments per user so the rate is
         # observable via `get_extractor_stats()` without grepping logs.
         #
-        # Confirmed-action rows are skipped because the canonical
-        # confirmation example "User confirmed PR #299 was merged on
-        # 2026-04-12" matches arm 2 of `_WORKFLOW_EVENT_RE`. The
-        # existing Rule 1/2/4/4b chain already gates the
-        # confirmed_action path with strict quote and tag rules;
-        # trusting them here keeps Rule 6 narrowly scoped to its
-        # purpose (workflow-event noise without a confirmation anchor).
+        # The rule has two arms keyed on whether the fact is tagged
+        # `confirmed_action`:
+        #
+        # Non-confirmed_action arm: the canonical Rule 6 path. Reject
+        # if `_WORKFLOW_EVENT_RE` matches the content.
+        #
+        # confirmed_action arm: the content-side check is skipped
+        # because the canonical legitimate confirmation example "User
+        # confirmed PR #299 was merged on 2026-04-12" matches arm 2
+        # of `_WORKFLOW_EVENT_RE` and would otherwise be rejected.
+        # Instead, inspect the confirmation_quote: if the quote is
+        # itself a user-announced workflow status event ("Just merged
+        # PR #501 finally", "Deployed X"), the user spoke the action
+        # as the agent rather than confirming an assistant claim, and
+        # the row is workflow noise wearing a confirmation tag.
+        # Legitimate confirmation quotes lead with a perceiver
+        # pronoun ("I see PR #299 is merged, thanks") and do not
+        # match `_WORKFLOW_SELF_ANNOUNCEMENT_QUOTE_RE`.
         if "confirmed_action" not in tags:
             content = fact.get("content", "")
             if isinstance(content, str) and _WORKFLOW_EVENT_RE.search(content):
                 log.info(
                     "_validate_facts: rejecting workflow-event-shaped fact: %r",
                     content[:120],
+                )
+                _RULE_6_REJECTIONS.increment(user_id=user_id)
+                continue
+        else:
+            quote = fact.get("confirmation_quote", "")
+            if isinstance(quote, str) and _WORKFLOW_SELF_ANNOUNCEMENT_QUOTE_RE.match(quote):
+                log.info(
+                    "_validate_facts: rejecting confirmed_action with self-announcement quote: %r",
+                    quote[:120],
                 )
                 _RULE_6_REJECTIONS.increment(user_id=user_id)
                 continue

--- a/tests/test_extraction_prompt.py
+++ b/tests/test_extraction_prompt.py
@@ -113,7 +113,7 @@ def test_store_block_does_not_reference_durability_test():
 
 def test_prompt_version_bumped():
     """Version stamp matches the prompt revision."""
-    assert _EXTRACTION_PROMPT_VERSION == "10"
+    assert _EXTRACTION_PROMPT_VERSION == "11"
 
 
 def test_no_em_or_en_dashes_in_quality_test_block():
@@ -156,15 +156,15 @@ def test_positive_worked_examples_present():
 
 
 def test_negative_worked_examples_present():
-    """The four negative (do-not-emit) worked examples are in the block.
+    """The five negative (do-not-emit) worked examples are in the block.
 
-    Same pinning rationale as the positive set. The four negatives
-    cover the four classes the prior IGNORE list targeted: workflow-
-    event metadata, decision-to-do, assistant self-report, and
-    in-progress task state ("ephemeral state"). PR #467 review (W-2)
-    added the ephemeral-state example to reconcile the spec prose
-    that named four classes against the original block which only
-    carried three.
+    Same pinning rationale as the positive set. The five negatives
+    cover assistant-spoken approvals, future intent, assistant
+    self-report, in-progress task state, and user-announced completed
+    workflow actions (PR merges, deploys, builds). The merge-PR
+    example was added because the codex backend was storing the
+    user-announced completed-status shape that none of the prior
+    four negatives named.
     """
     block = _extract_quality_test_block()
     for snippet in (
@@ -172,5 +172,6 @@ def test_negative_worked_examples_present():
         '"Let\'s file an issue about X."',
         '"I\'m extracting facts now"',
         '"I\'m writing the spec now."',
+        '"Just merged PR #501 finally."',
     ):
         assert snippet in block, f"negative worked example missing: {snippet}"

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -33,6 +33,7 @@ from kai.memory_extraction import (
     _GENERIC_CONFIRMATION_RE,
     _RULE_6_REJECTIONS,
     _WORKFLOW_EVENT_RE,
+    _WORKFLOW_SELF_ANNOUNCEMENT_QUOTE_RE,
     _build_extraction_payload,
     _capped_assistant,
     _emit_intent_log,
@@ -2764,12 +2765,15 @@ class TestRule6WorkflowEventRegex:
         after = sum(_RULE_6_REJECTIONS.snapshot().values())
         assert after - before == 1
 
-    def test_rule_6_skips_confirmed_action_rows(self):
-        """Pin the confirmed_action skip ahead of Rule 6: a
-        confirmation row whose content matches arm 2 ("User
-        confirmed PR #299 was merged on 2026-04-12") must NOT be
-        rejected, because the existing Rule 1/2/4/4b chain already
-        gates the confirmed_action path."""
+    def test_rule_6_keeps_legitimate_confirmed_action_rows(self):
+        """A legitimate confirmation row (assistant claimed an
+        action; user confirmed via perceiver-framed quote) must
+        survive Rule 6. The content matches arm 2 of
+        `_WORKFLOW_EVENT_RE` but the confirmed_action arm skips the
+        content check; the quote is perceiver-framed ("I see ...")
+        and does not match
+        `_WORKFLOW_SELF_ANNOUNCEMENT_QUOTE_RE`, so neither path
+        rejects."""
         before = sum(_RULE_6_REJECTIONS.snapshot().values())
         facts = [
             {
@@ -2784,15 +2788,82 @@ class TestRule6WorkflowEventRegex:
             facts,
             candidate_ids=set(),
             candidate_metadata={},
-            user_id="test-user-rule6-skip",
+            user_id="test-user-rule6-keep",
         )
         kept = [f["content"] for f in validated]
-        # The fact survives. The regex matches the content, but the
-        # confirmed_action skip protects it.
         assert "User confirmed PR #299 was merged on 2026-04-12." in kept
-        # Counter unchanged: Rule 6 did not fire on this fact.
         after = sum(_RULE_6_REJECTIONS.snapshot().values())
         assert after - before == 0
+
+    def test_rule_6_rejects_self_announcement_confirmation_quote(self):
+        """The originating-issue bypass: codex emits a
+        confirmed_action row whose confirmation_quote is the user's
+        own announcement of a completed workflow action ("Just
+        merged PR #501 finally."). The content-side skip would let
+        this pass under the prior contract; the quote-side arm
+        rejects it now. Pinning both the regex match and the
+        end-to-end rejection prevents accidental relaxation."""
+        before = sum(_RULE_6_REJECTIONS.snapshot().values())
+        facts = [
+            {
+                "content": "User confirmed PR #501 was merged.",
+                "tags": ["confirmed_action"],
+                "confidence": 0.9,
+                "intent": "new",
+                "confirmation_quote": "Just merged PR #501 finally.",
+            },
+        ]
+        validated = _validate_facts(
+            facts,
+            candidate_ids=set(),
+            candidate_metadata={},
+            user_id="test-user-rule6-reject",
+        )
+        kept = [f["content"] for f in validated]
+        assert "User confirmed PR #501 was merged." not in kept
+        after = sum(_RULE_6_REJECTIONS.snapshot().values())
+        assert after - before == 1
+
+    def test_self_announcement_regex_positives(self):
+        """The self-announcement regex catches the canonical
+        software-workflow announcement verbs: merge, deploy, ship,
+        push, roll back, release, land. Each verb is pinned with
+        the bare-verb and the "Just"-prefixed shape."""
+        positives = [
+            "Just merged PR #501 finally.",
+            "Merged the migration; tests are green.",
+            "Just deployed the v3.2 release to prod.",
+            "Deployed the build to staging.",
+            "Just shipped the feature behind the new flag.",
+            "Shipped v4.0 this morning.",
+            "Just pushed the wiki update.",
+            "Pushed the fix to fix/512.",
+            "Just rolled back the bad migration.",
+            "Rolled back the deploy at 14:30.",
+            "Just released the beta to the test cohort.",
+            "Released v2.1 ahead of schedule.",
+            "Just landed the spec change in main.",
+            "Landed the rename in PR #404.",
+        ]
+        for quote in positives:
+            assert _WORKFLOW_SELF_ANNOUNCEMENT_QUOTE_RE.match(quote), quote
+
+    def test_self_announcement_regex_negatives(self):
+        """Legitimate confirmation quotes lead with a perceiver
+        pronoun ("I see", "I noticed") or otherwise place the user
+        as observer, not agent. They must not match the
+        self-announcement regex, or the Rule 6 quote-side arm would
+        reject valid confirmations."""
+        negatives = [
+            "I see PR #299 is merged, thanks for the update.",
+            "I noticed the deploy went out this morning.",
+            "Confirmed - the migration shipped at 10am EST.",
+            "Thanks, I see the rollback completed.",
+            "Yes, the build passed for me too.",
+            "Got it; the spec is approved.",
+        ]
+        for quote in negatives:
+            assert not _WORKFLOW_SELF_ANNOUNCEMENT_QUOTE_RE.match(quote), quote
 
     def test_get_extractor_stats_exposes_rule_6_counter(self):
         """`get_extractor_stats()` returns the documented top-level

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -2610,7 +2610,7 @@ class TestExtractionPromptSoftVocab:
     def test_extraction_prompt_version_bumped(self):
         """The version stamp on every fact's metadata; bumped
         whenever the schema or prompt changes meaningfully."""
-        assert _EXTRACTION_PROMPT_VERSION == "10"
+        assert _EXTRACTION_PROMPT_VERSION == "11"
 
     def test_extraction_prompt_version_history_extended(self):
         """The prompt-version history comment block (the sequence
@@ -2620,9 +2620,9 @@ class TestExtractionPromptSoftVocab:
         fragments so a future unrelated edit that introduces a `vN:`
         token elsewhere cannot satisfy this test vacuously.
 
-        v5 through v10 fragments are pinned: each prior entry stays
+        v5 through v11 fragments are pinned: each prior entry stays
         in source unchanged across the next bump. The latest entry
-        (v10) gets its own date + phrase pin so the version-history
+        (v11) gets its own date + phrase pin so the version-history
         discipline keeps protecting the freshest revision."""
         from pathlib import Path
 
@@ -2645,9 +2645,15 @@ class TestExtractionPromptSoftVocab:
         # v10 entry: episode-side loosening for implicit-framing
         # technical-debugging arcs. Pinning the literal date plus the
         # distinguishing phrase keeps the history-discipline rule
-        # honest at the current head of the version sequence.
+        # honest at the prior head of the version sequence.
         assert "v10 (2026-05-24)" in src
         assert "implicit resolution framing" in src
+        # v11 entry: PR-merge / deploy-status negative worked
+        # example added to the QUALITY TEST. Pinning the literal
+        # date plus the distinguishing phrase keeps the rule honest
+        # at the current head of the version sequence.
+        assert "v11 (2026-05-24)" in src
+        assert "user-announced completed workflow actions" in src
 
 
 class TestRule6WorkflowEventRegex:


### PR DESCRIPTION
Closes #513.

## Problem

The codex extraction backend (`gpt-5.4-mini`) consistently stored the `w-merged` workflow-noise probe ("Just merged PR #501 finally." / "Nice.") as a durable fact across every gate run (5/5). The claude backend (`claude-haiku-4-5`) correctly classified the same probe as workflow noise on every run (0/5). Same prompt, different model behavior.

Two surfaces were involved:

1. **Prompt-side**: The four existing `QUALITY TEST` negative worked examples named assistant-spoken approvals, future intent, in-progress task state, and assistant self-report - none of them named the user-announced completed-status shape that the codex extractor was hitting.
2. **Validator-side**: `_validate_facts` Rule 6 skipped the workflow-event content check on every `confirmed_action` row to preserve the legitimate confirmation pattern ("User confirmed PR #299 was merged on 2026-04-12" + perceiver-framed quote). That skip became a bypass: a row tagged `confirmed_action` whose `confirmation_quote` was the user's own announcement ("Just merged PR #501 finally.") was accepted unchanged.

Relying only on the prompt fix would leave the validator bypass open. Same-prompt-different-model is the failure mode this PR targets, so a Python backstop is needed in addition to the prompt steer.

## Change

**Prompt** (`QUALITY TEST` block, `_EXTRACTION_PROMPT_VERSION` bumped `"10"` → `"11"`):

Added a fifth negative worked example for user-announced completed workflow actions (PR merges, deploys, builds, rollbacks), with an explicit aside that the `confirmed_action` machinery exists to prevent laundered assistant claims and is not authorization to store every user-announced workflow event.

**Validator** (`_WORKFLOW_SELF_ANNOUNCEMENT_QUOTE_RE` + Rule 6 confirmed_action arm):

Added a narrow regex matching `confirmation_quote` strings that lead with a software-workflow action verb (`merged`, `deployed`, `shipped`, `pushed`, `rolled back`, `released`, `landed`), optionally prefixed with `"Just"`. Legitimate confirmation quotes lead with a perceiver pronoun ("I see PR #299 is merged, thanks for the update.", "I noticed the deploy went out") and do not match.

Extended Rule 6 with a `confirmed_action` arm: the content-side check is still skipped (preserving the canonical legitimate confirmation shape), but the `confirmation_quote` is now checked against the new regex. A match counts as the user speaking the workflow event as agent rather than confirming an assistant's claim; the row is rejected.

Rejections increment the existing `_RULE_6_REJECTIONS` counter and log at INFO with a distinct message (`"rejecting confirmed_action with self-announcement quote"`) so operational triage can tell the two arms apart without splitting the counter.

## Tests

Prompt-side (unchanged from the first commit):

- `tests/test_extraction_prompt.py::test_negative_worked_examples_present` pins five negatives.
- `tests/test_extraction_prompt.py::test_prompt_version_bumped` at `"11"`.
- `tests/test_memory_extraction.py::test_extraction_prompt_version_bumped` at `"11"`.
- `tests/test_memory_extraction.py::test_extraction_prompt_version_history_extended` pins a v11 entry.

Validator-side (new in r2):

- `TestRule6WorkflowEventRegex::test_rule_6_keeps_legitimate_confirmed_action_rows`: a `confirmed_action` row with `"I see PR #299 is merged, thanks for the update."` as the quote survives Rule 6 end-to-end through `_validate_facts`.
- `TestRule6WorkflowEventRegex::test_rule_6_rejects_self_announcement_confirmation_quote`: the exact bad shape from #513 (content `"User confirmed PR #501 was merged."`, quote `"Just merged PR #501 finally."`) is rejected and the counter increments.
- `TestRule6WorkflowEventRegex::test_self_announcement_regex_positives`: 14 positive shapes across the 7 verbs (`merged`/`deployed`/`shipped`/`pushed`/`rolled back`/`released`/`landed`), with and without the `"Just "` prefix.
- `TestRule6WorkflowEventRegex::test_self_announcement_regex_negatives`: 6 perceiver-framed quotes confirm the regex does not over-reject legitimate confirmation patterns.

All 3436 tests pass; `make check` clean.

## Verification path

The unit tests now prove the bypass is closed even if the codex model emits the bad shape: `_validate_facts` rejects it before it reaches the store. The real end-to-end check remains running `kai.eval.memory_backend_gate` against the operator-private 62-probe fixture and confirming `w-merged` stores 0/5 on the codex arm with no regression on durable-content probes. The gate also exercises whether the prompt steer alone is sufficient (in which case the validator never has to fire) or whether the validator backstop is doing work in practice.

## Out of scope

- The other 11 workflow-noise probes both backends already classify correctly.
- The `FORMAT` block's past-tense exemplar (`"User confirmed PR #299 was merged on 2026-04-12"`), which uses the PR-merge shape to model formatting. Modifying it would change a separate priming surface; deferring until the gate run shows whether the QUALITY TEST negative + validator backstop together are sufficient.
- Splitting the `_RULE_6_REJECTIONS` counter into content-arm vs quote-arm buckets. The distinguishing log message handles current triage needs; per-arm exposure can be added if ops need it.

## Test plan

- [ ] Operator re-runs the memory backend gate and confirms `w-merged` stores 0/5 on the codex arm.
- [ ] Check the Rule 6 rejection log line shape on the first post-deploy run to verify the new "self-announcement quote" message renders correctly under production logging config.
- [ ] After merge + `sudo make install`, monitor `kai.memory` logs for the rate of the new rejection-arm hits. A high hit rate means the prompt steer alone was insufficient and the validator is carrying the load; a near-zero rate means the prompt is the primary effective layer.
