### PR TITLE
fix(install): scope the missing-binary warning to backends in use

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -4937,6 +4937,9 @@ def _apply_sudoers(
     if os_users:
         backends_in_use = {agent_backend} | _collect_backends_from_yaml(users_yaml_path)
         svc_home = _user_home(service_user)
+        # Each entry's path must resolve to exactly what _generate_sudoers
+        # pins for that backend's rule (including the fallbacks); a new
+        # backend with a sudoers rule needs an entry in both places.
         expected_bins: dict[str, tuple[Path, str]] = {
             "claude": (
                 Path(f"{svc_home}/.local/bin/claude"),

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2175,6 +2175,51 @@ def _collect_os_users_from_yaml(users_yaml_path: str | Path) -> list[str]:
     return result
 
 
+def _collect_backends_from_yaml(users_yaml_path: str | Path) -> set[str]:
+    """
+    Read users.yaml and return the distinct per-user agent_backend values.
+
+    Sibling of `_collect_os_users_from_yaml` with the same lightweight
+    posture: the installer only needs the backend names to scope the
+    missing-binary backstop in `_apply_sudoers` to backends the install
+    actually uses; full validation of backend values happens at runtime
+    in config's users.yaml loader. Unknown or misspelled values pass
+    through as-is and are ignored by the caller's intersection with the
+    known-binary map, so a typo in users.yaml cannot break the install
+    (the runtime surfaces it on the user's first message instead).
+
+    Behavior mirrors the os_user reader: missing file, empty file,
+    non-dict document, or missing `users:` list all yield an empty set;
+    malformed YAML raises so the install fails loudly.
+    """
+    path = Path(users_yaml_path)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return set()
+    if not text.strip():
+        return set()
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        return set()
+    users = data.get("users")
+    if not isinstance(users, list):
+        return set()
+    backends: set[str] = set()
+    for entry in users:
+        if not isinstance(entry, dict):
+            continue
+        backend = entry.get("agent_backend")
+        # PyYAML may parse unquoted scalars as non-strings; only string
+        # values can name a backend.
+        if not isinstance(backend, str):
+            continue
+        normalized = backend.strip()
+        if normalized:
+            backends.add(normalized)
+    return backends
+
+
 def _build_codex_login_reminder(
     env: dict[str, str],
     service_user: str,
@@ -3724,6 +3769,7 @@ def _cmd_apply() -> None:
             dry_run,
             codex_bin=env.get("CODEX_BIN"),
             opencode_bin=env.get("OPENCODE_BIN"),
+            agent_backend=env.get("AGENT_BACKEND", "claude"),
         )
 
         # -- Step 8: Migrate runtime data --
@@ -4834,6 +4880,7 @@ def _apply_sudoers(
     users_yaml_path: str | Path = "/etc/kai/users.yaml",
     codex_bin: str | None = None,
     opencode_bin: str | None = None,
+    agent_backend: str = "claude",
 ) -> None:
     """
     Write sudoers rules for the service user to read protected config.
@@ -4850,6 +4897,12 @@ def _apply_sudoers(
     /opt/homebrew/bin/codex; `opencode_bin` falls back to the service
     user's `~/.local/bin/opencode`. Both fallbacks fire only on first-
     time installs where the wizard has not run yet.
+
+    `agent_backend` is the install's global backend (the env dict's
+    AGENT_BACKEND, defaulting to claude when the key is absent, which
+    matches the runtime default). Together with the per-user
+    agent_backend overrides in users.yaml it scopes the missing-binary
+    backstop below to backends the install actually uses.
     """
     sudoers_path = Path("/etc/sudoers.d/kai")
     # Load and validate users.yaml *before* the dry_run gate. Intentional:
@@ -4864,26 +4917,53 @@ def _apply_sudoers(
         opencode_bin=opencode_bin,
     )
 
-    # Backstop check: the per-user rules pin the claude binary to
-    # {service_user_home}/.local/bin/claude (the native-installer
-    # location and where the bot's runtime PATH resolves `claude`).
-    # If the service user installed claude somewhere else (Homebrew,
-    # npm global, pipx), the rule will point at a nonexistent or
-    # mismatched binary and the bot's sudo dispatch will fail at
-    # runtime with no obvious cause. Warn loudly but do not abort -
-    # the warning catches the simple "wrong path" case; the operator
-    # still owns the symlink or reinstall to make the paths agree.
+    # Backstop check: each per-user rule pins a backend binary to a
+    # fixed absolute path; a rule that points at a nonexistent binary
+    # makes the bot's sudo dispatch fail at runtime with no obvious
+    # cause. Warn loudly but do not abort - the warning catches the
+    # simple "wrong path" case; the operator still owns the symlink,
+    # reinstall, or wizard re-run that makes the paths agree.
+    #
+    # The check is scoped to backends the install actually uses (the
+    # global agent_backend plus any per-user agent_backend overrides
+    # in users.yaml): telling an opencode-only operator to install
+    # claude would manufacture a requirement that does not exist and
+    # train operators to ignore the warning. Goose has no entry in the
+    # map because it has no per-user sudoers rule (it always runs as
+    # the service user). The rules themselves are still emitted for
+    # all three binaries: a rule pointing at an absent path is inert,
+    # and unconditional emission means a later backend switch cannot
+    # strand a user without a rule.
     if os_users:
-        expected_bin = Path(f"{_user_home(service_user)}/.local/bin/claude")
-        if not expected_bin.exists():
-            print(
-                f"Warning: {expected_bin} not found; sudoers rule may point at "
-                "a nonexistent binary. The bot's runtime spawn resolves bare "
-                "`claude` against the service user's PATH - install claude via "
-                "the native installer (`~/.local/bin/claude`) or symlink your "
-                "existing install there to keep the rule and runtime in sync.",
-                file=sys.stderr,
-            )
+        backends_in_use = {agent_backend} | _collect_backends_from_yaml(users_yaml_path)
+        svc_home = _user_home(service_user)
+        expected_bins: dict[str, tuple[Path, str]] = {
+            "claude": (
+                Path(f"{svc_home}/.local/bin/claude"),
+                "The bot's runtime spawn resolves bare `claude` against the "
+                "service user's PATH - install claude via the native installer "
+                "(`~/.local/bin/claude`) or symlink your existing install there "
+                "to keep the rule and runtime in sync.",
+            ),
+            "codex": (
+                Path(codex_bin or "/opt/homebrew/bin/codex"),
+                "Re-run 'make config' and point CODEX_BIN at the actual codex "
+                "install location to keep the rule and runtime in sync.",
+            ),
+            "opencode": (
+                Path(opencode_bin or f"{svc_home}/.local/bin/opencode"),
+                "Re-run 'make config' and point OPENCODE_BIN at the actual "
+                "opencode install location to keep the rule and runtime in sync.",
+            ),
+        }
+        for backend in sorted(backends_in_use & expected_bins.keys()):
+            expected_bin, remedy = expected_bins[backend]
+            if not expected_bin.exists():
+                print(
+                    f"Warning: {expected_bin} not found; the {backend} sudoers "
+                    f"rule may point at a nonexistent binary. {remedy}",
+                    file=sys.stderr,
+                )
 
     if dry_run:
         print(f"[DRY RUN] Would write: {sudoers_path} (mode 0440)")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -29,6 +29,7 @@ from kai.install import (
     _cmd_apply,
     _cmd_config,
     _cmd_status,
+    _collect_backends_from_yaml,
     _collect_os_users_from_yaml,
     _collect_user_memory_owners,
     _copy_tree,
@@ -7052,6 +7053,153 @@ class TestApplySudoersDryRun:
 
         captured = capsys.readouterr()
         assert "Warning" not in captured.err
+
+    def test_opencode_only_install_gets_no_claude_warning(self, tmp_path, capsys, monkeypatch):
+        """An install whose only backend is opencode is never told to
+        install claude; the backstop checks the opencode binary instead."""
+        svc_home = tmp_path / "home" / "kai"
+        svc_home.mkdir(parents=True)
+        # Neither the claude binary nor the opencode binary exists.
+        monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
+
+        _apply_sudoers(
+            "kai",
+            dry_run=True,
+            users_yaml_path=users_yaml,
+            opencode_bin=str(tmp_path / "nope" / "opencode"),
+            agent_backend="opencode",
+        )
+
+        captured = capsys.readouterr()
+        assert "claude" not in captured.err
+        assert "opencode sudoers" in captured.err
+        assert "OPENCODE_BIN" in captured.err
+
+    def test_opencode_only_install_silent_when_binary_exists(self, tmp_path, capsys, monkeypatch):
+        """An opencode-only install with its binary in place warns about
+        nothing, even though the claude binary is absent."""
+        svc_home = tmp_path / "home" / "kai"
+        svc_home.mkdir(parents=True)
+        opencode = tmp_path / "opencode"
+        opencode.write_text("#!/bin/sh\n")
+        monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
+
+        _apply_sudoers(
+            "kai",
+            dry_run=True,
+            users_yaml_path=users_yaml,
+            opencode_bin=str(opencode),
+            agent_backend="opencode",
+        )
+
+        captured = capsys.readouterr()
+        assert "Warning" not in captured.err
+
+    def test_codex_backend_missing_binary_names_codex_bin(self, tmp_path, capsys, monkeypatch):
+        """A codex install with a missing binary gets the codex warning
+        pointing at the CODEX_BIN wizard setting."""
+        svc_home = tmp_path / "home" / "kai"
+        svc_home.mkdir(parents=True)
+        monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
+
+        _apply_sudoers(
+            "kai",
+            dry_run=True,
+            users_yaml_path=users_yaml,
+            codex_bin=str(tmp_path / "nope" / "codex"),
+            agent_backend="codex",
+        )
+
+        captured = capsys.readouterr()
+        assert "codex sudoers" in captured.err
+        assert "CODEX_BIN" in captured.err
+        assert "claude" not in captured.err
+
+    def test_per_user_backend_override_widens_the_check(self, tmp_path, capsys, monkeypatch):
+        """A mixed install (global opencode, one per-user claude
+        override) checks both binaries: the claude warning fires for
+        the per-user claude even though the global backend is not
+        claude."""
+        svc_home = tmp_path / "home" / "kai"
+        svc_home.mkdir(parents=True)
+        opencode = tmp_path / "opencode"
+        opencode.write_text("#!/bin/sh\n")
+        monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            "users:\n"
+            "  - telegram_id: 1\n"
+            "    os_user: alice\n"
+            "  - telegram_id: 2\n"
+            "    os_user: bob\n"
+            "    agent_backend: claude\n"
+        )
+
+        _apply_sudoers(
+            "kai",
+            dry_run=True,
+            users_yaml_path=users_yaml,
+            opencode_bin=str(opencode),
+            agent_backend="opencode",
+        )
+
+        captured = capsys.readouterr()
+        assert "claude sudoers" in captured.err
+        assert "opencode" not in captured.err.replace("opencode sudoers", "")
+
+    def test_goose_only_install_warns_about_nothing(self, tmp_path, capsys, monkeypatch):
+        """Goose has no per-user sudoers rule, so a goose-only install
+        with os_users gets no missing-binary warning at all."""
+        svc_home = tmp_path / "home" / "kai"
+        svc_home.mkdir(parents=True)
+        monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
+
+        _apply_sudoers(
+            "kai",
+            dry_run=True,
+            users_yaml_path=users_yaml,
+            agent_backend="goose",
+        )
+
+        captured = capsys.readouterr()
+        assert "Warning" not in captured.err
+
+
+class TestCollectBackendsFromYaml:
+    """The lightweight per-user agent_backend reader that scopes the
+    sudoers missing-binary backstop."""
+
+    def test_missing_file_returns_empty_set(self, tmp_path):
+        assert _collect_backends_from_yaml(tmp_path / "nope.yaml") == set()
+
+    def test_collects_distinct_backends(self, tmp_path):
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            "users:\n"
+            "  - telegram_id: 1\n"
+            "    agent_backend: codex\n"
+            "  - telegram_id: 2\n"
+            "    agent_backend: opencode\n"
+            "  - telegram_id: 3\n"
+            "    agent_backend: codex\n"
+            "  - telegram_id: 4\n"
+        )
+        assert _collect_backends_from_yaml(path) == {"codex", "opencode"}
+
+    def test_non_string_and_blank_values_skipped(self, tmp_path):
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            "users:\n  - telegram_id: 1\n    agent_backend: 42\n  - telegram_id: 2\n    agent_backend: '  '\n"
+        )
+        assert _collect_backends_from_yaml(path) == set()
 
 
 # ── _apply_service dry run ───────────────────────────────────────────

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7150,12 +7150,18 @@ class TestApplySudoersDryRun:
         )
 
         captured = capsys.readouterr()
-        assert "claude sudoers" in captured.err
-        assert "opencode" not in captured.err.replace("opencode sudoers", "")
+        # The per-user override adds claude to the check, so its
+        # warning fires; the opencode binary exists, so no opencode
+        # warning appears.
+        assert "the claude sudoers rule" in captured.err
+        assert "the opencode sudoers rule" not in captured.err
 
     def test_goose_only_install_warns_about_nothing(self, tmp_path, capsys, monkeypatch):
-        """Goose has no per-user sudoers rule, so a goose-only install
-        with os_users gets no missing-binary warning at all."""
+        """A goose-only install with os_users gets no missing-binary
+        warning at all: the backstop's binary map deliberately omits
+        goose because goose has no per-user sudoers rule (it always
+        runs as the service user), so there is no pinned binary path
+        that can drift out of sync with a rule."""
         svc_home = tmp_path / "home" / "kai"
         svc_home.mkdir(parents=True)
         monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))


### PR DESCRIPTION
Closes #591

The sudoers backstop in `_apply_sudoers` warned about a missing `~/.local/bin/claude` whenever `users.yaml` carried `os_user` entries, regardless of which backends the install runs. An opencode-only operator was told to install Claude Code on every `sudo make install`, which both manufactures a requirement that does not exist and trains operators to ignore the warning for the case it actually protects (a claude install with the binary at a nonstandard path, where sudo dispatch fails at runtime with no obvious cause).

**Change**

- The backstop now derives the set of backends in use: the global `AGENT_BACKEND` (threaded from the apply env, defaulting to claude when absent, matching the runtime default) plus any per-user `agent_backend` overrides in `users.yaml`, read by a new `_collect_backends_from_yaml` free function that mirrors `_collect_os_users_from_yaml`'s lightweight posture (unknown values pass through and are ignored by the intersection with the known-binary map; runtime validation owns correctness).
- Each in-use backend's pinned binary path is checked against exactly what `_generate_sudoers` pins: claude at the service user's `~/.local/bin/claude`, codex at `CODEX_BIN` (fallback `/opt/homebrew/bin/codex`), opencode at `OPENCODE_BIN` (fallback `~/.local/bin/opencode`). Each warning carries a backend-specific remedy: symlink or native install for claude; re-run `make config` to fix the binary-path key for codex and opencode.
- Goose is not checked: it has no per-user sudoers rule (it always runs as the service user), so there is no rule path to drift.
- Rule emission stays unconditional for all three binaries (the issue's optional item 3, deliberately not taken): a rule pointing at an absent path is inert, and unconditional emission means a later backend switch cannot strand a user without a rule.

**Acceptance criteria from the issue, each pinned by a test**

- An opencode-only install with `os_user` entries produces no claude warning (and is fully silent when its own binary exists).
- A claude-backend install with the binary missing still warns (existing tests, unchanged via the claude default).
- A mixed install (global opencode plus one per-user claude override) warns for each in-use backend whose binary is missing, and only those.

**Testing**

- 8 new tests: five warning-scoping cases in the `_apply_sudoers` dry-run class (opencode-only no-claude-warning, opencode-only silent, codex names `CODEX_BIN`, per-user override widens the check, goose-only warns about nothing) and three unit tests for the collector.
- Full suite: 3771 passed, 1 skipped; ruff check + format clean.
