### PR TITLE
fix(config): use provider's strongest model defaults

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -127,20 +127,41 @@ PROVIDER_KEY_VARS: dict[str, str] = {
 # Goose passes model IDs through verbatim to the provider API - no
 # aliasing layer - so these must be the exact strings the APIs accept.
 PROVIDER_MODELS: dict[str, dict[str, str]] = {
+    # Claude CLI accepts short aliases that auto-resolve to the
+    # current SKU (`opus` -> claude-opus-4-8 as of 2026-06-09).
+    # Listing the aliases here keeps the registry stable across
+    # Anthropic version bumps; the CLI handles the resolution.
+    # Claude Fable 5 is Anthropic's strongest widely-released model
+    # today but is not yet wired as a Claude CLI short alias, so
+    # the keyboard surface stays at opus/sonnet/haiku.
     "anthropic": {
         "opus": "\U0001f9e0 Opus",
         "sonnet": "\u26a1 Sonnet",
         "haiku": "\U0001fab6 Haiku",
     },
+    # OpenAI current API surface (verified 2026-06-09 against
+    # developers.openai.com/api/docs/models). gpt-5.5-pro is the
+    # single strongest text model; gpt-5.5 is the standard frontier;
+    # the 5.4 family covers cheaper / cost-tier workloads. 5.3 and
+    # earlier are retired from this surface.
     "openai": {
-        "gpt-5.4": "\U0001f7e2 GPT-5.4",
-        "gpt-5.4-mini": "\U0001f7e1 GPT-5.4 Mini",
+        "gpt-5.5-pro": "\U0001f7e3 GPT-5.5 Pro",
+        "gpt-5.5": "\U0001f7e2 GPT-5.5",
+        "gpt-5.4-pro": "\U0001f7e1 GPT-5.4 Pro",
+        "gpt-5.4": "\U0001f7e1 GPT-5.4",
+        "gpt-5.4-mini": "\U0001f7e0 GPT-5.4 Mini",
         "gpt-5.4-nano": "\U0001f535 GPT-5.4 Nano",
     },
+    # Google Gemini current API surface (verified 2026-06-09 against
+    # ai.google.dev/gemini-api/docs/models). gemini-2.5-pro is the
+    # most advanced for complex tasks per the docs; the 2.5 Flash
+    # family covers speed and cost. The 3.x family exists but is
+    # mostly Preview variants and specialized SKUs (image / live /
+    # TTS); the curated keyboard stays on the stable 2.5 trio.
     "google": {
-        "gemini-3.1-pro": "\u264a Gemini 3.1 Pro",
-        "gemini-3-flash": "\u264a Gemini 3 Flash",
-        "gemini-3-deep-think": "\u264a Gemini 3 Deep Think",
+        "gemini-2.5-pro": "\u264a Gemini 2.5 Pro",
+        "gemini-2.5-flash": "\u264a Gemini 2.5 Flash",
+        "gemini-2.5-flash-lite": "\u264a Gemini 2.5 Flash Lite",
     },
     # DeepSeek's first-class OpenCode / Models.dev surface is exactly
     # these two V4 SKUs. The legacy `deepseek-chat` and
@@ -171,8 +192,8 @@ PROVIDER_MODELS: dict[str, dict[str, str]] = {
 # and cheap tiers split per-role per-(backend, provider).
 PROVIDER_DEFAULTS: dict[str, str] = {
     "anthropic": "opus",
-    "openai": "gpt-5.4",
-    "google": "gemini-3.1-pro",
+    "openai": "gpt-5.5-pro",
+    "google": "gemini-2.5-pro",
     "deepseek": "deepseek-v4-pro",
 }
 
@@ -277,17 +298,32 @@ _TIER_BY_ROLE: dict[ModelRole, str] = {
 #  - opencode takes full "provider/model" strings, structurally
 #    validated by is_opencode_model_shape
 #  - goose takes the provider's native model name verbatim
-# Codex collapses "balanced" and "cheap" onto gpt-5.4-mini: the next
-# step down (gpt-5.4-nano) is not in CODEX_MODELS so a "cheap" =
-# "gpt-5.4-nano" entry would fail _check_model_registry_complete at
-# startup. Every (backend, provider) pair in BACKEND_PROVIDERS must
-# have a row here; _build_registry raises KeyError at module import
-# time on any missing pair.
+# Cheap-tier picks must be in CODEX_MODELS for the codex backend
+# (the startup completeness check validates this); the balanced
+# tier picks the current frontier where the CLI surface allows.
+# Every (backend, provider) pair in BACKEND_PROVIDERS must have a
+# row here; _build_registry raises KeyError at module import time
+# on any missing pair.
 _BACKEND_PROVIDER_TIER_MODELS: dict[tuple[str, str], dict[str, str]] = {
+    # Claude CLI accepts short aliases that auto-resolve to the
+    # current SKU; `sonnet` -> claude-sonnet-4-6 and `haiku` ->
+    # claude-haiku-4-5 as of 2026-06-09. Keep the dated haiku ID for
+    # cheap-tier roles where a fully-pinned model version is
+    # preferable so an automated stage-2 episode generation stays
+    # reproducible across CLI version bumps.
     ("claude", "anthropic"): {"balanced": "sonnet", "cheap": "claude-haiku-4-5-20251001"},
-    ("codex", "openai"): {"balanced": "gpt-5.4-mini", "cheap": "gpt-5.4-mini"},
-    ("opencode", "anthropic"): {"balanced": "anthropic/claude-sonnet-4-5", "cheap": "anthropic/claude-haiku-4-5"},
-    ("opencode", "openai"): {"balanced": "openai/gpt-5.4-mini", "cheap": "openai/gpt-5.4-mini"},
+    # Codex CLI accepts the OpenAI model surface. gpt-5.5 is the
+    # current frontier reasoning model; gpt-5.4-mini stays as the
+    # cheap tier for high-volume roles (memory extraction, episode
+    # generation, behavioral judge).
+    ("codex", "openai"): {"balanced": "gpt-5.5", "cheap": "gpt-5.4-mini"},
+    # OpenCode/Anthropic surface uses the `anthropic/<model>`
+    # provider-prefixed shape; the model halves match the current
+    # Claude SKUs (Sonnet 4.6 and Haiku 4.5 as of 2026-06-09).
+    ("opencode", "anthropic"): {"balanced": "anthropic/claude-sonnet-4-6", "cheap": "anthropic/claude-haiku-4-5"},
+    # OpenCode/OpenAI: same tier split as codex/openai but in the
+    # opencode provider-prefixed shape.
+    ("opencode", "openai"): {"balanced": "openai/gpt-5.5", "cheap": "openai/gpt-5.4-mini"},
     # DeepSeek V4 first-class OpenCode surface (V4 Pro and V4 Flash).
     # The legacy `deepseek-chat` / `deepseek-reasoner` aliases (mode
     # flags on V4 Flash) retire 2026-07-24, so do not use them in
@@ -297,26 +333,29 @@ _BACKEND_PROVIDER_TIER_MODELS: dict[tuple[str, str], dict[str, str]] = {
     # covers memory extraction / memory episode / behavioral_judge).
     # Same 1M context on both; the split is capability-vs-cost.
     ("opencode", "deepseek"): {"balanced": "deepseek/deepseek-v4-pro", "cheap": "deepseek/deepseek-v4-flash"},
-    ("opencode", "google"): {"balanced": "google/gemini-3.1-pro", "cheap": "google/gemini-3-flash"},
+    # Google's most advanced for complex tasks per the Gemini API
+    # docs (2026-06-09) is gemini-2.5-pro; gemini-2.5-flash is the
+    # speed/cost tier. The 3.x family is mostly Preview / specialized.
+    ("opencode", "google"): {"balanced": "google/gemini-2.5-pro", "cheap": "google/gemini-2.5-flash"},
     # OpenRouter's "provider/model" shape nests under opencode's own
     # "provider/model" prefix; the structural check accepts this
     # because the outer slash is what matters to opencode.
     ("opencode", "openrouter"): {
-        "balanced": "openrouter/anthropic/claude-sonnet-4-5",
+        "balanced": "openrouter/anthropic/claude-sonnet-4-6",
         "cheap": "openrouter/anthropic/claude-haiku-4-5",
     },
     ("opencode", "ollama"): {"balanced": "ollama/llama4:70b", "cheap": "ollama/llama4:8b"},
     ("goose", "anthropic"): {"balanced": "claude-sonnet-4-6", "cheap": "claude-haiku-4-5"},
-    ("goose", "openai"): {"balanced": "gpt-5.4", "cheap": "gpt-5.4-mini"},
+    ("goose", "openai"): {"balanced": "gpt-5.5", "cheap": "gpt-5.4-mini"},
     # goose-on-deepseek: bare model names; goose passes them through
     # to the provider API directly (no opencode-style "provider/"
     # prefix). Same Pro / Flash split as opencode-on-deepseek above;
     # same 2026-07-24 deprecation reason for skipping the legacy
     # `deepseek-chat` alias.
     ("goose", "deepseek"): {"balanced": "deepseek-v4-pro", "cheap": "deepseek-v4-flash"},
-    ("goose", "google"): {"balanced": "gemini-3.1-pro", "cheap": "gemini-3-flash"},
+    ("goose", "google"): {"balanced": "gemini-2.5-pro", "cheap": "gemini-2.5-flash"},
     ("goose", "openrouter"): {
-        "balanced": "openrouter/anthropic/claude-sonnet-4-5",
+        "balanced": "openrouter/anthropic/claude-sonnet-4-6",
         "cheap": "openrouter/anthropic/claude-haiku-4-5",
     },
     ("goose", "ollama"): {"balanced": "llama4:70b", "cheap": "llama4:8b"},

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -965,7 +965,7 @@ class Config:
             Sent by Telegram as X-Telegram-Bot-Api-Secret-Token header on each update.
             Only required in webhook mode. Defaults to WEBHOOK_SECRET if not explicitly set.
         allowed_user_ids: Set of Telegram user IDs permitted to interact with the bot (required)
-        default_model: Default model name, provider-dependent (e.g. sonnet, gpt-5.4, gemini-3-flash)
+        default_model: Default model name, provider-dependent (e.g. sonnet, gpt-5.5-pro, gemini-2.5-pro)
         claude_timeout_seconds: Seconds before a Claude response is considered timed out
         budget_ceiling: Global budget ceiling in USD. Users cannot exceed
             this via /settings budget. Also serves as the fallback default

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -142,15 +142,38 @@ PROVIDER_MODELS: dict[str, dict[str, str]] = {
         "gemini-3-flash": "\u264a Gemini 3 Flash",
         "gemini-3-deep-think": "\u264a Gemini 3 Deep Think",
     },
+    # DeepSeek's first-class OpenCode / Models.dev surface is exactly
+    # these two V4 SKUs. The legacy `deepseek-chat` and
+    # `deepseek-reasoner` aliases (which mapped to V4 Flash's
+    # non-thinking and thinking modes respectively) are deprecated by
+    # DeepSeek and scheduled to retire 2026-07-24; do not list them
+    # here. Thinking-vs-non-thinking is a runtime mode flag handled
+    # by opencode's `options.reasoning.enabled`, not a model-name
+    # distinction at this layer.
+    "deepseek": {
+        "deepseek-v4-pro": "DeepSeek V4 Pro",
+        "deepseek-v4-flash": "DeepSeek V4 Flash",
+    },
 }
 
-# Default model for each provider, used when no model is explicitly
-# configured. Open-ended providers (openrouter, ollama) have no
-# default - users on those providers MUST have a model set.
+# Default model for each provider, used as the wizard prompt
+# suggestion for the conversational role (DEFAULT_MODEL / per-user
+# `models.agent`). The conversational role does the most work and
+# the heaviest work in the Kai system; defaulting to a balanced or
+# speed-tier model on this surface underspends on the highest-value
+# path. Each entry below is the strongest curated model the provider
+# offers. Open-ended providers (openrouter, ollama) have no entry;
+# users on those providers MUST set a model explicitly.
+#
+# Non-agent roles (PR review, issue triage, memory extraction,
+# memory episode, behavioral judge, behavioral gen) use the tier
+# scheme in `_BACKEND_PROVIDER_TIER_MODELS` instead, where balanced
+# and cheap tiers split per-role per-(backend, provider).
 PROVIDER_DEFAULTS: dict[str, str] = {
-    "anthropic": "sonnet",
+    "anthropic": "opus",
     "openai": "gpt-5.4",
-    "google": "gemini-3-flash",
+    "google": "gemini-3.1-pro",
+    "deepseek": "deepseek-v4-pro",
 }
 
 # Codex CLI model surface. Independent of PROVIDER_MODELS["openai"]:
@@ -265,7 +288,15 @@ _BACKEND_PROVIDER_TIER_MODELS: dict[tuple[str, str], dict[str, str]] = {
     ("codex", "openai"): {"balanced": "gpt-5.4-mini", "cheap": "gpt-5.4-mini"},
     ("opencode", "anthropic"): {"balanced": "anthropic/claude-sonnet-4-5", "cheap": "anthropic/claude-haiku-4-5"},
     ("opencode", "openai"): {"balanced": "openai/gpt-5.4-mini", "cheap": "openai/gpt-5.4-mini"},
-    ("opencode", "deepseek"): {"balanced": "deepseek/deepseek-chat", "cheap": "deepseek/deepseek-chat"},
+    # DeepSeek V4 first-class OpenCode surface (V4 Pro and V4 Flash).
+    # The legacy `deepseek-chat` / `deepseek-reasoner` aliases (mode
+    # flags on V4 Flash) retire 2026-07-24, so do not use them in
+    # registry defaults. Pro for reasoning-heavy roles (the
+    # balanced tier covers review / triage / behavioral_gen); Flash
+    # for high-volume / latency-sensitive roles (the cheap tier
+    # covers memory extraction / memory episode / behavioral_judge).
+    # Same 1M context on both; the split is capability-vs-cost.
+    ("opencode", "deepseek"): {"balanced": "deepseek/deepseek-v4-pro", "cheap": "deepseek/deepseek-v4-flash"},
     ("opencode", "google"): {"balanced": "google/gemini-3.1-pro", "cheap": "google/gemini-3-flash"},
     # OpenRouter's "provider/model" shape nests under opencode's own
     # "provider/model" prefix; the structural check accepts this
@@ -277,7 +308,12 @@ _BACKEND_PROVIDER_TIER_MODELS: dict[tuple[str, str], dict[str, str]] = {
     ("opencode", "ollama"): {"balanced": "ollama/llama4:70b", "cheap": "ollama/llama4:8b"},
     ("goose", "anthropic"): {"balanced": "claude-sonnet-4-6", "cheap": "claude-haiku-4-5"},
     ("goose", "openai"): {"balanced": "gpt-5.4", "cheap": "gpt-5.4-mini"},
-    ("goose", "deepseek"): {"balanced": "deepseek-chat", "cheap": "deepseek-chat"},
+    # goose-on-deepseek: bare model names; goose passes them through
+    # to the provider API directly (no opencode-style "provider/"
+    # prefix). Same Pro / Flash split as opencode-on-deepseek above;
+    # same 2026-07-24 deprecation reason for skipping the legacy
+    # `deepseek-chat` alias.
+    ("goose", "deepseek"): {"balanced": "deepseek-v4-pro", "cheap": "deepseek-v4-flash"},
     ("goose", "google"): {"balanced": "gemini-3.1-pro", "cheap": "gemini-3-flash"},
     ("goose", "openrouter"): {
         "balanced": "openrouter/anthropic/claude-sonnet-4-5",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3326,6 +3326,96 @@ class TestNoAdHocOneShotBackendTuples:
         )
 
 
+class TestProviderDefaultsStrongestModel:
+    """`PROVIDER_DEFAULTS` drives the wizard's conversational-model
+    prompt suggestion. Per the agent-role-strongest rule, each entry
+    must name the strongest curated model the provider offers; the
+    non-agent roles use the tier scheme elsewhere where balanced /
+    cheap tiers split per role.
+    """
+
+    def test_anthropic_default_is_opus(self):
+        """Opus is the strongest tier in PROVIDER_MODELS['anthropic']."""
+        from kai.config import PROVIDER_DEFAULTS
+
+        assert PROVIDER_DEFAULTS["anthropic"] == "opus"
+
+    def test_openai_default_is_strongest(self):
+        from kai.config import PROVIDER_DEFAULTS, PROVIDER_MODELS
+
+        assert PROVIDER_DEFAULTS["openai"] in PROVIDER_MODELS["openai"]
+        # gpt-5.4 (non-mini, non-nano) is the strongest current entry.
+        assert PROVIDER_DEFAULTS["openai"] == "gpt-5.4"
+
+    def test_google_default_is_pro(self):
+        """Pro is the strongest current entry; Flash is the speed tier."""
+        from kai.config import PROVIDER_DEFAULTS
+
+        assert PROVIDER_DEFAULTS["google"] == "gemini-3.1-pro"
+
+    def test_deepseek_default_is_v4_pro(self):
+        """V4 Pro is the strongest first-class OpenCode-on-DeepSeek
+        model. V4 Flash is the speed tier. The legacy `deepseek-chat`
+        alias is deprecated and not used as a default."""
+        from kai.config import PROVIDER_DEFAULTS
+
+        assert PROVIDER_DEFAULTS["deepseek"] == "deepseek-v4-pro"
+
+    def test_every_default_is_in_provider_models(self):
+        """Every default must be a key in PROVIDER_MODELS for the
+        same provider; without this invariant the wizard's
+        _prompt_choice would fail when offered the default as the
+        pre-selected entry."""
+        from kai.config import PROVIDER_DEFAULTS, PROVIDER_MODELS
+
+        for provider, model in PROVIDER_DEFAULTS.items():
+            assert provider in PROVIDER_MODELS, f"PROVIDER_MODELS missing entry for {provider!r}"
+            assert model in PROVIDER_MODELS[provider], (
+                f"PROVIDER_DEFAULTS[{provider!r}]={model!r} is not in PROVIDER_MODELS[{provider!r}]"
+            )
+
+
+class TestDeepSeekRegistryRowsAvoidDeprecatedAlias:
+    """The `deepseek-chat` and `deepseek-reasoner` aliases are
+    deprecated by DeepSeek and retire 2026-07-24. The registry
+    must use the canonical V4 SKUs instead."""
+
+    _DEPRECATED_NAMES = ("deepseek-chat", "deepseek-reasoner")
+
+    def test_opencode_deepseek_rows_use_v4_skus(self):
+        for role in ModelRole:
+            value = MODEL_REGISTRY[("opencode", "deepseek", role)]
+            for deprecated in self._DEPRECATED_NAMES:
+                assert deprecated not in value, (
+                    f"opencode/deepseek/{role.value}={value!r} contains deprecated alias {deprecated!r}"
+                )
+            assert value.startswith("deepseek/deepseek-v4-"), (
+                f"opencode/deepseek/{role.value}={value!r} should resolve to a V4 SKU"
+            )
+
+    def test_goose_deepseek_rows_use_v4_skus(self):
+        for role in ModelRole:
+            value = MODEL_REGISTRY[("goose", "deepseek", role)]
+            for deprecated in self._DEPRECATED_NAMES:
+                assert deprecated not in value, (
+                    f"goose/deepseek/{role.value}={value!r} contains deprecated alias {deprecated!r}"
+                )
+            assert value.startswith("deepseek-v4-"), f"goose/deepseek/{role.value}={value!r} should resolve to a V4 SKU"
+
+    def test_balanced_and_cheap_tiers_differ_on_deepseek(self):
+        """Both tiers collapsed onto `deepseek-chat` before this fix;
+        re-pinning the tier distinction prevents a future regression."""
+        opencode_balanced = MODEL_REGISTRY[("opencode", "deepseek", ModelRole.PR_REVIEW)]
+        opencode_cheap = MODEL_REGISTRY[("opencode", "deepseek", ModelRole.MEMORY_EXTRACTION)]
+        assert opencode_balanced != opencode_cheap, (
+            "opencode/deepseek balanced and cheap tiers must resolve to different models"
+        )
+
+        goose_balanced = MODEL_REGISTRY[("goose", "deepseek", ModelRole.PR_REVIEW)]
+        goose_cheap = MODEL_REGISTRY[("goose", "deepseek", ModelRole.MEMORY_EXTRACTION)]
+        assert goose_balanced != goose_cheap, "goose/deepseek balanced and cheap tiers must resolve to different models"
+
+
 class TestBackendProviders:
     """`BACKEND_PROVIDERS` is the single authoritative (backend, provider)
     allowlist. `BACKENDS_NEEDING_PROVIDER_PROMPT` is derived from it
@@ -3402,7 +3492,12 @@ class TestModelRegistryTripleKey:
         to the larger acceptance loop above."""
         assert MODEL_REGISTRY[("claude", "anthropic", ModelRole.PR_REVIEW)] == "sonnet"
         assert MODEL_REGISTRY[("codex", "openai", ModelRole.PR_REVIEW)] == "gpt-5.4-mini"
-        assert MODEL_REGISTRY[("opencode", "deepseek", ModelRole.PR_REVIEW)] == "deepseek/deepseek-chat"
+        # opencode-on-deepseek balanced tier resolves to V4 Pro for
+        # the reasoning-heavy PR review role; V4 Flash covers the
+        # cheap tier elsewhere. The legacy `deepseek-chat` alias is
+        # deprecated and not used here.
+        assert MODEL_REGISTRY[("opencode", "deepseek", ModelRole.PR_REVIEW)] == "deepseek/deepseek-v4-pro"
+        assert MODEL_REGISTRY[("opencode", "deepseek", ModelRole.MEMORY_EXTRACTION)] == "deepseek/deepseek-v4-flash"
         assert MODEL_REGISTRY[("goose", "anthropic", ModelRole.PR_REVIEW)] == "claude-sonnet-4-6"
 
     def test_codex_rows_are_in_codex_models(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2464,10 +2464,13 @@ class TestCodexModelsSurface:
 
         assert CODEX_DEFAULT_MODEL == "gpt-5.5"
 
-    def test_provider_defaults_openai_unchanged(self):
+    def test_provider_defaults_openai_is_strongest_available(self):
+        """PROVIDER_DEFAULTS["openai"] points at the OpenAI API's
+        single strongest text model (per the agent-role-strongest
+        rule). Verified 2026-06-09 against developers.openai.com."""
         from kai.config import PROVIDER_DEFAULTS
 
-        assert PROVIDER_DEFAULTS["openai"] == "gpt-5.4"
+        assert PROVIDER_DEFAULTS["openai"] == "gpt-5.5-pro"
 
 
 class TestValidateModelForBackend:
@@ -3341,17 +3344,21 @@ class TestProviderDefaultsStrongestModel:
         assert PROVIDER_DEFAULTS["anthropic"] == "opus"
 
     def test_openai_default_is_strongest(self):
+        """gpt-5.5-pro is the single strongest text model on the
+        OpenAI API per developers.openai.com (verified 2026-06-09).
+        Above the gpt-5.5 / 5.4-pro / 5.4 / 5.4-mini / 5.4-nano line."""
         from kai.config import PROVIDER_DEFAULTS, PROVIDER_MODELS
 
         assert PROVIDER_DEFAULTS["openai"] in PROVIDER_MODELS["openai"]
-        # gpt-5.4 (non-mini, non-nano) is the strongest current entry.
-        assert PROVIDER_DEFAULTS["openai"] == "gpt-5.4"
+        assert PROVIDER_DEFAULTS["openai"] == "gpt-5.5-pro"
 
     def test_google_default_is_pro(self):
-        """Pro is the strongest current entry; Flash is the speed tier."""
+        """gemini-2.5-pro is the most advanced Gemini for complex
+        tasks per ai.google.dev/gemini-api/docs/models (verified
+        2026-06-09). The 3.x family is mostly Preview / specialized."""
         from kai.config import PROVIDER_DEFAULTS
 
-        assert PROVIDER_DEFAULTS["google"] == "gemini-3.1-pro"
+        assert PROVIDER_DEFAULTS["google"] == "gemini-2.5-pro"
 
     def test_deepseek_default_is_v4_pro(self):
         """V4 Pro is the strongest first-class OpenCode-on-DeepSeek
@@ -3491,7 +3498,10 @@ class TestModelRegistryTripleKey:
         _BACKEND_PROVIDER_TIER_MODELS tweak surfaces here in addition
         to the larger acceptance loop above."""
         assert MODEL_REGISTRY[("claude", "anthropic", ModelRole.PR_REVIEW)] == "sonnet"
-        assert MODEL_REGISTRY[("codex", "openai", ModelRole.PR_REVIEW)] == "gpt-5.4-mini"
+        # codex balanced tier picks the current frontier (gpt-5.5);
+        # cheap tier stays at gpt-5.4-mini for high-volume roles.
+        assert MODEL_REGISTRY[("codex", "openai", ModelRole.PR_REVIEW)] == "gpt-5.5"
+        assert MODEL_REGISTRY[("codex", "openai", ModelRole.MEMORY_EXTRACTION)] == "gpt-5.4-mini"
         # opencode-on-deepseek balanced tier resolves to V4 Pro for
         # the reasoning-heavy PR review role; V4 Flash covers the
         # cheap tier elsewhere. The legacy `deepseek-chat` alias is

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3043,8 +3043,9 @@ class TestCmdConfigDefaultModelDispatch:
         helper.assert_called_once()
         # New signature: (agent_backend, eff_provider, default_val).
         # Third positional arg is the prefill. Must be
-        # PROVIDER_DEFAULTS["openai"] = "gpt-5.4", NOT "opus".
-        assert helper.call_args.args[2] == "gpt-5.4"
+        # PROVIDER_DEFAULTS["openai"] = "gpt-5.5-pro" (the strongest
+        # OpenAI text model), NOT the rejected "opus".
+        assert helper.call_args.args[2] == "gpt-5.5-pro"
         assert helper.call_args.args[2] != "opus"
         assert env["DEFAULT_MODEL"] == "gpt-5.4-mini"
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -212,8 +212,9 @@ class TestPerUserBackendRouting:
         config = _make_config(user_configs={111: user})
         pool = SubprocessPool(config=config, services_info=[])
         instance = pool.get(111)
-        # PROVIDER_DEFAULTS["openai"] = "gpt-5.4"
-        assert instance.model == "gpt-5.4"
+        # PROVIDER_DEFAULTS["openai"] = "gpt-5.5-pro" (the strongest
+        # current OpenAI text model; per the agent-role-strongest rule).
+        assert instance.model == "gpt-5.5-pro"
 
     @pytest.mark.asyncio
     async def test_invalid_stored_model_on_provider_mismatch(self):

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -795,17 +795,17 @@ class TestRunReviewCodex:
     @pytest.mark.asyncio
     async def test_codex_argv_uses_registry_model(self):
         """
-        With agent_backend=codex and no env override, the --model
-        argv slot matches the registry's (codex, PR_REVIEW) row
-        ("gpt-5.4-mini"). Locks the registry as the source of truth
-        for the codex side.
+        With agent_backend=codex and no override, the --model argv
+        slot matches the registry's (codex, openai, PR_REVIEW) row
+        (gpt-5.5, the current frontier). Locks the registry as the
+        source of truth for the codex side.
         """
         mock_proc = _mock_process(stdout=self._codex_ndjson(""))
         with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
             await run_review("prompt", agent_backend="codex")
         cmd = mock_exec.call_args[0]
         i = cmd.index("--model")
-        assert cmd[i + 1] == "gpt-5.4-mini"
+        assert cmd[i + 1] == "gpt-5.5"
 
     @pytest.mark.asyncio
     async def test_codex_model_override_param_wins(self):
@@ -1004,7 +1004,7 @@ class TestRunReviewGoose:
             "--provider",
             "openai",
             "--model",
-            "gpt-5.4",
+            "gpt-5.5",
             "-q",
             "--no-session",
             "--no-profile",
@@ -1219,7 +1219,7 @@ class TestGooseModelResolutionViaRegistry:
         """Goose+openai resolves the PR_REVIEW row from the registry."""
         from kai.config import MODEL_REGISTRY, ModelRole
 
-        assert MODEL_REGISTRY[("goose", "openai", ModelRole.PR_REVIEW)] == "gpt-5.4"
+        assert MODEL_REGISTRY[("goose", "openai", ModelRole.PR_REVIEW)] == "gpt-5.5"
 
     def test_open_ended_provider_registry_lookup(self):
         """Goose+ollama has a registry-shipped default; operators

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -528,7 +528,7 @@ class TestRunTriageGoose:
             "--provider",
             "openai",
             "--model",
-            "gpt-5.4",
+            "gpt-5.5",
             "-q",
             "--no-session",
             "--no-profile",
@@ -794,17 +794,17 @@ class TestRunTriageCodex:
     @pytest.mark.asyncio
     async def test_codex_argv_uses_registry_model(self):
         """
-        With agent_backend=codex and no env override, the --model argv
-        slot matches the registry's (codex, ISSUE_TRIAGE) row
-        ("gpt-5.4-mini"). Locks the registry as the source of truth
-        for the codex side.
+        With agent_backend=codex and no override, the --model argv
+        slot matches the registry's (codex, openai, ISSUE_TRIAGE) row
+        (gpt-5.5, the current frontier). Locks the registry as the
+        source of truth for the codex side.
         """
         mock_proc = _mock_subprocess(stdout=self._codex_ndjson("{}"))
         with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
             await run_triage("prompt", agent_backend="codex")
         cmd = mock_exec.call_args[0]
         i = cmd.index("--model")
-        assert cmd[i + 1] == "gpt-5.4-mini"
+        assert cmd[i + 1] == "gpt-5.5"
 
     @pytest.mark.asyncio
     async def test_codex_model_override_param_wins(self):
@@ -948,7 +948,7 @@ class TestGooseTriageModelResolutionViaRegistry:
         """Goose+openai resolves the ISSUE_TRIAGE row from the registry."""
         from kai.config import MODEL_REGISTRY, ModelRole
 
-        assert MODEL_REGISTRY[("goose", "openai", ModelRole.ISSUE_TRIAGE)] == "gpt-5.4"
+        assert MODEL_REGISTRY[("goose", "openai", ModelRole.ISSUE_TRIAGE)] == "gpt-5.5"
 
     def test_open_ended_provider_registry_lookup(self):
         """Goose+ollama has a registry-shipped default that operators


### PR DESCRIPTION
## Summary

- Apply the agent-role-strongest rule to `PROVIDER_DEFAULTS` (the wizard's conversational-model prompt suggestion). `anthropic` keeps `opus` (Claude CLI alias auto-resolves to current Opus 4.8); `openai` becomes `gpt-5.5-pro`; `google` becomes `gemini-2.5-pro`; `deepseek` becomes `deepseek-v4-pro` (new entry).
- Replace the deprecated `deepseek-chat` / `deepseek-reasoner` aliases in `_BACKEND_PROVIDER_TIER_MODELS` (DeepSeek retires both 2026-07-24) with `deepseek-v4-pro` (balanced tier) and `deepseek-v4-flash` (cheap tier). Restores the tier distinction that previously collapsed onto a single string.
- Add `PROVIDER_MODELS["deepseek"]` with V4 Pro / V4 Flash so the goose wizard's choice keyboard surfaces them as the two curated options instead of falling into free-text.
- Rewrite `PROVIDER_MODELS["openai"]` from the stale 5.4 family (`gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`) to the current surface (`gpt-5.5-pro`, `gpt-5.5`, `gpt-5.4-pro`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`) verified against the OpenAI API docs.
- Rewrite `PROVIDER_MODELS["google"]` from the stale 3.x family (`gemini-3.1-pro`, `gemini-3-flash`, `gemini-3-deep-think`) to the current strongest surface (`gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`) verified against the Gemini API docs. The 3.x family exists but is mostly Preview variants and specialized SKUs.
- Update stale tier-map cells across the rest of `_BACKEND_PROVIDER_TIER_MODELS`:
  - `codex/openai` balanced: `gpt-5.4-mini` -> `gpt-5.5`
  - `opencode/anthropic` balanced: `claude-sonnet-4-5` -> `claude-sonnet-4-6`
  - `opencode/openai` balanced: `openai/gpt-5.4-mini` -> `openai/gpt-5.5`
  - `opencode/google`: `google/gemini-2.5-pro` / `google/gemini-2.5-flash`
  - `opencode/openrouter` balanced: bumped to `claude-sonnet-4-6`
  - `goose/openai` balanced: `gpt-5.4` -> `gpt-5.5`
  - `goose/google`: `gemini-2.5-pro` / `gemini-2.5-flash`
  - `goose/openrouter` balanced: bumped to `claude-sonnet-4-6`

Two facets bundled because the underlying problem is one: stale model surfaces in `config.py` produced bad defaults. The `make refresh-models` opt-in command (added in PR #584) is the long-term mitigation; this PR is the manual reconciliation for everything that drifted since the last hand-edit.

## Behavior change

- **Existing claude installs**: no change (claude alias `opus` already auto-tracked).
- **Existing codex / opencode / goose installs**: the conversational-model prompt suggestion on the next `make config` shifts to the new strongest entries; operators who default-accept get a stronger model, operators who type a value pick whatever they want unchanged.
- **Existing opencode-on-deepseek installs (you)**: PR review / triage / memory extraction one-shot paths resolve to V4 Pro (balanced) or V4 Flash (cheap) instead of the deprecated `deepseek-chat`. The 2026-07-24 deprecation deadline is no longer a hard cliff.
- **Existing openai-on-codex / openai-on-goose installs**: PR review / triage resolve to `gpt-5.5` instead of `gpt-5.4-mini` / `gpt-5.4`. Operator-visible cost increase; per-user `models.pr_review` / `models.issue_triage` overrides continue to win.

## Known follow-ups

- **Ollama tier-map cells** still say `llama4:70b` / `llama4:8b`. Couldn't verify against the operator's local ollama install from this session.
- **Claude Fable 5** is the strongest released Anthropic model today (GA 2026-06-09); the Claude CLI short alias surface doesn't currently expose a `fable` equivalent. If/when it does, `PROVIDER_DEFAULTS["anthropic"]` should switch from `opus` to `fable`.

## Test plan

- [x] `make test` (3757 pass, 1 skipped)
- [x] `make check` (ruff check + format clean)
- [x] New `TestProviderDefaultsStrongestModel` class pins each PROVIDER_DEFAULTS entry against verified current values
- [x] New `TestDeepSeekRegistryRowsAvoidDeprecatedAlias` class pins both DeepSeek tier-map rows against the deprecated `deepseek-chat` / `deepseek-reasoner` aliases and pins `balanced != cheap` to prevent tier-collapse regression
- [x] Pin-value tests in `test_install`, `test_pool`, `test_review`, `test_triage` updated for the new resolved strings

Closes #585
