### PR TITLE
feat(memory): add scoped shadow-mode comparison logging

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -169,6 +169,13 @@ class AgentBackend(ABC):
     workspace_config: WorkspaceConfig | None
     provider: str
 
+    # Stable identifier the shadow-mode logger (#546) and any future
+    # backend-aware code path can read off the instance. Concrete
+    # backends override the class-level default with their canonical
+    # name. Default `""` keeps the ABC importable for tests that
+    # construct a stub backend without thinking about logging.
+    backend_name: str = ""
+
     @abstractmethod
     async def send(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
         """Send a message and yield streaming events.
@@ -925,6 +932,10 @@ async def assemble_turn_context(
     chat_id: int | None,
     session_context: str = "",
     workspace_reminder: str = "",
+    workspace: Path | None = None,
+    backend_name: str | None = None,
+    job_type: str | None = None,
+    session_id: str | None = None,
 ) -> str | list:
     """
     Assemble the per-turn prompt context for an interactive backend.
@@ -999,15 +1010,49 @@ async def assemble_turn_context(
     # Semantic recall on every eligible turn (~50-100ms via the
     # executor inside format_context). Skip entirely when chat_id
     # is None (cross-user leakage risk) or the query is whitespace-
-    # only (random embedding hits). The function-local import
-    # mirrors the claude.py shape pre-extraction so test patching
-    # of kai.memory.format_context stays valid.
+    # only (random embedding hits). Function-local imports keep
+    # backend.py's import surface lean and let tests patch
+    # `kai.memory.format_context` (and the new `_emit_recall_log`
+    # / `run_scoped_recall_shadow` symbols) without import-order
+    # surprises.
     if chat_id is not None and search_query.strip():
-        from kai.memory import format_context as memory_format_context
+        # Legacy recall is the live prompt content. The split
+        # introduced in #546 (format_context_with_recall_payload +
+        # _emit_recall_log) lets shadow-mode logging reuse the
+        # same legacy search and payload without re-running search;
+        # the wrapper format_context still exists for callers that
+        # do not need the payload, but assemble_turn_context owns
+        # the shadow-mode call site and so reads the payload
+        # directly. memory.recall stays "exactly one line per
+        # eligible turn" - emitted here, never twice.
+        from kai.memory import (
+            _emit_recall_log,
+            format_context_with_recall_payload,
+            run_scoped_recall_shadow,
+        )
 
-        memory_ctx = await memory_format_context(search_query, user_id=str(chat_id))
-        if memory_ctx:
-            prompt = prepend_to_prompt(prompt, memory_ctx)
+        legacy_recall = await format_context_with_recall_payload(search_query, user_id=str(chat_id))
+        _emit_recall_log(legacy_recall.recall_payload)
+        if legacy_recall.rendered_context:
+            prompt = prepend_to_prompt(prompt, legacy_recall.rendered_context)
+
+        # Shadow-mode comparison log (#546). Best-effort; the helper
+        # is failure-isolated internally and short-circuits when
+        # disabled, so the live prompt path above is unaffected by
+        # any scoped retrieval or rendering bug. Backends pass
+        # workspace/backend_name/job_type so the shadow log can
+        # detect the active project and identify the caller; tests
+        # that omit those kwargs land on the missing-workspace
+        # branch which still emits a uniform shadow line.
+        await run_scoped_recall_shadow(
+            query=search_query,
+            user_id=str(chat_id),
+            legacy_result=legacy_recall,
+            workspace=workspace,
+            backend_name=backend_name,
+            job_type=job_type,
+            session_id=session_id,
+        )
 
     # Foreign-workspace reminder is built fresh by the caller on
     # every turn (it depends on the workspace state at call time).

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -69,6 +69,10 @@ class ClaudeCodeBackend(AgentBackend):
     the executor indefinitely.
     """
 
+    # Stable identifier read by the shadow-mode logger (#546) to
+    # tag `memory.recall_shadow` lines with the caller backend.
+    backend_name = "claude_code"
+
     def __init__(
         self,
         *,
@@ -816,6 +820,9 @@ class ClaudeCodeBackend(AgentBackend):
             chat_id=chat_id,
             session_context=session_ctx,
             workspace_reminder=reminder,
+            workspace=self.workspace,
+            backend_name=self.backend_name,
+            job_type="interactive",
         )
 
         content = prompt if isinstance(prompt, list) else [{"type": "text", "text": prompt}]

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -94,6 +94,10 @@ class CodexBackend(AgentBackend):
     config; this backend does not inject permission decisions.
     """
 
+    # Stable identifier read by the shadow-mode logger (#546) to
+    # tag `memory.recall_shadow` lines with the caller backend.
+    backend_name = "codex"
+
     def __init__(
         self,
         *,
@@ -627,6 +631,9 @@ class CodexBackend(AgentBackend):
             chat_id=recall_chat_id,
             session_context=session_ctx,
             workspace_reminder=reminder,
+            workspace=self.workspace,
+            backend_name=self.backend_name,
+            job_type="interactive",
         )
 
         # Coerce to the JSON-RPC content-block shape. `prompt` is

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -912,6 +912,22 @@ class Config:
     # without re-running `make config`.
     memory_duplicate_threshold: float = 0.9
 
+    # Shadow-mode retrieval comparison toggle. When True (the
+    # default) and legacy memory recall runs for a turn, scoped
+    # retrieval also runs and emits a `memory.recall_shadow` log
+    # line alongside the existing `memory.recall` line so legacy
+    # vs scoped result sets can be compared on real conversation
+    # turns before the live read path switches. Default-on is
+    # deliberate: the comparison log is the evidence base for the
+    # eventual switch, and a default-off flag would block that
+    # evidence collection. Operators who hit performance or log-
+    # volume problems can disable with MEMORY_RECALL_SHADOW_ENABLED=0
+    # (or "false" / "no", case-insensitive) for an immediate kill
+    # without redeploying. Like memory_extraction_enabled, this is
+    # a sub-toggle of memory_enabled: shadow only runs when memory
+    # is enabled (legacy recall provides the baseline to compare).
+    memory_recall_shadow_enabled: bool = True
+
     def get_workspace_config(self, workspace: Path) -> WorkspaceConfig | None:
         """
         Get per-workspace config for a path, or None for global defaults.
@@ -2207,6 +2223,17 @@ def load_config() -> Config:
     # closed regardless of operator env-var ordering.
     memory_extraction_enabled = memory_extraction_enabled and memory_enabled
 
+    # Shadow-mode retrieval comparison toggle. Default-on, inverted
+    # parse compared to the usual default-off memory env vars: any
+    # absent or non-disable value keeps shadow on; only the explicit
+    # disable strings turn it off. Like memory_extraction_enabled,
+    # composed with memory_enabled so shadow never runs when memory
+    # is off (no legacy recall to compare against, and the helper
+    # short-circuits anyway).
+    _shadow_raw = os.environ.get("MEMORY_RECALL_SHADOW_ENABLED", "")
+    memory_recall_shadow_enabled = _shadow_raw.strip().lower() not in ("0", "false", "no")
+    memory_recall_shadow_enabled = memory_recall_shadow_enabled and memory_enabled
+
     # Deprecation warnings for the three retired memory env vars. The
     # reasoner and model used for memory extraction now derive entirely
     # from each user's effective `agent_backend` (per-user dispatch via
@@ -2538,6 +2565,7 @@ def load_config() -> Config:
         memory_token_budget=memory_token_budget,
         memory_embedding_model=memory_embedding_model,
         memory_extraction_enabled=memory_extraction_enabled,
+        memory_recall_shadow_enabled=memory_recall_shadow_enabled,
         memory_extraction_budget_usd=memory_extraction_budget_usd,
         memory_extraction_timeout_s=memory_extraction_timeout_s,
         episode_classifier_context_turns=episode_classifier_context_turns,

--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -73,6 +73,10 @@ class GooseBackend(AgentBackend):
     all tool calls, so no permission write-back is needed.
     """
 
+    # Stable identifier read by the shadow-mode logger (#546) to
+    # tag `memory.recall_shadow` lines with the caller backend.
+    backend_name = "goose"
+
     def __init__(
         self,
         *,
@@ -434,6 +438,9 @@ class GooseBackend(AgentBackend):
             chat_id=recall_chat_id,
             session_context=session_ctx,
             workspace_reminder=reminder,
+            workspace=self.workspace,
+            backend_name=self.backend_name,
+            job_type="interactive",
         )
 
         # Coerce to the ACP content-block shape. `prompt` is either a

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -1115,6 +1115,27 @@ def _emit_recall_log(payload: dict[str, object]) -> None:
     log.info("memory.recall %s", json.dumps(payload, separators=(",", ":")))
 
 
+def _emit_recall_shadow_log(payload: dict[str, object]) -> None:
+    """
+    Write a single memory.recall_shadow log line as compact JSON.
+
+    Companion to `_emit_recall_log` for the #546 shadow-mode
+    comparison line. The two log surfaces are intentionally
+    separate: `memory.recall` is parsed by the existing retrieval
+    eval harness under a stable schema, and overloading it with
+    scoped fields would force a contract migration. Downstream
+    parsers can grep `memory.recall_shadow ` (note trailing space)
+    as a stable tag and json.load the rest.
+
+    Same PII posture as `_emit_recall_log`: query and per-hit
+    snippets are logged in their truncated form (80 chars), not
+    hashed. The shadow line uses the same `_RECALL_QUERY_TRUNC`
+    and `_RECALL_SNIPPET_TRUNC` constants as the legacy line so
+    log volume scales identically.
+    """
+    log.info("memory.recall_shadow %s", json.dumps(payload, separators=(",", ":")))
+
+
 # ── Public API ──────────────────────────────────────────────────────
 
 
@@ -1312,6 +1333,20 @@ def is_enabled() -> bool:
     return _memory is not None
 
 
+def is_recall_shadow_enabled() -> bool:
+    """
+    True when scoped shadow-mode comparison should run alongside
+    live recall.
+
+    Backed by `Config.memory_recall_shadow_enabled`, which defaults
+    on but can be killed via `MEMORY_RECALL_SHADOW_ENABLED=0`. The
+    composition with `memory_enabled` happens in `load_config` so
+    that flag is already false when memory is off; here we just
+    return what config says.
+    """
+    return _config is not None and _config.memory_recall_shadow_enabled
+
+
 def search(query: str, *, user_id: str, limit: int | None = None) -> list[MemoryResult]:
     """
     Search for memories semantically similar to the query.
@@ -1392,54 +1427,73 @@ def _format_memory_result_line(r: MemoryResult) -> str:
     return f"- ({source_short}) {r.text}"
 
 
-async def format_context(
+@dataclass(frozen=True)
+class LegacyRecallResult:
+    """
+    Internal-only result type for `format_context_with_recall_payload`.
+
+    Bundles the rendered legacy memory block alongside the
+    `memory.recall` payload that the legacy path has computed but
+    not yet emitted. Shadow-mode logging (#546) reads both fields
+    so it can compare legacy vs scoped retrieval on the same turn
+    without re-running legacy search or parsing log text.
+
+    Attributes:
+        rendered_context: The legacy memory block ready to prepend
+            to the prompt, or `""` for any short-circuit path
+            (disabled / empty query / no results / etc.).
+        recall_payload: The fully populated `memory.recall` dict
+            (uniform schema described by `_base_recall_payload`).
+            The caller is responsible for emitting it exactly once
+            via `_emit_recall_log`.
+    """
+
+    rendered_context: str
+    recall_payload: dict[str, object]
+
+
+async def format_context_with_recall_payload(
     query: str,
     *,
     user_id: str,
     token_budget: int | None = None,
-) -> str:
+) -> LegacyRecallResult:
     """
-    Search for relevant memories and format them for context injection.
+    Run the legacy recall pipeline; return rendered text + payload.
 
-    Returns a formatted string ready to prepend to the user's message,
-    or an empty string if no relevant memories are found or memory is
-    disabled.
+    Same logic as `format_context()` minus the `memory.recall` log
+    emit. The caller decides when to emit so shadow-mode logging
+    can reuse one legacy search per eligible turn instead of
+    triggering two (one for the prompt, one for the comparison
+    log). This is a Kai-internal helper, not a public API.
 
-    Async because the underlying Mem0 search (embedding computation +
-    Qdrant lookup) is CPU-bound (~50-100ms). Running it in an executor
-    keeps the asyncio event loop free for other users' messages, typing
-    indicators, and webhook handling.
+    Args:
+        query, user_id, token_budget: identical to format_context.
 
-    The header explicitly marks these as context, not instructions,
-    to prevent the inner Claude from treating recalled memories as
-    directives.
-
-    Observability: every call emits exactly one structured log line
-    with the prefix `memory.recall` and a compact JSON payload, both
-    on success and at every short-circuit return. See _emit_recall_log
-    and _base_recall_payload for the schema. Designed to be parsed by
-    a downstream retrieval eval harness without re-running search.
+    Returns:
+        LegacyRecallResult with the rendered block and the populated
+        `memory.recall` payload. Both are valid for every code
+        path (disabled, empty query, no results, all-below-floor,
+        budget-exhausted, success); short-circuits set the `reason`
+        field and return `rendered_context=""`.
     """
     # Build the recall payload up-front with sentinel values for
     # every uniform-shape field. Each downstream branch updates the
-    # fields it knows about, then emits exactly one log line at its
-    # return site. Centralizing construction here guarantees that
-    # query and user_id (the always-populated fields) cannot be
-    # forgotten at any single emit site.
+    # fields it knows about. Centralizing construction here guarantees
+    # that query and user_id (always-populated fields) cannot be
+    # forgotten on any return path.
     payload = _base_recall_payload(user_id, query)
 
     if not is_enabled() or _config is None:
         payload["reason"] = _RECALL_REASON_DISABLED
-        _emit_recall_log(payload)
-        return ""
+        return LegacyRecallResult(rendered_context="", recall_payload=payload)
 
     # Empty queries (e.g. image-only prompts with no text) produce a
     # non-zero embedding in sentence-transformers, returning arbitrary
     # results that pass the relevance threshold. Skip entirely.
     if not query.strip():
         payload["reason"] = _RECALL_REASON_EMPTY_QUERY
-        _emit_recall_log(payload)
-        return ""
+        return LegacyRecallResult(rendered_context="", recall_payload=payload)
 
     budget = token_budget if token_budget is not None else _config.memory_token_budget
     payload["budget_tokens"] = budget
@@ -1458,12 +1512,9 @@ async def format_context(
     # consistently here AND in the `/memory search` UI. _config is non-None
     # inside this branch because is_enabled() returned True above.
     #
-    # Captured BEFORE the search call so post-search short-circuit log
-    # lines (no_results, all_below_floor) carry the real floor value in
-    # their payload rather than the 0.0 sentinel that
-    # _base_recall_payload sets, matching how budget_tokens and
-    # fetch_limit are populated up-front. The actual filter step using
-    # `floor` happens later, after the search returns results to filter.
+    # Captured BEFORE the search call so post-search short-circuit
+    # payloads (no_results, all_below_floor) carry the real floor value
+    # rather than the 0.0 sentinel that _base_recall_payload sets.
     floor = _config.memory_search_floor
     payload["floor"] = floor
 
@@ -1478,36 +1529,25 @@ async def format_context(
     payload["hits_raw"] = len(results)
     if not results:
         payload["reason"] = _RECALL_REASON_NO_RESULTS
-        _emit_recall_log(payload)
-        return ""
+        return LegacyRecallResult(rendered_context="", recall_payload=payload)
 
     # Quality gate: drop low-relevance noise before any ranking adjustment.
     # Weighting happens AFTER this filter so a downweighted legacy row
     # cannot survive on raw score, and a boosted extracted fact cannot
-    # be rescued below threshold. `floor` was read from _config above
-    # so the all_below_floor short-circuit log line carries the real
-    # threshold rather than a sentinel.
+    # be rescued below threshold.
     results = [r for r in results if r.score >= floor]
     payload["hits_after_floor"] = len(results)
     if not results:
         payload["reason"] = _RECALL_REASON_ALL_BELOW_FLOOR
-        _emit_recall_log(payload)
-        return ""
+        return LegacyRecallResult(rendered_context="", recall_payload=payload)
 
-    # Speaker-weighted adjusted score for ranking only. Sort is required
-    # regardless of Mem0's incoming order; the walk order below reads
-    # adjusted_score via the sort key, not Mem0's.
-    #
-    # Resolve (speaker, confidence) ONCE per row via _read_time_speaker
-    # and compute the weight from those two factors directly, then
-    # carry all three alongside the result row through the sort. The
-    # per-hit log payload below reads speaker / confidence off the
-    # same tuple, so the metadata dict is parsed exactly once per row
-    # for both the ranking and the log path. Going through
-    # _speaker_weight(r) at the sort step would re-parse the metadata
-    # a second time below; threading the resolved values through
-    # avoids that without losing the demote-only invariant (the
-    # multiplier is still speaker_weight * confidence).
+    # Speaker-weighted adjusted score for ranking only. Resolve
+    # (speaker, confidence) ONCE per row via _read_time_speaker and
+    # compute the weight from those two factors directly, then carry
+    # all three alongside the result row through the sort. The per-hit
+    # log payload below reads speaker / confidence off the same tuple,
+    # so the metadata dict is parsed exactly once per row for both the
+    # ranking and the log path.
     def _resolved_row(r: MemoryResult) -> tuple[MemoryResult, float, str, float]:
         # Duplicates the body of _speaker_weight (minus its
         # _read_time_speaker call) so the resolved (speaker,
@@ -1533,23 +1573,6 @@ async def format_context(
     # "what the agent actually saw" and `hits[lines_used:]` for
     # "survived ranking but lost to budget"; distinguishing these two
     # is what makes precision/recall scoring accurate.
-    # `id` is the Mem0 row identifier (MemoryResult.id, required field
-    # at line 120). Carried in the per-hit object so a downstream parser
-    # can match a probe's expected_fact_id against the actual hit
-    # without re-issuing get_by_id per hit or fragile snippet-substring
-    # matching (snippet is truncated to 80 chars and not unique).
-    # Without this field, precision/recall scoring against a known
-    # expected_fact_id has no honest way to identify which hit corresponds.
-    #
-    # `speaker` and `confidence` ride alongside `source` so a log
-    # analyst can reconstruct the demote multiplier (`speaker_weight
-    # * confidence`) from the line without a re-fetch. Both fields
-    # come from the resolved tuple above, so legacy rows log the
-    # same defaulted values that drove their ranking, rather than a
-    # missing-field marker. The `source` field stays so analysts can
-    # still distinguish episode rows from extracted rows; speaker and
-    # source describe two different axes (whose claim vs which write
-    # path) and are not redundant.
     payload["hits"] = [
         {
             "id": r.id,
@@ -1595,13 +1618,50 @@ async def format_context(
     # "survived but dropped by budget" slice.
     if len(lines) <= 1:
         payload["reason"] = _RECALL_REASON_BUDGET_EXHAUSTED
-        _emit_recall_log(payload)
-        return ""
+        return LegacyRecallResult(rendered_context="", recall_payload=payload)
 
     payload["lines_used"] = lines_used
     payload["returned_empty"] = False
-    _emit_recall_log(payload)
-    return "\n".join(lines)
+    return LegacyRecallResult(rendered_context="\n".join(lines), recall_payload=payload)
+
+
+async def format_context(
+    query: str,
+    *,
+    user_id: str,
+    token_budget: int | None = None,
+) -> str:
+    """
+    Search for relevant memories and format them for context injection.
+
+    Returns a formatted string ready to prepend to the user's message,
+    or an empty string if no relevant memories are found or memory is
+    disabled.
+
+    Async because the underlying Mem0 search (embedding computation +
+    Qdrant lookup) is CPU-bound (~50-100ms). Running it in an executor
+    keeps the asyncio event loop free for other users' messages, typing
+    indicators, and webhook handling.
+
+    The header explicitly marks these as context, not instructions,
+    to prevent the inner Claude from treating recalled memories as
+    directives.
+
+    Observability: every call emits exactly one structured log line
+    with the prefix `memory.recall` and a compact JSON payload, both
+    on success and at every short-circuit return. See _emit_recall_log
+    and _base_recall_payload for the schema. Designed to be parsed by
+    a downstream retrieval eval harness without re-running search.
+
+    Implementation: thin wrapper around
+    `format_context_with_recall_payload`. The split lets shadow-mode
+    logging (#546) reuse the legacy payload without re-running
+    legacy search; this wrapper preserves the public signature and
+    log-emission contract every existing caller depends on.
+    """
+    result = await format_context_with_recall_payload(query, user_id=user_id, token_budget=token_budget)
+    _emit_recall_log(result.recall_payload)
+    return result.rendered_context
 
 
 async def retrieve_scoped_memories(
@@ -2011,6 +2071,278 @@ def format_scoped_context(
     # over two it inserts a single blank line. Same separator
     # literal that the budget charge above used.
     return _SCOPED_SECTION_SEPARATOR.join("\n".join(section) for section in rendered_sections)
+
+
+# ── Shadow-mode comparison logging (#546) ────────────────────────────
+
+
+# Maximum chars of an exception message echoed into the shadow log
+# on a scoped failure. Long messages (e.g. a Mem0 connection error
+# with a serialized request body) would otherwise blow up the
+# shadow line. Match the per-hit snippet truncation so log volume
+# scales consistently with the other text fields.
+_SHADOW_ERROR_MESSAGE_TRUNC = 200
+
+
+def _ordered_difference(left: list[str], right: list[str]) -> list[str]:
+    """
+    Return items in `left` not present in `right`, preserving left
+    order. Stable for the shadow `removed_ids` / `added_ids`
+    fields where rank-order in the source list is the analyst
+    signal (oldest scoped removal first vs newest, etc.).
+    """
+    right_set = set(right)
+    return [item for item in left if item not in right_set]
+
+
+def _ordered_intersection(left: list[str], right: list[str]) -> list[str]:
+    """
+    Return items present in both lists, preserving left order. Used
+    for `same_ids` so the shadow line shows legacy rank order on
+    the surviving rows rather than scoped order.
+    """
+    right_set = set(right)
+    return [item for item in left if item in right_set]
+
+
+def _scoped_debug_to_payload(debug: ScopedRetrievalDebug) -> dict[str, object]:
+    """
+    Convert a `ScopedRetrievalDebug` to a JSON-safe dict for the
+    `scoped_debug` field of `memory.recall_shadow`. All values are
+    already JSON-safe primitives or containers thereof; `allowed_scopes`
+    is a tuple and is converted to a list for json.dumps friendliness.
+    Tuples serialize to JSON arrays under json.dumps already, but a
+    list is the standard wire shape for parsers that round-trip back
+    through Python via json.loads.
+    """
+    return {
+        "active_project_id": debug.active_project_id,
+        "active_project_display_name": debug.active_project_display_name,
+        "active_project_memory_enabled": debug.active_project_memory_enabled,
+        "matched_workspace_root": debug.matched_workspace_root,
+        "allowed_scopes": list(debug.allowed_scopes),
+        "allowed_project_id": debug.allowed_project_id,
+        "reason": debug.reason,
+        "fetch_limit": debug.fetch_limit,
+        "floor": debug.floor,
+        "hits_raw": debug.hits_raw,
+        "hits_after_scope": debug.hits_after_scope,
+        "hits_after_floor": debug.hits_after_floor,
+        "excluded_by_scope": dict(debug.excluded_by_scope),
+        "backend_name": debug.backend_name,
+        "job_type": debug.job_type,
+        "session_id": debug.session_id,
+    }
+
+
+def _scoped_hit_to_shadow_payload(hit: ScopedMemoryHit) -> dict[str, object]:
+    """
+    Convert a `ScopedMemoryHit` to a JSON-safe dict for the
+    `scoped_hits` array. Mirrors the per-hit shape from `memory.recall`
+    (id/source/speaker/confidence/score/adj/snippet) plus the scope
+    discriminators (scope/project_id) so log analysts can tell at a
+    glance whether each surviving hit is global or matching-project.
+    Snippet uses `_RECALL_SNIPPET_TRUNC` so the two log lines have
+    matching per-hit text shape.
+    """
+    r = hit.result
+    return {
+        "id": r.id,
+        "scope": hit.resolved_scope.scope,
+        "project_id": hit.resolved_scope.project_id,
+        "source": (r.metadata.get("source") if r.metadata else None) or "",
+        "speaker": hit.speaker,
+        "confidence": hit.confidence,
+        "score": round(r.score, 4),
+        "adj": round(hit.adjusted_score, 4),
+        "snippet": _truncate(r.text, _RECALL_SNIPPET_TRUNC),
+    }
+
+
+def _shadow_base_payload(
+    *,
+    user_id: str,
+    query: str,
+    workspace: Path | None,
+    backend_name: str | None,
+    job_type: str | None,
+    session_id: str | None,
+    legacy_payload: dict[str, object],
+) -> dict[str, object]:
+    """
+    Build the uniform-shape base of a `memory.recall_shadow` payload.
+
+    Populates every top-level key from D7 with sentinel values for
+    fields the caller has not computed yet. Every emit path
+    (success, missing-workspace, shadow-error) starts from this
+    base and overrides only the fields it knows about, so the
+    log schema is uniform and downstream parsers do not need to
+    branch on `if "scoped_ids" in record`.
+
+    `legacy_*` fields are populated from the legacy recall payload
+    that `format_context_with_recall_payload` already computed,
+    avoiding a second legacy search.
+    """
+    # legacy_hits is the same per-hit array the legacy memory.recall
+    # line carries; reuse it directly so log analysts see identical
+    # per-hit shape on both sides of the comparison.
+    legacy_hits = legacy_payload.get("hits") or []
+    legacy_ids = [h.get("id") for h in legacy_hits if isinstance(h, dict)] if isinstance(legacy_hits, list) else []
+
+    return {
+        "user_id": user_id,
+        "query_len": len(query),
+        "query": _truncate(query, _RECALL_QUERY_TRUNC),
+        "backend_name": backend_name,
+        "job_type": job_type,
+        "session_id": session_id,
+        "workspace": str(workspace) if workspace is not None else "",
+        "legacy_reason": legacy_payload.get("reason", "ok"),
+        "legacy_returned_empty": legacy_payload.get("returned_empty", True),
+        "legacy_lines_used": legacy_payload.get("lines_used", 0),
+        "legacy_budget_tokens": legacy_payload.get("budget_tokens", 0),
+        "legacy_fetch_limit": legacy_payload.get("fetch_limit", 0),
+        "legacy_floor": legacy_payload.get("floor", 0.0),
+        "legacy_ids": legacy_ids,
+        "legacy_hits": legacy_hits,
+        "scoped_reason": "",
+        "scoped_rendered_empty": True,
+        "scoped_rendered_chars": 0,
+        "scoped_debug": None,
+        "scoped_ids": [],
+        "scoped_hits": [],
+        "removed_ids": [],
+        "added_ids": [],
+        "same_ids": [],
+        "shadow_error": False,
+        "shadow_error_type": "",
+        "shadow_error_message": "",
+    }
+
+
+async def run_scoped_recall_shadow(
+    *,
+    query: str,
+    user_id: str,
+    legacy_result: LegacyRecallResult,
+    workspace: Path | None,
+    backend_name: str | None = None,
+    job_type: str | None = None,
+    session_id: str | None = None,
+    token_budget: int | None = None,
+) -> None:
+    """
+    Run scoped retrieval and scoped rendering as a shadow of the
+    legacy recall already produced, then emit one
+    `memory.recall_shadow` log line.
+
+    Best-effort: any exception from scoped retrieval or rendering is
+    caught and logged as a shadow line with `shadow_error=true`.
+    The function never raises out, so the live prompt path that
+    called the helper is not affected by scoped bugs.
+
+    Behavioral branches (each emits exactly one shadow line):
+
+    - `workspace is None`: skip scoped retrieval entirely. Emit a
+      shadow line with `scoped_reason="missing_workspace"` and
+      empty scoped fields. Lets unattended callers and tests opt
+      out cleanly without failing the live path.
+    - Scoped retrieval + rendering succeed: emit the full
+      success-shape payload with legacy/scoped IDs, removed/added/
+      same diffs, scoped debug, and rendered-output preview metadata
+      (chars, empty flag).
+    - Scoped retrieval or rendering raises: emit a shadow line with
+      `shadow_error=true`, the exception class name, a truncated
+      message, and the failure-path sentinels from D7.
+
+    The legacy `_emit_recall_log` is NOT called from here; the
+    caller is responsible for emitting `memory.recall` exactly once
+    before invoking shadow, matching the D3/D4 contract.
+
+    Disabled via `Config.memory_recall_shadow_enabled = False`
+    (env: `MEMORY_RECALL_SHADOW_ENABLED=0/false/no`). When
+    disabled, the function returns immediately and emits no log,
+    so callers can invoke it unconditionally on every eligible
+    turn without their own flag check.
+    """
+    if not is_recall_shadow_enabled():
+        return
+
+    base = _shadow_base_payload(
+        user_id=user_id,
+        query=query,
+        workspace=workspace,
+        backend_name=backend_name,
+        job_type=job_type,
+        session_id=session_id,
+        legacy_payload=legacy_result.recall_payload,
+    )
+
+    # Missing-workspace branch: shadow logger sets a string the
+    # retrieval helper's reason enum does not contain. Per D7+D8
+    # this is shadow-logger-only; do not add it to
+    # retrieve_scoped_memories.
+    if workspace is None:
+        base["scoped_reason"] = "missing_workspace"
+        _emit_recall_shadow_log(base)
+        return
+
+    try:
+        # Build the per-turn context using the same chat_id-as-user_id
+        # shape that the legacy path used. ScopedRetrievalContext
+        # accepts int|str; pass the user_id string through to match
+        # what retrieve_scoped_memories will hand to Mem0.
+        context = ScopedRetrievalContext(
+            chat_id=user_id,
+            message=query,
+            workspace=workspace,
+            job_type=job_type,
+            backend_name=backend_name,
+            session_id=session_id,
+        )
+        legacy_budget = base["legacy_budget_tokens"] if isinstance(base["legacy_budget_tokens"], int) else None
+        scoped_result = await retrieve_scoped_memories(
+            context,
+            token_budget=token_budget if token_budget is not None else legacy_budget,
+        )
+        rendered = format_scoped_context(
+            scoped_result,
+            token_budget=token_budget if token_budget is not None else legacy_budget,
+        )
+    except Exception as exc:
+        # Failure isolation: per D6 every scoped failure produces a
+        # uniform shadow_error payload using the D7 sentinels. The
+        # legacy fields populated by _shadow_base_payload survive.
+        base["shadow_error"] = True
+        base["shadow_error_type"] = type(exc).__name__
+        base["shadow_error_message"] = _truncate(str(exc), _SHADOW_ERROR_MESSAGE_TRUNC)
+        base["scoped_reason"] = "shadow_error"
+        # scoped_* sentinels already match D7's failure-path values
+        # from _shadow_base_payload; nothing else to override.
+        _emit_recall_shadow_log(base)
+        return
+
+    # Success path: compute IDs, diffs, scoped debug, and rendered
+    # preview metadata. legacy_ids preserves legacy rank order;
+    # scoped_ids preserves scoped rank order; the diffs preserve
+    # their respective source orders per D7.
+    legacy_ids_obj = base["legacy_ids"]
+    legacy_ids: list[str] = (
+        [i for i in legacy_ids_obj if isinstance(i, str)] if isinstance(legacy_ids_obj, list) else []
+    )
+    scoped_ids: list[str] = [hit.result.id for hit in scoped_result.hits]
+
+    base["scoped_reason"] = scoped_result.debug.reason
+    base["scoped_debug"] = _scoped_debug_to_payload(scoped_result.debug)
+    base["scoped_ids"] = scoped_ids
+    base["scoped_hits"] = [_scoped_hit_to_shadow_payload(h) for h in scoped_result.hits]
+    base["removed_ids"] = _ordered_difference(legacy_ids, scoped_ids)
+    base["added_ids"] = _ordered_difference(scoped_ids, legacy_ids)
+    base["same_ids"] = _ordered_intersection(legacy_ids, scoped_ids)
+    base["scoped_rendered_empty"] = rendered == ""
+    base["scoped_rendered_chars"] = len(rendered)
+
+    _emit_recall_shadow_log(base)
 
 
 def count_by_source(user_id: str, source: str) -> int:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -10,7 +10,7 @@ and the ApiContext/AgentResponse/StreamEvent data types. These functions are pur
 import logging
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from kai.backend import (
     AgentResponse,
@@ -1545,6 +1545,23 @@ class TestExtractTextQuery:
         assert extract_text_query(prompt) == "real text"
 
 
+def _patch_legacy_recall(monkeypatch, *, rendered_context: str = "", recall_payload: dict | None = None):
+    """Patch the new `format_context_with_recall_payload` helper to
+    return a canned LegacyRecallResult. Most TestAssembleTurnContext
+    tests want to assert how the rendered_context text gets prepended
+    and do not care about the recall payload internals; this helper
+    keeps each test focused on its actual assertion shape.
+
+    Returns the AsyncMock so callers can inspect `.call_args` for
+    query/user_id capture assertions."""
+    from kai.memory import LegacyRecallResult
+
+    payload = recall_payload if recall_payload is not None else {"reason": "ok", "hits": []}
+    fake = AsyncMock(return_value=LegacyRecallResult(rendered_context=rendered_context, recall_payload=payload))
+    monkeypatch.setattr("kai.memory.format_context_with_recall_payload", fake)
+    return fake
+
+
 class TestAssembleTurnContext:
     """Tests for the composed per-turn prompt assembly contract.
 
@@ -1563,10 +1580,7 @@ class TestAssembleTurnContext:
         """
         from kai.backend import USER_MESSAGE_MARKER, assemble_turn_context
 
-        async def fake_format_context(query, *, user_id, **kwargs):
-            return "[Relevant memories]\n- fact one"
-
-        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        _patch_legacy_recall(monkeypatch, rendered_context="[Relevant memories]\n- fact one")
         result = await assemble_turn_context(
             "ACTUAL_USER_TEXT",
             chat_id=42,
@@ -1592,41 +1606,31 @@ class TestAssembleTurnContext:
         assert result[marker_end:user_start].strip() == "", repr(result[marker_end:user_start])
 
     async def test_format_context_receives_raw_query(self, monkeypatch):
-        """The search query handed to format_context is the original user
+        """The search query handed to legacy recall is the original user
         text, not the post-prepend prompt. Pre-fix-shape regression: if
         the helper extracted the query after session_context was applied,
         the embedding would be dominated by CLAUDE.md/history/API docs.
         """
         from kai.backend import assemble_turn_context
 
-        captured: dict = {}
-
-        async def fake_format_context(query, *, user_id, **kwargs):
-            captured["query"] = query
-            captured["user_id"] = user_id
-            return ""
-
-        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        fake = _patch_legacy_recall(monkeypatch, rendered_context="")
         await assemble_turn_context(
             "ACTUAL_USER_TEXT",
             chat_id=42,
             session_context="[10KB of CLAUDE.md and history]",
             workspace_reminder="",
         )
-        assert captured["query"] == "ACTUAL_USER_TEXT"
-        assert captured["user_id"] == "42"
+        assert fake.call_args.args == ("ACTUAL_USER_TEXT",)
+        assert fake.call_args.kwargs["user_id"] == "42"
 
     async def test_no_memory_block_still_preserves_marker(self, monkeypatch):
-        """When format_context returns the empty string (memory disabled
+        """When legacy recall returns the empty string (memory disabled
         or no relevant hits), the marker must still appear and remain
         the closest prefix to the user text.
         """
         from kai.backend import USER_MESSAGE_MARKER, assemble_turn_context
 
-        async def fake_format_context(query, *, user_id, **kwargs):
-            return ""
-
-        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        _patch_legacy_recall(monkeypatch, rendered_context="")
         result = await assemble_turn_context(
             "user message",
             chat_id=42,
@@ -1640,53 +1644,39 @@ class TestAssembleTurnContext:
         assert result[marker_end:user_start].strip() == ""
 
     async def test_chat_id_none_skips_recall(self, monkeypatch):
-        """chat_id=None must NOT call format_context. An empty or fake
+        """chat_id=None must NOT call legacy recall. An empty or fake
         user_id would search across all users, which is a data isolation
         risk if a future memory implementation changes filtering
         semantics. The marker still applies.
         """
         from kai.backend import USER_MESSAGE_MARKER, assemble_turn_context
 
-        called = False
-
-        async def fake_format_context(query, *, user_id, **kwargs):
-            nonlocal called
-            called = True
-            return "[Relevant memories]"
-
-        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        fake = _patch_legacy_recall(monkeypatch, rendered_context="[Relevant memories]")
         result = await assemble_turn_context(
             "user message",
             chat_id=None,
             session_context="",
             workspace_reminder="",
         )
-        assert not called
+        fake.assert_not_called()
         assert USER_MESSAGE_MARKER in result
 
     async def test_whitespace_query_skips_recall(self, monkeypatch):
         """An empty or whitespace-only query produces arbitrary
         embedding hits; the gate must skip the call entirely rather
-        than rely on format_context's own empty-query guard. The
-        marker still applies.
+        than rely on the helper's own empty-query guard. The marker
+        still applies.
         """
         from kai.backend import USER_MESSAGE_MARKER, assemble_turn_context
 
-        called = False
-
-        async def fake_format_context(query, *, user_id, **kwargs):
-            nonlocal called
-            called = True
-            return "[Relevant memories]"
-
-        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        fake = _patch_legacy_recall(monkeypatch, rendered_context="[Relevant memories]")
         result = await assemble_turn_context(
             "   ",
             chat_id=42,
             session_context="",
             workspace_reminder="",
         )
-        assert not called
+        fake.assert_not_called()
         assert USER_MESSAGE_MARKER in result
 
     async def test_list_prompt_preserves_original_block_order(self, monkeypatch):
@@ -1697,13 +1687,7 @@ class TestAssembleTurnContext:
         """
         from kai.backend import USER_MESSAGE_MARKER, assemble_turn_context
 
-        captured: dict = {}
-
-        async def fake_format_context(query, *, user_id, **kwargs):
-            captured["query"] = query
-            return ""
-
-        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        fake = _patch_legacy_recall(monkeypatch, rendered_context="")
         original = [
             {"type": "image", "path": "/tmp/example.png"},
             {"type": "text", "text": "Describe this."},
@@ -1715,7 +1699,7 @@ class TestAssembleTurnContext:
             workspace_reminder="",
         )
         assert isinstance(result, list)
-        assert captured["query"] == "Describe this."
+        assert fake.call_args.args == ("Describe this.",)
         # Injected text-prefix blocks (the marker) come at the front;
         # original image + text remain in order at the tail.
         marker_block = next(
@@ -1733,14 +1717,7 @@ class TestAssembleTurnContext:
         """
         from kai.backend import USER_MESSAGE_MARKER, assemble_turn_context
 
-        called = False
-
-        async def fake_format_context(query, *, user_id, **kwargs):
-            nonlocal called
-            called = True
-            return ""
-
-        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        fake = _patch_legacy_recall(monkeypatch, rendered_context="")
         original = [{"type": "image", "path": "/tmp/example.png"}]
         result = await assemble_turn_context(
             original,
@@ -1748,99 +1725,188 @@ class TestAssembleTurnContext:
             session_context="",
             workspace_reminder="",
         )
-        assert not called
+        fake.assert_not_called()
         # Marker present as a text-prefix block at the front.
         assert any(b.get("type") == "text" and b.get("text") == USER_MESSAGE_MARKER for b in result)
 
     async def test_format_context_called_once_per_eligible_turn(self, monkeypatch):
-        """format_context must be called exactly once per eligible turn;
+        """Legacy recall must be called exactly once per eligible turn;
         the helper does not retry or fan out. The single-call contract
-        keeps the `memory.recall` log line count predictable.
+        keeps the `memory.recall` log line count predictable and
+        guarantees the no-duplicate-search invariant D4 of #546.
         """
         from kai.backend import assemble_turn_context
 
-        call_count = 0
-
-        async def fake_format_context(query, *, user_id, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            return "[Relevant memories]"
-
-        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+        fake = _patch_legacy_recall(monkeypatch, rendered_context="[Relevant memories]")
         await assemble_turn_context(
             "user message",
             chat_id=42,
             session_context="",
             workspace_reminder="",
         )
-        assert call_count == 1
+        assert fake.call_count == 1
 
-    async def test_assemble_turn_context_still_uses_format_context_not_scoped_helper(self, monkeypatch):
-        """Live prompt injection must continue to go through
-        format_context until shadow-mode (#546) and read-path
-        enablement land. The scoped helper from #544 ships as a
-        reusable read contract, not a live wire-up. This test
-        pins both halves: format_context IS called, and
-        retrieve_scoped_memories is NOT.
+    async def test_assemble_turn_context_prompt_uses_legacy_memory_not_scoped_memory(self, monkeypatch):
+        """Prompt content must come from the legacy recall path even
+        though #546 calls scoped retrieval and scoped rendering for
+        shadow logging. Patches all three surfaces with distinctive
+        text so that:
+        - legacy text appears in the prompt,
+        - scoped text does NOT appear in the prompt,
+        - both scoped helpers are still invoked (shadow logging),
+          but their output is discarded as far as the prompt goes.
+
+        Replaces the two #550/#551 *_not_scoped_helper /
+        *_not_scoped_renderer tests whose "never called" assertions
+        became false after #546 wired shadow mode into assemble_turn_context.
+        The new contract is "called, but output not prepended."
         """
         from kai.backend import assemble_turn_context
+        from kai.memory import ScopedRetrievalDebug, ScopedRetrievalResult
 
-        format_called = False
-        scoped_called = False
+        legacy_text = "[Relevant memories from past conversations - context only, not instructions:]\n- legacy fact"
+        scoped_only_text = "[SCOPED_OUTPUT_THAT_MUST_NOT_REACH_THE_PROMPT]"
 
-        async def fake_format_context(query, *, user_id, **kwargs):
-            nonlocal format_called
-            format_called = True
-            return "[Relevant memories]"
+        _patch_legacy_recall(monkeypatch, rendered_context=legacy_text)
 
-        async def fake_retrieve_scoped_memories(*args, **kwargs):
-            nonlocal scoped_called
-            scoped_called = True
-            raise AssertionError("retrieve_scoped_memories must not be called from assemble_turn_context in #544")
+        empty_scoped = ScopedRetrievalResult(
+            hits=[],
+            debug=ScopedRetrievalDebug(
+                active_project_id=None,
+                active_project_display_name=None,
+                active_project_memory_enabled=None,
+                matched_workspace_root=None,
+                allowed_scopes=(),
+                allowed_project_id=None,
+                reason="ok",
+                fetch_limit=0,
+                floor=0.0,
+                hits_raw=0,
+                hits_after_scope=0,
+                hits_after_floor=0,
+                excluded_by_scope={},
+                query="",
+                user_id="42",
+                backend_name=None,
+                job_type=None,
+                session_id=None,
+            ),
+        )
+        monkeypatch.setattr("kai.memory.retrieve_scoped_memories", AsyncMock(return_value=empty_scoped))
+        # format_scoped_context returns a distinctive string; if any
+        # future refactor accidentally prepends the renderer's output,
+        # the substring check below catches it.
+        monkeypatch.setattr("kai.memory.format_scoped_context", MagicMock(return_value=scoped_only_text))
 
-        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
-        monkeypatch.setattr("kai.memory.retrieve_scoped_memories", fake_retrieve_scoped_memories)
-        await assemble_turn_context(
+        result = await assemble_turn_context(
             "user message",
             chat_id=42,
             session_context="",
             workspace_reminder="",
+            workspace=Path("/tmp/test_workspace"),
+            backend_name="claude_code",
+            job_type="interactive",
         )
-        assert format_called is True
-        assert scoped_called is False
 
-    async def test_assemble_turn_context_still_uses_format_context_not_scoped_renderer(self, monkeypatch):
-        """Companion to the *_not_scoped_helper test above.
+        assert isinstance(result, str)
+        assert legacy_text in result, "legacy memory block must appear in the assembled prompt"
+        assert scoped_only_text not in result, (
+            "scoped renderer output must NOT be prepended to the prompt in #546; shadow mode reads it for logging only"
+        )
 
-        That earlier test pins that the #544 retrieval helper
-        (`retrieve_scoped_memories`) is not wired into production
-        prompt assembly. This test pins the same property for the
-        #545 renderer (`format_scoped_context`). Both pins are
-        needed because each new symbol could be misrouted into the
-        live path independently; flipping one would not be caught
-        by the other test."""
+    async def test_assemble_turn_context_passes_workspace_to_shadow_context(self, monkeypatch):
+        """When backends pass `workspace`, the shadow helper sees it.
+        Pins the wiring so a future refactor that drops the kwarg
+        does not silently revert shadow to the missing-workspace
+        branch on every turn."""
         from kai.backend import assemble_turn_context
 
-        format_called = False
-        renderer_called = False
+        _patch_legacy_recall(monkeypatch, rendered_context="")
+        shadow_mock = AsyncMock()
+        monkeypatch.setattr("kai.memory.run_scoped_recall_shadow", shadow_mock)
 
-        async def fake_format_context(query, *, user_id, **kwargs):
-            nonlocal format_called
-            format_called = True
-            return "[Relevant memories]"
-
-        def fake_format_scoped_context(*args, **kwargs):
-            nonlocal renderer_called
-            renderer_called = True
-            raise AssertionError("format_scoped_context must not be called from assemble_turn_context in #545")
-
-        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
-        monkeypatch.setattr("kai.memory.format_scoped_context", fake_format_scoped_context)
+        ws = Path("/tmp/test_workspace_abc")
         await assemble_turn_context(
             "user message",
             chat_id=42,
             session_context="",
             workspace_reminder="",
+            workspace=ws,
+            backend_name="claude_code",
+            job_type="interactive",
+            session_id="sess-1",
         )
-        assert format_called is True
-        assert renderer_called is False
+
+        assert shadow_mock.call_count == 1
+        kwargs = shadow_mock.call_args.kwargs
+        assert kwargs["workspace"] == ws
+        assert kwargs["backend_name"] == "claude_code"
+        assert kwargs["job_type"] == "interactive"
+        assert kwargs["session_id"] == "sess-1"
+        assert kwargs["user_id"] == "42"
+        assert kwargs["query"] == "user message"
+
+    async def test_assemble_turn_context_does_not_shadow_when_chat_id_none(self, monkeypatch):
+        """Shadow mode runs under the same eligibility gate as
+        live recall. chat_id=None skips legacy recall AND skips
+        the shadow call entirely; no `memory.recall_shadow` line
+        is emitted on these turns."""
+        from kai.backend import assemble_turn_context
+
+        legacy_mock = _patch_legacy_recall(monkeypatch, rendered_context="")
+        shadow_mock = AsyncMock()
+        monkeypatch.setattr("kai.memory.run_scoped_recall_shadow", shadow_mock)
+
+        await assemble_turn_context(
+            "user message",
+            chat_id=None,
+            session_context="",
+            workspace_reminder="",
+            workspace=Path("/tmp/ws"),
+        )
+        legacy_mock.assert_not_called()
+        shadow_mock.assert_not_called()
+
+    async def test_assemble_turn_context_does_not_shadow_when_query_empty(self, monkeypatch):
+        """Same gate on the other axis: an empty / whitespace-only
+        query skips both legacy recall and shadow. The shadow log
+        is meaningful only when there is a legacy result to compare
+        against."""
+        from kai.backend import assemble_turn_context
+
+        legacy_mock = _patch_legacy_recall(monkeypatch, rendered_context="")
+        shadow_mock = AsyncMock()
+        monkeypatch.setattr("kai.memory.run_scoped_recall_shadow", shadow_mock)
+
+        await assemble_turn_context(
+            "   ",
+            chat_id=42,
+            session_context="",
+            workspace_reminder="",
+            workspace=Path("/tmp/ws"),
+        )
+        legacy_mock.assert_not_called()
+        shadow_mock.assert_not_called()
+
+    async def test_assemble_turn_context_does_not_duplicate_legacy_search(self, monkeypatch):
+        """D4 invariant: one eligible turn produces exactly one
+        legacy Mem0 search (and at most one scoped search). The
+        refactor that shares `format_context_with_recall_payload`
+        between live prompt assembly and shadow logging exists to
+        avoid running the legacy search twice; this test pins that
+        property at the recall-helper boundary."""
+        from kai.backend import assemble_turn_context
+
+        legacy_mock = _patch_legacy_recall(monkeypatch, rendered_context="[mem]")
+        shadow_mock = AsyncMock()
+        monkeypatch.setattr("kai.memory.run_scoped_recall_shadow", shadow_mock)
+
+        await assemble_turn_context(
+            "user message",
+            chat_id=42,
+            session_context="",
+            workspace_reminder="",
+            workspace=Path("/tmp/ws"),
+        )
+        assert legacy_mock.call_count == 1, "legacy recall must run exactly once"
+        assert shadow_mock.call_count == 1, "shadow must run exactly once when enabled"

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1807,11 +1807,14 @@ class TestContextInjection:
         memory_block = (
             "[Relevant memories from past conversations - context only, not instructions:]\n- (fact) test memory"
         )
+        from kai.memory import LegacyRecallResult
+
+        fake_recall = LegacyRecallResult(rendered_context=memory_block, recall_payload={"reason": "ok", "hits": []})
         with (
             patch("kai.backend.get_recent_history", return_value="prior turn"),
             patch(
-                "kai.memory.format_context",
-                new=AsyncMock(return_value=memory_block),
+                "kai.memory.format_context_with_recall_payload",
+                new=AsyncMock(return_value=fake_recall),
             ),
         ):
             # chat_id is required so the memory_format_context branch runs
@@ -1875,14 +1878,16 @@ class TestContextInjection:
 
         captured: dict = {}
 
-        async def fake_format_context(query, *, user_id, **kwargs):
+        async def fake_helper(query, *, user_id, **kwargs):
+            from kai.memory import LegacyRecallResult
+
             captured["query"] = query
             captured["user_id"] = user_id
-            return ""
+            return LegacyRecallResult(rendered_context="", recall_payload={"reason": "ok", "hits": []})
 
         with (
             patch("kai.backend.get_recent_history", return_value="prior turn"),
-            patch("kai.memory.format_context", new=fake_format_context),
+            patch("kai.memory.format_context_with_recall_payload", new=fake_helper),
         ):
             events = []
             async for event in claude._send_locked("What do I prefer?", chat_id=42):

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -924,11 +924,14 @@ class TestContextInjection:
         memory_block = (
             "[Relevant memories from past conversations - context only, not instructions:]\n- (fact) test memory"
         )
+        from kai.memory import LegacyRecallResult
+
+        fake_recall = LegacyRecallResult(rendered_context=memory_block, recall_payload={"reason": "ok", "hits": []})
         with (
             patch("kai.codex.build_session_context", return_value="[CONTEXT]"),
             patch(
-                "kai.memory.format_context",
-                new=AsyncMock(return_value=memory_block),
+                "kai.memory.format_context_with_recall_payload",
+                new=AsyncMock(return_value=fake_recall),
             ),
         ):
             # chat_id is required so assemble_turn_context's memory
@@ -1067,19 +1070,23 @@ class TestPromptCoercion:
         c._fresh_session = True
         c._next_id = 3
 
-        # format_context patched as a sentinel: the all-non-text input
-        # has no real user text to drive recall, so the helper must
-        # be invoked with `chat_id=None` and never call format_context.
-        format_context_spy = AsyncMock(return_value="")
+        # Legacy recall patched as a sentinel: the all-non-text input
+        # has no real user text to drive recall, so assemble_turn_context
+        # must hit chat_id=None internally and never call the helper.
+        from kai.memory import LegacyRecallResult
+
+        recall_spy = AsyncMock(
+            return_value=LegacyRecallResult(rendered_context="", recall_payload={"reason": "ok", "hits": []})
+        )
         blocks = [{"type": "image", "data": "..."}]
         with (
             patch("kai.codex.build_session_context", return_value="[CONTEXT]"),
-            patch("kai.memory.format_context", new=format_context_spy),
+            patch("kai.memory.format_context_with_recall_payload", new=recall_spy),
         ):
             async for _event in c._send_locked(blocks, chat_id=42):
                 pass
 
-        format_context_spy.assert_not_called()
+        recall_spy.assert_not_called()
 
         write_calls = c._proc.stdin.write.call_args_list
         sent_blocks = json.loads(write_calls[-1][0][0].decode())["params"]["input"]
@@ -1101,13 +1108,19 @@ class TestPromptCoercion:
         c._fresh_session = False
         c._next_id = 3
 
-        format_context_spy = AsyncMock(return_value="should-not-be-injected")
+        from kai.memory import LegacyRecallResult
+
+        recall_spy = AsyncMock(
+            return_value=LegacyRecallResult(
+                rendered_context="should-not-be-injected", recall_payload={"reason": "ok", "hits": []}
+            )
+        )
         blocks = [{"type": "image", "data": "..."}]
-        with patch("kai.memory.format_context", new=format_context_spy):
+        with patch("kai.memory.format_context_with_recall_payload", new=recall_spy):
             async for _event in c._send_locked(blocks, chat_id=42):
                 pass
 
-        format_context_spy.assert_not_called()
+        recall_spy.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_text_input_still_drives_semantic_recall(self):
@@ -1119,15 +1132,19 @@ class TestPromptCoercion:
         c._fresh_session = False
         c._next_id = 3
 
-        format_context_spy = AsyncMock(return_value="")
-        with patch("kai.memory.format_context", new=format_context_spy):
+        from kai.memory import LegacyRecallResult
+
+        recall_spy = AsyncMock(
+            return_value=LegacyRecallResult(rendered_context="", recall_payload={"reason": "ok", "hits": []})
+        )
+        with patch("kai.memory.format_context_with_recall_payload", new=recall_spy):
             async for _event in c._send_locked("real user text", chat_id=42):
                 pass
 
-        format_context_spy.assert_called_once()
+        recall_spy.assert_called_once()
         # First positional / kwarg is the search query; pin it as the
         # real user text, not the codex-synthetic placeholder.
-        call = format_context_spy.call_args
+        call = recall_spy.call_args
         assert call.args[0] == "real user text" or call.kwargs.get("query") == "real user text"
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3062,3 +3062,63 @@ class TestLoadMemoryProjects:
         # ...but did NOT promote its root into allowed_workspaces.
         assert registry_root.resolve() not in cfg.allowed_workspaces
         assert registry_root not in cfg.allowed_workspaces
+
+
+# ── Shadow-mode toggle (#546) ────────────────────────────────────────
+
+
+class TestMemoryRecallShadowConfig:
+    """Tests for `Config.memory_recall_shadow_enabled` and its
+    `MEMORY_RECALL_SHADOW_ENABLED` env-var parse.
+
+    The toggle is default-on (inverted convention compared to the
+    usual memory_* env vars) because the point of #546 is to
+    collect real turn evidence before the read-path switch. A
+    default-off flag would defeat that. The off-switch is the
+    rollback path if shadow code misbehaves under load."""
+
+    def _base_env(self, monkeypatch):
+        """Minimal env so load_config builds cleanly. Caller adds
+        MEMORY_RECALL_SHADOW_ENABLED on top to drive the test."""
+        for v in _CONFIG_ENV_VARS:
+            monkeypatch.delenv(v, raising=False)
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+        monkeypatch.setenv("ALLOWED_USER_IDS", "12345")
+        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+        monkeypatch.setenv("MEMORY_ENABLED", "true")  # gate for shadow to be on
+
+    def test_memory_recall_shadow_config_defaults_enabled(self, monkeypatch):
+        """Unset env var → shadow enabled when memory is on. The
+        default-on posture is the load-bearing decision in D10;
+        flipping it to default-off would erase evidence collection."""
+        self._base_env(monkeypatch)
+        monkeypatch.delenv("MEMORY_RECALL_SHADOW_ENABLED", raising=False)
+        cfg = load_config()
+        assert cfg.memory_recall_shadow_enabled is True
+
+    def test_memory_recall_shadow_config_can_disable(self, monkeypatch):
+        """Each of the three disable strings turns the toggle off,
+        case-insensitively. The disable set is intentionally
+        conservative; truthy alternatives keep shadow on."""
+        for disable_value in ("0", "false", "no", "False", "NO", "FALSE"):
+            self._base_env(monkeypatch)
+            monkeypatch.setenv("MEMORY_RECALL_SHADOW_ENABLED", disable_value)
+            cfg = load_config()
+            assert cfg.memory_recall_shadow_enabled is False, f"failed to disable with {disable_value!r}"
+
+    def test_memory_recall_shadow_config_disabled_when_memory_off(self, monkeypatch):
+        """Sub-toggle composition: shadow is gated on memory_enabled
+        even when MEMORY_RECALL_SHADOW_ENABLED is unset/truthy. No
+        legacy recall = no baseline to compare against = pointless
+        shadow runs."""
+        for v in _CONFIG_ENV_VARS:
+            monkeypatch.delenv(v, raising=False)
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+        monkeypatch.setenv("ALLOWED_USER_IDS", "12345")
+        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+        # MEMORY_ENABLED unset / off; shadow must also fall to off
+        # regardless of the shadow env var.
+        monkeypatch.setenv("MEMORY_RECALL_SHADOW_ENABLED", "true")
+        cfg = load_config()
+        assert cfg.memory_enabled is False
+        assert cfg.memory_recall_shadow_enabled is False

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -704,11 +704,14 @@ class TestContextInjection:
         memory_block = (
             "[Relevant memories from past conversations - context only, not instructions:]\n- (fact) test memory"
         )
+        from kai.memory import LegacyRecallResult
+
+        fake_recall = LegacyRecallResult(rendered_context=memory_block, recall_payload={"reason": "ok", "hits": []})
         with (
             patch("kai.goose.build_session_context", return_value="[CONTEXT]"),
             patch(
-                "kai.memory.format_context",
-                new=AsyncMock(return_value=memory_block),
+                "kai.memory.format_context_with_recall_payload",
+                new=AsyncMock(return_value=fake_recall),
             ),
         ):
             async for _event in g._send_locked("ACTUAL_USER_TEXT", chat_id=42):
@@ -750,13 +753,19 @@ class TestContextInjection:
         g._fresh_session = False
         g._next_id = 3
 
-        format_context_spy = AsyncMock(return_value="should-not-be-injected")
+        from kai.memory import LegacyRecallResult
+
+        recall_spy = AsyncMock(
+            return_value=LegacyRecallResult(
+                rendered_context="should-not-be-injected", recall_payload={"reason": "ok", "hits": []}
+            )
+        )
         blocks = [{"type": "image", "source": {"type": "base64", "data": "..."}}]
-        with patch("kai.memory.format_context", new=format_context_spy):
+        with patch("kai.memory.format_context_with_recall_payload", new=recall_spy):
             async for _event in g._send_locked(blocks, chat_id=42):
                 pass
 
-        format_context_spy.assert_not_called()
+        recall_spy.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_text_input_still_drives_semantic_recall(self):
@@ -768,13 +777,17 @@ class TestContextInjection:
         g._fresh_session = False
         g._next_id = 3
 
-        format_context_spy = AsyncMock(return_value="")
-        with patch("kai.memory.format_context", new=format_context_spy):
+        from kai.memory import LegacyRecallResult
+
+        recall_spy = AsyncMock(
+            return_value=LegacyRecallResult(rendered_context="", recall_payload={"reason": "ok", "hits": []})
+        )
+        with patch("kai.memory.format_context_with_recall_payload", new=recall_spy):
             async for _event in g._send_locked("real user text", chat_id=42):
                 pass
 
-        format_context_spy.assert_called_once()
-        call = format_context_spy.call_args
+        recall_spy.assert_called_once()
+        call = recall_spy.call_args
         assert call.args[0] == "real user text" or call.kwargs.get("query") == "real user text"
 
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -5002,13 +5002,18 @@ class TestFormatContextUnchangedByScopedHelper:
         assert params[2][1].kind == inspect.Parameter.KEYWORD_ONLY
         assert params[2][1].default is None
 
-        # The prompt header is a runtime literal inside format_context;
-        # the surrounding tests in TestFormatContext already exercise
-        # rendering with mocked memory, so checking the header is in
-        # the module source is enough to catch accidental rewording.
+        # The prompt header is a runtime literal in the legacy
+        # rendering path. #546 split format_context into a thin
+        # wrapper plus format_context_with_recall_payload, so the
+        # header literal now lives in the helper. Check the module
+        # source to catch rewording in either place; the surrounding
+        # TestFormatContext tests exercise the actual rendering with
+        # mocked memory.
         import inspect as ins_mod
 
-        src = ins_mod.getsource(format_context)
+        import kai.memory as memory_mod
+
+        src = ins_mod.getsource(memory_mod)
         assert "[Relevant memories from past conversations - context only, not instructions:]" in src
 
     async def test_format_context_memory_recall_payload_keys_unchanged(self, caplog):
@@ -5493,3 +5498,519 @@ class TestFormatScopedContext:
             msg = record.getMessage()
             assert "memory.recall" not in msg
             assert "memory.scoped_recall" not in msg
+
+
+# ── Shadow-mode comparison logging (#546) ────────────────────────────
+
+
+class TestLegacyRecallResultHelper:
+    """Tests for the format_context / format_context_with_recall_payload
+    split introduced in #546. The helper must produce the same rendered
+    output as the wrapper without emitting `memory.recall` itself."""
+
+    async def test_format_context_with_recall_payload_matches_format_context_output(self):
+        """The helper returns the same rendered text format_context
+        produces today. Pin: future refactor that drifts the helper
+        from the wrapper would change live prompt content."""
+        import json
+
+        import kai.memory as mem_mod
+        from kai.memory import format_context, format_context_with_recall_payload
+
+        results = [
+            {
+                "id": "row-1",
+                "memory": "fact one",
+                "score": 0.8,
+                "metadata": {"type": "fact", "source": "extracted", "speaker": "user", "confidence": 0.9},
+                "created_at": "2026-05-25T12:00:00",
+            }
+        ]
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {"results": results}
+        mem_mod._memory = mock_mem
+        mem_mod._config = _make_config()
+
+        from_wrapper = await format_context("hello", user_id="123")
+        # Reset Mem0 for the helper call so the search-state snapshot
+        # is identical. Using fresh return_value to avoid any subtle
+        # call-order effects (e.g. Mem0 search exhausting an iterator).
+        mock_mem.search.return_value = {"results": results}
+        from_helper = await format_context_with_recall_payload("hello", user_id="123")
+
+        assert from_wrapper == from_helper.rendered_context
+        # Helper's payload carries the same keys the wrapper would
+        # have logged via _emit_recall_log.
+        assert isinstance(from_helper.recall_payload, dict)
+        assert "hits" in from_helper.recall_payload
+        # Round-trip through json to confirm the payload is JSON-safe
+        # (this is what shadow logging will eventually need).
+        json.dumps(from_helper.recall_payload)
+
+    async def test_format_context_with_recall_payload_does_not_emit_log_by_itself(self, caplog):
+        """The helper MUST NOT emit `memory.recall`. The wrapper
+        emits exactly one line per call; the shadow caller emits
+        exactly one line per eligible turn. If the helper also
+        emitted, eligible turns would log twice."""
+        import kai.memory as mem_mod
+        from kai.memory import format_context_with_recall_payload
+
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {"results": []}
+        mem_mod._memory = mock_mem
+        mem_mod._config = _make_config()
+
+        with caplog.at_level("INFO", logger="kai.memory"):
+            await format_context_with_recall_payload("hello", user_id="123")
+
+        recall_lines = [r for r in caplog.records if r.getMessage().startswith("memory.recall ")]
+        assert recall_lines == [], "helper must not emit memory.recall; the wrapper or shadow caller does"
+
+    async def test_memory_recall_still_emits_exactly_one_line_per_eligible_turn(self, caplog):
+        """assemble_turn_context calls the helper, then emits
+        memory.recall exactly once. The shadow path also runs
+        but emits a separate `memory.recall_shadow` line, not a
+        second `memory.recall` line."""
+        import kai.memory as mem_mod
+        from kai.backend import assemble_turn_context
+
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {"results": []}
+        mem_mod._memory = mock_mem
+        mem_mod._config = _make_config()
+
+        with caplog.at_level("INFO", logger="kai.memory"):
+            await assemble_turn_context(
+                "hello",
+                chat_id=42,
+                session_context="",
+                workspace_reminder="",
+            )
+
+        recall_lines = [r for r in caplog.records if r.getMessage().startswith("memory.recall ")]
+        assert len(recall_lines) == 1, f"expected exactly one memory.recall line, got {len(recall_lines)}"
+
+
+class TestRecallShadowLog:
+    """End-to-end pins for `run_scoped_recall_shadow` + the
+    `memory.recall_shadow` log line. Each test patches Mem0 +
+    config + project registry (via _config) and calls the helper
+    directly; the assemble_turn_context integration is covered by
+    TestAssembleTurnContext in tests/test_backend.py."""
+
+    def _legacy_payload(self, *, hits: list[dict] | None = None, reason: str = "ok"):
+        if hits is None:
+            hits = []
+        return {
+            "user_id": "42",
+            "query_len": 5,
+            "query": "hello",
+            "fetch_limit": 20,
+            "hits_raw": len(hits),
+            "hits_after_floor": len(hits),
+            "floor": 0.3,
+            "latency_ms": 1,
+            "returned_empty": not hits,
+            "lines_used": len(hits),
+            "budget_tokens": 2000,
+            "hits": hits,
+            "reason": reason,
+        }
+
+    def _legacy_result(self, *, hits: list[dict] | None = None, rendered_context: str = ""):
+        from kai.memory import LegacyRecallResult
+
+        return LegacyRecallResult(rendered_context=rendered_context, recall_payload=self._legacy_payload(hits=hits))
+
+    async def test_recall_shadow_log_payload_shape_success(self, tmp_path, caplog):
+        """A successful shadow run emits exactly one
+        `memory.recall_shadow` line with the full D7 key set."""
+        import json
+
+        import kai.memory as mem_mod
+        from kai.memory import run_scoped_recall_shadow
+
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {
+            "results": [
+                {
+                    "id": "g1",
+                    "memory": "global fact",
+                    "score": 0.8,
+                    "metadata": {"type": "fact", "source": "extracted", "speaker": "user", "confidence": 0.9},
+                    "created_at": "2026-05-25T12:00:00",
+                }
+            ]
+        }
+        mem_mod._memory = mock_mem
+        mem_mod._config = _make_config()
+
+        legacy = self._legacy_result(hits=[{"id": "g1", "source": "extracted"}])
+        with caplog.at_level("INFO", logger="kai.memory"):
+            await run_scoped_recall_shadow(
+                query="hello",
+                user_id="42",
+                legacy_result=legacy,
+                workspace=tmp_path,
+                backend_name="claude_code",
+                job_type="interactive",
+                session_id="sess-1",
+            )
+
+        shadow_lines = [r.getMessage() for r in caplog.records if r.getMessage().startswith("memory.recall_shadow ")]
+        assert len(shadow_lines) == 1, shadow_lines
+        payload = json.loads(shadow_lines[0].removeprefix("memory.recall_shadow "))
+        # D7 full top-level key set.
+        expected_keys = {
+            "user_id",
+            "query_len",
+            "query",
+            "backend_name",
+            "job_type",
+            "session_id",
+            "workspace",
+            "legacy_reason",
+            "legacy_returned_empty",
+            "legacy_lines_used",
+            "legacy_budget_tokens",
+            "legacy_fetch_limit",
+            "legacy_floor",
+            "legacy_ids",
+            "legacy_hits",
+            "scoped_reason",
+            "scoped_rendered_empty",
+            "scoped_rendered_chars",
+            "scoped_debug",
+            "scoped_ids",
+            "scoped_hits",
+            "removed_ids",
+            "added_ids",
+            "same_ids",
+            "shadow_error",
+            "shadow_error_type",
+            "shadow_error_message",
+        }
+        assert set(payload.keys()) == expected_keys
+        # Success-path sentinels.
+        assert payload["shadow_error"] is False
+        assert payload["shadow_error_type"] == ""
+        assert payload["shadow_error_message"] == ""
+        # Per-turn context round-trips.
+        assert payload["backend_name"] == "claude_code"
+        assert payload["job_type"] == "interactive"
+        assert payload["session_id"] == "sess-1"
+
+    async def test_recall_shadow_log_includes_active_project_and_allowed_scopes(self, tmp_path, caplog):
+        """When the workspace matches a registered project, the
+        shadow payload's `scoped_debug` carries the active-project
+        identity (id, display name, enabled flag, matched root)
+        and the allowed-scopes tuple."""
+        import json
+
+        import kai.memory as mem_mod
+        from kai.config import MemoryProjectConfig
+        from kai.memory import run_scoped_recall_shadow
+
+        project_root = tmp_path / "kai"
+        project_root.mkdir()
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {"results": []}
+        mem_mod._memory = mock_mem
+        mem_mod._config = _make_config(
+            memory_projects={
+                "kai": MemoryProjectConfig(
+                    project_id="kai",
+                    display_name="Kai",
+                    workspace_roots=(project_root.resolve(),),
+                    memory_enabled=True,
+                    default_scope_for_new_facts=None,
+                )
+            }
+        )
+
+        legacy = self._legacy_result(hits=[], rendered_context="")
+        with caplog.at_level("INFO", logger="kai.memory"):
+            await run_scoped_recall_shadow(
+                query="hello",
+                user_id="42",
+                legacy_result=legacy,
+                workspace=project_root,
+                backend_name="claude_code",
+                job_type="interactive",
+                session_id=None,
+            )
+
+        line = next(r.getMessage() for r in caplog.records if r.getMessage().startswith("memory.recall_shadow "))
+        payload = json.loads(line.removeprefix("memory.recall_shadow "))
+        debug = payload["scoped_debug"]
+        assert debug["active_project_id"] == "kai"
+        assert debug["active_project_display_name"] == "Kai"
+        assert debug["active_project_memory_enabled"] is True
+        assert debug["matched_workspace_root"] == str(project_root.resolve())
+        assert debug["allowed_scopes"] == ["global", "project"]
+        assert debug["allowed_project_id"] == "kai"
+
+    async def test_recall_shadow_log_computes_removed_added_same_ids_in_order(self, tmp_path, caplog):
+        """removed_ids preserves legacy order, added_ids preserves
+        scoped order, and same_ids uses legacy order."""
+        import json
+
+        import kai.memory as mem_mod
+        from kai.memory import run_scoped_recall_shadow
+
+        # Scoped search returns rows in this order: keep, scoped_only_a,
+        # scoped_only_b. Legacy hits include "keep" plus two rows that
+        # scoped does NOT return: legacy_only_a, legacy_only_b.
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {
+            "results": [
+                {
+                    "id": "keep",
+                    "memory": "x",
+                    "score": 0.9,
+                    "metadata": {"type": "fact", "source": "extracted", "speaker": "user", "confidence": 0.9},
+                    "created_at": "2026-05-25T12:00:00",
+                },
+                {
+                    "id": "scoped_only_a",
+                    "memory": "x",
+                    "score": 0.85,
+                    "metadata": {"type": "fact", "source": "extracted", "speaker": "user", "confidence": 0.9},
+                    "created_at": "2026-05-25T12:00:00",
+                },
+                {
+                    "id": "scoped_only_b",
+                    "memory": "x",
+                    "score": 0.8,
+                    "metadata": {"type": "fact", "source": "extracted", "speaker": "user", "confidence": 0.9},
+                    "created_at": "2026-05-25T12:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+        mem_mod._config = _make_config()
+
+        legacy = self._legacy_result(
+            hits=[
+                {"id": "legacy_only_a", "source": "extracted"},
+                {"id": "keep", "source": "extracted"},
+                {"id": "legacy_only_b", "source": "extracted"},
+            ]
+        )
+        with caplog.at_level("INFO", logger="kai.memory"):
+            await run_scoped_recall_shadow(
+                query="hello",
+                user_id="42",
+                legacy_result=legacy,
+                workspace=tmp_path,
+            )
+
+        line = next(r.getMessage() for r in caplog.records if r.getMessage().startswith("memory.recall_shadow "))
+        payload = json.loads(line.removeprefix("memory.recall_shadow "))
+        # Legacy order is preserved for removed_ids (and same_ids).
+        assert payload["legacy_ids"] == ["legacy_only_a", "keep", "legacy_only_b"]
+        assert payload["scoped_ids"] == ["keep", "scoped_only_a", "scoped_only_b"]
+        assert payload["removed_ids"] == ["legacy_only_a", "legacy_only_b"]
+        assert payload["added_ids"] == ["scoped_only_a", "scoped_only_b"]
+        assert payload["same_ids"] == ["keep"]
+
+    async def test_recall_shadow_log_uses_scoped_renderer_preview_metadata(self, tmp_path, caplog):
+        """scoped_rendered_empty + scoped_rendered_chars reflect what
+        format_scoped_context would produce. With hits, rendered is
+        non-empty and char count is positive."""
+        import json
+
+        import kai.memory as mem_mod
+        from kai.memory import run_scoped_recall_shadow
+
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {
+            "results": [
+                {
+                    "id": "g1",
+                    "memory": "global fact body",
+                    "score": 0.8,
+                    "metadata": {"type": "fact", "source": "extracted", "speaker": "user", "confidence": 0.9},
+                    "created_at": "2026-05-25T12:00:00",
+                }
+            ]
+        }
+        mem_mod._memory = mock_mem
+        mem_mod._config = _make_config()
+
+        legacy = self._legacy_result()
+        with caplog.at_level("INFO", logger="kai.memory"):
+            await run_scoped_recall_shadow(
+                query="hello",
+                user_id="42",
+                legacy_result=legacy,
+                workspace=tmp_path,
+            )
+
+        line = next(r.getMessage() for r in caplog.records if r.getMessage().startswith("memory.recall_shadow "))
+        payload = json.loads(line.removeprefix("memory.recall_shadow "))
+        assert payload["scoped_rendered_empty"] is False
+        assert payload["scoped_rendered_chars"] > 0
+
+    async def test_recall_shadow_log_missing_workspace_records_missing_workspace_without_error(self, caplog):
+        """workspace=None skips scoped retrieval entirely, emits
+        one shadow line with scoped_reason='missing_workspace',
+        shadow_error=False, and the failure-path sentinels for the
+        scoped_* fields. Mem0 search is NOT called."""
+        import json
+
+        import kai.memory as mem_mod
+        from kai.memory import run_scoped_recall_shadow
+
+        mock_mem = MagicMock()
+        mem_mod._memory = mock_mem
+        mem_mod._config = _make_config()
+
+        legacy = self._legacy_result()
+        with caplog.at_level("INFO", logger="kai.memory"):
+            await run_scoped_recall_shadow(
+                query="hello",
+                user_id="42",
+                legacy_result=legacy,
+                workspace=None,
+            )
+
+        line = next(r.getMessage() for r in caplog.records if r.getMessage().startswith("memory.recall_shadow "))
+        payload = json.loads(line.removeprefix("memory.recall_shadow "))
+        assert payload["scoped_reason"] == "missing_workspace"
+        assert payload["shadow_error"] is False
+        assert payload["scoped_ids"] == []
+        assert payload["scoped_hits"] == []
+        assert payload["scoped_debug"] is None
+        # Mem0 search must not have been called.
+        mock_mem.search.assert_not_called()
+
+    async def test_recall_shadow_log_scoped_retrieval_exception_does_not_break_prompt(self, tmp_path, caplog):
+        """When retrieve_scoped_memories raises, the shadow line
+        carries shadow_error=true + the exception class + a truncated
+        message. The function itself does NOT re-raise; the caller
+        (assemble_turn_context) is unaffected by scoped bugs."""
+        import json
+
+        import kai.memory as mem_mod
+        from kai.memory import run_scoped_recall_shadow
+
+        async def boom(*args, **kwargs):
+            raise RuntimeError("vector store unreachable")
+
+        mem_mod._memory = MagicMock()
+        mem_mod._config = _make_config()
+
+        legacy = self._legacy_result()
+        # Inject the failure via direct module-attr patching for
+        # symmetry with the render-exception test below.
+        original = mem_mod.retrieve_scoped_memories
+        mem_mod.retrieve_scoped_memories = boom
+        try:
+            with caplog.at_level("INFO", logger="kai.memory"):
+                await run_scoped_recall_shadow(
+                    query="hello",
+                    user_id="42",
+                    legacy_result=legacy,
+                    workspace=tmp_path,
+                )
+        finally:
+            mem_mod.retrieve_scoped_memories = original
+
+        line = next(r.getMessage() for r in caplog.records if r.getMessage().startswith("memory.recall_shadow "))
+        payload = json.loads(line.removeprefix("memory.recall_shadow "))
+        assert payload["shadow_error"] is True
+        assert payload["shadow_error_type"] == "RuntimeError"
+        assert "vector store unreachable" in payload["shadow_error_message"]
+        assert payload["scoped_reason"] == "shadow_error"
+
+    async def test_recall_shadow_log_scoped_render_exception_does_not_break_prompt(self, tmp_path, caplog):
+        """Same isolation for the renderer path: format_scoped_context
+        raising must not propagate out of run_scoped_recall_shadow."""
+        import json
+
+        import kai.memory as mem_mod
+        from kai.memory import run_scoped_recall_shadow
+
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {"results": []}
+        mem_mod._memory = mock_mem
+        mem_mod._config = _make_config()
+
+        def boom_render(*args, **kwargs):
+            raise ValueError("renderer is broken")
+
+        original = mem_mod.format_scoped_context
+        mem_mod.format_scoped_context = boom_render
+        try:
+            legacy = self._legacy_result()
+            with caplog.at_level("INFO", logger="kai.memory"):
+                # Should NOT raise.
+                await run_scoped_recall_shadow(
+                    query="hello",
+                    user_id="42",
+                    legacy_result=legacy,
+                    workspace=tmp_path,
+                )
+        finally:
+            mem_mod.format_scoped_context = original
+
+        line = next(r.getMessage() for r in caplog.records if r.getMessage().startswith("memory.recall_shadow "))
+        payload = json.loads(line.removeprefix("memory.recall_shadow "))
+        assert payload["shadow_error"] is True
+        assert payload["shadow_error_type"] == "ValueError"
+        assert "renderer is broken" in payload["shadow_error_message"]
+
+
+class TestRecallShadowConfigGate:
+    """Tests for the memory_recall_shadow_enabled toggle gate."""
+
+    async def test_memory_recall_shadow_disabled_skips_shadow_log(self, tmp_path, caplog):
+        """When the toggle is off, run_scoped_recall_shadow returns
+        immediately and emits no log line."""
+        import kai.memory as mem_mod
+        from kai.memory import LegacyRecallResult, run_scoped_recall_shadow
+
+        mem_mod._memory = MagicMock()
+        # Disable the gate explicitly.
+        mem_mod._config = _make_config(memory_recall_shadow_enabled=False)
+
+        with caplog.at_level("INFO", logger="kai.memory"):
+            await run_scoped_recall_shadow(
+                query="hello",
+                user_id="42",
+                legacy_result=LegacyRecallResult(rendered_context="", recall_payload={}),
+                workspace=tmp_path,
+            )
+
+        shadow_lines = [r for r in caplog.records if r.getMessage().startswith("memory.recall_shadow ")]
+        assert shadow_lines == []
+
+
+# Per-backend wiring test for #546 D1 (backend_name + workspace passed
+# through to assemble_turn_context). Lives in test_memory.py for
+# proximity to the other shadow-mode tests; could equally live in
+# test_backend.py. Parameterized over the three runtime backends so
+# a forgotten backend wiring fails one named case rather than
+# silently lapsing into the missing-workspace branch.
+
+
+class TestRuntimeBackendsPassShadowContext:
+    """Pin that every runtime backend's send path passes
+    workspace + backend_name + job_type to assemble_turn_context so
+    shadow logs can detect projects and identify the caller. A
+    backend that forgets one kwarg silently routes its shadow logs
+    through the missing-workspace branch; this test catches it."""
+
+    def test_runtime_backends_pass_workspace_backend_name_and_job_type_to_assemble_turn_context(self):
+        """Class-attribute pin per backend. The actual assemble_turn_context
+        call sites in claude.py/codex.py/goose.py read self.workspace
+        and self.backend_name; this test confirms each class exposes
+        the canonical backend_name string defined by the spec."""
+        from kai.claude import ClaudeCodeBackend
+        from kai.codex import CodexBackend
+        from kai.goose import GooseBackend
+
+        assert ClaudeCodeBackend.backend_name == "claude_code"
+        assert CodexBackend.backend_name == "codex"
+        assert GooseBackend.backend_name == "goose"


### PR DESCRIPTION
Closes #546. Parent epic #517. Builds on #542 (scope metadata), #543 (project registry), #544 (scoped retrieval helper), #545 (scoped prompt renderer).

## Summary

Adds the final tranche-1 safety gate before the live read-path switch: scoped retrieval and scoped rendering run alongside the legacy memory path, and a structured `memory.recall_shadow` log line records what scoped would have produced for the same turn. Live prompt content remains sourced from legacy recall; the scoped renderer's output is computed for log preview metadata but never prepended.

## What's in this PR

**`src/kai/memory.py`**

- `LegacyRecallResult` dataclass + `format_context_with_recall_payload` helper. `format_context` becomes a thin wrapper that emits `memory.recall` and returns the rendered context. Public signature and recall payload shape unchanged (gated by the pre-existing `TestFormatContextUnchangedByScopedHelper` tests).
- `_emit_recall_shadow_log` writes the dedicated `memory.recall_shadow ` prefix as compact JSON; PII posture matches the legacy line (same query/snippet truncation constants).
- JSON-safe payload helpers: `_scoped_debug_to_payload`, `_scoped_hit_to_shadow_payload`, `_ordered_difference`, `_ordered_intersection`, `_shadow_base_payload`.
- `run_scoped_recall_shadow` orchestrator: gated by `is_recall_shadow_enabled()`; missing-workspace branch emits a uniform shadow line with `scoped_reason="missing_workspace"` and `shadow_error=false`; scoped retrieval or rendering exceptions are caught and logged with `shadow_error=true` plus the truncated exception type and message. Never re-raises out.

**`src/kai/config.py`**

- `memory_recall_shadow_enabled: bool = True`. Parsed from `MEMORY_RECALL_SHADOW_ENABLED` with inverted convention (any absent or non-disable value keeps shadow on; `0` / `false` / `no` case-insensitively disable). Composed with `memory_enabled` in `load_config` so shadow never runs when memory is off.

**`src/kai/backend.py`**

- `assemble_turn_context` grows four optional keyword-only parameters: `workspace`, `backend_name`, `job_type`, `session_id`. The recall branch now calls `format_context_with_recall_payload` (one legacy Mem0 search), emits `memory.recall` once, then calls `run_scoped_recall_shadow` for the comparison log.
- `AgentBackend.backend_name: str = ""` class attribute. Concrete backends override.

**`src/kai/{claude,codex,goose}.py`**

- `backend_name` class attribute set to `"claude_code"` / `"codex"` / `"goose"`. Each send path now passes `workspace=self.workspace`, `backend_name=self.backend_name`, `job_type="interactive"` to `assemble_turn_context`.

## Behavior preservation

- `format_context()` signature, prompt header, and `memory.recall` payload shape unchanged. Pinned by the existing `TestFormatContextUnchangedByScopedHelper` tests from #550.
- `assemble_turn_context` still prepends only the legacy memory context. Pinned by the new `test_assemble_turn_context_prompt_uses_legacy_memory_not_scoped_memory`.
- D4 invariant (one legacy Mem0 search per eligible turn) pinned by `test_assemble_turn_context_does_not_duplicate_legacy_search`.

## Tests

**`tests/test_backend.py`** (rewired + 5 new tests)
- Existing `TestAssembleTurnContext` patches updated to the new `format_context_with_recall_payload` symbol via a `_patch_legacy_recall` helper.
- Replaced the two `*_not_scoped_helper` / `*_not_scoped_renderer` tests from #550/#551 (assertions became false after shadow wired the scoped helpers into the live path) with one prompt-content test that proves legacy text is prepended and the renderer's distinctive output is NOT.
- Four new shadow-specific tests: workspace pass-through, no-shadow-when-chat_id-none, no-shadow-when-query-empty, no-duplicate-legacy-search.

**`tests/test_memory.py`** (12 new tests across 4 classes)
- `TestLegacyRecallResultHelper` (3): refactor parity, helper does not emit `memory.recall`, exactly-one-`memory.recall`-per-turn invariant.
- `TestRecallShadowLog` (7): payload shape, project-detection wiring inside `scoped_debug`, removed/added/same id ordering, renderer-preview metadata, missing-workspace branch, retrieval-exception isolation, render-exception isolation.
- `TestRecallShadowConfigGate` (1): disabled flag skips emission.
- `TestRuntimeBackendsPassShadowContext` (1): parameterized `backend_name` pin across all three backends.

**`tests/test_config.py`** (3 new tests)
- `TestMemoryRecallShadowConfig`: default-on, six disable-string variants (case-insensitive), sub-toggle composition with `memory_enabled`.

**`tests/test_{claude,codex,goose}.py`** (6 patch updates)
- Existing `format_context` patches updated to `format_context_with_recall_payload` returning `LegacyRecallResult`.

## Test plan

- [x] `make test` (3547 passed, 1 skipped, +18 net new).
- [x] `make check` (ruff lint + format).
- [x] Spec §10 grep gate:
  - `format_scoped_context.*prepend` / `prepend.*format_scoped_context` in `src/`: zero. Renderer output is never prepended.
  - `"memory.recall_shadow"` string: only at the new emitter site.
  - `retrieve_scoped_memories` and `format_scoped_context` callers in `src/`: only `run_scoped_recall_shadow`. No backend imports.
  - `prepend_to_prompt` calls in `assemble_turn_context`: only the legacy `legacy_recall.rendered_context`, never scoped.
