### PR TITLE
fix(opencode): inject space at sentence-boundary chunk joins

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -374,6 +374,25 @@ class AcpBackend(AgentBackend):
             return msg["error"].get("message", "unknown ACP error")
         return None
 
+    def combine_text_chunks(self, prev: str, new: str) -> str:
+        """
+        Combine two streamed text chunks during prompt-response
+        accumulation. Default is verbatim concatenation (`prev + new`),
+        which is right for Goose and any future ACP harness whose
+        chunk boundaries already carry their own whitespace.
+        OpenCode overrides this to inject a single space at
+        sentence-boundary joins where the model dropped the space
+        between chunks; see `OpenCodeBackend.combine_text_chunks`
+        and `kai.opencode.concat_opencode_text` for the heuristic
+        and rationale.
+
+        The hook fires per chunk pair, not per accumulated string,
+        so backends that need a more elaborate normalization can
+        keep per-pair state in instance attributes if they need to.
+        Today only the simple lookahead-at-last-char shape is used.
+        """
+        return prev + new
+
     def handle_server_request(self, msg: dict) -> dict | None:
         """
         Return a JSON-RPC `result` payload for a server-initiated request.
@@ -785,10 +804,13 @@ class AcpBackend(AgentBackend):
                 # Streaming notifications (no id field) - extract user-
                 # visible text via the hook and accumulate; skip every
                 # other notification shape (tool calls, thoughts, etc.).
+                # `combine_text_chunks` is the seam where OpenCode
+                # injects sentence-boundary whitespace; Goose's default
+                # is verbatim `prev + new`.
                 if "method" in msg and "id" not in msg:
                     text = self.extract_text_delta(msg)
                     if text:
-                        accumulated += text
+                        accumulated = self.combine_text_chunks(accumulated, text)
                         yield StreamEvent(text_so_far=accumulated)
                     continue
 

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -42,7 +42,11 @@ from kai.acp import read_result, write_rpc
 from kai.codex_exec import extract_codex_text
 from kai.config import DATA_DIR, resolve_claude_user
 from kai.oneshot_binary import BinaryResolutionError, resolve_oneshot_binary
-from kai.opencode import extract_opencode_text_delta, handle_opencode_permission_request
+from kai.opencode import (
+    concat_opencode_text,
+    extract_opencode_text_delta,
+    handle_opencode_permission_request,
+)
 from kai.prompt_utils import make_boundary
 
 log = logging.getLogger(__name__)
@@ -1868,12 +1872,17 @@ class OpenCodeOneShotReasoner:
                 continue
 
             # Streaming notification (no `id` field). Accumulate text
-            # via the shared free function; skip every other
-            # notification shape.
+            # via the shared free functions; skip every other
+            # notification shape. `concat_opencode_text` handles the
+            # sentence-boundary whitespace join the conversational
+            # backend gets through `combine_text_chunks`; calling the
+            # free function directly here keeps the one-shot path
+            # symmetric without forcing it through the AcpBackend
+            # hook surface.
             if "method" in msg and "id" not in msg:
                 text = extract_opencode_text_delta(msg)
                 if text:
-                    accumulated += text
+                    accumulated = concat_opencode_text(accumulated, text)
                 continue
 
             # Server-initiated request (both `method` and `id`). The

--- a/src/kai/opencode.py
+++ b/src/kai/opencode.py
@@ -66,6 +66,41 @@ _OPENCODE_POLICY_PRIORITY: dict[OpenCodePermissionPolicy, tuple[str, ...]] = {
 # ── Shared free functions (used by conversational + one-shot) ────
 
 
+def concat_opencode_text(prev: str, new: str) -> str:
+    """
+    Concatenate two OpenCode text chunks, injecting a single space
+    when the join would glue a sentence end to a new sentence start.
+
+    OpenCode's `session/update` `agent_message_chunk` notifications
+    carry text verbatim from the model. The model usually emits the
+    space between sentences inside one chunk or the next, in which
+    case verbatim concatenation produces the right output. Sometimes
+    it does not: chunk A ends with `"diff."`, chunk B starts with
+    `"Now let me read the test files"`, and verbatim concat produces
+    `"diff.Now let me read the test files"` (operator-observed
+    example). The output reads as a typo and degrades the chat feel
+    without changing what the model actually said.
+
+    Heuristic: inject a single space iff `prev` ends in
+    sentence-terminating punctuation (`.`, `!`, `?`) AND `new` begins
+    with an uppercase letter. The narrow trigger preserves verbatim
+    joins for code (`function(`), numbers (`1.2.3`, semantic version
+    strings), URLs, markdown headers (`##`), quoted strings, and
+    word continuation (`hel` + `lo` -> `hello`). Lowercase sentence
+    starts are a known miss; the false-positive cost of widening the
+    trigger to cover them is higher than the rare miss.
+
+    Empty inputs round-trip unchanged so the first chunk's
+    accumulator initialization (`""` + first chunk) does not inject
+    a spurious space.
+    """
+    if not prev or not new:
+        return prev + new
+    if prev[-1] in ".!?" and new[0].isupper():
+        return prev + " " + new
+    return prev + new
+
+
 def extract_opencode_text_delta(msg: dict) -> str | None:
     """
     Return user-visible assistant text from an OpenCode
@@ -279,6 +314,18 @@ class OpenCodeBackend(AcpBackend):
         callers.
         """
         return extract_opencode_text_delta(msg)
+
+    def combine_text_chunks(self, prev: str, new: str) -> str:
+        """
+        Smart sentence-boundary concatenation for streamed OpenCode
+        text. Overrides the AcpBackend default (verbatim `prev + new`)
+        to inject a single space when the chunk boundary glues a
+        sentence end to a new sentence start. See
+        `concat_opencode_text` for the heuristic. The one-shot
+        reasoner calls the free function directly; only the
+        conversational backend goes through this hook.
+        """
+        return concat_opencode_text(prev, new)
 
     def handle_server_request(self, msg: dict) -> dict | None:
         """

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -607,3 +607,127 @@ class TestHandleOpencodePermissionRequestFreeFunction:
         }
         result = handle_opencode_permission_request(msg, policy="allow_always")
         assert result == {"outcome": {"outcome": "selected", "optionId": "x-id"}}
+
+
+class TestConcatOpencodeText:
+    """The sentence-boundary whitespace heuristic. Injects exactly
+    one space when prev ends in `.`, `!`, or `?` and new begins with
+    an uppercase letter; verbatim concat otherwise. Empty inputs
+    round-trip so the accumulator's first-chunk join does not
+    inject a spurious leading space."""
+
+    def test_sentence_boundary_injects_space(self):
+        from kai.opencode import concat_opencode_text
+
+        # The operator-observed example that motivated this fix.
+        assert (
+            concat_opencode_text("Let me read the rest of the diff.", "Now let me read the test files")
+            == "Let me read the rest of the diff. Now let me read the test files"
+        )
+
+    def test_question_and_exclamation_also_inject(self):
+        from kai.opencode import concat_opencode_text
+
+        assert concat_opencode_text("Ready?", "Then proceed") == "Ready? Then proceed"
+        assert concat_opencode_text("Done!", "Next step") == "Done! Next step"
+
+    def test_lowercase_start_does_not_inject(self):
+        """Lowercase sentence starts are a known miss; the false-
+        positive cost of widening the trigger is higher than the
+        rare miss. Pins the heuristic so a future widening is a
+        deliberate decision, not a drift."""
+        from kai.opencode import concat_opencode_text
+
+        assert concat_opencode_text("First.", "second sentence") == "First.second sentence"
+
+    def test_word_continuation_does_not_inject(self):
+        """A chunk split mid-word must NOT inject a space. Without
+        this guard the heuristic would damage the operator's view of
+        the streamed text in a worse way than the original gap."""
+        from kai.opencode import concat_opencode_text
+
+        # No trailing punctuation -> no space injected.
+        assert concat_opencode_text("hel", "lo world") == "hello world"
+        # Word continuation across a chunk that ends in a letter.
+        assert concat_opencode_text("write the implement", "ation") == "write the implementation"
+
+    def test_code_and_numeric_boundaries_do_not_inject(self):
+        """The heuristic must preserve verbatim joins for code (open
+        paren after a function name), version strings, URLs, and
+        markdown headers. Narrow trigger keeps these safe."""
+        from kai.opencode import concat_opencode_text
+
+        # Code: function call.
+        assert concat_opencode_text("function", "(arg)") == "function(arg)"
+        # Numeric: version string fragments. "1." + "2.3" is the
+        # canonical case where the dot is NOT a sentence terminator.
+        assert concat_opencode_text("1.", "2.3") == "1.2.3"
+        # URL: `://` shape.
+        assert concat_opencode_text("https", "://example.com") == "https://example.com"
+        # Markdown: header start without a space. `#` is not
+        # alphabetic, so `isupper()` returns False and the heuristic
+        # leaves the join verbatim. The rendered markdown is still
+        # correct because the parser treats `##` as a header regardless
+        # of the preceding punctuation, so verbatim is the right
+        # default here too.
+        assert concat_opencode_text("intro.", "## Section") == "intro.## Section"
+
+    def test_empty_inputs_round_trip(self):
+        """Empty `prev` (the accumulator's first-chunk state) must
+        return `new` verbatim; otherwise the first user-visible
+        chunk would gain a leading space. Symmetric for empty `new`."""
+        from kai.opencode import concat_opencode_text
+
+        assert concat_opencode_text("", "Hello") == "Hello"
+        assert concat_opencode_text("Hello", "") == "Hello"
+        assert concat_opencode_text("", "") == ""
+
+
+class TestCombineTextChunksHook:
+    """`combine_text_chunks` is the AcpBackend hook the conversational
+    backend's read loop calls. OpenCode overrides it to inject
+    sentence-boundary whitespace; Goose (and any other future ACP
+    harness) keeps the default verbatim concat so its behavior is
+    unaffected by this change."""
+
+    def test_opencode_backend_combines_with_smart_concat(self):
+        backend = _make_opencode()
+        assert backend.combine_text_chunks("First sentence.", "Second sentence") == "First sentence. Second sentence"
+
+    def test_opencode_backend_verbatim_for_non_sentence_boundary(self):
+        backend = _make_opencode()
+        assert backend.combine_text_chunks("partial", "continuation") == "partialcontinuation"
+
+    def test_acp_default_is_verbatim_concat(self):
+        """The default on `AcpBackend.combine_text_chunks` is
+        `prev + new`. Goose inherits this and stays unchanged; this
+        guards against an accidental widening of the new hook to
+        every backend."""
+        from kai.acp import AcpBackend
+        from kai.backend import AgentBackend
+
+        # Direct call via the class to bypass any subclass override.
+        # Mirrors the pattern existing _FakeAcp tests use to assert
+        # default hook behavior without instantiating a concrete
+        # AcpBackend subclass.
+        class _DefaultAcp(AcpBackend):
+            backend_name = "default_test"
+            backend_label = "DefaultTest"
+
+            def build_argv(self) -> list[str]:
+                return []
+
+            def build_env(self, base_env: dict[str, str]) -> dict[str, str]:
+                return base_env
+
+            def build_session_new_params(self) -> dict:
+                return {}
+
+            def extract_text_delta(self, msg: dict) -> str | None:
+                return None
+
+        assert issubclass(_DefaultAcp, AgentBackend)
+        backend = _DefaultAcp(model="m", workspace=Path("/tmp/x"), timeout_seconds=10)
+        # Sentence boundary that OpenCode would treat as a join site;
+        # the default backend leaves it verbatim.
+        assert backend.combine_text_chunks("End.", "Start") == "End.Start"


### PR DESCRIPTION
## Summary

- OpenCode's `session/update` `agent_message_chunk` notifications carry text verbatim. When the model emits "diff." in one chunk and "Now let me read the test files" in the next, the accumulator produces "diff.Now let me read the test files". Cosmetic but degrades the chat feel.
- Add `concat_opencode_text(prev, new)` in `kai/opencode.py`. Injects one space iff `prev` ends in `.`, `!`, or `?` AND `new` begins with an uppercase letter. Narrow trigger preserves verbatim joins for code (`function(`), numbers (`1.2.3`), URLs, markdown (`##`), word-continuation joins (`hel` + `lo`), and lowercase sentence starts. Lowercase starts are a known miss; the false-positive cost of widening is higher than the rare miss.
- Wired through two seams: `AcpBackend.combine_text_chunks(prev, new)` hook with verbatim default (used by `_send_locked`), overridden by `OpenCodeBackend` to call the free function; and `OpenCodeOneShotReasoner._drive_exchange` calling the free function directly. Goose and any other ACP harness keep the verbatim default.

Scope: OpenCode only. Claude and Codex stream-json paths have the same potential artifact but the operator scoped this fix to OpenCode; if it shows up elsewhere later, the helper can move to a shared module.

## Test plan

- [x] 9 new tests in `tests/test_opencode.py`:
  - 6 helper unit cases: sentence boundary, question/exclamation, lowercase start (must NOT inject), word continuation (must NOT inject), code/numeric/URL/markdown (must NOT inject), empty inputs (round-trip)
  - 2 OpenCodeBackend hook tests: smart concat fires at sentence boundary, verbatim for non-boundary joins
  - 1 AcpBackend default test: guards against accidental widening of the hook to every backend (goose regression guard)
- [x] Full pytest suite passes (3720 passed, 1 skipped)
- [x] `make check` passes (ruff check + format)
- [ ] Operator smoke after deploy: ask OpenCode-backed chat a question that triggers multi-sentence output; confirm the "diff.Now let me" artifact no longer appears in the Telegram render
- [ ] Operator smoke after deploy: confirm code blocks, version strings, and URLs in OpenCode-backed responses render without spurious space injection
