### PR TITLE
refactor(install): canonicalize users.yaml on /etc/kai

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Per-workspace configuration is supported via `workspaces.yaml` (or `/etc/kai/wor
 
 ### Multi-user
 
-A single Kai instance can serve multiple Telegram users, each fully isolated. Define users in `users.yaml` (or `/etc/kai/users.yaml` for protected installations):
+A single Kai instance can serve multiple Telegram users, each fully isolated. Define users in `/etc/kai/users.yaml` (the canonical location for protected installations):
 
 ```yaml
 users:
@@ -68,7 +68,7 @@ Each user gets:
 - **Per-user home workspace** - each user can have their own default workspace directory.
 - **Role-based routing** - admins receive unattributed webhook events (GitHub pushes, generic webhooks). Regular users interact only through Telegram messages.
 
-Run `make config` to generate `users.yaml`, or create one manually from `templates/users.yaml`. See the [Multi-User Setup](https://github.com/dcellison/kai/wiki/Multi-User-Setup) wiki page for the full field reference. When `users.yaml` is absent, Kai falls back to `ALLOWED_USER_IDS` for backward compatibility. If neither is set, Kai refuses to start (fail-closed). The `CLAUDE_USER` env var acts as a global fallback for subprocess isolation; per-user `os_user` in `users.yaml` takes precedence when set.
+Run `make config` to stage a first-time `users.yaml` (written to `~/.cache/kai-install/users.yaml`; `sudo make install` copies it to `/etc/kai/users.yaml` and removes the staging file). Alternatively, create one manually from `templates/users.yaml`. See the [Multi-User Setup](https://github.com/dcellison/kai/wiki/Multi-User-Setup) wiki page for the full field reference. When `/etc/kai/users.yaml` is absent, Kai falls back to `ALLOWED_USER_IDS` for backward compatibility. If neither is set, Kai refuses to start (fail-closed). The `CLAUDE_USER` env var acts as a global fallback for subprocess isolation; per-user `os_user` in `users.yaml` takes precedence when set.
 
 ### Memory
 

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1559,11 +1559,14 @@ def _load_user_configs(
     global_llm_provider: str,
 ) -> dict[int, UserConfig] | None:
     """
-    Load per-user configs from users.yaml.
+    Load per-user configs from /etc/kai/users.yaml.
 
-    Tries /etc/kai/users.yaml first (protected), falls back to
-    PROJECT_ROOT/users.yaml (dev). Returns None if neither exists
-    (signals the caller to fall back to ALLOWED_USER_IDS).
+    Reads the protected file via `_read_protected_yaml` (sudo-cat for
+    root-owned mode 0600 copies). Returns None when the file is absent
+    or malformed; the caller then falls back to the legacy
+    `ALLOWED_USER_IDS` auth path. There is no project-root fallback:
+    users.yaml is canonical at `/etc/kai/users.yaml` and a stray copy
+    inside the source tree is never consulted.
 
     Args:
         global_backend: The global agent_backend from env config.
@@ -1573,7 +1576,6 @@ def _load_user_configs(
 
     Returns a dict keyed by telegram_id for O(1) lookup.
     """
-    # Same dual-mode loading pattern as _load_workspace_configs.
     data = _read_protected_yaml("users.yaml")
     if data is _YAML_MALFORMED:
         # Fail closed: return None so the caller falls back to
@@ -1582,23 +1584,12 @@ def _load_user_configs(
         log.warning("Skipping user config: /etc/kai/users.yaml is malformed or empty")
         return None
     if data is None:
-        local_path = PROJECT_ROOT / "users.yaml"
-        if not local_path.exists():
-            return None
-        try:
-            with open(local_path) as f:
-                data = yaml.safe_load(f)
-        except (yaml.YAMLError, OSError) as e:
-            log.error("Cannot load %s: %s", local_path, e)
-            return None
-        if not isinstance(data, dict):
-            log.warning("%s: expected a YAML dict, got %s", local_path, type(data).__name__)
-            return None
+        return None
 
-    # After the _YAML_MALFORMED and None checks, data should be a dict
-    # (protected path returns _YAML_MALFORMED for non-dicts, local path
-    # checks isinstance explicitly). Guard defensively rather than assert
-    # since assertions are stripped under Python -O.
+    # After the _YAML_MALFORMED and None checks, `data` is guaranteed
+    # to be a dict (`_read_protected_yaml` returns `_YAML_MALFORMED`
+    # for any non-dict top-level value). Guard defensively rather than
+    # assert since assertions are stripped under Python -O.
     if not isinstance(data, dict):
         log.warning("users.yaml: expected a YAML dict, got %s", type(data).__name__)
         return None

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -349,6 +349,62 @@ def _validate_codex_bin(value: str) -> bool:
     return p.is_file() and os.access(p, os.X_OK)
 
 
+def _install_staging_path(filename: str) -> Path:
+    """Return the per-operator staging path for a first-time install file.
+
+    `make config` runs as the unprivileged operator account; `sudo make
+    install` runs as root. The staging file produced by config has to
+    live somewhere both runs can reach without crossing the secret-
+    discipline boundary at `/etc/kai/`. The operator's `${HOME}/.cache/
+    kai-install/` directory satisfies both: the operator owns it (config
+    can write without elevation) and root can read it during apply. We
+    deliberately avoid the project tree because the spec for #557
+    canonicalizes config locations outside the source checkout.
+
+    The parent directory is created mode 0700 on every call so the
+    staging file inherits a restrictive enclosing scope even before
+    its own 0600 chmod lands. Idempotent: a pre-existing directory
+    keeps its current mode.
+    """
+    cache_dir = Path.home() / ".cache" / "kai-install"
+    cache_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    return cache_dir / filename
+
+
+def _strip_install_conf_keys(*keys: str) -> None:
+    """Remove the named top-level keys from `install.conf` and rewrite.
+
+    Used by `_cmd_apply` after `apply_succeeded = True` to drop one-
+    shot installer-metadata keys (currently just `users_yaml_staging_
+    path`) so a subsequent re-run does not redo a handoff that already
+    completed. Top-level only: keys inside the `env` dict belong to
+    `/etc/kai/env` and are not touched by this helper.
+
+    Preserves the 0600 mode because `install.conf` still carries
+    secrets (bot token, webhook secret) until the operator explicitly
+    deletes it. Missing keys are silently ignored so the helper is
+    idempotent against repeated apply runs. A missing or unreadable
+    `install.conf` is a no-op rather than an error because the helper
+    is called during the success path of an apply that already
+    validated the file at start.
+    """
+    if not INSTALL_CONF.exists():
+        return
+    try:
+        conf = json.loads(INSTALL_CONF.read_text())
+    except (json.JSONDecodeError, OSError):
+        return
+    mutated = False
+    for key in keys:
+        if key in conf:
+            conf.pop(key)
+            mutated = True
+    if not mutated:
+        return
+    INSTALL_CONF.write_text(json.dumps(conf, indent=2) + "\n")
+    os.chmod(INSTALL_CONF, 0o600)
+
+
 def _read_users_yaml_text(path: Path) -> str | None:
     """Return the contents of a users.yaml file, falling back to sudo
     for root-owned protected copies.
@@ -455,23 +511,27 @@ def _cmd_config() -> None:
     )
 
     # -- User setup --
-    # Check for an existing users.yaml. Try local project root first,
-    # then the deployed copy at /etc/kai/ (for protected installs).
-    # If either exists, skip the user prompt to avoid overwriting
-    # manual edits.
+    # `/etc/kai/users.yaml` is the only canonical source for the wizard.
+    # The wizard reads it via `_read_users_yaml_text` which sudo-cats
+    # the mode 0600 root-owned file. `Path.exists()` works through the
+    # listable parent directory even though the file is unreadable to
+    # the operator account, so the existence check does not require
+    # elevation.
+    #
+    # If no canonical file exists, the first-time branch writes to a
+    # per-operator staging path at `${HOME}/.cache/kai-install/
+    # users.yaml`. `_apply_secrets` (invoked under `sudo make install`)
+    # reads the path back from `install.conf` and copies it into
+    # `/etc/kai/users.yaml`. A stray `PROJECT_ROOT/users.yaml` from a
+    # previous install cycle is ignored; a one-line deprecation
+    # warning tells the operator to remove it or move it to
+    # `/etc/kai/users.yaml`.
     print("-- User setup --")
-    users_yaml_path = PROJECT_ROOT / "users.yaml"
+    stray_project_users_yaml = PROJECT_ROOT / "users.yaml"
+    if stray_project_users_yaml.exists():
+        print(f"  Note: {stray_project_users_yaml} is no longer used. Move it to /etc/kai/users.yaml or remove it.")
+    users_yaml_path = Path("/etc/kai/users.yaml")
     users_yaml_exists = users_yaml_path.exists()
-
-    if not users_yaml_exists:
-        # `/etc/kai/users.yaml` is mode 0600 owned by root.
-        # `Path.exists()` works as long as the parent directory is
-        # listable; downstream reads from `users_yaml_path` go through
-        # `_read_users_yaml_text` which sudo-cats protected copies.
-        etc_users = Path("/etc/kai/users.yaml")
-        if etc_users.exists():
-            users_yaml_exists = True
-            users_yaml_path = etc_users
 
     # Track whether advanced mode set os_user, so we can skip the
     # CLAUDE_USER prompt later (section 8). Needs to be in scope
@@ -486,6 +546,16 @@ def _cmd_config() -> None:
     admin_telegram_id: str = ""
     admin_name: str = ""
     admin_home_workspace: str | None = None
+    # First-time wizard sets this to the absolute path of the staging
+    # file written below; on every other branch it stays None. The
+    # value is persisted as a top-level `install.conf` key (NOT inside
+    # the env dict) so `_cmd_apply` can locate the staging file when
+    # `sudo make install` runs under a different HOME than the wizard.
+    # When the canonical `/etc/kai/users.yaml` already exists we
+    # deliberately leave it None and DO NOT carry forward any prior
+    # value from `existing`: a stale key would cause apply to overwrite
+    # the canonical file from a no-longer-current staging artifact.
+    users_yaml_staging_path: str | None = None
 
     if users_yaml_exists:
         # Summarize the existing config without modifying it. Reads
@@ -558,8 +628,16 @@ def _cmd_config() -> None:
             # spec exists to eliminate.
             admin_home_workspace = None
 
-        # Write users.yaml to project root. _apply_secrets() copies it
-        # to /etc/kai/users.yaml during 'make install'.
+        # Stage the generated users.yaml at `${HOME}/.cache/kai-install/
+        # users.yaml`. `_apply_secrets` copies from this staging path
+        # into `/etc/kai/users.yaml` during `sudo make install`; the
+        # path is persisted as a top-level key in install.conf below so
+        # apply can resolve it even when running under a different HOME
+        # (root vs the operator account). After `apply_succeeded`,
+        # `_cmd_apply` unlinks the staging file and strips the conf key
+        # so a subsequent re-run does not redo a handoff that already
+        # completed.
+        users_yaml_path = _install_staging_path("users.yaml")
         users_yaml_content = _generate_users_yaml(
             admin_telegram_id,
             admin_name,
@@ -568,6 +646,7 @@ def _cmd_config() -> None:
         )
         users_yaml_path.write_text(users_yaml_content)
         os.chmod(users_yaml_path, 0o600)
+        users_yaml_staging_path = str(users_yaml_path)
         print(f"  Generated {users_yaml_path}")
     print()
 
@@ -1548,6 +1627,17 @@ def _cmd_config() -> None:
         "platform": platform,
         "env": env,
     }
+
+    # Pending first-install handoff: `_cmd_apply` reads this top-level
+    # key to locate the staging file written above and copies it to
+    # `/etc/kai/users.yaml`. The key sits alongside `version`/
+    # `install_dir`/`env` (NOT inside `env`) because it is installer
+    # metadata; routing it through `env` would surface it in
+    # `/etc/kai/env` and pollute runtime daemon configuration. The
+    # presence of this key is also the only signal apply uses: a stale
+    # staging file without a matching key in install.conf is ignored.
+    if users_yaml_staging_path:
+        conf["users_yaml_staging_path"] = users_yaml_staging_path
 
     INSTALL_CONF.write_text(json.dumps(conf, indent=2) + "\n")
     # Restrict permissions since the file contains secrets (bot token, webhook secret)
@@ -3155,6 +3245,14 @@ def _cmd_apply() -> None:
     service_user = conf.get("service_user")
     platform = conf.get("platform")
     env = conf.get("env", {})
+    # Top-level installer metadata: present only when the wizard
+    # staged a first-time users.yaml that has not yet been applied.
+    # The empty-string -> None coercion treats a hand-edited conf
+    # with an empty value the same as a missing key (apply skips
+    # the copy). `_apply_secrets` defends against a missing file
+    # behind a non-empty path so a wrong value silently skips
+    # rather than failing the apply.
+    users_yaml_staging_path = conf.get("users_yaml_staging_path", "") or None
 
     if not all([install_dir, data_dir, service_user, platform]):
         raise SystemExit("install.conf is missing required fields.")
@@ -3306,7 +3404,7 @@ def _cmd_apply() -> None:
         if "AGENT_TIMEOUT_SECONDS" not in env and "CLAUDE_TIMEOUT_SECONDS" in env:
             env["AGENT_TIMEOUT_SECONDS"] = env["CLAUDE_TIMEOUT_SECONDS"]
         env.pop("CLAUDE_TIMEOUT_SECONDS", None)
-        _apply_secrets(env, dry_run)
+        _apply_secrets(env, dry_run, users_yaml_staging_path=users_yaml_staging_path)
 
         # -- Step 6: Deploy Goose config (if backend=goose) --
         if env.get("AGENT_BACKEND") == "goose":
@@ -3329,6 +3427,24 @@ def _cmd_apply() -> None:
         # finally block reads it to decide how to handle a service
         # start failure.
         apply_succeeded = True
+
+        # First-install staging handoff cleanup. Gated on `not dry_run`
+        # because the dry-run contract is "no changes will be made";
+        # unguarded cleanup would consume the one-shot staging file
+        # during an inspection run and leave the next real apply with
+        # nothing to copy. Cleanup runs inside the try block (rather
+        # than after the finally) so it cannot delete the staging file
+        # before service-start results are known - cleanup completes
+        # before the service-start retry budget begins, and a
+        # service-start failure after this point does not invalidate
+        # the apply itself.
+        if users_yaml_staging_path:
+            if dry_run:
+                print(f"[DRY RUN] Would unlink staging file: {users_yaml_staging_path}")
+                print("[DRY RUN] Would strip users_yaml_staging_path from install.conf")
+            else:
+                Path(users_yaml_staging_path).unlink(missing_ok=True)
+                _strip_install_conf_keys("users_yaml_staging_path")
     except Exception:
         print("\nInstallation failed. See error above.")
         print("The installation may be in a partial state.")
@@ -4255,15 +4371,49 @@ def _apply_models(install_path: Path, dry_run: bool) -> None:
     print(f"  Copied models to {models_dst}")
 
 
-def _apply_secrets(env: dict[str, str], dry_run: bool) -> None:
-    """Write the /etc/kai/env file from install.conf environment values."""
+def _apply_secrets(
+    env: dict[str, str],
+    dry_run: bool,
+    users_yaml_staging_path: str | None = None,
+) -> None:
+    """Write the /etc/kai/env file from install.conf environment values.
+
+    `users_yaml_staging_path` is the absolute path of the first-time
+    install staging file as recorded by the wizard at the top level of
+    `install.conf`. It is passed explicitly (not read from `env`)
+    because routing it through `env` would surface it in `/etc/kai/env`
+    as runtime daemon configuration; the staging path is installer
+    metadata and must never leak there. The caller in `_cmd_apply`
+    handles post-success cleanup (unlink + strip the conf key); this
+    function only performs the copy.
+    """
     etc_kai = Path("/etc/kai")
     env_path = etc_kai / "env"
     env_content = _generate_env_file(env)
 
+    # Resolve users.yaml staging once so the dry-run preview and the
+    # real-apply branch share the same precedence rule. The presence
+    # of a non-empty path AND a readable file on disk is the entire
+    # signal: a stale staging file with no matching install.conf key
+    # never reaches this function (the caller passes None), and a
+    # recorded key that points at a missing file silently skips the
+    # copy rather than failing the apply.
+    users_yaml_src: Path | None = None
+    if users_yaml_staging_path:
+        candidate = Path(users_yaml_staging_path)
+        if candidate.is_file():
+            users_yaml_src = candidate
+
     if dry_run:
         print(f"[DRY RUN] Would write: {env_path} (mode 0600)")
-        for yaml_name in ("services.yaml", "users.yaml", "workspaces.yaml"):
+        if users_yaml_src is not None:
+            print(f"[DRY RUN] Would copy: {users_yaml_src} -> {etc_kai / 'users.yaml'} (mode 0600)")
+        # TODO: services.yaml and workspaces.yaml still copy from
+        # PROJECT_ROOT pending follow-up issues that mirror the
+        # users.yaml staging flow for those files. The asymmetry is
+        # intentional and tracked; users.yaml moves first because it
+        # is auth-bearing.
+        for yaml_name in ("services.yaml", "workspaces.yaml"):
             if (PROJECT_ROOT / yaml_name).exists():
                 print(f"[DRY RUN] Would copy: {etc_kai / yaml_name} (mode 0600)")
         return
@@ -4273,11 +4423,28 @@ def _apply_secrets(env: dict[str, str], dry_run: bool) -> None:
     os.chown(env_path, 0, 0)
     print(f"  Wrote {env_path}")
 
+    # users.yaml is handled separately from the other YAML files. Its
+    # source is the per-operator staging file recorded in install.conf
+    # by the wizard, not PROJECT_ROOT/users.yaml; the spec for #557
+    # canonicalizes users.yaml on /etc/kai/users.yaml and removes the
+    # project-tree path. Cleanup of the staging file and the conf key
+    # happens in `_cmd_apply` after `apply_succeeded = True` so a
+    # failed apply preserves both for a clean retry.
+    if users_yaml_src is not None:
+        users_yaml_dst = etc_kai / "users.yaml"
+        shutil.copy2(users_yaml_src, users_yaml_dst)
+        os.chmod(users_yaml_dst, 0o600)
+        os.chown(users_yaml_dst, 0, 0)
+        print(f"  Copied {users_yaml_dst}")
+
     # Copy optional YAML config files to /etc/kai/ if they exist in the
     # source directory. All get root-only permissions (mode 0600) since
-    # they may contain sensitive configuration (API keys in services.yaml,
-    # user IDs in users.yaml).
-    for yaml_name in ("services.yaml", "users.yaml", "workspaces.yaml"):
+    # they may contain sensitive configuration (API keys in services.yaml).
+    # TODO: services.yaml and workspaces.yaml still read from
+    # PROJECT_ROOT pending follow-up issues that mirror the users.yaml
+    # staging flow. The asymmetry is documented in-code so it is
+    # visible to anyone touching this function.
+    for yaml_name in ("services.yaml", "workspaces.yaml"):
         yaml_src = PROJECT_ROOT / yaml_name
         yaml_dst = etc_kai / yaml_name
         if yaml_src.exists():

--- a/templates/users.yaml
+++ b/templates/users.yaml
@@ -1,7 +1,9 @@
 # Per-user configuration for Kai.
 #
-# Copy to users.yaml (or /etc/kai/users.yaml for protected
-# installations) and customize with your users' details.
+# Copy to /etc/kai/users.yaml (the canonical location) and customize
+# with your users' details. Alternatively, run `make config`; the
+# wizard stages a generated file at `~/.cache/kai-install/users.yaml`
+# that `sudo make install` then copies into /etc/kai/users.yaml.
 #
 # Required fields: telegram_id, name.
 # All other fields are optional.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -119,6 +119,21 @@ def _set_required(monkeypatch, token="fake-token", user_ids="123"):
     monkeypatch.setenv("ALLOWED_USER_IDS", user_ids)
 
 
+def _patch_protected_users_yaml(monkeypatch, content: str) -> None:
+    """Feed `content` to `_load_user_configs` as if `/etc/kai/users.yaml`
+    held it. The loader reads via `_read_protected_file`; this helper
+    dispatches only the users.yaml path and returns None for every
+    other protected file (the default load_config shape on dev hosts).
+    """
+
+    def _fake_read(path):
+        if path == "/etc/kai/users.yaml":
+            return content
+        return None
+
+    monkeypatch.setattr("kai.config._read_protected_file", _fake_read)
+
+
 # ── Happy path ───────────────────────────────────────────────────────
 
 
@@ -1583,11 +1598,10 @@ class TestMemoryReasonerBinaryValidation:
         shape as claude."""
         from kai.oneshot_binary import BinaryResolutionError
 
-        users_yaml = tmp_path / "users.yaml"
-        users_yaml.write_text(
-            "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    agent_backend: codex\n    os_user: alice_os\n"
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    agent_backend: codex\n    os_user: alice_os\n",
         )
-        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
@@ -1674,14 +1688,15 @@ class TestCodexMemorySameUserSymmetry:
         assert config.agent_backend == "codex"
         assert config.memory_extraction_enabled is True
 
-    def test_codex_users_yaml_missing_os_user_starts_cleanly(self, tmp_path, monkeypatch):
+    def test_codex_users_yaml_missing_os_user_starts_cleanly(self, monkeypatch):
         """A codex-effective users.yaml entry without `os_user`
         loads successfully. The runtime treats missing os_user as
         in-process spawn (claude's existing pattern), so config-load
         does not refuse the shape."""
-        users_yaml = tmp_path / "users.yaml"
-        users_yaml.write_text("users:\n  - telegram_id: 67890\n    name: bob\n    role: user\n")
-        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 67890\n    name: bob\n    role: user\n",
+        )
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
@@ -1691,18 +1706,17 @@ class TestCodexMemorySameUserSymmetry:
         assert config.user_configs is not None
         assert config.user_configs[67890].os_user is None
 
-    def test_codex_users_yaml_same_user_as_bot_starts_cleanly(self, tmp_path, monkeypatch):
+    def test_codex_users_yaml_same_user_as_bot_starts_cleanly(self, monkeypatch):
         """A codex-effective users.yaml entry with `os_user`
         matching the bot user loads successfully. The runtime
         detects same-user via `resolve_claude_user` and spawns
         codex in-process - the same path claude has always used
         for same-user."""
         bot_user = pwd.getpwuid(os.getuid()).pw_name
-        users_yaml = tmp_path / "users.yaml"
-        users_yaml.write_text(
-            f"users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: {bot_user}\n"
+        _patch_protected_users_yaml(
+            monkeypatch,
+            f"users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: {bot_user}\n",
         )
-        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
@@ -1711,16 +1725,15 @@ class TestCodexMemorySameUserSymmetry:
         config = load_config()
         assert config.user_configs[12345].os_user == bot_user
 
-    def test_codex_users_yaml_cross_user_os_user_passes(self, tmp_path, monkeypatch):
+    def test_codex_users_yaml_cross_user_os_user_passes(self, monkeypatch):
         """The cross-user deployment shape still works: an `os_user`
         set to a non-bot account loads cleanly and is preserved on
         the UserConfig entry. Regression guard for the multi-user
         case."""
-        users_yaml = tmp_path / "users.yaml"
-        users_yaml.write_text(
-            "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: alice_os\n"
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: alice_os\n",
         )
-        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
@@ -1751,15 +1764,14 @@ class TestMemoryReasonerModelResolution:
         assert get_model_for(ModelRole.MEMORY_EXTRACTION, "claude") == "claude-haiku-4-5-20251001"
         assert get_model_for(ModelRole.MEMORY_EPISODE, "claude") == "claude-haiku-4-5-20251001"
 
-    def test_codex_default_resolves_to_codex_model(self, tmp_path, monkeypatch):
+    def test_codex_default_resolves_to_codex_model(self, monkeypatch):
         """Codex install: registry resolves to a codex-CLI-valid SKU.
         Test path is the per-user dispatch surface that production
         will follow: AGENT_BACKEND=codex + users.yaml with os_user."""
-        users_yaml = tmp_path / "users.yaml"
-        users_yaml.write_text(
-            "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: alice_os\n"
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: alice_os\n",
         )
-        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
@@ -1883,7 +1895,7 @@ class TestRegistryValidationPerEligibleBackend:
     codex override on a global-claude install must not reach
     runtime without its codex memory-role rows being validated."""
 
-    def test_missing_codex_memory_extraction_row_systemexits(self, monkeypatch, tmp_path):
+    def test_missing_codex_memory_extraction_row_systemexits(self, monkeypatch):
         """Mixed install: AGENT_BACKEND=claude with one users.yaml
         entry pinned to `agent_backend: codex`. Patch the registry
         so the codex MEMORY_EXTRACTION row is missing; load_config
@@ -1891,13 +1903,12 @@ class TestRegistryValidationPerEligibleBackend:
         import kai.config as config_mod
         from kai.config import ModelRole
 
-        users_yaml = tmp_path / "users.yaml"
-        users_yaml.write_text(
+        _patch_protected_users_yaml(
+            monkeypatch,
             "users:\n"
             "  - telegram_id: 1\n    name: alice\n    role: admin\n"
-            "    agent_backend: codex\n    os_user: alice_os\n"
+            "    agent_backend: codex\n    os_user: alice_os\n",
         )
-        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -276,16 +276,16 @@ class TestGenerateUsersYaml:
         assert entry["os_user"] == "kai"
         assert entry["home_workspace"] == "/opt/kai/home"
 
-    def test_roundtrip_with_loader(self, tmp_path, monkeypatch):
+    def test_roundtrip_with_loader(self, monkeypatch):
         """Generated YAML can be parsed by _load_user_configs("claude", "")."""
         from kai.config import _load_user_configs
 
         content = _generate_users_yaml("123456789", "alice", os_user="kai")
-        yaml_path = tmp_path / "users.yaml"
-        yaml_path.write_text(content)
-        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
-        # Skip the protected /etc/kai/ path so we read the tmp_path copy.
-        monkeypatch.setattr("kai.config._read_protected_yaml", lambda _: None)
+        parsed = yaml.safe_load(content)
+        # The runtime loader consumes the parsed dict returned by
+        # `_read_protected_yaml`. Patch that surface directly rather
+        # than writing a file the loader no longer reads.
+        monkeypatch.setattr("kai.config._read_protected_yaml", lambda _: parsed)
         configs = _load_user_configs("claude", "")
         assert configs is not None
         assert 123456789 in configs
@@ -1093,12 +1093,48 @@ class TestCmdConfig:
 
         monkeypatch.setattr(Path, "exists", _exists_no_etc)
 
+    @staticmethod
+    def _redirect_staging(monkeypatch, tmp_path):
+        """Redirect the staging-path helper so the wizard writes under tmp_path.
+
+        Tests that exercise the first-time wizard branch read the
+        generated file back from `tmp_path / "users.yaml"`; without this
+        redirect, the wizard would write to the operator's actual
+        `~/.cache/kai-install/users.yaml` and leak across test runs.
+        """
+        monkeypatch.setattr(
+            "kai.install._install_staging_path",
+            lambda filename: tmp_path / filename,
+        )
+
+    @staticmethod
+    def _simulate_existing_etc_users_yaml(monkeypatch, content):
+        """Simulate `/etc/kai/users.yaml` already existing with the given content.
+
+        Used by tests that want to exercise the wizard's "skip user
+        prompts; summarize existing config" branch without touching the
+        real `/etc/kai/`. Patches the path's existence check AND the
+        sudo-cat reader that the wizard goes through (`Path.exists` for
+        the existence gate; `_read_users_yaml_text` for the body the
+        wizard prints a summary of).
+        """
+        _real_exists = Path.exists
+
+        def _exists_with_etc(self):
+            if str(self) == "/etc/kai/users.yaml":
+                return True
+            return _real_exists(self)
+
+        monkeypatch.setattr(Path, "exists", _exists_with_etc)
+        monkeypatch.setattr("kai.install._read_users_yaml_text", lambda path: content)
+
     def test_writes_install_conf(self, tmp_path, monkeypatch):
         """Config subcommand writes valid JSON to install.conf."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         # Simulate user inputs for each prompt (in order)
         inputs = iter(
@@ -1172,6 +1208,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         inputs = iter(
             [
@@ -1253,6 +1290,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         inputs_basic = iter(
             [
@@ -1316,6 +1354,9 @@ class TestCmdConfig:
         monkeypatch.chdir(adv_root)
         monkeypatch.setattr("kai.install.INSTALL_CONF", adv_root / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", adv_root)
+        # Redirect staging again because the leg above changed PROJECT_ROOT
+        # but the staging helper is anchored to its own filename.
+        self._redirect_staging(monkeypatch, adv_root)
 
         inputs_advanced = iter(
             [
@@ -1368,6 +1409,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         # Pre-seed existing config with goose backend so the prompt
         # appears (it is gated behind an existing non-claude value).
@@ -1423,6 +1465,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         existing = {"version": 1, "env": {"AGENT_BACKEND": "goose"}}
         conf_path.write_text(json.dumps(existing))
@@ -1491,8 +1534,10 @@ class TestCmdConfig:
         }
         conf_path.write_text(json.dumps(existing))
 
-        # Place an existing users.yaml so the wizard skips user prompts
-        (tmp_path / "users.yaml").write_text("users:\n  - telegram_id: 999\n    name: existing\n    role: admin\n")
+        # Pretend /etc/kai/users.yaml is already in place; the wizard
+        # then summarizes it and skips the user-creation prompts.
+        existing_users_yaml = "users:\n  - telegram_id: 999\n    name: existing\n    role: admin\n"
+        self._simulate_existing_etc_users_yaml(monkeypatch, existing_users_yaml)
 
         # Press Enter for everything (accept all defaults)
         monkeypatch.setattr("builtins.input", lambda prompt: "")
@@ -1503,11 +1548,11 @@ class TestCmdConfig:
         # Should preserve existing values when user accepts defaults
         assert conf["install_dir"] == "/custom/path"
         assert conf["env"]["TELEGRAM_BOT_TOKEN"] == "existing-token"
-        # users.yaml should not have been overwritten
+        # Summary path printed; the wizard never staged a new users.yaml
+        # so no top-level staging key was written.
         output = capsys.readouterr().out
         assert "already configured" in output
-        data = yaml.safe_load((tmp_path / "users.yaml").read_text())
-        assert data["users"][0]["telegram_id"] == 999
+        assert "users_yaml_staging_path" not in conf
 
     def test_validates_required_fields(self):
         """Required-field validation rejects empty input."""
@@ -1649,6 +1694,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         inputs = iter(self._base_inputs(["false"]))  # memory disabled
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
@@ -1669,6 +1715,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         inputs = iter(self._base_inputs(["false"], effort=""))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
@@ -1691,6 +1738,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         inputs = iter(self._base_inputs(["false"], effort="xhigh"))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
@@ -1719,6 +1767,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         inputs = iter(self._base_inputs(["false"], agent_backend="goose"))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
@@ -1755,6 +1804,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         # Pre-seed: an install.conf as if the operator had previously
         # configured the wizard under claude with non-default values
@@ -1791,6 +1841,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         # Memory on, extraction on, custom timeout + consolidation candidates + episode tunables + token budget + search limit.
         # Budget prompts (extraction, episode) are skipped on the claude
@@ -1851,6 +1902,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         # Every input matches the corresponding dataclass default so
         # the emission gates suppress every key in the memory block.
@@ -1892,6 +1944,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         # Inputs in wizard order: enabled, ext enabled, timeout, consolidation, classifier-window, episode timeout, dedup threshold, token budget, search limit.
         # Budget prompts (extraction, episode) are skipped on the claude
@@ -1945,7 +1998,10 @@ class TestCmdConfig:
         conf_path = tmp_path / "install.conf"
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
-        self._block_etc_kai(monkeypatch)
+        self._simulate_existing_etc_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 999\n    name: existing\n    role: admin\n",
+        )
 
         # AGENT_BACKEND seeded explicitly so the extraction-keys cleanup (non-claude pops them) doesn't depend on the wizard's implicit default.
         existing = {
@@ -1967,8 +2023,9 @@ class TestCmdConfig:
             },
         }
         conf_path.write_text(json.dumps(existing))
-        # users.yaml prevents per-user prompts that lack defaults.
-        (tmp_path / "users.yaml").write_text("users:\n  - telegram_id: 999\n    name: existing\n    role: admin\n")
+        # users.yaml is simulated above via _simulate_existing_etc_users_yaml,
+        # which keeps the wizard on the existing-config branch and skips
+        # the per-user prompts that lack defaults.
 
         monkeypatch.setattr("builtins.input", lambda prompt: "")
 
@@ -1997,6 +2054,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         # Disabling memory must strip stale keys; otherwise the daemon keeps memory live after the operator opts out.
         existing = {
@@ -2028,6 +2086,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         # Switching claude -> goose must drop extraction keys: bot.py:3609 silently ignores them on non-claude.
         # MEMORY_EXTRACTION_TIMEOUT_S seeded so the cleanup pop is exercised, not just defaulted away.
@@ -2110,6 +2169,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         memory_block = [
             "true",  # memory enabled
@@ -2150,6 +2210,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         # All other fields at default; only the classifier window is
         # non-default so the test isolates the new emission path from
@@ -2182,6 +2243,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         memory_block = [
             "true",  # memory enabled
@@ -2213,6 +2275,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         # On goose, the extraction-enabled prompt itself is skipped, so
         # memory_block is shaped like a no-extraction run. The entire
@@ -2244,6 +2307,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
 
         # Goose install: extraction is gated out, so no reasoner prompt.
         # Inputs match the existing goose-skip test shape (memory_enabled,
@@ -2365,6 +2429,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
         # Pin the model + codex-binary helpers so the test does not
         # depend on the host having codex installed or a curated
         # model registry on disk. The mock value below is a real
@@ -2435,16 +2500,24 @@ class TestCmdConfig:
         assert entry.get("os_user") is None
 
         # Integration pin: feed the produced env + users.yaml into
-        # load_config and assert it accepts the shape. Neuter the
-        # /etc/kai/ readers and PROJECT_ROOT so load_config consumes
-        # the wizard-generated artifacts under tmp_path. The
-        # oneshot-binary resolver is mocked because the test host
-        # has no codex binary; load_config validates the resolved
-        # path on the codex extraction-eligible branch.
+        # load_config and assert it accepts the shape. The wizard
+        # staged users.yaml under tmp_path; loaded by load_config via
+        # the sudo-cat shim that we redirect here so it returns the
+        # staged content for /etc/kai/users.yaml. The oneshot-binary
+        # resolver is mocked because the test host has no codex
+        # binary; load_config validates the resolved path on the
+        # codex extraction-eligible branch.
         env_block = json.loads((tmp_path / "install.conf").read_text())["env"]
+        staged_users_yaml_text = users_yaml_path.read_text()
         monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
         monkeypatch.setattr("kai.config.load_dotenv", lambda *a, **kw: None)
-        monkeypatch.setattr("kai.config._read_protected_file", lambda path: None)
+
+        def _fake_read(path):
+            if path == "/etc/kai/users.yaml":
+                return staged_users_yaml_text
+            return None
+
+        monkeypatch.setattr("kai.config._read_protected_file", _fake_read)
         monkeypatch.setattr(
             "kai.oneshot_binary.resolve_oneshot_binary",
             lambda backend: f"/fake/{backend}",
@@ -2619,7 +2692,7 @@ class TestCmdApply:
         monkeypatch.setattr("os.geteuid", lambda: 0)
         monkeypatch.setenv("DRY_RUN", "1")
 
-        def fake_apply_secrets(env, dry_run):
+        def fake_apply_secrets(env, dry_run, users_yaml_staging_path=None):
             raise SystemExit("simulated apply SystemExit (e.g. venv version gate)")
 
         def fake_start(platform, dry_run, **kw):
@@ -2651,7 +2724,7 @@ class TestCmdApply:
         class ApplyBlewUp(RuntimeError):
             pass
 
-        def fake_apply_secrets(env, dry_run):
+        def fake_apply_secrets(env, dry_run, users_yaml_staging_path=None):
             raise ApplyBlewUp("simulated apply step failure")
 
         def fake_start(platform, dry_run, **kw):
@@ -2694,28 +2767,26 @@ class TestCmdConfigDefaultModelDispatch:
         """
         Configure the wizard sandbox so users_yaml_exists=True.
 
-        Writes a users.yaml under tmp_path (PROJECT_ROOT) so the wizard
-        takes the per-user branch. Optionally seeds install.conf with the
+        Simulates `/etc/kai/users.yaml` already in place (canonical
+        path) so the wizard takes the existing-config branch and skips
+        the per-user prompts. Optionally seeds install.conf with the
         given env so existing_env reflects the desired pre-existing state.
         """
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
-        # Block /etc/kai/users.yaml detection so only tmp_path/users.yaml
-        # determines users_yaml_exists.
+        # Pretend /etc/kai/users.yaml exists with empty user list; only
+        # the presence flag matters for this dispatch test, not the
+        # content.
         _real_exists = Path.exists
 
-        def _exists_no_etc(self):
+        def _exists_with_etc(self):
             if str(self) == "/etc/kai/users.yaml":
-                return False
+                return True
             return _real_exists(self)
 
-        monkeypatch.setattr(Path, "exists", _exists_no_etc)
-
-        # Seed users.yaml; content does not matter for this dispatch test,
-        # only its presence (PROJECT_ROOT / "users.yaml").exists() drives
-        # the branch.
-        (tmp_path / "users.yaml").write_text("users: []\n")
+        monkeypatch.setattr(Path, "exists", _exists_with_etc)
+        monkeypatch.setattr("kai.install._read_users_yaml_text", lambda path: "users: []\n")
 
         if existing_env is not None:
             (tmp_path / "install.conf").write_text(json.dumps({"env": existing_env, "version": 1}))
@@ -5876,6 +5947,474 @@ class TestApplySecretsDryRun:
         output = capsys.readouterr().out
         assert "DRY RUN" in output
         assert "env" in output
+
+    def test_dry_run_users_yaml_staging_path_previewed(self, tmp_path, capsys):
+        """Dry run with a staged users.yaml previews the copy step.
+
+        Pins the dry-run contract for the canonical-users-yaml flow:
+        when the wizard recorded `users_yaml_staging_path` and the
+        file is present, apply prints the source -> destination line
+        without touching the filesystem.
+        """
+        staging = tmp_path / "users.yaml"
+        staging.write_text("users: []\n")
+        _apply_secrets(
+            {"TELEGRAM_BOT_TOKEN": "test"},
+            dry_run=True,
+            users_yaml_staging_path=str(staging),
+        )
+        output = capsys.readouterr().out
+        assert str(staging) in output
+        assert "/etc/kai/users.yaml" in output
+
+
+# ── _apply_secrets staging copy precedence ───────────────────────────
+
+
+class TestApplySecretsUsersYamlStaging:
+    """Precedence rules for the new `users_yaml_staging_path` parameter.
+
+    The presence of a non-empty path plus an existing file on disk is
+    the entire signal: anything else (None, empty string, missing file)
+    silently skips the copy.
+    """
+
+    @staticmethod
+    def _no_other_yamls(monkeypatch, tmp_path):
+        """Make `PROJECT_ROOT/services.yaml` and `workspaces.yaml` absent.
+
+        Keeps the test focused on the users.yaml staging path; the
+        legacy project-tree copy for the other two files is out of
+        scope here.
+        """
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+
+    @staticmethod
+    def _intercept_filesystem(monkeypatch):
+        """Capture copy2 / chmod / chown calls; suppress real env file write.
+
+        Returns three call-log lists the test can assert against, plus
+        a `Path.write_text` no-op that lets `_apply_secrets` skip the
+        actual `/etc/kai/env` write (the test process is unprivileged).
+        """
+        copied: list[tuple[str, str]] = []
+        chmodded: list[tuple[str, int]] = []
+        chowned: list[tuple[str, int, int]] = []
+        monkeypatch.setattr("shutil.copy2", lambda src, dst: copied.append((str(src), str(dst))))
+        monkeypatch.setattr("os.chmod", lambda path, mode: chmodded.append((str(path), mode)))
+        monkeypatch.setattr("os.chown", lambda path, uid, gid: chowned.append((str(path), uid, gid)))
+        real_write_text = Path.write_text
+
+        def _maybe_write(self, *args, **kwargs):
+            if str(self).startswith("/etc/kai/"):
+                return None
+            return real_write_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_text", _maybe_write)
+        return copied, chmodded, chowned
+
+    def test_copies_when_path_set_and_file_exists(self, tmp_path, monkeypatch):
+        """Non-empty path + existing file -> copy + 0600 + root-owned."""
+        self._no_other_yamls(monkeypatch, tmp_path)
+        copied, chmodded, chowned = self._intercept_filesystem(monkeypatch)
+        staging = tmp_path / "staged-users.yaml"
+        staging.write_text("users:\n  - telegram_id: 1\n    name: alice\n")
+
+        _apply_secrets(
+            {"TELEGRAM_BOT_TOKEN": "test"},
+            dry_run=False,
+            users_yaml_staging_path=str(staging),
+        )
+
+        users_copies = [(src, dst) for src, dst in copied if dst == "/etc/kai/users.yaml"]
+        assert users_copies == [(str(staging), "/etc/kai/users.yaml")]
+        users_modes = [m for p, m in chmodded if p == "/etc/kai/users.yaml"]
+        assert 0o600 in users_modes
+        users_owners = [(uid, gid) for p, uid, gid in chowned if p == "/etc/kai/users.yaml"]
+        assert (0, 0) in users_owners
+
+    def test_skips_when_path_is_none(self, tmp_path, monkeypatch):
+        """No staging path -> no users.yaml copy."""
+        self._no_other_yamls(monkeypatch, tmp_path)
+        copied, _, _ = self._intercept_filesystem(monkeypatch)
+
+        _apply_secrets({"TELEGRAM_BOT_TOKEN": "test"}, dry_run=False, users_yaml_staging_path=None)
+
+        assert not any(dst.endswith("users.yaml") for _src, dst in copied)
+
+    def test_skips_when_path_is_empty_string(self, tmp_path, monkeypatch):
+        """Empty string -> treated as None; no copy."""
+        self._no_other_yamls(monkeypatch, tmp_path)
+        copied, _, _ = self._intercept_filesystem(monkeypatch)
+
+        _apply_secrets({"TELEGRAM_BOT_TOKEN": "test"}, dry_run=False, users_yaml_staging_path="")
+
+        assert not any(dst.endswith("users.yaml") for _src, dst in copied)
+
+    def test_skips_when_path_set_but_file_missing(self, tmp_path, monkeypatch):
+        """Non-empty path that points at a missing file -> no copy, no error.
+
+        A hand-edited install.conf with a stale staging path silently
+        skips rather than failing the apply. The defensive check
+        protects the operator from a partial-install failure mode.
+        """
+        self._no_other_yamls(monkeypatch, tmp_path)
+        copied, _, _ = self._intercept_filesystem(monkeypatch)
+
+        _apply_secrets(
+            {"TELEGRAM_BOT_TOKEN": "test"},
+            dry_run=False,
+            users_yaml_staging_path=str(tmp_path / "does-not-exist.yaml"),
+        )
+
+        assert not any(dst.endswith("users.yaml") for _src, dst in copied)
+
+
+# ── _strip_install_conf_keys helper ──────────────────────────────────
+
+
+class TestStripInstallConfKeys:
+    """Unit coverage for the install.conf top-level key remover used
+    by `_cmd_apply` to drop the one-shot `users_yaml_staging_path`
+    after a successful apply.
+    """
+
+    def test_strips_named_key_only(self, tmp_path, monkeypatch):
+        """Targeted key removed; siblings preserved; mode stays 0600."""
+        from kai.install import _strip_install_conf_keys
+
+        conf_path = tmp_path / "install.conf"
+        original = {
+            "version": 1,
+            "install_dir": "/opt/kai",
+            "users_yaml_staging_path": "/tmp/staged",
+            "env": {"TELEGRAM_BOT_TOKEN": "tok"},
+        }
+        conf_path.write_text(json.dumps(original, indent=2) + "\n")
+        os.chmod(conf_path, 0o600)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+
+        _strip_install_conf_keys("users_yaml_staging_path")
+
+        rewritten = json.loads(conf_path.read_text())
+        assert "users_yaml_staging_path" not in rewritten
+        assert rewritten["version"] == 1
+        assert rewritten["install_dir"] == "/opt/kai"
+        assert rewritten["env"] == {"TELEGRAM_BOT_TOKEN": "tok"}
+        assert stat.S_IMODE(conf_path.stat().st_mode) == 0o600
+
+    def test_idempotent_when_key_absent(self, tmp_path, monkeypatch):
+        """A second call (or a call against a conf that never had the
+        key) is a no-op rather than an error.
+        """
+        from kai.install import _strip_install_conf_keys
+
+        conf_path = tmp_path / "install.conf"
+        conf_path.write_text(json.dumps({"version": 1, "env": {}}, indent=2) + "\n")
+        os.chmod(conf_path, 0o600)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+
+        _strip_install_conf_keys("users_yaml_staging_path")
+        _strip_install_conf_keys("users_yaml_staging_path")
+
+        rewritten = json.loads(conf_path.read_text())
+        assert rewritten == {"version": 1, "env": {}}
+
+    def test_missing_conf_is_noop(self, tmp_path, monkeypatch):
+        """No install.conf on disk -> silent no-op, not a SystemExit."""
+        from kai.install import _strip_install_conf_keys
+
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "nope.conf")
+        _strip_install_conf_keys("users_yaml_staging_path")
+
+
+# ── _cmd_config: users.yaml canonicalization ─────────────────────────
+
+
+class TestCmdConfigCanonicalUsersYaml:
+    """The wizard reads /etc/kai/users.yaml only and writes any new
+    file to a per-operator staging path recorded as a top-level
+    install.conf key, never inside the env dict.
+    """
+
+    @staticmethod
+    def _base_inputs() -> list[str]:
+        """Inputs that drive the wizard through a minimal first-install
+        flow (no advanced options, claude backend, no memory, no
+        external services).
+        """
+        return [
+            "/opt/kai",
+            "/var/lib/kai",
+            "kai",
+            "darwin",
+            "fake-token",
+            "12345",  # admin telegram id
+            "admin",  # admin name
+            "false",  # advanced
+            "polling",
+            "claude",
+            "sonnet",
+            "120",
+            "10.0",
+            "200000",
+            "80",
+            "",  # effort level (default)
+            "8080",
+            "test-secret",
+            "~/Projects",
+            "",
+            "false",
+            "900",
+            "1.0",
+            "false",
+            "",
+            "false",
+            "false",
+            "",  # claude_user
+            "false",  # memory enabled
+            "",  # perplexity key
+        ]
+
+    def test_stray_project_root_users_yaml_warns_and_is_ignored(self, tmp_path, monkeypatch, capsys):
+        """Stray PROJECT_ROOT/users.yaml triggers a deprecation notice
+        and the wizard still treats the install as first-time.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        TestCmdConfig._block_etc_kai(monkeypatch)
+        TestCmdConfig._redirect_staging(monkeypatch, tmp_path)
+
+        stray = tmp_path / "users.yaml"
+        stray.write_text("users:\n  - telegram_id: 999\n    name: stale\n    role: admin\n")
+
+        inputs = iter(self._base_inputs())
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        _cmd_config()
+
+        output = capsys.readouterr().out
+        assert str(stray) in output
+        assert "no longer used" in output
+        # Wizard ignored the stray file: it prompted for a new admin
+        # and produced a fresh staging file at the redirected location.
+        # The redirect maps "users.yaml" -> tmp_path/users.yaml, which
+        # IS the stray path we wrote above. So the generated content
+        # overwrote the stray. Verify by parsing for the wizard-supplied
+        # telegram_id (12345), not the stray (999).
+        staged = yaml.safe_load(stray.read_text())
+        assert staged["users"][0]["telegram_id"] == 12345
+
+    def test_first_time_install_records_top_level_staging_path(self, tmp_path, monkeypatch):
+        """install.conf carries `users_yaml_staging_path` at the top
+        level, NOT inside the env dict.
+        """
+        monkeypatch.chdir(tmp_path)
+        conf_path = tmp_path / "install.conf"
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        TestCmdConfig._block_etc_kai(monkeypatch)
+        # Use a sibling staging location so we can distinguish "top-level
+        # key matches the actual staging path" from "test stuffed the
+        # value via redirect at tmp_path/users.yaml".
+        staging_dir = tmp_path / "stage"
+        staging_dir.mkdir()
+        monkeypatch.setattr(
+            "kai.install._install_staging_path",
+            lambda filename: staging_dir / filename,
+        )
+
+        inputs = iter(self._base_inputs())
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        _cmd_config()
+
+        conf = json.loads(conf_path.read_text())
+        assert "users_yaml_staging_path" in conf
+        assert conf["users_yaml_staging_path"] == str(staging_dir / "users.yaml")
+        # MUST NOT leak into env (would otherwise reach /etc/kai/env as
+        # runtime daemon configuration).
+        assert "users_yaml_staging_path" not in conf["env"]
+        assert "USERS_YAML_STAGING_PATH" not in conf["env"]
+
+    def test_env_file_does_not_carry_staging_path(self, tmp_path, monkeypatch):
+        """Regression guard: `_generate_env_file(env)` never emits a
+        `USERS_YAML_STAGING_PATH` line. Pins the schema discipline that
+        keeps installer metadata out of `/etc/kai/env`.
+        """
+        monkeypatch.chdir(tmp_path)
+        conf_path = tmp_path / "install.conf"
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        TestCmdConfig._block_etc_kai(monkeypatch)
+        TestCmdConfig._redirect_staging(monkeypatch, tmp_path)
+
+        inputs = iter(self._base_inputs())
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        _cmd_config()
+
+        env = json.loads(conf_path.read_text())["env"]
+        rendered = _generate_env_file(env)
+        assert "USERS_YAML_STAGING_PATH" not in rendered
+
+
+# ── _cmd_apply: staging handoff ──────────────────────────────────────
+
+
+class TestCmdApplyStagingHandoff:
+    """`_cmd_apply` consumes the top-level `users_yaml_staging_path`
+    key from install.conf, threads it through to `_apply_secrets`, and
+    cleans up the staging file plus the conf key after the apply
+    succeeds (real run only; dry-run preserves both for a retry).
+    """
+
+    @staticmethod
+    def _minimal_conf(tmp_path, staging_path: str | None) -> Path:
+        """Write a minimal install.conf the apply path can validate.
+
+        Mirrors what `_cmd_config` would have produced for a claude
+        backend install. When `staging_path` is non-empty, persists it
+        as the top-level key the apply expects.
+        """
+        conf = {
+            "version": 1,
+            "install_dir": str(tmp_path / "opt-kai"),
+            "data_dir": str(tmp_path / "var-lib-kai"),
+            "service_user": "kai",
+            "platform": "darwin",
+            "env": {
+                "TELEGRAM_BOT_TOKEN": "tok",
+                "WEBHOOK_SECRET": "secret",
+                "DEFAULT_MODEL": "sonnet",
+                "AGENT_BACKEND": "claude",
+            },
+        }
+        if staging_path is not None:
+            conf["users_yaml_staging_path"] = staging_path
+        path = tmp_path / "install.conf"
+        path.write_text(json.dumps(conf, indent=2) + "\n")
+        os.chmod(path, 0o600)
+        return path
+
+    @staticmethod
+    def _stub_apply_internals(monkeypatch, captured: dict) -> None:
+        """Stub everything except staging-handoff cleanup.
+
+        The test runs as a non-root user so the real apply steps
+        cannot mutate `/etc/`. We replace each step with a stub and
+        capture the `users_yaml_staging_path` kwarg that flowed into
+        `_apply_secrets`.
+        """
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+
+        class _FakePwd:
+            pw_uid = 4242
+            pw_gid = 4242
+
+        monkeypatch.setattr("pwd.getpwnam", lambda name: _FakePwd)
+
+        def _fake_apply_secrets(env, dry_run, users_yaml_staging_path=None):
+            captured["users_yaml_staging_path"] = users_yaml_staging_path
+
+        monkeypatch.setattr("kai.install._stop_service", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_directories", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_source", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_venv", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_models", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_secrets", _fake_apply_secrets)
+        monkeypatch.setattr("kai.install._apply_sudoers", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_migrate", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_service", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._start_service", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._check_traversal", lambda *a, **kw: None)
+
+    def test_real_apply_unlinks_and_strips(self, tmp_path, monkeypatch):
+        """Successful real apply removes the staging file AND drops the
+        top-level conf key, preserving env and other top-level keys.
+        """
+        staging = tmp_path / "users.yaml"
+        staging.write_text("users: []\n")
+        conf_path = self._minimal_conf(tmp_path, str(staging))
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.delenv("DRY_RUN", raising=False)
+        captured: dict = {}
+        self._stub_apply_internals(monkeypatch, captured)
+
+        _cmd_apply()
+
+        # _apply_secrets received the staging path from the top-level key.
+        assert captured["users_yaml_staging_path"] == str(staging)
+        # Cleanup removed the staging file and the conf key.
+        assert not staging.exists()
+        rewritten = json.loads(conf_path.read_text())
+        assert "users_yaml_staging_path" not in rewritten
+        assert rewritten["env"]["TELEGRAM_BOT_TOKEN"] == "tok"
+        assert rewritten["install_dir"] == str(tmp_path / "opt-kai")
+        # Mode preservation: install.conf still carries secrets.
+        assert stat.S_IMODE(conf_path.stat().st_mode) == 0o600
+
+    def test_dry_run_preserves_staging_and_conf_key(self, tmp_path, monkeypatch, capsys):
+        """DRY_RUN=1 must leave the staging file in place AND keep the
+        top-level conf key so a subsequent real apply completes the
+        handoff exactly as if the dry run had never happened.
+        """
+        staging = tmp_path / "users.yaml"
+        staging.write_text("users: []\n")
+        conf_path = self._minimal_conf(tmp_path, str(staging))
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setenv("DRY_RUN", "1")
+        captured: dict = {}
+        self._stub_apply_internals(monkeypatch, captured)
+
+        _cmd_apply()
+
+        assert staging.exists()
+        rewritten = json.loads(conf_path.read_text())
+        assert rewritten.get("users_yaml_staging_path") == str(staging)
+        # Operator-visible notice that the dry run skipped the cleanup.
+        out = capsys.readouterr().out
+        assert "[DRY RUN] Would unlink staging file" in out
+        assert "[DRY RUN] Would strip users_yaml_staging_path" in out
+
+    def test_no_staging_path_means_no_cleanup(self, tmp_path, monkeypatch):
+        """install.conf without the top-level key -> apply does not
+        invent a path or attempt cleanup; `_apply_secrets` receives None.
+        """
+        conf_path = self._minimal_conf(tmp_path, staging_path=None)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.delenv("DRY_RUN", raising=False)
+        captured: dict = {}
+        self._stub_apply_internals(monkeypatch, captured)
+
+        _cmd_apply()
+
+        assert captured["users_yaml_staging_path"] is None
+        rewritten = json.loads(conf_path.read_text())
+        assert "users_yaml_staging_path" not in rewritten
+
+    def test_home_mismatch_resolved_via_conf_key(self, tmp_path, monkeypatch):
+        """Apply locates the staging file from install.conf even when
+        HOME differs from the HOME under which `make config` ran.
+        Pins the cross-account contract: the wizard runs as the
+        operator; apply runs as root. They share the recorded path,
+        not `Path.home()`.
+        """
+        operator_cache = tmp_path / "operator-cache"
+        operator_cache.mkdir()
+        staging = operator_cache / "users.yaml"
+        staging.write_text("users: []\n")
+        conf_path = self._minimal_conf(tmp_path, str(staging))
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.delenv("DRY_RUN", raising=False)
+        # Apply-side HOME points somewhere unrelated to the operator
+        # cache; the only signal that survives is the recorded path.
+        monkeypatch.setenv("HOME", str(tmp_path / "root-home"))
+        captured: dict = {}
+        self._stub_apply_internals(monkeypatch, captured)
+
+        _cmd_apply()
+
+        assert captured["users_yaml_staging_path"] == str(staging)
+        assert not staging.exists()
 
 
 # ── _apply_sudoers dry run ───────────────────────────────────────────

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -15,8 +15,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from kai.config import (
+    _YAML_MALFORMED,
     Config,
     UserConfig,
     _load_user_configs,
@@ -94,18 +96,22 @@ class TestUserConfig:
 
 
 class TestLoadUserConfigs:
-    def _write_yaml(self, tmp_path, content):
-        """Write a users.yaml file."""
-        yaml_file = tmp_path / "users.yaml"
-        yaml_file.write_text(textwrap.dedent(content))
-        return yaml_file
+    def _yaml_dict(self, content):
+        """Parse YAML content as the loader would see it after sudo-cat.
+
+        The runtime path is `_read_protected_yaml('users.yaml')` which
+        returns a parsed dict (or `_YAML_MALFORMED` / None). Tests patch
+        that function with the dict this helper produces; no file is
+        written because the loader no longer reads from PROJECT_ROOT.
+        """
+        result = yaml.safe_load(textwrap.dedent(content))
+        return result if isinstance(result, dict) else _YAML_MALFORMED
 
     def test_basic_loading(self, tmp_path):
         """Loads two users with correct fields."""
         ws = tmp_path / "ws"
         ws.mkdir()
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             f"""\
             users:
               - telegram_id: 111
@@ -121,8 +127,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
 
@@ -137,39 +142,42 @@ class TestLoadUserConfigs:
         assert configs[222].name == "bob"
         assert configs[222].role == "user"
 
-    def test_missing_file(self, tmp_path):
-        """Returns None when no YAML file exists."""
-        with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
-        ):
+    def test_missing_file(self):
+        """Returns None when /etc/kai/users.yaml is absent.
+
+        The protected reader returns None for missing files (distinct
+        from `_YAML_MALFORMED`); the loader maps that to None so the
+        caller falls back to the legacy ALLOWED_USER_IDS path.
+        """
+        with patch("kai.config._read_protected_yaml", return_value=None):
             configs = _load_user_configs("claude", "")
         assert configs is None
 
-    def test_empty_file(self, tmp_path):
-        """Returns None for an empty YAML file."""
-        self._write_yaml(tmp_path, "")
-        with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
-        ):
+    def test_empty_file(self):
+        """Returns None when /etc/kai/users.yaml exists but is empty.
+
+        The protected reader normalizes an empty / non-dict top-level
+        to `_YAML_MALFORMED`; the loader treats that as "fail closed"
+        and returns None rather than silently constructing an empty
+        config.
+        """
+        with patch("kai.config._read_protected_yaml", return_value=_YAML_MALFORMED):
             configs = _load_user_configs("claude", "")
         assert configs is None
 
-    def test_invalid_yaml(self, tmp_path):
-        """Returns None for malformed YAML."""
-        (tmp_path / "users.yaml").write_text("{{bad yaml[")
-        with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
-        ):
+    def test_invalid_yaml(self):
+        """Returns None when /etc/kai/users.yaml is malformed.
+
+        Same code path as the empty-file case: the protected reader
+        already raised on parse and returned `_YAML_MALFORMED`.
+        """
+        with patch("kai.config._read_protected_yaml", return_value=_YAML_MALFORMED):
             configs = _load_user_configs("claude", "")
         assert configs is None
 
     def test_missing_telegram_id(self, tmp_path):
         """Entry without telegram_id is skipped."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - name: alice
@@ -177,8 +185,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -186,8 +193,7 @@ class TestLoadUserConfigs:
 
     def test_whitespace_only_name(self, tmp_path):
         """Whitespace-only name is treated as missing."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -195,8 +201,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -204,8 +209,7 @@ class TestLoadUserConfigs:
 
     def test_missing_name(self, tmp_path):
         """Entry without name is skipped."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -213,8 +217,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -222,8 +225,7 @@ class TestLoadUserConfigs:
 
     def test_invalid_role(self, tmp_path):
         """Invalid role causes the entry to be skipped."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -232,8 +234,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -241,8 +242,7 @@ class TestLoadUserConfigs:
 
     def test_invalid_budget(self, tmp_path):
         """Negative budget causes the entry to be skipped."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -251,8 +251,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -260,8 +259,7 @@ class TestLoadUserConfigs:
 
     def test_bool_budget_rejected(self, tmp_path):
         """Boolean budget is rejected (same bool guard as workspace config)."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -270,8 +268,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -279,8 +276,7 @@ class TestLoadUserConfigs:
 
     def test_bool_telegram_id_rejected(self, tmp_path):
         """Boolean telegram_id is rejected."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: true
@@ -288,8 +284,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -297,8 +292,7 @@ class TestLoadUserConfigs:
 
     def test_duplicate_ids(self, tmp_path):
         """Duplicate telegram_id: first wins."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -308,8 +302,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -318,8 +311,7 @@ class TestLoadUserConfigs:
 
     def test_home_workspace_empty_string(self, tmp_path):
         """Empty home_workspace string is treated as None, not CWD."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -328,8 +320,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -338,8 +329,7 @@ class TestLoadUserConfigs:
 
     def test_home_workspace_nonexistent_warns_but_keeps_user(self, tmp_path):
         """Non-existent home_workspace warns and falls back to None, not skip."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -348,8 +338,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -357,18 +346,36 @@ class TestLoadUserConfigs:
         # home_workspace falls back to None (global default)
         assert configs[111].home_workspace is None
 
-    def test_protected_installation_tried_first(self, tmp_path):
-        """Protected file (/etc/kai/users.yaml) is tried before local."""
+    def test_protected_path_is_the_only_path(self, tmp_path):
+        """`/etc/kai/users.yaml` is canonical; the loader reads it via
+        `_read_protected_yaml` and uses whatever that returns.
+        """
         protected_data = {"users": [{"telegram_id": 111, "name": "alice", "role": "admin"}]}
         with patch("kai.config._read_protected_yaml", return_value=protected_data):
             configs = _load_user_configs("claude", "")
         assert configs is not None
         assert configs[111].name == "alice"
 
+    def test_stray_project_root_users_yaml_is_ignored(self, tmp_path):
+        """A stray `PROJECT_ROOT/users.yaml` does not affect the loader.
+
+        The dual-path fallback was removed: when the protected reader
+        returns None (canonical file absent), the loader returns None
+        and the caller falls back to ALLOWED_USER_IDS. A leftover
+        users.yaml inside the source tree must not feed the daemon.
+        """
+        stray = tmp_path / "users.yaml"
+        stray.write_text("users:\n  - telegram_id: 999\n    name: stray\n    role: admin\n")
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            patch("kai.config.PROJECT_ROOT", tmp_path),
+        ):
+            configs = _load_user_configs("claude", "")
+        assert configs is None
+
     def test_no_admin_warning(self, tmp_path, caplog):
         """All users with role 'user' logs a warning but does not fail."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -380,8 +387,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -390,8 +396,7 @@ class TestLoadUserConfigs:
 
     def test_default_role_is_user(self, tmp_path):
         """Omitting role defaults to 'user'."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -399,8 +404,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -408,8 +412,7 @@ class TestLoadUserConfigs:
 
     def test_os_user_stored(self, tmp_path):
         """os_user is stored as a string (not validated in Phase 1)."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -418,8 +421,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -429,8 +431,7 @@ class TestLoadUserConfigs:
 
     def test_model_parsed(self, tmp_path):
         """Valid model name is stored, lowercased."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -439,8 +440,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -448,8 +448,7 @@ class TestLoadUserConfigs:
 
     def test_invalid_model_ignored(self, tmp_path, caplog):
         """Invalid model name is ignored (set to None), user still loads."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -458,8 +457,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -468,8 +466,7 @@ class TestLoadUserConfigs:
 
     def test_timeout_parsed(self, tmp_path):
         """Valid timeout is stored as int."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -478,8 +475,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -487,8 +483,7 @@ class TestLoadUserConfigs:
 
     def test_invalid_timeout_ignored(self, tmp_path, caplog):
         """Negative timeout is ignored, user still loads."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -497,8 +492,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -507,8 +501,7 @@ class TestLoadUserConfigs:
 
     def test_context_window_parsed(self, tmp_path):
         """Valid context_window is stored as int."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -517,8 +510,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -526,8 +518,7 @@ class TestLoadUserConfigs:
 
     def test_context_window_zero_allowed(self, tmp_path):
         """context_window of 0 means 'use default' and is valid."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -536,8 +527,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -545,8 +535,7 @@ class TestLoadUserConfigs:
 
     def test_context_window_below_minimum_ignored(self, tmp_path, caplog):
         """context_window below 50000 (and not 0) is ignored."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -555,8 +544,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -565,8 +553,7 @@ class TestLoadUserConfigs:
 
     def test_new_fields_default_none(self, tmp_path):
         """New optional fields default to None when omitted."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -574,8 +561,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -594,8 +580,7 @@ class TestLoadUserConfigs:
         """Valid workspace_base directory is stored as resolved Path."""
         ws_base = tmp_path / "projects"
         ws_base.mkdir()
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             f"""\
             users:
               - telegram_id: 111
@@ -604,8 +589,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -613,8 +597,7 @@ class TestLoadUserConfigs:
 
     def test_workspace_base_missing_dir_warns(self, tmp_path, caplog):
         """Non-existent workspace_base warns and falls back to None."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -623,8 +606,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -634,8 +616,7 @@ class TestLoadUserConfigs:
 
     def test_workspace_base_empty_string(self, tmp_path):
         """Empty workspace_base string is treated as None."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -644,8 +625,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -655,8 +635,7 @@ class TestLoadUserConfigs:
 
     def test_github_repos_parsed(self, tmp_path):
         """Valid github_repos list is stored as list of strings."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -667,8 +646,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -676,8 +654,7 @@ class TestLoadUserConfigs:
 
     def test_github_repos_invalid_format(self, tmp_path, caplog):
         """Invalid repo format (no slash) is skipped with warning."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -692,8 +669,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -703,8 +679,7 @@ class TestLoadUserConfigs:
 
     def test_github_repos_not_list(self, tmp_path, caplog):
         """Non-list github_repos is ignored with warning."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -713,8 +688,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -723,8 +697,7 @@ class TestLoadUserConfigs:
 
     def test_github_repos_default(self, tmp_path):
         """Omitted github_repos defaults to empty list."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -732,8 +705,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -743,8 +715,7 @@ class TestLoadUserConfigs:
 
     def test_github_notify_chat_id_parsed(self, tmp_path):
         """Valid github_notify_chat_id is stored as int."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -753,8 +724,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -762,8 +732,7 @@ class TestLoadUserConfigs:
 
     def test_github_notify_chat_id_negative(self, tmp_path):
         """Negative chat IDs (group chats) are valid."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -772,8 +741,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -781,8 +749,7 @@ class TestLoadUserConfigs:
 
     def test_github_notify_chat_id_invalid(self, tmp_path, caplog):
         """Invalid github_notify_chat_id warns and uses None."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -791,8 +758,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -803,8 +769,7 @@ class TestLoadUserConfigs:
 
     def test_pr_review_bool(self, tmp_path):
         """pr_review True/False parsed from yaml."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -816,8 +781,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -826,8 +790,7 @@ class TestLoadUserConfigs:
 
     def test_pr_review_none_when_omitted(self, tmp_path):
         """Omitted pr_review defaults to None (use global)."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -835,8 +798,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -844,8 +806,7 @@ class TestLoadUserConfigs:
 
     def test_issue_triage_bool(self, tmp_path):
         """issue_triage True/False parsed from yaml."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -854,8 +815,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -863,8 +823,7 @@ class TestLoadUserConfigs:
 
     def test_pr_review_non_bool_warns(self, tmp_path, caplog):
         """Non-boolean pr_review warns and uses None."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -873,8 +832,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -884,8 +842,7 @@ class TestLoadUserConfigs:
 
     def test_issue_triage_non_bool_warns(self, tmp_path, caplog):
         """Non-boolean issue_triage warns and uses None."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -894,8 +851,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -906,8 +862,7 @@ class TestLoadUserConfigs:
 
     def test_valid_agent_backend(self, tmp_path):
         """Valid agent_backend is parsed and stored."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -918,8 +873,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -929,8 +883,7 @@ class TestLoadUserConfigs:
 
     def test_invalid_agent_backend_exits(self, tmp_path):
         """Invalid agent_backend causes SystemExit."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -939,16 +892,14 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
             pytest.raises(SystemExit, match="invalid agent_backend"),
         ):
             _load_user_configs("claude", "")
 
     def test_invalid_llm_provider_exits(self, tmp_path):
         """Invalid llm_provider for the user's backend causes SystemExit."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -958,16 +909,14 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
             pytest.raises(SystemExit, match="invalid llm_provider"),
         ):
             _load_user_configs("claude", "")
 
     def test_goose_backend_without_provider_exits(self, tmp_path):
         """Goose backend with no resolvable provider is a fatal error."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -976,8 +925,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
             # Global provider is "" (empty), user has none set
             pytest.raises(SystemExit, match="no llm_provider"),
         ):
@@ -985,8 +933,7 @@ class TestLoadUserConfigs:
 
     def test_goose_backend_inherits_global_provider(self, tmp_path):
         """User with goose backend inherits global llm_provider."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -996,8 +943,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             # Global provider is "openai"
             configs = _load_user_configs("goose", "openai")
@@ -1008,8 +954,7 @@ class TestLoadUserConfigs:
 
     def test_model_validated_against_user_provider(self, tmp_path):
         """Model invalid for user's effective provider is rejected."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -1020,8 +965,7 @@ class TestLoadUserConfigs:
             """,
         )
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
@@ -1030,8 +974,7 @@ class TestLoadUserConfigs:
 
     def test_open_ended_provider_warns_no_model(self, tmp_path, caplog):
         """Open-ended provider with no model emits a warning."""
-        self._write_yaml(
-            tmp_path,
+        data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
@@ -1043,8 +986,7 @@ class TestLoadUserConfigs:
         import logging
 
         with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
+            patch("kai.config._read_protected_yaml", return_value=data),
             caplog.at_level(logging.WARNING, logger="kai.config"),
         ):
             configs = _load_user_configs("claude", "")


### PR DESCRIPTION
## Summary

- The wizard, the apply step, and the runtime daemon all stop reading `PROJECT_ROOT/users.yaml`. `/etc/kai/users.yaml` is canonical.
- First-time installs stage the generated file at `~/.cache/kai-install/users.yaml`. The path is persisted as a top-level `users_yaml_staging_path` key in `install.conf`, alongside `version` / `install_dir` / `env`, NOT inside the env dict. That keeps the staging path out of `/etc/kai/env`, which is runtime daemon configuration.
- `_apply_secrets` gains an explicit `users_yaml_staging_path` parameter and copies from the recorded path when a readable file is present. `_cmd_apply` reads the top-level key, threads it through, then on `apply_succeeded = True` unlinks the staging file and strips the conf key via the new `_strip_install_conf_keys` helper. The cleanup is gated on `not dry_run` so a dry run preserves both the file and the key for a clean real-apply retry.
- A stray `PROJECT_ROOT/users.yaml` from a prior install cycle triggers a one-line deprecation notice at wizard start and is otherwise ignored. The runtime loader returns `None` (fall-through to legacy `ALLOWED_USER_IDS`) rather than reading a stray file.
- `services.yaml` and `workspaces.yaml` still copy from `PROJECT_ROOT`; the asymmetry is documented in-code via a TODO. They follow in separate issues.

Closes #557.

## Test plan

- [x] `make check` clean
- [x] `make test` clean (3652 passed)
- [x] New unit coverage for `_strip_install_conf_keys` (strip + idempotent + missing-conf no-op)
- [x] New precedence coverage for `_apply_secrets(users_yaml_staging_path=...)` (copy on path+file; skip on None / empty / missing file)
- [x] New regression: `_generate_env_file(env)` never emits `USERS_YAML_STAGING_PATH`
- [x] New regression: stray `PROJECT_ROOT/users.yaml` warns and the wizard still treats the install as first-time
- [x] New regression: `install.conf` carries `users_yaml_staging_path` at the top level, not inside `env`
- [x] New regression: real apply unlinks staging + strips conf key; dry-run preserves both with operator-visible notices
- [x] New regression: HOME mismatch between `make config` and `sudo make install` resolves via the recorded path
- [x] New regression: stray `PROJECT_ROOT/users.yaml` does not affect runtime when `/etc/kai/users.yaml` is absent (daemon falls through to legacy auth)
- [ ] Manual smoke A: existing install with `/etc/kai/users.yaml` and no staging file
- [ ] Manual smoke B: fresh install (no `/etc/kai/users.yaml`)
- [ ] Manual smoke C: stale `PROJECT_ROOT/users.yaml` present alongside a real `/etc/kai/users.yaml`
