### PR TITLE
fix(codex): forward image blocks as localImage turn input

### DIFF
--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -38,11 +38,13 @@ decoupled from a vendor SDK's versioning.
 """
 
 import asyncio
+import base64
 import json
 import logging
 import os
 import signal
 import subprocess
+import tempfile
 import time
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -73,6 +75,88 @@ log = logging.getLogger(__name__)
 # "opus" / "haiku" to claude-sonnet-4-6 etc for the Anthropic case.
 # If a future codex version accepts a Kai-internal alias, add a map
 # here and apply it before setting CODEX_MODEL on the subprocess env.
+
+
+# Where per-turn image files for codex live. The app-server's
+# LocalImageUserInput takes a file path, not an inline payload, so the
+# base64 image data the bot layer sends in content blocks must be
+# materialized on disk for the duration of the turn. The directory
+# sits under DATA_DIR/files because that tree is the established
+# agent-readable upload area (the bot already tells agents to read
+# saved uploads there by absolute path); the workspace would also be
+# readable but project workspaces can be git repositories, and a
+# transient binary appearing inside one invites accidental commits.
+_TURN_IMAGE_DIR = DATA_DIR / "files" / "codex_turn_images"
+
+
+def write_turn_image_file(block: dict) -> Path | None:
+    """
+    Materialize an Anthropic-style base64 image block as a file for
+    codex's `localImage` input item.
+
+    The bot layer builds image content in the Anthropic form
+    (`{"type": "image", "source": {"type": "base64", "media_type":
+    ..., "data": ...}}`) because the claude backend forwards content
+    blocks verbatim. The codex app-server has no inline-payload image
+    input; its `LocalImageUserInput` is `{"type": "localImage",
+    "path": ...}`, so the payload is written to a temp file and the
+    path rides the turn. The caller owns the file's lifetime and
+    unlinks it when the turn ends.
+
+    The file is chmod 0o644 after writing (NamedTemporaryFile
+    defaults to 0o600, which the target-user subprocess cannot open
+    on the sudo-wrapped path) and the directory 0o755, the same
+    posture as the codex one-shot's `--output-schema` temp file.
+
+    Returns None when the block is not the expected Anthropic base64
+    shape, the payload is not valid base64, or the write fails; the
+    caller drops such blocks with a user-visible notice.
+    """
+    source = block.get("source")
+    if not isinstance(source, dict) or source.get("type") != "base64":
+        return None
+    media_type = source.get("media_type")
+    data = source.get("data")
+    if not isinstance(media_type, str) or not isinstance(data, str):
+        return None
+    try:
+        raw = base64.b64decode(data, validate=True)
+    except ValueError:
+        return None
+
+    # Suffix from the media subtype so the file extension matches the
+    # content (codex and the model both key on extensions for type
+    # hints). A subtype that is not a plain token falls back to a
+    # neutral suffix rather than letting caller-controlled text into
+    # the filename.
+    subtype = media_type.split("/", 1)[-1]
+    suffix = f".{subtype}" if subtype.isalnum() else ".img"
+    try:
+        _TURN_IMAGE_DIR.mkdir(parents=True, exist_ok=True)
+        _TURN_IMAGE_DIR.chmod(0o755)
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            suffix=suffix,
+            prefix="turn-image-",
+            dir=str(_TURN_IMAGE_DIR),
+            delete=False,
+        ) as fh:
+            fh.write(raw)
+            path = Path(fh.name)
+        path.chmod(0o644)
+    except OSError as e:
+        log.warning("CodexBackend: could not write turn image file: %s", e)
+        return None
+    return path
+
+
+def _unlink_turn_images(paths: list[Path]) -> None:
+    """Remove this turn's image files; missing files are fine."""
+    for path in paths:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as e:
+            log.warning("CodexBackend: could not remove turn image %s: %s", path, e)
 
 
 # ── Codex CLI backend ─────────────────────────────────────────────
@@ -593,28 +677,46 @@ class CodexBackend(AgentBackend):
         # through the helper signature.
         reminder = build_foreign_workspace_reminder(self.workspace, self.home_workspace) or ""
 
-        # Strip non-text user blocks before per-turn assembly. The
-        # codex CLI accepts text blocks only; the drop must run BEFORE
+        # Normalize user blocks to the app-server `UserInput` shape
+        # before per-turn assembly. Text blocks pass through; image
+        # blocks are materialized to disk and forwarded as
+        # `localImage` items (the protocol schema's image carrier; no
+        # capability gate exists or is needed, the schema is fixed by
+        # the installed CLI). A block that cannot be materialized
+        # (wrong shape, bad base64, write failure) is dropped and
+        # counted so the reply carries a user-visible notice; a
+        # log-only drop leaves the user believing the model saw an
+        # image it never received. Normalization must run BEFORE
         # assemble_turn_context so the marker it prepends labels a
-        # real user-text region. Stripping after the helper would
-        # leave injected text layers (session_context, reminder,
-        # memory) above the marker and nothing below it.
+        # real user region. Running it after the helper would leave
+        # injected text layers (session_context, reminder, memory)
+        # above the marker and nothing below it.
         had_user_text = isinstance(prompt, str)
+        dropped_images = 0
+        turn_image_paths: list[Path] = []
         if isinstance(prompt, list):
-            text_blocks: list[dict] = []
+            input_blocks: list[dict] = []
             for block in prompt:
-                if block.get("type") == "text":
-                    text_blocks.append({"type": "text", "text": block["text"]})
-                else:
-                    log.warning(
-                        "CodexBackend: dropping non-text content block type=%s",
-                        block.get("type"),
-                    )
-            had_user_text = bool(text_blocks)
-            # Codex requires a non-empty `input` array. An all-non-text
-            # input becomes a single placeholder so the marker has a
-            # user region to label.
-            prompt = text_blocks or [{"type": "text", "text": "(empty prompt)"}]
+                block_type = block.get("type")
+                if block_type == "text":
+                    input_blocks.append({"type": "text", "text": block["text"]})
+                    continue
+                if block_type == "image":
+                    image_path = write_turn_image_file(block)
+                    if image_path is not None:
+                        turn_image_paths.append(image_path)
+                        input_blocks.append({"type": "localImage", "path": str(image_path)})
+                        continue
+                    dropped_images += 1
+                log.warning(
+                    "CodexBackend: dropping content block type=%s",
+                    block_type,
+                )
+            had_user_text = any(b.get("type") == "text" for b in input_blocks)
+            # Codex requires a non-empty `input` array. Input whose
+            # every block was dropped becomes a single placeholder so
+            # the marker has a user region to label.
+            prompt = input_blocks or [{"type": "text", "text": "(empty prompt)"}]
 
         # `chat_id=None` to the helper suppresses semantic recall for
         # this turn. The placeholder text "(empty prompt)" is backend-
@@ -634,8 +736,8 @@ class CodexBackend(AgentBackend):
 
         # Coerce to the JSON-RPC content-block shape. `prompt` is
         # either a str (from a str input; the helper preserves the
-        # input type family) or a list of text blocks (every non-
-        # text block was stripped above).
+        # input type family) or a list already normalized to
+        # `UserInput` items above (text plus any localImage entries).
         rpc_prompt: list[dict]
         if isinstance(prompt, str):
             rpc_prompt = [{"type": "text", "text": prompt}]
@@ -665,6 +767,10 @@ class CodexBackend(AgentBackend):
         except OSError as e:
             log.error("Failed to write to Codex process: %s", e)
             await self._kill()
+            # The turn never dispatched, so this turn's image files
+            # have no reader; the streaming loop's cleanup is not
+            # reached on this path.
+            _unlink_turn_images(turn_image_paths)
             yield StreamEvent(
                 text_so_far="",
                 done=True,
@@ -692,7 +798,26 @@ class CodexBackend(AgentBackend):
         # override the CURRENT item's text - never the prior
         # committed content. The visible text streamed to telegram
         # is `committed + ("\n\n" + current if current)`.
+        # When images were dropped above, the committed prefix is
+        # seeded with a notice so the user learns the model never saw
+        # them; the drop is otherwise invisible (the reply reads as a
+        # normal answer to the caption text). The seed carries no
+        # trailing separator because every commit join below inserts
+        # "\n\n" after a non-empty committed prefix. `got_model_text`
+        # exists because the seed makes the visible text non-empty
+        # before the model says anything; the EOF branch below must
+        # judge "did the model produce output" from this flag, not
+        # from visible-text truthiness, or a process that dies
+        # silently after an image drop would surface as a successful
+        # notice-only reply.
         committed_text = ""
+        got_model_text = False
+        if dropped_images:
+            noun = "image" if dropped_images == 1 else "images"
+            committed_text = (
+                f"[Note: {dropped_images} attached {noun} could not be passed to "
+                f"Codex; this reply is based on the message text only.]"
+            )
         current_item_id: str | None = None
         current_item_text = ""
 
@@ -753,7 +878,9 @@ class CodexBackend(AgentBackend):
                 if line:
                     last_activity = time.monotonic()
                 else:
-                    # EOF - process died
+                    # EOF - process died. Success iff the model said
+                    # anything; the notice seed alone does not count
+                    # (see `got_model_text` above).
                     log.error("Codex process EOF")
                     await self._kill()
                     visible = _visible_text()
@@ -761,9 +888,9 @@ class CodexBackend(AgentBackend):
                         text_so_far=visible,
                         done=True,
                         response=AgentResponse(
-                            success=bool(visible),
+                            success=got_model_text,
                             text=visible,
-                            error=None if visible else "Codex process ended unexpectedly",
+                            error=None if got_model_text else "Codex process ended unexpectedly",
                         ),
                     )
                     return
@@ -825,6 +952,7 @@ class CodexBackend(AgentBackend):
                     delta_text = params.get("delta", "")
                     delta_item_id = params.get("itemId")
                     if delta_text:
+                        got_model_text = True
                         # Defensive: if a delta arrives without a
                         # prior item/started (out-of-order or schema
                         # drift), treat it as opening a new item.
@@ -851,8 +979,11 @@ class CodexBackend(AgentBackend):
                         # Commit the in-flight item to the prefix and
                         # reset. Subsequent items append after a blank
                         # line; subsequent deltas can never overwrite
-                        # this text.
+                        # this text. `got_model_text` is set here as
+                        # well as on deltas because an item/completed
+                        # can carry text that never streamed as deltas.
                         if current_item_text:
+                            got_model_text = True
                             committed_text = (
                                 committed_text + "\n\n" + current_item_text if committed_text else current_item_text
                             )
@@ -966,6 +1097,13 @@ class CodexBackend(AgentBackend):
                     error=str(e),
                 ),
             )
+        finally:
+            # Every exit from the loop above is terminal for the turn
+            # (completion, turn failure, timeout, EOF, mid-turn error,
+            # or the consumer closing the generator), and codex
+            # consumes image input when the turn is processed, so the
+            # files have no reader past this point.
+            _unlink_turn_images(turn_image_paths)
 
     # ── Kill / restart / shutdown ──────────────────────────────────
 

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1028,8 +1028,10 @@ class TestPromptCoercion:
 
     @pytest.mark.asyncio
     async def test_list_prompt_drops_non_text_blocks(self):
-        """Non-text blocks are dropped with a warning; the marker and
-        text blocks are preserved."""
+        """Unconvertible non-text blocks are dropped from the `input`
+        array; the marker and text blocks are preserved. The
+        user-visible drop notice for images is pinned separately in
+        TestImageForwarding."""
         c = _make_codex()
         c._proc = _make_mock_proc([_agent_message_delta("ok"), _turn_completed("completed")])
         c._session_id = "test-session"

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -17,9 +17,14 @@ Covers:
 7. Send serialization via the internal lock (concurrent sends queue).
 8. Prompt coercion: string -> single text block, list-of-blocks dropping
    non-text content.
+9. Image input: Anthropic base64 blocks materialized via
+   write_turn_image_file and forwarded as localImage items, per-turn
+   file cleanup on every exit path, drop notice in the reply text for
+   unconvertible blocks, and the EOF-after-drop path staying an error.
 """
 
 import asyncio
+import base64
 import inspect
 import json
 import os
@@ -30,7 +35,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from kai.backend import USER_MESSAGE_MARKER, StreamEvent
-from kai.codex import CodexBackend
+from kai.codex import CodexBackend, write_turn_image_file
 from kai.config import WorkspaceConfig
 
 # ── Shared helpers ──────────────────────────────────────────────────
@@ -192,6 +197,21 @@ def _handshake_lines(thread_id: str = "codex-thread-1") -> list[bytes]:
       3. client `thread/start` -> server response (id=2)
     """
     return [_initialize_result(), _thread_start_result(thread_id)]
+
+
+_IMAGE_BYTES = b"fake-image-bytes"
+
+
+def _anthropic_image_block(media_type: str = "image/jpeg") -> dict:
+    """Anthropic-style base64 image block, the shape the bot layer builds."""
+    return {
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": media_type,
+            "data": base64.b64encode(_IMAGE_BYTES).decode(),
+        },
+    }
 
 
 async def _collect_events(c: CodexBackend, prompt: str | list = "test") -> list[StreamEvent]:
@@ -1144,6 +1164,196 @@ class TestPromptCoercion:
         # real user text, not the codex-synthetic placeholder.
         call = recall_spy.call_args
         assert call.args[0] == "real user text" or call.kwargs.get("query") == "real user text"
+
+
+# ── Image input ────────────────────────────────────────────────────
+
+
+class TestWriteTurnImageFile:
+    """`write_turn_image_file` materializes the Anthropic base64 image
+    shape as a world-readable file for codex's localImage input, and
+    returns None on any other shape so the caller drops the block."""
+
+    def test_writes_decoded_bytes_with_subtype_suffix(self):
+        path = write_turn_image_file(_anthropic_image_block())
+        assert path is not None
+        try:
+            assert path.read_bytes() == _IMAGE_BYTES
+            assert path.name.startswith("turn-image-")
+            assert path.suffix == ".jpeg"
+            assert path.parent.name == "codex_turn_images"
+            # World-readable so a sudo-routed codex user can open it.
+            assert path.stat().st_mode & 0o777 == 0o644
+        finally:
+            path.unlink()
+
+    def test_non_alnum_subtype_falls_back_to_neutral_suffix(self):
+        path = write_turn_image_file(_anthropic_image_block(media_type="image/svg+xml"))
+        assert path is not None
+        try:
+            assert path.suffix == ".img"
+        finally:
+            path.unlink()
+
+    def test_non_dict_source_returns_none(self):
+        assert write_turn_image_file({"type": "image", "source": "fake"}) is None
+
+    def test_non_base64_source_type_returns_none(self):
+        block = {"type": "image", "source": {"type": "url", "url": "https://x.test/i.png"}}
+        assert write_turn_image_file(block) is None
+
+    def test_missing_fields_return_none(self):
+        block = {"type": "image", "source": {"type": "base64", "media_type": "image/png"}}
+        assert write_turn_image_file(block) is None
+
+    def test_invalid_base64_returns_none(self):
+        block = {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "not!valid!b64"},
+        }
+        assert write_turn_image_file(block) is None
+
+
+class TestImageForwarding:
+    """Image blocks ride turn/start as localImage items; unconvertible
+    blocks are dropped with a user-visible notice; this turn's files
+    are removed on every exit path."""
+
+    @pytest.mark.asyncio
+    async def test_image_forwarded_as_local_image_and_cleaned_up(self):
+        c = _make_codex()
+        c._proc = _make_mock_proc([_agent_message_delta("ok"), _turn_completed("completed")])
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        prompt: list = [
+            {"type": "text", "text": "what is in this image"},
+            _anthropic_image_block(),
+        ]
+        events = await _collect_events(c, prompt=prompt)
+
+        write_calls = c._proc.stdin.write.call_args_list
+        sent_input = json.loads(write_calls[-1][0][0].decode())["params"]["input"]
+        local_images = [b for b in sent_input if b.get("type") == "localImage"]
+        assert len(local_images) == 1
+        sent_path = Path(local_images[0]["path"])
+        assert sent_path.name.startswith("turn-image-")
+        # The turn is over once events complete; the file is gone.
+        assert not sent_path.exists()
+        final = events[-1].response
+        assert final is not None and final.success
+        assert "[Note:" not in final.text
+
+    @pytest.mark.asyncio
+    async def test_dropped_image_seeds_user_notice(self):
+        """An unconvertible image block drops AND the reply text says
+        so; a log-only drop leaves the user believing the model saw
+        the image."""
+        c = _make_codex()
+        c._proc = _make_mock_proc([_agent_message_delta("ok"), _turn_completed("completed")])
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        prompt: list = [
+            {"type": "text", "text": "what is in this image"},
+            {"type": "image", "source": "fake"},
+        ]
+        events = await _collect_events(c, prompt=prompt)
+
+        write_calls = c._proc.stdin.write.call_args_list
+        sent_input = json.loads(write_calls[-1][0][0].decode())["params"]["input"]
+        assert all(b["type"] == "text" for b in sent_input)
+        final = events[-1].response
+        assert final is not None and final.success
+        # The notice is the committed prefix; the model text joins
+        # after the standard blank-line separator.
+        assert final.text == (
+            "[Note: 1 attached image could not be passed to Codex; this reply is based on the message text only.]\n\nok"
+        )
+
+    @pytest.mark.asyncio
+    async def test_two_dropped_images_pluralize_notice(self):
+        c = _make_codex()
+        c._proc = _make_mock_proc([_agent_message_delta("ok"), _turn_completed("completed")])
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        prompt: list = [
+            {"type": "text", "text": "compare these"},
+            {"type": "image", "source": "fake"},
+            {"type": "image", "source": "also-fake"},
+        ]
+        events = await _collect_events(c, prompt=prompt)
+
+        final = events[-1].response
+        assert final is not None
+        assert final.text.startswith("[Note: 2 attached images could not be passed to Codex")
+
+    @pytest.mark.asyncio
+    async def test_eof_after_drop_is_error_not_notice_success(self):
+        """A process that dies without output after an image drop must
+        surface as an error; the notice seed alone is not a reply."""
+        c = _make_codex()
+        c._proc = _make_mock_proc([b""])  # immediate EOF
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        prompt: list = [
+            {"type": "text", "text": "what is in this image"},
+            {"type": "image", "source": "fake"},
+        ]
+        events = await _collect_events(c, prompt=prompt)
+
+        final = events[-1].response
+        assert final is not None
+        assert not final.success
+        assert final.error is not None and "ended unexpectedly" in final.error
+
+    @pytest.mark.asyncio
+    async def test_eof_after_completed_item_is_success(self):
+        """Text that arrived only via item/completed (no deltas) still
+        counts as model output when the process then dies."""
+        c = _make_codex()
+        c._proc = _make_mock_proc([_item_started_agent(), _item_completed_agent("done"), b""])
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c, prompt="hello")
+
+        final = events[-1].response
+        assert final is not None
+        assert final.success
+        assert "done" in final.text
+
+    @pytest.mark.asyncio
+    async def test_image_file_cleaned_up_on_eof(self):
+        """The finally-side cleanup runs on the error exits too, not
+        just on turn completion."""
+        c = _make_codex()
+        # Hold a direct reference: the EOF path kills the subprocess,
+        # which nulls c._proc before the assertions run.
+        proc = _make_mock_proc([b""])  # immediate EOF
+        c._proc = proc
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        prompt: list = [
+            {"type": "text", "text": "what is in this image"},
+            _anthropic_image_block(),
+        ]
+        await _collect_events(c, prompt=prompt)
+
+        write_calls = proc.stdin.write.call_args_list
+        sent_input = json.loads(write_calls[-1][0][0].decode())["params"]["input"]
+        local_images = [b for b in sent_input if b.get("type") == "localImage"]
+        assert len(local_images) == 1
+        assert not Path(local_images[0]["path"]).exists()
 
 
 # ── Restart / force_kill / shutdown / change_workspace ────────────


### PR DESCRIPTION
Closes #604

## Problem

Same defect class as #601, on the codex backend: the send path stripped every non-text block with only a log warning, so photos sent on codex were answered from the caption text alone while the user reasonably assumed the model saw the image. The strip-site comment claimed "the codex CLI accepts text blocks only", which is wrong at the protocol level.

## Change

Mirrors the ACP fix's split (forward when the protocol allows it, visible notice when it does not), adapted to the app-server's image carrier:

- The app-server takes images as file paths, not inline payloads: `LocalImageUserInput` (`{"type": "localImage", "path": ...}`) on `turn/start`, verified against the installed CLI's `generate-json-schema` output (0.130.0). There is no per-agent capability handshake to consult; the schema is fixed by the CLI version, so unlike ACP no runtime gate is needed.
- New `write_turn_image_file` in `src/kai/codex.py` materializes the bot layer's Anthropic-style base64 blocks as temp files and returns the path. Files are chmod 0644 (and their directory 0755) so the sudo-routed codex user can open them, the same posture as the codex one-shot's `--output-schema` temp file. They live under the agent-readable upload tree rather than the workspace, since project workspaces can be git repositories and a transient binary appearing inside one invites accidental commits.
- This turn's files are removed on every exit path: a `finally` on the streaming loop covers completion, turn failure, timeout, EOF, mid-turn error, and generator close; the turn-dispatch write-failure path cleans up explicitly since it returns before the loop.
- Blocks that cannot be materialized (wrong shape, invalid base64, write failure) are dropped and the reply text is seeded with the same notice wording the ACP backends ship: `[Note: N attached image(s) could not be passed to Codex; this reply is based on the message text only.]`. The seed rides the existing committed-prefix join, so model text follows after a blank line.
- The EOF-process-died path previously keyed success off non-empty visible text; it now uses an explicit got-model-text flag (set on deltas and on `item/completed` text, which can arrive without deltas) so a notice seed alone cannot surface as a successful reply.

## Testing

- `write_turn_image_file` unit tests: decoded bytes, suffix derivation (including the non-alnum subtype fallback), 0644 mode, and None on wrong shape / wrong source type / missing fields / invalid base64.
- Forwarding: `localImage` item present on the written `turn/start` input; file gone after the turn completes; no notice in the reply.
- Drop paths: exact notice text with the blank-line join to model text, plural form, EOF-after-drop staying an error, and cleanup running on the EOF exit too.
- `item/completed`-only text (no deltas) still counts as model output at EOF.
- Full suite: 3785 passed, 1 skipped. `ruff check` and `ruff format --check` clean.

## Deploy note

End-to-end verification needs a codex-backed user sending a photo over Telegram after deploy; the dev-side verification here is schema-level plus the mocked subprocess tests.
