### PR TITLE
fix: backend-agnostic wording in runtime strings

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -272,7 +272,7 @@ def build_session_context(
         except OSError:
             pass
 
-    # Memory subsystem state marker. Tells the inner Claude where to
+    # Memory subsystem state marker. Tells the inner agent where to
     # route new fact saves: enabled = POST /api/memory/add (Qdrant),
     # disabled = Edit MEMORY.md. Reflects operator INTENT (Config.
     # memory_enabled), not runtime success; if Qdrant init failed at
@@ -290,7 +290,7 @@ def build_session_context(
     # need to fire on every turn (writing style, formatting, behavioral
     # rules), while MEMORY.md holds project state and notes that surface
     # via similarity retrieval once the Qdrant-backed semantic memory
-    # is enabled. Injected above MEMORY.md so the inner Claude reads
+    # is enabled. Injected above MEMORY.md so the inner agent reads
     # rules before facts on a top-to-bottom scan. When chat_id is None
     # (one-shot CLI invocations) the block is omitted entirely; there
     # is no global-fallback PREFERENCES.md.
@@ -323,7 +323,7 @@ def build_session_context(
     #
     # Per-user scoping (#347): when chat_id is set, the file lives under
     # memory/<chat_id>/MEMORY.md so each user has their own writable
-    # copy. The inner Claude subprocess runs as that user's os_user
+    # copy. The inner agent subprocess runs as that user's os_user
     # (via sudo -H -u), so ownership of the subdirectory is set to
     # match. A non-service user cannot write the legacy single-global
     # file, which was the bug this scoping fixes. Falls back to the
@@ -352,7 +352,7 @@ def build_session_context(
         parts.append(f"## Workspace Instructions\n\n{ws_prompt}")
 
     # Always inject the per-user history directory path so the inner
-    # Claude's grep/jq searches are naturally scoped to this user.
+    # agent's grep/jq searches are naturally scoped to this user.
     history_dir = str(data_dir / "history" / str(chat_id)) if chat_id is not None else str(data_dir / "history")
 
     # Inject recent conversation history for continuity.
@@ -386,7 +386,7 @@ def build_session_context(
             )
         parts.append(api_note)
 
-    # Inject messaging and file exchange API info so Claude can
+    # Inject messaging and file exchange API info so the inner agent can
     # proactively send text or files to the user (e.g., when a
     # background task completes or a scheduled job has results).
     if api.webhook_secret:
@@ -440,7 +440,7 @@ def build_session_context(
         )
         parts.append("\n".join(svc_lines))
 
-    # Include chat_id so inner Claude can pass it back in API
+    # Include chat_id so the inner agent can pass it back in API
     # calls for correct multi-user routing. Without this, all
     # API calls route to the default admin user.
     if chat_id is not None:
@@ -464,7 +464,7 @@ def ensure_user_memory(chat_id: int | None, data_dir: Path) -> None:
     Idempotent and cheap: a stat, a possible mkdir, a possible copy2.
     Called on every send() path before build_session_context() so that
     a user without a pre-created `memory/<chat_id>/` (single-user dev,
-    test runs, or any deployment where the inner Claude runs as the
+    test runs, or any deployment where the inner agent runs as the
     same identity as the bot) still gets a writable memory surface on
     their first message.
 
@@ -502,7 +502,7 @@ def ensure_user_memory(chat_id: int | None, data_dir: Path) -> None:
     # data_dir/memory/MEMORY.md. This mirrors the behavior of the
     # removed main._bootstrap_memory() function so a fresh
     # `python -m kai` (no users.yaml, no prior install, memory disabled)
-    # still has a writable memory_root for the inner Claude to update.
+    # still has a writable memory_root for the inner agent to update.
     # Without this branch a write attempt from the subprocess would
     # FileNotFoundError on the missing parent directory.
     if chat_id is None:
@@ -716,7 +716,7 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
                 # No template on this host (incomplete install tree).
                 # Match ensure_user_memory's `# Memory\n` /
                 # ensure_user_preferences' `# Preferences\n` last-resort
-                # placeholder so the inner Claude has a writable file.
+                # placeholder so the inner agent has a writable file.
                 claude_dst.write_text("# Identity\n")
     except OSError:
         log.warning(

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -277,7 +277,7 @@ async def _acquire_lock_or_kill(
         return lock
     except TimeoutError:
         log.error(
-            "Lock acquisition timed out for chat %d after %ds; force-killing Claude",
+            "Lock acquisition timed out for chat %d after %ds; force-killing agent subprocess",
             chat_id,
             _LOCK_ACQUIRE_TIMEOUT,
         )
@@ -3661,14 +3661,14 @@ async def _handle_response(
     # the user already saw the "(stopped)" edit and doesn't need a false alarm.
     # Failed responses are logged to history so that after a session restart,
     # the injected history shows the message was attempted (not unanswered).
-    # Without this, Claude sees an unanswered user message in history and may
-    # try to address it instead of the current message.
+    # Without this, the agent sees an unanswered user message in history and
+    # may try to address it instead of the current message.
     if final_response is None:
         if stopped_by_user:
             log_message(direction="assistant", chat_id=chat_id, text="[stopped by user]")
         else:
             log_message(direction="assistant", chat_id=chat_id, text="[no response]")
-            await update.message.reply_text("Error: No response from Claude")
+            await update.message.reply_text("Error: No response from agent")
         return
 
     if not final_response.success:

--- a/src/kai/cron.py
+++ b/src/kai/cron.py
@@ -297,16 +297,16 @@ async def _job_callback(context: ContextTypes.DEFAULT_TYPE) -> None:
                     final_response = event.response
                     break
         except Exception:
-            log.exception("Job %d crashed during Claude interaction", job_id)
+            log.exception("Job %d crashed during agent interaction", job_id)
             return
 
         if final_response is None or not final_response.success:
             if final_response is None:
                 # Stream ended without a done event; helps distinguish from
                 # a done event with an error (which sets final_response.success=False)
-                log.warning("Job %d '%s': Claude stream ended without a done event", job_id, data["name"])
+                log.warning("Job %d '%s': agent stream ended without a done event", job_id, data["name"])
             error = final_response.error if final_response else "No response"
-            log.error("Job %d Claude error: %s", job_id, error)
+            log.error("Job %d agent error: %s", job_id, error)
             return
 
         response_text = final_response.text

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -4,16 +4,16 @@ SQLite database layer for sessions, jobs, settings, and workspace history.
 Provides async CRUD operations for all persistent state in Kai, organized
 into four tables:
 
-1. **sessions** — Claude Code session tracking (session ID, model, cost).
+1. **sessions** - Agent session tracking (session ID, model, cost).
    One row per chat_id, upserted on each response. Cost accumulates across
    the lifetime of a session.
 
-2. **jobs** — Scheduled tasks (reminders, Claude jobs, conditional monitors).
-   Created via the scheduling API (POST /api/schedule) or inner Claude's curl.
+2. **jobs** - Scheduled tasks (reminders, agent jobs with job_type "claude", conditional monitors).
+   Created via the scheduling API (POST /api/schedule) or the inner agent's curl.
    Jobs have a schedule_type (once/daily/interval) and can be deactivated
    without deletion to preserve history.
 
-3. **settings** — Generic key-value store for persistent config. Used for
+3. **settings** - Generic key-value store for persistent config. Used for
    workspace path, voice mode/name preferences, and future extensibility.
    Keys are namespaced strings like "voice_mode:{chat_id}".
 
@@ -202,7 +202,7 @@ async def init_db(db_path: Path) -> None:
 
 
 async def get_session(chat_id: int) -> str | None:
-    """Get the current Claude session ID for a chat, or None if no session exists."""
+    """Get the current agent session ID for a chat, or None if no session exists."""
     async with _get_db().execute("SELECT session_id FROM sessions WHERE chat_id = ?", (chat_id,)) as cursor:
         row = await cursor.fetchone()
         return row["session_id"] if row else None
@@ -210,7 +210,7 @@ async def get_session(chat_id: int) -> str | None:
 
 async def save_session(chat_id: int, session_id: str, model: str, cost_usd: float) -> None:
     """
-    Save or update a Claude session for a chat.
+    Save or update an agent session for a chat.
 
     On conflict (existing chat_id), the session_id and model are updated,
     last_used_at is refreshed, and total_cost_usd is accumulated (not replaced).

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -217,7 +217,7 @@ async def save_session(chat_id: int, session_id: str, model: str, cost_usd: floa
 
     Args:
         chat_id: Telegram chat ID.
-        session_id: Claude session identifier from the stream-json response.
+        session_id: Agent session identifier reported by the backend.
         model: Model name used for this session (e.g., "sonnet").
         cost_usd: Cost of this particular interaction (added to running total).
     """
@@ -273,8 +273,8 @@ async def create_job(
     Args:
         chat_id: Telegram chat ID that owns this job.
         name: Human-readable job name (shown in /jobs).
-        job_type: "reminder" (sends prompt as-is) or "claude" (processed by Claude).
-        prompt: Message text for reminders, or Claude prompt for Claude jobs.
+        job_type: "reminder" (sends prompt as-is) or "claude" (processed by the agent backend).
+        prompt: Message text for reminders, or the agent prompt for agent-type jobs.
         schedule_type: "once", "daily", or "interval".
         schedule_data: JSON string with schedule details.
             once: {"run_at": "ISO-datetime"}

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -662,13 +662,13 @@ async def run_triage(
 
 def _parse_triage_json(raw: str) -> dict:
     """
-    Parse Claude's triage response, stripping markdown fencing if present.
+    Parse the agent's triage response, stripping markdown fencing if present.
 
-    Claude sometimes wraps JSON in ```json ... ``` blocks despite being
+    Models sometimes wrap JSON in ```json ... ``` blocks despite being
     instructed not to. This handles that gracefully.
 
     Args:
-        raw: The raw response string from Claude.
+        raw: The raw response string from the triage agent.
 
     Returns:
         The parsed JSON as a dict.
@@ -691,7 +691,7 @@ def _parse_triage_json(raw: str) -> dict:
         text = text[:-3]
     text = text.strip()
 
-    # If Claude added preamble text before the JSON (e.g., "Here's the
+    # If the model added preamble text before the JSON (e.g., "Here's the
     # analysis:\n{...}"), try to extract a valid JSON object. The naive
     # first-{-to-last-} approach can grab the wrong span when the preamble
     # contains braces, so we validate each candidate by trying json.loads
@@ -716,7 +716,7 @@ def _parse_triage_json(raw: str) -> dict:
     try:
         result = json.loads(text)
     except json.JSONDecodeError as e:
-        raise ValueError(f"Claude returned non-JSON triage response: {e}") from e
+        raise ValueError(f"Agent returned non-JSON triage response: {e}") from e
     if not isinstance(result, dict):
         raise ValueError(f"Expected JSON object, got {type(result).__name__}")
     return result
@@ -1052,7 +1052,7 @@ async def triage_issue(
         # Step 3: Build the triage prompt
         prompt = build_triage_prompt(metadata, related_issues, projects)
 
-        # Step 4: Run the triage subprocess (Claude or Goose)
+        # Step 4: Run the triage subprocess (matching the active backend)
         raw_response = await run_triage(
             prompt,
             claude_user=claude_user,
@@ -1064,7 +1064,7 @@ async def triage_issue(
         if not raw_response.strip():
             log.warning("Empty triage output for %s#%d", metadata.repo, metadata.number)
             await _send_error_notification(
-                metadata, "Empty response from Claude", webhook_port, webhook_secret, notify_chat_id
+                metadata, "Empty response from agent", webhook_port, webhook_secret, notify_chat_id
             )
             return
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2871,7 +2871,7 @@ class TestHandleResponse:
 
     @pytest.mark.asyncio
     async def test_no_done_event_error(self):
-        """No done event: sends 'No response from Claude' error."""
+        """No done event: sends 'No response from agent' error."""
         from kai.bot import _handle_response
 
         update = _make_update()
@@ -2884,7 +2884,7 @@ class TestHandleResponse:
             await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
 
         replies = [c[0][0] for c in update.message.reply_text.call_args_list]
-        assert any("No response from Claude" in r for r in replies)
+        assert any("No response from agent" in r for r in replies)
 
     @pytest.mark.asyncio
     async def test_error_response_with_live_msg(self):

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -438,7 +438,7 @@ class TestJobCallbackClaude:
 
     @pytest.mark.asyncio()
     async def test_claude_stream_exception_returns_early(self, caplog):
-        """Exceptions during Claude interaction are caught and logged."""
+        """Exceptions during agent interaction are caught and logged."""
         mock_claude = MagicMock()
 
         async def exploding_send(prompt):


### PR DESCRIPTION
Refs #593 (sections 2 and 3: the string and comment sweep; the env var rename ships as its own PR, so this does not close the issue).

Runtime strings on shared code paths named Claude regardless of the active backend. All now say agent:

| File | String |
|---|---|
| `src/kai/triage.py` | `Agent returned non-JSON triage response: ...` (was Claude; this exact error was delivered for a deepseek-backed triage run) |
| `src/kai/triage.py` | `Empty response from agent` in the failure notification |
| `src/kai/bot.py` | Telegram reply `Error: No response from agent` |
| `src/kai/bot.py` | Lock-timeout log `force-killing agent subprocess` |
| `src/kai/cron.py` | Three job log lines: `agent interaction`, `agent stream ended`, `agent error` |

The cron lines were not in the issue's table but are the same class on the same shared path; the sweep grep found them, so they are included rather than left for a follow-up.

Comment sweep on the same paths:

- `src/kai/backend.py`: nine "inner Claude" comments in the context-injection and memory-bootstrap helpers now say "the inner agent". These helpers serve every backend.
- `src/kai/triage.py`: `_parse_triage_json` docstring and the preamble-extraction comment de-Clauded; the stale "(Claude or Goose)" dispatch comment now says "(matching the active backend)".
- `src/kai/bot.py`: two comments adjacent to the string edits.
- `src/kai/sessions.py`: module and function docstrings; the jobs table note keeps the literal `job_type "claude"` visible because that wire value is unchanged (renaming it would be an API change, out of scope).

Deliberately kept: "Inner Claude effort level" (prompt gated on the claude backend), backend class names, `claude.py` module references, real `CLAUDE.md` / `.claude/` paths, and pre-existing history comments.

**Testing**

- Detection greps for all three sweep classes return zero remaining sites; the only surviving string literal is the claude-gated effort-level prompt.
- Two test files updated where they asserted the old strings (`tests/test_bot.py`, `tests/test_cron.py`).
- Full suite: 3765 passed, 1 skipped; ruff check + format clean.
- No behavior change: strings, comments, and docstrings only.
