### PR TITLE
feat(memory): add memory project registry + workspace-root detector

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -490,6 +490,50 @@ class WorkspaceConfig:
     system_prompt_file: Path | None = None
 
 
+# ── Memory project registry ──────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class MemoryProjectConfig:
+    """
+    Per-project memory configuration loaded from memory-projects.yaml.
+
+    The memory project registry answers "what memory authority
+    boundary does this directory belong to?" - a separate question
+    from WorkspaceConfig's "how should the backend run in this
+    directory?" The two surfaces overlap on paths but not on meaning;
+    keeping them separate avoids accidentally enabling project memory
+    just because a workspace has a prompt or model override.
+
+    Attributes:
+        project_id: Stable identifier used as the registry key and as
+            the value stored in memory rows' `project_id` field.
+            Normalized at load time by stripping surrounding
+            whitespace.
+        display_name: Human-readable name used in logs and future
+            operator UI.
+        workspace_roots: Canonical resolved absolute paths whose
+            descendants belong to this project. Stored as a tuple
+            because MemoryProjectConfig is frozen and equality should
+            treat root order as significant for the longest-prefix
+            tie-breaker.
+        memory_enabled: When False, the project is still detectable
+            for logs and diagnostics, but later retrieval and write
+            paths treat it as global-only.
+        default_scope_for_new_facts: Optional policy hint for the
+            future write-scope routing path. Only `kai.memory.SCOPE_GLOBAL`
+            or `kai.memory.SCOPE_PROJECT` are accepted; `SCOPE_TASK` is
+            not because task scope is not a write target yet. The
+            field is inert until the write-routing issue lands.
+    """
+
+    project_id: str
+    display_name: str
+    workspace_roots: tuple[Path, ...]
+    memory_enabled: bool
+    default_scope_for_new_facts: str | None = None
+
+
 # ── Per-user configuration ──────────────────────────────────────────
 
 
@@ -670,6 +714,14 @@ class Config:
     # Per-workspace configuration from workspaces.yaml. Keyed by
     # canonical resolved path. Empty dict if no config file exists.
     workspace_configs: dict[Path, WorkspaceConfig] = field(default_factory=dict)
+
+    # Memory project registry from memory-projects.yaml. Keyed by
+    # project_id. Empty dict if no config file exists. The detector
+    # in kai.memory_projects consumes this; no retrieval or write
+    # routing path reads it yet (those land in #544 and later).
+    # Workspace access is still owned by allowed_workspaces and is
+    # NOT extended by registry roots.
+    memory_projects: dict[str, MemoryProjectConfig] = field(default_factory=dict)
 
     # User separation: run Claude as a different OS user for process isolation.
     # When set, the bot spawns Claude via 'sudo -u <user> claude ...'.
@@ -1164,6 +1216,226 @@ def _load_workspace_configs() -> dict[Path, WorkspaceConfig]:
             env_file=env_file,
             system_prompt=system_prompt,
             system_prompt_file=system_prompt_file,
+        )
+
+    return configs
+
+
+def _load_memory_project_configs() -> dict[str, MemoryProjectConfig]:
+    """
+    Load the memory project registry from memory-projects.yaml.
+
+    Tries /etc/kai/memory-projects.yaml first (protected
+    installation), falls back to PROJECT_ROOT/memory-projects.yaml
+    (development). Returns an empty dict if neither file exists.
+
+    The registry is keyed by project_id. Each MemoryProjectConfig
+    holds the canonical resolved workspace_roots tuple plus the
+    enablement flag and optional default-scope policy. Detection
+    logic lives in kai.memory_projects and consumes this dict.
+
+    Validation is fail-closed: any malformed entry is skipped (with
+    a warning) so an unmatched cwd returns no active project rather
+    than producing accidental project-scoped recall. Path existence
+    is NOT required at load time; registry config may be authored
+    before a checkout exists or while a mount is unavailable, and
+    detection's longest-prefix match handles the absent-root case
+    naturally by failing to match.
+
+    Duplicate handling:
+    - Duplicate project_id: first entry wins, later entries logged
+      and skipped.
+    - Duplicate workspace_root across distinct projects: the root is
+      dropped from the later project only. If the later project ends
+      up with no roots, the whole project is also skipped.
+    """
+    # Mirrors _load_workspace_configs: protected-first, fall back to
+    # PROJECT_ROOT for dev. A malformed protected file does NOT fall
+    # through to the local file (avoid silently using dev config on
+    # a production system); fail closed with an empty registry
+    # instead.
+    data = _read_protected_yaml("memory-projects.yaml")
+    if data is _YAML_MALFORMED:
+        log.warning("Skipping memory project registry: /etc/kai/memory-projects.yaml is malformed or empty")
+        return {}
+    if data is None:
+        local_path = PROJECT_ROOT / "memory-projects.yaml"
+        if not local_path.exists():
+            return {}
+        try:
+            with open(local_path) as f:
+                data = yaml.safe_load(f)
+        except (yaml.YAMLError, OSError) as e:
+            log.error("Cannot load %s: %s", local_path, e)
+            return {}
+        if not isinstance(data, dict):
+            log.warning("%s: expected a YAML dict, got %s", local_path, type(data).__name__)
+            return {}
+
+    entries = data.get("projects")
+    if not isinstance(entries, list):
+        if entries is not None:
+            log.warning(
+                "memory-projects.yaml: 'projects' must be a list, got %s",
+                type(entries).__name__,
+            )
+        return {}
+
+    # Lazy import: kai.memory imports kai.config at module load time,
+    # so importing the scope constants at module scope here would
+    # create a circular import. Importing inside the function body
+    # breaks the cycle and keeps config.py's import surface lean.
+    from kai.memory import SCOPE_GLOBAL, SCOPE_PROJECT
+
+    valid_default_scopes = {SCOPE_GLOBAL, SCOPE_PROJECT}
+
+    configs: dict[str, MemoryProjectConfig] = {}
+    # Track which resolved root path is already owned by which
+    # project_id so the "drop duplicate root from later project"
+    # rule is enforceable across the loop.
+    root_owners: dict[Path, str] = {}
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            log.warning("memory-projects.yaml: skipping non-dict entry: %s", entry)
+            continue
+
+        # project_id: non-empty string after whitespace strip.
+        raw_project_id = entry.get("project_id")
+        if not isinstance(raw_project_id, str):
+            log.warning(
+                "memory-projects.yaml: skipping entry; project_id must be a string, got %s",
+                type(raw_project_id).__name__,
+            )
+            continue
+        project_id = raw_project_id.strip()
+        if not project_id:
+            log.warning("memory-projects.yaml: skipping entry with empty project_id")
+            continue
+
+        # First-wins on duplicate project_id.
+        if project_id in configs:
+            log.warning(
+                "memory-projects.yaml: duplicate project_id %r; using first entry",
+                project_id,
+            )
+            continue
+
+        # display_name: non-empty string.
+        display_name = entry.get("display_name")
+        if not isinstance(display_name, str) or not display_name.strip():
+            log.warning(
+                "memory-projects.yaml: skipping project %r; display_name must be a non-empty string",
+                project_id,
+            )
+            continue
+
+        # memory_enabled: strict boolean. YAML truthy values like
+        # "true", "yes", 1 must NOT be coerced; force a hard reject
+        # so the operator notices the typo at load time. bool is a
+        # subclass of int in Python, so even though isinstance(True,
+        # int) is True, isinstance(1, bool) is False, which gives
+        # the correct rejection here.
+        memory_enabled = entry.get("memory_enabled")
+        if not isinstance(memory_enabled, bool):
+            log.warning(
+                "memory-projects.yaml: skipping project %r; memory_enabled must be a real boolean (true/false), got %r",
+                project_id,
+                memory_enabled,
+            )
+            continue
+
+        # workspace_roots: non-empty list of paths. Each is resolved
+        # (expanduser + resolve) but NOT required to exist - registry
+        # config may pre-date a checkout. Cross-project duplicates
+        # are dropped from later projects via the root_owners gate.
+        raw_roots = entry.get("workspace_roots")
+        if not isinstance(raw_roots, list) or not raw_roots:
+            log.warning(
+                "memory-projects.yaml: skipping project %r; workspace_roots must be a non-empty list",
+                project_id,
+            )
+            continue
+
+        resolved_roots: list[Path] = []
+        intra_project_seen: set[Path] = set()
+        for raw_root in raw_roots:
+            if not isinstance(raw_root, (str, Path)):
+                log.warning(
+                    "memory-projects.yaml: project %r: skipping non-string root %r",
+                    project_id,
+                    raw_root,
+                )
+                continue
+            try:
+                resolved = Path(str(raw_root)).expanduser().resolve()
+            except (OSError, ValueError) as e:
+                log.warning(
+                    "memory-projects.yaml: project %r: cannot resolve root %r: %s",
+                    project_id,
+                    raw_root,
+                    e,
+                )
+                continue
+            # Within-project duplicate: keep first only.
+            if resolved in intra_project_seen:
+                log.warning(
+                    "memory-projects.yaml: project %r: duplicate root %s within project; keeping first",
+                    project_id,
+                    resolved,
+                )
+                continue
+            # Cross-project duplicate: drop from the LATER project.
+            owner = root_owners.get(resolved)
+            if owner is not None:
+                log.warning(
+                    "memory-projects.yaml: root %s already owned by project %r; dropping from %r",
+                    resolved,
+                    owner,
+                    project_id,
+                )
+                continue
+            intra_project_seen.add(resolved)
+            resolved_roots.append(resolved)
+
+        if not resolved_roots:
+            # All roots were duplicates or malformed; drop the
+            # project entirely so detection never returns a project
+            # with no roots to match against.
+            log.warning(
+                "memory-projects.yaml: skipping project %r; no valid workspace_roots remain after deduplication",
+                project_id,
+            )
+            continue
+
+        # default_scope_for_new_facts: optional. When present, must
+        # match SCOPE_GLOBAL or SCOPE_PROJECT. SCOPE_TASK is rejected
+        # because task scope is not a write target in this issue.
+        default_scope = entry.get("default_scope_for_new_facts")
+        if default_scope is not None and (
+            not isinstance(default_scope, str) or default_scope not in valid_default_scopes
+        ):
+            log.warning(
+                "memory-projects.yaml: skipping project %r; default_scope_for_new_facts must be %r or %r, got %r",
+                project_id,
+                SCOPE_GLOBAL,
+                SCOPE_PROJECT,
+                default_scope,
+            )
+            continue
+
+        # Record ownership only after every validation has passed so
+        # a rejected project does not "claim" a root and lock it out
+        # of a later valid project.
+        for resolved in resolved_roots:
+            root_owners[resolved] = project_id
+
+        configs[project_id] = MemoryProjectConfig(
+            project_id=project_id,
+            display_name=display_name,
+            workspace_roots=tuple(resolved_roots),
+            memory_enabled=memory_enabled,
+            default_scope_for_new_facts=default_scope,
         )
 
     return configs
@@ -2062,6 +2334,16 @@ def load_config() -> Config:
             seen_allowed.add(p)
             allowed_workspaces.append(p)
 
+    # Memory project registry. Loaded independently of workspace_configs
+    # because memory authority and backend overrides are different
+    # concepts that happen to overlap on paths. Memory project roots
+    # are NOT merged into allowed_workspaces: workspace access is
+    # still owned by /workspace access configuration. Per-user
+    # workspace permissions still gate which workspaces the operator
+    # can enter; the registry only describes the memory boundary of
+    # workspaces the user is otherwise allowed to enter.
+    memory_projects = _load_memory_project_configs()
+
     # Per-user configuration. If users.yaml exists, it is authoritative;
     # ALLOWED_USER_IDS is ignored. If users.yaml does not exist,
     # ALLOWED_USER_IDS works as before (backward-compatible).
@@ -2233,6 +2515,7 @@ def load_config() -> Config:
         workspace_base=workspace_base,
         allowed_workspaces=allowed_workspaces,
         workspace_configs=workspace_configs,
+        memory_projects=memory_projects,
         claude_user=os.environ.get("CLAUDE_USER") or None,
         pr_review_enabled=pr_review_enabled,
         pr_review_cooldown=pr_review_cooldown,

--- a/src/kai/memory_projects.py
+++ b/src/kai/memory_projects.py
@@ -1,0 +1,151 @@
+"""
+Memory project detection: map a workspace path to its registered
+memory project, if any.
+
+The registry itself lives on `Config.memory_projects` and is loaded
+from `memory-projects.yaml` by `kai.config._load_memory_project_configs`.
+This module is the read-only consumer: it accepts a path and a
+registry dict and returns the matching `ActiveMemoryProject`, or
+`None` when the path is not registered.
+
+The detector is intentionally pure: it does not touch process state
+(no `Path.cwd()`, no globals), so callers must pass the active
+workspace path explicitly. Runtime callers should pass the backend's
+active `workspace` path (the chat/session workspace tracked per user
+by `kai.pool`); tests can pass any path constructed against
+`tmp_path`.
+
+Detection rules (also documented inline below):
+
+1. Resolve the input path with `expanduser().resolve()`.
+2. A registry root matches when the resolved path equals the root
+   or `Path.is_relative_to()` the root.
+3. When multiple roots match, the root with the most path parts
+   wins (longest-prefix). Nested project roots are common
+   (`/Users/kai/Projects/kai` vs `/Users/kai/Projects`), so the
+   narrower root must take precedence.
+4. Unknown paths return `None`. Detection does not guess.
+5. Disabled projects (`memory_enabled=False`) still return an
+   `ActiveMemoryProject` so logs and future shadow-mode metrics can
+   distinguish "no project here" from "known project with memory
+   disabled". Retrieval and write code must treat
+   `memory_enabled=False` as "global-only behavior".
+
+The detector does NOT change retrieval, prompt rendering, or write
+routing. Wiring those paths to the detector belongs to #544 and
+later issues in the scoped-memory epic.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from kai.config import MemoryProjectConfig
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ActiveMemoryProject:
+    """
+    The memory project that a given workspace path belongs to.
+
+    Returned by `detect_active_memory_project()` when the input path
+    matches a registered root. Carries the matched root so callers
+    can log which root won (useful when nested roots are configured)
+    and the policy field that future write-routing will consume.
+
+    Attributes:
+        project_id: The registry key of the matched project.
+        display_name: Human-readable name for logs and operator UI.
+        matched_root: The specific resolved registry root that won
+            the longest-prefix match. Useful for diagnostics when
+            multiple roots could have matched.
+        memory_enabled: When False, the project is detectable but
+            project-scoped retrieval and writes are not allowed;
+            callers should fall back to global-only behavior.
+        default_scope_for_new_facts: Optional policy hint for the
+            future write-scope routing path. Inert in #543; later
+            extraction code may consult it.
+    """
+
+    project_id: str
+    display_name: str
+    matched_root: Path
+    memory_enabled: bool
+    default_scope_for_new_facts: str | None
+
+
+def detect_active_memory_project(
+    cwd: Path,
+    projects: dict[str, MemoryProjectConfig],
+) -> ActiveMemoryProject | None:
+    """
+    Return the memory project that owns `cwd`, or None.
+
+    The path is resolved (`expanduser().resolve()`) before matching
+    so that symlink aliases collapse to the same canonical location
+    and a project cannot be "two projects" depending on which alias
+    the operator used to enter it.
+
+    Matching uses `Path.is_relative_to()` (and equality), NOT
+    string-prefix comparison: `/work/foo2` must not match a root of
+    `/work/foo`. When multiple roots match, the root with the most
+    path parts wins.
+
+    Args:
+        cwd: The workspace path to detect from. Runtime callers
+            should pass the backend's active workspace path;
+            tests can pass any path.
+        projects: The memory project registry from
+            `Config.memory_projects`. An empty dict returns None
+            for every input.
+
+    Returns:
+        `ActiveMemoryProject` when `cwd` is inside (or equals) a
+        registered root. `None` when no root matches; the caller
+        should fall back to global-only behavior.
+    """
+    if not projects:
+        return None
+
+    try:
+        resolved_cwd = Path(cwd).expanduser().resolve()
+    except (OSError, ValueError) as e:
+        log.warning("detect_active_memory_project: cannot resolve cwd %r: %s", cwd, e)
+        return None
+
+    # Track the best match by (path-parts depth, project, root). The
+    # registry loader has already deduplicated roots across projects,
+    # so two registered roots with the same depth covering the same
+    # cwd is structurally impossible: equality at the same depth
+    # would mean identical roots, which the loader rejects.
+    best_depth = -1
+    best_project: MemoryProjectConfig | None = None
+    best_root: Path | None = None
+
+    for project in projects.values():
+        for root in project.workspace_roots:
+            # Path containment, not string prefix. is_relative_to
+            # returns False for equality, so handle equality as a
+            # separate match.
+            if resolved_cwd != root and not resolved_cwd.is_relative_to(root):
+                continue
+            depth = len(root.parts)
+            if depth > best_depth:
+                best_depth = depth
+                best_project = project
+                best_root = root
+
+    if best_project is None or best_root is None:
+        return None
+
+    return ActiveMemoryProject(
+        project_id=best_project.project_id,
+        display_name=best_project.display_name,
+        matched_root=best_root,
+        memory_enabled=best_project.memory_enabled,
+        default_scope_for_new_facts=best_project.default_scope_for_new_facts,
+    )

--- a/templates/memory-projects.yaml
+++ b/templates/memory-projects.yaml
@@ -1,0 +1,60 @@
+# Memory project registry for Kai.
+#
+# Copy to memory-projects.yaml (or /etc/kai/memory-projects.yaml for
+# protected installations) and customize.
+#
+# This registry maps workspace paths to memory authority boundaries.
+# It is separate from workspaces.yaml on purpose: workspaces.yaml
+# answers "how should the backend run in this directory?" (model,
+# system prompt, env) while this file answers "what memory authority
+# boundary does this directory belong to?" The two often overlap on
+# paths but should not be conflated.
+#
+# Entries here do NOT grant workspace access. Workspace access is
+# still owned by users.yaml and /workspace configuration. A registry
+# entry only describes the memory scope for a workspace the operator
+# is otherwise allowed to enter.
+#
+# Each entry must define:
+#   project_id          stable identifier, used as the registry key
+#                       and stored on memory rows in the project_id
+#                       field. Surrounding whitespace is stripped at
+#                       load time.
+#   display_name        human-readable name for logs and operator UI.
+#   workspace_roots     non-empty list of absolute paths whose
+#                       descendants belong to this project. Paths
+#                       are resolved (~ expanded, symlinks followed)
+#                       at load time and do not need to exist yet.
+#                       When multiple registered roots match the
+#                       current path, the longest matching root wins.
+#                       Duplicate roots across projects are dropped
+#                       from the later project.
+#   memory_enabled      true or false (real YAML booleans only;
+#                       "true"/"yes"/1 are rejected). Disabled
+#                       projects are still detectable for logs but
+#                       cannot use project-scoped retrieval or
+#                       writes.
+#
+# Optional:
+#   default_scope_for_new_facts   either "global" or "project". A
+#                                 policy hint for the future
+#                                 write-scope routing path. Inert
+#                                 today.
+
+projects:
+  # Example: enabled project with two roots
+  # - project_id: kai
+  #   display_name: Kai
+  #   workspace_roots:
+  #     - /Users/kai/Projects/kai
+  #     - /var/lib/kai/home/2114582497
+  #   memory_enabled: true
+  #   default_scope_for_new_facts: project
+
+  # Example: known project with memory off (detectable but no
+  # project-scoped retrieval or writes)
+  # - project_id: experimental
+  #   display_name: Experimental
+  #   workspace_roots:
+  #     - /Users/kai/Projects/experimental
+  #   memory_enabled: false

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import logging
 import os
 import pwd
 import subprocess
+import textwrap
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -15,6 +16,7 @@ from kai.config import (
     ModelRole,
     UserConfig,
     _check_model_registry_complete,
+    _load_memory_project_configs,
     _read_protected_file,
     get_model_for,
     load_config,
@@ -2649,3 +2651,414 @@ class TestLoadConfigBackendAwareModelValidation:
         self._env(monkeypatch, AGENT_BACKEND="codex", DEFAULT_MODEL="gpt-5.5")
         cfg = load_config()
         assert cfg.default_model == "gpt-5.5"
+
+
+# ── Memory project registry loader (memory-projects.yaml) ────────────
+
+
+class TestLoadMemoryProjects:
+    """Tests for `_load_memory_project_configs()` and the
+    surrounding integration with `load_config()`.
+
+    The loader is fail-closed by design: malformed entries are
+    skipped (logged) so detection later returns no project rather
+    than producing accidental project-scoped recall. These tests
+    pin that posture across every validation rule plus the
+    interaction with `Config.allowed_workspaces`.
+    """
+
+    def _write_yaml(self, tmp_path: Path, content: str) -> Path:
+        """Write a memory-projects.yaml under tmp_path; PROJECT_ROOT
+        is patched to tmp_path so the loader's local-fallback branch
+        picks it up without touching real config files."""
+        yaml_file = tmp_path / "memory-projects.yaml"
+        yaml_file.write_text(textwrap.dedent(content))
+        return yaml_file
+
+    def test_load_memory_projects_from_local_yaml(self, tmp_path):
+        """Parses a valid two-project file and returns canonical
+        resolved roots, the strict bool memory_enabled value, and
+        the optional default-scope policy."""
+        root_a = tmp_path / "project_a"
+        root_a.mkdir()
+        root_b = tmp_path / "project_b"
+        root_b.mkdir()
+        self._write_yaml(
+            tmp_path,
+            f"""\
+            projects:
+              - project_id: alpha
+                display_name: Alpha
+                workspace_roots:
+                  - {root_a}
+                memory_enabled: true
+                default_scope_for_new_facts: project
+              - project_id: beta
+                display_name: Beta
+                workspace_roots:
+                  - {root_b}
+                memory_enabled: false
+            """,
+        )
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            patch("kai.config.PROJECT_ROOT", tmp_path),
+        ):
+            configs = _load_memory_project_configs()
+
+        assert set(configs.keys()) == {"alpha", "beta"}
+        assert configs["alpha"].display_name == "Alpha"
+        assert configs["alpha"].workspace_roots == (root_a.resolve(),)
+        assert configs["alpha"].memory_enabled is True
+        assert configs["alpha"].default_scope_for_new_facts == "project"
+        assert configs["beta"].memory_enabled is False
+        assert configs["beta"].default_scope_for_new_facts is None
+
+    def test_memory_projects_absent_defaults_empty(self, tmp_path):
+        """Neither protected nor local file exists -> empty dict."""
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            patch("kai.config.PROJECT_ROOT", tmp_path),
+        ):
+            configs = _load_memory_project_configs()
+        assert configs == {}
+
+    def test_malformed_protected_memory_projects_returns_empty(self, tmp_path, caplog):
+        """A malformed protected file fails closed at empty rather
+        than silently falling through to the local-dev file. Pinning
+        this stops a future refactor from re-introducing the
+        dev-config-on-prod failure mode."""
+        # _YAML_MALFORMED is the sentinel _read_protected_yaml returns
+        # when YAML parsing fails. We import it from kai.config to
+        # avoid leaking the sentinel value into the test surface.
+        from kai.config import _YAML_MALFORMED
+
+        # Even with a perfectly valid local file present, malformed
+        # protected stops loading. Write the local file too so the
+        # test would fail loudly if the fallthrough regressed.
+        root = tmp_path / "p"
+        root.mkdir()
+        self._write_yaml(
+            tmp_path,
+            f"""\
+            projects:
+              - project_id: should_not_load
+                display_name: Nope
+                workspace_roots:
+                  - {root}
+                memory_enabled: true
+            """,
+        )
+        with (
+            patch("kai.config._read_protected_yaml", return_value=_YAML_MALFORMED),
+            patch("kai.config.PROJECT_ROOT", tmp_path),
+            caplog.at_level("WARNING", logger="kai.config"),
+        ):
+            configs = _load_memory_project_configs()
+
+        assert configs == {}
+        assert "malformed" in caplog.text.lower() or "malformed" in caplog.text
+
+    def test_invalid_memory_project_entry_is_skipped(self, tmp_path, caplog):
+        """A missing required field on one entry skips only that
+        entry; subsequent valid entries still load."""
+        good_root = tmp_path / "good"
+        good_root.mkdir()
+        self._write_yaml(
+            tmp_path,
+            f"""\
+            projects:
+              - display_name: Missing Project Id
+                workspace_roots:
+                  - {good_root}
+                memory_enabled: true
+              - project_id: good
+                display_name: Good
+                workspace_roots:
+                  - {good_root}
+                memory_enabled: true
+            """,
+        )
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            patch("kai.config.PROJECT_ROOT", tmp_path),
+            caplog.at_level("WARNING", logger="kai.config"),
+        ):
+            configs = _load_memory_project_configs()
+
+        assert list(configs.keys()) == ["good"]
+
+    def test_memory_project_requires_boolean_memory_enabled(self, tmp_path):
+        """memory_enabled set to a string is rejected outright. The
+        loader does not coerce; the operator must use a real YAML
+        bool."""
+        root = tmp_path / "p"
+        root.mkdir()
+        self._write_yaml(
+            tmp_path,
+            f"""\
+            projects:
+              - project_id: p
+                display_name: P
+                workspace_roots:
+                  - {root}
+                memory_enabled: "true"
+            """,
+        )
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            patch("kai.config.PROJECT_ROOT", tmp_path),
+        ):
+            configs = _load_memory_project_configs()
+        assert configs == {}
+
+    def test_memory_project_requires_boolean_memory_enabled_rejects_yaml_truthy_non_bools(self, tmp_path):
+        """Beyond the "true" string, YAML's other truthy non-bools
+        (int 1/0 and "yes"/"no" strings) must also be rejected. Each
+        variant gets its own project so a single passing variant
+        cannot mask the others."""
+        root = tmp_path / "p"
+        root.mkdir()
+        # YAML 1.1 would parse "yes" as bool True; PyYAML's default
+        # safe_load is YAML 1.1, so "yes" already comes through as a
+        # real bool. To genuinely test the "string yes" rejection we
+        # quote it, forcing it to remain a string after parsing.
+        self._write_yaml(
+            tmp_path,
+            f"""\
+            projects:
+              - project_id: int_one
+                display_name: One
+                workspace_roots:
+                  - {root}
+                memory_enabled: 1
+              - project_id: int_zero
+                display_name: Zero
+                workspace_roots:
+                  - {root}
+                memory_enabled: 0
+              - project_id: str_yes
+                display_name: Yes
+                workspace_roots:
+                  - {root}
+                memory_enabled: "yes"
+            """,
+        )
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            patch("kai.config.PROJECT_ROOT", tmp_path),
+        ):
+            configs = _load_memory_project_configs()
+        # None of the three should have made it through; coercion of
+        # YAML truthy non-bools is the failure mode we are gating.
+        assert configs == {}
+
+    def test_memory_project_rejects_invalid_default_scope(self, tmp_path):
+        """default_scope_for_new_facts is gated to SCOPE_GLOBAL or
+        SCOPE_PROJECT. SCOPE_TASK is not a write target in this
+        issue and must be rejected; arbitrary strings likewise."""
+        root = tmp_path / "p"
+        root.mkdir()
+        self._write_yaml(
+            tmp_path,
+            f"""\
+            projects:
+              - project_id: task_scope
+                display_name: T
+                workspace_roots:
+                  - {root}
+                memory_enabled: true
+                default_scope_for_new_facts: task
+              - project_id: nonsense
+                display_name: N
+                workspace_roots:
+                  - {root}
+                memory_enabled: true
+                default_scope_for_new_facts: not_a_scope
+            """,
+        )
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            patch("kai.config.PROJECT_ROOT", tmp_path),
+        ):
+            configs = _load_memory_project_configs()
+        assert configs == {}
+
+    def test_memory_project_allows_nonexistent_roots(self, tmp_path):
+        """Roots are NOT required to exist at load time. Registry
+        may be authored before checkout exists or while a mount is
+        unavailable; detection's longest-prefix match handles the
+        absent-root case by failing to match (no false positive)."""
+        nonexistent = tmp_path / "does_not_exist_yet"
+        self._write_yaml(
+            tmp_path,
+            f"""\
+            projects:
+              - project_id: ghost
+                display_name: Ghost
+                workspace_roots:
+                  - {nonexistent}
+                memory_enabled: true
+            """,
+        )
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            patch("kai.config.PROJECT_ROOT", tmp_path),
+        ):
+            configs = _load_memory_project_configs()
+        assert "ghost" in configs
+        # Root is still resolved canonically even though it does not
+        # exist. resolve() on a non-existing path returns the
+        # absolute form without raising on macOS/Linux.
+        assert configs["ghost"].workspace_roots == (nonexistent.resolve(),)
+
+    def test_duplicate_memory_project_id_uses_first(self, tmp_path, caplog):
+        """When the same project_id appears twice, the first entry
+        wins and the later entry is logged + skipped. Pins the
+        documented duplicate-id behavior."""
+        root_a = tmp_path / "first"
+        root_a.mkdir()
+        root_b = tmp_path / "second"
+        root_b.mkdir()
+        self._write_yaml(
+            tmp_path,
+            f"""\
+            projects:
+              - project_id: dup
+                display_name: First
+                workspace_roots:
+                  - {root_a}
+                memory_enabled: true
+              - project_id: dup
+                display_name: Second
+                workspace_roots:
+                  - {root_b}
+                memory_enabled: false
+            """,
+        )
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            patch("kai.config.PROJECT_ROOT", tmp_path),
+            caplog.at_level("WARNING", logger="kai.config"),
+        ):
+            configs = _load_memory_project_configs()
+        assert configs["dup"].display_name == "First"
+        assert configs["dup"].memory_enabled is True
+        assert "duplicate project_id" in caplog.text
+
+    def test_duplicate_memory_project_root_drops_later_duplicate_root(self, tmp_path, caplog):
+        """When two distinct projects list the same root, the root
+        is dropped from the LATER project only. The later project
+        survives with its remaining unique roots."""
+        shared_root = tmp_path / "shared"
+        shared_root.mkdir()
+        unique_root = tmp_path / "unique"
+        unique_root.mkdir()
+        self._write_yaml(
+            tmp_path,
+            f"""\
+            projects:
+              - project_id: first_owner
+                display_name: First
+                workspace_roots:
+                  - {shared_root}
+                memory_enabled: true
+              - project_id: second_owner
+                display_name: Second
+                workspace_roots:
+                  - {shared_root}
+                  - {unique_root}
+                memory_enabled: true
+            """,
+        )
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            patch("kai.config.PROJECT_ROOT", tmp_path),
+            caplog.at_level("WARNING", logger="kai.config"),
+        ):
+            configs = _load_memory_project_configs()
+        assert "first_owner" in configs
+        assert "second_owner" in configs
+        # The shared root went to first_owner; second_owner keeps
+        # only its unique root.
+        assert configs["first_owner"].workspace_roots == (shared_root.resolve(),)
+        assert configs["second_owner"].workspace_roots == (unique_root.resolve(),)
+        assert "already owned" in caplog.text
+
+    def test_duplicate_memory_project_root_drops_project_when_no_roots_remain(self, tmp_path, caplog):
+        """When ALL of a later project's roots are duplicates of an
+        earlier project's roots, the entire later project is dropped
+        so detection never returns a project with no roots to match
+        against."""
+        shared_root = tmp_path / "shared"
+        shared_root.mkdir()
+        self._write_yaml(
+            tmp_path,
+            f"""\
+            projects:
+              - project_id: first_owner
+                display_name: First
+                workspace_roots:
+                  - {shared_root}
+                memory_enabled: true
+              - project_id: orphaned
+                display_name: Orphaned
+                workspace_roots:
+                  - {shared_root}
+                memory_enabled: true
+            """,
+        )
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            patch("kai.config.PROJECT_ROOT", tmp_path),
+            caplog.at_level("WARNING", logger="kai.config"),
+        ):
+            configs = _load_memory_project_configs()
+        assert "first_owner" in configs
+        assert "orphaned" not in configs
+        assert "no valid workspace_roots remain" in caplog.text
+
+    def test_memory_project_roots_do_not_extend_allowed_workspaces(self, monkeypatch, tmp_path):
+        """End-to-end load_config check: registry roots must NOT
+        sneak into Config.allowed_workspaces. Workspace access is
+        still owned by ALLOWED_WORKSPACES / workspaces.yaml; the
+        memory registry describes scope, not access."""
+        # Start with a fully minimal env to keep this independent of
+        # other env-based test pollution.
+        for v in _CONFIG_ENV_VARS:
+            monkeypatch.delenv(v, raising=False)
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+        monkeypatch.setenv("ALLOWED_USER_IDS", "12345")
+        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+
+        registry_root = tmp_path / "registry_root"
+        registry_root.mkdir()
+        # Write only the memory-projects.yaml; do NOT add the root to
+        # workspaces.yaml or ALLOWED_WORKSPACES. The assertion is that
+        # the registry root does not pull itself into allowed access.
+        yaml_file = tmp_path / "memory-projects.yaml"
+        yaml_file.write_text(
+            textwrap.dedent(
+                f"""\
+                projects:
+                  - project_id: scope_only
+                    display_name: Scope Only
+                    workspace_roots:
+                      - {registry_root}
+                    memory_enabled: true
+                """
+            )
+        )
+
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            patch("kai.config.PROJECT_ROOT", tmp_path),
+        ):
+            cfg = load_config()
+
+        # Registry loaded the project as expected.
+        assert "scope_only" in cfg.memory_projects
+        assert cfg.memory_projects["scope_only"].workspace_roots == (registry_root.resolve(),)
+        # ...but did NOT promote its root into allowed_workspaces.
+        assert registry_root.resolve() not in cfg.allowed_workspaces
+        assert registry_root not in cfg.allowed_workspaces

--- a/tests/test_memory_projects.py
+++ b/tests/test_memory_projects.py
@@ -1,0 +1,200 @@
+"""Tests for the memory-project detection helper.
+
+`detect_active_memory_project` is a pure read-only helper: it takes
+a workspace path and the registry dict and returns the matching
+`ActiveMemoryProject`, or None when no root matches. These tests
+pin the algorithm's correctness pieces: path containment (not
+string prefix), longest-prefix tie-breaking, symlink resolution
+before matching, and the disabled-project semantics that later
+retrieval and write paths will depend on.
+
+Detection wiring into pool/backend is deferred to #544; this issue
+only ships the helper.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import sys
+
+import pytest
+
+from kai.config import MemoryProjectConfig
+from kai.memory_projects import ActiveMemoryProject, detect_active_memory_project
+
+
+def _project(
+    project_id: str,
+    *roots,
+    memory_enabled: bool = True,
+    default_scope: str | None = None,
+):
+    """Build a `MemoryProjectConfig` from a list of roots. Test-only
+    convenience so each test reads as data, not as scaffolding."""
+    return MemoryProjectConfig(
+        project_id=project_id,
+        display_name=project_id.capitalize(),
+        workspace_roots=tuple(r.resolve() for r in roots),
+        memory_enabled=memory_enabled,
+        default_scope_for_new_facts=default_scope,
+    )
+
+
+class TestDetectActiveMemoryProject:
+    def test_detect_active_memory_project_exact_root(self, tmp_path):
+        """A cwd that equals a registered root matches it. Equality
+        is structurally different from `is_relative_to()` (which
+        returns False for equal paths), so the detector handles both
+        as a single "matched" outcome."""
+        root = tmp_path / "kai"
+        root.mkdir()
+        projects = {"kai": _project("kai", root)}
+
+        active = detect_active_memory_project(root, projects)
+
+        assert active is not None
+        assert active.project_id == "kai"
+        assert active.matched_root == root.resolve()
+        assert active.memory_enabled is True
+
+    def test_detect_active_memory_project_child_path(self, tmp_path):
+        """A nested path under a registered root resolves to the
+        project that owns the root. Path containment is the matching
+        rule; arbitrary descendants count."""
+        root = tmp_path / "kai"
+        nested = root / "src" / "kai" / "memory_projects.py"
+        nested.parent.mkdir(parents=True)
+        nested.touch()
+        projects = {"kai": _project("kai", root)}
+
+        active = detect_active_memory_project(nested, projects)
+
+        assert active is not None
+        assert active.project_id == "kai"
+        assert active.matched_root == root.resolve()
+
+    def test_detect_active_memory_project_uses_longest_matching_root(self, tmp_path):
+        """When two registered roots both contain the cwd, the root
+        with the most path parts wins. Common config shape: a broad
+        umbrella root and one or more narrower child roots; the
+        narrower one is the authoritative match."""
+        # Two roots configured under different projects; both contain
+        # the cwd `cwd_path`. The narrower root (more path parts)
+        # belongs to the inner project; it should win.
+        umbrella = tmp_path / "projects"
+        umbrella.mkdir()
+        inner = umbrella / "kai"
+        inner.mkdir()
+        cwd_path = inner / "src" / "kai"
+        cwd_path.mkdir(parents=True)
+        projects = {
+            "umbrella": _project("umbrella", umbrella),
+            "kai": _project("kai", inner),
+        }
+
+        active = detect_active_memory_project(cwd_path, projects)
+
+        assert active is not None
+        assert active.project_id == "kai"
+        assert active.matched_root == inner.resolve()
+
+    def test_detect_active_memory_project_rejects_string_prefix_match(self, tmp_path):
+        """`/work/foo2` MUST NOT match a root of `/work/foo`. This
+        is the load-bearing correctness pin for using
+        `Path.is_relative_to()` over `str.startswith()`. A
+        regression here would silently merge unrelated projects."""
+        sibling_root = tmp_path / "foo"
+        sibling_root.mkdir()
+        confusing_cwd = tmp_path / "foo2"
+        confusing_cwd.mkdir()
+        projects = {"foo": _project("foo", sibling_root)}
+
+        active = detect_active_memory_project(confusing_cwd, projects)
+
+        assert active is None
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlink fixtures require os.symlink, skipped on Windows")
+    def test_detect_active_memory_project_resolves_symlink_before_matching(self, tmp_path):
+        """A cwd that reaches a registered root through a symlink
+        resolves to the canonical path before matching. This keeps
+        memory scope tied to filesystem identity instead of the
+        access alias, preventing one project from looking like two
+        depending on which path the operator used."""
+        real_root = tmp_path / "real_kai"
+        real_root.mkdir()
+        link_path = tmp_path / "kai_alias"
+        os.symlink(real_root, link_path)
+        projects = {"kai": _project("kai", real_root)}
+
+        # Enter via the symlink alias; detection should resolve it
+        # to the canonical real_root before matching.
+        active = detect_active_memory_project(link_path, projects)
+
+        assert active is not None
+        assert active.project_id == "kai"
+        assert active.matched_root == real_root.resolve()
+
+    def test_detect_active_memory_project_unknown_workspace_returns_none(self, tmp_path):
+        """A cwd that is not inside any registered root returns
+        None. The detector does not guess; callers fall back to
+        global-only behavior."""
+        root = tmp_path / "known"
+        root.mkdir()
+        unknown_cwd = tmp_path / "elsewhere"
+        unknown_cwd.mkdir()
+        projects = {"known": _project("known", root)}
+
+        active = detect_active_memory_project(unknown_cwd, projects)
+
+        assert active is None
+
+    def test_detect_active_memory_project_disabled_project_detected_but_not_allowed(self, tmp_path):
+        """A disabled project still returns an `ActiveMemoryProject`
+        so logs and future shadow-mode metrics can distinguish "no
+        project here" from "known project with memory disabled".
+        The `memory_enabled=False` signal is what later retrieval
+        and write paths consume; the helper does not make the
+        global-only decision itself."""
+        root = tmp_path / "disabled_proj"
+        root.mkdir()
+        projects = {"disabled_proj": _project("disabled_proj", root, memory_enabled=False)}
+
+        active = detect_active_memory_project(root, projects)
+
+        assert active is not None
+        assert active.project_id == "disabled_proj"
+        assert active.memory_enabled is False
+
+    def test_detect_active_memory_project_empty_registry_returns_none(self, tmp_path):
+        """Defensive: an empty registry short-circuits to None
+        before any path work happens. Pinning this stops a future
+        refactor from doing pointless filesystem work on the common
+        no-projects-configured path."""
+        active = detect_active_memory_project(tmp_path, {})
+        assert active is None
+
+
+class TestActiveMemoryProjectDataclass:
+    """Light pin that the returned dataclass shape is frozen and
+    carries the exact fields the helper documents. Catches
+    accidental field rename or attribute injection in a refactor."""
+
+    def test_dataclass_is_frozen_and_carries_expected_fields(self, tmp_path):
+        root = tmp_path
+        active = ActiveMemoryProject(
+            project_id="x",
+            display_name="X",
+            matched_root=root,
+            memory_enabled=True,
+            default_scope_for_new_facts="project",
+        )
+        # Frozen: attribute assignment must raise FrozenInstanceError.
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            active.project_id = "y"  # type: ignore[misc]
+        # Field shape is what callers will rely on.
+        assert active.project_id == "x"
+        assert active.display_name == "X"
+        assert active.matched_root == root
+        assert active.memory_enabled is True
+        assert active.default_scope_for_new_facts == "project"


### PR DESCRIPTION
Closes #543. Parent epic #517. Builds on #542.

## Summary

Adds the schema and detection layer for scoped global/project memory. The registry maps workspace paths to memory authority boundaries; the detector returns the matching `ActiveMemoryProject` for a given path (or `None` when the path is not registered).

No retrieval, prompt-rendering, or write-routing behavior changes. Wiring those paths to the detector belongs to #544 and later issues.

## What's in this PR

**`src/kai/config.py`**
- `MemoryProjectConfig` frozen dataclass: `project_id`, `display_name`, resolved `workspace_roots` tuple, `memory_enabled`, optional `default_scope_for_new_facts`.
- `Config.memory_projects: dict[str, MemoryProjectConfig]`.
- `_load_memory_project_configs()` mirrors `_load_workspace_configs()`: try `/etc/kai/memory-projects.yaml` via `_read_protected_yaml`, then `PROJECT_ROOT/memory-projects.yaml`, return `{}` if neither exists. Malformed protected file fails closed (does not fall through to the local file).
- Fail-closed validation: strict bool `memory_enabled` (rejects `"true"`/`"yes"`/`1`), required `project_id`/`display_name`/`workspace_roots`, optional `default_scope_for_new_facts` gated to `SCOPE_GLOBAL` or `SCOPE_PROJECT`. The scope constants are imported lazily inside the loader to avoid the `kai.memory -> kai.config` circular.
- Duplicate handling: `project_id` first-wins; cross-project duplicate roots drop from the later project only; if all of a later project's roots are duplicates, the whole project is dropped.
- Path existence is NOT required at load time so registry config can predate a checkout or survive a missing mount.
- `load_config` wires the loader without merging registry roots into `allowed_workspaces`.

**`src/kai/memory_projects.py`** (new)
- `ActiveMemoryProject` frozen dataclass carrying the matched root for diagnostics.
- `detect_active_memory_project(cwd, projects)` resolves the input path (`expanduser().resolve()`) and uses `Path.is_relative_to()` + equality for containment (never string-prefix). Longest-matching root wins. Returns `None` for unknown paths and short-circuits to `None` for an empty registry.

**`templates/memory-projects.yaml`** (new)
- Commented example with one enabled + one disabled record. Documents the schema and the "registry roots do not grant workspace access" boundary.

## Tests

**`tests/test_config.py`** (12 loader tests)
- Valid YAML, missing, malformed-protected fail-closed.
- Invalid entry skipped (others still load).
- Strict bool rejection for both `"true"` string and the YAML truthy non-bools (`1`/`0`/`"yes"`).
- Invalid `default_scope_for_new_facts` rejection (covers `task` and arbitrary strings).
- Nonexistent roots allowed.
- Duplicate `project_id` first-wins.
- Duplicate root drops from later project; whole later project drops when no roots remain.
- End-to-end `load_config` check: registry roots do NOT extend `allowed_workspaces`.

**`tests/test_memory_projects.py`** (new; 7 detection tests + 2 defensive pins)
- Exact root match, child path, longest-root tie-breaking.
- String-prefix safety: `/work/foo2` MUST NOT match `/work/foo`.
- Symlink resolution before matching.
- Unknown path returns `None`.
- Disabled project detectable but reports `memory_enabled=False`.
- Empty registry short-circuits to `None`.
- `ActiveMemoryProject` is frozen and carries the documented field shape.

## Test plan

- [x] `pytest tests/test_memory_projects.py tests/test_config.py::TestLoadMemoryProjects` (21 passed)
- [x] `make test` (3491 passed, 1 skipped)
- [x] `make check` (ruff lint + format)
- [x] Spec §10 grep gate over the diff:
  - No `format_context(`, `assemble_turn_context`, or `_memory.search` touched in src/.
  - No new fields added to the `WorkspaceConfig` dataclass body.
  - No merges between `allowed_workspaces` and `memory_projects`.
  - `memory_projects` symbol appears only in `src/kai/config.py`, `src/kai/memory_projects.py`, `templates/memory-projects.yaml`, and tests.
