### PR TITLE
feat(config): rename session lifecycle env vars to AGENT_ prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ users:
 
 Each user gets:
 
-- **Own agent subprocess** - created lazily on first message, evicted after idle timeout (`CLAUDE_IDLE_TIMEOUT`, default 30 minutes). No shared conversation state.
+- **Own agent subprocess** - created lazily on first message, evicted after idle timeout (`AGENT_IDLE_TIMEOUT`, default 30 minutes). No shared conversation state.
 - **Isolated data** - conversation history, workspace settings, scheduled jobs, and file uploads are all namespaced by user. One user cannot see or affect another's state.
 - **Optional OS-level separation** - set `os_user` to run that user's agent process as a dedicated system account via `sudo -u`. Requires a sudoers rule (the install script generates one automatically).
 - **Per-user home workspace** - each user can have their own default workspace directory.
@@ -223,7 +223,7 @@ Authorization, per-user model selection, per-user OS isolation, per-user GitHub 
 | `BUDGET_CEILING` | No | `10.0` | Global budget ceiling in USD. Users cannot exceed this via `/settings budget`. Per-user defaults in `users.yaml` `max_budget`. |
 | `CLAUDE_MAX_CONTEXT_WINDOW` | No | `0` | Installation-wide default context window in tokens (0 = backend default). Per-user override in `users.yaml` `context_window`, or `/settings context`. |
 | `CLAUDE_AUTOCOMPACT_PCT` | No | `80` | Context compression threshold %, Claude Code only. When usage hits this, Claude compresses history. Can only lower the default (~83%), not raise it. |
-| `CLAUDE_MAX_SESSION_HOURS` | No | `0` | Maximum session age in hours before recycling the subprocess (0 = no limit). Recommended: 4-8 on memory-constrained machines. |
+| `AGENT_MAX_SESSION_HOURS` | No | `0` | Maximum session age in hours before recycling the subprocess (0 = no limit). Applies to every backend. Recommended: 4-8 on memory-constrained machines. |
 | `WORKSPACE_BASE` | No | | Installation-wide default workspace base directory. Per-user override in `users.yaml` `workspace_base`. |
 | `ALLOWED_WORKSPACES` | No | | Comma-separated extra workspace paths accessible by name. Users also manage their own via `/workspace allow`. |
 | `WEBHOOK_PORT` | No | `8080` | HTTP server port for webhooks and scheduling API |
@@ -234,7 +234,7 @@ Authorization, per-user model selection, per-user OS isolation, per-user GitHub 
 | `PR_REVIEW_TIMEOUT_S` | No | `900` | Subprocess timeout for a single PR review, in seconds. |
 | `PR_REVIEW_BUDGET_USD` | No | `1.0` | Hard USD ceiling for one PR review subprocess. Informational on the claude backend; enforced on non-claude backends. |
 | `SPEC_DIR` | No | `specs` | Spec directory relative to repo root, for branch-name matching in PR reviews |
-| `CLAUDE_IDLE_TIMEOUT` | No | `1800` | Seconds before idle subprocesses are evicted (0 to disable) |
+| `AGENT_IDLE_TIMEOUT` | No | `1800` | Seconds before idle subprocesses are evicted (0 to disable). Applies to every backend. |
 | `CLAUDE_EFFORT_LEVEL` | No | `high` | Reasoning effort for inner Claude: `low`, `medium`, `high`, `xhigh`, `max`. |
 | `VOICE_ENABLED` | No | `false` | Enable voice message transcription |
 | `TTS_ENABLED` | No | `false` | Enable text-to-speech voice responses |

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -975,7 +975,7 @@ class Config:
             --max-budget-usd flag is omitted from claude --print argv).
             Enforced on non-claude backends, which run on pay-per-token
             billing where the ceiling is a real cost gate.
-        claude_max_session_hours: Hours before the inner Claude process is recycled. Prevents
+        claude_max_session_hours: Hours before the inner agent subprocess is recycled. Prevents
             unbounded V8 memory growth that can trigger macOS Jetsam kernel panics. 0 = no limit.
         session_db_path: Path to the SQLite database for sessions, jobs, and settings
         webhook_port: Port for the local aiohttp server (webhooks + scheduling API)
@@ -2639,14 +2639,28 @@ def load_config() -> Config:
         budget_ceiling = float(raw_ceiling)
     except ValueError:
         raise SystemExit("BUDGET_CEILING must be a number") from None
+    # AGENT_MAX_SESSION_HOURS / AGENT_IDLE_TIMEOUT are the canonical
+    # keys; the CLAUDE_-prefixed forms are legacy aliases kept for
+    # installs upgrading without re-running the wizard. Apply-time
+    # migration in install.py rewrites /etc/kai/env to the new keys,
+    # so the fallback only fires on the first start after an upgrade
+    # (the _renamed_env_vars warning below tells the operator to
+    # migrate). Both govern the subprocess pool's session lifecycle
+    # for every backend, which is why the claude prefix was retired.
+    raw_session_hours = os.environ.get("AGENT_MAX_SESSION_HOURS", "").strip()
+    if not raw_session_hours:
+        raw_session_hours = os.environ.get("CLAUDE_MAX_SESSION_HOURS", "").strip() or "0"
     try:
-        claude_max_session_hours = float(os.environ.get("CLAUDE_MAX_SESSION_HOURS", "0"))
+        claude_max_session_hours = float(raw_session_hours)
     except ValueError:
-        raise SystemExit("CLAUDE_MAX_SESSION_HOURS must be a number") from None
+        raise SystemExit("AGENT_MAX_SESSION_HOURS must be a number") from None
+    raw_idle_timeout = os.environ.get("AGENT_IDLE_TIMEOUT", "").strip()
+    if not raw_idle_timeout:
+        raw_idle_timeout = os.environ.get("CLAUDE_IDLE_TIMEOUT", "").strip() or "1800"
     try:
-        claude_idle_timeout = int(os.environ.get("CLAUDE_IDLE_TIMEOUT", "1800"))
+        claude_idle_timeout = int(raw_idle_timeout)
     except ValueError:
-        raise SystemExit("CLAUDE_IDLE_TIMEOUT must be an integer") from None
+        raise SystemExit("AGENT_IDLE_TIMEOUT must be an integer") from None
     try:
         webhook_port = int(os.environ.get("WEBHOOK_PORT", "8080"))
     except ValueError:
@@ -3022,6 +3036,8 @@ def load_config() -> Config:
     _renamed_env_vars = {
         "CLAUDE_MAX_BUDGET_USD": "BUDGET_CEILING (global ceiling). Per-user defaults go in users.yaml 'max_budget'.",
         "CLAUDE_TIMEOUT_SECONDS": "AGENT_TIMEOUT_SECONDS.",
+        "CLAUDE_MAX_SESSION_HOURS": "AGENT_MAX_SESSION_HOURS.",
+        "CLAUDE_IDLE_TIMEOUT": "AGENT_IDLE_TIMEOUT.",
     }
     for var, replacement in _renamed_env_vars.items():
         if os.environ.get(var, "").strip():

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -332,6 +332,19 @@ def _validate_non_negative_int(value: str) -> bool:
         return False
 
 
+def _validate_non_negative_float(value: str) -> bool:
+    """Check that a string is a non-negative float (zero allowed).
+
+    Sibling of `_validate_non_negative_int` for float-typed fields
+    where 0 is a meaningful disable value (AGENT_MAX_SESSION_HOURS
+    uses 0 for "no session-age limit").
+    """
+    try:
+        return float(value) >= 0
+    except ValueError:
+        return False
+
+
 def _validate_chat_id(value: str) -> bool:
     """Check that a string is a valid Telegram chat ID (any non-zero integer)."""
     try:
@@ -1078,6 +1091,28 @@ def _cmd_config() -> None:
             break
         print("  Must be a positive integer.")
 
+    # Session lifecycle tunables. Both govern the subprocess pool for
+    # every backend (recycle-by-age and idle eviction), hence the
+    # AGENT_ prefix; the CLAUDE_-prefixed forms are legacy aliases
+    # honored as prefill fallbacks here and popped from the env dict
+    # below so a regenerated config carries only the canonical keys.
+    while True:
+        max_session_hours = _prompt(
+            "Max session age in hours (0 = no limit)",
+            existing_env.get("AGENT_MAX_SESSION_HOURS", existing_env.get("CLAUDE_MAX_SESSION_HOURS", "0")),
+        )
+        if _validate_non_negative_float(max_session_hours):
+            break
+        print("  Must be a non-negative number.")
+    while True:
+        idle_timeout = _prompt(
+            "Idle eviction timeout in seconds (0 disables)",
+            existing_env.get("AGENT_IDLE_TIMEOUT", existing_env.get("CLAUDE_IDLE_TIMEOUT", "1800")),
+        )
+        if _validate_non_negative_int(idle_timeout):
+            break
+        print("  Must be a non-negative integer.")
+
     # Skip the budget prompt on the claude backend: --max-budget-usd
     # is no longer emitted to claude --print argv (Max-plan OAuth
     # makes the CLI's computed-cost ceiling a phantom signal), so
@@ -1600,13 +1635,16 @@ def _cmd_config() -> None:
 
     # Remove stale renamed keys if present - leaving both the old and
     # new key causes silent confusion (the deprecation warning is
-    # suppressed when the new key exists). CLAUDE_TIMEOUT_SECONDS is
-    # renamed to AGENT_TIMEOUT_SECONDS; pop the legacy key on every
+    # suppressed when the new key exists). CLAUDE_TIMEOUT_SECONDS,
+    # CLAUDE_MAX_SESSION_HOURS, and CLAUDE_IDLE_TIMEOUT are renamed
+    # to their AGENT_-prefixed forms; pop the legacy keys on every
     # regenerate so the next /etc/kai/env carries only the canonical
-    # form.
+    # forms.
     env.pop("CLAUDE_MODEL", None)
     env.pop("CLAUDE_MAX_BUDGET_USD", None)
     env.pop("CLAUDE_TIMEOUT_SECONDS", None)
+    env.pop("CLAUDE_MAX_SESSION_HOURS", None)
+    env.pop("CLAUDE_IDLE_TIMEOUT", None)
 
     # BUDGET_CEILING is global (not per-user). Skipped entirely on the
     # claude backend (--max-budget-usd is omitted from claude --print
@@ -1647,6 +1685,16 @@ def _cmd_config() -> None:
     # CLAUDE_TIMEOUT_SECONDS; the legacy key is migrated to the new
     # name at apply time.)
     env["AGENT_TIMEOUT_SECONDS"] = timeout
+
+    # Session lifecycle keys are written delta-from-default (matching
+    # the autocompact / effort treatment below) so a default-accepting
+    # run keeps /etc/kai/env minimal; load_config supplies the same
+    # defaults at runtime. Compare as parsed numbers so inputs like
+    # "0.0" or "01800" that pass validation still count as defaults.
+    if float(max_session_hours) != 0:
+        env["AGENT_MAX_SESSION_HOURS"] = max_session_hours
+    if int(idle_timeout) != 1800:
+        env["AGENT_IDLE_TIMEOUT"] = idle_timeout
 
     # Context window tuning - only include if non-default.
     # Compare as int to handle inputs like "000" that pass validation.
@@ -3673,6 +3721,14 @@ def _cmd_apply() -> None:
         if "AGENT_TIMEOUT_SECONDS" not in env and "CLAUDE_TIMEOUT_SECONDS" in env:
             env["AGENT_TIMEOUT_SECONDS"] = env["CLAUDE_TIMEOUT_SECONDS"]
         env.pop("CLAUDE_TIMEOUT_SECONDS", None)
+        # Same migration for the session lifecycle keys (renamed from
+        # the CLAUDE_-prefixed forms; they govern every backend's pool).
+        if "AGENT_MAX_SESSION_HOURS" not in env and "CLAUDE_MAX_SESSION_HOURS" in env:
+            env["AGENT_MAX_SESSION_HOURS"] = env["CLAUDE_MAX_SESSION_HOURS"]
+        env.pop("CLAUDE_MAX_SESSION_HOURS", None)
+        if "AGENT_IDLE_TIMEOUT" not in env and "CLAUDE_IDLE_TIMEOUT" in env:
+            env["AGENT_IDLE_TIMEOUT"] = env["CLAUDE_IDLE_TIMEOUT"]
+        env.pop("CLAUDE_IDLE_TIMEOUT", None)
         _apply_secrets(env, dry_run, users_yaml_staging_path=users_yaml_staging_path)
 
         # -- Step 6: Deploy Goose config (if backend=goose) --

--- a/templates/.env
+++ b/templates/.env
@@ -53,9 +53,14 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 #CLAUDE_EFFORT_LEVEL=high
 
 # Maximum session age in hours before recycling (0 = no limit).
-# Prevents unbounded memory growth in the inner Claude process.
+# Prevents unbounded memory growth in the inner agent process.
 # Recommended: 4-8 hours for memory-constrained machines.
-#CLAUDE_MAX_SESSION_HOURS=4
+# Applies to every backend's subprocess pool.
+#AGENT_MAX_SESSION_HOURS=4
+
+# Seconds before idle agent subprocesses are evicted from the pool
+# (0 disables eviction). Applies to every backend's subprocess pool.
+#AGENT_IDLE_TIMEOUT=1800
 
 # Installation-wide default context window (tokens). Per-user
 # overrides go in users.yaml 'context_window', or via /settings context.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,8 +35,10 @@ _CONFIG_ENV_VARS = [
     "CLAUDE_TIMEOUT_SECONDS",
     "BUDGET_CEILING",
     "CLAUDE_MAX_BUDGET_USD",  # backward compat (renamed to BUDGET_CEILING)
-    "CLAUDE_MAX_SESSION_HOURS",
-    "CLAUDE_IDLE_TIMEOUT",
+    "AGENT_MAX_SESSION_HOURS",
+    "CLAUDE_MAX_SESSION_HOURS",  # backward compat (renamed to AGENT_MAX_SESSION_HOURS)
+    "AGENT_IDLE_TIMEOUT",
+    "CLAUDE_IDLE_TIMEOUT",  # backward compat (renamed to AGENT_IDLE_TIMEOUT)
     "WEBHOOK_PORT",
     "WEBHOOK_SECRET",
     "VOICE_ENABLED",
@@ -249,13 +251,13 @@ class TestLoadConfigErrors:
 
     def test_invalid_session_hours(self, monkeypatch):
         _set_required(monkeypatch)
-        monkeypatch.setenv("CLAUDE_MAX_SESSION_HOURS", "not-a-number")
-        with pytest.raises(SystemExit, match="CLAUDE_MAX_SESSION_HOURS"):
+        monkeypatch.setenv("AGENT_MAX_SESSION_HOURS", "not-a-number")
+        with pytest.raises(SystemExit, match="AGENT_MAX_SESSION_HOURS"):
             load_config()
 
     def test_session_hours_from_env(self, monkeypatch):
         _set_required(monkeypatch)
-        monkeypatch.setenv("CLAUDE_MAX_SESSION_HOURS", "4.5")
+        monkeypatch.setenv("AGENT_MAX_SESSION_HOURS", "4.5")
         config = load_config()
         assert config.claude_max_session_hours == 4.5
 
@@ -2696,6 +2698,71 @@ class TestAgentTimeoutSecondsRename:
         self._required_env(monkeypatch)
         cfg = load_config()
         assert cfg.claude_timeout_seconds == 120
+
+
+class TestAgentSessionLifecycleRename:
+    """CLAUDE_MAX_SESSION_HOURS / CLAUDE_IDLE_TIMEOUT renamed to the
+    AGENT_-prefixed forms with legacy aliases. The deprecation warning
+    comes from the _renamed_env_vars map, which fires whenever a legacy
+    key is present in the environment."""
+
+    def _required_env(self, monkeypatch, **overrides):
+        for var in _CONFIG_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        base = {
+            "TELEGRAM_BOT_TOKEN": "test-token",
+            "ALLOWED_USER_IDS": "12345",
+            "DEFAULT_MODEL": "sonnet",
+            "BUDGET_CEILING": "10.0",
+            "WEBHOOK_PORT": "8080",
+            "WEBHOOK_SECRET": "test-secret",
+        }
+        base.update(overrides)
+        for k, v in base.items():
+            monkeypatch.setenv(k, v)
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n",
+        )
+
+    def test_agent_keys_preferred_over_legacy(self, monkeypatch):
+        self._required_env(
+            monkeypatch,
+            AGENT_MAX_SESSION_HOURS="6",
+            CLAUDE_MAX_SESSION_HOURS="2",
+            AGENT_IDLE_TIMEOUT="900",
+            CLAUDE_IDLE_TIMEOUT="300",
+        )
+        cfg = load_config()
+        assert cfg.claude_max_session_hours == 6
+        assert cfg.claude_idle_timeout == 900
+
+    def test_legacy_only_falls_back_with_warning(self, monkeypatch, caplog):
+        self._required_env(
+            monkeypatch,
+            CLAUDE_MAX_SESSION_HOURS="4.5",
+            CLAUDE_IDLE_TIMEOUT="600",
+        )
+        with caplog.at_level(logging.WARNING, logger="kai.config"):
+            cfg = load_config()
+        assert cfg.claude_max_session_hours == 4.5
+        assert cfg.claude_idle_timeout == 600
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("CLAUDE_MAX_SESSION_HOURS in env is deprecated" in m for m in messages)
+        assert any("CLAUDE_IDLE_TIMEOUT in env is deprecated" in m for m in messages)
+
+    def test_neither_set_uses_defaults(self, monkeypatch):
+        self._required_env(monkeypatch)
+        cfg = load_config()
+        assert cfg.claude_max_session_hours == 0
+        assert cfg.claude_idle_timeout == 1800
+
+    def test_invalid_idle_timeout_names_canonical_key(self, monkeypatch):
+        """A bad value fails fast naming the canonical key, including
+        when the bad value arrives through the legacy alias."""
+        self._required_env(monkeypatch, CLAUDE_IDLE_TIMEOUT="soon")
+        with pytest.raises(SystemExit, match="AGENT_IDLE_TIMEOUT"):
+            load_config()
 
 
 class TestLoadConfigBackendAwareModelValidation:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1135,6 +1135,8 @@ class TestCmdConfig:
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
+                "0",  # max session age hours (0 = no limit)
+                "1800",  # idle eviction timeout seconds
                 "10.0",  # budget
                 "200000",  # max context window
                 "80",  # autocompact pct
@@ -1213,6 +1215,8 @@ class TestCmdConfig:
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
+                "0",  # max session age hours (0 = no limit)
+                "1800",  # idle eviction timeout seconds
                 "10.0",  # budget
                 "200000",  # max context window
                 "80",  # autocompact pct
@@ -1296,6 +1300,8 @@ class TestCmdConfig:
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
+                "0",  # max session age hours (0 = no limit)
+                "1800",  # idle eviction timeout seconds
                 "10.0",  # budget
                 "200000",  # max context window
                 "80",  # autocompact pct
@@ -1366,6 +1372,8 @@ class TestCmdConfig:
                 "sonnet",
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",
+                "0",  # max session age hours (0 = no limit)
+                "1800",  # idle eviction timeout seconds
                 "10.0",
                 "200000",
                 "80",
@@ -1428,6 +1436,8 @@ class TestCmdConfig:
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
+                "0",  # max session age hours (0 = no limit)
+                "1800",  # idle eviction timeout seconds
                 "10.0",  # budget
                 "200000",  # max context window
                 "8080",  # port
@@ -1485,6 +1495,8 @@ class TestCmdConfig:
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
+                "0",  # max session age hours (0 = no limit)
+                "1800",  # idle eviction timeout seconds
                 "10.0",  # budget
                 "200000",  # max context window
                 "8080",  # port
@@ -1663,6 +1675,8 @@ class TestCmdConfig:
             "sonnet",  # model
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # timeout
+            "0",  # max session age hours (0 = no limit)
+            "1800",  # idle eviction timeout seconds
             *budget_entry,  # BUDGET_CEILING (non-claude only)
             "200000",  # max context window
             *claude_only_pre_webhook,  # autocompact + effort (claude only)
@@ -2111,6 +2125,8 @@ class TestCmdConfig:
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
+                "0",  # max session age hours (0 = no limit)
+                "1800",  # idle eviction timeout seconds
                 "10.0",  # budget
                 "200000",  # max context window
                 "8080",  # port
@@ -2463,6 +2479,8 @@ class TestCmdConfig:
                 # model: handled by _prompt_default_model mock
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # agent timeout
+                "0",  # max session age hours (0 = no limit)
+                "1800",  # idle eviction timeout seconds
                 "10.0",  # budget (codex != claude branch)
                 "200000",  # max context window
                 # autocompact + effort skipped on non-claude backend
@@ -2828,6 +2846,8 @@ class TestCmdConfigDefaultModelDispatch:
             # model prompt is handled by the _prompt_default_model mock
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout (global default)
+            "0",  # max session age hours (0 = no limit)
+            "1800",  # idle eviction timeout seconds
             "200000",  # max context window (global default)
             "80",  # autocompact pct
             "",  # effort level (default)
@@ -2869,6 +2889,8 @@ class TestCmdConfigDefaultModelDispatch:
             # Model prompt handled by the _prompt_default_model mock
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout (global default)
+            "0",  # max session age hours (0 = no limit)
+            "1800",  # idle eviction timeout seconds
             "10.0",  # BUDGET_CEILING (non-claude only)
             "200000",  # max context window (global default)
             # No autocompact_pct / effort_level prompts (claude-only)
@@ -2902,6 +2924,8 @@ class TestCmdConfigDefaultModelDispatch:
             # model prompt is handled by the _prompt_default_model mock
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout (global default)
+            "0",  # max session age hours (0 = no limit)
+            "1800",  # idle eviction timeout seconds
             "10.0",  # BUDGET_CEILING (non-claude only)
             "200000",  # max context window (global default)
             # autocompact_pct / effort_level prompts are claude-only (gated)
@@ -6379,6 +6403,8 @@ class TestCmdConfigCanonicalUsersYaml:
             "sonnet",
             "false",  # customize per-role models (decline)
             "120",
+            "0",  # max session age hours (0 = no limit)
+            "1800",  # idle eviction timeout seconds
             "10.0",
             "200000",
             "80",
@@ -6730,6 +6756,8 @@ class TestCmdConfigSingleUserMode:
             "sonnet",  # model
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # timeout
+            "0",  # max session age hours (0 = no limit)
+            "1800",  # idle eviction timeout seconds
             "200000",  # max_context_window
             "80",  # autocompact
             "",  # effort level
@@ -7517,6 +7545,8 @@ class TestOpenCodeBinWizardPrompt:
             # model: handled by _prompt_default_model mock
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout
+            "0",  # max session age hours (0 = no limit)
+            "1800",  # idle eviction timeout seconds
             "10.0",  # budget (non-claude branch)
             "200000",  # max context window
             "8080",  # webhook port
@@ -7967,6 +7997,82 @@ class TestApplyBackendAwareModelValidation:
         )
         with pytest.raises(SystemExit, match="not valid for codex"):
             _cmd_apply()
+
+
+class TestCmdConfigSessionLifecycleKeys:
+    """Wizard emission and migration for AGENT_MAX_SESSION_HOURS /
+    AGENT_IDLE_TIMEOUT. Both are delta-from-default keys: a
+    default-accepting run writes neither, a non-default answer writes
+    the canonical AGENT_-prefixed key, and legacy CLAUDE_-prefixed
+    keys carried in an existing install.conf prefill the prompts and
+    are popped from the regenerated env."""
+
+    def _run_claude_chain(self, tmp_path, monkeypatch, mutate=None):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        TestCmdConfig._simulate_existing_etc_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n",
+        )
+        base = list(TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend())
+        if mutate:
+            mutate(base)
+        inputs = iter(base)
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            lambda backend, prov, default: "sonnet",
+        )
+        _cmd_config()
+        return json.loads((tmp_path / "install.conf").read_text())["env"]
+
+    def test_defaults_suppress_both_keys(self, tmp_path, monkeypatch):
+        env = self._run_claude_chain(tmp_path, monkeypatch)
+        assert "AGENT_MAX_SESSION_HOURS" not in env
+        assert "AGENT_IDLE_TIMEOUT" not in env
+
+    def test_non_default_values_land_with_canonical_names(self, tmp_path, monkeypatch):
+        def mutate(base):
+            # First "0" in the chain is the session-hours slot; "1800"
+            # appears only as the idle-timeout slot.
+            base[base.index("0")] = "6"
+            base[base.index("1800")] = "900"
+
+        env = self._run_claude_chain(tmp_path, monkeypatch, mutate)
+        assert env["AGENT_MAX_SESSION_HOURS"] == "6"
+        assert env["AGENT_IDLE_TIMEOUT"] == "900"
+
+    def test_legacy_keys_prefill_then_migrate_to_canonical(self, tmp_path, monkeypatch):
+        """A regenerate over an install.conf carrying the legacy
+        CLAUDE_-prefixed keys prefills the prompts with the legacy
+        values; accepting the prefills (empty input) lands the values
+        under the canonical names and the legacy keys do not survive
+        into the regenerated env."""
+        prior_conf = {
+            "install_dir": "/opt/kai",
+            "data_dir": "/var/lib/kai",
+            "service_user": "kai",
+            "platform": "darwin",
+            "env": {
+                "TELEGRAM_BOT_TOKEN": "fake-token",
+                "CLAUDE_MAX_SESSION_HOURS": "4",
+                "CLAUDE_IDLE_TIMEOUT": "600",
+            },
+        }
+        (tmp_path / "install.conf").write_text(json.dumps(prior_conf))
+
+        def mutate(base):
+            # Empty input accepts the prompt prefill, which reads the
+            # legacy keys as fallback defaults.
+            base[base.index("0")] = ""
+            base[base.index("1800")] = ""
+
+        env = self._run_claude_chain(tmp_path, monkeypatch, mutate)
+        assert env["AGENT_MAX_SESSION_HOURS"] == "4"
+        assert env["AGENT_IDLE_TIMEOUT"] == "600"
+        assert "CLAUDE_MAX_SESSION_HOURS" not in env
+        assert "CLAUDE_IDLE_TIMEOUT" not in env
 
 
 class TestApplyAgentTimeoutMigration:


### PR DESCRIPTION
Closes #593

`CLAUDE_MAX_SESSION_HOURS` and `CLAUDE_IDLE_TIMEOUT` govern the subprocess pool's recycle-by-age and idle eviction for every backend (claude, codex, goose, opencode), so the claude prefix misdescribed them. This renames them to `AGENT_MAX_SESSION_HOURS` / `AGENT_IDLE_TIMEOUT`, following the `AGENT_TIMEOUT_SECONDS` rename pattern at every layer, and closes the remaining section of #593 (the string and comment sweep already landed).

**Changes**

- **`src/kai/config.py`**: canonical keys read first with the legacy `CLAUDE_` forms as fallbacks; both legacy keys added to the `_renamed_env_vars` deprecation-warning map (warns whenever a legacy key is present, pointing at `make config`). Parse errors name the canonical keys, including when the bad value arrives through the legacy alias.
- **Wizard (`src/kai/install.py`)**: two new prompts in the agent section, "Max session age in hours (0 = no limit)" and "Idle eviction timeout in seconds (0 disables)". These tunables previously had no wizard path at all (hand-edit-only, contrary to the project posture that every tunable is wizard-settable): one was a commented example in `templates/.env`, the other documented only in the README. Prefill reads canonical-then-legacy; emission is delta-from-default so a default-accepting run keeps the env minimal; legacy keys are popped on every regenerate. New `_validate_non_negative_float` mirrors the existing non-negative-int validator (0 is the documented disable value for both fields, so the positive-only validators do not fit).
- **Apply-time migration**: `sudo make install` over an install.conf carrying the legacy keys rewrites them to the canonical names and drops the legacy forms, same as the timeout migration.
- **Docs**: `templates/.env` (renamed entry plus a new `AGENT_IDLE_TIMEOUT` block) and the three README sites. The wiki has three `CLAUDE_IDLE_TIMEOUT` mentions that will be updated immediately after this merges, since wiki edits publish on push.

**Compatibility**

Existing installs keep working without action: the runtime honors the legacy keys via fallback (with a deprecation warning), and either `make config` or `sudo make install` migrates the persisted config to the canonical names.

**Testing**

- 7 new tests: load_config precedence (canonical wins when both set), legacy-only fallback with warning, defaults when neither set, canonical-key naming in parse errors; wizard delta-from-default suppression, canonical emission of non-defaults, and the prefill-then-migrate path through a legacy install.conf.
- All 11 wizard input chains in `tests/test_install.py` updated for the two new prompt slots.
- Full suite: 3772 passed, 1 skipped; ruff check + format clean.
