### PR TITLE
fix(acp): forward image content blocks to agents that accept them

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -256,6 +256,33 @@ async def drain_late_text(
                 accumulated = combine(accumulated, text)
 
 
+def convert_image_block(block: dict) -> dict | None:
+    """
+    Convert an Anthropic-style base64 image block to the ACP shape.
+
+    The bot layer builds image content in the Anthropic form
+    (`{"type": "image", "source": {"type": "base64", "media_type":
+    ..., "data": ...}}`) because the claude backend forwards content
+    blocks verbatim. ACP defines its own image content block
+    (`{"type": "image", "mimeType": ..., "data": ...}` with base64
+    data), so the ACP path translates rather than asking the bot
+    layer to grow per-backend block shapes.
+
+    Returns None when the block is not the expected Anthropic base64
+    shape (non-dict source, a non-base64 source type, or missing
+    fields); the caller drops such blocks the same way it drops
+    unsupported block types.
+    """
+    source = block.get("source")
+    if not isinstance(source, dict) or source.get("type") != "base64":
+        return None
+    media_type = source.get("media_type")
+    data = source.get("data")
+    if not isinstance(media_type, str) or not isinstance(data, str):
+        return None
+    return {"type": "image", "mimeType": media_type, "data": data}
+
+
 # ── ACP base backend ──────────────────────────────────────────────
 
 
@@ -336,6 +363,13 @@ class AcpBackend(AgentBackend):
         # Subprocess and session state.
         self._proc: asyncio.subprocess.Process | None = None
         self._session_id: str | None = None
+        # Whether the agent accepts image content blocks on
+        # session/prompt, read from `promptCapabilities.image` in the
+        # initialize result. False until a handshake completes so a
+        # prompt can never race ahead of the capability answer; each
+        # handshake overwrites it, so a restart re-reads the agent's
+        # current answer.
+        self._supports_image_input: bool = False
         # Monotonically increasing JSON-RPC request ID. Reset to 1 on
         # each subprocess start; the request IDs are scoped to one
         # subprocess incarnation so the read loop's id-matching is
@@ -559,10 +593,21 @@ class AcpBackend(AgentBackend):
         )
         self._stderr_task = asyncio.create_task(self._drain_stderr())
 
-        # Step 1: initialize - establish protocol version.
+        # Step 1: initialize - establish protocol version and read the
+        # agent's capability answer. `promptCapabilities.image` gates
+        # whether image content blocks are forwarded on session/prompt
+        # or dropped with a user-visible notice. The chained
+        # isinstance guards treat any missing or malformed capability
+        # structure as "no image support": dropping an image a capable
+        # agent could have read is a degraded reply, but sending an
+        # image to an agent that never advertised support is a
+        # protocol violation with harness-defined behavior.
         self._next_id = 1
         await self._write_rpc("initialize", self.build_initialize_params())
-        await self._read_result(expected_id=1)
+        init_result = await self._read_result(expected_id=1)
+        agent_caps = init_result.get("agentCapabilities")
+        prompt_caps = agent_caps.get("promptCapabilities") if isinstance(agent_caps, dict) else None
+        self._supports_image_input = bool(prompt_caps.get("image")) if isinstance(prompt_caps, dict) else False
 
         # Step 2: session/new - create a session.
         await self._write_rpc("session/new", self.build_session_new_params())
@@ -720,29 +765,47 @@ class AcpBackend(AgentBackend):
 
         reminder = build_foreign_workspace_reminder(self.workspace, self.home_workspace) or ""
 
-        # Strip non-text user blocks before per-turn assembly. ACP
-        # accepts text content blocks only in the current contract;
-        # stripping must run BEFORE assemble_turn_context so the marker
-        # it prepends labels a real user-text region. Stripping after
-        # the helper would leave injected text layers (session_context,
-        # reminder, memory) above the marker and nothing below it.
+        # Normalize user blocks to the ACP content shape before
+        # per-turn assembly. Text blocks pass through; image blocks
+        # are converted to ACP's image shape when the agent advertised
+        # `promptCapabilities.image` on this handshake, and dropped
+        # otherwise (capability absent, or a block that is not the
+        # Anthropic base64 shape `convert_image_block` expects). Every
+        # dropped image is counted so the reply can carry a
+        # user-visible notice; a log-only warning leaves the user
+        # believing the model saw an image it never received.
+        # Normalization must run BEFORE assemble_turn_context so the
+        # marker it prepends labels a real user region. Running it
+        # after the helper would leave injected text layers
+        # (session_context, reminder, memory) above the marker and
+        # nothing below it.
         had_user_text = isinstance(prompt, str)
+        dropped_images = 0
         if isinstance(prompt, list):
-            text_blocks: list[dict] = []
+            acp_blocks: list[dict] = []
             for block in prompt:
-                if block.get("type") == "text":
-                    text_blocks.append({"type": "text", "text": block["text"]})
-                else:
-                    log.warning(
-                        "%s: dropping non-text content block type=%s",
-                        self.backend_label,
-                        block.get("type"),
-                    )
-            had_user_text = bool(text_blocks)
-            # ACP requires a non-empty prompt array. An all-non-text
-            # input becomes a single placeholder so the marker has a
-            # user region to label.
-            prompt = text_blocks or [{"type": "text", "text": "(empty prompt)"}]
+                block_type = block.get("type")
+                if block_type == "text":
+                    acp_blocks.append({"type": "text", "text": block["text"]})
+                    continue
+                if block_type == "image" and self._supports_image_input:
+                    converted = convert_image_block(block)
+                    if converted is not None:
+                        acp_blocks.append(converted)
+                        continue
+                if block_type == "image":
+                    dropped_images += 1
+                log.warning(
+                    "%s: dropping content block type=%s (supports_image_input=%s)",
+                    self.backend_label,
+                    block_type,
+                    self._supports_image_input,
+                )
+            had_user_text = any(b.get("type") == "text" for b in acp_blocks)
+            # ACP requires a non-empty prompt array. Input whose every
+            # block was dropped becomes a single placeholder so the
+            # marker has a user region to label.
+            prompt = acp_blocks or [{"type": "text", "text": "(empty prompt)"}]
 
         # `chat_id=None` to the helper suppresses semantic recall for
         # this turn. The placeholder "(empty prompt)" is backend-
@@ -762,8 +825,8 @@ class AcpBackend(AgentBackend):
 
         # Coerce to the ACP content-block shape. `prompt` is either a
         # str (from a str input; the helper preserves the input type
-        # family) or a list of text blocks (every non-text block was
-        # stripped above).
+        # family) or a list already normalized to ACP blocks above
+        # (text plus any forwarded images).
         acp_prompt: list[dict]
         if isinstance(prompt, str):
             acp_prompt = [{"type": "text", "text": prompt}]
@@ -800,7 +863,29 @@ class AcpBackend(AgentBackend):
 
         # Stream response: read stdout lines, accumulate text via the
         # extract_text_delta hook, and yield StreamEvents.
+        #
+        # When images were dropped above, the display text is seeded
+        # with a notice so the user learns the model never saw them;
+        # the drop is otherwise invisible (the reply reads as a normal
+        # answer to the caption text). Seeding `accumulated` puts the
+        # notice in every StreamEvent and in the final AgentResponse
+        # without touching the response protocol. The trailing
+        # newlines end the seed at a line break, so chunk-join
+        # heuristics (see combine_text_chunks) never fire against it.
+        # `got_model_text` exists because the seed makes `accumulated`
+        # non-empty before the agent says anything; the EOF branch
+        # below must judge "did the model produce output" from this
+        # flag, not from `accumulated` truthiness, or a process that
+        # dies silently after an image drop would surface as a
+        # successful notice-only reply.
         accumulated = ""
+        got_model_text = False
+        if dropped_images:
+            noun = "image" if dropped_images == 1 else "images"
+            accumulated = (
+                f"[Note: {dropped_images} attached {noun} could not be passed to "
+                f"{self.backend_label}; this reply is based on the message text only.]\n\n"
+            )
         last_activity = time.monotonic()
         max_idle_seconds = self.timeout_seconds * 5
 
@@ -850,16 +935,18 @@ class AcpBackend(AgentBackend):
                 if line:
                     last_activity = time.monotonic()
                 else:
-                    # EOF - process died.
+                    # EOF - process died. Success iff the model said
+                    # anything; the notice seed alone does not count
+                    # (see `got_model_text` above).
                     log.error("%s process EOF", self.backend_label)
                     await self._kill()
                     yield StreamEvent(
                         text_so_far=accumulated,
                         done=True,
                         response=AgentResponse(
-                            success=bool(accumulated),
+                            success=got_model_text,
                             text=accumulated,
-                            error=None if accumulated else f"{self.backend_label} process ended unexpectedly",
+                            error=None if got_model_text else f"{self.backend_label} process ended unexpectedly",
                         ),
                     )
                     return
@@ -880,6 +967,7 @@ class AcpBackend(AgentBackend):
                     text = self.extract_text_delta(msg)
                     if text:
                         accumulated = self.combine_text_chunks(accumulated, text)
+                        got_model_text = True
                         yield StreamEvent(text_so_far=accumulated)
                     continue
 

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -30,6 +30,10 @@ Covers:
 16. backend_label flows into error messages and log lines
 17. Workspace model validation uses self.backend_name (no "goose"
     literal in the shared layer)
+18. Image content blocks: promptCapabilities.image capture from the
+    initialize result, Anthropic-to-ACP block conversion, forwarding
+    when supported, drop notice in the reply text when not, and the
+    EOF-after-drop path staying an error
 """
 
 import asyncio
@@ -40,7 +44,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kai.acp import AcpBackend, drain_late_text
+from kai.acp import AcpBackend, convert_image_block, drain_late_text
 from kai.backend import USER_MESSAGE_MARKER, StreamEvent
 from kai.config import WorkspaceConfig
 
@@ -100,13 +104,22 @@ def _json_line(obj: dict) -> bytes:
     return json.dumps(obj).encode() + b"\n"
 
 
-def _initialize_result() -> bytes:
-    """Build the server's response to an initialize request."""
+def _initialize_result(prompt_capabilities: dict | None = None) -> bytes:
+    """Build the server's response to an initialize request.
+
+    `prompt_capabilities` lands under `agentCapabilities.
+    promptCapabilities` (the ACP location AcpBackend reads the image
+    capability from); None omits the key entirely, matching an agent
+    that does not advertise prompt capabilities.
+    """
+    caps: dict = {}
+    if prompt_capabilities is not None:
+        caps["promptCapabilities"] = prompt_capabilities
     return _json_line(
         {
             "jsonrpc": "2.0",
             "id": 1,
-            "result": {"protocolVersion": 0, "agentCapabilities": {}},
+            "result": {"protocolVersion": 0, "agentCapabilities": caps},
         }
     )
 
@@ -199,9 +212,9 @@ def _make_mock_proc(stdout_lines: list[bytes]) -> MagicMock:
     return proc
 
 
-def _handshake_lines(session_id: str = "sess-1") -> list[bytes]:
+def _handshake_lines(session_id: str = "sess-1", prompt_capabilities: dict | None = None) -> list[bytes]:
     """Return the two stdout lines for a successful handshake."""
-    return [_initialize_result(), _session_new_result(session_id)]
+    return [_initialize_result(prompt_capabilities), _session_new_result(session_id)]
 
 
 async def _collect_events(backend: _FakeAcp, prompt: str | list = "test") -> list[StreamEvent]:
@@ -210,6 +223,11 @@ async def _collect_events(backend: _FakeAcp, prompt: str | list = "test") -> lis
     async for event in backend._send_locked(prompt):
         events.append(event)
     return events
+
+
+def _anthropic_image_block(data: str = "QkFTRTY0", media_type: str = "image/jpeg") -> dict:
+    """Anthropic-style base64 image block, the shape the bot layer builds."""
+    return {"type": "image", "source": {"type": "base64", "media_type": media_type, "data": data}}
 
 
 # ── Hook surface contract ───────────────────────────────────────────
@@ -1026,6 +1044,204 @@ class TestContentStripping:
         prompt_texts = [block["text"] for block in prompt_msg["params"]["prompt"]]
         joined = " ".join(prompt_texts)
         assert "(empty prompt)" in joined
+
+    @pytest.mark.asyncio
+    async def test_image_forwarded_when_agent_supports_it(self):
+        """With `promptCapabilities.image` captured as True, an
+        Anthropic-style image block is converted to the ACP shape and
+        written on session/prompt; no drop notice appears."""
+        b = _make_fake(workspace=Path("/tmp/ws"), home_workspace=Path("/tmp/ws"))
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+        b._supports_image_input = True
+
+        prompt: list = [
+            {"type": "text", "text": "what is in this image"},
+            _anthropic_image_block(),
+        ]
+        events = await _collect_events(b, prompt=prompt)
+
+        write_calls = b._proc.stdin.write.call_args_list
+        prompt_msg = json.loads(write_calls[-1][0][0].decode())
+        sent_blocks = prompt_msg["params"]["prompt"]
+        assert {"type": "image", "mimeType": "image/jpeg", "data": "QkFTRTY0"} in sent_blocks
+        final = events[-1].response
+        assert final is not None and final.success
+        assert "[Note:" not in final.text
+
+    @pytest.mark.asyncio
+    async def test_dropped_image_seeds_user_notice(self):
+        """Without image capability the block is dropped AND the reply
+        text carries a notice; a log-only drop leaves the user
+        believing the model saw the image."""
+        b = _make_fake(workspace=Path("/tmp/ws"), home_workspace=Path("/tmp/ws"))
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        prompt: list = [
+            {"type": "text", "text": "what is in this image"},
+            _anthropic_image_block(),
+        ]
+        events = await _collect_events(b, prompt=prompt)
+
+        write_calls = b._proc.stdin.write.call_args_list
+        prompt_msg = json.loads(write_calls[-1][0][0].decode())
+        assert all(block["type"] == "text" for block in prompt_msg["params"]["prompt"])
+        final = events[-1].response
+        assert final is not None and final.success
+        assert final.text.startswith("[Note: 1 attached image could not be passed to FakeAcp")
+        assert "ok" in final.text
+
+    @pytest.mark.asyncio
+    async def test_two_dropped_images_pluralize_notice(self):
+        """The notice counts every dropped image in the turn."""
+        b = _make_fake(workspace=Path("/tmp/ws"), home_workspace=Path("/tmp/ws"))
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        prompt: list = [
+            {"type": "text", "text": "compare these"},
+            _anthropic_image_block(),
+            _anthropic_image_block(data="QUJD"),
+        ]
+        events = await _collect_events(b, prompt=prompt)
+
+        final = events[-1].response
+        assert final is not None
+        assert final.text.startswith("[Note: 2 attached images could not be passed to FakeAcp")
+
+    @pytest.mark.asyncio
+    async def test_malformed_image_dropped_despite_capability(self):
+        """A block that is not the Anthropic base64 shape is dropped
+        (with the notice) even when the agent supports images, rather
+        than sending a malformed ACP block."""
+        b = _make_fake(workspace=Path("/tmp/ws"), home_workspace=Path("/tmp/ws"))
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+        b._supports_image_input = True
+
+        prompt: list = [
+            {"type": "text", "text": "what is in this image"},
+            {"type": "image", "source": "fake"},
+        ]
+        events = await _collect_events(b, prompt=prompt)
+
+        write_calls = b._proc.stdin.write.call_args_list
+        prompt_msg = json.loads(write_calls[-1][0][0].decode())
+        assert all(block["type"] == "text" for block in prompt_msg["params"]["prompt"])
+        final = events[-1].response
+        assert final is not None
+        assert final.text.startswith("[Note: 1 attached image")
+
+    @pytest.mark.asyncio
+    async def test_eof_after_drop_is_error_not_notice_success(self):
+        """A process that dies without output after an image drop must
+        surface as an error; the notice seed alone is not a reply."""
+        b = _make_fake(workspace=Path("/tmp/ws"), home_workspace=Path("/tmp/ws"))
+        b._proc = _make_mock_proc([])  # immediate EOF
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        prompt: list = [
+            {"type": "text", "text": "what is in this image"},
+            _anthropic_image_block(),
+        ]
+        events = await _collect_events(b, prompt=prompt)
+
+        final = events[-1].response
+        assert final is not None
+        assert not final.success
+        assert final.error is not None and "ended unexpectedly" in final.error
+
+
+# ── Image block conversion ───────────────────────────────────────────
+
+
+class TestConvertImageBlock:
+    """`convert_image_block` translates the Anthropic base64 image
+    shape (built by the bot layer) into ACP's image content block, and
+    returns None on any other shape so the caller drops it."""
+
+    def test_converts_anthropic_base64_block(self):
+        assert convert_image_block(_anthropic_image_block()) == {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "data": "QkFTRTY0",
+        }
+
+    def test_non_dict_source_returns_none(self):
+        assert convert_image_block({"type": "image", "source": "fake"}) is None
+
+    def test_non_base64_source_type_returns_none(self):
+        block = {"type": "image", "source": {"type": "url", "url": "https://x.test/i.png"}}
+        assert convert_image_block(block) is None
+
+    def test_missing_data_returns_none(self):
+        block = {"type": "image", "source": {"type": "base64", "media_type": "image/png"}}
+        assert convert_image_block(block) is None
+
+    def test_missing_media_type_returns_none(self):
+        block = {"type": "image", "source": {"type": "base64", "data": "QkFTRTY0"}}
+        assert convert_image_block(block) is None
+
+
+# ── Image capability capture ─────────────────────────────────────────
+
+
+class TestImageCapabilityCapture:
+    """The handshake reads `agentCapabilities.promptCapabilities.image`
+    from the initialize result; missing or malformed structures mean
+    no image support."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("prompt_capabilities", "expected"),
+        [
+            ({"image": True}, True),
+            ({"image": False}, False),
+            ({"embeddedContext": True}, False),
+            (None, False),
+        ],
+    )
+    async def test_capability_captured_from_initialize(self, prompt_capabilities, expected):
+        b = _make_fake()
+
+        async def _fake_spawn(*args, **kwargs):
+            return _make_mock_proc(_handshake_lines(prompt_capabilities=prompt_capabilities))
+
+        with patch("kai.acp.asyncio.create_subprocess_exec", side_effect=_fake_spawn):
+            await b._ensure_started()
+
+        assert b._supports_image_input is expected
 
 
 # ── Server-initiated request handling ───────────────────────────────


### PR DESCRIPTION
Closes #601

## Problem

Photos sent to the bot never reached the model on ACP backends (opencode, goose), and the user got no indication. The bot layer builds Anthropic-style base64 image blocks; the claude backend forwards content blocks verbatim, but the ACP send path stripped every non-text block with only a log warning, so the reply was generated from the caption text alone while the user reasonably assumed the model saw the image.

## Change

Capability-gated forwarding, with a user-visible notice on the drop path:

- The initialize handshake now reads the agent's `agentCapabilities.promptCapabilities.image` instead of discarding the result. Missing or malformed capability structures count as no support, since sending an image to an agent that never advertised support is a protocol violation, while dropping one is only a degraded reply.
- New `convert_image_block` in `src/kai/acp.py` translates the Anthropic base64 shape (`source.media_type` / `source.data`) to ACP's image content block (`mimeType` / `data`). Blocks that are not the expected shape return None and are dropped.
- When the agent supports images, converted blocks ride through `assemble_turn_context` (which already handles mixed-modal lists) onto `session/prompt`. Both probed agents advertise support, so this lights up images on opencode 1.15.11 and goose 1.29.1.
- When a block is dropped (no capability, or unconvertible shape), the reply text is seeded with `[Note: N attached image(s) could not be passed to <backend>; this reply is based on the message text only.]` so the drop is no longer silent. The seed ends at a line break so the opencode chunk-join heuristic never fires against it.
- The EOF-process-died path previously keyed success off non-empty accumulated text; it now uses an explicit got-model-text flag so a notice seed alone cannot surface as a successful reply.

## Verification against live agents

Both installed ACP agents were probed with a real `initialize` handshake over stdio:

- opencode 1.15.11: `promptCapabilities: {"embeddedContext": true, "image": true}`
- goose 1.29.1: `promptCapabilities: {"image": true, "audio": false, "embeddedContext": true}`

The ACP image block shape (`type`/`mimeType`/`data`, base64) was taken from the protocol documentation at agentclientprotocol.com.

Note: capability is advertised per agent, not per model. A text-only model behind a capable agent is the provider's concern; what the model does with the image is outside Kai's visibility. An end-to-end check is sending a photo over Telegram on the opencode backend after deploy.

## Testing

- Capability capture parametrized over true/false/absent/malformed initialize results.
- Forwarding: ACP-shape image block present on the written `session/prompt`, no notice in the reply.
- Drop paths: notice seeded (singular and plural), malformed block dropped despite capability, all-dropped input still gets the `(empty prompt)` placeholder.
- EOF after a drop stays an error rather than a notice-only success.
- `convert_image_block` unit-tested across good and malformed shapes.
- Full suite: 3773 passed, 1 skipped. `ruff check` and `ruff format --check` clean.
