### PR TITLE
fix(opencode): emit ACP v1 nested-outcome permission response

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -60,6 +60,14 @@ from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file
 log = logging.getLogger(__name__)
 
 
+# Tokens that indicate an upstream-side rejection or schema failure
+# in an ACP-server stderr line. When any of these substrings (case-
+# insensitive) appears in a drained stderr line, the line is surfaced
+# at WARNING instead of DEBUG. Set at module scope so concrete
+# adapters cannot drift from the shared classifier.
+_STDERR_WARNING_TOKENS: tuple[str, ...] = ("permission", "rejected", "invalid", "schema")
+
+
 # ── ACP base backend ──────────────────────────────────────────────
 
 
@@ -364,9 +372,17 @@ class AcpBackend(AgentBackend):
         Continuously read and discard stderr from the ACP process.
 
         Without this, the stderr pipe buffer fills up and the process
-        deadlocks. Lines are logged at DEBUG level for diagnostics; the
-        backend label prefixes the log line so a multi-backend deployment
-        can tell streams apart.
+        deadlocks. Lines are logged at DEBUG level for routine
+        diagnostics; lines that match an upstream-error indicator
+        (`permission`, `rejected`, `invalid`, `schema`) are surfaced
+        at WARNING so operators see ACP-server-side rejections without
+        having to enable DEBUG. The backend label prefixes the log
+        line so a multi-backend deployment can tell streams apart.
+
+        Without the selective bump, an ACP server like OpenCode can
+        reject a client response as schema-invalid and the diagnostic
+        is silently swallowed at DEBUG level, leaving an operator
+        without any signal that the upstream complained.
         """
         while self._proc and self._proc.stderr:
             try:
@@ -374,7 +390,17 @@ class AcpBackend(AgentBackend):
                 if not line:
                     break
                 text = line.decode().strip()
-                if text:
+                if not text:
+                    continue
+                # Case-insensitive substring check is enough; the
+                # tokens are distinctive within ACP-server diagnostic
+                # output, and a quoted-string false positive would only
+                # mean one extra WARNING line per occurrence, which is
+                # an acceptable cost for the load-bearing real signal.
+                lowered = text.lower()
+                if any(token in lowered for token in _STDERR_WARNING_TOKENS):
+                    log.warning("%s stderr: %s", self.backend_label, text[:200])
+                else:
                     log.debug("%s stderr: %s", self.backend_label, text[:200])
             except Exception:
                 log.warning("Unexpected error in %s stderr drain", self.backend_label, exc_info=True)

--- a/src/kai/opencode.py
+++ b/src/kai/opencode.py
@@ -160,28 +160,75 @@ class OpenCodeBackend(AcpBackend):
         agent tasks can actually execute tools), without baking the
         decision into OpenCode's persistent config.
 
+        Response shape follows the ACP v1 protocol's
+        `RequestPermissionResult`: the result body carries an `outcome`
+        object with a discriminator (`selected` or `cancelled`) and an
+        `optionId` field when `selected`. The shared `_send_server_response`
+        wraps this dict under the JSON-RPC `result` key, producing
+        `result.outcome.optionId` on the wire. Sending a bare
+        `result.optionId` (the previous shape) is structurally invalid
+        against the ACP schema; OpenCode either stalls the prompt
+        indefinitely or closes the ACP session with an EOF on stdin.
+        See https://agentclientprotocol.com/protocol/v1/tool-calls for
+        the schema.
+
         Defensive fallback: if the request shape changes and we cannot
         find an allow_always option, look for any allow-shaped option,
         then for any optionId at all, and only then bail with None
         (which logs and skips at the shared-layer call site, letting
         OpenCode time out the request gracefully instead of crashing
         the read loop).
+
+        Every handled request emits one INFO line naming method, the
+        chosen optionId, and a rationale tag (`allow_always`,
+        `allow_once`, `fallback_first_option`, or `no_usable_option`)
+        so production logs surface what the auto-approver decided.
+        That diagnostic is load-bearing for the next time the ACP
+        protocol drifts: without it, a future change that breaks
+        option discrimination would only show up as silent stalls.
         """
         if msg.get("method") != "session/request_permission":
             return None
         options = msg.get("params", {}).get("options", []) or []
-        choice = (
-            _pick_option(options, "allow_always")
-            or _pick_option(options, "allow_once")
-            or (options[0] if options else None)
-        )
+        # Track the rationale alongside the choice so the INFO log
+        # below tells the operator WHY a given option was picked.
+        # `_pick_option` is the fast path; the project's two known
+        # auto-approve kinds (`allow_always`, `allow_once`) are tried
+        # in priority order. The first-element fallback fires only
+        # when neither kind matches; that is a real protocol drift
+        # signal and the rationale tag makes it loud.
+        rationale: str
+        if (choice := _pick_option(options, "allow_always")) is not None:
+            rationale = "allow_always"
+        elif (choice := _pick_option(options, "allow_once")) is not None:
+            rationale = "allow_once"
+        elif options:
+            choice = options[0]
+            rationale = "fallback_first_option"
+        else:
+            choice = None
+            rationale = "no_usable_option"
+
         if not choice or "optionId" not in choice:
             log.warning(
-                "OpenCode session/request_permission missing a usable option; params=%s",
+                "OpenCode session/request_permission missing a usable option; rationale=%s params=%s",
+                rationale,
                 msg.get("params"),
             )
             return None
-        return {"optionId": choice["optionId"]}
+
+        option_id = choice["optionId"]
+        log.info(
+            "OpenCode session/request_permission handled: optionId=%s rationale=%s",
+            option_id,
+            rationale,
+        )
+        return {
+            "outcome": {
+                "outcome": "selected",
+                "optionId": option_id,
+            }
+        }
 
 
 def _pick_option(options: list[dict], kind: str) -> dict | None:

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -33,6 +33,7 @@ Covers:
 """
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -928,12 +929,19 @@ class TestServerInitiatedRequest:
 
     @pytest.mark.asyncio
     async def test_hook_returning_dict_writes_response_with_matching_id(self):
-        """A hook that returns a dict triggers a JSON-RPC response with the server's id."""
+        """A hook that returns a dict triggers a JSON-RPC response with the server's id.
+
+        The shared envelope is JSON-RPC framing only: `jsonrpc`, the
+        server's `id`, and `result` containing whatever the hook
+        returned. A representative ACP v1 selected-outcome payload
+        exercises the result body without coupling this shared-layer
+        test to OpenCode's specific shape.
+        """
 
         class _AutoApprove(_FakeAcp):
             def handle_server_request(self, msg):
                 if msg.get("method") == "session/request_permission":
-                    return {"optionId": "always"}
+                    return {"outcome": {"outcome": "selected", "optionId": "always"}}
                 return None
 
         b = _AutoApprove(model="x", workspace=Path("/tmp/ws"))
@@ -965,7 +973,10 @@ class TestServerInitiatedRequest:
         assert response["jsonrpc"] == "2.0"
         # Response carries the SERVER's id, not the next client id.
         assert response["id"] == 42
-        assert response["result"] == {"optionId": "always"}
+        # The shared envelope passes the hook's return value through
+        # under `result` unchanged; specific shape contracts belong to
+        # the concrete adapter's tests, not here.
+        assert response["result"] == {"outcome": {"outcome": "selected", "optionId": "always"}}
 
     @pytest.mark.asyncio
     async def test_notifications_still_skip_hook(self):
@@ -1017,6 +1028,72 @@ class TestServerInitiatedRequest:
         await _collect_events(b, prompt="hi")
         response = json.loads(b._proc.stdin.write.call_args_list[1][0][0].decode())
         assert set(response.keys()) == {"jsonrpc", "id", "result"}
+
+
+# ── Selective stderr WARNING ───────────────────────────────────────
+
+
+class TestDrainStderrSelectiveWarning:
+    """
+    The stderr drain surfaces upstream-error-shaped lines at WARNING
+    instead of swallowing them at DEBUG.
+
+    Without the selective bump, an ACP server like OpenCode can
+    reject a client response as schema-invalid and the diagnostic
+    is silently swallowed at DEBUG level, leaving operators without
+    any signal that the upstream complained. Token list lives at
+    module scope in `kai.acp._STDERR_WARNING_TOKENS`; this test
+    pins every token in that list separately so dropping one is a
+    visible regression.
+    """
+
+    @staticmethod
+    def _make_stderr_proc(lines: list[bytes]):
+        """Build a fake subprocess with stderr.readline yielding the given lines + EOF."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        proc = MagicMock()
+        proc.stderr = MagicMock()
+        proc.stderr.readline = AsyncMock(side_effect=[*lines, b""])
+        # _drain_stderr's outer loop checks `self._proc.stderr`; both must
+        # stay truthy across iterations until readline returns empty.
+        return proc
+
+    @pytest.mark.asyncio
+    async def test_normal_line_logs_at_debug(self, caplog):
+        """A routine stderr line stays at DEBUG; the selective bump is conservative."""
+        b = _make_fake()
+        b._proc = self._make_stderr_proc([b"starting acp server on port 12345\n"])
+        with caplog.at_level(logging.DEBUG, logger="kai.acp"):
+            await b._drain_stderr()
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any("starting acp server" in r.message for r in debug_records)
+        # And no WARNING fired for that routine line.
+        warning_records = [
+            r for r in caplog.records if r.levelno >= logging.WARNING and "starting acp server" in r.message
+        ]
+        assert warning_records == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("token", ["permission", "rejected", "invalid", "schema"])
+    async def test_matching_line_logs_at_warning(self, caplog, token):
+        """Every documented token bumps the line to WARNING."""
+        b = _make_fake()
+        b._proc = self._make_stderr_proc([f"some {token} error: bad payload\n".encode()])
+        with caplog.at_level(logging.DEBUG, logger="kai.acp"):
+            await b._drain_stderr()
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING and token in r.message]
+        assert warning_records, f"expected WARNING for token={token!r}, got: {[r.message for r in caplog.records]}"
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_match(self, caplog):
+        """Uppercase / mixed-case tokens still bump to WARNING."""
+        b = _make_fake()
+        b._proc = self._make_stderr_proc([b"PERMISSION denied\n", b"Schema validation failed\n"])
+        with caplog.at_level(logging.DEBUG, logger="kai.acp"):
+            await b._drain_stderr()
+        warning_count = sum(1 for r in caplog.records if r.levelno == logging.WARNING)
+        assert warning_count == 2
 
 
 # ── Env layering ────────────────────────────────────────────────────

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -18,6 +18,7 @@ AcpBackend layer:
 """
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
@@ -245,6 +246,14 @@ class TestHandleServerRequest:
     options[*].kind in {allow_once, allow_always, reject_once}. The
     adapter auto-approves (returns the allow_always optionId) so tool
     calls do not hang waiting for an interactive answer.
+
+    Response payload follows the ACP v1 `RequestPermissionResult`
+    contract: result body is `{"outcome": {"outcome": "selected",
+    "optionId": <id>}}`. The shared `_send_server_response` wraps
+    that under the JSON-RPC `result` key. A bare `{"optionId": ...}`
+    payload (the pre-fix shape) is structurally invalid by ACP v1
+    and produces silent stalls or `OpenCode process EOF` on the live
+    install.
     """
 
     def _permission_request(self, options: list[dict]) -> dict:
@@ -255,8 +264,13 @@ class TestHandleServerRequest:
             "params": {"sessionId": "sess-1", "options": options},
         }
 
+    @staticmethod
+    def _selected(option_id: str) -> dict:
+        """Build the ACP v1 selected-outcome result body for an option."""
+        return {"outcome": {"outcome": "selected", "optionId": option_id}}
+
     def test_auto_approve_always_when_available(self):
-        """Returns the allow_always optionId."""
+        """Returns the ACP v1 selected-outcome for allow_always."""
         b = _make_opencode()
         msg = self._permission_request(
             [
@@ -265,7 +279,7 @@ class TestHandleServerRequest:
                 {"optionId": "reject", "kind": "reject_once"},
             ]
         )
-        assert b.handle_server_request(msg) == {"optionId": "always"}
+        assert b.handle_server_request(msg) == self._selected("always")
 
     def test_falls_back_to_allow_once_when_no_allow_always(self):
         """If allow_always is missing, return the allow_once option."""
@@ -276,7 +290,7 @@ class TestHandleServerRequest:
                 {"optionId": "reject", "kind": "reject_once"},
             ]
         )
-        assert b.handle_server_request(msg) == {"optionId": "once"}
+        assert b.handle_server_request(msg) == self._selected("once")
 
     def test_falls_back_to_first_option_when_no_allow_kinds(self):
         """If neither allow_always nor allow_once exist, take the first option as a last resort."""
@@ -287,7 +301,7 @@ class TestHandleServerRequest:
                 {"optionId": "reject", "kind": "reject_once"},
             ]
         )
-        assert b.handle_server_request(msg) == {"optionId": "weird"}
+        assert b.handle_server_request(msg) == self._selected("weird")
 
     def test_empty_options_returns_none(self):
         """No options at all = nothing to pick; return None so the loop logs and skips."""
@@ -307,6 +321,112 @@ class TestHandleServerRequest:
         b = _make_opencode()
         msg = {"jsonrpc": "2.0", "id": 7, "method": "session/something_new", "params": {}}
         assert b.handle_server_request(msg) is None
+
+
+class TestHandleServerRequestLoggingAndDiagnostics:
+    """
+    Pin the per-request INFO diagnostic.
+
+    Every handled session/request_permission emits one INFO line
+    naming the chosen optionId and a rationale tag so production
+    logs surface what the auto-approver decided. The rationale tag
+    is the load-bearing signal for the next time the ACP protocol
+    drifts; without it, an option-discrimination break would only
+    manifest as silent stalls.
+    """
+
+    @staticmethod
+    def _msg(options: list[dict]) -> dict:
+        return {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "session/request_permission",
+            "params": {"sessionId": "sess-1", "options": options},
+        }
+
+    def test_logs_allow_always_rationale(self, caplog):
+        b = _make_opencode()
+        with caplog.at_level(logging.INFO, logger="kai.opencode"):
+            b.handle_server_request(
+                self._msg(
+                    [
+                        {"optionId": "once", "kind": "allow_once"},
+                        {"optionId": "always", "kind": "allow_always"},
+                    ]
+                )
+            )
+        assert any("optionId=always" in r.message and "rationale=allow_always" in r.message for r in caplog.records)
+
+    def test_logs_allow_once_rationale(self, caplog):
+        b = _make_opencode()
+        with caplog.at_level(logging.INFO, logger="kai.opencode"):
+            b.handle_server_request(self._msg([{"optionId": "once", "kind": "allow_once"}]))
+        assert any("optionId=once" in r.message and "rationale=allow_once" in r.message for r in caplog.records)
+
+    def test_logs_fallback_first_option_rationale(self, caplog):
+        b = _make_opencode()
+        with caplog.at_level(logging.INFO, logger="kai.opencode"):
+            b.handle_server_request(self._msg([{"optionId": "weird", "kind": "ask_user"}]))
+        assert any(
+            "optionId=weird" in r.message and "rationale=fallback_first_option" in r.message for r in caplog.records
+        )
+
+    def test_logs_no_usable_option_rationale_as_warning(self, caplog):
+        """Empty options array emits the no_usable_option rationale at WARNING."""
+        b = _make_opencode()
+        with caplog.at_level(logging.WARNING, logger="kai.opencode"):
+            b.handle_server_request(self._msg([]))
+        assert any("rationale=no_usable_option" in r.message for r in caplog.records)
+
+
+class TestHandleServerRequestRejectedShapes:
+    """
+    Regression guard against silent reverts to broken response shapes.
+
+    The pre-fix payload was `{"optionId": <id>}` (bare optionId under
+    result). Other plausible-but-wrong shapes from the round-2 smoke
+    candidate list include the discriminator-at-top-level variant
+    `{"outcome": "selected", "optionId": <id>}`. Both produced silent
+    stalls or `OpenCode process EOF` on the live install. These
+    tests pin that the current implementation does NOT regress to
+    either shape.
+    """
+
+    @staticmethod
+    def _selected(option_id: str) -> dict:
+        return {"outcome": {"outcome": "selected", "optionId": option_id}}
+
+    def test_response_is_not_bare_optionId(self):
+        """Pre-fix payload shape MUST NOT come back."""
+        b = _make_opencode()
+        msg = {
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "session/request_permission",
+            "params": {
+                "sessionId": "sess-1",
+                "options": [{"optionId": "always", "kind": "allow_always"}],
+            },
+        }
+        result = b.handle_server_request(msg)
+        assert result != {"optionId": "always"}
+        assert result == self._selected("always")
+
+    def test_response_is_not_flat_discriminator(self):
+        """Discriminator-at-top-level variant MUST NOT come back either."""
+        b = _make_opencode()
+        msg = {
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "session/request_permission",
+            "params": {
+                "sessionId": "sess-1",
+                "options": [{"optionId": "once", "kind": "allow_once"}],
+            },
+        }
+        result = b.handle_server_request(msg)
+        assert result != {"outcome": "selected", "optionId": "once"}
+        assert result == self._selected("once")
 
 
 # ── Constructor (smoke) ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #574. OpenCode's conversational ACP backend hung or crashed on prompts that triggered `session/request_permission` for a permission-gated tool call. Same prompt worked in the OpenCode TUI, isolating the bug to Kai's response shape.

`OpenCodeBackend.handle_server_request` returned a bare `{"optionId": <id>}` result. ACP v1's `RequestPermissionResult` schema requires a nested discriminated union: `result.outcome = {"outcome": "selected", "optionId": <id>}`. The bare payload was structurally invalid; OpenCode either stalled the prompt or closed the session with EOF.

Production change is one block. Plus two diagnostic adds (orthogonal to the fix) so a future ACP-protocol drift surfaces earlier.

## Mechanism

### Production code

- `src/kai/opencode.py::OpenCodeBackend.handle_server_request`: returns `{"outcome": {"outcome": "selected", "optionId": <id>}}` matching ACP v1. The shared `_send_server_response` envelope is unchanged; it correctly wraps the hook return under `result`.
- Every handled request emits one INFO log line: `optionId=<id> rationale=<tag>`. Rationale tags: `allow_always`, `allow_once`, `fallback_first_option`, `no_usable_option`. Load-bearing for the next drift; without it, an option-discrimination break would only show as silent stalls.
- `src/kai/acp.py::AcpBackend._drain_stderr`: stderr lines containing any of `permission`, `rejected`, `invalid`, `schema` (case-insensitive) surface at WARNING instead of DEBUG. Without this, an ACP server rejecting a client response as schema-invalid had its diagnostic silently swallowed.
- Token list at module scope (`_STDERR_WARNING_TOKENS`) so concrete adapters cannot drift from the shared classifier.

### Tests

- Existing `TestHandleServerRequest`: three payload assertions updated to the ACP v1 selected-outcome shape.
- Existing shared-envelope test (`TestServerInitiatedRequest::test_hook_returning_dict_writes_response_with_matching_id`): updated to a representative nested-outcome result body.
- New `TestHandleServerRequestLoggingAndDiagnostics`: covers the four rationale strings and the WARNING level for the no-usable-option path.
- New `TestHandleServerRequestRejectedShapes`: regression guard against silent reverts to the bare-optionId or flat-discriminator payloads.
- New `TestDrainStderrSelectiveWarning`: parametrized over every token in `_STDERR_WARNING_TOKENS`; covers the case-insensitive contract.

### Smoke harness (operator-runnable, not part of CI)

`/var/lib/kai/home/<os_user>/docs/opencode-conversational-permission-smoke.py` drives `opencode acp` directly and probes six candidate response shapes (ACP v1 nested outcome, nested with optionId mirror, the pre-fix bare-optionId control, a flat discriminator variant, `cancelled` outcome, and a no-response probe to catch method-name drift). Verdict per probe writes to `/var/lib/kai/home/<os_user>/docs/opencode-conversational-permission-smoke-results.md`. Useful for confirming OpenCode 1.15.x accepts the documented shape on the live install and for catching any future ACP-protocol drift.

## Migration

No operator action required. The fix is fully internal. After deploy:

- Existing users with `agent_backend: opencode` who hit the stall on permission-gated prompts will see the prompt complete instead.
- Production logs gain an INFO line per `session/request_permission` and a WARNING-bumped surface for upstream-rejection stderr lines.
- No env var or users.yaml changes.

## Test plan

- [x] `make check` clean
- [x] `make test` clean (3648 passed, 1 skipped)
- [x] New regression-guard tests fail when the production code is reverted to the pre-fix bare-optionId payload (verified by reverting locally).
- [x] Smoke harness shipped; operator-runnable.
- [ ] **Manual smoke on the live install**: after deploy, send the original reproduction prompt (read a file outside the workspace cwd) through Kai's OpenCode backend. Confirm the response streams; no `OpenCode process EOF` in the log.
- [ ] **Manual smoke harness run**: `python3 /var/lib/kai/home/<os_user>/docs/opencode-conversational-permission-smoke.py` with `PROBE_MODEL=deepseek/deepseek-v4-pro` (or the operator's authenticated model). Confirm probe 1 (ACP v1 nested) verdict is `prompt_completed`; probe 3 (bare optionId control) is `process_eof` or `silent_stall_timeout`.

## Unblocks #555

Spec #555 (OpenCode one-shot reasoner) assumes the conversational ACP path is reliable. That assumption failed before this fix. With #574 closed, the spec's design premise holds and implementation can proceed. The one-shot reasoner's `reject_once` policy uses the same nested-outcome envelope with `optionId` set to the reject option's id; no further envelope work needed there.
