### PR TITLE
fix(eval): rebase T5 floors on relative-to-baseline shape

### DIFF
--- a/src/kai/eval/memory_backend_gate.py
+++ b/src/kai/eval/memory_backend_gate.py
@@ -1404,13 +1404,27 @@ def compare_thresholds(claude: BackendMetrics, codex: BackendMetrics) -> Thresho
             threshold=f"codex >= claude - {r_allowance:.4f}",
         )
     )
+    # T5 absolute floors use the same `max(absolute_minimum,
+    # claude_value - delta)` shape as `T6.episode_recall` below. The
+    # 0.80 absolute that lived here originally was a placeholder; the
+    # baseline (claude) currently scores ~0.72 on both axes on the
+    # operator-private fixture, so a fixed 0.80 floor failed every
+    # run regardless of whether codex was actually regressing. The
+    # max() form catches regressions in the achievable range: the
+    # absolute term (0.70) fires when the entire system gets
+    # fundamentally worse, the relative term (claude - 0.05) tracks
+    # the baseline as retrieval quality improves. Choosing the
+    # tighter of the two preserves the original spec's intent (catch
+    # codex when it drops below a reasonable absolute) without
+    # rejecting the current state of the system every run.
+    p_at_5_floor = max(0.70, claude.precision_at_5 - 0.05)
     checks.append(
         ThresholdCheck(
             name="T5.precision_at_5_floor",
-            passed=codex.precision_at_5 >= 0.80,
+            passed=codex.precision_at_5 >= p_at_5_floor,
             claude_value=claude.precision_at_5,
             codex_value=codex.precision_at_5,
-            threshold="codex precision_at_5 >= 0.80",
+            threshold=f"codex precision_at_5 >= {p_at_5_floor:.4f}",
         )
     )
     checks.append(
@@ -1431,13 +1445,14 @@ def compare_thresholds(claude: BackendMetrics, codex: BackendMetrics) -> Thresho
             threshold=f"codex >= claude - {r_allowance:.4f}",
         )
     )
+    fip_floor = max(0.70, claude.fraction_in_prompt - 0.05)
     checks.append(
         ThresholdCheck(
             name="T5.fraction_in_prompt_floor",
-            passed=codex.fraction_in_prompt >= 0.80,
+            passed=codex.fraction_in_prompt >= fip_floor,
             claude_value=claude.fraction_in_prompt,
             codex_value=codex.fraction_in_prompt,
-            threshold="codex fraction_in_prompt >= 0.80",
+            threshold=f"codex fraction_in_prompt >= {fip_floor:.4f}",
         )
     )
     checks.append(

--- a/tests/test_eval_memory_backend_gate.py
+++ b/tests/test_eval_memory_backend_gate.py
@@ -415,12 +415,56 @@ class TestCompareThresholds:
         assert "T1.parse_failure_rate" in failed
 
     def test_fails_codex_on_p_at_5_below_floor(self):
+        """With claude at the perfect baseline (1.0), the floor binds
+        on the relative arm: max(0.70, 1.0 - 0.05) = 0.95. Codex at
+        0.79 falls below the relative floor and fails."""
         claude = _clean_metrics()
         codex = _clean_metrics(precision_at_5=0.79)
         report = g.compare_thresholds(claude, codex)
         assert report.overall == "fail"
         failed = [c.name for c in report.checks if not c.passed]
         assert "T5.precision_at_5_floor" in failed
+
+    def test_passes_p_at_5_when_codex_above_relative_floor(self):
+        """Regression for the originating-issue calibration error: a
+        baseline run where claude=0.72 and codex=0.78 must pass the
+        floor under the max(0.70, claude - 0.05) shape. The previous
+        absolute 0.80 floor failed both arms on every run regardless
+        of whether codex was actually regressing.
+
+        max(0.70, 0.72 - 0.05) = max(0.70, 0.67) = 0.70; codex at
+        0.78 clears comfortably. The band check also passes because
+        codex >= claude."""
+        claude = _clean_metrics(precision_at_5=0.72, fraction_in_prompt=0.72)
+        codex = _clean_metrics(precision_at_5=0.78, fraction_in_prompt=0.79)
+        report = g.compare_thresholds(claude, codex)
+        failed = [c.name for c in report.checks if not c.passed]
+        assert "T5.precision_at_5_floor" not in failed
+        assert "T5.fraction_in_prompt_floor" not in failed
+
+    def test_fails_p_at_5_when_codex_below_absolute_minimum(self):
+        """The absolute minimum (0.70) fires when the entire system
+        gets fundamentally worse, even if claude is also poor. With
+        claude at 0.60 the relative term would yield 0.55, but the
+        absolute term holds the floor at 0.70; codex at 0.69 falls
+        below that and fails. Catches the case where everyone is
+        sliding together rather than codex specifically regressing."""
+        claude = _clean_metrics(precision_at_5=0.60)
+        codex = _clean_metrics(precision_at_5=0.69)
+        report = g.compare_thresholds(claude, codex)
+        failed = [c.name for c in report.checks if not c.passed]
+        assert "T5.precision_at_5_floor" in failed
+
+    def test_fails_fraction_in_prompt_floor_with_same_shape(self):
+        """`fraction_in_prompt_floor` mirrors `precision_at_5_floor`.
+        With claude high (0.95) and codex significantly below
+        (0.85), the relative arm fires: floor = max(0.70, 0.95 -
+        0.05) = 0.90; codex 0.85 falls below it."""
+        claude = _clean_metrics(fraction_in_prompt=0.95)
+        codex = _clean_metrics(fraction_in_prompt=0.85)
+        report = g.compare_thresholds(claude, codex)
+        failed = [c.name for c in report.checks if not c.passed]
+        assert "T5.fraction_in_prompt_floor" in failed
 
     def test_fails_codex_on_hallucinated_ids(self):
         claude = _clean_metrics()


### PR DESCRIPTION
Closes #511.

## Problem

`T5.precision_at_5_floor` and `T5.fraction_in_prompt_floor` in `kai.eval.memory_backend_gate` used an absolute 0.80 cutoff that sat above what the baseline (claude) currently achieves on the operator-private 62-probe fixture. The gate run at `2026-05-19T182259Z` showed:

| Floor | Demand | Claude | Codex |
|---|---|---|---|
| `T5.precision_at_5_floor` | >= 0.80 | 0.721 | 0.779 |
| `T5.fraction_in_prompt_floor` | >= 0.80 | 0.721 | 0.794 |

Both backends failed both floors. The relative band checks (`T5.precision_at_5_band`, `T5.fraction_in_prompt_band`) already pass because codex is consistently above claude on these axes; the absolute floors were producing a `fail` verdict on what is otherwise a clean relative comparison. With #517 and #518 about to lean heavily on this gate as the memory-system verification surface, calibrating the floors to fire on real regressions rather than every run is a prerequisite.

## Change

Switched both T5 floors to the `max(absolute_minimum, claude_value - delta)` shape that `T6.episode_recall` already uses (line 1504):

```python
p_at_5_floor = max(0.70, claude.precision_at_5 - 0.05)
fip_floor = max(0.70, claude.fraction_in_prompt - 0.05)
```

Two arms:

- **Absolute term (0.70)**: fires when the entire system gets fundamentally worse (catches scenarios where both backends slide together rather than codex specifically regressing).
- **Relative term (claude - 0.05)**: fires when codex is more than 0.05 below claude on a baseline that is otherwise healthy. Tracks the baseline as retrieval quality improves.

The `max()` picks whichever is stricter at the current claude value, preserving the original spec's intent (catch codex when it drops below a reasonable absolute) without rejecting every run.

A comment block explains the shape and the calibration history so a future maintainer who wonders why this is not a fixed value sees the answer in source.

## Tests

Existing `test_fails_codex_on_p_at_5_below_floor` was re-cast to name the relative-arm binding it now exercises (with claude=1.0 the floor becomes `max(0.70, 0.95) = 0.95`; codex at 0.79 still fails). Three new tests added:

- `test_passes_p_at_5_when_codex_above_relative_floor`: regression for the originating issue. Replays the actual failing-run numbers (claude=0.72, codex=0.78) and asserts both floors pass.
- `test_fails_p_at_5_when_codex_below_absolute_minimum`: pins the absolute term firing when both arms are poor (claude=0.60, codex=0.69; floor still 0.70).
- `test_fails_fraction_in_prompt_floor_with_same_shape`: mirror for the second T5 floor (claude=0.95, codex=0.85, relative floor at 0.90 fires).

All 3442 tests pass; `make check` clean.

## Out of scope

Per the originating issue:

- Improving the underlying retrieval quality. The gate is the measurement surface; tightening it is separate work.
- Changing the fixture. The fixture content is not the issue.
- Recalibrating the other absolute thresholds in the gate (e.g., `T2.fact_anchor_recall_floor` at 0.85). They have not been observed failing on the current baseline.

## Test plan

- [ ] Operator reruns the memory backend gate against the 62-probe fixture and confirms `T5.precision_at_5_floor` and `T5.fraction_in_prompt_floor` now pass on the current baseline.
- [ ] When #530 (episode classifier) and #531 (PR-merge negative) are validated by their own gate runs, the T5 floors should not be the limiting checks; the relative bands and other absolute thresholds remain the active signals.
