### PR TITLE
fix(goose): translate the deepseek provider key to goose's wire name

### DIFF
--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -35,6 +35,32 @@ _ANTHROPIC_MODEL_MAP: dict[str, str] = {
 }
 
 
+# Map Kai provider keys to goose's wire-level provider names. Kai uses
+# "deepseek" as its provider key everywhere (BACKEND_PROVIDERS, the
+# model registry, per-user config; shared with the opencode backend),
+# but goose ships DeepSeek as a declarative provider named
+# "custom_deepseek"; passing the bare name fails with "Unknown
+# provider: deepseek" before any API call. The .get(key, key) fallback
+# passes every other provider through unchanged, so the map only grows
+# when goose names a provider differently than Kai does.
+_GOOSE_PROVIDER_MAP: dict[str, str] = {
+    "deepseek": "custom_deepseek",
+}
+
+
+def goose_provider_id(provider: str) -> str:
+    """
+    Translate a Kai provider key to goose's wire-level provider name.
+
+    Used by every site that hands a provider name to the goose binary:
+    `GooseBackend.build_env` (GOOSE_PROVIDER) and the `goose run`
+    one-shot argv in review and triage (`--provider`). Kai-level
+    surfaces (wizard, /settings, users.yaml, the model registry) keep
+    the Kai key; only the goose wire name differs.
+    """
+    return _GOOSE_PROVIDER_MAP.get(provider, provider)
+
+
 # ── Goose ACP backend ─────────────────────────────────────────────
 
 
@@ -85,7 +111,10 @@ class GooseBackend(AcpBackend):
         has no default provider configured. Kai's wizard writes
         LLM_PROVIDER to /etc/kai/env for its own bookkeeping, but the
         goose binary reads the GOOSE_-prefixed name; the translation
-        happens here so the two layers stay decoupled.
+        happens here so the two layers stay decoupled. The value runs
+        through `goose_provider_id` because goose's wire-level provider
+        names can differ from Kai's keys (deepseek is custom_deepseek
+        on the goose side).
 
         Guarded on `self.provider` truthiness because it can be the
         empty-string default for the claude backend pre-wiring path,
@@ -99,7 +128,7 @@ class GooseBackend(AcpBackend):
         if mapped:
             base_env["GOOSE_MODEL"] = mapped
         if self.provider:
-            base_env["GOOSE_PROVIDER"] = self.provider
+            base_env["GOOSE_PROVIDER"] = goose_provider_id(self.provider)
         return base_env
 
     def build_session_new_params(self) -> dict:

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -39,6 +39,7 @@ import aiohttp
 
 from kai.codex_exec import extract_codex_text
 from kai.config import ModelRole, get_model_for, resolve_claude_user
+from kai.goose import goose_provider_id
 from kai.oneshot import OneShotError, OneShotTimeout, OpenCodeOneShotReasoner
 from kai.prompt_utils import make_boundary
 
@@ -814,9 +815,12 @@ async def run_review(
         # avoids creating session files, --no-profile skips user
         # config, --max-turns 1 prevents runaway tool loops. Model
         # comes from the unified (backend, provider, role) registry
-        # so a goose-on-deepseek install inherits deepseek-chat the
-        # same way claude inherits sonnet; openrouter / ollama users
-        # set their per-user `models.pr_review` in users.yaml.
+        # so a goose-on-deepseek install picks up the deepseek-shaped
+        # default; openrouter / ollama users set their per-user
+        # `models.pr_review` in users.yaml. The --provider value runs
+        # through `goose_provider_id` because goose's wire-level
+        # provider names can differ from Kai's keys (deepseek is
+        # custom_deepseek on the goose side).
         model = get_model_for(
             ModelRole.PR_REVIEW,
             agent_backend,
@@ -829,7 +833,7 @@ async def run_review(
             "-i",
             "-",
             "--provider",
-            provider,
+            goose_provider_id(provider),
             "--model",
             model,
             "-q",

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -37,6 +37,7 @@ import aiohttp
 
 from kai.codex_exec import extract_codex_text
 from kai.config import ModelRole, get_model_for, resolve_claude_user
+from kai.goose import goose_provider_id
 from kai.oneshot import OneShotError, OneShotTimeout, OpenCodeOneShotReasoner
 from kai.prompt_utils import make_boundary
 
@@ -530,7 +531,10 @@ async def run_triage(
         # resolution flows through the unified (backend, provider,
         # role) registry so a goose-on-deepseek install picks up the
         # deepseek-shaped default; openrouter / ollama users set
-        # their per-user `models.issue_triage` in users.yaml.
+        # their per-user `models.issue_triage` in users.yaml. The
+        # --provider value runs through `goose_provider_id` because
+        # goose's wire-level provider names can differ from Kai's
+        # keys (deepseek is custom_deepseek on the goose side).
         model = get_model_for(
             ModelRole.ISSUE_TRIAGE,
             agent_backend,
@@ -543,7 +547,7 @@ async def run_triage(
             "-i",
             "-",
             "--provider",
-            provider,
+            goose_provider_id(provider),
             "--model",
             model,
             "-q",

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -21,7 +21,7 @@ import pytest
 
 from kai.backend import USER_MESSAGE_MARKER, StreamEvent
 from kai.config import WorkspaceConfig
-from kai.goose import _ANTHROPIC_MODEL_MAP, GooseBackend
+from kai.goose import _ANTHROPIC_MODEL_MAP, GooseBackend, goose_provider_id
 
 # ── Shared helpers ───────────────────────────────────────────────────
 
@@ -212,6 +212,18 @@ class TestModelMapping:
         assert _ANTHROPIC_MODEL_MAP.get(model_id, model_id) == model_id
 
 
+class TestProviderTranslation:
+    """`goose_provider_id` maps Kai provider keys to goose's wire-level
+    provider names; everything without a mapping passes through."""
+
+    def test_deepseek_maps_to_custom_deepseek(self):
+        assert goose_provider_id("deepseek") == "custom_deepseek"
+
+    @pytest.mark.parametrize("provider", ["anthropic", "openai", "google", "openrouter", "ollama"])
+    def test_other_providers_pass_through(self, provider):
+        assert goose_provider_id(provider) == provider
+
+
 # ── Constructor ────────────────────────────────────────────────────
 
 
@@ -397,6 +409,25 @@ class TestHandshake:
 
         call_kwargs = mock_exec.call_args[1]
         assert call_kwargs["env"]["GOOSE_PROVIDER"] == "openai"
+
+    @pytest.mark.asyncio
+    async def test_deepseek_provider_translated_to_wire_name(self):
+        """
+        Kai's "deepseek" key becomes goose's "custom_deepseek" wire
+        name in GOOSE_PROVIDER. Goose ships DeepSeek as a declarative
+        provider under that name and rejects the bare key with
+        "Unknown provider: deepseek" before any API call.
+        """
+        g = _make_goose(model="deepseek-v4-pro", provider="deepseek")
+        proc = _make_mock_proc(_handshake_lines())
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await g._ensure_started()
+
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["env"]["GOOSE_PROVIDER"] == "custom_deepseek"
+        # Model names are NOT translated; only the provider name is.
+        assert call_kwargs["env"]["GOOSE_MODEL"] == "deepseek-v4-pro"
 
     @pytest.mark.asyncio
     async def test_provider_env_var_omitted_when_empty(self):

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -991,6 +991,23 @@ class TestRunReviewGoose:
         assert cmd[model_idx + 1] == "claude-sonnet-4-6"
 
     @pytest.mark.asyncio
+    async def test_deepseek_provider_translated_to_wire_name(self):
+        """Kai's "deepseek" key rides the argv as goose's
+        "custom_deepseek" wire name; goose rejects the bare key with
+        "Unknown provider: deepseek". The model name stays Kai's
+        registry value untranslated."""
+        mock_proc = _mock_process(stdout=b"output")
+
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_review("prompt", agent_backend="goose", provider="deepseek")
+
+        cmd = mock_exec.call_args[0]
+        provider_idx = cmd.index("--provider")
+        assert cmd[provider_idx + 1] == "custom_deepseek"
+        model_idx = cmd.index("--model")
+        assert cmd[model_idx + 1] == "deepseek-v4-pro"
+
+    @pytest.mark.asyncio
     async def test_successful_response_stripped(self):
         """Goose output is returned with whitespace stripped."""
         mock_proc = _mock_process(stdout=b"  review text with whitespace  \n")

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -530,6 +530,23 @@ class TestRunTriageGoose:
         assert cmd[model_idx + 1] == "claude-sonnet-4-6"
 
     @pytest.mark.asyncio
+    async def test_deepseek_provider_translated_to_wire_name(self):
+        """Kai's "deepseek" key rides the argv as goose's
+        "custom_deepseek" wire name; goose rejects the bare key with
+        "Unknown provider: deepseek". The model name stays Kai's
+        registry value untranslated."""
+        mock_proc = _mock_subprocess(stdout='{"labels": []}')
+
+        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await run_triage("prompt", agent_backend="goose", provider="deepseek")
+
+        cmd = mock_exec.call_args[0]
+        provider_idx = cmd.index("--provider")
+        assert cmd[provider_idx + 1] == "custom_deepseek"
+        model_idx = cmd.index("--model")
+        assert cmd[model_idx + 1] == "deepseek-v4-pro"
+
+    @pytest.mark.asyncio
     async def test_successful_response_stripped(self):
         """Goose output is returned with whitespace stripped."""
         mock_proc = _mock_subprocess(stdout='  {"labels": ["feature"]}  \n')


### PR DESCRIPTION
Closes #606

## Problem

Goose+DeepSeek did not work at all. Goose ships DeepSeek as a declarative provider named `custom_deepseek` (engine openai, base_url api.deepseek.com, `api_key_env: DEEPSEEK_API_KEY`), but Kai passed the literal string `deepseek` at every goose boundary, and goose rejects that with `Unknown provider: deepseek` before any API call. Probed against goose 1.29.1: `--provider deepseek` fails on name lookup; `--provider custom_deepseek --model deepseek-v4-pro` is recognized and proceeds to the expected 401 with no API key, with the V4 model name accepted client-side.

Affected surfaces: chat sessions (`GOOSE_PROVIDER` env), PR review, and issue triage (`--provider` argv).

## Change

- New `goose_provider_id` in `src/kai/goose.py`: a goose-owned wire-name map (`deepseek` to `custom_deepseek`, pass-through for everything else), mirroring how `_ANTHROPIC_MODEL_MAP` already translates model names at the same boundary.
- Applied at all three sites that hand a provider name to the goose binary: `GooseBackend.build_env`, the review goose branch, and the triage goose branch. A sweep confirms these are the only such sites.
- Kai-level surfaces (wizard, /settings, users.yaml, the model registry) keep `deepseek` as the provider key; model names are not translated (`deepseek-v4-pro` / `deepseek-v4-flash` ride through unchanged).
- The review goose-branch comment claiming the registry supplies `deepseek-chat` (the alias retiring 2026-07-24) is corrected; the registry value is `deepseek-v4-pro`, and the parallel triage comment already said so.

## Testing

- `goose_provider_id` unit tests: the deepseek mapping plus pass-through for the other five wizard-offered providers.
- `GooseBackend.build_env` with provider=deepseek exports `GOOSE_PROVIDER=custom_deepseek` and leaves `GOOSE_MODEL` untranslated.
- Review and triage goose-branch argv tests: `--provider custom_deepseek` with the registry model `deepseek-v4-pro`.
- Full suite: 3794 passed, 1 skipped. `ruff check` and `ruff format --check` clean.

## Deploy note

End-to-end verification needs a goose-backed user with `DEEPSEEK_API_KEY` provisioned; dev-side verification here is the no-auth probe matrix (provider recognized, correct 401) plus the mocked subprocess tests. Goose's own declarative model list for this provider still names the retiring aliases; client-side it did not reject the V4 names, but if model errors appear post-deploy, goose's stale list is the next suspect.
