### PR TITLE
refactor(install): decouple wizard from users.yaml mixed-backend detection

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -3288,11 +3288,13 @@ def _cmd_apply() -> None:
         # without round-tripping through the wizard. Apply-time env
         # wins over any value already in install.conf.
         #
-        # Gate on the global AGENT_BACKEND only. A non-codex global
-        # install does not pick up an apply-time CODEX_BIN override:
-        # per-user `agent_backend: codex` entries are operator-managed
-        # and should configure their own CODEX_BIN via the wizard
-        # rather than through an apply-time env var.
+        # Gate on the global AGENT_BACKEND only. The wizard and the
+        # apply-time CODEX_BIN env pass-through are both scoped to
+        # global Codex installs. A per-user `agent_backend: codex`
+        # entry on a non-Codex global install is operator-managed:
+        # ensure Codex is installed and authenticated out of band for
+        # that user's os_user; the runtime startup-failure event
+        # surfaces missing tooling at first message.
         env_codex_bin = os.environ.get("CODEX_BIN")
         if env_codex_bin and env.get("AGENT_BACKEND") == "codex":
             env["CODEX_BIN"] = env_codex_bin

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -35,7 +35,6 @@ import tempfile
 import textwrap
 import time
 from collections.abc import Iterable
-from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
@@ -600,45 +599,23 @@ def _cmd_config() -> None:
         existing_env.get("AGENT_BACKEND", "claude"),
     )
 
-    # Compute the codex predicate the wizard branches on. Uses the
-    # authoritative-source rule: when users.yaml exists, the configured
-    # users alone determine whether codex runs; without users.yaml,
-    # the global AGENT_BACKEND is the only signal (every authorized
-    # user inherits it). `codex_runs_anywhere` gates everything codex
-    # needs (CODEX_BIN collection, sudoers SETENV rule, post-install
-    # `codex login` reminder) regardless of memory state. Memory
-    # extraction has no codex-specific wizard gate of its own; codex
-    # memory follows claude's symmetry now (`os_user` optional,
-    # in-process when unset or matching the bot user).
-    #
-    # Re-read users.yaml here in case the wizard wrote a fresh
-    # admin entry above (lines ~485-493 for the not-users_yaml_exists
-    # branch); that file is now the authoritative source for the
-    # codex_users helper too. _codex_users_from_yaml falls back to []
-    # if the file is missing, so the fallback to global agent_backend
-    # in _compute_codex_runs_anywhere handles both fresh and
-    # existing-yaml paths.
-    try:
-        _codex_users_now = _codex_users_from_yaml(users_yaml_path, agent_backend)
-    except (OSError, ValueError):
-        _codex_users_now = []
-    codex_runs_anywhere = _compute_codex_runs_anywhere(agent_backend, users_yaml_exists, _codex_users_now)
-
     # Codex auth handling runs BEFORE the legacy provider/key block so
     # subscription mode is not gated on an OPENAI_API_KEY the operator
     # does not need. VALID_PROVIDERS["codex"] is intentionally unset
     # (codex is openai-only and has its own auth model), so the
     # legacy block below skips codex entirely - same path claude
-    # follows today. Gate is `codex_runs_anywhere` rather than
-    # `agent_backend == "codex"` so an install with global claude but
-    # a users.yaml that includes codex-effective users still collects
-    # CODEX_BIN, auth, and the login hint. Conversely, an install
-    # with global codex but a users.yaml where every entry overrides
-    # to non-codex skips codex setup entirely.
+    # follows today.
+    #
+    # Gate on the global `agent_backend` selection only. Per-user
+    # `agent_backend: codex` overrides in users.yaml do NOT trigger
+    # codex setup here; the operator is responsible for installing /
+    # authenticating codex out-of-band for those users, and the
+    # runtime surfaces a chat-visible startup-failure event when
+    # tooling is missing.
     codex_auth_mode = ""
     codex_api_key = ""
     codex_bin = ""
-    if codex_runs_anywhere:
+    if agent_backend == "codex":
         codex_auth_mode = _prompt_choice(
             "Codex auth mode",
             ["subscription", "api_key"],
@@ -652,11 +629,9 @@ def _cmd_config() -> None:
             )
         # Codex binary path: wizard-prompted and persisted in install.conf
         # so `make install` writes both /etc/kai/env's CODEX_BIN and the
-        # sudoers SETENV rule from the same source of truth, eliminating
-        # the env-var-stripping workaround that needed `sudo CODEX_BIN=...
-        # .venv/bin/python -m kai install apply` to bypass make's inner
-        # sudo. Default suggestion uses `which codex` from the operator's
-        # PATH; falls back to Homebrew only when which finds nothing.
+        # sudoers SETENV rule from the same source of truth. Default
+        # suggestion uses `which codex` from the operator's PATH; falls
+        # back to Homebrew only when which finds nothing.
         while True:
             which_codex = shutil.which("codex") or "/opt/homebrew/bin/codex"
             codex_bin = _prompt(
@@ -668,9 +643,11 @@ def _cmd_config() -> None:
                 break
             print(f"  Path '{codex_bin}' does not exist or is not executable.")
         if codex_auth_mode == "subscription":
-            print("  After install, log in as each os_user that should answer messages:")
-            print("    e.g.   <os_user> ~$ codex login")
+            print("  After install, log in to codex as the target os_user:")
+            print("    <os_user> ~$ codex login")
             print("  Run as the os_user themselves, not via sudo from another account.")
+            print("  If users.yaml has per-user `agent_backend: codex` entries with")
+            print("  different os_users, log in as each of those too.")
 
     # OpenCode setup: PATH check + post-install auth reminder. OpenCode
     # is intentionally absent from VALID_PROVIDERS (its auth lives in
@@ -681,18 +658,11 @@ def _cmd_config() -> None:
     # models_for_backend("opencode", _) returns None, the operator gets
     # a free-text prompt for a full `provider/model` ID.
     #
-    # Gate on `opencode_runs_anywhere` rather than `agent_backend ==
-    # "opencode"` for the same reason codex uses `codex_runs_anywhere`:
-    # an install with global claude but a users.yaml that includes
-    # opencode-effective users still needs the PATH check and the auth
-    # reminder. Conversely, an install with global opencode whose
-    # users.yaml overrides every entry to non-opencode skips this
-    # block entirely.
-    try:
-        opencode_runs_anywhere = _compute_opencode_runs_anywhere(agent_backend, users_yaml_exists, users_yaml_path)
-    except (OSError, ValueError):
-        opencode_runs_anywhere = agent_backend == "opencode"
-    if opencode_runs_anywhere:
+    # Gate on the global `agent_backend` selection only. Per-user
+    # `agent_backend: opencode` overrides in users.yaml do NOT trigger
+    # opencode setup here; the operator handles those installs and
+    # auth out-of-band.
+    if agent_backend == "opencode":
         if not shutil.which("opencode"):
             print("  WARNING: 'opencode' binary not found on PATH.")
             print("  Install it from https://opencode.ai/docs/install/ before starting Kai.")
@@ -1137,19 +1107,13 @@ def _cmd_config() -> None:
                 # Codex now follows claude's `resolve_claude_user`
                 # symmetry: missing `os_user` spawns codex in-process
                 # as the bot user, the same self-sudo-skip path
-                # claude uses. The earlier `codex_runs_anywhere`
-                # block already collected CODEX_BIN; nothing else
-                # specific to codex memory needs setup at this point.
-                # CODEX_BIN must be collected whenever codex runs
-                # anywhere on the install. The earlier codex agent
-                # block already prompts for the binary path when
-                # codex_runs_anywhere; this second prompt fires only
-                # in the rare case where the earlier block did not
-                # collect a value AND a codex user surfaces via the
-                # os_user re-prompt above. Defense in depth: even
-                # if the earlier prompt's gate was wrong, the binary
-                # path is collected before the env block writes.
-                if codex_runs_anywhere and not codex_bin:
+                # claude uses. The earlier global-codex block already
+                # collected CODEX_BIN; nothing else specific to codex
+                # memory needs setup at this point. CODEX_BIN must be
+                # collected on every global-codex install; this second
+                # prompt is a defense-in-depth no-op when the earlier
+                # block already ran.
+                if agent_backend == "codex" and not codex_bin:
                     while True:
                         which_codex = shutil.which("codex") or "/opt/homebrew/bin/codex"
                         codex_bin = _prompt(
@@ -1871,172 +1835,6 @@ def _collect_os_users_from_yaml(users_yaml_path: str | Path) -> list[str]:
     return result
 
 
-@dataclass(frozen=True)
-class CodexUserRef:
-    """Reference to a codex-effective user found in users.yaml.
-
-    Carries telegram_id and the optional os_user separately so a
-    misconfigured entry (codex backend with missing os_user) still
-    counts as "codex exists" for the predicate that gates install
-    plumbing, while only entries with a non-empty os_user appear in
-    the post-install login reminder.
-    """
-
-    telegram_id: int
-    os_user: str | None
-
-
-def _codex_users_from_yaml(users_yaml_path: str | Path, global_agent_backend: str) -> list[CodexUserRef]:
-    """Read users.yaml and return one CodexUserRef per codex-effective entry.
-
-    Effective backend cascade mirrors `_ingest_memory` in bot.py and
-    `config._compute_extraction_eligible_backends`: per-user
-    `agent_backend` overrides the
-    global default; an entry with no `agent_backend` field inherits
-    `global_agent_backend`. Only entries whose effective backend is
-    "codex" appear in the returned list.
-
-    Includes entries with a missing `os_user`. After #522, missing
-    `os_user` is a valid configuration that resolves to same-user
-    in-process spawn at runtime (the self-sudo-skip path). The helper
-    still includes those entries because codex itself runs for them,
-    so install plumbing (CODEX_BIN, sudoers, login reminder) must
-    fire regardless of whether `os_user` is set.
-
-    Behavior parallels `_collect_os_users_from_yaml`: missing file or
-    empty/non-dict/no-users-key returns []; malformed YAML raises;
-    non-dict entries are skipped. Telegram IDs that do not parse as
-    int are skipped (the entry is invalid and the same logic exists
-    in `_load_user_configs`).
-
-    The read path goes through `_read_users_yaml_text` so the
-    protected `/etc/kai/users.yaml` file (mode 0600 root-owned) is
-    reachable via sudo cat when the wizard runs as the operator.
-    """
-    path = Path(users_yaml_path)
-    text = _read_users_yaml_text(path)
-    if text is None:
-        return []
-
-    if not text.strip():
-        return []
-
-    data = yaml.safe_load(text)
-    if not isinstance(data, dict):
-        return []
-
-    users = data.get("users")
-    if not isinstance(users, list):
-        return []
-
-    result: list[CodexUserRef] = []
-    for entry in users:
-        if not isinstance(entry, dict):
-            continue
-        # Effective backend cascade. Per-user `agent_backend` is
-        # admin-controlled in users.yaml; missing field means inherit
-        # the global default. Only the "codex" effective backend
-        # matters here; "claude" / "goose" / anything else produces
-        # no ref.
-        per_user_backend = entry.get("agent_backend")
-        if not isinstance(per_user_backend, str) or not per_user_backend.strip():
-            effective = global_agent_backend
-        else:
-            effective = per_user_backend.strip().lower()
-        if effective != "codex":
-            continue
-        raw_tid = entry.get("telegram_id")
-        try:
-            tid = int(raw_tid)
-        except (TypeError, ValueError):
-            continue
-        os_user_raw = entry.get("os_user")
-        if isinstance(os_user_raw, str):
-            normalized = os_user_raw.strip()
-            os_user_val: str | None = normalized if normalized else None
-        else:
-            os_user_val = None
-        result.append(CodexUserRef(telegram_id=tid, os_user=os_user_val))
-    return result
-
-
-def _compute_codex_runs_anywhere(
-    global_agent_backend: str,
-    users_yaml_exists: bool,
-    codex_users: list[CodexUserRef],
-) -> bool:
-    """Return True when any user on this install routes to codex.
-
-    Authoritative-source rule (issue #515 v4): when `users_yaml_exists`
-    is True, the users.yaml is the user set; the global `AGENT_BACKEND`
-    is only the default users inherit when they have no per-user
-    override, NOT an additional virtual user. So `codex_users` alone
-    drives the answer.
-
-    Without users.yaml (legacy ALLOWED_USER_IDS auth or pre-wizard
-    fresh install where the file has not been written yet), every
-    authorized user inherits the global, so `global_agent_backend ==
-    "codex"` determines the answer.
-
-    The wizard uses this predicate for everything codex needs to run
-    AT ALL (CODEX_BIN collection, sudoers, login reminder). Memory
-    extraction has no codex-specific gate of its own; codex memory
-    spawns in-process when `os_user` is unset or matches the bot
-    user, the same self-sudo-skip path claude uses.
-    """
-    if users_yaml_exists:
-        return bool(codex_users)
-    return global_agent_backend == "codex"
-
-
-def _compute_opencode_runs_anywhere(
-    global_agent_backend: str,
-    users_yaml_exists: bool,
-    users_yaml_path: str | Path,
-) -> bool:
-    """Return True when any user on this install routes to opencode.
-
-    Same authoritative-source rule as `_compute_codex_runs_anywhere`:
-    when `users_yaml_exists` is True the users.yaml is the user set
-    and global `AGENT_BACKEND` is only the inherited default; when it
-    does NOT exist every authorized user inherits the global and the
-    global value alone decides.
-
-    Folds the yaml read into the predicate because, unlike codex, the
-    wizard does not need per-user os_user / telegram_id details for
-    opencode (auth lives in ~/.local/share/opencode/auth.json and
-    OpenCode runs as the service user). A boolean is sufficient to
-    gate the PATH check and the post-install auth reminder.
-
-    Mirrors the read-then-cascade pattern in `_codex_users_from_yaml`:
-    missing file returns False; malformed yaml propagates (the wizard
-    caller wraps in try/except so a transient read failure does not
-    crash the wizard).
-    """
-    if not users_yaml_exists:
-        return global_agent_backend == "opencode"
-    text = _read_users_yaml_text(Path(users_yaml_path))
-    if text is None or not text.strip():
-        return False
-    data = yaml.safe_load(text)
-    if not isinstance(data, dict):
-        return False
-    users = data.get("users")
-    if not isinstance(users, list):
-        return False
-    for entry in users:
-        if not isinstance(entry, dict):
-            continue
-        per_user_backend = entry.get("agent_backend")
-        if isinstance(per_user_backend, str) and per_user_backend.strip():
-            effective = per_user_backend.strip().lower()
-        else:
-            effective = global_agent_backend
-        if effective == "opencode":
-            return True
-    return False
-
-
 def _build_codex_login_reminder(
     env: dict[str, str],
     service_user: str,
@@ -2049,48 +1847,31 @@ def _build_codex_login_reminder(
     per-user via `sudo -u <os_user>`, so subscription auth must be
     completed AS each target user before the first call; a service-
     user-only login lands the token in the wrong home and every
-    cross-user spawn fails. Returns the reminder text (without a
-    leading blank line) when codex actually runs on this install AND
-    uses subscription auth, else None.
+    cross-user spawn fails.
 
-    Gate uses the authoritative-source `codex_runs_anywhere` rule:
-    when /etc/kai/users.yaml exists, only users.yaml entries with
-    effective codex backend count; without users.yaml, falls back to
-    `AGENT_BACKEND=codex`. Enumeration filters to codex-effective
-    users with a non-empty os_user (claude-effective users have no
-    codex login to perform; missing-os_user codex users surface as
-    config-load errors elsewhere).
+    Returns a generic reminder string when the global backend is codex
+    AND auth mode is subscription, else None. Does NOT enumerate
+    per-user os_users from users.yaml: that path was a leaky abstraction
+    where operator-managed users.yaml content drove install messaging.
+    Mixed-backend installs (global non-codex, per-user codex via
+    users.yaml) receive no reminder; the operator is responsible for
+    installing and authenticating codex out-of-band for those users.
+
+    `service_user` and `users_yaml_path` are retained on the signature
+    for backwards compatibility with the existing caller / tests, but
+    are no longer read.
     """
-    global_agent_backend = env.get("AGENT_BACKEND", "claude")
-    try:
-        codex_users = _codex_users_from_yaml(users_yaml_path, global_agent_backend)
-    except (OSError, ValueError):
-        # Malformed or sudoers-injection-flagged users.yaml. Apply
-        # path has already written sudoers from the same file, so
-        # raising here would be too late; treat as "no codex users
-        # readable" and fall back to the service-user hint below.
-        codex_users = []
-    users_yaml_exists = Path(users_yaml_path).exists()
-    if not _compute_codex_runs_anywhere(global_agent_backend, users_yaml_exists, codex_users):
+    if env.get("AGENT_BACKEND", "claude") != "codex":
         return None
     if env.get("CODEX_AUTH_MODE", "subscription") != "subscription":
         return None
-    # Enumerate codex-effective os_users with a usable account. A
-    # codex user without os_user does not get a line (login as which
-    # user?), so the missing-os_user case is handled by the
-    # config-load SystemExit elsewhere. Fall back to service_user
-    # only when no codex users contribute an os_user (legacy
-    # ALLOWED_USER_IDS install with global AGENT_BACKEND=codex).
-    login_users = sorted({ref.os_user for ref in codex_users if ref.os_user})
-    if not login_users:
-        login_users = [service_user]
-    user_lines = "\n".join(f"    {u} ~$ codex login" for u in login_users)
     return (
         "Codex subscription auth required:\n"
-        "  Log in once for each os_user that should answer Telegram messages:\n"
-        f"{user_lines}\n"
+        "  Log in to codex as the target os_user before the first message:\n"
+        "    <os_user> ~$ codex login\n"
         "  Run as the os_user themselves, not via sudo from another account.\n"
-        "  These must complete before the service answers its first message."
+        "  If users.yaml has per-user `agent_backend: codex` entries with\n"
+        "  different os_users, log in as each of those too."
     )
 
 
@@ -3502,28 +3283,18 @@ def _cmd_apply() -> None:
         _apply_models(install_path, dry_run)
 
         # -- Step 5: Write secrets --
-        # Inject CODEX_BIN from the apply-time env so a multi-user
-        # codex install can pin an absolute codex path without
-        # round-tripping through the wizard. Apply-time env wins over
-        # any value already in install.conf so the operator's explicit
-        # `sudo CODEX_BIN=... kai install apply` is honored. Gate uses
-        # the authoritative-source `codex_runs_anywhere` rule: when
-        # /etc/kai/users.yaml exists, only users.yaml entries with
-        # effective codex backend count; without users.yaml, falls back
-        # to the env's AGENT_BACKEND. Skipping the write on truly
-        # codex-free installs keeps /etc/kai/env clean.
+        # Inject CODEX_BIN from the apply-time env so the operator's
+        # explicit `sudo CODEX_BIN=... kai install apply` is honored
+        # without round-tripping through the wizard. Apply-time env
+        # wins over any value already in install.conf.
+        #
+        # Gate on the global AGENT_BACKEND only. A non-codex global
+        # install does not pick up an apply-time CODEX_BIN override:
+        # per-user `agent_backend: codex` entries are operator-managed
+        # and should configure their own CODEX_BIN via the wizard
+        # rather than through an apply-time env var.
         env_codex_bin = os.environ.get("CODEX_BIN")
-        _apply_global_backend = env.get("AGENT_BACKEND", "claude")
-        try:
-            _apply_codex_users = _codex_users_from_yaml("/etc/kai/users.yaml", _apply_global_backend)
-        except (OSError, ValueError):
-            _apply_codex_users = []
-        _apply_codex_runs_anywhere = _compute_codex_runs_anywhere(
-            _apply_global_backend,
-            Path("/etc/kai/users.yaml").exists(),
-            _apply_codex_users,
-        )
-        if env_codex_bin and _apply_codex_runs_anywhere:
+        if env_codex_bin and env.get("AGENT_BACKEND") == "codex":
             env["CODEX_BIN"] = env_codex_bin
         # AGENT_TIMEOUT_SECONDS migration. Operators upgrading without
         # re-running the wizard carry the legacy CLAUDE_TIMEOUT_SECONDS

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1813,3 +1813,42 @@ class TestCodexGrandchildEscalation:
         assert first_kill_argv[6] == "33333"
         assert second_kill_argv[6] == "22222"
         mock_killpg.assert_called_once_with(12345, signal.SIGKILL)
+
+
+class TestStartupFailureSurface:
+    """
+    Spec #556 acceptance criterion: a per-user `agent_backend: codex`
+    entry on a non-codex install must produce a chat-visible
+    startup-failure StreamEvent (not silent failure, not fall-through
+    to claude) when codex tooling is missing.
+
+    `CodexBackend._send_locked` wraps `_ensure_started` in a
+    try/except that catches OSError / RuntimeError / TimeoutError
+    and yields a done StreamEvent with
+    `error="Codex startup failed: <exc>"`. This is the runtime safety
+    net for the wizard-decoupling change that stopped preflighting
+    per-user codex tooling at install time.
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_codex_binary_yields_startup_failure_event(self):
+        """FileNotFoundError from subprocess spawn becomes a done event with chat-visible error."""
+        c = _make_codex()
+
+        async def _raise_filenotfound(*args, **kwargs):
+            raise FileNotFoundError(2, "No such file or directory", "codex")
+
+        events = []
+        with patch("kai.codex.asyncio.create_subprocess_exec", side_effect=_raise_filenotfound):
+            async for event in c._send_locked("hello"):
+                events.append(event)
+
+        assert events, "expected at least one StreamEvent"
+        final = events[-1]
+        assert final.done is True
+        assert final.response is not None
+        assert final.response.success is False
+        # Error message identifies codex specifically so the chat reply
+        # tells the operator which backend failed, not just "spawn error".
+        assert final.response.error is not None
+        assert "Codex startup failed:" in final.response.error

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -29,7 +29,6 @@ from kai.install import (
     _cmd_apply,
     _cmd_config,
     _cmd_status,
-    _codex_users_from_yaml,
     _collect_os_users_from_yaml,
     _collect_user_memory_owners,
     _copy_tree,
@@ -781,133 +780,6 @@ class TestReadUsersYamlText:
 
         monkeypatch.setattr("kai.install.subprocess.run", _fake_subprocess_run)
         assert _read_users_yaml_text(path) is None
-
-
-class TestCodexUsersFromYamlProtectedFallback:
-    """Regression for the failure mode where the wizard skipped the
-    entire codex setup block because it read users.yaml from the
-    project-root path while only `/etc/kai/users.yaml` existed. The
-    fix routes `_codex_users_from_yaml` through `_read_users_yaml_text`
-    so the protected-path fallback works."""
-
-    def test_protected_path_yields_codex_users(self, monkeypatch, tmp_path):
-        """When the path raises PermissionError on direct read, the
-        helper sudo-cats the file and returns the codex-effective
-        users. Without this, the wizard predicate `codex_runs_anywhere`
-        evaluates False on installs with only `/etc/kai/users.yaml`
-        present, and the codex setup block silently skips - the
-        symptom the operator hit on a real deployment."""
-        path = Path("/etc/kai/users.yaml")
-
-        def _raise_perm(self, encoding="utf-8"):
-            raise PermissionError(13, "Permission denied", str(self))
-
-        monkeypatch.setattr(Path, "read_text", _raise_perm)
-
-        def _fake_subprocess_run(argv, capture_output, text, timeout):
-            class _R:
-                returncode = 0
-                stdout = "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: alice_os\n"
-
-            return _R()
-
-        monkeypatch.setattr("kai.install.subprocess.run", _fake_subprocess_run)
-        refs = _codex_users_from_yaml(path, "codex")
-        assert len(refs) == 1
-        assert refs[0].telegram_id == 12345
-        assert refs[0].os_user == "alice_os"
-
-
-class TestComputeOpencodeRunsAnywhere:
-    """
-    Mirrors `_compute_codex_runs_anywhere` semantics for opencode.
-    Without users.yaml, the global AGENT_BACKEND alone decides.
-    With users.yaml, ANY user whose effective backend resolves to
-    opencode flips the predicate True so the PATH check and auth
-    reminder still fire on mixed installs.
-    """
-
-    def _yaml_at(self, tmp_path, contents: str) -> Path:
-        p = tmp_path / "users.yaml"
-        p.write_text(contents)
-        return p
-
-    def test_no_yaml_global_opencode_true(self, tmp_path):
-        from kai.install import _compute_opencode_runs_anywhere
-
-        assert _compute_opencode_runs_anywhere("opencode", False, tmp_path / "missing.yaml") is True
-
-    def test_no_yaml_global_claude_false(self, tmp_path):
-        from kai.install import _compute_opencode_runs_anywhere
-
-        assert _compute_opencode_runs_anywhere("claude", False, tmp_path / "missing.yaml") is False
-
-    def test_yaml_with_per_user_opencode_on_claude_global(self, tmp_path):
-        """The mixed-backend case the reviewer flagged: global=claude, one user opencode."""
-        from kai.install import _compute_opencode_runs_anywhere
-
-        path = self._yaml_at(
-            tmp_path,
-            "users:\n"
-            "  - telegram_id: 111\n"
-            "    name: alice\n"
-            "  - telegram_id: 222\n"
-            "    name: bob\n"
-            "    agent_backend: opencode\n",
-        )
-        assert _compute_opencode_runs_anywhere("claude", True, path) is True
-
-    def test_yaml_with_no_opencode_users_returns_false(self, tmp_path):
-        from kai.install import _compute_opencode_runs_anywhere
-
-        path = self._yaml_at(
-            tmp_path,
-            "users:\n"
-            "  - telegram_id: 111\n"
-            "    name: alice\n"
-            "  - telegram_id: 222\n"
-            "    name: bob\n"
-            "    agent_backend: codex\n",
-        )
-        assert _compute_opencode_runs_anywhere("claude", True, path) is False
-
-    def test_yaml_with_inherited_global_opencode(self, tmp_path):
-        """A user with no agent_backend inherits global, so global=opencode + yaml = True."""
-        from kai.install import _compute_opencode_runs_anywhere
-
-        path = self._yaml_at(
-            tmp_path,
-            "users:\n  - telegram_id: 111\n    name: alice\n",
-        )
-        assert _compute_opencode_runs_anywhere("opencode", True, path) is True
-
-    def test_yaml_overrides_all_users_off_opencode(self, tmp_path):
-        """Authoritative-source rule: global opencode + every user overrides = False."""
-        from kai.install import _compute_opencode_runs_anywhere
-
-        path = self._yaml_at(
-            tmp_path,
-            "users:\n"
-            "  - telegram_id: 111\n"
-            "    name: alice\n"
-            "    agent_backend: claude\n"
-            "  - telegram_id: 222\n"
-            "    name: bob\n"
-            "    agent_backend: codex\n",
-        )
-        assert _compute_opencode_runs_anywhere("opencode", True, path) is False
-
-    def test_empty_yaml_returns_false(self, tmp_path):
-        from kai.install import _compute_opencode_runs_anywhere
-
-        path = self._yaml_at(tmp_path, "")
-        assert _compute_opencode_runs_anywhere("claude", True, path) is False
-
-    def test_yaml_without_users_key_returns_false(self, tmp_path):
-        from kai.install import _compute_opencode_runs_anywhere
-
-        path = self._yaml_at(tmp_path, "other: thing\n")
-        assert _compute_opencode_runs_anywhere("claude", True, path) is False
 
 
 class TestCollectUserMemoryOwners:
@@ -3102,16 +2974,6 @@ class TestCmdConfigDefaultModelDispatch:
         assert env.get("AGENT_BACKEND") == "codex"
         # MEMORY_REASONER_BACKEND retired; the wizard must not emit it.
         assert "MEMORY_REASONER_BACKEND" not in env
-
-    # The old test_claude_install_codex_reasoner_emits_codex_bin_and_matches_sudoers
-    # tested a wizard prompt path that issue #515 retired (global
-    # MEMORY_REASONER_BACKEND=codex with AGENT_BACKEND=claude). The
-    # mixed-backend scenario it covered now requires a users.yaml entry
-    # with per-user `agent_backend: codex`, which the wizard does not
-    # prompt for - operators edit users.yaml directly. The CODEX_BIN
-    # sudoers wiring is covered by other tests in the suite; a
-    # dedicated regression for the codex_runs_anywhere predicate
-    # belongs in the new-tests pass for issue #515.
 
 
 class TestCmdApplyDefaultModelGate:
@@ -6571,16 +6433,18 @@ class TestApplyAgentTimeoutMigration:
         assert "CLAUDE_TIMEOUT_SECONDS" not in env
 
 
-class TestPerOsUserCodexLoginHint:
-    """Post-install hint enumerates per-os_user codex login.
+class TestBuildCodexLoginReminder:
+    """Post-install codex subscription-auth reminder policy.
 
-    The reminder fires when codex actually runs on this install: agent
-    backend = codex OR memory reasoner = codex. Subscription auth lives
-    under each spawning user's home, so the reminder must enumerate
-    every distinct os_user in users.yaml (falling back to the service
-    user only when none are configured). The gate and enumeration are
-    factored into `_build_codex_login_reminder` so this test exercises
-    them directly without driving the full _cmd_apply pipeline.
+    The reminder is global-only: it fires when AGENT_BACKEND=codex AND
+    auth mode is subscription. Per-user `agent_backend: codex` entries
+    in users.yaml DO NOT trigger the reminder; mixed-backend installs
+    are operator-managed and the reminder would be wizard noise for
+    operators who chose a non-codex global backend.
+
+    The reminder text is generic ("log in as the target os_user") and
+    does NOT enumerate per-user os_users. Operators read users.yaml
+    themselves to know which accounts need codex login.
     """
 
     @staticmethod
@@ -6589,14 +6453,62 @@ class TestPerOsUserCodexLoginHint:
         path.write_text(yaml.safe_dump({"users": entries}))
         return path
 
-    def test_claude_agent_with_per_user_codex_emits_reminder(self, tmp_path):
-        """Mixed-backend regression. With AGENT_BACKEND=claude but a
-        users.yaml entry pinned to `agent_backend: codex`, codex still
-        runs per-user; the operator must run `codex login` as the
-        target os_user or the first turn fails with no auth.
-        Pre-#515 fix the reminder was suppressed because the gate
-        keyed on AGENT_BACKEND alone; now the gate honors per-user
-        agent_backend overrides via `_codex_users_from_yaml`.
+    def test_global_codex_subscription_emits_reminder(self, tmp_path):
+        """The one case the reminder should fire."""
+        from kai.install import _build_codex_login_reminder
+
+        users_yaml = self._write_users_yaml(
+            tmp_path,
+            [{"telegram_id": 1, "name": "alice", "role": "admin", "os_user": "alice"}],
+        )
+        env = {"AGENT_BACKEND": "codex", "CODEX_AUTH_MODE": "subscription"}
+        text = _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml)
+        assert text is not None
+        assert "Codex subscription auth required:" in text
+        assert "codex login" in text
+
+    def test_default_auth_mode_is_subscription(self, tmp_path):
+        """Missing CODEX_AUTH_MODE defaults to subscription; reminder fires."""
+        from kai.install import _build_codex_login_reminder
+
+        users_yaml = self._write_users_yaml(tmp_path, [])
+        env = {"AGENT_BACKEND": "codex"}
+        text = _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml)
+        assert text is not None
+
+    def test_reminder_is_generic_no_per_user_enumeration(self, tmp_path):
+        """The reminder text does NOT enumerate users.yaml os_users.
+
+        Pre-#556 the reminder listed `    alice ~$ codex login`,
+        `    bob ~$ codex login`, etc. Post-#556 it's a single generic
+        line. The wizard does not read users.yaml for this reminder
+        any more; mixed-backend installs are operator-managed.
+        """
+        from kai.install import _build_codex_login_reminder
+
+        users_yaml = self._write_users_yaml(
+            tmp_path,
+            [
+                {"telegram_id": 1, "name": "alice", "role": "admin", "os_user": "alice"},
+                {"telegram_id": 2, "name": "bob", "role": "user", "os_user": "bob"},
+            ],
+        )
+        env = {"AGENT_BACKEND": "codex"}
+        text = _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml)
+        assert text is not None
+        # No per-user enumeration. Specific os_user lines must NOT appear.
+        assert "alice ~$ codex login" not in text
+        assert "bob ~$ codex login" not in text
+        # Generic <os_user> placeholder DOES appear.
+        assert "<os_user> ~$ codex login" in text
+
+    def test_claude_global_with_per_user_codex_returns_none(self, tmp_path):
+        """Mixed-backend installs receive no reminder.
+
+        Pre-#556 the reminder fired when users.yaml had any codex-
+        effective entry. Post-#556 the gate is global-only: a per-user
+        codex override on a non-codex global install means the operator
+        owns codex setup out-of-band; the wizard does not preflight it.
         """
         from kai.install import _build_codex_login_reminder
 
@@ -6604,7 +6516,7 @@ class TestPerOsUserCodexLoginHint:
             tmp_path,
             [
                 {
-                    "telegram_id": 12345,
+                    "telegram_id": 1,
                     "name": "alice",
                     "role": "admin",
                     "agent_backend": "codex",
@@ -6613,32 +6525,10 @@ class TestPerOsUserCodexLoginHint:
             ],
         )
         env = {"AGENT_BACKEND": "claude"}
-        text = _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml)
-        assert text is not None
-        assert "Codex subscription auth required:" in text
-        assert "alice ~$ codex login" in text
-        # service-user fallback must NOT fire when users.yaml has entries.
-        assert "kai ~$ codex login" not in text
+        assert _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml) is None
 
-    def test_codex_agent_backend_still_emits_reminder(self, tmp_path):
-        """Defense-in-depth for the original gate: AGENT_BACKEND=codex
-        alone (no memory) still produces the reminder.
-        """
-        from kai.install import _build_codex_login_reminder
-
-        users_yaml = self._write_users_yaml(
-            tmp_path,
-            [{"telegram_id": 1, "name": "alice", "role": "admin", "os_user": "alice"}],
-        )
-        env = {"AGENT_BACKEND": "codex"}
-        text = _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml)
-        assert text is not None
-        assert "alice ~$ codex login" in text
-
-    def test_pure_claude_no_codex_anywhere_returns_none(self, tmp_path):
-        """No codex surface, no reminder. Claude memory extraction does
-        not spawn codex; emitting the hint here would be wizard noise.
-        """
+    def test_pure_claude_returns_none(self, tmp_path):
+        """No codex surface, no reminder."""
         from kai.install import _build_codex_login_reminder
 
         users_yaml = self._write_users_yaml(
@@ -6649,73 +6539,19 @@ class TestPerOsUserCodexLoginHint:
         assert _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml) is None
 
     def test_codex_api_key_mode_returns_none(self, tmp_path):
-        """API-key auth needs no per-user login; the env var ships the
-        token. The reminder must skip both codex-anywhere cases when
-        CODEX_AUTH_MODE=api_key.
-        """
+        """API-key auth needs no per-user login; the env var ships the token."""
         from kai.install import _build_codex_login_reminder
 
         users_yaml = self._write_users_yaml(
             tmp_path,
             [{"telegram_id": 1, "name": "alice", "role": "admin", "os_user": "alice"}],
         )
-        # First env: global codex with api_key auth, users.yaml has
-        # alice as a generic claude-effective user (no agent_backend
-        # override). Second env: claude global with per-user codex
-        # override via users.yaml + api_key auth. Both must return None
-        # because api_key auth needs no per-user codex login.
-        env_codex_global = {"AGENT_BACKEND": "codex", "CODEX_AUTH_MODE": "api_key"}
-        assert _build_codex_login_reminder(env_codex_global, "kai", users_yaml_path=users_yaml) is None
+        env = {"AGENT_BACKEND": "codex", "CODEX_AUTH_MODE": "api_key"}
+        assert _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml) is None
 
-        users_yaml_mixed = self._write_users_yaml(
-            tmp_path,
-            [
-                {
-                    "telegram_id": 2,
-                    "name": "alice",
-                    "role": "admin",
-                    "agent_backend": "codex",
-                    "os_user": "alice",
-                }
-            ],
-        )
-        env_mixed = {"AGENT_BACKEND": "claude", "CODEX_AUTH_MODE": "api_key"}
-        assert _build_codex_login_reminder(env_mixed, "kai", users_yaml_path=users_yaml_mixed) is None
-
-    def test_no_os_users_falls_back_to_service_user(self, tmp_path):
-        """When users.yaml has no os_user entries (legacy single-user
-        mode or empty file), the fallback hint names the service user.
-        """
+    def test_missing_agent_backend_returns_none(self, tmp_path):
+        """No AGENT_BACKEND key in env defaults to claude; reminder skipped."""
         from kai.install import _build_codex_login_reminder
 
-        users_yaml = self._write_users_yaml(
-            tmp_path,
-            [{"telegram_id": 1, "name": "alice", "role": "admin"}],
-        )
-        env = {"AGENT_BACKEND": "codex"}
-        text = _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml)
-        assert text is not None
-        assert "kai ~$ codex login" in text
-
-    def test_multiple_os_users_enumerated_and_deduplicated(self, tmp_path):
-        """Each distinct os_user gets one line. Duplicates in users.yaml
-        collapse so the operator does not see redundant hints; order is
-        deterministic (sorted) so the post-install output is stable
-        across runs.
-        """
-        from kai.install import _build_codex_login_reminder
-
-        users_yaml = self._write_users_yaml(
-            tmp_path,
-            [
-                {"telegram_id": 1, "name": "alice", "role": "admin", "os_user": "alice"},
-                {"telegram_id": 2, "name": "bob", "role": "user", "os_user": "bob"},
-                {"telegram_id": 3, "name": "carol", "role": "user", "os_user": "alice"},
-            ],
-        )
-        env = {"AGENT_BACKEND": "codex"}
-        text = _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml)
-        assert text is not None
-        # alice once (dedup), bob once; sorted ordering puts alice first.
-        login_lines = [line for line in text.splitlines() if "~$ codex login" in line]
-        assert login_lines == ["    alice ~$ codex login", "    bob ~$ codex login"]
+        users_yaml = self._write_users_yaml(tmp_path, [])
+        assert _build_codex_login_reminder({}, "kai", users_yaml_path=users_yaml) is None

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -19,6 +19,9 @@ AcpBackend layer:
 
 import json
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
 
 from kai.opencode import OpenCodeBackend
 
@@ -326,3 +329,44 @@ class TestConstructor:
         assert b._proc is None
         assert b._session_id is None
         assert b._fresh_session is True
+
+
+# ── Startup-failure surface ──────────────────────────────────────────
+
+
+class TestStartupFailureSurface:
+    """
+    Spec #556 acceptance criterion: a per-user `agent_backend: opencode`
+    entry on a non-opencode install must produce a chat-visible
+    startup-failure StreamEvent (not silent failure, not fall-through
+    to claude) when `opencode` is missing from PATH.
+
+    `AcpBackend._send_locked` wraps `_ensure_started` in a try/except
+    that catches OSError / RuntimeError / TimeoutError and yields a
+    done StreamEvent with `error="<backend_label> startup failed: <exc>"`.
+    This is the runtime safety net for the wizard-decoupling change
+    that stopped preflighting per-user opencode tooling at install time.
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_opencode_binary_yields_startup_failure_event(self):
+        """FileNotFoundError from subprocess spawn becomes a done event with chat-visible error."""
+        b = _make_opencode()
+
+        async def _raise_filenotfound(*args, **kwargs):
+            raise FileNotFoundError(2, "No such file or directory", "opencode")
+
+        events = []
+        with patch("kai.acp.asyncio.create_subprocess_exec", side_effect=_raise_filenotfound):
+            async for event in b._send_locked("hello"):
+                events.append(event)
+
+        assert events, "expected at least one StreamEvent"
+        final = events[-1]
+        assert final.done is True
+        assert final.response is not None
+        assert final.response.success is False
+        # Error message identifies OpenCode specifically (via backend_label)
+        # so the chat reply tells the operator which backend failed.
+        assert final.response.error is not None
+        assert "OpenCode startup failed:" in final.response.error


### PR DESCRIPTION
## Summary

The install wizard's mixed-backend detection caused `make config` to ask about backends the operator did not pick. Picking `AGENT_BACKEND=opencode` still prompted for Codex auth whenever `users.yaml` had any entry whose effective backend resolved to codex; the same pattern was added for opencode in #554. This bled operator-managed `users.yaml` data into install prompts.

This PR collapses the wizard gates to simple global checks. `agent_backend == "codex"` gates codex prompts; `agent_backend == "opencode"` gates the opencode PATH check and auth reminder. Per-user `agent_backend` overrides in `users.yaml` no longer influence the wizard; operators manage per-user backend tooling out-of-band, and the runtime startup-failure event is the safety net.

## Symptom

```
$ make config
...
Agent backend (claude/codex/goose/opencode) [codex]: opencode
Codex auth mode (subscription/api_key) [subscription]: api_key
OPENAI_API_KEY:
```

Operator picked opencode; wizard asked for codex auth because `users.yaml` had a codex-effective entry.

## Changes

### `src/kai/install.py`
- `_cmd_config`: replaced the `_codex_users_from_yaml` + `_compute_codex_runs_anywhere` block with `if agent_backend == "codex":`. Same collapse for the opencode block (`_compute_opencode_runs_anywhere` → `if agent_backend == "opencode":`). Second CODEX_BIN prompt (memory-reasoner defense-in-depth) gates on `agent_backend == "codex"` as well.
- `_cmd_apply`: apply-time `CODEX_BIN` env-var pass-through now gates on `env.get("AGENT_BACKEND") == "codex"`. The mixed-install pass-through is gone; a non-codex global install does not pick up an apply-time CODEX_BIN.
- `_build_codex_login_reminder`: drops per-user os_user enumeration. Returns a generic reminder string only when `AGENT_BACKEND == "codex"` AND `CODEX_AUTH_MODE == "subscription"`, else `None`. Function signature unchanged for back-compat; `service_user` and `users_yaml_path` parameters are kept but no longer read.
- Removed: `_codex_users_from_yaml`, `_compute_codex_runs_anywhere`, `_compute_opencode_runs_anywhere`, `CodexUserRef`. Orphan `from dataclasses import dataclass` also removed.

### `src/kai/codex.py`, `src/kai/acp.py`
No changes. The runtime startup-failure surface (`Codex startup failed: …` from `CodexBackend._send_locked`; `OpenCode startup failed: …` from `AcpBackend._send_locked`) was already in place; this PR adds tests pinning it.

### Tests
- Dropped `TestCodexUsersFromYamlProtectedFallback` and `TestComputeOpencodeRunsAnywhere` (helpers removed).
- Replaced `TestPerOsUserCodexLoginHint` with `TestBuildCodexLoginReminder`: pins the global-only policy, the no-per-user-enumeration contract, and the API-key / non-codex / missing-key None returns.
- New `TestStartupFailureSurface` in `tests/test_codex.py`: a CodexBackend whose subprocess spawn raises `FileNotFoundError` yields a done StreamEvent with `error="Codex startup failed: …"`. No silent failure, no fall-through to claude.
- New `TestStartupFailureSurface` in `tests/test_opencode.py`: same shape for OpenCodeBackend via the shared `AcpBackend._send_locked` path.

## What stays

`_collect_os_users_from_yaml` and `_apply_sudoers` are unchanged. Per-user sudoers SETENV NOPASSWD rules are correctness-bearing for cross-user dispatch regardless of backend; that path keeps reading `users.yaml`.

Runtime per-user dispatch in `pool._create_instance` is unchanged. A per-user `agent_backend: codex` entry on a non-codex global install still routes to `CodexBackend`; if codex tooling is missing, the new startup-failure tests pin the chat-visible error.

## Behavior change to flag

A `sudo CODEX_BIN=/path kai install apply` invocation no longer does anything on a non-codex global install. Operators who relied on this pattern should set `AGENT_BACKEND=codex` first, or use the wizard.

Mixed-backend installs lose both the wizard's preflight tooling collection AND the post-install codex login reminder. The replacement signal is documentation plus the runtime startup-failure StreamEvent.

## Test plan

- [x] `make test` (3636 passed, 1 skipped)
- [x] `make check` (ruff clean)

Closes #556.
