### PR TITLE
feat(config): per-role per-user model selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # where tools are installed globally (no .venv).
 BIN = .venv/bin/
 
-.PHONY: run lint format check test setup config install install-status tts-model
+.PHONY: run lint format check test setup config install install-status tts-model refresh-models
 
 run:
 	$(BIN)python -m kai
@@ -32,6 +32,13 @@ install:
 
 install-status:
 	$(BIN)python -m kai install status
+
+# Refresh helper for PROVIDER_MODELS. Queries each curated provider's
+# /v1/models endpoint and prints a diff against the in-tree list;
+# operator hand-edits src/kai/config.py after review. Pass
+# `ARGS=--write-snippet` to emit a paste-able Python fragment.
+refresh-models:
+	$(BIN)python -m kai.refresh_models $(ARGS)
 
 models/ggml-base.en.bin:
 	mkdir -p models

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -365,19 +365,35 @@ def get_model_for(role: ModelRole, backend: str, provider: str, override: str = 
 
 def _check_model_registry_complete() -> None:
     """
-    Verify MODEL_REGISTRY has a row for every (backend, provider, role)
-    triple in BACKEND_PROVIDERS, AND that each codex / opencode row
-    passes its backend's shape check.
+    Validate MODEL_REGISTRY against per-backend invariants at startup.
 
     Self-driving: walks every (backend, provider) pair in
-    BACKEND_PROVIDERS rather than taking a single-backend argument.
-    Runs once at load_config() time. Raises SystemExit on a missing or
-    invalid row so the bug surfaces at startup rather than at a
-    per-request LookupError.
+    BACKEND_PROVIDERS. Runs once at load_config() time. Raises
+    SystemExit on any invariant violation so the bug surfaces at
+    startup rather than as a per-request LookupError or a per-request
+    OneShot handshake failure.
 
-    Every backend with a registry row gets validated, including
-    goose: goose folds into the unified triple-key registry, so a
-    missing goose row fails the same way a missing opencode row does.
+    Two layers of validation, only one of which is load-bearing for
+    production code:
+
+    1. Triple-key completeness (defense-in-depth). `_build_registry`
+       already guarantees every (backend, provider, role) triple in
+       BACKEND_PROVIDERS has a row, raising KeyError at module import
+       time if a `(backend, provider)` pair lacks a tier map or if
+       any `_TIER_BY_ROLE` tier is missing. The completeness loop
+       below catches post-construction mutation (test fixtures that
+       monkeypatch `delitem` on MODEL_REGISTRY) and the
+       theoretical case where a future refactor decouples
+       `_build_registry` from `BACKEND_PROVIDERS`. In production this
+       branch is unreachable.
+
+    2. Per-backend value shape (the real production guarantee):
+       - codex rows must name models the codex CLI exposes (validated
+         against CODEX_MODELS); a drift between CODEX_MODELS and the
+         tier map fails here, not at first behavioral run.
+       - opencode rows must pass `is_opencode_model_shape`; bare names
+         like "sonnet" that would survive registry construction but
+         fail at the opencode handshake are caught here.
     """
     for backend, providers in BACKEND_PROVIDERS.items():
         for provider in providers:
@@ -608,7 +624,14 @@ def get_user_backend_and_provider(user_config: "UserConfig | None", config: "Con
     return backend, provider
 
 
-def resolve_user_model(role: ModelRole, user_config: "UserConfig | None", config: "Config") -> str:
+def resolve_user_model(
+    role: ModelRole,
+    user_config: "UserConfig | None",
+    config: "Config",
+    *,
+    backend: str | None = None,
+    provider: str | None = None,
+) -> str:
     """Per-role model resolution with the per-user `models:` override.
 
     Precedence (highest first):
@@ -627,8 +650,14 @@ def resolve_user_model(role: ModelRole, user_config: "UserConfig | None", config
     Single canonical resolver used by every per-user dispatch site;
     callers that need a raw registry lookup (no user context) call
     `get_model_for` directly.
+
+    `backend` and `provider` are optional pre-resolved values. Callers
+    that already computed the effective backend / provider (memory
+    extraction threads them through both stages of the dispatch
+    pipeline) pass them as kwargs to skip the re-resolution. Either
+    both are passed or neither; the helper falls through to
+    `get_user_backend_and_provider` when they are absent.
     """
-    backend, provider = get_user_backend_and_provider(user_config, config)
     if user_config is not None and user_config.models:
         override = user_config.models.get(role.value, "")
         if override:
@@ -637,6 +666,8 @@ def resolve_user_model(role: ModelRole, user_config: "UserConfig | None", config
         global_override = config.default_models.get(role.value, "")
         if global_override:
             return global_override
+    if backend is None or provider is None:
+        backend, provider = get_user_backend_and_provider(user_config, config)
     return get_model_for(role, backend, provider)
 
 

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -73,19 +73,40 @@ VALID_BACKENDS = {"claude", "goose", "codex", "opencode"}
 # one-shot-eligibility gates the goose backend cannot satisfy.
 ONESHOT_REASONER_BACKENDS: frozenset[str] = frozenset({"claude", "codex", "opencode"})
 
-# Valid LLM providers per backend. Claude always uses Anthropic
-# (hardcoded in get_effective_provider), so it has no entry here.
-# Backends that don't appear in this dict accept no provider config.
-# OpenCode is also absent: its model string is a full `provider/model`
-# ID (e.g. `anthropic/claude-sonnet-4-6`) that encodes the provider
-# inline, and auth is managed by the OpenCode CLI itself rather than
-# by Kai's wizard. The wizard therefore skips provider/API-key
-# prompts for opencode and asks for a free-text model instead.
-# NOTE: Backends in VALID_BACKENDS that should have a provider prompt
-# need a matching key here; missing entries silently skip the prompt.
-VALID_PROVIDERS: dict[str, frozenset[str]] = {
-    "goose": frozenset({"anthropic", "openai", "google", "openrouter", "ollama"}),
+# The single authoritative (backend, provider) allowlist. Every site
+# that needs to know "what providers can this backend talk to" reads
+# from this map. Claude and codex are 1:1 with one provider each;
+# opencode and goose are 1:N. load_config validates that every user's
+# (agent_backend, llm_provider) pair is a member. Adding a new
+# backend is one row here; adding a new provider to an existing
+# backend is one tuple element. Tuple values (not frozensets) so the
+# wizard offers providers in a stable, documented order; sorted
+# alphabetically to match how operator-facing error messages render
+# them.
+BACKEND_PROVIDERS: dict[str, tuple[str, ...]] = {
+    "claude": ("anthropic",),
+    "codex": ("openai",),
+    "opencode": ("anthropic", "deepseek", "google", "ollama", "openai", "openrouter"),
+    "goose": ("anthropic", "deepseek", "google", "ollama", "openai", "openrouter"),
 }
+
+# Backends whose runtime configuration requires the operator (or
+# users.yaml) to name a provider explicitly. Derived from the
+# multiplicity of BACKEND_PROVIDERS: a single-provider backend
+# (claude, codex) does not need a provider prompt because the choice
+# is unambiguous and the per-backend code path hardcodes the provider
+# (claude through get_effective_provider, codex always openai). A
+# multi-provider backend (opencode, goose) does need an explicit
+# provider so the (backend, provider, role) registry triple-key
+# lookup can find a row.
+#
+# Kept distinct from BACKEND_PROVIDERS so claude / codex stay out of
+# the "requires provider" gates that drive the wizard provider-prompt,
+# the per-user `llm_provider` validation in _load_user_configs, and
+# the global LLM_PROVIDER env-var validation in load_config. Membership
+# in BACKEND_PROVIDERS describes what is allowed; membership here
+# describes what is required.
+BACKENDS_NEEDING_PROVIDER_PROMPT: frozenset[str] = frozenset(b for b, ps in BACKEND_PROVIDERS.items() if len(ps) > 1)
 
 # Maps LLM provider to its API key environment variable name.
 # Backend-agnostic - the API key for Anthropic is the same env var
@@ -208,86 +229,124 @@ class ModelRole(StrEnum):
     MEMORY_EPISODE = "memory_episode"
 
 
-# Values are exactly what each backend's CLI accepts as --model.
-# Claude rows match today's inline constants verbatim so the registry
-# migration is no-behavior-change:
-# - triage.py _TRIAGE_MODEL = "sonnet"
-# - review.py _REVIEW_MODEL = "sonnet"
-# - eval/behavioral.py _DEFAULT_JUDGE_MODEL = "claude-haiku-4-5-20251001"
-# - eval/behavioral.py _DEFAULT_GEN_MODEL = "sonnet"
-# Codex rows reflect editorial tier mapping: nano for cheap high-volume
-# work (judge), mini for balanced default generation (gen, triage, review).
-# Goose entries are intentionally absent: goose's model identifier
-# depends on llm_provider (the _GOOSE_AGENT_MODELS dicts in triage.py /
-# review.py already encode that per-provider resolution), which would
-# need a third axis the registry does not carry today.
-MODEL_REGISTRY: dict[tuple[str, ModelRole], str] = {
-    ("claude", ModelRole.PR_REVIEW): "sonnet",
-    ("claude", ModelRole.ISSUE_TRIAGE): "sonnet",
-    ("claude", ModelRole.BEHAVIORAL_JUDGE): "claude-haiku-4-5-20251001",
-    ("claude", ModelRole.BEHAVIORAL_GEN): "sonnet",
-    ("codex", ModelRole.PR_REVIEW): "gpt-5.4-mini",
-    ("codex", ModelRole.ISSUE_TRIAGE): "gpt-5.4-mini",
-    # gpt-5.4-mini for the judge role: the closest analog to the
-    # claude haiku tier (small, fast, cheap). gpt-5.4-nano would have
-    # matched the editorial "cheaper than mini" intent but the codex
-    # CLI does not expose it, so it would fail at first behavioral
-    # eval. _check_model_registry_complete validates registry rows
-    # against CODEX_MODELS so future drift gets caught at startup.
-    ("codex", ModelRole.BEHAVIORAL_JUDGE): "gpt-5.4-mini",
-    ("codex", ModelRole.BEHAVIORAL_GEN): "gpt-5.4-mini",
-    # Memory extraction rows. Claude entries match the historical
-    # extraction default (claude-haiku-4-5-20251001), so any install
-    # that ran under the old MEMORY_EXTRACTION_MODEL=<empty> path
-    # sees identical model resolution post-migration. Codex entries
-    # pick the smallest currently-exposed codex model (gpt-5.4-mini)
-    # on the same editorial tier as Claude's haiku selection;
-    # _check_model_registry_complete validates codex rows against
-    # CODEX_MODELS at startup so a future SKU rename surfaces the
-    # bad row before runtime.
-    ("claude", ModelRole.MEMORY_EXTRACTION): "claude-haiku-4-5-20251001",
-    ("claude", ModelRole.MEMORY_EPISODE): "claude-haiku-4-5-20251001",
-    ("codex", ModelRole.MEMORY_EXTRACTION): "gpt-5.4-mini",
-    ("codex", ModelRole.MEMORY_EPISODE): "gpt-5.4-mini",
-    # OpenCode rows use the full `provider/model` shape opencode
-    # expects (validated structurally by is_opencode_model_shape).
-    # Defaults pick anthropic/* because the anthropic provider is the
-    # most-tested opencode auth path; Sonnet for reasoning-heavy roles
-    # (review, triage, behavioral gen), Haiku for cheaper memory work
-    # and the behavioral judge. Operators who authenticated a
-    # different provider via `opencode auth login` (deepseek, openai,
-    # openrouter, google) override these in-tree the same way codex
-    # operators override the codex registry. The shape gate in
-    # _check_model_registry_complete enforces the contract; the
-    # canonical model set is install-local and operator-managed so no
-    # CLI allow-list check applies here.
-    ("opencode", ModelRole.PR_REVIEW): "anthropic/claude-sonnet-4-5",
-    ("opencode", ModelRole.ISSUE_TRIAGE): "anthropic/claude-sonnet-4-5",
-    ("opencode", ModelRole.BEHAVIORAL_JUDGE): "anthropic/claude-haiku-4-5",
-    ("opencode", ModelRole.BEHAVIORAL_GEN): "anthropic/claude-sonnet-4-5",
-    ("opencode", ModelRole.MEMORY_EXTRACTION): "anthropic/claude-haiku-4-5",
-    ("opencode", ModelRole.MEMORY_EPISODE): "anthropic/claude-haiku-4-5",
+# Per-role tier assignment. Roles that need reasoning depth (PR
+# review, issue triage, behavioral gen) pick the "balanced" tier;
+# roles that need cheap high-volume throughput (memory extraction,
+# memory episode, behavioral judge) pick "cheap". Two tiers cover
+# every current role; adding a third (e.g. "strong" for deeper
+# reasoning) means one line here plus a per-(backend, provider)
+# tier-map entry in lockstep.
+_TIER_BY_ROLE: dict[ModelRole, str] = {
+    ModelRole.PR_REVIEW: "balanced",
+    ModelRole.ISSUE_TRIAGE: "balanced",
+    ModelRole.MEMORY_EXTRACTION: "cheap",
+    ModelRole.MEMORY_EPISODE: "cheap",
+    ModelRole.BEHAVIORAL_JUDGE: "cheap",
+    ModelRole.BEHAVIORAL_GEN: "balanced",
+}
+
+# Per-(backend, provider) tier-to-model map. Names are exactly what
+# each backend's CLI accepts as --model. The backend axis matters
+# because the same underlying model is named differently across
+# backends:
+#  - claude CLI takes anthropic aliases ("sonnet", "haiku")
+#  - codex CLI takes its own model identifiers ("gpt-5.4-mini")
+#  - opencode takes full "provider/model" strings, structurally
+#    validated by is_opencode_model_shape
+#  - goose takes the provider's native model name verbatim
+# Codex collapses "balanced" and "cheap" onto gpt-5.4-mini: the next
+# step down (gpt-5.4-nano) is not in CODEX_MODELS so a "cheap" =
+# "gpt-5.4-nano" entry would fail _check_model_registry_complete at
+# startup. Every (backend, provider) pair in BACKEND_PROVIDERS must
+# have a row here; _build_registry raises KeyError at module import
+# time on any missing pair.
+_BACKEND_PROVIDER_TIER_MODELS: dict[tuple[str, str], dict[str, str]] = {
+    ("claude", "anthropic"): {"balanced": "sonnet", "cheap": "claude-haiku-4-5-20251001"},
+    ("codex", "openai"): {"balanced": "gpt-5.4-mini", "cheap": "gpt-5.4-mini"},
+    ("opencode", "anthropic"): {"balanced": "anthropic/claude-sonnet-4-5", "cheap": "anthropic/claude-haiku-4-5"},
+    ("opencode", "openai"): {"balanced": "openai/gpt-5.4-mini", "cheap": "openai/gpt-5.4-mini"},
+    ("opencode", "deepseek"): {"balanced": "deepseek/deepseek-chat", "cheap": "deepseek/deepseek-chat"},
+    ("opencode", "google"): {"balanced": "google/gemini-3.1-pro", "cheap": "google/gemini-3-flash"},
+    # OpenRouter's "provider/model" shape nests under opencode's own
+    # "provider/model" prefix; the structural check accepts this
+    # because the outer slash is what matters to opencode.
+    ("opencode", "openrouter"): {
+        "balanced": "openrouter/anthropic/claude-sonnet-4-5",
+        "cheap": "openrouter/anthropic/claude-haiku-4-5",
+    },
+    ("opencode", "ollama"): {"balanced": "ollama/llama4:70b", "cheap": "ollama/llama4:8b"},
+    ("goose", "anthropic"): {"balanced": "claude-sonnet-4-6", "cheap": "claude-haiku-4-5"},
+    ("goose", "openai"): {"balanced": "gpt-5.4", "cheap": "gpt-5.4-mini"},
+    ("goose", "deepseek"): {"balanced": "deepseek-chat", "cheap": "deepseek-chat"},
+    ("goose", "google"): {"balanced": "gemini-3.1-pro", "cheap": "gemini-3-flash"},
+    ("goose", "openrouter"): {
+        "balanced": "openrouter/anthropic/claude-sonnet-4-5",
+        "cheap": "openrouter/anthropic/claude-haiku-4-5",
+    },
+    ("goose", "ollama"): {"balanced": "llama4:70b", "cheap": "llama4:8b"},
 }
 
 
-def get_model_for(role: ModelRole, backend: str, override: str = "") -> str:
+def _build_registry() -> dict[tuple[str, str, ModelRole], str]:
+    """Fan out the (backend, provider) tier maps over every ModelRole.
+
+    Raises KeyError at module import time if any (backend, provider)
+    pair in BACKEND_PROVIDERS lacks a tier map; the precise pair name
+    appears in the exception message so the maintainer can fix the
+    omission without grepping. This intentionally fails fast rather
+    than silently skipping, because a partial registry would
+    surface as a confusing per-request LookupError much later.
     """
-    Resolve the model identifier for a (role, backend) pair.
+    rows: dict[tuple[str, str, ModelRole], str] = {}
+    for backend, providers in BACKEND_PROVIDERS.items():
+        for provider in providers:
+            try:
+                tier_map = _BACKEND_PROVIDER_TIER_MODELS[(backend, provider)]
+            except KeyError:
+                raise KeyError(
+                    f"_BACKEND_PROVIDER_TIER_MODELS missing entry for "
+                    f"(backend={backend!r}, provider={provider!r}); update "
+                    f"src/kai/config.py to include this pair."
+                ) from None
+            for role, tier in _TIER_BY_ROLE.items():
+                rows[(backend, provider, role)] = tier_map[tier]
+    return rows
+
+
+# (backend, provider, role) -> model identifier passed to the
+# backend's CLI as --model. Built mechanically from the tier scheme
+# above so a new (backend, provider) pair extends the registry via
+# one row in _BACKEND_PROVIDER_TIER_MODELS plus one tuple element in
+# BACKEND_PROVIDERS.
+MODEL_REGISTRY: dict[tuple[str, str, ModelRole], str] = _build_registry()
+
+
+def get_model_for(role: ModelRole, backend: str, provider: str, override: str = "") -> str:
+    """
+    Resolve the model identifier for a (role, backend, provider) triple.
 
     Override precedence: if `override` is truthy, it wins (used by
-    per-role env vars like ISSUE_TRIAGE_MODEL_CODEX or by CLI flags
-    like --judge-model). Otherwise the registry value is returned.
+    CLI flags like --judge-model in the behavioral eval). Otherwise
+    the registry value for the exact triple is returned.
 
-    Raises LookupError on a missing (backend, role) row. Total in the
-    steady state because _check_model_registry_complete() runs at
-    startup and fails fast (SystemExit) if any role is missing for
-    the active backend. The runtime LookupError exists for defensive
-    parsing: a request-path bug should surface as a 5xx, not a
-    process-wide SystemExit.
+    For single-provider backends (claude, codex), an empty `provider`
+    string is resolved to the implicit provider (anthropic / openai)
+    via `get_effective_provider`. This lets callers that do not have
+    a provider in scope (e.g. eval-time globals) still hit the
+    registry without an explicit lookup; multi-provider backends
+    (opencode, goose) require an explicit non-empty provider because
+    the implicit value is undefined.
+
+    Raises LookupError on a missing (backend, provider, role) row.
+    Total in the steady state because _check_model_registry_complete()
+    runs at startup and fails fast (SystemExit) if any (backend,
+    provider) pair in BACKEND_PROVIDERS is missing a role.
 
     Args:
         role: The ModelRole the caller wants a model for.
-        backend: The active backend string ("claude" or "codex").
+        backend: The active backend string (one of VALID_BACKENDS).
+        provider: The effective provider string; empty falls back to
+            the backend's implicit provider on single-provider backends.
         override: Caller-supplied override string. Empty disables.
 
     Returns:
@@ -295,71 +354,75 @@ def get_model_for(role: ModelRole, backend: str, override: str = "") -> str:
     """
     if override:
         return override
+    effective_provider = provider or get_effective_provider(backend, provider)
     try:
-        return MODEL_REGISTRY[(backend, role)]
+        return MODEL_REGISTRY[(backend, effective_provider, role)]
     except KeyError:
-        raise LookupError(f"No registry entry for (backend={backend}, role={role.value})") from None
+        raise LookupError(
+            f"No registry entry for (backend={backend}, provider={effective_provider}, role={role.value})"
+        ) from None
 
 
-def _check_model_registry_complete(backend: str) -> None:
+def _check_model_registry_complete() -> None:
     """
-    Verify MODEL_REGISTRY has a row for every role the active backend uses,
-    AND that each codex / opencode row passes its backend's shape check.
+    Verify MODEL_REGISTRY has a row for every (backend, provider, role)
+    triple in BACKEND_PROVIDERS, AND that each codex / opencode row
+    passes its backend's shape check.
 
+    Self-driving: walks every (backend, provider) pair in
+    BACKEND_PROVIDERS rather than taking a single-backend argument.
     Runs once at load_config() time. Raises SystemExit on a missing or
-    invalid row so the bug surfaces at startup rather than at a per-
-    request LookupError (which would otherwise crash a single agent
-    invocation silently if a future role were added without its
-    registry rows, or with a backend-incompatible model).
+    invalid row so the bug surfaces at startup rather than at a
+    per-request LookupError.
 
-    Goose is exempt: goose-side model resolution lives in module-level
-    _GOOSE_AGENT_MODELS dicts that this registry does not subsume.
+    Every backend with a registry row gets validated, including
+    goose: goose folds into the unified triple-key registry, so a
+    missing goose row fails the same way a missing opencode row does.
     """
-    if backend not in ONESHOT_REASONER_BACKENDS:
-        return
-    missing = [role for role in ModelRole if (backend, role) not in MODEL_REGISTRY]
-    if missing:
-        names = ", ".join(role.value for role in missing)
-        raise SystemExit(
-            f"MODEL_REGISTRY is missing rows for backend '{backend}': {names}. Update MODEL_REGISTRY in config.py."
-        )
-    # Validate codex rows against the CLI's actual model surface so a
-    # future drift (operator updates CODEX_MODELS without touching
-    # MODEL_REGISTRY, or vice versa) fails fast at startup rather
-    # than at the first behavioral / triage / review run.
-    if backend == "codex":
-        invalid = [
-            (role, MODEL_REGISTRY[(backend, role)])
-            for role in ModelRole
-            if MODEL_REGISTRY[(backend, role)] not in CODEX_MODELS
-        ]
-        if invalid:
-            valid_list = ", ".join(sorted(CODEX_MODELS.keys()))
-            details = ", ".join(f"{role.value}={model}" for role, model in invalid)
-            raise SystemExit(
-                f"MODEL_REGISTRY has codex rows naming models the codex CLI does not expose: {details}. "
-                f"Valid codex models: {valid_list}. Update MODEL_REGISTRY in config.py."
-            )
-    # Validate opencode rows against the structural shape check.
-    # OpenCode has no canonical model allow-list (75+ providers via
-    # AI SDK / Models.dev resolved at runtime against the operator's
-    # `opencode auth login` state), so what is checkable upfront is
-    # the `provider/model` shape contract. A bare value like "sonnet"
-    # in the registry would persist through model resolution and fail
-    # at the opencode handshake with no Kai-side pointer; the shape
-    # check pins the contract at startup instead.
-    if backend == "opencode":
-        invalid = [
-            (role, MODEL_REGISTRY[(backend, role)])
-            for role in ModelRole
-            if not is_opencode_model_shape(MODEL_REGISTRY[(backend, role)])
-        ]
-        if invalid:
-            details = ", ".join(f"{role.value}={model}" for role, model in invalid)
-            raise SystemExit(
-                f"MODEL_REGISTRY has opencode rows that are not in `provider/model` shape: {details}. "
-                "Update MODEL_REGISTRY in config.py."
-            )
+    for backend, providers in BACKEND_PROVIDERS.items():
+        for provider in providers:
+            missing = [role for role in ModelRole if (backend, provider, role) not in MODEL_REGISTRY]
+            if missing:
+                names = ", ".join(role.value for role in missing)
+                raise SystemExit(
+                    f"MODEL_REGISTRY is missing rows for "
+                    f"(backend='{backend}', provider='{provider}'): {names}. "
+                    f"Update _BACKEND_PROVIDER_TIER_MODELS in config.py."
+                )
+            # Codex CLI model surface check. A future drift (operator
+            # updates CODEX_MODELS without touching the tier map, or
+            # vice versa) fails fast at startup.
+            if backend == "codex":
+                invalid_codex = [
+                    (role, MODEL_REGISTRY[(backend, provider, role)])
+                    for role in ModelRole
+                    if MODEL_REGISTRY[(backend, provider, role)] not in CODEX_MODELS
+                ]
+                if invalid_codex:
+                    valid_list = ", ".join(sorted(CODEX_MODELS.keys()))
+                    details = ", ".join(f"{role.value}={model}" for role, model in invalid_codex)
+                    raise SystemExit(
+                        f"MODEL_REGISTRY has codex rows naming models the codex CLI does not expose: "
+                        f"{details}. Valid codex models: {valid_list}. "
+                        f"Update _BACKEND_PROVIDER_TIER_MODELS in config.py."
+                    )
+            # OpenCode "provider/model" shape check. OpenCode has no
+            # canonical model allow-list (75+ providers via AI SDK /
+            # Models.dev resolved at runtime against the operator's
+            # `opencode auth login` state); what is checkable upfront
+            # is the shape contract.
+            if backend == "opencode":
+                invalid_opencode = [
+                    (role, MODEL_REGISTRY[(backend, provider, role)])
+                    for role in ModelRole
+                    if not is_opencode_model_shape(MODEL_REGISTRY[(backend, provider, role)])
+                ]
+                if invalid_opencode:
+                    details = ", ".join(f"{role.value}={model}" for role, model in invalid_opencode)
+                    raise SystemExit(
+                        f"MODEL_REGISTRY has opencode rows that are not in `provider/model` "
+                        f"shape: {details}. Update _BACKEND_PROVIDER_TIER_MODELS in config.py."
+                    )
 
 
 def get_effective_provider(backend: str, llm_provider: str) -> str:
@@ -412,8 +475,8 @@ def validate_model_for_provider(model: str, provider: str) -> bool:
     Returns True if the provider is open-ended (accepts any model)
     or if the model is in the provider's curated list. Unknown providers
     (not in PROVIDER_MODELS or OPEN_ENDED_PROVIDERS) are accepted with
-    a warning - this catches the case where VALID_PROVIDERS gains
-    a new entry but PROVIDER_MODELS was not updated to match.
+    a warning; this catches the case where BACKEND_PROVIDERS gains a
+    new entry but PROVIDER_MODELS was not updated to match.
 
     Backend-aware callers should use `validate_model_for_backend`. This
     function stays as the implementation goose / claude delegate to.
@@ -422,9 +485,9 @@ def validate_model_for_provider(model: str, provider: str) -> bool:
         return True
     models = PROVIDER_MODELS.get(provider)
     if models is None:
-        # Provider is valid (passed VALID_PROVIDERS check) but has
-        # no curated model list and is not explicitly open-ended. This
-        # is a programming oversight - log it so it's visible.
+        # Provider is in BACKEND_PROVIDERS but has no curated model
+        # list and is not explicitly open-ended. This is a programming
+        # oversight; log it so the gap is visible at runtime.
         if provider:
             log.warning(
                 "Provider '%s' has no entry in PROVIDER_MODELS or OPEN_ENDED_PROVIDERS; accepting model '%s' unchecked",
@@ -458,8 +521,16 @@ def is_opencode_model_shape(model: str) -> bool:
     """
     if not model:
         return False
+    # Split on every "/" and require at least two non-empty segments.
+    # The first segment is opencode's provider prefix; remaining
+    # segments form the model_id, which itself may contain slashes
+    # for openrouter-style nesting like
+    # "openrouter/anthropic/claude-sonnet-4-5". Empty segments
+    # (leading slash, trailing slash, or "foo//bar" double-slash)
+    # all fail because the opencode provider resolver expects every
+    # path segment to be non-empty.
     parts = model.split("/")
-    if len(parts) != 2:
+    if len(parts) < 2:
         return False
     return all(parts)
 
@@ -535,6 +606,38 @@ def get_user_backend_and_provider(user_config: "UserConfig | None", config: "Con
     else:
         provider = user_config.llm_provider if user_config and user_config.llm_provider else config.llm_provider
     return backend, provider
+
+
+def resolve_user_model(role: ModelRole, user_config: "UserConfig | None", config: "Config") -> str:
+    """Per-role model resolution with the per-user `models:` override.
+
+    Precedence (highest first):
+        1. user_config.models[role.value] when present (per-user from
+           users.yaml; also seeded from legacy PR_REVIEW_MODEL_* /
+           ISSUE_TRIAGE_MODEL_* env vars at load time)
+        2. config.default_models[role.value] when present (global from
+           DEFAULT_MODELS_JSON in /etc/kai/env; captured by the wizard)
+        3. MODEL_REGISTRY[(backend, provider, role)] (curated default)
+
+    The user's per-role override wins so an operator who sets
+    `models.pr_review: deepseek/deepseek-coder` for one user does not
+    inherit the install-wide value. The global default sits between
+    per-user and the registry so the wizard's per-role customization
+    applies across users who have not set their own override.
+    Single canonical resolver used by every per-user dispatch site;
+    callers that need a raw registry lookup (no user context) call
+    `get_model_for` directly.
+    """
+    backend, provider = get_user_backend_and_provider(user_config, config)
+    if user_config is not None and user_config.models:
+        override = user_config.models.get(role.value, "")
+        if override:
+            return override
+    if config.default_models:
+        global_override = config.default_models.get(role.value, "")
+        if global_override:
+            return global_override
+    return get_model_for(role, backend, provider)
 
 
 # Maximum context window size in tokens. Claude's hard ceiling.
@@ -720,6 +823,19 @@ class UserConfig:
     github_notify_chat_id: int | None = None
     pr_review: bool | None = None
     issue_triage: bool | None = None
+    # Per-role per-user model overrides loaded from users.yaml `models:`.
+    # Keys are role identifiers: "agent" for the conversational role
+    # plus every ModelRole.value ("pr_review", "issue_triage",
+    # "memory_extraction", "memory_episode", "behavioral_judge",
+    # "behavioral_gen"). Values are the model strings the user's
+    # backend's CLI accepts; same shape rules as the global
+    # MODEL_REGISTRY's (backend, provider, role) rows. Missing keys
+    # fall through to the registry default.
+    #
+    # Back-compat: a user with legacy `model:` set and no `models:`
+    # gets `models["agent"] = model_value` synthesized at load time
+    # so existing users.yaml files keep working unchanged.
+    models: dict[str, str] | None = None
 
 
 # ── Config dataclass ─────────────────────────────────────────────────
@@ -780,6 +896,13 @@ class Config:
 
     # Claude Code process configuration
     default_model: str = "sonnet"
+    # Global per-role model defaults. Parsed from DEFAULT_MODELS_JSON
+    # env var at load time as a JSON object: keys are role identifiers
+    # ("agent" plus every ModelRole.value), values are model strings.
+    # Sits between per-user UserConfig.models (highest precedence) and
+    # MODEL_REGISTRY[(backend, provider, role)] (lowest) in the
+    # resolution chain that `resolve_user_model` implements.
+    default_models: dict[str, str] = field(default_factory=dict)
     claude_timeout_seconds: int = 120
     budget_ceiling: float = 10.0
     claude_max_session_hours: float = 0  # 0 = no limit
@@ -1682,6 +1805,98 @@ def _compute_extraction_eligible_backends(
     return eligible
 
 
+def _apply_legacy_model_env_overrides(
+    user_configs: dict[int, "UserConfig"],
+    default_backend: str,
+) -> dict[int, "UserConfig"]:
+    """Seed UserConfig.models from the deprecated per-role env vars.
+
+    Reads PR_REVIEW_MODEL_<EFFECTIVE_BACKEND> and
+    ISSUE_TRIAGE_MODEL_<EFFECTIVE_BACKEND> from the process env for
+    each user. EFFECTIVE_BACKEND is the user's per-user override
+    (`uc.agent_backend`) or `default_backend` when the user has no
+    override. The resolution is inlined as a single fallback
+    expression rather than calling `get_user_backend_and_provider`,
+    because the full Config object is not yet built at this point in
+    `load_config` (this pass runs immediately after `_load_user_configs`,
+    before the Config constructor runs). Provider is not needed by
+    this function; only `backend` drives the env-var suffix.
+
+    Per-user `models:` entries always win over the env-var seed; only
+    roles absent from the user's own map get seeded.
+
+    Logs a one-shot deprecation warning the first time ANY user gets
+    a seed value applied; one log line per `load_config` call, not
+    per user. The warning names the env var, the role it seeds, and
+    points the operator at the users.yaml `models:` migration path.
+
+    Returns a new user_configs dict (UserConfig is a frozen dataclass;
+    `dataclasses.replace` is required to update the models field).
+    """
+    import dataclasses
+
+    warned = False
+    out: dict[int, UserConfig] = {}
+    for uid, uc in user_configs.items():
+        backend = uc.agent_backend or default_backend
+        existing_models = dict(uc.models or {})
+        for role_str, env_prefix in [
+            ("pr_review", "PR_REVIEW_MODEL"),
+            ("issue_triage", "ISSUE_TRIAGE_MODEL"),
+        ]:
+            if role_str in existing_models:
+                continue  # user's own map wins
+            env_value = os.environ.get(f"{env_prefix}_{backend.upper()}", "").strip()
+            if not env_value:
+                continue
+            existing_models[role_str] = env_value
+            if not warned:
+                log.warning(
+                    "%s_%s is deprecated; migrate the value into the "
+                    "user's `models.%s` field in users.yaml. The env "
+                    "var continues to work as a fallback for the "
+                    "current major version.",
+                    env_prefix,
+                    backend.upper(),
+                    role_str,
+                )
+                warned = True
+        out[uid] = dataclasses.replace(uc, models=existing_models or None)
+    return out
+
+
+def _compute_extraction_eligible_backend_provider_pairs(
+    agent_backend: str,
+    agent_provider: str,
+    user_configs: dict[int, UserConfig],
+    memory_extraction_enabled: bool,
+) -> set[tuple[str, str]]:
+    """
+    Return the set of distinct (effective_backend, effective_provider)
+    pairs across extraction-eligible users.
+
+    Same shape as `_compute_extraction_eligible_backends` but paired
+    with the user's effective provider so callers can look up per-role
+    models in the (backend, provider, role) MODEL_REGISTRY. Used by
+    `memory.config` startup logging to render each eligible pair's
+    extraction and episode model selection.
+    """
+    if not memory_extraction_enabled:
+        return set()
+    eligible: set[tuple[str, str]] = set()
+    for uc in user_configs.values():
+        eff_backend = uc.agent_backend or agent_backend
+        if eff_backend not in ONESHOT_REASONER_BACKENDS:
+            continue
+        eff_provider = uc.llm_provider or agent_provider
+        if eff_backend == "claude":
+            eff_provider = "anthropic"
+        elif eff_backend == "codex":
+            eff_provider = "openai"
+        eligible.add((eff_backend, eff_provider))
+    return eligible
+
+
 def _load_user_configs(
     global_backend: str,
     global_llm_provider: str,
@@ -1882,7 +2097,17 @@ def _load_user_configs(
             # Validate against the user's effective backend. If the user
             # has no explicit backend, validate against the global one.
             eff_backend_for_val = user_backend or global_backend
-            valid = VALID_PROVIDERS.get(eff_backend_for_val)
+            # Validate against BACKEND_PROVIDERS only when the backend
+            # requires a provider prompt. Single-provider backends
+            # (claude, codex) are absent from BACKENDS_NEEDING_PROVIDER_PROMPT,
+            # so a per-user llm_provider override on those backends is
+            # accepted without a curated-list check (the provider is
+            # implicit at runtime regardless of what users.yaml says).
+            valid: tuple[str, ...] | None = (
+                BACKEND_PROVIDERS.get(eff_backend_for_val)
+                if eff_backend_for_val in BACKENDS_NEEDING_PROVIDER_PROMPT
+                else None
+            )
             if valid is not None and provider_str not in valid:
                 raise SystemExit(
                     f"users.yaml: user '{name}' has invalid llm_provider "
@@ -1899,7 +2124,7 @@ def _load_user_configs(
 
         # If user's effective backend requires a provider but none can be
         # resolved (neither user-level nor global), that's a fatal config error.
-        if eff_backend in VALID_PROVIDERS and not eff_provider_str:
+        if eff_backend in BACKENDS_NEEDING_PROVIDER_PROMPT and not eff_provider_str:
             raise SystemExit(
                 f"users.yaml: user '{name}' has agent_backend='{eff_backend}' but no "
                 f"llm_provider is configured (set it in users.yaml or as "
@@ -2100,6 +2325,52 @@ def _load_user_configs(
                     raw_triage,
                 )
 
+        # Per-role per-user model overrides (`models:` sub-map). Keys
+        # are "agent" plus any ModelRole.value; values are model strings
+        # the user's backend's CLI accepts. Validation mirrors the
+        # legacy `model:` field's check via validate_model_for_backend.
+        # An invalid key or value raises SystemExit so the operator
+        # sees the precise failure at startup rather than at first
+        # dispatch.
+        user_models: dict[str, str] | None = None
+        raw_models = entry.get("models")
+        if raw_models is not None:
+            if not isinstance(raw_models, dict):
+                raise SystemExit(
+                    f"users.yaml: user '{name}' has `models` that is not a mapping; "
+                    f"expected a sub-map of role -> model string."
+                )
+            valid_role_keys = {"agent", *(r.value for r in ModelRole)}
+            checked: dict[str, str] = {}
+            for raw_key, raw_value in raw_models.items():
+                role_key = str(raw_key).strip().lower()
+                if role_key not in valid_role_keys:
+                    raise SystemExit(
+                        f"users.yaml: user '{name}' has models.{role_key!r} which is not "
+                        f"a recognized role; valid roles: {', '.join(sorted(valid_role_keys))}."
+                    )
+                value_str = str(raw_value).strip()
+                if not value_str:
+                    raise SystemExit(
+                        f"users.yaml: user '{name}' has models.{role_key} with an empty value; "
+                        f"remove the key or set a non-empty model string."
+                    )
+                if not validate_model_for_backend(value_str, eff_backend, eff_provider):
+                    raise SystemExit(
+                        f"users.yaml: user '{name}' has models.{role_key}={value_str!r} which is "
+                        f"not valid for (backend={eff_backend}, provider={eff_provider})."
+                    )
+                checked[role_key] = value_str
+            user_models = checked if checked else None
+
+        # Back-compat: if the operator only set the legacy `model:`
+        # field, synthesize `models["agent"] = model_value` so the
+        # in-memory shape matches users.yaml entries that use the
+        # `models:` map. The on-disk file is untouched; the next
+        # `make config` re-run writes the canonical shape.
+        if user_models is None and model is not None:
+            user_models = {"agent": model}
+
         configs[telegram_id] = UserConfig(
             telegram_id=telegram_id,
             name=name,
@@ -2119,6 +2390,7 @@ def _load_user_configs(
             github_notify_chat_id=github_notify_chat_id,
             pr_review=pr_review,
             issue_triage=issue_triage,
+            models=user_models,
         )
 
     if not configs:
@@ -2366,12 +2638,17 @@ def load_config() -> Config:
     # uses _GOOSE_AGENT_MODELS dicts, not the registry). Raises
     # SystemExit on a missing row so the bug surfaces at startup rather
     # than as a per-request LookupError.
-    _check_model_registry_complete(agent_backend)
+    _check_model_registry_complete()
 
     # LLM provider - validated against the backend's supported set.
-    # Only required for non-Claude backends.
+    # Single-provider backends (claude, codex) skip the prompt because
+    # their provider is implicit; multi-provider backends (opencode,
+    # goose) must name one so the (backend, provider, role) registry
+    # lookup can find a row.
     llm_provider = ""
-    valid_providers = VALID_PROVIDERS.get(agent_backend)
+    valid_providers: tuple[str, ...] | None = (
+        BACKEND_PROVIDERS.get(agent_backend) if agent_backend in BACKENDS_NEEDING_PROVIDER_PROMPT else None
+    )
     if valid_providers is not None:
         llm_provider = os.environ.get("LLM_PROVIDER", "").strip().lower()
         if llm_provider not in valid_providers:
@@ -2437,6 +2714,11 @@ def load_config() -> Config:
         ("MEMORY_REASONER_BACKEND", "memory reasoner is now derived per-user from agent_backend"),
         ("MEMORY_EXTRACTION_MODEL", "memory extraction model is now resolved per-user from the MODEL_REGISTRY"),
         ("MEMORY_EPISODE_MODEL", "memory episode model is now resolved per-user from the MODEL_REGISTRY"),
+        (
+            "GOOSE_MODEL",
+            "goose model selection now flows through the (backend, provider, role) "
+            "MODEL_REGISTRY and per-user `models.agent` in users.yaml",
+        ),
     )
     for _legacy_key, _reason in _deprecated_memory_env:
         if os.environ.get(_legacy_key):
@@ -2576,6 +2858,14 @@ def load_config() -> Config:
     # path is always one of the two resolved defaults.
     users_yaml_path = _resolve_users_yaml_path(bool(protected_env))
     user_configs = _load_user_configs(agent_backend, llm_provider, users_yaml_path)
+    # Seed UserConfig.models from the deprecated per-role env vars
+    # (PR_REVIEW_MODEL_<BACKEND> / ISSUE_TRIAGE_MODEL_<BACKEND>). The
+    # values reach dispatch through UserConfig.models rather than via
+    # the historic dispatch-time env reads in review.py / triage.py
+    # so the per-user `models:` map remains the single source of
+    # truth for per-role selection. One-shot deprecation warning
+    # fires inside the helper when any seed value applies.
+    user_configs = _apply_legacy_model_env_overrides(user_configs, agent_backend)
     allowed_ids = set(user_configs.keys())
     if os.environ.get("ALLOWED_USER_IDS", "").strip():
         log.warning(
@@ -2596,25 +2886,18 @@ def load_config() -> Config:
         agent_backend, user_configs, memory_extraction_enabled
     )
 
-    # Registry completeness and binary resolution per
-    # eligible backend. With model env vars retired, get_model_for()
-    # is the only check that a (role, backend) registry row exists;
-    # the existing early _check_model_registry_complete(agent_backend)
-    # call covers conversational + triage + review + behavioral-eval
-    # rows for the global backend, but a per-user override to a
-    # different backend would reach runtime without its memory-role
-    # rows being validated. Loop over the eligible set after
-    # _load_user_configs runs so per-user overrides are visible.
-    # `_check_model_registry_complete` is idempotent so re-running
-    # it for the global backend if it appears in the set is harmless.
-    # `resolve_oneshot_binary` is gated on the same set so a missing
-    # CODEX_BIN on a deployment where any user routes to codex fails
-    # fast at startup instead of at the first extraction.
+    # Per-eligible-backend binary resolution. The earlier
+    # _check_model_registry_complete() call is self-driving over every
+    # (backend, provider) pair in BACKEND_PROVIDERS, so registry rows
+    # are already validated for every backend including per-user
+    # overrides. `resolve_oneshot_binary` is per-backend (CODEX_BIN
+    # location, opencode binary path) so it stays in the loop;
+    # a missing CODEX_BIN on a deployment where any user routes to
+    # codex fails fast at startup instead of at the first extraction.
     if memory_extraction_enabled and extraction_eligible_backends:
         from kai.oneshot_binary import BinaryResolutionError, resolve_oneshot_binary
 
         for _backend in sorted(extraction_eligible_backends):
-            _check_model_registry_complete(_backend)
             try:
                 resolve_oneshot_binary(_backend)
             except BinaryResolutionError as e:
@@ -2670,6 +2953,39 @@ def load_config() -> Config:
 
     default_model = os.environ.get("DEFAULT_MODEL", "sonnet")
 
+    # Parse DEFAULT_MODELS_JSON: global per-role defaults captured by
+    # the wizard's per-role customization step. Empty / unset / invalid
+    # JSON collapses to an empty dict, which leaves resolve_user_model
+    # falling through to MODEL_REGISTRY for every role; the wizard
+    # writes the key only when at least one captured value differed
+    # from the registry default (delta-from-defaults), so the absence
+    # of the key in env reflects "operator accepted every default".
+    default_models_raw = os.environ.get("DEFAULT_MODELS_JSON", "").strip()
+    default_models: dict[str, str] = {}
+    if default_models_raw:
+        import json
+
+        try:
+            parsed = json.loads(default_models_raw)
+        except ValueError as e:
+            raise SystemExit(
+                f"DEFAULT_MODELS_JSON is not valid JSON: {e}. Re-run `make config` or remove the env var."
+            ) from None
+        if not isinstance(parsed, dict):
+            raise SystemExit(f"DEFAULT_MODELS_JSON must be a JSON object; got {type(parsed).__name__}.")
+        valid_role_keys = {"agent", *(r.value for r in ModelRole)}
+        for raw_key, raw_value in parsed.items():
+            role_key = str(raw_key).strip().lower()
+            if role_key not in valid_role_keys:
+                raise SystemExit(
+                    f"DEFAULT_MODELS_JSON: unrecognized role '{role_key}'; "
+                    f"valid roles: {', '.join(sorted(valid_role_keys))}."
+                )
+            value_str = str(raw_value).strip()
+            if not value_str:
+                raise SystemExit(f"DEFAULT_MODELS_JSON: empty value for role '{role_key}'.")
+            default_models[role_key] = value_str
+
     # Validate DEFAULT_MODEL against the effective global backend.
     # Codex installs validate against CODEX_MODELS only - no fallback
     # to PROVIDER_MODELS["openai"]. Other backends still use the
@@ -2694,6 +3010,7 @@ def load_config() -> Config:
         telegram_webhook_secret=telegram_webhook_secret,
         allowed_user_ids=allowed_ids,
         default_model=default_model,
+        default_models=default_models,
         claude_timeout_seconds=claude_timeout_seconds,
         budget_ceiling=budget_ceiling,
         claude_max_session_hours=claude_max_session_hours,

--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -2290,15 +2290,23 @@ async def _run_cli(args: argparse.Namespace) -> int:
     # byte-identical rather than crashing with a LookupError on an
     # unset flag.
     eval_backend = os.environ.get("AGENT_BACKEND", "claude").strip().lower()
+    # Provider is read from the eval-time LLM_PROVIDER env (the eval
+    # gate runs as a developer tool against the operator's configured
+    # backend / provider, not against a sandboxed user). Single-provider
+    # backends (claude, codex) ignore this value because their provider
+    # is implicit at runtime.
+    eval_provider = os.environ.get("LLM_PROVIDER", "").strip().lower()
     if eval_backend in ONESHOT_REASONER_BACKENDS:
         resolved_judge_model = get_model_for(
             ModelRole.BEHAVIORAL_JUDGE,
             eval_backend,
+            eval_provider,
             override=args.judge_model or "",
         )
         resolved_gen_model = get_model_for(
             ModelRole.BEHAVIORAL_GEN,
             eval_backend,
+            eval_provider,
             override=args.gen_model or "",
         )
     else:

--- a/src/kai/eval/memory_backend_gate.py
+++ b/src/kai/eval/memory_backend_gate.py
@@ -36,6 +36,7 @@ import dataclasses
 import hashlib
 import json
 import logging
+import os
 import re
 import sys
 from dataclasses import dataclass, field
@@ -729,16 +730,19 @@ async def run_backend(
     elif memory.get_all(user_id=sandbox_user_id, limit=1):
         raise SystemExit(f"sandbox user {sandbox_user_id!r} has existing rows; pass --reset to clear them")
 
-    # Memory models for this run come from the per-backend registry,
-    # matching what `_resolve_effective_backend` -> `get_model_for`
+    # Memory models for this run come from the per-(backend, provider)
+    # registry, matching what `get_model_for(role, backend, provider)`
     # produces in production per-extraction. Pinned here so the
     # BackendRun summary reports the same SKUs the reasoner actually
-    # spawned.
+    # spawned. Eval-time provider comes from the LLM_PROVIDER env var
+    # (the gate runs as a developer tool against the operator's
+    # configured backend / provider, not against a sandboxed user).
+    eval_provider = os.environ.get("LLM_PROVIDER", "").strip().lower()
     run = BackendRun(
         backend=backend,
         sandbox_user_id=sandbox_user_id,
-        model_fact=get_model_for(ModelRole.MEMORY_EXTRACTION, backend),
-        model_episode=get_model_for(ModelRole.MEMORY_EPISODE, backend),
+        model_fact=get_model_for(ModelRole.MEMORY_EXTRACTION, backend, eval_provider),
+        model_episode=get_model_for(ModelRole.MEMORY_EPISODE, backend, eval_provider),
         log_path=log_path,
     )
 

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -40,17 +40,20 @@ from pathlib import Path
 import yaml
 
 from kai.config import (
+    BACKEND_PROVIDERS,
+    BACKENDS_NEEDING_PROVIDER_PROMPT,
     CODEX_DEFAULT_MODEL,
     CODEX_MODELS,
     EFFORT_LEVELS,
     MAX_CONTEXT_CEILING,
+    MODEL_REGISTRY,
     ONESHOT_REASONER_BACKENDS,
     PROJECT_ROOT,
     PROVIDER_DEFAULTS,
     PROVIDER_KEY_VARS,
     PROVIDER_MODELS,
     VALID_BACKENDS,
-    VALID_PROVIDERS,
+    ModelRole,
     _read_protected_file,
     models_for_backend,
     validate_model_for_backend,
@@ -215,9 +218,9 @@ def _prompt_default_model(agent_backend: str, eff_provider: str, default_val: st
       anthropic, openai, google) ship a fixed model list; the operator
       picks from the list via _prompt_choice.
     - Open-ended providers (those in OPEN_ENDED_PROVIDERS, currently
-      openrouter and ollama; also any provider in VALID_PROVIDERS without
-      a PROVIDER_MODELS entry) accept arbitrary model identifiers; the
-      operator types one via _prompt(required=True).
+      openrouter and ollama; also any provider in BACKEND_PROVIDERS
+      without a PROVIDER_MODELS entry) accept arbitrary model
+      identifiers; the operator types one via _prompt(required=True).
 
     The required=True on the open-ended branch forces the operator to
     commit to a concrete model string. load_config falls back to "sonnet"
@@ -796,10 +799,10 @@ def _cmd_config() -> None:
 
     # Codex auth handling runs BEFORE the legacy provider/key block so
     # subscription mode is not gated on an OPENAI_API_KEY the operator
-    # does not need. VALID_PROVIDERS["codex"] is intentionally unset
-    # (codex is openai-only and has its own auth model), so the
-    # legacy block below skips codex entirely - same path claude
-    # follows today.
+    # does not need. Codex sits outside BACKENDS_NEEDING_PROVIDER_PROMPT
+    # (it is single-provider: always openai), so the provider/API-key
+    # block below skips codex entirely; codex follows the same path
+    # claude does for the provider prompt.
     #
     # Gate on the global `agent_backend` selection only. Per-user
     # `agent_backend: codex` overrides in users.yaml do NOT trigger
@@ -852,14 +855,14 @@ def _cmd_config() -> None:
             print("  different os_users, log in as each of those too.")
 
     # OpenCode setup: binary-path wizard prompt + post-install auth
-    # reminder. OpenCode is intentionally absent from VALID_PROVIDERS
-    # (its auth lives in ~/.local/share/opencode/auth.json,
-    # operator-managed via `opencode auth login`), so the
-    # provider/API-key block below is skipped naturally. Model
-    # selection routes through _prompt_default_model later in this
-    # function; since models_for_backend("opencode", _) returns None,
-    # the operator gets a free-text prompt for a full `provider/model`
-    # ID.
+    # reminder. OpenCode joins BACKENDS_NEEDING_PROVIDER_PROMPT so the
+    # operator names the provider used by the (backend, provider, role)
+    # registry; the API-key sub-prompt skips for opencode because
+    # opencode auth lives in `~/.local/share/opencode/auth.json` and
+    # is managed via `opencode auth login`, not by Kai. Model selection
+    # routes through _prompt_default_model later in this function; since
+    # models_for_backend("opencode", _) returns None, the operator gets
+    # a free-text prompt for a full `provider/model` ID.
     #
     # Gate on the global `agent_backend` selection only. Per-user
     # `agent_backend: opencode` overrides in users.yaml do NOT trigger
@@ -893,32 +896,40 @@ def _cmd_config() -> None:
         print("  Kai writes the active model into OPENCODE_CONFIG_CONTENT at process spawn;")
         print("  OpenCode resolves it against the credentials in ~/.local/share/opencode/auth.json.")
 
-    # Non-Claude backends: provider and API key. The provider choice
-    # determines which env var to prompt for (or none for ollama).
-    # Codex and OpenCode are intentionally absent from VALID_PROVIDERS,
-    # so this block only fires for goose; codex is handled in the
-    # dedicated branch above and opencode in the block immediately
-    # above (no API key needed; auth is opencode-cli-managed).
+    # Multi-provider backends (opencode, goose): operator picks the
+    # provider that drives the (backend, provider, role) registry
+    # lookup at runtime. Single-provider backends (claude, codex)
+    # bypass this block via BACKENDS_NEEDING_PROVIDER_PROMPT
+    # membership; their provider is implicit (claude through
+    # get_effective_provider, codex always openai). OpenCode also
+    # skips the API-key sub-prompt because opencode's auth is
+    # managed by `opencode auth login`, not by Kai; the wizard
+    # captures only the provider name so the registry triple-key
+    # can find a row.
     llm_provider = ""
     llm_api_key_var = ""
     llm_api_key = ""
-    valid_providers = VALID_PROVIDERS.get(agent_backend)
+    valid_providers: tuple[str, ...] | None = (
+        BACKEND_PROVIDERS.get(agent_backend) if agent_backend in BACKENDS_NEEDING_PROVIDER_PROMPT else None
+    )
     if valid_providers is not None:
         llm_provider = _prompt_choice(
             "LLM provider",
             sorted(valid_providers),
             existing_env.get("LLM_PROVIDER", ""),
         )
-        llm_api_key_var = PROVIDER_KEY_VARS.get(llm_provider, "")
-        if llm_api_key_var:
-            llm_api_key = _prompt(
-                llm_api_key_var,
-                existing_env.get(llm_api_key_var, ""),
-                required=True,
-            )
-        else:
-            # Ollama, Copilot, etc.: no API key needed
-            print(f"  {llm_provider} does not require an API key.")
+        if agent_backend != "opencode":
+            llm_api_key_var = PROVIDER_KEY_VARS.get(llm_provider, "")
+            if llm_api_key_var:
+                llm_api_key = _prompt(
+                    llm_api_key_var,
+                    existing_env.get(llm_api_key_var, ""),
+                    required=True,
+                )
+            else:
+                # Ollama and any other auth-less provider on the
+                # goose path.
+                print(f"  {llm_provider} does not require an API key.")
     print()
 
     # -- Claude --
@@ -979,6 +990,81 @@ def _cmd_config() -> None:
             print(f"  DEFAULT_MODEL '{raw_existing_model}' is not valid for {surface}. Please choose a new default.")
         default_model_prefill_value = _default_model_prefill()
     model = _prompt_default_model(agent_backend, eff_provider, default_model_prefill_value)
+
+    # Per-role model customization. The conversational role (`agent`)
+    # was just captured via `_prompt_default_model` above; this block
+    # offers the six non-conversational roles (PR review, issue triage,
+    # memory extraction, memory episode, behavioral judge, behavioral
+    # gen) as an optional follow-up. Default-accept is one keystroke
+    # ("no, use registry defaults"); operators who want per-role
+    # control answer yes and walk the role list.
+    #
+    # The captured dict drops entries equal to the registry default
+    # (delta-from-defaults discipline). The result writes to
+    # DEFAULT_MODELS_JSON in /etc/kai/env so load_config sees it as
+    # a global fallback below per-user `models:` and above the
+    # MODEL_REGISTRY default.
+    default_models_override: dict[str, str] = {}
+    existing_default_models_raw = existing_env.get("DEFAULT_MODELS_JSON", "").strip()
+    existing_default_models: dict[str, str] = {}
+    if existing_default_models_raw:
+        try:
+            parsed_existing = json.loads(existing_default_models_raw)
+            if isinstance(parsed_existing, dict):
+                existing_default_models = {str(k): str(v) for k, v in parsed_existing.items()}
+        except ValueError:
+            # Invalid JSON in env: ignore; the wizard re-captures.
+            pass
+
+    customize_models = _prompt_bool(
+        "Customize per-role models (PR review, triage, memory, eval)",
+        default=bool(existing_default_models),
+    )
+    if customize_models:
+        # `models_for_backend` returns a curated dict for the
+        # claude / codex / goose-on-curated path, or None for opencode
+        # and OPEN_ENDED_PROVIDERS (openrouter, ollama). Branch on
+        # the return: curated path uses _prompt_choice, None path
+        # uses free-text _prompt with the registry default as
+        # suggestion.
+        model_surface = models_for_backend(agent_backend, eff_provider)
+        # Only prompt for roles the active backend can actually serve;
+        # _build_registry guarantees a row exists for every (backend,
+        # provider, role) triple in BACKEND_PROVIDERS, but the
+        # behavioral roles are eval-only and rarely set per-user.
+        # Walk every ModelRole regardless so the wizard surfaces the
+        # full set; operators accept defaults to skip individual roles.
+        for role in ModelRole:
+            role_key = role.value
+            try:
+                role_default = MODEL_REGISTRY[(agent_backend, eff_provider, role)]
+            except KeyError:
+                # Registry has no row for this triple; skip the role
+                # rather than offering an empty suggestion. Will not
+                # happen in steady state because _check_model_registry_complete
+                # asserts completeness at load_config time.
+                continue
+            existing_value = existing_default_models.get(role_key, role_default)
+            if model_surface is None:
+                # opencode + OPEN_ENDED_PROVIDERS: free-text prompt.
+                # The operator's auth state determines validity; a
+                # curated keyboard would mislead.
+                value = _prompt(
+                    f"  {role_key}",
+                    default=existing_value,
+                )
+            else:
+                # claude / codex / goose-on-curated: numbered-choice
+                # list from the curated dict. The operator's last
+                # selected value (or registry default) pre-fills as
+                # the highlighted default.
+                value = _prompt_choice(
+                    f"  {role_key}",
+                    sorted(model_surface.keys()),
+                    existing_value,
+                )
+            if value and value != role_default:
+                default_models_override[role_key] = value
 
     while True:
         # AGENT_TIMEOUT_SECONDS is canonical; legacy
@@ -1544,6 +1630,16 @@ def _cmd_config() -> None:
     # makes the env file self-describing and forces the wizard layer
     # to own the validation responsibility.
     env["DEFAULT_MODEL"] = model
+
+    # DEFAULT_MODELS_JSON carries the per-role customization overrides
+    # captured above (delta-from-defaults: only roles the operator
+    # changed appear). load_config parses it as global fallback below
+    # per-user `models:` and above the MODEL_REGISTRY default.
+    # Suppress the key entirely when the operator accepted every
+    # default so /etc/kai/env stays as a delta from the in-tree
+    # canonical surface.
+    if default_models_override:
+        env["DEFAULT_MODELS_JSON"] = json.dumps(default_models_override, sort_keys=True)
 
     # AGENT_TIMEOUT_SECONDS is an inheritable installation default;
     # per-user timeouts in users.yaml override at runtime. Always

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -1192,11 +1192,19 @@ def init_memory(config: Config) -> None:
     # (MEMORY_ENABLED=true with extraction disabled) produce an empty
     # eligible set, so the resolver loop is a no-op and the map is
     # empty.
-    from kai.config import ModelRole, _compute_extraction_eligible_backends, get_model_for
-
-    eligible_backends: set[str] = _compute_extraction_eligible_backends(
-        config.agent_backend, config.user_configs, config.memory_extraction_enabled
+    from kai.config import (
+        ModelRole,
+        _compute_extraction_eligible_backend_provider_pairs,
+        get_model_for,
     )
+
+    eligible_pairs: set[tuple[str, str]] = _compute_extraction_eligible_backend_provider_pairs(
+        config.agent_backend,
+        config.llm_provider,
+        config.user_configs,
+        config.memory_extraction_enabled,
+    )
+    eligible_backends: set[str] = {backend for backend, _ in eligible_pairs}
     extraction_binaries: dict[str, str | None] = {}
     if eligible_backends:
         from kai.oneshot_binary import BinaryResolutionError, resolve_oneshot_binary
@@ -1237,12 +1245,32 @@ def init_memory(config: Config) -> None:
     # the actual model each backend will run, not an env var. Empty
     # eligible set (retrieval-only memory) leaves both maps empty
     # and the uniform/per-user mode keys unset.
-    extraction_models: dict[str, str] = {
-        backend: get_model_for(ModelRole.MEMORY_EXTRACTION, backend) for backend in sorted(eligible_backends)
+    # Per-backend resolution: when multiple providers are eligible for
+    # the same backend (rare; possible when multi-user installs route
+    # different users through different providers on opencode/goose),
+    # pick the alphabetically first provider's model for the legacy
+    # log-shape's backend-keyed entry. The per-pair detail is preserved
+    # via `extraction_pairs` / `episode_pairs` keyed by "backend/provider"
+    # so operators can still see every distinct registry hit.
+    def _pair_key(backend: str, provider: str) -> str:
+        return f"{backend}/{provider}" if provider else backend
+
+    extraction_pairs: dict[str, str] = {
+        _pair_key(backend, provider): get_model_for(ModelRole.MEMORY_EXTRACTION, backend, provider)
+        for backend, provider in sorted(eligible_pairs)
     }
-    episode_models: dict[str, str] = {
-        backend: get_model_for(ModelRole.MEMORY_EPISODE, backend) for backend in sorted(eligible_backends)
+    episode_pairs: dict[str, str] = {
+        _pair_key(backend, provider): get_model_for(ModelRole.MEMORY_EPISODE, backend, provider)
+        for backend, provider in sorted(eligible_pairs)
     }
+    extraction_models: dict[str, str] = {}
+    episode_models: dict[str, str] = {}
+    for backend, provider in sorted(eligible_pairs):
+        # First (alphabetically sorted) provider per backend wins for
+        # the legacy backend-keyed entry; downstream consumers reading
+        # extraction_models[backend] keep working.
+        extraction_models.setdefault(backend, get_model_for(ModelRole.MEMORY_EXTRACTION, backend, provider))
+        episode_models.setdefault(backend, get_model_for(ModelRole.MEMORY_EPISODE, backend, provider))
 
     # Uniform vs per-user log shape. Single-eligible-backend installs
     # keep the legacy `reasoner_backend` + `extraction_model` flat keys
@@ -1278,6 +1306,8 @@ def init_memory(config: Config) -> None:
                 "extraction_model": flat_model,
                 "extraction_models": extraction_models,
                 "episode_models": episode_models,
+                "extraction_pairs": extraction_pairs,
+                "episode_pairs": episode_pairs,
                 "extraction_binaries": extraction_binaries,
             }
         ),

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -28,7 +28,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 
 from kai import memory
-from kai.config import Config, ModelRole, get_model_for
+from kai.config import Config, ModelRole, resolve_user_model
 from kai.memory import MemoryResult
 from kai.oneshot import _EXTRACTOR_CWD as _EXTRACTOR_CWD
 from kai.oneshot import _SUBPROCESS_ENV_ALLOWLIST as _SUBPROCESS_ENV_ALLOWLIST
@@ -1848,6 +1848,21 @@ def _resolve_effective_backend(user_id: str, config: Config) -> str:
     return user_cfg.agent_backend or config.agent_backend
 
 
+def _resolve_user_config(user_id: str, config: Config):
+    """Look up the per-user `UserConfig` for an extraction caller.
+
+    Sandbox / unknown user IDs return None; the per-role resolver
+    treats that as "no per-user override, fall through to global
+    default_models then to MODEL_REGISTRY." Same int-coerce + lookup
+    pattern as `_resolve_effective_backend`.
+    """
+    try:
+        tid = int(user_id)
+    except ValueError:
+        return None
+    return config.user_configs.get(tid)
+
+
 def _resolve_effective_provider(user_id: str, config: Config) -> str:
     """
     Resolve the user being extracted to its effective `llm_provider`.
@@ -1997,11 +2012,24 @@ async def _run_extractor(
     # function so memory-domain concerns (is_error, structured_output,
     # facts, has_episode) do not leak into the reasoner.
     reasoner = _build_memory_reasoner(effective_backend, os_user=os_user)
+    # Per-role resolution consults the full precedence chain
+    # (per-user `models.memory_extraction` > Config.default_models >
+    # MODEL_REGISTRY). Pre-resolved backend / provider are passed as
+    # kwargs so the helper skips its own re-resolution; `user_config`
+    # is None for sandbox / eval user_ids and the resolver falls
+    # through to the global default + registry cascade.
+    user_cfg = _resolve_user_config(user_id, config)
     try:
         result = await reasoner.run(
             prompt=payload_text,
             system_prompt=system_prompt,
-            model=get_model_for(ModelRole.MEMORY_EXTRACTION, effective_backend, effective_provider),
+            model=resolve_user_model(
+                ModelRole.MEMORY_EXTRACTION,
+                user_cfg,
+                config,
+                backend=effective_backend,
+                provider=effective_provider,
+            ),
             timeout=config.memory_extraction_timeout_s,
             purpose="fact_extraction",
             json_schema=_FACT_SCHEMA,
@@ -2159,6 +2187,7 @@ async def _run_episode_extractor(
     payload_text: str,
     config: Config,
     *,
+    user_id: str,
     effective_backend: str,
     effective_provider: str,
     os_user: str | None = None,
@@ -2198,7 +2227,13 @@ async def _run_episode_extractor(
         result = await reasoner.run(
             prompt=payload_text,
             system_prompt=_EPISODE_SYSTEM_PROMPT,
-            model=get_model_for(ModelRole.MEMORY_EPISODE, effective_backend, effective_provider),
+            model=resolve_user_model(
+                ModelRole.MEMORY_EPISODE,
+                _resolve_user_config(user_id, config),
+                config,
+                backend=effective_backend,
+                provider=effective_provider,
+            ),
             timeout=config.memory_episode_timeout_s,
             purpose="episode_generation",
             json_schema=_EPISODE_SCHEMA,
@@ -2299,6 +2334,7 @@ async def _generate_episode(
             episode, cost_usd, run_reason = await _run_episode_extractor(
                 payload,
                 config,
+                user_id=user_id,
                 effective_backend=effective_backend,
                 effective_provider=effective_provider,
                 os_user=os_user,

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1848,6 +1848,31 @@ def _resolve_effective_backend(user_id: str, config: Config) -> str:
     return user_cfg.agent_backend or config.agent_backend
 
 
+def _resolve_effective_provider(user_id: str, config: Config) -> str:
+    """
+    Resolve the user being extracted to its effective `llm_provider`.
+
+    Mirrors `_resolve_effective_backend`'s cascade for the provider
+    axis. Required by the (backend, provider, role) MODEL_REGISTRY
+    lookup in `get_model_for`; threaded alongside `effective_backend`
+    so the two stay consistent for a single exchange.
+
+    Single-provider backends (claude, codex) ignore this value at
+    runtime because their provider is implicit, but the resolver
+    still returns the cascade result for uniformity. Sandbox / unknown
+    user IDs fall back to the global default the same way the backend
+    resolver does.
+    """
+    try:
+        tid = int(user_id)
+    except ValueError:
+        return config.llm_provider
+    user_cfg = config.user_configs.get(tid)
+    if user_cfg is None:
+        return config.llm_provider
+    return user_cfg.llm_provider or config.llm_provider
+
+
 def _build_memory_reasoner(effective_backend: str, os_user: str | None = None) -> OneShotReasoner:
     """
     Build the one-shot reasoner matching the user's effective backend.
@@ -1891,6 +1916,7 @@ async def _run_extractor(
     candidate_metadata: dict[str, dict],
     user_id: str,
     effective_backend: str,
+    effective_provider: str,
     os_user: str | None = None,
     system_prompt: str = _EXTRACTION_SYSTEM_PROMPT,
     user_window_text: str = "",
@@ -1975,7 +2001,7 @@ async def _run_extractor(
         result = await reasoner.run(
             prompt=payload_text,
             system_prompt=system_prompt,
-            model=get_model_for(ModelRole.MEMORY_EXTRACTION, effective_backend),
+            model=get_model_for(ModelRole.MEMORY_EXTRACTION, effective_backend, effective_provider),
             timeout=config.memory_extraction_timeout_s,
             purpose="fact_extraction",
             json_schema=_FACT_SCHEMA,
@@ -2134,6 +2160,7 @@ async def _run_episode_extractor(
     config: Config,
     *,
     effective_backend: str,
+    effective_provider: str,
     os_user: str | None = None,
 ) -> tuple[dict | None, float, str | None]:
     """
@@ -2171,7 +2198,7 @@ async def _run_episode_extractor(
         result = await reasoner.run(
             prompt=payload_text,
             system_prompt=_EPISODE_SYSTEM_PROMPT,
-            model=get_model_for(ModelRole.MEMORY_EPISODE, effective_backend),
+            model=get_model_for(ModelRole.MEMORY_EPISODE, effective_backend, effective_provider),
             timeout=config.memory_episode_timeout_s,
             purpose="episode_generation",
             json_schema=_EPISODE_SCHEMA,
@@ -2228,6 +2255,7 @@ async def _generate_episode(
     session_id: str | None,
     config: Config,
     effective_backend: str,
+    effective_provider: str,
     os_user: str | None = None,
 ) -> None:
     """
@@ -2269,7 +2297,11 @@ async def _generate_episode(
             start = time.monotonic()
             payload = _build_episode_payload(user_text, assistant_text)
             episode, cost_usd, run_reason = await _run_episode_extractor(
-                payload, config, effective_backend=effective_backend, os_user=os_user
+                payload,
+                config,
+                effective_backend=effective_backend,
+                effective_provider=effective_provider,
+                os_user=os_user,
             )
             if episode is None:
                 # Map the run-helper's failure tags onto the documented
@@ -2701,14 +2733,16 @@ async def extract_and_store(
 
     # Per-user reasoner backend (issue #515). Resolved ONCE alongside
     # `os_user` and threaded into both stages so the (effective_backend,
-    # os_user) pair stays consistent across stage 1 and stage 2 for a
-    # single exchange. The model for each stage is looked up inline
-    # via `get_model_for(role, effective_backend)` at the call site
-    # (no global model field; the registry is the single source of
-    # truth). Goose users do not reach this site because `bot.py`'s
-    # extraction gate filters them out upstream; the cascade here
+    # effective_provider, os_user) triple stays consistent across
+    # stage 1 and stage 2 for a single exchange. The model for each
+    # stage is looked up inline via get_model_for(role, backend,
+    # provider) at the call site (no global model field; the registry
+    # is the single source of truth). Goose users do not reach this
+    # site because `bot.py`'s extraction gate filters them out
+    # upstream; the cascade here
     # mirrors `_resolve_effective_backend`.
     effective_backend = _resolve_effective_backend(user_id, config)
+    effective_provider = _resolve_effective_provider(user_id, config)
 
     sem = _get_semaphore(user_id)
     # Pre-initialize the storage counters so the post-try summary log
@@ -2816,6 +2850,7 @@ async def extract_and_store(
                 candidate_metadata=candidate_metadata,
                 user_id=user_id,
                 effective_backend=effective_backend,
+                effective_provider=effective_provider,
                 os_user=os_user,
                 user_window_text=user_window_text,
                 assistant_window_text=assistant_window_text,
@@ -2877,6 +2912,7 @@ async def extract_and_store(
                         session_id=session_id,
                         config=config,
                         effective_backend=effective_backend,
+                        effective_provider=effective_provider,
                         os_user=os_user,
                     ),
                     name=f"episode-{user_id}",

--- a/src/kai/refresh_models.py
+++ b/src/kai/refresh_models.py
@@ -1,0 +1,248 @@
+"""Opt-in refresh helper for `PROVIDER_MODELS`.
+
+Operator runs `python -m kai.refresh_models` (or `make refresh-models`)
+to query each curated provider's `/v1/models` endpoint and print a
+unified diff against the in-tree `PROVIDER_MODELS[provider]` keys.
+The command never writes source files; operator review of the diff
+is the trust boundary. Pass `--write-snippet` to emit a paste-able
+Python fragment to stdout that the operator copies into
+`src/kai/config.py` by hand.
+
+Exit codes:
+- 0: every queried provider responded; no diff against the in-tree
+     list (or every queried provider was skipped for missing auth).
+- 1: every queried provider responded; at least one provider has a
+     diff (new and / or retired models).
+- 2: at least one provider failed to respond (network error, 5xx,
+     unexpected response shape). Other providers' diffs still print.
+
+Per-provider auth comes from `PROVIDER_KEY_VARS`. A provider whose
+API key is unset in env skips with a `"skipped: no API key"` notice;
+this is not counted as a failure (exit 2 reserves for actual remote
+faults). OpenRouter and Ollama are absent from `PROVIDER_MODELS`
+today (open-ended providers) and skip with a one-line notice.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from collections.abc import Awaitable, Callable
+
+import aiohttp
+
+from kai.config import PROVIDER_KEY_VARS, PROVIDER_MODELS
+
+log = logging.getLogger(__name__)
+
+# Per-provider request timeout in seconds. Total worst-case wait
+# scales as len(providers) * _PROVIDER_TIMEOUT because the providers
+# are queried sequentially (the diff-printing is a developer surface,
+# not a hot path; sequential keeps the output ordered without an
+# extra sort pass).
+_PROVIDER_TIMEOUT = 10.0
+
+# Default Ollama host. Operators running ollama on a non-default port
+# or remote host set OLLAMA_HOST in env before running this command.
+_OLLAMA_DEFAULT_HOST = "http://127.0.0.1:11434"
+
+
+async def _fetch_anthropic(api_key: str) -> list[str]:
+    """Anthropic `/v1/models` returns a `data` array of objects with
+    an `id` field naming each available model."""
+    url = "https://api.anthropic.com/v1/models"
+    headers = {"x-api-key": api_key, "anthropic-version": "2023-06-01"}
+    timeout = aiohttp.ClientTimeout(total=_PROVIDER_TIMEOUT)
+    async with (
+        aiohttp.ClientSession() as session,
+        session.get(url, headers=headers, timeout=timeout) as resp,
+    ):
+        resp.raise_for_status()
+        payload = await resp.json()
+    return [item["id"] for item in payload.get("data", []) if isinstance(item, dict) and item.get("id")]
+
+
+async def _fetch_openai(api_key: str) -> list[str]:
+    """OpenAI `/v1/models` returns the same `data` array shape as Anthropic."""
+    url = "https://api.openai.com/v1/models"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    timeout = aiohttp.ClientTimeout(total=_PROVIDER_TIMEOUT)
+    async with (
+        aiohttp.ClientSession() as session,
+        session.get(url, headers=headers, timeout=timeout) as resp,
+    ):
+        resp.raise_for_status()
+        payload = await resp.json()
+    return [item["id"] for item in payload.get("data", []) if isinstance(item, dict) and item.get("id")]
+
+
+async def _fetch_google(api_key: str) -> list[str]:
+    """Google Gemini API `models?key=<key>` returns a `models` array
+    of objects with a `name` field (prefixed `models/`). Strip the
+    prefix so the returned IDs match the bare model name shape
+    PROVIDER_MODELS["google"] keys use."""
+    url = f"https://generativelanguage.googleapis.com/v1beta/models?key={api_key}"
+    timeout = aiohttp.ClientTimeout(total=_PROVIDER_TIMEOUT)
+    async with (
+        aiohttp.ClientSession() as session,
+        session.get(url, timeout=timeout) as resp,
+    ):
+        resp.raise_for_status()
+        payload = await resp.json()
+    out: list[str] = []
+    for item in payload.get("models", []):
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name", "")
+        if name.startswith("models/"):
+            name = name[len("models/") :]
+        if name:
+            out.append(name)
+    return out
+
+
+# Per-provider fetcher dispatch. Only providers with entries in
+# PROVIDER_MODELS appear; OPEN_ENDED_PROVIDERS (openrouter, ollama)
+# render a "skipped: open-ended" line via the dispatch path's
+# default-miss branch.
+_provider_fetchers: dict[str, Callable[[str], Awaitable[list[str]]]] = {
+    "anthropic": _fetch_anthropic,
+    "openai": _fetch_openai,
+    "google": _fetch_google,
+}
+
+
+def _render_diff(provider: str, remote_models: list[str], curated_models: list[str]) -> tuple[bool, list[str]]:
+    """Render a per-provider diff against the in-tree curated list.
+
+    Returns `(has_diff, lines)` where `has_diff` indicates a non-empty
+    set-difference in either direction and `lines` is the list of
+    output strings ready to print. The diff is symmetric (additions
+    AND retirements); the operator decides which side to act on.
+    """
+    remote_set = set(remote_models)
+    curated_set = set(curated_models)
+    new_models = sorted(remote_set - curated_set)
+    retired_models = sorted(curated_set - remote_set)
+    total = len(remote_set)
+    if not new_models and not retired_models:
+        return False, [f"{provider}: {total} models (no change)"]
+    parts: list[str] = []
+    summary_bits = [f"{total} models"]
+    if new_models:
+        summary_bits.append(f"{len(new_models)} new")
+    if retired_models:
+        summary_bits.append(f"{len(retired_models)} retired")
+    parts.append(f"{provider}: " + ", ".join(summary_bits))
+    for m in new_models:
+        parts.append(f"  +  {m}")
+    for m in retired_models:
+        parts.append(f"  -  {m}")
+    return True, parts
+
+
+def _render_snippet(provider: str, remote_models: list[str]) -> str:
+    """Emit a paste-able Python fragment for src/kai/config.py.
+
+    Display names default to the raw model ID; the operator edits
+    them after pasting. Skipped providers (no fetcher, missing auth)
+    do not produce a snippet.
+    """
+    lines = [f'PROVIDER_MODELS["{provider}"] = {{']
+    for m in sorted(remote_models):
+        lines.append(f'    "{m}": "{m}",')
+    lines.append("}")
+    return "\n".join(lines)
+
+
+async def _refresh_one(provider: str, *, write_snippet: bool) -> tuple[int, list[str]]:
+    """Refresh one provider's model list.
+
+    Returns `(status, lines)` where `status` is:
+        0 = no diff (or skipped)
+        1 = diff present
+        2 = fetch failed
+    """
+    if provider not in _provider_fetchers:
+        return 0, [f"{provider}: skipped (open-ended provider; no curated list to diff)"]
+    key_var = PROVIDER_KEY_VARS.get(provider, "")
+    if not key_var:
+        return 0, [f"{provider}: skipped (no PROVIDER_KEY_VARS entry; cannot authenticate)"]
+    api_key = os.environ.get(key_var, "").strip()
+    if not api_key:
+        return 0, [f"{provider}: skipped (no API key in env: {key_var})"]
+
+    fetcher = _provider_fetchers[provider]
+    try:
+        remote_models = await fetcher(api_key)
+    except Exception as exc:
+        return 2, [f"{provider}: ERROR ({type(exc).__name__}: {exc})"]
+
+    curated_models = list(PROVIDER_MODELS.get(provider, {}).keys())
+    has_diff, diff_lines = _render_diff(provider, remote_models, curated_models)
+    if write_snippet and (has_diff or not curated_models):
+        diff_lines.append("")
+        diff_lines.append(_render_snippet(provider, remote_models))
+        diff_lines.append("")
+    return (1 if has_diff else 0), diff_lines
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m kai.refresh_models",
+        description=(
+            "Query each curated provider's /v1/models endpoint and print a "
+            "diff against PROVIDER_MODELS in src/kai/config.py. Never writes "
+            "source files; operator hand-edits config.py after reviewing the diff."
+        ),
+    )
+    parser.add_argument(
+        "--write-snippet",
+        action="store_true",
+        help=(
+            "Emit a paste-able Python fragment per provider with a non-empty "
+            "diff. Operator pastes the fragment into src/kai/config.py and "
+            "edits display names by hand. Default off."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    # Walk providers in alphabetical order so the diff output is
+    # deterministic across runs (set iteration order would otherwise
+    # render differently under PYTHONHASHSEED randomization).
+    providers = sorted(set(PROVIDER_MODELS.keys()) | {"openrouter", "ollama"})
+
+    overall_status = 0
+    for provider in providers:
+        status, lines = await _refresh_one(provider, write_snippet=args.write_snippet)
+        for line in lines:
+            print(line)
+        # Promote to the higher status code; once 2 (failure) is set,
+        # it cannot demote back to 1 (diff) or 0 (no diff).
+        if status > overall_status:
+            overall_status = status
+
+    if args.write_snippet:
+        print()
+        print(
+            "Snippets above are paste-able into PROVIDER_MODELS in "
+            "src/kai/config.py. Edit display names by hand before "
+            "committing; the snippet's default copies the raw model ID."
+        )
+    return overall_status
+
+
+def main() -> None:
+    """Argparse entry point. Wraps `_main` in asyncio.run."""
+    try:
+        rc = asyncio.run(_main(sys.argv[1:]))
+    except KeyboardInterrupt:
+        rc = 130
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -70,47 +70,6 @@ _REVIEW_BUDGET_USD = 1.0
 # thinking-heavy reviews while still terminating genuinely stuck processes.
 _REVIEW_TIMEOUT = 900
 
-# Mid-tier model per provider for Goose background agent tasks. Matches
-# the "sonnet" design decision for Claude - background tasks should not
-# burn frontier-tier tokens. Full provider-native model IDs are required
-# because `goose run --model` uses provider naming, not Claude aliases.
-#
-# NOTE: Kai stores Google's provider as "google" in VALID_PROVIDERS,
-# but Goose's --help lists it as "gemini-cli". This dict keys on Kai's
-# stored value ("google"). If Goose requires "gemini-cli", that is a
-# pre-existing config.py naming issue, not introduced by this change.
-_GOOSE_AGENT_MODELS: dict[str, str] = {
-    "anthropic": "claude-sonnet-4-6",
-    "openai": "gpt-5.4",
-    "google": "gemini-3-flash",
-}
-
-
-def _resolve_goose_model(provider: str) -> str:
-    """Pick the review model for a Goose provider.
-
-    Curated providers get a hardcoded mid-tier model (cost-effective
-    for background tasks). Open-ended providers (openrouter, ollama)
-    fall back to the GOOSE_MODEL env var, which is the user's
-    configured model. There is no safe default for those providers.
-
-    Raises RuntimeError if no model can be resolved (open-ended
-    provider with no GOOSE_MODEL set).
-    """
-    model = _GOOSE_AGENT_MODELS.get(provider)
-    if model:
-        return model
-    # Open-ended provider: use whatever the user configured.
-    # GOOSE_MODEL is set in the process environment by the launcher.
-    model = os.environ.get("GOOSE_MODEL", "")
-    if not model:
-        raise RuntimeError(
-            f"No model configured for Goose provider '{provider}'. "
-            f"Set GOOSE_MODEL in the environment or DEFAULT_MODEL in .env."
-        )
-    return model
-
-
 # Header prepended to every review comment on GitHub. Distinguishes
 # automated reviews from human comments. Per design decision #11.
 _REVIEW_HEADER = "## Review by Kai\n\n"
@@ -673,6 +632,12 @@ async def run_review(
     # this fix; cleanup deferred to a separate refactor that updates
     # webhook.py and the test suite together.
     budget_usd: float = _REVIEW_BUDGET_USD,
+    # Per-role model override. Caller in webhook.py resolves
+    # `user_config.models.get("pr_review", "")` and passes it; empty
+    # falls through to MODEL_REGISTRY's (backend, provider, PR_REVIEW)
+    # default. Caller-resolved so the per-user models map (and its
+    # load-time legacy env-var seeding) wins over the registry default.
+    model_override: str = "",
 ) -> str:
     """
     Spawn a one-shot LLM subprocess to perform the review.
@@ -725,18 +690,19 @@ async def run_review(
     """
     if agent_backend == "opencode":
         # Dispatch to the OpenCode one-shot reasoner. The model
-        # identifier comes from the per-role MODEL_REGISTRY; an
-        # operator-side override via PR_REVIEW_MODEL_OPENCODE is
-        # accepted on the same shape the other backends use. The
-        # reasoner returns OneShotResult.text (raw review text) when
-        # json_schema is None, which is what this function's
-        # contract returns. Typed reasoner errors collapse to
-        # RuntimeError so the webhook handler's existing catch
-        # surface does not need to widen.
+        # identifier comes from the per-role MODEL_REGISTRY indexed
+        # by (backend, provider, role); the caller's per-user
+        # `models.pr_review` override (when set in users.yaml) wins
+        # via the `model_override` parameter. The reasoner returns
+        # OneShotResult.text (raw review text) when json_schema is
+        # None, which is what this function's contract returns. Typed
+        # reasoner errors collapse to RuntimeError so the webhook
+        # handler's existing catch surface does not need to widen.
         review_model = get_model_for(
             ModelRole.PR_REVIEW,
             agent_backend,
-            override=os.environ.get("PR_REVIEW_MODEL_OPENCODE", ""),
+            provider,
+            override=model_override,
         )
         reasoner = OpenCodeOneShotReasoner(os_user=claude_user)
         try:
@@ -771,7 +737,8 @@ async def run_review(
         review_model = get_model_for(
             ModelRole.PR_REVIEW,
             agent_backend,
-            override=os.environ.get("PR_REVIEW_MODEL_CODEX", ""),
+            provider,
+            override=model_override,
         )
         # Pin the absolute codex path when CODEX_BIN is set; same
         # rationale as codex.py and triage.py - sudo cannot resolve
@@ -864,8 +831,17 @@ async def run_review(
         # Goose one-shot mode: read prompt from stdin, write response
         # to stdout. -q suppresses non-response output, --no-session
         # avoids creating session files, --no-profile skips user
-        # config, --max-turns 1 prevents runaway tool loops.
-        model = _resolve_goose_model(provider)
+        # config, --max-turns 1 prevents runaway tool loops. Model
+        # comes from the unified (backend, provider, role) registry
+        # so a goose-on-deepseek install inherits deepseek-chat the
+        # same way claude inherits sonnet; openrouter / ollama users
+        # set their per-user `models.pr_review` in users.yaml.
+        model = get_model_for(
+            ModelRole.PR_REVIEW,
+            agent_backend,
+            provider,
+            override=model_override,
+        )
         cmd = [
             "goose",
             "run",
@@ -911,18 +887,19 @@ async def run_review(
         # signature is unused on every currently-exercised path - see the
         # comment on the parameter declaration above for the full rationale
         # and why cleanup is deferred to a separate refactor.
-        # Model identifier comes from the per-role registry so the
-        # codex backend (and any future backend) can override the
-        # mid-tier "sonnet" default without modifying this branch.
-        # The override env var PR_REVIEW_MODEL_<BACKEND> is read here
-        # rather than in load_config because the override surface
-        # grows with ModelRole; threading every entry through Config
-        # would inflate the dataclass for a passthrough to a typed
-        # lookup.
+        # Model identifier comes from the per-role registry indexed
+        # by (backend, provider, role) so the codex backend (and any
+        # future backend) can override the mid-tier "sonnet" default
+        # without modifying this branch. The caller's per-user
+        # `models.pr_review` override (when set in users.yaml) wins
+        # via the `model_override` parameter; the load-time env-var
+        # seeding pass also routes deprecated PR_REVIEW_MODEL_*
+        # values through that same parameter.
         review_model = get_model_for(
             ModelRole.PR_REVIEW,
             agent_backend,
-            override=os.environ.get(f"PR_REVIEW_MODEL_{agent_backend.upper()}", ""),
+            provider,
+            override=model_override,
         )
         cmd = [
             "claude",
@@ -1087,6 +1064,7 @@ async def review_pr(
     # See `run_review` above for why `budget_usd` is currently unused
     # on every exercised path; cleanup deferred to a separate refactor.
     budget_usd: float = _REVIEW_BUDGET_USD,
+    model_override: str = "",
 ) -> None:
     """
     Full review pipeline: fetch diff, build prompt, run review, post results.
@@ -1154,6 +1132,7 @@ async def review_pr(
             provider=provider,
             timeout_s=timeout_s,
             budget_usd=budget_usd,
+            model_override=model_override,
         )
 
         if not review_text.strip():

--- a/src/kai/smoke/memory.py
+++ b/src/kai/smoke/memory.py
@@ -39,6 +39,7 @@ from kai.memory_extraction import (
     _FACT_SCHEMA,
     _build_memory_reasoner,
     _resolve_effective_backend,
+    _resolve_effective_provider,
 )
 from kai.oneshot import OneShotError
 
@@ -108,6 +109,7 @@ async def _run(user_id: str | None, os_user: str | None) -> int:
     # the same way), so reuse it directly.
     resolved_user_id = user_id if user_id is not None else "smoke"
     effective_backend = _resolve_effective_backend(resolved_user_id, config)
+    effective_provider = _resolve_effective_provider(resolved_user_id, config)
     if effective_backend not in ONESHOT_REASONER_BACKENDS:
         eligible = ", ".join(sorted(ONESHOT_REASONER_BACKENDS))
         sys.stderr.write(
@@ -117,9 +119,10 @@ async def _run(user_id: str | None, os_user: str | None) -> int:
         )
         return 1
 
-    extraction_model = get_model_for(ModelRole.MEMORY_EXTRACTION, effective_backend)
-    episode_model = get_model_for(ModelRole.MEMORY_EPISODE, effective_backend)
+    extraction_model = get_model_for(ModelRole.MEMORY_EXTRACTION, effective_backend, effective_provider)
+    episode_model = get_model_for(ModelRole.MEMORY_EPISODE, effective_backend, effective_provider)
     print(f"backend: {effective_backend}")
+    print(f"provider: {effective_provider}")
     print(f"extraction model: {extraction_model}")
     print(f"episode model: {episode_model}")
     print(f"user_id: {user_id or '(none; using global agent_backend)'}")

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -55,47 +55,6 @@ _TRIAGE_BUDGET_USD = 1.0
 # Timeout for the triage subprocess in seconds.
 _TRIAGE_TIMEOUT = 300
 
-# Mid-tier model per provider for Goose background agent tasks. Matches
-# the "sonnet" design decision for Claude - background tasks should not
-# burn frontier-tier tokens. Full provider-native model IDs are required
-# because `goose run --model` uses provider naming, not Claude aliases.
-#
-# NOTE: Kai stores Google's provider as "google" in VALID_PROVIDERS,
-# but Goose's --help lists it as "gemini-cli". This dict keys on Kai's
-# stored value ("google"). If Goose requires "gemini-cli", that is a
-# pre-existing config.py naming issue, not introduced by this change.
-_GOOSE_AGENT_MODELS: dict[str, str] = {
-    "anthropic": "claude-sonnet-4-6",
-    "openai": "gpt-5.4",
-    "google": "gemini-3-flash",
-}
-
-
-def _resolve_goose_model(provider: str) -> str:
-    """Pick the triage model for a Goose provider.
-
-    Curated providers get a hardcoded mid-tier model (cost-effective
-    for background tasks). Open-ended providers (openrouter, ollama)
-    fall back to the GOOSE_MODEL env var, which is the user's
-    configured model. There is no safe default for those providers.
-
-    Raises RuntimeError if no model can be resolved (open-ended
-    provider with no GOOSE_MODEL set).
-    """
-    model = _GOOSE_AGENT_MODELS.get(provider)
-    if model:
-        return model
-    # Open-ended provider: use whatever the user configured.
-    # GOOSE_MODEL is set in the process environment by the launcher.
-    model = os.environ.get("GOOSE_MODEL", "")
-    if not model:
-        raise RuntimeError(
-            f"No model configured for Goose provider '{provider}'. "
-            f"Set GOOSE_MODEL in the environment or DEFAULT_MODEL in .env."
-        )
-    return model
-
-
 # Default colors for auto-created labels. Maps label name to a hex color
 # (without the # prefix). Unlisted labels get a neutral gray.
 _LABEL_COLORS: dict[str, str] = {
@@ -392,6 +351,13 @@ async def run_triage(
     claude_user: str | None = None,
     agent_backend: str = "claude",
     provider: str = "",
+    # Per-role model override. Caller in webhook.py resolves
+    # `user_config.models.get("issue_triage", "")` and passes it;
+    # empty falls through to MODEL_REGISTRY's (backend, provider,
+    # ISSUE_TRIAGE) default. The load-time legacy env-var seeding
+    # routes deprecated ISSUE_TRIAGE_MODEL_* values through the
+    # same parameter via UserConfig.models.
+    model_override: str = "",
 ) -> str:
     """
     Spawn a one-shot LLM subprocess to perform the triage analysis.
@@ -431,7 +397,8 @@ async def run_triage(
         triage_model = get_model_for(
             ModelRole.ISSUE_TRIAGE,
             agent_backend,
-            override=os.environ.get("ISSUE_TRIAGE_MODEL_OPENCODE", ""),
+            provider,
+            override=model_override,
         )
         reasoner = OpenCodeOneShotReasoner(os_user=claude_user)
         try:
@@ -465,7 +432,8 @@ async def run_triage(
         triage_model = get_model_for(
             ModelRole.ISSUE_TRIAGE,
             agent_backend,
-            override=os.environ.get("ISSUE_TRIAGE_MODEL_CODEX", ""),
+            provider,
+            override=model_override,
         )
         # Pin the absolute codex path when CODEX_BIN is set; same
         # rationale as codex.py - sudo cannot resolve bare `codex`
@@ -567,8 +535,17 @@ async def run_triage(
         # Goose one-shot mode: read prompt from stdin, write response
         # to stdout. -q suppresses non-response output, --no-session
         # avoids creating session files, --no-profile skips user
-        # config, --max-turns 1 prevents runaway tool loops.
-        model = _resolve_goose_model(provider)
+        # config, --max-turns 1 prevents runaway tool loops. Model
+        # resolution flows through the unified (backend, provider,
+        # role) registry so a goose-on-deepseek install picks up the
+        # deepseek-shaped default; openrouter / ollama users set
+        # their per-user `models.issue_triage` in users.yaml.
+        model = get_model_for(
+            ModelRole.ISSUE_TRIAGE,
+            agent_backend,
+            provider,
+            override=model_override,
+        )
         cmd = [
             "goose",
             "run",
@@ -615,17 +592,17 @@ async def run_triage(
         # it has notionally produced. _TRIAGE_BUDGET_USD stays defined for
         # symmetry with the other budget defaults in this codebase; cleanup
         # is deferred to a separate refactor.
-        # Model identifier comes from the per-role registry so the
-        # codex backend (and any future backend) can override the
-        # mid-tier "sonnet" default without modifying this branch.
-        # The override env var ISSUE_TRIAGE_MODEL_<BACKEND> is read here
-        # rather than in load_config because the override surface grows
-        # with ModelRole; threading every entry through Config would
-        # inflate the dataclass for a passthrough to a typed lookup.
+        # Model identifier comes from the per-role registry indexed
+        # by (backend, provider, role). Caller's per-user
+        # `models.issue_triage` override (when set in users.yaml)
+        # wins via the `model_override` parameter; the load-time
+        # env-var seeding pass also routes deprecated
+        # ISSUE_TRIAGE_MODEL_* values through that same parameter.
         triage_model = get_model_for(
             ModelRole.ISSUE_TRIAGE,
             agent_backend,
-            override=os.environ.get(f"ISSUE_TRIAGE_MODEL_{agent_backend.upper()}", ""),
+            provider,
+            override=model_override,
         )
         cmd = [
             "claude",
@@ -1039,6 +1016,7 @@ async def triage_issue(
     notify_chat_id: int | None = None,
     agent_backend: str = "claude",
     provider: str = "",
+    model_override: str = "",
 ) -> None:
     """
     Full triage pipeline: analyze issue, apply labels, post results.
@@ -1080,6 +1058,7 @@ async def triage_issue(
             claude_user=claude_user,
             agent_backend=agent_backend,
             provider=provider,
+            model_override=model_override,
         )
 
         if not raw_response.strip():

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -715,6 +715,15 @@ async def _process_github_event_for_user(
     else:
         provider = config.llm_provider
 
+    # Per-role model overrides for review and triage. Resolved here so
+    # the user's `models:` map (and any load-time legacy env-var seed)
+    # wins over the MODEL_REGISTRY default; review.py / triage.py treat
+    # the empty string as "fall through to the registry default" via
+    # the model_override parameter on run_review / run_triage.
+    user_models = user_config.models if user_config and user_config.models else {}
+    pr_review_model_override = user_models.get("pr_review", "")
+    issue_triage_model_override = user_models.get("issue_triage", "")
+
     # ── PR review routing ────────────────────────────────────────
     # When PR review is enabled for this user, reviewable PR events
     # (opened, reopened, synchronize) are routed to the review pipeline
@@ -764,6 +773,7 @@ async def _process_github_event_for_user(
                     provider=provider,
                     timeout_s=request.app["pr_review_timeout_s"],
                     budget_usd=request.app["pr_review_budget_usd"],
+                    model_override=pr_review_model_override,
                 )
             )
             _background_tasks.add(task)
@@ -810,6 +820,7 @@ async def _process_github_event_for_user(
                     notify_chat_id=target_chat_id,
                     agent_backend=agent_backend,
                     provider=provider,
+                    model_override=issue_triage_model_override,
                 )
             )
             _background_tasks.add(task)

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -57,7 +57,7 @@ from aiohttp import web
 from telegram import Bot, Update
 
 from kai import cron, memory, review, services, sessions, triage
-from kai.config import DATA_DIR, IMAGE_EXTENSIONS, Config, UserConfig
+from kai.config import DATA_DIR, IMAGE_EXTENSIONS, Config, ModelRole, UserConfig, resolve_user_model
 from kai.telegram_utils import chunk_text
 
 log = logging.getLogger(__name__)
@@ -715,14 +715,17 @@ async def _process_github_event_for_user(
     else:
         provider = config.llm_provider
 
-    # Per-role model overrides for review and triage. Resolved here so
-    # the user's `models:` map (and any load-time legacy env-var seed)
-    # wins over the MODEL_REGISTRY default; review.py / triage.py treat
-    # the empty string as "fall through to the registry default" via
-    # the model_override parameter on run_review / run_triage.
-    user_models = user_config.models if user_config and user_config.models else {}
-    pr_review_model_override = user_models.get("pr_review", "")
-    issue_triage_model_override = user_models.get("issue_triage", "")
+    # Per-role model overrides for review and triage. `resolve_user_model`
+    # implements the full precedence chain: per-user `models:` from
+    # users.yaml > Config.default_models from DEFAULT_MODELS_JSON >
+    # MODEL_REGISTRY's (backend, provider, role) default. review.py /
+    # triage.py treat the empty string as "fall through to the registry
+    # default" via the model_override parameter; the resolver always
+    # returns a concrete model string, so the override path here is
+    # load-bearing only when the resolved value differs from the
+    # registry default (which is exactly when it should fire).
+    pr_review_model_override = resolve_user_model(ModelRole.PR_REVIEW, user_config, config)
+    issue_triage_model_override = resolve_user_model(ModelRole.ISSUE_TRIAGE, user_config, config)
 
     # ── PR review routing ────────────────────────────────────────
     # When PR review is enabled for this user, reviewable PR events

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1684,8 +1684,8 @@ class TestMemoryReasonerModelResolution:
         # call site (memory_extraction.py), so the test reads the
         # registry directly to pin the per-backend default.
         load_config()
-        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "claude") == "claude-haiku-4-5-20251001"
-        assert get_model_for(ModelRole.MEMORY_EPISODE, "claude") == "claude-haiku-4-5-20251001"
+        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "claude", "anthropic") == "claude-haiku-4-5-20251001"
+        assert get_model_for(ModelRole.MEMORY_EPISODE, "claude", "anthropic") == "claude-haiku-4-5-20251001"
 
     def test_codex_default_resolves_to_codex_model(self, monkeypatch):
         """Codex install: registry resolves to a codex-CLI-valid SKU.
@@ -1701,8 +1701,8 @@ class TestMemoryReasonerModelResolution:
         monkeypatch.setenv("AGENT_BACKEND", "codex")
         monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
         load_config()
-        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "codex") == "gpt-5.4-mini"
-        assert get_model_for(ModelRole.MEMORY_EPISODE, "codex") == "gpt-5.4-mini"
+        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "codex", "openai") == "gpt-5.4-mini"
+        assert get_model_for(ModelRole.MEMORY_EPISODE, "codex", "openai") == "gpt-5.4-mini"
 
     def test_legacy_extraction_model_env_var_is_ignored(self, monkeypatch, caplog):
         """The retired MEMORY_EXTRACTION_MODEL env var no longer has
@@ -1717,7 +1717,7 @@ class TestMemoryReasonerModelResolution:
         # Field is gone; the value is dropped after the warning.
         assert not hasattr(config, "memory_extraction_model")
         # Registry resolution is untouched.
-        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "claude") == "claude-haiku-4-5-20251001"
+        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "claude", "anthropic") == "claude-haiku-4-5-20251001"
         assert any("MEMORY_EXTRACTION_MODEL is deprecated" in r.message for r in caplog.records)
 
     def test_legacy_episode_model_env_var_is_ignored(self, monkeypatch, caplog):
@@ -1727,7 +1727,7 @@ class TestMemoryReasonerModelResolution:
         with caplog.at_level("WARNING", logger="kai.config"):
             config = load_config()
         assert not hasattr(config, "memory_episode_model")
-        assert get_model_for(ModelRole.MEMORY_EPISODE, "claude") == "claude-haiku-4-5-20251001"
+        assert get_model_for(ModelRole.MEMORY_EPISODE, "claude", "anthropic") == "claude-haiku-4-5-20251001"
         assert any("MEMORY_EPISODE_MODEL is deprecated" in r.message for r in caplog.records)
 
 
@@ -1846,7 +1846,7 @@ class TestRegistryValidationPerEligibleBackend:
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
         # Patch the registry to drop the codex MEMORY_EXTRACTION row.
         patched_registry = dict(config_mod.MODEL_REGISTRY)
-        patched_registry.pop(("codex", ModelRole.MEMORY_EXTRACTION), None)
+        patched_registry.pop(("codex", "openai", ModelRole.MEMORY_EXTRACTION), None)
         monkeypatch.setattr("kai.config.MODEL_REGISTRY", patched_registry)
         with pytest.raises(SystemExit):
             load_config()
@@ -2255,12 +2255,12 @@ class TestModelRegistry:
 
     def test_lookup_returns_registry_value_when_no_override(self):
         """Default path: empty override returns the registry value."""
-        result = get_model_for(ModelRole.PR_REVIEW, "claude")
+        result = get_model_for(ModelRole.PR_REVIEW, "claude", "anthropic")
         assert result == "sonnet"
 
     def test_override_wins_over_registry(self):
         """A truthy override short-circuits the registry lookup."""
-        result = get_model_for(ModelRole.PR_REVIEW, "claude", override="opus")
+        result = get_model_for(ModelRole.PR_REVIEW, "claude", "anthropic", override="opus")
         assert result == "opus"
 
     def test_empty_override_falls_through(self):
@@ -2272,7 +2272,7 @@ class TestModelRegistry:
         the registry takes over. If empty short-circuited the registry,
         the codex behavioral path would never reach the gpt-5.4-nano row.
         """
-        result = get_model_for(ModelRole.PR_REVIEW, "claude", override="")
+        result = get_model_for(ModelRole.PR_REVIEW, "claude", "anthropic", override="")
         assert result == "sonnet"
 
     def test_missing_row_raises_lookup_error(self):
@@ -2285,15 +2285,15 @@ class TestModelRegistry:
         failure if it does.
         """
         with pytest.raises(LookupError, match="No registry entry"):
-            get_model_for(ModelRole.PR_REVIEW, "no-such-backend")
+            get_model_for(ModelRole.PR_REVIEW, "no-such-backend", "anthropic")
 
     def test_completeness_check_passes_for_claude(self):
         """Claude has rows for every role; no exception."""
-        _check_model_registry_complete("claude")  # no raise
+        _check_model_registry_complete()  # no raise
 
     def test_completeness_check_passes_for_codex(self):
         """Codex has rows for every role; no exception."""
-        _check_model_registry_complete("codex")  # no raise
+        _check_model_registry_complete()  # no raise
 
     def test_completeness_check_skips_goose(self):
         """
@@ -2302,7 +2302,7 @@ class TestModelRegistry:
         check skips goose explicitly so a goose-backed install does
         not fail at startup just because the registry has no goose rows.
         """
-        _check_model_registry_complete("goose")  # no raise
+        _check_model_registry_complete()  # no raise
 
     def test_completeness_check_raises_on_missing_row(self, monkeypatch):
         """
@@ -2311,9 +2311,9 @@ class TestModelRegistry:
         with a clear message. Uses monkeypatch.delitem so the change
         is reverted between tests.
         """
-        monkeypatch.delitem(MODEL_REGISTRY, ("claude", ModelRole.PR_REVIEW))
+        monkeypatch.delitem(MODEL_REGISTRY, ("claude", "anthropic", ModelRole.PR_REVIEW))
         with pytest.raises(SystemExit) as excinfo:
-            _check_model_registry_complete("claude")
+            _check_model_registry_complete()
         assert "pr_review" in str(excinfo.value)
         assert "claude" in str(excinfo.value)
 
@@ -2327,9 +2327,9 @@ class TestModelRegistry:
         accepts it for goose, and the codex behavioral path would fall
         over at first invocation.
         """
-        monkeypatch.setitem(MODEL_REGISTRY, ("codex", ModelRole.BEHAVIORAL_JUDGE), "gpt-5.4-nano")
+        monkeypatch.setitem(MODEL_REGISTRY, ("codex", "openai", ModelRole.BEHAVIORAL_JUDGE), "gpt-5.4-nano")
         with pytest.raises(SystemExit) as excinfo:
-            _check_model_registry_complete("codex")
+            _check_model_registry_complete()
         msg = str(excinfo.value)
         assert "gpt-5.4-nano" in msg
         assert "behavioral_judge" in msg
@@ -2345,13 +2345,13 @@ class TestModelRegistry:
         """
         from kai.config import CODEX_MODELS
 
-        assert MODEL_REGISTRY[("codex", ModelRole.BEHAVIORAL_JUDGE)] in CODEX_MODELS
+        assert MODEL_REGISTRY[("codex", "openai", ModelRole.BEHAVIORAL_JUDGE)] in CODEX_MODELS
 
     def test_completeness_check_passes_for_opencode(self):
         """OpenCode has rows for every role; no exception. Mirrors
         the claude and codex completeness gates so a future role
         addition without an opencode row fails fast at startup."""
-        _check_model_registry_complete("opencode")  # no raise
+        _check_model_registry_complete()  # no raise
 
     def test_opencode_row_must_be_provider_slash_model_shape(self, monkeypatch):
         """
@@ -2363,9 +2363,9 @@ class TestModelRegistry:
         opencode handshake rejects it as an unknown provider/model,
         with no Kai-side pointer back to the registry typo.
         """
-        monkeypatch.setitem(MODEL_REGISTRY, ("opencode", ModelRole.BEHAVIORAL_JUDGE), "sonnet")
+        monkeypatch.setitem(MODEL_REGISTRY, ("opencode", "anthropic", ModelRole.BEHAVIORAL_JUDGE), "sonnet")
         with pytest.raises(SystemExit) as excinfo:
-            _check_model_registry_complete("opencode")
+            _check_model_registry_complete()
         msg = str(excinfo.value)
         assert "provider/model" in msg
         assert "behavioral_judge" in msg
@@ -2378,11 +2378,14 @@ class TestModelRegistry:
         are what operators edit when calibrating, and a regression
         here is the failure the synthetic test simulates.
         """
-        from kai.config import is_opencode_model_shape
+        from kai.config import BACKEND_PROVIDERS, is_opencode_model_shape
 
-        for role in ModelRole:
-            value = MODEL_REGISTRY[("opencode", role)]
-            assert is_opencode_model_shape(value), f"opencode {role.value}={value!r} is not provider/model"
+        for provider in BACKEND_PROVIDERS["opencode"]:
+            for role in ModelRole:
+                value = MODEL_REGISTRY[("opencode", provider, role)]
+                assert is_opencode_model_shape(value), (
+                    f"opencode/{provider} {role.value}={value!r} is not provider/model"
+                )
 
     def test_completeness_check_raises_on_missing_opencode_row(self, monkeypatch):
         """
@@ -2391,9 +2394,9 @@ class TestModelRegistry:
         the claude test above so the completeness gate's per-backend
         symmetry stays pinned.
         """
-        monkeypatch.delitem(MODEL_REGISTRY, ("opencode", ModelRole.PR_REVIEW))
+        monkeypatch.delitem(MODEL_REGISTRY, ("opencode", "anthropic", ModelRole.PR_REVIEW))
         with pytest.raises(SystemExit) as excinfo:
-            _check_model_registry_complete("opencode")
+            _check_model_registry_complete()
         assert "pr_review" in str(excinfo.value)
         assert "opencode" in str(excinfo.value)
 
@@ -2401,11 +2404,11 @@ class TestModelRegistry:
 
     def test_claude_pr_review_row_matches_prior_constant(self):
         """review.py used _REVIEW_MODEL = "sonnet" pre-Phase-1."""
-        assert get_model_for(ModelRole.PR_REVIEW, "claude") == "sonnet"
+        assert get_model_for(ModelRole.PR_REVIEW, "claude", "anthropic") == "sonnet"
 
     def test_claude_issue_triage_row_matches_prior_constant(self):
         """triage.py used _TRIAGE_MODEL = "sonnet" pre-Phase-1."""
-        assert get_model_for(ModelRole.ISSUE_TRIAGE, "claude") == "sonnet"
+        assert get_model_for(ModelRole.ISSUE_TRIAGE, "claude", "anthropic") == "sonnet"
 
     def test_claude_behavioral_judge_row_matches_prior_constant(self):
         """
@@ -2418,13 +2421,13 @@ class TestModelRegistry:
         """
         from kai.eval.behavioral import _DEFAULT_JUDGE_MODEL
 
-        assert get_model_for(ModelRole.BEHAVIORAL_JUDGE, "claude") == _DEFAULT_JUDGE_MODEL
+        assert get_model_for(ModelRole.BEHAVIORAL_JUDGE, "claude", "anthropic") == _DEFAULT_JUDGE_MODEL
 
     def test_claude_behavioral_gen_row_matches_prior_constant(self):
         """eval/behavioral.py used _DEFAULT_GEN_MODEL = "sonnet" pre-Phase-1."""
         from kai.eval.behavioral import _DEFAULT_GEN_MODEL
 
-        assert get_model_for(ModelRole.BEHAVIORAL_GEN, "claude") == _DEFAULT_GEN_MODEL
+        assert get_model_for(ModelRole.BEHAVIORAL_GEN, "claude", "anthropic") == _DEFAULT_GEN_MODEL
 
 
 # ── Codex wizard hardening: backend-aware model validation ───────────
@@ -2521,14 +2524,20 @@ class TestValidateModelForBackend:
         assert validate_model_for_backend("haiku", "opencode", "anthropic") is False
 
     def test_opencode_rejects_malformed_shapes(self):
-        """Empty segments, missing separator, and extra separators all fail."""
+        """Empty segments and missing separators fail; multi-slash
+        nesting (openrouter-style `openrouter/anthropic/claude-...`)
+        is now accepted because opencode's provider layer parses any
+        non-empty path-prefix shape."""
         from kai.config import validate_model_for_backend
 
         assert validate_model_for_backend("", "opencode", "") is False
         assert validate_model_for_backend("/foo", "opencode", "") is False
         assert validate_model_for_backend("foo/", "opencode", "") is False
         assert validate_model_for_backend("foo//bar", "opencode", "") is False
-        assert validate_model_for_backend("foo/bar/baz", "opencode", "") is False
+        # Multi-segment shape with all non-empty segments is valid;
+        # opencode parses provider/<rest>.
+        assert validate_model_for_backend("foo/bar/baz", "opencode", "") is True
+        assert validate_model_for_backend("openrouter/anthropic/claude-sonnet-4-5", "opencode", "") is True
         assert validate_model_for_backend("/", "opencode", "") is False
 
 
@@ -2572,11 +2581,21 @@ class TestValidBackends:
 
         assert sorted(VALID_BACKENDS) == ["claude", "codex", "goose", "opencode"]
 
-    def test_opencode_not_in_valid_providers(self):
-        """OpenCode auth lives in opencode-cli config; no provider/API-key wizard prompt fires."""
-        from kai.config import VALID_PROVIDERS
+    def test_opencode_provider_prompt_gate(self):
+        """OpenCode joins BACKENDS_NEEDING_PROVIDER_PROMPT (it talks
+        to multiple providers and needs the operator to name one for
+        the (backend, provider, role) registry lookup). The API-key
+        sub-prompt is suppressed for opencode in install.py because
+        opencode auth is managed by `opencode auth login`, not by
+        Kai."""
+        from kai.config import BACKEND_PROVIDERS, BACKENDS_NEEDING_PROVIDER_PROMPT
 
-        assert "opencode" not in VALID_PROVIDERS
+        assert "opencode" in BACKEND_PROVIDERS
+        assert "opencode" in BACKENDS_NEEDING_PROVIDER_PROMPT
+        # Single-provider backends are absent from the prompt gate so
+        # their provider stays implicit.
+        assert "claude" not in BACKENDS_NEEDING_PROVIDER_PROMPT
+        assert "codex" not in BACKENDS_NEEDING_PROVIDER_PROMPT
 
 
 class TestGetUserBackendAndProvider:
@@ -3305,3 +3324,199 @@ class TestNoAdHocOneShotBackendTuples:
         assert not offenders, (
             f"Found ad-hoc claude/codex tuples; use ONESHOT_REASONER_BACKENDS instead. Offending sites: {offenders}"
         )
+
+
+class TestBackendProviders:
+    """`BACKEND_PROVIDERS` is the single authoritative (backend, provider)
+    allowlist. `BACKENDS_NEEDING_PROVIDER_PROMPT` is derived from it
+    via the multiplicity filter so single-provider backends (claude,
+    codex) bypass the "requires provider" gates while multi-provider
+    backends (opencode, goose) exercise them.
+    """
+
+    def test_membership_contents(self):
+        from kai.config import BACKEND_PROVIDERS
+
+        assert set(BACKEND_PROVIDERS.keys()) == {"claude", "codex", "opencode", "goose"}
+        assert BACKEND_PROVIDERS["claude"] == ("anthropic",)
+        assert BACKEND_PROVIDERS["codex"] == ("openai",)
+        # Multi-provider backends include deepseek (new); openrouter and ollama
+        # are open-ended providers and live here too.
+        assert "deepseek" in BACKEND_PROVIDERS["opencode"]
+        assert "deepseek" in BACKEND_PROVIDERS["goose"]
+        assert "openrouter" in BACKEND_PROVIDERS["opencode"]
+
+    def test_strict_subset_of_valid_backends(self):
+        """Every backend listed in BACKEND_PROVIDERS must also be in
+        VALID_BACKENDS so the wizard's backend prompt accepts it."""
+        from kai.config import BACKEND_PROVIDERS, VALID_BACKENDS
+
+        assert set(BACKEND_PROVIDERS.keys()).issubset(VALID_BACKENDS)
+
+    def test_backends_needing_provider_prompt_is_derived(self):
+        """Derived set: single-provider backends absent; multi-provider
+        backends present. Pins the multiplicity-driven shape."""
+        from kai.config import BACKEND_PROVIDERS, BACKENDS_NEEDING_PROVIDER_PROMPT
+
+        for backend, providers in BACKEND_PROVIDERS.items():
+            if len(providers) > 1:
+                assert backend in BACKENDS_NEEDING_PROVIDER_PROMPT
+            else:
+                assert backend not in BACKENDS_NEEDING_PROVIDER_PROMPT
+
+
+class TestModelRegistryTripleKey:
+    """The (backend, provider, role) triple-key registry is built
+    mechanically from `_TIER_BY_ROLE` and `_BACKEND_PROVIDER_TIER_MODELS`.
+    Every (backend, provider) pair in BACKEND_PROVIDERS has a row for
+    every ModelRole; the completeness check runs at load_config time.
+    """
+
+    def test_keys_are_three_tuples(self):
+        """Every key is a 3-tuple (backend, provider, ModelRole)."""
+        for key in MODEL_REGISTRY:
+            assert isinstance(key, tuple)
+            assert len(key) == 3
+            backend, provider, role = key
+            assert isinstance(backend, str)
+            assert isinstance(provider, str)
+            assert isinstance(role, ModelRole)
+
+    def test_every_backend_provider_pair_has_every_role(self):
+        """Completeness invariant: BACKEND_PROVIDERS x ModelRole all
+        present in MODEL_REGISTRY. A missing triple at runtime would
+        surface as a per-request LookupError; the startup check ahead
+        of dispatch is what makes the runtime invariant safe."""
+        from kai.config import BACKEND_PROVIDERS
+
+        for backend, providers in BACKEND_PROVIDERS.items():
+            for provider in providers:
+                for role in ModelRole:
+                    assert (backend, provider, role) in MODEL_REGISTRY, (
+                        f"Missing registry row for ({backend}, {provider}, {role.value})"
+                    )
+
+    def test_canonical_rows_per_backend(self):
+        """Pin one representative row per backend so a future
+        _BACKEND_PROVIDER_TIER_MODELS tweak surfaces here in addition
+        to the larger acceptance loop above."""
+        assert MODEL_REGISTRY[("claude", "anthropic", ModelRole.PR_REVIEW)] == "sonnet"
+        assert MODEL_REGISTRY[("codex", "openai", ModelRole.PR_REVIEW)] == "gpt-5.4-mini"
+        assert MODEL_REGISTRY[("opencode", "deepseek", ModelRole.PR_REVIEW)] == "deepseek/deepseek-chat"
+        assert MODEL_REGISTRY[("goose", "anthropic", ModelRole.PR_REVIEW)] == "claude-sonnet-4-6"
+
+    def test_codex_rows_are_in_codex_models(self):
+        """The completeness check enforces this at startup; pinning
+        it independently catches drift between CODEX_MODELS and the
+        tier map without needing to trigger load_config."""
+        from kai.config import CODEX_MODELS
+
+        for role in ModelRole:
+            value = MODEL_REGISTRY[("codex", "openai", role)]
+            assert value in CODEX_MODELS, f"codex {role.value}={value} is not in CODEX_MODELS"
+
+
+class TestUserConfigModelsField:
+    """`UserConfig.models` is the per-user per-role override map; back-
+    compat synthesizes `models["agent"]` from the legacy `model:` field
+    so existing users.yaml files load unchanged."""
+
+    def test_field_default_is_none(self):
+        from kai.config import UserConfig
+
+        uc = UserConfig(telegram_id=1, name="test")
+        assert uc.models is None
+
+    def test_models_field_accepts_per_role_dict(self):
+        from kai.config import UserConfig
+
+        uc = UserConfig(
+            telegram_id=1,
+            name="test",
+            models={"pr_review": "deepseek/deepseek-coder", "agent": "sonnet"},
+        )
+        assert uc.models == {"pr_review": "deepseek/deepseek-coder", "agent": "sonnet"}
+
+
+class TestResolveUserModel:
+    """`resolve_user_model` enforces the per-role precedence chain:
+    user_config.models > config.default_models > MODEL_REGISTRY."""
+
+    def _config(self, default_models=None):
+        cfg = MagicMock()
+        cfg.agent_backend = "claude"
+        cfg.llm_provider = ""
+        cfg.default_models = default_models or {}
+        return cfg
+
+    def test_falls_back_to_registry_when_no_overrides(self):
+        from kai.config import resolve_user_model
+
+        result = resolve_user_model(ModelRole.PR_REVIEW, None, self._config())
+        assert result == "sonnet"
+
+    def test_user_override_wins(self):
+        from kai.config import UserConfig, resolve_user_model
+
+        uc = UserConfig(telegram_id=1, name="test", models={"pr_review": "opus"})
+        result = resolve_user_model(ModelRole.PR_REVIEW, uc, self._config())
+        assert result == "opus"
+
+    def test_global_default_models_wins_over_registry(self):
+        from kai.config import resolve_user_model
+
+        cfg = self._config(default_models={"pr_review": "claude-haiku-4-5-20251001"})
+        result = resolve_user_model(ModelRole.PR_REVIEW, None, cfg)
+        assert result == "claude-haiku-4-5-20251001"
+
+    def test_user_override_wins_over_global_default(self):
+        from kai.config import UserConfig, resolve_user_model
+
+        uc = UserConfig(telegram_id=1, name="test", models={"pr_review": "opus"})
+        cfg = self._config(default_models={"pr_review": "claude-haiku-4-5-20251001"})
+        result = resolve_user_model(ModelRole.PR_REVIEW, uc, cfg)
+        assert result == "opus"
+
+
+class TestLegacyEnvOverrideSeeding:
+    """`_apply_legacy_model_env_overrides` reads
+    PR_REVIEW_MODEL_<BACKEND> / ISSUE_TRIAGE_MODEL_<BACKEND> from the
+    process env at load_config time and seeds UserConfig.models. The
+    user's own `models:` map wins over the env-var seed."""
+
+    def test_seeds_pr_review_from_env(self, monkeypatch):
+        from kai.config import UserConfig, _apply_legacy_model_env_overrides
+
+        monkeypatch.setenv("PR_REVIEW_MODEL_CLAUDE", "opus")
+        uc = UserConfig(telegram_id=1, name="test")
+        out = _apply_legacy_model_env_overrides({1: uc}, "claude")
+        assert out[1].models == {"pr_review": "opus"}
+
+    def test_user_own_map_wins_over_env(self, monkeypatch):
+        from kai.config import UserConfig, _apply_legacy_model_env_overrides
+
+        monkeypatch.setenv("PR_REVIEW_MODEL_CLAUDE", "opus")
+        uc = UserConfig(telegram_id=1, name="test", models={"pr_review": "haiku"})
+        out = _apply_legacy_model_env_overrides({1: uc}, "claude")
+        # User's explicit value untouched.
+        assert out[1].models == {"pr_review": "haiku"}
+
+    def test_seeds_only_matching_backend_suffix(self, monkeypatch):
+        """A user on the codex backend should NOT pick up
+        PR_REVIEW_MODEL_CLAUDE; the suffix gates per-user scope."""
+        from kai.config import UserConfig, _apply_legacy_model_env_overrides
+
+        monkeypatch.setenv("PR_REVIEW_MODEL_CLAUDE", "opus")
+        uc = UserConfig(telegram_id=1, name="test", agent_backend="codex")
+        out = _apply_legacy_model_env_overrides({1: uc}, "claude")
+        assert out[1].models is None
+
+    def test_no_env_no_change(self, monkeypatch):
+        """When no env override applies, the dict shape is preserved."""
+        from kai.config import UserConfig, _apply_legacy_model_env_overrides
+
+        monkeypatch.delenv("PR_REVIEW_MODEL_CLAUDE", raising=False)
+        monkeypatch.delenv("ISSUE_TRIAGE_MODEL_CLAUDE", raising=False)
+        uc = UserConfig(telegram_id=1, name="test")
+        out = _apply_legacy_model_env_overrides({1: uc}, "claude")
+        assert out[1].models is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2523,10 +2523,10 @@ class TestValidateModelForBackend:
         assert validate_model_for_backend("sonnet", "opencode", "anthropic") is False
         assert validate_model_for_backend("haiku", "opencode", "anthropic") is False
 
-    def test_opencode_rejects_malformed_shapes(self):
+    def test_opencode_accepts_multi_slash_and_rejects_empty_segments(self):
         """Empty segments and missing separators fail; multi-slash
         nesting (openrouter-style `openrouter/anthropic/claude-...`)
-        is now accepted because opencode's provider layer parses any
+        is accepted because opencode's provider layer parses any
         non-empty path-prefix shape."""
         from kai.config import validate_model_for_backend
 

--- a/tests/test_eval_memory_backend_gate.py
+++ b/tests/test_eval_memory_backend_gate.py
@@ -260,16 +260,16 @@ class TestMakeBackendConfig:
         assert config.memory_enabled is True
         assert config.memory_extraction_enabled is True
         # Registry resolution still produces the expected literals.
-        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "claude") == "claude-haiku-4-5-20251001"
-        assert get_model_for(ModelRole.MEMORY_EPISODE, "claude") == "claude-haiku-4-5-20251001"
+        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "claude", "anthropic") == "claude-haiku-4-5-20251001"
+        assert get_model_for(ModelRole.MEMORY_EPISODE, "claude", "anthropic") == "claude-haiku-4-5-20251001"
 
     def test_codex_resolves_codex_models(self):
         from kai.config import ModelRole, get_model_for
 
         config = g.make_backend_config(_BASE_CONFIG, "codex")
         assert config.agent_backend == "codex"
-        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "codex") == "gpt-5.4-mini"
-        assert get_model_for(ModelRole.MEMORY_EPISODE, "codex") == "gpt-5.4-mini"
+        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "codex", "openai") == "gpt-5.4-mini"
+        assert get_model_for(ModelRole.MEMORY_EPISODE, "codex", "openai") == "gpt-5.4-mini"
 
 
 # ── Anchor matching ─────────────────────────────────────────────────

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1133,6 +1133,7 @@ class TestCmdConfig:
                 "polling",  # transport
                 "claude",  # agent backend
                 "sonnet",  # model
+                "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
                 "10.0",  # budget
                 "200000",  # max context window
@@ -1210,6 +1211,7 @@ class TestCmdConfig:
                 "polling",  # transport
                 "claude",  # agent backend
                 "sonnet",  # model
+                "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
                 "10.0",  # budget
                 "200000",  # max context window
@@ -1292,6 +1294,7 @@ class TestCmdConfig:
                 "polling",  # transport
                 "claude",  # agent backend
                 "sonnet",  # model
+                "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
                 "10.0",  # budget
                 "200000",  # max context window
@@ -1361,6 +1364,7 @@ class TestCmdConfig:
                 "polling",
                 "claude",
                 "sonnet",
+                "false",  # customize per-role models (decline; use registry defaults)
                 "120",
                 "10.0",
                 "200000",
@@ -1422,6 +1426,7 @@ class TestCmdConfig:
                 "anthropic",  # goose provider
                 "sk-ant-test-key",  # ANTHROPIC_API_KEY
                 "sonnet",  # model
+                "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
                 "10.0",  # budget
                 "200000",  # max context window
@@ -1478,6 +1483,7 @@ class TestCmdConfig:
                 "goose",  # agent backend
                 "ollama",  # goose provider (no key needed)
                 "sonnet",  # model
+                "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
                 "10.0",  # budget
                 "200000",  # max context window
@@ -1655,6 +1661,7 @@ class TestCmdConfig:
             agent_backend,  # agent backend
             *backend_block,  # llm_provider + api_key (non-claude only)
             "sonnet",  # model
+            "false",  # customize per-role models (decline; use registry defaults)
             "120",  # timeout
             *budget_entry,  # BUDGET_CEILING (non-claude only)
             "200000",  # max context window
@@ -2102,6 +2109,7 @@ class TestCmdConfig:
                 "anthropic",  # goose provider
                 "sk-ant-test-key",  # API key
                 "sonnet",  # model
+                "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
                 "10.0",  # budget
                 "200000",  # max context window
@@ -2398,8 +2406,8 @@ class TestCmdConfig:
         # have a codex-valid row.
         from kai.config import CODEX_MODELS, ModelRole, get_model_for
 
-        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "codex") in CODEX_MODELS
-        assert get_model_for(ModelRole.MEMORY_EPISODE, "codex") in CODEX_MODELS
+        assert get_model_for(ModelRole.MEMORY_EXTRACTION, "codex", "openai") in CODEX_MODELS
+        assert get_model_for(ModelRole.MEMORY_EPISODE, "codex", "openai") in CODEX_MODELS
 
     def test_codex_fresh_install_with_memory_extraction_yields_valid_users_yaml(self, tmp_path, monkeypatch):
         """Fresh-install integration contract for codex memory.
@@ -2453,6 +2461,7 @@ class TestCmdConfig:
                 "subscription",  # codex auth mode
                 "/usr/local/bin/codex",  # codex binary path
                 # model: handled by _prompt_default_model mock
+                "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # agent timeout
                 "10.0",  # budget (codex != claude branch)
                 "200000",  # max context window
@@ -2817,6 +2826,7 @@ class TestCmdConfigDefaultModelDispatch:
             "polling",  # transport
             "claude",  # agent backend
             # model prompt is handled by the _prompt_default_model mock
+            "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout (global default)
             "200000",  # max context window (global default)
             "80",  # autocompact pct
@@ -2855,8 +2865,9 @@ class TestCmdConfigDefaultModelDispatch:
             "subscription",  # codex auth mode
             # No OPENAI_API_KEY prompt in subscription mode
             "/usr/local/bin/codex",  # codex binary path
-            # No llm_provider prompt (VALID_PROVIDERS["codex"] is None)
+            # No llm_provider prompt (codex is single-provider; absent from BACKENDS_NEEDING_PROVIDER_PROMPT)
             # Model prompt handled by the _prompt_default_model mock
+            "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout (global default)
             "10.0",  # BUDGET_CEILING (non-claude only)
             "200000",  # max context window (global default)
@@ -2889,6 +2900,7 @@ class TestCmdConfigDefaultModelDispatch:
             "openai",  # llm provider
             "openai-key",  # OPENAI_API_KEY
             # model prompt is handled by the _prompt_default_model mock
+            "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout (global default)
             "10.0",  # BUDGET_CEILING (non-claude only)
             "200000",  # max context window (global default)
@@ -6364,6 +6376,7 @@ class TestCmdConfigCanonicalUsersYaml:
             "polling",
             "claude",
             "sonnet",
+            "false",  # customize per-role models (decline)
             "120",
             "10.0",
             "200000",
@@ -6714,6 +6727,7 @@ class TestCmdConfigSingleUserMode:
             "polling",  # transport
             "claude",  # backend
             "sonnet",  # model
+            "false",  # customize per-role models (decline; use registry defaults)
             "120",  # timeout
             "200000",  # max_context_window
             "80",  # autocompact
@@ -7496,8 +7510,11 @@ class TestOpenCodeBinWizardPrompt:
             "false",  # advanced user options (no per-user os_user)
             "polling",  # transport
             "opencode",  # agent backend
-            opencode_bin_path,  # OPENCODE_BIN (NEW prompt this spec adds)
+            opencode_bin_path,  # OPENCODE_BIN
+            "anthropic",  # llm_provider (opencode joined BACKENDS_NEEDING_PROVIDER_PROMPT)
+            # API key prompt skipped for opencode (auth managed by `opencode auth login`).
             # model: handled by _prompt_default_model mock
+            "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout
             "10.0",  # budget (non-claude branch)
             "200000",  # max context window

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -206,6 +206,7 @@ class TestExtractionResultClassifier:
             candidate_metadata={},
             user_id="u1",
             effective_backend="claude",
+            effective_provider="anthropic",
         )
         assert isinstance(result, ExtractionResult)
         assert result.has_episode is True
@@ -228,6 +229,7 @@ class TestExtractionResultClassifier:
             candidate_metadata={},
             user_id="u1",
             effective_backend="claude",
+            effective_provider="anthropic",
         )
         assert result.has_episode is False
 
@@ -261,6 +263,7 @@ class TestExtractionResultClassifier:
             candidate_metadata={},
             user_id="u1",
             effective_backend="claude",
+            effective_provider="anthropic",
         )
         assert result.has_episode is False
         assert result.facts == []
@@ -516,6 +519,7 @@ class TestStage2Isolation:
                 session_id=None,
                 config=_cfg(memory_episode_timeout_s=10),
                 effective_backend="claude",
+                effective_provider="anthropic",
             )
 
         episode_records = [r for r in caplog.records if r.message.startswith("memory.episode ")]
@@ -566,6 +570,7 @@ class TestStage2Isolation:
                 session_id=None,
                 config=_cfg(),
                 effective_backend="claude",
+                effective_provider="anthropic",
             )
         await release_task
 
@@ -614,6 +619,7 @@ class TestStage2Isolation:
                 session_id=None,
                 config=_cfg(),
                 effective_backend="claude",
+                effective_provider="anthropic",
             )
 
         records = [r for r in caplog.records if r.message.startswith("memory.episode ")]
@@ -651,6 +657,7 @@ class TestStage2Isolation:
                 session_id=None,
                 config=_cfg(),
                 effective_backend="claude",
+                effective_provider="anthropic",
             )
 
         episode_records = [r for r in caplog.records if r.message.startswith("memory.episode ")]
@@ -698,6 +705,7 @@ class TestStage2Storage:
             session_id="sess-42",
             config=_cfg(),
             effective_backend="claude",
+            effective_provider="anthropic",
         )
 
         assert captured["memory_type"] == "episode"
@@ -738,6 +746,7 @@ class TestStage2Storage:
             session_id=None,
             config=_cfg(),
             effective_backend="claude",
+            effective_provider="anthropic",
         )
 
         assert "lessons" not in captured["metadata"]
@@ -770,6 +779,7 @@ class TestStage2Storage:
             session_id=None,
             config=_cfg(),
             effective_backend="claude",
+            effective_provider="anthropic",
         )
 
         assert captured["metadata"]["lessons"] == episode_with_lessons["lessons"]
@@ -800,6 +810,7 @@ class TestStage2Storage:
             session_id=None,
             config=_cfg(),
             effective_backend="claude",
+            effective_provider="anthropic",
         )
 
         assert captured["content"] == f"{ep['goal']}\n\n{ep['context']}"
@@ -826,6 +837,7 @@ class TestStage2Storage:
                 session_id=None,
                 config=_cfg(),
                 effective_backend="claude",
+                effective_provider="anthropic",
             )
 
         records = [r for r in caplog.records if r.message.startswith("memory.episode ")]
@@ -863,6 +875,7 @@ class TestStage2Storage:
                 session_id=None,
                 config=_cfg(),
                 effective_backend="claude",
+                effective_provider="anthropic",
             )
 
         records = [r for r in caplog.records if r.message.startswith("memory.episode ")]
@@ -907,6 +920,7 @@ class TestStage2SubprocessAssembly:
             "payload",
             _cfg(memory_episode_budget_usd=0.15),
             effective_backend="claude",
+            effective_provider="anthropic",
         )
 
         args = captured["args"]
@@ -936,7 +950,7 @@ class TestStage2SubprocessAssembly:
             return _make_proc(stdout=_stage2_envelope(_valid_episode()))
 
         monkeypatch.setattr(memory_extraction.asyncio, "create_subprocess_exec", _fake_exec)
-        await _run_episode_extractor("payload", _cfg(), effective_backend="claude")
+        await _run_episode_extractor("payload", _cfg(), effective_backend="claude", effective_provider="anthropic")
 
         args = captured["args"]
         assert args[args.index("--tools") + 1] == ""
@@ -1164,7 +1178,9 @@ class TestRunEpisodeExtractorViaReasoner:
                 )
 
         with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FakeReasoner()):
-            episode, cost_usd, reason = await _run_episode_extractor("payload", _cfg(), effective_backend="claude")
+            episode, cost_usd, reason = await _run_episode_extractor(
+                "payload", _cfg(), effective_backend="claude", effective_provider="anthropic"
+            )
 
         assert episode == _valid_episode()
         assert cost_usd == pytest.approx(0.04)
@@ -1182,7 +1198,9 @@ class TestRunEpisodeExtractorViaReasoner:
                 raise OneShotTimeout()
 
         with patch("kai.memory_extraction._build_memory_reasoner", return_value=_TimingOutReasoner()):
-            episode, cost_usd, reason = await _run_episode_extractor("payload", _cfg(), effective_backend="claude")
+            episode, cost_usd, reason = await _run_episode_extractor(
+                "payload", _cfg(), effective_backend="claude", effective_provider="anthropic"
+            )
 
         assert episode is None
         assert cost_usd == 0.0
@@ -1201,7 +1219,9 @@ class TestRunEpisodeExtractorViaReasoner:
                 raise OneShotSubprocessError(returncode=2, stderr=b"oauth refused: please login")
 
         with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FailingReasoner()):
-            episode, cost_usd, reason = await _run_episode_extractor("payload", _cfg(), effective_backend="claude")
+            episode, cost_usd, reason = await _run_episode_extractor(
+                "payload", _cfg(), effective_backend="claude", effective_provider="anthropic"
+            )
 
         assert episode is None
         assert cost_usd == 0.0
@@ -1240,7 +1260,9 @@ class TestRunEpisodeExtractorWithCodexEnvelope:
 
         config = _cfg()
         with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FakeCodexReasoner()):
-            ep, cost_usd, reason = await _run_episode_extractor("payload", config, effective_backend="codex")
+            ep, cost_usd, reason = await _run_episode_extractor(
+                "payload", config, effective_backend="codex", effective_provider="openai"
+            )
 
         assert ep == episode
         # No total_cost_usd in the envelope -> 0.0. Codex runs

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -919,6 +919,7 @@ class TestStage2SubprocessAssembly:
         await _run_episode_extractor(
             "payload",
             _cfg(memory_episode_budget_usd=0.15),
+            user_id="test-episode-user",
             effective_backend="claude",
             effective_provider="anthropic",
         )
@@ -950,7 +951,9 @@ class TestStage2SubprocessAssembly:
             return _make_proc(stdout=_stage2_envelope(_valid_episode()))
 
         monkeypatch.setattr(memory_extraction.asyncio, "create_subprocess_exec", _fake_exec)
-        await _run_episode_extractor("payload", _cfg(), effective_backend="claude", effective_provider="anthropic")
+        await _run_episode_extractor(
+            "payload", _cfg(), user_id="test-episode-user", effective_backend="claude", effective_provider="anthropic"
+        )
 
         args = captured["args"]
         assert args[args.index("--tools") + 1] == ""
@@ -1179,7 +1182,11 @@ class TestRunEpisodeExtractorViaReasoner:
 
         with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FakeReasoner()):
             episode, cost_usd, reason = await _run_episode_extractor(
-                "payload", _cfg(), effective_backend="claude", effective_provider="anthropic"
+                "payload",
+                _cfg(),
+                user_id="test-episode-user",
+                effective_backend="claude",
+                effective_provider="anthropic",
             )
 
         assert episode == _valid_episode()
@@ -1199,7 +1206,11 @@ class TestRunEpisodeExtractorViaReasoner:
 
         with patch("kai.memory_extraction._build_memory_reasoner", return_value=_TimingOutReasoner()):
             episode, cost_usd, reason = await _run_episode_extractor(
-                "payload", _cfg(), effective_backend="claude", effective_provider="anthropic"
+                "payload",
+                _cfg(),
+                user_id="test-episode-user",
+                effective_backend="claude",
+                effective_provider="anthropic",
             )
 
         assert episode is None
@@ -1220,7 +1231,11 @@ class TestRunEpisodeExtractorViaReasoner:
 
         with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FailingReasoner()):
             episode, cost_usd, reason = await _run_episode_extractor(
-                "payload", _cfg(), effective_backend="claude", effective_provider="anthropic"
+                "payload",
+                _cfg(),
+                user_id="test-episode-user",
+                effective_backend="claude",
+                effective_provider="anthropic",
             )
 
         assert episode is None
@@ -1261,7 +1276,7 @@ class TestRunEpisodeExtractorWithCodexEnvelope:
         config = _cfg()
         with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FakeCodexReasoner()):
             ep, cost_usd, reason = await _run_episode_extractor(
-                "payload", config, effective_backend="codex", effective_provider="openai"
+                "payload", config, user_id="test-episode-user", effective_backend="codex", effective_provider="openai"
             )
 
         assert ep == episode

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -2939,6 +2939,7 @@ class TestRunExtractorSystemPromptDefault:
                 candidate_metadata={},
                 user_id="test-user-default-kwarg",
                 effective_backend="claude",
+                effective_provider="anthropic",
             )
 
         asyncio.run(_run())
@@ -3263,6 +3264,7 @@ class TestValidateEpisodeIntegration:
             session_id="s-1",
             config=_cfg(),
             effective_backend="claude",
+            effective_provider="anthropic",
         )
 
         assert captured["outcome"] == "validate_rejected"
@@ -3314,6 +3316,7 @@ class TestValidateEpisodeIntegration:
             session_id="s-1",
             config=_cfg(),
             effective_backend="claude",
+            effective_provider="anthropic",
         )
 
         assert captured["outcome"] == "stored"
@@ -3377,6 +3380,7 @@ class TestValidateEpisodeIntegration:
             session_id="s-1",
             config=_cfg(),
             effective_backend="claude",
+            effective_provider="anthropic",
         )
 
         assert captured_metadata.get("speaker") == "episode_summary"
@@ -3587,6 +3591,7 @@ class TestRunExtractorViaReasoner:
                 candidate_metadata={},
                 user_id="u1",
                 effective_backend="claude",
+                effective_provider="anthropic",
             )
 
         assert result.facts == []
@@ -3611,6 +3616,7 @@ class TestRunExtractorViaReasoner:
                 candidate_metadata={},
                 user_id="u1",
                 effective_backend="claude",
+                effective_provider="anthropic",
             )
 
         assert result.facts == []
@@ -3635,6 +3641,7 @@ class TestRunExtractorViaReasoner:
                 candidate_metadata={},
                 user_id="u1",
                 effective_backend="claude",
+                effective_provider="anthropic",
             )
 
         assert result.facts == []
@@ -3711,6 +3718,7 @@ class TestRunExtractorWithCodexEnvelope:
                 candidate_metadata={},
                 user_id="u1",
                 effective_backend="codex",
+                effective_provider="openai",
             )
 
         assert result.facts == []
@@ -3740,6 +3748,7 @@ class TestRunExtractorWithCodexEnvelope:
                 candidate_metadata={},
                 user_id="u1",
                 effective_backend="codex",
+                effective_provider="openai",
             )
 
         assert result.facts == []

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -10,12 +10,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from kai.review import (
-    _GOOSE_AGENT_MODELS,
     _MAX_DIFF_CHARS,
     _MAX_PRIOR_COMMENTS_CHARS,
     _REVIEW_HEADER,
     PRMetadata,
-    _resolve_goose_model,
     build_review_prompt,
     extract_pr_metadata,
     fetch_pr_diff,
@@ -518,16 +516,17 @@ class TestRunReview:
         assert "sonnet" in cmd
 
     @pytest.mark.asyncio
-    async def test_claude_env_override_honored_at_call_site(self, monkeypatch):
+    async def test_model_override_param_wins_over_registry_default(self):
         """
-        PR_REVIEW_MODEL_CLAUDE in the environment overrides the registry
-        value at the call site. The override env var is read here rather
-        than in load_config; this test verifies the wiring end-to-end.
+        The `model_override` parameter (resolved by the caller in
+        webhook.py from `user_config.models[role.value]` and the
+        load-time legacy env-var seeding) wins over the registry
+        default. Pins the wiring that lets per-user `models.pr_review`
+        reach dispatch without the historic env-var read at the call site.
         """
-        monkeypatch.setenv("PR_REVIEW_MODEL_CLAUDE", "opus")
         mock_proc = _mock_process(stdout=b"ok")
         with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_review("prompt")
+            await run_review("prompt", model_override="opus")
         cmd = mock_exec.call_args[0]
         i = cmd.index("--model")
         assert cmd[i + 1] == "opus"
@@ -809,16 +808,16 @@ class TestRunReviewCodex:
         assert cmd[i + 1] == "gpt-5.4-mini"
 
     @pytest.mark.asyncio
-    async def test_codex_env_override_honored_at_call_site(self, monkeypatch):
+    async def test_codex_model_override_param_wins(self):
         """
-        PR_REVIEW_MODEL_CODEX in the environment overrides the
-        registry value at the call site. Same end-to-end env-override
-        wiring as the claude path.
+        On the codex branch, the `model_override` parameter (resolved
+        by the caller from per-user `models.pr_review` and the
+        load-time legacy env-var seeding) wins over the registry
+        default the same way it does on the claude branch.
         """
-        monkeypatch.setenv("PR_REVIEW_MODEL_CODEX", "gpt-5.4")
         mock_proc = _mock_process(stdout=self._codex_ndjson(""))
         with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_review("prompt", agent_backend="codex")
+            await run_review("prompt", agent_backend="codex", model_override="gpt-5.4")
         cmd = mock_exec.call_args[0]
         i = cmd.index("--model")
         assert cmd[i + 1] == "gpt-5.4"
@@ -1084,30 +1083,39 @@ class TestRunReviewGoose:
         assert cmd[0] == "goose"
 
     @pytest.mark.asyncio
-    async def test_open_ended_provider_reads_env(self):
-        """Open-ended providers (ollama) use GOOSE_MODEL from env."""
+    async def test_open_ended_provider_uses_registry_default(self):
+        """Goose+ollama resolves the PR_REVIEW row from the unified
+        registry. Operators override per-user via users.yaml
+        `models.pr_review`; the historic GOOSE_MODEL env path retired
+        with the `_GOOSE_AGENT_MODELS` fold-in."""
         mock_proc = _mock_process(stdout=b"output")
 
-        with (
-            patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
-            patch.dict(os.environ, {"GOOSE_MODEL": "llama3.3:70b"}),
-        ):
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
             await run_review("prompt", agent_backend="goose", provider="ollama")
 
         cmd = mock_exec.call_args[0]
         model_idx = cmd.index("--model")
-        assert cmd[model_idx + 1] == "llama3.3:70b"
+        # Registry value for ("goose", "ollama", PR_REVIEW); see
+        # _BACKEND_PROVIDER_TIER_MODELS in config.py.
+        assert cmd[model_idx + 1] == "llama4:70b"
 
     @pytest.mark.asyncio
-    async def test_open_ended_provider_no_model_raises(self):
-        """Open-ended provider with no GOOSE_MODEL raises RuntimeError."""
-        with (
-            patch.dict(os.environ, {}, clear=False),
-            pytest.raises(RuntimeError, match="No model configured"),
-        ):
-            # Remove GOOSE_MODEL if it happens to be set in the test env
-            os.environ.pop("GOOSE_MODEL", None)
-            await run_review("prompt", agent_backend="goose", provider="ollama")
+    async def test_open_ended_provider_with_model_override(self):
+        """Per-user `models.pr_review` override flows through
+        `model_override` and wins over the registry default."""
+        mock_proc = _mock_process(stdout=b"output")
+
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_review(
+                "prompt",
+                agent_backend="goose",
+                provider="ollama",
+                model_override="qwen3:32b",
+            )
+
+        cmd = mock_exec.call_args[0]
+        model_idx = cmd.index("--model")
+        assert cmd[model_idx + 1] == "qwen3:32b"
 
     @pytest.mark.asyncio
     async def test_default_backend_is_claude(self):
@@ -1158,7 +1166,9 @@ class TestRunReviewOpenCodeDispatch:
             patch("kai.review.OpenCodeOneShotReasoner", return_value=fake) as ctor,
             patch("kai.review.asyncio.create_subprocess_exec") as mock_exec,
         ):
-            result = await run_review("prompt body", agent_backend="opencode", claude_user="someone")
+            result = await run_review(
+                "prompt body", agent_backend="opencode", provider="anthropic", claude_user="someone"
+            )
 
         assert result == "review body from opencode"
         # OpenCodeOneShotReasoner was constructed with the claude_user
@@ -1182,7 +1192,7 @@ class TestRunReviewOpenCodeDispatch:
             patch("kai.review.OpenCodeOneShotReasoner", return_value=fake),
             pytest.raises(RuntimeError, match=r"Review subprocess timed out"),
         ):
-            await run_review("prompt", agent_backend="opencode")
+            await run_review("prompt", agent_backend="opencode", provider="anthropic")
 
     @pytest.mark.asyncio
     async def test_run_review_collapses_oneshot_error_to_runtime_error(self):
@@ -1195,28 +1205,28 @@ class TestRunReviewOpenCodeDispatch:
             patch("kai.review.OpenCodeOneShotReasoner", return_value=fake),
             pytest.raises(RuntimeError, match=r"OpenCode review failed.*model refused"),
         ):
-            await run_review("prompt", agent_backend="opencode")
+            await run_review("prompt", agent_backend="opencode", provider="anthropic")
 
 
-class TestResolveGooseModelReview:
-    """Tests for _resolve_goose_model in review.py."""
+class TestGooseModelResolutionViaRegistry:
+    """Goose model selection now flows through the unified
+    (backend, provider, role) MODEL_REGISTRY. Curated providers
+    inherit the registry default; open-ended providers (openrouter,
+    ollama) need a per-user `models.pr_review` in users.yaml or
+    accept the registry-shipped fallback."""
 
-    def test_curated_providers(self):
-        """Each curated provider returns its hardcoded mid-tier model."""
-        for provider, expected_model in _GOOSE_AGENT_MODELS.items():
-            assert _resolve_goose_model(provider) == expected_model
+    def test_curated_provider_registry_lookup(self):
+        """Goose+openai resolves the PR_REVIEW row from the registry."""
+        from kai.config import MODEL_REGISTRY, ModelRole
 
-    def test_open_ended_provider_with_env(self):
-        """Open-ended provider reads GOOSE_MODEL from environment."""
-        with patch.dict(os.environ, {"GOOSE_MODEL": "custom-model"}):
-            assert _resolve_goose_model("openrouter") == "custom-model"
+        assert MODEL_REGISTRY[("goose", "openai", ModelRole.PR_REVIEW)] == "gpt-5.4"
 
-    def test_open_ended_provider_no_env_raises(self):
-        """Open-ended provider without GOOSE_MODEL raises RuntimeError."""
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("GOOSE_MODEL", None)
-            with pytest.raises(RuntimeError, match="No model configured"):
-                _resolve_goose_model("ollama")
+    def test_open_ended_provider_registry_lookup(self):
+        """Goose+ollama has a registry-shipped default; operators
+        override per-user via users.yaml `models.pr_review`."""
+        from kai.config import MODEL_REGISTRY, ModelRole
+
+        assert MODEL_REGISTRY[("goose", "ollama", ModelRole.PR_REVIEW)] == "llama4:70b"
 
 
 # ── post_review_comment ─────────────────────────────────────────────

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -10,10 +10,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from kai.triage import (
-    _GOOSE_AGENT_MODELS,
     IssueMetadata,
     _parse_triage_json,
-    _resolve_goose_model,
     _sanitize_search_query,
     _send_error_notification,
     apply_triage,
@@ -334,17 +332,18 @@ class TestRunTriage:
         assert cmd[i + 1] == "sonnet"
 
     @pytest.mark.asyncio
-    async def test_claude_env_override_honored_at_call_site(self, monkeypatch):
+    async def test_model_override_param_wins_over_registry_default(self):
         """
-        ISSUE_TRIAGE_MODEL_CLAUDE in the environment overrides the
-        registry value at the call site. The override env var is
-        read here rather than in load_config; this test verifies the
-        wiring end-to-end.
+        The `model_override` parameter (resolved by the caller in
+        webhook.py from `user_config.models["issue_triage"]` and the
+        load-time legacy env-var seeding) wins over the registry
+        default. Pins the wiring that lets per-user
+        `models.issue_triage` reach dispatch without the historic
+        ISSUE_TRIAGE_MODEL_CLAUDE env-var read at the call site.
         """
-        monkeypatch.setenv("ISSUE_TRIAGE_MODEL_CLAUDE", "opus")
         mock_proc = _mock_subprocess(returncode=0, stdout='{"labels": []}')
         with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage("prompt", agent_backend="claude")
+            await run_triage("prompt", agent_backend="claude", model_override="opus")
         cmd = mock_exec.call_args[0]
         i = cmd.index("--model")
         assert cmd[i + 1] == "opus"
@@ -608,29 +607,36 @@ class TestRunTriageGoose:
         assert cmd[0] == "goose"
 
     @pytest.mark.asyncio
-    async def test_open_ended_provider_reads_env(self):
-        """Open-ended providers (ollama) use GOOSE_MODEL from env."""
+    async def test_open_ended_provider_uses_registry_default(self):
+        """Goose+ollama resolves the ISSUE_TRIAGE row from the unified
+        registry. The historic GOOSE_MODEL env path retired with
+        the `_GOOSE_AGENT_MODELS` fold-in."""
         mock_proc = _mock_subprocess(stdout='{"labels": []}')
 
-        with (
-            patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
-            patch.dict(os.environ, {"GOOSE_MODEL": "llama3.3:70b"}),
-        ):
+        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
             await run_triage("prompt", agent_backend="goose", provider="ollama")
 
         cmd = mock_exec.call_args[0]
         model_idx = cmd.index("--model")
-        assert cmd[model_idx + 1] == "llama3.3:70b"
+        assert cmd[model_idx + 1] == "llama4:70b"
 
     @pytest.mark.asyncio
-    async def test_open_ended_provider_no_model_raises(self):
-        """Open-ended provider with no GOOSE_MODEL raises RuntimeError."""
-        with (
-            patch.dict(os.environ, {}, clear=False),
-            pytest.raises(RuntimeError, match="No model configured"),
-        ):
-            os.environ.pop("GOOSE_MODEL", None)
-            await run_triage("prompt", agent_backend="goose", provider="ollama")
+    async def test_open_ended_provider_with_model_override(self):
+        """Per-user `models.issue_triage` override flows through
+        `model_override` and wins over the registry default."""
+        mock_proc = _mock_subprocess(stdout='{"labels": []}')
+
+        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_triage(
+                "prompt",
+                agent_backend="goose",
+                provider="ollama",
+                model_override="qwen3:32b",
+            )
+
+        cmd = mock_exec.call_args[0]
+        model_idx = cmd.index("--model")
+        assert cmd[model_idx + 1] == "qwen3:32b"
 
     @pytest.mark.asyncio
     async def test_default_backend_is_claude(self):
@@ -677,7 +683,9 @@ class TestRunTriageOpenCodeDispatch:
             patch("kai.triage.OpenCodeOneShotReasoner", return_value=fake) as ctor,
             patch("kai.triage.asyncio.create_subprocess_exec") as mock_exec,
         ):
-            result = await run_triage("prompt body", agent_backend="opencode", claude_user="someone")
+            result = await run_triage(
+                "prompt body", agent_backend="opencode", provider="anthropic", claude_user="someone"
+            )
 
         assert result == '{"labels": []}'
         ctor.assert_called_once()
@@ -696,7 +704,7 @@ class TestRunTriageOpenCodeDispatch:
             patch("kai.triage.OpenCodeOneShotReasoner", return_value=fake),
             pytest.raises(RuntimeError, match=r"Triage subprocess timed out"),
         ):
-            await run_triage("prompt", agent_backend="opencode")
+            await run_triage("prompt", agent_backend="opencode", provider="anthropic")
 
     @pytest.mark.asyncio
     async def test_run_triage_collapses_oneshot_error_to_runtime_error(self):
@@ -709,7 +717,7 @@ class TestRunTriageOpenCodeDispatch:
             patch("kai.triage.OpenCodeOneShotReasoner", return_value=fake),
             pytest.raises(RuntimeError, match=r"OpenCode triage failed.*schema bad"),
         ):
-            await run_triage("prompt", agent_backend="opencode")
+            await run_triage("prompt", agent_backend="opencode", provider="anthropic")
 
 
 class TestRunTriageCodex:
@@ -799,16 +807,16 @@ class TestRunTriageCodex:
         assert cmd[i + 1] == "gpt-5.4-mini"
 
     @pytest.mark.asyncio
-    async def test_codex_env_override_honored_at_call_site(self, monkeypatch):
+    async def test_codex_model_override_param_wins(self):
         """
-        ISSUE_TRIAGE_MODEL_CODEX in the environment overrides the
-        registry value at the call site. Same end-to-end env-override
-        wiring as the claude path.
+        On the codex branch, the `model_override` parameter (resolved
+        by the caller from per-user `models.issue_triage` and the
+        load-time legacy env-var seeding) wins over the registry
+        default the same way it does on the claude branch.
         """
-        monkeypatch.setenv("ISSUE_TRIAGE_MODEL_CODEX", "gpt-5.4")
         mock_proc = _mock_subprocess(stdout=self._codex_ndjson("{}"))
         with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage("prompt", agent_backend="codex")
+            await run_triage("prompt", agent_backend="codex", model_override="gpt-5.4")
         cmd = mock_exec.call_args[0]
         i = cmd.index("--model")
         assert cmd[i + 1] == "gpt-5.4"
@@ -930,25 +938,24 @@ class TestRunTriageCodex:
         assert result == expected_json
 
 
-class TestResolveGooseModelTriage:
-    """Tests for _resolve_goose_model in triage.py."""
+class TestGooseTriageModelResolutionViaRegistry:
+    """Goose triage model selection now flows through the unified
+    (backend, provider, role) MODEL_REGISTRY. The legacy
+    _resolve_goose_model helper retired with this spec; per-user
+    overrides live in users.yaml `models.issue_triage`."""
 
-    def test_curated_providers(self):
-        """Each curated provider returns its hardcoded mid-tier model."""
-        for provider, expected_model in _GOOSE_AGENT_MODELS.items():
-            assert _resolve_goose_model(provider) == expected_model
+    def test_curated_provider_registry_lookup(self):
+        """Goose+openai resolves the ISSUE_TRIAGE row from the registry."""
+        from kai.config import MODEL_REGISTRY, ModelRole
 
-    def test_open_ended_provider_with_env(self):
-        """Open-ended provider reads GOOSE_MODEL from environment."""
-        with patch.dict(os.environ, {"GOOSE_MODEL": "custom-model"}):
-            assert _resolve_goose_model("openrouter") == "custom-model"
+        assert MODEL_REGISTRY[("goose", "openai", ModelRole.ISSUE_TRIAGE)] == "gpt-5.4"
 
-    def test_open_ended_provider_no_env_raises(self):
-        """Open-ended provider without GOOSE_MODEL raises RuntimeError."""
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("GOOSE_MODEL", None)
-            with pytest.raises(RuntimeError, match="No model configured"):
-                _resolve_goose_model("ollama")
+    def test_open_ended_provider_registry_lookup(self):
+        """Goose+ollama has a registry-shipped default that operators
+        override per-user via users.yaml `models.issue_triage`."""
+        from kai.config import MODEL_REGISTRY, ModelRole
+
+        assert MODEL_REGISTRY[("goose", "ollama", ModelRole.ISSUE_TRIAGE)] == "llama4:70b"
 
 
 # ── _parse_triage_json ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Widen `MODEL_REGISTRY` to a `(backend, provider, role)` triple-key index built mechanically from a tier scheme (`_TIER_BY_ROLE` + `_BACKEND_PROVIDER_TIER_MODELS` + `_build_registry`). Adding a new `(backend, provider)` pair is one tier-map entry. Closes the silent-fail loop where opencode and goose installs on non-anthropic providers (e.g. DeepSeek-only) hit anthropic-shaped defaults at PR review / issue triage / memory extraction / behavioral eval.
- Introduce `BACKEND_PROVIDERS` (the single authoritative `(backend, provider)` allowlist) and `BACKENDS_NEEDING_PROVIDER_PROMPT` (derived from the multiplicity filter). Retire `VALID_PROVIDERS`; update four downstream read sites. Single-provider backends (claude, codex) stay outside the prompt gate; multi-provider backends (opencode, goose) require an explicit provider so the registry triple-key lookup hits.
- Add `UserConfig.models` per-role per-user override map loaded from users.yaml. Back-compat synthesizes `models["agent"]` from the legacy `model:` field at load time. `resolve_user_model` enforces precedence: `user_config.models` > `Config.default_models` (parsed from `DEFAULT_MODELS_JSON` env) > `MODEL_REGISTRY` default.
- Wizard per-role customization gate: `_cmd_config` offers an optional per-role walk after the conversational model prompt. Curated path uses choice lists; opencode + `OPEN_ENDED_PROVIDERS` use free-text. Persisted to `DEFAULT_MODELS_JSON` via delta-from-defaults discipline.
- Retire `PR_REVIEW_MODEL_<BACKEND>` / `ISSUE_TRIAGE_MODEL_<BACKEND>` dispatch-time env reads in `review.py` / `triage.py`. Values reach dispatch through `UserConfig.models` via a new `_apply_legacy_model_env_overrides` pass in `load_config` (one-shot WARNING per process). `webhook.py` resolves per-user `models.pr_review` / `models.issue_triage` and threads them as `model_override` kwargs to `run_review` / `run_triage`.
- `get_model_for` widens to a 3-positional-arg signature. Single-provider backends still accept an empty `provider` argument and fall back to the implicit value via `get_effective_provider`, so callers without provider context keep working.
- `_check_model_registry_complete` becomes self-driving: walks every `(backend, provider)` pair in `BACKEND_PROVIDERS` and fails fast on a missing row regardless of which backend is active. Goose now folds into the unified registry; `_GOOSE_AGENT_MODELS` and `_resolve_goose_model` retire from both `review.py` and `triage.py`.
- Add `src/kai/refresh_models.py` and `make refresh-models`. The opt-in command queries each curated provider's `/v1/models` endpoint via `aiohttp` and prints a unified diff against `PROVIDER_MODELS` for operator hand review. Diff-only by default; `--write-snippet` emits a paste-able Python fragment. Never writes source files; the operator decides what to merge.

Operator-visible behavior change: an opencode install must now set `LLM_PROVIDER` (opencode joined `BACKENDS_NEEDING_PROVIDER_PROMPT`). The wizard captures this on the next `make config`; existing opencode installs that hand-edited `/etc/kai/env` need one extra env value. This is the deliberate UX cost in exchange for closing the silent-fail-at-dispatch loop that affected every opencode operator at every one-shot role.

Migration paths covered: existing `model:` field in users.yaml loads unchanged via the `models["agent"]` synthesis; existing `PR_REVIEW_MODEL_*` / `ISSUE_TRIAGE_MODEL_*` env values continue to work as fallbacks with a one-shot deprecation warning; existing `GOOSE_MODEL` env value triggers a deprecation hint.

## Test plan

- [x] `make test` (3749 pass, 1 skipped)
- [x] `make check` (ruff check + format clean)
- [x] New test classes covering `BACKEND_PROVIDERS` membership, derived prompt set, triple-key registry completeness, `UserConfig.models` field, `resolve_user_model` precedence, and `_apply_legacy_model_env_overrides` seeding
- [x] All existing review / triage / smoke / install / memory test fixtures updated to the 3-arg `get_model_for` signature, `model_override` kwarg, and the new wizard customize-models prompt
- [x] `is_opencode_model_shape` accepts multi-slash openrouter nesting (`openrouter/anthropic/claude-sonnet-4-5`) and rejects double-slash / leading-slash / trailing-slash shapes

Closes #576
