### PR TITLE
fix(acp): drain text chunks arriving after the prompt response

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -39,7 +39,7 @@ import json
 import logging
 import os
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 
 import kai
@@ -181,6 +181,79 @@ async def read_result(
             return msg.get("result", {})
 
         # Discard notifications (session/update during startup).
+
+
+# Quiet window for draining text chunks that land on stdout AFTER the
+# session/prompt response. OpenCode resolves the prompt request when
+# the session goes idle, but its event forwarding is asynchronous: the
+# final agent_message_chunk notification(s) can flush milliseconds
+# after the response (observed lag ~100ms on opencode 1.15.11). The
+# window restarts on every received line, so it bounds the wait for
+# the NEXT line, not the total drain time; 0.5s gives roughly 5x
+# margin over the observed lag while capping the added per-call
+# latency when nothing trails the response.
+COMPLETION_DRAIN_WINDOW_S: float = 0.5
+
+
+async def drain_late_text(
+    *,
+    proc: asyncio.subprocess.Process | None,
+    accumulated: str,
+    extract_delta: Callable[[dict], str | None],
+    combine: Callable[[str, str], str],
+    window_s: float | None = None,
+) -> str:
+    """
+    Drain trailing text-chunk notifications after a prompt response
+    and return the updated accumulated text.
+
+    The ACP read loops treat the matching-id response to
+    session/prompt as end-of-turn, but the response can beat the
+    turn's final text chunk(s) onto stdout (see
+    COMPLETION_DRAIN_WINDOW_S above for the mechanism). Stopping at
+    the response therefore truncates the tail of the answer: fatal
+    for one-shot JSON consumers, whose whole response becomes
+    unparseable, and wrong for the conversational loop, where the
+    unread chunk stays buffered in the pipe and surfaces at the START
+    of the next turn's reply.
+
+    Reads lines until the quiet window passes with no output or the
+    pipe reaches EOF, feeding each notification through the caller's
+    `extract_delta` / `combine` hooks so opencode's sentence-boundary
+    whitespace join applies to drained chunks exactly as it does to
+    in-turn chunks. Non-text notifications and non-JSON lines are
+    skipped. Server-initiated requests are not answered here: the
+    turn is already complete, so no permission request can be
+    pending, and anything else with an id is a response to a request
+    this client never sent.
+
+    EOF ends the drain rather than raising: by this point the turn
+    succeeded and the accumulated text is the answer. The one-shot
+    caller kills the subprocess right after this returns anyway, and
+    the conversational caller's next send() handles respawn.
+
+    `window_s=None` resolves COMPLETION_DRAIN_WINDOW_S at call time
+    so tests can patch the module constant and cover both call sites
+    with one knob.
+    """
+    if window_s is None:
+        window_s = COMPLETION_DRAIN_WINDOW_S
+    assert proc is not None and proc.stdout is not None
+    while True:
+        try:
+            line = await asyncio.wait_for(proc.stdout.readline(), timeout=window_s)
+        except TimeoutError:
+            return accumulated
+        if not line:
+            return accumulated
+        try:
+            msg = json.loads(line.decode())
+        except json.JSONDecodeError:
+            continue
+        if "method" in msg and "id" not in msg:
+            text = extract_delta(msg)
+            if text:
+                accumulated = combine(accumulated, text)
 
 
 # ── ACP base backend ──────────────────────────────────────────────
@@ -844,6 +917,18 @@ class AcpBackend(AgentBackend):
 
                 # Final result for our prompt (has matching id).
                 if self.is_completion(msg, prompt_id):
+                    # The response can beat the turn's final text
+                    # chunk(s) onto stdout; without the drain those
+                    # chunks stay buffered in the pipe and surface at
+                    # the start of the NEXT turn's reply (the
+                    # subprocess persists across turns). See
+                    # drain_late_text for the mechanism.
+                    accumulated = await drain_late_text(
+                        proc=self._proc,
+                        accumulated=accumulated,
+                        extract_delta=self.extract_text_delta,
+                        combine=self.combine_text_chunks,
+                    )
                     response = AgentResponse(
                         success=True,
                         text=accumulated,

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
 
-from kai.acp import read_result, write_rpc
+from kai.acp import drain_late_text, read_result, write_rpc
 from kai.codex_exec import extract_codex_text
 from kai.config import DATA_DIR, resolve_claude_user
 from kai.oneshot_binary import BinaryResolutionError, resolve_oneshot_binary
@@ -1845,8 +1845,10 @@ class OpenCodeOneShotReasoner:
         # Step 4: read loop. Accumulate `agent_message_chunk` text;
         # reject any `session/request_permission` requests with the
         # `reject_once` policy; stop when the prompt response arrives
-        # (success or error). The loop has no timeout of its own
-        # because the outer `asyncio.wait_for` is the per-call cap.
+        # (success or error), draining any text chunks that flush
+        # after the success response before returning. The loop has
+        # no timeout of its own because the outer `asyncio.wait_for`
+        # is the per-call cap (it also bounds the drain).
         accumulated = ""
         assert proc.stdout is not None
         while True:
@@ -1915,7 +1917,19 @@ class OpenCodeOneShotReasoner:
                     return accumulated, str(err)
                 # Success. The result body is not consumed; the
                 # accumulated text from session/update notifications
-                # IS the answer.
+                # IS the answer. The response can beat the turn's
+                # final text chunk(s) onto stdout, and the caller
+                # kills the subprocess after this returns, so any
+                # undrained tail would be silently lost; for the
+                # JSON-consuming purposes (triage, extraction) a
+                # missing tail makes the entire response unparseable.
+                # See drain_late_text for the mechanism.
+                accumulated = await drain_late_text(
+                    proc=proc,
+                    accumulated=accumulated,
+                    extract_delta=extract_opencode_text_delta,
+                    combine=concat_opencode_text,
+                )
                 return accumulated, None
 
             # Some other shape (a response to a request we did not

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -32,6 +32,7 @@ Covers:
     literal in the shared layer)
 """
 
+import asyncio
 import json
 import logging
 from pathlib import Path
@@ -39,7 +40,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kai.acp import AcpBackend
+from kai.acp import AcpBackend, drain_late_text
 from kai.backend import USER_MESSAGE_MARKER, StreamEvent
 from kai.config import WorkspaceConfig
 
@@ -170,7 +171,10 @@ def _make_mock_proc(stdout_lines: list[bytes]) -> MagicMock:
     Build a mock subprocess that yields predefined stdout lines.
 
     stdout_lines should be a list of bytes, each ending with b"\\n".
-    A final entry of b"" signals EOF on the next readline call.
+    Once the list is exhausted, every further readline call returns
+    b"" (EOF), so tests do not need to count exactly how many reads
+    the send loop performs; the post-completion drain in particular
+    issues reads past the completion result.
     """
     proc = MagicMock()
     proc.returncode = None
@@ -179,7 +183,14 @@ def _make_mock_proc(stdout_lines: list[bytes]) -> MagicMock:
     proc.stdin.write = MagicMock()
     proc.stdin.drain = AsyncMock()
     proc.stdout = MagicMock()
-    proc.stdout.readline = AsyncMock(side_effect=stdout_lines)
+    queue = list(stdout_lines)
+
+    async def _readline() -> bytes:
+        if not queue:
+            return b""
+        return queue.pop(0)
+
+    proc.stdout.readline = _readline
     proc.stderr = MagicMock()
     proc.stderr.readline = AsyncMock(return_value=b"")
     proc.wait = AsyncMock()
@@ -606,6 +617,141 @@ class TestSendStream:
         assert events[-1].response is not None
         assert events[-1].response.success is True
         assert events[-1].response.text == "ok"
+
+
+# ── Post-completion drain ──────────────────────────────────────────
+
+
+class TestCompletionDrain:
+    """Text chunks can land on stdout AFTER the session/prompt
+    response: the server resolves the prompt when the session goes
+    idle while its event forwarding still has chunks in flight. The
+    send loop drains those trailing chunks before yielding the done
+    event, so the final text is complete and nothing stays buffered
+    in the pipe to surface at the start of the next turn."""
+
+    @pytest.mark.asyncio
+    async def test_late_chunk_after_completion_included_in_final_text(self):
+        b = _make_fake()
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("hello wor"),
+                _completion_result(prompt_id=3),
+                _text_chunk("ld"),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+        events = await _collect_events(b, prompt="hi")
+        assert events[-1].done is True
+        assert events[-1].response is not None
+        assert events[-1].response.success is True
+        assert events[-1].response.text == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_drain_skips_non_text_and_id_bearing_messages(self):
+        """During the drain, non-JSON garbage, non-text notifications,
+        and id-bearing messages (server requests, stray responses) are
+        ignored; only text chunks accumulate."""
+        b = _make_fake()
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("body"),
+                _completion_result(prompt_id=3),
+                b"not json\n",
+                _other_notification(),
+                _json_line({"jsonrpc": "2.0", "id": 99, "method": "session/request_permission", "params": {}}),
+                _json_line({"jsonrpc": "2.0", "id": 98, "result": {}}),
+                _text_chunk(" tail"),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+        events = await _collect_events(b, prompt="hi")
+        assert events[-1].response is not None
+        assert events[-1].response.success is True
+        assert events[-1].response.text == "body tail"
+
+    @pytest.mark.asyncio
+    async def test_drain_quiet_window_closes_with_pipe_open(self, monkeypatch):
+        """When the pipe stays open but nothing arrives within the
+        drain window, the drain stops and the done event carries the
+        text accumulated so far. The window constant lives in kai.acp
+        and is resolved at call time, so patching it there covers
+        every drain call site."""
+        monkeypatch.setattr("kai.acp.COMPLETION_DRAIN_WINDOW_S", 0.05)
+        b = _make_fake()
+        b._proc = _make_mock_proc([])
+        queue = [_text_chunk("done body"), _completion_result(prompt_id=3)]
+
+        async def _readline() -> bytes:
+            if queue:
+                return queue.pop(0)
+            # Pipe open, no data: block until the drain window
+            # cancels the read.
+            await asyncio.Event().wait()
+            return b""
+
+        b._proc.stdout.readline = _readline
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+        events = await _collect_events(b, prompt="hi")
+        assert events[-1].done is True
+        assert events[-1].response is not None
+        assert events[-1].response.success is True
+        assert events[-1].response.text == "done body"
+
+
+class TestDrainLateTextFreeFunction:
+    """drain_late_text contract: accumulate text deltas through the
+    caller's hooks until the quiet window passes or the pipe reaches
+    EOF; everything that is not a text notification is ignored."""
+
+    @pytest.mark.asyncio
+    async def test_eof_ends_drain_and_returns_accumulated(self):
+        proc = _make_mock_proc([_text_chunk("Hello"), _text_chunk(" world")])
+        out = await drain_late_text(
+            proc=proc,
+            accumulated="say: ",
+            extract_delta=_make_fake().extract_text_delta,
+            combine=lambda prev, new: prev + new,
+        )
+        assert out == "say: Hello world"
+
+    @pytest.mark.asyncio
+    async def test_quiet_window_returns_accumulated_unchanged(self):
+        proc = _make_mock_proc([])
+
+        async def _readline() -> bytes:
+            await asyncio.Event().wait()
+            return b""
+
+        proc.stdout.readline = _readline
+        out = await drain_late_text(
+            proc=proc,
+            accumulated="full answer",
+            extract_delta=_make_fake().extract_text_delta,
+            combine=lambda prev, new: prev + new,
+            window_s=0.05,
+        )
+        assert out == "full answer"
+
+    @pytest.mark.asyncio
+    async def test_combine_hook_applies_to_drained_chunks(self):
+        """The caller's combine hook runs on drained chunks exactly as
+        it does on in-turn chunks (opencode's sentence-boundary space
+        injection must not be bypassed for the tail)."""
+        proc = _make_mock_proc([_text_chunk("Tail starts here")])
+        out = await drain_late_text(
+            proc=proc,
+            accumulated="Sentence ends.",
+            extract_delta=_make_fake().extract_text_delta,
+            combine=lambda prev, new: prev + " " + new,
+        )
+        assert out == "Sentence ends. Tail starts here"
 
 
 # ── Timeouts ───────────────────────────────────────────────────────

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -153,7 +153,10 @@ def _make_mock_proc(stdout_lines: list[bytes]) -> MagicMock:
     Build a mock subprocess that yields predefined stdout lines.
 
     stdout_lines should be a list of bytes, each ending with b"\\n".
-    The final entry should be b"" to signal EOF.
+    Once the list is exhausted, every further readline call returns
+    b"" (EOF), so tests do not need to count exactly how many reads
+    the send loop performs; the post-completion drain in particular
+    issues reads past the completion result.
     """
     proc = MagicMock()
     proc.returncode = None
@@ -162,7 +165,14 @@ def _make_mock_proc(stdout_lines: list[bytes]) -> MagicMock:
     proc.stdin.write = MagicMock()
     proc.stdin.drain = AsyncMock()
     proc.stdout = MagicMock()
-    proc.stdout.readline = AsyncMock(side_effect=stdout_lines)
+    queue = list(stdout_lines)
+
+    async def _readline() -> bytes:
+        if not queue:
+            return b""
+        return queue.pop(0)
+
+    proc.stdout.readline = _readline
     proc.stderr = MagicMock()
     proc.stderr.readline = AsyncMock(return_value=b"")
     proc.wait = AsyncMock()

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -7,6 +7,7 @@ memory-specific contracts (envelope parsing, schema validation, fact
 storage) live in `tests/test_memory_extraction.py` and stay there.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -2346,6 +2347,62 @@ class TestOpenCodeOneShotReasonerFlow:
             result = await reasoner.run(prompt="hi", purpose="fact_extraction")
 
         assert result.text == "REAL"
+        assert "FILTERED" not in result.text
+
+    @pytest.mark.asyncio
+    async def test_drains_text_chunk_arriving_after_prompt_response(self, tmp_path):
+        """A text chunk that flushes to stdout after the session/prompt
+        response still accumulates. OpenCode resolves the prompt when
+        the session goes idle while its event forwarding can still
+        have the final agent_message_chunk in flight; without the
+        post-response drain the tail is lost, and for JSON consumers
+        (triage, extraction) a missing tail makes the entire response
+        unparseable."""
+        reasoner = OpenCodeOneShotReasoner(cwd=tmp_path, os_user=_current_user())
+        proc = _make_acp_proc(
+            _opencode_handshake_lines()
+            + [
+                _session_update_line('{\n  "priority": "'),
+                _rpc_response_line(request_id=3, result={"stopReason": "end_turn"}),
+                _session_update_line('low"\n}'),
+            ]
+        )
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(prompt="hi", purpose="fact_extraction")
+
+        assert json.loads(result.text) == {"priority": "low"}
+
+    @pytest.mark.asyncio
+    async def test_drain_filters_non_text_shapes_and_quiet_window_closes(self, tmp_path, monkeypatch):
+        """The drain applies the same notification filter as the main
+        loop (thought chunks do not accumulate), and when the pipe
+        stays open with nothing arriving inside the drain window the
+        accumulated text is returned as-is."""
+        monkeypatch.setattr("kai.acp.COMPLETION_DRAIN_WINDOW_S", 0.05)
+        reasoner = OpenCodeOneShotReasoner(cwd=tmp_path, os_user=_current_user())
+        proc = _make_acp_proc([])
+        queue = _opencode_handshake_lines() + [
+            _session_update_line("REAL"),
+            _rpc_response_line(request_id=3, result={"stopReason": "end_turn"}),
+            _filtered_session_update_line("agent_thought_chunk"),
+            _session_update_line("-TAIL"),
+        ]
+
+        async def _readline() -> bytes:
+            if queue:
+                return queue.pop(0)
+            # Pipe open, no data: block until the drain window
+            # cancels the read.
+            await asyncio.Event().wait()
+            return b""
+
+        proc.stdout.readline = _readline
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(prompt="hi", purpose="fact_extraction")
+
+        assert result.text == "REAL-TAIL"
         assert "FILTERED" not in result.text
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #589

OpenCode resolves the `session/prompt` JSON-RPC request when the session goes idle, but its event forwarding is asynchronous: the final `agent_message_chunk` notification can flush to stdout after the response (observed lag ~100ms on opencode 1.15.11). Both ACP read loops treated the prompt response as end-of-turn and stopped reading immediately, so a late chunk was either lost outright (one-shot reasoner, which kills the subprocess right after) or left buffered in the pipe to surface at the start of the next turn's reply (conversational loop, where the subprocess persists across turns). For one-shot JSON consumers (issue triage, memory extraction) the missing tail makes the entire response unparseable: a triage run failed with `Unterminated string` at the final 7 characters of an otherwise complete, valid response.

**Change**

- New shared `drain_late_text` free function in `acp.py`: after the prompt response, keep reading stdout for a quiet window (`COMPLETION_DRAIN_WINDOW_S`, 0.5s; restarted on each received line, ended by timeout or EOF), feeding text notifications through the caller's extract/combine hooks so opencode's sentence-boundary whitespace join applies to drained chunks exactly as it does to in-turn chunks. Non-text notifications, non-JSON lines, and id-bearing messages are ignored.
- Wired into the conversational completion branch (`AcpBackend.send`) and the one-shot success branch (`OpenCodeOneShotReasoner._drive_exchange`).
- Test mock procs for the ACP loops now return EOF after their queued lines instead of exhausting a finite `side_effect` list, since the drain legitimately reads past the completion result (`test_acp.py`, `test_goose.py`; `test_oneshot.py` already did this).

**Testing**

- 8 new tests, including the exact regression shape: a text chunk ending `"priority": "` followed by the prompt response, then a late `low"\n}` chunk; the accumulated result parses. Drain filtering, quiet-window close with the pipe still open, EOF close, and combine-hook application are each pinned, for both loops.
- Full suite: 3765 passed, 1 skipped; ruff check + format clean.
- Live verification: six consecutive one-shot triage-shaped runs against `deepseek/deepseek-v4-pro` through the real `opencode acp` subprocess (same sudo wrap the daemon uses) all returned complete JSON that the real triage parser accepts, with intact tails. The race itself cannot be forced against the live API; the unit tests pin it deterministically.
