### PR TITLE
feat(opencode): add OpenCode ACP as a fourth agent backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![License](https://img.shields.io/github/license/dcellison/kai)](LICENSE)
 [![Version](https://img.shields.io/github/v/tag/dcellison/kai?label=version)](https://github.com/dcellison/kai/releases)
 
-Kai is an AI agent, not a chatbot. It manages persistent agent subprocesses running on your hardware - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) by default, with [Goose](https://block.github.io/goose/) as an alternative backend - and connects them to Telegram as a control surface. Shell, filesystem, git, web search, scheduling - the agent has real access to your system and can take real action on it. It reviews PRs when code is pushed, triages issues when they're opened, monitors conditions on a schedule, and operates across any project on your machine. Multiple users can share a single Kai instance, each with their own isolated subprocess, workspace, conversation history, and optional OS-level process separation.
+Kai is an AI agent, not a chatbot. It manages persistent agent subprocesses running on your hardware - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) by default, with [Goose](https://block.github.io/goose/), [OpenAI Codex CLI](https://github.com/openai/codex), or [OpenCode](https://opencode.ai/) as alternative backends - and connects them to Telegram as a control surface. Shell, filesystem, git, web search, scheduling - the agent has real access to your system and can take real action on it. It reviews PRs when code is pushed, triages issues when they're opened, monitors conditions on a schedule, and operates across any project on your machine. Multiple users can share a single Kai instance, each with their own isolated subprocess, workspace, conversation history, and optional OS-level process separation.
 
 For detailed guides on setup, architecture, and optional features, see the **[Wiki](https://github.com/dcellison/kai/wiki)**.
 
 ## Architecture
 
-Kai is two layers: an outer Python application that handles Telegram, HTTP, and scheduling, and one or more inner agent subprocesses that do the thinking and acting. The outer process programs against an `AgentBackend` ABC (`backend.py`), so it manages lifecycle, authentication, and transport identically regardless of which backend is running. Claude Code is the default; Goose ACP is an alternative. Both follow the same lifecycle: one subprocess per user, lazy creation, idle eviction. Resource usage scales with active users, not registered ones.
+Kai is two layers: an outer Python application that handles Telegram, HTTP, and scheduling, and one or more inner agent subprocesses that do the thinking and acting. The outer process programs against an `AgentBackend` ABC (`backend.py`), so it manages lifecycle, authentication, and transport identically regardless of which backend is running. Claude Code is the default; Goose ACP, OpenAI Codex CLI, and OpenCode ACP are alternatives. All four follow the same lifecycle: one subprocess per user, lazy creation, idle eviction. Resource usage scales with active users, not registered ones. The two ACP-based backends (Goose and OpenCode) share a transport layer in `acp.py`; each adds a thin adapter for the harness-specific argv, env, and notification shapes.
 
 This is what separates Kai from API-wrapper bots that send text to a model endpoint and relay the response. The inner agent is a full agentic runtime - it reads files, runs shell commands, searches the web, writes and commits code, and maintains context across a session. Claude Code and Goose each bring their own model ecosystem. Kai gives the runtime a durable home, a scheduling system, event-driven inputs, persistent memory, and a security model designed around the fact that it has all of this power.
 
@@ -120,7 +120,7 @@ Responses stream into Telegram in real time, updating the message every 2 second
 
 ### Model switching
 
-Switch models via `/models` (interactive picker) or `/model <name>` (direct). Available models depend on the configured backend: Claude Code offers Opus, Sonnet, and Haiku; Goose offers whatever the user's configured provider supports. Changing models restarts the session.
+Switch models via `/models` (interactive picker) or `/model <name>` (direct). Available models depend on the configured backend: Claude Code offers Opus, Sonnet, and Haiku; Goose offers whatever the user's configured provider supports; Codex offers the Codex CLI's curated model list; OpenCode accepts free-text `provider/model` IDs (for example `anthropic/claude-sonnet-4-6`) that OpenCode resolves at runtime against the credentials in `~/.local/share/opencode/auth.json`. Changing models restarts the session.
 
 ### Voice input
 
@@ -184,7 +184,7 @@ If interrupted mid-response, Kai notifies you on restart and asks you to resend 
 ## Requirements
 
 - Python 3.13+
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (default) or [Goose CLI](https://block.github.io/goose/) installed and authenticated
+- One of: [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (default), [Goose CLI](https://block.github.io/goose/), [OpenAI Codex CLI](https://github.com/openai/codex), or [OpenCode CLI](https://opencode.ai/) - installed and authenticated for the backend you select
 - A Telegram bot token from [@BotFather](https://t.me/BotFather)
 - Your Telegram user ID (get it from [@userinfobot](https://t.me/userinfobot))
 
@@ -346,7 +346,9 @@ kai/
 │   ├── bot.py                # Telegram handlers, commands, message routing
 │   ├── claude.py             # Persistent Claude Code subprocess management
 │   ├── config.py             # Environment and per-workspace config loading
-│   ├── goose.py              # Goose ACP backend (JSON-RPC subprocess)
+│   ├── acp.py                # Shared ACP transport (Goose + OpenCode base layer)
+│   ├── goose.py              # Goose ACP backend (adapter over acp.py)
+│   ├── opencode.py           # OpenCode ACP backend (adapter over acp.py)
 │   ├── sessions.py           # SQLite session, job, and settings storage
 │   ├── cron.py               # Scheduled job execution (APScheduler)
 │   ├── webhook.py            # HTTP server: GitHub/generic webhooks, scheduling API

--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -251,6 +251,44 @@ class AcpBackend(AgentBackend):
             return msg["error"].get("message", "unknown ACP error")
         return None
 
+    def handle_server_request(self, msg: dict) -> dict | None:
+        """
+        Return a JSON-RPC `result` payload for a server-initiated request.
+
+        Some ACP harnesses (OpenCode in particular) emit JSON-RPC
+        requests TO the client mid-stream, expecting a matching-id
+        response before the prompt can continue. The classic example is
+        `session/request_permission` for a tool call: OpenCode waits for
+        the client to pick an `optionId` before the tool runs. Goose
+        never does this (auto-approves via `--with-builtin developer`),
+        so the default returns None (the shared read loop logs and
+        skips) and Goose's behavior is unchanged.
+
+        Concrete adapters override to recognize specific server methods
+        and return the response body. The shared layer wraps the
+        returned dict as `{jsonrpc: "2.0", id: <request_id>, result: <dict>}`
+        and writes it back on stdin. Returning None for an unrecognized
+        request method is the safe default; the harness either retries,
+        times out, or proceeds without the answer.
+        """
+        return None
+
+    async def _send_server_response(self, request_id: int, result: dict) -> None:
+        """
+        Write a JSON-RPC response back to the subprocess for a
+        server-initiated request.
+
+        Distinct from `_write_rpc` (which sends a new request and
+        consumes a fresh `_next_id`); this writes a response using the
+        id the SERVER sent us. Helper kept out of the read loop so the
+        ordering and error handling stay clear.
+        """
+        assert self._proc is not None and self._proc.stdin is not None
+        payload = {"jsonrpc": "2.0", "id": request_id, "result": result}
+        line = (json.dumps(payload) + "\n").encode()
+        self._proc.stdin.write(line)
+        await self._proc.stdin.drain()
+
     # ── Lifecycle properties ──────────────────────────────────────────
 
     @property
@@ -642,6 +680,34 @@ class AcpBackend(AgentBackend):
                     if text:
                         accumulated += text
                         yield StreamEvent(text_so_far=accumulated)
+                    continue
+
+                # Server-initiated JSON-RPC request (has BOTH method AND
+                # id). OpenCode emits these for tool-permission decisions
+                # and waits on a matching-id response before continuing.
+                # The shape-keyed branch keeps the no-backend_name-in-
+                # shared-loop rule intact: the hook does the per-backend
+                # work. Goose never reaches this branch in practice
+                # because its `--with-builtin developer` auto-approves.
+                if "method" in msg and "id" in msg:
+                    server_id = msg["id"]
+                    result = self.handle_server_request(msg)
+                    if result is not None:
+                        try:
+                            await self._send_server_response(server_id, result)
+                        except OSError as e:
+                            log.error(
+                                "Failed to write server-request response to %s: %s",
+                                self.backend_label,
+                                e,
+                            )
+                    else:
+                        log.debug(
+                            "%s emitted server request method=%s id=%s; hook returned None, skipping",
+                            self.backend_label,
+                            msg.get("method"),
+                            server_id,
+                        )
                     continue
 
                 # Final result for our prompt (has matching id).

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -510,10 +510,15 @@ def _get_user_models(pool: SubprocessPool, chat_id: int, config: Config) -> dict
     """
     backend, provider = _get_user_backend_provider(pool, chat_id, config)
     models = models_for_backend(backend, provider)
-    if models is None and backend != "codex" and provider not in OPEN_ENDED_PROVIDERS:
+    if models is None and backend != "codex" and backend != "opencode" and provider not in OPEN_ENDED_PROVIDERS:
         # Provider is not open-ended but has no curated list. This means
         # PROVIDER_MODELS is missing an entry for a valid provider -
-        # programming oversight, not user error.
+        # programming oversight, not user error. OpenCode is excluded
+        # alongside codex because its None return is intentional (full
+        # provider/model IDs are open-ended, not a missing registry
+        # entry), and the global llm_provider for opencode is usually
+        # empty so the OPEN_ENDED_PROVIDERS check above would not catch
+        # it.
         log.warning(
             "Provider '%s' has no curated model list; falling back to text input",
             provider,

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -371,6 +371,35 @@ def validate_model_for_provider(model: str, provider: str) -> bool:
     return model in models
 
 
+def is_opencode_model_shape(model: str) -> bool:
+    """Structural check: OpenCode model IDs are `provider_id/model_id`.
+
+    OpenCode resolves models against its own provider registry at
+    runtime; Kai cannot enumerate the supported set (75+ providers
+    via AI SDK and Models.dev, varying by what the operator has
+    authenticated through `opencode auth login`). What IS knowable
+    upfront is the structural contract documented at
+    https://opencode.ai/docs/models/: every accepted model string
+    splits on `/` into exactly two non-empty segments.
+
+    Rejecting strings that violate that contract catches the common
+    operator footgun where a bare Anthropic name like `sonnet` or
+    `opus` (correct for the claude / goose / codex surfaces) is
+    typed into `/model` on an opencode install. Without this check,
+    such a value persists through DB write -> pool restore ->
+    OpenCodeBackend.build_env, where it becomes
+    `OPENCODE_CONFIG_CONTENT='{"model": "sonnet"}'` and OpenCode
+    fails model resolution at handshake time with no clear pointer
+    back to the Kai-side typo.
+    """
+    if not model:
+        return False
+    parts = model.split("/")
+    if len(parts) != 2:
+        return False
+    return all(parts)
+
+
 def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> bool:
     """Check if a model is valid for the active backend.
 
@@ -380,11 +409,12 @@ def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> b
     its own CLI's curated set); other backends delegate to the existing
     provider-only validator, which is unchanged for goose / claude.
 
-    OpenCode is open-ended: model strings are full `provider/model`
-    IDs OpenCode resolves at runtime (75+ providers via AI SDK and
-    Models.dev), so any non-empty string is accepted. Curating a list
-    here would either go stale or block valid models; OpenCode itself
-    is the source of truth on which IDs work.
+    OpenCode validates STRUCTURALLY: model strings must match
+    `provider/model` (both segments non-empty). The supported provider/
+    model SET is not curated here - OpenCode is the source of truth on
+    which IDs resolve - but the structural contract blocks the obvious
+    operator typo (bare Anthropic names like "opus" or "sonnet" that
+    are correct on other backends but unusable on OpenCode).
 
     Canonical model validator: every model-selection site in the
     codebase routes through this function so codex / goose / opencode
@@ -393,7 +423,7 @@ def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> b
     if backend == "codex":
         return model in CODEX_MODELS
     if backend == "opencode":
-        return bool(model)
+        return is_opencode_model_shape(model)
     return validate_model_for_provider(model, eff_provider)
 
 

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -42,14 +42,21 @@ DATA_DIR = Path(os.environ.get("KAI_DATA_DIR") or str(PROJECT_ROOT))
 
 # Valid agent backend choices. "claude" uses Claude Code CLI,
 # "goose" uses Goose ACP, "codex" uses OpenAI Codex CLI's app-server
-# JSON-RPC protocol. Shared between load_config() and install.py.
-VALID_BACKENDS = {"claude", "goose", "codex"}
+# JSON-RPC protocol, "opencode" uses OpenCode's ACP (model selected
+# via OPENCODE_CONFIG_CONTENT; auth managed by the operator through
+# `opencode auth login`). Shared between load_config() and install.py.
+VALID_BACKENDS = {"claude", "goose", "codex", "opencode"}
 
 # Valid LLM providers per backend. Claude always uses Anthropic
 # (hardcoded in get_effective_provider), so it has no entry here.
 # Backends that don't appear in this dict accept no provider config.
-# NOTE: Non-Claude entries in VALID_BACKENDS should have a matching
-# key here. Missing entries silently skip provider validation.
+# OpenCode is also absent: its model string is a full `provider/model`
+# ID (e.g. `anthropic/claude-sonnet-4-6`) that encodes the provider
+# inline, and auth is managed by the OpenCode CLI itself rather than
+# by Kai's wizard. The wizard therefore skips provider/API-key
+# prompts for opencode and asks for a free-text model instead.
+# NOTE: Backends in VALID_BACKENDS that should have a provider prompt
+# need a matching key here; missing entries silently skip the prompt.
 VALID_PROVIDERS: dict[str, frozenset[str]] = {
     "goose": frozenset({"anthropic", "openai", "google", "openrouter", "ollama"}),
 }
@@ -297,9 +304,14 @@ def get_effective_provider(backend: str, llm_provider: str) -> str:
     Claude is always anthropic; codex is always openai (codex CLI has
     no other provider surface, so a wizard-generated codex install with
     LLM_PROVIDER unset still needs the runtime to know its provider is
-    openai). Goose is the only backend that consults the raw
-    llm_provider, because it routes to whatever provider the user
-    configured. Kept identical to the backend->provider rule
+    openai). Goose consults the raw llm_provider because it routes to
+    whatever provider the user configured. OpenCode also returns the
+    raw llm_provider: the provider lives inside the full `provider/model`
+    string OpenCode resolves at runtime, so Kai's effective_provider
+    is informational (used for shadow recall logging metadata and the
+    /stats display) rather than load-bearing for OpenCode dispatch.
+
+    Kept identical to the backend->provider rule
     get_user_backend_and_provider uses so the two cascade helpers do
     not drift; any caller resolving an effective provider for a
     backend gets the same answer regardless of which helper it uses.
@@ -368,27 +380,42 @@ def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> b
     its own CLI's curated set); other backends delegate to the existing
     provider-only validator, which is unchanged for goose / claude.
 
+    OpenCode is open-ended: model strings are full `provider/model`
+    IDs OpenCode resolves at runtime (75+ providers via AI SDK and
+    Models.dev), so any non-empty string is accepted. Curating a list
+    here would either go stale or block valid models; OpenCode itself
+    is the source of truth on which IDs work.
+
     Canonical model validator: every model-selection site in the
-    codebase routes through this function so codex and goose share
-    no fallback path.
+    codebase routes through this function so codex / goose / opencode
+    share no fallback path.
     """
     if backend == "codex":
         return model in CODEX_MODELS
+    if backend == "opencode":
+        return bool(model)
     return validate_model_for_provider(model, eff_provider)
 
 
 def models_for_backend(agent_backend: str, eff_provider: str) -> dict[str, str] | None:
     """Curated model list for the given (backend, provider) pair.
 
-    Codex consults its own CODEX_MODELS surface; everything else falls
-    back to PROVIDER_MODELS[eff_provider]. Returns None for open-ended
-    providers (caller falls back to a free-text prompt rather than a
-    fixed-choice keyboard). Used by both install.py (wizard prompt +
-    apply-time validator) and bot.py (/model keyboard + selection
-    validator).
+    Codex consults its own CODEX_MODELS surface; OpenCode and the
+    open-ended providers return None (caller falls back to a free-text
+    prompt rather than a fixed-choice keyboard). Used by both
+    install.py (wizard prompt + apply-time validator) and bot.py
+    (/model keyboard + selection validator).
+
+    OpenCode returns None unconditionally: model strings are full
+    `provider/model` IDs and the supported set depends on which
+    providers the operator authenticated via `opencode auth login`.
+    A curated keyboard would mislead users into picking IDs their
+    OpenCode install cannot resolve.
     """
     if agent_backend == "codex":
         return CODEX_MODELS
+    if agent_backend == "opencode":
+        return None
     if eff_provider in OPEN_ENDED_PROVIDERS:
         return None
     return PROVIDER_MODELS.get(eff_provider)
@@ -401,8 +428,10 @@ def get_user_backend_and_provider(user_config: "UserConfig | None", config: "Con
     > config.agent_backend, similar for llm_provider); this function
     consolidates it in one place so every runtime model-validation site
     sees the same effective backend for a given user. Backend determines
-    provider 1:1 for codex (openai) and claude (anthropic); goose's
-    provider comes from the same cascade as its backend.
+    provider 1:1 for codex (openai) and claude (anthropic); goose and
+    opencode both consult the raw llm_provider cascade (opencode's
+    value is informational - the real provider/model resolution lives
+    inside OpenCode's full `provider/model` string at runtime).
     """
     backend = user_config.agent_backend if user_config and user_config.agent_backend else config.agent_backend
     if backend == "claude":

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -680,7 +680,19 @@ def _cmd_config() -> None:
     # _prompt_default_model later in this function; since
     # models_for_backend("opencode", _) returns None, the operator gets
     # a free-text prompt for a full `provider/model` ID.
-    if agent_backend == "opencode":
+    #
+    # Gate on `opencode_runs_anywhere` rather than `agent_backend ==
+    # "opencode"` for the same reason codex uses `codex_runs_anywhere`:
+    # an install with global claude but a users.yaml that includes
+    # opencode-effective users still needs the PATH check and the auth
+    # reminder. Conversely, an install with global opencode whose
+    # users.yaml overrides every entry to non-opencode skips this
+    # block entirely.
+    try:
+        opencode_runs_anywhere = _compute_opencode_runs_anywhere(agent_backend, users_yaml_exists, users_yaml_path)
+    except (OSError, ValueError):
+        opencode_runs_anywhere = agent_backend == "opencode"
+    if opencode_runs_anywhere:
         if not shutil.which("opencode"):
             print("  WARNING: 'opencode' binary not found on PATH.")
             print("  Install it from https://opencode.ai/docs/install/ before starting Kai.")
@@ -1975,6 +1987,54 @@ def _compute_codex_runs_anywhere(
     if users_yaml_exists:
         return bool(codex_users)
     return global_agent_backend == "codex"
+
+
+def _compute_opencode_runs_anywhere(
+    global_agent_backend: str,
+    users_yaml_exists: bool,
+    users_yaml_path: str | Path,
+) -> bool:
+    """Return True when any user on this install routes to opencode.
+
+    Same authoritative-source rule as `_compute_codex_runs_anywhere`:
+    when `users_yaml_exists` is True the users.yaml is the user set
+    and global `AGENT_BACKEND` is only the inherited default; when it
+    does NOT exist every authorized user inherits the global and the
+    global value alone decides.
+
+    Folds the yaml read into the predicate because, unlike codex, the
+    wizard does not need per-user os_user / telegram_id details for
+    opencode (auth lives in ~/.local/share/opencode/auth.json and
+    OpenCode runs as the service user). A boolean is sufficient to
+    gate the PATH check and the post-install auth reminder.
+
+    Mirrors the read-then-cascade pattern in `_codex_users_from_yaml`:
+    missing file returns False; malformed yaml propagates (the wizard
+    caller wraps in try/except so a transient read failure does not
+    crash the wizard).
+    """
+    if not users_yaml_exists:
+        return global_agent_backend == "opencode"
+    text = _read_users_yaml_text(Path(users_yaml_path))
+    if text is None or not text.strip():
+        return False
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        return False
+    users = data.get("users")
+    if not isinstance(users, list):
+        return False
+    for entry in users:
+        if not isinstance(entry, dict):
+            continue
+        per_user_backend = entry.get("agent_backend")
+        if isinstance(per_user_backend, str) and per_user_backend.strip():
+            effective = per_user_backend.strip().lower()
+        else:
+            effective = global_agent_backend
+        if effective == "opencode":
+            return True
+    return False
 
 
 def _build_codex_login_reminder(

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -672,10 +672,29 @@ def _cmd_config() -> None:
             print("    e.g.   <os_user> ~$ codex login")
             print("  Run as the os_user themselves, not via sudo from another account.")
 
+    # OpenCode setup: PATH check + post-install auth reminder. OpenCode
+    # is intentionally absent from VALID_PROVIDERS (its auth lives in
+    # ~/.local/share/opencode/auth.json, operator-managed via
+    # `opencode auth login`), so the provider/API-key block below is
+    # skipped naturally. Model selection routes through
+    # _prompt_default_model later in this function; since
+    # models_for_backend("opencode", _) returns None, the operator gets
+    # a free-text prompt for a full `provider/model` ID.
+    if agent_backend == "opencode":
+        if not shutil.which("opencode"):
+            print("  WARNING: 'opencode' binary not found on PATH.")
+            print("  Install it from https://opencode.ai/docs/install/ before starting Kai.")
+        print("  After install, authenticate OpenCode for at least one provider:")
+        print("    <service_user> ~$ opencode auth login")
+        print("  Kai writes the active model into OPENCODE_CONFIG_CONTENT at process spawn;")
+        print("  OpenCode resolves it against the credentials in ~/.local/share/opencode/auth.json.")
+
     # Non-Claude backends: provider and API key. The provider choice
     # determines which env var to prompt for (or none for ollama).
-    # Codex is intentionally absent from VALID_PROVIDERS, so this block
-    # only fires for goose; codex is handled in the dedicated branch above.
+    # Codex and OpenCode are intentionally absent from VALID_PROVIDERS,
+    # so this block only fires for goose; codex is handled in the
+    # dedicated branch above and opencode in the block immediately
+    # above (no API key needed; auth is opencode-cli-managed).
     llm_provider = ""
     llm_api_key_var = ""
     llm_api_key = ""

--- a/src/kai/opencode.py
+++ b/src/kai/opencode.py
@@ -1,0 +1,192 @@
+"""
+OpenCode ACP (Agent Client Protocol) subprocess backend.
+
+Thin adapter over the shared `AcpBackend` layer for OpenCode's specific
+argv (`opencode acp`), env-driven model selection
+(`OPENCODE_CONFIG_CONTENT`), integer protocol version, and
+server-initiated tool-permission request handling. All transport,
+lifecycle, context injection, and timeout behavior live in
+`kai.acp.AcpBackend`; this module owns only the OpenCode-specific
+hooks the base class delegates to.
+
+The OpenCode ACP protocol matches the shared ACP shape for everything
+except two harness-specific points:
+
+1. `initialize` requires `protocolVersion` as an INTEGER (1). Goose
+   accepts the string "v1"; OpenCode rejects it with a Zod schema
+   error and the handshake fails before session/new ever runs.
+2. Tool calls in OpenCode emit a server-initiated JSON-RPC request
+   `session/request_permission` and BLOCK until the client returns a
+   matching-id response with one of the `options` (allow_once /
+   allow_always / reject_once). Goose has no equivalent: its
+   `--with-builtin developer` extension auto-approves silently.
+
+Model selection flows through `OPENCODE_CONFIG_CONTENT`. The CLI does
+not accept `--model` on argv; the only argv flags are
+`--cwd`, `--port`, `--hostname`, `--log-level`, `--print-logs`,
+`--pure`, `--mdns`, `--mdns-domain`, `--cors`, `--help`, `--version`.
+OpenCode reads inline config from the env var at startup; Kai writes
+the active model into a one-shot JSON blob per process.
+
+Operator authentication is handled OUTSIDE Kai: `opencode auth login`
+writes credentials to `~/.local/share/opencode/auth.json`. The Kai
+installer prints a reminder; the wizard does not attempt to manage
+OpenCode auth state.
+"""
+
+import json
+import logging
+
+from kai.acp import AcpBackend
+
+log = logging.getLogger(__name__)
+
+
+# ── OpenCode ACP backend ──────────────────────────────────────────
+
+
+class OpenCodeBackend(AcpBackend):
+    """
+    OpenCode adapter over the shared AcpBackend layer.
+
+    Provides OpenCode-specific hooks: integer protocol version on the
+    initialize handshake, `OPENCODE_CONFIG_CONTENT` env-driven model
+    selection, agent_message_chunk parsing (identical shape to Goose),
+    and auto-approval of server-initiated
+    `session/request_permission` requests so tool calls do not hang.
+    """
+
+    # Machine identifier consumed by pool/bot dispatch and by the
+    # shadow-mode recall logger to tag `memory.recall_shadow` lines
+    # with the caller backend.
+    backend_name = "opencode"
+    # Human-readable label used in error messages and log lines.
+    backend_label = "OpenCode"
+
+    # ── Hook implementations ──────────────────────────────────────────
+
+    def build_argv(self) -> list[str]:
+        """
+        Static argv for `opencode acp`.
+
+        The CLI does not accept `--model` on argv; model selection
+        flows through `OPENCODE_CONFIG_CONTENT` in `build_env`. `--cwd`
+        is supplied via the subprocess `cwd=` argument in
+        `AcpBackend._ensure_started`, not as an explicit argv entry.
+        """
+        return ["opencode", "acp"]
+
+    def build_env(self, base_env: dict[str, str]) -> dict[str, str]:
+        """
+        Inject the active model into `OPENCODE_CONFIG_CONTENT`.
+
+        OpenCode reads inline JSON config from this env var at startup
+        (verified empirically: setting `{"model": "<provider/model>"}`
+        changes the model reported in `session/new`'s
+        `_meta.opencode.modelId` from the default to the requested ID).
+        Model strings use OpenCode's full `provider_id/model_id`
+        format (e.g. `anthropic/claude-sonnet-4-6`); see the wizard
+        prompt and the README for the supported pattern.
+
+        Only emitted when `self.model` is truthy. Empty model lets
+        OpenCode fall back to whatever its own config files specify,
+        which is the right behavior for an unconfigured-on-purpose
+        adapter (e.g. operator running tests).
+        """
+        if self.model:
+            base_env["OPENCODE_CONFIG_CONTENT"] = json.dumps({"model": self.model})
+        return base_env
+
+    def build_initialize_params(self) -> dict:
+        """
+        OpenCode requires `protocolVersion` as an integer.
+
+        The shared `AcpBackend.build_initialize_params` default sends
+        the string `"v1"` (Goose-compatible). OpenCode's Zod schema
+        rejects strings with `"expected number, received string"`,
+        breaking the handshake before session/new. Sending integer `1`
+        is accepted; OpenCode's response carries `protocolVersion: 1`.
+        """
+        from kai import __version__
+
+        return {
+            "protocolVersion": 1,
+            "clientInfo": {"name": "kai", "version": __version__},
+        }
+
+    def build_session_new_params(self) -> dict:
+        """
+        OpenCode's session/new params: cwd + empty mcpServers array.
+
+        Identical to Goose's payload; OpenCode accepts both fields
+        without complaint and returns a `sessionId` in the result
+        (matching the AcpBackend default `extract_session_id`).
+        """
+        return {
+            "cwd": str(self.workspace),
+            "mcpServers": [],
+        }
+
+    def extract_text_delta(self, msg: dict) -> str | None:
+        """
+        Return text from an OpenCode `agent_message_chunk` notification.
+
+        OpenCode's `session/update` shape matches Goose's exactly: a
+        `params.update.sessionUpdate` discriminator with text under
+        `params.update.content.text`. Other discriminators observed
+        (`agent_thought_chunk`, `available_commands_update`,
+        `usage_update`, `tool_call`, `tool_call_update`) are filtered
+        out (return None) so only user-visible assistant text streams
+        to the Telegram client.
+        """
+        if msg.get("method") != "session/update":
+            return None
+        update = msg.get("params", {}).get("update", {})
+        if update.get("sessionUpdate") != "agent_message_chunk":
+            return None
+        text = update.get("content", {}).get("text", "")
+        return text or None
+
+    def handle_server_request(self, msg: dict) -> dict | None:
+        """
+        Auto-approve OpenCode `session/request_permission` requests.
+
+        OpenCode emits a server-initiated JSON-RPC request when a tool
+        needs a permission decision; the prompt does not progress
+        until the client returns a matching-id response. The request's
+        `options` array always carries an entry with
+        `kind: "allow_always"`; returning its `optionId` matches the
+        Goose `--with-builtin developer` posture (auto-approve so
+        agent tasks can actually execute tools), without baking the
+        decision into OpenCode's persistent config.
+
+        Defensive fallback: if the request shape changes and we cannot
+        find an allow_always option, look for any allow-shaped option,
+        then for any optionId at all, and only then bail with None
+        (which logs and skips at the shared-layer call site, letting
+        OpenCode time out the request gracefully instead of crashing
+        the read loop).
+        """
+        if msg.get("method") != "session/request_permission":
+            return None
+        options = msg.get("params", {}).get("options", []) or []
+        choice = (
+            _pick_option(options, "allow_always")
+            or _pick_option(options, "allow_once")
+            or (options[0] if options else None)
+        )
+        if not choice or "optionId" not in choice:
+            log.warning(
+                "OpenCode session/request_permission missing a usable option; params=%s",
+                msg.get("params"),
+            )
+            return None
+        return {"optionId": choice["optionId"]}
+
+
+def _pick_option(options: list[dict], kind: str) -> dict | None:
+    """Return the first option whose `kind` matches, or None."""
+    for opt in options:
+        if opt.get("kind") == kind:
+            return opt
+    return None

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -158,6 +158,21 @@ class SubprocessPool:
             # which goose-on-openai still consults and which would
             # bypass the codex/goose surface separation.
             model = CODEX_DEFAULT_MODEL
+        elif backend == "opencode":
+            # Per-user opencode override on a non-opencode global install
+            # with no user.model. There is no safe per-provider default
+            # we can guess (opencode model strings are full provider/model
+            # IDs and we do not know which providers the operator has
+            # authenticated). Pass empty so OpenCodeBackend.build_env
+            # skips OPENCODE_CONFIG_CONTENT and OpenCode falls back to
+            # its own config files. Warn so the operator notices.
+            log.warning(
+                "No model configured for opencode user %d; OpenCode will use "
+                "its own config defaults (set DEFAULT_MODEL globally or per-user "
+                "in users.yaml to override)",
+                chat_id,
+            )
+            model = ""
         else:
             model = PROVIDER_DEFAULTS.get(effective_provider, "")
             if not model:
@@ -197,11 +212,33 @@ class SubprocessPool:
         # clarity of two separate resolution calls is worth it.
         home_ws = resolve_home_workspace(chat_id, self._config)
 
-        # Backend selection: "goose" uses Goose ACP, "codex" uses
-        # OpenAI Codex CLI's app-server JSON-RPC protocol, anything
-        # else (including the default "claude") uses Claude Code CLI.
+        # Backend selection: "goose" uses Goose ACP, "opencode" uses
+        # OpenCode ACP, "codex" uses OpenAI Codex CLI's app-server
+        # JSON-RPC protocol, anything else (including the default
+        # "claude") uses Claude Code CLI.
         if backend == "goose":
             return GooseBackend(
+                model=model,
+                workspace=workspace,
+                home_workspace=home_ws,
+                webhook_port=self._config.webhook_port,
+                webhook_secret=self._config.webhook_secret,
+                max_budget_usd=budget,
+                timeout_seconds=timeout,
+                services_info=self._services_info,
+                workspace_config=ws_config,
+                max_context_window=context_window,
+                provider=effective_provider,
+                memory_enabled=self._config.memory_enabled,
+            )
+
+        if backend == "opencode":
+            # Import locally so opencode.py is only imported on an
+            # opencode-active install. Mirrors the codex pattern below
+            # rather than goose's module-top import.
+            from kai.opencode import OpenCodeBackend
+
+            return OpenCodeBackend(
                 model=model,
                 workspace=workspace,
                 home_workspace=home_ws,
@@ -219,9 +256,11 @@ class SubprocessPool:
         # os_user for sudo -u isolation. None = run as bot user.
         # Resolved here (rather than inside each branch) because both
         # ClaudeCodeBackend and CodexBackend consume it for per-user
-        # subprocess isolation. Goose is the only backend that does
-        # not: goose runs as the service user and bills against a
-        # single GOOSE_PROVIDER auth set in /etc/kai/env.
+        # subprocess isolation. Goose and OpenCode do not: both run as
+        # the service user. Goose bills against a single GOOSE_PROVIDER
+        # auth set in /etc/kai/env; OpenCode reads its auth from
+        # ~/.local/share/opencode/auth.json which is per-OS-user but
+        # operator-managed via `opencode auth login` outside the wizard.
         os_user = user.os_user if user else self._config.claude_user
 
         if backend == "codex":

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -709,7 +709,26 @@ async def run_review(
 
     Raises:
         RuntimeError: If the subprocess fails or times out.
+        ValueError: If agent_backend has no supported one-shot path
+            here (e.g. "opencode"). The conversational OpenCode adapter
+            does not bring a one-shot reasoner; a per-user opencode
+            override must surface this gap loudly rather than silently
+            falling through to Claude.
     """
+    if agent_backend == "opencode":
+        # Reject before the codex / goose / claude dispatch below.
+        # OpenCode has no one-shot reasoner today; the conversational
+        # backend cannot be reused for review because the wire shapes
+        # and lifecycle differ. Surface this as a clean ValueError so
+        # the operator gets a deterministic failure mode instead of an
+        # unexpected Claude-billed review.
+        raise ValueError(
+            "PR review with agent_backend='opencode' is not supported. "
+            "OpenCode users currently have no one-shot reasoner; configure "
+            "a per-user agent_backend override of 'claude', 'codex', or 'goose' "
+            "for PR review, or disable PR review for opencode users."
+        )
+
     if agent_backend == "codex":
         # Codex one-shot mode: --json emits NDJSON events on stdout
         # (thread.started, turn.started, item.*, turn.completed,

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -413,7 +413,26 @@ async def run_triage(
 
     Raises:
         RuntimeError: If the subprocess fails or times out.
+        ValueError: If agent_backend has no supported one-shot path
+            here (e.g. "opencode"). The conversational OpenCode adapter
+            does not bring a one-shot reasoner; a per-user opencode
+            override must surface this gap loudly rather than silently
+            falling through to Claude.
     """
+    if agent_backend == "opencode":
+        # Reject before the codex / goose / claude dispatch below.
+        # OpenCode has no one-shot reasoner today; the conversational
+        # backend cannot be reused for triage because the wire shapes
+        # and lifecycle differ. Surface this as a clean ValueError so
+        # the operator gets a deterministic failure mode instead of an
+        # unexpected Claude-billed triage.
+        raise ValueError(
+            "Issue triage with agent_backend='opencode' is not supported. "
+            "OpenCode users currently have no one-shot reasoner; configure "
+            "a per-user agent_backend override of 'claude', 'codex', or 'goose' "
+            "for issue triage, or disable issue triage for opencode users."
+        )
+
     if agent_backend == "codex":
         # Codex one-shot mode: --json emits NDJSON events on stdout
         # (thread.started, turn.started, item.*, turn.completed, error).

--- a/templates/users.yaml
+++ b/templates/users.yaml
@@ -35,10 +35,13 @@ users:
     # context_window: 200000  # context window in tokens (0 = default)
 
     # Agent backend. Overrides the global AGENT_BACKEND from .env for
-    # this user only. Default is "claude" (Claude Code CLI). Set to
-    # "goose" to use Goose ACP with the specified LLM provider.
+    # this user only. Default is "claude" (Claude Code CLI). Other
+    # options: "goose" (Goose ACP, requires llm_provider + API key),
+    # "codex" (OpenAI Codex CLI), "opencode" (OpenCode ACP; model is
+    # a full "provider/model" ID, auth managed by `opencode auth login`).
     # agent_backend: goose
-    # llm_provider: openai    # required for non-Claude backends
+    # llm_provider: openai    # required for goose; ignored for opencode
+    # model: anthropic/claude-sonnet-4-6   # opencode example (full provider/model ID)
 
     # GitHub notification settings. github_repos controls which repos
     # route events to this user. pr_review and issue_triage toggle

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -881,6 +881,144 @@ class TestContentStripping:
         assert "(empty prompt)" in joined
 
 
+# ── Server-initiated request handling ───────────────────────────────
+
+
+class TestServerInitiatedRequest:
+    """
+    OpenCode emits server-initiated JSON-RPC requests (e.g.
+    session/request_permission) and BLOCKS until the client returns
+    a matching-id response. The shared read loop must dispatch these
+    to handle_server_request and write the response back; the branch
+    is keyed on message shape (method AND id), not backend_name, so
+    Goose's behavior (no server requests) is unchanged.
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_hook_returns_none_skips_request(self):
+        """Default handle_server_request returns None; loop continues and the request is skipped."""
+        b = _make_fake()
+        server_request = _json_line(
+            {
+                "jsonrpc": "2.0",
+                "id": 99,
+                "method": "session/request_permission",
+                "params": {"sessionId": "sess-1", "options": [{"optionId": "always"}]},
+            }
+        )
+        b._proc = _make_mock_proc(
+            [
+                server_request,  # default hook returns None -> skip
+                _text_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        events = await _collect_events(b, prompt="hi")
+        # No response sent back to the server (only the initial session/prompt).
+        write_calls = b._proc.stdin.write.call_args_list
+        assert len(write_calls) == 1
+        # Prompt completed normally.
+        assert events[-1].done is True
+        assert events[-1].response is not None
+        assert events[-1].response.success is True
+
+    @pytest.mark.asyncio
+    async def test_hook_returning_dict_writes_response_with_matching_id(self):
+        """A hook that returns a dict triggers a JSON-RPC response with the server's id."""
+
+        class _AutoApprove(_FakeAcp):
+            def handle_server_request(self, msg):
+                if msg.get("method") == "session/request_permission":
+                    return {"optionId": "always"}
+                return None
+
+        b = _AutoApprove(model="x", workspace=Path("/tmp/ws"))
+        server_request = _json_line(
+            {
+                "jsonrpc": "2.0",
+                "id": 42,
+                "method": "session/request_permission",
+                "params": {"sessionId": "sess-1"},
+            }
+        )
+        b._proc = _make_mock_proc(
+            [
+                server_request,
+                _text_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        await _collect_events(b, prompt="hi")
+
+        write_calls = b._proc.stdin.write.call_args_list
+        # Two writes: original session/prompt + the server-request response.
+        assert len(write_calls) == 2
+        response = json.loads(write_calls[1][0][0].decode())
+        assert response["jsonrpc"] == "2.0"
+        # Response carries the SERVER's id, not the next client id.
+        assert response["id"] == 42
+        assert response["result"] == {"optionId": "always"}
+
+    @pytest.mark.asyncio
+    async def test_notifications_still_skip_hook(self):
+        """A plain notification (method, no id) does NOT call handle_server_request."""
+
+        class _RecordingHook(_FakeAcp):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.calls = []
+
+            def handle_server_request(self, msg):
+                self.calls.append(msg)
+                return None
+
+        b = _RecordingHook(model="x", workspace=Path("/tmp/ws"))
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("hello"),  # notification (no id)
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        await _collect_events(b, prompt="hi")
+        # Hook never invoked - text chunks remain in the notification branch.
+        assert b.calls == []
+
+    @pytest.mark.asyncio
+    async def test_response_writes_match_jsonrpc_shape(self):
+        """The response payload is well-formed JSON-RPC: jsonrpc + id + result keys only."""
+
+        class _AutoApprove(_FakeAcp):
+            def handle_server_request(self, msg):
+                return {"optionId": "always", "kind": "allow_always"}
+
+        b = _AutoApprove(model="x", workspace=Path("/tmp/ws"))
+        b._proc = _make_mock_proc(
+            [
+                _json_line({"jsonrpc": "2.0", "id": 7, "method": "session/request_permission", "params": {}}),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        await _collect_events(b, prompt="hi")
+        response = json.loads(b._proc.stdin.write.call_args_list[1][0][0].decode())
+        assert set(response.keys()) == {"jsonrpc", "id", "result"}
+
+
 # ── Env layering ────────────────────────────────────────────────────
 
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -146,6 +146,64 @@ class TestBackendNameForInstance:
         assert any("empty backend_name" in rec.message for rec in caplog.records)
 
 
+# ── _get_user_models warning suppression ─────────────────────────────
+
+
+class TestGetUserModelsWarningSuppression:
+    """
+    `_get_user_models` warns when models_for_backend returns None for a
+    provider that should have a curated list (programming oversight).
+    Codex AND opencode are intentionally excluded: both return None for
+    legitimate reasons (codex curates separately; opencode model IDs
+    are open-ended provider/model strings whose set Kai cannot curate).
+    Pin the exclusion so a real missing-registry-entry warning is not
+    drowned out by per-turn opencode noise.
+    """
+
+    def test_opencode_does_not_log_missing_registry_warning(self, caplog):
+        """Global opencode install with empty llm_provider should NOT log the warning."""
+        import logging
+
+        from kai.bot import _get_user_models
+        from kai.pool import SubprocessPool
+
+        # Empty llm_provider is the realistic global-opencode case
+        # (VALID_PROVIDERS["opencode"] does not exist; the wizard never
+        # prompts for an llm_provider). The pre-fix code path warns
+        # because "" is not in OPEN_ENDED_PROVIDERS.
+        config = MagicMock()
+        config.agent_backend = "opencode"
+        config.llm_provider = ""
+        config.get_user_config = MagicMock(return_value=None)
+        pool = MagicMock(spec=SubprocessPool)
+        pool.get_if_exists = MagicMock(return_value=None)
+
+        with caplog.at_level(logging.WARNING, logger="kai.bot"):
+            result = _get_user_models(pool, 111, config)
+        # OpenCode returns None deliberately (free-text /model input).
+        assert result is None
+        # And no false warning was logged.
+        assert not any("no curated model list" in rec.message for rec in caplog.records)
+
+    def test_codex_does_not_log_missing_registry_warning(self, caplog):
+        """Confirm the pre-existing codex exclusion still works (regression guard)."""
+        import logging
+
+        from kai.bot import _get_user_models
+        from kai.pool import SubprocessPool
+
+        config = MagicMock()
+        config.agent_backend = "codex"
+        config.llm_provider = ""
+        config.get_user_config = MagicMock(return_value=None)
+        pool = MagicMock(spec=SubprocessPool)
+        pool.get_if_exists = MagicMock(return_value=None)
+
+        with caplog.at_level(logging.WARNING, logger="kai.bot"):
+            _get_user_models(pool, 111, config)
+        assert not any("no curated model list" in rec.message for rec in caplog.records)
+
+
 # ── _resolve_workspace_path ──────────────────────────────────────────
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2504,6 +2504,23 @@ class TestValidateModelForBackend:
 
         assert validate_model_for_backend("opus", "claude", "anthropic") is True
 
+    def test_opencode_accepts_any_nonempty_string(self):
+        """OpenCode is open-ended: full provider/model IDs are not curated by Kai."""
+        from kai.config import validate_model_for_backend
+
+        assert validate_model_for_backend("anthropic/claude-sonnet-4-6", "opencode", "") is True
+        assert validate_model_for_backend("openai/gpt-5.5", "opencode", "") is True
+        # Curated codex/goose model strings are also accepted by opencode because
+        # the validator simply checks non-empty (OpenCode resolves the actual
+        # provider/model at runtime against operator's ~/.local/share/opencode/auth.json).
+        assert validate_model_for_backend("opus", "opencode", "anthropic") is True
+
+    def test_opencode_rejects_empty_model(self):
+        """Empty model is the one case opencode rejects."""
+        from kai.config import validate_model_for_backend
+
+        assert validate_model_for_backend("", "opencode", "") is False
+
 
 class TestModelsForBackend:
     """Wizard/runtime model-keyboard list helper."""
@@ -2527,6 +2544,29 @@ class TestModelsForBackend:
         from kai.config import models_for_backend
 
         assert models_for_backend("goose", "openrouter") is None
+
+    def test_opencode_returns_none(self):
+        """OpenCode has no curated keyboard; bot.py /model falls back to free text."""
+        from kai.config import models_for_backend
+
+        assert models_for_backend("opencode", "") is None
+        assert models_for_backend("opencode", "anthropic") is None
+
+
+class TestValidBackends:
+    """Pin the VALID_BACKENDS set membership."""
+
+    def test_all_four_backends_listed(self):
+        """claude, goose, codex, opencode."""
+        from kai.config import VALID_BACKENDS
+
+        assert sorted(VALID_BACKENDS) == ["claude", "codex", "goose", "opencode"]
+
+    def test_opencode_not_in_valid_providers(self):
+        """OpenCode auth lives in opencode-cli config; no provider/API-key wizard prompt fires."""
+        from kai.config import VALID_PROVIDERS
+
+        assert "opencode" not in VALID_PROVIDERS
 
 
 class TestGetUserBackendAndProvider:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2504,22 +2504,39 @@ class TestValidateModelForBackend:
 
         assert validate_model_for_backend("opus", "claude", "anthropic") is True
 
-    def test_opencode_accepts_any_nonempty_string(self):
-        """OpenCode is open-ended: full provider/model IDs are not curated by Kai."""
+    def test_opencode_accepts_provider_slash_model_shape(self):
+        """OpenCode requires the `provider/model` structural shape."""
         from kai.config import validate_model_for_backend
 
         assert validate_model_for_backend("anthropic/claude-sonnet-4-6", "opencode", "") is True
         assert validate_model_for_backend("openai/gpt-5.5", "opencode", "") is True
-        # Curated codex/goose model strings are also accepted by opencode because
-        # the validator simply checks non-empty (OpenCode resolves the actual
-        # provider/model at runtime against operator's ~/.local/share/opencode/auth.json).
-        assert validate_model_for_backend("opus", "opencode", "anthropic") is True
+        assert validate_model_for_backend("opencode/big-pickle", "opencode", "") is True
 
-    def test_opencode_rejects_empty_model(self):
-        """Empty model is the one case opencode rejects."""
+    def test_opencode_rejects_bare_anthropic_names(self):
+        """`opus` / `sonnet` are valid on claude/goose/codex but typos on opencode.
+
+        The operator footgun the structural check guards against: a
+        bare Anthropic name typed into /model on an opencode install
+        would otherwise persist as OPENCODE_CONFIG_CONTENT='{"model":
+        "opus"}' and fail at handshake without pointing back to the
+        Kai-side typo.
+        """
+        from kai.config import validate_model_for_backend
+
+        assert validate_model_for_backend("opus", "opencode", "anthropic") is False
+        assert validate_model_for_backend("sonnet", "opencode", "anthropic") is False
+        assert validate_model_for_backend("haiku", "opencode", "anthropic") is False
+
+    def test_opencode_rejects_malformed_shapes(self):
+        """Empty segments, missing separator, and extra separators all fail."""
         from kai.config import validate_model_for_backend
 
         assert validate_model_for_backend("", "opencode", "") is False
+        assert validate_model_for_backend("/foo", "opencode", "") is False
+        assert validate_model_for_backend("foo/", "opencode", "") is False
+        assert validate_model_for_backend("foo//bar", "opencode", "") is False
+        assert validate_model_for_backend("foo/bar/baz", "opencode", "") is False
+        assert validate_model_for_backend("/", "opencode", "") is False
 
 
 class TestModelsForBackend:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -818,6 +818,98 @@ class TestCodexUsersFromYamlProtectedFallback:
         assert refs[0].os_user == "alice_os"
 
 
+class TestComputeOpencodeRunsAnywhere:
+    """
+    Mirrors `_compute_codex_runs_anywhere` semantics for opencode.
+    Without users.yaml, the global AGENT_BACKEND alone decides.
+    With users.yaml, ANY user whose effective backend resolves to
+    opencode flips the predicate True so the PATH check and auth
+    reminder still fire on mixed installs.
+    """
+
+    def _yaml_at(self, tmp_path, contents: str) -> Path:
+        p = tmp_path / "users.yaml"
+        p.write_text(contents)
+        return p
+
+    def test_no_yaml_global_opencode_true(self, tmp_path):
+        from kai.install import _compute_opencode_runs_anywhere
+
+        assert _compute_opencode_runs_anywhere("opencode", False, tmp_path / "missing.yaml") is True
+
+    def test_no_yaml_global_claude_false(self, tmp_path):
+        from kai.install import _compute_opencode_runs_anywhere
+
+        assert _compute_opencode_runs_anywhere("claude", False, tmp_path / "missing.yaml") is False
+
+    def test_yaml_with_per_user_opencode_on_claude_global(self, tmp_path):
+        """The mixed-backend case the reviewer flagged: global=claude, one user opencode."""
+        from kai.install import _compute_opencode_runs_anywhere
+
+        path = self._yaml_at(
+            tmp_path,
+            "users:\n"
+            "  - telegram_id: 111\n"
+            "    name: alice\n"
+            "  - telegram_id: 222\n"
+            "    name: bob\n"
+            "    agent_backend: opencode\n",
+        )
+        assert _compute_opencode_runs_anywhere("claude", True, path) is True
+
+    def test_yaml_with_no_opencode_users_returns_false(self, tmp_path):
+        from kai.install import _compute_opencode_runs_anywhere
+
+        path = self._yaml_at(
+            tmp_path,
+            "users:\n"
+            "  - telegram_id: 111\n"
+            "    name: alice\n"
+            "  - telegram_id: 222\n"
+            "    name: bob\n"
+            "    agent_backend: codex\n",
+        )
+        assert _compute_opencode_runs_anywhere("claude", True, path) is False
+
+    def test_yaml_with_inherited_global_opencode(self, tmp_path):
+        """A user with no agent_backend inherits global, so global=opencode + yaml = True."""
+        from kai.install import _compute_opencode_runs_anywhere
+
+        path = self._yaml_at(
+            tmp_path,
+            "users:\n  - telegram_id: 111\n    name: alice\n",
+        )
+        assert _compute_opencode_runs_anywhere("opencode", True, path) is True
+
+    def test_yaml_overrides_all_users_off_opencode(self, tmp_path):
+        """Authoritative-source rule: global opencode + every user overrides = False."""
+        from kai.install import _compute_opencode_runs_anywhere
+
+        path = self._yaml_at(
+            tmp_path,
+            "users:\n"
+            "  - telegram_id: 111\n"
+            "    name: alice\n"
+            "    agent_backend: claude\n"
+            "  - telegram_id: 222\n"
+            "    name: bob\n"
+            "    agent_backend: codex\n",
+        )
+        assert _compute_opencode_runs_anywhere("opencode", True, path) is False
+
+    def test_empty_yaml_returns_false(self, tmp_path):
+        from kai.install import _compute_opencode_runs_anywhere
+
+        path = self._yaml_at(tmp_path, "")
+        assert _compute_opencode_runs_anywhere("claude", True, path) is False
+
+    def test_yaml_without_users_key_returns_false(self, tmp_path):
+        from kai.install import _compute_opencode_runs_anywhere
+
+        path = self._yaml_at(tmp_path, "other: thing\n")
+        assert _compute_opencode_runs_anywhere("claude", True, path) is False
+
+
 class TestCollectUserMemoryOwners:
     """
     Tests for the (telegram_id, os_user) loader used by the per-user

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -3661,6 +3661,17 @@ class TestMemoryReasonerSelection:
         reasoner = memory_extraction._build_memory_reasoner("codex")
         assert isinstance(reasoner, CodexOneShotReasoner)
 
+    def test_opencode_backend_raises_defensive_runtime_error(self):
+        """OpenCode has no memory reasoner; the defensive raise fires.
+
+        Production flow never reaches here (the bot.py eligibility gate
+        filters opencode users out upstream, same way it filters goose
+        out), but the defensive branch guards against a future gate
+        regression silently selecting Claude for opencode users.
+        """
+        with pytest.raises(RuntimeError, match=r"non-extraction backend.*opencode"):
+            memory_extraction._build_memory_reasoner("opencode")
+
 
 class TestRunExtractorWithCodexEnvelope:
     """A fake Codex reasoner returning a normalized envelope

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -1,0 +1,328 @@
+"""
+Tests for opencode.py OpenCode ACP subprocess backend.
+
+Covers OpenCode-specific hook implementations on top of the shared
+AcpBackend layer:
+
+1. backend_name / backend_label class attributes
+2. Static argv `opencode acp` (no --model flag; flag is not accepted)
+3. build_env injects OPENCODE_CONFIG_CONTENT with the active model
+4. Integer protocolVersion in build_initialize_params (NOT string "v1")
+5. session/new params: cwd + empty mcpServers (same as Goose)
+6. extract_text_delta parses agent_message_chunk (skips agent_thought_chunk,
+   available_commands_update, usage_update, tool_call, tool_call_update)
+7. handle_server_request auto-approves session/request_permission with
+   allow_always (falls back through allow_once and the first option;
+   returns None when no usable option is found)
+8. Other server-request methods return None (no auto-response)
+"""
+
+import json
+from pathlib import Path
+
+from kai.opencode import OpenCodeBackend
+
+
+def _make_opencode(**kwargs) -> OpenCodeBackend:
+    """Create an OpenCodeBackend with sensible defaults for testing."""
+    defaults = {
+        "model": "anthropic/claude-sonnet-4-6",
+        "workspace": Path("/tmp/test-workspace"),
+        "timeout_seconds": 30,
+    }
+    defaults.update(kwargs)
+    return OpenCodeBackend(**defaults)
+
+
+# ── Class attributes ────────────────────────────────────────────────
+
+
+class TestClassAttributes:
+    """Pin backend_name and backend_label."""
+
+    def test_backend_name(self):
+        """backend_name is 'opencode' (config-key match in VALID_BACKENDS)."""
+        assert OpenCodeBackend.backend_name == "opencode"
+
+    def test_backend_label(self):
+        """backend_label is the human-readable 'OpenCode' string."""
+        assert OpenCodeBackend.backend_label == "OpenCode"
+
+
+# ── build_argv ──────────────────────────────────────────────────────
+
+
+class TestBuildArgv:
+    """The CLI does not accept --model on argv; model flows through env."""
+
+    def test_static_argv_no_model_flag(self):
+        """argv is exactly `opencode acp` regardless of self.model."""
+        b = _make_opencode(model="anthropic/claude-sonnet-4-6")
+        assert b.build_argv() == ["opencode", "acp"]
+
+    def test_argv_unchanged_with_empty_model(self):
+        """Empty model still produces the same argv (model goes via env)."""
+        b = _make_opencode(model="")
+        assert b.build_argv() == ["opencode", "acp"]
+
+
+# ── build_env ───────────────────────────────────────────────────────
+
+
+class TestBuildEnv:
+    """Verify OPENCODE_CONFIG_CONTENT injection."""
+
+    def test_model_written_into_inline_config(self):
+        """Active model lands in OPENCODE_CONFIG_CONTENT as inline JSON."""
+        b = _make_opencode(model="anthropic/claude-sonnet-4-6")
+        env = b.build_env({})
+        assert "OPENCODE_CONFIG_CONTENT" in env
+        parsed = json.loads(env["OPENCODE_CONFIG_CONTENT"])
+        assert parsed == {"model": "anthropic/claude-sonnet-4-6"}
+
+    def test_empty_model_omits_inline_config(self):
+        """Empty model = no OPENCODE_CONFIG_CONTENT; OpenCode falls back to its own config files."""
+        b = _make_opencode(model="")
+        env = b.build_env({})
+        assert "OPENCODE_CONFIG_CONTENT" not in env
+
+    def test_base_env_preserved(self):
+        """Caller-supplied env keys flow through unchanged."""
+        b = _make_opencode(model="x/y")
+        env = b.build_env({"FOO": "bar", "BAZ": "qux"})
+        assert env["FOO"] == "bar"
+        assert env["BAZ"] == "qux"
+        assert "OPENCODE_CONFIG_CONTENT" in env
+
+
+# ── build_initialize_params ─────────────────────────────────────────
+
+
+class TestBuildInitializeParams:
+    """Verify the integer protocolVersion override (OpenCode rejects string)."""
+
+    def test_protocol_version_is_integer(self):
+        """OpenCode's Zod schema requires a number; string 'v1' is rejected."""
+        b = _make_opencode()
+        params = b.build_initialize_params()
+        assert params["protocolVersion"] == 1
+        assert isinstance(params["protocolVersion"], int)
+
+    def test_client_info_identifies_kai(self):
+        """clientInfo.name is 'kai' so OpenCode logs identify the caller."""
+        b = _make_opencode()
+        params = b.build_initialize_params()
+        assert params["clientInfo"]["name"] == "kai"
+        assert "version" in params["clientInfo"]
+
+
+# ── build_session_new_params ────────────────────────────────────────
+
+
+class TestBuildSessionNewParams:
+    """Verify session/new payload shape (cwd + empty mcpServers)."""
+
+    def test_session_new_params(self):
+        """OpenCode accepts the same shape Goose uses; cwd is workspace, mcpServers is []."""
+        ws = Path("/tmp/some-workspace")
+        b = _make_opencode(workspace=ws)
+        params = b.build_session_new_params()
+        assert params == {"cwd": str(ws), "mcpServers": []}
+
+
+# ── extract_text_delta ──────────────────────────────────────────────
+
+
+class TestExtractTextDelta:
+    """
+    Verify only `agent_message_chunk` text reaches the user.
+
+    Smoke run on opencode 1.15.11 observed these notification shapes:
+    agent_message_chunk (keep), agent_thought_chunk (skip),
+    available_commands_update (skip), usage_update (skip),
+    tool_call (skip), tool_call_update (skip). Pin each one so a
+    future OpenCode change can't quietly leak thoughts or tool noise.
+    """
+
+    def _notification(self, session_update: str, content_text: str = "x") -> dict:
+        return {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "sess-1",
+                "update": {
+                    "sessionUpdate": session_update,
+                    "content": {"type": "text", "text": content_text},
+                },
+            },
+        }
+
+    def test_agent_message_chunk_returns_text(self):
+        """agent_message_chunk text is user-visible; hook returns it."""
+        b = _make_opencode()
+        assert b.extract_text_delta(self._notification("agent_message_chunk", "hello")) == "hello"
+
+    def test_agent_thought_chunk_returns_none(self):
+        """agent_thought_chunk is internal reasoning; hook returns None."""
+        b = _make_opencode()
+        assert b.extract_text_delta(self._notification("agent_thought_chunk", "thinking...")) is None
+
+    def test_available_commands_update_returns_none(self):
+        """available_commands_update advertises OpenCode slash commands; not for the user."""
+        b = _make_opencode()
+        msg = {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "sess-1",
+                "update": {"sessionUpdate": "available_commands_update", "availableCommands": []},
+            },
+        }
+        assert b.extract_text_delta(msg) is None
+
+    def test_usage_update_returns_none(self):
+        """usage_update carries token telemetry, not user text."""
+        b = _make_opencode()
+        msg = {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "sess-1",
+                "update": {"sessionUpdate": "usage_update", "used": 100, "size": 200000},
+            },
+        }
+        assert b.extract_text_delta(msg) is None
+
+    def test_tool_call_returns_none(self):
+        """tool_call notifications announce tool invocations; not user-visible."""
+        b = _make_opencode()
+        msg = {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "sess-1",
+                "update": {"sessionUpdate": "tool_call", "toolCallId": "tc-1", "title": "read"},
+            },
+        }
+        assert b.extract_text_delta(msg) is None
+
+    def test_tool_call_update_returns_none(self):
+        """tool_call_update reports tool progress; not user-visible."""
+        b = _make_opencode()
+        msg = {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "sess-1",
+                "update": {"sessionUpdate": "tool_call_update", "toolCallId": "tc-1", "status": "in_progress"},
+            },
+        }
+        assert b.extract_text_delta(msg) is None
+
+    def test_empty_text_returns_none(self):
+        """An agent_message_chunk with empty text is treated as no-op."""
+        b = _make_opencode()
+        assert b.extract_text_delta(self._notification("agent_message_chunk", "")) is None
+
+    def test_non_session_update_method_returns_none(self):
+        """Methods other than session/update are not text deltas."""
+        b = _make_opencode()
+        msg = {"jsonrpc": "2.0", "method": "session/something_else", "params": {}}
+        assert b.extract_text_delta(msg) is None
+
+
+# ── handle_server_request ───────────────────────────────────────────
+
+
+class TestHandleServerRequest:
+    """
+    Verify session/request_permission auto-approval.
+
+    OpenCode emits server-initiated session/request_permission with
+    options[*].kind in {allow_once, allow_always, reject_once}. The
+    adapter auto-approves (returns the allow_always optionId) so tool
+    calls do not hang waiting for an interactive answer.
+    """
+
+    def _permission_request(self, options: list[dict]) -> dict:
+        return {
+            "jsonrpc": "2.0",
+            "id": 99,
+            "method": "session/request_permission",
+            "params": {"sessionId": "sess-1", "options": options},
+        }
+
+    def test_auto_approve_always_when_available(self):
+        """Returns the allow_always optionId."""
+        b = _make_opencode()
+        msg = self._permission_request(
+            [
+                {"optionId": "once", "kind": "allow_once"},
+                {"optionId": "always", "kind": "allow_always"},
+                {"optionId": "reject", "kind": "reject_once"},
+            ]
+        )
+        assert b.handle_server_request(msg) == {"optionId": "always"}
+
+    def test_falls_back_to_allow_once_when_no_allow_always(self):
+        """If allow_always is missing, return the allow_once option."""
+        b = _make_opencode()
+        msg = self._permission_request(
+            [
+                {"optionId": "once", "kind": "allow_once"},
+                {"optionId": "reject", "kind": "reject_once"},
+            ]
+        )
+        assert b.handle_server_request(msg) == {"optionId": "once"}
+
+    def test_falls_back_to_first_option_when_no_allow_kinds(self):
+        """If neither allow_always nor allow_once exist, take the first option as a last resort."""
+        b = _make_opencode()
+        msg = self._permission_request(
+            [
+                {"optionId": "weird", "kind": "ask_user"},
+                {"optionId": "reject", "kind": "reject_once"},
+            ]
+        )
+        assert b.handle_server_request(msg) == {"optionId": "weird"}
+
+    def test_empty_options_returns_none(self):
+        """No options at all = nothing to pick; return None so the loop logs and skips."""
+        b = _make_opencode()
+        msg = self._permission_request([])
+        assert b.handle_server_request(msg) is None
+
+    def test_option_without_optionId_returns_none(self):
+        """Malformed option (missing optionId) = bail; never send a half-formed response."""
+        b = _make_opencode()
+        msg = self._permission_request([{"kind": "allow_always"}])
+        # First (and only) candidate is allow_always but has no optionId.
+        assert b.handle_server_request(msg) is None
+
+    def test_non_permission_method_returns_none(self):
+        """Other server-request methods (if any) are not auto-handled."""
+        b = _make_opencode()
+        msg = {"jsonrpc": "2.0", "id": 7, "method": "session/something_new", "params": {}}
+        assert b.handle_server_request(msg) is None
+
+
+# ── Constructor (smoke) ─────────────────────────────────────────────
+
+
+class TestConstructor:
+    """OpenCodeBackend inherits all AcpBackend init logic; pin the smoke."""
+
+    def test_attributes_set_from_kwargs(self):
+        """ABC-required attributes flow through unchanged."""
+        b = _make_opencode(
+            model="openai/gpt-5.5",
+            workspace=Path("/tmp/abc"),
+            timeout_seconds=120,
+        )
+        assert b.model == "openai/gpt-5.5"
+        assert b.workspace == Path("/tmp/abc")
+        assert b.timeout_seconds == 120
+        # Lifecycle defaults inherited from AcpBackend.
+        assert b._proc is None
+        assert b._session_id is None
+        assert b._fresh_session is True

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -238,6 +238,62 @@ class TestPerUserBackendRouting:
             # "opus" is invalid for openai - should be ignored, model stays at gpt-5.4
             assert instance.model == "gpt-5.4"
 
+    def test_opencode_user_on_claude_global_install(self):
+        """
+        Per-user `agent_backend: opencode` on a globally-claude install
+        with a free-text model gets an OpenCodeBackend with the supplied
+        model intact. OpenCode model strings are full provider/model
+        IDs; no per-provider default substitution applies.
+        """
+        from kai.opencode import OpenCodeBackend
+
+        user = UserConfig(
+            telegram_id=111,
+            name="alice",
+            agent_backend="opencode",
+            model="anthropic/claude-sonnet-4-6",
+        )
+        config = _make_config(
+            agent_backend="claude",
+            llm_provider="anthropic",
+            default_model="sonnet",
+            user_configs={111: user},
+        )
+        pool = SubprocessPool(config=config, services_info=[])
+        instance = pool.get(111)
+        assert isinstance(instance, OpenCodeBackend)
+        assert instance.model == "anthropic/claude-sonnet-4-6"
+
+    def test_opencode_user_without_model_falls_back_to_empty(self, caplog):
+        """
+        Per-user `agent_backend: opencode` with no model and global
+        backend != opencode: OpenCodeBackend gets model="" so OPENCODE_
+        CONFIG_CONTENT is omitted and OpenCode uses its own config
+        files. A warning is logged so the operator notices the gap.
+        """
+        import logging
+
+        from kai.opencode import OpenCodeBackend
+
+        user = UserConfig(
+            telegram_id=111,
+            name="alice",
+            agent_backend="opencode",
+            # NO model: tests the bare opencode-override case.
+        )
+        config = _make_config(
+            agent_backend="claude",
+            llm_provider="anthropic",
+            default_model="sonnet",
+            user_configs={111: user},
+        )
+        pool = SubprocessPool(config=config, services_info=[])
+        with caplog.at_level(logging.WARNING, logger="kai.pool"):
+            instance = pool.get(111)
+        assert isinstance(instance, OpenCodeBackend)
+        assert instance.model == ""
+        assert any("No model configured for opencode" in rec.message for rec in caplog.records)
+
     def test_codex_user_on_claude_global_install_gets_codex_default(self):
         """
         Per-user `agent_backend: codex` on a globally-claude install

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1128,6 +1128,37 @@ class TestRunReviewGoose:
             await run_review("prompt", agent_backend="goose", provider="")
 
 
+class TestRunReviewRejectsOpenCode:
+    """
+    OpenCode has no one-shot reasoner; run_review must surface this
+    as a clean ValueError rather than silently dispatching the
+    Claude branch (which would spawn `claude --print` and bill the
+    operator's Claude auth for what should have been an opencode
+    operation). Pin both the rejection AND the absence of any
+    subprocess spawn for `agent_backend="opencode"`.
+    """
+
+    @pytest.mark.asyncio
+    async def test_run_review_rejects_opencode_backend(self):
+        """`agent_backend="opencode"` raises ValueError before any subprocess spawn."""
+        with (
+            patch("kai.review.asyncio.create_subprocess_exec") as mock_exec,
+            pytest.raises(ValueError, match=r"opencode.*not supported"),
+        ):
+            await run_review("prompt", agent_backend="opencode")
+        mock_exec.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_review_does_not_spawn_claude_for_opencode(self):
+        """No fall-through to the claude branch for opencode users."""
+        with patch("kai.review.asyncio.create_subprocess_exec") as mock_exec, pytest.raises(ValueError):
+            await run_review("prompt", agent_backend="opencode", provider="anthropic")
+        # Confirm no `claude --print` was even attempted.
+        for call in mock_exec.call_args_list:
+            argv = call[0]
+            assert "claude" not in argv, f"Unexpected claude spawn: {argv}"
+
+
 class TestResolveGooseModelReview:
     """Tests for _resolve_goose_model in review.py."""
 

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -651,6 +651,36 @@ class TestRunTriageGoose:
             await run_triage("prompt", agent_backend="goose", provider="")
 
 
+class TestRunTriageRejectsOpenCode:
+    """
+    OpenCode has no one-shot reasoner; run_triage must surface this
+    as a clean ValueError rather than silently dispatching the Claude
+    branch (which would spawn `claude --print` and bill the operator's
+    Claude auth for what should have been an opencode operation). Pin
+    both the rejection AND the absence of any subprocess spawn for
+    `agent_backend="opencode"`.
+    """
+
+    @pytest.mark.asyncio
+    async def test_run_triage_rejects_opencode_backend(self):
+        """`agent_backend="opencode"` raises ValueError before any subprocess spawn."""
+        with (
+            patch("kai.triage.asyncio.create_subprocess_exec") as mock_exec,
+            pytest.raises(ValueError, match=r"opencode.*not supported"),
+        ):
+            await run_triage("prompt", agent_backend="opencode")
+        mock_exec.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_triage_does_not_spawn_claude_for_opencode(self):
+        """No fall-through to the claude branch for opencode users."""
+        with patch("kai.triage.asyncio.create_subprocess_exec") as mock_exec, pytest.raises(ValueError):
+            await run_triage("prompt", agent_backend="opencode", provider="anthropic")
+        for call in mock_exec.call_args_list:
+            argv = call[0]
+            assert "claude" not in argv, f"Unexpected claude spawn: {argv}"
+
+
 class TestRunTriageCodex:
     """
     Tests for the codex branch of run_triage.


### PR DESCRIPTION
## Summary

Adds OpenCode ([opencode.ai](https://opencode.ai/)) as a fourth agent backend. PR 2 of two against #296; PR 1 (#553) extracted the shared ACP transport layer that this PR builds on. Hook shapes and the one new shared-layer affordance were driven by a live wire-shape smoke against `opencode acp` 1.15.11.

- New `OpenCodeBackend(AcpBackend)` in `src/kai/opencode.py` (~180 lines, adapter only).
- One new shared-layer hook: `AcpBackend.handle_server_request(msg) -> dict | None`. Default returns None so Goose's behavior is unchanged. The shared read loop adds a branch keyed on message SHAPE (has both `method` AND `id`) for server-initiated JSON-RPC requests; the branch dispatches the hook and writes a matching-id response back via stdin. No `backend_name` conditional in the loop.

## OpenCode-specific hooks

| Hook | Behavior |
|---|---|
| `build_argv()` | `["opencode", "acp"]`. The CLI does not accept `--model`; model selection flows through env. |
| `build_env(base_env)` | Sets `OPENCODE_CONFIG_CONTENT='{"model": "<provider/model>"}'`. Verified: this changes `session/new`'s `_meta.opencode.modelId` from the default to the requested ID. |
| `build_initialize_params()` | Sends `protocolVersion: 1` as an INTEGER. OpenCode's Zod schema rejects the string `"v1"` Goose uses; the handshake fails before `session/new` without this override. |
| `build_session_new_params()` | `{cwd, mcpServers: []}`, same shape as Goose. |
| `extract_text_delta(msg)` | Returns text from `agent_message_chunk` notifications; filters out `agent_thought_chunk`, `available_commands_update`, `usage_update`, `tool_call`, `tool_call_update`. |
| `handle_server_request(msg)` | Auto-approves `session/request_permission` by returning the `allow_always` `optionId` (matches Goose's `--with-builtin developer` posture). Falls back through `allow_once` and then the first option; returns None if no usable option is found (loop logs and skips). |

## Wiring

- `opencode` added to `VALID_BACKENDS`.
- `validate_model_for_backend("opencode", _)` enforces the structural `provider/model` shape via the new `is_opencode_model_shape()` helper. Bare names like `opus` or `sonnet` are rejected at the validator boundary (real operator footgun on `/model`, `/settings model`, `/workspace config model`, and the load_config fallback chain) so an invalid value never persists to `OPENCODE_CONFIG_CONTENT` and fails opaquely at ACP handshake.
- `models_for_backend("opencode", _)` returns None so the `/model` keyboard falls back to free-text input (same path as openrouter / ollama).
- `pool._create_instance` dispatches `backend == "opencode"` to `OpenCodeBackend`. Per-user opencode override with no model gets `model=""` and a logged warning (OPENCODE_CONFIG_CONTENT omitted; OpenCode falls back to its own config files).
- Install wizard accepts `opencode`. The PATH check and the post-install `opencode auth login` reminder gate on `_compute_opencode_runs_anywhere()` (mirrors `_compute_codex_runs_anywhere`), so mixed-backend installs with a per-user `agent_backend: opencode` still get the warning and reminder when the global backend is not opencode. NO `VALID_PROVIDERS["opencode"]` entry: OpenCode auth lives in `~/.local/share/opencode/auth.json`, operator-managed, so the wizard skips the provider/API-key prompt for opencode.
- `bot._get_user_models` suppresses the "no curated model list" log warning for opencode (the None return is intentional, same as codex - not a missing PROVIDER_MODELS entry).
- `templates/users.yaml` documents `agent_backend: opencode` with a `provider/model` example.
- README backend list, prerequisites, and repository-layout notes reflect the new fourth backend.

## Background-agent leakage closed

`run_review` and `run_triage` now raise `ValueError` for `agent_backend="opencode"` BEFORE the codex / goose / claude dispatch. OpenCode has no one-shot reasoner; the explicit branch prevents the silent fall-through to `claude --print` that previously would have billed the operator's Claude auth for what should have been an opencode operation. Memory extraction is already safe via the existing `_build_memory_reasoner` defensive raise.

## Tests

52 net new, 3642 total passing locally.

- `tests/test_opencode.py` (25) — every hook and class attribute, including all six `session/update` discriminators and all five `session/request_permission` option-shape paths.
- `tests/test_acp.py` (+4) — server-request branch: default hook skips; payload writes back with the server's id; notifications still bypass the hook; response shape is well-formed JSON-RPC.
- `tests/test_config.py` (+6) — structural `provider/model` validation (positive cases plus negative cases for bare names `opus`/`sonnet`/`haiku` and malformed shapes `/foo`, `foo/`, `foo//bar`, `foo/bar/baz`, `/`); `models_for_backend=None`; VALID_BACKENDS membership; VALID_PROVIDERS absence.
- `tests/test_pool.py` (+2) — opencode dispatch + empty-model warning fallback.
- `tests/test_review.py` (+2) and `tests/test_triage.py` (+2) — explicit ValueError + no claude spawn for opencode.
- `tests/test_memory_extraction.py` (+1) — defensive `_build_memory_reasoner("opencode")` raise.
- `tests/test_install.py` (+8) — `TestComputeOpencodeRunsAnywhere` covers the no-yaml / global-opencode / mixed-backend / inherited-global / authoritative-override / empty / missing-users-key paths.
- `tests/test_bot.py` (+2) — `TestGetUserModelsWarningSuppression` pins the suppressed warning for opencode plus a regression guard for codex.

## Test plan

- [x] `make test` (3642 passed, 1 skipped)
- [x] `make check` (ruff clean)
- [ ] Operator-side manual verification with `AGENT_BACKEND=opencode` and a configured `provider/model` after `opencode auth login`

Closes #296.
