### PR TITLE
fix(install): capture launchd stderr/stdout to logs so startup crashes are visible

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2350,6 +2350,16 @@ def _generate_launchd_plist(install_dir: str, data_dir: str, service_user: str) 
     launchd to lose track of the process. The launcher script stays as the
     tracked parent and forwards signals to Python.
 
+    StandardErrorPath and StandardOutPath capture Python's stderr/stdout to
+    files under {data_dir}/logs/ rather than the launchd default of /dev/null.
+    Without these keys, an early-init crash (a missing env var, an unimportable
+    module, a SystemExit before logging is configured) goes nowhere visible
+    and the bash wrapper's tracked PID stays alive, so `launchctl print`
+    reports `state = running` even when the actual Python process is dead.
+    The {data_dir}/logs/ directory is created with service-user ownership
+    earlier in the install path; launchd creates the files themselves on
+    first write.
+
     Args:
         install_dir: Root of the protected installation (e.g., /opt/kai).
         data_dir: Writable data directory (e.g., /var/lib/kai).
@@ -2389,6 +2399,12 @@ def _generate_launchd_plist(install_dir: str, data_dir: str, service_user: str) 
                 <key>KAI_INSTALL_DIR</key>
                 <string>{install_dir}</string>
             </dict>
+
+            <key>StandardErrorPath</key>
+            <string>{data_dir}/logs/kai.stderr.log</string>
+
+            <key>StandardOutPath</key>
+            <string>{data_dir}/logs/kai.stdout.log</string>
 
             <key>RunAtLoad</key>
             <true/>

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -938,6 +938,29 @@ class TestGenerateLaunchdPlist:
         assert result.startswith("<?xml")
         assert "</plist>" in result
 
+    def test_captures_stderr_and_stdout_to_log_files(self):
+        """Without StandardErrorPath / StandardOutPath, launchd routes
+        Python's stderr and stdout to /dev/null. An early-init crash
+        (missing env var, SystemExit before logging is configured)
+        then leaves no trail while the bash wrapper's tracked PID
+        keeps `launchctl print` reporting `state = running`. Pin both
+        keys plus the {data_dir}/logs/ derivation so a future refactor
+        cannot silently drop the visibility surface."""
+        result = _generate_launchd_plist("/opt/kai", "/var/lib/kai", "kai")
+        assert "<key>StandardErrorPath</key>" in result
+        assert "<string>/var/lib/kai/logs/kai.stderr.log</string>" in result
+        assert "<key>StandardOutPath</key>" in result
+        assert "<string>/var/lib/kai/logs/kai.stdout.log</string>" in result
+
+    def test_log_paths_derive_from_data_dir(self):
+        """A non-default data_dir lands the log files under that
+        directory, not under a hardcoded /var/lib/kai/. Catches a
+        regression where the paths were ever inlined as literal
+        strings instead of f-string interpolations of `data_dir`."""
+        result = _generate_launchd_plist("/opt/kai", "/srv/kai", "kai")
+        assert "<string>/srv/kai/logs/kai.stderr.log</string>" in result
+        assert "<string>/srv/kai/logs/kai.stdout.log</string>" in result
+
 
 class TestGenerateSystemdUnit:
     def test_contains_user(self):


### PR DESCRIPTION
Closes #533.

## Problem

Without `StandardErrorPath` / `StandardOutPath` keys, launchd routes Python's stderr and stdout to `/dev/null`. An early-init crash (missing env var, unimportable module, `SystemExit` before logging is configured) then leaves no trail while the bash wrapper's tracked PID keeps `launchctl print` reporting `state = running`. The wrapper itself falls through to a `sleep 86400` loop when it cannot find the Python child's PID, so the false-positive `state = running` persists indefinitely.

The visibility gap turned a one-line traceback into a multi-step diagnosis during the recent codex memory deployment (compare deployed config against runtime state, verify env-file contents under sudo, locate the actual Python PID, etc.).

## Change

Added `StandardErrorPath` and `StandardOutPath` to the launchd plist in `_generate_launchd_plist()`. Both paths are derived from the `data_dir` parameter so a non-default install lands them in the right place:

```xml
<key>StandardErrorPath</key>
<string>{data_dir}/logs/kai.stderr.log</string>

<key>StandardOutPath</key>
<string>{data_dir}/logs/kai.stdout.log</string>
```

The `{data_dir}/logs/` directory is already created with service-user ownership earlier in the install path (`_setup_runtime_dirs`, around install.py:3447); launchd creates the files themselves on first write.

The docstring was extended to name the visibility-gap rationale so a future maintainer who finds the keys does not strip them as cosmetic.

The systemd unit at `_generate_systemd_unit()` is unchanged because stdout/stderr default to the journal (`journalctl -u kai`); the gap was macOS-specific.

## Tests

Two new tests under `TestGenerateLaunchdPlist`:

- `test_captures_stderr_and_stdout_to_log_files`: pins both keys + the canonical `/var/lib/kai/logs/kai.stderr.log` and `/var/lib/kai/logs/kai.stdout.log` paths.
- `test_log_paths_derive_from_data_dir`: passes a non-default `data_dir` (`/srv/kai`) and asserts the log paths follow, catching a regression where the paths get inlined as literal strings instead of f-string interpolations of `data_dir`.

All 3438 tests pass; `make check` clean.

## Out of scope

- The bash wrapper's `sleep 86400` fall-through: when the wrapper cannot find the Python child's PID, it should `exit 1` so `KeepAlive=true` plus `ThrottleInterval=10` triggers a launchd restart. Sleeping forever lets `state = running` stay green while the service is dead. Worth its own issue; this PR only closes the stderr/stdout visibility gap.
- Log rotation for the new stderr/stdout files (system handles via newsyslog if needed).
- Restructuring the wrapper to drop the `lsof` polling pattern.

## Test plan

- [ ] After merge + `sudo make install`, the LaunchDaemon plist at `/Library/LaunchDaemons/com.syrinx.kai.plist` contains both keys.
- [ ] `/var/lib/kai/logs/kai.stderr.log` and `kai.stdout.log` exist after the first service start and are owned by the service user.
- [ ] Manual smoke: introduce a deliberate early-init `SystemExit` (e.g., set an invalid value for a required env var), `sudo launchctl bootout system/com.syrinx.kai && sudo launchctl bootstrap system/...`, and confirm the traceback appears in `/var/lib/kai/logs/kai.stderr.log`.
