### PR TITLE
fix(claude): pop CLAUDE_AUTOCOMPACT_PCT_OVERRIDE when autocompact_pct=0

### DIFF
--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -289,8 +289,19 @@ class ClaudeCodeBackend(AgentBackend):
         # Set autocompact threshold so Claude compacts earlier, reducing
         # token usage. Passed as an env var (not a CLI flag) because
         # Claude Code reads it from its process environment.
+        #
+        # The else-branch pop is load-bearing: without it, a parent
+        # process that has CLAUDE_AUTOCOMPACT_PCT_OVERRIDE set (a
+        # profile dotfile, /etc/kai/env loaded via load_dotenv, a
+        # launchd plist EnvironmentVariables, or a manual export in
+        # the shell that started the daemon) leaks the var into the
+        # subprocess even when autocompact_pct=0. The contract is
+        # set-or-absent on this exact key, independent of what the
+        # parent env carried.
         if self.autocompact_pct > 0:
             env["CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"] = str(self.autocompact_pct)
+        else:
+            env.pop("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", None)
 
         # Per-os-user TMPDIR (cross-user mode only). The claude binary
         # writes its --settings JSON into `$TMPDIR/claude-settings-<hex>

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -392,8 +392,13 @@ class TestCommandConstruction:
             assert "--settings" not in cmd
 
     @pytest.mark.asyncio
-    async def test_autocompact_pct_in_env(self):
+    async def test_autocompact_pct_in_env(self, monkeypatch):
         """CLAUDE_AUTOCOMPACT_PCT_OVERRIDE is set in subprocess env when configured."""
+        # Defense against a parent shell that already exports the var
+        # at a different value; the assertion below pins the value to
+        # the config setting, so a leaked parent value would otherwise
+        # silently satisfy the `in env` half of the check.
+        monkeypatch.delenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", raising=False)
         claude = _make_claude(autocompact_pct=80)
 
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
@@ -408,8 +413,43 @@ class TestCommandConstruction:
             assert env["CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"] == "80"
 
     @pytest.mark.asyncio
-    async def test_no_autocompact_env_when_zero(self):
-        """CLAUDE_AUTOCOMPACT_PCT_OVERRIDE is not set when autocompact_pct is 0."""
+    async def test_no_autocompact_env_when_zero(self, monkeypatch):
+        """CLAUDE_AUTOCOMPACT_PCT_OVERRIDE is not set when autocompact_pct is 0.
+
+        Belt-and-suspenders: the monkeypatch.delenv ensures the test
+        passes regardless of the developer's parent env. The
+        production-side fix (the else-branch pop in _ensure_started)
+        is what makes the assertion hold under a parent that DOES
+        set the var; the dedicated parent-env-set test below
+        exercises that path directly."""
+        monkeypatch.delenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", raising=False)
+        claude = _make_claude(autocompact_pct=0)
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = AsyncMock()
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+            env = mock_exec.call_args[1]["env"]
+            assert "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE" not in env
+
+    @pytest.mark.asyncio
+    async def test_no_autocompact_env_when_zero_with_parent_env_set(self, monkeypatch):
+        """The originating-issue bug: parent process has
+        CLAUDE_AUTOCOMPACT_PCT_OVERRIDE set (a dotfile, /etc/kai/env
+        loaded via load_dotenv, a launchd plist EnvironmentVariables,
+        or a manual export). Without the symmetric pop in
+        _ensure_started, the var leaks through unconditionally even
+        when autocompact_pct=0; the operator's "disable" setting is
+        silently ignored.
+
+        Pins the contract: set-or-absent on this exact key,
+        independent of what the parent env carried. Regression for
+        the same failure class the rest of the PR is closing."""
+        monkeypatch.setenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "75")
         claude = _make_claude(autocompact_pct=0)
 
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:


### PR DESCRIPTION
Closes #394.

## Problem

`ClaudeCodeBackend._ensure_started` built the subprocess env with `env = os.environ.copy()` and then conditionally set `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` only when `autocompact_pct > 0`. No symmetric `else: env.pop(...)`. A parent process that already had the var set (a profile dotfile, `/etc/kai/env` loaded via `load_dotenv`, a launchd plist `EnvironmentVariables`, or a manual `export` in the shell that started the daemon) leaked the value into the subprocess unconditionally.

The user-visible effect: `autocompact_pct=0` (the operator's "disable" setting) was silently ignored, and the inner Claude compacted at the leaked threshold. No log entry exposed the divergence; the operator had to inspect the spawned subprocess's env to discover it.

## Change

Symmetric set-or-pop in `claude.py`:

```python
if self.autocompact_pct > 0:
    env["CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"] = str(self.autocompact_pct)
else:
    env.pop("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", None)
```

Inline comment names the four leak paths so a future refactor cannot strip the pop as "redundant defensive code".

## Tests

- **`test_no_autocompact_env_when_zero_with_parent_env_set`** (new): sets the var in the parent env via `monkeypatch.setenv`, then asserts the subprocess env does NOT carry it when `autocompact_pct=0`. Verified the test catches the bug by reverting the pop in a stash; the test failed as expected and passes with the fix.
- **`test_autocompact_pct_in_env` and `test_no_autocompact_env_when_zero`** (modified): both gained a defensive `monkeypatch.delenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", raising=False)` so they pass regardless of the developer's parent env. Belt-and-suspenders so a future regression surfaces under any local env, not just CI's pristine env.

All 3451 tests pass; `make check` clean.

## Audit per issue acceptance #3

Per the issue's "grep audit of other Config-to-env-var mappings in `claude.py`": two other sites mutate the subprocess env, neither matches the AUTOCOMPACT bug pattern.

- `env["KAI_WEBHOOK_SECRET"]` is guarded by `if self._api_context.webhook_secret:`. Production always has the secret set; the policy is "set when applicable, otherwise inherit parent" rather than "operator can disable by setting value to 0." Different shape; not the same bug.
- `env["TMPDIR"]` is guarded by `if effective_claude_user:` (cross-user mode only). Single-user mode falls through to the parent's TMPDIR. Same "set when applicable" policy as above. Different shape; not the same bug.

The AUTOCOMPACT case is uniquely a "0 means disable" setting where the parent env can leak past the disable. The other two use a different policy that does not have the same operator-surprise potential.

## Out of scope

- Changing the KAI_WEBHOOK_SECRET or TMPDIR inheritance policies. They use a deliberate "set when applicable, otherwise inherit" shape; correcting either would be a behavior change, not a bug fix.
- The `parse_env_file` workspace-config update at `claude.py`'s `env.update(parse_env_file(...))` site. Workspace env is operator-controlled by design.

## Test plan

- [ ] After merge, set `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=75` in the daemon's environment (e.g., add to `/etc/kai/env`), restart the daemon with `claude_autocompact_pct=0` in config, and verify the spawned subprocess does NOT carry the var (`ps eww <claude-pid>` or `cat /proc/<claude-pid>/environ`).
