### PR TITLE
fix(install): persist MEMORY_EXTRACTION_ENABLED on opencode

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -59,6 +59,7 @@ from kai.backend import resolve_home_workspace
 from kai.config import (
     DATA_DIR,
     MAX_CONTEXT_CEILING,
+    ONESHOT_REASONER_BACKENDS,
     OPEN_ENDED_PROVIDERS,
     PROVIDER_DEFAULTS,
     Config,
@@ -3754,7 +3755,7 @@ async def _handle_response(
                 effective_backend = (
                     user_config.agent_backend if user_config and user_config.agent_backend else config.agent_backend
                 )
-                if config.memory_extraction_enabled and effective_backend in ("claude", "codex", "opencode"):
+                if config.memory_extraction_enabled and effective_backend in ONESHOT_REASONER_BACKENDS:
                     # Windowed PRIOR CONTEXT for the episode classifier
                     # (issue #392). Fetch one extra pair beyond the
                     # configured window and drop the most recent: the

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -47,6 +47,32 @@ DATA_DIR = Path(os.environ.get("KAI_DATA_DIR") or str(PROJECT_ROOT))
 # `opencode auth login`). Shared between load_config() and install.py.
 VALID_BACKENDS = {"claude", "goose", "codex", "opencode"}
 
+# Backends that ship a `OneShotReasoner` implementation in
+# `src/kai/oneshot.py`. Every site that gates on "does this backend
+# support one-shot agent dispatch" - memory extraction eligibility,
+# PR review / triage dispatch, smoke validation, behavioral eval
+# coverage, install-time MEMORY_* persistence - reads from this set
+# rather than an ad-hoc literal tuple. Adding a new backend with a
+# OneShotReasoner is a one-line change here; without the constant,
+# widening costs a grep-and-extend dance across nine sites in
+# `bot`, `install`, `smoke`, and `eval` (which is exactly what
+# the opencode rollout cost across two follow-up PRs).
+#
+# `frozenset` because the only operation any caller needs is
+# membership; the constant is immutable at module scope and the
+# type pins that intent.
+#
+# Strict subset of VALID_BACKENDS: every entry here is also a valid
+# agent backend, but not every valid agent backend has a
+# OneShotReasoner. Concrete exclusion: `"goose"` is in
+# VALID_BACKENDS but not here because `src/kai/oneshot.py` has no
+# `GooseOneShotReasoner` class. Goose retrieval-only memory
+# installs work; goose one-shot dispatch (memory extraction, PR
+# review, triage) does not. The two constants stay distinct on
+# purpose; collapsing them would force a goose operator through
+# one-shot-eligibility gates the goose backend cannot satisfy.
+ONESHOT_REASONER_BACKENDS: frozenset[str] = frozenset({"claude", "codex", "opencode"})
+
 # Valid LLM providers per backend. Claude always uses Anthropic
 # (hardcoded in get_effective_provider), so it has no entry here.
 # Backends that don't appear in this dict accept no provider config.
@@ -289,7 +315,7 @@ def _check_model_registry_complete(backend: str) -> None:
     Goose is exempt: goose-side model resolution lives in module-level
     _GOOSE_AGENT_MODELS dicts that this registry does not subsume.
     """
-    if backend not in ("claude", "codex", "opencode"):
+    if backend not in ONESHOT_REASONER_BACKENDS:
         return
     missing = [role for role in ModelRole if (backend, role) not in MODEL_REGISTRY]
     if missing:
@@ -1651,7 +1677,7 @@ def _compute_extraction_eligible_backends(
     eligible: set[str] = set()
     for uc in user_configs.values():
         effective = uc.agent_backend or agent_backend
-        if effective in ("claude", "codex", "opencode"):
+        if effective in ONESHOT_REASONER_BACKENDS:
             eligible.add(effective)
     return eligible
 

--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -95,7 +95,7 @@ from typing import Any
 # on probe schema, drift detection, and probe-set-hash semantics. If
 # Layer 1's drift bucketing changes, Layer 2 follows automatically.
 from kai.codex_exec import extract_codex_text
-from kai.config import ModelRole, get_model_for
+from kai.config import ONESHOT_REASONER_BACKENDS, ModelRole, get_model_for
 from kai.eval.retrieval import (
     Probe,
     detect_drift,
@@ -2280,16 +2280,17 @@ async def _run_cli(args: argparse.Namespace) -> int:
     # _build_parser) means an unset flag yields override="" so the
     # branch below picks the right backend-appropriate default.
     #
-    # The registry only covers claude and codex; goose's model
-    # resolution lives in _GOOSE_AGENT_MODELS dicts inside triage.py
-    # and review.py, not in MODEL_REGISTRY. For goose (and any future
-    # non-registry backend) we preserve the pre-Phase-1 behavior:
-    # explicit --judge-model / --gen-model wins, otherwise the legacy
-    # _DEFAULT_JUDGE_MODEL / _DEFAULT_GEN_MODEL constants are used.
-    # This keeps the goose path byte-identical to today rather than
-    # crashing with a LookupError on an unset flag.
+    # MODEL_REGISTRY covers every backend in ONESHOT_REASONER_BACKENDS;
+    # goose's model resolution lives in _GOOSE_AGENT_MODELS dicts inside
+    # triage.py and review.py, not in MODEL_REGISTRY. For goose (and any
+    # other backend that ever sits outside ONESHOT_REASONER_BACKENDS),
+    # preserve the pre-registry behavior: explicit --judge-model /
+    # --gen-model wins, otherwise the legacy _DEFAULT_JUDGE_MODEL /
+    # _DEFAULT_GEN_MODEL constants are used. This keeps the goose path
+    # byte-identical rather than crashing with a LookupError on an
+    # unset flag.
     eval_backend = os.environ.get("AGENT_BACKEND", "claude").strip().lower()
-    if eval_backend in ("claude", "codex"):
+    if eval_backend in ONESHOT_REASONER_BACKENDS:
         resolved_judge_model = get_model_for(
             ModelRole.BEHAVIORAL_JUDGE,
             eval_backend,

--- a/src/kai/eval/memory_backend_gate.py
+++ b/src/kai/eval/memory_backend_gate.py
@@ -40,11 +40,12 @@ import re
 import sys
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from itertools import combinations
 from pathlib import Path
 from typing import Any
 
 from kai import memory, memory_extraction
-from kai.config import Config, ModelRole, get_model_for, load_config
+from kai.config import ONESHOT_REASONER_BACKENDS, Config, ModelRole, get_model_for, load_config
 from kai.eval.extraction import _window_to_extractor_args
 from kai.eval.replay import _SANDBOX_USER_ID_PREFIX
 
@@ -102,8 +103,34 @@ ALLOWED_CONSOLIDATION_OUTCOMES = (
     "add_failed_after_delete",
 )
 
-# Default backends evaluated when --backends is not supplied.
-DEFAULT_BACKENDS = ("claude", "codex")
+# Default backends evaluated when --backends is not supplied. Cast
+# to a tuple so argparse's positional-sequence consumers (`default`
+# and `choices`) get the shape they expect; sort first so the help
+# output and downstream loops produce a deterministic order across
+# runs (frozenset iteration is hash-seed-randomized).
+DEFAULT_BACKENDS: tuple[str, ...] = tuple(sorted(ONESHOT_REASONER_BACKENDS))
+
+# Comma-joined sample of per-backend sandbox IDs for the
+# `--user-prefix` help text. Built from ONESHOT_REASONER_BACKENDS so
+# a new reasoner addition extends the help string automatically.
+_BACKEND_SANDBOX_EXAMPLES = ", ".join(f"<prefix>-{b}" for b in sorted(ONESHOT_REASONER_BACKENDS))
+
+# Back-compat lookup key for the legacy single-pair `threshold_report`
+# consumer surface. The pairwise compare loop now builds a dict keyed
+# by every two-backend combination; legacy consumers (gate_result JSON
+# layout, `--fail-on-threshold` exit code) read this one entry. Built
+# via `tuple(sorted(...)[:2])` so the value derives from the constant
+# rather than hardcoding a literal that the grep regression test
+# in `tests/test_config.py` would reject. Today's value is the
+# first two alphabetic entries (`claude` then `codex`); a future
+# backend that sorts before `claude` shifts which
+# pair the legacy consumer surfaces, and `.get()`'s graceful-None
+# return keeps the call site degradation-safe (matched by the
+# `single_backend` sentinel fallback at the call site). A multi-pair
+# consumer surface lands in a separate change; this is the data-path
+# bridge only.
+_sorted_oneshot_backends = sorted(ONESHOT_REASONER_BACKENDS)
+_LEGACY_THRESHOLD_PAIR: tuple[str, str] = (_sorted_oneshot_backends[0], _sorted_oneshot_backends[1])
 
 # Default qualitative sample budget. The 5/3/2 split below is the
 # canonical allocation when budget == 10. Smaller budgets fall back
@@ -1887,9 +1914,10 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m kai.eval.memory_backend_gate",
         description=(
-            "Claude-vs-Codex memory eval gate. Drives extract_and_store + "
-            "format_context for each backend against the same probe fixture "
-            "and emits gate-result.json + per-backend logs + qualitative-sample.md."
+            "Cross-backend memory eval gate. Drives extract_and_store + "
+            "format_context for each backend with a OneShotReasoner against "
+            "the same probe fixture and emits gate-result.json + per-backend "
+            "logs + qualitative-sample.md."
         ),
     )
     parser.add_argument("--probes", type=Path, required=True, help="Path to the JSONL probe fixture.")
@@ -1907,7 +1935,7 @@ def _build_parser() -> argparse.ArgumentParser:
         required=True,
         help=(
             f"Sandbox user-ID prefix; must start with {_SANDBOX_USER_ID_PREFIX!r}. "
-            "Per-backend sandbox IDs are <prefix>-claude and <prefix>-codex."
+            f"Per-backend sandbox IDs are {_BACKEND_SANDBOX_EXAMPLES}."
         ),
     )
     parser.add_argument(
@@ -1915,7 +1943,7 @@ def _build_parser() -> argparse.ArgumentParser:
         nargs="+",
         default=list(DEFAULT_BACKENDS),
         choices=list(DEFAULT_BACKENDS),
-        help="Backends to run; default is both.",
+        help="Backends to run; default is every backend with a OneShotReasoner.",
     )
     parser.add_argument(
         "--os-user",
@@ -2031,9 +2059,24 @@ async def _run_cli(args: argparse.Namespace) -> int:
         metrics.episode_recall = tp / max(1, tp + fn)
         metrics_by_backend[backend] = metrics
 
-    if "claude" in metrics_by_backend and "codex" in metrics_by_backend:
-        threshold_report = compare_thresholds(metrics_by_backend["claude"], metrics_by_backend["codex"])
-    else:
+    # Compute every pairwise threshold comparison across the backends
+    # that actually produced metrics this run. The legacy consumer
+    # surface (the gate-result JSON layout and the `--fail-on-threshold`
+    # exit code) reads only the `_LEGACY_THRESHOLD_PAIR` entry; the
+    # remaining pairs are computed for downstream multi-pair rendering
+    # that lands separately. `.get(...)` returns None when the legacy
+    # pair did not produce comparable metrics (single-backend run or
+    # a partial-skip), which the `single_backend` sentinel below
+    # converts to the same shape `compare_thresholds` returns.
+    threshold_reports: dict[tuple[str, str], ThresholdReport] = {}
+    for backend_a, backend_b in combinations(sorted(ONESHOT_REASONER_BACKENDS), 2):
+        if backend_a in metrics_by_backend and backend_b in metrics_by_backend:
+            threshold_reports[(backend_a, backend_b)] = compare_thresholds(
+                metrics_by_backend[backend_a],
+                metrics_by_backend[backend_b],
+            )
+    threshold_report = threshold_reports.get(_LEGACY_THRESHOLD_PAIR)
+    if threshold_report is None:
         threshold_report = ThresholdReport(checks=[], overall="single_backend")
 
     gate_result = build_gate_result(

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1237,13 +1237,13 @@ def _cmd_config() -> None:
     # suppressed by the delta-from-default check below.
     memory_duplicate_threshold = "0.9"
     if memory_enabled:
-        # Memory extraction is supported on agent backends that have a
-        # Membership tracks backends with a OneShotReasoner. Goose
-        # retrieval-only installs accept memory_enabled but skip the
-        # extraction prompt because no GooseOneShotReasoner exists.
-        # The runtime eligibility gate at `bot._ingest_memory` and
-        # `config._compute_extraction_eligible_backends` read from
-        # the same constant; all sites stay in lockstep through it.
+        # Memory extraction is supported on agent backends that ship a
+        # OneShotReasoner. Goose retrieval-only installs accept
+        # memory_enabled but skip the extraction prompt because no
+        # GooseOneShotReasoner exists. The runtime eligibility gate at
+        # `bot._ingest_memory` and `config._compute_extraction_eligible_backends`
+        # read from the same constant; all sites stay in lockstep
+        # through it.
         if agent_backend in ONESHOT_REASONER_BACKENDS:
             memory_extraction_enabled = _prompt_bool(
                 "Enable memory extraction (proactive memory writes)",

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -44,6 +44,7 @@ from kai.config import (
     CODEX_MODELS,
     EFFORT_LEVELS,
     MAX_CONTEXT_CEILING,
+    ONESHOT_REASONER_BACKENDS,
     PROJECT_ROOT,
     PROVIDER_DEFAULTS,
     PROVIDER_KEY_VARS,
@@ -1237,14 +1238,13 @@ def _cmd_config() -> None:
     memory_duplicate_threshold = "0.9"
     if memory_enabled:
         # Memory extraction is supported on agent backends that have a
-        # OneShotReasoner implementation: claude, codex, and (since
-        # PR #577) opencode. Goose retrieval-only installs accept
-        # memory_enabled but skip the extraction prompt because no
-        # reasoner exists for goose. Add to the tuple when a new
-        # reasoner ships. The runtime eligibility gate at
-        # `bot._ingest_memory` and `config._compute_extraction_eligible_backends`
-        # widened to the same set; both stay in lockstep.
-        if agent_backend in ("claude", "codex", "opencode"):
+        # Membership tracks backends with a OneShotReasoner. Goose
+        # retrieval-only installs accept memory_enabled but skip the
+        # extraction prompt because no GooseOneShotReasoner exists.
+        # The runtime eligibility gate at `bot._ingest_memory` and
+        # `config._compute_extraction_eligible_backends` read from
+        # the same constant; all sites stay in lockstep through it.
+        if agent_backend in ONESHOT_REASONER_BACKENDS:
             memory_extraction_enabled = _prompt_bool(
                 "Enable memory extraction (proactive memory writes)",
                 existing_env.get("MEMORY_EXTRACTION_ENABLED", "false").lower() in ("1", "true", "yes"),
@@ -1694,11 +1694,14 @@ def _cmd_config() -> None:
     env.pop("MEMORY_EPISODE_MODEL", None)
 
     # Drop stale extraction keys when the agent backend has no memory
-    # reasoner. Today that is goose; claude and codex both support
-    # extraction. A user who flips backend from claude/codex to goose
-    # should not see lingering extraction config that would be
-    # silently ignored at runtime.
-    if agent_backend not in ("claude", "codex"):
+    # reasoner (i.e. is not in ONESHOT_REASONER_BACKENDS). A user who
+    # flips backend from a reasoner-capable backend to one without a
+    # reasoner should not see lingering extraction config that would
+    # be silently ignored at runtime. Mirrors the wizard-side
+    # extraction-prompt gate above so a value prompted-and-accepted on
+    # an eligible backend persists end to end; a value prompted on a
+    # then-ineligible backend gets dropped here.
+    if agent_backend not in ONESHOT_REASONER_BACKENDS:
         env.pop("MEMORY_EXTRACTION_ENABLED", None)
         env.pop("MEMORY_EXTRACTION_BUDGET_USD", None)
         env.pop("MEMORY_EXTRACTION_TIMEOUT_S", None)

--- a/src/kai/smoke/memory.py
+++ b/src/kai/smoke/memory.py
@@ -33,7 +33,7 @@ import logging
 import sys
 import time
 
-from kai.config import ModelRole, get_model_for, load_config
+from kai.config import ONESHOT_REASONER_BACKENDS, ModelRole, get_model_for, load_config
 from kai.memory_extraction import (
     _EXTRACTION_SYSTEM_PROMPT,
     _FACT_SCHEMA,
@@ -108,11 +108,12 @@ async def _run(user_id: str | None, os_user: str | None) -> int:
     # the same way), so reuse it directly.
     resolved_user_id = user_id if user_id is not None else "smoke"
     effective_backend = _resolve_effective_backend(resolved_user_id, config)
-    if effective_backend not in ("claude", "codex"):
+    if effective_backend not in ONESHOT_REASONER_BACKENDS:
+        eligible = ", ".join(sorted(ONESHOT_REASONER_BACKENDS))
         sys.stderr.write(
             f"smoke: effective backend {effective_backend!r} has no memory reasoner. "
-            "Pass --user-id matching a claude- or codex-effective entry in users.yaml, "
-            "or run with a global AGENT_BACKEND of claude or codex.\n"
+            f"Pass --user-id matching an entry in users.yaml whose effective backend "
+            f"is one of: {eligible}, or run with a matching global AGENT_BACKEND.\n"
         )
         return 1
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,7 @@ import pytest
 
 from kai.config import (
     MODEL_REGISTRY,
+    ONESHOT_REASONER_BACKENDS,
     Config,
     ModelRole,
     UserConfig,
@@ -3192,3 +3193,115 @@ class TestMemoryRecallShadowConfig:
         cfg = load_config()
         assert cfg.memory_enabled is False
         assert cfg.memory_recall_shadow_enabled is False
+
+
+class TestOneShotReasonerBackendsConstant:
+    """Pin the contract of `ONESHOT_REASONER_BACKENDS`. This constant
+    drives every site that gates on "does this backend support
+    one-shot agent dispatch" (memory extraction, PR review, triage,
+    smoke, behavioral eval, install-time MEMORY_* persistence). The
+    tests below pin both its membership (the set of backends with a
+    OneShotReasoner in `src/kai/oneshot.py`) and its type
+    (`frozenset`, communicating immutability and membership-only
+    intent). A type or membership drift would silently break the
+    one-shot-eligible call sites; pin both invariants here so any
+    future change is intentional.
+    """
+
+    def test_membership(self):
+        """Exactly claude, codex, and opencode have OneShotReasoner
+        implementations in `src/kai/oneshot.py` today. Goose is a
+        valid agent backend (retrieval-only memory installs work) but
+        has no `GooseOneShotReasoner`, so it must NOT be in the
+        constant.
+        """
+        assert "claude" in ONESHOT_REASONER_BACKENDS
+        assert "codex" in ONESHOT_REASONER_BACKENDS
+        assert "opencode" in ONESHOT_REASONER_BACKENDS
+        # Goose-exclusion is load-bearing: collapsing the goose
+        # backend into the one-shot-eligible set would force a goose
+        # operator into memory-extraction / review / triage paths
+        # that the goose backend cannot satisfy.
+        assert "goose" not in ONESHOT_REASONER_BACKENDS
+        # Pin the exact contents so an accidental addition is caught
+        # at test time; intentional additions update this assertion
+        # in lockstep with the constant's definition.
+        assert frozenset({"claude", "codex", "opencode"}) == ONESHOT_REASONER_BACKENDS
+
+    def test_is_frozenset(self):
+        """The constant must be a `frozenset` so callers only do
+        membership checks; a mutable container would invite per-site
+        mutation (`.add(...)`) that breaks the single-source-of-
+        truth invariant the constant is designed to enforce.
+        """
+        assert isinstance(ONESHOT_REASONER_BACKENDS, frozenset)
+
+
+class TestNoAdHocOneShotBackendTuples:
+    """Regression guard for the "no ad-hoc literal tuples" invariant.
+
+    Every site that gates on "is this backend one of the backends
+    with a OneShotReasoner" must read from `ONESHOT_REASONER_BACKENDS`
+    rather than typing a fresh literal tuple. Without this guard, a
+    future contributor who adds a new gate can silently re-introduce
+    the ad-hoc-tuple pattern that this constant was created to
+    eliminate (and that cost the opencode rollout two follow-up
+    fix-up PRs to correct).
+    """
+
+    def test_no_ad_hoc_oneshot_backend_tuples_in_source(self):
+        """Production source files must use ONESHOT_REASONER_BACKENDS
+        instead of literal claude/codex tuples for the one-shot-
+        eligibility check. This pins the invariant the constant is
+        meant to enforce: a future contributor who adds a new gate
+        must read from the constant, not type a new literal.
+
+        Allowed sites for the literal patterns:
+        - The constant's own definition in `config.py`.
+        - Module / function docstrings naming the set (informational).
+        - String literals in error messages naming the set explicitly.
+
+        Disallowed: a bare tuple `("claude", "codex")` or
+        `("claude", "codex", "opencode")` used as a membership-check
+        source.
+
+        KNOWN BLIND SPOTS the pattern does NOT catch (acceptable
+        best-effort scope; the constant's existence and the wider
+        code-review discipline catch what regex cannot):
+
+        - Reversed-order tuples (`("codex", "claude")`). No site uses
+          this shape today; if a contributor introduces one, the next
+          maintainer's grep catches it during review.
+        - Multi-line tuples (`("claude",\\n    "codex",\\n    ...)`).
+          The pattern is single-line. A contributor splitting the
+          tuple across lines bypasses the test; black/ruff formatting
+          keeps short tuples on one line in practice.
+        - Tuples with extra elements (`("claude", "codex", "opencode",
+          "goose")` or any other 4+ form). The pattern matches exactly
+          the 2-element and 3-element forms that were the historical
+          ad-hoc shape; a future widening to a literal 4-tuple would
+          not trip the test.
+        - Set / list / dict-keys forms of the same membership
+          (`{"claude", "codex"}` or `["claude", "codex"]`). The
+          operator-visible bug class this test guards against (the
+          install.py extraction-keys cleanup gate) used tuples; sets
+          and lists are rarer in this codebase but a future use
+          would slip past.
+        """
+        import re
+        from pathlib import Path
+
+        pattern = re.compile(r'\(\s*"claude"\s*,\s*"codex"(\s*,\s*"opencode")?\s*\)')
+        repo_root = Path(__file__).resolve().parent.parent
+        src = repo_root / "src" / "kai"
+        offenders: list[tuple[str, int, str]] = []
+        for path in src.rglob("*.py"):
+            # Allowed: the constant's own definition file.
+            if path.name == "config.py":
+                continue
+            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if pattern.search(line):
+                    offenders.append((str(path.relative_to(repo_root)), lineno, line.strip()))
+        assert not offenders, (
+            f"Found ad-hoc claude/codex tuples; use ONESHOT_REASONER_BACKENDS instead. Offending sites: {offenders}"
+        )

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7803,6 +7803,73 @@ class TestOpenCodeBinWizardPrompt:
         _, default, _ = opencode_prompts[0]
         assert default == str(prior_path)
 
+    def test_memory_extraction_enabled_persists_for_opencode_install(self, tmp_path, monkeypatch):
+        """An opencode operator who answers `true` to the memory
+        extraction prompt must see the value persist all the way to
+        install.conf's env dict (and from there to /etc/kai/env and
+        the runtime Config). The install-time cleanup gate that drops
+        stale MEMORY_EXTRACTION_* keys for backends without a
+        OneShotReasoner must NOT strip them for opencode (which DOES
+        have an OpenCodeOneShotReasoner).
+
+        This is the operator-visible regression test for the
+        install.py cleanup gate that previously read
+        `("claude", "codex")` and silently dropped the operator's
+        `MEMORY_EXTRACTION_ENABLED=true` answer on opencode installs.
+        Once the gate reads ONESHOT_REASONER_BACKENDS, opencode is
+        admitted and the value persists.
+
+        The base `_opencode_inputs` helper drives the wizard through
+        the memory-extraction prompt with answer `true`; this test
+        also overrides two tunable values to non-defaults so the
+        wizard's delta-from-defaults emission rule writes those keys
+        into install.conf, giving the cleanup gate's matching `.pop`
+        sites real keys to (not) strip.
+        """
+        opencode_path = tmp_path / "fake_opencode"
+        opencode_path.write_text("#!/bin/sh\necho hi\n")
+        opencode_path.chmod(0o755)
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            MagicMock(return_value="anthropic/claude-sonnet-4-5"),
+        )
+
+        # Build the input sequence; override two extraction tunables
+        # to non-default values so the wizard's delta-from-defaults
+        # emission rule writes them into install.conf and the
+        # cleanup gate has matching keys to (not) strip. The "120"
+        # value appears twice (agent timeout, then episode timeout);
+        # take the second occurrence for the episode-timeout slot.
+        inputs_list = self._opencode_inputs(str(opencode_path))
+        inputs_list[inputs_list.index("10")] = "20"  # MEMORY_EXTRACTION_TIMEOUT_S
+        first_120 = inputs_list.index("120")
+        inputs_list[inputs_list.index("120", first_120 + 1)] = "180"  # MEMORY_EPISODE_TIMEOUT_S
+        inputs = iter(inputs_list)
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        env = json.loads((tmp_path / "install.conf").read_text())["env"]
+        # AGENT_BACKEND pins which gate branch fired; opencode here
+        # exercises the previously-broken cleanup path.
+        assert env["AGENT_BACKEND"] == "opencode"
+        # MEMORY_EXTRACTION_ENABLED was always emitted by the wizard,
+        # then silently stripped by the cleanup gate before the gate
+        # read from ONESHOT_REASONER_BACKENDS. Load-bearing assertion
+        # for the operator-visible bug.
+        assert env["MEMORY_EXTRACTION_ENABLED"] == "true"
+        # The two non-default extraction tunables must also survive
+        # the cleanup. Wizard's emission rule wrote them because the
+        # operator chose values different from the dataclass defaults.
+        assert env["MEMORY_EXTRACTION_TIMEOUT_S"] == "20"
+        assert env["MEMORY_EPISODE_TIMEOUT_S"] == "180"
+
 
 class TestGenerateSudoersCodexBinArg:
     """_generate_sudoers takes codex_bin as an argument."""


### PR DESCRIPTION
## Summary

- Fix install-time cleanup gate that silently dropped `MEMORY_EXTRACTION_ENABLED=true` for opencode operators (gate still read the narrow `("claude", "codex")` tuple, so opencode fell through and lost the operator's wizard answer).
- Collapse nine ad-hoc literal tuples onto a single canonical `ONESHOT_REASONER_BACKENDS: frozenset[str]` in `kai.config`. Sites: `bot.py` extraction dispatch, `config.py` registry-completeness + extraction-eligibility, `install.py` wizard prompt gate + cleanup gate, `smoke/memory.py` acceptance, `eval/memory_backend_gate.py` `DEFAULT_BACKENDS` + pairwise threshold compare, `eval/behavioral.py` registry-backend gate.
- Add `TestOneShotReasonerBackendsConstant` (pins membership + frozenset type), `TestNoAdHocOneShotBackendTuples` (grep regression guard against future ad-hoc literals), and an opencode wizard integration test that drives `_cmd_config` with `MEMORY_EXTRACTION_ENABLED=true` plus two non-default tunables, then asserts the env dict carries them end to end.

Adding a future backend with a `OneShotReasoner` is now a one-line constant extension; the previous shape cost the opencode rollout two follow-up PRs to widen the literal across all nine sites.

The `eval/memory_backend_gate.py` pairwise compare now iterates over every pair via `itertools.combinations`; the legacy single-pair consumer is preserved via a `_LEGACY_THRESHOLD_PAIR` bridge constant derived from the constant itself rather than a hardcoded literal (the grep regression test would otherwise reject the literal). Multi-pair report rendering is left for a follow-up; this PR ships the data path only.

## Test plan

- [x] `make test` (3735 pass, 1 skipped)
- [x] `make check` (ruff check + ruff format both clean)
- [x] Focused tests for `TestOneShotReasonerBackendsConstant`, `TestNoAdHocOneShotBackendTuples`, and the new opencode wizard integration test all green
- [x] Pre-existing `TestMemoryRecallShadowConfig` still green (caught and restored a clipped assertion during testing)
- [x] Independent grep of the source tree confirms zero ad-hoc tuple sites remain

Closes #582
