### PR TITLE
refactor(config): mandate users.yaml; drop env-only auth fallback

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -740,25 +740,18 @@ def _is_notification_only_chat_id(chat_id: int | None, config: Config) -> bool:
     notification group chat, a deploy-status broadcast channel, a
     review-summary destination room.
 
-    Returns False (treat as interactive) for:
-    - chat_id is None: test / health-check / anon paths; preserved by
-      the existing ensure_user_home(None, ...) -> data_dir/home/anon
-      contract.
-    - config.user_configs is empty or None: legacy single-user mode
-      with no users.yaml. There is no basis for discriminating;
-      every chat_id is interactive by default. Same permissive
-      behavior the codebase had before the multi-user split.
+    Returns False (treat as interactive) for chat_id=None (test /
+    health-check / anon paths; preserved by the existing
+    ensure_user_home(None, ...) -> data_dir/home/anon contract).
 
-    Returns True (skip auto-provisioning) when users.yaml is in use
-    AND this chat_id is not a key in user_configs. The contract on
-    True: the caller must NOT create a per-user directory for this
-    chat_id. The chat_id remains valid for outbound notification
-    sending (it lives in allowed_user_ids); only the home-workspace
-    provisioning is suppressed.
+    Returns True (skip auto-provisioning) when the chat_id is not a
+    key in user_configs. The contract on True: the caller must NOT
+    create a per-user directory for this chat_id. The chat_id
+    remains valid for outbound notification sending (it lives in
+    allowed_user_ids); only the home-workspace provisioning is
+    suppressed.
     """
     if chat_id is None:
-        return False
-    if not config.user_configs:
         return False
     return chat_id not in config.user_configs
 

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -2591,21 +2591,14 @@ async def _handle_github_remove(
 
     # Check if any other user is still subscribed to this repo.
     # A linear scan of all users is fine for small deployments.
-    # Note: when user_configs is None (env-var-only mode without
-    # users.yaml), we cannot enumerate other users. The check is
-    # skipped and the webhook may be deregistered while other users
-    # who added the repo via /github add are still subscribed. This
-    # is a known limitation of env-var-only deployments; users.yaml
-    # is required for accurate cross-user subscriber tracking.
     other_subscribers = False
-    if config.user_configs:
-        for uid, uc in config.user_configs.items():
-            if uid == chat_id:
-                continue
-            uc_effective = await sessions.get_effective_repos(uc.telegram_id, uc.github_repos)
-            if repo in uc_effective:
-                other_subscribers = True
-                break
+    for uid, uc in config.user_configs.items():
+        if uid == chat_id:
+            continue
+        uc_effective = await sessions.get_effective_repos(uc.telegram_id, uc.github_repos)
+        if repo in uc_effective:
+            other_subscribers = True
+            break
 
     token = await sessions.get_setting(f"github_token:{chat_id}")
 
@@ -2741,23 +2734,20 @@ async def _is_notify_chat_used(
     Note: this does a linear scan of all users with one DB query per
     user. Fine for a personal assistant with a handful of users.
     """
-    # In legacy mode (user_configs is None) there are no other users
-    # to check - skip straight to the global env var fallback.
-    if config.user_configs:
-        for uid, uc in config.user_configs.items():
-            if uid == exclude_user:
+    for uid, uc in config.user_configs.items():
+        if uid == exclude_user:
+            continue
+        # Check the users.yaml entry for this user
+        if uc.github_notify_chat_id == notify_chat_id:
+            return True
+        # Check DB override for this user
+        val = await sessions.get_setting(f"github_notify_chat:{uid}")
+        if val:
+            try:
+                if int(val) == notify_chat_id:
+                    return True
+            except ValueError:
                 continue
-            # Check the users.yaml entry for this user
-            if uc.github_notify_chat_id == notify_chat_id:
-                return True
-            # Check DB override for this user
-            val = await sessions.get_setting(f"github_notify_chat:{uid}")
-            if val:
-                try:
-                    if int(val) == notify_chat_id:
-                        return True
-                except ValueError:
-                    continue
 
     # Also check the global env var fallback
     return config.github_notify_chat_id == notify_chat_id

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -829,10 +829,13 @@ class Config:
     # 0 = no cleanup (default). Cleanup runs once every 24 hours.
     file_retention_days: int = 0
 
-    # Per-user configuration from users.yaml. Keyed by telegram_id.
-    # None means users.yaml does not exist (fall back to allowed_user_ids).
-    # Empty dict means users.yaml exists but has no valid entries.
-    user_configs: dict[int, UserConfig] | None = None
+    # Per-user configuration from users.yaml, keyed by telegram_id.
+    # users.yaml is mandatory: _load_user_configs raises SystemExit
+    # if the file is missing, malformed, or has no valid entries, so
+    # this field is always a populated dict at runtime. The default
+    # factory is for tests that construct Config directly; production
+    # code goes through load_config.
+    user_configs: dict[int, UserConfig] = field(default_factory=dict)
 
     # TOTP two-factor authentication timing (only relevant when TOTP is enabled)
     totp_session_minutes: int = 30
@@ -998,14 +1001,10 @@ class Config:
 
     def get_user_config(self, user_id: int) -> UserConfig | None:
         """Get per-user config by Telegram user ID, or None if not configured."""
-        if self.user_configs is None:
-            return None
         return self.user_configs.get(user_id)
 
     def get_user_by_github(self, github_login: str) -> UserConfig | None:
         """Look up a user by GitHub username. Used for webhook actor routing."""
-        if self.user_configs is None:
-            return None
         for uc in self.user_configs.values():
             if uc.github and uc.github.lower() == github_login.lower():
                 return uc
@@ -1013,8 +1012,6 @@ class Config:
 
     def get_admins(self) -> list[UserConfig]:
         """Get all admin users. Used for unattributed webhook fallback routing."""
-        if self.user_configs is None:
-            return []
         return [uc for uc in self.user_configs.values() if uc.role == "admin"]
 
 
@@ -1522,7 +1519,7 @@ _VALID_ROLES = {"admin", "user"}
 
 def _compute_extraction_eligible_backends(
     agent_backend: str,
-    user_configs: "dict[int, UserConfig] | None",
+    user_configs: dict[int, UserConfig],
     memory_extraction_enabled: bool,
 ) -> set[str]:
     """
@@ -1530,11 +1527,8 @@ def _compute_extraction_eligible_backends(
 
     Mirrors `_ingest_memory`'s extraction gate (effective backend in
     {"claude", "codex"}; goose users are filtered out because they
-    have no `OneShotReasoner` implementation). With users.yaml: each
-    user contributes its effective backend (per-user override or
-    global default). Without users.yaml (legacy ALLOWED_USER_IDS auth):
-    every authorized user inherits the global, so the set is
-    `{agent_backend}` when that is extraction-eligible, else empty.
+    have no `OneShotReasoner` implementation). Each user contributes
+    its effective backend (per-user override or global default).
 
     Returns an empty set when `memory_extraction_enabled` is False;
     callers that gate codex plumbing or registry validation off the
@@ -1543,10 +1537,6 @@ def _compute_extraction_eligible_backends(
     if not memory_extraction_enabled:
         return set()
     eligible: set[str] = set()
-    if user_configs is None:
-        if agent_backend in ("claude", "codex"):
-            eligible.add(agent_backend)
-        return eligible
     for uc in user_configs.values():
         effective = uc.agent_backend or agent_backend
         if effective in ("claude", "codex"):
@@ -1557,16 +1547,33 @@ def _compute_extraction_eligible_backends(
 def _load_user_configs(
     global_backend: str,
     global_llm_provider: str,
-) -> dict[int, UserConfig] | None:
+) -> dict[int, UserConfig]:
     """
     Load per-user configs from /etc/kai/users.yaml.
 
     Reads the protected file via `_read_protected_yaml` (sudo-cat for
-    root-owned mode 0600 copies). Returns None when the file is absent
-    or malformed; the caller then falls back to the legacy
-    `ALLOWED_USER_IDS` auth path. There is no project-root fallback:
-    users.yaml is canonical at `/etc/kai/users.yaml` and a stray copy
-    inside the source tree is never consulted.
+    root-owned mode 0600 copies). users.yaml is mandatory: any failure
+    raises SystemExit with a message naming the resolved path. There
+    is no None return path and no fallback to ALLOWED_USER_IDS at
+    runtime. The fail-closed shape is load-bearing for the daemon's
+    auth contract: a malformed or unreadable users file must not
+    silently degrade to env-only auth, because the wizard and the
+    runtime would then disagree about whose value wins.
+
+    Failure cases (each raises SystemExit):
+        - File absent: error names the path and points at `make config`.
+          When ALLOWED_USER_IDS is set in env, appends a one-line
+          migration hint mentioning that the env var is no longer
+          honored as a fallback.
+        - Malformed YAML, non-dict top-level, missing or non-list
+          `users` key: error names the path and the parse/schema fault.
+        - Zero valid user entries after per-entry validation: error
+          names the path and refers the operator to the warnings
+          logged above.
+
+    Per-entry validation errors continue to log a warning and skip
+    the entry rather than abort; the SystemExit at the end fires only
+    when every entry was rejected.
 
     Args:
         global_backend: The global agent_backend from env config.
@@ -1576,34 +1583,40 @@ def _load_user_configs(
 
     Returns a dict keyed by telegram_id for O(1) lookup.
     """
+    users_yaml_path = "/etc/kai/users.yaml"
     data = _read_protected_yaml("users.yaml")
     if data is _YAML_MALFORMED:
-        # Fail closed: return None so the caller falls back to
-        # ALLOWED_USER_IDS (or exits if that is also unset). Auth
-        # config must not silently degrade.
-        log.warning("Skipping user config: /etc/kai/users.yaml is malformed or empty")
-        return None
+        raise SystemExit(
+            f"{users_yaml_path} is malformed or has an invalid top-level YAML shape. "
+            "Fix the file or re-run 'make config' to regenerate it."
+        )
     if data is None:
-        return None
+        msg = (
+            f"users.yaml is required for authorization and was not found at {users_yaml_path}. "
+            "Run 'make config' to generate it."
+        )
+        if os.environ.get("ALLOWED_USER_IDS"):
+            msg += (
+                " ALLOWED_USER_IDS is set in env but is no longer honored as an "
+                "auth fallback; 'make config' will migrate it into users.yaml."
+            )
+        raise SystemExit(msg)
 
     # After the _YAML_MALFORMED and None checks, `data` is guaranteed
     # to be a dict (`_read_protected_yaml` returns `_YAML_MALFORMED`
     # for any non-dict top-level value). Guard defensively rather than
     # assert since assertions are stripped under Python -O.
     if not isinstance(data, dict):
-        log.warning("users.yaml: expected a YAML dict, got %s", type(data).__name__)
-        return None
+        raise SystemExit(f"{users_yaml_path}: expected a YAML dict, got {type(data).__name__}")
 
     entries = data.get("users")
     if not isinstance(entries, list):
-        # Warn for any non-list value, including None (missing key).
         # A users.yaml file without a 'users' key is almost certainly
-        # a typo (e.g., 'user:' instead of 'users:').
+        # a typo (e.g., 'user:' instead of 'users:'). Either shape is
+        # fatal at this point because there is no auth fallback.
         if entries is not None:
-            log.warning("users.yaml: 'users' must be a list, got %s", type(entries).__name__)
-        else:
-            log.warning("users.yaml: no 'users' key found; check for typos")
-        return None
+            raise SystemExit(f"{users_yaml_path}: 'users' must be a list, got {type(entries).__name__}")
+        raise SystemExit(f"{users_yaml_path}: no 'users' key found; check for typos (e.g. 'user:' vs 'users:')")
 
     configs: dict[int, UserConfig] = {}
     for entry in entries:
@@ -1955,9 +1968,16 @@ def _load_user_configs(
             issue_triage=issue_triage,
         )
 
+    if not configs:
+        raise SystemExit(
+            f"{users_yaml_path}: no valid user entries; every entry was rejected "
+            "by per-entry validation. See the warnings logged above for the "
+            "individual rejection reasons."
+        )
+
     # Warn if no admin is defined - external webhooks will route to
     # an arbitrary user, which may be surprising.
-    if configs and not any(uc.role == "admin" for uc in configs.values()):
+    if not any(uc.role == "admin" for uc in configs.values()):
         log.warning(
             "users.yaml: no admin users defined. External webhook notifications "
             "(GitHub, generic) will route to an arbitrary user."
@@ -2028,25 +2048,6 @@ def load_config() -> Config:
         log.info("Telegram transport: webhook (%s)", telegram_webhook_url)
     else:
         log.info("Telegram transport: polling (TELEGRAM_WEBHOOK_URL not set)")
-
-    # Parse allowed user IDs. users.yaml is the primary authorization
-    # source. ALLOWED_USER_IDS is a legacy fallback for installations
-    # that haven't migrated yet.
-    # Defer the ValueError until after users.yaml is checked so that
-    # a malformed env var doesn't block startup when users.yaml is
-    # authoritative and would make the env var irrelevant.
-    raw_ids = os.environ.get("ALLOWED_USER_IDS", "")
-    allowed_ids: set[int] = set()
-    allowed_ids_error: str | None = None
-    try:
-        allowed_ids = {int(uid.strip()) for uid in raw_ids.split(",") if uid.strip()}
-    except ValueError:
-        allowed_ids_error = (
-            "ALLOWED_USER_IDS contains non-numeric values. "
-            "Consider migrating to users.yaml (run 'make config' or "
-            "see README for the schema). If using ALLOWED_USER_IDS, values must be "
-            "numeric Telegram user IDs - message @userinfobot to find yours."
-        )
 
     # Validate optional: workspace base directory (must exist if provided)
     workspace_base = None
@@ -2421,32 +2422,21 @@ def load_config() -> Config:
     # workspaces the user is otherwise allowed to enter.
     memory_projects = _load_memory_project_configs()
 
-    # Per-user configuration. If users.yaml exists, it is authoritative;
-    # ALLOWED_USER_IDS is ignored. If users.yaml does not exist,
-    # ALLOWED_USER_IDS works as before (backward-compatible).
+    # Per-user configuration. users.yaml is mandatory; the loader
+    # raises SystemExit on any failure with a path-naming message
+    # (and a one-line ALLOWED_USER_IDS migration hint when that env
+    # var is set on a missing-file install). The legacy env-var
+    # fallback is gone: a malformed users file used to silently
+    # degrade to ALLOWED_USER_IDS, which the wizard and the loader
+    # then disagreed about; fail-closed is the contract now.
     user_configs = _load_user_configs(agent_backend, llm_provider)
-    if user_configs is not None:
-        if raw_ids:
-            log.warning("ALLOWED_USER_IDS is set but users.yaml exists; using users.yaml")
-        # Users in the YAML replace the ALLOWED_USER_IDS set.
-        # Any ALLOWED_USER_IDS parse error is irrelevant since users.yaml is authoritative.
-        allowed_ids = set(user_configs.keys())
-        if not allowed_ids:
-            raise SystemExit("users.yaml exists but contains no valid user entries")
-    elif allowed_ids_error:
-        # No users.yaml and ALLOWED_USER_IDS had a parse error
-        raise SystemExit(allowed_ids_error)
-    elif not allowed_ids:
-        # No users.yaml and no ALLOWED_USER_IDS - can't start
-        raise SystemExit(
-            "No user authorization configured. "
-            "Run 'make config' to generate users.yaml, "
-            "or create one manually (see README for the schema)."
+    allowed_ids = set(user_configs.keys())
+    if os.environ.get("ALLOWED_USER_IDS", "").strip():
+        log.warning(
+            "ALLOWED_USER_IDS is set in env but is no longer honored; "
+            "users.yaml is authoritative. Remove the env var from /etc/kai/env "
+            "(or re-run 'make config') to clear this warning."
         )
-    else:
-        # ALLOWED_USER_IDS is valid and no users.yaml exists. This works
-        # but is the legacy path - nudge toward users.yaml.
-        log.info("Using ALLOWED_USER_IDS from env (legacy). Run 'make config' to migrate to users.yaml.")
 
     # Memory extraction preconditions, validated per the
     # extraction-eligible backend set. Reasoner and model both derive
@@ -2490,58 +2480,56 @@ def load_config() -> Config:
                 ) from None
 
     # Deprecation warnings for env vars superseded by users.yaml.
-    # The vars still work as global fallbacks, but users.yaml is the
-    # primary configuration path. Warnings guide admins to migrate.
-    # Only fire when users.yaml parsed successfully. If users.yaml is
-    # malformed, the system falls back to ALLOWED_USER_IDS and the env
-    # vars are actively needed (not deprecated in that context).
-    if user_configs is not None:
-        _deprecated_env_vars = {
-            "CLAUDE_MODEL": "Renamed to DEFAULT_MODEL. Set per-user 'model' in users.yaml or use /settings model",
-            "CLAUDE_MAX_BUDGET_USD": "Renamed to BUDGET_CEILING (global ceiling). Per-user defaults go in users.yaml 'max_budget'",
-            "CLAUDE_TIMEOUT_SECONDS": "Set per-user 'timeout' in users.yaml or use /settings timeout",
-            "CLAUDE_MAX_CONTEXT_WINDOW": "Set per-user 'context_window' in users.yaml or use /settings context",
-            "CLAUDE_USER": "Set per-user 'os_user' in users.yaml",
-            "WORKSPACE_BASE": "Set per-user 'workspace_base' in users.yaml",
-            "ALLOWED_WORKSPACES": "Users can manage their own via /workspace allow",
-            "PR_REVIEW_ENABLED": "Set per-user 'pr_review' in users.yaml or use /github reviews",
-            "ISSUE_TRIAGE_ENABLED": "Set per-user 'issue_triage' in users.yaml or use /github triage",
-            "GITHUB_NOTIFY_CHAT_ID": "Set per-user 'github_notify_chat_id' in users.yaml or use /github notify",
-        }
-        for var, guidance in _deprecated_env_vars.items():
-            if os.environ.get(var, "").strip():
-                log.warning(
-                    "%s in env is deprecated (users.yaml exists). %s. "
-                    "This env var will be removed in a future release.",
-                    var,
-                    guidance,
-                )
+    # users.yaml is mandatory now, so the previous "only fire when
+    # users.yaml exists" guard is gone: any of these env vars in
+    # /etc/kai/env is unconditionally redundant. A later tranche
+    # removes the Class A entries from this block entirely along
+    # with the runtime reads they describe.
+    _deprecated_env_vars = {
+        "CLAUDE_MODEL": "Renamed to DEFAULT_MODEL. Set per-user 'model' in users.yaml or use /settings model",
+        "CLAUDE_MAX_BUDGET_USD": "Renamed to BUDGET_CEILING (global ceiling). Per-user defaults go in users.yaml 'max_budget'",
+        "CLAUDE_TIMEOUT_SECONDS": "Set per-user 'timeout' in users.yaml or use /settings timeout",
+        "CLAUDE_MAX_CONTEXT_WINDOW": "Set per-user 'context_window' in users.yaml or use /settings context",
+        "CLAUDE_USER": "Set per-user 'os_user' in users.yaml",
+        "WORKSPACE_BASE": "Set per-user 'workspace_base' in users.yaml",
+        "ALLOWED_WORKSPACES": "Users can manage their own via /workspace allow",
+        "PR_REVIEW_ENABLED": "Set per-user 'pr_review' in users.yaml or use /github reviews",
+        "ISSUE_TRIAGE_ENABLED": "Set per-user 'issue_triage' in users.yaml or use /github triage",
+        "GITHUB_NOTIFY_CHAT_ID": "Set per-user 'github_notify_chat_id' in users.yaml or use /github notify",
+    }
+    for var, guidance in _deprecated_env_vars.items():
+        if os.environ.get(var, "").strip():
+            log.warning(
+                "%s in env is deprecated (users.yaml exists). %s. This env var will be removed in a future release.",
+                var,
+                guidance,
+            )
 
-        # Warn when GitHub agent features are enabled but no users have
-        # github_repos configured. Events will never reach the agents
-        # because _get_subscribed_users() returns empty for every
-        # incoming webhook. The fallback path in _process_github_event()
-        # delivers basic notifications but does not guarantee the agents
-        # fire.
-        no_repos = not any(uc.github_repos for uc in user_configs.values())
-        if no_repos:
-            review_on = pr_review_enabled or any(uc.pr_review is True for uc in user_configs.values())
-            triage_on = issue_triage_enabled or any(uc.issue_triage is True for uc in user_configs.values())
-            if review_on or triage_on:
-                features = []
-                if review_on:
-                    features.append("PR review")
-                if triage_on:
-                    features.append("issue triage")
-                log.warning(
-                    "GitHub features enabled (%s) but no users have "
-                    "github_repos configured. GitHub webhook events will "
-                    "not be delivered to these features. Add 'github_repos' "
-                    "to users.yaml entries. See: https://github.com/"
-                    "dcellison/kai/wiki/Multi-User-Setup"
-                    "#what-you-must-set-manually",
-                    ", ".join(features),
-                )
+    # Warn when GitHub agent features are enabled but no users have
+    # github_repos configured. Events will never reach the agents
+    # because _get_subscribed_users() returns empty for every
+    # incoming webhook. The fallback path in _process_github_event()
+    # delivers basic notifications but does not guarantee the agents
+    # fire.
+    no_repos = not any(uc.github_repos for uc in user_configs.values())
+    if no_repos:
+        review_on = pr_review_enabled or any(uc.pr_review is True for uc in user_configs.values())
+        triage_on = issue_triage_enabled or any(uc.issue_triage is True for uc in user_configs.values())
+        if review_on or triage_on:
+            features = []
+            if review_on:
+                features.append("PR review")
+            if triage_on:
+                features.append("issue triage")
+            log.warning(
+                "GitHub features enabled (%s) but no users have "
+                "github_repos configured. GitHub webhook events will "
+                "not be delivered to these features. Add 'github_repos' "
+                "to users.yaml entries. See: https://github.com/"
+                "dcellison/kai/wiki/Multi-User-Setup"
+                "#what-you-must-set-manually",
+                ", ".join(features),
+            )
 
     # Read DEFAULT_MODEL, falling back to CLAUDE_MODEL for backward
     # compat with existing /etc/kai/env files that haven't been

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1593,12 +1593,18 @@ def _load_user_configs(
     if data is None:
         msg = (
             f"users.yaml is required for authorization and was not found at {users_yaml_path}. "
-            "Run 'make config' to generate it."
+            "Run 'make config' to generate it; the wizard prompts for the admin Telegram ID."
         )
         if os.environ.get("ALLOWED_USER_IDS"):
+            # Surface the breaking change explicitly so a legacy
+            # env-only operator understands why the daemon stopped
+            # starting. The hint does NOT claim the wizard auto-seeds
+            # the new users.yaml from the env var; that auto-seed
+            # behavior is not implemented here and the wizard will
+            # prompt for the Telegram ID manually.
             msg += (
                 " ALLOWED_USER_IDS is set in env but is no longer honored as an "
-                "auth fallback; 'make config' will migrate it into users.yaml."
+                "auth fallback; copy each ID into the wizard prompt when it asks."
             )
         raise SystemExit(msg)
 

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -222,19 +222,15 @@ def main() -> None:
         await sessions.init_db(config.session_db_path)
         app = create_bot(config, use_webhook=use_webhook)
 
-        # Determine the default user (admin or first allowed user) for
-        # per-user data migrations and workspace restoration. Config
-        # validation ensures at least one user exists, but guard against
-        # edge cases to avoid a StopIteration crash at startup.
-        default_chat_id: int | None = None
-        if config.user_configs:
-            admins = config.get_admins()
-            if admins:
-                default_chat_id = admins[0].telegram_id
-            else:
-                default_chat_id = next(iter(config.user_configs))
-        elif config.allowed_user_ids:
-            default_chat_id = next(iter(config.allowed_user_ids))
+        # Determine the default user (admin or first user) for per-user
+        # data migrations and workspace restoration. users.yaml is
+        # mandatory so user_configs is always non-empty; the admin
+        # branch is preferred, otherwise the first entry wins.
+        admins = config.get_admins()
+        if admins:
+            default_chat_id: int | None = admins[0].telegram_id
+        else:
+            default_chat_id = next(iter(config.user_configs))
 
         # One-time migration: rename global "workspace" setting to
         # "workspace:{chat_id}" for per-user namespacing (Phase 2).

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1789,8 +1789,6 @@ def _resolve_os_user(user_id: str, config: Config) -> str | None:
     Returns None for any path that does not produce a per-user OS
     routing target:
 
-    - `config.user_configs is None` (legacy ALLOWED_USER_IDS install
-      that never built a users.yaml).
     - `user_id` does not parse as an int (eval-gate sandbox IDs like
       `sandbox-498-claude`).
     - The parsed telegram_id is not present in `user_configs`.
@@ -1807,8 +1805,6 @@ def _resolve_os_user(user_id: str, config: Config) -> str | None:
     threading `Config.user_configs` into deeper call sites for no
     extra correctness benefit.
     """
-    if config.user_configs is None:
-        return None
     try:
         tid = int(user_id)
     except ValueError:
@@ -1841,8 +1837,6 @@ def _resolve_effective_backend(user_id: str, config: Config) -> str:
     `_build_memory_reasoner` below catches a future regression where
     the gate moves or changes.
     """
-    if config.user_configs is None:
-        return config.agent_backend
     try:
         tid = int(user_id)
     except ValueError:

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -569,8 +569,6 @@ async def _get_subscribed_users(config: Config, repo_full_name: str) -> list[Use
         List of UserConfig objects for users who should receive this event.
         May contain both explicitly-subscribed users and admin wildcards.
     """
-    if config.user_configs is None:
-        return []
     repo_lower = repo_full_name.lower()
 
     explicitly_subscribed: list[UserConfig] = []
@@ -613,26 +611,19 @@ async def _process_github_event(request: web.Request, payload: dict, event_type:
     subscribed_users = await _get_subscribed_users(config, repo_full_name)
 
     if not subscribed_users:
-        # No subscribers and no admin wildcards for this repo.
-        # This can happen when:
-        #   - No users.yaml exists (env-var only mode, debug-log to avoid noise)
-        #   - All admins have explicit github_repos that don't include this repo
-        #   - No admins are configured (unusual; warned at config load time)
-        if config.user_configs:
-            log.warning(
-                "GitHub %s event for %s: no subscribed users. "
-                "Add 'github_repos: [%s]' to users.yaml to receive "
-                "events for this repo.",
-                event_type,
-                repo_full_name,
-                repo_full_name,
-            )
-        else:
-            log.debug(
-                "GitHub %s event for %s: no user_configs, using admin fallback",
-                event_type,
-                repo_full_name,
-            )
+        # No subscribers and no admin wildcards for this repo. With
+        # users.yaml mandatory the cause is now narrowly that all
+        # admins have explicit github_repos that don't include this
+        # repo, or that no admin is configured at all (a warning at
+        # config load time covers the latter).
+        log.warning(
+            "GitHub %s event for %s: no subscribed users. "
+            "Add 'github_repos: [%s]' to users.yaml to receive "
+            "events for this repo.",
+            event_type,
+            repo_full_name,
+            repo_full_name,
+        )
         # Fall back to the first admin in the app config so the event is
         # not silently dropped. Wrapped in try/except for consistency with
         # the fan-out path - a transient failure should return 200, not 500.
@@ -2050,30 +2041,22 @@ async def start(telegram_app, config) -> None:
     _app["webhook_secret"] = config.webhook_secret
 
     # Set the default chat_id for API calls that don't specify a target.
-    # When users.yaml exists, the first admin is the default. When no
-    # admin is defined, fall back to the first user with a warning.
-    # Without users.yaml, use the first ALLOWED_USER_IDS entry.
-    if config.user_configs:
-        admins = config.get_admins()
-        if admins:
-            _app["chat_id"] = admins[0].telegram_id
-        else:
-            # No admin defined - fall back to arbitrary first user.
-            fallback = next(iter(config.user_configs.values()))
-            log.warning(
-                "No admin users defined in users.yaml; using %s "
-                "(telegram_id: %d) as default webhook target. "
-                "External notifications may route unexpectedly.",
-                fallback.name,
-                fallback.telegram_id,
-            )
-            _app["chat_id"] = fallback.telegram_id
+    # users.yaml is mandatory so the first admin is the default; when
+    # no admin is defined, fall back to the first user with a warning
+    # (the same warning at config load time covers the no-admin case).
+    admins = config.get_admins()
+    if admins:
+        _app["chat_id"] = admins[0].telegram_id
     else:
-        # Legacy: ALLOWED_USER_IDS only
-        chat_id = next(iter(config.allowed_user_ids), None)
-        if chat_id is None:
-            raise SystemExit("No allowed user IDs configured; cannot start webhook server")
-        _app["chat_id"] = chat_id
+        fallback = next(iter(config.user_configs.values()))
+        log.warning(
+            "No admin users defined in users.yaml; using %s "
+            "(telegram_id: %d) as default webhook target. "
+            "External notifications may route unexpectedly.",
+            fallback.name,
+            fallback.telegram_id,
+        )
+        _app["chat_id"] = fallback.telegram_id
 
     # Store allowed user IDs for chat_id validation in _resolve_chat_id.
     # Prevents prompt injection from routing messages to arbitrary users.
@@ -2105,23 +2088,22 @@ async def start(telegram_app, config) -> None:
     # Add per-user github_notify_chat_id values to allowed_user_ids
     # so review/triage agents can POST to /api/send-message with
     # these chat_ids. Loads from both users.yaml and DB.
-    if config.user_configs:
-        for uc in config.user_configs.values():
-            if uc.github_notify_chat_id is not None:
-                _app["allowed_user_ids"].add(uc.github_notify_chat_id)
-        # Also add any DB-stored notify chat IDs (set via /github notify).
-        # webhook.start() is already async so the await is fine.
-        for uid in config.user_configs:
-            val = await sessions.get_setting(f"github_notify_chat:{uid}")
-            if val:
-                try:
-                    _app["allowed_user_ids"].add(int(val))
-                except ValueError:
-                    log.warning(
-                        "Invalid github_notify_chat for user %s in DB: %s (ignoring)",
-                        uid,
-                        val,
-                    )
+    for uc in config.user_configs.values():
+        if uc.github_notify_chat_id is not None:
+            _app["allowed_user_ids"].add(uc.github_notify_chat_id)
+    # Also add any DB-stored notify chat IDs (set via /github notify).
+    # webhook.start() is already async so the await is fine.
+    for uid in config.user_configs:
+        val = await sessions.get_setting(f"github_notify_chat:{uid}")
+        if val:
+            try:
+                _app["allowed_user_ids"].add(int(val))
+            except ValueError:
+                log.warning(
+                    "Invalid github_notify_chat for user %s in DB: %s (ignoring)",
+                    uid,
+                    val,
+                )
     # Also add the global env var fallback if set
     if config.github_notify_chat_id is not None:
         _app["allowed_user_ids"].add(config.github_notify_chat_id)
@@ -2280,10 +2262,6 @@ def remove_allowed_chat_id(chat_id: int) -> None:
     chat_id we previously added via add_allowed_chat_id() would also
     appear there. Instead, check config.user_configs (a dict keyed
     by telegram_id, populated at load time, never mutated at runtime).
-
-    In legacy mode (no users.yaml), config.user_configs is None and
-    this guard does not fire. The caller in bot.py must handle the
-    self-ID case before calling this function.
     """
     if _app is not None:
         allowed = _app.get("allowed_user_ids")
@@ -2292,6 +2270,6 @@ def remove_allowed_chat_id(chat_id: int) -> None:
         # Never remove a chat_id that belongs to an actual user.
         # user_configs keys are telegram_ids of real users.
         config = _app.get("config")
-        if config and config.user_configs and chat_id in config.user_configs:
+        if config and chat_id in config.user_configs:
             return
         allowed.discard(chat_id)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -889,12 +889,17 @@ class TestResolveHomeWorkspace:
     answer cannot drift between session init and `/workspace home`.
     """
 
-    def _config(self, user_configs=None) -> Config:
-        """Build a minimal Config with optional user_configs dict."""
+    def _config(self, user_configs: dict | None = None) -> Config:
+        """Build a minimal Config with optional user_configs dict.
+
+        Post-#565 tranche A `Config.user_configs` is a non-optional
+        dict; a None argument here is coerced to `{}` to preserve the
+        empty-dict test ergonomics callers expect.
+        """
         return Config(
             telegram_bot_token="test",
             allowed_user_ids={1},
-            user_configs=user_configs,
+            user_configs=user_configs if user_configs is not None else {},
         )
 
     def test_prefers_users_yaml(self, tmp_path):
@@ -922,11 +927,11 @@ class TestResolveHomeWorkspace:
 
     def test_falls_back_to_data_dir(self, tmp_path):
         """
-        When no users.yaml override exists, the resolver lands the user
-        in data_dir/home/<chat_id>/ via ensure_user_home (which creates
-        the directory as a side effect).
+        When the user is in users.yaml without a home_workspace override,
+        the resolver lands them in data_dir/home/<chat_id>/ via
+        ensure_user_home (which creates the directory as a side effect).
         """
-        config = self._config()
+        config = self._config(user_configs={42: UserConfig(telegram_id=42, name="real-user")})
         result = resolve_home_workspace(42, config, data_dir=tmp_path)
         assert result == tmp_path / "home" / "42"
         assert result.is_dir()
@@ -967,24 +972,6 @@ class TestResolveHomeWorkspace:
 
         assert result == tmp_path / "home" / str(notify_chat)
         assert not result.exists(), "notification-only chat_id must not auto-provision a home directory"
-
-    def test_single_user_mode_preserves_legacy_provisioning(self, tmp_path):
-        """
-        When users.yaml is empty or absent (config.user_configs is
-        falsy), there is no basis for discriminating interactive vs
-        notification chat_ids. Every chat_id is treated as
-        interactive and the directory is provisioned as before.
-
-        Pinning this case prevents an over-eager future tightening
-        of the notification check from breaking single-user dev /
-        test installations that have always used the legacy
-        permissive behavior.
-        """
-        config = self._config()  # user_configs=None
-        result = resolve_home_workspace(99999, config, data_dir=tmp_path)
-
-        assert result == tmp_path / "home" / "99999"
-        assert result.is_dir(), "single-user mode must continue to auto-provision the home dir"
 
 
 # ── Test prepend_to_prompt ──────────────────────────────────────────

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1557,7 +1557,10 @@ class TestHandleWorkspace:
 
         # No claude_workspace= override -> no UserConfig.home_workspace,
         # so resolve_home_workspace must fall through to ensure_user_home.
-        config = _make_config()
+        # users.yaml is mandatory post-#565 tranche A; supply a minimal
+        # entry for the default test chat_id so the resolver treats it
+        # as interactive rather than a runtime-added notification chat.
+        config = _make_config(user_configs={12345: UserConfig(telegram_id=12345, name="test")})
         claude = _make_mock_claude(workspace=Path("/other"))
         # _make_update defaults to chat_id=12345; the per-user home
         # directory therefore lands at tmp_path/home/12345.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -110,13 +110,33 @@ def _mock_binary_resolver(monkeypatch):
 
 
 def _set_required(monkeypatch, token="fake-token", user_ids="123"):
-    """Set only the truly required env vars (token + user IDs).
+    """Set the truly required env vars and the mandatory users.yaml.
+
+    Post-#565 tranche A, users.yaml is mandatory: load_config raises
+    SystemExit when it cannot resolve the file. Most config tests
+    exercise env-driven behavior orthogonal to auth, so this helper
+    auto-patches a minimal users.yaml derived from `user_ids` so the
+    auth contract is satisfied without each test caller wiring it.
+
+    Tests that specifically exercise the mandatory-users contract or
+    a custom users.yaml shape should call `_patch_protected_users_yaml`
+    directly and skip this helper (or override its protected-file
+    patch afterwards).
 
     TELEGRAM_WEBHOOK_URL is no longer required - omitting it selects polling mode.
     Tests that need webhook mode should set it explicitly.
     """
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", token)
     monkeypatch.setenv("ALLOWED_USER_IDS", user_ids)
+    # Build a minimal valid users.yaml from `user_ids` so the
+    # mandatory-users contract is met. Names are auto-generated;
+    # role=admin so the no-admin-warning does not fire.
+    user_entries = "\n".join(
+        f"  - telegram_id: {uid.strip()}\n    name: test-user-{uid.strip()}\n    role: admin"
+        for uid in user_ids.split(",")
+        if uid.strip()
+    )
+    _patch_protected_users_yaml(monkeypatch, f"users:\n{user_entries}\n")
 
 
 def _patch_protected_users_yaml(monkeypatch, content: str) -> None:
@@ -181,15 +201,29 @@ class TestLoadConfigErrors:
         with pytest.raises(SystemExit, match="TELEGRAM_BOT_TOKEN"):
             load_config()
 
-    def test_missing_user_ids(self, monkeypatch):
+    def test_missing_users_yaml(self, monkeypatch):
+        """Missing /etc/kai/users.yaml is a hard startup failure
+        (#565 tranche A). ALLOWED_USER_IDS no longer authorizes the
+        daemon to start; it only contributes a migration hint.
+        """
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok")
-        with pytest.raises(SystemExit, match="No user authorization configured"):
+        monkeypatch.delenv("ALLOWED_USER_IDS", raising=False)
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            pytest.raises(SystemExit, match=r"users\.yaml is required"),
+        ):
             load_config()
 
-    def test_non_numeric_user_ids(self, monkeypatch):
+    def test_missing_users_yaml_with_allowed_user_ids_includes_migration_hint(self, monkeypatch):
+        """Operator UX: env-only legacy installs need to see the
+        ALLOWED_USER_IDS migration hint in the error message.
+        """
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok")
-        monkeypatch.setenv("ALLOWED_USER_IDS", "notanumber")
-        with pytest.raises(SystemExit, match="non-numeric"):
+        monkeypatch.setenv("ALLOWED_USER_IDS", "12345")
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            pytest.raises(SystemExit, match="ALLOWED_USER_IDS is set in env but is no longer honored"),
+        ):
             load_config()
 
     def test_workspace_base_nonexistent(self, monkeypatch, tmp_path):
@@ -585,13 +619,31 @@ class TestReadProtectedFile:
 
 
 class TestDualModeLoading:
+    @staticmethod
+    def _protected_reader(env_content: str):
+        """Lambda that responds to both /etc/kai/env and /etc/kai/users.yaml.
+
+        users.yaml is mandatory post-#565 tranche A, so the dual-mode
+        loader tests must provide a minimal admin entry to satisfy
+        the auth contract; otherwise load_config raises before
+        reaching the env-file assertions these tests exist for.
+        """
+        users_yaml = "users:\n  - telegram_id: 999\n    name: test\n    role: admin\n"
+
+        def _read(path):
+            if path == "/etc/kai/env":
+                return env_content
+            if path == "/etc/kai/users.yaml":
+                return users_yaml
+            return None
+
+        return _read
+
     def test_loads_from_protected_env(self, monkeypatch):
         """When /etc/kai/env is readable, values are used as config."""
         monkeypatch.setattr(
             "kai.config._read_protected_file",
-            lambda path: (
-                "TELEGRAM_BOT_TOKEN=protected-token\nALLOWED_USER_IDS=999\n" if path == "/etc/kai/env" else None
-            ),
+            self._protected_reader("TELEGRAM_BOT_TOKEN=protected-token\nALLOWED_USER_IDS=999\n"),
         )
         config = load_config()
         assert config.telegram_bot_token == "protected-token"
@@ -601,9 +653,7 @@ class TestDualModeLoading:
         """Quote marks around values in /etc/kai/env are stripped."""
         monkeypatch.setattr(
             "kai.config._read_protected_file",
-            lambda path: (
-                "TELEGRAM_BOT_TOKEN=\"quoted-token\"\nALLOWED_USER_IDS='999'\n" if path == "/etc/kai/env" else None
-            ),
+            self._protected_reader("TELEGRAM_BOT_TOKEN=\"quoted-token\"\nALLOWED_USER_IDS='999'\n"),
         )
         config = load_config()
         assert config.telegram_bot_token == "quoted-token"
@@ -613,9 +663,7 @@ class TestDualModeLoading:
         """Comments and blank lines in /etc/kai/env are ignored."""
         monkeypatch.setattr(
             "kai.config._read_protected_file",
-            lambda path: (
-                "# comment\n\nTELEGRAM_BOT_TOKEN=tok\n\nALLOWED_USER_IDS=1\n" if path == "/etc/kai/env" else None
-            ),
+            self._protected_reader("# comment\n\nTELEGRAM_BOT_TOKEN=tok\n\nALLOWED_USER_IDS=999\n"),
         )
         config = load_config()
         assert config.telegram_bot_token == "tok"
@@ -636,7 +684,7 @@ class TestDualModeLoading:
         """Explicitly set env vars override values from /etc/kai/env."""
         monkeypatch.setattr(
             "kai.config._read_protected_file",
-            lambda path: "TELEGRAM_BOT_TOKEN=from-file\nALLOWED_USER_IDS=1\n" if path == "/etc/kai/env" else None,
+            self._protected_reader("TELEGRAM_BOT_TOKEN=from-file\nALLOWED_USER_IDS=999\n"),
         )
         # Set token explicitly in env - should override file value
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "from-env")
@@ -863,21 +911,6 @@ class TestDeprecationWarnings:
             load_config()
         assert f"{var} in env is deprecated" in caplog.text
 
-    def test_no_warning_without_users_yaml(self, monkeypatch, caplog):
-        """Per-user deprecated env vars do NOT warn when users.yaml is absent.
-
-        Note: CLAUDE_MODEL still emits a standalone rename warning (it was
-        renamed to DEFAULT_MODEL) regardless of users.yaml. This test uses
-        a non-CLAUDE_MODEL var to verify the users.yaml-gated warnings.
-        """
-        _set_required(monkeypatch)
-        monkeypatch.setenv("CLAUDE_USER", "somebody")
-        # _load_user_configs returns None (no users.yaml) by default
-        # because _clean_env patches _read_protected_file to None
-        with caplog.at_level(logging.WARNING, logger="kai.config"):
-            load_config()
-        assert "deprecated" not in caplog.text.lower()
-
     def test_empty_var_does_not_warn(self, monkeypatch, caplog):
         """Empty string env vars are not treated as 'set'."""
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
@@ -958,19 +991,6 @@ class TestGitHubReposWarning:
         """No warning when neither feature is enabled (empty repos is fine)."""
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
         _mock_user_configs(monkeypatch)
-        with caplog.at_level(logging.WARNING, logger="kai.config"):
-            load_config()
-        repo_warnings = [
-            r
-            for r in caplog.records
-            if r.levelno >= logging.WARNING and "github_repos" in r.message and "deprecated" not in r.message
-        ]
-        assert repo_warnings == []
-
-    def test_no_warn_when_no_user_configs(self, monkeypatch, caplog):
-        """No warning in env-var-only mode (no users.yaml)."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("PR_REVIEW_ENABLED", "true")
         with caplog.at_level(logging.WARNING, logger="kai.config"):
             load_config()
         repo_warnings = [
@@ -1196,24 +1216,16 @@ class TestResolutionWithoutEnvVars:
 # ── Legacy env-only backward compatibility ──────────────────────────
 
 
-class TestLegacyEnvOnlyMode:
-    """Verify backward compatibility when users.yaml does not exist.
+class TestLegacyEnvBackwardCompat:
+    """Backward-compat coverage for env-var renames that still apply
+    even though users.yaml is now mandatory (#565 tranche A).
 
-    Single-user installs with only env vars (no users.yaml) must
-    continue to work exactly as before.
+    Pre-tranche-A this class covered the "single-user install via
+    env vars only" path; that path is gone (the loader raises
+    SystemExit on absent users.yaml). What remains is the env-var
+    rename surface (BUDGET_CEILING <- CLAUDE_MAX_BUDGET_USD,
+    AGENT_TIMEOUT_SECONDS <- CLAUDE_TIMEOUT_SECONDS).
     """
-
-    def test_loads_from_env_only(self, monkeypatch):
-        """Full config from env vars works when users.yaml is absent."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("CLAUDE_MODEL", "opus")
-        monkeypatch.setenv("BUDGET_CEILING", "25.0")
-        monkeypatch.setenv("CLAUDE_TIMEOUT_SECONDS", "300")
-        config = load_config()
-        assert config.default_model == "opus"
-        assert config.budget_ceiling == 25.0
-        assert config.claude_timeout_seconds == 300
-        assert config.user_configs is None
 
     def test_old_budget_env_var_backward_compat(self, monkeypatch):
         """CLAUDE_MAX_BUDGET_USD still works as fallback when BUDGET_CEILING is not set."""
@@ -1598,11 +1610,11 @@ class TestMemoryReasonerBinaryValidation:
         shape as claude."""
         from kai.oneshot_binary import BinaryResolutionError
 
+        _set_required(monkeypatch)
         _patch_protected_users_yaml(
             monkeypatch,
             "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    agent_backend: codex\n    os_user: alice_os\n",
         )
-        _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
 
@@ -1693,11 +1705,11 @@ class TestCodexMemorySameUserSymmetry:
         loads successfully. The runtime treats missing os_user as
         in-process spawn (claude's existing pattern), so config-load
         does not refuse the shape."""
+        _set_required(monkeypatch)
         _patch_protected_users_yaml(
             monkeypatch,
             "users:\n  - telegram_id: 67890\n    name: bob\n    role: user\n",
         )
-        _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
         monkeypatch.setenv("AGENT_BACKEND", "codex")
@@ -1713,11 +1725,11 @@ class TestCodexMemorySameUserSymmetry:
         codex in-process - the same path claude has always used
         for same-user."""
         bot_user = pwd.getpwuid(os.getuid()).pw_name
+        _set_required(monkeypatch)
         _patch_protected_users_yaml(
             monkeypatch,
             f"users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: {bot_user}\n",
         )
-        _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
         monkeypatch.setenv("AGENT_BACKEND", "codex")
@@ -1730,11 +1742,11 @@ class TestCodexMemorySameUserSymmetry:
         set to a non-bot account loads cleanly and is preserved on
         the UserConfig entry. Regression guard for the multi-user
         case."""
+        _set_required(monkeypatch)
         _patch_protected_users_yaml(
             monkeypatch,
             "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: alice_os\n",
         )
-        _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
         monkeypatch.setenv("AGENT_BACKEND", "codex")
@@ -1768,11 +1780,11 @@ class TestMemoryReasonerModelResolution:
         """Codex install: registry resolves to a codex-CLI-valid SKU.
         Test path is the per-user dispatch surface that production
         will follow: AGENT_BACKEND=codex + users.yaml with os_user."""
+        _set_required(monkeypatch)
         _patch_protected_users_yaml(
             monkeypatch,
             "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: alice_os\n",
         )
-        _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
         monkeypatch.setenv("AGENT_BACKEND", "codex")
@@ -1817,29 +1829,11 @@ class TestExtractionEligibleBackendsHelper:
     def test_returns_empty_when_memory_extraction_disabled(self):
         """Retrieval-only and memory-disabled installs do not run any
         reasoner, so the eligible set is empty regardless of
-        agent_backend and users.yaml."""
+        agent_backend and users.yaml content."""
         from kai.config import _compute_extraction_eligible_backends
 
-        assert _compute_extraction_eligible_backends("claude", None, False) == set()
-        assert _compute_extraction_eligible_backends("codex", None, False) == set()
-
-    def test_no_users_yaml_uses_global_backend(self):
-        """ALLOWED_USER_IDS-only authorization (no users.yaml): every
-        authorized user inherits the global agent backend, so the
-        eligible set is `{agent_backend}` when extraction-eligible."""
-        from kai.config import _compute_extraction_eligible_backends
-
-        assert _compute_extraction_eligible_backends("claude", None, True) == {"claude"}
-        assert _compute_extraction_eligible_backends("codex", None, True) == {"codex"}
-
-    def test_goose_global_with_no_users_yaml_returns_empty(self):
-        """Goose is not extraction-eligible (no OneShotReasoner
-        implementation). ALLOWED_USER_IDS install with
-        AGENT_BACKEND=goose produces an empty set; no reasoner
-        plumbing fires."""
-        from kai.config import _compute_extraction_eligible_backends
-
-        assert _compute_extraction_eligible_backends("goose", None, True) == set()
+        assert _compute_extraction_eligible_backends("claude", {}, False) == set()
+        assert _compute_extraction_eligible_backends("codex", {}, False) == set()
 
     def test_mixed_users_yaml_contributes_each_effective_backend(self):
         """users.yaml with both claude and codex users: the eligible
@@ -1903,13 +1897,13 @@ class TestRegistryValidationPerEligibleBackend:
         import kai.config as config_mod
         from kai.config import ModelRole
 
+        _set_required(monkeypatch)
         _patch_protected_users_yaml(
             monkeypatch,
             "users:\n"
             "  - telegram_id: 1\n    name: alice\n    role: admin\n"
             "    agent_backend: codex\n    os_user: alice_os\n",
         )
-        _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
         # Patch the registry to drop the codex MEMORY_EXTRACTION row.
@@ -2665,6 +2659,12 @@ class TestAgentTimeoutSecondsRename:
         base.update(overrides)
         for k, v in base.items():
             monkeypatch.setenv(k, v)
+        # users.yaml is mandatory post-#565 tranche A; patch a minimal
+        # admin entry so load_config completes for these env-driven tests.
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n",
+        )
 
     def test_agent_timeout_seconds_preferred(self, monkeypatch):
         self._required_env(
@@ -2704,6 +2704,12 @@ class TestLoadConfigBackendAwareModelValidation:
         base.update(overrides)
         for k, v in base.items():
             monkeypatch.setenv(k, v)
+        # users.yaml is mandatory post-#565 tranche A; patch a minimal
+        # admin entry so the validation tests reach the model check.
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n",
+        )
 
     def test_codex_rejects_goose_only_model(self, monkeypatch):
         self._env(monkeypatch, AGENT_BACKEND="codex", DEFAULT_MODEL="gpt-5.4-nano")
@@ -3098,6 +3104,10 @@ class TestLoadMemoryProjects:
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
         monkeypatch.setenv("ALLOWED_USER_IDS", "12345")
         monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n",
+        )
 
         registry_root = tmp_path / "registry_root"
         registry_root.mkdir()
@@ -3118,10 +3128,7 @@ class TestLoadMemoryProjects:
             )
         )
 
-        with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
-        ):
+        with patch("kai.config.PROJECT_ROOT", tmp_path):
             cfg = load_config()
 
         # Registry loaded the project as expected.
@@ -3154,6 +3161,10 @@ class TestMemoryRecallShadowConfig:
         monkeypatch.setenv("ALLOWED_USER_IDS", "12345")
         monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
         monkeypatch.setenv("MEMORY_ENABLED", "true")  # gate for shadow to be on
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n",
+        )
 
     def test_memory_recall_shadow_config_defaults_enabled(self, monkeypatch):
         """Unset env var → shadow enabled when memory is on. The
@@ -3184,6 +3195,10 @@ class TestMemoryRecallShadowConfig:
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
         monkeypatch.setenv("ALLOWED_USER_IDS", "12345")
         monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n",
+        )
         # MEMORY_ENABLED unset / off; shadow must also fall to off
         # regardless of the shadow env var.
         monkeypatch.setenv("MEMORY_RECALL_SHADOW_ENABLED", "true")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2365,8 +2365,7 @@ class TestCmdConfig:
         # builds this alongside the env block; here we set up a
         # minimal users.yaml inline so the test focuses on the
         # memory env contract.
-        users_yaml = tmp_path / "users.yaml"
-        users_yaml.write_text("users:\n  - telegram_id: 1\n    name: tester\n    role: admin\n    os_user: tester_os\n")
+        users_yaml_text = "users:\n  - telegram_id: 1\n    name: tester\n    role: admin\n    os_user: tester_os\n"
         monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
         # Pin protected-env / dotenv to be inert. Without this,
         # load_config reads /etc/kai/env (when present on the dev
@@ -2379,7 +2378,15 @@ class TestCmdConfig:
         # its scope; this test is in test_install.py and has to do
         # it explicitly.
         monkeypatch.setattr("kai.config.load_dotenv", lambda *a, **kw: None)
-        monkeypatch.setattr("kai.config._read_protected_file", lambda path: None)
+
+        def _fake_read(path):
+            # users.yaml is mandatory post-#565 tranche A; serve the
+            # inline content so the loader's auth contract is met.
+            if path == "/etc/kai/users.yaml":
+                return users_yaml_text
+            return None
+
+        monkeypatch.setattr("kai.config._read_protected_file", _fake_read)
         # Seed only the env keys the wizard would emit. Everything
         # else falls back to dataclass defaults via load_config.
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from kai.config import Config
+from kai.config import Config, UserConfig
 
 # Default config for tests - memory disabled unless explicitly enabled.
 # Real tests override memory_enabled=True via the memory_config fixture.
@@ -234,10 +234,13 @@ class TestInitMemory:
         # `agent_backend` (legacy ALLOWED_USER_IDS auth has no
         # users.yaml, so every user inherits the global). A
         # single-backend install logs the uniform-mode flat keys plus
-        # the per-backend maps.
+        # the per-backend maps. users.yaml is mandatory post-#565
+        # tranche A, so we provide a minimal user whose effective
+        # backend matches the global.
         config = _make_config(
             memory_extraction_enabled=True,
             agent_backend="codex",
+            user_configs={1: UserConfig(telegram_id=1, name="alice", os_user="a")},
         )
         with (
             caplog.at_level(logging.INFO, logger="kai.memory"),

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -3764,7 +3764,7 @@ class TestResolveOsUser:
     def test_returns_none_when_user_configs_absent(self):
         """Legacy ALLOWED_USER_IDS install: no users.yaml means no
         os_user mapping exists."""
-        config = replace(_BASE_CONFIG, user_configs=None)
+        config = replace(_BASE_CONFIG, user_configs={})
         assert memory_extraction._resolve_os_user("42", config) is None
 
     def test_returns_none_for_non_numeric_user_id(self):

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -90,14 +90,18 @@ class TestInstanceCreation:
 
     def test_get_falls_back_to_defaults(self, tmp_path, monkeypatch):
         """
-        User not in users.yaml gets global defaults plus the per-user
-        DATA_DIR/home/<chat_id>/ landing directory (#353). The shared
-        global home was removed; the new fallback is keyed by chat_id.
+        User in users.yaml with no per-user overrides gets global
+        defaults plus the per-user DATA_DIR/home/<chat_id>/ landing
+        directory. The shared global home was removed; the new
+        fallback is keyed by chat_id.
         """
         # Point the resolver at a tmp DATA_DIR so the test does not
         # touch the host's real /var/lib/kai or PROJECT_ROOT tree.
         monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
-        config = _make_config(claude_user=None)
+        config = _make_config(
+            claude_user=None,
+            user_configs={999: UserConfig(telegram_id=999, name="bob")},
+        )
         pool = SubprocessPool(config=config, services_info=[])
         instance = pool.get(999)
         assert instance.claude_user is None

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -549,7 +549,7 @@ class TestUserSettings:
 class TestResolveUserDefaults:
     """Tests for the per-user settings resolution function."""
 
-    def _make_config(self, user_configs=None, **kwargs):
+    def _make_config(self, user_configs: dict | None = None, **kwargs):
         """Build a minimal Config with overridable defaults."""
         from kai.config import Config
 
@@ -769,7 +769,7 @@ class TestAllowedWorkspaces:
 class TestResolveWorkspaceAccess:
     """Tests for per-user workspace_base and allowed_workspaces resolution."""
 
-    def _make_config(self, user_configs=None, **kwargs):
+    def _make_config(self, user_configs: dict | None = None, **kwargs):
         """Build a minimal Config with overridable defaults."""
         from kai.config import Config
 
@@ -1086,7 +1086,7 @@ class TestEffectiveRepos:
 class TestResolveGitHubSettings:
     """Tests for per-user GitHub notification settings resolution."""
 
-    def _make_config(self, user_configs=None, **kwargs):
+    def _make_config(self, user_configs: dict | None = None, **kwargs):
         """Build a minimal Config with overridable defaults."""
         from kai.config import Config
 

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -142,38 +142,59 @@ class TestLoadUserConfigs:
         assert configs[222].name == "bob"
         assert configs[222].role == "user"
 
-    def test_missing_file(self):
-        """Returns None when /etc/kai/users.yaml is absent.
+    def test_missing_file(self, monkeypatch):
+        """Raises SystemExit when /etc/kai/users.yaml is absent.
 
-        The protected reader returns None for missing files (distinct
-        from `_YAML_MALFORMED`); the loader maps that to None so the
-        caller falls back to the legacy ALLOWED_USER_IDS path.
+        users.yaml is mandatory. The protected reader returns None
+        for missing files; the loader raises with an operator-facing
+        error naming the path and pointing at `make config`. No
+        fallback to ALLOWED_USER_IDS at runtime.
         """
-        with patch("kai.config._read_protected_yaml", return_value=None):
-            configs = _load_user_configs("claude", "")
-        assert configs is None
+        monkeypatch.delenv("ALLOWED_USER_IDS", raising=False)
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            pytest.raises(SystemExit, match=r"users\.yaml is required"),
+        ):
+            _load_user_configs("claude", "")
+
+    def test_missing_file_with_allowed_user_ids_appends_migration_hint(self, monkeypatch):
+        """Missing-file error appends a migration hint when ALLOWED_USER_IDS is set.
+
+        Operator UX: a legacy env-only install needs to know that the
+        old auth path no longer works and that `make config` will
+        migrate the existing telegram_ids into users.yaml.
+        """
+        monkeypatch.setenv("ALLOWED_USER_IDS", "12345")
+        with (
+            patch("kai.config._read_protected_yaml", return_value=None),
+            pytest.raises(SystemExit, match="ALLOWED_USER_IDS is set in env but is no longer honored"),
+        ):
+            _load_user_configs("claude", "")
 
     def test_empty_file(self):
-        """Returns None when /etc/kai/users.yaml exists but is empty.
+        """Raises SystemExit when /etc/kai/users.yaml is empty / non-dict top-level.
 
-        The protected reader normalizes an empty / non-dict top-level
-        to `_YAML_MALFORMED`; the loader treats that as "fail closed"
-        and returns None rather than silently constructing an empty
-        config.
+        The protected reader normalizes an empty or non-dict top-level
+        to `_YAML_MALFORMED`; the loader treats that as fail-closed and
+        raises rather than silently constructing an empty config.
         """
-        with patch("kai.config._read_protected_yaml", return_value=_YAML_MALFORMED):
-            configs = _load_user_configs("claude", "")
-        assert configs is None
+        with (
+            patch("kai.config._read_protected_yaml", return_value=_YAML_MALFORMED),
+            pytest.raises(SystemExit, match="malformed"),
+        ):
+            _load_user_configs("claude", "")
 
     def test_invalid_yaml(self):
-        """Returns None when /etc/kai/users.yaml is malformed.
+        """Raises SystemExit when /etc/kai/users.yaml is malformed.
 
         Same code path as the empty-file case: the protected reader
         already raised on parse and returned `_YAML_MALFORMED`.
         """
-        with patch("kai.config._read_protected_yaml", return_value=_YAML_MALFORMED):
-            configs = _load_user_configs("claude", "")
-        assert configs is None
+        with (
+            patch("kai.config._read_protected_yaml", return_value=_YAML_MALFORMED),
+            pytest.raises(SystemExit, match="malformed"),
+        ):
+            _load_user_configs("claude", "")
 
     def test_missing_telegram_id(self, tmp_path):
         """Entry without telegram_id is skipped."""
@@ -186,10 +207,9 @@ class TestLoadUserConfigs:
         )
         with (
             patch("kai.config._read_protected_yaml", return_value=data),
+            pytest.raises(SystemExit, match="no valid user entries"),
         ):
-            configs = _load_user_configs("claude", "")
-        assert configs is not None
-        assert len(configs) == 0
+            _load_user_configs("claude", "")
 
     def test_whitespace_only_name(self, tmp_path):
         """Whitespace-only name is treated as missing."""
@@ -202,10 +222,9 @@ class TestLoadUserConfigs:
         )
         with (
             patch("kai.config._read_protected_yaml", return_value=data),
+            pytest.raises(SystemExit, match="no valid user entries"),
         ):
-            configs = _load_user_configs("claude", "")
-        assert configs is not None
-        assert len(configs) == 0
+            _load_user_configs("claude", "")
 
     def test_missing_name(self, tmp_path):
         """Entry without name is skipped."""
@@ -218,10 +237,9 @@ class TestLoadUserConfigs:
         )
         with (
             patch("kai.config._read_protected_yaml", return_value=data),
+            pytest.raises(SystemExit, match="no valid user entries"),
         ):
-            configs = _load_user_configs("claude", "")
-        assert configs is not None
-        assert len(configs) == 0
+            _load_user_configs("claude", "")
 
     def test_invalid_role(self, tmp_path):
         """Invalid role causes the entry to be skipped."""
@@ -235,10 +253,9 @@ class TestLoadUserConfigs:
         )
         with (
             patch("kai.config._read_protected_yaml", return_value=data),
+            pytest.raises(SystemExit, match="no valid user entries"),
         ):
-            configs = _load_user_configs("claude", "")
-        assert configs is not None
-        assert len(configs) == 0
+            _load_user_configs("claude", "")
 
     def test_invalid_budget(self, tmp_path):
         """Negative budget causes the entry to be skipped."""
@@ -252,10 +269,9 @@ class TestLoadUserConfigs:
         )
         with (
             patch("kai.config._read_protected_yaml", return_value=data),
+            pytest.raises(SystemExit, match="no valid user entries"),
         ):
-            configs = _load_user_configs("claude", "")
-        assert configs is not None
-        assert len(configs) == 0
+            _load_user_configs("claude", "")
 
     def test_bool_budget_rejected(self, tmp_path):
         """Boolean budget is rejected (same bool guard as workspace config)."""
@@ -269,10 +285,9 @@ class TestLoadUserConfigs:
         )
         with (
             patch("kai.config._read_protected_yaml", return_value=data),
+            pytest.raises(SystemExit, match="no valid user entries"),
         ):
-            configs = _load_user_configs("claude", "")
-        assert configs is not None
-        assert len(configs) == 0
+            _load_user_configs("claude", "")
 
     def test_bool_telegram_id_rejected(self, tmp_path):
         """Boolean telegram_id is rejected."""
@@ -285,10 +300,9 @@ class TestLoadUserConfigs:
         )
         with (
             patch("kai.config._read_protected_yaml", return_value=data),
+            pytest.raises(SystemExit, match="no valid user entries"),
         ):
-            configs = _load_user_configs("claude", "")
-        assert configs is not None
-        assert len(configs) == 0
+            _load_user_configs("claude", "")
 
     def test_duplicate_ids(self, tmp_path):
         """Duplicate telegram_id: first wins."""
@@ -356,22 +370,24 @@ class TestLoadUserConfigs:
         assert configs is not None
         assert configs[111].name == "alice"
 
-    def test_stray_project_root_users_yaml_is_ignored(self, tmp_path):
+    def test_stray_project_root_users_yaml_is_ignored(self, tmp_path, monkeypatch):
         """A stray `PROJECT_ROOT/users.yaml` does not affect the loader.
 
-        The dual-path fallback was removed: when the protected reader
-        returns None (canonical file absent), the loader returns None
-        and the caller falls back to ALLOWED_USER_IDS. A leftover
-        users.yaml inside the source tree must not feed the daemon.
+        The dual-path fallback was removed in #559: when the protected
+        reader returns None (canonical file absent), the loader raises
+        SystemExit (mandatory users.yaml). A leftover users.yaml inside
+        the source tree must not feed the daemon and must not bypass
+        the mandatory-users contract.
         """
+        monkeypatch.delenv("ALLOWED_USER_IDS", raising=False)
         stray = tmp_path / "users.yaml"
         stray.write_text("users:\n  - telegram_id: 999\n    name: stray\n    role: admin\n")
         with (
             patch("kai.config._read_protected_yaml", return_value=None),
             patch("kai.config.PROJECT_ROOT", tmp_path),
+            pytest.raises(SystemExit, match=r"users\.yaml is required"),
         ):
-            configs = _load_user_configs("claude", "")
-        assert configs is None
+            _load_user_configs("claude", "")
 
     def test_no_admin_warning(self, tmp_path, caplog):
         """All users with role 'user' logs a warning but does not fail."""
@@ -999,11 +1015,15 @@ class TestLoadUserConfigs:
 
 
 class TestConfigUserMethods:
-    def _make_config(self, user_configs=None):
+    def _make_config(self, user_configs: dict | None = None):
+        # user_configs is non-optional on Config post-#565 tranche A.
+        # Tests that previously passed None now default to empty dict;
+        # the loader's mandatory-users contract is verified elsewhere
+        # in TestLoadUserConfigs.
         return Config(
             telegram_bot_token="test",
             allowed_user_ids={1},
-            user_configs=user_configs,
+            user_configs=user_configs if user_configs is not None else {},
         )
 
     def test_get_user_config_found(self):
@@ -1016,11 +1036,6 @@ class TestConfigUserMethods:
         """Returns None for unknown telegram_id."""
         config = self._make_config({})
         assert config.get_user_config(999) is None
-
-    def test_get_user_config_no_yaml(self):
-        """Returns None when user_configs is None (no users.yaml)."""
-        config = self._make_config(None)
-        assert config.get_user_config(111) is None
 
     def test_get_user_by_github(self):
         """Finds user by GitHub login."""
@@ -1041,11 +1056,6 @@ class TestConfigUserMethods:
         config = self._make_config({111: uc})
         assert config.get_user_by_github("unknown") is None
 
-    def test_get_user_by_github_no_yaml(self):
-        """Returns None when user_configs is None."""
-        config = self._make_config(None)
-        assert config.get_user_by_github("alice") is None
-
     def test_get_admins(self):
         """Returns list of admin users only."""
         admin = UserConfig(telegram_id=111, name="alice", role="admin")
@@ -1059,9 +1069,4 @@ class TestConfigUserMethods:
         """Returns empty list when no admins exist."""
         user = UserConfig(telegram_id=222, name="bob", role="user")
         config = self._make_config({222: user})
-        assert config.get_admins() == []
-
-    def test_get_admins_no_yaml(self):
-        """Returns empty list when user_configs is None."""
-        config = self._make_config(None)
         assert config.get_admins() == []

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -395,7 +395,7 @@ def _build_test_app(
     """Build a minimal aiohttp app with _handle_github wired up.
 
     The config parameter controls per-user routing. When None, a mock
-    Config with user_configs=None is used, which causes _get_subscribed_users
+    Config with user_configs={} is used, which causes _get_subscribed_users
     to return empty and the fallback path (admin chat_id) to fire. To test
     per-user routing, pass a mock with user_configs populated.
 
@@ -427,7 +427,7 @@ def _build_test_app(
     # so all events fall through to admin chat_id.
     if config is None:
         mock_config = AsyncMock()
-        mock_config.user_configs = None
+        mock_config.user_configs = {}
         # get_user_config is synchronous in real Config; must not
         # return a coroutine. With no users configured, always None.
         mock_config.get_user_config = lambda uid: None
@@ -1232,9 +1232,14 @@ class TestGetSubscribedUsers:
             yield
 
     def _make_config(self, user_configs: dict | None = None) -> AsyncMock:
-        """Build a mock Config with the given user_configs dict."""
+        """Build a mock Config with the given user_configs dict.
+
+        Post-#565 tranche A `Config.user_configs` is a non-optional
+        dict; a None argument here is coerced to `{}` to preserve the
+        empty-dict test ergonomics callers expect.
+        """
         config = AsyncMock()
-        config.user_configs = user_configs
+        config.user_configs = user_configs if user_configs is not None else {}
         return config
 
     def _make_user(
@@ -1284,8 +1289,8 @@ class TestGetSubscribedUsers:
         assert result == []
 
     async def test_no_user_configs(self):
-        """Config with user_configs=None returns empty list."""
-        config = self._make_config(None)
+        """Config with empty user_configs returns empty list."""
+        config = self._make_config({})
         result = await _get_subscribed_users(config, "dcellison/kai")
         assert result == []
 
@@ -1829,7 +1834,7 @@ class TestPerUserRouting:
         app = _build_test_app()
         # Set the global fallback on the mock config
         app["config"].claude_user = "global-user"
-        app["config"].user_configs = None
+        app["config"].user_configs = {}
         app["config"].get_user_config = lambda uid: None
         payload = _make_pr_payload("opened")
         body = json.dumps(payload).encode()
@@ -1890,7 +1895,7 @@ class TestPerUserRouting:
         """Legacy mode (no user_configs) falls back to global claude_user for triage."""
         app = _build_test_app()
         app["config"].claude_user = "global-user"
-        app["config"].user_configs = None
+        app["config"].user_configs = {}
         app["config"].get_user_config = lambda uid: None
         payload = _make_issue_payload("opened")
         body = json.dumps(payload).encode()
@@ -2186,7 +2191,7 @@ class TestAllowedChatIdMutations:
         app["allowed_user_ids"] = {100, -100123}
         # No config needed for this case - group IDs are never in user_configs
         mock_config = AsyncMock()
-        mock_config.user_configs = None
+        mock_config.user_configs = {}
         app["config"] = mock_config
         old_app = wh._app
         wh._app = app

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -567,12 +567,12 @@ def _sign_body(secret: str, body: bytes) -> str:
 def github_request():
     """Create a mock request for the GitHub webhook endpoint.
 
-    Includes a mock config with user_configs=None (no per-user routing)
+    Includes a mock config with user_configs={} (no per-user routing)
     and mocks resolve_github_settings to return defaults. This simulates
     fallback routing where events go to the admin chat_id.
     """
     mock_config = MagicMock()
-    mock_config.user_configs = None
+    mock_config.user_configs = {}
     request = MagicMock(spec=web.Request)
     request.app = {
         "webhook_secret": "test-secret",


### PR DESCRIPTION
## Summary

Second of four tranches against #565 (runtime mandate). users.yaml becomes the only authorization shape at runtime; the legacy `ALLOWED_USER_IDS` fallback in `load_config` is gone.

Mechanism:

- `_load_user_configs` returns `dict[int, UserConfig]` on success or raises `SystemExit` on every failure (missing file, malformed YAML, non-dict top level, missing or non-list `users` key, zero valid entries). The error message names the resolved `/etc/kai/users.yaml` path and points at `make config`. When `ALLOWED_USER_IDS` is still set in env on a missing-file install, a one-line migration hint is appended so legacy operators know the env var is no longer honored as auth.
- `load_config` drops the `ALLOWED_USER_IDS` parsing block, the legacy fallback branch, the "Using ALLOWED_USER_IDS (legacy)" log path, and the malformed-users-fallback path. `allowed_user_ids` derives from `set(user_configs.keys())`.
- `Config.user_configs` becomes a non-Optional `dict[int, UserConfig]` with an empty-dict default factory (test ergonomics; production goes through `load_config`).
- Production callers in `pool.py`, `bot.py`, `webhook.py`, `backend.py`, `main.py`, and `memory_extraction.py` shed every `user_configs is None` branch. The previous "legacy mode" conditional logic was dead code under the new contract; removing it tightens the data flow without changing observable behavior under any users.yaml-present install.
- `_compute_extraction_eligible_backends` and the three `Config` convenience methods (`get_user_config`, `get_user_by_github`, `get_admins`) lose their None guards.

Out of scope (deferred to other tranches):

- Class A env-mirror removal (`CLAUDE_MODEL`, `CLAUDE_USER`, `PR_REVIEW_ENABLED`, `ISSUE_TRIAGE_ENABLED`, `GITHUB_NOTIFY_CHAT_ID` reads and the deprecated-env-warning entries): tranche D.
- Single-user / XDG deployment mode: tranche C.
- README and `templates/.env` language: tranche D.

## Tranche tracking (#565 v2)

- [x] **B** wizard prompt re-gating (PR #566, merged)
- [x] **A** runtime mandate (this PR)
- [ ] **C** deployment mode + XDG (depends on A)
- [ ] **D** cleanup + docs (depends on A-C)

## Migration

- Existing installs with valid `/etc/kai/users.yaml`: no action.
- Existing installs with `ALLOWED_USER_IDS` only and no `/etc/kai/users.yaml`: daemon fails closed at next start with an error naming the path and the migration command. The error appends a one-line hint when `ALLOWED_USER_IDS` is set, telling the operator that `make config` migrates the existing telegram_ids.
- Installs with `ALLOWED_USER_IDS` AND a valid `/etc/kai/users.yaml`: previously the env var was silently ignored; now a startup warning surfaces the redundancy so the operator removes it from `/etc/kai/env`.

## Test plan

- [x] `make check` clean
- [x] `make test` clean (3649 passed)
- [x] New `_load_user_configs` raises for: missing file, missing file with `ALLOWED_USER_IDS` set (migration hint asserted), malformed YAML, non-dict top level, missing / non-list `users` key, zero valid entries.
- [x] `TestLoadConfigErrors` updated: new `test_missing_users_yaml` and `test_missing_users_yaml_with_allowed_user_ids_includes_migration_hint` replace the deleted `ALLOWED_USER_IDS`-shape tests.
- [x] Test surface across `test_user_config`, `test_config`, `test_bot`, `test_webhook`, `test_pool`, `test_sessions`, `test_backend`, `test_memory`, `test_memory_extraction`, `test_install`, `test_webhook_api` updated to feed users.yaml via the protected reader. Legacy "user_configs is None" tests deleted where they pinned removed behavior.
- [ ] Manual smoke: existing protected install (`/etc/kai/users.yaml` present) restarts cleanly with `ALLOWED_USER_IDS` still in `/etc/kai/env`; the new redundancy warning fires once and the daemon continues.
- [ ] Manual smoke: protected install with `/etc/kai/users.yaml` deleted (or unreadable) fails closed at next start with the migration error.
