### PR TITLE
refactor: remove the USD budget system

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For the full architecture, see [System Architecture](https://github.com/dcelliso
 
 Switch the agent between projects on your system with `/workspace <name>`. Names resolve relative to `WORKSPACE_BASE` (set in `.env`). Identity and memory carry over from the home workspace, so Kai retains full context regardless of what it's working on. Create new workspaces with `/workspace new <name>`. Absolute paths are not accepted - all workspaces must live under the configured base directory.
 
-Per-workspace configuration is supported via `workspaces.yaml` (or `/etc/kai/workspaces.yaml` for protected installations). Each workspace can override the model, budget, timeout, environment variables, and system prompt. See `templates/workspaces.yaml` for the full format.
+Per-workspace configuration is supported via `workspaces.yaml` (or `/etc/kai/workspaces.yaml` for protected installations). Each workspace can override the model, timeout, environment variables, and system prompt. See `templates/workspaces.yaml` for the full format.
 
 ### Multi-user
 
@@ -62,7 +62,6 @@ users:
     github: alice-dev     # routes GitHub events to this user
     os_user: alice        # subprocess runs as this OS account
     home_workspace: /home/alice/workspace
-    max_budget: 15.0      # default budget for this user (BUDGET_CEILING is the global ceiling)
     pr_review: true       # enable automatic PR review for this user
     issue_triage: true    # enable automatic issue triage for this user
     github_notify_chat_id: -100123456789   # route GitHub notifications to a group
@@ -156,8 +155,8 @@ If interrupted mid-response, Kai notifies you on restart and asks you to resend 
 | `/stop` | Interrupt a response mid-stream |
 | `/models` | Interactive model picker |
 | `/model <name>` | Switch model (available models depend on backend) |
-| `/settings` | Show per-user settings (model, budget, timeout) |
-| `/settings <field> <value>` | Change a setting (`model`, `budget`, `timeout`) |
+| `/settings` | Show per-user settings (model, timeout) |
+| `/settings <field> <value>` | Change a setting (`model`, `timeout`) |
 | `/settings reset [field]` | Clear all overrides, or one field |
 | `/workspace` (or `/ws`) | Show current workspace |
 | `/workspace <name>` | Switch by name (resolved under `WORKSPACE_BASE`) |
@@ -220,7 +219,6 @@ Authorization, per-user model selection, per-user OS isolation, per-user GitHub 
 | `LLM_PROVIDER` | Non-claude | | Global provider for non-claude backends. Per-user override in `users.yaml`. |
 | `DEFAULT_MODEL` | No | `sonnet` | Installation-wide default model. Per-user override in `users.yaml` `model`, or `/settings model`. |
 | `AGENT_TIMEOUT_SECONDS` | No | `120` | Installation-wide default per-message timeout. Per-user override in `users.yaml` `timeout`, or `/settings timeout`. |
-| `BUDGET_CEILING` | No | `10.0` | Global budget ceiling in USD. Users cannot exceed this via `/settings budget`. Per-user defaults in `users.yaml` `max_budget`. |
 | `CLAUDE_AUTOCOMPACT_PCT` | No | `80` | Context compression threshold %, Claude Code only. When usage hits this, Claude compresses history. Can only lower the default (~83%), not raise it. |
 | `AGENT_MAX_SESSION_HOURS` | No | `0` | Maximum session age in hours before recycling the subprocess (0 = no limit). Applies to every backend. Recommended: 4-8 on memory-constrained machines. |
 | `WORKSPACE_BASE` | No | | Installation-wide default workspace base directory. Per-user override in `users.yaml` `workspace_base`. |
@@ -231,7 +229,6 @@ Authorization, per-user model selection, per-user OS isolation, per-user GitHub 
 | `TELEGRAM_WEBHOOK_SECRET` | No | | Separate secret for Telegram webhook auth (defaults to `WEBHOOK_SECRET`) |
 | `PR_REVIEW_COOLDOWN` | No | `300` | Minimum seconds between reviews of the same PR. Machine-wide resource limit. |
 | `PR_REVIEW_TIMEOUT_S` | No | `900` | Subprocess timeout for a single PR review, in seconds. |
-| `PR_REVIEW_BUDGET_USD` | No | `1.0` | Hard USD ceiling for one PR review subprocess. Informational on the claude backend; enforced on non-claude backends. |
 | `SPEC_DIR` | No | `specs` | Spec directory relative to repo root, for branch-name matching in PR reviews |
 | `AGENT_IDLE_TIMEOUT` | No | `1800` | Seconds before idle subprocesses are evicted (0 to disable). Applies to every backend. |
 | `CLAUDE_EFFORT_LEVEL` | No | `high` | Reasoning effort for inner Claude: `low`, `medium`, `high`, `xhigh`, `max`. |
@@ -243,7 +240,7 @@ Authorization, per-user model selection, per-user OS isolation, per-user GitHub 
 | `TOTP_LOCKOUT_MINUTES` | No | `15` | TOTP lockout duration in minutes |
 | `FILE_RETENTION_DAYS` | No | `0` | Days to keep uploaded files before cleanup (0 to disable) |
 
-`BUDGET_CEILING` limits spending in a single session. On the Claude Code backend the flag is omitted on Max-plan OAuth (no real cost is incurred); runaway prevention is handled by the per-session timeout instead. Goose does not currently enforce this limit. The session resets on `/new`, model switch, or workspace switch.
+There is no spending cap: every supported backend runs on subscription auth where per-token cost numbers are not real billing. Runaway prevention comes from the per-message timeout (`AGENT_TIMEOUT_SECONDS`) and session lifecycle limits (`AGENT_MAX_SESSION_HOURS`, `AGENT_IDLE_TIMEOUT`).
 
 ## Running
 

--- a/scripts/episode-classifier-probe.py
+++ b/scripts/episode-classifier-probe.py
@@ -5,8 +5,8 @@ Episode-classifier probe (issue #392).
 Spawns `claude --print` with the production stage-1 extractor flags and
 drives a small labeled corpus through the windowed payload builder.
 For each labeled case prints per-case `has_episode`, `facts_count`,
-`cost_usd`, and the input payload size, plus a final pass/fail summary
-against the expected `has_episode` labels.
+and the input payload size, plus a final pass/fail summary against
+the expected `has_episode` labels.
 
 This is the manual-verification gate referenced by issue #392's
 acceptance criterion: a post-merge run reproduces the (true, false)
@@ -29,10 +29,8 @@ from `kai.memory_extraction` so the probe uses the same prompt + schema
 between probe and production should fail loudly here rather than
 silently masking real classifier behavior.
 
-Cost: at the default 2-case corpus and Haiku-rate billing, well under
-$0.01 per run on pay-per-token billing. On Max-plan OAuth (the only
-deployment posture for the claude backend after #390), the run is
-unbilled. Operators can iterate on the corpus and prompt freely.
+The run is unbilled under the subscription-auth deployment posture;
+operators can iterate on the corpus and prompt freely.
 """
 
 from __future__ import annotations
@@ -157,13 +155,12 @@ _LABELED_CORPUS: list[_LabeledCase] = [
 async def _run_one(case: _LabeledCase, model: str, prior_turns: int, timeout_s: int) -> dict:
     """
     Spawn one extraction subprocess for the labeled case and return a
-    per-case result dict. The dict is the merged shape of the CLI
-    envelope's relevant fields (`cost_usd`) and the parsed extractor
-    output (`has_episode`, `facts` list).
+    per-case result dict. The dict carries the parsed extractor
+    output (`has_episode`, `facts` list) plus payload metadata.
 
     Mirrors the production stage-1 invocation in
-    `kai.memory_extraction._run_extractor` (no --max-budget-usd per
-    #390; allow-listed env per the original sandboxing rationale;
+    `kai.memory_extraction._run_extractor` (no cost cap on argv;
+    allow-listed env per the original sandboxing rationale;
     `asyncio.wait_for` around `proc.communicate` so a hung Haiku call
     surfaces as an explicit error rather than freezing the operator's
     terminal). The probe diverges from production only by reading the
@@ -267,7 +264,6 @@ async def _run_one(case: _LabeledCase, model: str, prior_turns: int, timeout_s: 
         "case": case.name,
         "has_episode": parsed.get("has_episode"),
         "facts_count": len(parsed.get("facts", [])),
-        "cost_usd": envelope.get("total_cost_usd") or envelope.get("cost_usd"),
         "payload_size": len(payload_bytes),
         "expected_has_episode": case.expected_has_episode,
     }
@@ -317,7 +313,6 @@ async def _main() -> int:
         status = "PASS" if actual == expected else "FAIL"
         print(f"  has_episode={actual}  expected={expected}  [{status}]")
         print(f"  facts_count={result['facts_count']}")
-        print(f"  cost_usd={result.get('cost_usd')}")
         print(f"  payload_size={result['payload_size']} bytes")
         print()
 

--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -289,7 +289,6 @@ class AcpBackend(AgentBackend):
         home_workspace: Path | None = None,
         webhook_port: int = 8080,
         webhook_secret: str = "",
-        max_budget_usd: float = 1.0,
         timeout_seconds: int = 120,
         services_info: list[dict] | None = None,
         workspace_config: WorkspaceConfig | None = None,
@@ -306,7 +305,6 @@ class AcpBackend(AgentBackend):
         self.model = model
         self.workspace = workspace
         self.home_workspace = home_workspace or workspace
-        self.max_budget_usd = max_budget_usd
         self.timeout_seconds = timeout_seconds
         self.workspace_config = workspace_config
         self.provider = provider
@@ -931,8 +929,6 @@ class AcpBackend(AgentBackend):
                         success=True,
                         text=accumulated,
                         session_id=self._session_id,
-                        # ACP backends do not currently report cost.
-                        cost_usd=0.0,
                         duration_ms=0,
                     )
                     yield StreamEvent(

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -77,7 +77,6 @@ class AgentResponse:
         success: True if the backend returned a valid response, False on error.
         text: The full response text (accumulated from streaming chunks).
         session_id: Session identifier (used for session continuity).
-        cost_usd: Cost of this interaction in USD.
         duration_ms: Wall-clock duration of the interaction in milliseconds.
         error: Error message if success is False, None otherwise.
     """
@@ -85,7 +84,6 @@ class AgentResponse:
     success: bool
     text: str
     session_id: str | None = None
-    cost_usd: float = 0.0
     duration_ms: int = 0
     error: str | None = None
 
@@ -146,8 +144,8 @@ class AgentBackend(ABC):
     Mutable attributes on the ABC (set by pool.py during workspace
     restore, /settings, and /model commands). These are generic to any
     backend:
-        model, workspace, home_workspace, max_budget_usd,
-        timeout_seconds, workspace_config, provider
+        model, workspace, home_workspace, timeout_seconds,
+        workspace_config, provider
 
     Backend-specific attributes (NOT on the ABC) stay on the concrete
     class. For ClaudeCodeBackend these include: claude_user,
@@ -163,7 +161,6 @@ class AgentBackend(ABC):
     model: str
     workspace: Path
     home_workspace: Path
-    max_budget_usd: float
     timeout_seconds: int
     workspace_config: WorkspaceConfig | None
     provider: str

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -21,7 +21,7 @@ The response flow for a text message:
     5. Prompt sent to ClaudeCodeBackend.send() → streaming begins
     6. Live message created and progressively edited (2-second intervals)
     7. Final response delivered (text, voice, or both depending on voice mode)
-    8. Session saved to database (cost tracking)
+    8. Session saved to database
     9. Flag file cleared
 
 Handler registration order in create_bot() matters: python-telegram-bot matches
@@ -190,68 +190,6 @@ _LOCK_ACQUIRE_TIMEOUT = 3600  # 1 hour
 # into a single global set would obscure which subsystem is responsible
 # for a given task's lifetime.
 _pending_memory_tasks: set[asyncio.Task[None]] = set()
-
-
-# Budget-exhaustion recovery directive.
-#
-# When the inner Claude session hits BUDGET_CEILING (default $10), the
-# CLI emits an `is_error=true` event whose `errors` field carries the
-# string "Reached maximum budget ($N)". `claude.py` populates
-# AgentResponse.error from that field; the bot uses the helper below
-# to detect the budget variant and append a recovery hint as a
-# follow-up message.
-#
-# The hint is a SEPARATE message, not appended to the error notice
-# itself, so Telegram clients show it with a notification badge and
-# the user immediately sees "what to do next" alongside "what
-# happened". The bot remains responsive to /new (and every other
-# command) after the error - the per-chat lock is released by the
-# return below, and the dispatch loop continues unaffected.
-_BUDGET_RECOVERY_HINT_WITH_AMOUNT = (
-    "Hit session budget ({amount}). Type /new to start a fresh session, "
-    "or ask your operator to raise BUDGET_CEILING in /etc/kai/env."
-)
-_BUDGET_RECOVERY_HINT_NO_AMOUNT = (
-    "Hit session budget. Type /new to start a fresh session, "
-    "or ask your operator to raise BUDGET_CEILING in /etc/kai/env."
-)
-
-# Matches the CLI's "Reached maximum budget ($N)" wording. The regex
-# is anchored on the documented phrasing; if Anthropic ever changes the
-# wording the budget detection regresses to "no match", the dollar
-# amount can't be extracted, and the no-amount hint is sent. The chat
-# still surfaces the real error string from claude.py either way -
-# only the dollar-amount-aware directive is missed.
-#
-# `\d+(?:\.\d+)?` accepts integer ($10) or one-decimal ($10.50)
-# amounts and rejects malformed compositions like $1.2.3.4. Tighter
-# than `[\d.]+`; signals intent to a future reader that we expect a
-# single decimal point at most.
-_BUDGET_PHRASE_RE = re.compile(r"maximum budget \(\$(\d+(?:\.\d+)?)\)", re.IGNORECASE)
-
-
-def _is_budget_exhaustion(error_text: str | None) -> bool:
-    """True iff the error string indicates BUDGET_CEILING exhaustion.
-
-    Substring match on the CLI's documented phrasing. Wording change
-    in a future Anthropic release would silently regress this to
-    False, in which case the recovery hint stops appearing - the
-    error notice itself still surfaces. A regression test pins the
-    current phrasing.
-    """
-    if not error_text:
-        return False
-    return "maximum budget" in error_text.lower()
-
-
-def _budget_recovery_hint(error_text: str | None) -> str:
-    """Return the budget-exhaustion recovery directive, with the
-    dollar amount inlined when extractable from the error string."""
-    if error_text:
-        match = _BUDGET_PHRASE_RE.search(error_text)
-        if match:
-            return _BUDGET_RECOVERY_HINT_WITH_AMOUNT.format(amount=f"${match.group(1)}")
-    return _BUDGET_RECOVERY_HINT_NO_AMOUNT
 
 
 async def _acquire_lock_or_kill(
@@ -439,8 +377,8 @@ async def handle_new(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     """
     Handle /new — kill the Claude process and start a fresh session.
 
-    Clears the session from the database so cost tracking resets, and
-    kills the subprocess so the next message launches a new one.
+    Clears the session from the database and kills the subprocess so
+    the next message launches a new one.
     """
     assert update.message is not None
     chat_id = _chat_id(update)
@@ -722,34 +660,6 @@ async def handle_settings(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         await update.message.reply_text(f"Default model set to {display}. Session restarted.")
         return
 
-    # /settings budget <n>
-    if field == "budget":
-        if not value:
-            await update.message.reply_text("Usage: /settings budget <amount>")
-            return
-        try:
-            budget = float(value)
-            if budget <= 0 or not math.isfinite(budget):
-                raise ValueError
-        except ValueError:
-            await update.message.reply_text("Budget must be a positive number.")
-            return
-        # Enforce ceiling: always from global config, never per-user.
-        # 0 means "no ceiling" (skip enforcement).
-        ceiling = config.budget_ceiling
-        if ceiling and budget > ceiling:
-            await update.message.reply_text(f"Budget cannot exceed ${ceiling:.2f} (admin limit).")
-            return
-        await sessions.set_user_setting(chat_id, "budget", str(budget))
-        # Apply to running instance if one exists. Don't use pool.get()
-        # here - it would create a new instance just to set an attribute.
-        pool = _get_pool(context)
-        instance = pool.get_if_exists(chat_id)
-        if instance:
-            instance.max_budget_usd = budget
-        await update.message.reply_text(f"Default budget set to ${budget:.2f}.")
-        return
-
     # /settings timeout <n>
     if field == "timeout":
         if not value:
@@ -762,14 +672,15 @@ async def handle_settings(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         except ValueError:
             await update.message.reply_text("Timeout must be a positive integer (seconds).")
             return
-        # Cap at 600s (10 minutes). The real cost guard is the budget
-        # ceiling; this cap prevents a single stuck request from holding
-        # the per-chat lock indefinitely.
+        # Cap at 600s (10 minutes). The timeout is the runaway guard
+        # for a stuck subprocess; this cap prevents a single stuck
+        # request from holding the per-chat lock indefinitely.
         if timeout > 600:
             await update.message.reply_text("Timeout cannot exceed 600 seconds.")
             return
         await sessions.set_user_setting(chat_id, "timeout", str(timeout))
-        # Apply to running instance if one exists (same rationale as budget)
+        # Apply to running instance if one exists. Don't use pool.get()
+        # here - it would create a new instance just to set an attribute.
         pool = _get_pool(context)
         instance = pool.get_if_exists(chat_id)
         if instance:
@@ -777,7 +688,7 @@ async def handle_settings(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         await update.message.reply_text(f"Default timeout set to {timeout}s.")
         return
 
-    await update.message.reply_text(f"Unknown setting: {field}\nSettings: model, budget, timeout, reset")
+    await update.message.reply_text(f"Unknown setting: {field}\nSettings: model, timeout, reset")
 
 
 async def _show_settings(update: Update, context: ContextTypes.DEFAULT_TYPE, chat_id: int, config: Config) -> None:
@@ -803,17 +714,6 @@ async def _show_settings(update: Update, context: ContextTypes.DEFAULT_TYPE, cha
     yaml_model = user_config.model if user_config else None
     model, model_src = _resolve("model", yaml_model, config.default_model, str)
 
-    # Budget - 0 means "unlimited" (consistent with the ceiling check
-    # in the budget handler, where 0 = no ceiling).
-    # budget_ceiling doubles as the fallback default for unconfigured users
-    yaml_budget = user_config.max_budget if user_config else None
-    budget, budget_src = _resolve(
-        "budget",
-        yaml_budget,
-        config.budget_ceiling,
-        lambda v: "unlimited" if float(v) == 0 else f"${float(v):.2f}",
-    )
-
     # Timeout
     yaml_timeout = user_config.timeout if user_config else None
     timeout, timeout_src = _resolve("timeout", yaml_timeout, config.claude_timeout_seconds, lambda v: f"{int(v)}s")
@@ -827,11 +727,7 @@ async def _show_settings(update: Update, context: ContextTypes.DEFAULT_TYPE, cha
     provider_line = f"\n  Provider: {provider}"
 
     await update.message.reply_text(
-        f"Your settings:\n"
-        f"  Model: {model} ({model_src})"
-        f"{provider_line}\n"
-        f"  Budget: {budget} ({budget_src})\n"
-        f"  Timeout: {timeout} ({timeout_src})"
+        f"Your settings:\n  Model: {model} ({model_src}){provider_line}\n  Timeout: {timeout} ({timeout_src})"
     )
 
 
@@ -871,9 +767,6 @@ def _revert_instance_field(pool: SubprocessPool, chat_id: int, field: str, confi
                     )
                     fallback = config.default_model
                 instance.model = fallback
-    elif field == "budget":
-        # budget_ceiling doubles as the fallback default for unconfigured users
-        instance.max_budget_usd = user.max_budget if user and user.max_budget is not None else config.budget_ceiling
     elif field == "timeout":
         instance.timeout_seconds = user.timeout if user and user.timeout is not None else config.claude_timeout_seconds
 
@@ -888,13 +781,13 @@ async def _handle_settings_reset(
     """
     Handle /settings reset [field].
 
-    Always restarts the process even for non-flag settings (budget,
-    timeout) where a restart isn't strictly necessary. The simplicity
-    of "reset always restarts" outweighs the minor overhead of one
+    Always restarts the process even for non-flag settings (timeout)
+    where a restart isn't strictly necessary. The simplicity of
+    "reset always restarts" outweighs the minor overhead of one
     extra process restart during an infrequent operation.
     """
     assert update.message is not None
-    valid_fields = {"model", "budget", "timeout"}
+    valid_fields = {"model", "timeout"}
 
     if field:
         field = field.lower()
@@ -913,9 +806,9 @@ async def _handle_settings_reset(
     else:
         await sessions.delete_all_user_settings(chat_id)
         pool = _get_pool(context)
-        # Revert all three fields to their resolved defaults before
+        # Revert all fields to their resolved defaults before
         # restarting (same rationale as single-field reset above).
-        for f in ("model", "budget", "timeout"):
+        for f in ("model", "timeout"):
             _revert_instance_field(pool, chat_id, f, config)
         await pool.restart(chat_id)
         await _end_session(chat_id)
@@ -1056,7 +949,7 @@ async def handle_voice_callback(update: Update, context: ContextTypes.DEFAULT_TY
 
 @_require_auth
 async def handle_stats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Handle /stats — show session info, model, cost, and process status."""
+    """Handle /stats: show session info, model, and process status."""
     assert update.message is not None
     chat_id = _chat_id(update)
     pool = _get_pool(context)
@@ -1070,7 +963,6 @@ async def handle_stats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         f"Model: {stats['model']}\n"
         f"Started: {stats['created_at']}\n"
         f"Last used: {stats['last_used_at']}\n"
-        f"Total cost: ${stats['total_cost_usd']:.4f}\n"
         f"Process alive: {alive}"
     )
 
@@ -1268,13 +1160,11 @@ def _short_workspace_name(path: str, base: Path | None) -> str:
 def _workspace_config_suffix(ws_config: WorkspaceConfig | None) -> str:
     """Build a parenthesized suffix showing workspace config details.
 
-    Returns e.g. " (model: opus, budget: $15.00)" or "" if no config.
+    Returns e.g. " (model: opus)" or "" if no config.
     """
     extras = []
     if ws_config and ws_config.model:
         extras.append(f"model: {ws_config.model}")
-    if ws_config and ws_config.budget is not None:
-        extras.append(f"budget: ${ws_config.budget:.2f}")
     return f" ({', '.join(extras)})" if extras else ""
 
 
@@ -1485,29 +1375,6 @@ async def _handle_workspace_config(
         await update.message.reply_text(f"Model set to {value.lower()}.")
         return
 
-    # /workspace config budget <n>
-    if field == "budget":
-        if not value:
-            await update.message.reply_text("Usage: /workspace config budget <amount>")
-            return
-        try:
-            budget = float(value)
-            if budget <= 0 or not math.isfinite(budget):
-                raise ValueError
-        except ValueError:
-            await update.message.reply_text("Budget must be a positive number.")
-            return
-        # Enforce ceiling: always from global config, never per-user.
-        # 0 means "no ceiling" (skip enforcement).
-        ceiling = config.budget_ceiling
-        if ceiling and budget > ceiling:
-            await update.message.reply_text(f"Budget cannot exceed ${ceiling:.2f} (admin limit).")
-            return
-        await sessions.set_workspace_config_setting(chat_id, workspace_str, "budget", str(budget))
-        await _apply_config_change(context, chat_id, workspace, config)
-        await update.message.reply_text(f"Budget set to ${budget:.2f}.")
-        return
-
     # /workspace config timeout <n>
     if field == "timeout":
         if not value:
@@ -1539,9 +1406,7 @@ async def _handle_workspace_config(
             await _apply_config_change(context, chat_id, workspace, config)
         return
 
-    await update.message.reply_text(
-        f"Unknown config field: {field}\nFields: model, budget, timeout, env, prompt, reset"
-    )
+    await update.message.reply_text(f"Unknown config field: {field}\nFields: model, timeout, env, prompt, reset")
 
 
 async def _show_workspace_config(
@@ -1577,24 +1442,6 @@ async def _show_workspace_config(
     else:
         model, model_src = config.default_model, "global default"
     lines.append(f"  Model: {model} ({model_src})")
-
-    # Budget: workspace DB > workspaces.yaml > user DB > users.yaml > global.
-    # users.yaml uses max_budget (serves as both ceiling and default).
-    try:
-        if "budget" in db_settings:
-            budget, budget_src = float(db_settings["budget"]), "workspace override"
-        elif yaml_config and yaml_config.budget is not None:
-            budget, budget_src = yaml_config.budget, "workspaces.yaml"
-        elif "budget" in user_settings:
-            budget, budget_src = float(user_settings["budget"]), "user setting"
-        elif user_config and user_config.max_budget is not None:
-            budget, budget_src = user_config.max_budget, "users.yaml"
-        else:
-            # budget_ceiling doubles as the fallback default for unconfigured users
-            budget, budget_src = config.budget_ceiling, "global default"
-        lines.append(f"  Budget: ${budget:.2f} ({budget_src})")
-    except (ValueError, TypeError):
-        lines.append("  Budget: (corrupted - reset with /workspace config reset budget)")
 
     # Timeout: workspace DB > workspaces.yaml > user DB > users.yaml > global
     try:
@@ -2874,7 +2721,6 @@ async def handle_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         "\n"
         "/settings - Show your settings\n"
         "/settings model <name> - Default model\n"
-        "/settings budget <n> - Spending cap (USD)\n"
         "/settings timeout <n> - Response timeout (seconds)\n"
         "/settings reset [field] - Clear overrides\n"
         "\n"
@@ -2912,7 +2758,7 @@ async def handle_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         "/voice <name> - Set voice\n"
         "/voices - Choose a voice (inline buttons)\n"
         "\n"
-        "/stats - Show session info and cost\n"
+        "/stats - Show session info\n"
         "/job - List scheduled jobs\n"
         "/job info <id> - Show job details\n"
         "/job cancel <id> - Cancel a job\n"
@@ -3616,17 +3462,11 @@ async def _handle_response(
         # back to plain text on BadRequest while letting network
         # errors propagate naturally.
         await _reply_safe(update.message, error_text)
-        # Budget-exhaustion gets a recovery directive as a second
-        # follow-up message. Other error types fall through with no
-        # extra guidance; structure leaves room for additional
-        # error-class directives if recurring patterns emerge.
-        if _is_budget_exhaustion(real_error):
-            await _reply_safe(update.message, _budget_recovery_hint(real_error))
         return
 
-    # Persist session info for /stats (cost accumulates across interactions)
+    # Persist session info for /stats
     if final_response.session_id:
-        await sessions.save_session(chat_id, final_response.session_id, model, final_response.cost_usd)
+        await sessions.save_session(chat_id, final_response.session_id, model)
 
     final_text = final_response.text
     log_message(direction="assistant", chat_id=chat_id, text=final_text)

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -14,7 +14,7 @@ The stream-json protocol:
     Input:  {"type": "user", "message": {"role": "user", "content": [...]}}
     Output: {"type": "system", ...}      - session metadata
             {"type": "assistant", ...}   - partial text (streaming)
-            {"type": "result", ...}      - final response with cost/session info
+            {"type": "result", ...}      - final response with session info
 """
 
 import asyncio
@@ -57,12 +57,8 @@ class ClaudeCodeBackend(AgentBackend):
     lock to prevent interleaving.
 
     The process runs with --permission-mode bypassPermissions (required
-    for headless operation via Telegram). No --max-budget-usd is emitted:
-    the claude backend is committed to Max-plan OAuth, where the CLI's
-    computed-cost ceiling has no relation to actual billing (the CLI
-    tracks pay-per-token rates whether or not the operator owes any of
-    that money). Terminating the subprocess at a phantom ceiling would
-    just stop work that is not costing anything. Runaway protection
+    for headless operation via Telegram). No cost cap is passed:
+    subscription auth has no real per-token cost. Runaway protection
     comes from the per-message stdout-read timeouts and idle detection
     (both derived from `timeout_seconds`) - a stuck or recursive
     subprocess surfaces via stream-read failure rather than holding
@@ -81,7 +77,6 @@ class ClaudeCodeBackend(AgentBackend):
         home_workspace: Path | None = None,
         webhook_port: int = 8080,
         webhook_secret: str = "",
-        max_budget_usd: float = 1.0,
         timeout_seconds: int = 120,
         services_info: list[dict] | None = None,
         claude_user: str | None = None,
@@ -106,7 +101,6 @@ class ClaudeCodeBackend(AgentBackend):
         self.model = model
         self.workspace = workspace
         self.home_workspace = home_workspace or workspace
-        self.max_budget_usd = max_budget_usd
         self.timeout_seconds = timeout_seconds
         self.workspace_config = workspace_config
         # Effort level for the inner Claude --effort flag. Stored on the
@@ -136,7 +130,6 @@ class ClaudeCodeBackend(AgentBackend):
         # Global defaults, preserved so we can restore them when
         # switching away from a configured workspace.
         self._default_model = model
-        self._default_budget = max_budget_usd
         self._default_timeout = timeout_seconds
 
         # Apply per-workspace overrides (if configured). These become
@@ -146,8 +139,6 @@ class ClaudeCodeBackend(AgentBackend):
         # with a codex-only model is silently rejected here.
         if workspace_config:
             self.model = apply_workspace_model(workspace_config, "claude", "anthropic", self.model)
-            if workspace_config.budget is not None:
-                self.max_budget_usd = workspace_config.budget
             if workspace_config.timeout is not None:
                 self.timeout_seconds = workspace_config.timeout
 
@@ -186,7 +177,7 @@ class ClaudeCodeBackend(AgentBackend):
         Start the Claude Code subprocess if not already running.
 
         Launches claude with stream-json I/O, bypassPermissions mode (required
-        for headless operation), and the configured model and budget. The process
+        for headless operation), and the configured model. The process
         runs in the current workspace directory and persists across messages.
 
         When claude_user is set, the process is spawned via sudo -u to run as
@@ -939,10 +930,8 @@ class ClaudeCodeBackend(AgentBackend):
                     # See issue #326 for the paired UX fix.
                     if event.get("is_error", False) and not result_text:
                         log.warning(
-                            "Result event with is_error=true has no result field; "
-                            "session=%s cost_usd=%s duration_ms=%s keys=%s",
+                            "Result event with is_error=true has no result field; session=%s duration_ms=%s keys=%s",
                             event.get("session_id"),
-                            event.get("total_cost_usd"),
                             event.get("duration_ms"),
                             sorted(event.keys()),
                         )
@@ -952,9 +941,7 @@ class ClaudeCodeBackend(AgentBackend):
                     #   (a) `result` populated with a human-readable
                     #       reason. Use it directly.
                     #   (b) `result` empty BUT `errors` populated with a
-                    #       list of strings (the documented variant for
-                    #       BUDGET_CEILING exhaustion: errors carries
-                    #       ["Reached maximum budget ($N)"]).
+                    #       list of strings.
                     #
                     # Falls back to a non-None sentinel when both fields
                     # are empty so downstream rendering never produces
@@ -983,7 +970,6 @@ class ClaudeCodeBackend(AgentBackend):
                         success=not event.get("is_error", False),
                         text=text,
                         session_id=event.get("session_id", self._session_id),
-                        cost_usd=event.get("total_cost_usd", 0.0),
                         duration_ms=event.get("duration_ms", 0),
                         error=response_error,
                     )
@@ -1149,16 +1135,14 @@ class ClaudeCodeBackend(AgentBackend):
         # Always revert to global defaults first, then apply overrides.
         # This prevents stale values when switching from a fully-configured
         # workspace to a partially-configured one (e.g., workspace A has
-        # budget=15.0 but workspace B only sets model - without the reset,
-        # budget would carry over from A instead of reverting to default).
+        # timeout=300 but workspace B only sets model - without the reset,
+        # the timeout would carry over from A instead of reverting to
+        # default).
         self.model = self._default_model
-        self.max_budget_usd = self._default_budget
         self.timeout_seconds = self._default_timeout
 
         if workspace_config:
             self.model = apply_workspace_model(workspace_config, "claude", "anthropic", self.model)
-            if workspace_config.budget is not None:
-                self.max_budget_usd = workspace_config.budget
             if workspace_config.timeout is not None:
                 self.timeout_seconds = workspace_config.timeout
 

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -106,7 +106,6 @@ class CodexBackend(AgentBackend):
         home_workspace: Path | None = None,
         webhook_port: int = 8080,
         webhook_secret: str = "",
-        max_budget_usd: float = 1.0,
         timeout_seconds: int = 120,
         services_info: list[dict] | None = None,
         workspace_config: WorkspaceConfig | None = None,
@@ -136,7 +135,6 @@ class CodexBackend(AgentBackend):
         self.model = model
         self.workspace = workspace
         self.home_workspace = home_workspace or workspace
-        self.max_budget_usd = max_budget_usd
         self.timeout_seconds = timeout_seconds
         self.workspace_config = workspace_config
         self.provider = provider  # ABC-mandated; bot.py reads this
@@ -885,7 +883,6 @@ class CodexBackend(AgentBackend):
                                 success=True,
                                 text=final_visible,
                                 session_id=self._session_id,
-                                cost_usd=0.0,
                                 duration_ms=0,
                             ),
                         )

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -799,7 +799,6 @@ class WorkspaceConfig:
     Attributes:
         path: Canonical resolved workspace directory.
         model: Claude model override (haiku/sonnet/opus).
-        budget: Per-session spending cap in USD.
         timeout: Per-readline timeout in seconds.
         env: Inline environment variables for the Claude subprocess.
         env_file: Path to a KEY=VALUE file to load as environment vars.
@@ -809,7 +808,6 @@ class WorkspaceConfig:
 
     path: Path
     model: str | None = None
-    budget: float | None = None
     timeout: int | None = None
     env: dict[str, str] | None = None
     env_file: Path | None = None
@@ -870,9 +868,9 @@ class UserConfig:
     Per-user configuration loaded from users.yaml.
 
     Defines a user's identity, authorization, and resource limits.
-    Preferences that the user controls (active model, working budget)
-    live in the settings table, not here. The fields below are
-    admin-set baselines that users can override within boundaries.
+    Preferences that the user controls (active model, timeout) live
+    in the settings table, not here. The fields below are admin-set
+    baselines that users can override within boundaries.
 
     Attributes:
         telegram_id: Telegram user ID (authorization key).
@@ -881,10 +879,6 @@ class UserConfig:
         github: GitHub username for webhook actor routing.
         os_user: OS username for subprocess isolation (Phase 3).
         home_workspace: Per-user home workspace directory.
-        max_budget: Default budget in USD for this user. Used as the
-            baseline when the user has not set their own via /settings
-            budget. Does NOT serve as a ceiling - the ceiling is
-            BUDGET_CEILING (global env var).
         model: Default model name (e.g., "opus", "sonnet", "haiku").
         timeout: Default timeout in seconds for Claude responses.
         workspace_base: Base directory for /workspace new and name resolution.
@@ -897,7 +891,6 @@ class UserConfig:
     github: str | None = None
     os_user: str | None = None
     home_workspace: Path | None = None
-    max_budget: float | None = None
     model: str | None = None
     timeout: int | None = None
     workspace_base: Path | None = None
@@ -960,14 +953,6 @@ class Config:
         allowed_user_ids: Set of Telegram user IDs permitted to interact with the bot (required)
         default_model: Default model name, provider-dependent (e.g. sonnet, gpt-5.5-pro, gemini-2.5-pro)
         claude_timeout_seconds: Seconds before a Claude response is considered timed out
-        budget_ceiling: Global budget ceiling in USD. Users cannot exceed
-            this via /settings budget. Also serves as the fallback default
-            for users without a per-user max_budget in users.yaml.
-            Informational only on the claude backend (Max-plan OAuth makes
-            the CLI's computed-cost ceiling a phantom signal; the
-            --max-budget-usd flag is omitted from claude --print argv).
-            Enforced on non-claude backends, which run on pay-per-token
-            billing where the ceiling is a real cost gate.
         claude_max_session_hours: Hours before the inner agent subprocess is recycled. Prevents
             unbounded V8 memory growth that can trigger macOS Jetsam kernel panics. 0 = no limit.
         session_db_path: Path to the SQLite database for sessions, jobs, and settings
@@ -1003,7 +988,6 @@ class Config:
     # resolution chain that `resolve_user_model` implements.
     default_models: dict[str, str] = field(default_factory=dict)
     claude_timeout_seconds: int = 120
-    budget_ceiling: float = 10.0
     claude_max_session_hours: float = 0  # 0 = no limit
     claude_idle_timeout: int = 1800  # seconds before idle subprocess eviction; 0 = no eviction
 
@@ -1013,7 +997,7 @@ class Config:
 
     # Effort level passed to inner Claude as `--effort <value>`. Higher
     # settings spend more reasoning tokens per turn, improving answer
-    # quality at the cost of latency and budget. Default "high" matches
+    # quality at the cost of latency. Default "high" matches
     # the operator's outer-Claude default; switching to "medium" globally
     # would silently downgrade existing reasoning quality. Critical when
     # users.yaml `os_user` is set, because inner Claude then runs as a
@@ -1079,14 +1063,6 @@ class Config:
     # a long time; the default gives thinking-heavy reviews room while
     # still terminating genuinely stuck processes.
     pr_review_timeout_s: int = 900
-    # Hard USD ceiling for one PR review subprocess. Omitted from claude
-    # --print argv on the claude backend (Max-plan OAuth makes the CLI's
-    # computed-cost ceiling a phantom signal); the field is consulted by
-    # non-claude backends, where reviews run on pay-per-token billing
-    # and the ceiling is a real cost gate. Field stays defined so
-    # operators with hand-edited /etc/kai/env from a previous install
-    # are not affected by upgrade.
-    pr_review_budget_usd: float = 1.0
     # Deprecated: review agent now resolves repos via workspace config.
     # Kept for backwards compatibility with existing .env files; the value
     # is parsed but no longer used by webhook.py.
@@ -1151,15 +1127,6 @@ class Config:
     # different model for a (role, backend) pair edits MODEL_REGISTRY
     # in code.
     memory_extraction_enabled: bool = False
-    # Per-call budget ceiling. Retained as inert compatibility config.
-    # Both supported memory reasoners (claude and codex) are
-    # subscription-backed in the operator deployment model and no code
-    # path forwards this value to subprocess argv. Runaway protection
-    # comes from memory_extraction_timeout_s instead. The field stays
-    # in the dataclass so operators upgrading from a deployment with
-    # MEMORY_EXTRACTION_BUDGET_USD already set in /etc/kai/env do not
-    # see a startup error after upgrade.
-    memory_extraction_budget_usd: float = 0.01
     # Timeout (seconds) for a single extraction subprocess. Haiku
     # typically finishes in 2-4s; 10s gives headroom without stranding
     # an executor thread on a hung subprocess.
@@ -1207,15 +1174,6 @@ class Config:
     # resolved per-user from the registry at episode-extraction time
     # via get_model_for(ModelRole.MEMORY_EPISODE, effective_backend);
     # there is no global override field.
-    # Per-call budget ceiling (USD). Retained as inert compatibility
-    # config. Same rationale as memory_extraction_budget_usd above:
-    # both supported reasoners are subscription-backed and no code
-    # path forwards this value to subprocess argv. Runaway protection
-    # comes from memory_episode_timeout_s instead. The field stays in
-    # the dataclass so operators upgrading from a deployment with
-    # MEMORY_EPISODE_BUDGET_USD already set in /etc/kai/env do not see
-    # a startup error after upgrade.
-    memory_episode_budget_usd: float = 0.15
     # Subprocess timeout (seconds). Default 120 - twice the production-
     # tuned stage-1 value (60s) and 12x the stage-1 dataclass default
     # (10s). The asymmetry is intentional: stage 2 is fire-and-forget
@@ -1567,18 +1525,11 @@ def _load_workspace_configs() -> dict[Path, WorkspaceConfig]:
                 )
                 # Don't skip - could be an open-ended provider model ID
 
-        # Validate budget (same bool guard as timeout - float(True) is 1.0)
-        budget = claude_section.get("budget")
-        if budget is not None:
-            try:
-                if isinstance(budget, bool):
-                    raise ValueError("must be a number, not a boolean")
-                budget = float(budget)
-                if budget <= 0:
-                    raise ValueError("must be positive")
-            except (TypeError, ValueError) as e:
-                log.warning("workspaces.yaml: invalid budget for %s: %s; skipping entry", path, e)
-                continue
+        # Budgets are no longer tracked; tolerate a lingering key from
+        # an older workspaces.yaml rather than failing the entry, so an
+        # un-migrated file keeps loading after upgrade.
+        if claude_section.get("budget") is not None:
+            log.warning("workspaces.yaml: 'budget' for %s is no longer supported; ignoring", path)
 
         # Validate timeout (must be a positive integer, not a float or bool).
         # bool is a subclass of int in Python, so `timeout: true` would
@@ -1638,7 +1589,6 @@ def _load_workspace_configs() -> dict[Path, WorkspaceConfig]:
         configs[path] = WorkspaceConfig(
             path=path,
             model=model,
-            budget=budget,
             timeout=timeout,
             env=env,
             env_file=env_file,
@@ -2161,18 +2111,11 @@ def _load_user_configs(
                     )
                     home_workspace = None
 
-        # Validate max_budget (same bool guard as workspace budget)
-        max_budget = entry.get("max_budget")
-        if max_budget is not None:
-            try:
-                if isinstance(max_budget, bool):
-                    raise ValueError("must be a number, not a boolean")
-                max_budget = float(max_budget)
-                if max_budget <= 0:
-                    raise ValueError("must be positive")
-            except (TypeError, ValueError) as e:
-                log.warning("users.yaml: invalid max_budget for %s: %s; skipping entry", name, e)
-                continue
+        # Budgets are no longer tracked; tolerate a lingering key from
+        # an older users.yaml rather than failing the entry, so an
+        # un-migrated file keeps loading after upgrade.
+        if entry.get("max_budget") is not None:
+            log.warning("users.yaml: 'max_budget' for %s is no longer supported; ignoring", name)
 
         # Validate optional agent_backend (must be valid if set)
         user_backend: str | None = None
@@ -2465,7 +2408,6 @@ def _load_user_configs(
             github=github,
             os_user=os_user,
             home_workspace=home_workspace,
-            max_budget=max_budget,
             model=model,
             timeout=user_timeout,
             workspace_base=user_workspace_base,
@@ -2608,17 +2550,6 @@ def load_config() -> Config:
         claude_timeout_seconds = int(raw_timeout)
     except ValueError:
         raise SystemExit("AGENT_TIMEOUT_SECONDS must be an integer") from None
-    # Budget ceiling: new var takes precedence, fall back to old var
-    # for backward compat on upgrade (existing .env has old key name).
-    raw_ceiling = os.environ.get("BUDGET_CEILING", "").strip()
-    if not raw_ceiling:
-        raw_ceiling = os.environ.get("CLAUDE_MAX_BUDGET_USD", "").strip()
-    if not raw_ceiling:
-        raw_ceiling = "10.0"
-    try:
-        budget_ceiling = float(raw_ceiling)
-    except ValueError:
-        raise SystemExit("BUDGET_CEILING must be a number") from None
     # AGENT_MAX_SESSION_HOURS / AGENT_IDLE_TIMEOUT are the canonical
     # keys; the CLAUDE_-prefixed forms are legacy aliases kept for
     # installs upgrading without re-running the wizard. Apply-time
@@ -2684,7 +2615,7 @@ def load_config() -> Config:
 
     # PR review agent config. The global `pr_review` toggle now lives
     # per-user in users.yaml; PR_REVIEW_COOLDOWN / PR_REVIEW_TIMEOUT_S
-    # / PR_REVIEW_BUDGET_USD remain as global resource controls.
+    # remain as global resource controls.
     try:
         pr_review_cooldown = int(os.environ.get("PR_REVIEW_COOLDOWN", "300"))
     except ValueError:
@@ -2695,12 +2626,6 @@ def load_config() -> Config:
             raise SystemExit("PR_REVIEW_TIMEOUT_S must be a positive integer")
     except ValueError:
         raise SystemExit("PR_REVIEW_TIMEOUT_S must be an integer") from None
-    try:
-        pr_review_budget_usd = float(os.environ.get("PR_REVIEW_BUDGET_USD", "1.0"))
-        if pr_review_budget_usd <= 0:
-            raise SystemExit("PR_REVIEW_BUDGET_USD must be a positive number")
-    except ValueError:
-        raise SystemExit("PR_REVIEW_BUDGET_USD must be a number") from None
 
     try:
         totp_session_minutes = int(os.environ.get("TOTP_SESSION_MINUTES", "30"))
@@ -2776,9 +2701,9 @@ def load_config() -> Config:
     # dataclass docstring documents this dependency, but without
     # parse-time enforcement the extraction subprocess fires when
     # MEMORY_EXTRACTION_ENABLED=true is set with MEMORY_ENABLED=false,
-    # burning ~$0.01/turn of Haiku budget whose result silently no-ops
-    # in the `_memory is None` guard inside add_structured. Compose
-    # here so the dependency is explicit and the budget-burn hole is
+    # spawning a per-turn Haiku call whose result silently no-ops in
+    # the `_memory is None` guard inside add_structured. Compose here
+    # so the dependency is explicit and the wasted-subprocess hole is
     # closed regardless of operator env-var ordering.
     memory_extraction_enabled = memory_extraction_enabled and memory_enabled
 
@@ -2823,12 +2748,6 @@ def load_config() -> Config:
             )
 
     try:
-        memory_extraction_budget_usd = float(os.environ.get("MEMORY_EXTRACTION_BUDGET_USD", "0.01"))
-        if memory_extraction_budget_usd < 0:
-            raise SystemExit("MEMORY_EXTRACTION_BUDGET_USD must be non-negative")
-    except ValueError:
-        raise SystemExit("MEMORY_EXTRACTION_BUDGET_USD must be a number") from None
-    try:
         memory_extraction_timeout_s = int(os.environ.get("MEMORY_EXTRACTION_TIMEOUT_S", "10"))
         if memory_extraction_timeout_s <= 0:
             raise SystemExit("MEMORY_EXTRACTION_TIMEOUT_S must be a positive integer")
@@ -2865,16 +2784,8 @@ def load_config() -> Config:
     # extraction time (memory_extraction._resolve_episode_model uses
     # get_model_for(ModelRole.MEMORY_EPISODE, effective_backend)); the
     # global MEMORY_EPISODE_MODEL env var is deprecated and warned
-    # about above. Budget is strictly positive (zero would silently
-    # disable a real subprocess; the intentional kill switch is
-    # MEMORY_ENABLED). Timeout floor is 10s to prevent accidentally
+    # about above. Timeout floor is 10s to prevent accidentally
     # tightening it below Haiku's warm-up time.
-    try:
-        memory_episode_budget_usd = float(os.environ.get("MEMORY_EPISODE_BUDGET_USD", "0.15"))
-        if memory_episode_budget_usd <= 0:
-            raise SystemExit("MEMORY_EPISODE_BUDGET_USD must be positive")
-    except ValueError:
-        raise SystemExit("MEMORY_EPISODE_BUDGET_USD must be a number") from None
     try:
         memory_episode_timeout_s = int(os.environ.get("MEMORY_EPISODE_TIMEOUT_S", "120"))
         if memory_episode_timeout_s < 10:
@@ -3007,7 +2918,6 @@ def load_config() -> Config:
     # not legacy renames; the runtime no longer reads them at all and
     # the corresponding wizard prompts have been retired.
     _renamed_env_vars = {
-        "CLAUDE_MAX_BUDGET_USD": "BUDGET_CEILING (global ceiling). Per-user defaults go in users.yaml 'max_budget'.",
         "CLAUDE_TIMEOUT_SECONDS": "AGENT_TIMEOUT_SECONDS.",
         "CLAUDE_MAX_SESSION_HOURS": "AGENT_MAX_SESSION_HOURS.",
         "CLAUDE_IDLE_TIMEOUT": "AGENT_IDLE_TIMEOUT.",
@@ -3023,12 +2933,23 @@ def load_config() -> Config:
     # Retired env vars: the setting no longer exists, so unlike the
     # renames above there is no replacement key to point at. Warn so
     # the operator knows the lingering value has no effect; the wizard
-    # drops the key on the next regenerate.
-    if os.environ.get("CLAUDE_MAX_CONTEXT_WINDOW", "").strip():
-        log.warning(
-            "CLAUDE_MAX_CONTEXT_WINDOW is no longer supported; the agent CLI's default "
-            "context window applies. Re-run 'make config' to clean /etc/kai/env."
-        )
+    # drops the key on the next regenerate. The reason clause finishes
+    # the sentence "<KEY> is no longer supported; ...".
+    _retired_env_vars = {
+        "CLAUDE_MAX_CONTEXT_WINDOW": "the agent CLI's default context window applies",
+        "BUDGET_CEILING": "budgets are no longer tracked",
+        "CLAUDE_MAX_BUDGET_USD": "budgets are no longer tracked",
+        "PR_REVIEW_BUDGET_USD": "budgets are no longer tracked",
+        "MEMORY_EXTRACTION_BUDGET_USD": "budgets are no longer tracked",
+        "MEMORY_EPISODE_BUDGET_USD": "budgets are no longer tracked",
+    }
+    for var, reason in _retired_env_vars.items():
+        if os.environ.get(var, "").strip():
+            log.warning(
+                "%s is no longer supported; %s. Re-run 'make config' to clean /etc/kai/env.",
+                var,
+                reason,
+            )
 
     # Warn when GitHub features are configured but no user has a
     # repo list. Events will never reach the agents because
@@ -3117,7 +3038,6 @@ def load_config() -> Config:
         default_model=default_model,
         default_models=default_models,
         claude_timeout_seconds=claude_timeout_seconds,
-        budget_ceiling=budget_ceiling,
         claude_max_session_hours=claude_max_session_hours,
         claude_idle_timeout=claude_idle_timeout,
         claude_autocompact_pct=claude_autocompact_pct,
@@ -3133,7 +3053,6 @@ def load_config() -> Config:
         memory_projects=memory_projects,
         pr_review_cooldown=pr_review_cooldown,
         pr_review_timeout_s=pr_review_timeout_s,
-        pr_review_budget_usd=pr_review_budget_usd,
         github_repo=os.getenv("GITHUB_REPO", ""),
         spec_dir=os.getenv("SPEC_DIR", "specs"),
         file_retention_days=file_retention_days,
@@ -3150,11 +3069,9 @@ def load_config() -> Config:
         memory_embedding_model=memory_embedding_model,
         memory_extraction_enabled=memory_extraction_enabled,
         memory_recall_shadow_enabled=memory_recall_shadow_enabled,
-        memory_extraction_budget_usd=memory_extraction_budget_usd,
         memory_extraction_timeout_s=memory_extraction_timeout_s,
         episode_classifier_context_turns=episode_classifier_context_turns,
         memory_consolidation_candidates_n=memory_consolidation_candidates_n,
-        memory_episode_budget_usd=memory_episode_budget_usd,
         memory_episode_timeout_s=memory_episode_timeout_s,
         memory_search_floor=memory_search_floor,
         memory_duplicate_threshold=memory_duplicate_threshold,

--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -61,7 +61,7 @@ Design rationale (the parts that are not obvious from the code):
   separate so a noisy run is diagnosable: a 30% generation_error rate
   means the gen subprocess is broken (rate-limited, timed out, model
   unavailable); a 30% judge_error rate means the judge subprocess is
-  broken (bad budget cap, schema regression). Mixing them would hide
+  broken (schema regression, auth failure). Mixing them would hide
   which side needs operator attention.
 
 PII posture: probe questions and gold-fact text remain in the gitignored
@@ -129,14 +129,6 @@ _DEFAULT_JUDGE_MODEL = "claude-haiku-4-5-20251001"
 # the operator typically wants this to match whatever the bot runs in
 # production. Sonnet is the production default; override via `--gen-model`.
 _DEFAULT_GEN_MODEL = "sonnet"
-
-
-# Per-call cost ceilings. The judge call is small (~3-4k input tokens,
-# tens of output tokens), so 0.05 USD is generous. The generator can
-# emit longer responses for multi-fact questions; 0.10 USD covers a
-# 1-2k output-token reply at Sonnet rates.
-_DEFAULT_JUDGE_BUDGET_USD = 0.05
-_DEFAULT_GEN_BUDGET_USD = 0.10
 
 
 # Subprocess timeout ceilings. Match the extractor's 60s default; a
@@ -282,10 +274,8 @@ class BehavioralConfig:
     """
 
     judge_model: str
-    judge_budget_usd: float
     judge_timeout_s: int
     gen_model: str
-    gen_budget_usd: float
     gen_timeout_s: int
     seed: str
     max_concurrency: int
@@ -330,9 +320,9 @@ class ProbeOutcome:
     so a future debugger can see what the judge actually said before
     the de-anonymization step.
 
-    `responses` and `latency_ms`/`cost_usd` are dicts keyed by arm
-    letter ("A", "B") so the per-probe row in the output JSON can
-    surface both arms symmetrically.
+    `responses` and `latency_ms` are dicts keyed by arm letter
+    ("A", "B") so the per-probe row in the output JSON can surface
+    both arms symmetrically.
     """
 
     probe: Probe
@@ -343,7 +333,6 @@ class ProbeOutcome:
     judge_reasoning: str
     memory_outcome: str  # rolled-up bucket name (one of _OUTCOME_BUCKETS or "drift")
     latency_ms: dict[str, float]  # {"A": ..., "B": ..., "judge": ...}
-    cost_usd: dict[str, float | None]  # {"A": None, "B": None, "judge": ...}
 
 
 # ── Probe loading ──────────────────────────────────────────────────
@@ -430,8 +419,6 @@ def _build_judge_cmd(config: BehavioralConfig) -> list[str]:
         "json",
         "--json-schema",
         json.dumps(_JUDGE_SCHEMA),
-        "--max-budget-usd",
-        str(config.judge_budget_usd),
         "--system-prompt",
         _JUDGE_SYSTEM_PROMPT,
         "--permission-mode",
@@ -450,10 +437,7 @@ def _build_gen_cmd(config: BehavioralConfig) -> list[str]:
     - `--output-format text` (not `json`): the generator's output is a
       free-form reply that the judge will read; the JSON envelope would
       need to be unwrapped, and we don't need the structured-output
-      validator path. Side effect: the per-call cost is NOT recoverable
-      from text output (the JSON envelope carries it). The harness
-      records `cost_usd` as None for the generator arms; this is a
-      documented limitation, not a bug.
+      validator path.
 
     - No `--json-schema`: text output, no schema to validate against.
 
@@ -473,8 +457,6 @@ def _build_gen_cmd(config: BehavioralConfig) -> list[str]:
         config.gen_model,
         "--output-format",
         "text",
-        "--max-budget-usd",
-        str(config.gen_budget_usd),
         # Literally empty, not omitted. Omitting would let the CLI's
         # default system prompt confound the measurement; passing ""
         # replaces it with the empty string. Verified accepted by
@@ -497,11 +479,6 @@ def _build_judge_cmd_codex(config: BehavioralConfig) -> list[str]:
     `--tools` flag set; the harness handles schema validation post-hoc
     (see `_validate_judge_envelope`) and injects the system prompt as
     a boundary-delimited prefix to stdin (see `_render_codex_stdin`).
-
-    The `--max-budget-usd` knob is also absent because codex on
-    subscription auth has no per-call billing surface. The CLI flag
-    is silently ignored on codex; the corresponding harness output
-    field records `cost_usd = None`.
 
     `CODEX_BIN` env override is honored same as triage/review and the
     persistent backend: installs where codex lives in a per-os_user
@@ -834,7 +811,7 @@ def _extract_judge_choice(envelope: dict) -> tuple[str, str] | None:
     Caller buckets None as `judge_error`.
 
     1. `is_error: true` -> None. The CLI can exit 0 with is_error set
-       when a budget cap was hit mid-retry; we treat that as failure
+       (e.g. an auth failure mid-retry); we treat that as failure
        rather than partial-success-with-noise.
     2. Schema-validated payload nests under `structured_output` (this
        is what `--json-schema` produces, not at the top level;
@@ -862,31 +839,14 @@ def _extract_judge_choice(envelope: dict) -> tuple[str, str] | None:
 def _parse_judge_stdout(stdout: bytes) -> tuple[str, str] | None:
     """Convenience wrapper: decode envelope + extract (choice, reasoning).
 
-    Used by the test suite (which passes raw bytes) and as a single
-    call point when the caller does not also need the cost field.
-    Production's `_run_one_judge` bypasses this and decodes the
-    envelope once so the cost extractor can reuse it; see that
-    function for the rationale on avoiding the duplicate decode.
+    Used by the test suite (which passes raw bytes) and by
+    production's `_run_one_judge` as the single decode + extract
+    call point.
     """
     envelope = _decode_judge_envelope(stdout)
     if envelope is None:
         return None
     return _extract_judge_choice(envelope)
-
-
-def _extract_judge_cost_usd(envelope: dict) -> float | None:
-    """Pull the judge's per-call cost from an already-decoded envelope.
-
-    Takes a dict (not raw bytes) so callers that already decoded the
-    envelope for the choice extractor do not pay for a second
-    json.loads. Returns None if `total_cost_usd` is missing or not
-    numeric. The extractor uses `total_cost_usd` at the envelope top
-    level (verified via the smoke test referenced in
-    memory_extraction's spec 320 §13.2). Different from the generator
-    case where text-format output has no cost field at all.
-    """
-    cost = envelope.get("total_cost_usd")
-    return float(cost) if isinstance(cost, (int, float)) else None
 
 
 # ── Anonymization + outcome rollup ─────────────────────────────────
@@ -1200,15 +1160,11 @@ async def _run_one_arm(
     arm_prompt: str,
     cwd: Path,
     env: dict[str, str],
-) -> tuple[str | None, float, float | None]:
-    """Run one generator arm; return (response_text, latency_ms, cost_usd).
+) -> tuple[str | None, float]:
+    """Run one generator arm; return (response_text, latency_ms).
 
     Returns response_text=None on any failure (non-zero exit, timeout,
     empty stdout); the caller buckets None as `generation_error`.
-    cost_usd is always None for text-format output (the JSON envelope
-    that carries cost is not produced when --output-format=text), so
-    the field is included for schema symmetry with the judge call but
-    not populated. Documented limitation per spec §3.3.
 
     Backend dispatch: claude builds `claude --print` argv and reads
     the raw stdout text; codex builds `codex exec --json` argv,
@@ -1231,7 +1187,7 @@ async def _run_one_arm(
         env=env,
     )
     if rc != 0:
-        return None, elapsed_ms, None
+        return None, elapsed_ms
     if config.backend == "codex":
         text = _parse_codex_gen_stdout(stdout).strip()
     else:
@@ -1241,8 +1197,8 @@ async def _run_one_arm(
         # the judge cannot score nothing against the gold fact. Bucket
         # as generation_error rather than feeding empty string into
         # the comparison.
-        return None, elapsed_ms, None
-    return text, elapsed_ms, None
+        return None, elapsed_ms
+    return text, elapsed_ms
 
 
 async def _run_one_judge(
@@ -1254,8 +1210,8 @@ async def _run_one_judge(
     response_b: str,
     cwd: Path,
     env: dict[str, str],
-) -> tuple[tuple[str, str] | None, float, float | None]:
-    """Run one judge call; return ((choice, reasoning) or None, latency_ms, cost_usd).
+) -> tuple[tuple[str, str] | None, float]:
+    """Run one judge call; return ((choice, reasoning) or None, latency_ms).
 
     None signals any failure in the parsing chain (timeout, non-zero
     exit, malformed JSON, missing structured_output, invalid choice).
@@ -1285,29 +1241,14 @@ async def _run_one_judge(
         env=env,
     )
     if rc != 0:
-        return None, elapsed_ms, None
+        return None, elapsed_ms
     if config.backend == "codex":
         # Codex has no --json-schema CLI-side; the harness parses NDJSON,
         # extracts the agent_message text, parses as JSON, and validates
-        # against _JUDGE_SCHEMA via _validate_judge_envelope. Cost is
-        # always None on codex (subscription auth has no per-call billing).
+        # against _JUDGE_SCHEMA via _validate_judge_envelope.
         parsed = _parse_codex_judge_stdout(stdout)
-        return parsed, elapsed_ms, None
-    # Decode the envelope once and feed it to BOTH the choice extractor
-    # and the cost extractor; previously each function called
-    # json.loads(stdout) independently, doubling the parse work per
-    # judge call. Cost is still recorded when the envelope is
-    # well-formed JSON but the contents fail validation (e.g.
-    # is_error=True or invalid choice enum) so that operator-side
-    # accounting stays accurate even on bucketed-as-judge_error probes.
-    envelope = _decode_judge_envelope(stdout)
-    if envelope is None:
-        return None, elapsed_ms, None
-    cost = _extract_judge_cost_usd(envelope)
-    parsed = _extract_judge_choice(envelope)
-    if parsed is None:
-        return None, elapsed_ms, cost
-    return parsed, elapsed_ms, cost
+        return parsed, elapsed_ms
+    return _parse_judge_stdout(stdout), elapsed_ms
 
 
 async def _run_one_probe(
@@ -1372,12 +1313,12 @@ async def _run_one_probe(
     # log readability, NOT memory-on then memory-off — the latter
     # would leak the arm assignment via timing patterns visible in
     # the bot's API logs.
-    response_a, lat_a, cost_a = await _run_one_arm(config=config, arm_prompt=arm_prompts["A"], cwd=cwd, env=env)
-    response_b, lat_b, cost_b = await _run_one_arm(config=config, arm_prompt=arm_prompts["B"], cwd=cwd, env=env)
+    response_a, lat_a = await _run_one_arm(config=config, arm_prompt=arm_prompts["A"], cwd=cwd, env=env)
+    response_b, lat_b = await _run_one_arm(config=config, arm_prompt=arm_prompts["B"], cwd=cwd, env=env)
 
     if response_a is None or response_b is None:
-        # One or both arms broken; skip the judge call (cost-saving)
-        # and bucket as generation_error. Per-arm latencies are still
+        # One or both arms broken; skip the pointless judge call and
+        # bucket as generation_error. Per-arm latencies are still
         # recorded so the operator can see which side timed out.
         return ProbeOutcome(
             probe=probe,
@@ -1388,10 +1329,9 @@ async def _run_one_probe(
             judge_reasoning="",
             memory_outcome="generation_error",
             latency_ms={"A": lat_a, "B": lat_b, "judge": 0.0},
-            cost_usd={"A": cost_a, "B": cost_b, "judge": None},
         )
 
-    judged, lat_judge, cost_judge = await _run_one_judge(
+    judged, lat_judge = await _run_one_judge(
         config=config,
         question=probe.question,
         ground_truth_text=ground_truth_text,
@@ -1410,7 +1350,6 @@ async def _run_one_probe(
             judge_reasoning="",
             memory_outcome="judge_error",
             latency_ms={"A": lat_a, "B": lat_b, "judge": lat_judge},
-            cost_usd={"A": cost_a, "B": cost_b, "judge": cost_judge},
         )
 
     choice, reasoning = judged
@@ -1423,7 +1362,6 @@ async def _run_one_probe(
         judge_reasoning=reasoning,
         memory_outcome=_rollup_outcome(judge_choice=choice, memory_arm_letter=memory_arm_letter),
         latency_ms={"A": lat_a, "B": lat_b, "judge": lat_judge},
-        cost_usd={"A": cost_a, "B": cost_b, "judge": cost_judge},
     )
 
 
@@ -1435,8 +1373,8 @@ def _make_drift_outcome(probe: Probe, tags: tuple[str, ...]) -> ProbeOutcome:
     against. Surface them as a separate `drift` row so the per-probe
     output preserves the probe identity and the aggregation logic
     knows to exclude them from rate denominators. All response /
-    latency / cost fields are zero/None — no subprocess call ran for
-    this probe.
+    latency fields are zero/empty; no subprocess call ran for this
+    probe.
     """
     return ProbeOutcome(
         probe=probe,
@@ -1447,7 +1385,6 @@ def _make_drift_outcome(probe: Probe, tags: tuple[str, ...]) -> ProbeOutcome:
         judge_reasoning="",
         memory_outcome="drift",
         latency_ms={"A": 0.0, "B": 0.0, "judge": 0.0},
-        cost_usd={"A": None, "B": None, "judge": None},
     )
 
 
@@ -1470,8 +1407,8 @@ async def _run_all_probes(
     capacity of N translates to up to N concurrent claude subprocesses;
     the second subprocess in a slot cannot start until the first has
     returned. The default cap (4) is a tradeoff between throughput and
-    Anthropic-side rate-limit headroom; operators on a tight budget
-    can drop it to 1 for fully serial execution.
+    Anthropic-side rate-limit headroom; operators can drop it to 1
+    for fully serial execution.
 
     Per-probe RNG note: each probe gets its own seeded `random.Random`
     derived from (run_seed, expected_fact_id). This keeps arm assignment
@@ -1616,7 +1553,6 @@ async def _run_all_probes(
                     judge_reasoning=f"probe execution raised: {type(e).__name__}",
                     memory_outcome="generation_error",
                     latency_ms={"A": 0.0, "B": 0.0, "judge": 0.0},
-                    cost_usd={"A": None, "B": None, "judge": None},
                 )
 
     tasks = [_run_under_semaphore(p) for p in probes]
@@ -1838,10 +1774,8 @@ def _outcome_to_per_probe_dict(outcome: ProbeOutcome, *, probe_id: int) -> dict[
         "memory_outcome": outcome.memory_outcome,
         # Round latencies to 1ms precision to keep the JSON readable;
         # sub-millisecond timing is meaningless for whole-subprocess
-        # calls anyway. cost_usd round to 6 places (sub-cent precision
-        # is what Anthropic's billing API reports).
+        # calls anyway.
         "latency_ms": {k: round(v, 1) for k, v in outcome.latency_ms.items()},
-        "cost_usd": {k: (round(v, 6) if isinstance(v, (int, float)) else None) for k, v in outcome.cost_usd.items()},
     }
 
 
@@ -2078,12 +2012,6 @@ def _build_parser() -> argparse.ArgumentParser:
         help=f"Model for the judge call (default for claude: {_DEFAULT_JUDGE_MODEL}; codex uses MODEL_REGISTRY's BEHAVIORAL_JUDGE row).",
     )
     parser.add_argument(
-        "--judge-budget-usd",
-        type=float,
-        default=_DEFAULT_JUDGE_BUDGET_USD,
-        help=f"Max USD per judge call (default: {_DEFAULT_JUDGE_BUDGET_USD}).",
-    )
-    parser.add_argument(
         "--judge-timeout-s",
         type=int,
         default=_DEFAULT_JUDGE_TIMEOUT_S,
@@ -2094,12 +2022,6 @@ def _build_parser() -> argparse.ArgumentParser:
         # See --judge-model above for the rationale on default=None.
         default=None,
         help=f"Model for the generation arms (default for claude: {_DEFAULT_GEN_MODEL}; codex uses MODEL_REGISTRY's BEHAVIORAL_GEN row).",
-    )
-    parser.add_argument(
-        "--gen-budget-usd",
-        type=float,
-        default=_DEFAULT_GEN_BUDGET_USD,
-        help=f"Max USD per generation arm (default: {_DEFAULT_GEN_BUDGET_USD}).",
     )
     parser.add_argument(
         "--gen-timeout-s",
@@ -2318,10 +2240,8 @@ async def _run_cli(args: argparse.Namespace) -> int:
         resolved_gen_model = args.gen_model or _DEFAULT_GEN_MODEL
     config = BehavioralConfig(
         judge_model=resolved_judge_model,
-        judge_budget_usd=args.judge_budget_usd,
         judge_timeout_s=args.judge_timeout_s,
         gen_model=resolved_gen_model,
-        gen_budget_usd=args.gen_budget_usd,
         gen_timeout_s=args.gen_timeout_s,
         seed=_resolve_seed(cli_seed=args.seed, probes=probes, user_id=args.user_id),
         max_concurrency=args.max_concurrency,
@@ -2335,20 +2255,6 @@ async def _run_cli(args: argparse.Namespace) -> int:
     # claude_cli_version / codex_cli_version under the right key
     # without the caller juggling two Optional[str] arguments.
     cli_version_field, cli_version_value = _capture_agent_cli_version(eval_backend)
-
-    # Codex on subscription auth has no per-call billing surface, so
-    # the budget flags are not enforced at the subprocess level. The
-    # output JSON records cost_usd=None per call. Log once at startup
-    # so an operator who set --judge-budget-usd / --gen-budget-usd
-    # explicitly sees that the flags were not enforced; otherwise the
-    # eval would silently consume subscription quota.
-    if eval_backend == "codex":
-        print(
-            "eval: codex on subscription auth has no per-call cost surface; "
-            "--judge-budget-usd / --gen-budget-usd are not enforced and "
-            "cost_usd in the output JSON will be None.",
-            file=sys.stderr,
-        )
 
     print(
         f"Running {len(scored_probes)} probes "

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -302,14 +302,6 @@ def _validate_port(value: str) -> bool:
         return False
 
 
-def _validate_positive_float(value: str) -> bool:
-    """Check that a string is a positive float."""
-    try:
-        return float(value) > 0
-    except ValueError:
-        return False
-
-
 def _validate_positive_int(value: str) -> bool:
     """Check that a string is a positive integer."""
     try:
@@ -945,7 +937,7 @@ def _cmd_config() -> None:
     print()
 
     # -- Agent --
-    # DEFAULT_MODEL, AGENT_TIMEOUT_SECONDS, and BUDGET_CEILING are
+    # DEFAULT_MODEL and AGENT_TIMEOUT_SECONDS are
     # inheritable installation defaults:
     # users.yaml entries that omit a per-user override fall back to
     # these values at runtime. The prompts therefore fire on every
@@ -1112,27 +1104,6 @@ def _cmd_config() -> None:
             break
         print("  Must be a non-negative integer.")
 
-    # Skip the budget prompt on the claude backend: --max-budget-usd
-    # is no longer emitted to claude --print argv (Max-plan OAuth
-    # makes the CLI's computed-cost ceiling a phantom signal), so
-    # asking the operator for a value that is never enforced would
-    # be wizard noise. Pre-init `budget = ""` here; the BUDGET_CEILING
-    # env emission below (in the env-build block) skips writing the
-    # key entirely on the claude branch, leaving Config.budget_ceiling
-    # at its dataclass default for the (informational) /settings
-    # budget readback.
-    if agent_backend != "claude":
-        while True:
-            budget = _prompt(
-                "Agent budget (USD)",
-                existing_env.get("BUDGET_CEILING", existing_env.get("CLAUDE_MAX_BUDGET_USD", "10.0")),
-            )
-            if _validate_positive_float(budget):
-                break
-            print("  Must be a positive number.")
-    else:
-        budget = ""
-
     # Autocompact threshold controls when Claude automatically compresses
     # conversation history. Lower values compact sooner, reducing token
     # usage at the cost of losing raw context earlier. Claude Code caps
@@ -1226,11 +1197,10 @@ def _cmd_config() -> None:
     print()
 
     # -- PR review agent --
-    # PR_REVIEW_COOLDOWN, PR_REVIEW_TIMEOUT_S, and PR_REVIEW_BUDGET_USD
-    # are global resource controls for the review subprocess: any
-    # review by any user counts against the same cooldown, the same
-    # subprocess timeout, and (on non-claude backends) the same USD
-    # budget per run. All three fire on every wizard run. The per-user
+    # PR_REVIEW_COOLDOWN and PR_REVIEW_TIMEOUT_S are global resource
+    # controls for the review subprocess: any review by any user
+    # counts against the same cooldown and the same subprocess
+    # timeout. Both fire on every wizard run. The per-user
     # `pr_review` toggle lives in users.yaml (or /github reviews).
     print("-- PR review agent --")
     print("  Per-user PR review toggle lives in users.yaml ('pr_review')")
@@ -1248,8 +1218,8 @@ def _cmd_config() -> None:
             break
         print("  Must be a positive integer.")
 
-    # Timeout + budget for the review subprocess. Always collectable: they
-    # apply to any review whether or not the global env flag is set.
+    # Timeout for the review subprocess. Always collectable: it
+    # applies to any review whether or not the global env flag is set.
     while True:
         pr_review_timeout_s = _prompt(
             "Review subprocess timeout in seconds",
@@ -1258,22 +1228,6 @@ def _cmd_config() -> None:
         if _validate_positive_int(pr_review_timeout_s):
             break
         print("  Must be a positive integer.")
-    # Skip the PR review budget prompt on the claude backend:
-    # --max-budget-usd is no longer emitted to claude --print argv on
-    # this site either (review.py:738 else branch). Pre-init to the
-    # dataclass default so the env emission below correctly suppresses
-    # writing PR_REVIEW_BUDGET_USD on the claude branch.
-    if agent_backend != "claude":
-        while True:
-            pr_review_budget_usd = _prompt(
-                "Review subprocess USD budget ceiling",
-                existing_env.get("PR_REVIEW_BUDGET_USD", "1.0"),
-            )
-            if _validate_positive_float(pr_review_budget_usd):
-                break
-            print("  Must be a positive number.")
-    else:
-        pr_review_budget_usd = "1.0"
     print()
 
     # -- Optional features --
@@ -1313,7 +1267,6 @@ def _cmd_config() -> None:
     # Defaults match the dataclass values in config.py. Only non-defaults
     # (or memory_enabled=true itself) are written to the env dict below.
     memory_extraction_enabled = False
-    memory_extraction_budget_usd = "0.01"
     memory_extraction_timeout_s = "10"
     memory_consolidation_candidates_n = "8"
     # Issue #392: episode classifier context window. Pre-init matches
@@ -1324,13 +1277,12 @@ def _cmd_config() -> None:
     # when the operator is on the claude backend AND extraction is
     # enabled - same gating pattern as the other extraction tunables.
     episode_classifier_context_turns = "3"
-    # Stage-2 episode budget + timeout pre-inits (issue #385). Each
-    # value matches the corresponding wizard prompt default and the
-    # emission-gate sentinel so the data flow reads consistently
-    # whether the operator runs the episode block or skips it. The
-    # episode model itself is resolved per-user from the registry
-    # at extraction time; no wizard prompt or env var carries it.
-    memory_episode_budget_usd = "0.15"
+    # Stage-2 episode timeout pre-init (issue #385). The value matches
+    # the corresponding wizard prompt default and the emission-gate
+    # sentinel so the data flow reads consistently whether the
+    # operator runs the episode block or skips it. The episode model
+    # itself is resolved per-user from the registry at extraction
+    # time; no wizard prompt or env var carries it.
     memory_episode_timeout_s = "120"
     memory_token_budget = "2000"
     memory_search_limit = "10"
@@ -1408,14 +1360,6 @@ def _cmd_config() -> None:
                         if _validate_opencode_bin(opencode_bin):
                             break
                         print(f"  Path '{opencode_bin}' does not exist or is not executable.")
-                # No MEMORY_EXTRACTION_BUDGET_USD prompt on this branch:
-                # --max-budget-usd is omitted from the stage-1 claude
-                # --print argv (memory_extraction.py:_run_extractor),
-                # so prompting for a value that is never enforced would
-                # be wizard noise. The pre-init `memory_extraction_budget_usd
-                # = "0.01"` from above is left untouched; the env emission
-                # below double-gates on agent_backend != "claude" so the
-                # key is never written on the claude branch.
                 # Extraction timeout is the LLM-call hard cap inside
                 # memory_extraction.py:541. Default 10s is too aggressive
                 # for production - real extractions routinely take 20-30s
@@ -1473,23 +1417,15 @@ def _cmd_config() -> None:
                     except ValueError:
                         pass
                     print("  Must be 0-10.")
-                # Stage-2 episode tunables (issue #385). Budget and
-                # timeout sit inside the extraction-enabled guard
-                # because episodes only fire when stage 1 fires (the
-                # has_episode classifier comes from stage 1's output).
+                # Stage-2 episode timeout (issue #385) sits inside the
+                # extraction-enabled guard because episodes only fire
+                # when stage 1 fires (the has_episode classifier comes
+                # from stage 1's output).
                 # The episode model is resolved per-user from the
                 # registry at extraction time via get_model_for(
                 # ModelRole.MEMORY_EPISODE, effective_backend); the
                 # wizard prompt for the model was retired with the
                 # MEMORY_EPISODE_MODEL env var.
-                # No MEMORY_EPISODE_BUDGET_USD prompt on this branch:
-                # --max-budget-usd is omitted from the stage-2 claude
-                # --print argv (memory_extraction.py:_run_episode_extractor)
-                # for the same Max-plan reason as stage 1. The pre-init
-                # `memory_episode_budget_usd = "0.15"` above is left
-                # untouched; the env emission below double-gates on
-                # agent_backend != "claude" so the key is never written
-                # on the claude branch.
                 # Episode timeout has a 10s floor: Haiku's warm-up alone
                 # routinely runs several seconds, so a sub-floor timeout
                 # would surface as systematic timeouts that mask real
@@ -1624,27 +1560,19 @@ def _cmd_config() -> None:
     # regenerate so the next /etc/kai/env carries only the canonical
     # forms.
     env.pop("CLAUDE_MODEL", None)
-    env.pop("CLAUDE_MAX_BUDGET_USD", None)
     env.pop("CLAUDE_TIMEOUT_SECONDS", None)
     env.pop("CLAUDE_MAX_SESSION_HOURS", None)
     env.pop("CLAUDE_IDLE_TIMEOUT", None)
-    # CLAUDE_MAX_CONTEXT_WINDOW is retired outright (no canonical
-    # replacement); drop a lingering key so the regenerated env does
-    # not carry a setting the runtime no longer reads.
+    # Retired keys (no canonical replacement); drop lingering values
+    # so the regenerated env does not carry settings the runtime no
+    # longer reads. Mirrors the `_retired_env_vars` warning map in
+    # load_config.
     env.pop("CLAUDE_MAX_CONTEXT_WINDOW", None)
-
-    # BUDGET_CEILING is global (not per-user). Skipped entirely on the
-    # claude backend (--max-budget-usd is omitted from claude --print
-    # argv). The `and budget` truthiness check is load-bearing, not
-    # defensive: on the users.yaml branch, `budget` is initialized via
-    # `existing_env.get("BUDGET_CEILING", existing_env.get("CLAUDE_MAX_BUDGET_USD", ""))`
-    # which defaults to "" when neither key is in the existing env, and
-    # writing `BUDGET_CEILING=` (empty value) into /etc/kai/env would
-    # crash load_config()'s float() parsing at startup. The legacy
-    # branch's _validate_positive_float loop guarantees a non-empty
-    # number string there, so the guard is a no-op for that branch.
-    if agent_backend != "claude" and budget:
-        env["BUDGET_CEILING"] = budget
+    env.pop("CLAUDE_MAX_BUDGET_USD", None)
+    env.pop("BUDGET_CEILING", None)
+    env.pop("PR_REVIEW_BUDGET_USD", None)
+    env.pop("MEMORY_EXTRACTION_BUDGET_USD", None)
+    env.pop("MEMORY_EPISODE_BUDGET_USD", None)
 
     # DEFAULT_MODEL is always emitted. The model is global (per-user
     # values in users.yaml are overrides on top of it, not replacements),
@@ -1726,8 +1654,6 @@ def _cmd_config() -> None:
     # review, regardless of which user opted in.
     if pr_review_timeout_s != "900":
         env["PR_REVIEW_TIMEOUT_S"] = pr_review_timeout_s
-    if agent_backend != "claude" and pr_review_budget_usd != "1.0":
-        env["PR_REVIEW_BUDGET_USD"] = pr_review_budget_usd
 
     # Semantic memory: global env vars (per-user partitioning is runtime).
     # Toggling memory_enabled from true back to false correctly drops
@@ -1746,19 +1672,7 @@ def _cmd_config() -> None:
             # as deprecation warnings at load_config time so existing
             # installs survive one reboot before this wizard regenerates
             # /etc/kai/env without those keys.
-            # Double-gate (agent_backend AND non-default value) is
-            # intentionally redundant: the wizard now skips the
-            # extraction-budget prompt on claude, so the value is
-            # always "0.01" on that branch and the float comparison
-            # alone would also exclude it. The explicit
-            # `agent_backend != "claude"` makes the intent legible at
-            # the emission site without forcing the reader to trace
-            # the pre-init default. Same shape as the autocompact
-            # and effort emissions earlier in the function.
-            if agent_backend != "claude" and float(memory_extraction_budget_usd) != 0.01:
-                env["MEMORY_EXTRACTION_BUDGET_USD"] = memory_extraction_budget_usd
-            # Timeout written under the same gate as budget: both are
-            # extraction-only tunables. Numeric compare so "10" vs "10 "
+            # Extraction-only tunable. Numeric compare so "10" vs "10 "
             # or "010" do not produce a spurious env entry equal to
             # the dataclass default.
             if int(memory_extraction_timeout_s) != 10:
@@ -1785,9 +1699,6 @@ def _cmd_config() -> None:
             # is no longer emitted: the episode model resolves per-user
             # from the registry at extraction time via get_model_for
             # (issue #515).
-            # Double-gate matches the stage-1 budget treatment above.
-            if agent_backend != "claude" and float(memory_episode_budget_usd) != 0.15:
-                env["MEMORY_EPISODE_BUDGET_USD"] = memory_episode_budget_usd
             if int(memory_episode_timeout_s) != 120:
                 env["MEMORY_EPISODE_TIMEOUT_S"] = memory_episode_timeout_s
             # Paraphrase-dedup threshold. Same delta-from-default gate
@@ -1826,7 +1737,6 @@ def _cmd_config() -> None:
     # then-ineligible backend gets dropped here.
     if agent_backend not in ONESHOT_REASONER_BACKENDS:
         env.pop("MEMORY_EXTRACTION_ENABLED", None)
-        env.pop("MEMORY_EXTRACTION_BUDGET_USD", None)
         env.pop("MEMORY_EXTRACTION_TIMEOUT_S", None)
         env.pop("MEMORY_CONSOLIDATION_CANDIDATES_N", None)
         # Episode-classifier window key (issue #392). Same lifecycle
@@ -1838,7 +1748,6 @@ def _cmd_config() -> None:
         # when stage 1 fires, and stage 1 silently skips on backends
         # without a reasoner. Leaving these in the env file would
         # mislead an operator who flips backend.
-        env.pop("MEMORY_EPISODE_BUDGET_USD", None)
         env.pop("MEMORY_EPISODE_TIMEOUT_S", None)
         # Paraphrase-dedup threshold is consulted by `_store_facts`,
         # which only runs under the Haiku extraction path. Same
@@ -3753,10 +3662,16 @@ def _cmd_apply() -> None:
         if "AGENT_IDLE_TIMEOUT" not in env and "CLAUDE_IDLE_TIMEOUT" in env:
             env["AGENT_IDLE_TIMEOUT"] = env["CLAUDE_IDLE_TIMEOUT"]
         env.pop("CLAUDE_IDLE_TIMEOUT", None)
-        # CLAUDE_MAX_CONTEXT_WINDOW is retired outright (no canonical
-        # replacement); drop it at apply time so /etc/kai/env does not
-        # carry a setting the runtime no longer reads.
+        # Retired keys (no canonical replacement); drop them at apply
+        # time so /etc/kai/env does not carry settings the runtime no
+        # longer reads. Mirrors the `_retired_env_vars` warning map in
+        # load_config.
         env.pop("CLAUDE_MAX_CONTEXT_WINDOW", None)
+        env.pop("CLAUDE_MAX_BUDGET_USD", None)
+        env.pop("BUDGET_CEILING", None)
+        env.pop("PR_REVIEW_BUDGET_USD", None)
+        env.pop("MEMORY_EXTRACTION_BUDGET_USD", None)
+        env.pop("MEMORY_EPISODE_BUDGET_USD", None)
         _apply_secrets(env, dry_run, users_yaml_staging_path=users_yaml_staging_path)
 
         # -- Step 6: Deploy Goose config (if backend=goose) --

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -47,9 +47,7 @@ log = logging.getLogger(__name__)
 
 # Maximum length (chars) for the assistant portion of an ingested
 # exchange. Long tool outputs (file dumps, stack traces, large diffs)
-# would otherwise dominate the Haiku extraction payload, pushing
-# per-call token cost above the expected $0.02-$0.03 envelope
-# documented in config.memory_extraction_budget_usd. Used by
+# would otherwise dominate the Haiku extraction payload. Used by
 # memory_extraction._build_extraction_payload. The user-side
 # counterpart lives next to its sole consumer in memory_extraction.py;
 # kept here on the assistant side because moving it would be churn

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1966,19 +1966,11 @@ async def _run_extractor(
       disable all tools`). The extractor only reads stdin and writes JSON.
     - --no-session-persistence keeps ~/.claude/projects/ from growing a
       directory per extraction.
-    - NO --max-budget-usd on the claude backend. The flag enforces a
-      computed-cost ceiling that has no relation to actual billing under
-      Max-plan OAuth (the CLI tracks token rates whether or not money is
-      charged), so terminating a subprocess at the configured ceiling
-      would just stop work that is not costing anything. Runaway-loop
-      protection comes from `memory_extraction_timeout_s` (passed to
-      `asyncio.wait_for` below), which is sufficient: a stuck or
-      recursive extractor cannot hold the executor longer than the
-      timeout, regardless of how many tokens it has notionally generated.
-      The `memory_extraction_budget_usd` Config field stays defined as
-      inert compatibility config: both supported reasoners (claude and
-      codex) are subscription-backed in the operator deployment model
-      and no code path forwards the value to subprocess argv.
+    - No cost cap is passed: subscription auth has no real per-token
+      cost. Runaway-loop protection comes from
+      `memory_extraction_timeout_s` (passed to `asyncio.wait_for`
+      below), which is sufficient: a stuck or recursive extractor
+      cannot hold the executor longer than the timeout.
     - --permission-mode bypassPermissions is acceptable because
       --tools "" leaves nothing to permit or deny.
 
@@ -2068,9 +2060,9 @@ async def _run_extractor(
     if not isinstance(parsed, dict):
         log.warning("Memory extraction returned non-object JSON: %r", parsed)
         return ExtractionResult(facts=[], has_episode=False)
-    # Defense-in-depth: the CLI can exit 0 with is_error=true when a
-    # retry loop burns the budget but the envelope still parses. Treat
-    # that as extraction failure, not silent success with partial data.
+    # Defense-in-depth: the CLI can exit 0 with is_error=true while the
+    # envelope still parses. Treat that as extraction failure, not
+    # silent success with partial data.
     if parsed.get("is_error") is True:
         log.warning(
             "Memory extraction CLI envelope reports is_error=true (subtype=%s)",
@@ -2117,7 +2109,6 @@ def _emit_episode_log(
     user_id: str,
     outcome: str,
     memory_id: str | None,
-    cost_usd: float,
     duration_ms: int,
     reason: str | None,
 ) -> None:
@@ -2129,10 +2120,8 @@ def _emit_episode_log(
     per-recall `memory.recall` patterns. Compact JSON separators so
     downstream parsers see one wire format across the memory subsystem.
 
-    `cost_usd` and `duration_ms` are always populated for budget tracking
-    parity with stage 1's _emit_intent_log; on the timeout path cost is
-    0.0 because the subprocess was killed before it returned a billed
-    envelope.
+    `duration_ms` is always populated; on the timeout path it reflects
+    the elapsed time up to the kill.
 
     `memory_id` and `reason` are presence-symmetric: each is included
     only when it carries information. `memory_id` appears only on the
@@ -2152,7 +2141,6 @@ def _emit_episode_log(
     payload: dict = {
         "user_id": user_id,
         "outcome": outcome,
-        "cost_usd": cost_usd,
         "duration_ms": duration_ms,
     }
     if memory_id is not None:
@@ -2195,11 +2183,9 @@ async def _run_episode_extractor(
     """
     Spawn `claude --print` with the episode-generator prompt and parse.
 
-    Returns a triple `(episode, cost_usd, reason)` where:
+    Returns a pair `(episode, reason)` where:
     - `episode` is the validated episode dict on success, or None on any
       failure path.
-    - `cost_usd` is the CLI envelope's `total_cost_usd` (0.0 on timeout
-      because the envelope never returned).
     - `reason` is a short failure tag for telemetry on non-success paths
       (`timeout`, `subprocess_error`, `parse_error`); None on success.
 
@@ -2210,9 +2196,9 @@ async def _run_episode_extractor(
     and system prompt - the env allowlist, sandboxing flags, auth
     posture, and stdin-only payload delivery are all reused so the
     security review of stage 1 transfers without re-evaluation.
-    --max-budget-usd is omitted for the same Max-plan reason documented
-    on `_run_extractor`; runaway protection comes from
-    `memory_episode_timeout_s` at the `asyncio.wait_for` call below.
+    No cost cap is passed (subscription auth has no real per-token
+    cost); runaway protection comes from `memory_episode_timeout_s`
+    at the `asyncio.wait_for` call below.
     """
     # Stage 2 routes through the same reasoner as stage 1; the
     # caller-side mapping recovers the exact failure-reason strings
@@ -2239,11 +2225,10 @@ async def _run_episode_extractor(
             json_schema=_EPISODE_SCHEMA,
         )
     except OneShotTimeout:
-        return None, 0.0, "timeout"
+        return None, "timeout"
     except OneShotSubprocessError as e:
         return (
             None,
-            0.0,
             f"exit_{e.returncode}: {e.stderr[:200].decode('utf-8', errors='replace')}",
         )
     except OneShotError:
@@ -2252,21 +2237,15 @@ async def _run_episode_extractor(
         # _generate_episode's broad except handles the truly
         # unexpected case; this branch keeps known reasoner failures
         # in the stage-2 vocabulary.
-        return None, 0.0, "reasoner_error"
+        return None, "reasoner_error"
     try:
         parsed = json.loads(result.text)
     except json.JSONDecodeError:
-        return None, 0.0, f"invalid_json: {result.text[:200]}"
+        return None, f"invalid_json: {result.text[:200]}"
     if not isinstance(parsed, dict):
-        return None, 0.0, "non_object_envelope"
-    # Cost lives in the CLI envelope. Coerce defensively: a future CLI
-    # version that renames or omits the field should produce 0.0, not a
-    # KeyError that would be caught by the broad except in
-    # `_generate_episode` and report `unexpected_exception` for what is
-    # actually just a CLI shape drift.
-    cost_usd = float(parsed.get("total_cost_usd") or 0.0)
+        return None, "non_object_envelope"
     if parsed.get("is_error") is True:
-        return None, cost_usd, f"is_error subtype={parsed.get('subtype')}"
+        return None, f"is_error subtype={parsed.get('subtype')}"
     # Same nested/root resolution as stage 1: `claude --print
     # --output-format json --json-schema ...` puts the schema-validated
     # payload under `structured_output`. Fall back to root for tests
@@ -2278,8 +2257,8 @@ async def _run_episode_extractor(
         episode_root = parsed
     episode = episode_root.get("episode")
     if not isinstance(episode, dict):
-        return None, cost_usd, "missing_episode_field"
-    return episode, cost_usd, None
+        return None, "missing_episode_field"
+    return episode, None
 
 
 async def _generate_episode(
@@ -2317,7 +2296,6 @@ async def _generate_episode(
     start = time.monotonic()
     outcome: str = "store_failed"
     memory_id: str | None = None
-    cost_usd: float = 0.0
     reason: str | None = None
     try:
         async with sem:
@@ -2331,7 +2309,7 @@ async def _generate_episode(
             # quick succession and the second waits on the first.
             start = time.monotonic()
             payload = _build_episode_payload(user_text, assistant_text)
-            episode, cost_usd, run_reason = await _run_episode_extractor(
+            episode, run_reason = await _run_episode_extractor(
                 payload,
                 config,
                 user_id=user_id,
@@ -2345,25 +2323,24 @@ async def _generate_episode(
                 # store_failed, validate_rejected, stored.
                 #
                 # Subprocess-level faults (exit code, is_error envelope
-                # from a budget burn or auth failure) collapse to
+                # from an auth or CLI-internal failure) collapse to
                 # `subprocess_error`. Content faults (malformed JSON,
                 # non-object envelope, missing episode field) collapse
                 # to `parse_error`. The is_error branch is load-bearing:
-                # without it, budget exhaustion would silently mislabel
-                # as a parse error and operators triaging by outcome
-                # would see budget burns mixed with genuine JSON
-                # problems.
+                # without it, a CLI-signaled failure would silently
+                # mislabel as a parse error and operators triaging by
+                # outcome would see subprocess faults mixed with
+                # genuine JSON problems.
                 if run_reason == "timeout":
                     outcome = "timeout"
                 elif run_reason and (run_reason.startswith("exit_") or run_reason.startswith("is_error")):
                     # Subprocess-level faults: nonzero exit (binary
                     # crashed, env wrong, OOM kill) or is_error
-                    # envelope (CLI exited 0 but signaled failure -
-                    # most commonly error_max_budget_usd from a budget
-                    # burn, occasionally an auth error). Both belong
-                    # under the same outcome label so operators
-                    # triaging by outcome see them together rather
-                    # than scanning two buckets for related symptoms.
+                    # envelope (CLI exited 0 but signaled failure,
+                    # e.g. an auth error). Both belong under the same
+                    # outcome label so operators triaging by outcome
+                    # see them together rather than scanning two
+                    # buckets for related symptoms.
                     outcome = "subprocess_error"
                 elif run_reason and run_reason.startswith("invalid_json"):
                     outcome = "parse_error"
@@ -2470,7 +2447,6 @@ async def _generate_episode(
         user_id=user_id,
         outcome=outcome,
         memory_id=memory_id,
-        cost_usd=cost_usd,
         duration_ms=duration_ms,
         reason=reason,
     )

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -454,9 +454,9 @@ class ClaudeOneShotReasoner:
     - `--tools ""` disables all built-in tools.
     - `--no-session-persistence` keeps `~/.claude/projects/` from
       growing a directory per call.
-    - NO `--max-budget-usd`. On Max-plan OAuth the CLI's computed-
-      cost ceiling has no relation to actual billing; runaway-loop
-      protection comes from `asyncio.wait_for(timeout)` instead.
+    - No cost cap is passed: subscription auth has no real per-token
+      cost. Runaway-loop protection comes from
+      `asyncio.wait_for(timeout)` instead.
     - `--permission-mode bypassPermissions` is acceptable because
       `--tools ""` leaves nothing to permit or deny.
 

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -102,7 +102,7 @@ class SubprocessPool:
 
         Resolution order for each setting:
         1. UserConfig from users.yaml (os_user, home_workspace, model,
-           budget, timeout, agent_backend, llm_provider)
+           timeout, agent_backend, llm_provider)
         2. Global config defaults (from .env)
 
         Per-user DB overrides (set via /settings or /model) are applied
@@ -188,8 +188,6 @@ class SubprocessPool:
                 )
                 model = self._config.default_model
 
-        # budget_ceiling doubles as the fallback default for unconfigured users
-        budget = user.max_budget if user and user.max_budget is not None else self._config.budget_ceiling
         timeout = user.timeout if user and user.timeout is not None else self._config.claude_timeout_seconds
         # home_ws is what the backend treats as "home" for the foreign-
         # workspace reminder. Same resolution as the workspace above so
@@ -220,7 +218,6 @@ class SubprocessPool:
                 home_workspace=home_ws,
                 webhook_port=self._config.webhook_port,
                 webhook_secret=self._config.webhook_secret,
-                max_budget_usd=budget,
                 timeout_seconds=timeout,
                 services_info=self._services_info,
                 workspace_config=ws_config,
@@ -240,7 +237,6 @@ class SubprocessPool:
                 home_workspace=home_ws,
                 webhook_port=self._config.webhook_port,
                 webhook_secret=self._config.webhook_secret,
-                max_budget_usd=budget,
                 timeout_seconds=timeout,
                 services_info=self._services_info,
                 workspace_config=ws_config,
@@ -271,7 +267,6 @@ class SubprocessPool:
                 home_workspace=home_ws,
                 webhook_port=self._config.webhook_port,
                 webhook_secret=self._config.webhook_secret,
-                max_budget_usd=budget,
                 timeout_seconds=timeout,
                 services_info=self._services_info,
                 workspace_config=ws_config,
@@ -286,7 +281,6 @@ class SubprocessPool:
             home_workspace=home_ws,
             webhook_port=self._config.webhook_port,
             webhook_secret=self._config.webhook_secret,
-            max_budget_usd=budget,
             timeout_seconds=timeout,
             services_info=self._services_info,
             claude_user=os_user,
@@ -418,14 +412,6 @@ class SubprocessPool:
                         instance.provider,
                     )
 
-            # Budget: workspace config budget overrides user default
-            ws_budget = instance.workspace_config.budget if instance.workspace_config else None
-            if ws_budget is None and "budget" in db_settings:
-                try:
-                    instance.max_budget_usd = float(db_settings["budget"])
-                except (ValueError, TypeError):
-                    log.warning("Corrupt budget in DB for user %d", chat_id)
-
             # Timeout: workspace config timeout overrides user default
             ws_timeout = instance.workspace_config.timeout if instance.workspace_config else None
             if ws_timeout is None and "timeout" in db_settings:
@@ -436,7 +422,7 @@ class SubprocessPool:
 
             # restart() kills the subprocess and spawns a new one, but
             # the backend *object* is preserved. Mutations made
-            # above (budget, timeout, model) survive the
+            # above (timeout, model) survive the
             # restart because the new subprocess reads from self.* attrs.
             if needs_restart:
                 log.info("Restarting process for user %d: per-user DB overrides differ", chat_id)

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -50,22 +50,10 @@ log = logging.getLogger(__name__)
 # Claude's context window while leaving room for the prompt frame.
 _MAX_DIFF_CHARS = 100_000
 
-# Default per-review budget cap in USD. Vestigial after #390:
-# --max-budget-usd is no longer emitted to claude --print argv on the
-# claude branch (Max-plan OAuth makes the CLI's computed-cost ceiling
-# a phantom signal), and the Goose branch uses --max-turns 1 rather
-# than a dollar ceiling, so the constant's only remaining role is to
-# provide the default for the `budget_usd` parameter on `run_review`
-# / `run_review_session` - a parameter that is itself unused on every
-# currently-exercised path. Retained for symmetry with
-# _TRIAGE_BUDGET_USD and to avoid changing public signatures (see
-# PR_REVIEW_BUDGET_USD env var); cleanup deferred to a separate
-# refactor that can also drop the `budget_usd` parameter.
-_REVIEW_BUDGET_USD = 1.0
-
 # Default subprocess timeout for a single review, in seconds. Overridable
-# via PR_REVIEW_TIMEOUT_S in config; same fallback rationale as the budget
-# default above. Sonnet 4.6+ uses extended thinking, which can take a long
+# via PR_REVIEW_TIMEOUT_S in config; the in-code default keeps direct
+# callers working without config plumbing. Sonnet 4.6+ uses extended
+# thinking, which can take a long
 # time on large diffs with prior review context - 15 minutes accommodates
 # thinking-heavy reviews while still terminating genuinely stuck processes.
 _REVIEW_TIMEOUT = 900
@@ -625,13 +613,6 @@ async def run_review(
     agent_backend: str = "claude",
     provider: str = "",
     timeout_s: int = _REVIEW_TIMEOUT,
-    # `budget_usd` is unused on every currently-exercised path: the
-    # claude branch no longer emits --max-budget-usd to argv (#390),
-    # and the Goose branch uses --max-turns 1 rather than a dollar
-    # ceiling. Kept on the signature to avoid a public API break in
-    # this fix; cleanup deferred to a separate refactor that updates
-    # webhook.py and the test suite together.
-    budget_usd: float = _REVIEW_BUDGET_USD,
     # Per-role model override. Caller in webhook.py resolves
     # `user_config.models.get("pr_review", "")` and passes it; empty
     # falls through to MODEL_REGISTRY's (backend, provider, PR_REVIEW)
@@ -648,8 +629,8 @@ async def run_review(
     of review text; the prompt and output handling are identical
     regardless of backend.
 
-    Claude path: supports sudo -u for OS-level isolation, process
-    group kills for cleanup, and per-run budget caps.
+    Claude path: supports sudo -u for OS-level isolation and process
+    group kills for cleanup.
 
     Codex path: sudo -H -u when claude_user is set (codex needs
     HOME pointing at the user's home so it reads the right
@@ -731,9 +712,9 @@ async def run_review(
         # `sudo -H -u <user>` so codex reads ~<user>/.codex/auth.json
         # instead of the service user's home. The parameter name is
         # claude-historical; rename is out of scope for this fix.
-        # No --max-budget-usd: codex on subscription auth has no
-        # per-call billing; runaway protection comes from
-        # timeout_s at the asyncio.wait_for below.
+        # No cost cap is passed: subscription auth has no per-call
+        # billing; runaway protection comes from timeout_s at the
+        # asyncio.wait_for below.
         review_model = get_model_for(
             ModelRole.PR_REVIEW,
             agent_backend,
@@ -878,15 +859,9 @@ async def run_review(
             raise RuntimeError(f"Review subprocess timed out after {timeout_s}s") from None
     else:
         # Claude one-shot mode: --print reads from stdin, writes to stdout.
-        # No --max-budget-usd on this branch: the claude backend runs under
-        # Max-plan OAuth, where the CLI tracks computed token cost regardless
-        # of whether any money is being charged. Passing the flag would
-        # terminate the subprocess at a ceiling that does not correspond to
-        # real billing. Runaway protection comes from `timeout_s` at the
-        # asyncio.wait_for call below. The `budget_usd` parameter on the
-        # signature is unused on every currently-exercised path - see the
-        # comment on the parameter declaration above for the full rationale
-        # and why cleanup is deferred to a separate refactor.
+        # No cost cap is passed: subscription auth has no real per-token
+        # cost. Runaway protection comes from `timeout_s` at the
+        # asyncio.wait_for call below.
         # Model identifier comes from the per-role registry indexed
         # by (backend, provider, role) so the codex backend (and any
         # future backend) can override the mid-tier "sonnet" default
@@ -1061,9 +1036,6 @@ async def review_pr(
     agent_backend: str = "claude",
     provider: str = "",
     timeout_s: int = _REVIEW_TIMEOUT,
-    # See `run_review` above for why `budget_usd` is currently unused
-    # on every exercised path; cleanup deferred to a separate refactor.
-    budget_usd: float = _REVIEW_BUDGET_USD,
     model_override: str = "",
 ) -> None:
     """
@@ -1131,7 +1103,6 @@ async def review_pr(
             agent_backend=agent_backend,
             provider=provider,
             timeout_s=timeout_s,
-            budget_usd=budget_usd,
             model_override=model_override,
         )
 

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -4,9 +4,8 @@ SQLite database layer for sessions, jobs, settings, and workspace history.
 Provides async CRUD operations for all persistent state in Kai, organized
 into four tables:
 
-1. **sessions** - Agent session tracking (session ID, model, cost).
-   One row per chat_id, upserted on each response. Cost accumulates across
-   the lifetime of a session.
+1. **sessions** - Agent session tracking (session ID, model).
+   One row per chat_id, upserted on each response.
 
 2. **jobs** - Scheduled tasks (reminders, agent jobs with job_type "claude", conditional monitors).
    Created via the scheduling API (POST /api/schedule) or the inner agent's curl.
@@ -99,8 +98,7 @@ async def init_db(db_path: Path) -> None:
                 session_id TEXT NOT NULL,
                 model TEXT,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                last_used_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                total_cost_usd REAL DEFAULT 0.0
+                last_used_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         """)
         log.debug("Creating jobs table")
@@ -208,30 +206,28 @@ async def get_session(chat_id: int) -> str | None:
         return row["session_id"] if row else None
 
 
-async def save_session(chat_id: int, session_id: str, model: str, cost_usd: float) -> None:
+async def save_session(chat_id: int, session_id: str, model: str) -> None:
     """
     Save or update an agent session for a chat.
 
-    On conflict (existing chat_id), the session_id and model are updated,
-    last_used_at is refreshed, and total_cost_usd is accumulated (not replaced).
+    On conflict (existing chat_id), the session_id and model are updated
+    and last_used_at is refreshed.
 
     Args:
         chat_id: Telegram chat ID.
         session_id: Agent session identifier reported by the backend.
         model: Model name used for this session (e.g., "sonnet").
-        cost_usd: Cost of this particular interaction (added to running total).
     """
     await _get_db().execute(
         """
-        INSERT INTO sessions (chat_id, session_id, model, total_cost_usd)
-        VALUES (?, ?, ?, ?)
+        INSERT INTO sessions (chat_id, session_id, model)
+        VALUES (?, ?, ?)
         ON CONFLICT(chat_id) DO UPDATE SET
             session_id = excluded.session_id,
             model = excluded.model,
-            last_used_at = CURRENT_TIMESTAMP,
-            total_cost_usd = total_cost_usd + excluded.total_cost_usd
+            last_used_at = CURRENT_TIMESTAMP
     """,
-        (chat_id, session_id, model, cost_usd),
+        (chat_id, session_id, model),
     )
     await _get_db().commit()
 
@@ -245,7 +241,7 @@ async def clear_session(chat_id: int) -> None:
 async def get_stats(chat_id: int) -> dict | None:
     """Get session statistics for the /stats command. Returns None if no session exists."""
     async with _get_db().execute(
-        "SELECT session_id, model, created_at, last_used_at, total_cost_usd FROM sessions WHERE chat_id = ?",
+        "SELECT session_id, model, created_at, last_used_at FROM sessions WHERE chat_id = ?",
         (chat_id,),
     ) as cursor:
         row = await cursor.fetchone()
@@ -505,7 +501,7 @@ async def get_workspace_config_settings(chat_id: int, workspace_path: str) -> di
     Get all config overrides for a user's workspace.
 
     Returns a dict of field->value pairs (e.g., {"model": "opus",
-    "budget": "20.0"}). Values are strings; callers parse as needed.
+    "timeout": "300"}). Values are strings; callers parse as needed.
     Config is per-user-per-workspace: each user has independent overrides.
     """
     # Use SUBSTR for exact prefix matching instead of LIKE, which
@@ -576,7 +572,6 @@ async def build_workspace_config(
 
     # Start from YAML baseline or empty defaults
     model = yaml_config.model if yaml_config else None
-    budget = yaml_config.budget if yaml_config else None
     timeout = yaml_config.timeout if yaml_config else None
     env = dict(yaml_config.env) if yaml_config and yaml_config.env else None
     env_file = yaml_config.env_file if yaml_config else None
@@ -587,11 +582,6 @@ async def build_workspace_config(
     # Layer database overrides
     if "model" in db_settings:
         model = db_settings["model"]
-    if "budget" in db_settings:
-        try:
-            budget = float(db_settings["budget"])
-        except (ValueError, TypeError):
-            log.warning("Corrupt budget in DB for chat %d workspace %s", chat_id, workspace_path)
     if "timeout" in db_settings:
         try:
             timeout = int(db_settings["timeout"])
@@ -619,7 +609,6 @@ async def build_workspace_config(
     return WorkspaceConfig(
         path=path,
         model=model,
-        budget=budget,
         timeout=timeout,
         env=env,
         env_file=env_file,
@@ -637,7 +626,7 @@ async def build_workspace_config(
 
 # Canonical field names for per-user settings. Must match the storage
 # keys used by set_user_setting / get_user_settings.
-_USER_SETTING_FIELDS = {"model", "budget", "timeout"}
+_USER_SETTING_FIELDS = {"model", "timeout"}
 
 
 async def get_user_settings(chat_id: int) -> dict[str, str]:
@@ -645,7 +634,7 @@ async def get_user_settings(chat_id: int) -> dict[str, str]:
     Get all per-user settings from the database.
 
     Returns a dict of field->value pairs (e.g., {"model": "opus",
-    "budget": "15.0"}). Values are strings; callers parse as needed.
+    "timeout": "300"}). Values are strings; callers parse as needed.
     Only includes fields that have been explicitly set - missing keys
     mean the user hasn't overridden that setting.
     """
@@ -658,7 +647,7 @@ async def get_user_settings(chat_id: int) -> dict[str, str]:
 
 
 async def set_user_setting(chat_id: int, field: str, value: str) -> None:
-    """Set a single per-user setting (e.g., model, budget, timeout)."""
+    """Set a single per-user setting (e.g., model, timeout)."""
     await set_setting(f"{field}:{chat_id}", value)
 
 
@@ -684,7 +673,6 @@ class UserDefaults(TypedDict):
     """Resolved per-user settings with concrete types (never None)."""
 
     model: str
-    budget: float
     timeout: int
 
 
@@ -696,7 +684,7 @@ async def resolve_user_defaults(
     Resolve per-user settings by layering DB overrides on top of
     users.yaml and env var defaults.
 
-    Returns a UserDefaults dict with keys: model, budget, timeout.
+    Returns a UserDefaults dict with keys: model, timeout.
     All values are resolved - never None.
 
     Precedence (highest to lowest):
@@ -726,19 +714,6 @@ async def resolve_user_defaults(
     yaml_model = raw_yaml_model.strip() if raw_yaml_model is not None else None
     model = db_model if db_model else yaml_model if yaml_model else config.default_model
 
-    # Budget: DB > users.yaml max_budget (as default only) > global ceiling.
-    # max_budget in users.yaml is the admin-set baseline default, NOT a
-    # ceiling. The ceiling comes solely from BUDGET_CEILING (config.budget_ceiling).
-    # Defensive try/except matches _restore_workspace and _show_settings.
-    yaml_budget = user_config.max_budget if user_config and user_config.max_budget is not None else None
-    try:
-        budget = float(db_settings["budget"]) if "budget" in db_settings else None
-    except (ValueError, TypeError):
-        budget = None
-    if budget is None:
-        # budget_ceiling doubles as the fallback default for unconfigured users
-        budget = yaml_budget if yaml_budget is not None else config.budget_ceiling
-
     # Timeout: DB > users.yaml > env > 120
     yaml_timeout = user_config.timeout if user_config and user_config.timeout is not None else None
     try:
@@ -750,7 +725,6 @@ async def resolve_user_defaults(
 
     return {
         "model": model,
-        "budget": budget,
         "timeout": timeout,
     }
 
@@ -1083,7 +1057,7 @@ async def resolve_github_settings(chat_id: int, config: Config) -> GitHubSetting
     repos = await get_effective_repos(chat_id, yaml_repos)
 
     # Notification destination: DB > yaml > telegram_id.
-    # Defensive try/except matches budget/timeout above.
+    # Defensive try/except matches timeout above.
     # A corrupt DB value falls through to yaml/default rather than
     # aborting the entire resolution.
     notify: int | None = None

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -43,15 +43,6 @@ from kai.prompt_utils import make_boundary
 log = logging.getLogger(__name__)
 
 
-# Per-triage budget cap in USD. Vestigial after #390: --max-budget-usd
-# is no longer emitted to claude --print argv on the claude branch
-# (Max-plan OAuth makes the CLI's computed-cost ceiling a phantom
-# signal), and the Goose branch uses --max-turns 1 rather than a
-# dollar ceiling, so this constant has no consumer at present.
-# Retained for symmetry with _REVIEW_BUDGET_USD and for future
-# non-claude triage paths; cleanup deferred to a separate refactor.
-_TRIAGE_BUDGET_USD = 1.0
-
 # Timeout for the triage subprocess in seconds.
 _TRIAGE_TIMEOUT = 300
 
@@ -426,9 +417,9 @@ async def run_triage(
         # `sudo -H -u <user>` so codex reads ~<user>/.codex/auth.json
         # instead of the service user's home. The parameter name is
         # claude-historical; rename is out of scope for this fix.
-        # No --max-budget-usd: codex on subscription auth has no
-        # per-call billing; runaway protection comes from
-        # _TRIAGE_TIMEOUT at the asyncio.wait_for below.
+        # No cost cap is passed: subscription auth has no per-call
+        # billing; runaway protection comes from _TRIAGE_TIMEOUT at
+        # the asyncio.wait_for below.
         triage_model = get_model_for(
             ModelRole.ISSUE_TRIAGE,
             agent_backend,
@@ -582,16 +573,10 @@ async def run_triage(
             raise RuntimeError(f"Triage subprocess timed out after {_TRIAGE_TIMEOUT}s") from None
     else:
         # Claude one-shot mode: --print reads from stdin, writes to stdout.
-        # No --max-budget-usd on this branch: the claude backend runs under
-        # Max-plan OAuth, where the CLI tracks computed token cost regardless
-        # of whether any money is being charged. Passing the flag would
-        # terminate the subprocess at a ceiling that does not correspond to
-        # real billing. Runaway protection comes from _TRIAGE_TIMEOUT at the
+        # No cost cap is passed: subscription auth has no real per-token
+        # cost. Runaway protection comes from _TRIAGE_TIMEOUT at the
         # asyncio.wait_for call below: a stuck subprocess cannot hold the
-        # executor longer than that timeout, regardless of how many tokens
-        # it has notionally produced. _TRIAGE_BUDGET_USD stays defined for
-        # symmetry with the other budget defaults in this codebase; cleanup
-        # is deferred to a separate refactor.
+        # executor longer than that timeout.
         # Model identifier comes from the per-role registry indexed
         # by (backend, provider, role). Caller's per-user
         # `models.issue_triage` override (when set in users.yaml)

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -775,7 +775,6 @@ async def _process_github_event_for_user(
                     agent_backend=agent_backend,
                     provider=provider,
                     timeout_s=request.app["pr_review_timeout_s"],
-                    budget_usd=request.app["pr_review_budget_usd"],
                     model_override=pr_review_model_override,
                 )
             )
@@ -2087,7 +2086,6 @@ async def start(telegram_app, config) -> None:
     # via sessions.resolve_github_settings(), not stored here.
     _app["pr_review_cooldown"] = config.pr_review_cooldown
     _app["pr_review_timeout_s"] = config.pr_review_timeout_s
-    _app["pr_review_budget_usd"] = config.pr_review_budget_usd
     _app["webhook_port"] = config.webhook_port
 
     # Workspace config for review agent repo resolution. These let

--- a/templates/.env
+++ b/templates/.env
@@ -41,14 +41,9 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 # overrides go in users.yaml 'timeout', or via /settings timeout.
 #AGENT_TIMEOUT_SECONDS=120
 
-# Global budget ceiling in USD. Users cannot exceed this via /settings.
-# Per-user defaults are set via 'max_budget' in users.yaml.
-#BUDGET_CEILING=10.0
-
 # Effort level for inner Claude reasoning (low|medium|high|xhigh|max).
 # Higher = more thinking tokens per turn = better answers + higher
-# token spend. Interacts with BUDGET_CEILING: high effort spends tokens
-# faster, so pair with a higher BUDGET_CEILING for long sessions.
+# token spend.
 # Truly global; applies to every chat's inner Claude subprocess.
 #CLAUDE_EFFORT_LEVEL=high
 
@@ -96,14 +91,6 @@ WEBHOOK_SECRET=your-webhook-secret
 # several minutes. Raise if reviews are being killed mid-run; lower if
 # stuck processes should be reaped faster. Must be a positive integer.
 #PR_REVIEW_TIMEOUT_S=900
-
-# Hard USD ceiling for one PR review subprocess. Informational only on
-# the claude backend (Max-plan OAuth makes the CLI's computed-cost
-# ceiling a phantom signal; --max-budget-usd is omitted from claude
-# --print argv). Enforced on non-claude backends (e.g. Goose), which
-# run on pay-per-token billing where the ceiling is a real cost gate.
-# Must be a positive number.
-#PR_REVIEW_BUDGET_USD=1.0
 
 # Deprecated: review agent now resolves repos via workspace config
 # (WORKSPACE_BASE, ALLOWED_WORKSPACES, workspace history). Kept for
@@ -186,12 +173,6 @@ MEMORY_ENABLED=false
 # the default flips). Kill switch is the same flag. Extraction
 # routing is per-user (see note above).
 #MEMORY_EXTRACTION_ENABLED=false
-# Per-call budget ceiling (USD). Retained as inert compatibility
-# config. Both supported memory reasoners (claude and codex) are
-# subscription-backed in the operator deployment model and no
-# code path forwards this value to subprocess argv. Runaway
-# protection comes from MEMORY_EXTRACTION_TIMEOUT_S instead.
-#MEMORY_EXTRACTION_BUDGET_USD=0.01
 # Subprocess timeout (seconds). Haiku typically finishes in 2-4s.
 #MEMORY_EXTRACTION_TIMEOUT_S=10
 # Number of paraphrase-equivalent prior facts shown to the extractor
@@ -216,13 +197,6 @@ MEMORY_ENABLED=false
 # MEMORY_ENABLED; no dedicated kill switch. Episode model is
 # resolved per-user from MODEL_REGISTRY (see the memory reasoner
 # note above); there is no MEMORY_EPISODE_MODEL env var.
-# Budget ceiling per episode call (USD). Retained as inert
-# compatibility config. Same rationale as MEMORY_EXTRACTION_BUDGET_USD
-# above: both supported reasoners are subscription-backed in the
-# operator deployment model and no code path forwards this value to
-# subprocess argv. Runaway protection comes from MEMORY_EPISODE_TIMEOUT_S
-# instead.
-#MEMORY_EPISODE_BUDGET_USD=0.15
 # Subprocess timeout (seconds). Default 120 - twice the production
 # stage-1 value. Stage 2 is fire-and-forget off the user turn, so a
 # long-tailed timeout only delays storage, not the user's reply.

--- a/templates/users.yaml
+++ b/templates/users.yaml
@@ -28,13 +28,6 @@ users:
     # Inherits the global WORKSPACE_BASE installation default if unset.
     # workspace_base: ~/projects
 
-    # max_budget serves double duty: it is the user's default budget
-    # AND the ceiling they cannot exceed via /settings budget. The
-    # global BUDGET_CEILING is the hard upper bound; /settings
-    # enforces it. If max_budget is unset, the user falls back to
-    # BUDGET_CEILING as their baseline.
-    max_budget: 20.0
-
     # Optional per-user defaults. Users can override these at runtime
     # via /settings. Omitted fields inherit installation defaults
     # (DEFAULT_MODEL, AGENT_TIMEOUT_SECONDS).

--- a/templates/workspaces.yaml
+++ b/templates/workspaces.yaml
@@ -7,11 +7,10 @@
 # defaults from .env / /etc/kai/env.
 
 workspaces:
-  # Example: heavy-duty workspace with Opus and a generous budget
+  # Example: heavy-duty workspace with Opus and a generous timeout
   # - path: ~/projects/complex-app
   #   claude:
   #     model: opus
-  #     budget: 20.0
   #     timeout: 300
   #     env:
   #       DATABASE_URL: "postgres://localhost/myapp"

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1042,7 +1042,6 @@ class TestDataTypes:
         """AgentResponse has sensible defaults."""
         resp = AgentResponse(success=True, text="hello")
         assert resp.session_id is None
-        assert resp.cost_usd == 0.0
         assert resp.duration_ms == 0
         assert resp.error is None
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -625,7 +625,7 @@ def _text_event(text: str) -> StreamEvent:
     return StreamEvent(text_so_far=text, done=False, response=None)
 
 
-def _done_event(text="Final response", cost=0.01, session_id="sess-1", success=True, error=None) -> StreamEvent:
+def _done_event(text="Final response", session_id="sess-1", success=True, error=None) -> StreamEvent:
     """Final streaming event with an AgentResponse."""
     return StreamEvent(
         text_so_far=text,
@@ -634,7 +634,6 @@ def _done_event(text="Final response", cost=0.01, session_id="sess-1", success=T
             text=text,
             success=success,
             error=error,
-            cost_usd=cost,
             duration_ms=1000,
             session_id=session_id,
         ),
@@ -947,14 +946,12 @@ class TestHandleStats:
             "model": "sonnet",
             "created_at": "2026-01-01",
             "last_used_at": "2026-01-02",
-            "total_cost_usd": 0.1234,
         }
         with patch("kai.bot.sessions.get_stats", new_callable=AsyncMock, return_value=stats):
             await handle_stats(update, ctx)
         reply = update.message.reply_text.call_args[0][0]
         assert "abcd1234" in reply
         assert "sonnet" in reply
-        assert "0.1234" in reply
 
 
 # ── handle_jobs ──────────────────────────────────────────────────────
@@ -2324,15 +2321,8 @@ class TestWorkspaceSubcommandRouting:
 
 
 class TestWorkspaceConfigSuffix:
-    def test_with_model_and_budget(self):
-        """Shows model and budget when both are configured."""
-        from kai.config import WorkspaceConfig
-
-        ws = WorkspaceConfig(path=Path("/tmp/ws"), model="opus", budget=15.0)
-        assert _workspace_config_suffix(ws) == " (model: opus, budget: $15.00)"
-
-    def test_model_only(self):
-        """Shows model only when budget is not set."""
+    def test_with_model(self):
+        """Shows model when configured."""
         from kai.config import WorkspaceConfig
 
         ws = WorkspaceConfig(path=Path("/tmp/ws"), model="haiku")
@@ -2343,7 +2333,7 @@ class TestWorkspaceConfigSuffix:
         assert _workspace_config_suffix(None) == ""
 
     def test_config_with_no_overrides(self):
-        """Returns empty string when config has no model or budget."""
+        """Returns empty string when config has no model."""
         from kai.config import WorkspaceConfig
 
         ws = WorkspaceConfig(path=Path("/tmp/ws"))
@@ -2407,7 +2397,7 @@ class TestSwitchWorkspaceConfig:
 
         ws_path = tmp_path / "ws"
         ws_path.mkdir()
-        ws_config = WorkspaceConfig(path=ws_path.resolve(), model="opus", budget=20.0)
+        ws_config = WorkspaceConfig(path=ws_path.resolve(), model="opus")
         config = _make_config(
             claude_workspace=Path("/home/workspace"),
             workspace_configs={ws_path.resolve(): ws_config},
@@ -2426,7 +2416,6 @@ class TestSwitchWorkspaceConfig:
 
         reply_text = update.message.reply_text.call_args[0][0]
         assert "model: opus" in reply_text
-        assert "budget: $20.00" in reply_text
 
     @pytest.mark.asyncio
     async def test_switch_deleted_directory(self, tmp_path):
@@ -3731,7 +3720,7 @@ class TestHandleWorkspaceConfig:
             await _handle_workspace_config(update, ctx, "config")
 
         reply = update.message.reply_text.call_args[0][0]
-        # Should show model, budget, timeout with "global default" source
+        # Should show model and timeout with "global default" source
         assert "sonnet" in reply
         assert "global default" in reply
 
@@ -3776,45 +3765,6 @@ class TestHandleWorkspaceConfig:
         # Should confirm to the user
         reply = update.message.reply_text.call_args[0][0]
         assert "opus" in reply.lower()
-
-    # ── 3. Set budget with validation ───────────────────────────────
-
-    @pytest.mark.asyncio
-    async def test_set_budget(self):
-        """/workspace config budget 5 sets the budget."""
-        update = _make_update(text="/workspace config budget 5")
-        config = _make_config()
-        pool = _make_mock_claude()
-        ctx = _make_context(config=config, pool=pool)
-        mock_sessions = self._mock_sessions()
-
-        with self._patches(mock_sessions):
-            await _handle_workspace_config(update, ctx, "config budget 5")
-
-        mock_sessions.set_workspace_config_setting.assert_called_once_with(
-            12345, str(pool.get_workspace(12345)), "budget", "5.0"
-        )
-        reply = update.message.reply_text.call_args[0][0]
-        assert "$5.00" in reply
-
-    # ── 4. Reject negative budget ───────────────────────────────────
-
-    @pytest.mark.asyncio
-    async def test_reject_negative_budget(self):
-        """/workspace config budget -5 is rejected."""
-        update = _make_update(text="/workspace config budget -5")
-        config = _make_config()
-        pool = _make_mock_claude()
-        ctx = _make_context(config=config, pool=pool)
-        mock_sessions = self._mock_sessions()
-
-        with self._patches(mock_sessions):
-            await _handle_workspace_config(update, ctx, "config budget -5")
-
-        # Should not persist anything
-        mock_sessions.set_workspace_config_setting.assert_not_called()
-        reply = update.message.reply_text.call_args[0][0]
-        assert "positive" in reply.lower()
 
     # ── 5. Set timeout ──────────────────────────────────────────────
 
@@ -3995,50 +3945,8 @@ class TestHandleWorkspaceConfig:
         reply = update.message.reply_text.call_args[0][0]
         assert "bogus" in reply
         assert "model" in reply
-        assert "budget" in reply
         # Should NOT apply any config change
         pool.change_workspace.assert_not_called()
-
-    # ── Budget ceiling enforcement ──────────────────────────────────
-
-    @pytest.mark.asyncio
-    async def test_budget_ceiling_from_global_config(self):
-        """Budget exceeding global budget_ceiling is rejected."""
-        # Ceiling comes from config.budget_ceiling, not per-user max_budget.
-        # User has max_budget=5 but global ceiling is 8; requesting 10
-        # should be rejected because 10 > 8 (global ceiling).
-        user = UserConfig(telegram_id=12345, name="test", max_budget=5.0)
-        config = _make_config(budget_ceiling=8.0, user_configs={12345: user})
-        update = _make_update(text="/workspace config budget 10")
-        pool = _make_mock_claude()
-        ctx = _make_context(config=config, pool=pool)
-        mock_sessions = self._mock_sessions()
-
-        with self._patches(mock_sessions):
-            await _handle_workspace_config(update, ctx, "config budget 10")
-
-        # Should reject - 10 exceeds global ceiling of 8
-        mock_sessions.set_workspace_config_setting.assert_not_called()
-        reply = update.message.reply_text.call_args[0][0]
-        assert "$8.00" in reply
-        assert "admin limit" in reply.lower()
-
-    @pytest.mark.asyncio
-    async def test_budget_above_yaml_default_but_under_ceiling_allowed(self):
-        """Budget above per-user max_budget but under global ceiling succeeds."""
-        # User has max_budget=5 in users.yaml, but global ceiling is 20.
-        # Setting budget to 10 should succeed (above yaml default, under ceiling).
-        user = UserConfig(telegram_id=12345, name="test", max_budget=5.0)
-        config = _make_config(budget_ceiling=20.0, user_configs={12345: user})
-        update = _make_update(text="/workspace config budget 10")
-        pool = _make_mock_claude()
-        ctx = _make_context(config=config, pool=pool)
-        mock_sessions = self._mock_sessions()
-
-        with self._patches(mock_sessions):
-            await _handle_workspace_config(update, ctx, "config budget 10")
-
-        mock_sessions.set_workspace_config_setting.assert_called_once()
 
     # ── Invalid model rejected ──────────────────────────────────────
 
@@ -4127,33 +4035,15 @@ class TestHandleSettings:
         reply = update.message.reply_text.call_args[0][0]
         assert "opus" in reply.lower()
 
-    # ── 3. Set budget ──────────────────────────────────────────────
+    # ── 3. Unknown setting rejected ────────────────────────────────
 
     @pytest.mark.asyncio
-    async def test_set_budget(self):
-        """/settings budget 5 sets the budget (within default $10 ceiling)."""
+    async def test_budget_is_unknown_setting(self):
+        """/settings budget 5 answers with the unknown-setting message
+        listing the supported fields."""
         update = _make_update(text="/settings budget 5")
         config = _make_config()
-        pool = _make_mock_claude()
-        pool.get_if_exists = MagicMock(return_value=MagicMock())
-        ctx = _make_context(config=config, pool=pool, args=["budget", "5"])
-        mock_sessions = self._mock_sessions()
-
-        with self._patches(mock_sessions):
-            await handle_settings(update, ctx)
-
-        mock_sessions.set_user_setting.assert_called_once_with(12345, "budget", "5.0")
-        reply = update.message.reply_text.call_args[0][0]
-        assert "$5.00" in reply
-
-    # ── 4. Reject negative budget ──────────────────────────────────
-
-    @pytest.mark.asyncio
-    async def test_reject_negative_budget(self):
-        """/settings budget -5 is rejected."""
-        update = _make_update(text="/settings budget -5")
-        config = _make_config()
-        ctx = _make_context(config=config, args=["budget", "-5"])
+        ctx = _make_context(config=config, args=["budget", "5"])
         mock_sessions = self._mock_sessions()
 
         with self._patches(mock_sessions):
@@ -4161,47 +4051,9 @@ class TestHandleSettings:
 
         mock_sessions.set_user_setting.assert_not_called()
         reply = update.message.reply_text.call_args[0][0]
-        assert "positive" in reply.lower()
-
-    # ── 5. Budget exceeds ceiling ──────────────────────────────────
-
-    @pytest.mark.asyncio
-    async def test_budget_exceeds_ceiling(self):
-        """/settings budget 999 is rejected when global ceiling is lower."""
-        # Ceiling comes from config.budget_ceiling (global), not per-user
-        config = _make_config(budget_ceiling=25.0)
-        update = _make_update(text="/settings budget 999")
-        ctx = _make_context(config=config, args=["budget", "999"])
-        mock_sessions = self._mock_sessions()
-
-        with self._patches(mock_sessions):
-            await handle_settings(update, ctx)
-
-        mock_sessions.set_user_setting.assert_not_called()
-        reply = update.message.reply_text.call_args[0][0]
-        assert "$25.00" in reply
-        assert "admin limit" in reply.lower()
-
-    # ── 5b. Budget allowed when ceiling is zero (no limit) ──────────
-
-    @pytest.mark.asyncio
-    async def test_budget_allowed_when_ceiling_zero(self):
-        """/settings budget 50 succeeds when global ceiling is 0 (no limit)."""
-        # If BUDGET_CEILING=0 and no users.yaml entry, 0 means
-        # "no admin ceiling" - budget should be allowed, not rejected.
-        config = _make_config(budget_ceiling=0.0)
-        update = _make_update(text="/settings budget 50")
-        pool = _make_mock_claude()
-        pool.get_if_exists = MagicMock(return_value=MagicMock())
-        ctx = _make_context(config=config, pool=pool, args=["budget", "50"])
-        mock_sessions = self._mock_sessions()
-
-        with self._patches(mock_sessions):
-            await handle_settings(update, ctx)
-
-        mock_sessions.set_user_setting.assert_called_once_with(12345, "budget", "50.0")
-        reply = update.message.reply_text.call_args[0][0]
-        assert "$50.00" in reply
+        assert "Unknown setting" in reply
+        assert "model" in reply
+        assert "timeout" in reply
 
     # ── 6. Set timeout ─────────────────────────────────────────────
 
@@ -4420,13 +4272,12 @@ class TestHandleSettings:
 
     @pytest.mark.asyncio
     async def test_reset_all_reverts_instance(self):
-        """/settings reset reverts all three fields on the live instance."""
+        """/settings reset reverts all fields on the live instance."""
         update = _make_update(text="/settings reset")
         config = _make_config()
         pool = _make_mock_claude()
         instance = MagicMock()
         instance.model = "opus"
-        instance.max_budget_usd = 99.0
         instance.timeout_seconds = 500
         pool.get_if_exists = MagicMock(return_value=instance)
         ctx = _make_context(config=config, pool=pool, args=["reset"])
@@ -4436,46 +4287,7 @@ class TestHandleSettings:
             await handle_settings(update, ctx)
 
         assert instance.model == config.default_model
-        assert instance.max_budget_usd == config.budget_ceiling
         assert instance.timeout_seconds == config.claude_timeout_seconds
-
-    # ── 19. Budget displays "unlimited" when zero ─────────────────
-
-    @pytest.mark.asyncio
-    async def test_show_settings_budget_zero_displays_unlimited(self):
-        """Budget of $0.00 displays as 'unlimited', not '$0.00'."""
-        update = _make_update(text="/settings")
-        config = _make_config(budget_ceiling=0.0)
-        ctx = _make_context(config=config)
-        mock_sessions = self._mock_sessions()
-
-        with self._patches(mock_sessions):
-            await _show_settings(update, ctx, 12345, config)
-
-        reply = update.message.reply_text.call_args[0][0]
-        assert "unlimited" in reply.lower()
-        assert "$0.00" not in reply
-
-    # ── 20. Ceiling enforced from global config, not per-user ────
-
-    @pytest.mark.asyncio
-    async def test_ceiling_enforced_from_global_config(self):
-        """Ceiling comes from config.budget_ceiling, not per-user max_budget."""
-        # User has max_budget=15 in users.yaml, but global ceiling is 50.
-        # User should be able to set budget up to $50, not just $15.
-        user = UserConfig(telegram_id=12345, name="testuser", max_budget=15.0)
-        config = _make_config(budget_ceiling=50.0, user_configs={12345: user})
-        update = _make_update(text="/settings budget 40")
-        pool = _make_mock_claude()
-        pool.get_if_exists = MagicMock(return_value=MagicMock())
-        ctx = _make_context(config=config, pool=pool, args=["budget", "40"])
-        mock_sessions = self._mock_sessions()
-
-        with self._patches(mock_sessions):
-            await handle_settings(update, ctx)
-
-        # Budget of $40 should succeed (under $50 ceiling, above $15 yaml default)
-        mock_sessions.set_user_setting.assert_called_once_with(12345, "budget", "40.0")
 
 
 # ── /github command ─────────────────────────────────────────────────

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -36,7 +36,6 @@ def _make_claude(**kwargs) -> ClaudeCodeBackend:
     defaults = {
         "model": "sonnet",
         "workspace": Path("/tmp/test-workspace"),
-        "max_budget_usd": 1.0,
         "timeout_seconds": 30,
     }
     defaults.update(kwargs)
@@ -96,7 +95,6 @@ def _result_event(
     text: str = "Final",
     is_error: bool = False,
     session_id: str = "sess-123",
-    cost: float = 0.05,
     duration: int = 1500,
 ) -> bytes:
     """Build a result event JSON line."""
@@ -106,7 +104,6 @@ def _result_event(
             "result": text,
             "is_error": is_error,
             "session_id": session_id,
-            "total_cost_usd": cost,
             "duration_ms": duration,
         }
     )
@@ -491,44 +488,6 @@ class TestCommandConstruction:
             assert "--effort" in cmd
             idx = cmd.index("--effort")
             assert cmd[idx + 1] == "xhigh"
-
-    @pytest.mark.asyncio
-    async def test_max_budget_usd_flag_absent_on_claude_backend(self):
-        """--max-budget-usd must NOT be emitted to the inner Claude
-        argv (issue #390). ClaudeCodeBackend is only instantiated for
-        the claude backend (pool.py selects between ClaudeCodeBackend
-        and GooseBackend by agent_backend), so the absence is
-        unconditional at this site. Max-plan OAuth makes the CLI's
-        computed-cost ceiling a phantom signal; runaway protection
-        comes from timeout_seconds at the per-message wait_for() call.
-        The max_budget_usd attribute on the instance stays so
-        /settings budget can read it back, but the value no longer
-        reaches the subprocess argv. Pinned as an absence assertion
-        so a future regression that re-adds the flag fails here.
-        """
-        # Construct with a non-default max_budget_usd so the assertion
-        # would catch a regression that simply forgot to remove the
-        # argv pair (rather than a regression that emits the dataclass
-        # default 1.0). Using an obviously-non-default 7.0 makes the
-        # intent legible at the call site.
-        claude = _make_claude(max_budget_usd=7.0)
-        assert claude.max_budget_usd == 7.0  # constructor wired it through
-
-        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
-            mock_proc = MagicMock()
-            mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
-            mock_exec.return_value = mock_proc
-
-            await claude._ensure_started()
-
-            cmd = mock_exec.call_args[0]
-            assert "--max-budget-usd" not in cmd
-            # The numeric value also must not slip into argv as a
-            # bare positional. Belt-and-suspenders: covers a regression
-            # that drops the flag name but accidentally leaves the
-            # value behind in the list.
-            assert "7.0" not in cmd
 
 
 # ── Process signal handling ──────────────────────────────────────────
@@ -1116,7 +1075,7 @@ class TestSendLockedBasic:
             [
                 _system_event(),
                 _assistant_event("Hello"),
-                _result_event("Hello", cost=0.05, duration=1500),
+                _result_event("Hello", duration=1500),
                 b"",
             ]
         )
@@ -1130,7 +1089,6 @@ class TestSendLockedBasic:
         assert done_event.done is True
         assert done_event.response is not None
         assert done_event.response.success is True
-        assert done_event.response.cost_usd == 0.05
         assert done_event.response.duration_ms == 1500
         assert done_event.response.session_id == "sess-123"
 
@@ -3491,57 +3449,52 @@ class TestRestart:
 
 class TestWorkspaceConfig:
     def test_constructor_with_workspace_config(self):
-        """WorkspaceConfig overrides model, budget, and timeout."""
+        """WorkspaceConfig overrides model and timeout."""
         ws_config = WorkspaceConfig(
             path=Path("/tmp/ws"),
             model="opus",
-            budget=15.0,
             timeout=300,
         )
         claude = _make_claude(workspace_config=ws_config)
         assert claude.model == "opus"
-        assert claude.max_budget_usd == 15.0
         assert claude.timeout_seconds == 300
 
     def test_constructor_without_workspace_config(self):
         """Without config, global defaults are used."""
         claude = _make_claude()
         assert claude.model == "sonnet"
-        assert claude.max_budget_usd == 1.0
         assert claude.timeout_seconds == 30
 
     def test_constructor_partial_workspace_config(self):
-        """Config with only model set leaves budget and timeout at defaults."""
+        """Config with only model set leaves timeout at the default."""
         ws_config = WorkspaceConfig(path=Path("/tmp/ws"), model="haiku")
         claude = _make_claude(workspace_config=ws_config)
         assert claude.model == "haiku"
-        assert claude.max_budget_usd == 1.0  # unchanged
         assert claude.timeout_seconds == 30  # unchanged
 
     def test_defaults_preserved(self):
         """Constructor stores the original global defaults."""
-        ws_config = WorkspaceConfig(path=Path("/tmp/ws"), model="opus", budget=20.0)
+        ws_config = WorkspaceConfig(path=Path("/tmp/ws"), model="opus", timeout=300)
         claude = _make_claude(workspace_config=ws_config)
         assert claude._default_model == "sonnet"
-        assert claude._default_budget == 1.0
         assert claude._default_timeout == 30
 
     @pytest.mark.asyncio
     async def test_change_workspace_with_config(self):
         """Switching to a configured workspace applies overrides."""
         claude = _make_claude()
-        ws_config = WorkspaceConfig(path=Path("/tmp/ws2"), model="opus", budget=20.0)
+        ws_config = WorkspaceConfig(path=Path("/tmp/ws2"), model="opus", timeout=300)
 
         with patch.object(claude, "_kill", new_callable=AsyncMock):
             await claude.change_workspace(Path("/tmp/ws2"), workspace_config=ws_config)
 
         assert claude.model == "opus"
-        assert claude.max_budget_usd == 20.0
+        assert claude.timeout_seconds == 300
 
     @pytest.mark.asyncio
     async def test_change_workspace_to_unconfigured(self):
         """Switching from configured to unconfigured reverts to global defaults."""
-        ws_config = WorkspaceConfig(path=Path("/tmp/ws"), model="opus", budget=20.0)
+        ws_config = WorkspaceConfig(path=Path("/tmp/ws"), model="opus", timeout=300)
         claude = _make_claude(workspace_config=ws_config)
         assert claude.model == "opus"
 
@@ -3549,17 +3502,17 @@ class TestWorkspaceConfig:
             await claude.change_workspace(Path("/tmp/other"))
 
         assert claude.model == "sonnet"  # reverted to default
-        assert claude.max_budget_usd == 1.0  # reverted to default
+        assert claude.timeout_seconds == 30  # reverted to default
 
     @pytest.mark.asyncio
     async def test_change_workspace_no_stale_values(self):
         """Partial config doesn't carry over values from previous workspace.
 
-        Scenario: workspace A has budget=20.0. Switch to workspace B
-        which only sets model. Budget must revert to the global default,
-        not carry over workspace A's 20.0.
+        Scenario: workspace A has timeout=300. Switch to workspace B
+        which only sets model. Timeout must revert to the global
+        default, not carry over workspace A's 300.
         """
-        ws_a = WorkspaceConfig(path=Path("/tmp/a"), model="opus", budget=20.0)
+        ws_a = WorkspaceConfig(path=Path("/tmp/a"), model="opus", timeout=300)
         ws_b = WorkspaceConfig(path=Path("/tmp/b"), model="haiku")
         claude = _make_claude(workspace_config=ws_a)
 
@@ -3567,7 +3520,7 @@ class TestWorkspaceConfig:
             await claude.change_workspace(Path("/tmp/b"), workspace_config=ws_b)
 
         assert claude.model == "haiku"
-        assert claude.max_budget_usd == 1.0  # global default, not 20.0
+        assert claude.timeout_seconds == 30  # global default, not 300
 
     @pytest.mark.asyncio
     async def test_change_workspace_model_override_cycle(self):

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -568,7 +568,6 @@ class TestStreamParsing:
         assert events[2].response is not None
         assert events[2].response.success is True
         assert events[2].response.text == "Hello world"
-        assert events[2].response.cost_usd == 0.0
 
     @pytest.mark.asyncio
     async def test_multi_agent_message_items_join_with_blank_line(self):
@@ -755,7 +754,6 @@ class TestCompletion:
         assert final.response.success is True
         assert final.response.text == "answer"
         assert final.response.session_id == "test-session"
-        assert final.response.cost_usd == 0.0
 
     @pytest.mark.asyncio
     async def test_eof_with_accumulated_text(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,8 +33,8 @@ _CONFIG_ENV_VARS = [
     "DEFAULT_MODEL",
     "CLAUDE_MODEL",
     "CLAUDE_TIMEOUT_SECONDS",
-    "BUDGET_CEILING",
-    "CLAUDE_MAX_BUDGET_USD",  # backward compat (renamed to BUDGET_CEILING)
+    "BUDGET_CEILING",  # retired (budgets are no longer tracked)
+    "CLAUDE_MAX_BUDGET_USD",  # retired (budgets are no longer tracked)
     "AGENT_MAX_SESSION_HOURS",
     "CLAUDE_MAX_SESSION_HOURS",  # backward compat (renamed to AGENT_MAX_SESSION_HOURS)
     "AGENT_IDLE_TIMEOUT",
@@ -186,7 +186,6 @@ class TestLoadConfigDefaults:
         config = load_config()
         assert config.default_model == "sonnet"
         assert config.claude_timeout_seconds == 120
-        assert config.budget_ceiling == 10.0
         assert config.claude_max_session_hours == 0
         assert config.webhook_port == 8080
         # Without TELEGRAM_WEBHOOK_URL, defaults to polling mode
@@ -698,7 +697,6 @@ class TestPRReviewConfig:
         config = load_config()
         assert config.pr_review_cooldown == 300
         assert config.pr_review_timeout_s == 900
-        assert config.pr_review_budget_usd == 1.0
 
     def test_custom_cooldown(self, monkeypatch):
         """PR_REVIEW_COOLDOWN is picked up from env."""
@@ -732,27 +730,6 @@ class TestPRReviewConfig:
         _set_required(monkeypatch)
         monkeypatch.setenv("PR_REVIEW_TIMEOUT_S", "0")
         with pytest.raises(SystemExit, match="PR_REVIEW_TIMEOUT_S"):
-            load_config()
-
-    def test_budget_override(self, monkeypatch):
-        """PR_REVIEW_BUDGET_USD parses to a float and reaches the Config."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("PR_REVIEW_BUDGET_USD", "2.5")
-        config = load_config()
-        assert config.pr_review_budget_usd == 2.5
-
-    def test_budget_rejects_non_number(self, monkeypatch):
-        """Non-numeric PR_REVIEW_BUDGET_USD raises SystemExit."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("PR_REVIEW_BUDGET_USD", "cheap")
-        with pytest.raises(SystemExit, match="PR_REVIEW_BUDGET_USD"):
-            load_config()
-
-    def test_budget_rejects_non_positive(self, monkeypatch):
-        """Zero or negative PR_REVIEW_BUDGET_USD raises SystemExit."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("PR_REVIEW_BUDGET_USD", "-1.0")
-        with pytest.raises(SystemExit, match="PR_REVIEW_BUDGET_USD"):
             load_config()
 
     def test_github_repo_from_env(self, monkeypatch):
@@ -829,7 +806,6 @@ def _mock_user_configs(monkeypatch):
 # GITHUB_NOTIFY_CHAT_ID) are no longer read at runtime and have no
 # deprecation handling here — the loader silently ignores them.
 _RENAMED_VARS_WITH_VALUES = {
-    "CLAUDE_MAX_BUDGET_USD": "10.0",
     "CLAUDE_TIMEOUT_SECONDS": "120",
 }
 
@@ -849,11 +825,57 @@ class TestRenamedEnvWarnings:
     def test_empty_var_does_not_warn(self, monkeypatch, caplog):
         """Empty string env vars are not treated as 'set'."""
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
-        monkeypatch.setenv("CLAUDE_MAX_BUDGET_USD", "")
+        monkeypatch.setenv("CLAUDE_TIMEOUT_SECONDS", "")
         _mock_user_configs(monkeypatch)
         with caplog.at_level(logging.WARNING, logger="kai.config"):
             load_config()
-        assert "CLAUDE_MAX_BUDGET_USD in env is deprecated" not in caplog.text
+        assert "CLAUDE_TIMEOUT_SECONDS in env is deprecated" not in caplog.text
+
+
+# Retired env vars: the setting no longer exists, so the loader warns
+# that the lingering value has no effect (no replacement key to point
+# at) and continues without error.
+_RETIRED_VARS_WITH_VALUES = {
+    "CLAUDE_MAX_CONTEXT_WINDOW": "100000",
+    "BUDGET_CEILING": "10.0",
+    "CLAUDE_MAX_BUDGET_USD": "10.0",
+    "PR_REVIEW_BUDGET_USD": "1.0",
+    "MEMORY_EXTRACTION_BUDGET_USD": "0.01",
+    "MEMORY_EPISODE_BUDGET_USD": "0.15",
+}
+
+
+class TestRetiredEnvWarnings:
+    """Retired env vars surface a single no-longer-supported warning
+    and never abort startup."""
+
+    @pytest.mark.parametrize("var,value", _RETIRED_VARS_WITH_VALUES.items())
+    def test_warns_on_retired_key(self, monkeypatch, caplog, var, value):
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
+        monkeypatch.setenv(var, value)
+        _mock_user_configs(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger="kai.config"):
+            load_config()
+        assert f"{var} is no longer supported" in caplog.text
+
+    @pytest.mark.parametrize("var,value", _RETIRED_VARS_WITH_VALUES.items())
+    def test_retired_key_does_not_abort(self, monkeypatch, var, value):
+        """A lingering retired key has no effect beyond the warning;
+        load_config still returns a usable Config."""
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
+        monkeypatch.setenv(var, value)
+        _mock_user_configs(monkeypatch)
+        config = load_config()
+        assert config.telegram_bot_token == "fake"
+
+    def test_empty_retired_key_does_not_warn(self, monkeypatch, caplog):
+        """Empty string env vars are not treated as 'set'."""
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
+        monkeypatch.setenv("BUDGET_CEILING", "")
+        _mock_user_configs(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger="kai.config"):
+            load_config()
+        assert "BUDGET_CEILING is no longer supported" not in caplog.text
 
 
 # ── GitHub repos empty warning ───────────────────────────────────────
@@ -955,7 +977,6 @@ class TestMinimalEnvWithUsersYaml:
         # Uses dataclass defaults when no env var is set
         assert config.default_model == "sonnet"
         assert config.claude_timeout_seconds == 120
-        assert config.budget_ceiling == 10.0
         assert config.workspace_base is None
         assert config.allowed_workspaces == []
         # users.yaml IDs are the authorization surface
@@ -977,20 +998,6 @@ class TestMinimalEnvWithUsersYaml:
         # Per-user is "opus" from users.yaml
         assert config.user_configs is not None
         assert config.user_configs[123].model == "opus"
-
-    def test_per_user_budget_without_env(self, monkeypatch):
-        """Per-user budget from users.yaml works when BUDGET_CEILING is unset."""
-        for var, val in _MINIMAL_GLOBAL_ENV.items():
-            monkeypatch.setenv(var, val)
-        user = UserConfig(telegram_id=123, name="testuser", max_budget=25.0)
-        monkeypatch.setattr(
-            "kai.config._load_user_configs",
-            lambda *_a: {123: user},
-        )
-        config = load_config()
-        assert config.budget_ceiling == 10.0  # dataclass default
-        assert config.user_configs is not None
-        assert config.user_configs[123].max_budget == 25.0
 
     def test_workspace_base_from_users_yaml_only(self, monkeypatch, tmp_path):
         """Per-user workspace_base works when WORKSPACE_BASE env is unset."""
@@ -1125,24 +1132,8 @@ class TestLegacyEnvBackwardCompat:
     Pre-tranche-A this class covered the "single-user install via
     env vars only" path; that path is gone (the loader raises
     SystemExit on absent users.yaml). What remains is the env-var
-    rename surface (BUDGET_CEILING <- CLAUDE_MAX_BUDGET_USD,
-    AGENT_TIMEOUT_SECONDS <- CLAUDE_TIMEOUT_SECONDS).
+    rename surface (AGENT_TIMEOUT_SECONDS <- CLAUDE_TIMEOUT_SECONDS).
     """
-
-    def test_old_budget_env_var_backward_compat(self, monkeypatch):
-        """CLAUDE_MAX_BUDGET_USD still works as fallback when BUDGET_CEILING is not set."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("CLAUDE_MAX_BUDGET_USD", "42.0")
-        config = load_config()
-        assert config.budget_ceiling == 42.0
-
-    def test_new_budget_env_var_takes_precedence(self, monkeypatch):
-        """BUDGET_CEILING wins over CLAUDE_MAX_BUDGET_USD when both are set."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("BUDGET_CEILING", "50.0")
-        monkeypatch.setenv("CLAUDE_MAX_BUDGET_USD", "25.0")
-        config = load_config()
-        assert config.budget_ceiling == 50.0
 
     def test_no_deprecation_warnings(self, monkeypatch, caplog):
         """No users.yaml deprecation warnings when users.yaml is absent."""
@@ -1250,7 +1241,6 @@ class TestMemoryExtractionConfig:
         _set_required(monkeypatch)
         config = load_config()
         assert config.memory_extraction_enabled is False
-        assert config.memory_extraction_budget_usd == 0.01
         assert config.memory_extraction_timeout_s == 10
 
     def test_enabled_from_env(self, monkeypatch):
@@ -1268,7 +1258,7 @@ class TestMemoryExtractionConfig:
 
         Without enforcement, MEMORY_EXTRACTION_ENABLED=true with
         MEMORY_ENABLED=false would let the Haiku extraction subprocess
-        fire every turn, burning ~$0.01/turn of budget whose result
+        fire every turn, spawning a per-turn call whose result
         silently no-ops in the `_memory is None` guard inside
         add_structured. Pin the dependency so future refactors don't
         accidentally remove it.
@@ -1295,29 +1285,11 @@ class TestMemoryExtractionConfig:
         deprecation_msgs = [r.message for r in caplog.records if "MEMORY_EXTRACTION_MODEL is deprecated" in r.message]
         assert len(deprecation_msgs) == 1, deprecation_msgs
 
-    def test_budget_override(self, monkeypatch):
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_EXTRACTION_BUDGET_USD", "0.25")
-        config = load_config()
-        assert config.memory_extraction_budget_usd == 0.25
-
     def test_timeout_override(self, monkeypatch):
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_EXTRACTION_TIMEOUT_S", "30")
         config = load_config()
         assert config.memory_extraction_timeout_s == 30
-
-    def test_budget_rejects_negative(self, monkeypatch):
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_EXTRACTION_BUDGET_USD", "-0.01")
-        with pytest.raises(SystemExit, match="non-negative"):
-            load_config()
-
-    def test_budget_rejects_non_number(self, monkeypatch):
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_EXTRACTION_BUDGET_USD", "not-a-number")
-        with pytest.raises(SystemExit, match="must be a number"):
-            load_config()
 
     def test_timeout_rejects_zero(self, monkeypatch):
         """Timeout=0 would cancel the subprocess before it started;
@@ -1848,10 +1820,9 @@ class TestRegistryValidationPerEligibleBackend:
 
 class TestMemoryEpisode:
     """The MEMORY_EPISODE_* env vars: stage-2 episode generation, which
-    runs out-of-band on stage-1 positives. Bounds: budget is strictly
-    positive (no zero kill-switch; the master switch is MEMORY_ENABLED)
-    and timeout has a 10s floor (Haiku warm-up time). The model is no
-    longer configurable here (issue #515 retired MEMORY_EPISODE_MODEL);
+    runs out-of-band on stage-1 positives. Timeout has a 10s floor
+    (Haiku warm-up time). The model is not configurable here (issue
+    #515 retired MEMORY_EPISODE_MODEL);
     `get_model_for(ModelRole.MEMORY_EPISODE, effective_backend)` is the
     only source."""
 
@@ -1859,47 +1830,13 @@ class TestMemoryEpisode:
         """Defaults must stay stable so unset = production behavior."""
         _set_required(monkeypatch)
         config = load_config()
-        assert config.memory_episode_budget_usd == 0.15
         assert config.memory_episode_timeout_s == 120
-
-    def test_budget_override(self, monkeypatch):
-        """Override path: arbitrary positive value beats the dataclass
-        default of 0.15. Test value 0.30 chosen specifically to be
-        non-default so a future flip of the dataclass default to 0.30
-        would not silently mask a regression in the override path."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_EPISODE_BUDGET_USD", "0.30")
-        config = load_config()
-        assert config.memory_episode_budget_usd == 0.30
 
     def test_timeout_override(self, monkeypatch):
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_EPISODE_TIMEOUT_S", "60")
         config = load_config()
         assert config.memory_episode_timeout_s == 60
-
-    def test_budget_rejects_zero(self, monkeypatch):
-        """Stage-2 budget of zero would mean every call exits at first
-        token with error_max_budget_usd. Unlike the consolidation
-        candidates field, zero is NOT a kill switch here - the master
-        switch is MEMORY_ENABLED. Reject explicitly so a typo doesn't
-        silently disable the feature."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_EPISODE_BUDGET_USD", "0")
-        with pytest.raises(SystemExit, match="positive"):
-            load_config()
-
-    def test_budget_rejects_negative(self, monkeypatch):
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_EPISODE_BUDGET_USD", "-0.05")
-        with pytest.raises(SystemExit, match="positive"):
-            load_config()
-
-    def test_budget_rejects_non_number(self, monkeypatch):
-        _set_required(monkeypatch)
-        monkeypatch.setenv("MEMORY_EPISODE_BUDGET_USD", "not-a-number")
-        with pytest.raises(SystemExit, match="must be a number"):
-            load_config()
 
     def test_timeout_rejects_below_floor(self, monkeypatch):
         """Floor is 10s because Haiku's warm-up alone can run several
@@ -2653,7 +2590,6 @@ class TestAgentTimeoutSecondsRename:
             "TELEGRAM_BOT_TOKEN": "test-token",
             "ALLOWED_USER_IDS": "12345",
             "DEFAULT_MODEL": "sonnet",
-            "BUDGET_CEILING": "10.0",
             "WEBHOOK_PORT": "8080",
             "WEBHOOK_SECRET": "test-secret",
         }
@@ -2702,7 +2638,6 @@ class TestAgentSessionLifecycleRename:
             "TELEGRAM_BOT_TOKEN": "test-token",
             "ALLOWED_USER_IDS": "12345",
             "DEFAULT_MODEL": "sonnet",
-            "BUDGET_CEILING": "10.0",
             "WEBHOOK_PORT": "8080",
             "WEBHOOK_SECRET": "test-secret",
         }
@@ -2763,7 +2698,6 @@ class TestLoadConfigBackendAwareModelValidation:
         base = {
             "TELEGRAM_BOT_TOKEN": "test-token",
             "ALLOWED_USER_IDS": "12345",
-            "BUDGET_CEILING": "10.0",
             "WEBHOOK_PORT": "8080",
             "WEBHOOK_SECRET": "test-secret",
         }

--- a/tests/test_episode_classifier_eval.py
+++ b/tests/test_episode_classifier_eval.py
@@ -49,13 +49,12 @@ _BASE_CONFIG = Config(
 def _eval_config() -> Config:
     """Stage-1 config tuned for the eval pass: extraction enabled,
     consolidation off (the labeled exchanges have no prior facts to
-    consolidate against). Budget and timeout match production-tuned
-    values so the eval reflects realistic latency."""
+    consolidate against). The timeout matches the production-tuned
+    value so the eval reflects realistic latency."""
     return replace(
         _BASE_CONFIG,
         memory_enabled=True,
         memory_extraction_enabled=True,
-        memory_extraction_budget_usd=0.05,
         memory_extraction_timeout_s=60,
         memory_consolidation_candidates_n=0,
     )

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -1,24 +1,18 @@
 """
 Tests for error-recovery UX (issue #326).
 
-Three layers of behavior change:
+Two layers of behavior:
 
 1. claude.py: when the CLI emits an `is_error=true` event with an
-   empty `result` field, the actual reason now comes from the
-   `errors` field (where BUDGET_CEILING exhaustion places it). Falls
-   back to a non-None sentinel string when both are empty so the
-   downstream "Error: None" surface can never recur.
+   empty `result` field, the actual reason comes from the `errors`
+   field. Falls back to a non-None sentinel string when both are
+   empty so the downstream "Error: None" surface can never recur.
 
 2. bot.py: error rendering APPENDS a follow-up message instead of
    OVERWRITING the live streamed message. Pre-#326 the error edit
    erased any tool-use, partial reasoning, and intermediate output
    the user was watching - on long sessions, minutes of visible
    work disappearing into a single error line.
-
-3. bot.py: budget-exhaustion errors send a recovery directive as a
-   second follow-up message ("Type /new to start fresh, or ask your
-   operator to raise BUDGET_CEILING"). Other error types fall
-   through with no extra guidance for v1.
 """
 
 from __future__ import annotations
@@ -31,7 +25,6 @@ import pytest
 
 from kai import bot
 from kai.backend import AgentResponse, StreamEvent
-from kai.bot import _budget_recovery_hint, _is_budget_exhaustion
 from kai.claude import ClaudeCodeBackend
 
 # ── claude.py error-event handling ──────────────────────────────────
@@ -44,7 +37,6 @@ def _make_claude(**kwargs) -> ClaudeCodeBackend:
     defaults = {
         "model": "sonnet",
         "workspace": Path("/tmp/test-workspace"),
-        "max_budget_usd": 1.0,
         "timeout_seconds": 30,
     }
     defaults.update(kwargs)
@@ -83,26 +75,25 @@ def _system_event(session_id: str = "sess-326") -> bytes:
 class TestClaudeErrorPopulation:
     """The CLI's `is_error=true` events come in two shapes (per #326):
     (a) `result` populated with a human-readable reason, (b) `result`
-    empty BUT `errors` populated with a list of strings (the
-    BUDGET_CEILING variant). Pre-#326 only shape (a) produced a
-    non-None error string; shape (b) silently fell through to None
-    and rendered as the literal "Error: None" in chat. The fix reads
-    `errors` when `result` is empty, with a sentinel fallback for the
-    pathological case where both fields are absent."""
+    empty BUT `errors` populated with a list of strings. Pre-#326
+    only shape (a) produced a non-None error string; shape (b)
+    silently fell through to None and rendered as the literal
+    "Error: None" in chat. The fix reads `errors` when `result` is
+    empty, with a sentinel fallback for the pathological case where
+    both fields are absent."""
 
     @pytest.mark.asyncio
     async def test_errors_field_populates_response_error_when_result_empty(self):
-        """The BUDGET_CEILING variant: result is empty, errors carries
-        the reason. AgentResponse.error must reflect the errors-field
-        content, not None."""
+        """Shape (b): result is empty, errors carries the reason.
+        AgentResponse.error must reflect the errors-field content,
+        not None."""
         result_event = _json_line(
             {
                 "type": "result",
                 "result": "",
                 "is_error": True,
-                "errors": ["Reached maximum budget ($10)"],
+                "errors": ["API connection lost"],
                 "session_id": "sess-326",
-                "total_cost_usd": 10.103919,
                 "duration_ms": 90000,
             }
         )
@@ -116,7 +107,7 @@ class TestClaudeErrorPopulation:
         response = done[0].response
         assert response is not None
         assert response.success is False
-        assert response.error == "Reached maximum budget ($10)"
+        assert response.error == "API connection lost"
 
     @pytest.mark.asyncio
     async def test_empty_result_and_empty_errors_falls_back_to_sentinel(self):
@@ -130,7 +121,6 @@ class TestClaudeErrorPopulation:
                 "result": "",
                 "is_error": True,
                 "session_id": "sess-326",
-                "total_cost_usd": 0.0,
                 "duration_ms": 100,
             }
         )
@@ -164,7 +154,6 @@ class TestClaudeErrorPopulation:
                 "is_error": True,
                 "errors": ["should-be-ignored"],
                 "session_id": "sess-326",
-                "total_cost_usd": 0.05,
                 "duration_ms": 1500,
             }
         )
@@ -178,76 +167,14 @@ class TestClaudeErrorPopulation:
         assert response.error == "Model self-reported error"
 
 
-# ── budget detection helpers ────────────────────────────────────────
-
-
-class TestBudgetDetection:
-    """`_is_budget_exhaustion` and `_budget_recovery_hint` are pure
-    helpers, easiest to verify directly. The bot.py message-lifecycle
-    integration exercises them through the response handler in the
-    next class."""
-
-    def test_is_budget_exhaustion_matches_canonical_phrasing(self):
-        """The CLI's documented error text includes 'maximum budget'.
-        Substring match is case-insensitive and tolerant of dollar
-        amount variation."""
-        assert _is_budget_exhaustion("Reached maximum budget ($10)") is True
-        assert _is_budget_exhaustion("Reached maximum budget ($25.50)") is True
-        # Case-insensitive: a future CLI capitalization tweak still matches.
-        assert _is_budget_exhaustion("REACHED MAXIMUM BUDGET ($10)") is True
-
-    def test_is_budget_exhaustion_rejects_non_matches(self):
-        """Auth failures, network errors, generic strings, and
-        None/empty all return False - the directive should NOT fire
-        for these."""
-        assert _is_budget_exhaustion("Authentication failed") is False
-        assert _is_budget_exhaustion("Connection refused") is False
-        assert _is_budget_exhaustion("no error detail provided") is False
-        assert _is_budget_exhaustion(None) is False
-        assert _is_budget_exhaustion("") is False
-
-    def test_budget_recovery_hint_includes_dollar_amount_when_extractable(self):
-        """The hint inlines the actual ceiling so the user sees the
-        number they hit, not a generic placeholder."""
-        hint = _budget_recovery_hint("Reached maximum budget ($10)")
-        assert "$10" in hint
-        assert "/new" in hint
-        assert "BUDGET_CEILING" in hint
-
-        hint_2 = _budget_recovery_hint("Reached maximum budget ($25.50)")
-        assert "$25.50" in hint_2
-
-    def test_budget_recovery_hint_falls_back_when_amount_unparseable(self):
-        """If the CLI ever emits the budget phrasing without a dollar
-        amount in parens (or with a different format), the hint
-        gracefully drops the amount rather than failing or rendering
-        a malformed string."""
-        hint = _budget_recovery_hint("Reached maximum budget")
-        # No $ amount in the output, but the directive is still useful
-        assert "/new" in hint
-        assert "BUDGET_CEILING" in hint
-        # No "$N" leakage from the template
-        assert "{amount}" not in hint
-        assert "$" not in hint
-
-    def test_budget_recovery_hint_tolerates_none(self):
-        """Defensive: hint should not crash on None input, since the
-        caller's contract relies on this being safe even on
-        unexpected error-string shapes."""
-        hint = _budget_recovery_hint(None)
-        assert "/new" in hint
-        assert "BUDGET_CEILING" in hint
-
-
 # ── bot.py error message lifecycle ──────────────────────────────────
 
 
 class TestErrorMessageLifecycle:
     """End-to-end behavior of `_handle_response` when the stream ends
-    in an error: append (don't overwrite), no "Error: None", budget
-    errors get the directive, non-budget errors don't.
+    in an error: append (don't overwrite), no "Error: None".
 
-    All five tests stream a text event BEFORE the terminal error so
+    All tests stream a text event BEFORE the terminal error so
     `_handle_response` actually creates a live_msg via the streaming
     loop. Without that, the live_msg branch in the error path is
     never exercised and the overwrite-not-called assertion is
@@ -256,7 +183,7 @@ class TestErrorMessageLifecycle:
     internal `reply_text` call, so a future refactor of `_reply_safe`
     cannot silently void these tests."""
 
-    def _make_pool_text_then_error(self, error_text: str | None = "Reached maximum budget ($10)"):
+    def _make_pool_text_then_error(self, error_text: str | None = "API connection lost"):
         """Mock pool whose .send() yields a text event followed by a
         done StreamEvent with the given error string. The text event
         triggers live_msg creation in the streaming loop, so the
@@ -274,7 +201,6 @@ class TestErrorMessageLifecycle:
                     text="streamed work",
                     success=False,
                     error=error_text,
-                    cost_usd=10.10,
                     duration_ms=90000,
                     session_id="sess-326",
                 ),
@@ -326,7 +252,7 @@ class TestErrorMessageLifecycle:
         rendering AND _reply_safe IS invoked with an error notice."""
         update, live_msg = self._make_update_with_live_msg()
         ctx = self._make_context()
-        pool = self._make_pool_text_then_error("Reached maximum budget ($10)")
+        pool = self._make_pool_text_then_error("API connection lost")
 
         with (
             patch("kai.bot.log_message"),
@@ -364,56 +290,23 @@ class TestErrorMessageLifecycle:
     @staticmethod
     def _error_path_calls(mock_reply_safe) -> list:
         """Filter `_reply_safe` calls to those carrying an error
-        notice or budget directive, separating them from the
-        streaming-loop's live_msg-creation call (which uses the same
-        wrapper to send the initial text chunk). Error-path calls
-        are identified by the "Error: " prefix or the presence of
-        BUDGET_CEILING in the directive - both of which the
-        streaming text would never legitimately contain."""
+        notice, separating them from the streaming-loop's
+        live_msg-creation call (which uses the same wrapper to send
+        the initial text chunk). Error-path calls are identified by
+        the "Error: " prefix, which the streaming text would never
+        legitimately contain."""
         out = []
         for call in mock_reply_safe.await_args_list:
             text = call.args[1] if len(call.args) > 1 else ""
-            if text.startswith("Error: ") or "BUDGET_CEILING" in text:
+            if text.startswith("Error: "):
                 out.append(call)
         return out
 
     @pytest.mark.asyncio
-    async def test_budget_error_sends_two_messages(self):
-        """Budget-exhaustion: error notice + recovery directive,
-        sent as two separate _reply_safe calls (in addition to the
-        streaming loop's live_msg-creation call)."""
-        update, _live_msg = self._make_update_with_live_msg()
-        ctx = self._make_context()
-        pool = self._make_pool_text_then_error("Reached maximum budget ($10)")
-
-        with (
-            patch("kai.bot.log_message"),
-            patch("kai.bot.sessions"),
-            patch("kai.bot._edit_message_safe", new_callable=AsyncMock),
-            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply_safe,
-        ):
-            await bot._handle_response(update, ctx, chat_id=12345, prompt="hi", pool=pool, model="sonnet")
-
-        # Filter to error-path calls so the streaming-loop's
-        # live_msg-creation call (which also goes through _reply_safe)
-        # does not pollute the count. Patching _reply_safe directly
-        # (rather than asserting on the inner reply_text) keeps this
-        # test stable against future _reply_safe internal changes.
-        error_calls = self._error_path_calls(mock_reply_safe)
-        assert len(error_calls) == 2
-        first_text = error_calls[0].args[1]
-        second_text = error_calls[1].args[1]
-        assert first_text == "Error: Reached maximum budget ($10)"
-        assert "$10" in second_text
-        assert "/new" in second_text
-        assert "BUDGET_CEILING" in second_text
-
-    @pytest.mark.asyncio
-    async def test_non_budget_error_sends_one_message(self):
-        """Generic errors (auth failures, transport errors, etc.)
-        get just the error notice; no directive. Structure leaves
-        room for additional error-class directives if recurring
-        patterns emerge."""
+    async def test_error_sends_exactly_one_message(self):
+        """An error produces exactly one error notice (in addition to
+        the streaming loop's live_msg-creation call); no extra
+        directive messages follow it."""
         update, _live_msg = self._make_update_with_live_msg()
         ctx = self._make_context()
         pool = self._make_pool_text_then_error("Authentication failed")
@@ -478,7 +371,7 @@ class TestErrorMessageLifecycle:
         debuggability."""
         update, _live_msg = self._make_update_with_live_msg()
         ctx = self._make_context()
-        pool = self._make_pool_text_then_error("Reached maximum budget ($10)")
+        pool = self._make_pool_text_then_error("API connection lost")
 
         captured_log: list[str] = []
 
@@ -500,6 +393,6 @@ class TestErrorMessageLifecycle:
         error_calls = self._error_path_calls(mock_reply_safe)
         assert len(error_calls) >= 1
         chat_error = error_calls[0].args[1]
-        assert "Reached maximum budget ($10)" in chat_error
+        assert "API connection lost" in chat_error
         # Synthetic history entry uses the same reason string.
-        assert any("Reached maximum budget ($10)" in t for t in captured_log)
+        assert any("API connection lost" in t for t in captured_log)

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -99,10 +99,8 @@ def _make_config(**overrides) -> BehavioralConfig:
     """
     base: dict = {
         "judge_model": "claude-haiku-4-5-20251001",
-        "judge_budget_usd": 0.05,
         "judge_timeout_s": 60,
         "gen_model": "sonnet",
-        "gen_budget_usd": 0.10,
         "gen_timeout_s": 120,
         "seed": "0123456789abcdef",
         "max_concurrency": 4,
@@ -140,7 +138,6 @@ def _make_outcome(*, probe: Probe, memory_outcome: str) -> ProbeOutcome:
         judge_reasoning="reason",
         memory_outcome=memory_outcome,
         latency_ms={"A": 1.0, "B": 1.0, "judge": 1.0},
-        cost_usd={"A": None, "B": None, "judge": 0.001},
     )
 
 
@@ -267,12 +264,11 @@ class TestJudgeOutputParsingValid:
     @pytest.mark.parametrize("choice", ["A_wins", "B_wins", "tie", "both_wrong"])
     def test_parse_valid_choices(self, choice: str):
         # Build the envelope shape that `claude --print --output-format
-        # json --json-schema ...` produces: outer dict with structured
-        # output nested, plus the cost field used by _extract_judge_cost.
+        # json --json-schema ...` produces: outer dict with the
+        # structured output nested.
         envelope = {
             "is_error": False,
             "structured_output": {"choice": choice, "reasoning": "test reasoning"},
-            "total_cost_usd": 0.001,
         }
         parsed = _parse_judge_stdout(json.dumps(envelope).encode("utf-8"))
         assert parsed is not None
@@ -316,7 +312,7 @@ class TestJudgeOutputParsingMalformed:
         assert _parse_judge_stdout(b'["a", "b"]') is None
 
     def test_is_error_true(self):
-        # CLI exits 0 with is_error=true on budget-cap mid-retry.
+        # CLI exits 0 with is_error=true on a mid-retry failure.
         # Treat as failure rather than partial-success-with-noise.
         env = {
             "is_error": True,
@@ -326,7 +322,7 @@ class TestJudgeOutputParsingMalformed:
 
     def test_missing_structured_output(self):
         # Top-level envelope present but the nested payload is missing.
-        env = {"total_cost_usd": 0.001}
+        env = {"is_error": False}
         assert _parse_judge_stdout(json.dumps(env).encode("utf-8")) is None
 
     def test_structured_output_not_dict(self):
@@ -471,9 +467,8 @@ class TestRollupOutcome:
 class TestSubprocessTimeout:
     """Generator subprocess timeout -> probe lands in generation_error.
 
-    Verifies the cost-saving short-circuit also fires: when both arms
-    fail, the judge call is skipped (no point spending money to score
-    nothing against nothing).
+    Verifies the short-circuit also fires: when both arms fail, the
+    judge call is skipped (no point scoring nothing against nothing).
     """
 
     def test_subprocess_timeout_buckets_as_generation_error(self):
@@ -515,7 +510,7 @@ class TestSubprocessTimeout:
 
         # Per-arm latencies are still recorded so the operator can see
         # which side timed out. Judge latency is zero because the call
-        # was short-circuited (cost discipline).
+        # was short-circuited.
         assert outcome.latency_ms["A"] == 50.0
         assert outcome.latency_ms["B"] == 50.0
         assert outcome.latency_ms["judge"] == 0.0
@@ -705,8 +700,8 @@ class TestGeneratorEmptySystemPrompt:
 
     def test_generator_uses_text_output_format(self):
         # Generator emits free-form text for the judge to read; locks
-        # the design choice that --output-format=text (no JSON envelope,
-        # which is why generator cost is None in the output JSON).
+        # the design choice that --output-format=text (no JSON
+        # envelope to unwrap).
         cmd = _build_gen_cmd(_make_config())
         assert "--output-format" in cmd
         assert cmd[cmd.index("--output-format") + 1] == "text"
@@ -846,10 +841,8 @@ class TestOutputWriteFailure:
         args.user_id = "user-1"
         args.output = bad_output
         args.judge_model = "claude-haiku-4-5-20251001"
-        args.judge_budget_usd = 0.05
         args.judge_timeout_s = 60
         args.gen_model = "sonnet"
-        args.gen_budget_usd = 0.10
         args.gen_timeout_s = 120
         args.seed = None
         args.max_concurrency = 1
@@ -870,7 +863,6 @@ class TestOutputWriteFailure:
                     judge_reasoning="",
                     memory_outcome="generation_error",
                     latency_ms={"A": 0.0, "B": 0.0, "judge": 0.0},
-                    cost_usd={"A": None, "B": None, "judge": None},
                 ),
             ]
 
@@ -927,10 +919,8 @@ class TestBackendAwareModelResolution:
         args.user_id = "user-1"
         args.output = None
         args.judge_model = judge_model
-        args.judge_budget_usd = 0.05
         args.judge_timeout_s = 60
         args.gen_model = gen_model
-        args.gen_budget_usd = 0.10
         args.gen_timeout_s = 120
         args.seed = None
         args.max_concurrency = 1
@@ -1483,7 +1473,6 @@ class TestBuildJudgeCmdCodex:
         assert "--system-prompt" not in cmd
         assert "--permission-mode" not in cmd
         assert "--tools" not in cmd
-        assert "--max-budget-usd" not in cmd
 
     def test_codex_bin_env_override(self, monkeypatch):
         monkeypatch.setenv("CODEX_BIN", "/tmp/fake-codex")
@@ -1509,7 +1498,6 @@ class TestBuildGenCmdCodex:
         assert cmd[i + 1] == "gpt-5.4-mini"
         assert "--system-prompt" not in cmd
         assert "--tools" not in cmd
-        assert "--max-budget-usd" not in cmd
 
     def test_codex_bin_env_override(self, monkeypatch):
         monkeypatch.setenv("CODEX_BIN", "/tmp/fake-codex")

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -459,7 +459,6 @@ class TestStreamParsing:
         assert events[2].response is not None
         assert events[2].response.success is True
         assert events[2].response.text == "Hello world"
-        assert events[2].response.cost_usd == 0.0
 
     @pytest.mark.asyncio
     async def test_thought_chunks_skipped(self):
@@ -552,7 +551,6 @@ class TestCompletion:
         assert final.response.success is True
         assert final.response.text == "answer"
         assert final.response.session_id == "test-session"
-        assert final.response.cost_usd == 0.0
         assert final.response.duration_ms == 0
 
     @pytest.mark.asyncio

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -54,7 +54,6 @@ from kai.install import (
     _validate_display_name,
     _validate_os_user,
     _validate_port,
-    _validate_positive_float,
     _validate_positive_int,
     _validate_telegram_id,
     _validate_user_ids,
@@ -169,20 +168,6 @@ class TestValidatePort:
 
     def test_port_non_numeric(self):
         assert _validate_port("abc") is False
-
-
-class TestValidatePositiveFloat:
-    def test_valid(self):
-        assert _validate_positive_float("10.0") is True
-
-    def test_zero(self):
-        assert _validate_positive_float("0") is False
-
-    def test_negative(self):
-        assert _validate_positive_float("-1.5") is False
-
-    def test_non_numeric(self):
-        assert _validate_positive_float("abc") is False
 
 
 class TestValidatePositiveInt:
@@ -1138,7 +1123,6 @@ class TestCmdConfig:
                 "120",  # timeout
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
-                "10.0",  # budget
                 "80",  # autocompact pct
                 "",  # claude effort level (take default "high")
                 "8080",  # port
@@ -1148,7 +1132,6 @@ class TestCmdConfig:
                 "false",  # pr review enabled
                 "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout (seconds)
-                "1.0",  # pr review budget (USD)
                 "false",  # issue triage enabled
                 "",  # github notify chat id (empty)
                 "false",  # voice
@@ -1219,7 +1202,6 @@ class TestCmdConfig:
                 "120",  # timeout
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
-                "10.0",  # budget
                 "80",  # autocompact pct
                 "",  # claude effort level (take default "high")
                 "8080",  # port
@@ -1229,7 +1211,6 @@ class TestCmdConfig:
                 "false",  # pr review enabled
                 "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout (seconds)
-                "1.0",  # pr review budget (USD)
                 "false",  # issue triage enabled
                 "",  # github notify chat id (empty)
                 "false",  # voice
@@ -1303,7 +1284,6 @@ class TestCmdConfig:
                 "120",  # timeout
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
-                "10.0",  # budget
                 "80",  # autocompact pct
                 "",  # claude effort level (take default "high")
                 "8080",  # port
@@ -1313,7 +1293,6 @@ class TestCmdConfig:
                 "false",  # pr review enabled
                 "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout
-                "1.0",  # pr review budget
                 "false",  # issue triage enabled
                 "",  # github notify chat id
                 "false",  # voice
@@ -1437,7 +1416,6 @@ class TestCmdConfig:
                 "120",  # timeout
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
-                "10.0",  # budget
                 "8080",  # port
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
@@ -1445,7 +1423,6 @@ class TestCmdConfig:
                 "false",  # pr review enabled
                 "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout (seconds)
-                "1.0",  # pr review budget (USD)
                 "false",  # issue triage enabled
                 "",  # github notify chat id (empty)
                 "false",  # voice
@@ -1495,7 +1472,6 @@ class TestCmdConfig:
                 "120",  # timeout
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
-                "10.0",  # budget
                 "8080",  # port
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
@@ -1503,7 +1479,6 @@ class TestCmdConfig:
                 "false",  # pr review enabled
                 "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout (seconds)
-                "1.0",  # pr review budget (USD)
                 "false",  # issue triage enabled
                 "",  # github notify chat id (empty)
                 "false",  # voice
@@ -1642,20 +1617,6 @@ class TestCmdConfig:
                 effort,  # claude effort level ("" = default "high")
             ]
 
-        # BUDGET_CEILING and PR_REVIEW_BUDGET_USD prompts are skipped
-        # on the claude backend (issue #390): --max-budget-usd is no
-        # longer emitted to claude --print argv, so prompting for a
-        # value that is never enforced would be wizard noise. The
-        # fixture entries are conditional to match the wizard's
-        # runtime conditional. Same shape as claude_only_pre_webhook
-        # immediately above; the inverted conditional reflects that
-        # these prompts now fire ONLY on non-claude backends.
-        budget_entry: list[str] = []
-        pr_review_budget_entry: list[str] = []
-        if agent_backend != "claude":
-            budget_entry = ["10.0"]  # BUDGET_CEILING
-            pr_review_budget_entry = ["1.0"]  # PR_REVIEW_BUDGET_USD
-
         return [
             "protected",  # deployment mode
             "/opt/kai",  # install dir
@@ -1674,7 +1635,6 @@ class TestCmdConfig:
             "120",  # timeout
             "0",  # max session age hours (0 = no limit)
             "1800",  # idle eviction timeout seconds
-            *budget_entry,  # BUDGET_CEILING (non-claude only)
             *claude_only_pre_webhook,  # autocompact + effort (claude only)
             "8080",  # port
             "test-secret",  # webhook secret
@@ -1682,7 +1642,6 @@ class TestCmdConfig:
             "",  # allowed workspaces
             "300",  # pr review cooldown (global resource control)
             "900",  # pr review timeout
-            *pr_review_budget_entry,  # PR_REVIEW_BUDGET_USD (non-claude only)
             "false",  # voice
             "false",  # tts
             *memory_block,
@@ -1845,12 +1804,8 @@ class TestCmdConfig:
         self._redirect_staging(monkeypatch, tmp_path)
 
         # Memory on, extraction on, custom timeout + consolidation candidates + episode tunables + token budget + search limit.
-        # Budget prompts (extraction, episode) are skipped on the claude
-        # backend per issue #390 - --max-budget-usd is no longer emitted
-        # to claude --print argv at either stage, so the wizard does not
-        # ask for a value that would never be enforced. The memory
-        # reasoner backend and episode model prompts were retired in
-        # issue #515 (per-user dispatch via agent_backend).
+        # The memory reasoner backend and episode model prompts were
+        # retired in issue #515 (per-user dispatch via agent_backend).
         memory_block = [
             "true",  # memory enabled
             "true",  # extraction enabled (claude backend)
@@ -1876,8 +1831,7 @@ class TestCmdConfig:
         assert "MEMORY_REASONER_BACKEND" not in env
         assert "MEMORY_EXTRACTION_MODEL" not in env
         assert "MEMORY_EPISODE_MODEL" not in env
-        # Budget keys absent on claude backend: prompt is skipped, value
-        # stays at dataclass default, double-gated emission suppresses.
+        # Retired budget keys are never written.
         assert "MEMORY_EXTRACTION_BUDGET_USD" not in env
         assert env["MEMORY_EXTRACTION_TIMEOUT_S"] == "60"
         assert env["MEMORY_CONSOLIDATION_CANDIDATES_N"] == "5"
@@ -1928,7 +1882,8 @@ class TestCmdConfig:
         assert "MEMORY_REASONER_BACKEND" not in env
         assert "MEMORY_EXTRACTION_MODEL" not in env
         assert "MEMORY_EPISODE_MODEL" not in env
-        # Budget and timeout match dataclass defaults → no emission.
+        # Retired budget keys are never written; timeout matches the
+        # dataclass default → no emission.
         assert "MEMORY_EPISODE_BUDGET_USD" not in env
         assert "MEMORY_EPISODE_TIMEOUT_S" not in env
         # Stage-1 keys also suppressed because their inputs match
@@ -1948,9 +1903,8 @@ class TestCmdConfig:
         self._redirect_staging(monkeypatch, tmp_path)
 
         # Inputs in wizard order: enabled, ext enabled, timeout, consolidation, classifier-window, episode timeout, dedup threshold, token budget, search limit.
-        # Budget prompts (extraction, episode) are skipped on the claude
-        # backend per issue #390. The memory reasoner backend and
-        # episode model prompts were retired in issue #515.
+        # The memory reasoner backend and episode model prompts were
+        # retired in issue #515.
         memory_block = [
             "true",
             "true",
@@ -1971,9 +1925,9 @@ class TestCmdConfig:
         rendered = _generate_env_file(conf["env"])
         assert 'MEMORY_ENABLED="true"' in rendered
         assert 'MEMORY_EXTRACTION_ENABLED="true"' in rendered
-        # Budget keys never reach the env file on claude (prompt skipped,
-        # double-gated emission suppresses) - asserted absent here as the
-        # round-trip equivalent of test_memory_enabled_writes_tunables.
+        # Retired budget keys never reach the env file - asserted
+        # absent here as the round-trip equivalent of
+        # test_memory_enabled_writes_tunables.
         assert "MEMORY_EXTRACTION_BUDGET_USD" not in rendered
         assert 'MEMORY_EXTRACTION_TIMEOUT_S="45"' in rendered
         assert 'MEMORY_CONSOLIDATION_CANDIDATES_N="4"' in rendered
@@ -1986,8 +1940,8 @@ class TestCmdConfig:
         assert "MEMORY_EXTRACTION_MODEL" not in rendered
         assert "MEMORY_EPISODE_MODEL" not in rendered
         # Episode tunables: non-default timeout survives. Round-trip
-        # parity with the extraction tunables above. Budget is
-        # suppressed on claude for the same reason.
+        # parity with the extraction tunables above; the retired
+        # budget key stays absent.
         assert "MEMORY_EPISODE_BUDGET_USD" not in rendered
         assert 'MEMORY_EPISODE_TIMEOUT_S="90"' in rendered
         assert 'MEMORY_TOKEN_BUDGET="2500"' in rendered
@@ -2036,13 +1990,9 @@ class TestCmdConfig:
         env = conf["env"]
         assert env["MEMORY_ENABLED"] == "true"
         assert env["MEMORY_EXTRACTION_ENABLED"] == "true"
-        # Budget key dropped on claude backend per issue #390: prompt
-        # is skipped, the pre-init "0.01" stays untouched (existing env
-        # is no longer consulted for this key on claude), and the
-        # double-gated emission suppresses. A previously-set value on
-        # an upgrade path is intentionally cleared - the field is
-        # informational only on claude, so a stale operator value does
-        # not need to round-trip.
+        # The retired budget key is dropped on regenerate: a
+        # previously-set value on an upgrade path is intentionally
+        # cleared rather than round-tripped.
         assert "MEMORY_EXTRACTION_BUDGET_USD" not in env
         assert env["MEMORY_EXTRACTION_TIMEOUT_S"] == "75"
         assert env["MEMORY_TOKEN_BUDGET"] == "4000"
@@ -2123,14 +2073,12 @@ class TestCmdConfig:
                 "120",  # timeout
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
-                "10.0",  # budget
                 "8080",  # port
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces
                 "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout
-                "1.0",  # pr review budget
                 "false",  # voice
                 "false",  # tts
                 "true",  # memory enabled (extraction + timeout prompts skipped: non-claude)
@@ -2153,13 +2101,11 @@ class TestCmdConfig:
         """Extraction off must skip the timeout, consolidation, classifier-window, AND episode prompts; search limit still asked.
 
         Regression guard for the off-by-one trap: timeout, consolidation,
-        the new episode-classifier context window (#392), and the entire
+        the episode-classifier context window (#392), and the entire
         episode block sit inside the extraction-enabled branch, so
         disabling extraction must consume strictly fewer prompts than
-        enabling it. (Issue #390 removed the extraction budget and
-        episode budget prompts; #392 adds the classifier window prompt;
-        the extraction-enabled branch now drives only timeout,
-        consolidation, classifier-window, episode model, and episode
+        enabling it. (The extraction-enabled branch drives only
+        timeout, consolidation, classifier-window, and episode
         timeout.) If the gating drifts on any of these prompts - notably
         if a future edit accidentally hoists the classifier-window
         prompt out of the extraction-enabled branch - the input iterator
@@ -2476,7 +2422,6 @@ class TestCmdConfig:
                 "120",  # agent timeout
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
-                "10.0",  # budget (codex != claude branch)
                 # autocompact + effort skipped on non-claude backend
                 "8080",  # webhook port
                 "test-secret",  # webhook secret
@@ -2484,7 +2429,6 @@ class TestCmdConfig:
                 "",  # allowed workspaces
                 "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout
-                "1.0",  # pr review budget (non-claude branch)
                 "false",  # voice
                 "false",  # tts
                 "true",  # memory enabled
@@ -2884,7 +2828,6 @@ class TestCmdConfigDefaultModelDispatch:
             "120",  # agent timeout (global default)
             "0",  # max session age hours (0 = no limit)
             "1800",  # idle eviction timeout seconds
-            "10.0",  # BUDGET_CEILING (non-claude only)
             # No autocompact_pct / effort_level prompts (claude-only)
             "8080",  # webhook port
             "test-secret",  # webhook secret
@@ -2892,7 +2835,6 @@ class TestCmdConfigDefaultModelDispatch:
             "",  # allowed workspaces (global default, empty)
             "300",  # pr review cooldown (global resource control)
             "900",  # pr review subprocess timeout
-            "1.0",  # pr review subprocess budget (non-claude only)
             "false",  # voice
             "false",  # tts
             memory_enabled,  # memory enabled
@@ -2918,7 +2860,6 @@ class TestCmdConfigDefaultModelDispatch:
             "120",  # agent timeout (global default)
             "0",  # max session age hours (0 = no limit)
             "1800",  # idle eviction timeout seconds
-            "10.0",  # BUDGET_CEILING (non-claude only)
             # autocompact_pct / effort_level prompts are claude-only (gated)
             "8080",  # webhook port
             "test-secret",  # webhook secret
@@ -2926,7 +2867,6 @@ class TestCmdConfigDefaultModelDispatch:
             "",  # allowed workspaces (global default, empty)
             "300",  # pr review cooldown (global resource control)
             "900",  # pr review subprocess timeout
-            "1.0",  # pr review subprocess budget (non-claude only)
             "false",  # voice
             "false",  # tts
             "false",  # memory enabled
@@ -6201,9 +6141,9 @@ class TestStripInstallConfKeys:
 
 class TestCmdConfigGlobalDefaultsRegardlessOfUsersYaml:
     """Pins the contract that installation-wide defaults (DEFAULT_MODEL,
-    AGENT_TIMEOUT_SECONDS, BUDGET_CEILING on non-claude,
-    WORKSPACE_BASE, PR_REVIEW_COOLDOWN) prompt on every wizard run and
-    land in install.conf's env regardless of users.yaml presence.
+    AGENT_TIMEOUT_SECONDS, WORKSPACE_BASE, PR_REVIEW_COOLDOWN) prompt
+    on every wizard run and land in install.conf's env regardless of
+    users.yaml presence.
 
     The pre-fix wizard gated those prompts on `not users_yaml_exists`
     so a re-run on an existing install silently kept stale globals - the
@@ -6352,26 +6292,6 @@ class TestCmdConfigGlobalDefaultsRegardlessOfUsersYaml:
 
         env = json.loads((tmp_path / "install.conf").read_text())["env"]
         assert env["ALLOWED_WORKSPACES"] == f"{ws_a},{ws_b}"
-
-    def test_budget_ceiling_lands_with_users_yaml_on_non_claude(self, tmp_path, monkeypatch):
-        """BUDGET_CEILING reaches env on non-claude backends when
-        users.yaml exists. Claude-branch budget suppression is unchanged.
-        """
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
-        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
-        self._existing_etc_users(monkeypatch)
-
-        inputs = iter(TestCmdConfigDefaultModelDispatch._inputs_for_goose_openai())
-        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
-        monkeypatch.setattr(
-            "kai.install._prompt_default_model",
-            lambda backend, prov, default: "gpt-5.4",
-        )
-        _cmd_config()
-
-        env = json.loads((tmp_path / "install.conf").read_text())["env"]
-        assert env["BUDGET_CEILING"] == "10.0"
 
 
 # ── _cmd_config: users.yaml canonicalization ─────────────────────────
@@ -7699,14 +7619,12 @@ class TestOpenCodeBinWizardPrompt:
             "120",  # agent timeout
             "0",  # max session age hours (0 = no limit)
             "1800",  # idle eviction timeout seconds
-            "10.0",  # budget (non-claude branch)
             "8080",  # webhook port
             "test-secret",  # webhook secret
             "",  # workspace base
             "",  # allowed workspaces
             "300",  # pr review cooldown (global resource control)
             "900",  # pr review timeout
-            "1.0",  # pr review budget (non-claude branch)
             "false",  # voice
             "false",  # tts
             "true",  # memory enabled

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -62,10 +62,8 @@ def _cfg(**overrides) -> Config:
     defaults = {
         "memory_enabled": True,
         "memory_extraction_enabled": True,
-        "memory_extraction_budget_usd": 0.05,
         "memory_extraction_timeout_s": 60,
         "memory_consolidation_candidates_n": 0,
-        "memory_episode_budget_usd": 0.15,
         "memory_episode_timeout_s": 120,
     }
     defaults.update(overrides)
@@ -119,15 +117,12 @@ def _valid_episode() -> dict:
     }
 
 
-def _stage2_envelope(episode: dict | None = None, *, cost_usd: float = 0.04) -> bytes:
+def _stage2_envelope(episode: dict | None = None) -> bytes:
     """Build a stage-2 CLI envelope JSON. Same nesting convention as
-    stage 1: `episode` field under `structured_output`. `cost_usd` is
-    surfaced because the stage-2 telemetry path captures it from the
-    envelope; tests that assert log payload depend on it."""
+    stage 1: `episode` field under `structured_output`."""
     return json.dumps(
         {
             "is_error": False,
-            "total_cost_usd": cost_usd,
             "structured_output": {
                 "episode": episode or _valid_episode(),
             },
@@ -283,13 +278,13 @@ def _timeout_proc() -> MagicMock:
 
 def _is_error_envelope() -> bytes:
     """Stage-1 envelope with envelope-level is_error=true. The CLI
-    emits this when a retry loop burned the budget but the JSON still
-    parsed cleanly; stage 1 must treat it as failure even though the
+    can emit this on a mid-retry failure where the JSON still parsed
+    cleanly; stage 1 must treat it as failure even though the
     structured payload is technically present."""
     return json.dumps(
         {
             "is_error": True,
-            "subtype": "error_max_budget_usd",
+            "subtype": "error_during_execution",
             "structured_output": {"facts": [], "has_episode": True},
         }
     ).encode("utf-8")
@@ -527,10 +522,7 @@ class TestStage2Isolation:
         payload = json.loads(episode_records[0].message[len("memory.episode ") :])
         assert payload["outcome"] == "timeout"
         assert payload["reason"] == "timeout"
-        # cost_usd is 0.0 on timeout (the envelope never returned).
-        assert payload["cost_usd"] == 0.0
-        # duration_ms always present for budget-tracking parity with
-        # stage 1's _emit_intent_log.
+        # duration_ms is always present, even on the timeout path.
         assert payload["duration_ms"] >= 0
 
     @pytest.mark.asyncio
@@ -556,7 +548,7 @@ class TestStage2Isolation:
 
         # Stub the subprocess so the in-acquire body runs near-instantly.
         async def _fake_exec(*args, **kwargs):
-            return _make_proc(stdout=_stage2_envelope(_valid_episode(), cost_usd=0.01))
+            return _make_proc(stdout=_stage2_envelope(_valid_episode()))
 
         monkeypatch.setattr(memory_extraction.asyncio, "create_subprocess_exec", _fake_exec)
         monkeypatch.setattr(memory_extraction.memory, "add_structured", lambda *a, **kw: "fake-id")
@@ -590,18 +582,18 @@ class TestStage2Isolation:
 
     @pytest.mark.asyncio
     async def test_stage2_is_error_envelope_maps_to_subprocess_error(self, monkeypatch, caplog):
-        """Budget exhaustion (and any other CLI is_error condition) must
-        map to outcome=subprocess_error, NOT parse_error. Pre-fix this
-        was silently mislabeled because the only branches checking
+        """Any CLI is_error condition must map to
+        outcome=subprocess_error, NOT parse_error. Pre-fix this was
+        silently mislabeled because the only branches checking
         run_reason were `timeout`, `exit_*`, and `invalid_json`; an
         is_error envelope fell through to the else and got tagged as a
-        content fault. Operators triaging by outcome would otherwise see
-        budget burns mixed with genuine JSON-parse failures."""
+        content fault. Operators triaging by outcome would otherwise
+        see CLI-signaled failures mixed with genuine JSON-parse
+        failures."""
         is_error_envelope = json.dumps(
             {
                 "is_error": True,
-                "subtype": "error_max_budget_usd",
-                "total_cost_usd": 0.15,
+                "subtype": "error_during_execution",
                 "structured_output": {"episode": _valid_episode()},
             }
         ).encode("utf-8")
@@ -627,14 +619,9 @@ class TestStage2Isolation:
         payload = json.loads(records[0].message[len("memory.episode ") :])
         assert payload["outcome"] == "subprocess_error"
         # The subtype detail survives in the reason field so operators
-        # can distinguish budget burns from auth failures.
+        # can distinguish failure classes.
         assert payload["reason"] is not None
-        assert "error_max_budget_usd" in payload["reason"]
-        # Cost_usd is captured from the envelope even on the error path
-        # so budget tracking still sees the burn. Value matches the
-        # Sonnet-sized 0.15 dataclass default to make the budget-burn
-        # scenario read as realistic for the recommended model.
-        assert payload["cost_usd"] == 0.15
+        assert "error_during_execution" in payload["reason"]
 
     @pytest.mark.asyncio
     async def test_stage2_unexpected_exception_caught(self, monkeypatch, caplog):
@@ -674,7 +661,7 @@ class TestStage2Storage:
     """Stage-2 success path: a valid episode JSON lands in Mem0 with
     the full Sophia field set in metadata, the embedded content is
     goal+context, lessons is omitted when not produced, and the
-    success log carries cost+duration for budget tracking."""
+    success log carries the call duration."""
 
     @pytest.mark.asyncio
     async def test_episode_stored_with_full_sophia_fields(self, monkeypatch):
@@ -694,7 +681,7 @@ class TestStage2Storage:
         monkeypatch.setattr(memory_extraction.memory, "add_structured", _fake_add)
 
         async def _fake_exec(*args, **kwargs):
-            return _make_proc(stdout=_stage2_envelope(_valid_episode(), cost_usd=0.04))
+            return _make_proc(stdout=_stage2_envelope(_valid_episode()))
 
         monkeypatch.setattr(memory_extraction.asyncio, "create_subprocess_exec", _fake_exec)
 
@@ -816,16 +803,14 @@ class TestStage2Storage:
         assert captured["content"] == f"{ep['goal']}\n\n{ep['context']}"
 
     @pytest.mark.asyncio
-    async def test_episode_log_includes_cost_and_duration(self, monkeypatch, caplog):
-        """The success log carries cost_usd (from the CLI envelope) and
-        duration_ms (end-to-end). Without these, operators cannot do
-        budget tracking on stage-2 calls. Asserted at the JSON-payload
-        level so a future log-format change still surfaces a missing
-        field as a test failure."""
+    async def test_episode_log_includes_duration(self, monkeypatch, caplog):
+        """The success log carries duration_ms (end-to-end). Asserted
+        at the JSON-payload level so a future log-format change still
+        surfaces a missing field as a test failure."""
         monkeypatch.setattr(memory_extraction.memory, "add_structured", lambda *a, **kw: "fake-id")
 
         async def _fake_exec(*args, **kwargs):
-            return _make_proc(stdout=_stage2_envelope(_valid_episode(), cost_usd=0.039))
+            return _make_proc(stdout=_stage2_envelope(_valid_episode()))
 
         monkeypatch.setattr(memory_extraction.asyncio, "create_subprocess_exec", _fake_exec)
 
@@ -845,7 +830,6 @@ class TestStage2Storage:
         payload = json.loads(records[0].message[len("memory.episode ") :])
         assert payload["outcome"] == "stored"
         assert payload["memory_id"] == "fake-id"
-        assert payload["cost_usd"] == 0.039
         assert payload["duration_ms"] >= 0
         # `memory_id` and `reason` are presence-symmetric: each is
         # included only when it carries information. Success has a
@@ -894,7 +878,7 @@ class TestStage2Storage:
 
 class TestStage2SubprocessAssembly:
     """The stage-2 subprocess flag set is identical to stage 1 except
-    for model, budget, timeout, schema, and system prompt. Asserted
+    for model, timeout, schema, and system prompt. Asserted
     here so a future change that diverges the security-sensitive flags
     (--tools, --permission-mode, --no-session-persistence) shows up as
     a test failure - those flags are the security review of the
@@ -902,9 +886,9 @@ class TestStage2SubprocessAssembly:
 
     @pytest.mark.asyncio
     async def test_stage2_command_uses_episode_config(self, monkeypatch):
-        """Budget, timeout, system prompt, and JSON schema all come
-        from the episode-specific config fields, not the stage-1 ones.
-        The model now resolves through `get_model_for(MEMORY_EPISODE,
+        """Timeout, system prompt, and JSON schema all come from the
+        episode-specific config fields, not the stage-1 ones. The
+        model resolves through `get_model_for(MEMORY_EPISODE,
         effective_backend)` (issue #515 retired the per-stage env vars),
         so the assertion pins the registry-resolved value rather than a
         config-field override."""
@@ -918,7 +902,7 @@ class TestStage2SubprocessAssembly:
         monkeypatch.setattr(memory_extraction.asyncio, "create_subprocess_exec", _fake_exec)
         await _run_episode_extractor(
             "payload",
-            _cfg(memory_episode_budget_usd=0.15),
+            _cfg(),
             user_id="test-episode-user",
             effective_backend="claude",
             effective_provider="anthropic",
@@ -928,11 +912,6 @@ class TestStage2SubprocessAssembly:
         # Registry MEMORY_EPISODE row for claude is the Haiku SKU; same
         # value the retired `memory_episode_model` default pointed at.
         assert args[args.index("--model") + 1] == "claude-haiku-4-5-20251001"
-        # --max-budget-usd is NOT emitted on the claude backend (issue
-        # #390): Max-plan OAuth makes the CLI's computed-cost ceiling a
-        # phantom signal. Runaway protection comes from
-        # memory_episode_timeout_s instead.
-        assert "--max-budget-usd" not in args
         assert args[args.index("--system-prompt") + 1] == _EPISODE_SYSTEM_PROMPT
         # Schema arg is the episode schema, not the fact schema.
         schema_str = args[args.index("--json-schema") + 1]
@@ -1156,19 +1135,18 @@ def test_module_exposes_extraction_result():
 
 
 class TestRunEpisodeExtractorViaReasoner:
-    """`_run_episode_extractor` now routes through the OneShotReasoner
+    """`_run_episode_extractor` routes through the OneShotReasoner
     boundary. These tests monkeypatch the reasoner helper so the
     caller-side mapping from typed reasoner exceptions to the stage-2
-    `(episode, cost_usd, reason)` triple is exercised directly."""
+    `(episode, reason)` pair is exercised directly."""
 
     @pytest.mark.asyncio
-    async def test_valid_envelope_returns_episode_triple(self):
+    async def test_valid_envelope_returns_episode_pair(self):
         """A reasoner returning a well-formed Claude envelope produces
-        the same `(episode, cost_usd, None)` triple the subprocess
-        path produces today."""
+        the `(episode, None)` success pair."""
         from kai.oneshot import OneShotResult
 
-        envelope_text = _stage2_envelope(_valid_episode(), cost_usd=0.04).decode("utf-8")
+        envelope_text = _stage2_envelope(_valid_episode()).decode("utf-8")
 
         class _FakeReasoner:
             async def run(self, **kwargs):
@@ -1181,7 +1159,7 @@ class TestRunEpisodeExtractorViaReasoner:
                 )
 
         with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FakeReasoner()):
-            episode, cost_usd, reason = await _run_episode_extractor(
+            episode, reason = await _run_episode_extractor(
                 "payload",
                 _cfg(),
                 user_id="test-episode-user",
@@ -1190,14 +1168,12 @@ class TestRunEpisodeExtractorViaReasoner:
             )
 
         assert episode == _valid_episode()
-        assert cost_usd == pytest.approx(0.04)
         assert reason is None
 
     @pytest.mark.asyncio
     async def test_timeout_maps_to_literal_timeout_reason(self):
-        """OneShotTimeout maps to the literal `"timeout"` reason string
-        with `cost_usd=0.0` (no envelope ever returned). Downstream
-        telemetry pins this exact string."""
+        """OneShotTimeout maps to the literal `"timeout"` reason
+        string. Downstream telemetry pins this exact string."""
         from kai.oneshot import OneShotTimeout
 
         class _TimingOutReasoner:
@@ -1205,7 +1181,7 @@ class TestRunEpisodeExtractorViaReasoner:
                 raise OneShotTimeout()
 
         with patch("kai.memory_extraction._build_memory_reasoner", return_value=_TimingOutReasoner()):
-            episode, cost_usd, reason = await _run_episode_extractor(
+            episode, reason = await _run_episode_extractor(
                 "payload",
                 _cfg(),
                 user_id="test-episode-user",
@@ -1214,7 +1190,6 @@ class TestRunEpisodeExtractorViaReasoner:
             )
 
         assert episode is None
-        assert cost_usd == 0.0
         assert reason == "timeout"
 
     @pytest.mark.asyncio
@@ -1230,7 +1205,7 @@ class TestRunEpisodeExtractorViaReasoner:
                 raise OneShotSubprocessError(returncode=2, stderr=b"oauth refused: please login")
 
         with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FailingReasoner()):
-            episode, cost_usd, reason = await _run_episode_extractor(
+            episode, reason = await _run_episode_extractor(
                 "payload",
                 _cfg(),
                 user_id="test-episode-user",
@@ -1239,7 +1214,6 @@ class TestRunEpisodeExtractorViaReasoner:
             )
 
         assert episode is None
-        assert cost_usd == 0.0
         assert reason is not None
         assert reason.startswith("exit_2: ")
         assert "oauth refused" in reason
@@ -1253,14 +1227,11 @@ class TestRunEpisodeExtractorWithCodexEnvelope:
     re-introduce a backend branch in the episode extractor."""
 
     @pytest.mark.asyncio
-    async def test_codex_envelope_produces_episode_triple(self):
+    async def test_codex_envelope_produces_episode_pair(self):
         from kai.oneshot import OneShotResult
 
         episode = _valid_episode()
-        # CodexOneShotReasoner emits exactly this envelope shape (no
-        # total_cost_usd field; codex subscription auth has no
-        # per-call billing surface). The stage-2 cost coercion to 0.0
-        # is the documented behavior for non-claude backends.
+        # CodexOneShotReasoner emits exactly this envelope shape.
         envelope_text = '{"is_error": false, "structured_output": {"episode": ' + json.dumps(episode) + "}}"
 
         class _FakeCodexReasoner:
@@ -1275,13 +1246,9 @@ class TestRunEpisodeExtractorWithCodexEnvelope:
 
         config = _cfg()
         with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FakeCodexReasoner()):
-            ep, cost_usd, reason = await _run_episode_extractor(
+            ep, reason = await _run_episode_extractor(
                 "payload", config, user_id="test-episode-user", effective_backend="codex", effective_provider="openai"
             )
 
         assert ep == episode
-        # No total_cost_usd in the envelope -> 0.0. Codex runs
-        # subscription-backed in the supported deployment model, so
-        # the cost field is informational and reads as zero.
-        assert cost_usd == 0.0
         assert reason is None

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -91,7 +91,6 @@ def _cfg(**overrides) -> Config:
     defaults = {
         "memory_enabled": True,
         "memory_extraction_enabled": True,
-        "memory_extraction_budget_usd": 0.01,
         "memory_extraction_timeout_s": 10,
         "memory_consolidation_candidates_n": 0,
     }
@@ -773,7 +772,7 @@ class TestSubprocessCommandAssembly:
             "hi",
             "hello",
             user_id="u1",
-            config=_cfg(memory_extraction_budget_usd=0.05, memory_extraction_timeout_s=7),
+            config=_cfg(memory_extraction_timeout_s=7),
         )
 
         args = captured["args"]
@@ -785,14 +784,6 @@ class TestSubprocessCommandAssembly:
         # values immediately following them.
         assert args[args.index("--model") + 1] == "claude-haiku-4-5-20251001"
         assert args[args.index("--output-format") + 1] == "json"
-        # --max-budget-usd is NOT emitted on the claude backend (issue
-        # #390): Max-plan OAuth makes the CLI's computed-cost ceiling a
-        # phantom signal. Runaway protection comes from
-        # memory_extraction_timeout_s instead. Pinned as an absence
-        # assertion so a future regression that re-adds the flag fails
-        # here rather than silently re-introducing phantom-cost
-        # subprocess termination.
-        assert "--max-budget-usd" not in args
         # Schema arg must be a JSON string that round-trips. Both root
         # required fields are present: `facts` (the original extractor
         # output) and `has_episode` (the stage-2 classifier; issue
@@ -1087,13 +1078,13 @@ class TestExtractAndStoreOutcomes:
 
     @pytest.mark.asyncio
     async def test_is_error_envelope_returns_zero(self, monkeypatch):
-        """Exit 0 with is_error=true (e.g. budget ceiling trip mid-retry)
+        """Exit 0 with is_error=true (e.g. an auth failure mid-retry)
         must be treated as extraction failure, not silent success."""
         envelope = {
             "type": "result",
-            "subtype": "error_max_budget_usd",
+            "subtype": "error_during_execution",
             "is_error": True,
-            "errors": ["Reached maximum budget ($0.01)"],
+            "errors": ["Authentication failed"],
             "structured_output": {"facts": [{"content": "x", "tags": ["fact"]}]},
         }
 
@@ -3171,7 +3162,7 @@ class TestValidateEpisodeWorkflowRegex:
             "Run a 10-probe eval to determine whether removing assistant-derived facts helps",
             "Determine which iterate-epic candidate should land first",
             "Correct two design mistakes in the memory feature plan",
-            "Establish that budget framing has no place in the claude backend",
+            "Establish that per-user model routing has no place in the recall path",
         ]
         for goal in negatives:
             payload = {"goal": goal}
@@ -3237,7 +3228,7 @@ class TestValidateEpisodeIntegration:
         }
 
         async def _fake_runner(payload, config, **kwargs):
-            return episode_payload, 0.001, None
+            return episode_payload, None
 
         captured: dict = {}
 
@@ -3293,7 +3284,7 @@ class TestValidateEpisodeIntegration:
         }
 
         async def _fake_runner(payload, config, **kwargs):
-            return episode_payload, 0.001, None
+            return episode_payload, None
 
         captured: dict = {}
 
@@ -3352,7 +3343,7 @@ class TestValidateEpisodeIntegration:
         }
 
         async def _fake_runner(payload, config, **kwargs):
-            return episode_payload, 0.001, None
+            return episode_payload, None
 
         captured_metadata: dict = {}
 

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -124,7 +124,7 @@ def _make_proc(
 class TestClaudeOneShotReasonerArgv:
     """The Claude reasoner's argv must match the pre-refactor memory
     extraction shape: claude --print, schema flag when provided,
-    sandboxing flags, no --bare, no --max-budget-usd."""
+    sandboxing flags, no --bare."""
 
     @pytest.mark.asyncio
     async def test_argv_shape_with_schema_and_system_prompt(self, tmp_path):
@@ -170,20 +170,6 @@ class TestClaudeOneShotReasonerArgv:
 
         cmd = mock_exec.call_args[0]
         assert "--bare" not in cmd
-
-    @pytest.mark.asyncio
-    async def test_argv_omits_max_budget_usd_flag(self, tmp_path):
-        """Max-plan OAuth makes --max-budget-usd a phantom signal; runaway
-        protection is the wait_for timeout. The reasoner must not emit
-        the flag regardless of how a future config knob looks."""
-        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
-        proc = _make_proc()
-
-        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
-            await reasoner.run(prompt="p", purpose="fact_extraction")
-
-        cmd = mock_exec.call_args[0]
-        assert "--max-budget-usd" not in cmd
 
     @pytest.mark.asyncio
     async def test_payload_sent_on_stdin_not_argv(self, tmp_path):

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -44,7 +44,6 @@ def _make_config(**overrides) -> Config:
         "allowed_user_ids": {111, 222},
         "default_model": "sonnet",
         "claude_timeout_seconds": 30,
-        "budget_ceiling": 1.0,
         "claude_max_session_hours": 0,
         "claude_idle_timeout": 1800,
         "webhook_port": 8080,
@@ -110,7 +109,7 @@ class TestInstanceCreation:
         assert (tmp_path / "home" / "999").is_dir()
 
     def test_create_uses_user_config_settings(self, tmp_path):
-        """User with model/timeout/budget in users.yaml gets those values."""
+        """User with model/timeout in users.yaml gets those values."""
         ws = tmp_path / "ws"
         ws.mkdir()
         user = UserConfig(
@@ -118,14 +117,12 @@ class TestInstanceCreation:
             name="alice",
             home_workspace=ws,
             model="opus",
-            max_budget=25.0,
             timeout=300,
         )
         config = _make_config(user_configs={111: user})
         pool = SubprocessPool(config=config, services_info=[])
         instance = pool.get(111)
         assert instance.model == "opus"
-        assert instance.max_budget_usd == 25.0
         assert instance.timeout_seconds == 300
 
     def test_create_falls_back_to_global_for_missing_user_fields(self):
@@ -134,13 +131,11 @@ class TestInstanceCreation:
         config = _make_config(
             user_configs={111: user},
             default_model="haiku",
-            budget_ceiling=5.0,
             claude_timeout_seconds=60,
         )
         pool = SubprocessPool(config=config, services_info=[])
         instance = pool.get(111)
         assert instance.model == "haiku"
-        assert instance.max_budget_usd == 5.0
         assert instance.timeout_seconds == 60
 
 
@@ -412,7 +407,6 @@ class TestPropertyAccessors:
             new_callable=AsyncMock,
             return_value={
                 "model": "opus",
-                "budget": 10.0,
                 "timeout": 120,
             },
         ):
@@ -542,8 +536,8 @@ class TestWorkspaceRestoration:
         # Instance starts with global model "sonnet"
         assert instance.model == "sonnet"
 
-        # Simulate DB overrides: user set model=opus and budget=20.0
-        db_settings = {"model": "opus", "budget": "20.0"}
+        # Simulate DB overrides: user set model=opus
+        db_settings = {"model": "opus"}
         with (
             patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
             patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value=db_settings),
@@ -552,7 +546,6 @@ class TestWorkspaceRestoration:
             await pool._restore_workspace(111, instance)
             # Model is a CLI flag, so changing it triggers restart
             assert instance.model == "opus"
-            assert instance.max_budget_usd == 20.0
             mock_restart.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -532,27 +532,6 @@ class TestRunReview:
         assert cmd[i + 1] == "opus"
 
     @pytest.mark.asyncio
-    async def test_max_budget_usd_flag_absent_on_claude_backend(self):
-        """
-        --max-budget-usd must NOT be emitted to claude --print argv
-        on the claude backend (issue #390): Max-plan OAuth makes the
-        CLI's computed-cost ceiling a phantom signal, so passing the
-        flag would terminate the subprocess at a ceiling that does
-        not correspond to real billing. Runaway protection comes from
-        the per-review timeout instead. Pinned as an absence assertion
-        so a future regression that re-adds the flag fails here.
-        """
-        mock_proc = _mock_process(stdout=b"ok")
-
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            # agent_backend defaults to "claude"; budget_usd is still
-            # accepted on the signature but no longer reaches argv.
-            await run_review("prompt", budget_usd=1.0)
-
-        cmd = mock_exec.call_args[0]
-        assert "--max-budget-usd" not in cmd
-
-    @pytest.mark.asyncio
     async def test_failure_raises(self):
         """Non-zero exit from Claude subprocess raises RuntimeError."""
         mock_proc = _mock_process(stderr=b"model not found", returncode=1)
@@ -860,20 +839,6 @@ class TestRunReviewCodex:
         assert "codex" in cmd
         codex_i = cmd.index("codex")
         assert cmd[codex_i + 1] == "exec"
-
-    @pytest.mark.asyncio
-    async def test_codex_no_max_budget_flag(self):
-        """
-        --max-budget-usd is not emitted on the codex branch. Codex on
-        subscription auth has no per-call billing; runaway protection
-        comes from the asyncio.wait_for timeout. Mirror of the
-        existing claude-side absence assertion.
-        """
-        mock_proc = _mock_process(stdout=self._codex_ndjson(""))
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_review("prompt", agent_backend="codex")
-        cmd = mock_exec.call_args[0]
-        assert "--max-budget-usd" not in cmd
 
     @pytest.mark.asyncio
     async def test_codex_extracts_final_text_from_ndjson(self):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -24,27 +24,27 @@ class TestSessions:
         assert await sessions.get_session(999) is None
 
     async def test_save_then_get(self, db):
-        await sessions.save_session(1, "sess-abc", "sonnet", 0.5)
+        await sessions.save_session(1, "sess-abc", "sonnet")
         result = await sessions.get_session(1)
         assert result == "sess-abc"
 
-    async def test_save_twice_accumulates_cost(self, db):
-        await sessions.save_session(1, "sess-1", "sonnet", 0.5)
-        await sessions.save_session(1, "sess-1", "sonnet", 0.3)
+    async def test_save_twice_updates_in_place(self, db):
+        await sessions.save_session(1, "sess-1", "sonnet")
+        await sessions.save_session(1, "sess-2", "opus")
         stats = await sessions.get_stats(1)
-        assert stats["total_cost_usd"] == pytest.approx(0.8)
+        assert stats["session_id"] == "sess-2"
+        assert stats["model"] == "opus"
 
     async def test_clear_session(self, db):
-        await sessions.save_session(1, "sess-1", "sonnet", 0.0)
+        await sessions.save_session(1, "sess-1", "sonnet")
         await sessions.clear_session(1)
         assert await sessions.get_session(1) is None
 
     async def test_get_stats(self, db):
-        await sessions.save_session(1, "sess-1", "opus", 1.23)
+        await sessions.save_session(1, "sess-1", "opus")
         stats = await sessions.get_stats(1)
         assert stats["session_id"] == "sess-1"
         assert stats["model"] == "opus"
-        assert stats["total_cost_usd"] == pytest.approx(1.23)
         assert "created_at" in stats
         assert "last_used_at" in stats
 
@@ -318,23 +318,21 @@ class TestWorkspaceConfigSettings:
     async def test_set_multiple_fields(self, db):
         """Multiple fields for the same workspace are returned together."""
         await sessions.set_workspace_config_setting(111, "/projects/kai", "model", "opus")
-        await sessions.set_workspace_config_setting(111, "/projects/kai", "budget", "20.0")
         await sessions.set_workspace_config_setting(111, "/projects/kai", "timeout", "300")
         result = await sessions.get_workspace_config_settings(111, "/projects/kai")
-        assert result == {"model": "opus", "budget": "20.0", "timeout": "300"}
+        assert result == {"model": "opus", "timeout": "300"}
 
     async def test_delete_single_field(self, db):
         """Deleting one field leaves others intact."""
         await sessions.set_workspace_config_setting(111, "/projects/kai", "model", "opus")
-        await sessions.set_workspace_config_setting(111, "/projects/kai", "budget", "20.0")
+        await sessions.set_workspace_config_setting(111, "/projects/kai", "timeout", "300")
         await sessions.delete_workspace_config_setting(111, "/projects/kai", "model")
         result = await sessions.get_workspace_config_settings(111, "/projects/kai")
-        assert result == {"budget": "20.0"}
+        assert result == {"timeout": "300"}
 
     async def test_delete_all(self, db):
         """Bulk delete removes all overrides for a workspace."""
         await sessions.set_workspace_config_setting(111, "/projects/kai", "model", "opus")
-        await sessions.set_workspace_config_setting(111, "/projects/kai", "budget", "20.0")
         await sessions.set_workspace_config_setting(111, "/projects/kai", "timeout", "300")
         await sessions.delete_all_workspace_config(111, "/projects/kai")
         result = await sessions.get_workspace_config_settings(111, "/projects/kai")
@@ -389,44 +387,43 @@ class TestBuildWorkspaceConfig:
         """YAML config present, no DB overrides, returns YAML values."""
         from kai.config import WorkspaceConfig
 
-        yaml = WorkspaceConfig(path=Path("/projects/kai"), model="opus", budget=15.0)
+        yaml = WorkspaceConfig(path=Path("/projects/kai"), model="opus", timeout=150)
         result = await sessions.build_workspace_config(yaml, Path("/projects/kai"), 111)
         assert result is not None
         assert result.model == "opus"
-        assert result.budget == 15.0
+        assert result.timeout == 150
 
     async def test_db_only(self, db):
         """No YAML config, DB overrides present, returns DB values."""
         await sessions.set_workspace_config_setting(111, "/projects/kai", "model", "haiku")
-        await sessions.set_workspace_config_setting(111, "/projects/kai", "budget", "5.0")
+        await sessions.set_workspace_config_setting(111, "/projects/kai", "timeout", "150")
         result = await sessions.build_workspace_config(None, Path("/projects/kai"), 111)
         assert result is not None
         assert result.model == "haiku"
-        assert result.budget == 5.0
+        assert result.timeout == 150
         assert result.path == Path("/projects/kai")
 
     async def test_db_overrides_yaml(self, db):
         """DB values take precedence over YAML values."""
         from kai.config import WorkspaceConfig
 
-        yaml = WorkspaceConfig(path=Path("/projects/kai"), model="opus", budget=15.0)
+        yaml = WorkspaceConfig(path=Path("/projects/kai"), model="opus", timeout=150)
         await sessions.set_workspace_config_setting(111, "/projects/kai", "model", "sonnet")
         result = await sessions.build_workspace_config(yaml, Path("/projects/kai"), 111)
         assert result is not None
         assert result.model == "sonnet"
-        # Budget from YAML is preserved (not overridden)
-        assert result.budget == 15.0
+        # Timeout from YAML is preserved (not overridden)
+        assert result.timeout == 150
 
     async def test_partial_override(self, db):
-        """YAML has model+budget, DB overrides only model. Budget from YAML."""
+        """YAML has model+timeout, DB overrides only model. Timeout from YAML."""
         from kai.config import WorkspaceConfig
 
-        yaml = WorkspaceConfig(path=Path("/projects/kai"), model="opus", budget=20.0, timeout=300)
+        yaml = WorkspaceConfig(path=Path("/projects/kai"), model="opus", timeout=300)
         await sessions.set_workspace_config_setting(111, "/projects/kai", "model", "haiku")
         result = await sessions.build_workspace_config(yaml, Path("/projects/kai"), 111)
         assert result is not None
         assert result.model == "haiku"
-        assert result.budget == 20.0
         assert result.timeout == 300
 
     async def test_env_merge(self, db):
@@ -499,23 +496,21 @@ class TestUserSettings:
     async def test_set_multiple_fields(self, db):
         """Multiple fields are returned together."""
         await sessions.set_user_setting(111, "model", "opus")
-        await sessions.set_user_setting(111, "budget", "15.0")
         await sessions.set_user_setting(111, "timeout", "300")
         result = await sessions.get_user_settings(111)
-        assert result == {"model": "opus", "budget": "15.0", "timeout": "300"}
+        assert result == {"model": "opus", "timeout": "300"}
 
     async def test_delete_single(self, db):
         """Deleting one field leaves others intact."""
         await sessions.set_user_setting(111, "model", "opus")
-        await sessions.set_user_setting(111, "budget", "15.0")
+        await sessions.set_user_setting(111, "timeout", "300")
         await sessions.delete_user_setting(111, "model")
         result = await sessions.get_user_settings(111)
-        assert result == {"budget": "15.0"}
+        assert result == {"timeout": "300"}
 
     async def test_delete_all(self, db):
         """Bulk delete removes all per-user settings."""
         await sessions.set_user_setting(111, "model", "opus")
-        await sessions.set_user_setting(111, "budget", "15.0")
         await sessions.set_user_setting(111, "timeout", "300")
         await sessions.delete_all_user_settings(111)
         result = await sessions.get_user_settings(111)
@@ -556,7 +551,6 @@ class TestResolveUserDefaults:
             "telegram_bot_token": "test",
             "allowed_user_ids": {111},
             "default_model": "sonnet",
-            "budget_ceiling": 10.0,
             "claude_timeout_seconds": 120,
         }
         defaults.update(kwargs)
@@ -569,17 +563,14 @@ class TestResolveUserDefaults:
         config = self._make_config()
         result = await sessions.resolve_user_defaults(111, config)
         assert result["model"] == "sonnet"
-        assert result["budget"] == 10.0
         assert result["timeout"] == 120
 
     async def test_db_overrides_globals(self, db):
         """DB settings override global defaults."""
         config = self._make_config()
         await sessions.set_user_setting(111, "model", "opus")
-        await sessions.set_user_setting(111, "budget", "25.0")
         result = await sessions.resolve_user_defaults(111, config)
         assert result["model"] == "opus"
-        assert result["budget"] == 25.0
         # Unset fields still come from globals
         assert result["timeout"] == 120
 
@@ -591,13 +582,11 @@ class TestResolveUserDefaults:
             telegram_id=111,
             name="alice",
             model="opus",
-            max_budget=20.0,
             timeout=300,
         )
         config = self._make_config(user_configs={111: uc})
         result = await sessions.resolve_user_defaults(111, config)
         assert result["model"] == "opus"
-        assert result["budget"] == 20.0
         assert result["timeout"] == 300
 
     async def test_db_overrides_yaml(self, db):
@@ -608,15 +597,12 @@ class TestResolveUserDefaults:
             telegram_id=111,
             name="alice",
             model="opus",
-            max_budget=20.0,
             timeout=300,
         )
         config = self._make_config(user_configs={111: uc})
         await sessions.set_user_setting(111, "model", "haiku")
-        await sessions.set_user_setting(111, "budget", "5.0")
         result = await sessions.resolve_user_defaults(111, config)
         assert result["model"] == "haiku"
-        assert result["budget"] == 5.0
         # Timeout not overridden in DB, comes from YAML
         assert result["timeout"] == 300
 
@@ -634,7 +620,6 @@ class TestResolveUserDefaults:
         result = await sessions.resolve_user_defaults(111, config)
         assert result["model"] == "opus"  # from DB
         assert result["timeout"] == 300  # from YAML
-        assert result["budget"] == 10.0  # from global
 
     # ── Empty/blank model fallthrough (finding 1) ────────────────
 
@@ -1337,8 +1322,7 @@ class TestWorkspaceHistoryMigration:
                 CREATE TABLE sessions (
                     chat_id INTEGER PRIMARY KEY,
                     session_id TEXT NOT NULL,
-                    model TEXT DEFAULT 'sonnet',
-                    total_cost REAL DEFAULT 0.0
+                    model TEXT DEFAULT 'sonnet'
                 )
             """)
             await conn.execute("""

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -349,26 +349,6 @@ class TestRunTriage:
         assert cmd[i + 1] == "opus"
 
     @pytest.mark.asyncio
-    async def test_max_budget_usd_flag_absent_on_claude_backend(self):
-        """
-        --max-budget-usd must NOT be emitted to claude --print argv on
-        the claude backend (issue #390). Max-plan OAuth makes the CLI's
-        computed-cost ceiling a phantom signal, and the triage
-        subprocess's runaway protection comes from _TRIAGE_TIMEOUT
-        instead. Pinned as an absence assertion so a future regression
-        that re-adds the flag fails here.
-        """
-        mock_proc = _mock_subprocess(returncode=0, stdout='{"labels": []}')
-
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            # agent_backend defaults to "claude" via the kwarg default
-            # on run_triage; explicit pass for clarity.
-            await run_triage("prompt", agent_backend="claude")
-
-        cmd = mock_exec.call_args[0]
-        assert "--max-budget-usd" not in cmd
-
-    @pytest.mark.asyncio
     async def test_timeout(self):
         """Timed-out subprocess raises RuntimeError and kills the process."""
         mock_proc = AsyncMock()
@@ -864,20 +844,6 @@ class TestRunTriageCodex:
         assert "codex" in cmd
         codex_i = cmd.index("codex")
         assert cmd[codex_i + 1] == "exec"
-
-    @pytest.mark.asyncio
-    async def test_codex_no_max_budget_flag(self):
-        """
-        --max-budget-usd is not emitted on the codex branch. Codex on
-        subscription auth has no per-call billing; runaway protection
-        comes from the asyncio.wait_for timeout. Mirror of the existing
-        claude-side absence assertion.
-        """
-        mock_proc = _mock_subprocess(stdout=self._codex_ndjson("{}"))
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage("prompt", agent_backend="codex")
-        cmd = mock_exec.call_args[0]
-        assert "--max-budget-usd" not in cmd
 
     @pytest.mark.asyncio
     async def test_codex_extracts_final_text_from_ndjson(self):

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -10,6 +10,7 @@ Covers:
 6. Legacy fallback via ALLOWED_USER_IDS
 """
 
+import logging
 import textwrap
 from pathlib import Path
 from unittest.mock import patch
@@ -37,7 +38,6 @@ class TestUserConfig:
         assert uc.github is None
         assert uc.os_user is None
         assert uc.home_workspace is None
-        assert uc.max_budget is None
         assert uc.model is None
         assert uc.timeout is None
         assert uc.workspace_base is None
@@ -57,7 +57,6 @@ class TestUserConfig:
             github="alice-dev",
             os_user="alice",
             home_workspace=Path("/home/alice/workspace"),
-            max_budget=15.0,
             model="opus",
             timeout=300,
             workspace_base=Path("/home/alice/projects"),
@@ -71,7 +70,6 @@ class TestUserConfig:
         assert uc.role == "admin"
         assert uc.github == "alice-dev"
         assert uc.os_user == "alice"
-        assert uc.max_budget == 15.0
         assert uc.model == "opus"
         assert uc.timeout == 300
         assert uc.workspace_base == Path("/home/alice/projects")
@@ -117,7 +115,6 @@ class TestLoadUserConfigs:
                 github: alice-dev
                 os_user: alice
                 home_workspace: {ws}
-                max_budget: 15.0
               - telegram_id: 222
                 name: bob
                 role: user
@@ -135,7 +132,6 @@ class TestLoadUserConfigs:
         assert configs[111].github == "alice-dev"
         assert configs[111].os_user == "alice"
         assert configs[111].home_workspace == ws.resolve()
-        assert configs[111].max_budget == 15.0
         assert configs[222].name == "bob"
         assert configs[222].role == "user"
 
@@ -254,37 +250,27 @@ class TestLoadUserConfigs:
         ):
             _load_user_configs("claude", "")
 
-    def test_invalid_budget(self, tmp_path):
-        """Negative budget causes the entry to be skipped."""
+    def test_lingering_max_budget_ignored_with_warning(self, tmp_path, caplog):
+        """A `max_budget` key from an older users.yaml is ignored with
+        a warning; the entry itself still loads. Tolerance keeps an
+        un-migrated file working after upgrade."""
         data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
                 name: alice
-                max_budget: -5.0
+                max_budget: 15.0
             """,
         )
         with (
             patch("kai.config._read_protected_yaml", return_value=data),
-            pytest.raises(SystemExit, match="no valid user entries"),
+            caplog.at_level(logging.WARNING, logger="kai.config"),
         ):
-            _load_user_configs("claude", "")
+            configs = _load_user_configs("claude", "")
 
-    def test_bool_budget_rejected(self, tmp_path):
-        """Boolean budget is rejected (same bool guard as workspace config)."""
-        data = self._yaml_dict(
-            """\
-            users:
-              - telegram_id: 111
-                name: alice
-                max_budget: true
-            """,
-        )
-        with (
-            patch("kai.config._read_protected_yaml", return_value=data),
-            pytest.raises(SystemExit, match="no valid user entries"),
-        ):
-            _load_user_configs("claude", "")
+        assert configs is not None
+        assert configs[111].name == "alice"
+        assert "'max_budget' for alice is no longer supported; ignoring" in caplog.text
 
     def test_bool_telegram_id_rejected(self, tmp_path):
         """Boolean telegram_id is rejected."""

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -408,7 +408,6 @@ def _build_test_app(
     app["pr_review_cooldown"] = cooldown
     # Review subprocess resource limits (defaults match config.py).
     app["pr_review_timeout_s"] = 900
-    app["pr_review_budget_usd"] = 1.0
     # Config needed by review background tasks
     app["webhook_port"] = 8080
     app["claude_user"] = None

--- a/tests/test_workspace_config.py
+++ b/tests/test_workspace_config.py
@@ -33,7 +33,6 @@ class TestWorkspaceConfig:
         ws = WorkspaceConfig(path=Path("/tmp/ws"))
         assert ws.path == Path("/tmp/ws")
         assert ws.model is None
-        assert ws.budget is None
         assert ws.timeout is None
         assert ws.env is None
         assert ws.env_file is None
@@ -45,14 +44,12 @@ class TestWorkspaceConfig:
         ws = WorkspaceConfig(
             path=Path("/tmp/ws"),
             model="opus",
-            budget=15.0,
             timeout=300,
             env={"FOO": "bar"},
             env_file=Path("/tmp/.env"),
             system_prompt="Be helpful",
         )
         assert ws.model == "opus"
-        assert ws.budget == 15.0
         assert ws.timeout == 300
         assert ws.env == {"FOO": "bar"}
         assert ws.system_prompt == "Be helpful"
@@ -236,7 +233,6 @@ class TestLoadWorkspaceConfigs:
               - path: {ws1}
                 claude:
                   model: opus
-                  budget: 15.0
                   timeout: 300
               - path: {ws2}
                 claude:
@@ -251,7 +247,6 @@ class TestLoadWorkspaceConfigs:
 
         assert len(configs) == 2
         assert configs[ws1.resolve()].model == "opus"
-        assert configs[ws1.resolve()].budget == 15.0
         assert configs[ws1.resolve()].timeout == 300
         assert configs[ws2.resolve()].model == "haiku"
 
@@ -353,8 +348,10 @@ class TestLoadWorkspaceConfigs:
         assert configs[ws.resolve()].model == "some-custom-model"
         assert "unrecognized model" in caplog.text
 
-    def test_bool_budget_rejected(self, tmp_path):
-        """Boolean budget (e.g. true) is rejected, not silently cast to $1.00."""
+    def test_lingering_budget_ignored_with_warning(self, tmp_path, caplog):
+        """A `budget` key from an older workspaces.yaml is ignored with
+        a warning; the entry itself still loads. Tolerance keeps an
+        un-migrated file working after upgrade."""
         ws = tmp_path / "ws"
         ws.mkdir()
         self._write_yaml(
@@ -363,35 +360,20 @@ class TestLoadWorkspaceConfigs:
             workspaces:
               - path: {ws}
                 claude:
-                  budget: true
+                  model: opus
+                  budget: 15.0
             """,
         )
         with (
             patch("kai.config._read_protected_yaml", return_value=None),
             patch("kai.config.PROJECT_ROOT", tmp_path),
+            caplog.at_level("WARNING", logger="kai.config"),
         ):
             configs = _load_workspace_configs()
-        assert configs == {}
-
-    def test_negative_budget(self, tmp_path):
-        """Negative budget causes the entry to be skipped."""
-        ws = tmp_path / "ws"
-        ws.mkdir()
-        self._write_yaml(
-            tmp_path,
-            f"""\
-            workspaces:
-              - path: {ws}
-                claude:
-                  budget: -5.0
-            """,
-        )
-        with (
-            patch("kai.config._read_protected_yaml", return_value=None),
-            patch("kai.config.PROJECT_ROOT", tmp_path),
-        ):
-            configs = _load_workspace_configs()
-        assert configs == {}
+        cfg = configs[ws.resolve()]
+        assert cfg.model == "opus"
+        assert "'budget' for" in caplog.text
+        assert "no longer supported; ignoring" in caplog.text
 
     def test_mutual_exclusion_system_prompt(self, tmp_path):
         """Both system_prompt and system_prompt_file causes skip."""
@@ -603,7 +585,6 @@ class TestLoadWorkspaceConfigs:
             configs = _load_workspace_configs()
         cfg = configs[ws.resolve()]
         assert cfg.model is None
-        assert cfg.budget is None
         assert cfg.timeout is None
 
     def test_env_dict_values_coerced_to_strings(self, tmp_path):


### PR DESCRIPTION
Removes the USD budget system and the cost telemetry built on the same numbers. No backend enforces a budget: `--max-budget-usd` was dropped from `claude --print` argv in #390 because subscription-auth costs are computed by the CLI but never billed, and codex, opencode, and goose hardwire `cost_usd=0.0`. Everything that remained parsed, validated, stored, resolved, displayed, and plumbed values that nothing read.

## Removed

- Config fields and env parsing: `budget_ceiling` (`BUDGET_CEILING`, with the `CLAUDE_MAX_BUDGET_USD` legacy fallback), `pr_review_budget_usd`, `memory_extraction_budget_usd`, `memory_episode_budget_usd`, `UserConfig.max_budget`, `WorkspaceConfig.budget`.
- `/settings budget` and `/workspace config budget`, the budget lines in both displays, and the budget-exhaustion recovery hints in the bot (unreachable: a CLI that never receives the flag never says "Reached maximum budget").
- `max_budget_usd` on every backend class, the pool pass-through, and the workspace-switch budget reset.
- The `budget_usd` parameter on the review entry points, the webhook wiring, and the vestigial `_REVIEW_BUDGET_USD` / `_TRIAGE_BUDGET_USD` constants.
- The behavioral eval harness budget knobs (`--judge-budget-usd`, `--gen-budget-usd`, the last live `--max-budget-usd` emitters) and its `cost_usd` run-record field.
- Cost telemetry: `AgentResponse.cost_usd`, the sessions DB `total_cost_usd` accumulation, the `Total cost` line in `/stats`, and the `cost_usd` field in `memory.episode` log lines (no in-repo consumer reads it).
- The two wizard prompts ("Agent budget (USD)", "Review subprocess USD budget ceiling") and their env emission.
- README rows, template examples, and the budget paragraph.

## Compatibility

- `users.yaml` `max_budget` and `workspaces.yaml` `budget` keys are ignored with a per-entry warning; entries still load.
- The five retired env keys are dropped from `/etc/kai/env` at apply time; `load_config` warns about lingering values via the generalized retired-key map (joining `CLAUDE_MAX_CONTEXT_WINDOW`) and never aborts.
- Stale `budget` rows in the settings DB (user-level and workspace-level) are simply never read again; not purged.
- Existing sessions databases keep the `total_cost_usd` column inert; new installs create the table without it. No migration code.

## Out of scope

`MEMORY_TOKEN_BUDGET` and the memory-injection token budget are a prompt-context sizing knob, not a cost control; they are untouched, as are the sample-count quotas in the eval tooling that use the word budget.

## Testing

3741 tests pass; `make check` clean. New coverage: retired-key startup warnings (per key, plus the does-not-abort and empty-value cases), users.yaml/workspaces.yaml ignore-with-warning, and `/settings budget` answering with the unknown-setting message. The wizard's positional input chains were re-derived for the two removed prompts.

Closes #598
