### PR TITLE
feat(install): say when memory extraction is unavailable on a backend

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1465,6 +1465,18 @@ def _cmd_config() -> None:
                     except ValueError:
                         pass
                     print("  Must be a number between 0.3 and 1.01.")
+        else:
+            # Backends without a OneShotReasoner never see the
+            # extraction prompts above, and without this line the
+            # operator's only signal is silence: retrieval works but
+            # facts never accumulate, and nothing says why. One
+            # sentence at configure time names the limitation the
+            # moment the operator opts into memory.
+            print(
+                f"  Note: memory extraction is not available on the {agent_backend} "
+                "backend; memory will be retrieval-only (no facts are written from "
+                "conversations)."
+            )
         while True:
             memory_token_budget = _prompt(
                 "Memory context token budget per turn",

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -62,7 +62,7 @@ from telegram.error import BadRequest
 from telegram.ext import ContextTypes
 
 from kai import memory
-from kai.config import Config
+from kai.config import ONESHOT_REASONER_BACKENDS, Config
 from kai.memory import MemoryResult, MemoryStats
 
 if TYPE_CHECKING:
@@ -1306,6 +1306,24 @@ async def _send_dashboard(
         await _send_or_edit(update, _MSG_QUERY_FAILED, None, edit=edit)
         return
     text, kb = _build_dashboard(stats)
+    # Backends without a OneShotReasoner never run extraction, so for
+    # those users this dashboard only ever shrinks toward (or stays
+    # at) empty. Without an explicit line the user's only signal is
+    # silence: nothing accumulates and nothing says why. Appended
+    # here rather than in _build_dashboard so the builder stays a
+    # pure view over MemoryStats and the note also rides the
+    # empty-state text, where the question "why is this empty?" is
+    # sharpest. The per-user fall-through matches the extraction
+    # gate's backend resolution in bot.py.
+    config: Config = context.bot_data["config"]
+    user_config = config.get_user_config(chat_id)
+    effective_backend = user_config.agent_backend if user_config and user_config.agent_backend else config.agent_backend
+    if effective_backend not in ONESHOT_REASONER_BACKENDS:
+        text += (
+            f"\n\nNote: memory extraction is not available on the {effective_backend} "
+            "backend; this memory is retrieval-only (no facts are written from "
+            "conversations)."
+        )
     # Reset the cache: dashboard is the root. memory_ids cleared so
     # any stale fact button taps (from a previous search or episode
     # list) trip the session-expired branch instead of resolving to

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1382,7 +1382,7 @@ class TestCmdConfig:
             "in spec #353; an admin who needs a custom path must hand-edit users.yaml."
         )
 
-    def test_goose_backend_writes_env(self, tmp_path, monkeypatch):
+    def test_goose_backend_writes_env(self, tmp_path, monkeypatch, capsys):
         """Selecting goose backend writes AGENT_BACKEND to env."""
         monkeypatch.chdir(tmp_path)
         conf_path = tmp_path / "install.conf"
@@ -1439,6 +1439,69 @@ class TestCmdConfig:
         assert conf["env"]["AGENT_BACKEND"] == "goose"
         assert conf["env"]["LLM_PROVIDER"] == "anthropic"
         assert conf["env"]["ANTHROPIC_API_KEY"] == "sk-ant-test-key"
+        # Memory was declined, so the retrieval-only note must not
+        # print; it belongs only to the memory-enabled flow.
+        out = capsys.readouterr().out
+        assert "retrieval-only" not in out
+
+    def test_goose_memory_enabled_prints_retrieval_only_note(self, tmp_path, monkeypatch, capsys):
+        """Goose plus memory: the extraction prompts are skipped (no
+        OneShotReasoner), and the operator must be told the result is
+        retrieval-only rather than discovering it through facts never
+        accumulating."""
+        monkeypatch.chdir(tmp_path)
+        conf_path = tmp_path / "install.conf"
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
+
+        existing = {"version": 1, "env": {"AGENT_BACKEND": "goose"}}
+        conf_path.write_text(json.dumps(existing))
+
+        inputs = iter(
+            [
+                "protected",  # deployment mode
+                "/opt/kai",  # install dir
+                "/var/lib/kai",  # data dir
+                "kai",  # service user
+                "darwin",  # platform
+                "fake-token",  # bot token
+                "12345",  # admin telegram ID
+                "admin",  # admin display name
+                "false",  # advanced user options
+                "polling",  # transport
+                "goose",  # agent backend
+                "anthropic",  # goose provider
+                "sk-ant-test-key",  # ANTHROPIC_API_KEY
+                "sonnet",  # model
+                "false",  # customize per-role models
+                "120",  # timeout
+                "0",  # max session age hours
+                "1800",  # idle eviction timeout seconds
+                "8080",  # port
+                "test-secret",  # webhook secret
+                "~/Projects",  # workspace base
+                "",  # allowed workspaces (empty)
+                "300",  # pr review cooldown (global resource control)
+                "900",  # pr review timeout
+                "false",  # voice
+                "false",  # tts
+                "true",  # memory enabled
+                "2000",  # memory token budget (extraction prompts skipped)
+                "10",  # memory search limit
+                "",  # perplexity key (empty)
+            ]
+        )
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        out = capsys.readouterr().out
+        assert "memory extraction is not available on the goose backend" in out
+        assert "retrieval-only" in out
+        conf = json.loads((tmp_path / "install.conf").read_text())
+        assert conf["env"]["MEMORY_ENABLED"] == "true"
 
     def test_goose_ollama_no_api_key(self, tmp_path, monkeypatch):
         """Selecting ollama provider skips the API key prompt."""

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -2093,10 +2093,19 @@ class TestForgetConfirmMultiSource:
 
 @pytest.fixture
 def auth_config():
-    """A Config-shaped object that authorizes user_id 999."""
+    """A Config-shaped object that authorizes user_id 999.
+
+    Backend attributes are pinned to a reasoner-capable default
+    (claude, no per-user override) so the dashboard's retrieval-only
+    note stays out of tests that are not about it; a bare MagicMock
+    here would read as a non-reasoner backend and append the note
+    (with a mock repr in it) to every dashboard render.
+    """
     cfg = MagicMock()
     cfg.allowed_user_ids = {999}
     cfg.memory_search_floor = 0.3
+    cfg.agent_backend = "claude"
+    cfg.get_user_config.return_value = None
     return cfg
 
 
@@ -2324,6 +2333,88 @@ class TestCommandDispatch:
         # unauthorized users get silence, matching the rest of the bot.
         upd.message.reply_text.assert_not_called()
         upd.effective_chat.send_message.assert_not_called()
+
+
+# ── Dashboard retrieval-only note ──────────────────────────────────
+
+
+class TestDashboardBackendNote:
+    """Users on a backend without a OneShotReasoner never get
+    extraction; the dashboard must say so instead of letting the
+    user discover it through facts never accumulating."""
+
+    @pytest.mark.asyncio
+    async def test_note_appended_for_non_reasoner_backend(
+        self, monkeypatch, update_factory, context_factory, auth_config
+    ):
+        auth_config.agent_backend = "goose"
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        monkeypatch.setattr(
+            memory_command.memory,
+            "get_stats",
+            lambda *, user_id: _stats(extracted_count=3),
+        )
+        upd = update_factory()
+        ctx = context_factory(args=[])
+        await memory_command.handle_memory_command(upd, ctx)
+        sent_text = upd.effective_chat.send_message.call_args.kwargs["text"]
+        assert "memory extraction is not available on the goose backend" in sent_text
+        assert "retrieval-only" in sent_text
+
+    @pytest.mark.asyncio
+    async def test_note_rides_empty_state(self, monkeypatch, update_factory, context_factory, auth_config):
+        """The empty state is where "why is this empty?" is sharpest;
+        the note must appear there too, not only on populated
+        dashboards."""
+        auth_config.agent_backend = "goose"
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        monkeypatch.setattr(
+            memory_command.memory,
+            "get_stats",
+            lambda *, user_id: _stats(extracted_count=0),
+        )
+        upd = update_factory()
+        ctx = context_factory(args=[])
+        await memory_command.handle_memory_command(upd, ctx)
+        sent_text = upd.effective_chat.send_message.call_args.kwargs["text"]
+        assert "No memories yet" in sent_text
+        assert "retrieval-only" in sent_text
+
+    @pytest.mark.asyncio
+    async def test_no_note_for_reasoner_backend(self, monkeypatch, update_factory, context_factory):
+        """The auth_config fixture default (claude, no override) is a
+        reasoner backend; the note must not appear."""
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        monkeypatch.setattr(
+            memory_command.memory,
+            "get_stats",
+            lambda *, user_id: _stats(extracted_count=3),
+        )
+        upd = update_factory()
+        ctx = context_factory(args=[])
+        await memory_command.handle_memory_command(upd, ctx)
+        sent_text = upd.effective_chat.send_message.call_args.kwargs["text"]
+        assert "retrieval-only" not in sent_text
+
+    @pytest.mark.asyncio
+    async def test_per_user_override_drives_note(self, monkeypatch, update_factory, context_factory, auth_config):
+        """A per-user goose override on a claude-global install gets
+        the note; the fall-through matches the extraction gate's
+        backend resolution."""
+        user_cfg = MagicMock()
+        user_cfg.agent_backend = "goose"
+        auth_config.get_user_config.return_value = user_cfg
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        monkeypatch.setattr(
+            memory_command.memory,
+            "get_stats",
+            lambda *, user_id: _stats(extracted_count=3),
+        )
+        upd = update_factory()
+        ctx = context_factory(args=[])
+        await memory_command.handle_memory_command(upd, ctx)
+        sent_text = upd.effective_chat.send_message.call_args.kwargs["text"]
+        assert "memory extraction is not available on the goose backend" in sent_text
 
 
 # ── Cache TTL ──────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #607

## Problem

A goose operator enabling semantic memory was never told that extraction does not exist on their backend. Goose has no OneShotReasoner, so the wizard's entire extraction block is skipped and the runtime gate filters goose users out of `extract_and_store`. Both gates are correct, but nothing said so: the operator answered "Enable semantic memory", saw only the retrieval tunables, and the first signal that facts never accumulate was the accumulation never happening.

## Change

Two small visibility surfaces; no behavior change to any gate:

- **Wizard:** the `agent_backend in ONESHOT_REASONER_BACKENDS` block in `_cmd_config` gains an else that prints one line: `Note: memory extraction is not available on the <backend> backend; memory will be retrieval-only (no facts are written from conversations).` Backend-generic, so any future non-reasoner backend inherits it.
- **/memory dashboard:** `_send_dashboard` appends the same retrieval-only note when the user's effective backend (per-user override, else global, the same fall-through the extraction gate uses) has no reasoner. Appended in the send helper rather than `_build_dashboard` so the builder stays a pure view over stats and the note also rides the empty state, where "why is this empty?" is sharpest.

## Testing

- Wizard: a goose memory-enabled walk asserts the note prints (and the existing memory-declined walk asserts it does not). The new walk uses the canonical goose prompt sequence taken from the existing non-claude memory test.
- Dashboard: four handler-level tests; note present on populated and empty dashboards for a non-reasoner backend, absent for a reasoner backend, and driven by the per-user override fall-through. The shared config fixture is pinned to a reasoner-backend default so unrelated dashboard tests keep their semantics.
- Full suite: 3799 passed, 1 skipped. `ruff check` and `ruff format --check` clean.

## Test-debt observation (pre-existing, not touched)

Several older wizard walks in the install tests carry input lines for prompts that no longer exist (pr-review enabled, issue triage, github notify chat id) and pass only because numeric-validation retries absorb the extra values; one stray "Must be a positive integer." appears in their wizard output. The new test uses the correct sequence instead of copying the drift, but cleaning up the old walks is left for a separate change.
