### PR TITLE
feat(install): wizard prompt for OPENCODE_BIN

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -350,6 +350,25 @@ def _validate_codex_bin(value: str) -> bool:
     return p.is_file() and os.access(p, os.X_OK)
 
 
+def _validate_opencode_bin(value: str) -> bool:
+    """Return True when the path exists and is executable.
+
+    Required by the opencode wizard prompt; the path is baked into
+    both the runtime OPENCODE_BIN env var and the sudoers rule that
+    allows cross-os_user opencode spawns, so a non-existent path
+    here would surface as a confusing 'a password is required' or
+    'command not found' at the first one-shot call. Paired with
+    `_validate_codex_bin` above so the two binary validators stay
+    together; the body shape matches codex byte-for-byte (is-file
+    plus executable) because the underlying requirement is the
+    same.
+    """
+    if not value:
+        return False
+    p = Path(value)
+    return p.is_file() and os.access(p, os.X_OK)
+
+
 def _install_staging_path(filename: str) -> Path:
     """Return the per-operator staging path for a first-time install file.
 
@@ -790,6 +809,13 @@ def _cmd_config() -> None:
     codex_auth_mode = ""
     codex_api_key = ""
     codex_bin = ""
+    # OpenCode binary path collected by the global-opencode block
+    # below (and re-prompted by the memory-extraction defense-in-depth
+    # gate if a future refactor exposes a path where the global block
+    # did not run). Empty when opencode is not in play so the
+    # persistence gate at the tail of this function skips emitting
+    # OPENCODE_BIN to install.conf.
+    opencode_bin = ""
     if agent_backend == "codex":
         codex_auth_mode = _prompt_choice(
             "Codex auth mode",
@@ -824,23 +850,43 @@ def _cmd_config() -> None:
             print("  If users.yaml has per-user `agent_backend: codex` entries with")
             print("  different os_users, log in as each of those too.")
 
-    # OpenCode setup: PATH check + post-install auth reminder. OpenCode
-    # is intentionally absent from VALID_PROVIDERS (its auth lives in
-    # ~/.local/share/opencode/auth.json, operator-managed via
-    # `opencode auth login`), so the provider/API-key block below is
-    # skipped naturally. Model selection routes through
-    # _prompt_default_model later in this function; since
-    # models_for_backend("opencode", _) returns None, the operator gets
-    # a free-text prompt for a full `provider/model` ID.
+    # OpenCode setup: binary-path wizard prompt + post-install auth
+    # reminder. OpenCode is intentionally absent from VALID_PROVIDERS
+    # (its auth lives in ~/.local/share/opencode/auth.json,
+    # operator-managed via `opencode auth login`), so the
+    # provider/API-key block below is skipped naturally. Model
+    # selection routes through _prompt_default_model later in this
+    # function; since models_for_backend("opencode", _) returns None,
+    # the operator gets a free-text prompt for a full `provider/model`
+    # ID.
     #
     # Gate on the global `agent_backend` selection only. Per-user
     # `agent_backend: opencode` overrides in users.yaml do NOT trigger
     # opencode setup here; the operator handles those installs and
     # auth out-of-band.
     if agent_backend == "opencode":
-        if not shutil.which("opencode"):
-            print("  WARNING: 'opencode' binary not found on PATH.")
-            print("  Install it from https://opencode.ai/docs/install/ before starting Kai.")
+        # OpenCode binary path: wizard-prompted and persisted in
+        # install.conf so `make install` writes both /etc/kai/env's
+        # OPENCODE_BIN and the sudoers SETENV rule from the same
+        # source of truth. Default suggestion uses `which opencode`
+        # from the operator's PATH; falls back to the empty string
+        # when which finds nothing (opencode has no single canonical
+        # install location across operator platforms, so an empty
+        # default forces the operator to type the path explicitly
+        # rather than accept a wrong default). The _cmd_apply env
+        # passthrough (`sudo OPENCODE_BIN=... make install`) still
+        # works as the ad-hoc deploy escape hatch; the wizard path is
+        # the canonical source of truth.
+        while True:
+            which_opencode = shutil.which("opencode") or ""
+            opencode_bin = _prompt(
+                "OpenCode binary path",
+                existing_env.get("OPENCODE_BIN", which_opencode),
+                required=True,
+            )
+            if _validate_opencode_bin(opencode_bin):
+                break
+            print(f"  Path '{opencode_bin}' does not exist or is not executable.")
         print("  After install, authenticate OpenCode for at least one provider:")
         print("    <service_user> ~$ opencode auth login")
         print("  Kai writes the active model into OPENCODE_CONFIG_CONTENT at process spawn;")
@@ -1230,6 +1276,30 @@ def _cmd_config() -> None:
                         if _validate_codex_bin(codex_bin):
                             break
                         print(f"  Path '{codex_bin}' does not exist or is not executable.")
+                # Symmetric defense-in-depth for the opencode global
+                # backend. The global-opencode block above already
+                # collected opencode_bin on the normal flow; the gate
+                # here exists for the same future-refactor reason
+                # codex documents above: a refactor that moved the
+                # memory-extraction prompt before the global-backend
+                # block could reach this point with opencode_bin
+                # still empty. Default-suggestion value differs from
+                # codex (empty fallback instead of Homebrew) because
+                # opencode has no canonical install location across
+                # platforms; an empty default forces the operator to
+                # type the path explicitly rather than accept a wrong
+                # default.
+                if agent_backend == "opencode" and not opencode_bin:
+                    while True:
+                        which_opencode = shutil.which("opencode") or ""
+                        opencode_bin = _prompt(
+                            "OpenCode binary path (required by opencode memory reasoner)",
+                            existing_env.get("OPENCODE_BIN", which_opencode),
+                            required=True,
+                        )
+                        if _validate_opencode_bin(opencode_bin):
+                            break
+                        print(f"  Path '{opencode_bin}' does not exist or is not executable.")
                 # No MEMORY_EXTRACTION_BUDGET_USD prompt on this branch:
                 # --max-budget-usd is omitted from the stage-1 claude
                 # --print argv (memory_extraction.py:_run_extractor),
@@ -1430,6 +1500,14 @@ def _cmd_config() -> None:
     # the canonical source of truth.
     if codex_bin:
         env["CODEX_BIN"] = codex_bin
+    # Same gating shape as codex above: the value persists only when
+    # the wizard collected one (truthy opencode_bin), so a claude or
+    # goose install does not pollute install.conf with an empty
+    # OPENCODE_BIN= line. The single env emission drives both
+    # /etc/kai/env's OPENCODE_BIN and the sudoers SETENV rule so the
+    # two cannot drift.
+    if opencode_bin:
+        env["OPENCODE_BIN"] = opencode_bin
 
     # Remove stale renamed keys if present - leaving both the old and
     # new key causes silent confusion (the deprecation warning is

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1237,11 +1237,14 @@ def _cmd_config() -> None:
     memory_duplicate_threshold = "0.9"
     if memory_enabled:
         # Memory extraction is supported on agent backends that have a
-        # OneShotReasoner implementation. Today that is claude and
-        # codex; goose retrieval-only installs accept memory_enabled
-        # but skip the extraction prompt because no reasoner exists
-        # for goose. Add to the tuple when a new reasoner ships.
-        if agent_backend in ("claude", "codex"):
+        # OneShotReasoner implementation: claude, codex, and (since
+        # PR #577) opencode. Goose retrieval-only installs accept
+        # memory_enabled but skip the extraction prompt because no
+        # reasoner exists for goose. Add to the tuple when a new
+        # reasoner ships. The runtime eligibility gate at
+        # `bot._ingest_memory` and `config._compute_extraction_eligible_backends`
+        # widened to the same set; both stay in lockstep.
+        if agent_backend in ("claude", "codex", "opencode"):
             memory_extraction_enabled = _prompt_bool(
                 "Enable memory extraction (proactive memory writes)",
                 existing_env.get("MEMORY_EXTRACTION_ENABLED", "false").lower() in ("1", "true", "yes"),

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7652,6 +7652,98 @@ class TestOpenCodeBinWizardPrompt:
         assert default == sentinel_which_value
         assert required is True
 
+    def test_memory_extraction_defense_in_depth_block_collects_opencode_bin(self, tmp_path, monkeypatch):
+        """Defense-in-depth: when `agent_backend == "opencode"` and the
+        memory-extraction block is reached without `opencode_bin`
+        having been collected (e.g., a future refactor moved the
+        memory-extraction prompt before the global-backend block),
+        the wizard re-prompts with a memory-reasoner-flavored label
+        rather than silently leaving install.conf without
+        `OPENCODE_BIN`.
+
+        The current wizard ordering makes this combination
+        unreachable in practice; the test simulates it by forcing
+        the global-opencode block's validator to accept an empty
+        string (which the operator types when the first prompt
+        appears), so the wizard exits that block with
+        `opencode_bin == ""`. The memory-extraction block's
+        `if agent_backend == "opencode" and not opencode_bin:` gate
+        fires, re-prompts, and the second value is what persists.
+        Pinned so a future refactor that exposes this code path is
+        covered by an existing test rather than discovered at
+        runtime.
+        """
+        valid_path = tmp_path / "fake_opencode"
+        valid_path.write_text("#!/bin/sh\necho hi\n")
+        valid_path.chmod(0o755)
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            MagicMock(return_value="anthropic/claude-sonnet-4-5"),
+        )
+
+        # Force the validator to accept the empty string the
+        # global-opencode block sees so the loop exits with
+        # opencode_bin == "" and the memory-extraction defense-in-
+        # depth gate fires. The real validator still rejects empty
+        # in production; this monkeypatch is what simulates the
+        # future-refactor failure mode the defense-in-depth block
+        # guards against.
+        monkeypatch.setattr("kai.install._validate_opencode_bin", lambda p: True)
+
+        # Stub `_prompt` so the global-opencode label returns empty
+        # (bypassing `_prompt`'s required-field re-prompt loop) and
+        # the defense-in-depth label returns the valid path. Every
+        # other prompt label passes through to the real `_prompt`
+        # so the rest of the wizard flow consumes the input
+        # iterator normally. This is the precision the test needs:
+        # forcing opencode_bin to "" after the global block without
+        # changing the wizard's other prompts.
+        captured: list[tuple] = []
+        from kai.install import _prompt as _real_prompt
+
+        def _stub_prompt(label, default="", required=False, **kwargs):
+            captured.append((label, default, required))
+            if label == "OpenCode binary path":
+                return ""
+            if label == "OpenCode binary path (required by opencode memory reasoner)":
+                return str(valid_path)
+            return _real_prompt(label, default=default, required=required, **kwargs)
+
+        monkeypatch.setattr("kai.install._prompt", _stub_prompt)
+
+        # The stubbed _prompt for "OpenCode binary path" does not
+        # call input(), so the slot in _opencode_inputs for that
+        # prompt is unused. Drop it so the subsequent timeout
+        # prompt does not consume the placeholder path as its
+        # integer input.
+        inputs_list = self._opencode_inputs(str(valid_path))
+        inputs_list.remove(str(valid_path))
+        inputs = iter(inputs_list)
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        # Both labels appear in the captured prompts: the global-
+        # opencode one (no memory-reasoner suffix) and the defense-
+        # in-depth one (with the suffix).
+        labels = [c[0] for c in captured]
+        assert "OpenCode binary path" in labels
+        assert "OpenCode binary path (required by opencode memory reasoner)" in labels
+
+        # install.conf carries the value from the second prompt
+        # (the defense-in-depth block's collection), which is the
+        # valid path. The empty value from the first prompt is
+        # overwritten when the defense-in-depth block re-assigns
+        # opencode_bin.
+        env = json.loads((tmp_path / "install.conf").read_text())["env"]
+        assert env["OPENCODE_BIN"] == str(valid_path)
+
     def test_wizard_re_run_preserves_existing_opencode_bin(self, tmp_path, monkeypatch):
         """A re-run of `make config` with an existing OPENCODE_BIN
         in install.conf uses the existing value as the default

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7401,6 +7401,317 @@ class TestValidateCodexBin:
         assert _validate_codex_bin(str(f)) is True
 
 
+class TestValidateOpenCodeBin:
+    """opencode binary path existence validator. Mirrors
+    `TestValidateCodexBin` exactly: same five edge cases (empty,
+    nonexistent, directory, non-executable file, executable file).
+    The shared validator shape (`is_file()` AND `os.access(_, X_OK)`)
+    is the same one codex uses; pinning both halves protects against
+    a future refactor that drops one and silently weakens the
+    binary-path check for one backend but not the other."""
+
+    def test_empty_value_rejected(self):
+        from kai.install import _validate_opencode_bin
+
+        assert _validate_opencode_bin("") is False
+
+    def test_nonexistent_path_rejected(self, tmp_path):
+        from kai.install import _validate_opencode_bin
+
+        assert _validate_opencode_bin(str(tmp_path / "does_not_exist")) is False
+
+    def test_directory_rejected(self, tmp_path):
+        from kai.install import _validate_opencode_bin
+
+        assert _validate_opencode_bin(str(tmp_path)) is False
+
+    def test_non_executable_file_rejected(self, tmp_path):
+        from kai.install import _validate_opencode_bin
+
+        f = tmp_path / "fake_opencode"
+        f.write_text("#!/bin/sh\necho hi\n")
+        assert _validate_opencode_bin(str(f)) is False
+
+    def test_executable_file_accepted(self, tmp_path):
+        from kai.install import _validate_opencode_bin
+
+        f = tmp_path / "fake_opencode"
+        f.write_text("#!/bin/sh\necho hi\n")
+        f.chmod(0o755)
+        assert _validate_opencode_bin(str(f)) is True
+
+
+class TestOpenCodeBinWizardPrompt:
+    """Wizard collects OPENCODE_BIN when the operator picks opencode
+    as the global backend. Mirrors the codex wizard's collection
+    pattern: prompt with `shutil.which("opencode")` as the default
+    suggestion, validate the chosen path, persist to install.conf
+    so `make install` reads from the same source of truth as the
+    sudoers SETENV rule emitter (PR #577). The escape hatch
+    `sudo OPENCODE_BIN=... make install` is preserved by the
+    `_cmd_apply` env passthrough also added in PR #577.
+
+    These tests focus on the wizard surface; the sudoers-rule
+    threading is already covered under TestGenerateSudoersCodexBinArg
+    and the matching opencode regression tests in test_install.py.
+    """
+
+    def _block_etc_kai(self, monkeypatch):
+        """Prevent the wizard from detecting /etc/kai/users.yaml on the host."""
+        _real_exists = Path.exists
+
+        def _exists_no_etc(self):
+            if str(self) == "/etc/kai/users.yaml":
+                return False
+            return _real_exists(self)
+
+        monkeypatch.setattr(Path, "exists", _exists_no_etc)
+
+    def _redirect_staging(self, monkeypatch, tmp_path):
+        """Redirect the staging-path helper so the wizard writes under tmp_path."""
+        monkeypatch.setattr(
+            "kai.install._install_staging_path",
+            lambda filename: tmp_path / filename,
+        )
+
+    def _opencode_inputs(self, opencode_bin_path: str) -> list[str]:
+        """Build the input sequence for an opencode-backend wizard run.
+
+        Mirrors the codex-install test's input sequence at line ~2440
+        of test_install.py except for the agent backend and the
+        binary-path prompt: codex has `codex_auth_mode` plus the
+        codex binary path; opencode has only the opencode binary
+        path (no auth mode prompt because opencode auth lives outside
+        the wizard surface, in `~/.local/share/opencode/auth.json`).
+        """
+        return [
+            "protected",  # deployment mode
+            "/opt/kai",  # install dir
+            "/var/lib/kai",  # data dir
+            "kai",  # service user
+            "darwin",  # platform
+            "fake-token",  # bot token
+            "12345",  # admin telegram ID
+            "admin",  # admin display name
+            "false",  # advanced user options (no per-user os_user)
+            "polling",  # transport
+            "opencode",  # agent backend
+            opencode_bin_path,  # OPENCODE_BIN (NEW prompt this spec adds)
+            # model: handled by _prompt_default_model mock
+            "120",  # agent timeout
+            "10.0",  # budget (non-claude branch)
+            "200000",  # max context window
+            "8080",  # webhook port
+            "test-secret",  # webhook secret
+            "",  # workspace base
+            "",  # allowed workspaces
+            "300",  # pr review cooldown (global resource control)
+            "900",  # pr review timeout
+            "1.0",  # pr review budget (non-claude branch)
+            "false",  # voice
+            "false",  # tts
+            "true",  # memory enabled
+            "true",  # memory extraction enabled
+            "10",  # extraction timeout
+            "8",  # consolidation candidates
+            "3",  # episode classifier context turns
+            "120",  # episode timeout
+            "0.9",  # paraphrase-dedup threshold
+            "2000",  # token budget
+            "10",  # search limit
+            "",  # perplexity key
+        ]
+
+    def test_wizard_persists_opencode_bin_to_install_conf(self, tmp_path, monkeypatch):
+        """The wizard's opencode block collects OPENCODE_BIN and
+        persists it under `env` in install.conf. The persisted value
+        is then threaded into /etc/kai/env and the sudoers rule by
+        `_cmd_apply` and `_generate_sudoers` (covered separately)."""
+        opencode_path = tmp_path / "fake_opencode"
+        opencode_path.write_text("#!/bin/sh\necho hi\n")
+        opencode_path.chmod(0o755)
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
+        # Mock the model prompt so the test doesn't drive the
+        # provider/model free-text branch directly.
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            MagicMock(return_value="anthropic/claude-sonnet-4-5"),
+        )
+
+        inputs = iter(self._opencode_inputs(str(opencode_path)))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        env = json.loads((tmp_path / "install.conf").read_text())["env"]
+        assert env["OPENCODE_BIN"] == str(opencode_path)
+        assert env["AGENT_BACKEND"] == "opencode"
+
+    def test_wizard_loops_on_invalid_opencode_bin(self, tmp_path, monkeypatch):
+        """An invalid path (does not exist, or not executable) must
+        re-prompt until the operator types a valid one. Symmetric
+        with the codex validator loop at install.py:810-819."""
+        valid_path = tmp_path / "fake_opencode"
+        valid_path.write_text("#!/bin/sh\necho hi\n")
+        valid_path.chmod(0o755)
+        invalid_path = tmp_path / "does_not_exist"
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            MagicMock(return_value="anthropic/claude-sonnet-4-5"),
+        )
+
+        # Build inputs: first opencode_bin is invalid; loop pulls the
+        # next input from the iterator, which is the valid path. The
+        # rest of the wizard inputs follow.
+        inputs_list = self._opencode_inputs(str(valid_path))
+        # Find the position of opencode_bin in the input list and
+        # inject the invalid path before it.
+        opencode_idx = inputs_list.index(str(valid_path))
+        inputs_list.insert(opencode_idx, str(invalid_path))
+        inputs = iter(inputs_list)
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        env = json.loads((tmp_path / "install.conf").read_text())["env"]
+        # The persisted value is the valid path, NOT the invalid one
+        # the operator typed first. Confirms the validator loop did
+        # not accept the bad input.
+        assert env["OPENCODE_BIN"] == str(valid_path)
+
+    def test_wizard_uses_shutil_which_as_default_suggestion(self, tmp_path, monkeypatch):
+        """When no existing OPENCODE_BIN is in install.conf, the
+        wizard's prompt uses `shutil.which("opencode")` as the
+        default suggestion. Pinned via a capture-and-assert on the
+        `_prompt` call's `default` argument."""
+        opencode_path = tmp_path / "fake_opencode"
+        opencode_path.write_text("#!/bin/sh\necho hi\n")
+        opencode_path.chmod(0o755)
+        # Sentinel which `shutil.which` returns; the wizard should
+        # pass this value as the prompt default.
+        sentinel_which_value = "/sentinel/which/opencode"
+        # Make `shutil.which("opencode")` return the sentinel; leave
+        # other lookups untouched so the wizard's other PATH-based
+        # checks still work.
+        original_which = shutil.which
+
+        def _which(name):
+            if name == "opencode":
+                return sentinel_which_value
+            return original_which(name)
+
+        monkeypatch.setattr("kai.install.shutil.which", _which)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            MagicMock(return_value="anthropic/claude-sonnet-4-5"),
+        )
+
+        # Capture every `_prompt` call so the test can verify the
+        # OpenCode binary prompt was offered the sentinel value as
+        # the default. The captured tuples are (label, default, ...).
+        captured: list[tuple] = []
+        from kai.install import _prompt as _real_prompt
+
+        def _capturing_prompt(label, default="", required=False, **kwargs):
+            captured.append((label, default, required))
+            # Return the typed value via the input iterator path so
+            # the rest of the wizard flow proceeds normally. Re-route
+            # by calling the real prompt, which uses input().
+            return _real_prompt(label, default=default, required=required, **kwargs)
+
+        monkeypatch.setattr("kai.install._prompt", _capturing_prompt)
+
+        inputs = iter(self._opencode_inputs(str(opencode_path)))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        # Find the OpenCode binary path prompt in the captured list
+        # and assert its default value was the sentinel from
+        # `shutil.which("opencode")`. The exact label text matches
+        # what the spec specifies.
+        opencode_prompts = [c for c in captured if c[0] == "OpenCode binary path"]
+        assert opencode_prompts, "wizard did not prompt for OpenCode binary path"
+        _label, default, required = opencode_prompts[0]
+        assert default == sentinel_which_value
+        assert required is True
+
+    def test_wizard_re_run_preserves_existing_opencode_bin(self, tmp_path, monkeypatch):
+        """A re-run of `make config` with an existing OPENCODE_BIN
+        in install.conf uses the existing value as the default
+        suggestion, NOT the PATH-derived value. Mirrors the codex
+        re-run preservation pattern: `existing_env.get("OPENCODE_BIN",
+        which_opencode)` reads from the already-persisted value
+        first."""
+        opencode_path = tmp_path / "fake_opencode"
+        opencode_path.write_text("#!/bin/sh\necho hi\n")
+        opencode_path.chmod(0o755)
+        prior_path = tmp_path / "prior_opencode"
+        prior_path.write_text("#!/bin/sh\necho prior\n")
+        prior_path.chmod(0o755)
+
+        # Pre-populate install.conf with an existing OPENCODE_BIN
+        # value so the wizard's re-run branch fires.
+        prior_conf = {
+            "install_dir": "/opt/kai",
+            "data_dir": "/var/lib/kai",
+            "service_user": "kai",
+            "platform": "darwin",
+            "env": {
+                "OPENCODE_BIN": str(prior_path),
+                "TELEGRAM_BOT_TOKEN": "fake-token",
+            },
+        }
+        (tmp_path / "install.conf").write_text(json.dumps(prior_conf))
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            MagicMock(return_value="anthropic/claude-sonnet-4-5"),
+        )
+
+        captured: list[tuple] = []
+        from kai.install import _prompt as _real_prompt
+
+        def _capturing_prompt(label, default="", required=False, **kwargs):
+            captured.append((label, default, required))
+            return _real_prompt(label, default=default, required=required, **kwargs)
+
+        monkeypatch.setattr("kai.install._prompt", _capturing_prompt)
+
+        inputs = iter(self._opencode_inputs(str(opencode_path)))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        # The OpenCode binary prompt's default came from the
+        # pre-populated env, not from shutil.which.
+        opencode_prompts = [c for c in captured if c[0] == "OpenCode binary path"]
+        assert opencode_prompts, "wizard did not prompt for OpenCode binary path"
+        _, default, _ = opencode_prompts[0]
+        assert default == str(prior_path)
+
+
 class TestGenerateSudoersCodexBinArg:
     """_generate_sudoers takes codex_bin as an argument."""
 


### PR DESCRIPTION
## Summary

- Codex has had a wizard prompt for `CODEX_BIN` since the codex backend landed: prompt with `shutil.which("codex")` as the default, validate, persist to install.conf so the runtime env file and the sudoers SETENV rule resolve against the same source of truth. PR #577 added the install.conf -> sudoers threading for opencode but skipped the wizard prompt; the `_generate_sudoers` fallback is a hardcoded `<svc_home>/.local/bin/opencode` which does not match Homebrew on macOS or other custom install locations.
- This PR mirrors the codex wizard pattern for opencode: new `_validate_opencode_bin` (byte-for-byte mirror of `_validate_codex_bin`), prompt-and-validate loop in the global-opencode block (default suggestion `shutil.which("opencode") or ""`), defense-in-depth gate in the memory-extraction block matching codex's existing future-refactor guard, and `if opencode_bin: env["OPENCODE_BIN"] = opencode_bin` persistence alongside the codex line.
- The leading comment header at the global-opencode block is rewritten from "PATH check + post-install auth reminder" to "binary-path wizard prompt + post-install auth reminder" so the comment matches the new block content. The VALID_PROVIDERS-absence rationale and per-user-override gate policy in the same comment stay verbatim.

The PR #577 sudoers fallback and the `sudo OPENCODE_BIN=... make install` env passthrough are both preserved. The wizard path is now the canonical source of truth; the env-passthrough is the operator's ad-hoc deploy escape hatch.

Closes #580.

## Test plan

- [x] 9 new tests in `tests/test_install.py`:
  - `TestValidateOpenCodeBin` (5 unit tests): mirrors `TestValidateCodexBin` coverage — empty, nonexistent, directory, non-executable file, executable file. Directory case exercises the `is_file()` branch (F-3 in the spec review).
  - `TestOpenCodeBinWizardPrompt` (4 integration tests): install.conf persistence, validator loop (invalid path -> re-prompt -> valid), `shutil.which("opencode")` suggestion source captured at the prompt boundary, and re-run preservation of existing `OPENCODE_BIN` value.
- [x] Full pytest suite passes (3729 passed, 1 skipped)
- [x] `make check` passes (ruff check + format)
- [ ] Operator smoke: run `make config` on an opencode-effective install and confirm the OpenCode binary path prompt appears with the correct PATH-derived suggestion
- [ ] Operator smoke: run `make config` again and confirm the prior `OPENCODE_BIN` value appears as the default suggestion (not a re-derivation from `which opencode`)
- [ ] Operator smoke: `sudo make install` reads `OPENCODE_BIN` from install.conf and bakes it into the sudoers rule at `/etc/sudoers.d/kai`

## Migration notes

| Install state | Behavior after this lands |
|---|---|
| Pre-#577 install (never re-ran `make config` since PR #577) | No `OPENCODE_BIN` in install.conf; sudoers rule falls back to `<svc_home>/.local/bin/opencode` (PR #577 behavior, unchanged). Next `make config` re-run collects the path interactively. |
| Post-#577 install that set `OPENCODE_BIN` via the env passthrough | `OPENCODE_BIN` is in /etc/kai/env but NOT in install.conf. Next `make config` re-run prompts with the empty default (or `which opencode` if available); operator accepts or overrides. Persisted to install.conf going forward. |
| Fresh install after this PR | First-time `make config` prompts during the opencode backend block. Validator gates the value before the wizard accepts. Persisted to install.conf; `sudo make install` reads it from there. |
