### PR TITLE
fix(bot): hold strong reference to memory ingestion task

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -173,6 +173,25 @@ _QUEUED_MESSAGE_MARKER = (
 _LOCK_ACQUIRE_TIMEOUT = 3600  # 1 hour
 
 
+# Strong references to in-flight memory-ingestion tasks.
+#
+# `asyncio.create_task` returns a Task that the runtime holds only by
+# WEAK reference. Without a strong reference somewhere, a heap-pressure
+# GC cycle can reap a still-running task; the failure mode is silent
+# because the task simply disappears and the exchange never makes it
+# into semantic memory. The set holds a strong reference until the
+# task completes; the done-callback `_pending_memory_tasks.discard`
+# registered at spawn keeps the set self-pruning so a long-running
+# deployment does not accumulate references without bound.
+#
+# Same pattern as `webhook.py`'s `_background_tasks` and
+# `memory_extraction.py`'s `_pending_episode_tasks`. Each module owns
+# its own set so the ownership boundary stays explicit; consolidating
+# into a single global set would obscure which subsystem is responsible
+# for a given task's lifetime.
+_pending_memory_tasks: set[asyncio.Task[None]] = set()
+
+
 # Budget-exhaustion recovery directive.
 #
 # When the inner Claude session hits BUDGET_CEILING (default $10), the
@@ -3770,7 +3789,9 @@ async def _handle_response(
             except Exception:
                 log.warning("Memory ingestion failed", exc_info=True)
 
-        asyncio.create_task(_ingest_memory())  # noqa: RUF006
+        task = asyncio.create_task(_ingest_memory())
+        _pending_memory_tasks.add(task)
+        task.add_done_callback(_pending_memory_tasks.discard)
 
     # Voice-only mode: synthesize and send voice, fall back to text on failure
     if voice_only and final_text:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3095,6 +3095,93 @@ class TestHandleResponse:
 
         extract_mock.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_memory_ingest_task_held_by_module_set(self, monkeypatch):
+        """The ingest task is added to `_pending_memory_tasks` at
+        schedule time and discarded by the done-callback after the
+        task completes. Pinning both sides of the lifecycle prevents
+        a regression that reverts to `asyncio.create_task(...)` with
+        no strong reference, which Python's GC can reap mid-flight.
+
+        Drives the lifecycle with an asyncio.Event so the test can
+        observe the set membership at three points: pre-call (empty
+        baseline), mid-task (one entry, task in flight), and
+        post-task (back to empty after the done-callback fires)."""
+        from kai import bot
+        from kai.bot import _handle_response, _pending_memory_tasks
+
+        # Baseline: prior tests may have left the set populated if
+        # they did not wait for their tasks to complete. Snapshot the
+        # baseline rather than asserting empty so test ordering does
+        # not couple this test to its siblings.
+        baseline = set(_pending_memory_tasks)
+
+        monkeypatch.setattr("kai.memory.is_enabled", lambda: True)
+
+        # extract_and_store waits on this event so the test can
+        # inspect the set while the task is in flight. The mid-task
+        # assertion races the done-callback only if extract returns
+        # immediately; the event keeps the task pending until the
+        # test releases it.
+        in_flight = asyncio.Event()
+        release = asyncio.Event()
+
+        async def blocking_extract(*args, **kwargs):
+            in_flight.set()
+            await release.wait()
+
+        monkeypatch.setattr("kai.memory_extraction.extract_and_store", blocking_extract)
+
+        update = _make_update()
+        pool = _make_mock_claude()
+        pool.send = MagicMock(return_value=_fake_stream(_done_event("Hello world", session_id="sess-1")))
+        config = _make_config(
+            memory_extraction_enabled=True,
+            episode_classifier_context_turns=0,
+        )
+        ctx = _make_context(config=config, pool=pool)
+
+        with patch.multiple("kai.bot", **self._base_patches()):
+            await _handle_response(update, ctx, 12345, "test prompt", pool, "claude-opus")
+
+        # The ingest task is scheduled inside _handle_response and
+        # blocked at the extract_and_store await. Wait for the
+        # in-flight signal so the assertion does not race the
+        # task's first await.
+        await asyncio.wait_for(in_flight.wait(), timeout=1.0)
+
+        # Mid-task: exactly one new entry above baseline. The
+        # add() at schedule time put it there; the done-callback
+        # has not fired because the task is still blocked.
+        assert len(_pending_memory_tasks - baseline) == 1, (
+            "ingest task should be held in _pending_memory_tasks while it runs"
+        )
+
+        # Release the task so it can complete and the done-callback
+        # can run.
+        release.set()
+
+        # Wait for the done-callback to discard the task. The
+        # task itself completes inside extract_and_store; the
+        # discard runs as a callback after. A short asyncio.sleep
+        # loop lets the runtime schedule both.
+        for _ in range(100):
+            if not (_pending_memory_tasks - baseline):
+                break
+            await asyncio.sleep(0.01)
+
+        # Post-task: the set is back to baseline. The discard
+        # callback fired and self-pruned the entry, so a
+        # long-running deployment does not accumulate references.
+        assert _pending_memory_tasks - baseline == set(), (
+            "done-callback should have discarded the completed task from _pending_memory_tasks"
+        )
+
+        # Silence pyflakes/ruff: `bot` is imported above to anchor
+        # the patched attribute path; the assertions read from the
+        # re-imported `_pending_memory_tasks` reference.
+        _ = bot
+
 
 # ── _notify_if_queued ────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #386.

## Problem

`bot.py` scheduled the memory ingestion subtask with a bare `asyncio.create_task(_ingest_memory())` and a `# noqa: RUF006` suppression. asyncio's runtime holds only a WEAK reference to a returned Task; without a strong reference somewhere, a heap-pressure GC cycle can reap the task mid-flight. The failure mode is silent: the user's exchange is never extracted, no facts land, and there is no error log because the task simply disappears.

The codebase already has the documented-correct pattern in two places:

- `webhook.py`'s `_background_tasks` (Telegram update processing).
- `memory_extraction.py`'s `_pending_episode_tasks` (stage-2 episode generator).

Both keep a strong reference in a module-level set and self-prune via a done-callback. `bot.py`'s ingestion call was the only outstanding site that fit the same pattern without using it.

## Change

Added `_pending_memory_tasks: set[asyncio.Task[None]] = set()` at module level in `bot.py` and replaced the bare `create_task` with the three-line pattern:

```python
task = asyncio.create_task(_ingest_memory())
_pending_memory_tasks.add(task)
task.add_done_callback(_pending_memory_tasks.discard)
```

The `# noqa: RUF006` suppression is removed in the same change because the underlying RUF006 violation no longer applies.

A docstring on the new set names the rationale (weak-ref GC, self-pruning discard, ownership boundary) so a future maintainer who finds it does not strip it as decorative state.

## Tests

`TestHandleResponse::test_memory_ingest_task_held_by_module_set`: drives the lifecycle with an `asyncio.Event` so set membership can be observed at three points:

1. **Pre-call baseline** - snapshot the set before `_handle_response` runs. Avoids coupling the test to whether earlier tests left entries behind.
2. **Mid-task** - inside `extract_and_store`, the test asserts exactly one new entry above baseline. The blocking event guarantees the task is still in flight when the assertion runs.
3. **Post-task** - after the event releases, a short async-sleep loop waits for the done-callback to run; the set is back to baseline.

This pins both sides of the lifecycle. A regression that reverts to a bare `create_task` fails on the mid-task assertion; one that drops the done-callback fails on the post-task assertion.

All 3439 tests pass; `make check` clean.

## Out of scope

Per the originating issue: this PR covers only `bot.py`'s ingestion call site. Other `asyncio.create_task` sites exist in `pool.py`, `claude.py`, `main.py`, and additional sites in `webhook.py`; a broader audit can happen later if there is appetite. No change to memory extraction behavior, scope, or content. No change to the per-user semaphore serialization in `memory_extraction.py`.

## Test plan

- [ ] After merge + `sudo make install`, confirm memory extraction continues to write facts at the expected per-turn rate. A silent regression here would manifest as a drop in the per-user fact write rate.
- [ ] Watch the kai.log for any `_pending_memory_tasks`-related errors during the first day of production use (none expected; the pattern is in use elsewhere already).
