### PR TITLE
fix(install): backend-agnostic wording in config wizard

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -932,7 +932,7 @@ def _cmd_config() -> None:
                 print(f"  {llm_provider} does not require an API key.")
     print()
 
-    # -- Claude --
+    # -- Agent --
     # DEFAULT_MODEL, AGENT_TIMEOUT_SECONDS, BUDGET_CEILING, and
     # CLAUDE_MAX_CONTEXT_WINDOW are inheritable installation defaults:
     # users.yaml entries that omit a per-user override fall back to
@@ -959,7 +959,7 @@ def _cmd_config() -> None:
             return CODEX_DEFAULT_MODEL
         return PROVIDER_DEFAULTS.get(eff_provider, "")
 
-    print("-- Claude --")
+    print("-- Agent --")
     # DEFAULT_MODEL is an inheritable installation default; the prompt
     # fires on every wizard run with the existing env value prefilled
     # when it validates for the (possibly newly chosen) backend.
@@ -1090,7 +1090,7 @@ def _cmd_config() -> None:
     if agent_backend != "claude":
         while True:
             budget = _prompt(
-                "Claude budget (USD)",
+                "Agent budget (USD)",
                 existing_env.get("BUDGET_CEILING", existing_env.get("CLAUDE_MAX_BUDGET_USD", "10.0")),
             )
             if _validate_positive_float(budget):


### PR DESCRIPTION
Closes #587

The config wizard printed Claude-specific wording at two backend-agnostic sites in `src/kai/install.py`:

- The `-- Claude --` section header (DEFAULT_MODEL, per-role models, agent timeout, budget ceiling, context window) printed unconditionally, so codex/goose/opencode operators walked through a section titled "Claude". Renamed to `-- Agent --`, matching the other backend-neutral headers; the mirror code comment is updated alongside.
- The `Claude budget (USD)` prompt is gated on `agent_backend != "claude"`, so the label was wrong every time it appeared. Renamed to `Agent budget (USD)`, parallel to "Agent timeout (seconds)".

Genuinely claude-specific prompts ("Inner Claude effort level", autocompact threshold) are gated on the claude backend and keep their wording.

Display strings only; no env var names, keys, or behavior change.

**Testing**

- `make check` clean (ruff check + format)
- Full suite: 3757 passed, 1 skipped
