### PR TITLE
fix(oneshot): tolerate fenced or prose-wrapped JSON in schema output

### DIFF
--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -32,6 +32,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 import tempfile
 import time
 from dataclasses import dataclass, field
@@ -425,6 +426,98 @@ def _os_user_log_field(effective_user: str | None) -> str:
     site uses the same vocabulary.
     """
     return effective_user if effective_user else "self"
+
+
+# ── Shared schema-payload parsing ────────────────────────────────────
+
+
+# Matches one fenced code block and captures its body. The info
+# string after the opening fence (`json`, `JSON`, or anything else)
+# is consumed but not constrained: models label payload fences
+# inconsistently and the json.loads attempt on the body is the real
+# filter. DOTALL lets the body span newlines; the non-greedy body
+# keeps back-to-back fences in one response as separate matches
+# instead of one block swallowing everything between the first
+# opener and the last closer.
+_FENCED_BLOCK_RE = re.compile(r"```[^\n`]*\n(.*?)```", re.DOTALL)
+
+
+def _parse_schema_payload(text: str) -> Any:
+    """
+    Parse a schema-backed one-shot response out of a model's chat text.
+
+    Claude one-shots never need this leniency (`--json-schema` makes
+    the CLI emit validated JSON) and codex rarely does
+    (`--output-schema` shapes the final message CLI-side), but
+    opencode has no structured-output channel at all: the JSON-only
+    instruction rides inside the prompt, so compliance is pure model
+    discipline. Models that narrate before answering wrap the payload
+    in chat noise (observed with deepseek-v4-flash: a reasoning
+    preamble followed by a ```json fence), and a bare json.loads on
+    that text rejects an otherwise valid payload. Both the opencode
+    and codex schema paths parse through this helper so the two
+    reasoners keep mirroring each other.
+
+    Three tiers, cheapest first:
+
+    1. Bare parse of the stripped text. Preserves the strict-path
+       behavior exactly, including non-dict results (a bare scalar or
+       list still reaches the caller's non_object_json check rather
+       than being rejected here).
+    2. Fenced blocks: each block body that parses as a JSON object is
+       a candidate.
+    3. Brace scan: `raw_decode` at each `{` pulls an object out of
+       unfenced prose.
+
+    Within tiers 2 and 3 the LAST candidate wins: models think first
+    and answer last, so when a preamble quotes an example object the
+    payload that follows it is the real answer.
+
+    Raises the tier-1 `json.JSONDecodeError` when no tier produces an
+    object, so call sites keep their existing except shape and the
+    logged error carries the position of the original parse failure.
+    """
+    stripped = text.strip()
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        bare_error = exc
+
+    payload: Any = None
+    for match in _FENCED_BLOCK_RE.finditer(text):
+        try:
+            candidate = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(candidate, dict):
+            payload = candidate
+    if payload is not None:
+        return payload
+
+    # Tier 3 walks every `{` because a failed raw_decode reports
+    # nothing about where a viable object might start. On success the
+    # scan resumes AFTER the parsed object: nested objects are part
+    # of the outer candidate, and re-parsing them would let an inner
+    # fragment shadow the complete payload. Quadratic on brace-dense
+    # garbage in the worst case, but one-shot responses are a few KB
+    # and this tier only runs after both cheaper tiers missed.
+    decoder = json.JSONDecoder()
+    search_from = 0
+    while True:
+        brace = text.find("{", search_from)
+        if brace == -1:
+            break
+        try:
+            candidate, end = decoder.raw_decode(text, brace)
+        except json.JSONDecodeError:
+            search_from = brace + 1
+            continue
+        payload = candidate
+        search_from = end
+    if payload is not None:
+        return payload
+
+    raise bare_error
 
 
 # ── Claude implementation ───────────────────────────────────────────
@@ -1189,11 +1282,13 @@ class CodexOneShotReasoner:
                     duration_ms=duration_ms,
                 )
 
-            # Schema-backed path. The final agent_message must parse
-            # as a JSON object; anything else is OneShotOutputError so
-            # memory_extraction's caller-side mapping collapses it to
-            # the zero-state extraction result instead of letting a
-            # malformed payload reach the fact validator.
+            # Schema-backed path. The final agent_message must carry
+            # a JSON object; `_parse_schema_payload` tolerates fence /
+            # prose wrapping around it, and anything it cannot recover
+            # is OneShotOutputError so memory_extraction's caller-side
+            # mapping collapses it to the zero-state extraction result
+            # instead of letting a malformed payload reach the fact
+            # validator.
             if not final_text:
                 log.info(
                     "oneshot_reasoner purpose=%s backend=codex model=%s duration_ms=%d outcome=output_error error_category=empty_agent_message returncode=0 os_user=%s",
@@ -1204,7 +1299,7 @@ class CodexOneShotReasoner:
                 )
                 raise OneShotOutputError("codex produced no final agent_message")
             try:
-                payload = json.loads(final_text)
+                payload = _parse_schema_payload(final_text)
             except json.JSONDecodeError as exc:
                 log.info(
                     "oneshot_reasoner purpose=%s backend=codex model=%s duration_ms=%d outcome=output_error error_category=invalid_json returncode=0 os_user=%s",
@@ -1213,7 +1308,7 @@ class CodexOneShotReasoner:
                     duration_ms,
                     os_user_field,
                 )
-                raise OneShotOutputError(f"codex final text was not valid JSON: {exc}") from None
+                raise OneShotOutputError(f"codex final text did not contain a JSON object: {exc}") from None
 
             # Codex's `--output-schema` enforcement is best-effort:
             # the CLI does not hard-reject a final message that
@@ -1639,11 +1734,13 @@ class OpenCodeOneShotReasoner:
                 )
 
             # Schema-backed path. Mirrors the codex reasoner exactly:
-            # the accumulated text must parse as a JSON object;
-            # anything else is OneShotOutputError so memory
-            # extraction's caller-side mapping collapses it to the
-            # zero-state extraction result instead of letting a
-            # malformed payload reach the fact validator.
+            # the accumulated text must carry a JSON object, with
+            # `_parse_schema_payload` tolerating fence / prose wrapping
+            # around it; anything it cannot recover is
+            # OneShotOutputError so memory extraction's caller-side
+            # mapping collapses it to the zero-state extraction result
+            # instead of letting a malformed payload reach the fact
+            # validator.
             if not accumulated:
                 log.info(
                     "oneshot_reasoner purpose=%s backend=opencode model=%s duration_ms=%d outcome=output_error error_category=empty_response returncode=0 os_user=%s",
@@ -1654,7 +1751,7 @@ class OpenCodeOneShotReasoner:
                 )
                 raise OneShotOutputError("opencode produced no accumulated text")
             try:
-                payload = json.loads(accumulated)
+                payload = _parse_schema_payload(accumulated)
             except json.JSONDecodeError as exc:
                 log.info(
                     "oneshot_reasoner purpose=%s backend=opencode model=%s duration_ms=%d outcome=output_error error_category=invalid_json returncode=0 os_user=%s",
@@ -1663,7 +1760,7 @@ class OpenCodeOneShotReasoner:
                     duration_ms,
                     os_user_field,
                 )
-                raise OneShotOutputError(f"opencode accumulated text was not valid JSON: {exc}") from None
+                raise OneShotOutputError(f"opencode accumulated text did not contain a JSON object: {exc}") from None
 
             if not isinstance(payload, dict):
                 log.info(

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -29,6 +29,7 @@ from kai.oneshot import (
     OneShotSubprocessError,
     OneShotTimeout,
     OpenCodeOneShotReasoner,
+    _parse_schema_payload,
     _preserved_auth_vars_for,
     _render_opencode_session_prompt,
 )
@@ -1129,6 +1130,28 @@ class TestCodexOneShotReasonerSuccess:
         assert envelope == {"is_error": False, "structured_output": payload}
 
     @pytest.mark.asyncio
+    async def test_schema_backed_recovers_fenced_final_message(self, tmp_path):
+        """`--output-schema` shaping is best-effort, so a model that
+        fences its final JSON must still reach the envelope; the
+        codex parse runs through the same tolerant helper as
+        opencode."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user=_current_user())
+        payload = {"facts": [], "has_episode": False}
+        fenced = "```json\n" + json.dumps(payload) + "\n```"
+        stdout = (_codex_event("agent_message", fenced) + "\n").encode("utf-8")
+        proc = _make_proc(stdout=stdout, returncode=0)
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+        envelope = json.loads(result.text)
+        assert envelope == {"is_error": False, "structured_output": payload}
+
+    @pytest.mark.asyncio
     async def test_non_schema_success_returns_raw_text(self, tmp_path):
         """A None schema means the caller wants the free-form
         agent_message text back unchanged; no envelope wrapping
@@ -2021,6 +2044,71 @@ class TestCodexReasonerWritesSanitizedSchema:
         assert "maxItems" not in disk["properties"]["facts"]
 
 
+# ── Schema-payload parsing tests ─────────────────────────────────
+
+
+class TestParseSchemaPayload:
+    """Contract for `_parse_schema_payload`: bare JSON passes through
+    unchanged (including non-dict values, which must reach the
+    caller's non_object_json check), fenced or prose-wrapped objects
+    are recovered, the last candidate wins within a tier, and text
+    with no recoverable object re-raises the bare-parse
+    JSONDecodeError."""
+
+    def test_bare_object_passes_through(self):
+        assert _parse_schema_payload('{"facts": []}') == {"facts": []}
+
+    @pytest.mark.parametrize("bare_non_dict", ["[1, 2]", "42", "true", "null", '"text"'])
+    def test_bare_non_dict_passes_through(self, bare_non_dict):
+        assert _parse_schema_payload(bare_non_dict) == json.loads(bare_non_dict)
+
+    def test_fenced_json_block(self):
+        assert _parse_schema_payload('```json\n{"a": 1}\n```') == {"a": 1}
+
+    def test_fence_without_info_string(self):
+        assert _parse_schema_payload('```\n{"a": 1}\n```') == {"a": 1}
+
+    def test_preamble_then_fenced_payload(self):
+        # The exact production failure shape: reasoning prose
+        # followed by a fenced payload.
+        text = (
+            'Let me analyze the current exchange to extract facts.\n\n```json\n{"facts": [], "has_episode": false}\n```'
+        )
+        assert _parse_schema_payload(text) == {"facts": [], "has_episode": False}
+
+    def test_last_fenced_object_wins(self):
+        text = '```json\n{"example": true}\n```\nThe real answer:\n```json\n{"a": 1}\n```'
+        assert _parse_schema_payload(text) == {"a": 1}
+
+    def test_unfenced_object_in_prose(self):
+        text = 'Here is the result: {"a": 1} hope that helps.'
+        assert _parse_schema_payload(text) == {"a": 1}
+
+    def test_last_unfenced_object_wins(self):
+        text = 'I will use {"draft": true} as a template. Final: {"a": 1}'
+        assert _parse_schema_payload(text) == {"a": 1}
+
+    def test_nested_object_returns_outer(self):
+        # The brace scan resumes after a parsed object so an inner
+        # fragment cannot shadow the complete payload.
+        text = 'payload {"outer": {"inner": 1}} end'
+        assert _parse_schema_payload(text) == {"outer": {"inner": 1}}
+
+    def test_fenced_payload_beats_unfenced_prose_example(self):
+        text = 'The shape is {"facts": []} with values.\n```json\n{"facts": ["x"], "has_episode": true}\n```'
+        assert _parse_schema_payload(text) == {"facts": ["x"], "has_episode": True}
+
+    def test_no_json_raises_decode_error(self):
+        with pytest.raises(json.JSONDecodeError):
+            _parse_schema_payload("not json at all")
+
+    def test_fenced_non_object_raises_decode_error(self):
+        # A fenced list is not a candidate (the schema demands an
+        # object) and the body has no `{` for the brace scan.
+        with pytest.raises(json.JSONDecodeError):
+            _parse_schema_payload("```json\n[1, 2]\n```")
+
+
 # ── OpenCode reasoner tests ──────────────────────────────────────
 
 
@@ -2514,16 +2602,49 @@ class TestOpenCodeOneShotReasonerFailures:
 
 
 class TestOpenCodeOneShotReasonerSchema:
-    """When `json_schema` is supplied, the accumulated text must parse
-    as a JSON object containing the schema's `required` fields. The
-    reasoner wraps the parsed payload in the same envelope claude /
-    codex emit, so the memory extraction caller does not need an
-    opencode branch."""
+    """When `json_schema` is supplied, the accumulated text must carry
+    a JSON object containing the schema's `required` fields; fence /
+    prose wrapping around the object is tolerated. The reasoner wraps
+    the parsed payload in the same envelope claude / codex emit, so
+    the memory extraction caller does not need an opencode branch."""
 
     @pytest.mark.asyncio
     async def test_schema_backed_returns_envelope(self, tmp_path):
         reasoner = OpenCodeOneShotReasoner(cwd=tmp_path, os_user=_current_user())
         body = json.dumps({"facts": [], "has_episode": False})
+        proc = _make_acp_proc(
+            _opencode_handshake_lines()
+            + [
+                _session_update_line(body),
+                _rpc_response_line(request_id=3, result={"stopReason": "end_turn"}),
+            ]
+        )
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={
+                    "type": "object",
+                    "required": ["facts", "has_episode"],
+                },
+            )
+
+        envelope = json.loads(result.text)
+        assert envelope == {
+            "is_error": False,
+            "structured_output": {"facts": [], "has_episode": False},
+        }
+
+    @pytest.mark.asyncio
+    async def test_schema_backed_recovers_fenced_payload_with_preamble(self, tmp_path):
+        """Some models narrate before answering and fence the JSON
+        (deepseek-v4-flash does both); the payload must still reach
+        the envelope instead of collapsing to invalid_json."""
+        reasoner = OpenCodeOneShotReasoner(cwd=tmp_path, os_user=_current_user())
+        body = (
+            'Let me analyze the current exchange to extract facts.\n\n```json\n{"facts": [], "has_episode": false}\n```'
+        )
         proc = _make_acp_proc(
             _opencode_handshake_lines()
             + [


### PR DESCRIPTION
Closes #600

## Problem

The opencode one-shot reasoner's schema-backed path required the accumulated agent text to parse as bare JSON. DeepSeek models (observed with deepseek-v4-flash on memory fact extraction) frequently emit a reasoning preamble and wrap the payload in a ```json fence, so `json.loads` failed at char 0, the call raised `OneShotOutputError`, and extraction silently collapsed to zero facts. Over one day of service logs, 20 of 24 extraction runs failed this way.

opencode is structurally exposed here: claude one-shots get CLI-side enforcement (`--json-schema`) and codex passes the schema to its CLI (`--output-schema`), but opencode has no structured-output channel, so the JSON-only instruction rides inside the prompt and compliance is pure model discipline.

## Change

- New shared helper `_parse_schema_payload` in `src/kai/oneshot.py`, tiered cheapest-first:
  1. Bare parse of the stripped text (preserves strict-path behavior exactly, including non-dict results reaching the existing `non_object_json` check).
  2. Fenced-block extraction: each fence body that parses as a JSON object is a candidate.
  3. Brace scan: `raw_decode` at each `{` recovers an object from unfenced prose.
  Within tiers 2 and 3 the last candidate wins (models think first, answer last). When no tier produces an object, the original tier-1 `JSONDecodeError` is re-raised, so the `error_category=invalid_json` logging and `OneShotOutputError` mapping are unchanged.
- Both the opencode and codex schema paths parse through the helper, keeping the two reasoners mirrored. The claude path is untouched (CLI-validated already).
- Error message wording updated from "was not valid JSON" to "did not contain a JSON object" to match the new contract.

## Not addressed

`missing_required_fields` failures (valid JSON missing `has_episode`, 2 of the 24 logged runs) are model schema drift, not parsing, and still fail with the existing dedicated category. If they persist, the lever is the DeepSeek tier assignment or the prompt instruction, tracked in #600's out-of-scope note.

## Testing

- 12 direct unit tests for `_parse_schema_payload` (bare/fenced/prose/nested/last-wins/raise cases).
- Integration tests through both fake-subprocess harnesses: opencode recovers the exact production failure shape (preamble + fenced payload); codex recovers a fenced final message.
- Full suite: 3759 passed, 1 skipped. `ruff check` and `ruff format --check` clean.
