### PR TITLE
fix(backend): skip home-dir provisioning for notification-only chat IDs

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -721,6 +721,41 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
     return path
 
 
+def _is_notification_only_chat_id(chat_id: int | None, config: Config) -> bool:
+    """
+    True iff this chat_id has no interactive user entry in users.yaml.
+
+    A chat_id is "notification-only" when it appears in the running
+    system (a github_notify_chat_id field on another user's config, or
+    an /api/send-message target, or any chat that received a
+    notification and is therefore in allowed_user_ids) but is NOT the
+    primary telegram_id key of any user entry. Examples: a GitHub
+    notification group chat, a deploy-status broadcast channel, a
+    review-summary destination room.
+
+    Returns False (treat as interactive) for:
+    - chat_id is None: test / health-check / anon paths; preserved by
+      the existing ensure_user_home(None, ...) -> data_dir/home/anon
+      contract.
+    - config.user_configs is empty or None: legacy single-user mode
+      with no users.yaml. There is no basis for discriminating;
+      every chat_id is interactive by default. Same permissive
+      behavior the codebase had before the multi-user split.
+
+    Returns True (skip auto-provisioning) when users.yaml is in use
+    AND this chat_id is not a key in user_configs. The contract on
+    True: the caller must NOT create a per-user directory for this
+    chat_id. The chat_id remains valid for outbound notification
+    sending (it lives in allowed_user_ids); only the home-workspace
+    provisioning is suppressed.
+    """
+    if chat_id is None:
+        return False
+    if not config.user_configs:
+        return False
+    return chat_id not in config.user_configs
+
+
 def resolve_home_workspace(
     chat_id: int | None,
     config: Config,
@@ -732,7 +767,12 @@ def resolve_home_workspace(
     Resolution order:
     1. `user.home_workspace` from users.yaml when set (admin override,
        returned as-is with no second-guessing).
-    2. `<data_dir>/home/<chat_id>/`, auto-created via ensure_user_home().
+    2. `<data_dir>/home/<chat_id>/`, auto-created via ensure_user_home()
+       for interactive users. For notification-only chat_ids (a chat
+       that received a routed notification but has no users.yaml
+       entry of its own) the path is returned without bootstrapping,
+       so the bot does not silently provision an empty home directory
+       for a chat that will never have an interactive session.
 
     All call sites (pool.py session init / get_workspace fallback,
     bot.py `/workspace home` handler and workspace listings) MUST go
@@ -765,13 +805,28 @@ def resolve_home_workspace(
     if user and user.home_workspace:
         return user.home_workspace
 
-    # No users.yaml override: use the per-user Kai-managed directory
-    # under data_dir. Resolve DATA_DIR from the module here (not as a
-    # default arg value) so monkeypatching `kai.backend.DATA_DIR` in
-    # tests still flows through. ensure_user_home is idempotent so
-    # calling it on every resolution is cheap.
     if data_dir is None:
         data_dir = DATA_DIR
+
+    # Notification-only chat_ids must not auto-provision a home
+    # directory. The chat_id is real enough to receive outbound
+    # notifications (it was added to allowed_user_ids at config-load
+    # time), but it has no interactive user entry in users.yaml. The
+    # previous unconditional ensure_user_home call mkdir'd an empty
+    # `home/<chat_id>/` on first contact - either a stray inbound
+    # message from the notification chat (a human in the GitHub
+    # notification group typing in the room) or a code path that
+    # resolves the workspace eagerly. The empty directory then
+    # lingered indefinitely, requiring manual cleanup. Returning
+    # the path without bootstrapping leaves the downstream caller
+    # to fail naturally on a missing directory, which is the right
+    # behavior for a chat_id without an interactive session.
+    if _is_notification_only_chat_id(chat_id, config):
+        return data_dir / "home" / str(chat_id)
+
+    # Interactive user: use the per-user Kai-managed directory under
+    # data_dir. ensure_user_home is idempotent so calling it on every
+    # resolution is cheap.
     return ensure_user_home(chat_id, data_dir)
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -941,6 +941,51 @@ class TestResolveHomeWorkspace:
         assert result == tmp_path / "home" / "anon"
         assert result.is_dir()
 
+    def test_notification_only_chat_id_does_not_create_directory(self, tmp_path):
+        """
+        The originating-issue bug: a chat_id that has no users.yaml
+        entry (a GitHub notification group chat, a deploy broadcast
+        room) used to trigger ensure_user_home and silently mkdir
+        an empty `home/<chat_id>/` directory on first contact. The
+        directory then lingered indefinitely.
+
+        With the notification-only check, the path is returned
+        verbatim but the directory is NOT created. Downstream
+        callers that try to use the path will fail naturally,
+        which is the right behavior for a chat_id without an
+        interactive session.
+
+        Pinning both halves of the contract: path computed
+        deterministically AND directory absence.
+        """
+        config = self._config(
+            user_configs={42: UserConfig(telegram_id=42, name="real-user")},
+        )
+        notify_chat = -5241088228
+
+        result = resolve_home_workspace(notify_chat, config, data_dir=tmp_path)
+
+        assert result == tmp_path / "home" / str(notify_chat)
+        assert not result.exists(), "notification-only chat_id must not auto-provision a home directory"
+
+    def test_single_user_mode_preserves_legacy_provisioning(self, tmp_path):
+        """
+        When users.yaml is empty or absent (config.user_configs is
+        falsy), there is no basis for discriminating interactive vs
+        notification chat_ids. Every chat_id is treated as
+        interactive and the directory is provisioned as before.
+
+        Pinning this case prevents an over-eager future tightening
+        of the notification check from breaking single-user dev /
+        test installations that have always used the legacy
+        permissive behavior.
+        """
+        config = self._config()  # user_configs=None
+        result = resolve_home_workspace(99999, config, data_dir=tmp_path)
+
+        assert result == tmp_path / "home" / "99999"
+        assert result.is_dir(), "single-user mode must continue to auto-provision the home dir"
+
 
 # ── Test prepend_to_prompt ──────────────────────────────────────────
 


### PR DESCRIPTION
Closes #440.

## Problem

`resolve_home_workspace` unconditionally called `ensure_user_home` on its fallback path, which mkdir'd `<data_dir>/home/<chat_id>/` regardless of whether the chat_id corresponded to an interactive user. A chat that received outbound notifications (a `github_notify_chat_id` target, a deploy broadcast room, any chat in `allowed_user_ids` purely for outbound traffic) silently got an empty home directory provisioned on first contact and the directory lingered indefinitely.

The originating issue named `/var/lib/kai/home/-5241088228/` as the example case: a GitHub notification group chat that was never an interactive user.

## Change

Added a small helper `_is_notification_only_chat_id` that classifies a chat_id against `config.user_configs`:

- `chat_id is None`: returns False. Preserves the existing admin-less startup contract (`anon` path under `ensure_user_home`).
- `config.user_configs` is empty or None: returns False. Legacy single-user mode has no basis for discrimination; every chat_id is interactive.
- `users.yaml` is in use AND `chat_id not in config.user_configs`: returns True. The chat is real enough to be in `allowed_user_ids` (so outbound notifications work) but has no interactive entry; suppress provisioning.

`resolve_home_workspace` consults the helper between the `users.yaml`-override branch and the `ensure_user_home` call. For notification-only chat_ids it returns the computed path without mkdir'ing; downstream callers that try to use the path will fail naturally, which is the right behavior for a chat without an interactive session.

## Why not a migration

The issue's acceptance allows "either cleaned up by a migration or flagged for manual removal." Migration was considered and deferred: walking `<data_dir>/home/` and deleting subdirs whose chat_id is not in `users.yaml` is a small change but couples the fix to data deletion, which raises the review burden without a proportional safety benefit. Operators with existing spurious directories (the originating example: `home/-5241088228/`) can `rm -rf` them manually after this deploy.

## Tests

- **`test_notification_only_chat_id_does_not_create_directory`** (new): the originating-bug regression. Builds a config with one interactive user (`telegram_id=42`) and resolves a notify chat (`-5241088228`). Asserts the path is returned but the directory is NOT created. Verified the test catches the bug by reverting the gate in a stash.
- **`test_single_user_mode_preserves_legacy_provisioning`** (new): pins the empty-`user_configs` case so an over-eager future tightening does not break dev / test installations.
- Existing `test_prefers_users_yaml`, `test_falls_back_to_data_dir`, `test_anon_when_chat_id_none` all still pass; the gate sits between users.yaml-override and the lazy bootstrap, so the three pre-existing paths are unaffected.

All 3454 tests pass; `make check` clean.

## Out of scope

- Cleanup migration for existing spurious directories (deferred to manual removal per issue acceptance).
- Whether the bot should accept inbound messages from notification-only chat_ids at all. This PR only changes the home-provisioning behavior; the `allowed_user_ids` set still admits inbound traffic from notify chats and the bot's existing handlers still respond to them. Suppressing inbound interactivity for notify-only chats would be a separate behavior change.
- Audit of other call sites that take a chat_id and create per-user state. `ensure_user_memory` and `ensure_user_preferences` could have the same shape; not addressed here because the issue scope is specifically the home directory and broadening would couple the review.

## Test plan

- [ ] After merge + deploy: confirm the existing spurious `home/-5241088228/` directory remains (the fix does not clean up existing dirs) and can be `rm -rf`'d safely.
- [ ] Trigger an outbound notification to a notify-only chat (e.g., a PR review summary). Confirm no new `home/<notify-chat-id>/` directory is created.
- [ ] Confirm interactive users continue to get their home directory provisioned on first message (the bug fix should not regress the normal path).
