### PR TITLE
fix(install): prompt for global defaults regardless of users.yaml

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -806,29 +806,36 @@ def _cmd_config() -> None:
         return PROVIDER_DEFAULTS.get(eff_provider, "")
 
     print("-- Claude --")
-    # Re-validate any existing DEFAULT_MODEL against the (possibly
-    # newly chosen) backend so a switch from claude to codex doesn't
-    # silently keep an anthropic model. Backend-aware, not provider-
-    # only: codex rejects gpt-5.4-nano even though it's valid for
-    # goose-on-openai. Empty raw_existing_model fails validation for
-    # any curated backend; the _prompt(required=True) branch in
+    # DEFAULT_MODEL is an inheritable installation default; the prompt
+    # fires on every wizard run with the existing env value prefilled
+    # when it validates for the (possibly newly chosen) backend.
+    # Always routing through _prompt_default_model is load-bearing for
+    # the operator who wants to change the global model without
+    # changing backends: the previous "keep silently on valid match"
+    # shortcut left them with no path to update it via the wizard.
+    #
+    # Re-validation is backend-aware, not provider-only: codex rejects
+    # gpt-5.4-nano even though it's valid for goose-on-openai, so a
+    # backend switch with a model that lives only on the prior surface
+    # falls through to the curated default. Empty raw_existing_model
+    # also fails validation; the _prompt(required=True) branch in
     # _prompt_default_model handles the open-ended case.
+    #
+    # When the existing value fails validation, the rejection reason
+    # is printed and the prefill becomes the backend-aware default
+    # rather than the rejected value, because _prompt_default_model
+    # returns its default parameter without re-validating against the
+    # choices list. Prefilling the bad value would let the operator
+    # accept the just-rejected value with Enter.
     raw_existing_model = existing_env.get("DEFAULT_MODEL", existing_env.get("CLAUDE_MODEL", ""))
     if raw_existing_model and validate_model_for_backend(raw_existing_model, agent_backend, eff_provider):
-        model = raw_existing_model
+        default_model_prefill_value = raw_existing_model
     else:
         if raw_existing_model:
-            # Surface the rejection reason so the operator sees why the
-            # prior value is being re-prompted rather than getting a
-            # bare default with no explanation.
             surface = "codex" if agent_backend == "codex" else f"provider '{eff_provider}'"
             print(f"  DEFAULT_MODEL '{raw_existing_model}' is not valid for {surface}. Please choose a new default.")
-        # Prefill uses the backend-aware default rather than the
-        # rejected raw_existing_model. _prompt_default_model returns
-        # its default parameter without validating it against the
-        # choices list, so prefilling the bad value would let the
-        # operator accept the just-rejected value with Enter.
-        model = _prompt_default_model(agent_backend, eff_provider, _default_model_prefill())
+        default_model_prefill_value = _default_model_prefill()
+    model = _prompt_default_model(agent_backend, eff_provider, default_model_prefill_value)
 
     while True:
         # AGENT_TIMEOUT_SECONDS is canonical; legacy

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -779,9 +779,17 @@ def _cmd_config() -> None:
     print()
 
     # -- Claude --
-    # When users.yaml exists, model/timeout/budget/context are per-user
-    # settings managed via /settings commands or users.yaml fields.
-    # Only prompt for truly global Claude settings (autocompact).
+    # DEFAULT_MODEL, AGENT_TIMEOUT_SECONDS, BUDGET_CEILING, and
+    # CLAUDE_MAX_CONTEXT_WINDOW are inheritable installation defaults:
+    # users.yaml entries that omit a per-user override fall back to
+    # these values at runtime. The prompts therefore fire on every
+    # wizard run regardless of users.yaml presence. The previous
+    # users_yaml_exists gate skipped them entirely on the
+    # re-run-with-users.yaml path, which let a stale global model
+    # survive a backend switch (the operator-visible bug: switching
+    # AGENT_BACKEND from one model surface to another left the prior
+    # value unchanged because the re-validation path never ran).
+    #
     # Determine the effective provider for model choices. Claude
     # backend always uses Anthropic; Goose uses the selected provider.
     eff_provider = "anthropic" if agent_backend == "claude" else llm_provider
@@ -797,98 +805,78 @@ def _cmd_config() -> None:
             return CODEX_DEFAULT_MODEL
         return PROVIDER_DEFAULTS.get(eff_provider, "")
 
-    if users_yaml_exists:
-        print("-- Claude --")
-        print("  Model, timeout, budget, and context window are now per-user.")
-        print("  Set defaults in users.yaml or let users configure via /settings.")
-        # Read DEFAULT_MODEL, falling back to CLAUDE_MODEL for backward compat
-        existing_model = existing_env.get("DEFAULT_MODEL", existing_env.get("CLAUDE_MODEL", ""))
-        # Re-validate the existing value against the (possibly newly chosen)
-        # backend - backend-aware, not provider-only, so codex rejects
-        # gpt-5.4-nano even though it's valid for goose-on-openai.
-        # Empty existing_model fails validation for any curated backend;
-        # the _prompt(required=True) branch in _prompt_default_model
-        # handles the open-ended case.
-        if existing_model and validate_model_for_backend(existing_model, agent_backend, eff_provider):
-            model = existing_model
-        else:
-            if existing_model:
-                surface = "codex" if agent_backend == "codex" else f"provider '{eff_provider}'"
-                print(f"  DEFAULT_MODEL '{existing_model}' is not valid for {surface}. Please choose a new default.")
-            # Prefill always uses the backend-aware default rather than
-            # existing_env["DEFAULT_MODEL"]. We entered this branch because
-            # the existing value is missing or invalid; offering it as the
-            # prefill would let the operator accept the just-rejected value
-            # with Enter, since _prompt_choice returns its default parameter
-            # without validating it against the choices list.
-            model = _prompt_default_model(agent_backend, eff_provider, _default_model_prefill())
-        # AGENT_TIMEOUT_SECONDS is the canonical key; fall back to the
-        # legacy CLAUDE_TIMEOUT_SECONDS for installs that haven't re-run
-        # the wizard since the rename.
-        timeout = existing_env.get("AGENT_TIMEOUT_SECONDS", existing_env.get("CLAUDE_TIMEOUT_SECONDS", ""))
-        budget = existing_env.get("BUDGET_CEILING", existing_env.get("CLAUDE_MAX_BUDGET_USD", ""))
-        max_context_window = existing_env.get("CLAUDE_MAX_CONTEXT_WINDOW", "")
+    print("-- Claude --")
+    # Re-validate any existing DEFAULT_MODEL against the (possibly
+    # newly chosen) backend so a switch from claude to codex doesn't
+    # silently keep an anthropic model. Backend-aware, not provider-
+    # only: codex rejects gpt-5.4-nano even though it's valid for
+    # goose-on-openai. Empty raw_existing_model fails validation for
+    # any curated backend; the _prompt(required=True) branch in
+    # _prompt_default_model handles the open-ended case.
+    raw_existing_model = existing_env.get("DEFAULT_MODEL", existing_env.get("CLAUDE_MODEL", ""))
+    if raw_existing_model and validate_model_for_backend(raw_existing_model, agent_backend, eff_provider):
+        model = raw_existing_model
     else:
-        print("-- Claude --")
-        # Re-validate any existing DEFAULT_MODEL against the chosen
-        # backend so a switch from claude to codex doesn't silently
-        # keep an anthropic model.
-        raw_existing = existing_env.get("DEFAULT_MODEL", existing_env.get("CLAUDE_MODEL", ""))
-        if raw_existing and validate_model_for_backend(raw_existing, agent_backend, eff_provider):
-            default_model_val = raw_existing
-        else:
-            default_model_val = _default_model_prefill()
-        model = _prompt_default_model(agent_backend, eff_provider, default_model_val)
+        if raw_existing_model:
+            # Surface the rejection reason so the operator sees why the
+            # prior value is being re-prompted rather than getting a
+            # bare default with no explanation.
+            surface = "codex" if agent_backend == "codex" else f"provider '{eff_provider}'"
+            print(f"  DEFAULT_MODEL '{raw_existing_model}' is not valid for {surface}. Please choose a new default.")
+        # Prefill uses the backend-aware default rather than the
+        # rejected raw_existing_model. _prompt_default_model returns
+        # its default parameter without validating it against the
+        # choices list, so prefilling the bad value would let the
+        # operator accept the just-rejected value with Enter.
+        model = _prompt_default_model(agent_backend, eff_provider, _default_model_prefill())
 
+    while True:
+        # AGENT_TIMEOUT_SECONDS is canonical; legacy
+        # CLAUDE_TIMEOUT_SECONDS is the fallback for upgrades.
+        timeout_default = existing_env.get("AGENT_TIMEOUT_SECONDS", existing_env.get("CLAUDE_TIMEOUT_SECONDS", "120"))
+        timeout = _prompt(
+            "Agent timeout (seconds)",
+            timeout_default,
+        )
+        if _validate_positive_int(timeout):
+            break
+        print("  Must be a positive integer.")
+
+    # Skip the budget prompt on the claude backend: --max-budget-usd
+    # is no longer emitted to claude --print argv (Max-plan OAuth
+    # makes the CLI's computed-cost ceiling a phantom signal), so
+    # asking the operator for a value that is never enforced would
+    # be wizard noise. Pre-init `budget = ""` here; the BUDGET_CEILING
+    # env emission below (in the env-build block) skips writing the
+    # key entirely on the claude branch, leaving Config.budget_ceiling
+    # at its dataclass default for the (informational) /settings
+    # budget readback.
+    if agent_backend != "claude":
         while True:
-            # AGENT_TIMEOUT_SECONDS is canonical; legacy
-            # CLAUDE_TIMEOUT_SECONDS is the fallback for upgrades.
-            timeout_default = existing_env.get(
-                "AGENT_TIMEOUT_SECONDS", existing_env.get("CLAUDE_TIMEOUT_SECONDS", "120")
+            budget = _prompt(
+                "Claude budget (USD)",
+                existing_env.get("BUDGET_CEILING", existing_env.get("CLAUDE_MAX_BUDGET_USD", "10.0")),
             )
-            timeout = _prompt(
-                "Agent timeout (seconds)",
-                timeout_default,
-            )
-            if _validate_positive_int(timeout):
+            if _validate_positive_float(budget):
                 break
-            print("  Must be a positive integer.")
+            print("  Must be a positive number.")
+    else:
+        budget = ""
 
-        # Skip the budget prompt on the claude backend: --max-budget-usd
-        # is no longer emitted to claude --print argv (Max-plan OAuth
-        # makes the CLI's computed-cost ceiling a phantom signal), so
-        # asking the operator for a value that is never enforced would
-        # be wizard noise. Pre-init `budget = ""` here; the BUDGET_CEILING
-        # env emission below (in the env-build block) skips writing the
-        # key entirely on the claude branch, leaving Config.budget_ceiling
-        # at its dataclass default for the (informational) /settings
-        # budget readback.
-        if agent_backend != "claude":
-            while True:
-                budget = _prompt(
-                    "Claude budget (USD)",
-                    existing_env.get("BUDGET_CEILING", existing_env.get("CLAUDE_MAX_BUDGET_USD", "10.0")),
-                )
-                if _validate_positive_float(budget):
-                    break
-                print("  Must be a positive number.")
-        else:
-            budget = ""
-
-        # Context window tuning - smaller windows reduce token usage and
-        # cache invalidation pressure on the inner Claude process.
-        while True:
-            max_context_window = _prompt(
-                "Max context window (tokens, 0 = default 1M)",
-                existing_env.get("CLAUDE_MAX_CONTEXT_WINDOW", "200000"),
-            )
-            try:
-                val = int(max_context_window)
-                if 0 <= val <= MAX_CONTEXT_CEILING:
-                    break
-            except ValueError:
-                pass
-            print(f"  Must be 0-{MAX_CONTEXT_CEILING} (0 = use default).")
+    # Context window tuning - smaller windows reduce token usage and
+    # cache invalidation pressure on the inner Claude process.
+    while True:
+        max_context_window = _prompt(
+            "Max context window (tokens, 0 = default 1M)",
+            existing_env.get("CLAUDE_MAX_CONTEXT_WINDOW", "200000"),
+        )
+        try:
+            val = int(max_context_window)
+            if 0 <= val <= MAX_CONTEXT_CEILING:
+                break
+        except ValueError:
+            pass
+        print(f"  Must be 0-{MAX_CONTEXT_CEILING} (0 = use default).")
 
     # Autocompact threshold controls when Claude automatically compresses
     # conversation history. Lower values compact sooner, reducing token
@@ -961,24 +949,27 @@ def _cmd_config() -> None:
     print()
 
     # -- Workspaces --
+    # WORKSPACE_BASE is an inheritable installation default: users.yaml
+    # entries that omit `workspace_base` fall back to it. The prompt
+    # fires on every wizard run. ALLOWED_WORKSPACES remains a legacy
+    # per-user-mirror env var and stays gated on users.yaml absence;
+    # users.yaml carries per-user `allowed_workspaces` lists and the
+    # global env emission is preserved for installs that have not
+    # migrated yet (tranche D removes the gate when the env var goes
+    # away entirely).
+    print("-- Workspaces --")
+    workspace_base = _prompt(
+        "Workspace base directory",
+        existing_env.get("WORKSPACE_BASE", ""),
+    )
+    # Expand ~ for display but store as-is (load_config handles expansion)
+    if workspace_base.startswith("~"):
+        expanded = os.path.expanduser(workspace_base)
+        print(f"  (expands to {expanded})")
+
     if users_yaml_exists:
-        print("-- Workspaces --")
-        print("  Workspace base and allowed workspaces are now per-user.")
-        print("  Set workspace_base in users.yaml. Users manage allowed")
-        print("  workspaces via /workspace allow and /workspace deny.")
-        workspace_base = existing_env.get("WORKSPACE_BASE", "")
         allowed_workspaces = existing_env.get("ALLOWED_WORKSPACES", "")
     else:
-        print("-- Workspaces --")
-        workspace_base = _prompt(
-            "Workspace base directory",
-            existing_env.get("WORKSPACE_BASE", ""),
-        )
-        # Expand ~ for display but store as-is (load_config handles expansion)
-        if workspace_base.startswith("~"):
-            expanded = os.path.expanduser(workspace_base)
-            print(f"  (expands to {expanded})")
-
         allowed_workspaces = _prompt(
             "Allowed workspaces (comma-separated paths, optional)",
             existing_env.get("ALLOWED_WORKSPACES", ""),
@@ -986,34 +977,37 @@ def _cmd_config() -> None:
     print()
 
     # -- PR review agent --
-    # pr_review_timeout_s and pr_review_budget_usd are global resource limits
-    # for the review subprocess, not per-user preferences. They are prompted
-    # unconditionally below (unlike pr_review_cooldown, which is only
-    # prompted when users.yaml is absent and pr_review is enabled) because
-    # any review can time out or hit budget regardless of how users are
-    # configured.
+    # PR_REVIEW_COOLDOWN, PR_REVIEW_TIMEOUT_S, and PR_REVIEW_BUDGET_USD
+    # are global resource controls for the review subprocess: any
+    # review by any user counts against the same cooldown, the same
+    # subprocess timeout, and (on non-claude backends) the same USD
+    # budget per run. All three fire on every wizard run regardless
+    # of users.yaml presence. PR_REVIEW_ENABLED is the Class A per-user
+    # mirror and remains gated on users.yaml absence until tranche D
+    # removes it.
+    print("-- PR review agent --")
     if users_yaml_exists:
-        print("-- PR review agent --")
-        print("  PR review is now per-user. Set 'pr_review' in users.yaml")
+        print("  Global PR review toggle is now per-user. Set 'pr_review' in users.yaml")
         print("  or let users toggle via /github reviews on|off.")
         pr_review_enabled = existing_env.get("PR_REVIEW_ENABLED", "false").lower() in ("1", "true", "yes")
-        pr_review_cooldown = existing_env.get("PR_REVIEW_COOLDOWN", "300")
     else:
-        print("-- PR review agent --")
         pr_review_enabled = _prompt_bool(
             "Enable PR review agent",
             existing_env.get("PR_REVIEW_ENABLED", "false").lower() in ("1", "true", "yes"),
         )
-        pr_review_cooldown = "300"
-        if pr_review_enabled:
-            while True:
-                pr_review_cooldown = _prompt(
-                    "Review cooldown in seconds (prevents spam from rapid pushes)",
-                    existing_env.get("PR_REVIEW_COOLDOWN", "300"),
-                )
-                if _validate_positive_int(pr_review_cooldown):
-                    break
-                print("  Must be a positive integer.")
+
+    # Global cooldown always prompts: a per-user opt-in via users.yaml
+    # or /github reviews can drive reviews even when the global env
+    # toggle is absent, so the cooldown must be configurable for any
+    # install that has any opted-in user.
+    while True:
+        pr_review_cooldown = _prompt(
+            "Review cooldown in seconds (prevents spam from rapid pushes)",
+            existing_env.get("PR_REVIEW_COOLDOWN", "300"),
+        )
+        if _validate_positive_int(pr_review_cooldown):
+            break
+        print("  Must be a positive integer.")
 
     # Timeout + budget for the review subprocess. Always collectable: they
     # apply to any review whether or not the global env flag is set.
@@ -1437,18 +1431,20 @@ def _cmd_config() -> None:
     # to own the validation responsibility.
     env["DEFAULT_MODEL"] = model
 
-    # AGENT_TIMEOUT_SECONDS remains gated on the legacy single-user
-    # path; per-user timeouts live in users.yaml and override the
-    # global default at runtime. (Renamed from CLAUDE_TIMEOUT_SECONDS;
-    # the legacy key is migrated to the new name at apply time.)
-    if not users_yaml_exists:
-        env["AGENT_TIMEOUT_SECONDS"] = timeout
+    # AGENT_TIMEOUT_SECONDS is an inheritable installation default;
+    # per-user timeouts in users.yaml override at runtime. Always
+    # emitted because the prompt always fires. (Renamed from
+    # CLAUDE_TIMEOUT_SECONDS; the legacy key is migrated to the new
+    # name at apply time.)
+    env["AGENT_TIMEOUT_SECONDS"] = timeout
 
     # Context window tuning - only include if non-default.
     # Compare as int to handle inputs like "000" that pass validation.
-    # CLAUDE_MAX_CONTEXT_WINDOW is deprecated (per-user), but
-    # CLAUDE_AUTOCOMPACT_PCT is truly global (machine resource limit).
-    if not users_yaml_exists and max_context_window and int(max_context_window) != 0:
+    # CLAUDE_MAX_CONTEXT_WINDOW is an inheritable installation default
+    # (per-user override in users.yaml `context_window`). Emitted
+    # whenever non-default regardless of users.yaml presence so the
+    # global value the wizard just collected actually reaches runtime.
+    if max_context_window and int(max_context_window) != 0:
         env["CLAUDE_MAX_CONTEXT_WINDOW"] = max_context_window
     if int(autocompact_pct) != 0:
         env["CLAUDE_AUTOCOMPACT_PCT"] = autocompact_pct
@@ -1473,28 +1469,34 @@ def _cmd_config() -> None:
     if perplexity_key:
         env["PERPLEXITY_API_KEY"] = perplexity_key
 
-    # Deprecated per-user optional vars: only write without users.yaml
+    # WORKSPACE_BASE is an inheritable installation default; per-user
+    # `workspace_base` in users.yaml overrides at runtime. Always
+    # emitted when set, regardless of users.yaml presence.
+    if workspace_base:
+        env["WORKSPACE_BASE"] = workspace_base
+
+    # PR_REVIEW_COOLDOWN is a global resource control. Always written
+    # when non-default because any user can drive reviews via users.yaml
+    # or /github reviews even when the global PR_REVIEW_ENABLED toggle
+    # is unset.
+    if pr_review_cooldown != "300":
+        env["PR_REVIEW_COOLDOWN"] = pr_review_cooldown
+
+    # Class A per-user mirrors. The prompts and emissions are gated on
+    # users.yaml absence so legacy single-user installs continue to
+    # work via env; tranche D removes the Class A surface entirely
+    # once users.yaml is mandatory.
     if not users_yaml_exists:
-        if workspace_base:
-            env["WORKSPACE_BASE"] = workspace_base
         if allowed_workspaces:
             env["ALLOWED_WORKSPACES"] = allowed_workspaces
         if claude_user:
             env["CLAUDE_USER"] = claude_user
         if pr_review_enabled:
             env["PR_REVIEW_ENABLED"] = "true"
-            if pr_review_cooldown != "300":
-                env["PR_REVIEW_COOLDOWN"] = pr_review_cooldown
         if issue_triage_enabled:
             env["ISSUE_TRIAGE_ENABLED"] = "true"
         if github_notify_chat_id:
             env["GITHUB_NOTIFY_CHAT_ID"] = github_notify_chat_id
-    else:
-        # PR_REVIEW_COOLDOWN is a global rate limit - always write it
-        # if non-default, since any user may have PR review enabled
-        # via users.yaml even when the global env var is unset.
-        if pr_review_cooldown != "300":
-            env["PR_REVIEW_COOLDOWN"] = pr_review_cooldown
 
     # Review subprocess resource limits. Written in both branches because
     # they apply globally to any review, regardless of users.yaml presence.

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1160,6 +1160,7 @@ class TestCmdConfig:
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces (empty)
                 "false",  # pr review enabled
+                "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout (seconds)
                 "1.0",  # pr review budget (USD)
                 "false",  # issue triage enabled
@@ -1235,6 +1236,7 @@ class TestCmdConfig:
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces (empty)
                 "false",  # pr review enabled
+                "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout (seconds)
                 "1.0",  # pr review budget (USD)
                 "false",  # issue triage enabled
@@ -1315,6 +1317,7 @@ class TestCmdConfig:
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces
                 "false",  # pr review enabled
+                "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout
                 "1.0",  # pr review budget
                 "false",  # issue triage enabled
@@ -1382,6 +1385,7 @@ class TestCmdConfig:
                 "~/Projects",
                 "",
                 "false",
+                "300",  # pr review cooldown (global resource control)
                 "900",
                 "1.0",
                 "false",
@@ -1439,6 +1443,7 @@ class TestCmdConfig:
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces (empty)
                 "false",  # pr review enabled
+                "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout (seconds)
                 "1.0",  # pr review budget (USD)
                 "false",  # issue triage enabled
@@ -1493,6 +1498,7 @@ class TestCmdConfig:
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces (empty)
                 "false",  # pr review enabled
+                "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout (seconds)
                 "1.0",  # pr review budget (USD)
                 "false",  # issue triage enabled
@@ -1677,6 +1683,7 @@ class TestCmdConfig:
             "~/Projects",  # workspace base
             "",  # allowed workspaces
             "false",  # pr review enabled
+            "300",  # pr review cooldown (global resource control, always prompts)
             "900",  # pr review timeout
             *pr_review_budget_entry,  # PR_REVIEW_BUDGET_USD (non-claude only)
             "false",  # issue triage
@@ -2125,6 +2132,7 @@ class TestCmdConfig:
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces
                 "false",  # pr review enabled
+                "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout
                 "1.0",  # pr review budget
                 "false",  # issue triage
@@ -2465,6 +2473,7 @@ class TestCmdConfig:
                 "",  # workspace base
                 "",  # allowed workspaces
                 "false",  # pr review enabled
+                "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout
                 "1.0",  # pr review budget (non-claude branch)
                 "false",  # issue triage enabled
@@ -2793,7 +2802,14 @@ class TestCmdConfigDefaultModelDispatch:
 
     @staticmethod
     def _inputs_for_claude_backend() -> list[str]:
-        """Input chain for the users_yaml_exists=True + claude path."""
+        """Input chain for the users_yaml_exists=True + claude path.
+
+        Post-tranche-B, the global-default prompts fire unconditionally
+        even when users.yaml exists, so the chain feeds timeout,
+        max_context_window, workspace_base, and pr_review_cooldown
+        values that the pre-tranche-B users-yaml-exists branch had
+        skipped silently.
+        """
         return [
             "/opt/kai",  # install dir
             "/var/lib/kai",  # data dir
@@ -2803,10 +2819,14 @@ class TestCmdConfigDefaultModelDispatch:
             "polling",  # transport
             "claude",  # agent backend
             # model prompt is handled by the _prompt_default_model mock
+            "120",  # agent timeout (global default)
+            "200000",  # max context window (global default)
             "80",  # autocompact pct
             "",  # effort level (default)
             "8080",  # webhook port
             "test-secret",  # webhook secret
+            "~/Projects",  # workspace base (global default)
+            "300",  # pr review cooldown (global resource control)
             "900",  # pr review subprocess timeout
             "false",  # voice
             "false",  # tts
@@ -2836,10 +2856,15 @@ class TestCmdConfigDefaultModelDispatch:
             # No OPENAI_API_KEY prompt in subscription mode
             "/usr/local/bin/codex",  # codex binary path
             # No llm_provider prompt (VALID_PROVIDERS["codex"] is None)
-            # No autocompact_pct / effort_level prompts (claude-only)
             # Model prompt handled by the _prompt_default_model mock
+            "120",  # agent timeout (global default)
+            "10.0",  # BUDGET_CEILING (non-claude only)
+            "200000",  # max context window (global default)
+            # No autocompact_pct / effort_level prompts (claude-only)
             "8080",  # webhook port
             "test-secret",  # webhook secret
+            "~/Projects",  # workspace base (global default)
+            "300",  # pr review cooldown (global resource control)
             "900",  # pr review subprocess timeout
             "1.0",  # pr review subprocess budget (non-claude only)
             "false",  # voice
@@ -2862,9 +2887,14 @@ class TestCmdConfigDefaultModelDispatch:
             "openai",  # llm provider
             "openai-key",  # OPENAI_API_KEY
             # model prompt is handled by the _prompt_default_model mock
-            "80",  # autocompact pct
+            "120",  # agent timeout (global default)
+            "10.0",  # BUDGET_CEILING (non-claude only)
+            "200000",  # max context window (global default)
+            # autocompact_pct / effort_level prompts are claude-only (gated)
             "8080",  # webhook port
             "test-secret",  # webhook secret
+            "~/Projects",  # workspace base (global default)
+            "300",  # pr review cooldown (global resource control)
             "900",  # pr review subprocess timeout
             "1.0",  # pr review subprocess budget (non-claude only)
             "false",  # voice
@@ -6128,6 +6158,136 @@ class TestStripInstallConfKeys:
         _strip_install_conf_keys("users_yaml_staging_path")
 
 
+# ── _cmd_config: global-default prompts fire regardless of users.yaml ──
+
+
+class TestCmdConfigGlobalDefaultsRegardlessOfUsersYaml:
+    """Pins the contract that installation-wide defaults (DEFAULT_MODEL,
+    AGENT_TIMEOUT_SECONDS, BUDGET_CEILING on non-claude, CLAUDE_MAX_CONTEXT_WINDOW,
+    WORKSPACE_BASE, PR_REVIEW_COOLDOWN) prompt on every wizard run and
+    land in install.conf's env regardless of users.yaml presence.
+
+    The pre-fix wizard gated those prompts on `not users_yaml_exists`
+    so a re-run on an existing install silently kept stale globals - the
+    operator-visible bug was a backend switch leaving DEFAULT_MODEL set
+    to a model from the prior backend's surface. Each test below
+    exercises one global-default key on the users-yaml-exists branch
+    and asserts the new value lands.
+    """
+
+    @staticmethod
+    def _existing_etc_users(monkeypatch):
+        TestCmdConfig._simulate_existing_etc_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n",
+        )
+
+    def test_agent_timeout_lands_with_users_yaml(self, tmp_path, monkeypatch):
+        """AGENT_TIMEOUT_SECONDS reaches env when users.yaml is present."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._existing_etc_users(monkeypatch)
+
+        inputs = iter(TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend())
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            lambda backend, prov, default: "sonnet",
+        )
+        _cmd_config()
+
+        env = json.loads((tmp_path / "install.conf").read_text())["env"]
+        assert env["AGENT_TIMEOUT_SECONDS"] == "120"
+
+    def test_max_context_window_lands_with_users_yaml(self, tmp_path, monkeypatch):
+        """CLAUDE_MAX_CONTEXT_WINDOW reaches env when users.yaml is present.
+
+        Pre-fix: the env emission was gated on `not users_yaml_exists`,
+        so the prompt fired but the value never made it to install.conf.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._existing_etc_users(monkeypatch)
+
+        inputs = iter(TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend())
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            lambda backend, prov, default: "sonnet",
+        )
+        _cmd_config()
+
+        env = json.loads((tmp_path / "install.conf").read_text())["env"]
+        assert env["CLAUDE_MAX_CONTEXT_WINDOW"] == "200000"
+
+    def test_workspace_base_lands_with_users_yaml(self, tmp_path, monkeypatch):
+        """WORKSPACE_BASE reaches env when users.yaml is present."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._existing_etc_users(monkeypatch)
+
+        inputs = iter(TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend())
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            lambda backend, prov, default: "sonnet",
+        )
+        _cmd_config()
+
+        env = json.loads((tmp_path / "install.conf").read_text())["env"]
+        assert env["WORKSPACE_BASE"] == "~/Projects"
+
+    def test_pr_review_cooldown_always_prompts(self, tmp_path, monkeypatch):
+        """PR_REVIEW_COOLDOWN is a global resource control: the prompt
+        fires whether users.yaml exists or pr_review_enabled is true,
+        and a non-default value lands in env.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._existing_etc_users(monkeypatch)
+
+        # Override the cooldown slot in the claude chain to a non-default
+        # value so the env-emission assertion is meaningful (the default
+        # "300" is suppressed by the delta-from-default check).
+        base = list(TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend())
+        cooldown_idx = base.index("300")
+        base[cooldown_idx] = "450"
+        inputs = iter(base)
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            lambda backend, prov, default: "sonnet",
+        )
+        _cmd_config()
+
+        env = json.loads((tmp_path / "install.conf").read_text())["env"]
+        assert env["PR_REVIEW_COOLDOWN"] == "450"
+
+    def test_budget_ceiling_lands_with_users_yaml_on_non_claude(self, tmp_path, monkeypatch):
+        """BUDGET_CEILING reaches env on non-claude backends when
+        users.yaml exists. Claude-branch budget suppression is unchanged.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._existing_etc_users(monkeypatch)
+
+        inputs = iter(TestCmdConfigDefaultModelDispatch._inputs_for_goose_openai())
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            lambda backend, prov, default: "gpt-5.4",
+        )
+        _cmd_config()
+
+        env = json.loads((tmp_path / "install.conf").read_text())["env"]
+        assert env["BUDGET_CEILING"] == "10.0"
+
+
 # ── _cmd_config: users.yaml canonicalization ─────────────────────────
 
 
@@ -6165,6 +6325,7 @@ class TestCmdConfigCanonicalUsersYaml:
             "~/Projects",
             "",
             "false",
+            "300",  # pr review cooldown (global resource control)
             "900",
             "1.0",
             "false",

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2760,10 +2760,17 @@ class TestCmdConfigDefaultModelDispatch:
     Wizard dispatch for DEFAULT_MODEL when users.yaml exists.
 
     Dispatch shape:
-    - if the existing model is non-empty and validates against the effective
-      provider, keep it (no prompt);
-    - otherwise call _prompt_default_model with the provider's curated
-      default as the prefill (never the just-rejected value).
+    - _prompt_default_model fires on every wizard run, regardless of
+      whether the existing value validates;
+    - the prefill is the existing value when it validates against the
+      effective backend, otherwise the backend-aware curated default
+      (never the just-rejected value).
+
+    Always routing through the prompt is load-bearing: it lets an
+    operator with users.yaml present change the inherited global
+    model via `make config` instead of needing to hand-edit
+    /etc/kai/env. The previous "keep silently on valid match"
+    shortcut closed that path.
 
     The wizard has many prompts that fire before and after the model
     dispatch. The helper below mocks _prompt_default_model to capture
@@ -2946,21 +2953,28 @@ class TestCmdConfigDefaultModelDispatch:
         assert helper.call_args.args[1] == "openai"
         assert env["DEFAULT_MODEL"] == "gpt-5.4-mini"
 
-    def test_no_reprompt_when_claude_backend_unchanged(self, tmp_path, monkeypatch):
+    def test_prompt_fires_with_valid_existing_as_prefill(self, tmp_path, monkeypatch):
         """
-        With users.yaml present, DEFAULT_MODEL=sonnet, and the wizard kept
-        on claude, no model prompt fires AND install.conf still emits
-        DEFAULT_MODEL=sonnet (the unconditional-emission half of the fix).
+        With users.yaml present, DEFAULT_MODEL=sonnet, and the wizard
+        kept on claude, the model prompt STILL fires and the existing
+        value is passed as the prefill. The operator's choice (from
+        the helper return) lands in install.conf. Pins the contract
+        that the operator can always edit the global model via
+        `make config`, not just when it is invalid for the backend.
         """
         self._setup(monkeypatch, tmp_path, existing_env={"DEFAULT_MODEL": "sonnet"})
         helper, env = self._run(
             monkeypatch,
             tmp_path,
             self._inputs_for_claude_backend(),
-            helper_return="should-not-be-used",
+            helper_return="haiku",
         )
-        helper.assert_not_called()
-        assert env["DEFAULT_MODEL"] == "sonnet"
+        helper.assert_called_once()
+        # Prefill is the existing value because it validates for claude.
+        assert helper.call_args.args[0] == "claude"
+        assert helper.call_args.args[1] == "anthropic"
+        assert helper.call_args.args[2] == "sonnet"
+        assert env["DEFAULT_MODEL"] == "haiku"
 
     def test_reprompts_on_empty_existing_model_claude(self, tmp_path, monkeypatch):
         """


### PR DESCRIPTION
## Summary

First of four tranches against #565. Closes the operator-visible bug class where switching `AGENT_BACKEND` with `users.yaml` already in place left a stale `DEFAULT_MODEL` in `/etc/kai/env`.

The wizard previously gated prompts for `DEFAULT_MODEL`, `AGENT_TIMEOUT_SECONDS`, `BUDGET_CEILING` (non-claude), `CLAUDE_MAX_CONTEXT_WINDOW`, `WORKSPACE_BASE`, and `PR_REVIEW_COOLDOWN` on `users_yaml_exists`, on the rationale that those settings had "become per-user." For most of them the global env value is still the inheritable runtime default for any user without a per-user override; for `DEFAULT_MODEL` the skip created a silent typo trap on a backend flip.

This PR removes the gate around the merged Claude block and around `WORKSPACE_BASE` / `PR_REVIEW_COOLDOWN`. It also removes the `not users_yaml_exists` gates on the env emission for those keys so the values the wizard just collected actually reach `/etc/kai/env`. `_prompt_default_model` continues to be the dispatch hook for the re-prompt-on-invalid path; `validate_model_for_backend` stays as apply-time defense in depth.

What this PR does NOT change (deliberately, follows tranche split):

- `_load_user_configs` still returns `None` for absent users.yaml (tranche A).
- Class A per-user mirror prompts and runtime reads (`ALLOWED_USER_IDS`, `CLAUDE_USER`, `CLAUDE_MODEL`, `PR_REVIEW_ENABLED`, `ISSUE_TRIAGE_ENABLED`, `GITHUB_NOTIFY_CHAT_ID`) stay as they are (tranche D).
- Single-user / XDG deployment mode is not introduced here (tranche C).
- README and `templates/.env` language changes are deferred (tranche D).

## Tranche tracking (per #565 v2 implementation tranches)

- [x] **B** wizard prompt re-gating (this PR)
- [ ] **A** runtime mandate (`_load_user_configs` returns dict or raises; drop `ALLOWED_USER_IDS` fallback)
- [ ] **C** deployment mode + XDG (single-user install support)
- [ ] **D** cleanup + docs (remove Class A env reads, update README + templates)

A and B are mutually independent; C depends on A; D depends on A-C.

## Test plan

- [x] `make check` clean
- [x] `make test` clean (3657 passed)
- [x] New `TestCmdConfigGlobalDefaultsRegardlessOfUsersYaml` regressions pin that `AGENT_TIMEOUT_SECONDS`, `CLAUDE_MAX_CONTEXT_WINDOW`, `WORKSPACE_BASE`, `PR_REVIEW_COOLDOWN`, and (non-claude) `BUDGET_CEILING` each land in env when users.yaml is present.
- [x] Existing `TestCmdConfigDefaultModelDispatch` suite continues to cover the model re-prompt path; input chains updated to feed the now-always-prompting values.
- [x] First-time install input chains in `TestCmdConfig` and `TestCmdConfigCanonicalUsersYaml` updated to feed `pr_review_cooldown` between `pr_review_enabled` and `pr_review_timeout`.
- [ ] Manual smoke: existing `/etc/kai/users.yaml` install, flip `AGENT_BACKEND` from opencode to codex via `make config`, confirm `DEFAULT_MODEL` re-prompt fires with codex curated default, confirm new value lands in `/etc/kai/env` after `sudo make install`.
