### PR TITLE
refactor(config): retire Class A env mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,12 @@ Per-workspace configuration is supported via `workspaces.yaml` (or `/etc/kai/wor
 
 ### Multi-user
 
-A single Kai instance can serve multiple Telegram users, each fully isolated. Define users in `/etc/kai/users.yaml` (the canonical location for protected installations):
+A single Kai instance can serve multiple Telegram users, each fully isolated. `users.yaml` is mandatory; the daemon fails closed at startup if it cannot find or parse it. The canonical path depends on the deployment mode:
+
+- **Protected install** (`sudo make install`): `/etc/kai/users.yaml` (root-owned, mode 0600).
+- **Single-user install** (`make config` then `make run`): `${XDG_CONFIG_HOME:-$HOME/.config}/kai/users.yaml` (operator-owned, mode 0600 in a 0700 parent).
+
+`make config` writes the correct location for the deployment mode you select at the first prompt.
 
 ```yaml
 users:
@@ -58,6 +63,9 @@ users:
     os_user: alice        # subprocess runs as this OS account
     home_workspace: /home/alice/workspace
     max_budget: 15.0      # default budget for this user (BUDGET_CEILING is the global ceiling)
+    pr_review: true       # enable automatic PR review for this user
+    issue_triage: true    # enable automatic issue triage for this user
+    github_notify_chat_id: -100123456789   # route GitHub notifications to a group
 ```
 
 Each user gets:
@@ -68,7 +76,7 @@ Each user gets:
 - **Per-user home workspace** - each user can have their own default workspace directory.
 - **Role-based routing** - admins receive unattributed webhook events (GitHub pushes, generic webhooks). Regular users interact only through Telegram messages.
 
-Run `make config` to stage a first-time `users.yaml` (written to `~/.cache/kai-install/users.yaml`; `sudo make install` copies it to `/etc/kai/users.yaml` and removes the staging file). Alternatively, create one manually from `templates/users.yaml`. See the [Multi-User Setup](https://github.com/dcellison/kai/wiki/Multi-User-Setup) wiki page for the full field reference. When `/etc/kai/users.yaml` is absent, Kai falls back to `ALLOWED_USER_IDS` for backward compatibility. If neither is set, Kai refuses to start (fail-closed). The `CLAUDE_USER` env var acts as a global fallback for subprocess isolation; per-user `os_user` in `users.yaml` takes precedence when set.
+Per-user GitHub agent toggles (`pr_review`, `issue_triage`) and notification routing (`github_notify_chat_id`) live in `users.yaml` and can be overridden at runtime via `/github reviews on|off`, `/github triage on|off`, and `/github notify <chat_id>`. See the [Multi-User Setup](https://github.com/dcellison/kai/wiki/Multi-User-Setup) wiki page for the full field reference.
 
 ### Memory
 
@@ -100,11 +108,11 @@ When code is pushed to a pull request, Kai automatically reviews it. A one-shot 
 
 When a new issue is opened, Kai triages it automatically. A one-shot agent subprocess reads the issue, applies labels (creating them if they don't exist), checks for duplicates and related issues, assigns it to a project board if appropriate, posts a triage summary comment, and sends you a Telegram notification. See [Issue Triage Agent](https://github.com/dcellison/kai/wiki/Issue-Triage-Agent).
 
-Both agents are fire-and-forget background tasks that run independently of your chat session. They use separate agent processes, so a review or triage can happen while you're mid-conversation. Opt-in per-user via `/github reviews on` and `/github triage on`, or in `users.yaml`. The `PR_REVIEW_ENABLED` and `ISSUE_TRIAGE_ENABLED` env vars still work as global fallbacks.
+Both agents are fire-and-forget background tasks that run independently of your chat session. They use separate agent processes, so a review or triage can happen while you're mid-conversation. Opt-in per-user via `pr_review` / `issue_triage` in `users.yaml`, or toggle at runtime with `/github reviews on|off` and `/github triage on|off`.
 
 ### GitHub notification routing
 
-GitHub event notifications (pushes, PRs, issues, comments, reviews) can be routed to a separate Telegram group via `/github notify <chat_id>` (or the deprecated `GITHUB_NOTIFY_CHAT_ID` env var as a global fallback), keeping your primary DM clean for conversation. Agent output (review comments, triage summaries) also routes to the group. See [GitHub Notification Routing](https://github.com/dcellison/kai/wiki/GitHub-Notification-Routing).
+GitHub event notifications (pushes, PRs, issues, comments, reviews) can be routed to a separate Telegram group via `github_notify_chat_id` in `users.yaml` (or `/github notify <chat_id>` at runtime), keeping your primary DM clean for conversation. Agent output (review comments, triage summaries) also routes to the group. See [GitHub Notification Routing](https://github.com/dcellison/kai/wiki/GitHub-Notification-Routing).
 
 ### Webhooks
 
@@ -201,29 +209,31 @@ cp templates/.env .env
 
 ### Environment variables
 
+Authorization, per-user model selection, per-user OS isolation, per-user GitHub routing, and per-user agent toggles all live in `users.yaml`. The variables below are global resource controls and installation-wide defaults; per-user fields are documented in [Multi-User Setup](https://github.com/dcellison/kai/wiki/Multi-User-Setup).
+
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `TELEGRAM_BOT_TOKEN` | Yes | | Bot token from BotFather |
-| `ALLOWED_USER_IDS` | Deprecated* | | Comma-separated Telegram user IDs. Superseded by `users.yaml`; use `make config` instead. (*Still works if `users.yaml` absent.) |
-| `CLAUDE_MODEL` | Deprecated* | `sonnet` | Default model. Set per-user in `users.yaml` or via `/settings model`. |
-| `CLAUDE_TIMEOUT_SECONDS` | Deprecated* | `120` | Per-message timeout. Set per-user in `users.yaml` or via `/settings timeout`. |
-| `BUDGET_CEILING` | No | `10.0` | Global budget ceiling in USD. Users cannot exceed this via `/settings budget`. Per-user defaults are set via `max_budget` in `users.yaml`. |
-| `CLAUDE_MAX_CONTEXT_WINDOW` | Deprecated* | `0` | Context window size in tokens (0 = backend default). Set per-user in `users.yaml` or via `/settings context`. |
+| `AGENT_BACKEND` | No | `claude` | Global agent backend: `claude`, `goose`, `codex`, or `opencode`. Per-user override goes in `users.yaml`. |
+| `LLM_PROVIDER` | Non-claude | | Global provider for non-claude backends. Per-user override in `users.yaml`. |
+| `DEFAULT_MODEL` | No | `sonnet` | Installation-wide default model. Per-user override in `users.yaml` `model`, or `/settings model`. |
+| `AGENT_TIMEOUT_SECONDS` | No | `120` | Installation-wide default per-message timeout. Per-user override in `users.yaml` `timeout`, or `/settings timeout`. |
+| `BUDGET_CEILING` | No | `10.0` | Global budget ceiling in USD. Users cannot exceed this via `/settings budget`. Per-user defaults in `users.yaml` `max_budget`. |
+| `CLAUDE_MAX_CONTEXT_WINDOW` | No | `0` | Installation-wide default context window in tokens (0 = backend default). Per-user override in `users.yaml` `context_window`, or `/settings context`. |
 | `CLAUDE_AUTOCOMPACT_PCT` | No | `80` | Context compression threshold %, Claude Code only. When usage hits this, Claude compresses history. Can only lower the default (~83%), not raise it. |
 | `CLAUDE_MAX_SESSION_HOURS` | No | `0` | Maximum session age in hours before recycling the subprocess (0 = no limit). Recommended: 4-8 on memory-constrained machines. |
-| `WORKSPACE_BASE` | Deprecated* | | Base directory for workspace name resolution. Set per-user in `users.yaml`. |
-| `ALLOWED_WORKSPACES` | Deprecated* | | Comma-separated extra workspace paths. Users now manage their own via `/workspace allow`. |
+| `WORKSPACE_BASE` | No | | Installation-wide default workspace base directory. Per-user override in `users.yaml` `workspace_base`. |
+| `ALLOWED_WORKSPACES` | No | | Comma-separated extra workspace paths accessible by name. Users also manage their own via `/workspace allow`. |
 | `WEBHOOK_PORT` | No | `8080` | HTTP server port for webhooks and scheduling API |
 | `WEBHOOK_SECRET` | No | | Secret for webhook validation and scheduling API auth |
 | `TELEGRAM_WEBHOOK_URL` | No | | Telegram webhook URL (enables webhook mode; omit for polling) |
 | `TELEGRAM_WEBHOOK_SECRET` | No | | Separate secret for Telegram webhook auth (defaults to `WEBHOOK_SECRET`) |
-| `PR_REVIEW_ENABLED` | Deprecated* | `false` | Enable automatic PR review globally. Set per-user in `users.yaml` or via `/github reviews`. |
-| `PR_REVIEW_COOLDOWN` | No | `300` | Minimum seconds between reviews of the same PR. Machine-wide resource limit, not per-user. |
+| `PR_REVIEW_COOLDOWN` | No | `300` | Minimum seconds between reviews of the same PR. Machine-wide resource limit. |
+| `PR_REVIEW_TIMEOUT_S` | No | `900` | Subprocess timeout for a single PR review, in seconds. |
+| `PR_REVIEW_BUDGET_USD` | No | `1.0` | Hard USD ceiling for one PR review subprocess. Informational on the claude backend; enforced on non-claude backends. |
 | `SPEC_DIR` | No | `specs` | Spec directory relative to repo root, for branch-name matching in PR reviews |
-| `ISSUE_TRIAGE_ENABLED` | Deprecated* | `false` | Enable automatic issue triage globally. Set per-user in `users.yaml` or via `/github triage`. |
-| `GITHUB_NOTIFY_CHAT_ID` | Deprecated* | | Global fallback for GitHub notification routing. Set per-user in `users.yaml` or via `/github notify`. |
-| `CLAUDE_USER` | Deprecated* | | Global OS user for subprocess isolation. Set per-user via `os_user` in `users.yaml`. |
 | `CLAUDE_IDLE_TIMEOUT` | No | `1800` | Seconds before idle subprocesses are evicted (0 to disable) |
+| `CLAUDE_EFFORT_LEVEL` | No | `high` | Reasoning effort for inner Claude: `low`, `medium`, `high`, `xhigh`, `max`. |
 | `VOICE_ENABLED` | No | `false` | Enable voice message transcription |
 | `TTS_ENABLED` | No | `false` | Enable text-to-speech voice responses |
 | `TOTP_SESSION_MINUTES` | No | `30` | Minutes before TOTP re-authentication is required |
@@ -232,14 +242,27 @@ cp templates/.env .env
 | `TOTP_LOCKOUT_MINUTES` | No | `15` | TOTP lockout duration in minutes |
 | `FILE_RETENTION_DAYS` | No | `0` | Days to keep uploaded files before cleanup (0 to disable) |
 
-*Deprecated vars still work for backward compatibility when `users.yaml` is absent. When `users.yaml` is present, `users.yaml` wins and a warning is logged. Run `make config` to migrate.
-
 `BUDGET_CEILING` limits spending in a single session. On the Claude Code backend the flag is omitted on Max-plan OAuth (no real cost is incurred); runaway prevention is handled by the per-session timeout instead. Goose does not currently enforce this limit. The session resets on `/new`, model switch, or workspace switch.
 
 ## Running
 
+Run the configuration wizard first; it writes both `users.yaml` (mandatory authorization) and the runtime env file in the location that matches your deployment mode.
+
 ```bash
-make run
+make config
+```
+
+The wizard's first prompt picks the deployment mode:
+
+- **`single_user`** - Kai runs from the cloned repo under your own OS account. Secrets go to `PROJECT_ROOT/.env` (mode 0600). `users.yaml` goes to `${XDG_CONFIG_HOME:-$HOME/.config}/kai/users.yaml` (mode 0600 in a 0700 parent). No `sudo` required.
+- **`protected`** - Kai runs from a root-owned install at `/opt/kai/`. Secrets go to `/etc/kai/env`, `users.yaml` goes to `/etc/kai/users.yaml`, and a sudoers rule lets the service user read them via `sudo cat`. Requires `sudo make install` after the wizard.
+
+After the wizard:
+
+```bash
+make run    # single-user mode
+# OR
+sudo make install   # protected mode (creates /opt/kai layout; copies secrets)
 ```
 
 Or manually: `source .venv/bin/activate && python -m kai`
@@ -396,10 +419,10 @@ make run        # Start the bot
 
 ## Production deployment
 
-For a hardened installation that separates source, data, and secrets across protected directories:
+The protected install mode separates source, data, and secrets across protected directories:
 
 ```bash
-python -m kai install config       # Interactive Q&A, writes install.conf (no sudo)
+python -m kai install config       # Interactive Q&A; pick `protected` at the first prompt (no sudo)
 sudo python -m kai install apply   # Creates /opt layout, migrates data (root)
 python -m kai install status       # Shows current installation state (no sudo)
 ```
@@ -408,11 +431,13 @@ This creates a split layout:
 
 - `/opt/kai/` - read-only source and venv (root-owned)
 - `/var/lib/kai/` - writable runtime data: database, logs, files (service-user-owned)
-- `/etc/kai/` - secrets: env file, service configs, TOTP (root-owned, mode 0600)
+- `/etc/kai/` - secrets: env file, `users.yaml`, service configs, TOTP (root-owned, mode 0600)
 
 The install module handles directory creation, source copying, venv setup, secret deployment, sudoers rules, data migration, service definition generation, and service lifecycle (stop/start). Use `--dry-run` to preview changes without applying them.
 
 The service user reads secrets via narrowly-scoped sudoers rules (`sudo cat` on specific files only). The inner agent process cannot read secrets or modify source code.
+
+`make config` also supports single-user installs (pick `single_user` at the first prompt). In that mode `.env` and `users.yaml` live under the operator's account; `make install` is a no-op and Kai starts via `make run` directly from the cloned repo.
 
 ## License
 

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -2727,9 +2727,8 @@ async def _is_notify_chat_used(
     Check if any user other than exclude_user still uses this chat_id
     as their GitHub notification destination.
 
-    Checks users.yaml (via config), the database, and the global env
-    var fallback. Returns True if at least one other source references
-    this chat_id.
+    Checks users.yaml (via config) and the database. Returns True if
+    at least one other source references this chat_id.
 
     Note: this does a linear scan of all users with one DB query per
     user. Fine for a personal assistant with a handful of users.
@@ -2748,9 +2747,7 @@ async def _is_notify_chat_used(
                     return True
             except ValueError:
                 continue
-
-    # Also check the global env var fallback
-    return config.github_notify_chat_id == notify_chat_id
+    return False
 
 
 async def _handle_github_notify(

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -37,7 +37,7 @@ PROJECT_ROOT = Path(os.environ.get("KAI_INSTALL_DIR") or str(_FILE_ROOT))
 # Writable data directory for runtime artifacts (database, logs, crash flag).
 # Defaults to PROJECT_ROOT for development. In a protected installation where
 # source lives in read-only /opt/kai/, this points to user-owned /var/lib/kai/.
-# Uses `or` so that an empty string also falls back (same pattern as CLAUDE_USER).
+# Uses `or` so that an empty string also falls back to the project default.
 DATA_DIR = Path(os.environ.get("KAI_DATA_DIR") or str(PROJECT_ROOT))
 
 # Valid agent backend choices. "claude" uses Claude Code CLI,
@@ -702,9 +702,6 @@ class Config:
         allowed_workspaces: Additional workspace directories accessible by name, from config only.
             These appear as pinned workspaces in /workspaces and are reachable via /workspace <name>
             without being under WORKSPACE_BASE. Non-existent paths are skipped at startup.
-        claude_user: OS user for the inner Claude process. When set, Claude is spawned
-            via 'sudo -u <user>' for OS-level isolation. Must be a non-admin user.
-            When None, Claude runs as the same user as the bot (development default).
     """
 
     # Required fields - no defaults, must be provided
@@ -735,11 +732,11 @@ class Config:
     # quality at the cost of latency and budget. Default "high" matches
     # the operator's outer-Claude default; switching to "medium" globally
     # would silently downgrade existing reasoning quality. Critical when
-    # CLAUDE_USER / users.yaml `os_user` is set, because inner Claude
-    # then runs as a different OS user and does NOT inherit the outer
-    # operator's settings.json effort default - without this CLI value,
-    # user-isolated installs would silently fall to whatever the claude
-    # binary picks as its own default. Validated at config load against
+    # users.yaml `os_user` is set, because inner Claude then runs as a
+    # different OS user and does NOT inherit the outer operator's
+    # settings.json effort default - without this CLI value, user-isolated
+    # installs would silently fall to whatever the claude binary picks
+    # as its own default. Validated at config load against
     # _VALID_EFFORT_LEVELS so a typo fails fast rather than at the
     # subprocess startup of the next chat session.
     claude_effort_level: str = "high"
@@ -782,15 +779,14 @@ class Config:
     # NOT extended by registry roots.
     memory_projects: dict[str, MemoryProjectConfig] = field(default_factory=dict)
 
-    # User separation: run Claude as a different OS user for process isolation.
-    # When set, the bot spawns Claude via 'sudo -u <user> claude ...'.
-    # The user must exist on the system and must NOT have admin/sudo privileges.
-    # When unset, Claude runs as the same user as the bot (development default).
-    claude_user: str | None = None
+    # Per-user OS isolation lives in `UserConfig.os_user` (loaded from
+    # users.yaml). The bot spawns the inner agent via
+    # `sudo -u <user>` when that field is set; when unset the agent
+    # runs as the bot's own OS user.
 
-    # PR review agent: automatically review PRs when GitHub webhooks fire.
-    # Disabled by default so existing users are not surprised by automatic reviews.
-    pr_review_enabled: bool = False
+    # PR review agent: per-user toggle lives in users.yaml `pr_review`
+    # (or the per-chat /github reviews command). Global resource
+    # controls stay on Config.
     # Minimum seconds between reviews of the same PR. Absorbs force-push bursts
     # so rapid pushes to an open PR don't trigger a review for each one.
     pr_review_cooldown: int = 300
@@ -816,14 +812,12 @@ class Config:
     # which accepts any path relative to the repo root.
     spec_dir: str = "specs"
 
-    # Issue triage agent: automatically triage new issues when webhooks fire.
-    # Disabled by default so existing users are not surprised by automatic triage.
-    issue_triage_enabled: bool = False
+    # Issue triage agent: per-user toggle lives in users.yaml
+    # `issue_triage` (or the per-chat /github triage command).
 
-    # Global notification chat override. When set, acts as fallback for
-    # users without a per-user github_notify_chat_id. Parsed from
-    # GITHUB_NOTIFY_CHAT_ID env var.
-    github_notify_chat_id: int | None = None
+    # GitHub notification routing is per-user: `github_notify_chat_id`
+    # in users.yaml, with /github notify as the per-chat override. When
+    # neither is set the runtime falls back to the user's own chat_id.
 
     # File retention: delete uploaded files older than this many days.
     # 0 = no cleanup (default). Cleanup runs once every 24 hours.
@@ -2257,8 +2251,9 @@ def load_config() -> Config:
         # expects to see in an error string.
         raise SystemExit(f"CLAUDE_EFFORT_LEVEL must be one of {list(EFFORT_LEVELS)}, got {claude_effort_level!r}")
 
-    # PR review agent config
-    pr_review_enabled = os.environ.get("PR_REVIEW_ENABLED", "").lower() in ("1", "true", "yes")
+    # PR review agent config. The global `pr_review` toggle now lives
+    # per-user in users.yaml; PR_REVIEW_COOLDOWN / PR_REVIEW_TIMEOUT_S
+    # / PR_REVIEW_BUDGET_USD remain as global resource controls.
     try:
         pr_review_cooldown = int(os.environ.get("PR_REVIEW_COOLDOWN", "300"))
     except ValueError:
@@ -2275,22 +2270,6 @@ def load_config() -> Config:
             raise SystemExit("PR_REVIEW_BUDGET_USD must be a positive number")
     except ValueError:
         raise SystemExit("PR_REVIEW_BUDGET_USD must be a number") from None
-
-    # Issue triage agent config
-    issue_triage_enabled = os.environ.get("ISSUE_TRIAGE_ENABLED", "").lower() in ("1", "true", "yes")
-
-    # Global GitHub notification chat override. When set, acts as fallback
-    # for users without a per-user github_notify_chat_id in users.yaml or DB.
-    github_notify_raw = os.environ.get("GITHUB_NOTIFY_CHAT_ID", "")
-    github_notify_chat_id: int | None = None
-    if github_notify_raw:
-        try:
-            github_notify_chat_id = int(github_notify_raw)
-        except ValueError:
-            log.warning(
-                "Invalid GITHUB_NOTIFY_CHAT_ID: %s (ignoring)",
-                github_notify_raw,
-            )
 
     try:
         totp_session_minutes = int(os.environ.get("TOTP_SESSION_MINUTES", "30"))
@@ -2580,42 +2559,33 @@ def load_config() -> Config:
                     f"rerun the wizard if you no longer want memory extraction enabled."
                 ) from None
 
-    # Deprecation warnings for env vars superseded by users.yaml.
-    # users.yaml is mandatory now, so the previous "only fire when
-    # users.yaml exists" guard is gone: any of these env vars in
-    # /etc/kai/env is unconditionally redundant. A later tranche
-    # removes the Class A entries from this block entirely along
-    # with the runtime reads they describe.
-    _deprecated_env_vars = {
-        "CLAUDE_MODEL": "Renamed to DEFAULT_MODEL. Set per-user 'model' in users.yaml or use /settings model",
-        "CLAUDE_MAX_BUDGET_USD": "Renamed to BUDGET_CEILING (global ceiling). Per-user defaults go in users.yaml 'max_budget'",
-        "CLAUDE_TIMEOUT_SECONDS": "Set per-user 'timeout' in users.yaml or use /settings timeout",
-        "CLAUDE_MAX_CONTEXT_WINDOW": "Set per-user 'context_window' in users.yaml or use /settings context",
-        "CLAUDE_USER": "Set per-user 'os_user' in users.yaml",
-        "WORKSPACE_BASE": "Set per-user 'workspace_base' in users.yaml",
-        "ALLOWED_WORKSPACES": "Users can manage their own via /workspace allow",
-        "PR_REVIEW_ENABLED": "Set per-user 'pr_review' in users.yaml or use /github reviews",
-        "ISSUE_TRIAGE_ENABLED": "Set per-user 'issue_triage' in users.yaml or use /github triage",
-        "GITHUB_NOTIFY_CHAT_ID": "Set per-user 'github_notify_chat_id' in users.yaml or use /github notify",
+    # Renamed env vars: warn when the legacy name is present so the
+    # operator knows to re-run `make config`. Only renames remain in
+    # this map. Per-user fields (model, os_user, pr_review, etc.) are
+    # not legacy renames; the runtime no longer reads them at all and
+    # the corresponding wizard prompts have been retired.
+    _renamed_env_vars = {
+        "CLAUDE_MAX_BUDGET_USD": "BUDGET_CEILING (global ceiling). Per-user defaults go in users.yaml 'max_budget'.",
+        "CLAUDE_TIMEOUT_SECONDS": "AGENT_TIMEOUT_SECONDS.",
     }
-    for var, guidance in _deprecated_env_vars.items():
+    for var, replacement in _renamed_env_vars.items():
         if os.environ.get(var, "").strip():
             log.warning(
-                "%s in env is deprecated (users.yaml exists). %s. This env var will be removed in a future release.",
+                "%s in env is deprecated; use %s Re-run 'make config' to migrate /etc/kai/env automatically.",
                 var,
-                guidance,
+                replacement,
             )
 
-    # Warn when GitHub agent features are enabled but no users have
-    # github_repos configured. Events will never reach the agents
-    # because _get_subscribed_users() returns empty for every
-    # incoming webhook. The fallback path in _process_github_event()
+    # Warn when GitHub features are configured but no user has a
+    # repo list. Events will never reach the agents because
+    # `_get_subscribed_users()` returns empty for every incoming
+    # webhook. The fallback path in `_process_github_event()` still
     # delivers basic notifications but does not guarantee the agents
     # fire.
     no_repos = not any(uc.github_repos for uc in user_configs.values())
     if no_repos:
-        review_on = pr_review_enabled or any(uc.pr_review is True for uc in user_configs.values())
-        triage_on = issue_triage_enabled or any(uc.issue_triage is True for uc in user_configs.values())
+        review_on = any(uc.pr_review is True for uc in user_configs.values())
+        triage_on = any(uc.issue_triage is True for uc in user_configs.values())
         if review_on or triage_on:
             features = []
             if review_on:
@@ -2632,15 +2602,7 @@ def load_config() -> Config:
                 ", ".join(features),
             )
 
-    # Read DEFAULT_MODEL, falling back to CLAUDE_MODEL for backward
-    # compat with existing /etc/kai/env files that haven't been
-    # regenerated via make config.
-    default_model = os.environ.get(
-        "DEFAULT_MODEL",
-        os.environ.get("CLAUDE_MODEL", "sonnet"),
-    )
-    if os.environ.get("CLAUDE_MODEL") and not os.environ.get("DEFAULT_MODEL"):
-        log.warning("CLAUDE_MODEL is deprecated, use DEFAULT_MODEL instead")
+    default_model = os.environ.get("DEFAULT_MODEL", "sonnet")
 
     # Validate DEFAULT_MODEL against the effective global backend.
     # Codex installs validate against CODEX_MODELS only - no fallback
@@ -2682,15 +2644,11 @@ def load_config() -> Config:
         allowed_workspaces=allowed_workspaces,
         workspace_configs=workspace_configs,
         memory_projects=memory_projects,
-        claude_user=os.environ.get("CLAUDE_USER") or None,
-        pr_review_enabled=pr_review_enabled,
         pr_review_cooldown=pr_review_cooldown,
         pr_review_timeout_s=pr_review_timeout_s,
         pr_review_budget_usd=pr_review_budget_usd,
         github_repo=os.getenv("GITHUB_REPO", ""),
         spec_dir=os.getenv("SPEC_DIR", "specs"),
-        issue_triage_enabled=issue_triage_enabled,
-        github_notify_chat_id=github_notify_chat_id,
         file_retention_days=file_retention_days,
         user_configs=user_configs,
         totp_session_minutes=totp_session_minutes,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1052,14 +1052,11 @@ def _cmd_config() -> None:
     print()
 
     # -- Workspaces --
-    # WORKSPACE_BASE is an inheritable installation default: users.yaml
-    # entries that omit `workspace_base` fall back to it. The prompt
-    # fires on every wizard run. ALLOWED_WORKSPACES remains a legacy
-    # per-user-mirror env var and stays gated on users.yaml absence;
-    # users.yaml carries per-user `allowed_workspaces` lists and the
-    # global env emission is preserved for installs that have not
-    # migrated yet (tranche D removes the gate when the env var goes
-    # away entirely).
+    # WORKSPACE_BASE and ALLOWED_WORKSPACES are inheritable installation
+    # defaults. users.yaml entries can override `workspace_base` per user
+    # and add per-user allowed_workspaces, but the global env values
+    # apply across every user without an override. Both prompts fire on
+    # every wizard run.
     print("-- Workspaces --")
     workspace_base = _prompt(
         "Workspace base directory",
@@ -1070,13 +1067,10 @@ def _cmd_config() -> None:
         expanded = os.path.expanduser(workspace_base)
         print(f"  (expands to {expanded})")
 
-    if users_yaml_exists:
-        allowed_workspaces = existing_env.get("ALLOWED_WORKSPACES", "")
-    else:
-        allowed_workspaces = _prompt(
-            "Allowed workspaces (comma-separated paths, optional)",
-            existing_env.get("ALLOWED_WORKSPACES", ""),
-        )
+    allowed_workspaces = _prompt(
+        "Allowed workspaces (comma-separated paths, optional)",
+        existing_env.get("ALLOWED_WORKSPACES", ""),
+    )
     print()
 
     # -- PR review agent --

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -620,9 +620,9 @@ def _cmd_config() -> None:
         print(f"  Note: {stray_project_users_yaml} is no longer used. Move it to {users_yaml_path} or remove it.")
     users_yaml_exists = users_yaml_path.exists()
 
-    # Track whether advanced mode set os_user, so we can skip the
-    # CLAUDE_USER prompt later (section 8). Needs to be in scope
-    # regardless of which branch we take.
+    # Admin os_user captured by the advanced-mode prompt block below.
+    # Carried in scope here so the codex-memory branch can reuse it
+    # when re-prompting on a malformed admin entry.
     admin_os_user: str | None = None
     # Admin identity is captured in scope so the codex-memory branch
     # below can re-prompt for a valid os_user and rewrite the wizard-
@@ -688,17 +688,16 @@ def _cmd_config() -> None:
         advanced = _prompt_bool("Configure advanced user options", False)
 
         if advanced:
-            # Default os_user to CLAUDE_USER if previously set, else $USER.
-            # `os_user` is optional on both backends and follows the same
-            # semantics: an empty value (or a value matching the bot
-            # process user) spawns the agent in-process via the
+            # `os_user` is optional on both backends and follows the
+            # same semantics: an empty value (or a value matching the
+            # bot process user) spawns the agent in-process via the
             # self-sudo-skip path detected by `resolve_claude_user`;
             # a different OS account wraps the agent argv in `sudo -H
             # -u <user>` for cross-user isolation. Operators who run
             # kai under their own account leave this empty; operators
             # with a dedicated kai service user and separate per-user
             # OS accounts set it to those accounts.
-            default_os_user = existing_env.get("CLAUDE_USER", "") or os.environ.get("USER", "")
+            default_os_user = os.environ.get("USER", "")
             while True:
                 admin_os_user = _prompt("OS user for subprocess isolation", default_os_user).strip() or None
                 if admin_os_user is None or _validate_os_user(admin_os_user):
@@ -1085,25 +1084,15 @@ def _cmd_config() -> None:
     # are global resource controls for the review subprocess: any
     # review by any user counts against the same cooldown, the same
     # subprocess timeout, and (on non-claude backends) the same USD
-    # budget per run. All three fire on every wizard run regardless
-    # of users.yaml presence. PR_REVIEW_ENABLED is the Class A per-user
-    # mirror and remains gated on users.yaml absence until tranche D
-    # removes it.
+    # budget per run. All three fire on every wizard run. The per-user
+    # `pr_review` toggle lives in users.yaml (or /github reviews).
     print("-- PR review agent --")
-    if users_yaml_exists:
-        print("  Global PR review toggle is now per-user. Set 'pr_review' in users.yaml")
-        print("  or let users toggle via /github reviews on|off.")
-        pr_review_enabled = existing_env.get("PR_REVIEW_ENABLED", "false").lower() in ("1", "true", "yes")
-    else:
-        pr_review_enabled = _prompt_bool(
-            "Enable PR review agent",
-            existing_env.get("PR_REVIEW_ENABLED", "false").lower() in ("1", "true", "yes"),
-        )
+    print("  Per-user PR review toggle lives in users.yaml ('pr_review')")
+    print("  or via /github reviews on|off.")
 
-    # Global cooldown always prompts: a per-user opt-in via users.yaml
-    # or /github reviews can drive reviews even when the global env
-    # toggle is absent, so the cooldown must be configurable for any
-    # install that has any opted-in user.
+    # Global cooldown always prompts: any opted-in user can drive
+    # reviews, so the cooldown must be configurable for any install
+    # that has any opted-in user.
     while True:
         pr_review_cooldown = _prompt(
             "Review cooldown in seconds (prevents spam from rapid pushes)",
@@ -1141,41 +1130,6 @@ def _cmd_config() -> None:
         pr_review_budget_usd = "1.0"
     print()
 
-    # -- Issue triage agent --
-    # Independent from PR review - you might want one without the other.
-    if users_yaml_exists:
-        print("-- Issue triage agent --")
-        print("  Issue triage is now per-user. Set 'issue_triage' in users.yaml")
-        print("  or let users toggle via /github triage on|off.")
-        issue_triage_enabled = existing_env.get("ISSUE_TRIAGE_ENABLED", "false").lower() in ("1", "true", "yes")
-    else:
-        print("-- Issue triage agent --")
-        issue_triage_enabled = _prompt_bool(
-            "Enable issue triage agent",
-            existing_env.get("ISSUE_TRIAGE_ENABLED", "false").lower() in ("1", "true", "yes"),
-        )
-    print()
-
-    # -- GitHub notifications --
-    if users_yaml_exists:
-        print("-- GitHub notifications --")
-        print("  Notification routing is now per-user. Set 'github_notify_chat_id'")
-        print("  in users.yaml or let users configure via /github notify.")
-        github_notify_chat_id = existing_env.get("GITHUB_NOTIFY_CHAT_ID", "")
-    else:
-        print("-- GitHub notifications --")
-        github_notify_chat_id = ""
-        while True:
-            github_notify_chat_id = _prompt(
-                "GitHub notification chat ID (optional)",
-                existing_env.get("GITHUB_NOTIFY_CHAT_ID", ""),
-            )
-            # Empty is valid (feature disabled)
-            if not github_notify_chat_id or _validate_chat_id(github_notify_chat_id):
-                break
-            print("  Must be a valid Telegram chat ID (integer).")
-    print()
-
     # -- Optional features --
     print("-- Optional features --")
     voice_enabled = _prompt_bool(
@@ -1187,30 +1141,11 @@ def _cmd_config() -> None:
         existing_env.get("TTS_ENABLED", "false").lower() in ("1", "true", "yes"),
     )
 
-    # Skip if the user already set os_user via advanced user options
-    # or if users.yaml exists (os_user is per-user there).
-    # CLAUDE_USER is the global fallback; os_user in users.yaml takes
-    # precedence per-user at runtime.
-    if users_yaml_exists:
-        print("  OS user isolation is now per-user. Set 'os_user' in users.yaml.")
-        claude_user = ""
-    elif admin_os_user:
-        claude_user = ""
-    elif agent_backend != "claude":
-        # CLAUDE_USER is the legacy global fallback for sudo subprocess
-        # isolation. Only ClaudeCodeBackend wires it through (claude.py
-        # invokes `sudo -H -u <user> -- claude ...`). Goose has no sudo
-        # path - GooseBackend takes no claude_user kwarg in pool.py,
-        # so the prompt has no meaning when agent_backend is
-        # not claude. Short-circuit to "" here matches the two branches
-        # above, both of which suppress the prompt for the same shape
-        # of "this prompt does not apply" reason.
-        claude_user = ""
-    else:
-        claude_user = _prompt(
-            "Claude subprocess user (optional, for process isolation)",
-            existing_env.get("CLAUDE_USER", ""),
-        )
+    # Per-user OS isolation lives in users.yaml `os_user` (admin-set
+    # baseline) and is no longer mirrored to a global env var. The
+    # wizard surfaces this here only so an operator coming from an
+    # older install knows where the setting moved.
+    print("  Per-user OS isolation: set 'os_user' in users.yaml.")
     print()
 
     # -- Semantic memory --
@@ -1581,29 +1516,16 @@ def _cmd_config() -> None:
 
     # PR_REVIEW_COOLDOWN is a global resource control. Always written
     # when non-default because any user can drive reviews via users.yaml
-    # or /github reviews even when the global PR_REVIEW_ENABLED toggle
-    # is unset.
+    # or /github reviews on|off.
     if pr_review_cooldown != "300":
         env["PR_REVIEW_COOLDOWN"] = pr_review_cooldown
 
-    # Class A per-user mirrors. The prompts and emissions are gated on
-    # users.yaml absence so legacy single-user installs continue to
-    # work via env; tranche D removes the Class A surface entirely
-    # once users.yaml is mandatory.
-    if not users_yaml_exists:
-        if allowed_workspaces:
-            env["ALLOWED_WORKSPACES"] = allowed_workspaces
-        if claude_user:
-            env["CLAUDE_USER"] = claude_user
-        if pr_review_enabled:
-            env["PR_REVIEW_ENABLED"] = "true"
-        if issue_triage_enabled:
-            env["ISSUE_TRIAGE_ENABLED"] = "true"
-        if github_notify_chat_id:
-            env["GITHUB_NOTIFY_CHAT_ID"] = github_notify_chat_id
+    # ALLOWED_WORKSPACES is an inheritable installation default.
+    if allowed_workspaces:
+        env["ALLOWED_WORKSPACES"] = allowed_workspaces
 
-    # Review subprocess resource limits. Written in both branches because
-    # they apply globally to any review, regardless of users.yaml presence.
+    # Review subprocess resource limits. They apply globally to any
+    # review, regardless of which user opted in.
     if pr_review_timeout_s != "900":
         env["PR_REVIEW_TIMEOUT_S"] = pr_review_timeout_s
     if agent_backend != "claude" and pr_review_budget_usd != "1.0":
@@ -1973,9 +1895,8 @@ def _collect_os_users_from_yaml(users_yaml_path: str | Path) -> list[str]:
 
     The runtime (pool.py / claude.py) spawns the inner Claude as each user's
     `os_user` via `sudo -u`. That requires a matching sudoers rule for every
-    distinct os_user. Without this loader, only the legacy single CLAUDE_USER
-    env var got a rule, and additional users had to be hand-added with visudo
-    only to be wiped by the next `make install`.
+    distinct os_user. Without this loader, additional users had to be
+    hand-added with visudo only to be wiped by the next `make install`.
 
     The reader is intentionally lightweight: it does not validate roles,
     models, or providers (config._load_user_configs already does that at
@@ -2228,7 +2149,6 @@ def _collect_user_home_overrides(users_yaml_path: str | Path) -> dict[int, Path]
 
 def _generate_sudoers(
     service_user: str,
-    claude_user: str | None = None,
     os_users: Iterable[str] = (),
     codex_bin: str | None = None,
 ) -> str:
@@ -2245,19 +2165,16 @@ def _generate_sudoers(
 
     Per-user `(target_user) SETENV: NOPASSWD:` rules for the claude and codex
     binaries (plus a `NOPASSWD: /bin/kill` rule for the cross-user kill
-    escalation) are emitted for every distinct user in `os_users` and
-    `claude_user` combined. Users matching `service_user` are skipped (the
-    runtime detects self-sudo via resolve_claude_user() and spawns the agent
-    directly without sudo). The codex binary path defaults to
-    /opt/homebrew/bin/codex; Linux installs override with the CODEX_BIN env
-    var at install time.
+    escalation) are emitted for every distinct `os_user` value in users.yaml.
+    Users matching `service_user` are skipped (the runtime detects self-sudo
+    via resolve_claude_user() and spawns the agent directly without sudo).
+    The codex binary path defaults to /opt/homebrew/bin/codex; Linux installs
+    override with the CODEX_BIN env var at install time.
 
     Args:
         service_user: The OS username that runs the Kai service.
-        claude_user: Optional OS username for the inner Claude process
-            (legacy single CLAUDE_USER env var path; kept for backwards compat).
-        os_users: Distinct os_user values from users.yaml. Combined with
-            claude_user; duplicates and self-sudo entries are dropped.
+        os_users: Distinct os_user values from users.yaml. Self-sudo entries
+            (matching service_user) and duplicates are dropped.
 
     Returns:
         The sudoers file contents as a string.
@@ -2279,21 +2196,20 @@ def _generate_sudoers(
         {service_user} ALL=(root) NOPASSWD: {tee_path} /etc/kai/totp.attempts
     """)
 
-    # Merge legacy claude_user with yaml-derived os_users. Order: legacy first
-    # so behavior is stable when only claude_user is set (existing installs).
-    # Drop self-sudo entries — pool.py uses resolve_claude_user() to skip the
-    # sudo wrapper entirely when the target matches the service user, so a
-    # rule would be dead code (and slightly misleading to future readers).
+    # Yaml-derived os_users only. Drop self-sudo entries: pool.py uses
+    # resolve_claude_user() to skip the sudo wrapper entirely when the
+    # target matches the service user, so a rule would be dead code
+    # (and slightly misleading to future readers).
     #
-    # Defense-in-depth: validate every candidate before interpolating into
-    # the sudoers template. _collect_os_users_from_yaml already validates,
-    # but claude_user can come straight from the legacy CLAUDE_USER env var
-    # without going through that path. A `)` or newline in an unvalidated
-    # username would let an attacker with control of that env var inject
-    # arbitrary sudoers directives.
+    # Defense-in-depth: validate every candidate before interpolating
+    # into the sudoers template. `_collect_os_users_from_yaml` already
+    # validates, but the guard stays here so any future caller cannot
+    # bypass it. A `)` or newline in an unvalidated username would let
+    # an attacker with control of the source inject arbitrary sudoers
+    # directives.
     target_users: list[str] = []
     seen: set[str] = set()
-    for candidate in (claude_user, *os_users):
+    for candidate in os_users:
         if not candidate or candidate == service_user or candidate in seen:
             continue
         if not _validate_os_user(candidate):
@@ -3566,8 +3482,7 @@ def _cmd_apply() -> None:
             _apply_goose_config(service_user, install_path, svc_uid, svc_gid, dry_run)
 
         # -- Step 7: Configure sudoers --
-        claude_user = env.get("CLAUDE_USER") or None
-        _apply_sudoers(service_user, dry_run, claude_user, codex_bin=env.get("CODEX_BIN"))
+        _apply_sudoers(service_user, dry_run, codex_bin=env.get("CODEX_BIN"))
 
         # -- Step 8: Migrate runtime data --
         _apply_migrate(data_path, install_path, svc_uid, svc_gid, dry_run)
@@ -4674,7 +4589,6 @@ def _apply_goose_config(
 def _apply_sudoers(
     service_user: str,
     dry_run: bool,
-    claude_user: str | None = None,
     users_yaml_path: str | Path = "/etc/kai/users.yaml",
     codex_bin: str | None = None,
 ) -> None:
@@ -4698,7 +4612,7 @@ def _apply_sudoers(
     # dry run, since the operator's next step is `sudo make install` which
     # would hit the same error with worse blast radius (partial install).
     os_users = _collect_os_users_from_yaml(users_yaml_path)
-    sudoers_content = _generate_sudoers(service_user, claude_user, os_users, codex_bin=codex_bin)
+    sudoers_content = _generate_sudoers(service_user, os_users, codex_bin=codex_bin)
 
     # Backstop check: the per-user rules pin the claude binary to
     # {service_user_home}/.local/bin/claude (the native-installer
@@ -4709,8 +4623,7 @@ def _apply_sudoers(
     # runtime with no obvious cause. Warn loudly but do not abort -
     # the warning catches the simple "wrong path" case; the operator
     # still owns the symlink or reinstall to make the paths agree.
-    has_target_users = bool(claude_user) or bool(os_users)
-    if has_target_users:
+    if os_users:
         expected_bin = Path(f"{_user_home(service_user)}/.local/bin/claude")
         if not expected_bin.exists():
             print(

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -261,7 +261,7 @@ class SubprocessPool:
         # auth set in /etc/kai/env; OpenCode reads its auth from
         # ~/.local/share/opencode/auth.json which is per-OS-user but
         # operator-managed via `opencode auth login` outside the wizard.
-        os_user = user.os_user if user else self._config.claude_user
+        os_user = user.os_user if user else None
 
         if backend == "codex":
             # Import locally so codex.py is only imported on a

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -1081,13 +1081,12 @@ class GitHubSettings(TypedDict):
 async def resolve_github_settings(chat_id: int, config: Config) -> GitHubSettings:
     """
     Resolve per-user GitHub settings by layering DB overrides on top
-    of users.yaml and env var defaults.
+    of users.yaml.
 
     Precedence (highest to lowest):
     1. Database (user-set via /github commands)
     2. users.yaml (admin baseline per user)
-    3. Env var (global defaults)
-    4. Hardcoded defaults
+    3. Hardcoded defaults (False / chat_id)
     """
     user_config = config.get_user_config(chat_id)
     db = await get_github_db_settings(chat_id)
@@ -1096,9 +1095,9 @@ async def resolve_github_settings(chat_id: int, config: Config) -> GitHubSetting
     yaml_repos = user_config.github_repos if user_config else []
     repos = await get_effective_repos(chat_id, yaml_repos)
 
-    # Notification destination: DB > yaml > env > telegram_id.
+    # Notification destination: DB > yaml > telegram_id.
     # Defensive try/except matches budget/timeout/context_window above.
-    # A corrupt DB value falls through to yaml/env/default rather than
+    # A corrupt DB value falls through to yaml/default rather than
     # aborting the entire resolution.
     notify: int | None = None
     if "github_notify_chat" in db:
@@ -1114,26 +1113,25 @@ async def resolve_github_settings(chat_id: int, config: Config) -> GitHubSetting
         if user_config and user_config.github_notify_chat_id is not None:
             notify = user_config.github_notify_chat_id
         else:
-            # Fall back to the global env var. If that is also unset,
-            # use the user's own telegram_id (notifications go to DM).
-            global_notify = config.github_notify_chat_id
-            notify = global_notify if global_notify is not None else chat_id
+            # No per-user routing configured; deliver notifications to
+            # the user's own DM (telegram_id == chat_id for private chats).
+            notify = chat_id
 
-    # PR review: DB > yaml > env > False
+    # PR review: DB > yaml > False
     if "pr_review" in db:
         pr_review = isinstance(db["pr_review"], str) and db["pr_review"].lower() == "true"
     elif user_config and user_config.pr_review is not None:
         pr_review = user_config.pr_review
     else:
-        pr_review = config.pr_review_enabled
+        pr_review = False
 
-    # Issue triage: DB > yaml > env > False
+    # Issue triage: DB > yaml > False
     if "issue_triage" in db:
         issue_triage = isinstance(db["issue_triage"], str) and db["issue_triage"].lower() == "true"
     elif user_config and user_config.issue_triage is not None:
         issue_triage = user_config.issue_triage
     else:
-        issue_triage = config.issue_triage_enabled
+        issue_triage = False
 
     return {
         "repos": repos,

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -697,11 +697,10 @@ async def _process_github_event_for_user(
     settings = await sessions.resolve_github_settings(chat_id, config)
     target_chat_id = settings["notify_chat_id"]
 
-    # Resolve per-user os_user for subprocess isolation.
-    # Falls back to the global claude_user when the user has no os_user
-    # or no UserConfig at all (legacy mode).
+    # Resolve per-user os_user for subprocess isolation. None falls
+    # back to "run as the bot's own OS user" inside the agent backend.
     user_config = config.get_user_config(chat_id)
-    claude_user = user_config.os_user if user_config and user_config.os_user else config.claude_user
+    claude_user = user_config.os_user if user_config and user_config.os_user else None
 
     # Resolve per-user backend/provider for the review/triage agents.
     # Same resolution logic as pool.py _create_instance: per-user
@@ -2076,7 +2075,6 @@ async def start(telegram_app, config) -> None:
     _app["pr_review_timeout_s"] = config.pr_review_timeout_s
     _app["pr_review_budget_usd"] = config.pr_review_budget_usd
     _app["webhook_port"] = config.webhook_port
-    _app["claude_user"] = config.claude_user
 
     # Workspace config for review agent repo resolution. These let
     # _resolve_local_repo() match incoming PR webhook repos against
@@ -2104,10 +2102,6 @@ async def start(telegram_app, config) -> None:
                     uid,
                     val,
                 )
-    # Also add the global env var fallback if set
-    if config.github_notify_chat_id is not None:
-        _app["allowed_user_ids"].add(config.github_notify_chat_id)
-
     _app.router.add_get("/health", _handle_health)
 
     # Only register the Telegram webhook route in webhook mode. In polling mode,

--- a/templates/.env
+++ b/templates/.env
@@ -3,15 +3,18 @@
 # Bot token from @BotFather on Telegram
 TELEGRAM_BOT_TOKEN=your-token-from-botfather
 
-# DEPRECATED when users.yaml exists. Run 'make config' to create users.yaml.
-# Comma-separated Telegram user IDs allowed to interact with Kai
-# Message @userinfobot on Telegram to find yours
-#ALLOWED_USER_IDS=your-telegram-user-id
+# Per-user authorization, per-user model selection, per-user OS
+# isolation, per-user GitHub routing, and per-user agent toggles all
+# live in users.yaml (mandatory). Run 'make config' to generate one;
+# the wizard writes /etc/kai/users.yaml (protected install) or
+# ${XDG_CONFIG_HOME:-$HOME/.config}/kai/users.yaml (single-user
+# install).
 
 # ── Agent Backend ─────────────────────────────────────────────────
 
-# Agent backend: "claude" (default) or "goose"
-# "claude" uses Claude Code CLI, "goose" uses Goose ACP protocol.
+# Agent backend: "claude" (default), "goose", "codex", or "opencode".
+# "claude" uses Claude Code CLI; "goose"/"opencode" use ACP;
+# "codex" uses the OpenAI Codex CLI's app-server JSON-RPC protocol.
 #AGENT_BACKEND=claude
 
 # LLM provider. Required when AGENT_BACKEND is a non-Claude backend.
@@ -28,17 +31,15 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 #GOOGLE_API_KEY=...
 #OPENROUTER_API_KEY=sk-or-...
 
-# ── Claude Code ───────────────────────────────────────────────────
+# ── Global agent defaults ─────────────────────────────────────────
 
-# Default model (provider-dependent). CLAUDE_MODEL is still accepted
-# for backward compat but DEFAULT_MODEL takes precedence.
-# DEPRECATED when users.yaml exists - set per-user 'model' in
-# users.yaml or use /settings model via Telegram.
+# Installation-wide default model (provider-dependent). Per-user
+# overrides go in users.yaml 'model', or via /settings model in chat.
 #DEFAULT_MODEL=sonnet
 
-# DEPRECATED when users.yaml exists - set per-user 'timeout' in
-# users.yaml or use /settings timeout via Telegram.
-#CLAUDE_TIMEOUT_SECONDS=120
+# Installation-wide default subprocess timeout (seconds). Per-user
+# overrides go in users.yaml 'timeout', or via /settings timeout.
+#AGENT_TIMEOUT_SECONDS=120
 
 # Global budget ceiling in USD. Users cannot exceed this via /settings.
 # Per-user defaults are set via 'max_budget' in users.yaml.
@@ -56,25 +57,25 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 # Recommended: 4-8 hours for memory-constrained machines.
 #CLAUDE_MAX_SESSION_HOURS=4
 
-# DEPRECATED when users.yaml exists - set per-user 'context_window'
-# in users.yaml or use /settings context via Telegram.
+# Installation-wide default context window (tokens). Per-user
+# overrides go in users.yaml 'context_window', or via /settings context.
 #CLAUDE_MAX_CONTEXT_WINDOW=200000
 
-# Autocompact threshold (truly global, not deprecated).
-# When context usage hits this percentage, Claude automatically compresses
-# conversation history. Lower values compact sooner, trading raw context
-# for reduced token consumption. Note: Claude Code silently clamps values
-# above ~83%, so this can only lower the threshold, not raise it.
+# Autocompact threshold. When context usage hits this percentage,
+# Claude automatically compresses conversation history. Lower values
+# compact sooner, trading raw context for reduced token consumption.
+# Note: Claude Code silently clamps values above ~83%, so this can
+# only lower the threshold, not raise it.
 CLAUDE_AUTOCOMPACT_PCT=80
 
 # ── Workspaces ───────────────────────────────────────────────────
 
-# DEPRECATED when users.yaml exists - set per-user 'workspace_base'
-# in users.yaml.
+# Installation-wide default workspace base directory. Per-user
+# overrides go in users.yaml 'workspace_base'.
 #WORKSPACE_BASE=
 
-# DEPRECATED when users.yaml exists - users manage their own via
-# /workspace allow and /workspace deny.
+# Additional workspace directories accessible by name across all
+# users. Users can also add their own via /workspace allow.
 #ALLOWED_WORKSPACES=
 
 # ── Webhook & Scheduling API ─────────────────────────────────────
@@ -85,12 +86,8 @@ WEBHOOK_PORT=8080
 # HMAC secret for verifying incoming webhook payloads
 WEBHOOK_SECRET=your-webhook-secret
 
-# DEPRECATED when users.yaml exists - set per-user 'pr_review' in
-# users.yaml or use /github reviews on|off via Telegram.
-#PR_REVIEW_ENABLED=true
-
 # Global rate limit: minimum seconds between reviews on the same PR.
-# Not deprecated - this is a machine-wide resource limit.
+# Machine-wide resource limit shared across all users.
 #PR_REVIEW_COOLDOWN=300
 
 # Subprocess timeout for a single PR review, in seconds. Sonnet with
@@ -116,10 +113,6 @@ WEBHOOK_SECRET=your-webhook-secret
 # Used by the review agent for automatic branch-name matching.
 # Body marker specs (spec: path/to/file.md) can reference any path regardless.
 #SPEC_DIR=specs
-
-# DEPRECATED when users.yaml exists - set per-user 'issue_triage' in
-# users.yaml or use /github triage on|off via Telegram.
-#ISSUE_TRIAGE_ENABLED=true
 
 # Telegram webhook URL - where Telegram pushes updates
 # If set, uses webhook mode (requires a tunnel/proxy). If unset, falls back to polling.
@@ -272,26 +265,3 @@ MEMORY_ENABLED=false
 # source directory is read-only.
 # When unset, defaults to the project root (development default).
 #KAI_DATA_DIR=/var/lib/kai
-
-# ── User Separation (optional) ──────────────────────────────────
-
-# DEPRECATED when users.yaml exists - set per-user 'os_user' in users.yaml.
-#
-# Run the inner Claude process as a different OS user for security isolation.
-# The bot spawns Claude via 'sudo -u <user> claude ...', creating a hard
-# OS-level boundary between the bot and the AI subprocess.
-#
-# Requirements:
-#   - The user must exist on the system
-#   - The user must NOT be an admin (no sudo privileges)
-#   - A sudoers rule must allow kai to run claude as this user (see README)
-#   - Claude Code must be installed and accessible to this user
-#
-# Important: If you plan to use this feature, enable it early - before Claude
-# accumulates memory, chat history, and project associations under the bot
-# user's home directory. Claude's state is path-dependent (~/.claude/), so
-# migrating to a different user later means either starting fresh or manually
-# relocating path-encoded directories.
-#
-# When unset, Claude runs as the same user as the bot (no isolation).
-#CLAUDE_USER=daniel

--- a/templates/users.yaml
+++ b/templates/users.yaml
@@ -1,12 +1,19 @@
-# Per-user configuration for Kai.
+# Per-user configuration for Kai. users.yaml is mandatory; the
+# daemon fails closed at startup if it cannot find or parse it.
 #
-# Copy to /etc/kai/users.yaml (the canonical location) and customize
-# with your users' details. Alternatively, run `make config`; the
-# wizard stages a generated file at `~/.cache/kai-install/users.yaml`
-# that `sudo make install` then copies into /etc/kai/users.yaml.
+# Canonical paths:
+#   protected installs (`sudo make install`): /etc/kai/users.yaml
+#   single-user installs (`make config` then `make run`):
+#       ${XDG_CONFIG_HOME:-$HOME/.config}/kai/users.yaml
 #
-# Required fields: telegram_id, name.
-# All other fields are optional.
+# `make config` writes the correct location for the deployment mode
+# you select. KAI_USERS_YAML can override either for tests/dev.
+#
+# Required fields per user: telegram_id, name.
+# All other fields are optional. Omitted fields inherit installation
+# defaults from .env / /etc/kai/env (model, timeout, context_window,
+# workspace_base) or the hardcoded defaults documented in the
+# templates/.env header.
 
 users:
   # Example: admin user with full settings
@@ -19,20 +26,20 @@ users:
 
     # workspace_base: directory for /workspace new and name resolution.
     # /workspace <name> looks for subdirectories under this path.
-    # Falls back to WORKSPACE_BASE env var if not set.
+    # Inherits the global WORKSPACE_BASE installation default if unset.
     # workspace_base: ~/projects
 
-    # max_budget serves double duty: it is both the user's default
-    # budget AND the ceiling they cannot exceed via /settings budget.
-    # If alice sets /settings budget 15, she gets $15. If she tries
-    # /settings budget 25, she gets "Budget cannot exceed $20.00
-    # (admin limit)." If she has not set any /settings budget, she
-    # gets $20 as the baseline default.
+    # max_budget serves double duty: it is the user's default budget
+    # AND the ceiling they cannot exceed via /settings budget. The
+    # global BUDGET_CEILING is the hard upper bound; /settings
+    # enforces it. If max_budget is unset, the user falls back to
+    # BUDGET_CEILING as their baseline.
     max_budget: 20.0
 
-    # Optional per-user defaults. Users can override these with
-    # /settings commands. Omitted fields use global defaults from .env.
-    # model: opus             # default model (haiku/sonnet/opus)
+    # Optional per-user defaults. Users can override these at runtime
+    # via /settings. Omitted fields inherit installation defaults
+    # (DEFAULT_MODEL, AGENT_TIMEOUT_SECONDS, CLAUDE_MAX_CONTEXT_WINDOW).
+    # model: opus             # haiku/sonnet/opus for claude; provider/model for opencode
     # timeout: 300            # response timeout in seconds (max 600)
     # context_window: 200000  # context window in tokens (0 = default)
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -4889,18 +4889,6 @@ class TestIsNotifyChatUsed:
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_env_var_match(self):
-        """Returns True when the global env var fallback uses the chat_id."""
-        config = _make_config(github_notify_chat_id=-100999)
-
-        mock_sessions = AsyncMock()
-        mock_sessions.get_setting = AsyncMock(return_value=None)
-
-        with patch("kai.bot.sessions", mock_sessions):
-            result = await _is_notify_chat_used(-100999, exclude_user=111, config=config)
-        assert result is True
-
-    @pytest.mark.asyncio
     async def test_no_match(self):
         """Returns False when no other source references the chat_id."""
         from kai.config import UserConfig

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -359,12 +359,6 @@ class TestLoadConfigOptional:
         monkeypatch.setenv("DEFAULT_MODEL", "opus")
         assert load_config().default_model == "opus"
 
-    def test_claude_model_backward_compat(self, monkeypatch):
-        """Old CLAUDE_MODEL env var is still read when DEFAULT_MODEL is absent."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("CLAUDE_MODEL", "opus")
-        assert load_config().default_model == "opus"
-
     def test_voice_enabled_true(self, monkeypatch):
         _set_required(monkeypatch)
         monkeypatch.setenv("VOICE_ENABLED", "true")
@@ -445,21 +439,6 @@ class TestLoadConfigOptional:
         monkeypatch.setenv("ALLOWED_WORKSPACES", f"{dir_a},{non_canonical}")
         config = load_config()
         assert len(config.allowed_workspaces) == 1
-
-    def test_claude_user_default_none(self, monkeypatch):
-        _set_required(monkeypatch)
-        assert load_config().claude_user is None
-
-    def test_claude_user_from_env(self, monkeypatch):
-        _set_required(monkeypatch)
-        monkeypatch.setenv("CLAUDE_USER", "daniel")
-        assert load_config().claude_user == "daniel"
-
-    def test_claude_user_empty_string_becomes_none(self, monkeypatch):
-        # Empty CLAUDE_USER is treated as unset (the `or None` coercion)
-        _set_required(monkeypatch)
-        monkeypatch.setenv("CLAUDE_USER", "")
-        assert load_config().claude_user is None
 
 
 # ── Telegram webhook config ─────────────────────────────────────────
@@ -721,22 +700,18 @@ class TestDualModeLoading:
 
 class TestPRReviewConfig:
     def test_defaults(self, monkeypatch):
-        """PR review is disabled by default with a 5-minute cooldown."""
+        """PR review resource controls take dataclass defaults when env is empty."""
         _set_required(monkeypatch)
         config = load_config()
-        assert config.pr_review_enabled is False
         assert config.pr_review_cooldown == 300
         assert config.pr_review_timeout_s == 900
         assert config.pr_review_budget_usd == 1.0
 
-    def test_enabled_with_custom_cooldown(self, monkeypatch):
-        """PR_REVIEW_ENABLED and PR_REVIEW_COOLDOWN are picked up from env."""
+    def test_custom_cooldown(self, monkeypatch):
+        """PR_REVIEW_COOLDOWN is picked up from env."""
         _set_required(monkeypatch)
-        monkeypatch.setenv("PR_REVIEW_ENABLED", "true")
         monkeypatch.setenv("PR_REVIEW_COOLDOWN", "60")
-        config = load_config()
-        assert config.pr_review_enabled is True
-        assert config.pr_review_cooldown == 60
+        assert load_config().pr_review_cooldown == 60
 
     def test_cooldown_invalid_raises(self, monkeypatch):
         """Non-numeric PR_REVIEW_COOLDOWN raises SystemExit."""
@@ -808,57 +783,6 @@ class TestPRReviewConfig:
         assert config.spec_dir == "home/specs"
 
 
-# ── Issue triage config ─────────────────────────────────────────────
-
-
-class TestIssueTriageConfig:
-    def test_defaults(self, monkeypatch):
-        """Issue triage is disabled by default."""
-        _set_required(monkeypatch)
-        config = load_config()
-        assert config.issue_triage_enabled is False
-
-    def test_enabled(self, monkeypatch):
-        """ISSUE_TRIAGE_ENABLED=true enables the triage agent."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("ISSUE_TRIAGE_ENABLED", "true")
-        config = load_config()
-        assert config.issue_triage_enabled is True
-
-
-# ── GITHUB_NOTIFY_CHAT_ID config ───────────────────────────────────
-
-
-class TestGitHubNotifyChatIdConfig:
-    def test_default_none(self, monkeypatch):
-        """Unset GITHUB_NOTIFY_CHAT_ID defaults to None."""
-        _set_required(monkeypatch)
-        config = load_config()
-        assert config.github_notify_chat_id is None
-
-    def test_valid_positive(self, monkeypatch):
-        """Positive chat ID is parsed correctly."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("GITHUB_NOTIFY_CHAT_ID", "123456789")
-        config = load_config()
-        assert config.github_notify_chat_id == 123456789
-
-    def test_valid_negative(self, monkeypatch):
-        """Negative chat ID (group chat) is parsed correctly."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("GITHUB_NOTIFY_CHAT_ID", "-100123456789")
-        config = load_config()
-        assert config.github_notify_chat_id == -100123456789
-
-    def test_invalid_warns(self, monkeypatch, caplog):
-        """Non-numeric value warns and uses None."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("GITHUB_NOTIFY_CHAT_ID", "not-a-number")
-        config = load_config()
-        assert config.github_notify_chat_id is None
-        assert "invalid github_notify_chat_id" in caplog.text.lower()
-
-
 # ── resolve_claude_user() ────────────────────────────────────────────
 
 
@@ -906,28 +830,22 @@ def _mock_user_configs(monkeypatch):
     )
 
 
-# Deprecated env vars and representative test values. /tmp is used
-# for path vars because it always exists on both macOS and Linux.
-_DEPRECATED_VARS_WITH_VALUES = {
-    "CLAUDE_MODEL": "sonnet",
-    "CLAUDE_MAX_BUDGET_USD": "10.0",  # old name, still tested for deprecation warning
+# Renamed env vars whose legacy name still triggers a one-line
+# operator-facing migration warning. Class A mirrors (CLAUDE_MODEL,
+# CLAUDE_USER, PR_REVIEW_ENABLED, ISSUE_TRIAGE_ENABLED,
+# GITHUB_NOTIFY_CHAT_ID) are no longer read at runtime and have no
+# deprecation handling here — the loader silently ignores them.
+_RENAMED_VARS_WITH_VALUES = {
+    "CLAUDE_MAX_BUDGET_USD": "10.0",
     "CLAUDE_TIMEOUT_SECONDS": "120",
-    "CLAUDE_MAX_CONTEXT_WINDOW": "200000",
-    "CLAUDE_USER": "kai",
-    "WORKSPACE_BASE": "/tmp",
-    "ALLOWED_WORKSPACES": "/tmp",
-    "PR_REVIEW_ENABLED": "true",
-    "ISSUE_TRIAGE_ENABLED": "true",
-    "GITHUB_NOTIFY_CHAT_ID": "12345",
 }
 
 
-class TestDeprecationWarnings:
-    """Verify deprecated env vars emit warnings when users.yaml exists."""
+class TestRenamedEnvWarnings:
+    """Renamed env vars surface a single migration warning."""
 
-    @pytest.mark.parametrize("var,value", _DEPRECATED_VARS_WITH_VALUES.items())
-    def test_warns_when_users_yaml_exists(self, monkeypatch, caplog, var, value):
-        """Deprecated env var emits warning when users.yaml is present."""
+    @pytest.mark.parametrize("var,value", _RENAMED_VARS_WITH_VALUES.items())
+    def test_warns_on_legacy_name(self, monkeypatch, caplog, var, value):
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
         monkeypatch.setenv(var, value)
         _mock_user_configs(monkeypatch)
@@ -938,54 +856,26 @@ class TestDeprecationWarnings:
     def test_empty_var_does_not_warn(self, monkeypatch, caplog):
         """Empty string env vars are not treated as 'set'."""
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
-        # Use CLAUDE_USER instead of CLAUDE_MODEL because an empty
-        # CLAUDE_MODEL fails the model validation step downstream.
-        monkeypatch.setenv("CLAUDE_USER", "")
+        monkeypatch.setenv("CLAUDE_MAX_BUDGET_USD", "")
         _mock_user_configs(monkeypatch)
         with caplog.at_level(logging.WARNING, logger="kai.config"):
             load_config()
-        assert "CLAUDE_USER in env is deprecated" not in caplog.text
+        assert "CLAUDE_MAX_BUDGET_USD in env is deprecated" not in caplog.text
 
 
 # ── GitHub repos empty warning ───────────────────────────────────────
 
 
 class TestGitHubReposWarning:
-    """Verify startup warning when GitHub features are on but no repos configured."""
+    """Startup warning when GitHub features are on but no repos configured.
 
-    def test_warns_when_pr_review_enabled_no_repos(self, monkeypatch, caplog):
-        """PR review enabled globally + no github_repos = warning."""
-        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
-        monkeypatch.setenv("PR_REVIEW_ENABLED", "true")
-        _mock_user_configs(monkeypatch)
-        with caplog.at_level(logging.WARNING, logger="kai.config"):
-            load_config()
-        assert "PR review" in caplog.text
-        assert "github_repos" in caplog.text
+    With Class A globals retired, the warning's gating signal is
+    per-user (`pr_review`/`issue_triage` in users.yaml). The check
+    runs once across all users.
+    """
 
-    def test_warns_when_issue_triage_enabled_no_repos(self, monkeypatch, caplog):
-        """Issue triage enabled globally + no github_repos = warning."""
-        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
-        monkeypatch.setenv("ISSUE_TRIAGE_ENABLED", "true")
-        _mock_user_configs(monkeypatch)
-        with caplog.at_level(logging.WARNING, logger="kai.config"):
-            load_config()
-        assert "issue triage" in caplog.text
-        assert "github_repos" in caplog.text
-
-    def test_warns_when_both_features_enabled_no_repos(self, monkeypatch, caplog):
-        """Both features enabled + no github_repos = warning naming both."""
-        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
-        monkeypatch.setenv("PR_REVIEW_ENABLED", "true")
-        monkeypatch.setenv("ISSUE_TRIAGE_ENABLED", "true")
-        _mock_user_configs(monkeypatch)
-        with caplog.at_level(logging.WARNING, logger="kai.config"):
-            load_config()
-        assert "PR review" in caplog.text
-        assert "issue triage" in caplog.text
-
-    def test_warns_when_per_user_pr_review_enabled_no_repos(self, monkeypatch, caplog):
-        """Per-user pr_review=True (no global env var) + no repos = warning."""
+    def test_warns_when_per_user_pr_review_no_repos(self, monkeypatch, caplog):
+        """A user with pr_review=True but no github_repos triggers the warning."""
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
         user = UserConfig(telegram_id=123, name="testuser", pr_review=True)
         monkeypatch.setattr("kai.config._load_user_configs", lambda *_a: {123: user})
@@ -994,50 +884,54 @@ class TestGitHubReposWarning:
         assert "PR review" in caplog.text
         assert "github_repos" in caplog.text
 
-    def test_no_warn_when_repos_configured(self, monkeypatch, caplog):
-        """No warning when at least one user has github_repos set."""
+    def test_warns_when_per_user_triage_no_repos(self, monkeypatch, caplog):
+        """A user with issue_triage=True but no github_repos triggers the warning."""
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
-        monkeypatch.setenv("PR_REVIEW_ENABLED", "true")
-        user = UserConfig(telegram_id=123, name="testuser", github_repos=["owner/repo"])
+        user = UserConfig(telegram_id=123, name="testuser", issue_triage=True)
         monkeypatch.setattr("kai.config._load_user_configs", lambda *_a: {123: user})
         with caplog.at_level(logging.WARNING, logger="kai.config"):
             load_config()
-        # The github_repos warning should not fire; filter out deprecation
-        # warnings which also mention github_repos tangentially.
-        repo_warnings = [
-            r
-            for r in caplog.records
-            if r.levelno >= logging.WARNING and "github_repos" in r.message and "deprecated" not in r.message
-        ]
+        assert "issue triage" in caplog.text
+        assert "github_repos" in caplog.text
+
+    def test_warns_when_both_features_no_repos(self, monkeypatch, caplog):
+        """A user opted into both features without repos triggers a joint warning."""
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
+        user = UserConfig(telegram_id=123, name="testuser", pr_review=True, issue_triage=True)
+        monkeypatch.setattr("kai.config._load_user_configs", lambda *_a: {123: user})
+        with caplog.at_level(logging.WARNING, logger="kai.config"):
+            load_config()
+        assert "PR review" in caplog.text
+        assert "issue triage" in caplog.text
+
+    def test_no_warn_when_repos_configured(self, monkeypatch, caplog):
+        """No warning when the opted-in user has github_repos set."""
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
+        user = UserConfig(telegram_id=123, name="testuser", pr_review=True, github_repos=["owner/repo"])
+        monkeypatch.setattr("kai.config._load_user_configs", lambda *_a: {123: user})
+        with caplog.at_level(logging.WARNING, logger="kai.config"):
+            load_config()
+        repo_warnings = [r for r in caplog.records if r.levelno >= logging.WARNING and "github_repos" in r.message]
         assert repo_warnings == []
 
     def test_no_warn_when_features_disabled(self, monkeypatch, caplog):
-        """No warning when neither feature is enabled (empty repos is fine)."""
+        """No warning when no user opts into either feature."""
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
         _mock_user_configs(monkeypatch)
         with caplog.at_level(logging.WARNING, logger="kai.config"):
             load_config()
-        repo_warnings = [
-            r
-            for r in caplog.records
-            if r.levelno >= logging.WARNING and "github_repos" in r.message and "deprecated" not in r.message
-        ]
+        repo_warnings = [r for r in caplog.records if r.levelno >= logging.WARNING and "github_repos" in r.message]
         assert repo_warnings == []
 
     def test_no_warn_when_any_user_has_repos(self, monkeypatch, caplog):
-        """No warning when at least one of multiple users has repos."""
+        """Across users, any single user with repos suppresses the warning."""
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
-        monkeypatch.setenv("PR_REVIEW_ENABLED", "true")
-        user_a = UserConfig(telegram_id=123, name="alice", github_repos=["owner/repo"])
+        user_a = UserConfig(telegram_id=123, name="alice", pr_review=True, github_repos=["owner/repo"])
         user_b = UserConfig(telegram_id=456, name="bob")
         monkeypatch.setattr("kai.config._load_user_configs", lambda *_a: {123: user_a, 456: user_b})
         with caplog.at_level(logging.WARNING, logger="kai.config"):
             load_config()
-        repo_warnings = [
-            r
-            for r in caplog.records
-            if r.levelno >= logging.WARNING and "github_repos" in r.message and "deprecated" not in r.message
-        ]
+        repo_warnings = [r for r in caplog.records if r.levelno >= logging.WARNING and "github_repos" in r.message]
         assert repo_warnings == []
 
 
@@ -1070,13 +964,9 @@ class TestMinimalEnvWithUsersYaml:
         assert config.claude_timeout_seconds == 120
         assert config.budget_ceiling == 10.0
         assert config.claude_max_context_window == 0
-        assert config.claude_user is None
         assert config.workspace_base is None
         assert config.allowed_workspaces == []
-        assert config.pr_review_enabled is False
-        assert config.issue_triage_enabled is False
-        assert config.github_notify_chat_id is None
-        # users.yaml IDs replace ALLOWED_USER_IDS
+        # users.yaml IDs are the authorization surface
         assert config.allowed_user_ids == {123}
         assert config.user_configs is not None
 
@@ -1125,7 +1015,7 @@ class TestMinimalEnvWithUsersYaml:
         assert config.user_configs[123].workspace_base == tmp_path
 
     def test_github_settings_from_users_yaml_only(self, monkeypatch):
-        """GitHub routing works when env var globals are all unset."""
+        """GitHub routing reads from users.yaml only; no global env fallbacks remain."""
         for var, val in _MINIMAL_GLOBAL_ENV.items():
             monkeypatch.setenv(var, val)
         user = UserConfig(
@@ -1141,10 +1031,6 @@ class TestMinimalEnvWithUsersYaml:
             lambda *_a: {123: user},
         )
         config = load_config()
-        # Global env fallbacks are all at their defaults
-        assert config.pr_review_enabled is False
-        assert config.issue_triage_enabled is False
-        assert config.github_notify_chat_id is None
         # Per-user overrides are set
         assert config.user_configs is not None
         uc = config.user_configs[123]
@@ -1283,8 +1169,8 @@ class TestClaudeEffortLevel:
     string validated against a hard-coded allow-list pulled from
     `claude --help` output. Default "high" is intentional - it must
     match the operator's outer-Claude default so user-isolated inner
-    Claude (CLAUDE_USER / users.yaml `os_user`) does not silently
-    fall to whatever the binary picks as its own default. Tests here
+    Claude (users.yaml `os_user`) does not silently fall to whatever
+    the binary picks as its own default. Tests here
     cover happy path, allow-list rejection, and the two normalization
     behaviors (case + whitespace) that exist to absorb common copy-
     paste shapes from .env files."""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2824,6 +2824,7 @@ class TestCmdConfigDefaultModelDispatch:
             "8080",  # webhook port
             "test-secret",  # webhook secret
             "~/Projects",  # workspace base (global default)
+            "",  # allowed workspaces (global default, empty)
             "300",  # pr review cooldown (global resource control)
             "900",  # pr review subprocess timeout
             "false",  # voice
@@ -2863,6 +2864,7 @@ class TestCmdConfigDefaultModelDispatch:
             "8080",  # webhook port
             "test-secret",  # webhook secret
             "~/Projects",  # workspace base (global default)
+            "",  # allowed workspaces (global default, empty)
             "300",  # pr review cooldown (global resource control)
             "900",  # pr review subprocess timeout
             "1.0",  # pr review subprocess budget (non-claude only)
@@ -2894,6 +2896,7 @@ class TestCmdConfigDefaultModelDispatch:
             "8080",  # webhook port
             "test-secret",  # webhook secret
             "~/Projects",  # workspace base (global default)
+            "",  # allowed workspaces (global default, empty)
             "300",  # pr review cooldown (global resource control)
             "900",  # pr review subprocess timeout
             "1.0",  # pr review subprocess budget (non-claude only)
@@ -6273,6 +6276,44 @@ class TestCmdConfigGlobalDefaultsRegardlessOfUsersYaml:
 
         env = json.loads((tmp_path / "install.conf").read_text())["env"]
         assert env["PR_REVIEW_COOLDOWN"] == "450"
+
+    def test_allowed_workspaces_lands_with_users_yaml(self, tmp_path, monkeypatch):
+        """ALLOWED_WORKSPACES reaches env when users.yaml is present.
+
+        Pre-fix: the prompt was gated on `not users_yaml_exists`, so a
+        re-run on an existing install silently carried forward the
+        previous env value (or stayed empty), with no operator-facing
+        path to add or change a machine-wide allowed workspace.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._existing_etc_users(monkeypatch)
+
+        # Real, existing paths under tmp_path because the env emission
+        # block only writes ALLOWED_WORKSPACES when non-empty, and
+        # downstream loaders skip non-existent entries on apply.
+        ws_a = tmp_path / "ws_a"
+        ws_a.mkdir()
+        ws_b = tmp_path / "ws_b"
+        ws_b.mkdir()
+
+        base = list(TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend())
+        # ALLOWED_WORKSPACES is the slot immediately after WORKSPACE_BASE
+        # (~/Projects). Locate it by neighbor anchor rather than `.index("")`
+        # because other slots (effort level, perplexity key) are also empty.
+        allowed_idx = base.index("~/Projects") + 1
+        base[allowed_idx] = f"{ws_a},{ws_b}"
+        inputs = iter(base)
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            lambda backend, prov, default: "sonnet",
+        )
+        _cmd_config()
+
+        env = json.loads((tmp_path / "install.conf").read_text())["env"]
+        assert env["ALLOWED_WORKSPACES"] == f"{ws_a},{ws_b}"
 
     def test_budget_ceiling_lands_with_users_yaml_on_non_claude(self, tmp_path, monkeypatch):
         """BUDGET_CEILING reaches env on non-claude backends when

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -347,12 +347,12 @@ class TestGenerateSudoers:
         result = _generate_sudoers("kai")
         assert "NOPASSWD" in result
 
-    def test_no_claude_user_rule_by_default(self):
-        """No claude binary rule when claude_user is None."""
+    def test_no_per_user_rule_without_os_users(self):
+        """No claude binary rule when os_users is empty."""
         result = _generate_sudoers("kai")
         assert "claude" not in result
 
-    def test_claude_user_rule_anchored_to_service_user_home(self, monkeypatch):
+    def test_os_user_rule_anchored_to_service_user_home(self, monkeypatch):
         """
         The rule's claude binary path is anchored to the SERVICE user's
         home (~/.local/bin/claude under the service user, NOT the target
@@ -362,7 +362,7 @@ class TestGenerateSudoers:
         actually try to execute.
         """
         monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
-        result = _generate_sudoers("kai", claude_user="alice")
+        result = _generate_sudoers("kai", os_users=["alice"])
         assert "kai ALL=(alice) SETENV: NOPASSWD: /home/kai/.local/bin/claude" in result
 
     def test_claude_bin_ignores_caller_path(self, monkeypatch):
@@ -386,7 +386,7 @@ class TestGenerateSudoers:
             "which",
             lambda n: "/some/other/users/local/bin/claude" if n == "claude" else real_which(n),
         )
-        result = _generate_sudoers("kai", claude_user="alice")
+        result = _generate_sudoers("kai", os_users=["alice"])
         assert "/home/kai/.local/bin/claude" in result
         assert "/some/other/users/local/bin/claude" not in result
 
@@ -440,19 +440,6 @@ class TestGenerateSudoers:
         bin_path = "/home/kai/.local/bin/claude"
         assert f"kai ALL=(sellison) SETENV: NOPASSWD: {bin_path}" in result
         assert result.count(f"SETENV: NOPASSWD: {bin_path}") == 1
-
-    def test_legacy_claude_user_combined_with_os_users(self, monkeypatch):
-        """Legacy CLAUDE_USER and yaml os_users coexist; deduped."""
-        monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
-        # claude_user and os_users overlap on "alice"; should produce
-        # one ruleset (claude + codex + kill rules) for each distinct
-        # target. Counting on the full claude-rule prefix verifies
-        # dedup at the target level without the codex-rule or
-        # kill-rule occurrences inflating the count.
-        result = _generate_sudoers("kai", claude_user="alice", os_users=["alice", "bob"])
-        claude_bin = "/home/kai/.local/bin/claude"
-        assert result.count(f"kai ALL=(alice) SETENV: NOPASSWD: {claude_bin}") == 1
-        assert result.count(f"kai ALL=(bob) SETENV: NOPASSWD: {claude_bin}") == 1
 
     # -- Codex per-target rule (per-user OAuth isolation) ----------------
 
@@ -868,11 +855,6 @@ class TestGenerateSudoersValidation:
         """Bad os_users values must raise even if they bypass the loader."""
         with pytest.raises(ValueError, match="Invalid sudoers target user"):
             _generate_sudoers("kai", os_users=["alice) NOPASSWD: ALL"])
-
-    def test_invalid_claude_user_raises(self):
-        """Legacy CLAUDE_USER env var path must also be validated."""
-        with pytest.raises(ValueError, match="Invalid sudoers target user"):
-            _generate_sudoers("kai", claude_user="alice\nroot ALL")
 
 
 class TestGenerateLaunchdPlist:
@@ -1606,8 +1588,8 @@ class TestCmdConfig:
           - Inserts an llm_provider prompt answer (and the API key for
             non-ollama providers) immediately after the agent_backend
             slot, matching the wizard's flow for non-claude backends.
-          - Omits the autocompact, effort, and claude_user entries that
-            the wizard now skips for non-claude backends per issue #380.
+          - Omits the autocompact and effort entries that the wizard
+            now skips for non-claude backends per issue #380.
         Defaults (anthropic + sk-ant-test-key) are sufficient for the
         gating tests. For ollama, the API key prompt is skipped by the
         wizard, so the llm_api_key default is harmless and unused (no
@@ -1645,14 +1627,6 @@ class TestCmdConfig:
                 effort,  # claude effort level ("" = default "high")
             ]
 
-        # Legacy CLAUDE_USER prompt in install.py is gated on
-        # agent_backend == "claude" by issue #380. The
-        # fixture entry is conditional so the input iterator does not
-        # carry a surplus value when the prompt is skipped.
-        claude_user_entry: list[str] = []
-        if agent_backend == "claude":
-            claude_user_entry = [""]
-
         # BUDGET_CEILING and PR_REVIEW_BUDGET_USD prompts are skipped
         # on the claude backend (issue #390): --max-budget-usd is no
         # longer emitted to claude --print argv, so prompting for a
@@ -1689,15 +1663,11 @@ class TestCmdConfig:
             "test-secret",  # webhook secret
             "~/Projects",  # workspace base
             "",  # allowed workspaces
-            "false",  # pr review enabled
-            "300",  # pr review cooldown (global resource control, always prompts)
+            "300",  # pr review cooldown (global resource control)
             "900",  # pr review timeout
             *pr_review_budget_entry,  # PR_REVIEW_BUDGET_USD (non-claude only)
-            "false",  # issue triage
-            "",  # github notify chat id
             "false",  # voice
             "false",  # tts
-            *claude_user_entry,  # claude user (claude only)
             *memory_block,
             "",  # perplexity key
         ]
@@ -2139,12 +2109,9 @@ class TestCmdConfig:
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces
-                "false",  # pr review enabled
                 "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout
                 "1.0",  # pr review budget
-                "false",  # issue triage
-                "",  # github notify chat id
                 "false",  # voice
                 "false",  # tts
                 "true",  # memory enabled (extraction + timeout prompts skipped: non-claude)
@@ -2494,15 +2461,11 @@ class TestCmdConfig:
                 "test-secret",  # webhook secret
                 "",  # workspace base
                 "",  # allowed workspaces
-                "false",  # pr review enabled
                 "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout
                 "1.0",  # pr review budget (non-claude branch)
-                "false",  # issue triage enabled
-                "",  # github notify chat id
                 "false",  # voice
                 "false",  # tts
-                # claude_user skipped on agent_backend != claude
                 "true",  # memory enabled
                 "true",  # memory extraction enabled
                 # No codex-memory os_user reprompt (#522 removed it).
@@ -7405,7 +7368,6 @@ class TestGenerateSudoersCodexBinArg:
 
         out = _generate_sudoers(
             service_user="kai",
-            claude_user=None,
             os_users=["daniel"],
             codex_bin="/Users/daniel/.npm-global/bin/codex",
         )
@@ -7417,7 +7379,6 @@ class TestGenerateSudoersCodexBinArg:
 
         out = _generate_sudoers(
             service_user="kai",
-            claude_user=None,
             os_users=["daniel"],
             codex_bin=None,
         )
@@ -7431,7 +7392,6 @@ class TestGenerateSudoersCodexBinArg:
         monkeypatch.setenv("CODEX_BIN", "/should/not/be/used")
         out = _generate_sudoers(
             service_user="kai",
-            claude_user=None,
             os_users=["daniel"],
             codex_bin="/correct/path/codex",
         )

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -99,7 +99,6 @@ class TestInstanceCreation:
         # touch the host's real /var/lib/kai or PROJECT_ROOT tree.
         monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
         config = _make_config(
-            claude_user=None,
             user_configs={999: UserConfig(telegram_id=999, name="bob")},
         )
         pool = SubprocessPool(config=config, services_info=[])

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1093,16 +1093,14 @@ class TestResolveGitHubSettings:
         defaults = {
             "telegram_bot_token": "test",
             "allowed_user_ids": {111},
-            "pr_review_enabled": False,
-            "issue_triage_enabled": False,
         }
         defaults.update(kwargs)
         if user_configs is not None:
             defaults["user_configs"] = user_configs
         return Config(**defaults)
 
-    async def test_no_config_returns_global_defaults(self, db):
-        """Without user config or DB overrides, returns global defaults."""
+    async def test_no_config_returns_defaults(self, db):
+        """Without user config or DB overrides, returns hardcoded defaults."""
         config = self._make_config()
         result = await sessions.resolve_github_settings(111, config)
         assert result["repos"] == []
@@ -1110,8 +1108,8 @@ class TestResolveGitHubSettings:
         assert result["pr_review"] is False
         assert result["issue_triage"] is False
 
-    async def test_yaml_overrides_globals(self, db):
-        """users.yaml values override global defaults."""
+    async def test_yaml_overrides_defaults(self, db):
+        """users.yaml values override hardcoded defaults."""
         from kai.config import UserConfig
 
         uc = UserConfig(
@@ -1153,42 +1151,37 @@ class TestResolveGitHubSettings:
         assert result["issue_triage"] is False
         assert result["notify_chat_id"] == -200888
 
-    async def test_db_overrides_env(self, db):
-        """DB settings override env var global defaults."""
-        config = self._make_config(
-            pr_review_enabled=True,
-            issue_triage_enabled=True,
-        )
-        await sessions.set_setting("pr_review:111", "false")
-        result = await sessions.resolve_github_settings(111, config)
-        assert result["pr_review"] is False
-        # issue_triage not in DB, falls through to env
-        assert result["issue_triage"] is True
-
-    async def test_notify_fallback_chain(self, db):
-        """Notification destination: DB > yaml > env > telegram_id."""
+    async def test_db_partial_override_falls_back(self, db):
+        """DB overrides one field; other fields take their own resolution."""
         from kai.config import UserConfig
 
-        # Level 4: no config at all - falls back to telegram_id
+        uc = UserConfig(
+            telegram_id=111,
+            name="alice",
+            issue_triage=True,
+        )
+        config = self._make_config(user_configs={111: uc})
+        await sessions.set_setting("pr_review:111", "false")
+        result = await sessions.resolve_github_settings(111, config)
+        assert result["pr_review"] is False  # DB override
+        assert result["issue_triage"] is True  # users.yaml value
+
+    async def test_notify_fallback_chain(self, db):
+        """Notification destination: DB > yaml > telegram_id."""
+        from kai.config import UserConfig
+
+        # Level 3: no config at all - falls back to telegram_id
         config = self._make_config()
         result = await sessions.resolve_github_settings(111, config)
         assert result["notify_chat_id"] == 111
 
-        # Level 3: global env var set
-        config = self._make_config(github_notify_chat_id=-300)
-        result = await sessions.resolve_github_settings(111, config)
-        assert result["notify_chat_id"] == -300
-
-        # Level 2: yaml set (overrides env)
+        # Level 2: users.yaml set
         uc = UserConfig(
             telegram_id=111,
             name="alice",
             github_notify_chat_id=-200,
         )
-        config = self._make_config(
-            user_configs={111: uc},
-            github_notify_chat_id=-300,
-        )
+        config = self._make_config(user_configs={111: uc})
         result = await sessions.resolve_github_settings(111, config)
         assert result["notify_chat_id"] == -200
 
@@ -1198,28 +1191,25 @@ class TestResolveGitHubSettings:
         assert result["notify_chat_id"] == -100
 
     async def test_partial_overrides(self, db):
-        """Some fields from DB, some from yaml, some from globals."""
+        """Some fields from DB, some from yaml."""
         from kai.config import UserConfig
 
         uc = UserConfig(
             telegram_id=111,
             name="alice",
             pr_review=True,
-            # issue_triage omitted (None) - falls to global
+            issue_triage=True,
         )
-        config = self._make_config(
-            user_configs={111: uc},
-            issue_triage_enabled=True,
-        )
+        config = self._make_config(user_configs={111: uc})
         # Override only pr_review in DB
         await sessions.set_setting("pr_review:111", "false")
 
         result = await sessions.resolve_github_settings(111, config)
         assert result["pr_review"] is False  # DB override
-        assert result["issue_triage"] is True  # global default
+        assert result["issue_triage"] is True  # users.yaml value
 
-    async def test_pr_review_none_uses_global(self, db):
-        """yaml pr_review=None falls through to global env var."""
+    async def test_pr_review_unset_defaults_false(self, db):
+        """yaml pr_review=None resolves to False (no global fallback)."""
         from kai.config import UserConfig
 
         uc = UserConfig(
@@ -1227,12 +1217,9 @@ class TestResolveGitHubSettings:
             name="alice",
             # pr_review not set (None)
         )
-        config = self._make_config(
-            user_configs={111: uc},
-            pr_review_enabled=True,
-        )
+        config = self._make_config(user_configs={111: uc})
         result = await sessions.resolve_github_settings(111, config)
-        assert result["pr_review"] is True
+        assert result["pr_review"] is False
 
     async def test_repos_from_yaml_only(self, db):
         """Repos come from users.yaml, not DB (DB repos are #220)."""
@@ -1264,14 +1251,6 @@ class TestResolveGitHubSettings:
         result = await sessions.resolve_github_settings(111, config)
         assert result["notify_chat_id"] == -100999
 
-    async def test_corrupt_db_notify_falls_through_to_env(self, db):
-        """Non-numeric DB value falls through to global env var."""
-        config = self._make_config(github_notify_chat_id=-300)
-        await sessions.set_setting("github_notify_chat:111", "abc")
-
-        result = await sessions.resolve_github_settings(111, config)
-        assert result["notify_chat_id"] == -300
-
     async def test_corrupt_db_notify_falls_through_to_telegram_id(self, db):
         """Non-numeric DB value falls through to user's own telegram_id."""
         config = self._make_config()
@@ -1293,12 +1272,12 @@ class TestResolveGitHubSettings:
         assert any("Corrupt github_notify_chat" in r.message and "xyz" in r.message for r in caplog.records)
 
     async def test_empty_string_db_notify_falls_through(self, db):
-        """Empty string in DB fails int() and falls through gracefully."""
-        config = self._make_config(github_notify_chat_id=-500)
+        """Empty string in DB fails int() and falls through to telegram_id."""
+        config = self._make_config()
         await sessions.set_setting("github_notify_chat:111", "")
 
         result = await sessions.resolve_github_settings(111, config)
-        assert result["notify_chat_id"] == -500
+        assert result["notify_chat_id"] == 111
 
     # ── Case-insensitive booleans (finding 5) ────────────────────
 
@@ -1317,15 +1296,21 @@ class TestResolveGitHubSettings:
         assert result["issue_triage"] is True
 
     async def test_pr_review_false_case_insensitive(self, db):
-        """Mixed-case 'False' in DB resolves to False, not True."""
-        config = self._make_config(pr_review_enabled=True)
+        """Mixed-case 'False' in DB resolves to False even when users.yaml says True."""
+        from kai.config import UserConfig
+
+        uc = UserConfig(telegram_id=111, name="alice", pr_review=True)
+        config = self._make_config(user_configs={111: uc})
         await sessions.set_setting("pr_review:111", "False")
         result = await sessions.resolve_github_settings(111, config)
         assert result["pr_review"] is False
 
     async def test_issue_triage_false_case_insensitive(self, db):
-        """Uppercase 'FALSE' in DB resolves to False, not True."""
-        config = self._make_config(issue_triage_enabled=True)
+        """Uppercase 'FALSE' in DB resolves to False even when users.yaml says True."""
+        from kai.config import UserConfig
+
+        uc = UserConfig(telegram_id=111, name="alice", issue_triage=True)
+        config = self._make_config(user_configs={111: uc})
         await sessions.set_setting("issue_triage:111", "FALSE")
         result = await sessions.resolve_github_settings(111, config)
         assert result["issue_triage"] is False

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1829,43 +1829,10 @@ class TestPerUserRouting:
             assert mock_triage.call_args[1]["claude_user"] == "bob"
 
     @pytest.mark.asyncio
-    async def test_review_falls_back_to_global_claude_user(self, _clear_cooldowns, _mock_resolve_repo):
-        """Legacy mode (no user_configs) falls back to global claude_user."""
-        app = _build_test_app()
-        # Set the global fallback on the mock config
-        app["config"].claude_user = "global-user"
-        app["config"].user_configs = {}
-        app["config"].get_user_config = lambda uid: None
-        payload = _make_pr_payload("opened")
-        body = json.dumps(payload).encode()
-        sig = _sign_payload(payload)
-
-        with (
-            _mock_settings(pr_review=True, notify_chat_id=12345),
-            patch("kai.webhook.review.review_pr", new_callable=AsyncMock) as mock_review,
-        ):
-            async with TestClient(TestServer(app)) as client:
-                resp = await client.post(
-                    "/webhook/github",
-                    data=body,
-                    headers={
-                        "X-GitHub-Event": "pull_request",
-                        "X-Hub-Signature-256": sig,
-                    },
-                )
-                assert resp.status == 200
-
-            await asyncio.sleep(0.01)
-            mock_review.assert_called_once()
-            assert mock_review.call_args[1]["claude_user"] == "global-user"
-
-    @pytest.mark.asyncio
-    async def test_review_user_without_os_user_falls_back(self, _clear_cooldowns, _mock_resolve_repo):
-        """UserConfig with os_user=None falls back to global claude_user."""
-        # No os_user set on this user
+    async def test_review_user_without_os_user_runs_as_bot(self, _clear_cooldowns, _mock_resolve_repo):
+        """UserConfig with os_user=None means run as bot user (claude_user=None)."""
         user = self._make_user_config(111, repos=["owner/repo"])
         config = self._make_config_with_users([user])
-        config.claude_user = "global-user"
         app = _build_test_app(config=config)
         payload = _make_pr_payload("opened")
         body = json.dumps(payload).encode()
@@ -1888,37 +1855,7 @@ class TestPerUserRouting:
 
             await asyncio.sleep(0.01)
             mock_review.assert_called_once()
-            assert mock_review.call_args[1]["claude_user"] == "global-user"
-
-    @pytest.mark.asyncio
-    async def test_triage_falls_back_to_global_claude_user(self, _clear_cooldowns):
-        """Legacy mode (no user_configs) falls back to global claude_user for triage."""
-        app = _build_test_app()
-        app["config"].claude_user = "global-user"
-        app["config"].user_configs = {}
-        app["config"].get_user_config = lambda uid: None
-        payload = _make_issue_payload("opened")
-        body = json.dumps(payload).encode()
-        sig = _sign_payload(payload)
-
-        with (
-            _mock_settings(issue_triage=True, notify_chat_id=12345),
-            patch("kai.webhook.triage.triage_issue", new_callable=AsyncMock) as mock_triage,
-        ):
-            async with TestClient(TestServer(app)) as client:
-                resp = await client.post(
-                    "/webhook/github",
-                    data=body,
-                    headers={
-                        "X-GitHub-Event": "issues",
-                        "X-Hub-Signature-256": sig,
-                    },
-                )
-                assert resp.status == 200
-
-            await asyncio.sleep(0.01)
-            mock_triage.assert_called_once()
-            assert mock_triage.call_args[1]["claude_user"] == "global-user"
+            assert mock_review.call_args[1]["claude_user"] is None
 
     # ── Admin wildcard integration tests ─────────────────────────
 


### PR DESCRIPTION
## Summary

Final tranche against #565. Retires the Class A per-user env-var mirror surface left over from before users.yaml became mandatory. With users.yaml load-bearing for authorization and per-user fields the source of truth, the parallel global env vars were dead code paths.

This PR removes them from runtime semantics, the wizard, the docs, and the templates.

## Class A vars retired

`CLAUDE_USER`, `PR_REVIEW_ENABLED`, `ISSUE_TRIAGE_ENABLED`, `GITHUB_NOTIFY_CHAT_ID`, plus the `CLAUDE_MODEL` -> `DEFAULT_MODEL` one-time rename fallback. The wizard no longer prompts for any of them and the runtime no longer reads them.

`CLAUDE_TIMEOUT_SECONDS` and `CLAUDE_MAX_BUDGET_USD` remain as legacy aliases for `AGENT_TIMEOUT_SECONDS` and `BUDGET_CEILING`; they're the only entries left in the renamed-env warning dict.

## Mechanism

### Config

- `Config` dataclass loses `claude_user`, `pr_review_enabled`, `issue_triage_enabled`, `github_notify_chat_id`.
- `load_config` drops the matching `os.environ.get` reads plus the `CLAUDE_MODEL`-fallback branch in `DEFAULT_MODEL` resolution.
- Deprecation-warning dict reduced to the two bona fide renames; "users.yaml exists" framing removed (the loader already rejects missing users.yaml at startup, so the gate was redundant).
- The no-repos GitHub warning now reads per-user `pr_review` / `issue_triage` exclusively.

### Runtime call sites

- `pool.py`: drops `config.claude_user` fallback. None os_user => "run as bot user."
- `sessions.py::resolve_github_settings`: precedence chain collapses from DB > yaml > env > default to DB > yaml > default.
- `webhook.py`: drops `_app["claude_user"]` and the global `github_notify_chat_id` auth add-on.
- `bot.py::_is_notify_chat_used`: drops the global env-var match arm.

### Installer

- Wizard drops the `CLAUDE_USER`, `PR_REVIEW_ENABLED`, `ISSUE_TRIAGE_ENABLED`, `GITHUB_NOTIFY_CHAT_ID` prompts and their env emission.
- `admin_os_user` default for advanced mode reads `$USER` directly rather than the legacy env var.
- `_apply_sudoers` / `_generate_sudoers` lose the `claude_user` parameter; the generator consumes only the users.yaml `os_user` list.
- `_cmd_apply` drops the `claude_user = env.get("CLAUDE_USER")` read.

### Docs and templates

- `templates/.env` loses Class A entries and all "DEPRECATED when users.yaml exists" wording. Surviving globals are relabeled as installation defaults with the per-user override location named.
- `templates/users.yaml` header names both protected (`/etc/kai/users.yaml`) and XDG (`${XDG_CONFIG_HOME:-$HOME/.config}/kai/users.yaml`) canonical paths.
- README's Multi-user section names users.yaml as mandatory, documents both deployment paths, adds per-user GitHub fields to the example.
- README env-variable table loses the Deprecated column and the Class A rows; surviving globals carry a "per-user override in users.yaml" pointer where applicable.
- README Running section gets a deployment-mode preamble walking through `make config` and the protected-vs-single-user fork.

## Tranche tracking (#565)

- [x] **B** wizard prompt re-gating (PR #566, merged)
- [x] **A** runtime mandate (PR #567, merged)
- [x] **C** deployment mode + XDG (PR #568, merged)
- [x] **D** cleanup + docs (this PR)

## Migration

- **Existing protected install with `/etc/kai/users.yaml`**: no operator action required. Class A env vars in `/etc/kai/env` are silently ignored; next `make config` writes a clean file without them.
- **Existing install carrying Class A env vars**: the runtime ignores them. The wizard's regenerate path drops them on the next run. No automated migration since the per-user values must be authored in users.yaml anyway.
- **`CLAUDE_MODEL` in env**: no longer read. Operators relying on this rename should set `DEFAULT_MODEL` (or run `make config`).

## Test plan

- [x] `make check` clean
- [x] `make test` clean (3635 passed, 1 skipped)
- [x] `TestRenamedEnvWarnings` pins the two-entry surface: only `CLAUDE_MAX_BUDGET_USD` and `CLAUDE_TIMEOUT_SECONDS` trigger renamed-env warnings.
- [x] `TestGitHubReposWarning` rewritten around per-user `pr_review` / `issue_triage` only.
- [x] `TestResolveGitHubSettings` rewritten around the three-level precedence chain.
- [x] `TestMinimalEnvWithUsersYaml` no longer references retired Config fields.
- [x] Wizard input-chain fixture (`TestCmdConfig._base_inputs`) trimmed by four prompt slots.
- [ ] Manual smoke: `make config` (protected) on a host with an existing `/etc/kai/env` containing Class A keys -> verify regenerated env file drops them and the daemon starts cleanly.
- [ ] Manual smoke: `make config` (single_user) on a fresh host -> verify no Class A prompts surface and `make run` boots from `PROJECT_ROOT/.env` + XDG users.yaml.
- [ ] Manual smoke: existing protected install with a user that has `pr_review: true` in users.yaml + a real GitHub PR webhook -> verify the review still fires (no global env toggle required).
