### PR TITLE
fix(codex): demote ESRCH from cross-user kill to DEBUG

### DIFF
--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -1108,6 +1108,39 @@ class CodexBackend(AgentBackend):
         except ValueError:
             return None
 
+    @staticmethod
+    def _stderr_is_esrch(stderr: bytes | None) -> bool:
+        """
+        True iff `stderr` contains the POSIX ESRCH diagnostic from
+        `/bin/kill` for a no-such-process condition.
+
+        Used by `_async_sudo_kill` and `_send_signal` to discriminate
+        the benign race (inner codex already exited between PID cache
+        and signal delivery; kill returns rc=1 with "No such process")
+        from real failure modes (sudoers misconfiguration, signal
+        permission denied, kill binary missing). The benign case
+        demotes to DEBUG; everything else keeps the existing WARNING.
+
+        Substring match because BSD `/bin/kill` on macOS and util-linux
+        `kill` on Linux both emit `kill: <pid>: No such process\\n`;
+        the prefix varies slightly but the "No such process" portion is
+        the stable POSIX `strerror(ESRCH)` text. Case-sensitive because
+        that diagnostic is fixed by libc and not localized for these
+        binaries on any production platform.
+
+        Returns False on `None` or empty bytes so a missing-stderr
+        rc!=0 (itself unusual and probably a real failure) keeps the
+        WARNING.
+
+        Bytes rather than decoded str because both call sites already
+        hold raw bytes from the subprocess result; keeping the helper
+        one level lower avoids duplicating the `.decode(errors="replace")`
+        rendering the WARNING line already does for display.
+        """
+        if not stderr:
+            return False
+        return b"No such process" in stderr
+
     async def _async_sudo_kill(self, target_user: str, pid: int, sig: int) -> None:
         """
         Run `sudo -n -u <target> /bin/kill -<sig> <pid>` without blocking.
@@ -1152,12 +1185,25 @@ class CodexBackend(AgentBackend):
             )
             return
         if proc.returncode != 0:
-            log.warning(
-                "sudo kill escalation failed (rc=%d, stderr=%r); inner codex pid=%d may orphan",
-                proc.returncode,
-                stderr_bytes[:200].decode(errors="replace") if stderr_bytes else "",
-                pid,
-            )
+            # ESRCH from `/bin/kill` means the inner codex exited on its
+            # own between the PID cache time and this signal delivery;
+            # the process is already reaped, not orphaned. Demoting the
+            # benign race to DEBUG keeps the WARNING stream focused on
+            # real failures (sudoers missing, signal permission denied,
+            # kill binary missing) that an operator actually needs to
+            # see.
+            if self._stderr_is_esrch(stderr_bytes):
+                log.debug(
+                    "sudo kill escalation: inner codex pid=%d already gone (ESRCH); benign race",
+                    pid,
+                )
+            else:
+                log.warning(
+                    "sudo kill escalation failed (rc=%d, stderr=%r); inner codex pid=%d may orphan",
+                    proc.returncode,
+                    stderr_bytes[:200].decode(errors="replace") if stderr_bytes else "",
+                    pid,
+                )
 
     def _send_signal(self, sig: int) -> None:
         """
@@ -1216,12 +1262,25 @@ class CodexBackend(AgentBackend):
                             check=False,
                         )
                         if result.returncode != 0:
-                            log.warning(
-                                "sudo kill escalation failed (rc=%d, stderr=%r); codex pid=%d may orphan",
-                                result.returncode,
-                                result.stderr[:200].decode(errors="replace") if result.stderr else "",
-                                pid,
-                            )
+                            # ESRCH branches to DEBUG; everything else
+                            # keeps the WARNING. See `_async_sudo_kill`
+                            # for the full rationale; the two call
+                            # sites must stay in lockstep so the
+                            # operator-visible WARNING surface is the
+                            # same regardless of which path delivered
+                            # the signal.
+                            if self._stderr_is_esrch(result.stderr):
+                                log.debug(
+                                    "sudo kill escalation: codex pid=%d already gone (ESRCH); benign race",
+                                    pid,
+                                )
+                            else:
+                                log.warning(
+                                    "sudo kill escalation failed (rc=%d, stderr=%r); codex pid=%d may orphan",
+                                    result.returncode,
+                                    result.stderr[:200].decode(errors="replace") if result.stderr else "",
+                                    pid,
+                                )
                     except (subprocess.TimeoutExpired, OSError):
                         # Inner codex already dead, sudoers rule
                         # missing on an old install, or kill timed

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1663,6 +1663,142 @@ class TestCodexCrossUserTeardown:
         assert c._inner_codex_pids == []
 
 
+class TestSudoKillEsrchDemotion:
+    """
+    The `/bin/kill` ESRCH stderr means the inner codex exited on its
+    own between the PID cache time and the signal delivery; the
+    process is already reaped, not orphaned. Both signal paths
+    (`_async_sudo_kill` and `_send_signal`) must demote that case to
+    DEBUG so the WARNING stream stays focused on real failure modes
+    (sudoers missing, signal permission denied, kill binary missing).
+    The helper `CodexBackend._stderr_is_esrch` discriminates; the two
+    call sites both consult it.
+    """
+
+    def test_stderr_is_esrch_helper(self):
+        """Pure unit test of the discriminator. Matching substring is
+        the POSIX `strerror(ESRCH)` text; everything else returns
+        False, including `None` and empty bytes."""
+        # Matching: the exact macOS/Linux /bin/kill diagnostic.
+        assert CodexBackend._stderr_is_esrch(b"kill: 12345: No such process\n") is True
+        # Matching: the substring fires regardless of prefix shape.
+        assert CodexBackend._stderr_is_esrch(b"No such process") is True
+        # Non-matching: real failure modes that must keep the WARNING.
+        assert CodexBackend._stderr_is_esrch(b"a password is required") is False
+        assert CodexBackend._stderr_is_esrch(b"kill: Operation not permitted") is False
+        # Empty / None: a missing-stderr rc!=0 is itself unusual and
+        # should keep the WARNING.
+        assert CodexBackend._stderr_is_esrch(b"") is False
+        assert CodexBackend._stderr_is_esrch(None) is False
+
+    @pytest.mark.asyncio
+    async def test_async_sudo_kill_esrch_demoted_to_debug(self, caplog):
+        """The async path's rc=1 + ESRCH stderr fires the DEBUG branch
+        with the "already gone (ESRCH); benign race" message; no
+        WARNING record appears."""
+        c = _make_codex(codex_user="ci-fake-user")
+
+        sudo_proc = MagicMock()
+        sudo_proc.returncode = 1
+        sudo_proc.communicate = AsyncMock(return_value=(b"", b"kill: 99999: No such process\n"))
+
+        # Capture at DEBUG so both the new DEBUG record and any
+        # accidental WARNING land in caplog.records.
+        with (
+            patch("kai.codex.asyncio.create_subprocess_exec", AsyncMock(return_value=sudo_proc)),
+            caplog.at_level("DEBUG", logger="kai.codex"),
+        ):
+            await c._async_sudo_kill(target_user="ci-fake-user", pid=99999, sig=int(signal.SIGKILL))
+
+        # No WARNING: the benign race must not pollute the operator's
+        # WARNING stream.
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert warnings == [], f"expected no WARNING, got {warnings}"
+        # One DEBUG line carrying the distinctive ESRCH-race text so
+        # an operator grepping for it can count race frequency.
+        debugs = [r for r in caplog.records if r.levelname == "DEBUG"]
+        assert any("already gone (ESRCH); benign race" in r.message for r in debugs)
+
+    @pytest.mark.asyncio
+    async def test_async_sudo_kill_real_failure_warns(self, caplog):
+        """A non-ESRCH rc!=0 (e.g., sudoers misconfiguration) keeps the
+        existing WARNING text. Without this guard the ESRCH demotion
+        would mask real failure modes."""
+        c = _make_codex(codex_user="ci-fake-user")
+
+        sudo_proc = MagicMock()
+        sudo_proc.returncode = 1
+        sudo_proc.communicate = AsyncMock(return_value=(b"", b"sudo: a password is required\n"))
+
+        with (
+            patch("kai.codex.asyncio.create_subprocess_exec", AsyncMock(return_value=sudo_proc)),
+            caplog.at_level("WARNING", logger="kai.codex"),
+        ):
+            await c._async_sudo_kill(target_user="ci-fake-user", pid=99999, sig=int(signal.SIGKILL))
+
+        # Pin both the WARNING text and the "may orphan" suffix so a
+        # future log-format change cannot silently break the alert
+        # rules that watch this string.
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("sudo kill escalation failed" in r.message for r in warnings)
+        assert any("may orphan" in r.message for r in warnings)
+
+    def test_send_signal_esrch_demoted_to_debug(self, caplog):
+        """The synchronous path's rc=1 + ESRCH stderr fires the DEBUG
+        branch with no WARNING. Mirrors the async test; both paths
+        must stay in lockstep."""
+        c = _make_codex(codex_user="ci-fake-user")
+        c._proc = MagicMock()
+        c._proc.pid = 12345
+        c._pgid = 12345
+        c._effective_codex_user = "ci-fake-user"
+        c._inner_codex_pids = [67890]
+        c._stderr_task = MagicMock()
+
+        sudo_kill_result = MagicMock()
+        sudo_kill_result.returncode = 1
+        sudo_kill_result.stderr = b"kill: 67890: No such process\n"
+
+        with (
+            patch("kai.codex.subprocess.run", return_value=sudo_kill_result),
+            patch("kai.codex.os.killpg"),
+            caplog.at_level("DEBUG", logger="kai.codex"),
+        ):
+            c.force_kill()
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert warnings == [], f"expected no WARNING, got {warnings}"
+        debugs = [r for r in caplog.records if r.levelname == "DEBUG"]
+        assert any("already gone (ESRCH); benign race" in r.message for r in debugs)
+
+    def test_send_signal_real_failure_warns(self, caplog):
+        """Non-ESRCH rc!=0 at the synchronous site keeps the WARNING.
+        Symmetric guard to the async case; covers the
+        `subprocess.run`-shaped path that `force_kill` drives."""
+        c = _make_codex(codex_user="ci-fake-user")
+        c._proc = MagicMock()
+        c._proc.pid = 12345
+        c._pgid = 12345
+        c._effective_codex_user = "ci-fake-user"
+        c._inner_codex_pids = [67890]
+        c._stderr_task = MagicMock()
+
+        sudo_kill_result = MagicMock()
+        sudo_kill_result.returncode = 1
+        sudo_kill_result.stderr = b"kill: Operation not permitted\n"
+
+        with (
+            patch("kai.codex.subprocess.run", return_value=sudo_kill_result),
+            patch("kai.codex.os.killpg"),
+            caplog.at_level("WARNING", logger="kai.codex"),
+        ):
+            c.force_kill()
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("sudo kill escalation failed" in r.message for r in warnings)
+        assert any("may orphan" in r.message for r in warnings)
+
+
 class TestCodexGrandchildEscalation:
     """
     Codex's npm-global packaging interposes a `node` wrapper between


### PR DESCRIPTION
## Summary

- `/bin/kill` returning rc=1 with `No such process` during the codex cross-user kill escalation is the POSIX ESRCH diagnostic: the inner codex exited on its own between the PID cache time and the signal delivery. The process is already reaped, not orphaned. Today's "may orphan" WARNING misclassifies the benign race and forces operators to investigate every occurrence.
- Add `CodexBackend._stderr_is_esrch(stderr: bytes | None) -> bool` as a `@staticmethod` next to the existing `_pgrep_first_child` / `_async_pgrep_first_child` staticmethods. Both cross-user kill paths consult it: `_async_sudo_kill` and `_send_signal`. The ESRCH case demotes to DEBUG with a distinctive `"already gone (ESRCH); benign race"` message; every other rc!=0 keeps the existing WARNING text and field set unchanged.
- WARNING text is preserved verbatim so existing log-search and alert rules continue to fire on real failure modes (sudoers missing, signal permission denied, kill binary missing). The new DEBUG message uses a distinct shape so an operator who wants to surface race frequency can grep for it.

Closes #548.

## Test plan

- [x] `tests/test_codex.py::TestSudoKillEsrchDemotion` (5 new tests): helper unit, async ESRCH-demoted, async non-ESRCH-warns, sync ESRCH-demoted, sync non-ESRCH-warns
- [x] `tests/test_codex.py::test_force_kill_logs_when_sudo_kill_fails` (existing) passes unchanged because its stderr `b"a password is required"` does not contain `No such process`
- [x] Full pytest suite passes (3711 passed, 1 skipped)
- [x] `make check` passes (ruff check + format)
- [ ] Operator smoke after deploy: trigger a pool eviction of a cross-user codex subprocess; confirm the ESRCH race no longer emits a WARNING and a DEBUG line with "already gone (ESRCH); benign race" appears at debug log level
- [ ] Operator smoke after deploy: confirm any genuine failure mode (test by revoking the sudoers rule for one os_user, then triggering a kill) still emits the existing WARNING text

## Notes

`claude.py` has the same misclassification at sibling sites (`_async_sudo_kill` and `_send_signal`). The issue and this PR scope to codex; a mirror-edit on claude is a separate follow-up. The PID-cache-vs-signal-delivery race window itself is unchanged; only its observable misclassification is corrected.
