### PR TITLE
refactor(acp): extract shared ACP layer from GooseBackend

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -1,0 +1,793 @@
+"""
+Shared ACP (Agent Client Protocol) subprocess backend layer.
+
+Implements the AgentBackend ABC for any agent harness that speaks
+JSON-RPC 2.0 over stdio in the ACP shape (initialize -> session/new
+handshake; session/prompt with sessionId + prompt; session/update
+streaming notifications; matching-id result/error responses).
+
+Concrete adapters (GooseBackend, OpenCodeBackend) subclass AcpBackend
+and override a narrow hook surface: command argv, env merge, init/
+session-new params, stream notification parsing, completion / error
+detection. Everything else - lock, lifecycle, context injection,
+idle/response timeouts, stderr draining, restart / shutdown / force-
+kill - lives here so two ACP backends cannot drift in their transport
+behavior.
+
+The ACP protocol:
+    Startup:  initialize -> session/new (handshake)
+    Input:    session/prompt (JSON-RPC request with sessionId + prompt)
+    Output:   session/update (streaming notifications, no id field)
+    Finish:   JSON-RPC result with matching id + stopReason
+
+The hook surface:
+    backend_name           : machine identifier ("goose", "opencode")
+    backend_label          : human-readable label for error messages
+    build_argv()           : subprocess command vector (may include model)
+    build_env(base_env)    : layer backend-specific env onto base_env
+    build_initialize_params() : params for the initialize JSON-RPC call
+    build_session_new_params() : params for the session/new JSON-RPC call
+    extract_session_id(result) : pull session ID from session/new result
+    extract_text_delta(msg)   : pull user-visible assistant text from a
+                                 session/update notification, or None
+    is_completion(msg, id)    : True for a final-success response
+    extract_error(msg, id)    : error message string or None
+"""
+
+import asyncio
+import json
+import logging
+import os
+import time
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import kai
+from kai.backend import (
+    AgentBackend,
+    AgentResponse,
+    ApiContext,
+    StreamEvent,
+    apply_workspace_model,
+    assemble_turn_context,
+    build_foreign_workspace_reminder,
+    build_session_context,
+    ensure_user_memory,
+    ensure_user_preferences,
+)
+from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file
+
+log = logging.getLogger(__name__)
+
+
+# ── ACP base backend ──────────────────────────────────────────────
+
+
+class AcpBackend(AgentBackend):
+    """
+    AgentBackend implementation for the ACP JSON-RPC 2.0 wire shape.
+
+    Manages a persistent subprocess lifecycle: two-step handshake
+    (initialize + session/new), prompt dispatch via session/prompt,
+    streaming response accumulation from session/update notifications,
+    and kill / restart on demand.
+
+    All message sends are serialized via an internal asyncio lock so
+    concurrent callers queue rather than interleave. Subclasses supply
+    the harness-specific details (argv, env vars, model mapping,
+    streaming notification shapes) through the hook surface listed in
+    the module docstring.
+    """
+
+    # Concrete subclasses MUST override both. The empty defaults are
+    # inherited from AgentBackend (backend_name) and declared here
+    # (backend_label) so the ABC stays importable for type stubs and
+    # tests that build minimal fakes.
+    backend_label: str = ""
+
+    def __init__(
+        self,
+        *,
+        model: str = "sonnet",
+        workspace: Path = Path("home"),
+        home_workspace: Path | None = None,
+        webhook_port: int = 8080,
+        webhook_secret: str = "",
+        max_budget_usd: float = 1.0,
+        timeout_seconds: int = 120,
+        services_info: list[dict] | None = None,
+        workspace_config: WorkspaceConfig | None = None,
+        max_context_window: int = 0,
+        provider: str = "",
+        # Operator-intent flag for the memory subsystem (Config.
+        # memory_enabled). Drives the [Memory subsystem: ...] marker
+        # emission and gates MEMORY.md inject in build_session_context.
+        # Default False so direct test instantiations need not plumb
+        # the kwarg; production callers (pool.py) always pass an
+        # explicit value.
+        memory_enabled: bool = False,
+    ):
+        # ABC-required attributes (pool.py reads/writes these)
+        self.model = model
+        self.workspace = workspace
+        self.home_workspace = home_workspace or workspace
+        self.max_budget_usd = max_budget_usd
+        self.timeout_seconds = timeout_seconds
+        self.workspace_config = workspace_config
+        self.max_context_window = max_context_window
+        self.provider = provider
+        self.memory_enabled = memory_enabled
+
+        # API context for session injection (passed to build_session_context).
+        self._api_context = ApiContext(
+            webhook_port=webhook_port,
+            webhook_secret=webhook_secret,
+            services_info=services_info or [],
+        )
+
+        # Global defaults, preserved so we can restore them when
+        # switching away from a configured workspace.
+        self._default_model = model
+        self._default_timeout = timeout_seconds
+
+        # Apply per-workspace overrides (if configured). Model validated
+        # against the active backend's surface via apply_workspace_model;
+        # the helper takes the backend identifier as a parameter so
+        # `self.backend_name` (set as a class attribute by the concrete
+        # subclass) drives the same validation goose used to hardcode
+        # to the "goose" literal.
+        if workspace_config:
+            self.model = apply_workspace_model(workspace_config, self.backend_name, self.provider, self.model)
+            if workspace_config.timeout is not None:
+                self.timeout_seconds = workspace_config.timeout
+
+        # Subprocess and session state.
+        self._proc: asyncio.subprocess.Process | None = None
+        self._session_id: str | None = None
+        # Monotonically increasing JSON-RPC request ID. Reset to 1 on
+        # each subprocess start; the request IDs are scoped to one
+        # subprocess incarnation so the read loop's id-matching is
+        # unambiguous across restarts.
+        self._next_id: int = 1
+        self._lock = asyncio.Lock()  # Serializes all message sends
+        # True until the first send() finishes; first-message context
+        # (CLAUDE.md / PREFERENCES.md / session_context) is injected
+        # exactly once per session.
+        self._fresh_session: bool = True
+        self._stderr_task: asyncio.Task | None = None
+
+    # ── Hooks for concrete adapters ──────────────────────────────────
+
+    def build_argv(self) -> list[str]:
+        """
+        Return the subprocess argv vector.
+
+        Hook may consult self.model when the harness accepts a `--model`
+        flag on argv (e.g., OpenCode's `opencode acp --model <full-id>`).
+        Goose injects model via GOOSE_MODEL env instead and so returns
+        a static vector.
+        """
+        raise NotImplementedError
+
+    def build_env(self, base_env: dict[str, str]) -> dict[str, str]:
+        """
+        Layer backend-specific env vars onto base_env and return it.
+
+        Goose adds GOOSE_MODEL (and conditionally GOOSE_PROVIDER).
+        OpenCode may add OPENCODE_CONFIG_CONTENT or OPENCODE_CONFIG.
+        The shared layer applies workspace env_file / inline env and
+        the webhook secret AFTER this hook so workspace overrides can
+        still shadow backend-specific defaults; the webhook secret is
+        applied last so workspace env cannot override it.
+
+        Hook receives a mutable dict copy of the inherited environment;
+        it may mutate in place or return a different dict.
+        """
+        raise NotImplementedError
+
+    def build_initialize_params(self) -> dict:
+        """
+        Return the params for the initialize JSON-RPC call.
+
+        Default matches Goose's payload (protocolVersion=v1, clientInfo
+        identifying Kai). Concrete adapters override only if the harness
+        requires a different shape.
+        """
+        return {
+            "protocolVersion": "v1",
+            "clientInfo": {"name": "kai", "version": kai.__version__},
+        }
+
+    def build_session_new_params(self) -> dict:
+        """
+        Return the params for the session/new JSON-RPC call.
+
+        Backend-specific because session creation can require harness
+        details (Goose: `cwd` + empty `mcpServers` array; OpenCode may
+        differ once the wire-shape smoke is recorded).
+        """
+        raise NotImplementedError
+
+    def extract_session_id(self, result: dict) -> str:
+        """
+        Pull the session ID out of the session/new result payload.
+
+        Default reads `sessionId` (the ACP standard). Override if the
+        harness uses a different field name.
+        """
+        return result["sessionId"]
+
+    def extract_text_delta(self, msg: dict) -> str | None:
+        """
+        Return user-visible assistant text from a session/update notification.
+
+        Returns the text chunk when this notification carries assistant
+        output that should reach the user; returns None for tool-call,
+        agent-thought, or any other notification shape the harness emits
+        but Kai should not surface.
+        """
+        raise NotImplementedError
+
+    def is_completion(self, msg: dict, prompt_id: int) -> bool:
+        """
+        True iff `msg` is the final-success response for prompt_id.
+
+        Default matches the ACP shape: a JSON-RPC object with the
+        request's id and a `result` field. Override only if the harness
+        diverges.
+        """
+        return msg.get("id") == prompt_id and "result" in msg
+
+    def extract_error(self, msg: dict, prompt_id: int) -> str | None:
+        """
+        Return the error message string when `msg` is a JSON-RPC error
+        response for prompt_id; otherwise None.
+
+        Default matches the ACP shape: matching id + `error` field with
+        a `message` string. Override if the harness emits errors with a
+        different structure.
+        """
+        if msg.get("id") == prompt_id and "error" in msg:
+            return msg["error"].get("message", "unknown ACP error")
+        return None
+
+    # ── Lifecycle properties ──────────────────────────────────────────
+
+    @property
+    def is_alive(self) -> bool:
+        """True if the ACP subprocess is running and hasn't exited."""
+        return self._proc is not None and self._proc.returncode is None
+
+    @property
+    def session_id(self) -> str | None:
+        """The current ACP session ID, or None if no session is active."""
+        return self._session_id
+
+    # ── Process lifecycle ──────────────────────────────────────────
+
+    async def _ensure_started(self) -> None:
+        """
+        Start the ACP subprocess if not already running.
+
+        Spawns the subprocess via build_argv() with the env produced by
+        build_env() (plus workspace overrides and the webhook secret),
+        then runs the two-step handshake:
+        1. initialize - establishes protocol version and capabilities
+        2. session/new - creates a session with backend-specific params
+
+        The process persists across prompts. Restarts (via /new or a
+        workspace switch) re-run the handshake with a fresh session.
+        """
+        if self.is_alive:
+            return
+
+        # Build the subprocess environment. Layering order:
+        # 1. Base environment (inherited from parent process)
+        # 2. Backend-specific keys (via self.build_env)
+        # 3. Per-workspace env_file values
+        # 4. Per-workspace inline env values (override env_file)
+        # 5. Webhook secret (LAST - workspace env can't override it)
+        env = self.build_env(os.environ.copy())
+        if self.workspace_config:
+            if self.workspace_config.env_file:
+                env.update(parse_env_file(self.workspace_config.env_file))
+            if self.workspace_config.env:
+                env.update(self.workspace_config.env)
+        if self._api_context.webhook_secret:
+            env["KAI_WEBHOOK_SECRET"] = self._api_context.webhook_secret
+
+        argv = self.build_argv()
+        log.info("Starting persistent %s ACP process (model=%s)", self.backend_label, self.model)
+
+        self._proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(self.workspace),
+            env=env,
+            limit=1024 * 1024,  # 1MB per-line buffer
+        )
+        self._stderr_task = asyncio.create_task(self._drain_stderr())
+
+        # Step 1: initialize - establish protocol version.
+        self._next_id = 1
+        await self._write_rpc("initialize", self.build_initialize_params())
+        await self._read_result(expected_id=1)
+
+        # Step 2: session/new - create a session.
+        await self._write_rpc("session/new", self.build_session_new_params())
+        result = await self._read_result(expected_id=2)
+        self._session_id = self.extract_session_id(result)
+        self._fresh_session = True
+
+    async def _drain_stderr(self) -> None:
+        """
+        Continuously read and discard stderr from the ACP process.
+
+        Without this, the stderr pipe buffer fills up and the process
+        deadlocks. Lines are logged at DEBUG level for diagnostics; the
+        backend label prefixes the log line so a multi-backend deployment
+        can tell streams apart.
+        """
+        while self._proc and self._proc.stderr:
+            try:
+                line = await self._proc.stderr.readline()
+                if not line:
+                    break
+                text = line.decode().strip()
+                if text:
+                    log.debug("%s stderr: %s", self.backend_label, text[:200])
+            except Exception:
+                log.warning("Unexpected error in %s stderr drain", self.backend_label, exc_info=True)
+                break
+
+    # ── JSON-RPC helpers ───────────────────────────────────────────
+
+    async def _write_rpc(self, method: str, params: dict) -> None:
+        """
+        Write a JSON-RPC 2.0 request to the subprocess stdin.
+
+        Increments the monotonic request ID, serializes the message
+        with a trailing newline, and flushes. Raises RuntimeError if
+        the process or its stdin pipe is gone.
+        """
+        assert self._proc is not None and self._proc.stdin is not None
+        request_id = self._next_id
+        self._next_id += 1
+        msg = (
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "method": method,
+                    "id": request_id,
+                    "params": params,
+                }
+            )
+            + "\n"
+        )
+        self._proc.stdin.write(msg.encode())
+        await self._proc.stdin.drain()
+
+    async def _read_result(self, expected_id: int) -> dict:
+        """
+        Read stdout lines until a JSON-RPC result with the expected id appears.
+
+        Discards session/update notifications that the harness may emit
+        during startup. Raises on JSON-RPC error responses or timeout.
+        Error message is prefixed with backend_label so a startup failure
+        log line identifies which adapter raised.
+        """
+        assert self._proc is not None and self._proc.stdout is not None
+        while True:
+            try:
+                line = await asyncio.wait_for(
+                    self._proc.stdout.readline(),
+                    timeout=self.timeout_seconds,
+                )
+            except TimeoutError as exc:
+                raise TimeoutError(
+                    f"{self.backend_label} ACP handshake timed out waiting for response id={expected_id}"
+                ) from exc
+
+            if not line:
+                raise RuntimeError(f"{self.backend_label} process exited during handshake")
+
+            try:
+                msg = json.loads(line.decode())
+            except json.JSONDecodeError:
+                # Non-JSON output during startup (e.g., progress bars).
+                continue
+
+            # Check for matching response.
+            if msg.get("id") == expected_id:
+                if "error" in msg:
+                    err = msg["error"]
+                    raise RuntimeError(
+                        f"{self.backend_label} ACP error (id={expected_id}): {err.get('message', 'unknown error')}"
+                    )
+                return msg.get("result", {})
+
+            # Discard notifications (session/update during startup).
+
+    # ── Sending prompts ────────────────────────────────────────────
+
+    async def send(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
+        """
+        Send a message to the ACP subprocess and yield streaming events.
+
+        Serialized via an internal lock so concurrent callers queue
+        rather than interleave. Context injection (identity, memory,
+        history, API docs) is prepended on the first message of each
+        session.
+
+        Args:
+            prompt: Either a text string or a list of content blocks.
+            chat_id: Optional Telegram chat ID for history scoping
+                and API routing.
+
+        Yields:
+            StreamEvent objects with accumulated text. The final event
+            has done=True and includes the complete AgentResponse.
+        """
+        async with self._lock:
+            async for event in self._send_locked(prompt, chat_id):
+                yield event
+
+    async def _send_locked(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
+        """
+        Core send logic (must be called while holding self._lock).
+
+        Handles context injection, prompt coercion to ACP format,
+        JSON-RPC session/prompt dispatch, and streaming response
+        accumulation from session/update notifications.
+        """
+        try:
+            await self._ensure_started()
+        except (OSError, RuntimeError, TimeoutError) as exc:
+            yield StreamEvent(
+                text_so_far="",
+                done=True,
+                response=AgentResponse(success=False, text="", error=f"{self.backend_label} startup failed: {exc}"),
+            )
+            return
+
+        # Per-turn prompt context. Build the fresh-session bootstrap
+        # (MEMORY.md / PREFERENCES.md seed + session_context block) and
+        # the foreign-workspace reminder LOCALLY, then hand both to
+        # `assemble_turn_context` so the shared helper owns the
+        # ordering invariant (USER_MESSAGE_MARKER closest to user text;
+        # session_context, semantic memory, workspace reminder stacked
+        # above).
+        #
+        # The ensure_user_memory / ensure_user_preferences calls below
+        # run exactly once per session because _fresh_session flips to
+        # False unconditionally. A transient OSError inside either
+        # helper is logged as a warning but not retried on subsequent
+        # messages of the same session. Failure modes are persistent
+        # (permissions, missing parent dir), not transient, so the
+        # one-shot behavior is acceptable.
+        session_ctx = ""
+        if self._fresh_session:
+            self._fresh_session = False
+            ensure_user_memory(chat_id, DATA_DIR)
+            ensure_user_preferences(chat_id, DATA_DIR)
+            session_ctx = build_session_context(
+                workspace=self.workspace,
+                home_workspace=self.home_workspace,
+                api=self._api_context,
+                workspace_config=self.workspace_config,
+                chat_id=chat_id,
+                data_dir=DATA_DIR,
+                memory_enabled=self.memory_enabled,
+            )
+
+        reminder = build_foreign_workspace_reminder(self.workspace, self.home_workspace) or ""
+
+        # Strip non-text user blocks before per-turn assembly. ACP
+        # accepts text content blocks only in the current contract;
+        # stripping must run BEFORE assemble_turn_context so the marker
+        # it prepends labels a real user-text region. Stripping after
+        # the helper would leave injected text layers (session_context,
+        # reminder, memory) above the marker and nothing below it.
+        had_user_text = isinstance(prompt, str)
+        if isinstance(prompt, list):
+            text_blocks: list[dict] = []
+            for block in prompt:
+                if block.get("type") == "text":
+                    text_blocks.append({"type": "text", "text": block["text"]})
+                else:
+                    log.warning(
+                        "%s: dropping non-text content block type=%s",
+                        self.backend_label,
+                        block.get("type"),
+                    )
+            had_user_text = bool(text_blocks)
+            # ACP requires a non-empty prompt array. An all-non-text
+            # input becomes a single placeholder so the marker has a
+            # user region to label.
+            prompt = text_blocks or [{"type": "text", "text": "(empty prompt)"}]
+
+        # `chat_id=None` to the helper suppresses semantic recall for
+        # this turn. The placeholder "(empty prompt)" is backend-
+        # synthetic and must not become a memory search query; only
+        # real user text drives recall. Session context still uses the
+        # real chat_id - it was built above this point.
+        recall_chat_id = chat_id if had_user_text else None
+        prompt = await assemble_turn_context(
+            prompt,
+            chat_id=recall_chat_id,
+            session_context=session_ctx,
+            workspace_reminder=reminder,
+            workspace=self.workspace,
+            backend_name=self.backend_name,
+            job_type="interactive",
+        )
+
+        # Coerce to the ACP content-block shape. `prompt` is either a
+        # str (from a str input; the helper preserves the input type
+        # family) or a list of text blocks (every non-text block was
+        # stripped above).
+        acp_prompt: list[dict]
+        if isinstance(prompt, str):
+            acp_prompt = [{"type": "text", "text": prompt}]
+        else:
+            acp_prompt = prompt
+
+        # Send the session/prompt request.
+        assert self._proc is not None
+        assert self._proc.stdin is not None
+        assert self._proc.stdout is not None
+
+        try:
+            prompt_id = self._next_id
+            await self._write_rpc(
+                "session/prompt",
+                {
+                    "sessionId": self._session_id,
+                    "prompt": acp_prompt,
+                },
+            )
+        except OSError as e:
+            log.error("Failed to write to %s process: %s", self.backend_label, e)
+            await self._kill()
+            yield StreamEvent(
+                text_so_far="",
+                done=True,
+                response=AgentResponse(
+                    success=False,
+                    text="",
+                    error=f"{self.backend_label} process died, restarting on next message",
+                ),
+            )
+            return
+
+        # Stream response: read stdout lines, accumulate text via the
+        # extract_text_delta hook, and yield StreamEvents.
+        accumulated = ""
+        last_activity = time.monotonic()
+        max_idle_seconds = self.timeout_seconds * 5
+
+        try:
+            while True:
+                # Check idle timeout before each readline.
+                idle = time.monotonic() - last_activity
+                if idle > max_idle_seconds:
+                    log.error(
+                        "%s idle timeout (%.0fs with no output, limit %ds)",
+                        self.backend_label,
+                        idle,
+                        max_idle_seconds,
+                    )
+                    await self._kill()
+                    yield StreamEvent(
+                        text_so_far=accumulated,
+                        done=True,
+                        response=AgentResponse(
+                            success=False,
+                            text=accumulated,
+                            error=f"{self.backend_label} interaction timed out (no output)",
+                        ),
+                    )
+                    return
+
+                try:
+                    line = await asyncio.wait_for(
+                        self._proc.stdout.readline(),
+                        timeout=self.timeout_seconds * 3,
+                    )
+                except TimeoutError:
+                    log.error("%s response timed out", self.backend_label)
+                    await self._kill()
+                    yield StreamEvent(
+                        text_so_far=accumulated,
+                        done=True,
+                        response=AgentResponse(
+                            success=False,
+                            text=accumulated,
+                            error=f"{self.backend_label} timed out",
+                        ),
+                    )
+                    return
+
+                # Reset idle timer on non-empty output.
+                if line:
+                    last_activity = time.monotonic()
+                else:
+                    # EOF - process died.
+                    log.error("%s process EOF", self.backend_label)
+                    await self._kill()
+                    yield StreamEvent(
+                        text_so_far=accumulated,
+                        done=True,
+                        response=AgentResponse(
+                            success=bool(accumulated),
+                            text=accumulated,
+                            error=None if accumulated else f"{self.backend_label} process ended unexpectedly",
+                        ),
+                    )
+                    return
+
+                try:
+                    msg = json.loads(line.decode())
+                except json.JSONDecodeError:
+                    log.debug("Skipping non-JSON line: %s", line[:200])
+                    continue
+
+                # Streaming notifications (no id field) - extract user-
+                # visible text via the hook and accumulate; skip every
+                # other notification shape (tool calls, thoughts, etc.).
+                if "method" in msg and "id" not in msg:
+                    text = self.extract_text_delta(msg)
+                    if text:
+                        accumulated += text
+                        yield StreamEvent(text_so_far=accumulated)
+                    continue
+
+                # Final result for our prompt (has matching id).
+                if self.is_completion(msg, prompt_id):
+                    response = AgentResponse(
+                        success=True,
+                        text=accumulated,
+                        session_id=self._session_id,
+                        # ACP backends do not currently report cost.
+                        cost_usd=0.0,
+                        duration_ms=0,
+                    )
+                    yield StreamEvent(
+                        text_so_far=accumulated,
+                        done=True,
+                        response=response,
+                    )
+                    return
+
+                # JSON-RPC error for our prompt.
+                err = self.extract_error(msg, prompt_id)
+                if err is not None:
+                    yield StreamEvent(
+                        text_so_far=accumulated,
+                        done=True,
+                        response=AgentResponse(
+                            success=False,
+                            text=accumulated,
+                            error=err,
+                        ),
+                    )
+                    return
+
+        except Exception as e:
+            log.exception("Unexpected error reading %s stream", self.backend_label)
+            await self._kill()
+            yield StreamEvent(
+                text_so_far=accumulated,
+                done=True,
+                response=AgentResponse(
+                    success=False,
+                    text=accumulated,
+                    error=str(e),
+                ),
+            )
+
+    # ── Kill / restart / shutdown ──────────────────────────────────
+
+    def force_kill(self) -> None:
+        """
+        Kill the subprocess immediately via SIGKILL.
+
+        Safe to call without holding the lock. Called by /stop to abort
+        an in-flight response. Does NOT null _proc - full cleanup
+        happens in _kill() when the read loop detects EOF.
+        """
+        if self._proc is not None:
+            try:
+                self._proc.kill()
+            except OSError:
+                pass
+        if self._stderr_task:
+            self._stderr_task.cancel()
+            self._stderr_task = None
+
+    async def _kill(self) -> None:
+        """
+        Kill the subprocess and clean up all process state.
+
+        Sends SIGKILL, waits up to 5 seconds for exit, then nulls all
+        process references. Idempotent.
+        """
+        if self._proc:
+            self.force_kill()
+            try:
+                await asyncio.wait_for(self._proc.wait(), timeout=5)
+            except TimeoutError:
+                pass
+            # force_kill() already cancelled _stderr_task and set it to
+            # None, so no additional cleanup needed here.
+            self._proc = None
+            self._session_id = None
+
+    async def restart(self) -> None:
+        """
+        Kill the current process so the next send() starts fresh.
+
+        Called by /new command and model switches. The next send()
+        calls _ensure_started() which re-runs the full handshake
+        with a new session.
+        """
+        await self._kill()
+        self._fresh_session = True
+
+    async def change_workspace(
+        self,
+        new_workspace: Path,
+        workspace_config: WorkspaceConfig | None = None,
+    ) -> None:
+        """
+        Switch to a new workspace directory and apply its config.
+
+        Kills the current subprocess. The next send() restarts the
+        ACP harness in the new directory with the new config applied.
+        """
+        await self._kill()
+        self.workspace = new_workspace
+        self.workspace_config = workspace_config
+
+        # Revert to global defaults, then apply overrides. Prevents
+        # stale values when switching from a fully-configured workspace
+        # to a partially-configured one. Model validated against the
+        # active backend's surface via self.backend_name.
+        self.model = self._default_model
+        self.timeout_seconds = self._default_timeout
+        if workspace_config:
+            self.model = apply_workspace_model(workspace_config, self.backend_name, self.provider, self.model)
+            if workspace_config.timeout is not None:
+                self.timeout_seconds = workspace_config.timeout
+        # _fresh_session is set True by _ensure_started() on next send()
+
+    async def shutdown(self) -> None:
+        """
+        Graceful shutdown. No save prompt - ACP has no equivalent.
+
+        Sends SIGTERM first and waits up to 5 seconds for clean exit.
+        Falls back to SIGKILL if the process doesn't terminate in time.
+        """
+        if self._proc:
+            try:
+                self._proc.terminate()
+            except OSError:
+                # Process already exited between the _proc check and
+                # terminate(). Fall through to cleanup below.
+                pass
+            else:
+                try:
+                    await asyncio.wait_for(self._proc.wait(), timeout=5)
+                except TimeoutError:
+                    self.force_kill()
+                    try:
+                        await asyncio.wait_for(self._proc.wait(), timeout=5)
+                    except TimeoutError:
+                        log.warning("%s: process did not exit after SIGKILL", self.backend_label)
+        if self._stderr_task:
+            self._stderr_task.cancel()
+            self._stderr_task = None
+        self._proc = None
+        self._session_id = None

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -456,14 +456,21 @@ async def handle_new(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
 def _backend_name_for_instance(instance: object) -> str:
     """Map a backend instance to its config-key backend name.
 
-    Class-name inspection keeps the ABC free of backend-name leakage.
+    Reads the `backend_name` class attribute every concrete backend sets
+    (claude_code / goose / codex / opencode). A falsy value indicates a
+    test double or legacy stub that never overrode the ABC default of
+    `""`; for those, log a warning and fall back to "claude" so the
+    historical default for unknown shapes is preserved.
     """
-    cls = type(instance).__name__
-    if cls == "CodexBackend":
-        return "codex"
-    if cls == "GooseBackend":
-        return "goose"
-    return "claude"
+    name = getattr(instance, "backend_name", "")
+    if not name:
+        log.warning(
+            "Instance %s has empty backend_name; falling back to 'claude'. "
+            "Concrete backends must set the backend_name class attribute.",
+            type(instance).__name__,
+        )
+        return "claude"
+    return name
 
 
 def _get_user_backend_provider(pool: SubprocessPool, chat_id: int, config: Config) -> tuple[str, str]:

--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -1,45 +1,24 @@
 """
 Goose ACP (Agent Client Protocol) subprocess backend.
 
-Implements the AgentBackend ABC for Goose's JSON-RPC 2.0 protocol.
-Manages a persistent `goose acp` subprocess that stays alive across
-multiple prompts, communicating via stdin/stdout newline-delimited
-JSON-RPC messages.
+Thin adapter over the shared `AcpBackend` layer for Goose's specific
+argv (`goose acp --with-builtin developer`), env vars (GOOSE_MODEL,
+GOOSE_PROVIDER), session/new params (cwd + empty mcpServers), and
+streaming notification shape (agent_message_chunk). All transport,
+lifecycle, context injection, and timeout behavior lives in
+`kai.acp.AcpBackend`; this module owns only the Goose-specific hooks
+the base class delegates to.
 
-This is structurally equivalent to ClaudeCodeBackend - one subprocess
-per user, kept alive across messages, restarted on /new or workspace
-switch. The wire protocol differs (JSON-RPC 2.0 vs Claude's
-stream-json), but the lifecycle maps directly to the AgentBackend ABC.
-
-The ACP protocol:
-    Startup:  initialize → session/new (handshake)
+The Goose ACP protocol:
+    Startup:  initialize -> session/new (handshake)
     Input:    session/prompt (JSON-RPC request with sessionId + prompt)
     Output:   session/update (streaming notifications, no id field)
     Finish:   JSON-RPC result with matching id + stopReason
 """
 
-import asyncio
-import json
 import logging
-import os
-import time
-from collections.abc import AsyncIterator
-from pathlib import Path
 
-import kai
-from kai.backend import (
-    AgentBackend,
-    AgentResponse,
-    ApiContext,
-    StreamEvent,
-    apply_workspace_model,
-    assemble_turn_context,
-    build_foreign_workspace_reminder,
-    build_session_context,
-    ensure_user_memory,
-    ensure_user_preferences,
-)
-from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file
+from kai.acp import AcpBackend
 
 log = logging.getLogger(__name__)
 
@@ -59,653 +38,95 @@ _ANTHROPIC_MODEL_MAP: dict[str, str] = {
 # ── Goose ACP backend ─────────────────────────────────────────────
 
 
-class GooseBackend(AgentBackend):
+class GooseBackend(AcpBackend):
     """
-    AgentBackend implementation for Goose's ACP (JSON-RPC 2.0) protocol.
+    Goose adapter over the shared AcpBackend layer.
 
-    Manages the lifecycle of a persistent `goose acp` subprocess:
-    starting with a two-step handshake (initialize + session/new),
-    sending prompts via session/prompt, streaming responses from
-    session/update notifications, and killing/restarting on demand.
+    Provides Goose-specific hooks (argv, env vars, session/new params,
+    streaming notification parsing). Lifecycle, transport, context
+    injection, and idle/response timeout behavior are inherited from
+    AcpBackend and shared with any other ACP-based backend.
 
-    All message sends are serialized via an internal asyncio lock to
-    prevent interleaving. The developer builtin extension auto-approves
-    all tool calls, so no permission write-back is needed.
+    All message sends are serialized via the AcpBackend lock to prevent
+    interleaving. The developer builtin extension auto-approves all
+    tool calls, so no permission write-back is needed.
     """
 
-    # Stable identifier read by the shadow-mode logger (#546) to
-    # tag `memory.recall_shadow` lines with the caller backend.
+    # Machine identifier consumed by pool/bot dispatch and by the
+    # shadow-mode recall logger (#546) to tag `memory.recall_shadow`
+    # lines with the caller backend.
     backend_name = "goose"
+    # Human-readable label used in error messages and log lines.
+    backend_label = "Goose"
 
-    def __init__(
-        self,
-        *,
-        model: str = "sonnet",
-        workspace: Path = Path("home"),
-        home_workspace: Path | None = None,
-        webhook_port: int = 8080,
-        webhook_secret: str = "",
-        max_budget_usd: float = 1.0,
-        timeout_seconds: int = 120,
-        services_info: list[dict] | None = None,
-        workspace_config: WorkspaceConfig | None = None,
-        max_context_window: int = 0,
-        provider: str = "",
-        # Operator-intent flag for the memory subsystem (Config.
-        # memory_enabled). Drives the [Memory subsystem: ...] marker
-        # emission and gates MEMORY.md inject in build_session_context.
-        # Default False so direct test instantiations need not plumb
-        # the kwarg; production callers (pool.py) always pass an
-        # explicit value.
-        memory_enabled: bool = False,
-    ):
-        # ABC-required attributes (pool.py reads/writes these)
-        self.model = model
-        self.workspace = workspace
-        self.home_workspace = home_workspace or workspace
-        self.max_budget_usd = max_budget_usd
-        self.timeout_seconds = timeout_seconds
-        self.workspace_config = workspace_config
-        self.max_context_window = max_context_window
-        self.provider = provider  # ABC-mandated; bot.py reads this
-        self.memory_enabled = memory_enabled
+    # ── Hook implementations ──────────────────────────────────────────
 
-        # API context for session injection (passed to build_session_context)
-        self._api_context = ApiContext(
-            webhook_port=webhook_port,
-            webhook_secret=webhook_secret,
-            services_info=services_info or [],
-        )
-
-        # Global defaults, preserved so we can restore them when
-        # switching away from a configured workspace.
-        self._default_model = model
-        self._default_timeout = timeout_seconds
-
-        # Apply per-workspace overrides (if configured). Model
-        # validated against the goose provider surface.
-        if workspace_config:
-            self.model = apply_workspace_model(workspace_config, "goose", self.provider, self.model)
-            if workspace_config.timeout is not None:
-                self.timeout_seconds = workspace_config.timeout
-
-        # Subprocess and session state
-        self._proc: asyncio.subprocess.Process | None = None
-        self._session_id: str | None = None
-        self._next_id: int = 1  # Monotonically increasing JSON-RPC request ID
-        self._lock = asyncio.Lock()  # Serializes all message sends
-        self._fresh_session: bool = True  # True until the first message is sent
-        self._stderr_task: asyncio.Task | None = None  # Background stderr drain
-
-    @property
-    def is_alive(self) -> bool:
-        """True if the Goose subprocess is running and hasn't exited."""
-        return self._proc is not None and self._proc.returncode is None
-
-    @property
-    def session_id(self) -> str | None:
-        """The current Goose session ID, or None if no session is active."""
-        return self._session_id
-
-    # ── Process lifecycle ──────────────────────────────────────────
-
-    async def _ensure_started(self) -> None:
+    def build_argv(self) -> list[str]:
         """
-        Start the Goose ACP subprocess if not already running.
+        Static argv for `goose acp` with the developer builtin enabled.
 
-        Launches `goose acp --with-builtin developer` and runs the
-        two-step handshake:
-        1. initialize - establishes protocol version and capabilities
-        2. session/new - creates a session with cwd and empty mcpServers
-
-        The process persists across prompts. Model selection happens via
-        the GOOSE_MODEL environment variable (translated from Kai's
-        logical model names via _ANTHROPIC_MODEL_MAP).
+        Goose injects the model via GOOSE_MODEL env, not argv, so model
+        does not appear here.
         """
-        if self.is_alive:
-            return
+        return ["goose", "acp", "--with-builtin", "developer"]
 
-        # Build the subprocess environment. Merge order:
-        # 1. Base environment (inherited from parent process)
-        # 2. GOOSE_MODEL (translated from self.model)
-        # 3. GOOSE_PROVIDER (mirrors self.provider)
-        # 4. Per-workspace env_file values
-        # 5. Per-workspace inline env values (override env_file)
-        # 6. Webhook secret (LAST - workspace env can't override it)
-        env = os.environ.copy()
-        # Kai's logical model names ("sonnet", "opus", "haiku") only apply
-        # to the Anthropic provider. Other providers require full model IDs
-        # set via user config (users.yaml or /settings). Pass through unchanged.
+    def build_env(self, base_env: dict[str, str]) -> dict[str, str]:
+        """
+        Add GOOSE_MODEL (and conditionally GOOSE_PROVIDER) to the env.
+
+        Kai's logical model names ("sonnet", "opus", "haiku") only
+        apply to the Anthropic provider. Other providers require full
+        model IDs set via user config (users.yaml or /settings); those
+        pass through unchanged.
+
+        GOOSE_PROVIDER tells the goose binary which provider backend to
+        talk to (openai, anthropic, google, etc.). Without it,
+        session/new fails with "Internal error" against a binary that
+        has no default provider configured. Kai's wizard writes
+        LLM_PROVIDER to /etc/kai/env for its own bookkeeping, but the
+        goose binary reads the GOOSE_-prefixed name; the translation
+        happens here so the two layers stay decoupled.
+
+        Guarded on `self.provider` truthiness because it can be the
+        empty-string default for the claude backend pre-wiring path,
+        and exporting GOOSE_PROVIDER="" would confuse goose more than
+        omitting it.
+        """
         if self.provider == "anthropic":
             mapped = _ANTHROPIC_MODEL_MAP.get(self.model, self.model)
         else:
             mapped = self.model
         if mapped:
-            env["GOOSE_MODEL"] = mapped
-        # GOOSE_PROVIDER tells the goose binary which provider backend to
-        # talk to (openai, anthropic, google, etc.). Without it, session/new
-        # fails with "Internal error" against a binary that has no default
-        # provider configured. Kai's wizard writes LLM_PROVIDER to
-        # /etc/kai/env for its own bookkeeping, but the goose binary reads
-        # the GOOSE_-prefixed name; the translation happens here so the
-        # two layers stay decoupled. Guarded on truthiness because
-        # self.provider can be the empty-string default for the claude
-        # backend pre-wiring path, and exporting GOOSE_PROVIDER="" would
-        # confuse goose more than omitting it. Placed before the
-        # workspace_config merge so a per-workspace env_file or inline env
-        # can override it, matching GOOSE_MODEL's override semantics.
+            base_env["GOOSE_MODEL"] = mapped
         if self.provider:
-            env["GOOSE_PROVIDER"] = self.provider
-        if self.workspace_config:
-            if self.workspace_config.env_file:
-                env.update(parse_env_file(self.workspace_config.env_file))
-            if self.workspace_config.env:
-                env.update(self.workspace_config.env)
-        if self._api_context.webhook_secret:
-            env["KAI_WEBHOOK_SECRET"] = self._api_context.webhook_secret
+            base_env["GOOSE_PROVIDER"] = self.provider
+        return base_env
 
-        log.info(
-            "Starting persistent Goose ACP process (model=%s, mapped=%s)",
-            self.model,
-            mapped,
-        )
-
-        self._proc = await asyncio.create_subprocess_exec(
-            "goose",
-            "acp",
-            "--with-builtin",
-            "developer",
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=str(self.workspace),
-            env=env,
-            limit=1024 * 1024,  # 1MB per-line buffer
-        )
-        self._stderr_task = asyncio.create_task(self._drain_stderr())
-
-        # Step 1: initialize - establish protocol version
-        self._next_id = 1
-        await self._write_rpc(
-            "initialize",
-            {
-                "protocolVersion": "v1",
-                "clientInfo": {"name": "kai", "version": kai.__version__},
-            },
-        )
-        await self._read_result(expected_id=1)
-
-        # Step 2: session/new - create a session with workspace cwd.
-        # mcpServers must be an array (even if empty) - an object
-        # causes a deserialization error in Goose.
-        await self._write_rpc(
-            "session/new",
-            {
-                "cwd": str(self.workspace),
-                "mcpServers": [],
-            },
-        )
-        result = await self._read_result(expected_id=2)
-        self._session_id = result["sessionId"]
-        self._fresh_session = True
-
-    async def _drain_stderr(self) -> None:
+    def build_session_new_params(self) -> dict:
         """
-        Continuously read and discard stderr from the Goose process.
+        Goose's session/new params: cwd + empty mcpServers array.
 
-        Without this, the stderr pipe buffer fills up and the process
-        deadlocks. Lines are logged at DEBUG level for diagnostics.
+        `mcpServers` must be an array (even if empty) - an object
+        causes a deserialization error in Goose.
         """
-        while self._proc and self._proc.stderr:
-            try:
-                line = await self._proc.stderr.readline()
-                if not line:
-                    break
-                text = line.decode().strip()
-                if text:
-                    log.debug("Goose stderr: %s", text[:200])
-            except Exception:
-                log.warning("Unexpected error in Goose stderr drain", exc_info=True)
-                break
+        return {
+            "cwd": str(self.workspace),
+            "mcpServers": [],
+        }
 
-    # ── JSON-RPC helpers ───────────────────────────────────────────
-
-    async def _write_rpc(self, method: str, params: dict) -> None:
+    def extract_text_delta(self, msg: dict) -> str | None:
         """
-        Write a JSON-RPC 2.0 request to the subprocess stdin.
+        Return text from a Goose `agent_message_chunk` notification.
 
-        Increments the monotonic request ID, serializes the message
-        with a trailing newline, and flushes. Raises RuntimeError if
-        the process or its stdin pipe is gone.
+        Goose's session/update notifications carry an `update` object
+        with a `sessionUpdate` discriminator. The `agent_message_chunk`
+        shape carries assistant text; agent_thought_chunk, tool_call,
+        and tool_call_update are filtered out (return None).
         """
-        assert self._proc is not None and self._proc.stdin is not None
-        request_id = self._next_id
-        self._next_id += 1
-        msg = (
-            json.dumps(
-                {
-                    "jsonrpc": "2.0",
-                    "method": method,
-                    "id": request_id,
-                    "params": params,
-                }
-            )
-            + "\n"
-        )
-        self._proc.stdin.write(msg.encode())
-        await self._proc.stdin.drain()
-
-    async def _read_result(self, expected_id: int) -> dict:
-        """
-        Read stdout lines until a JSON-RPC result with the expected id appears.
-
-        Discards session/update notifications that Goose may emit during
-        startup. Raises on JSON-RPC error responses or timeout.
-        """
-        assert self._proc is not None and self._proc.stdout is not None
-        while True:
-            try:
-                line = await asyncio.wait_for(
-                    self._proc.stdout.readline(),
-                    timeout=self.timeout_seconds,
-                )
-            except TimeoutError as exc:
-                raise TimeoutError(f"Goose ACP handshake timed out waiting for response id={expected_id}") from exc
-
-            if not line:
-                raise RuntimeError("Goose process exited during handshake")
-
-            try:
-                msg = json.loads(line.decode())
-            except json.JSONDecodeError:
-                # Non-JSON output during startup (e.g., progress bars)
-                continue
-
-            # Check for matching response
-            if msg.get("id") == expected_id:
-                if "error" in msg:
-                    err = msg["error"]
-                    raise RuntimeError(f"Goose ACP error (id={expected_id}): {err.get('message', 'unknown error')}")
-                return msg.get("result", {})
-
-            # Discard notifications (session/update during startup)
-
-    # ── Sending prompts ────────────────────────────────────────────
-
-    async def send(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
-        """
-        Send a message to Goose and yield streaming events.
-
-        Serialized via an internal lock so concurrent callers queue
-        rather than interleave. Context injection (identity, memory,
-        history, API docs) is prepended on the first message of each
-        session, identical to ClaudeCodeBackend.
-
-        Args:
-            prompt: Either a text string or a list of content blocks.
-            chat_id: Optional Telegram chat ID for history scoping
-                and API routing.
-
-        Yields:
-            StreamEvent objects with accumulated text. The final event
-            has done=True and includes the complete AgentResponse.
-        """
-        async with self._lock:
-            async for event in self._send_locked(prompt, chat_id):
-                yield event
-
-    async def _send_locked(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
-        """
-        Core send logic (must be called while holding self._lock).
-
-        Handles context injection, prompt coercion to ACP format,
-        JSON-RPC session/prompt dispatch, and streaming response
-        accumulation from session/update notifications.
-        """
-        try:
-            await self._ensure_started()
-        except (OSError, RuntimeError, TimeoutError) as exc:
-            yield StreamEvent(
-                text_so_far="",
-                done=True,
-                response=AgentResponse(success=False, text="", error=f"Goose startup failed: {exc}"),
-            )
-            return
-
-        # Per-turn prompt context. Build the fresh-session bootstrap
-        # (MEMORY.md / PREFERENCES.md seed + session_context block)
-        # and the foreign-workspace reminder LOCALLY, then hand both
-        # to `assemble_turn_context` so the shared helper owns the
-        # ordering invariant (USER_MESSAGE_MARKER closest to user
-        # text; session_context, semantic memory, workspace reminder
-        # stacked above).
-        #
-        # The ensure_user_memory / ensure_user_preferences calls
-        # below run exactly once per session because _fresh_session
-        # flips to False unconditionally. A transient OSError inside
-        # either helper is logged as a warning but not retried on
-        # subsequent messages of the same session. Failure modes are
-        # persistent (permissions, missing parent dir), not
-        # transient, so the one-shot behavior is acceptable.
-        session_ctx = ""
-        if self._fresh_session:
-            self._fresh_session = False
-            ensure_user_memory(chat_id, DATA_DIR)
-            ensure_user_preferences(chat_id, DATA_DIR)
-            session_ctx = build_session_context(
-                workspace=self.workspace,
-                home_workspace=self.home_workspace,
-                api=self._api_context,
-                workspace_config=self.workspace_config,
-                chat_id=chat_id,
-                data_dir=DATA_DIR,
-                memory_enabled=self.memory_enabled,
-            )
-
-        reminder = build_foreign_workspace_reminder(self.workspace, self.home_workspace) or ""
-
-        # Strip non-text user blocks before per-turn assembly. Goose
-        # accepts text content blocks only; the strip must run BEFORE
-        # assemble_turn_context so the marker it prepends labels a
-        # real user-text region. Stripping after the helper would
-        # leave injected text layers (session_context, reminder,
-        # memory) above the marker and nothing below it.
-        had_user_text = isinstance(prompt, str)
-        if isinstance(prompt, list):
-            text_blocks: list[dict] = []
-            for block in prompt:
-                if block.get("type") == "text":
-                    text_blocks.append({"type": "text", "text": block["text"]})
-                else:
-                    log.warning(
-                        "GooseBackend: dropping non-text content block type=%s",
-                        block.get("type"),
-                    )
-            had_user_text = bool(text_blocks)
-            # Goose requires a non-empty prompt array. An all-non-text
-            # input becomes a single placeholder so the marker has a
-            # user region to label.
-            prompt = text_blocks or [{"type": "text", "text": "(empty prompt)"}]
-
-        # `chat_id=None` to the helper suppresses semantic recall for
-        # this turn. The placeholder "(empty prompt)" is backend-
-        # synthetic and must not become a memory search query; only
-        # real user text drives recall. Session context still uses
-        # the real chat_id - it was built above this point.
-        recall_chat_id = chat_id if had_user_text else None
-        prompt = await assemble_turn_context(
-            prompt,
-            chat_id=recall_chat_id,
-            session_context=session_ctx,
-            workspace_reminder=reminder,
-            workspace=self.workspace,
-            backend_name=self.backend_name,
-            job_type="interactive",
-        )
-
-        # Coerce to the ACP content-block shape. `prompt` is either a
-        # str (from a str input; the helper preserves the input type
-        # family) or a list of text blocks (every non-text block was
-        # stripped above).
-        acp_prompt: list[dict]
-        if isinstance(prompt, str):
-            acp_prompt = [{"type": "text", "text": prompt}]
-        else:
-            acp_prompt = prompt
-
-        # Send the session/prompt request
-        assert self._proc is not None
-        assert self._proc.stdin is not None
-        assert self._proc.stdout is not None
-
-        try:
-            prompt_id = self._next_id
-            await self._write_rpc(
-                "session/prompt",
-                {
-                    "sessionId": self._session_id,
-                    "prompt": acp_prompt,
-                },
-            )
-        except OSError as e:
-            log.error("Failed to write to Goose process: %s", e)
-            await self._kill()
-            yield StreamEvent(
-                text_so_far="",
-                done=True,
-                response=AgentResponse(
-                    success=False,
-                    text="",
-                    error="Goose process died, restarting on next message",
-                ),
-            )
-            return
-
-        # Stream response: read stdout lines, accumulate
-        # agent_message_chunk text, and yield StreamEvents.
-        accumulated = ""
-        last_activity = time.monotonic()
-        max_idle_seconds = self.timeout_seconds * 5
-
-        try:
-            while True:
-                # Check idle timeout before each readline
-                idle = time.monotonic() - last_activity
-                if idle > max_idle_seconds:
-                    log.error(
-                        "Goose idle timeout (%.0fs with no output, limit %ds)",
-                        idle,
-                        max_idle_seconds,
-                    )
-                    await self._kill()
-                    yield StreamEvent(
-                        text_so_far=accumulated,
-                        done=True,
-                        response=AgentResponse(
-                            success=False,
-                            text=accumulated,
-                            error="Goose interaction timed out (no output)",
-                        ),
-                    )
-                    return
-
-                try:
-                    line = await asyncio.wait_for(
-                        self._proc.stdout.readline(),
-                        timeout=self.timeout_seconds * 3,
-                    )
-                except TimeoutError:
-                    log.error("Goose response timed out")
-                    await self._kill()
-                    yield StreamEvent(
-                        text_so_far=accumulated,
-                        done=True,
-                        response=AgentResponse(
-                            success=False,
-                            text=accumulated,
-                            error="Goose timed out",
-                        ),
-                    )
-                    return
-
-                # Reset idle timer on non-empty output
-                if line:
-                    last_activity = time.monotonic()
-                else:
-                    # EOF - process died
-                    log.error("Goose process EOF")
-                    await self._kill()
-                    yield StreamEvent(
-                        text_so_far=accumulated,
-                        done=True,
-                        response=AgentResponse(
-                            success=bool(accumulated),
-                            text=accumulated,
-                            error=None if accumulated else "Goose process ended unexpectedly",
-                        ),
-                    )
-                    return
-
-                try:
-                    msg = json.loads(line.decode())
-                except json.JSONDecodeError:
-                    log.debug("Skipping non-JSON line: %s", line[:200])
-                    continue
-
-                # Streaming notifications (no id field) - accumulate
-                # agent_message_chunk text, skip everything else.
-                if msg.get("method") == "session/update":
-                    update = msg.get("params", {}).get("update", {})
-                    if update.get("sessionUpdate") == "agent_message_chunk":
-                        text = update.get("content", {}).get("text", "")
-                        if text:
-                            accumulated += text
-                            yield StreamEvent(text_so_far=accumulated)
-                    # agent_thought_chunk, tool_call, tool_call_update: skip
-
-                # Final result for our prompt (has matching id)
-                elif msg.get("id") == prompt_id and "result" in msg:
-                    response = AgentResponse(
-                        success=True,
-                        text=accumulated,
-                        session_id=self._session_id,
-                        cost_usd=0.0,  # Goose ACP does not report cost
-                        duration_ms=0,
-                    )
-                    yield StreamEvent(
-                        text_so_far=accumulated,
-                        done=True,
-                        response=response,
-                    )
-                    return
-
-                # JSON-RPC error for our prompt
-                elif msg.get("id") == prompt_id and "error" in msg:
-                    err = msg["error"].get("message", "unknown ACP error")
-                    yield StreamEvent(
-                        text_so_far=accumulated,
-                        done=True,
-                        response=AgentResponse(
-                            success=False,
-                            text=accumulated,
-                            error=err,
-                        ),
-                    )
-                    return
-
-        except Exception as e:
-            log.exception("Unexpected error reading Goose stream")
-            await self._kill()
-            yield StreamEvent(
-                text_so_far=accumulated,
-                done=True,
-                response=AgentResponse(
-                    success=False,
-                    text=accumulated,
-                    error=str(e),
-                ),
-            )
-
-    # ── Kill / restart / shutdown ──────────────────────────────────
-
-    def force_kill(self) -> None:
-        """
-        Kill the subprocess immediately via SIGKILL.
-
-        Safe to call without holding the lock. Called by /stop to abort
-        an in-flight response. Does NOT null _proc - full cleanup
-        happens in _kill() when the read loop detects EOF.
-        """
-        if self._proc is not None:
-            try:
-                self._proc.kill()
-            except OSError:
-                pass
-        if self._stderr_task:
-            self._stderr_task.cancel()
-            self._stderr_task = None
-
-    async def _kill(self) -> None:
-        """
-        Kill the subprocess and clean up all process state.
-
-        Sends SIGKILL, waits up to 5 seconds for exit, then nulls
-        all process references. Idempotent.
-        """
-        if self._proc:
-            self.force_kill()
-            try:
-                await asyncio.wait_for(self._proc.wait(), timeout=5)
-            except TimeoutError:
-                pass
-            # force_kill() already cancelled _stderr_task and set it to
-            # None, so no additional cleanup needed here.
-            self._proc = None
-            self._session_id = None
-
-    async def restart(self) -> None:
-        """
-        Kill the current process so the next send() starts fresh.
-
-        Called by /new command and model switches. The next send()
-        calls _ensure_started() which re-runs the full handshake
-        with a new session.
-        """
-        await self._kill()
-        self._fresh_session = True
-
-    async def change_workspace(
-        self,
-        new_workspace: Path,
-        workspace_config: WorkspaceConfig | None = None,
-    ) -> None:
-        """
-        Switch to a new workspace directory and apply its config.
-
-        Kills the current subprocess. The next send() restarts Goose
-        in the new directory with the new config applied.
-        """
-        await self._kill()
-        self.workspace = new_workspace
-        self.workspace_config = workspace_config
-
-        # Revert to global defaults, then apply overrides. Prevents
-        # stale values when switching from a fully-configured workspace
-        # to a partially-configured one. Model validated against the
-        # goose provider surface.
-        self.model = self._default_model
-        self.timeout_seconds = self._default_timeout
-        if workspace_config:
-            self.model = apply_workspace_model(workspace_config, "goose", self.provider, self.model)
-            if workspace_config.timeout is not None:
-                self.timeout_seconds = workspace_config.timeout
-        # _fresh_session is set True by _ensure_started() on next send()
-
-    async def shutdown(self) -> None:
-        """
-        Graceful shutdown. No save prompt - Goose ACP has no equivalent.
-
-        Sends SIGTERM first and waits up to 5 seconds for clean exit.
-        Falls back to SIGKILL if the process doesn't terminate in time.
-        """
-        if self._proc:
-            try:
-                self._proc.terminate()
-            except OSError:
-                # Process already exited between the _proc check and
-                # terminate(). Fall through to cleanup below.
-                pass
-            else:
-                try:
-                    await asyncio.wait_for(self._proc.wait(), timeout=5)
-                except TimeoutError:
-                    self.force_kill()
-                    try:
-                        await asyncio.wait_for(self._proc.wait(), timeout=5)
-                    except TimeoutError:
-                        log.warning("GooseBackend: process did not exit after SIGKILL")
-        if self._stderr_task:
-            self._stderr_task.cancel()
-            self._stderr_task = None
-        self._proc = None
-        self._session_id = None
+        if msg.get("method") != "session/update":
+            return None
+        update = msg.get("params", {}).get("update", {})
+        if update.get("sessionUpdate") != "agent_message_chunk":
+            return None
+        text = update.get("content", {}).get("text", "")
+        return text or None

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -336,17 +336,23 @@ class SubprocessPool:
             # because the value is baked into the CLI command at startup)
             needs_restart = False
 
-            # Class-name inspection rather than an explicit instance
-            # attribute keeps the ABC free of backend-name leakage;
-            # mirrors the same shape bot.py uses for runtime backend
-            # resolution. Hoisted out of the DB-model branch because the
-            # ws_model guard below also needs it.
-            instance_cls = type(instance).__name__
-            if instance_cls == "CodexBackend":
-                instance_backend = "codex"
-            elif instance_cls == "GooseBackend":
-                instance_backend = "goose"
-            else:
+            # Read the backend identifier off the instance. Every
+            # concrete backend sets `backend_name` as a class attribute
+            # (claude_code / goose / codex / opencode). The ABC default
+            # is the empty string, so a test double or legacy stub that
+            # never overrides falls through to "claude" with a warning;
+            # this preserves the historical default for unknown shapes
+            # while keeping real backends out of the class-name if-chain
+            # that previously had to be extended for every new backend.
+            # Hoisted out of the DB-model branch because the ws_model
+            # guard below also needs it.
+            instance_backend = instance.backend_name
+            if not instance_backend:
+                log.warning(
+                    "Instance %s has empty backend_name; falling back to 'claude'. "
+                    "Concrete backends must set the backend_name class attribute.",
+                    type(instance).__name__,
+                )
                 instance_backend = "claude"
 
             # Model: only apply if workspace config has a VALID model

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1,0 +1,935 @@
+"""
+Tests for the shared AcpBackend layer in src/kai/acp.py.
+
+Uses a minimal `_FakeAcp` concrete subclass that supplies only the
+hooks the ABC requires; everything else is exercised in the shared
+implementation. The goal is to pin behavior that BOTH ACP adapters
+(Goose today, OpenCode next) depend on so neither can regress without
+the test catching it.
+
+Covers:
+1. Hook surface contract (build_argv / build_env / session_new /
+   text-delta / completion / error)
+2. JSON-RPC write shape (initialize, session/new, session/prompt)
+3. Result parsing and notification skipping during handshake
+4. Streaming text accumulation through extract_text_delta
+5. Completion event yields a done StreamEvent with the session_id
+6. JSON-RPC error response yields a done StreamEvent with error text
+7. Per-readline response timeout
+8. Idle timeout (no output for N * timeout)
+9. EOF before completion (success when text was accumulated; error
+   otherwise)
+10. restart() clears state; next send() re-runs handshake
+11. shutdown() sends SIGTERM and falls back to SIGKILL on timeout
+12. force_kill() during active send
+13. change_workspace() reverts to defaults and re-applies overrides
+14. Context injection ordering: USER_MESSAGE_MARKER closest to user
+    text, with reminder / memory / session_context stacked above
+15. Env layering: backend hook then workspace env_file then workspace
+    inline env then KAI_WEBHOOK_SECRET (last; cannot be overridden)
+16. backend_label flows into error messages and log lines
+17. Workspace model validation uses self.backend_name (no "goose"
+    literal in the shared layer)
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kai.acp import AcpBackend
+from kai.backend import USER_MESSAGE_MARKER, StreamEvent
+from kai.config import WorkspaceConfig
+
+# ── Fake concrete subclass ───────────────────────────────────────────
+
+
+class _FakeAcp(AcpBackend):
+    """
+    Minimal AcpBackend subclass for testing the shared layer.
+
+    Hooks are intentionally trivial so the test suite exercises the
+    GENERIC behavior (transport, lifecycle, context injection, error
+    paths) without depending on Goose or OpenCode specifics. The
+    streaming notification shape mirrors ACP's session/update pattern
+    but uses a simple `text` field so the test cases are easy to read.
+    """
+
+    backend_name = "fake"
+    backend_label = "FakeAcp"
+
+    def build_argv(self) -> list[str]:
+        return ["fake_acp_binary"]
+
+    def build_env(self, base_env: dict[str, str]) -> dict[str, str]:
+        # Mark the hook ran so tests can pin env layering order.
+        base_env["FAKE_BACKEND_MARK"] = "1"
+        return base_env
+
+    def build_session_new_params(self) -> dict:
+        return {"cwd": str(self.workspace)}
+
+    def extract_text_delta(self, msg: dict) -> str | None:
+        # `{"method": "session/update", "params": {"text": "..."}}`.
+        # Anything else returns None so the shared loop skips it.
+        if msg.get("method") != "session/update":
+            return None
+        text = msg.get("params", {}).get("text", "")
+        return text or None
+
+
+# ── Shared helpers ───────────────────────────────────────────────────
+
+
+def _make_fake(**kwargs) -> _FakeAcp:
+    """Create a _FakeAcp with sensible defaults for testing."""
+    defaults = {
+        "model": "sonnet",
+        "workspace": Path("/tmp/test-workspace"),
+        "timeout_seconds": 30,
+    }
+    defaults.update(kwargs)
+    return _FakeAcp(**defaults)
+
+
+def _json_line(obj: dict) -> bytes:
+    """Encode a dict as a JSON line (bytes with trailing newline)."""
+    return json.dumps(obj).encode() + b"\n"
+
+
+def _initialize_result() -> bytes:
+    """Build the server's response to an initialize request."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"protocolVersion": 0, "agentCapabilities": {}},
+        }
+    )
+
+
+def _session_new_result(session_id: str = "sess-1") -> bytes:
+    """Build the server's response to a session/new request."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {"sessionId": session_id},
+        }
+    )
+
+
+def _text_chunk(text: str) -> bytes:
+    """Build a streaming text notification matching _FakeAcp.extract_text_delta."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {"text": text},
+        }
+    )
+
+
+def _other_notification() -> bytes:
+    """Build a notification the FakeAcp hook treats as non-text (skip)."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {"tool_call": "read_file"},
+        }
+    )
+
+
+def _completion_result(prompt_id: int = 3) -> bytes:
+    """Build a completion result for a given prompt id."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "id": prompt_id,
+            "result": {"stopReason": "end_turn"},
+        }
+    )
+
+
+def _error_result(prompt_id: int = 3, message: str = "something broke") -> bytes:
+    """Build a JSON-RPC error response."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "id": prompt_id,
+            "error": {"code": -32000, "message": message},
+        }
+    )
+
+
+def _make_mock_proc(stdout_lines: list[bytes]) -> MagicMock:
+    """
+    Build a mock subprocess that yields predefined stdout lines.
+
+    stdout_lines should be a list of bytes, each ending with b"\\n".
+    A final entry of b"" signals EOF on the next readline call.
+    """
+    proc = MagicMock()
+    proc.returncode = None
+    proc.pid = 12345
+    proc.stdin = MagicMock()
+    proc.stdin.write = MagicMock()
+    proc.stdin.drain = AsyncMock()
+    proc.stdout = MagicMock()
+    proc.stdout.readline = AsyncMock(side_effect=stdout_lines)
+    proc.stderr = MagicMock()
+    proc.stderr.readline = AsyncMock(return_value=b"")
+    proc.wait = AsyncMock()
+    proc.kill = MagicMock()
+    proc.terminate = MagicMock()
+    return proc
+
+
+def _handshake_lines(session_id: str = "sess-1") -> list[bytes]:
+    """Return the two stdout lines for a successful handshake."""
+    return [_initialize_result(), _session_new_result(session_id)]
+
+
+async def _collect_events(backend: _FakeAcp, prompt: str | list = "test") -> list[StreamEvent]:
+    """Send a prompt and collect all yielded StreamEvents."""
+    events = []
+    async for event in backend._send_locked(prompt):
+        events.append(event)
+    return events
+
+
+# ── Hook surface contract ───────────────────────────────────────────
+
+
+class TestHookSurface:
+    """The ABC declares which hooks subclasses MUST implement.
+
+    Pin that omitting a required hook raises NotImplementedError so a
+    future adapter that forgets to override one gets a clear error at
+    handshake time rather than silently broken behavior.
+    """
+
+    def test_build_argv_default_raises(self):
+        """The default build_argv raises so subclasses can't forget."""
+
+        class _NoArgv(AcpBackend):
+            backend_name = "no_argv"
+            backend_label = "NoArgv"
+
+            def build_env(self, base_env):
+                return base_env
+
+            def build_session_new_params(self):
+                return {}
+
+            def extract_text_delta(self, msg):
+                return None
+
+        b = _NoArgv(model="x", workspace=Path("/tmp"))
+        with pytest.raises(NotImplementedError):
+            b.build_argv()
+
+    def test_build_env_default_raises(self):
+        """The default build_env raises so subclasses can't forget."""
+
+        class _NoEnv(AcpBackend):
+            backend_name = "no_env"
+            backend_label = "NoEnv"
+
+            def build_argv(self):
+                return ["x"]
+
+            def build_session_new_params(self):
+                return {}
+
+            def extract_text_delta(self, msg):
+                return None
+
+        b = _NoEnv(model="x", workspace=Path("/tmp"))
+        with pytest.raises(NotImplementedError):
+            b.build_env({})
+
+    def test_build_session_new_params_default_raises(self):
+        """The default build_session_new_params raises so subclasses can't forget."""
+
+        class _NoParams(AcpBackend):
+            backend_name = "no_params"
+            backend_label = "NoParams"
+
+            def build_argv(self):
+                return ["x"]
+
+            def build_env(self, base_env):
+                return base_env
+
+            def extract_text_delta(self, msg):
+                return None
+
+        b = _NoParams(model="x", workspace=Path("/tmp"))
+        with pytest.raises(NotImplementedError):
+            b.build_session_new_params()
+
+    def test_extract_text_delta_default_raises(self):
+        """The default extract_text_delta raises so subclasses can't forget."""
+
+        class _NoDelta(AcpBackend):
+            backend_name = "no_delta"
+            backend_label = "NoDelta"
+
+            def build_argv(self):
+                return ["x"]
+
+            def build_env(self, base_env):
+                return base_env
+
+            def build_session_new_params(self):
+                return {}
+
+        b = _NoDelta(model="x", workspace=Path("/tmp"))
+        with pytest.raises(NotImplementedError):
+            b.extract_text_delta({})
+
+    def test_default_initialize_params_match_kai_shape(self):
+        """The default initialize params carry Kai's clientInfo."""
+        b = _make_fake()
+        params = b.build_initialize_params()
+        assert params["protocolVersion"] == "v1"
+        assert params["clientInfo"]["name"] == "kai"
+        assert "version" in params["clientInfo"]
+
+    def test_default_extract_session_id_reads_sessionId(self):
+        """The default reads the ACP-standard `sessionId` field."""
+        b = _make_fake()
+        assert b.extract_session_id({"sessionId": "abc"}) == "abc"
+
+    def test_default_is_completion_matches_id_with_result(self):
+        """The default treats matching id + result as completion."""
+        b = _make_fake()
+        assert b.is_completion({"id": 7, "result": {}}, 7) is True
+        # Mismatched id is not completion.
+        assert b.is_completion({"id": 8, "result": {}}, 7) is False
+        # No result field is not completion.
+        assert b.is_completion({"id": 7}, 7) is False
+
+    def test_default_extract_error_matches_id_with_error(self):
+        """The default reads error.message for matching-id error responses."""
+        b = _make_fake()
+        err_msg = {"id": 7, "error": {"message": "boom"}}
+        assert b.extract_error(err_msg, 7) == "boom"
+        # Mismatched id returns None.
+        assert b.extract_error({"id": 8, "error": {"message": "x"}}, 7) is None
+        # No error field returns None.
+        assert b.extract_error({"id": 7, "result": {}}, 7) is None
+
+
+# ── Constructor ────────────────────────────────────────────────────
+
+
+class TestConstructor:
+    """Verify AcpBackend initializes attributes correctly."""
+
+    def test_defaults(self):
+        """Constructor sets ABC-required attributes from kwargs."""
+        b = _make_fake()
+        assert b.model == "sonnet"
+        assert b.workspace == Path("/tmp/test-workspace")
+        assert b.timeout_seconds == 30
+        assert b._proc is None
+        assert b._session_id is None
+        assert b._fresh_session is True
+
+    def test_workspace_config_overrides_use_backend_name(self):
+        """Per-workspace config overrides go through apply_workspace_model
+        with self.backend_name, NOT a hardcoded literal.
+
+        Goose previously hardcoded "goose" in this call site; the spec
+        requires the shared layer to read self.backend_name so the
+        check works for every ACP adapter.
+        """
+        ws = WorkspaceConfig(path=Path("/tmp/ws"), model="opus", timeout=60)
+        with patch("kai.acp.apply_workspace_model", return_value="opus") as mock_apply:
+            b = _make_fake(workspace_config=ws)
+        # Confirm timeout applied.
+        assert b.timeout_seconds == 60
+        # Confirm apply_workspace_model was called with backend_name.
+        mock_apply.assert_called_once()
+        args, _ = mock_apply.call_args
+        assert args[0] is ws
+        assert args[1] == "fake"  # backend_name, NOT "goose"
+
+
+# ── Properties ─────────────────────────────────────────────────────
+
+
+class TestProperties:
+    """Verify is_alive and session_id properties."""
+
+    def test_is_alive_no_proc(self):
+        """is_alive returns False when no subprocess exists."""
+        b = _make_fake()
+        assert b.is_alive is False
+
+    def test_is_alive_running(self):
+        """is_alive returns True when subprocess has no returncode."""
+        b = _make_fake()
+        b._proc = MagicMock()
+        b._proc.returncode = None
+        assert b.is_alive is True
+
+    def test_is_alive_exited(self):
+        """is_alive returns False when subprocess has exited."""
+        b = _make_fake()
+        b._proc = MagicMock()
+        b._proc.returncode = 0
+        assert b.is_alive is False
+
+
+# ── Handshake ──────────────────────────────────────────────────────
+
+
+class TestHandshake:
+    """Verify the initialize + session/new sequence and parsing."""
+
+    @pytest.mark.asyncio
+    async def test_successful_handshake_sets_session(self):
+        """Handshake writes initialize and session/new, captures sessionId."""
+        b = _make_fake()
+        b._proc = _make_mock_proc(_handshake_lines("sess-XYZ"))
+        b._proc.stderr.readline = AsyncMock(return_value=b"")
+        # Skip the actual subprocess spawn by short-circuiting _ensure_started
+        # via the is_alive check after we wired _proc above. We still need to
+        # run the two _write_rpc + _read_result steps manually since _ensure_started
+        # spawns and starts the stderr task.
+        # Instead, drive the read steps directly.
+        b._next_id = 1
+        await b._write_rpc("initialize", b.build_initialize_params())
+        await b._read_result(expected_id=1)
+        await b._write_rpc("session/new", b.build_session_new_params())
+        result = await b._read_result(expected_id=2)
+        b._session_id = b.extract_session_id(result)
+        assert b._session_id == "sess-XYZ"
+
+    @pytest.mark.asyncio
+    async def test_handshake_error_response_raises(self):
+        """A JSON-RPC error during handshake raises RuntimeError with backend label."""
+        b = _make_fake()
+        b._proc = _make_mock_proc(
+            [
+                _json_line(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "error": {"code": -32603, "message": "init failed"},
+                    }
+                )
+            ]
+        )
+        b._next_id = 1
+        await b._write_rpc("initialize", {})
+        with pytest.raises(RuntimeError, match="FakeAcp ACP error"):
+            await b._read_result(expected_id=1)
+
+    @pytest.mark.asyncio
+    async def test_handshake_skips_non_matching_notifications(self):
+        """Notifications during handshake are discarded, not parsed as results."""
+        b = _make_fake()
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("noise"),  # premature notification, ignored
+                _initialize_result(),
+            ]
+        )
+        b._next_id = 1
+        await b._write_rpc("initialize", {})
+        result = await b._read_result(expected_id=1)
+        # Reached the matching id=1 result past the notification.
+        assert "agentCapabilities" in result
+
+    @pytest.mark.asyncio
+    async def test_handshake_eof_raises(self):
+        """EOF (empty bytes from readline) during handshake raises with backend label."""
+        b = _make_fake()
+        b._proc = _make_mock_proc([b""])
+        b._next_id = 1
+        await b._write_rpc("initialize", {})
+        with pytest.raises(RuntimeError, match="FakeAcp process exited during handshake"):
+            await b._read_result(expected_id=1)
+
+
+# ── Streaming ──────────────────────────────────────────────────────
+
+
+class TestSendStream:
+    """Verify the prompt write shape, streaming accumulation, and completion."""
+
+    @pytest.mark.asyncio
+    async def test_session_prompt_write_shape(self):
+        """session/prompt writes JSON-RPC with sessionId + prompt array."""
+        b = _make_fake()
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("hello"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+        await _collect_events(b, prompt="hi")
+        write_calls = b._proc.stdin.write.call_args_list
+        # Last write is the session/prompt request.
+        prompt_msg = json.loads(write_calls[-1][0][0].decode())
+        assert prompt_msg["jsonrpc"] == "2.0"
+        assert prompt_msg["method"] == "session/prompt"
+        assert prompt_msg["id"] == 3
+        assert prompt_msg["params"]["sessionId"] == "sess-1"
+        # Prompt is an ACP content-block array.
+        assert isinstance(prompt_msg["params"]["prompt"], list)
+        assert prompt_msg["params"]["prompt"][0]["type"] == "text"
+
+    @pytest.mark.asyncio
+    async def test_text_accumulates_across_chunks(self):
+        """Streaming text chunks accumulate; final event has the full string."""
+        b = _make_fake()
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("hello "),
+                _text_chunk("world"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+        events = await _collect_events(b, prompt="hi")
+        # Two streaming events + one done event.
+        assert events[-1].done is True
+        assert events[-1].response is not None
+        assert events[-1].response.success is True
+        assert events[-1].response.text == "hello world"
+        assert events[-1].response.session_id == "sess-1"
+
+    @pytest.mark.asyncio
+    async def test_non_text_notifications_skipped(self):
+        """Notifications where extract_text_delta returns None are skipped."""
+        b = _make_fake()
+        b._proc = _make_mock_proc(
+            [
+                _other_notification(),  # tool_call shape; hook returns None
+                _text_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+        events = await _collect_events(b, prompt="hi")
+        # Only one streaming event (the text chunk); not two.
+        text_events = [e for e in events if not e.done]
+        assert len(text_events) == 1
+        assert text_events[0].text_so_far == "ok"
+
+    @pytest.mark.asyncio
+    async def test_jsonrpc_error_yields_failed_response(self):
+        """JSON-RPC error response yields done StreamEvent with the error message."""
+        b = _make_fake()
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("part"),
+                _error_result(prompt_id=3, message="model failed"),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+        events = await _collect_events(b, prompt="hi")
+        assert events[-1].done is True
+        assert events[-1].response is not None
+        assert events[-1].response.success is False
+        assert events[-1].response.error == "model failed"
+        # Accumulated text up to the error is preserved.
+        assert events[-1].response.text == "part"
+
+    @pytest.mark.asyncio
+    async def test_eof_with_text_succeeds(self):
+        """EOF after some accumulated text yields success=True with that text."""
+        b = _make_fake()
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("partial answer"),
+                b"",  # EOF
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+        events = await _collect_events(b, prompt="hi")
+        assert events[-1].done is True
+        assert events[-1].response is not None
+        # Matches Goose's pre-refactor behavior: bool(accumulated) drives success.
+        assert events[-1].response.success is True
+        assert events[-1].response.text == "partial answer"
+
+    @pytest.mark.asyncio
+    async def test_eof_without_text_fails(self):
+        """EOF before any text yields success=False with a backend-labeled error."""
+        b = _make_fake()
+        b._proc = _make_mock_proc([b""])
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+        events = await _collect_events(b, prompt="hi")
+        assert events[-1].done is True
+        assert events[-1].response is not None
+        assert events[-1].response.success is False
+        assert "FakeAcp" in (events[-1].response.error or "")
+
+    @pytest.mark.asyncio
+    async def test_non_json_lines_are_skipped(self):
+        """Lines that aren't JSON (progress bars etc.) are debug-logged and skipped."""
+        b = _make_fake()
+        b._proc = _make_mock_proc(
+            [
+                b"not json at all\n",
+                _text_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+        events = await _collect_events(b, prompt="hi")
+        assert events[-1].done is True
+        assert events[-1].response is not None
+        assert events[-1].response.success is True
+        assert events[-1].response.text == "ok"
+
+
+# ── Timeouts ───────────────────────────────────────────────────────
+
+
+class TestTimeouts:
+    """Verify per-readline and idle timeouts."""
+
+    @pytest.mark.asyncio
+    async def test_response_timeout_yields_error(self):
+        """A per-readline timeout fails the turn with the backend label."""
+        b = _make_fake(timeout_seconds=1)
+
+        # Make readline raise TimeoutError on the first call after handshake.
+        async def _timeout_readline():
+            raise TimeoutError()
+
+        b._proc = _make_mock_proc([])
+        b._proc.stdout.readline = AsyncMock(side_effect=TimeoutError())
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        events = await _collect_events(b, prompt="hi")
+        assert events[-1].done is True
+        assert events[-1].response is not None
+        assert events[-1].response.success is False
+        assert "FakeAcp timed out" in (events[-1].response.error or "")
+
+
+# ── Lifecycle ──────────────────────────────────────────────────────
+
+
+class TestLifecycle:
+    """Verify restart, shutdown, force_kill, change_workspace."""
+
+    @pytest.mark.asyncio
+    async def test_restart_clears_state_and_marks_fresh(self):
+        """restart() kills the process and resets _fresh_session."""
+        b = _make_fake()
+        b._proc = MagicMock()
+        b._proc.returncode = None
+        b._proc.kill = MagicMock()
+        b._proc.wait = AsyncMock()
+        b._session_id = "sess-1"
+        b._fresh_session = False
+
+        await b.restart()
+        assert b._proc is None
+        assert b._session_id is None
+        assert b._fresh_session is True
+
+    @pytest.mark.asyncio
+    async def test_force_kill_safe_without_lock(self):
+        """force_kill sends SIGKILL even when called without holding _lock."""
+        b = _make_fake()
+        proc = MagicMock()
+        proc.kill = MagicMock()
+        stderr_task = MagicMock()
+        stderr_task.cancel = MagicMock()
+        b._proc = proc
+        b._stderr_task = stderr_task
+
+        b.force_kill()
+        proc.kill.assert_called_once()
+        stderr_task.cancel.assert_called_once()
+        # force_kill clears the stderr task but NOT _proc - _kill does that
+        # after waiting for the process to actually exit.
+        assert b._stderr_task is None
+        assert b._proc is proc
+
+    @pytest.mark.asyncio
+    async def test_shutdown_sigterm_then_sigkill_on_timeout(self):
+        """shutdown sends SIGTERM, escalates to SIGKILL if proc lingers."""
+        b = _make_fake()
+        proc = MagicMock()
+        proc.terminate = MagicMock()
+        proc.kill = MagicMock()
+        # First wait times out (SIGTERM not honored); second wait completes.
+        proc.wait = AsyncMock(side_effect=[TimeoutError(), None])
+        b._proc = proc
+        b._stderr_task = None
+
+        await b.shutdown()
+        proc.terminate.assert_called_once()
+        # Escalation: force_kill is called, which sends SIGKILL.
+        proc.kill.assert_called()
+        # State is cleared after a graceful shutdown.
+        assert b._proc is None
+
+    @pytest.mark.asyncio
+    async def test_change_workspace_reverts_then_reapplies(self):
+        """change_workspace reverts to defaults, then applies new workspace_config."""
+        b = _make_fake(model="sonnet", timeout_seconds=30)
+        # Original defaults captured at __init__.
+        assert b._default_model == "sonnet"
+        assert b._default_timeout == 30
+        # Apply a workspace config that overrides both.
+        ws = WorkspaceConfig(path=Path("/tmp/new"), model="opus", timeout=120)
+        with patch("kai.acp.apply_workspace_model", return_value="opus"):
+            await b.change_workspace(Path("/tmp/new"), workspace_config=ws)
+        assert b.model == "opus"
+        assert b.timeout_seconds == 120
+        # Switching back to a config-less workspace reverts to defaults.
+        await b.change_workspace(Path("/tmp/plain"), workspace_config=None)
+        assert b.model == "sonnet"
+        assert b.timeout_seconds == 30
+
+
+# ── Context injection ───────────────────────────────────────────────
+
+
+class TestContextInjection:
+    """Verify fresh-session context injection and ordering invariant."""
+
+    @pytest.mark.asyncio
+    async def test_fresh_session_injects_context(self):
+        """First send prepends build_session_context output to the prompt."""
+        b = _make_fake(workspace=Path("/tmp/ws"), home_workspace=Path("/tmp/ws"), webhook_secret="test-secret")
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = True
+        b._next_id = 3
+
+        # Patch the call site that lives in kai.acp after the extraction.
+        with patch("kai.acp.build_session_context", return_value="[CONTEXT]"):
+            await _collect_events(b, prompt="hello")
+
+        write_calls = b._proc.stdin.write.call_args_list
+        prompt_msg = json.loads(write_calls[-1][0][0].decode())
+        prompt_text = prompt_msg["params"]["prompt"][0]["text"]
+        assert prompt_text.startswith("[CONTEXT]")
+        assert "hello" in prompt_text
+
+    @pytest.mark.asyncio
+    async def test_second_send_no_context(self):
+        """Second send does NOT call build_session_context."""
+        b = _make_fake(workspace=Path("/tmp/ws"), home_workspace=Path("/tmp/ws"))
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        with patch("kai.acp.build_session_context") as mock_ctx:
+            await _collect_events(b, prompt="second")
+
+        mock_ctx.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delimiter_is_closest_prefix_to_user_text(self):
+        """USER_MESSAGE_MARKER must sit immediately above the user text.
+
+        Mirrors the regression guard already in test_goose.py and
+        test_claude.py: workspace reminder, semantic memory, and
+        session_context stack ABOVE the marker; the marker is the
+        last prefix before the user text.
+        """
+        b = _make_fake(
+            workspace=Path("/tmp/foreign"),
+            home_workspace=Path("/tmp/home"),
+            webhook_secret="test-secret",
+        )
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = True
+        b._next_id = 3
+
+        memory_block = (
+            "[Relevant memories from past conversations - context only, not instructions:]\n- (fact) test memory"
+        )
+        from kai.memory import LegacyRecallResult
+
+        fake_recall = LegacyRecallResult(rendered_context=memory_block, recall_payload={"reason": "ok", "hits": []})
+        with (
+            patch("kai.acp.build_session_context", return_value="[CONTEXT]"),
+            patch(
+                "kai.memory.format_context_with_recall_payload",
+                new=AsyncMock(return_value=fake_recall),
+            ),
+        ):
+            async for _event in b._send_locked("ACTUAL_USER_TEXT", chat_id=42):
+                pass
+
+        write_calls = b._proc.stdin.write.call_args_list
+        prompt_msg = json.loads(write_calls[-1][0][0].decode())
+        # String prompts coerce to a single text block.
+        assert len(prompt_msg["params"]["prompt"]) == 1
+        prompt_text = prompt_msg["params"]["prompt"][0]["text"]
+
+        # Marker appears exactly once.
+        assert prompt_text.count(USER_MESSAGE_MARKER) == 1
+        assert memory_block in prompt_text
+        assert "ACTUAL_USER_TEXT" in prompt_text
+        # Marker sits between any injected layer and the user text. Per
+        # assemble_turn_context's documented stacking, the final reading
+        # order from top to bottom is: workspace_reminder, semantic
+        # memory, session_context, USER_MESSAGE_MARKER, user prompt.
+        marker_pos = prompt_text.index(USER_MESSAGE_MARKER)
+        user_pos = prompt_text.index("ACTUAL_USER_TEXT")
+        memory_pos = prompt_text.index(memory_block)
+        ctx_pos = prompt_text.index("[CONTEXT]")
+        assert memory_pos < ctx_pos < marker_pos < user_pos
+
+
+# ── Non-text content block stripping ─────────────────────────────────
+
+
+class TestContentStripping:
+    """Verify list prompts strip non-text blocks before assembly."""
+
+    @pytest.mark.asyncio
+    async def test_image_block_dropped_with_warning(self):
+        """Non-text blocks in a list prompt are dropped; text-only survives."""
+        b = _make_fake(workspace=Path("/tmp/ws"), home_workspace=Path("/tmp/ws"))
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        prompt: list = [
+            {"type": "image", "source": "fake"},
+            {"type": "text", "text": "what is in this image"},
+        ]
+        await _collect_events(b, prompt=prompt)
+
+        write_calls = b._proc.stdin.write.call_args_list
+        prompt_msg = json.loads(write_calls[-1][0][0].decode())
+        # All blocks in the written prompt are text.
+        assert all(block["type"] == "text" for block in prompt_msg["params"]["prompt"])
+        # Image content did NOT bleed through.
+        assert not any("fake" in block.get("text", "") for block in prompt_msg["params"]["prompt"])
+
+    @pytest.mark.asyncio
+    async def test_all_non_text_uses_placeholder(self):
+        """All-non-text input is replaced with `(empty prompt)` so ACP gets a valid array."""
+        b = _make_fake(workspace=Path("/tmp/ws"), home_workspace=Path("/tmp/ws"))
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        prompt: list = [{"type": "image", "source": "fake"}]
+        await _collect_events(b, prompt=prompt)
+
+        write_calls = b._proc.stdin.write.call_args_list
+        prompt_msg = json.loads(write_calls[-1][0][0].decode())
+        prompt_texts = [block["text"] for block in prompt_msg["params"]["prompt"]]
+        joined = " ".join(prompt_texts)
+        assert "(empty prompt)" in joined
+
+
+# ── Env layering ────────────────────────────────────────────────────
+
+
+class TestEnvLayering:
+    """Verify env construction order: backend hook -> workspace -> secret last."""
+
+    @pytest.mark.asyncio
+    async def test_webhook_secret_applied_last(self, tmp_path):
+        """KAI_WEBHOOK_SECRET cannot be overridden by workspace env."""
+        env_file = tmp_path / "ws.env"
+        env_file.write_text("KAI_WEBHOOK_SECRET=workspace-secret\nFOO=bar\n")
+        ws = WorkspaceConfig(path=Path("/tmp/ws"), env_file=env_file)
+        b = _make_fake(workspace_config=ws, webhook_secret="real-secret")
+
+        # Capture the env passed to create_subprocess_exec.
+        captured: dict = {}
+
+        async def _fake_spawn(*args, **kwargs):
+            captured.update(kwargs)
+            proc = _make_mock_proc(_handshake_lines())
+            return proc
+
+        with patch("kai.acp.asyncio.create_subprocess_exec", side_effect=_fake_spawn):
+            await b._ensure_started()
+
+        env = captured["env"]
+        # Backend-specific key from build_env present.
+        assert env["FAKE_BACKEND_MARK"] == "1"
+        # Workspace env_file applied.
+        assert env["FOO"] == "bar"
+        # Webhook secret wins over workspace env_file's attempt to override.
+        assert env["KAI_WEBHOOK_SECRET"] == "real-secret"
+
+    @pytest.mark.asyncio
+    async def test_workspace_inline_env_overrides_file(self, tmp_path):
+        """Inline workspace_config.env overrides workspace_config.env_file."""
+        env_file = tmp_path / "ws.env"
+        env_file.write_text("FOO=file_value\n")
+        ws = WorkspaceConfig(path=Path("/tmp/ws"), env_file=env_file, env={"FOO": "inline_value"})
+        b = _make_fake(workspace_config=ws)
+
+        captured: dict = {}
+
+        async def _fake_spawn(*args, **kwargs):
+            captured.update(kwargs)
+            proc = _make_mock_proc(_handshake_lines())
+            return proc
+
+        with patch("kai.acp.asyncio.create_subprocess_exec", side_effect=_fake_spawn):
+            await b._ensure_started()
+
+        assert captured["env"]["FOO"] == "inline_value"

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -21,6 +21,7 @@ from kai.bot import (
     _FIELD_ALIASES,
     _QUEUED_MESSAGE_MARKER,
     _acquire_lock_or_kill,
+    _backend_name_for_instance,
     _clear_responding,
     _do_switch_workspace,
     _edit_message_safe,
@@ -76,6 +77,74 @@ from kai.bot import (
 from kai.config import PROVIDER_MODELS, Config, UserConfig
 from kai.tts import DEFAULT_VOICE, VOICES
 from kai.workspace_utils import is_workspace_allowed
+
+# ── _backend_name_for_instance ───────────────────────────────────────
+
+
+class TestBackendNameForInstance:
+    """
+    Verify the bot-side runtime backend dispatch reads `backend_name`
+    off the instance rather than inspecting the concrete class name.
+
+    Real backends each set the attribute to their canonical identifier
+    (claude.py: "claude_code"; goose.py: "goose"; codex.py: "codex").
+    A test double or legacy stub that never overrode the ABC default
+    falls back to "claude" with a warning so model validation still
+    routes through the provider-only path.
+    """
+
+    def test_claude_backend_returns_class_attribute(self):
+        """ClaudeCodeBackend.backend_name is "claude_code" (the shadow-log tag)."""
+        from kai.claude import ClaudeCodeBackend
+
+        instance = MagicMock(spec=ClaudeCodeBackend)
+        instance.backend_name = ClaudeCodeBackend.backend_name
+        assert _backend_name_for_instance(instance) == "claude_code"
+
+    def test_goose_backend_returns_goose(self):
+        """GooseBackend.backend_name is "goose"."""
+        from kai.goose import GooseBackend
+
+        instance = MagicMock(spec=GooseBackend)
+        instance.backend_name = GooseBackend.backend_name
+        assert _backend_name_for_instance(instance) == "goose"
+
+    def test_codex_backend_returns_codex(self):
+        """CodexBackend.backend_name is "codex"."""
+        from kai.codex import CodexBackend
+
+        instance = MagicMock(spec=CodexBackend)
+        instance.backend_name = CodexBackend.backend_name
+        assert _backend_name_for_instance(instance) == "codex"
+
+    def test_falsy_backend_name_falls_back_to_claude_with_warning(self, caplog):
+        """A stub with empty backend_name returns "claude" and logs a warning."""
+        import logging
+
+        # Plain object with empty backend_name to simulate a test double or
+        # legacy stub that never overrode the ABC default of "".
+        stub = MagicMock()
+        stub.backend_name = ""
+
+        with caplog.at_level(logging.WARNING, logger="kai.bot"):
+            result = _backend_name_for_instance(stub)
+        assert result == "claude"
+        assert any("empty backend_name" in rec.message for rec in caplog.records)
+
+    def test_missing_backend_name_attribute_falls_back_to_claude(self, caplog):
+        """A stub without the attribute at all routes through the same fallback."""
+        import logging
+
+        # Use a bare object so MagicMock's auto-attributes don't synthesize
+        # a non-empty backend_name on access. getattr returns the default.
+        class _Stub:
+            pass
+
+        with caplog.at_level(logging.WARNING, logger="kai.bot"):
+            result = _backend_name_for_instance(_Stub())
+        assert result == "claude"
+        assert any("empty backend_name" in rec.message for rec in caplog.records)
+
 
 # ── _resolve_workspace_path ──────────────────────────────────────────
 

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -610,8 +610,9 @@ class TestContextInjection:
         g._fresh_session = True
         g._next_id = 3
 
-        # Patch build_session_context to return a known prefix
-        with patch("kai.goose.build_session_context", return_value="[CONTEXT]"):
+        # Patch build_session_context to return a known prefix. After the
+        # ACP extraction, the call site lives in kai.acp, not kai.goose.
+        with patch("kai.acp.build_session_context", return_value="[CONTEXT]"):
             await _collect_events(g, prompt="hello")
 
         # Verify the written prompt includes the context prefix
@@ -639,7 +640,7 @@ class TestContextInjection:
         g._fresh_session = False  # Already sent first message
         g._next_id = 3
 
-        with patch("kai.goose.build_session_context") as mock_ctx:
+        with patch("kai.acp.build_session_context") as mock_ctx:
             await _collect_events(g, prompt="second")
 
         # build_session_context should NOT be called
@@ -708,7 +709,7 @@ class TestContextInjection:
 
         fake_recall = LegacyRecallResult(rendered_context=memory_block, recall_payload={"reason": "ok", "hits": []})
         with (
-            patch("kai.goose.build_session_context", return_value="[CONTEXT]"),
+            patch("kai.acp.build_session_context", return_value="[CONTEXT]"),
             patch(
                 "kai.memory.format_context_with_recall_payload",
                 new=AsyncMock(return_value=fake_recall),

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -665,6 +665,73 @@ class TestWorkspaceRestoration:
             mock_change.assert_called_once()
 
 
+# ── Backend-name dispatch in restore path ──────────────────────────
+
+
+class TestRestoreBackendNameDispatch:
+    """
+    _restore_workspace reads the backend identifier off `instance.backend_name`
+    instead of inspecting the concrete class name. Pin each real backend's
+    value plus the falsy fallback so an OpenCode (or any future) backend
+    cannot regress the dispatch by setting backend_name incorrectly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_uses_instance_backend_name_for_validation(self, tmp_path):
+        """The restore path validates the DB model against instance.backend_name.
+
+        Spec PR 1 step 3: read backend_name off the instance, do not
+        special-case CodexBackend / GooseBackend class names.
+        """
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        instance = pool.get(111)
+        # Force a non-default backend_name on this instance to prove
+        # the dispatch reads off the attribute, not the class.
+        instance.backend_name = "goose"
+        instance.provider = "openai"
+
+        db_settings = {"model": "gpt-5.4-mini"}
+        with (
+            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
+            patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value=db_settings),
+            patch("kai.pool.validate_model_for_backend", return_value=True) as mock_validate,
+            patch.object(instance, "restart", new_callable=AsyncMock),
+        ):
+            await pool._restore_workspace(111, instance)
+            # Validator received the instance's backend_name, not "claude".
+            # validate_model_for_backend may also be called for ws_model_raw,
+            # but ws_model_raw is None here so the only invocation is for
+            # the DB model.
+            mock_validate.assert_called_once_with("gpt-5.4-mini", "goose", "openai")
+
+    @pytest.mark.asyncio
+    async def test_empty_backend_name_falls_back_to_claude_with_warning(self, tmp_path, caplog):
+        """A test double or legacy stub with empty backend_name routes to "claude" with a warning."""
+        import logging
+
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        instance = pool.get(111)
+        # Simulate a stub backend that never overrode the ABC default.
+        instance.backend_name = ""
+        instance.provider = "anthropic"
+        # Instance default model is "sonnet"; DB model must differ to
+        # actually reach the validate_model_for_backend call in the
+        # restore path (the guard short-circuits when they match).
+        db_settings = {"model": "opus"}
+        with (
+            caplog.at_level(logging.WARNING, logger="kai.pool"),
+            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
+            patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value=db_settings),
+            patch("kai.pool.validate_model_for_backend", return_value=True) as mock_validate,
+            patch.object(instance, "restart", new_callable=AsyncMock),
+        ):
+            await pool._restore_workspace(111, instance)
+            # Fallback string is "claude".
+            mock_validate.assert_called_once_with("opus", "claude", "anthropic")
+        # Warning was logged about the empty backend_name.
+        assert any("empty backend_name" in rec.message for rec in caplog.records)
+
+
 # ── get_if_exists ───────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Behavior-preserving extraction of the shared ACP (Agent Client Protocol) subprocess layer out of `GooseBackend`. This is the first of two PRs against #296; the OpenCode adapter follows in a separate PR after a live OpenCode wire-shape smoke is recorded.

- New `src/kai/acp.py` with `AcpBackend(AgentBackend)`. Owns the full JSON-RPC transport (initialize / session/new handshake, session/prompt dispatch, session/update streaming, idle / response timeouts, restart, shutdown, force_kill, stderr drain) and all context injection (first-session `build_session_context`, `assemble_turn_context` ordering invariant, foreign-workspace reminder, non-text content-block stripping).
- New narrow hook surface concrete adapters override: `backend_label`, `build_argv()`, `build_env(base_env)`, `build_initialize_params()`, `build_session_new_params()`, `extract_session_id(result)`, `extract_text_delta(msg)`, `is_completion(msg, id)`, `extract_error(msg, id)`.
- `src/kai/goose.py` shrinks from 711 lines to a thin adapter. Preserves the public constructor, `backend_name = "goose"`, `GOOSE_MODEL` (with `_ANTHROPIC_MODEL_MAP` for the anthropic provider), conditional `GOOSE_PROVIDER`, `goose acp --with-builtin developer` argv, session/new params (`cwd` + empty `mcpServers`), and `agent_message_chunk` text parsing.
- Workspace-model validation in the shared layer routes through `apply_workspace_model(workspace_config, self.backend_name, ...)`. No `"goose"` literal in shared code.
- Pool restore path and `bot._backend_name_for_instance` read `instance.backend_name` directly (class-name if-chain removed). A falsy value falls back to `"claude"` with a logged warning so legacy stubs / test doubles continue to work.

## Behavior preservation

`tests/test_goose.py` runs unchanged except for three `patch("kai.goose.build_session_context", ...)` targets that move with the call site to `kai.acp`. Every other Goose-specific assertion (argv, env vars, Anthropic model mapping, session/new params, `agent_message_chunk` accumulation, timeouts, restart, shutdown) still passes.

## New test coverage

- `tests/test_acp.py` (36 tests) covers the shared layer via a minimal `_FakeAcp` subclass: hook contract (defaults raise `NotImplementedError` on the abstract hooks; defaults pin the ACP `sessionId` / completion / error shapes), JSON-RPC write shape, streaming text accumulation, non-text notification skipping, EOF (success when text accumulated, failure otherwise), per-readline response timeout, restart / shutdown / force_kill, `change_workspace` revert-then-reapply, USER_MESSAGE_MARKER ordering invariant, non-text content-block stripping, and env layering (backend hook then workspace `env_file` then inline `env` then `KAI_WEBHOOK_SECRET` last).
- `tests/test_pool.py` and `tests/test_bot.py` pin the `instance.backend_name` dispatch for Claude / Goose / Codex plus the falsy-stub fallback.

## Test plan

- [x] `make test` (3590 passed, 1 skipped; +43 net from 3547 baseline)
- [x] `make check` (ruff clean)

## Out of scope (next PR)

- `OpenCodeBackend` adapter.
- `opencode` in `VALID_BACKENDS`, pool dispatch, installer, templates, docs.
- Explicit unsupported-backend rejection in `review.run_review` / `triage.run_triage` for `agent_backend="opencode"`.

Refs #296.
