### PR TITLE
feat(memory): add scope metadata helpers with legacy-safe reads

### DIFF
--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -390,12 +390,16 @@ class ResolvedMemoryScope:
 
     Returned by `resolve_memory_scope()`. The flags
     `legacy_defaulted` and `invalid_defaulted` are mutually
-    exclusive by construction (only one of the three resolver
-    branches sets each); both False means the stored `scope` field
-    was present and valid.
+    exclusive by construction; both False means the stored `scope`
+    field was present and valid AND the stored `scope_source` was a
+    recognized write-path value.
 
     Attributes:
-        scope: One of "global", "project", or "task".
+        scope: One of "global", "project", or "task". Preserved from
+            the stored row when the scope value is recognized; forced
+            to "global" only when the row predates scope metadata
+            (legacy_defaulted) or carries a scope value outside the
+            valid set (invalid_defaulted).
         project_id: Project identifier for project-scoped rows;
             None for global rows or for project rows missing an id
             (the resolver does not guess).
@@ -408,9 +412,10 @@ class ResolvedMemoryScope:
             SCOPE_SOURCE_* constants.
         legacy_defaulted: True if the row had no `scope` field and
             was defaulted to global by the resolver.
-        invalid_defaulted: True if the row had a `scope` field with
-            an unknown value and was defaulted to global by the
-            resolver.
+        invalid_defaulted: True if the row was malformed - either a
+            `scope` field with an unknown value (collapsed to global)
+            or a valid `scope` with a missing or unrecognized
+            `scope_source` (scope preserved, provenance flagged).
     """
 
     scope: str
@@ -583,13 +588,24 @@ def resolve_memory_scope(metadata: dict[str, Any] | None) -> ResolvedMemoryScope
        default to global with `scope_source="invalid_default"` and
        `scope_confidence=0.0`. Distinct from legacy so audit queries
        can tell the two populations apart.
-    3. Valid row (`scope` key present and recognized): return the
+    3. Valid scope with valid provenance (`scope` key present and
+       recognized, `scope_source` in the write-path set): return the
        stored values. Global rows have their `project_id` and
        `workspace_root` normalized to None even if a bad row carries
        stray values. Project rows missing `project_id` keep their
        project scope with a None id; later retrieval filtering is
        responsible for excluding them when project matching is
        required.
+    4. Valid scope with missing or unrecognized `scope_source`:
+       preserve the stored scope, project_id, workspace_root, and
+       scope_confidence (operator intent is meaningful), but tag the
+       row `scope_source="invalid_default"` and
+       `invalid_defaulted=True`. `legacy_default` is reserved for
+       rows with no `scope` key at all; a row that carries scope but
+       no provenance was either written by a code path that bypassed
+       `build_scope_metadata` or written before scope_source was
+       required, so the audit boundary lumps it in with corrupted
+       rows rather than genuine legacy rows.
 
     Args:
         metadata: The memory row's full metadata dict (typically
@@ -627,16 +643,12 @@ def resolve_memory_scope(metadata: dict[str, Any] | None) -> ResolvedMemoryScope
             invalid_defaulted=True,
         )
 
-    # Branch 3: valid stored scope. Pull the optional fields with
+    # Branch 3 / 4: valid stored scope. Pull the optional fields with
     # safe defaults so callers do not have to repeat .get() chains.
-    # Defaulting `scope_source` to legacy_default here covers the
-    # case where a row was hand-written with `scope` but no
-    # provenance; future write paths always go through
-    # `build_scope_metadata` and will set an explicit source.
     project_id = md.get("project_id")
     workspace_root = md.get("workspace_root")
     scope_confidence = md.get("scope_confidence", 1.0)
-    scope_source = md.get("scope_source", SCOPE_SOURCE_LEGACY_DEFAULT)
+    raw_scope_source = md.get("scope_source")
 
     # Global rows should never carry project_id or workspace_root.
     # Normalize so downstream callers can rely on the invariant
@@ -645,12 +657,34 @@ def resolve_memory_scope(metadata: dict[str, Any] | None) -> ResolvedMemoryScope
         project_id = None
         workspace_root = None
 
+    # Branch 4: valid scope but missing or unrecognized provenance.
+    # `legacy_default` is reserved for rows with no `scope` key at
+    # all (branch 1); a row that carries scope but no provenance is
+    # malformed, not legacy. Preserve the stored scope so operator
+    # intent is not lost, but flag invalid_defaulted=True so audit
+    # queries can find the row. The accepted provenance set is the
+    # builder's write-path set: the two resolver-only values
+    # (legacy_default, invalid_default) appearing in stored metadata
+    # indicate a write path bypassed `build_scope_metadata` and are
+    # treated as malformed.
+    if raw_scope_source not in _BUILDER_SCOPE_SOURCES:
+        return ResolvedMemoryScope(
+            scope=raw_scope,
+            project_id=project_id,
+            workspace_root=workspace_root,
+            scope_confidence=scope_confidence,
+            scope_source=SCOPE_SOURCE_INVALID_DEFAULT,
+            legacy_defaulted=False,
+            invalid_defaulted=True,
+        )
+
+    # Branch 3: valid scope with recognized provenance.
     return ResolvedMemoryScope(
         scope=raw_scope,
         project_id=project_id,
         workspace_root=workspace_root,
         scope_confidence=scope_confidence,
-        scope_source=scope_source,
+        scope_source=raw_scope_source,
         legacy_defaulted=False,
         invalid_defaulted=False,
     )

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -324,6 +324,104 @@ _DELETE_PAGE_SIZE = 10_000
 USER_VISIBLE_SOURCES: frozenset[str] = frozenset({"extracted", "episode", "migration"})
 
 
+# ── Scope metadata: schema for scoped global/project memory ──────────
+#
+# Adds scope fields (`scope`, `project_id`, `workspace_root`,
+# `scope_confidence`, `scope_source`) to memory metadata without
+# changing retrieval behavior. The keys live inside the existing
+# Mem0 metadata dict and are not promoted to MemoryResult fields,
+# because retrieval, prompt rendering, and write routing all still
+# operate on the legacy unscoped shape until later issues land
+# filter-before-rank, separate prompt sections, and write-scope
+# classification.
+#
+# Two read-time helpers (`ResolvedMemoryScope` and
+# `resolve_memory_scope()`, defined after _wrap_result below) give
+# downstream callers one place to interpret these fields safely for
+# rows that may or may not have them. `_wrap_result()` deliberately
+# does not call the resolver: read-time defaults are compatibility
+# behavior, not a migration, and mutating the visible metadata dict
+# would make legacy rows look deliberately classified when they
+# were not.
+#
+# `source` and `scope_source` are different provenance axes. `source`
+# describes where the memory content came from ("extracted",
+# "episode", "migration"). `scope_source` describes how the scope
+# assignment was chosen ("legacy_default", "invalid_default",
+# "classifier", "operator", "extraction_default"). Do not overload
+# `source` to infer scope; migration rows can be global or project
+# in the future, and so can extracted rows.
+
+SCOPE_GLOBAL = "global"
+SCOPE_PROJECT = "project"
+SCOPE_TASK = "task"
+
+# Frozenset of valid scope values used by the resolver and builder.
+# A row whose stored `scope` is outside this set is treated as
+# invalid-defaulted (not legacy-defaulted) so the audit boundary
+# between "row predates scope" and "row has corrupted scope" stays
+# visible to later reclassification passes.
+_VALID_SCOPES: frozenset[str] = frozenset({SCOPE_GLOBAL, SCOPE_PROJECT, SCOPE_TASK})
+
+# `legacy_default` and `invalid_default` are read-time resolver
+# outputs only; `build_scope_metadata` rejects them so no write path
+# can mint a legacy-shaped or invalid-shaped row.
+SCOPE_SOURCE_LEGACY_DEFAULT = "legacy_default"
+SCOPE_SOURCE_INVALID_DEFAULT = "invalid_default"
+SCOPE_SOURCE_CLASSIFIER = "classifier"
+SCOPE_SOURCE_OPERATOR = "operator"
+SCOPE_SOURCE_EXTRACTION_DEFAULT = "extraction_default"
+
+# Only write-path scope_source values are accepted by
+# `build_scope_metadata`. The two resolver-only values are excluded.
+_BUILDER_SCOPE_SOURCES: frozenset[str] = frozenset(
+    {
+        SCOPE_SOURCE_CLASSIFIER,
+        SCOPE_SOURCE_OPERATOR,
+        SCOPE_SOURCE_EXTRACTION_DEFAULT,
+    }
+)
+
+
+@dataclass(frozen=True)
+class ResolvedMemoryScope:
+    """
+    Read-time interpretation of a memory row's scope metadata.
+
+    Returned by `resolve_memory_scope()`. The flags
+    `legacy_defaulted` and `invalid_defaulted` are mutually
+    exclusive by construction (only one of the three resolver
+    branches sets each); both False means the stored `scope` field
+    was present and valid.
+
+    Attributes:
+        scope: One of "global", "project", or "task".
+        project_id: Project identifier for project-scoped rows;
+            None for global rows or for project rows missing an id
+            (the resolver does not guess).
+        workspace_root: Absolute workspace path associated with the
+            scope when known; None for global rows.
+        scope_confidence: Stored confidence for valid rows; 1.0 for
+            legacy-default (pre-scope deliberate write), 0.0 for
+            invalid-default (corrupted scope value).
+        scope_source: How the scope assignment was chosen. See
+            SCOPE_SOURCE_* constants.
+        legacy_defaulted: True if the row had no `scope` field and
+            was defaulted to global by the resolver.
+        invalid_defaulted: True if the row had a `scope` field with
+            an unknown value and was defaulted to global by the
+            resolver.
+    """
+
+    scope: str
+    project_id: str | None
+    workspace_root: str | None
+    scope_confidence: float
+    scope_source: str
+    legacy_defaulted: bool
+    invalid_defaulted: bool
+
+
 @dataclass(frozen=True)
 class MemoryResult:
     """A single memory from search or retrieval."""
@@ -469,6 +567,174 @@ def _wrap_result(raw: dict) -> MemoryResult:
         created_at=raw.get("created_at", ""),
         updated_at=raw.get("updated_at", ""),
     )
+
+
+def resolve_memory_scope(metadata: dict[str, Any] | None) -> ResolvedMemoryScope:
+    """
+    Interpret scope metadata for a memory row, with legacy-safe defaults.
+
+    Three resolution branches:
+    1. Legacy row (no `scope` key): default to global with
+       `scope_source="legacy_default"` and `scope_confidence=1.0`.
+       The high confidence reflects that the row was a deliberate
+       pre-scope write; the audit boundary for later reclassification
+       is the `scope_source` value, not the confidence.
+    2. Corrupted row (`scope` key present but not in `_VALID_SCOPES`):
+       default to global with `scope_source="invalid_default"` and
+       `scope_confidence=0.0`. Distinct from legacy so audit queries
+       can tell the two populations apart.
+    3. Valid row (`scope` key present and recognized): return the
+       stored values. Global rows have their `project_id` and
+       `workspace_root` normalized to None even if a bad row carries
+       stray values. Project rows missing `project_id` keep their
+       project scope with a None id; later retrieval filtering is
+       responsible for excluding them when project matching is
+       required.
+
+    Args:
+        metadata: The memory row's full metadata dict (typically
+            `MemoryResult.metadata`), or None for callers that may
+            pass a missing dict.
+
+    Returns:
+        A frozen `ResolvedMemoryScope`. The underlying metadata dict
+        is not mutated.
+    """
+    md = metadata or {}
+    raw_scope = md.get("scope")
+
+    # Branch 1: legacy row with no scope field.
+    if raw_scope is None:
+        return ResolvedMemoryScope(
+            scope=SCOPE_GLOBAL,
+            project_id=None,
+            workspace_root=None,
+            scope_confidence=1.0,
+            scope_source=SCOPE_SOURCE_LEGACY_DEFAULT,
+            legacy_defaulted=True,
+            invalid_defaulted=False,
+        )
+
+    # Branch 2: scope field present but unknown value.
+    if raw_scope not in _VALID_SCOPES:
+        return ResolvedMemoryScope(
+            scope=SCOPE_GLOBAL,
+            project_id=None,
+            workspace_root=None,
+            scope_confidence=0.0,
+            scope_source=SCOPE_SOURCE_INVALID_DEFAULT,
+            legacy_defaulted=False,
+            invalid_defaulted=True,
+        )
+
+    # Branch 3: valid stored scope. Pull the optional fields with
+    # safe defaults so callers do not have to repeat .get() chains.
+    # Defaulting `scope_source` to legacy_default here covers the
+    # case where a row was hand-written with `scope` but no
+    # provenance; future write paths always go through
+    # `build_scope_metadata` and will set an explicit source.
+    project_id = md.get("project_id")
+    workspace_root = md.get("workspace_root")
+    scope_confidence = md.get("scope_confidence", 1.0)
+    scope_source = md.get("scope_source", SCOPE_SOURCE_LEGACY_DEFAULT)
+
+    # Global rows should never carry project_id or workspace_root.
+    # Normalize so downstream callers can rely on the invariant
+    # without re-checking the scope value.
+    if raw_scope == SCOPE_GLOBAL:
+        project_id = None
+        workspace_root = None
+
+    return ResolvedMemoryScope(
+        scope=raw_scope,
+        project_id=project_id,
+        workspace_root=workspace_root,
+        scope_confidence=scope_confidence,
+        scope_source=scope_source,
+        legacy_defaulted=False,
+        invalid_defaulted=False,
+    )
+
+
+def build_scope_metadata(
+    *,
+    scope: str,
+    project_id: str | None = None,
+    workspace_root: str | None = None,
+    scope_confidence: float = 1.0,
+    scope_source: str,
+) -> dict[str, Any]:
+    """
+    Build a scope-metadata dict for a new memory write.
+
+    Centralizes scope-field assembly so extraction, operator tools,
+    and future classifier code cannot diverge on field names or
+    silently ship invalid values. Returns a plain dict that the
+    caller merges with other metadata before passing to
+    `add_structured()` or `update_metadata()`.
+
+    Validation rules (all raise `ValueError` on violation):
+    - `scope` must be one of `global`, `project`, or `task`.
+    - `scope_source` must be one of `operator`, `classifier`, or
+      `extraction_default`. The resolver-only values
+      `legacy_default` and `invalid_default` are rejected so no
+      write path can mint a legacy- or invalid-shaped row.
+    - `scope_confidence` must lie in [0.0, 1.0]; out-of-range values
+      raise rather than clamp so classifier bugs are visible.
+    - Global scope discards any caller-supplied `project_id` and
+      `workspace_root` so the write shape matches the resolver's
+      read-time invariant.
+    - Project scope requires a non-empty `project_id`. Repair
+      tooling that needs to construct anomalous rows can bypass
+      this builder and rely on `resolve_memory_scope()` at read
+      time.
+
+    Args:
+        scope: Scope value (global/project/task).
+        project_id: Required for project scope; ignored for global;
+            optional for task.
+        workspace_root: Optional absolute workspace path; ignored
+            for global.
+        scope_confidence: Confidence in the scope assignment, in
+            [0.0, 1.0]. Defaults to 1.0 (confident write).
+        scope_source: How the scope assignment was chosen.
+
+    Returns:
+        A dict containing the five canonical scope keys, ready to
+        be merged into a memory row's metadata.
+
+    Raises:
+        ValueError: If any validation rule fails. The message names
+            the offending field so callers can fix the input.
+    """
+    if scope not in _VALID_SCOPES:
+        raise ValueError(f"build_scope_metadata: scope must be one of {sorted(_VALID_SCOPES)}, got {scope!r}")
+    if scope_source not in _BUILDER_SCOPE_SOURCES:
+        raise ValueError(
+            "build_scope_metadata: scope_source must be one of "
+            f"{sorted(_BUILDER_SCOPE_SOURCES)}, got {scope_source!r} "
+            "(legacy_default and invalid_default are resolver-only)"
+        )
+    if not (0.0 <= scope_confidence <= 1.0):
+        raise ValueError(f"build_scope_metadata: scope_confidence must be in [0.0, 1.0], got {scope_confidence!r}")
+
+    # Global scope discards stray project/workspace values so the
+    # write shape matches the resolver's read-time invariant. Project
+    # scope requires a non-empty id; task scope allows None because
+    # task rows that belong to no detected project are valid.
+    if scope == SCOPE_GLOBAL:
+        project_id = None
+        workspace_root = None
+    elif scope == SCOPE_PROJECT and not project_id:
+        raise ValueError("build_scope_metadata: project scope requires a non-empty project_id")
+
+    return {
+        "scope": scope,
+        "project_id": project_id,
+        "workspace_root": workspace_root,
+        "scope_confidence": scope_confidence,
+        "scope_source": scope_source,
+    }
 
 
 def _estimate_tokens(text: str) -> int:
@@ -1649,13 +1915,18 @@ def update_metadata(*, user_id: str, memory_id: str, data: str, metadata: dict[s
     absent in new), `actor_id` (always), `role` (when absent in new).
     Every other field on the existing row (e.g. `source`, `confidence`,
     `prompt_version`, `confirmation_quote`, `tags`, `outcome_quality`,
-    `approach`, `outcome`, `lessons`, `actors`) is DESTROYED unless the
-    caller passes it explicitly. Callers that want to change only
-    specific fields must read the existing row first, modify those
-    fields on the existing metadata dict, and pass the merged dict to
-    this wrapper. Failure to follow this pattern silently erases
-    metadata that may matter for downstream reads (UI rendering,
-    extractor consolidation gates, etc.).
+    `approach`, `outcome`, `lessons`, `actors`, and the scope fields
+    `scope`, `project_id`, `workspace_root`, `scope_confidence`,
+    `scope_source`) is DESTROYED unless the caller passes it
+    explicitly. Callers that want to change only specific fields must
+    read the existing row first, modify those fields on the existing
+    metadata dict, and pass the merged dict to this wrapper. Failure
+    to follow this pattern silently erases metadata that may matter
+    for downstream reads (UI rendering, extractor consolidation gates,
+    scope interpretation, etc.). Scope loss is especially quiet
+    because a row that loses its scope fields falls back to legacy-
+    global interpretation through `resolve_memory_scope()` instead of
+    raising.
 
     Mem0's `update` requires the row's text content (`data`) and
     recomputes the embedding regardless. Callers that want to change

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -4152,6 +4152,70 @@ class TestResolveMemoryScope:
         assert resolved.legacy_defaulted is False
         assert resolved.invalid_defaulted is False
 
+    def test_missing_scope_source_on_scoped_row_is_invalid_default(self):
+        """A row with a valid `scope` but no `scope_source` is
+        malformed provenance, not legacy. `legacy_default` is
+        reserved for rows with no `scope` key at all (branch 1);
+        mixing genuine pre-scope rows with scoped rows missing
+        provenance would break the audit boundary the resolver
+        exists to maintain. The stored scope value is preserved
+        because it reflects operator intent; only provenance is
+        flagged."""
+        from kai.memory import (
+            SCOPE_PROJECT,
+            SCOPE_SOURCE_INVALID_DEFAULT,
+            resolve_memory_scope,
+        )
+
+        resolved = resolve_memory_scope(
+            {
+                "scope": SCOPE_PROJECT,
+                "project_id": "kai",
+                "workspace_root": "/Users/kai/Projects/kai",
+                "scope_confidence": 0.8,
+            }
+        )
+
+        # Scope value preserved (not collapsed to global).
+        assert resolved.scope == SCOPE_PROJECT
+        assert resolved.project_id == "kai"
+        assert resolved.workspace_root == "/Users/kai/Projects/kai"
+        assert resolved.scope_confidence == 0.8
+        # Provenance flagged as malformed, not legacy.
+        assert resolved.scope_source == SCOPE_SOURCE_INVALID_DEFAULT
+        assert resolved.legacy_defaulted is False
+        assert resolved.invalid_defaulted is True
+
+    def test_unrecognized_scope_source_on_scoped_row_is_invalid_default(self):
+        """The resolver-only sources (`legacy_default`,
+        `invalid_default`) and any unknown provenance string appearing
+        in stored metadata indicate a write path bypassed
+        `build_scope_metadata`. Treat as malformed provenance: preserve
+        the stored scope, flag invalid_defaulted=True."""
+        from kai.memory import (
+            SCOPE_PROJECT,
+            SCOPE_SOURCE_INVALID_DEFAULT,
+            SCOPE_SOURCE_LEGACY_DEFAULT,
+            resolve_memory_scope,
+        )
+
+        for bad_source in (SCOPE_SOURCE_LEGACY_DEFAULT, SCOPE_SOURCE_INVALID_DEFAULT, "weird_thing"):
+            resolved = resolve_memory_scope(
+                {
+                    "scope": SCOPE_PROJECT,
+                    "project_id": "kai",
+                    "scope_confidence": 0.9,
+                    "scope_source": bad_source,
+                }
+            )
+
+            assert resolved.scope == SCOPE_PROJECT
+            assert resolved.project_id == "kai"
+            assert resolved.scope_confidence == 0.9
+            assert resolved.scope_source == SCOPE_SOURCE_INVALID_DEFAULT
+            assert resolved.legacy_defaulted is False
+            assert resolved.invalid_defaulted is True
+
     def test_normalizes_global_project_fields(self):
         """A global row that carries stray `project_id` or
         `workspace_root` (a malformed write) gets normalized to None

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -4008,3 +4008,433 @@ class TestAddStructured:
 
         assert result is None
         assert "add_structured failed" in caplog.text
+
+
+class TestResolveMemoryScope:
+    """Read-time scope interpretation for memory rows.
+
+    The resolver gives downstream callers a single place to interpret
+    the five scope fields (`scope`, `project_id`, `workspace_root`,
+    `scope_confidence`, `scope_source`) for rows that may or may not
+    have them. Three branches: missing scope (legacy), invalid scope
+    (corrupted), and valid stored scope.
+
+    These tests pin the legacy-safe defaults so a future refactor
+    cannot quietly reclassify legacy rows or merge the legacy and
+    invalid branches together. The two branches use distinct
+    `scope_source` values precisely so audit queries can tell the two
+    populations apart.
+    """
+
+    def test_defaults_missing_metadata_to_legacy_global(self):
+        """A row written before scope existed has no `scope` key. The
+        resolver returns global with `legacy_default` provenance and
+        full confidence (the row was a deliberate pre-scope write)."""
+        from kai.memory import (
+            SCOPE_GLOBAL,
+            SCOPE_SOURCE_LEGACY_DEFAULT,
+            resolve_memory_scope,
+        )
+
+        resolved = resolve_memory_scope({"source": "extracted", "type": "fact"})
+
+        assert resolved.scope == SCOPE_GLOBAL
+        assert resolved.project_id is None
+        assert resolved.workspace_root is None
+        assert resolved.scope_confidence == 1.0
+        assert resolved.scope_source == SCOPE_SOURCE_LEGACY_DEFAULT
+        assert resolved.legacy_defaulted is True
+        assert resolved.invalid_defaulted is False
+
+    def test_defaults_invalid_scope_to_invalid_global(self):
+        """A row carrying an unknown `scope` value is corrupted, not
+        legacy. The resolver still returns global so retrieval keeps
+        working, but uses `invalid_default` provenance and zero
+        confidence so audit queries can find these rows separately
+        from genuine legacy rows."""
+        from kai.memory import (
+            SCOPE_GLOBAL,
+            SCOPE_SOURCE_INVALID_DEFAULT,
+            resolve_memory_scope,
+        )
+
+        resolved = resolve_memory_scope({"scope": "garbage", "project_id": "kai"})
+
+        assert resolved.scope == SCOPE_GLOBAL
+        assert resolved.project_id is None
+        assert resolved.workspace_root is None
+        assert resolved.scope_confidence == 0.0
+        assert resolved.scope_source == SCOPE_SOURCE_INVALID_DEFAULT
+        assert resolved.legacy_defaulted is False
+        assert resolved.invalid_defaulted is True
+
+    def test_preserves_complete_global_scope(self):
+        """A row written with a complete global scope round-trips
+        through the resolver unchanged. Neither default flag is set."""
+        from kai.memory import (
+            SCOPE_GLOBAL,
+            SCOPE_SOURCE_OPERATOR,
+            resolve_memory_scope,
+        )
+
+        resolved = resolve_memory_scope(
+            {
+                "scope": SCOPE_GLOBAL,
+                "project_id": None,
+                "workspace_root": None,
+                "scope_confidence": 1.0,
+                "scope_source": SCOPE_SOURCE_OPERATOR,
+            }
+        )
+
+        assert resolved.scope == SCOPE_GLOBAL
+        assert resolved.project_id is None
+        assert resolved.workspace_root is None
+        assert resolved.scope_confidence == 1.0
+        assert resolved.scope_source == SCOPE_SOURCE_OPERATOR
+        assert resolved.legacy_defaulted is False
+        assert resolved.invalid_defaulted is False
+
+    def test_preserves_complete_project_scope(self):
+        """A row written with a complete project scope round-trips
+        through the resolver unchanged. The project_id and
+        workspace_root pass through; both default flags stay False."""
+        from kai.memory import (
+            SCOPE_PROJECT,
+            SCOPE_SOURCE_CLASSIFIER,
+            resolve_memory_scope,
+        )
+
+        resolved = resolve_memory_scope(
+            {
+                "scope": SCOPE_PROJECT,
+                "project_id": "kai",
+                "workspace_root": "/Users/kai/Projects/kai",
+                "scope_confidence": 0.92,
+                "scope_source": SCOPE_SOURCE_CLASSIFIER,
+            }
+        )
+
+        assert resolved.scope == SCOPE_PROJECT
+        assert resolved.project_id == "kai"
+        assert resolved.workspace_root == "/Users/kai/Projects/kai"
+        assert resolved.scope_confidence == 0.92
+        assert resolved.scope_source == SCOPE_SOURCE_CLASSIFIER
+        assert resolved.legacy_defaulted is False
+        assert resolved.invalid_defaulted is False
+
+    def test_preserves_complete_task_scope(self):
+        """Task scope is structurally valid and round-trips even though
+        no retrieval semantics consume it yet. The resolver preserves
+        the value so a future task-aware retrieval path can act on it
+        without a separate migration."""
+        from kai.memory import (
+            SCOPE_SOURCE_OPERATOR,
+            SCOPE_TASK,
+            resolve_memory_scope,
+        )
+
+        resolved = resolve_memory_scope(
+            {
+                "scope": SCOPE_TASK,
+                "project_id": "kai",
+                "workspace_root": "/Users/kai/Projects/kai",
+                "scope_confidence": 0.7,
+                "scope_source": SCOPE_SOURCE_OPERATOR,
+            }
+        )
+
+        assert resolved.scope == SCOPE_TASK
+        assert resolved.project_id == "kai"
+        assert resolved.workspace_root == "/Users/kai/Projects/kai"
+        assert resolved.scope_confidence == 0.7
+        assert resolved.scope_source == SCOPE_SOURCE_OPERATOR
+        assert resolved.legacy_defaulted is False
+        assert resolved.invalid_defaulted is False
+
+    def test_normalizes_global_project_fields(self):
+        """A global row that carries stray `project_id` or
+        `workspace_root` (a malformed write) gets normalized to None
+        for both. Downstream callers can rely on the invariant that
+        `scope=global` implies both are None, without re-checking the
+        scope value."""
+        from kai.memory import (
+            SCOPE_GLOBAL,
+            SCOPE_SOURCE_OPERATOR,
+            resolve_memory_scope,
+        )
+
+        resolved = resolve_memory_scope(
+            {
+                "scope": SCOPE_GLOBAL,
+                "project_id": "stray-leftover",
+                "workspace_root": "/some/path",
+                "scope_confidence": 1.0,
+                "scope_source": SCOPE_SOURCE_OPERATOR,
+            }
+        )
+
+        assert resolved.scope == SCOPE_GLOBAL
+        assert resolved.project_id is None
+        assert resolved.workspace_root is None
+        assert resolved.scope_source == SCOPE_SOURCE_OPERATOR
+
+
+class TestWrapResultScopePreservation:
+    """`_wrap_result` is the read-path entry point; it must stay free of
+    scope-aware behavior so legacy rows do not get auto-classified at
+    read time. The single test below pins that the wrapper neither
+    injects default scope keys nor mutates the upstream metadata dict.
+
+    The invariant matters because a row that picked up phantom scope
+    keys at read time would look deliberately classified the next time
+    something inspected its metadata, defeating the audit boundary
+    between legacy and operator/classifier writes.
+    """
+
+    def test_does_not_inject_scope_keys(self):
+        """A legacy raw row has no scope fields. Wrapping it must
+        produce a MemoryResult whose metadata still has no scope
+        fields; the upstream dict must not be mutated either."""
+        from kai.memory import _wrap_result
+
+        raw = {
+            "id": "row-1",
+            "memory": "operator likes terse responses",
+            "score": 0.42,
+            "metadata": {"source": "extracted", "type": "fact"},
+            "created_at": "2026-05-25T00:00:00Z",
+            "updated_at": "2026-05-25T00:00:00Z",
+        }
+        original_metadata_snapshot = dict(raw["metadata"])
+
+        result = _wrap_result(raw)
+
+        # No scope key injected anywhere.
+        for scope_key in (
+            "scope",
+            "project_id",
+            "workspace_root",
+            "scope_confidence",
+            "scope_source",
+        ):
+            assert scope_key not in result.metadata
+            assert scope_key not in raw["metadata"]
+
+        # Upstream metadata dict matches the snapshot taken before the
+        # wrap call; the wrapper did not mutate it.
+        assert raw["metadata"] == original_metadata_snapshot
+
+
+class TestBuildScopeMetadata:
+    """Write-time scope-metadata builder. Centralizes field assembly so
+    extraction, operator tools, and future classifier code cannot
+    diverge on field names or silently ship invalid values.
+
+    All validation is fail-fast: out-of-range or unknown values raise
+    `ValueError` rather than silently clamping or substituting. The
+    rejection tests pin that no write path can mint a row that the
+    resolver would have to interpret as legacy or invalid.
+    """
+
+    def test_rejects_unknown_scope(self):
+        """An unknown scope value is a programmer bug; reject loudly
+        so the caller learns at write time rather than at read time."""
+        from kai.memory import SCOPE_SOURCE_OPERATOR, build_scope_metadata
+
+        with pytest.raises(ValueError, match="scope must be one of"):
+            build_scope_metadata(scope="garbage", scope_source=SCOPE_SOURCE_OPERATOR)
+
+    def test_rejects_invalid_confidence(self):
+        """Confidence outside [0.0, 1.0] indicates a classifier bug.
+        Reject rather than clamp so the bug surfaces at the write
+        boundary instead of producing rows whose confidence does not
+        match what the classifier intended."""
+        from kai.memory import (
+            SCOPE_GLOBAL,
+            SCOPE_SOURCE_CLASSIFIER,
+            build_scope_metadata,
+        )
+
+        for bad_confidence in (-0.1, 1.5, 2.0):
+            with pytest.raises(ValueError, match="scope_confidence must be in"):
+                build_scope_metadata(
+                    scope=SCOPE_GLOBAL,
+                    scope_source=SCOPE_SOURCE_CLASSIFIER,
+                    scope_confidence=bad_confidence,
+                )
+
+    def test_rejects_legacy_default_source(self):
+        """`legacy_default` is a resolver-only output for rows that
+        predate scope. No write path should ever mint such a row: a
+        new write is by definition not legacy. Builder rejects."""
+        from kai.memory import (
+            SCOPE_GLOBAL,
+            SCOPE_SOURCE_LEGACY_DEFAULT,
+            build_scope_metadata,
+        )
+
+        with pytest.raises(ValueError, match="scope_source must be one of"):
+            build_scope_metadata(
+                scope=SCOPE_GLOBAL,
+                scope_source=SCOPE_SOURCE_LEGACY_DEFAULT,
+            )
+
+    def test_rejects_invalid_default_source(self):
+        """`invalid_default` is the resolver's output for corrupted
+        rows. As with `legacy_default`, the builder rejects it so the
+        write boundary cannot reproduce a state that only the resolver
+        is supposed to construct."""
+        from kai.memory import (
+            SCOPE_GLOBAL,
+            SCOPE_SOURCE_INVALID_DEFAULT,
+            build_scope_metadata,
+        )
+
+        with pytest.raises(ValueError, match="scope_source must be one of"):
+            build_scope_metadata(
+                scope=SCOPE_GLOBAL,
+                scope_source=SCOPE_SOURCE_INVALID_DEFAULT,
+            )
+
+    def test_requires_project_id_for_project_scope(self):
+        """Project-scoped rows must carry a matching `project_id`; the
+        design doc treats this as the invariant that downstream
+        filtering relies on. Builder enforces at write time so no
+        project-scoped row without an id can be created through the
+        sanctioned path. Repair tooling that needs to construct
+        anomalous rows can bypass the builder."""
+        from kai.memory import (
+            SCOPE_PROJECT,
+            SCOPE_SOURCE_OPERATOR,
+            build_scope_metadata,
+        )
+
+        for empty in (None, ""):
+            with pytest.raises(ValueError, match="project scope requires"):
+                build_scope_metadata(
+                    scope=SCOPE_PROJECT,
+                    scope_source=SCOPE_SOURCE_OPERATOR,
+                    project_id=empty,
+                )
+
+
+class TestScopeMetadataPersistence:
+    """End-to-end pins for scope metadata flowing through the write
+    surfaces that exist today: `add_structured` for new rows and
+    `update_metadata` for in-place edits. These tests demonstrate the
+    caller patterns later issues will rely on, and pin them so a
+    future refactor cannot quietly drop scope fields on the way to
+    Mem0.
+    """
+
+    def test_add_structured_preserves_scope_metadata(self):
+        """`add_structured` already copies caller metadata before
+        overwriting the reserved `type` and `tags` keys. Scope fields
+        supplied through `build_scope_metadata` must reach Mem0
+        unchanged, while `type` and `tags` still get set from the
+        explicit arguments."""
+        import kai.memory as mem_mod
+        from kai.memory import (
+            SCOPE_GLOBAL,
+            SCOPE_SOURCE_OPERATOR,
+            add_structured,
+            build_scope_metadata,
+        )
+
+        mock_mem = MagicMock()
+        mock_mem.add.return_value = {"results": [{"id": "abc", "memory": "test"}]}
+        mem_mod._memory = mock_mem
+
+        scope_metadata = build_scope_metadata(
+            scope=SCOPE_GLOBAL,
+            scope_source=SCOPE_SOURCE_OPERATOR,
+        )
+
+        add_structured(
+            "operator prefers terse responses",
+            user_id="123",
+            memory_type="fact",
+            tags=["style"],
+            metadata=scope_metadata,
+        )
+
+        passed_metadata = mock_mem.add.call_args.kwargs["metadata"]
+        # All five scope keys reach Mem0 unchanged.
+        assert passed_metadata["scope"] == SCOPE_GLOBAL
+        assert passed_metadata["project_id"] is None
+        assert passed_metadata["workspace_root"] is None
+        assert passed_metadata["scope_confidence"] == 1.0
+        assert passed_metadata["scope_source"] == SCOPE_SOURCE_OPERATOR
+        # Reserved keys still come from the explicit arguments.
+        assert passed_metadata["type"] == "fact"
+        assert passed_metadata["tags"] == ["style"]
+
+    def test_scope_metadata_survives_caller_merged_update(self):
+        """`update_metadata` is replace-all by design. A caller that
+        wants to change one scope field without losing the others
+        (and without losing `source`, `tags`, etc.) must read the
+        existing metadata, merge the new scope fields, and pass the
+        full merged dict. This test demonstrates the pattern and pins
+        that the wrapper forwards the merged dict literally so no
+        scope field is dropped on the way to Mem0.
+
+        The complementary anti-pattern (passing only the changed
+        scope key, which would silently drop everything else) is
+        already pinned by `test_sparse_metadata_passes_through_unchanged`
+        on the wrapper."""
+        import kai.memory as mem_mod
+        from kai.memory import (
+            SCOPE_PROJECT,
+            SCOPE_SOURCE_CLASSIFIER,
+            SCOPE_SOURCE_OPERATOR,
+            update_metadata,
+        )
+
+        existing_metadata = {
+            "source": "extracted",
+            "type": "fact",
+            "tags": ["semantic-memory"],
+            "confidence": 0.9,
+            "scope": SCOPE_PROJECT,
+            "project_id": "kai",
+            "workspace_root": "/Users/kai/Projects/kai",
+            "scope_confidence": 0.7,
+            "scope_source": SCOPE_SOURCE_CLASSIFIER,
+        }
+        mock_mem = MagicMock()
+        mock_mem.get.return_value = {
+            "id": "abc",
+            "user_id": "123",
+            "metadata": existing_metadata,
+        }
+        mem_mod._memory = mock_mem
+
+        # Caller pattern: read existing, merge new scope fields, write
+        # back the full dict. Here the operator is upgrading the
+        # provenance from classifier to operator and raising confidence
+        # to 1.0; everything else must survive.
+        merged = dict(existing_metadata)
+        merged["scope_source"] = SCOPE_SOURCE_OPERATOR
+        merged["scope_confidence"] = 1.0
+
+        result = update_metadata(
+            user_id="123",
+            memory_id="abc",
+            data="fact text",
+            metadata=merged,
+        )
+        assert result is True
+
+        passed_metadata = mock_mem.update.call_args.kwargs["metadata"]
+        # All scope fields preserved (only the two intentionally
+        # changed values differ).
+        assert passed_metadata["scope"] == SCOPE_PROJECT
+        assert passed_metadata["project_id"] == "kai"
+        assert passed_metadata["workspace_root"] == "/Users/kai/Projects/kai"
+        assert passed_metadata["scope_confidence"] == 1.0
+        assert passed_metadata["scope_source"] == SCOPE_SOURCE_OPERATOR
+        # Non-scope fields also preserved by the merge.
+        assert passed_metadata["source"] == "extracted"
+        assert passed_metadata["tags"] == ["semantic-memory"]
+        assert passed_metadata["confidence"] == 0.9


### PR DESCRIPTION
Closes #542. Parent epic #517.

## Summary

Adds scope metadata schema and helpers for scoped global/project memory. No retrieval, prompt-rendering, or write-routing behavior changes; that work belongs to later issues in the epic.

Five canonical scope keys (`scope`, `project_id`, `workspace_root`, `scope_confidence`, `scope_source`) live inside the existing Mem0 metadata dict. Two helpers interpret and build them safely:

- `resolve_memory_scope(metadata)` returns a frozen `ResolvedMemoryScope` for any row, distinguishing legacy (no scope) from invalid (corrupted scope) with distinct `scope_source` values so future audit queries can tell the two populations apart.
- `build_scope_metadata(...)` is the write-time builder. Rejects unknown scope, out-of-range confidence, the resolver-only sources (`legacy_default`, `invalid_default`), and project scope without a non-empty `project_id`.

`_wrap_result` is unchanged: read-time defaults are compatibility behavior, not a migration. Injecting phantom scope keys into the visible metadata dict would defeat the audit boundary.

`update_metadata`'s docstring is expanded to name the scope fields among the metadata that callers must preserve through the replace-all update path. Scope loss is especially quiet because a row that loses its scope fields falls back to legacy-global interpretation through `resolve_memory_scope()` rather than raising.

## Behavior preservation

- `format_context` output header unchanged.
- `search()` filters unchanged.
- `add_structured()` already had the right merge posture (copy caller metadata, then overwrite reserved `type`/`tags`); scope fields supplied by callers pass through.
- No existing tests changed.

## Tests

16 new tests across four classes in `tests/test_memory.py`:

- `TestResolveMemoryScope` (8): missing, invalid, complete global, complete project, complete task, stray-field normalization, missing-provenance-on-scoped-row, unrecognized-provenance-on-scoped-row.
- `TestWrapResultScopePreservation` (1): no scope-key injection, no upstream-metadata mutation.
- `TestBuildScopeMetadata` (5): rejects unknown scope, invalid confidence, `legacy_default`, `invalid_default`, project scope without `project_id`.
- `TestScopeMetadataPersistence` (2): `add_structured` pass-through, caller-merged `update_metadata` round-trip.

## Test plan

- [x] `pytest tests/test_memory.py tests/test_memory_command.py tests/test_memory_episodes.py` (348 passed)
- [x] `make test` (3468 passed, 1 skipped)
- [x] `make check` (ruff lint + format)
- [x] Grep gate over `src/` diff: no `metadata["scope"]`, `metadata.get("scope"`, or `scope=` near `_memory.search(...)` outside the resolver and builder themselves.
