### PR TITLE
feat(memory): split recall-log truncation; raise query cap to 256 chars

### DIFF
--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -476,14 +476,25 @@ def _estimate_tokens(text: str) -> int:
     return len(text) // 4
 
 
-# Maximum characters of query and per-hit snippet to embed in the
-# memory.recall log line. 80 is enough to fingerprint a hit for an
-# eval harness (which treats the snippet as an identifier, not as
-# full retrieved text) while keeping the log line within a single
-# terminal width and avoiding the ingestion of multi-paragraph user
-# messages verbatim. Single source of truth so query and snippet
-# stay in lockstep.
-_RECALL_TRUNC = 80
+# Maximum characters of the query field to embed in the memory.recall
+# log line. The full query reaches the semantic search; this cap
+# applies only to the log copy. 256 covers the common single-message
+# user turn so an eval harness can reproduce the search input from
+# logs alone without joining against chat-history JSONL by timestamp.
+# Queries longer than 256 chars still hit the fallback path (the eval
+# harness reads the full text from chat history); the cap exists to
+# bound multi-paragraph paste cases that would otherwise inflate
+# every recall log line.
+_RECALL_QUERY_TRUNC = 256
+
+# Maximum characters of each per-hit snippet in the memory.recall log
+# line. 80 is enough to fingerprint a hit for an eval harness, which
+# treats the snippet as an identifier rather than full retrieved
+# text. The snippet cap stays narrower than the query cap because a
+# single recall returns up to MEMORY_K hits; raising both together
+# would multiply the log-line length by the hit count for a use case
+# (full hit-text recovery) that the eval harness does not need.
+_RECALL_SNIPPET_TRUNC = 80
 
 
 def _truncate(s: str, n: int) -> str:
@@ -543,7 +554,7 @@ def _base_recall_payload(user_id: str, query: str) -> dict[str, object]:
     return {
         "user_id": user_id,
         "query_len": len(query),
-        "query": _truncate(query, _RECALL_TRUNC),
+        "query": _truncate(query, _RECALL_QUERY_TRUNC),
         "fetch_limit": 0,
         "hits_raw": 0,
         "hits_after_floor": 0,
@@ -973,7 +984,7 @@ async def format_context(
             "confidence": confidence,
             "score": round(r.score, 4),
             "adj": round(r.score * w, 4),
-            "snippet": _truncate(r.text, _RECALL_TRUNC),
+            "snippet": _truncate(r.text, _RECALL_SNIPPET_TRUNC),
         }
         for r, w, speaker, confidence in weighted
     ]

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1342,16 +1342,16 @@ class TestRecallLogging:
             )
 
     async def test_memory_recall_log_snippet_and_query_truncated_and_sanitized(self, caplog):
-        """Both the query field and per-hit snippets honor the 80-char
-        truncation cap and rewrite \\n and \\r into single spaces. The
-        eval harness treats snippets as fingerprints and parses log
-        lines as single-line JSON; either escape leaking through
-        breaks both contracts at once."""
+        """The query field honors the 256-char cap and per-hit snippets
+        honor the 80-char cap. Both rewrite \\n and \\r into single
+        spaces. The eval harness reproduces the search input from the
+        query field and treats snippets as fingerprints; either
+        escape leaking through breaks the single-line JSON contract."""
         import kai.memory as mem_mod
         from kai.memory import format_context
 
         # Long memory text that contains both \n and \r. The text is
-        # well over 80 chars so truncation is exercised.
+        # well over 80 chars so snippet truncation is exercised.
         long_text = "Line one of stored memory\nLine two with newline\rAnd a CR plus more padding text " * 5
         mock_mem = MagicMock()
         mock_mem.search.return_value = {
@@ -1368,26 +1368,84 @@ class TestRecallLogging:
         mem_mod._memory = mock_mem
         mem_mod._config = _make_config(memory_token_budget=2000)
 
-        # Query also contains both escapes and exceeds 80 chars so the
-        # query-field path is exercised on the same call.
-        long_query = "what do I prefer for editing\nplus a newline\rand carriage return then a long tail" * 3
+        # Query also contains both escapes and exceeds 256 chars so
+        # the query-field truncation path is exercised on the same
+        # call.
+        long_query = "what do I prefer for editing\nplus a newline\rand carriage return then a long tail" * 6
 
         with caplog.at_level(logging.INFO, logger="kai.memory"):
             await format_context(long_query, user_id="7")
 
         payload = _parse_recall_log(caplog)
 
-        # Query field must be capped and free of newlines / CRs.
-        assert len(payload["query"]) <= 80
+        # Query field must be capped at 256 (the wider cap that
+        # supports eval-harness reproducibility) and free of escapes.
+        assert len(payload["query"]) <= 256
         assert "\n" not in payload["query"]
         assert "\r" not in payload["query"]
 
-        # Every snippet must be capped and free of newlines / CRs.
+        # Every snippet must be capped at 80 (the narrower
+        # fingerprint cap) and free of escapes.
         assert payload["hits"], "expected at least one hit"
         for hit in payload["hits"]:
             assert len(hit["snippet"]) <= 80
             assert "\n" not in hit["snippet"]
             assert "\r" not in hit["snippet"]
+
+    @pytest.mark.asyncio
+    async def test_memory_recall_log_preserves_medium_query_for_eval_harness(self, caplog):
+        """The originating-issue use case: an eval harness reads the
+        recall log to reproduce the search input. A typical user
+        message in the 80-256 char range used to truncate to 80,
+        forcing the harness to join against chat-history JSONL by
+        timestamp. With the query cap raised to 256, the harness
+        can reproduce the input directly from the log.
+
+        Pins the contract: a ~170-char query lands in the log at
+        full length (well below 256, well above the old 80 cap).
+        Regression for the same observability gap the issue is
+        closing."""
+        import kai.memory as mem_mod
+        from kai.memory import format_context
+
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {
+            "results": [
+                {
+                    "id": "fact-1",
+                    "memory": "stored fact",
+                    "score": 0.9,
+                    "metadata": {"type": "fact", "source": "extracted"},
+                    "created_at": "2026-04-01T00:00:00",
+                }
+            ]
+        }
+        mem_mod._memory = mock_mem
+        mem_mod._config = _make_config(memory_token_budget=2000)
+
+        # 200-char query: representative of a typical user turn that
+        # describes context plus a request. Above the old 80 cap so
+        # the previous behavior would have lost the bulk of it;
+        # below the new 256 cap so the full text survives.
+        query = (
+            "what do I prefer for editing when working on long-form prose "
+            "as opposed to code, particularly around line wrapping and "
+            "whether to break at semantic units or fixed widths"
+        )
+        assert 80 < len(query) <= 256, "test fixture must sit in the gap the new cap covers"
+
+        with caplog.at_level(logging.INFO, logger="kai.memory"):
+            await format_context(query, user_id="7")
+
+        payload = _parse_recall_log(caplog)
+
+        # Full query reaches the log; an eval harness can reproduce
+        # the search input without joining against chat-history.
+        assert payload["query"] == query
+        # query_len carries the actual length regardless; sanity
+        # check that the two stay in agreement on a query that
+        # fits under the cap.
+        assert payload["query_len"] == len(query)
 
 
 class TestGetAll:


### PR DESCRIPTION
Closes #395.

## Problem

The `memory.recall` structured log carried both `query` and per-hit `snippet` fields truncated at 80 chars through a shared `_RECALL_TRUNC` constant. The snippet cap is right (the eval harness treats snippets as fingerprints), but the query cap was too narrow to let the same harness reproduce the search input. An investigator who saw an unexpected retrieval had to join against chat-history JSONL by timestamp to recover the full query.

The actual semantic search was always passed the full query; this is a log-cosmetic change with observability impact.

## Change

Split `_RECALL_TRUNC` into two constants per the issue's acceptance #3 (the per-hit snippet truncation is reviewed during the change so the two consumers do not silently diverge):

```python
_RECALL_QUERY_TRUNC = 256    # was 80; covers common user turns for eval replay
_RECALL_SNIPPET_TRUNC = 80   # unchanged; snippets are fingerprints
```

Rationale captured inline next to each constant. The two emit sites (`_base_recall_payload` for `query`, the hits comprehension in `format_context` for `snippet`) now use the right constant.

The wider cap stays narrower than full text deliberately. Multi-paragraph paste cases that exceed 256 still fall back to chat-history JSONL, but that fallback becomes the edge case rather than the common case.

## Why this shape and not the alternatives

The issue proposed two options: (1) raise the shared constant to 256, or (2) add a separate `query_full` field for parsers while keeping `query` at 80 for humans.

The split-constant approach picks the upside of both:
- Option 1's effect on `query` reproducibility, without the multiplied log-line length on snippets.
- Option 2's clean separation between human-readable and machine-readable surfaces, without doubling the query payload (the eval harness reads one `query` field, not two).

Snippets stay at 80 because a single recall returns up to MEMORY_K hits; raising both to 256 would inflate log-line length by the hit count for a use case (full hit-text recovery) the eval harness does not need.

## Tests

- `test_memory_recall_log_snippet_and_query_truncated_and_sanitized`: updated to assert the split caps (256 / 80) rather than the merged 80.
- `test_memory_recall_log_preserves_medium_query_for_eval_harness` (new): exercises a 169-char query (in the gap between the old and new caps) and asserts the full text reaches the log. Verified the test catches the bug by reverting the constant split in a stash; failed as expected.

All 3452 tests pass; `make check` clean.

## Out of scope

- Adding a `query_full` field alongside `query`. The single-field-with-wider-cap shape is sufficient for the eval harness use case and avoids the doubled payload.
- Raising the snippet cap. Per the rationale above, this would inflate log line length without serving a documented use case.
- The `query_len` field already on the payload remains the source of truth for the actual unflattened query length, regardless of how much the `query` field carries.

## Test plan

- [ ] After merge, send a 100-200 char user message to the bot, grep `kai.log` for the `memory.recall` line, and confirm the `query` field carries the full message text (not the 80-char prefix).
- [ ] Confirm the per-hit snippets remain at 80 chars (no regression that broadened that cap by accident).
