### PR TITLE
fix(install): verify service registration with launchctl print, not bootstrap exit code

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -3373,6 +3373,18 @@ def _cmd_apply() -> None:
     # -- Stop service before making changes --
     _stop_service(platform, dry_run)
 
+    # apply_succeeded is initialized BEFORE the try block so the
+    # finally handler can always read it. Several apply-time
+    # failures raise SystemExit (a BaseException, not an Exception)
+    # rather than going through the `except Exception` handler;
+    # without the pre-initialization, those paths would propagate
+    # SystemExit out of the try, the finally would read
+    # apply_succeeded, and Python would raise UnboundLocalError -
+    # replacing the actionable apply failure with an internal
+    # control-flow error. The default value of False is correct
+    # because the flag flips True only after the last apply step
+    # returns cleanly.
+    apply_succeeded = False
     try:
         # -- Step 1: Create directories --
         # Resolve WORKSPACE_BASE, expanding ~ relative to the service user's home
@@ -3458,15 +3470,14 @@ def _cmd_apply() -> None:
         # -- Step 9: Generate service definition --
         webhook_port = int(env.get("WEBHOOK_PORT", "8080"))
         _apply_service(install_dir, data_dir, service_user, platform, dry_run, webhook_port)
-        # Apply path completed without an exception. Setting the flag
-        # at the bottom of the try block (rather than relying on a
-        # missed except below) keeps the apply_succeeded state local
-        # and unambiguous: True iff every step above ran cleanly. The
+        # Apply path completed without exception. Flipping the flag
+        # at the bottom of the try block (rather than in the
+        # except branch) keeps the apply_succeeded state local and
+        # unambiguous: True iff every step above ran cleanly. The
         # finally block reads it to decide how to handle a service
         # start failure.
         apply_succeeded = True
     except Exception:
-        apply_succeeded = False
         print("\nInstallation failed. See error above.")
         print("The installation may be in a partial state.")
         print("Fix the issue and re-run: sudo python -m kai install apply")

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -70,6 +70,41 @@ _CONF_VERSION = 1
 # Plist label for the launchd service
 _LAUNCHD_LABEL = "com.syrinx.kai"
 
+
+# Retry budget for `_start_service`. The bootstrap-then-verify cycle
+# runs at most _SERVICE_START_MAX_ATTEMPTS times: a brief settle
+# delay after each bootstrap call gives the service manager time to
+# update its bookkeeping before the verify query, and a longer retry
+# delay between attempts absorbs the transient launchd-domain-not-yet-
+# released window that follows a bootout. Total worst-case wait is
+# (settle + retry) * (attempts - 1) + settle = 7 seconds at the
+# current values, which is generous enough to cover the failure
+# pattern observed in the originating incident while staying short
+# enough that an install run does not feel hung.
+_SERVICE_START_MAX_ATTEMPTS = 3
+_SERVICE_START_SETTLE_SECONDS = 1
+_SERVICE_START_RETRY_SECONDS = 2
+
+
+class ServiceStartError(Exception):
+    """Raised by `_start_service` when the post-condition verify
+    confirms the service is not actually registered/running after the
+    retry budget is exhausted.
+
+    The platform service managers do not always report start failures
+    reliably via exit code: launchctl bootstrap returns 5 ("Input/
+    output error") for several distinct conditions including
+    "actually succeeded" and "actually failed". The authoritative
+    check is the verify query (`launchctl print system/<label>` on
+    macOS, `systemctl is-active <unit>` on Linux). This exception
+    distinguishes "tried, verified, definitely failed" from any
+    other failure mode so the caller in `_cmd_apply` can decide
+    whether to swallow (apply already failed; don't mask the
+    original) or propagate (apply succeeded; the install has not
+    produced a working system).
+    """
+
+
 # Files and directories to copy from source to the install location.
 # Excludes __pycache__, .pyc, and other build artifacts.
 _SOURCE_EXCLUDES = {"__pycache__", "*.pyc", "*.egg-info", ".git", ".venv", ".env"}
@@ -2502,52 +2537,99 @@ def _stop_service(platform: str, dry_run: bool, **_kwargs: object) -> None:
 
 def _start_service(platform: str, dry_run: bool, **_kwargs: object) -> None:
     """
-    Start the Kai service after applying changes.
+    Start the Kai service after applying changes and verify it actually
+    registered.
 
-    Best-effort: uses check=False since launchctl/systemctl may report
-    warnings that aren't actually failures (e.g., service already running).
+    The platform start commands (`launchctl bootstrap` on macOS,
+    `systemctl start` on Linux) do not always report failures
+    reliably via exit code. launchctl bootstrap is the worst
+    offender: it returns exit code 5 ("Input/output error") for
+    several distinct conditions including "actually succeeded" and
+    "actually failed". The previous implementation trusted that
+    exit code, which let installs report a passing warning while
+    the daemon was actually unregistered, leaving the operator
+    with a silently broken bot.
 
-    On macOS, launchctl bootstrap can fail transiently after a bootout
-    if launchd hasn't fully released the service domain (common with
-    KeepAlive daemons). We retry once after a brief delay to handle this.
+    The bootstrap/start exit code is now treated as advisory; the
+    authoritative check is the post-condition verify query
+    (`launchctl print system/<label>` on macOS, `systemctl
+    is-active <unit>` on Linux). The cycle is retried up to
+    _SERVICE_START_MAX_ATTEMPTS times with a brief settle delay
+    after each start and a longer retry delay between attempts to
+    absorb transient launchd-domain-not-yet-released windows.
 
     Args:
         platform: "darwin" or "linux".
         dry_run: If True, print the command without executing.
+
+    Raises:
+        ServiceStartError: The verify query confirmed the service
+            is not registered after every attempt in the retry
+            budget. The caller in `_cmd_apply` decides whether to
+            propagate (apply succeeded; the install has not produced
+            a working system) or swallow (apply already failed; do
+            not mask the original exception).
     """
     if platform == "darwin":
         plist_path = Path("/Library/LaunchDaemons") / f"{_LAUNCHD_LABEL}.plist"
-        cmd = ["launchctl", "bootstrap", "system", str(plist_path)]
+        start_cmd = ["launchctl", "bootstrap", "system", str(plist_path)]
+        verify_cmd = ["launchctl", "print", f"system/{_LAUNCHD_LABEL}"]
     elif platform == "linux":
-        cmd = ["systemctl", "start", "kai"]
+        start_cmd = ["systemctl", "start", "kai"]
+        verify_cmd = ["systemctl", "is-active", "kai"]
     else:
         print(f"  Warning: cannot start service on platform '{platform}'")
         return
 
     if dry_run:
-        print(f"[DRY RUN] Would run: {' '.join(cmd)}")
+        print(f"[DRY RUN] Would run: {' '.join(start_cmd)}")
         return
 
-    result = subprocess.run(cmd, check=False, capture_output=True)
-    if result.returncode == 0:
-        print(f"  Started service ({' '.join(cmd[:2])})")
-        return
-
-    # On macOS, bootstrap can fail transiently after bootout.
-    # Wait briefly for launchd to finish tearing down, then retry.
-    if platform == "darwin":
-        stderr_msg = result.stderr.decode().strip()
-        print(f"  Bootstrap failed ({stderr_msg or 'unknown'}), retrying...")
-        time.sleep(2)
-        result = subprocess.run(cmd, check=False, capture_output=True)
-        if result.returncode == 0:
-            print(f"  Started service ({' '.join(cmd[:2])})")
+    last_start_stderr = ""
+    last_verify_stderr = ""
+    for attempt in range(1, _SERVICE_START_MAX_ATTEMPTS + 1):
+        # Exit code from the start command is advisory only. The
+        # authoritative check is the verify query below.
+        start = subprocess.run(start_cmd, check=False, capture_output=True)
+        # Brief settle window so the service manager finishes its
+        # internal bookkeeping before we query state.
+        time.sleep(_SERVICE_START_SETTLE_SECONDS)
+        verify = subprocess.run(verify_cmd, check=False, capture_output=True)
+        if verify.returncode == 0:
+            print(f"  Started service ({' '.join(start_cmd[:2])})")
             return
+        # Verify failed. Capture both stderrs for the retry hint and
+        # the eventual exhaustion error. Guard with `or b""` so a
+        # CompletedProcess with stderr=None (only reachable via test
+        # mocks; production capture_output=True always populates the
+        # field) does not raise AttributeError mid-error-handling.
+        last_start_stderr = (start.stderr or b"").decode().strip()
+        last_verify_stderr = (verify.stderr or b"").decode().strip()
+        if attempt < _SERVICE_START_MAX_ATTEMPTS:
+            # Hint at the cause when available; an empty start stderr
+            # under a verify-failure is itself diagnostic (the start
+            # command exited cleanly but the daemon still is not
+            # registered, which is exactly the launchctl bootstrap
+            # exit-code-5-but-actually-failed pattern).
+            hint = last_start_stderr or "start command exited cleanly but verify did not confirm registration"
+            print(
+                f"  Service not yet registered after attempt {attempt}/{_SERVICE_START_MAX_ATTEMPTS} "
+                f"({hint}); retrying in {_SERVICE_START_RETRY_SECONDS}s..."
+            )
+            time.sleep(_SERVICE_START_RETRY_SECONDS)
 
-    # Show the actual error so the user knows what went wrong
-    stderr_text = result.stderr.decode().strip()
-    hint = f": {stderr_text}" if stderr_text else ""
-    print(f"  Warning: service start failed ({' '.join(cmd[:2])}){hint}")
+    # Retry budget exhausted. Surface both the start stderr and the
+    # verify stderr so the operator sees the authoritative failure
+    # state rather than only the unreliable start exit code.
+    detail = (
+        f"verify command ({' '.join(verify_cmd)}) reported the service is not registered "
+        f"after {_SERVICE_START_MAX_ATTEMPTS} attempts"
+    )
+    if last_verify_stderr:
+        detail += f"; verify stderr: {last_verify_stderr}"
+    if last_start_stderr:
+        detail += f"; last start stderr: {last_start_stderr}"
+    raise ServiceStartError(detail)
 
 
 def _apply_migrate(
@@ -3376,7 +3458,15 @@ def _cmd_apply() -> None:
         # -- Step 9: Generate service definition --
         webhook_port = int(env.get("WEBHOOK_PORT", "8080"))
         _apply_service(install_dir, data_dir, service_user, platform, dry_run, webhook_port)
+        # Apply path completed without an exception. Setting the flag
+        # at the bottom of the try block (rather than relying on a
+        # missed except below) keeps the apply_succeeded state local
+        # and unambiguous: True iff every step above ran cleanly. The
+        # finally block reads it to decide how to handle a service
+        # start failure.
+        apply_succeeded = True
     except Exception:
+        apply_succeeded = False
         print("\nInstallation failed. See error above.")
         print("The installation may be in a partial state.")
         print("Fix the issue and re-run: sudo python -m kai install apply")
@@ -3385,17 +3475,42 @@ def _cmd_apply() -> None:
         # Always restart the service, even after failure. A partially updated
         # installation is better than an offline bot. Most steps are idempotent,
         # so re-running apply after fixing the cause will complete the update.
-        # Wrapped in its own try/except so a start failure does not mask the
-        # original exception (Python replaces the propagating exception if
-        # finally raises).
         try:
             _start_service(platform, dry_run)
-        except Exception:
-            print("WARNING: Failed to restart service after apply.")
+        except ServiceStartError as e:
+            # Verify confirmed the service is not registered after the
+            # retry budget. Two paths:
+            #
+            # - apply already failed: emit a recovery hint and SWALLOW
+            #   the start error. Python replaces the propagating
+            #   exception if the finally block raises, and the original
+            #   apply failure is the more important one to surface.
+            #
+            # - apply succeeded: re-raise. Without this propagation
+            #   the install would print "Installed" and exit 0 with
+            #   the daemon unregistered, which is the originating
+            #   silent-failure mode this rewrite closes.
+            print(f"ERROR: service failed to start after apply: {e}")
             if platform == "darwin":
-                print("Manually restart with: sudo launchctl kickstart system/com.syrinx.kai")
+                print("Manual recovery: sudo launchctl kickstart system/com.syrinx.kai")
+                print("Then verify: sudo launchctl print system/com.syrinx.kai")
             else:
-                print("Manually restart with: sudo systemctl start kai")
+                print("Manual recovery: sudo systemctl start kai")
+                print("Then verify: systemctl is-active kai")
+            if apply_succeeded:
+                raise
+        except Exception:
+            # Any other exception from _start_service is an unexpected
+            # bug, not the verified-failure path. Same masking rule:
+            # propagate only when apply succeeded, so a pre-existing
+            # apply failure is not hidden.
+            print("ERROR: unexpected failure while starting service.")
+            if platform == "darwin":
+                print("Manual recovery: sudo launchctl kickstart system/com.syrinx.kai")
+            else:
+                print("Manual recovery: sudo systemctl start kai")
+            if apply_succeeded:
+                raise
 
     # -- Summary --
     print()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -13,6 +13,7 @@ import yaml
 
 from kai.install import (
     _LAUNCHD_LABEL,
+    ServiceStartError,
     _apply_directories,
     _apply_goose_config,
     _apply_migrate,
@@ -2587,6 +2588,92 @@ class TestCmdApply:
         assert "[Service]" in unit
         assert "KAI_DATA_DIR=/var/lib/kai" in unit
 
+    def _minimal_install_conf(self, tmp_path):
+        """Write the smallest valid install.conf that lets _cmd_apply
+        reach its try/finally block; the rest of the apply path is
+        either short-circuited by dry-run or monkey-patched per test.
+        Returns the conf path."""
+        conf_path = tmp_path / "install.conf"
+        conf_path.write_text(
+            json.dumps(
+                {
+                    "install_dir": str(tmp_path / "opt" / "kai"),
+                    "data_dir": str(tmp_path / "var" / "lib" / "kai"),
+                    "service_user": "nobody",
+                    "platform": "darwin",
+                    "env": {"TELEGRAM_BOT_TOKEN": "tok"},
+                }
+            )
+        )
+        return conf_path
+
+    def test_apply_propagates_service_start_error_when_apply_succeeds(self, monkeypatch, tmp_path, capsys):
+        """The originating-issue propagation contract: when the apply
+        path completes cleanly but _start_service raises
+        ServiceStartError (verify exhausted), _cmd_apply re-raises so
+        the install exits non-zero rather than reporting success with
+        a dead daemon.
+
+        Uses DRY_RUN=1 so the apply helpers no-op cleanly, then
+        patches _start_service to simulate the verify-exhaustion
+        path that the dry-run branch would otherwise skip."""
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        monkeypatch.setenv("DRY_RUN", "1")
+
+        def fake_start(platform, dry_run, **kw):
+            raise ServiceStartError("simulated verify exhaustion")
+
+        monkeypatch.setattr("kai.install._start_service", fake_start)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", self._minimal_install_conf(tmp_path))
+
+        with pytest.raises(ServiceStartError):
+            _cmd_apply()
+
+        # Recovery hint should reach the operator regardless of
+        # propagation; pinning it here documents that the message
+        # is part of the contract, not a side effect.
+        out = capsys.readouterr().out
+        assert "Manual recovery" in out
+
+    def test_apply_swallows_service_start_error_when_apply_failed(self, monkeypatch, tmp_path, capsys):
+        """The mask-prevention contract: when an apply step has
+        already raised, a subsequent _start_service failure must NOT
+        replace the original exception. Python normally swaps the
+        propagating exception when a finally block raises; the
+        finally guard explicitly checks apply_succeeded and skips
+        the raise so the original failure is what the operator
+        sees.
+
+        Constructs an apply failure by patching _apply_secrets to
+        raise; that step runs deep enough in the try block that the
+        apply_succeeded flag has not been set yet."""
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        monkeypatch.setenv("DRY_RUN", "1")
+
+        class ApplyBlewUp(RuntimeError):
+            pass
+
+        def fake_apply_secrets(env, dry_run):
+            raise ApplyBlewUp("simulated apply step failure")
+
+        def fake_start(platform, dry_run, **kw):
+            raise ServiceStartError("would otherwise replace ApplyBlewUp")
+
+        monkeypatch.setattr("kai.install._apply_secrets", fake_apply_secrets)
+        monkeypatch.setattr("kai.install._start_service", fake_start)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", self._minimal_install_conf(tmp_path))
+
+        # The ORIGINAL apply exception propagates, not the
+        # ServiceStartError raised inside the finally.
+        with pytest.raises(ApplyBlewUp):
+            _cmd_apply()
+
+        # The recovery hint is still printed; the swallowing only
+        # affects the propagating exception type, not the operator's
+        # visibility into both failure modes.
+        out = capsys.readouterr().out
+        assert "Manual recovery" in out
+
 
 class TestCmdConfigDefaultModelDispatch:
     """
@@ -4591,8 +4678,10 @@ class TestStopService:
 
 
 class TestStartService:
-    def test_darwin(self, monkeypatch, tmp_path):
-        """Calls launchctl bootstrap on macOS with system domain."""
+    def test_darwin(self, monkeypatch):
+        """Calls launchctl bootstrap then launchctl print to verify on
+        macOS. Two calls per attempt because the bootstrap exit code is
+        treated as advisory; verify is the authoritative check."""
         calls: list[list[str]] = []
 
         def mock_run(cmd, **kwargs):
@@ -4600,16 +4689,18 @@ class TestStartService:
             return subprocess.CompletedProcess(args=cmd, returncode=0)
 
         monkeypatch.setattr("kai.install.subprocess.run", mock_run)
+        monkeypatch.setattr("kai.install.time.sleep", lambda _s: None)
 
         _start_service("darwin", svc_uid=501, service_user="kai", dry_run=False)
 
-        assert len(calls) == 1
-        assert calls[0][0] == "launchctl"
-        assert calls[0][1] == "bootstrap"
-        assert calls[0][2] == "system"
+        assert len(calls) == 2
+        assert calls[0][:3] == ["launchctl", "bootstrap", "system"]
+        assert calls[1] == ["launchctl", "print", "system/com.syrinx.kai"]
 
     def test_linux(self, monkeypatch):
-        """Calls systemctl start on Linux."""
+        """Calls systemctl start then systemctl is-active to verify on
+        Linux. Mirrors the macOS verify-after-start shape so an
+        operator does not see different success contracts per platform."""
         calls: list[list[str]] = []
 
         def mock_run(cmd, **kwargs):
@@ -4617,10 +4708,14 @@ class TestStartService:
             return subprocess.CompletedProcess(args=cmd, returncode=0)
 
         monkeypatch.setattr("kai.install.subprocess.run", mock_run)
+        monkeypatch.setattr("kai.install.time.sleep", lambda _s: None)
 
         _start_service("linux", svc_uid=1000, service_user="kai", dry_run=False)
 
-        assert calls == [["systemctl", "start", "kai"]]
+        assert calls == [
+            ["systemctl", "start", "kai"],
+            ["systemctl", "is-active", "kai"],
+        ]
 
     def test_dry_run(self, monkeypatch, capsys):
         """Dry run prints the command without executing."""
@@ -4635,6 +4730,106 @@ class TestStartService:
         output = capsys.readouterr().out
         assert "[DRY RUN]" in output
         assert len(calls) == 0
+
+    def test_succeeds_when_bootstrap_returns_nonzero_but_verify_passes(self, monkeypatch):
+        """The originating-issue pattern: launchctl bootstrap returns
+        exit code 5 ("Input/output error") but the daemon is actually
+        registered. The previous implementation trusted the bootstrap
+        exit code and reported failure; the new contract checks the
+        verify post-condition and returns success.
+
+        Pinning this prevents a regression that re-introduces the
+        `if start.returncode == 0: return` short-circuit."""
+
+        def mock_run(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "bootstrap"]:
+                return subprocess.CompletedProcess(
+                    args=cmd,
+                    returncode=5,
+                    stderr=b"Bootstrap failed: 5: Input/output error",
+                )
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+        monkeypatch.setattr("kai.install.subprocess.run", mock_run)
+        monkeypatch.setattr("kai.install.time.sleep", lambda _s: None)
+
+        # No exception means the verify was treated as authoritative.
+        _start_service("darwin", svc_uid=501, service_user="kai", dry_run=False)
+
+    def test_retries_then_succeeds_when_first_verify_fails(self, monkeypatch):
+        """Two settling attempts to absorb the transient launchd-
+        domain-not-yet-released window. The retry cycle should succeed
+        when an early verify fails but a later one confirms
+        registration; budget exhaustion is a separate test below."""
+        verify_calls = 0
+
+        def mock_run(cmd, **kwargs):
+            nonlocal verify_calls
+            if cmd[:2] == ["launchctl", "print"]:
+                verify_calls += 1
+                rc = 0 if verify_calls >= 2 else 1
+                return subprocess.CompletedProcess(args=cmd, returncode=rc)
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+        monkeypatch.setattr("kai.install.subprocess.run", mock_run)
+        monkeypatch.setattr("kai.install.time.sleep", lambda _s: None)
+
+        # Returns cleanly on the second attempt; no exception raised.
+        _start_service("darwin", svc_uid=501, service_user="kai", dry_run=False)
+        assert verify_calls == 2
+
+    def test_raises_service_start_error_when_verify_never_passes(self, monkeypatch):
+        """The verify-failure exhaustion path: every retry attempt
+        sees a passing-looking bootstrap and a failing verify. The
+        contract is that this raises ServiceStartError rather than
+        warning and returning, so the caller in _cmd_apply can
+        propagate the failure and the install does not exit 0 with
+        the daemon unregistered.
+
+        The error message names the verify command so the operator
+        sees the authoritative failure rather than the misleading
+        bootstrap exit code."""
+
+        def mock_run(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "print"]:
+                return subprocess.CompletedProcess(
+                    args=cmd,
+                    returncode=1,
+                    stderr=b'Could not find service "com.syrinx.kai" in domain for system',
+                )
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+        monkeypatch.setattr("kai.install.subprocess.run", mock_run)
+        monkeypatch.setattr("kai.install.time.sleep", lambda _s: None)
+
+        with pytest.raises(ServiceStartError) as excinfo:
+            _start_service("darwin", svc_uid=501, service_user="kai", dry_run=False)
+
+        msg = str(excinfo.value)
+        assert "launchctl print" in msg
+        assert "Could not find service" in msg
+
+    def test_raises_service_start_error_on_linux_when_is_active_fails(self, monkeypatch):
+        """Same exhaustion contract on Linux: a passing systemctl
+        start with a failing systemctl is-active still raises so the
+        platform contracts stay symmetric."""
+
+        def mock_run(cmd, **kwargs):
+            if cmd[:2] == ["systemctl", "is-active"]:
+                return subprocess.CompletedProcess(
+                    args=cmd,
+                    returncode=3,
+                    stdout=b"inactive\n",
+                )
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+        monkeypatch.setattr("kai.install.subprocess.run", mock_run)
+        monkeypatch.setattr("kai.install.time.sleep", lambda _s: None)
+
+        with pytest.raises(ServiceStartError) as excinfo:
+            _start_service("linux", svc_uid=1000, service_user="kai", dry_run=False)
+
+        assert "systemctl is-active" in str(excinfo.value)
 
 
 # ── CLI dispatch ─────────────────────────────────────────────────────

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2635,6 +2635,40 @@ class TestCmdApply:
         out = capsys.readouterr().out
         assert "Manual recovery" in out
 
+    def test_apply_swallows_service_start_error_when_apply_raised_systemexit(self, monkeypatch, tmp_path):
+        """SystemExit is a BaseException, not an Exception, so it
+        bypasses the apply try block's `except Exception` handler.
+        An earlier implementation only initialized apply_succeeded
+        inside the try body or the except clause; a SystemExit apply
+        failure (`_apply_venv` Python-version gate, missing Goose
+        template, visudo validation failure) left apply_succeeded
+        unbound, and the finally block then raised UnboundLocalError,
+        replacing the actionable apply failure with an internal
+        control-flow error.
+
+        Pre-initializing apply_succeeded = False before the try
+        block is the fix. This test patches an apply step to raise
+        SystemExit and asserts the SystemExit propagates intact, not
+        UnboundLocalError, even when _start_service also raises.
+        Regression for the same failure class the rest of the PR
+        is closing."""
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        monkeypatch.setenv("DRY_RUN", "1")
+
+        def fake_apply_secrets(env, dry_run):
+            raise SystemExit("simulated apply SystemExit (e.g. venv version gate)")
+
+        def fake_start(platform, dry_run, **kw):
+            raise ServiceStartError("would otherwise replace the SystemExit")
+
+        monkeypatch.setattr("kai.install._apply_secrets", fake_apply_secrets)
+        monkeypatch.setattr("kai.install._start_service", fake_start)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", self._minimal_install_conf(tmp_path))
+
+        with pytest.raises(SystemExit) as excinfo:
+            _cmd_apply()
+        assert "simulated apply SystemExit" in str(excinfo.value)
+
     def test_apply_swallows_service_start_error_when_apply_failed(self, monkeypatch, tmp_path, capsys):
         """The mask-prevention contract: when an apply step has
         already raised, a subsequent _start_service failure must NOT


### PR DESCRIPTION
Closes #359.

## Problem

`launchctl bootstrap` returns exit code 5 ("Input/output error") for several distinct conditions including "actually succeeded" and "actually failed". The previous `_start_service` trusted that exit code, with two distinct silent-failure modes:

1. **Bootstrap returns 5, daemon actually registered**: install printed `Warning: service start failed`, exited 0; the daemon was fine. False negative on the noise channel only.
2. **Bootstrap returns 5, daemon NOT registered**: install printed the same warning, exited 0; the bot was silently dead until traffic hit a closed port. **This is the originating bug.**

The operator-side experience was the worst of all worlds: the install reported a passing warning, `launchctl print system/com.syrinx.kai` returned `Could not find service`, and `make install` exited 0. Diagnosing it from scratch required several rounds of `launchctl print`, log inspection, and foreground `python -m kai` runs.

## Change

### Verify the post-condition, ignore the start exit code

`_start_service` now runs:

1. `launchctl bootstrap system <plist>` (exit code treated as advisory only).
2. Brief settle (1s) so the service manager finishes its bookkeeping.
3. `launchctl print system/com.syrinx.kai` to verify registration. Returncode 0 = the daemon is registered, regardless of what bootstrap claimed.
4. If verify confirms, declare success and return.
5. Otherwise retry the bootstrap+verify cycle up to 3 attempts with 2s waits between. Total worst-case wait: 7 seconds.
6. If all attempts fail, raise a new `ServiceStartError` with both the verify stderr and the most recent start stderr in the message.

Linux gets the same shape: `systemctl start kai` followed by `systemctl is-active kai`. systemd is more reliable about start exit codes than launchd, but symmetric verification keeps the contract identical and catches any unit-file issue that lets start succeed without bringing the service up.

### Propagate the failure when apply succeeded

`_cmd_apply` now tracks `apply_succeeded` explicitly. The finally block catches `ServiceStartError`:

- **`apply_succeeded=True`**: re-raise. The install exits non-zero with a clearly-labeled failure message and manual recovery hints. Closes the originating "exit 0 with daemon unregistered" bug.
- **`apply_succeeded=False`**: swallow. An apply step already raised; preserving that original exception is more important than the secondary start failure. Python normally replaces the propagating exception when a finally block raises; the explicit `if apply_succeeded: raise` is what keeps the original visible.

A recovery hint with the manual `launchctl kickstart` (or `systemctl start`) and verify commands prints on both paths regardless of swallowing.

## Tests

`TestStartService` adds four tests covering the new contract:

- `test_succeeds_when_bootstrap_returns_nonzero_but_verify_passes`: the originating pattern. Bootstrap returns 5, verify returns 0. Old code raised; new code returns cleanly.
- `test_retries_then_succeeds_when_first_verify_fails`: transient verify failure recovers on attempt 2.
- `test_raises_service_start_error_when_verify_never_passes`: budget exhaustion raises `ServiceStartError` with both stderrs in the message.
- `test_raises_service_start_error_on_linux_when_is_active_fails`: the Linux mirror raises when `systemctl is-active` never confirms.

Existing `test_darwin` and `test_linux` updated to assert the new bootstrap+verify call pattern (was 1 call; now 2 calls per attempt).

`TestCmdApply` adds two tests for the propagation contract:

- `test_apply_propagates_service_start_error_when_apply_succeeds`: the originating fix. Apply path completes cleanly (dry-run), `_start_service` mocked to raise; `_cmd_apply` propagates the error so the install exits non-zero.
- `test_apply_swallows_service_start_error_when_apply_failed`: mask-prevention. An apply step raises a custom `ApplyBlewUp`; `_start_service` then raises `ServiceStartError`; the original `ApplyBlewUp` propagates, not the `ServiceStartError`.

All 3448 tests pass; `make check` clean.

## Acceptance per #359

- [x] `sudo make install` either leaves the LaunchDaemon registered and running, or exits with a non-zero status and a clearly-labeled failure message. Never both "exit 0" and "service not actually running."
- [x] The verification check uses `launchctl print system/com.syrinx.kai`, not the bootstrap exit code.
- [x] Linux parity: `systemctl is-active kai` mirror added.
- [ ] Reproducibly testable on a Mac mini that exhibits the failure mode (operator validation; not gated by tests in this repo).

## Out of scope

- The bash wrapper's `sleep 86400` fall-through when its Python child cannot be located. The launchd plist `KeepAlive=true` would normally restart on wrapper exit; the wrapper currently sleeps instead. Separate KeepAlive contract issue; not this one. The recent #533 stderr/stdout capture work makes a crashed Python diagnosable post-hoc, but does not fix the wrapper loop.
- Changes to the plist format itself.

## Test plan

- [ ] Operator runs `sudo make install` on the affected Mac mini and confirms one of two outcomes: install reports success with `launchctl print system/com.syrinx.kai` showing `state = running`, OR install exits non-zero with the `ERROR: service failed to start` message and the manual recovery hints.
- [ ] Manual recovery: when the install fails non-zero, running `sudo launchctl kickstart system/com.syrinx.kai` followed by `sudo launchctl print system/com.syrinx.kai` should bring the service up and confirm registration.
