### PR TITLE
feat(install): add single_user deployment mode

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1071,6 +1071,84 @@ def _read_protected_yaml(filename: str) -> dict | object | None:
         return _YAML_MALFORMED
 
 
+def _xdg_config_home() -> Path:
+    """Return `$XDG_CONFIG_HOME` (if set) or `$HOME/.config` otherwise.
+
+    Used by single-user installs that run without root to locate
+    `kai/users.yaml` under the operator's config tree. The XDG variable
+    is honored when set so operators who have configured an alternate
+    config home for other tools see the same convention apply here.
+    """
+    explicit = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    return Path.home() / ".config"
+
+
+def _resolve_users_yaml_path(protected_env_was_loaded: bool) -> Path:
+    """Resolve the canonical users.yaml path for this deployment.
+
+    Resolution order, first match wins:
+      1. `KAI_USERS_YAML` env var. Test / explicit-development override
+         only; the README does not document this as a normal operator
+         path. Lets tests pin a tmp path without faking
+         protected-env-loaded state.
+      2. `/etc/kai/users.yaml` when `protected_env_was_loaded` is True.
+         The signal is "_read_protected_file('/etc/kai/env') returned
+         non-empty content during this load_config call." Ambient env
+         vars like `KAI_INSTALL_DIR` and `KAI_DATA_DIR` deliberately
+         do NOT participate: they are path overrides for data and
+         install layout but do not imply protected deployment mode.
+      3. `${XDG_CONFIG_HOME:-$HOME/.config}/kai/users.yaml` otherwise.
+         The single-user repo install lives entirely under the
+         operator's home; no `/etc/kai/` writes, no sudo at startup.
+
+    Returning a Path (not a string) lets callers stat the file
+    directly when reading without round-tripping through the
+    protected-file sudo shim.
+    """
+    override = os.environ.get("KAI_USERS_YAML", "").strip()
+    if override:
+        return Path(override).expanduser()
+    if protected_env_was_loaded:
+        return Path("/etc/kai/users.yaml")
+    return _xdg_config_home() / "kai" / "users.yaml"
+
+
+def _read_users_yaml(path: Path) -> dict | object | None:
+    """Read users.yaml at `path` with read mechanism keyed to location.
+
+    `/etc/kai/users.yaml` is root-owned mode 0600 and goes through the
+    `_read_protected_yaml` sudo-cat shim. Any other path (XDG
+    single-user, `KAI_USERS_YAML` test override) is read directly with
+    `Path.read_text` because the operator owns it and no privilege
+    escalation is needed or appropriate.
+
+    Returns the same tri-state as `_read_protected_yaml`: parsed dict
+    on success, None when the file does not exist or cannot be read,
+    `_YAML_MALFORMED` when the file exists but parses to an invalid
+    shape.
+    """
+    if path == Path("/etc/kai/users.yaml"):
+        return _read_protected_yaml("users.yaml")
+    if not path.is_file():
+        return None
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as e:
+        log.warning("Cannot read %s: %s", path, e)
+        return None
+    try:
+        result = yaml.safe_load(content)
+    except yaml.YAMLError as e:
+        log.error("Invalid YAML in %s: %s", path, e)
+        return _YAML_MALFORMED
+    if isinstance(result, dict):
+        return result
+    log.warning("%s: expected a YAML dict, got %s", path, type(result).__name__)
+    return _YAML_MALFORMED
+
+
 def _strip_quotes(value: str) -> str:
     """
     Remove matched surrounding quotes from a value string.
@@ -1547,18 +1625,21 @@ def _compute_extraction_eligible_backends(
 def _load_user_configs(
     global_backend: str,
     global_llm_provider: str,
+    users_yaml_path: Path | None = None,
 ) -> dict[int, UserConfig]:
     """
-    Load per-user configs from /etc/kai/users.yaml.
+    Load per-user configs from users.yaml at the given path.
 
-    Reads the protected file via `_read_protected_yaml` (sudo-cat for
-    root-owned mode 0600 copies). users.yaml is mandatory: any failure
-    raises SystemExit with a message naming the resolved path. There
-    is no None return path and no fallback to ALLOWED_USER_IDS at
-    runtime. The fail-closed shape is load-bearing for the daemon's
-    auth contract: a malformed or unreadable users file must not
-    silently degrade to env-only auth, because the wizard and the
-    runtime would then disagree about whose value wins.
+    Reads via `_read_users_yaml`, which routes `/etc/kai/users.yaml`
+    through the sudo-cat shim and any other path (XDG single-user,
+    `KAI_USERS_YAML` override) through a direct `Path.read_text`.
+    users.yaml is mandatory: any failure raises SystemExit with a
+    message naming the resolved path. There is no None return path
+    and no fallback to ALLOWED_USER_IDS at runtime. The fail-closed
+    shape is load-bearing for the daemon's auth contract: a
+    malformed or unreadable users file must not silently degrade to
+    env-only auth, because the wizard and the runtime would then
+    disagree about whose value wins.
 
     Failure cases (each raises SystemExit):
         - File absent: error names the path and points at `make config`.
@@ -1580,11 +1661,17 @@ def _load_user_configs(
         global_llm_provider: The global llm_provider from env config.
             Both are needed to cascade per-user model validation:
             a user's effective provider determines which models are valid.
+        users_yaml_path: Resolved users.yaml path for this deployment.
+            Defaults to `/etc/kai/users.yaml` to preserve protected-install
+            ergonomics for tests that do not exercise XDG resolution.
+            Production callers in `load_config` pass the result of
+            `_resolve_users_yaml_path(protected_env_was_loaded)`.
 
     Returns a dict keyed by telegram_id for O(1) lookup.
     """
-    users_yaml_path = "/etc/kai/users.yaml"
-    data = _read_protected_yaml("users.yaml")
+    if users_yaml_path is None:
+        users_yaml_path = Path("/etc/kai/users.yaml")
+    data = _read_users_yaml(users_yaml_path)
     if data is _YAML_MALFORMED:
         raise SystemExit(
             f"{users_yaml_path} is malformed or has an invalid top-level YAML shape. "
@@ -2435,7 +2522,15 @@ def load_config() -> Config:
     # fallback is gone: a malformed users file used to silently
     # degrade to ALLOWED_USER_IDS, which the wizard and the loader
     # then disagreed about; fail-closed is the contract now.
-    user_configs = _load_user_configs(agent_backend, llm_provider)
+    #
+    # The path resolves based on whether `/etc/kai/env` had readable
+    # content at the top of this load_config call (protected install)
+    # or not (single-user install reads from PROJECT_ROOT/.env and
+    # places users.yaml under XDG config home). KAI_USERS_YAML is an
+    # explicit override for tests and ad-hoc development; the operator
+    # path is always one of the two resolved defaults.
+    users_yaml_path = _resolve_users_yaml_path(bool(protected_env))
+    user_configs = _load_user_configs(agent_backend, llm_provider, users_yaml_path)
     allowed_ids = set(user_configs.keys())
     if os.environ.get("ALLOWED_USER_IDS", "").strip():
         log.warning(

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -50,6 +50,7 @@ from kai.config import (
     PROVIDER_MODELS,
     VALID_BACKENDS,
     VALID_PROVIDERS,
+    _read_protected_file,
     models_for_backend,
     validate_model_for_backend,
 )
@@ -511,6 +512,28 @@ def _cmd_config() -> None:
         existing.get("deployment_mode", "protected"),
     )
     print()
+
+    # Migration safety: if the operator picks single_user but a
+    # readable `/etc/kai/env` exists from a previous protected install,
+    # the runtime predicate in `config._resolve_users_yaml_path` will
+    # still see the protected env as authoritative and route at
+    # `/etc/kai/users.yaml`, silently bypassing the single-user
+    # artifacts we are about to write. The runtime cannot tell which
+    # is the operator's intent; the wizard refuses up front so the
+    # operator removes the protected leftovers before reaching that
+    # ambiguous state. A protected install on a host whose operator
+    # has the sudoers cat rule from a prior `sudo make install` is
+    # the typical trigger.
+    if deployment_mode == "single_user" and _read_protected_file("/etc/kai/env"):
+        raise SystemExit(
+            "single_user mode was selected, but /etc/kai/env is readable from a "
+            "previous protected install. The runtime would still boot from the "
+            "protected files, silently ignoring the single-user artifacts. "
+            "Remove the protected install before retrying:\n"
+            "    sudo rm -rf /etc/kai\n"
+            "    sudo rm -f /etc/sudoers.d/kai\n"
+            "Then re-run 'make config' and pick single_user."
+        )
 
     # In single-user mode the install location, data directory,
     # service user, and platform service manager are not relevant:

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -405,6 +405,21 @@ def _strip_install_conf_keys(*keys: str) -> None:
     os.chmod(INSTALL_CONF, 0o600)
 
 
+def _xdg_users_yaml_path() -> Path:
+    """Return the canonical single-user users.yaml location.
+
+    Mirrors the runtime resolver in `config._resolve_users_yaml_path`
+    for the non-protected branch: `${XDG_CONFIG_HOME:-$HOME/.config}/
+    kai/users.yaml`. The wizard writes directly to this path in
+    single-user mode (no staging handoff is needed because the
+    operator owns the destination and there is no privilege boundary
+    to cross on apply).
+    """
+    explicit = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    base = Path(explicit).expanduser() if explicit else Path.home() / ".config"
+    return base / "kai" / "users.yaml"
+
+
 def _read_users_yaml_text(path: Path) -> str | None:
     """Return the contents of a users.yaml file, falling back to sudo
     for root-owned protected copies.
@@ -450,7 +465,7 @@ def _cmd_config() -> None:
 
     No sudo required - this runs as the current user.
     """
-    print("Kai Protected Installation - Configuration")
+    print("Kai Installation - Configuration")
     print("=" * 45)
     print()
 
@@ -473,34 +488,75 @@ def _cmd_config() -> None:
     else:
         detected_platform = sys.platform
 
-    # -- Installation paths --
-    print("-- Installation paths --")
-    install_dir = _prompt(
-        "Install location",
-        existing.get("install_dir", _DEFAULT_INSTALL_DIR),
-    )
-    if not os.path.isabs(install_dir):
-        raise SystemExit("Install location must be an absolute path.")
-
-    data_dir = _prompt(
-        "Data directory",
-        existing.get("data_dir", _DEFAULT_DATA_DIR),
-    )
-    if not os.path.isabs(data_dir):
-        raise SystemExit("Data directory must be an absolute path.")
-
-    service_user = _prompt(
-        "Service user",
-        existing.get("service_user", _DEFAULT_SERVICE_USER),
-        required=True,
-    )
-
-    platform = _prompt_choice(
-        "Platform",
-        ["darwin", "linux"],
-        existing.get("platform", detected_platform),
+    # -- Deployment mode --
+    # `protected`: root-owned install at /opt/kai with /etc/kai/ secrets,
+    # the service-management apply flow, and `sudo make install` to
+    # finalize. This is the existing multi-user / production shape.
+    #
+    # `single_user`: the operator runs Kai directly from the repo
+    # without root. Secrets and per-user config live under the
+    # operator's home (.env in PROJECT_ROOT, users.yaml under XDG
+    # config home). `make config` writes everything and there is no
+    # `sudo make install` step; `make run` (or `python -m kai`) starts
+    # the daemon. This is the on-ramp for evaluators and the
+    # documented dev workflow.
+    #
+    # Default to `protected` when install.conf has no mode so existing
+    # operators on the long-standing path see no behavior change on a
+    # re-run.
+    print("-- Deployment mode --")
+    deployment_mode = _prompt_choice(
+        "Deployment mode",
+        ["protected", "single_user"],
+        existing.get("deployment_mode", "protected"),
     )
     print()
+
+    # In single-user mode the install location, data directory,
+    # service user, and platform service manager are not relevant:
+    # Kai runs from the cloned repo under the operator's account.
+    # We initialize these fields with stable defaults so downstream
+    # install.conf shape stays consistent across modes; nothing reads
+    # them in single-user mode but consumers that check for the keys
+    # do not need a mode-aware lookup.
+    if deployment_mode == "protected":
+        # -- Installation paths --
+        print("-- Installation paths --")
+        install_dir = _prompt(
+            "Install location",
+            existing.get("install_dir", _DEFAULT_INSTALL_DIR),
+        )
+        if not os.path.isabs(install_dir):
+            raise SystemExit("Install location must be an absolute path.")
+
+        data_dir = _prompt(
+            "Data directory",
+            existing.get("data_dir", _DEFAULT_DATA_DIR),
+        )
+        if not os.path.isabs(data_dir):
+            raise SystemExit("Data directory must be an absolute path.")
+
+        service_user = _prompt(
+            "Service user",
+            existing.get("service_user", _DEFAULT_SERVICE_USER),
+            required=True,
+        )
+
+        platform = _prompt_choice(
+            "Platform",
+            ["darwin", "linux"],
+            existing.get("platform", detected_platform),
+        )
+        print()
+    else:
+        # Single-user defaults. install_dir points at PROJECT_ROOT so
+        # any code that resolves paths through install.conf still
+        # finds a real directory; data_dir defaults to PROJECT_ROOT
+        # for the same reason. service_user is the current account.
+        install_dir = str(PROJECT_ROOT)
+        data_dir = str(PROJECT_ROOT)
+        service_user = os.environ.get("USER", _DEFAULT_SERVICE_USER)
+        platform = detected_platform
 
     # -- Telegram --
     print("-- Telegram --")
@@ -518,19 +574,27 @@ def _cmd_config() -> None:
     # the operator account, so the existence check does not require
     # elevation.
     #
-    # If no canonical file exists, the first-time branch writes to a
-    # per-operator staging path at `${HOME}/.cache/kai-install/
-    # users.yaml`. `_apply_secrets` (invoked under `sudo make install`)
-    # reads the path back from `install.conf` and copies it into
-    # `/etc/kai/users.yaml`. A stray `PROJECT_ROOT/users.yaml` from a
-    # previous install cycle is ignored; a one-line deprecation
-    # warning tells the operator to remove it or move it to
-    # `/etc/kai/users.yaml`.
+    # The canonical users.yaml location depends on deployment mode:
+    # - protected: `/etc/kai/users.yaml` (mode 0600 root-owned). The
+    #   wizard reads it via `_read_users_yaml_text`'s sudo-cat path
+    #   when it cannot read directly; the existence check goes through
+    #   the listable parent directory and does not require elevation.
+    # - single_user: `${XDG_CONFIG_HOME:-$HOME/.config}/kai/users.yaml`,
+    #   owned by the operator. Direct read.
+    #
+    # If no canonical file exists, the first-time branch writes to the
+    # appropriate location for the chosen mode (see below). A stray
+    # `PROJECT_ROOT/users.yaml` from a previous install cycle is
+    # ignored; a one-line deprecation warning tells the operator to
+    # remove it or move it to the canonical location.
     print("-- User setup --")
     stray_project_users_yaml = PROJECT_ROOT / "users.yaml"
+    if deployment_mode == "protected":
+        users_yaml_path = Path("/etc/kai/users.yaml")
+    else:
+        users_yaml_path = _xdg_users_yaml_path()
     if stray_project_users_yaml.exists():
-        print(f"  Note: {stray_project_users_yaml} is no longer used. Move it to /etc/kai/users.yaml or remove it.")
-    users_yaml_path = Path("/etc/kai/users.yaml")
+        print(f"  Note: {stray_project_users_yaml} is no longer used. Move it to {users_yaml_path} or remove it.")
     users_yaml_exists = users_yaml_path.exists()
 
     # Track whether advanced mode set os_user, so we can skip the
@@ -628,25 +692,35 @@ def _cmd_config() -> None:
             # spec exists to eliminate.
             admin_home_workspace = None
 
-        # Stage the generated users.yaml at `${HOME}/.cache/kai-install/
-        # users.yaml`. `_apply_secrets` copies from this staging path
-        # into `/etc/kai/users.yaml` during `sudo make install`; the
-        # path is persisted as a top-level key in install.conf below so
-        # apply can resolve it even when running under a different HOME
-        # (root vs the operator account). After `apply_succeeded`,
-        # `_cmd_apply` unlinks the staging file and strips the conf key
-        # so a subsequent re-run does not redo a handoff that already
-        # completed.
-        users_yaml_path = _install_staging_path("users.yaml")
+        # First-time write target depends on deployment mode:
+        # - protected: stage at `${HOME}/.cache/kai-install/users.yaml`
+        #   so `sudo make install` can copy it into `/etc/kai/users.yaml`
+        #   without the operator running the wizard as root. The path
+        #   is persisted as a top-level key in install.conf below;
+        #   `_cmd_apply` unlinks the staging file and strips the conf
+        #   key after `apply_succeeded`.
+        # - single_user: write directly to the XDG users.yaml path
+        #   (`${XDG_CONFIG_HOME:-$HOME/.config}/kai/users.yaml`). No
+        #   staging handoff is needed because the operator owns the
+        #   destination and there is no privilege boundary to cross
+        #   on apply. The staging key stays unset so apply (if it ever
+        #   runs by mistake) does not try to copy this file anywhere.
         users_yaml_content = _generate_users_yaml(
             admin_telegram_id,
             admin_name,
             os_user=admin_os_user,
             home_workspace=admin_home_workspace,
         )
-        users_yaml_path.write_text(users_yaml_content)
-        os.chmod(users_yaml_path, 0o600)
-        users_yaml_staging_path = str(users_yaml_path)
+        if deployment_mode == "protected":
+            users_yaml_path = _install_staging_path("users.yaml")
+            users_yaml_path.write_text(users_yaml_content)
+            os.chmod(users_yaml_path, 0o600)
+            users_yaml_staging_path = str(users_yaml_path)
+        else:
+            users_yaml_path = _xdg_users_yaml_path()
+            users_yaml_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            users_yaml_path.write_text(users_yaml_content)
+            os.chmod(users_yaml_path, 0o600)
         print(f"  Generated {users_yaml_path}")
     print()
 
@@ -1630,6 +1704,7 @@ def _cmd_config() -> None:
     # Build and write install.conf
     conf = {
         "version": _CONF_VERSION,
+        "deployment_mode": deployment_mode,
         "install_dir": install_dir,
         "data_dir": data_dir,
         "service_user": service_user,
@@ -1645,6 +1720,10 @@ def _cmd_config() -> None:
     # `/etc/kai/env` and pollute runtime daemon configuration. The
     # presence of this key is also the only signal apply uses: a stale
     # staging file without a matching key in install.conf is ignored.
+    # Single-user mode never sets this key because the wizard writes
+    # directly to the XDG users.yaml destination; the apply guard
+    # below double-checks by requiring deployment_mode == "protected"
+    # before honoring any recorded staging path.
     if users_yaml_staging_path:
         conf["users_yaml_staging_path"] = users_yaml_staging_path
 
@@ -1652,7 +1731,24 @@ def _cmd_config() -> None:
     # Restrict permissions since the file contains secrets (bot token, webhook secret)
     os.chmod(INSTALL_CONF, 0o600)
     print(f"Configuration written to {INSTALL_CONF}")
-    print("Review the file, then run: sudo python -m kai install apply")
+    if deployment_mode == "protected":
+        print("Review the file, then run: sudo python -m kai install apply")
+    else:
+        # In single-user mode, also write the local .env so the
+        # daemon can find runtime env config via `load_dotenv`
+        # (protected mode reads `/etc/kai/env` via `_read_protected_file`
+        # which is not available without root). `_generate_env_file`
+        # produces the same KEY=VALUE shape `/etc/kai/env` would carry;
+        # we restrict the mode to 0600 because the file holds the same
+        # secrets (bot token, webhook secret).
+        env_path = PROJECT_ROOT / ".env"
+        env_path.write_text(_generate_env_file(env))
+        os.chmod(env_path, 0o600)
+        print(f"Wrote runtime env to {env_path}")
+        print(f"users.yaml is at {users_yaml_path}")
+        print()
+        print("Single-user mode does not require 'sudo make install'.")
+        print("Start the daemon with: make run")
 
 
 # ── Apply subcommand ─────────────────────────────────────────────────
@@ -3248,6 +3344,26 @@ def _cmd_apply() -> None:
     except (json.JSONDecodeError, OSError) as e:
         raise SystemExit(f"Could not read {INSTALL_CONF}: {e}") from e
 
+    # Deployment mode gate. Apply is meaningful only for protected
+    # installs: it copies the staged users.yaml into /etc/kai/, writes
+    # /etc/kai/env, installs the systemd / launchd service, and
+    # configures sudoers. None of that applies to a single-user
+    # install, where `make config` already wrote everything the
+    # daemon reads (PROJECT_ROOT/.env, XDG users.yaml) and `make run`
+    # starts the daemon from the repo.
+    #
+    # Default missing `deployment_mode` to `protected` so a legacy
+    # install.conf written before this key existed continues to apply
+    # cleanly. Single-user installs always carry the key because the
+    # wizard writes it.
+    deployment_mode = conf.get("deployment_mode", "protected")
+    if deployment_mode == "single_user":
+        raise SystemExit(
+            "single_user mode is already applied by 'make config'; "
+            "run 'make run' (or 'python -m kai') from the repo. "
+            "'make install' is a no-op in this mode."
+        )
+
     # Validate required fields
     install_dir = conf.get("install_dir")
     data_dir = conf.get("data_dir")
@@ -3261,6 +3377,13 @@ def _cmd_apply() -> None:
     # the copy). `_apply_secrets` defends against a missing file
     # behind a non-empty path so a wrong value silently skips
     # rather than failing the apply.
+    #
+    # The staging path is consumed only in protected mode (the gate
+    # above already refused single-user). A stale top-level key
+    # carried forward across a mode switch would point at a path
+    # under the operator's home that this apply has no business
+    # touching; the protected-mode gate ensures we never reach here
+    # with that combination.
     users_yaml_staging_path = conf.get("users_yaml_staging_path", "") or None
 
     if not all([install_dir, data_dir, service_user, platform]):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -140,15 +140,29 @@ def _set_required(monkeypatch, token="fake-token", user_ids="123"):
 
 
 def _patch_protected_users_yaml(monkeypatch, content: str) -> None:
-    """Feed `content` to `_load_user_configs` as if `/etc/kai/users.yaml`
-    held it. The loader reads via `_read_protected_file`; this helper
-    dispatches only the users.yaml path and returns None for every
-    other protected file (the default load_config shape on dev hosts).
+    """Simulate a protected install with the given users.yaml content.
+
+    Patches `_read_protected_file` so:
+      - `/etc/kai/env` returns a sentinel string, which makes
+        `_resolve_users_yaml_path(protected_env_was_loaded=True)` route
+        the loader at `/etc/kai/users.yaml` instead of XDG.
+      - `/etc/kai/users.yaml` returns `content`, which the protected-
+        path branch of `_read_users_yaml` consumes via the existing
+        `_read_protected_yaml` sudo-cat shim.
+
+    Any other protected-file lookup returns None (the default shape
+    on dev hosts). Tests that specifically need the XDG / single-user
+    path should use `_patch_xdg_users_yaml` (or set `KAI_USERS_YAML`).
     """
 
     def _fake_read(path):
         if path == "/etc/kai/users.yaml":
             return content
+        if path == "/etc/kai/env":
+            # Non-empty content satisfies the protected-mode predicate
+            # without contributing any env vars (the comment line is
+            # skipped by the parser).
+            return "# test sentinel: protected install\n"
         return None
 
     monkeypatch.setattr("kai.config._read_protected_file", _fake_read)
@@ -668,15 +682,25 @@ class TestDualModeLoading:
         config = load_config()
         assert config.telegram_bot_token == "tok"
 
-    def test_falls_back_to_dotenv(self, monkeypatch):
-        """When /etc/kai/env is not readable, load_dotenv is called."""
+    def test_falls_back_to_dotenv(self, monkeypatch, tmp_path):
+        """When /etc/kai/env is not readable, load_dotenv is called.
+
+        Single-user mode (no protected env): the resolver picks the
+        XDG users.yaml path. We pin that path via `KAI_USERS_YAML` so
+        the loader's mandatory-users contract is satisfied from a
+        tmp file the test owns.
+        """
         load_dotenv_called = []
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+        monkeypatch.setenv("ALLOWED_USER_IDS", "123")
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 123\n    name: test\n    role: admin\n")
+        monkeypatch.setenv("KAI_USERS_YAML", str(users_yaml))
         monkeypatch.setattr("kai.config._read_protected_file", lambda path: None)
         monkeypatch.setattr(
             "kai.config.load_dotenv",
             lambda *a, **kw: load_dotenv_called.append(True),
         )
-        _set_required(monkeypatch)
         load_config()
         assert load_dotenv_called, "load_dotenv should have been called"
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1139,6 +1139,7 @@ class TestCmdConfig:
         # Simulate user inputs for each prompt (in order)
         inputs = iter(
             [
+                "protected",  # deployment mode
                 "/opt/kai",  # install dir
                 "/var/lib/kai",  # data dir
                 "kai",  # service user
@@ -1213,6 +1214,7 @@ class TestCmdConfig:
 
         inputs = iter(
             [
+                "protected",  # deployment mode
                 "/opt/kai",  # install dir
                 "/var/lib/kai",  # data dir
                 "kai",  # service user
@@ -1296,6 +1298,7 @@ class TestCmdConfig:
 
         inputs_basic = iter(
             [
+                "protected",  # deployment mode
                 "/opt/kai",  # install dir
                 "/var/lib/kai",  # data dir
                 "kai",  # service user
@@ -1363,6 +1366,7 @@ class TestCmdConfig:
 
         inputs_advanced = iter(
             [
+                "protected",
                 "/opt/kai",
                 "/var/lib/kai",
                 "kai",
@@ -1422,6 +1426,7 @@ class TestCmdConfig:
 
         inputs = iter(
             [
+                "protected",  # deployment mode
                 "/opt/kai",  # install dir
                 "/var/lib/kai",  # data dir
                 "kai",  # service user
@@ -1478,6 +1483,7 @@ class TestCmdConfig:
         # No API key input after "ollama" - the prompt is skipped.
         inputs = iter(
             [
+                "protected",  # deployment mode
                 "/opt/kai",  # install dir
                 "/var/lib/kai",  # data dir
                 "kai",  # service user
@@ -1662,6 +1668,7 @@ class TestCmdConfig:
             pr_review_budget_entry = ["1.0"]  # PR_REVIEW_BUDGET_USD
 
         return [
+            "protected",  # deployment mode
             "/opt/kai",  # install dir
             "/var/lib/kai",  # data dir
             "kai",  # service user
@@ -2111,6 +2118,7 @@ class TestCmdConfig:
 
         inputs = iter(
             [
+                "protected",  # deployment mode
                 "/opt/kai",  # install dir
                 "/var/lib/kai",  # data dir
                 "kai",  # service user
@@ -2384,6 +2392,12 @@ class TestCmdConfig:
             # inline content so the loader's auth contract is met.
             if path == "/etc/kai/users.yaml":
                 return users_yaml_text
+            if path == "/etc/kai/env":
+                # Non-empty content satisfies the protected-mode
+                # predicate so the resolver picks /etc/kai/users.yaml
+                # instead of XDG. The comment line is skipped by
+                # the parser.
+                return "# test sentinel: protected install\n"
             return None
 
         monkeypatch.setattr("kai.config._read_protected_file", _fake_read)
@@ -2458,6 +2472,7 @@ class TestCmdConfig:
 
         inputs = iter(
             [
+                "protected",  # deployment mode
                 "/opt/kai",  # install dir
                 "/var/lib/kai",  # data dir
                 "kai",  # service user
@@ -2531,6 +2546,11 @@ class TestCmdConfig:
         def _fake_read(path):
             if path == "/etc/kai/users.yaml":
                 return staged_users_yaml_text
+            if path == "/etc/kai/env":
+                # Mark the load as protected-mode so the resolver
+                # routes at /etc/kai/users.yaml. The comment line is
+                # skipped by the env-file parser.
+                return "# test sentinel: protected install\n"
             return None
 
         monkeypatch.setattr("kai.config._read_protected_file", _fake_read)
@@ -2825,6 +2845,7 @@ class TestCmdConfigDefaultModelDispatch:
         skipped silently.
         """
         return [
+            "protected",  # deployment mode
             "/opt/kai",  # install dir
             "/var/lib/kai",  # data dir
             "kai",  # service user
@@ -2859,6 +2880,7 @@ class TestCmdConfigDefaultModelDispatch:
         The codex auth-mode prompt is the new line vs the goose chain.
         """
         return [
+            "protected",  # deployment mode
             "/opt/kai",  # install dir
             "/var/lib/kai",  # data dir
             "kai",  # service user
@@ -2891,6 +2913,7 @@ class TestCmdConfigDefaultModelDispatch:
     def _inputs_for_goose_openai() -> list[str]:
         """Input chain for the users_yaml_exists=True + goose+openai path."""
         return [
+            "protected",  # deployment mode
             "/opt/kai",  # install dir
             "/var/lib/kai",  # data dir
             "kai",  # service user
@@ -6325,6 +6348,7 @@ class TestCmdConfigCanonicalUsersYaml:
         external services).
         """
         return [
+            "protected",
             "/opt/kai",
             "/var/lib/kai",
             "kai",
@@ -6597,6 +6621,266 @@ class TestCmdApplyStagingHandoff:
 
         assert captured["users_yaml_staging_path"] == str(staging)
         assert not staging.exists()
+
+
+# ── Runtime users.yaml path resolution ────────────────────────────────
+
+
+class TestResolveUsersYamlPath:
+    """Pins the runtime predicate for choosing /etc/kai/users.yaml vs
+    the XDG single-user path. The spec carves three rules:
+
+      1. KAI_USERS_YAML wins outright when set (test / development override).
+      2. Otherwise, protected_env_was_loaded -> /etc/kai/users.yaml.
+      3. Otherwise -> ${XDG_CONFIG_HOME:-$HOME/.config}/kai/users.yaml.
+
+    `KAI_INSTALL_DIR` and `KAI_DATA_DIR` deliberately do NOT participate
+    in the predicate; they are pure path overrides for data and install
+    layout and must not make runtime select the protected path.
+    """
+
+    def test_protected_env_loaded_routes_protected(self, monkeypatch):
+        from kai.config import _resolve_users_yaml_path
+
+        monkeypatch.delenv("KAI_USERS_YAML", raising=False)
+        assert _resolve_users_yaml_path(True) == Path("/etc/kai/users.yaml")
+
+    def test_no_protected_env_routes_xdg(self, monkeypatch, tmp_path):
+        from kai.config import _resolve_users_yaml_path
+
+        monkeypatch.delenv("KAI_USERS_YAML", raising=False)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert _resolve_users_yaml_path(False) == tmp_path / ".config" / "kai" / "users.yaml"
+
+    def test_xdg_config_home_overrides_home(self, monkeypatch, tmp_path):
+        from kai.config import _resolve_users_yaml_path
+
+        monkeypatch.delenv("KAI_USERS_YAML", raising=False)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+        monkeypatch.setenv("HOME", str(tmp_path / "should-not-be-used"))
+        assert _resolve_users_yaml_path(False) == tmp_path / "xdg" / "kai" / "users.yaml"
+
+    def test_explicit_override_wins_in_both_modes(self, monkeypatch, tmp_path):
+        from kai.config import _resolve_users_yaml_path
+
+        override = tmp_path / "explicit-users.yaml"
+        monkeypatch.setenv("KAI_USERS_YAML", str(override))
+        assert _resolve_users_yaml_path(True) == override
+        assert _resolve_users_yaml_path(False) == override
+
+    def test_kai_install_dir_does_not_route_protected(self, monkeypatch, tmp_path):
+        """Pins the spec's blast-radius rule: a single-user host with
+        `KAI_INSTALL_DIR` set for unrelated reasons (custom install
+        layout) must not be misclassified as a protected install.
+        """
+        from kai.config import _resolve_users_yaml_path
+
+        monkeypatch.delenv("KAI_USERS_YAML", raising=False)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("KAI_INSTALL_DIR", "/opt/kai")
+        monkeypatch.setenv("KAI_DATA_DIR", "/var/lib/kai")
+        # protected_env_was_loaded is False (no /etc/kai/env content);
+        # the env vars above must NOT override that decision.
+        assert _resolve_users_yaml_path(False) == tmp_path / ".config" / "kai" / "users.yaml"
+
+
+# ── Single-user wizard branch ─────────────────────────────────────────
+
+
+class TestCmdConfigSingleUserMode:
+    """The wizard writes XDG users.yaml + local .env directly when the
+    operator selects `single_user`; no staging handoff, no apply step,
+    no /etc/kai/ writes.
+    """
+
+    @staticmethod
+    def _single_user_inputs() -> list[str]:
+        """Minimal single-user input chain: claude backend, no advanced
+        options, no memory, no external services.
+        """
+        return [
+            "single_user",  # deployment mode
+            # install_dir / data_dir / service_user / platform are skipped
+            "fake-token",  # bot token
+            "12345",  # admin telegram id
+            "admin",  # admin display name
+            "false",  # advanced
+            "polling",  # transport
+            "claude",  # backend
+            "sonnet",  # model
+            "120",  # timeout
+            "200000",  # max_context_window
+            "80",  # autocompact
+            "",  # effort level
+            "8080",  # webhook port
+            "test-secret",  # webhook secret
+            "~/Projects",  # workspace_base
+            "",  # allowed_workspaces
+            "false",  # pr_review_enabled
+            "300",  # pr_review_cooldown
+            "900",  # pr_review_timeout_s
+            "false",  # issue_triage
+            "",  # github_notify_chat_id
+            "false",  # voice
+            "false",  # tts
+            "",  # claude_user
+            "false",  # memory enabled
+            "",  # perplexity
+        ]
+
+    @staticmethod
+    def _redirect_xdg(monkeypatch, tmp_path):
+        """Pin XDG_CONFIG_HOME at tmp_path so the wizard writes the
+        XDG users.yaml under the test root rather than the operator's
+        real `~/.config/kai/`.
+        """
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+    def test_writes_xdg_users_yaml_and_local_env(self, tmp_path, monkeypatch):
+        """Single-user fresh install: users.yaml lands under XDG,
+        runtime env lands at PROJECT_ROOT/.env, install.conf records
+        deployment_mode=single_user with no staging key.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        TestCmdConfig._block_etc_kai(monkeypatch)
+        self._redirect_xdg(monkeypatch, tmp_path)
+
+        inputs = iter(self._single_user_inputs())
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        _cmd_config()
+
+        users_yaml = tmp_path / "xdg" / "kai" / "users.yaml"
+        assert users_yaml.exists()
+        assert stat.S_IMODE(users_yaml.stat().st_mode) == 0o600
+        parsed = yaml.safe_load(users_yaml.read_text())
+        assert parsed["users"][0]["telegram_id"] == 12345
+
+        env_file = tmp_path / ".env"
+        assert env_file.exists()
+        assert stat.S_IMODE(env_file.stat().st_mode) == 0o600
+        env_text = env_file.read_text()
+        assert "TELEGRAM_BOT_TOKEN" in env_text
+        assert "fake-token" in env_text
+
+        conf = json.loads((tmp_path / "install.conf").read_text())
+        assert conf["deployment_mode"] == "single_user"
+        # No staging handoff in single-user mode; apply is refused
+        # outright so a stale key would point at a path apply has no
+        # business consuming.
+        assert "users_yaml_staging_path" not in conf
+
+    def test_writes_users_yaml_parent_mode_0700(self, tmp_path, monkeypatch):
+        """Operator-private parent directory: the XDG kai/ subdir is
+        created mode 0700 so a freshly minted users.yaml inherits a
+        restrictive enclosing scope even before its own 0600 chmod.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        TestCmdConfig._block_etc_kai(monkeypatch)
+        self._redirect_xdg(monkeypatch, tmp_path)
+
+        inputs = iter(self._single_user_inputs())
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        _cmd_config()
+
+        parent = tmp_path / "xdg" / "kai"
+        assert parent.is_dir()
+        assert stat.S_IMODE(parent.stat().st_mode) == 0o700
+
+
+# ── _cmd_apply: single-user refusal ───────────────────────────────────
+
+
+class TestCmdApplySingleUserRefuses:
+    """`make install` (the apply subcommand) is meaningful only for
+    protected mode. Single-user installs are fully configured by
+    `make config`; running apply against a single-user install would
+    silently leave the operator confused about what changed. The
+    wizard's success message points at `make run`; the apply gate
+    enforces the same contract from the install command side.
+    """
+
+    @staticmethod
+    def _write_single_user_conf(tmp_path: Path) -> Path:
+        conf = {
+            "version": 1,
+            "deployment_mode": "single_user",
+            "install_dir": str(tmp_path),
+            "data_dir": str(tmp_path),
+            "service_user": "kai",
+            "platform": "darwin",
+            "env": {"TELEGRAM_BOT_TOKEN": "tok"},
+        }
+        path = tmp_path / "install.conf"
+        path.write_text(json.dumps(conf, indent=2) + "\n")
+        os.chmod(path, 0o600)
+        return path
+
+    def test_apply_refuses_single_user_with_no_op_message(self, tmp_path, monkeypatch):
+        """Apply on a single-user install exits with a clear message
+        pointing the operator at `make run` instead.
+        """
+        conf_path = self._write_single_user_conf(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        with pytest.raises(SystemExit, match="single_user mode is already applied"):
+            _cmd_apply()
+
+    def test_apply_protected_default_when_mode_missing(self, tmp_path, monkeypatch):
+        """Legacy install.conf written before the deployment_mode key
+        existed defaults to protected so the existing apply flow keeps
+        running. Pins the migration shape: nothing forces operators to
+        re-run `make config` purely to gain the key.
+        """
+        conf = {
+            "version": 1,
+            "install_dir": str(tmp_path / "opt-kai"),
+            "data_dir": str(tmp_path / "var-lib-kai"),
+            "service_user": "kai",
+            "platform": "darwin",
+            "env": {
+                "TELEGRAM_BOT_TOKEN": "tok",
+                "WEBHOOK_SECRET": "secret",
+                "DEFAULT_MODEL": "sonnet",
+                "AGENT_BACKEND": "claude",
+            },
+        }
+        conf_path = tmp_path / "install.conf"
+        conf_path.write_text(json.dumps(conf, indent=2) + "\n")
+        os.chmod(conf_path, 0o600)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+
+        # The legacy-shape apply runs through all the real apply steps,
+        # which is more than this regression cares about. Stub them
+        # out and verify only that the single-user refusal does NOT
+        # fire when deployment_mode is missing from the conf.
+
+        class _FakePwd:
+            pw_uid = 4242
+            pw_gid = 4242
+
+        monkeypatch.setattr("pwd.getpwnam", lambda name: _FakePwd)
+        monkeypatch.setattr("kai.install._stop_service", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_directories", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_source", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_venv", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_models", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_secrets", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_sudoers", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_migrate", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_service", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._start_service", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._check_traversal", lambda *a, **kw: None)
+        monkeypatch.delenv("DRY_RUN", raising=False)
+
+        # No SystemExit expected; the legacy-shape apply completes.
+        _cmd_apply()
 
 
 # ── _apply_sudoers dry run ───────────────────────────────────────────

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -6738,6 +6738,19 @@ class TestCmdConfigSingleUserMode:
         """
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
 
+    @staticmethod
+    def _no_protected_artifacts(monkeypatch):
+        """Pretend the host has no readable /etc/kai/env.
+
+        The wizard's single-user refusal check probes the protected env
+        file via sudo-cat; tests run against the live operator machine
+        would otherwise trip the refusal because the production install
+        leaves /etc/kai/env readable through the sudoers rule. Stubbing
+        the reader to None simulates a clean host with no protected
+        leftovers.
+        """
+        monkeypatch.setattr("kai.install._read_protected_file", lambda path: None)
+
     def test_writes_xdg_users_yaml_and_local_env(self, tmp_path, monkeypatch):
         """Single-user fresh install: users.yaml lands under XDG,
         runtime env lands at PROJECT_ROOT/.env, install.conf records
@@ -6748,6 +6761,7 @@ class TestCmdConfigSingleUserMode:
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         TestCmdConfig._block_etc_kai(monkeypatch)
         self._redirect_xdg(monkeypatch, tmp_path)
+        self._no_protected_artifacts(monkeypatch)
 
         inputs = iter(self._single_user_inputs())
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
@@ -6773,6 +6787,62 @@ class TestCmdConfigSingleUserMode:
         # business consuming.
         assert "users_yaml_staging_path" not in conf
 
+    def test_refuses_single_user_when_protected_env_is_readable(self, tmp_path, monkeypatch):
+        """Migration guard: a host with a previous protected install
+        leaves /etc/kai/env readable through the sudoers rule. The
+        runtime's resolver would still see that as authoritative and
+        boot from the protected artifacts, silently ignoring the
+        single-user files the wizard is about to write. The wizard
+        refuses up front with an actionable removal recipe.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        TestCmdConfig._block_etc_kai(monkeypatch)
+        self._redirect_xdg(monkeypatch, tmp_path)
+        # Simulate the leftover sudoers rule: /etc/kai/env reads back
+        # non-empty content via sudo -n cat.
+        monkeypatch.setattr(
+            "kai.install._read_protected_file",
+            lambda path: "TELEGRAM_BOT_TOKEN=leftover\n" if path == "/etc/kai/env" else None,
+        )
+
+        # Only the deployment_mode prompt is reached before the refusal
+        # fires; the rest of the chain is unused but kept here so the
+        # test does not depend on prompt-count specifics.
+        inputs = iter(["single_user"] + ["x"] * 50)
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        with pytest.raises(SystemExit, match="single_user mode was selected"):
+            _cmd_config()
+
+    def test_protected_mode_unaffected_by_protected_env_check(self, tmp_path, monkeypatch):
+        """Protected mode does not consult the single-user refusal
+        check. Re-running `make config` on a working protected install
+        must continue to work even though /etc/kai/env is readable
+        (which is the normal protected-install state).
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        TestCmdConfig._simulate_existing_etc_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n",
+        )
+        # /etc/kai/env reads back content (sudoers rule from a real
+        # protected install). The refusal must NOT fire for protected mode.
+        monkeypatch.setattr(
+            "kai.install._read_protected_file",
+            lambda path: "TELEGRAM_BOT_TOKEN=current\n" if path == "/etc/kai/env" else None,
+        )
+
+        inputs = iter(TestCmdConfig._base_inputs(memory_block=["false"]))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        _cmd_config()
+        # install.conf written with deployment_mode=protected; no
+        # SystemExit means the refusal did not fire.
+        conf = json.loads((tmp_path / "install.conf").read_text())
+        assert conf["deployment_mode"] == "protected"
+
     def test_writes_users_yaml_parent_mode_0700(self, tmp_path, monkeypatch):
         """Operator-private parent directory: the XDG kai/ subdir is
         created mode 0700 so a freshly minted users.yaml inherits a
@@ -6783,6 +6853,7 @@ class TestCmdConfigSingleUserMode:
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         TestCmdConfig._block_etc_kai(monkeypatch)
         self._redirect_xdg(monkeypatch, tmp_path)
+        self._no_protected_artifacts(monkeypatch)
 
         inputs = iter(self._single_user_inputs())
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))


### PR DESCRIPTION
## Summary

Third of four tranches against #565. Adds first-class single-user / non-protected install support so a fresh evaluator can `git clone`, run `make config`, and `make run` without ever needing root.

The wizard now opens with a `Deployment mode` prompt:

- **`protected`** (default): the existing root-owned install at `/opt/kai` with `/etc/kai/` secrets, sudoers, and the launchd / systemd service flow. `make config` -> `sudo make install`.
- **`single_user`**: Kai runs from the cloned repo under the operator's account. Secrets live in `PROJECT_ROOT/.env` (mode 0600). users.yaml lives at `${XDG_CONFIG_HOME:-$HOME/.config}/kai/users.yaml` (parent created mode 0700, file mode 0600). No staging handoff because the operator owns the destination. `make config` -> `make run`.

Both modes converge on the same runtime contract: `users.yaml` is mandatory (per tranche A); only the resolution rule and the wizard's write target change.

## Mechanism

### Runtime path resolution (`config._resolve_users_yaml_path`)

1. `KAI_USERS_YAML` env var wins outright. Test / explicit-development override.
2. `/etc/kai/users.yaml` when `_read_protected_file("/etc/kai/env")` returned non-empty content during the current `load_config` call.
3. `${XDG_CONFIG_HOME:-$HOME/.config}/kai/users.yaml` otherwise.

`KAI_INSTALL_DIR` and `KAI_DATA_DIR` deliberately do **not** participate in the predicate. They remain pure path overrides for data and install layout; the spec specifically calls out the failure mode of misclassifying a single-user host as protected because it happened to set `KAI_INSTALL_DIR` for an unrelated reason.

### Reader dispatch (`config._read_users_yaml`)

`/etc/kai/users.yaml` continues to go through the existing `_read_protected_yaml` sudo-cat shim. Any other path (XDG single-user, `KAI_USERS_YAML` test override) is read directly with `Path.read_text` because the operator owns it.

### Installer

- New top-level `deployment_mode` key in `install.conf` alongside `version` / `install_dir` / `env`. Default missing -> `protected` so legacy install.conf files keep applying.
- In single-user mode the wizard skips `install_dir` / `data_dir` / `service_user` / `platform` prompts and stable-defaults those fields so consumers that check the conf shape do not need a mode-aware lookup.
- Single-user wizard writes users.yaml directly to the XDG path and `.env` to `PROJECT_ROOT/.env`; no `users_yaml_staging_path` is ever set in single-user mode.
- `_cmd_apply` refuses single_user with: `single_user mode is already applied by 'make config'; run 'make run' (or 'python -m kai') from the repo.`

## Tranche tracking (#565 v2)

- [x] **B** wizard prompt re-gating (PR #566, merged)
- [x] **A** runtime mandate (PR #567, merged)
- [x] **C** deployment mode + XDG (this PR)
- [ ] **D** cleanup + docs (Class A env reads, README, templates)

## Out of scope (deferred to D)

- README rewrite of the multi-user section + quickstart for single-user mode.
- `templates/.env` and `templates/users.yaml` language updates.
- Class A env mirror removal (`CLAUDE_MODEL`, `CLAUDE_USER`, `PR_REVIEW_ENABLED`, `ISSUE_TRIAGE_ENABLED`, `GITHUB_NOTIFY_CHAT_ID`).

## Migration

- Existing protected installs: no action. `make config` defaults to `protected` and produces the same install.conf shape plus the new top-level key.
- Existing install.conf written before this PR (no `deployment_mode` key): apply defaults to `protected` mode automatically. Operators do not need to re-run `make config` purely for the key.
- Single-user existing flows that relied on running `python -m kai` from the repo with a hand-edited `.env` and a hand-written users.yaml will keep working as long as the users.yaml lives at the XDG path (or `KAI_USERS_YAML` points at it).

## Test plan

- [x] `make check` clean
- [x] `make test` clean (3658 passed)
- [x] `TestResolveUsersYamlPath`: pins all five resolution rules including the `KAI_INSTALL_DIR` non-participation guard.
- [x] `TestCmdConfigSingleUserMode`: pins that single-user wizard writes XDG users.yaml + local `.env` at mode 0600, parent mode 0700, install.conf carries `deployment_mode=single_user` with no staging key.
- [x] `TestCmdApplySingleUserRefuses`: pins the no-op refusal message AND that legacy install.conf (no `deployment_mode` key) continues to apply as protected.
- [x] All pre-existing input chains in `test_install.py` updated to feed `protected` at the new first prompt slot; protected-flow regressions all green.
- [ ] Manual smoke: fresh repo on a host with no `/etc/kai/`. `make config` -> pick `single_user` -> verify XDG users.yaml + `.env` at expected paths -> `make run`.
- [ ] Manual smoke: existing protected install. `make config` -> pick `protected` -> verify install.conf has the new key -> `sudo make install` cleanly.
- [ ] Manual smoke: existing install.conf with no `deployment_mode` key. `sudo make install` runs as protected without re-running `make config`.
