### PR TITLE
feat(oneshot): add the goose one-shot reasoner

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -62,16 +62,17 @@ VALID_BACKENDS = {"claude", "goose", "codex", "opencode"}
 # membership; the constant is immutable at module scope and the
 # type pins that intent.
 #
-# Strict subset of VALID_BACKENDS: every entry here is also a valid
-# agent backend, but not every valid agent backend has a
-# OneShotReasoner. Concrete exclusion: `"goose"` is in
-# VALID_BACKENDS but not here because `src/kai/oneshot.py` has no
-# `GooseOneShotReasoner` class. Goose retrieval-only memory
-# installs work; goose one-shot dispatch (memory extraction, PR
-# review, triage) does not. The two constants stay distinct on
-# purpose; collapsing them would force a goose operator through
-# one-shot-eligibility gates the goose backend cannot satisfy.
-ONESHOT_REASONER_BACKENDS: frozenset[str] = frozenset({"claude", "codex", "opencode"})
+# Subset of VALID_BACKENDS by contract: every entry here is also a
+# valid agent backend, and membership asserts that
+# `src/kai/oneshot.py` ships a OneShotReasoner for it. Today every
+# valid backend qualifies, so the two sets happen to be equal, but
+# they stay distinct constants on purpose: a future backend lands in
+# VALID_BACKENDS first and joins this set only when its reasoner
+# exists, and every extraction-eligibility gate (bot dispatch, config
+# validation, wizard prompts, smoke, the /memory retrieval-only
+# note) keys off this set rather than VALID_BACKENDS so that gap
+# stays representable.
+ONESHOT_REASONER_BACKENDS: frozenset[str] = frozenset({"claude", "codex", "goose", "opencode"})
 
 # The single authoritative (backend, provider) allowlist. Every site
 # that needs to know "what providers can this backend talk to" reads
@@ -1832,10 +1833,9 @@ def _compute_extraction_eligible_backends(
     Return the set of distinct effective backends across extraction-eligible users.
 
     Mirrors `_ingest_memory`'s extraction gate (effective backend in
-    {"claude", "codex", "opencode"}; goose users are filtered out
-    because they have no `OneShotReasoner` implementation). Each user
-    contributes its effective backend (per-user override or global
-    default).
+    ONESHOT_REASONER_BACKENDS; a backend without a OneShotReasoner is
+    filtered out). Each user contributes its effective backend
+    (per-user override or global default).
 
     Returns an empty set when `memory_extraction_enabled` is False;
     callers that gate codex / opencode plumbing or registry validation
@@ -2884,8 +2884,8 @@ def load_config() -> Config:
     # time, so the "is this install in a valid state for memory
     # extraction" question must read the full eligible set rather than
     # a single global backend value. The helper mirrors
-    # `_ingest_memory`'s extraction gate in bot.py (goose users are
-    # filtered out because they have no `OneShotReasoner` implementation).
+    # `_ingest_memory`'s extraction gate in bot.py (membership in
+    # ONESHOT_REASONER_BACKENDS).
     extraction_eligible_backends = _compute_extraction_eligible_backends(
         agent_backend, user_configs, memory_extraction_enabled
     )

--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -2202,15 +2202,13 @@ async def _run_cli(args: argparse.Namespace) -> int:
     # _build_parser) means an unset flag yields override="" so the
     # branch below picks the right backend-appropriate default.
     #
-    # MODEL_REGISTRY covers every backend in ONESHOT_REASONER_BACKENDS;
-    # goose's model resolution lives in _GOOSE_AGENT_MODELS dicts inside
-    # triage.py and review.py, not in MODEL_REGISTRY. For goose (and any
-    # other backend that ever sits outside ONESHOT_REASONER_BACKENDS),
-    # preserve the pre-registry behavior: explicit --judge-model /
-    # --gen-model wins, otherwise the legacy _DEFAULT_JUDGE_MODEL /
-    # _DEFAULT_GEN_MODEL constants are used. This keeps the goose path
-    # byte-identical rather than crashing with a LookupError on an
-    # unset flag.
+    # MODEL_REGISTRY covers every backend in ONESHOT_REASONER_BACKENDS,
+    # which is every real backend today. The else arm below survives as
+    # the defensive path for an AGENT_BACKEND env value the registry
+    # does not know (a typo, or a future backend mid-introduction):
+    # explicit --judge-model / --gen-model wins, otherwise the legacy
+    # _DEFAULT_JUDGE_MODEL / _DEFAULT_GEN_MODEL constants are used
+    # rather than crashing with a LookupError on an unset flag.
     eval_backend = os.environ.get("AGENT_BACKEND", "claude").strip().lower()
     # Provider is read from the eval-time LLM_PROVIDER env (the eval
     # gate runs as a developer tool against the operator's configured
@@ -2232,10 +2230,8 @@ async def _run_cli(args: argparse.Namespace) -> int:
             override=args.gen_model or "",
         )
     else:
-        # Non-registry backend (goose). Preserve pre-Phase-1 behavior:
-        # explicit flag wins, otherwise the legacy _DEFAULT_* constant
-        # is used. Codex-aware behavioral wiring on non-registry
-        # backends is Phase 5 scope.
+        # Unrecognized AGENT_BACKEND env value: explicit flag wins,
+        # otherwise the legacy _DEFAULT_* constant is used.
         resolved_judge_model = args.judge_model or _DEFAULT_JUDGE_MODEL
         resolved_gen_model = args.gen_model or _DEFAULT_GEN_MODEL
     config = BehavioralConfig(

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -377,6 +377,20 @@ def _validate_opencode_bin(value: str) -> bool:
     return p.is_file() and os.access(p, os.X_OK)
 
 
+def _validate_goose_bin(value: str) -> bool:
+    """Return True when the path exists and is executable.
+
+    Required by the goose wizard prompt; same dual consumer as the
+    codex and opencode validators above (runtime GOOSE_BIN env var
+    plus the per-user sudoers rule), and the same is-file plus
+    executable body because the underlying requirement is the same.
+    """
+    if not value:
+        return False
+    p = Path(value)
+    return p.is_file() and os.access(p, os.X_OK)
+
+
 def _install_staging_path(filename: str) -> Path:
     """Return the per-operator staging path for a first-time install file.
 
@@ -824,6 +838,10 @@ def _cmd_config() -> None:
     # persistence gate at the tail of this function skips emitting
     # OPENCODE_BIN to install.conf.
     opencode_bin = ""
+    # Goose binary path: same collection and persistence shape as
+    # opencode above (global-goose block, extraction defense-in-depth
+    # re-prompt, empty-skip persistence gate for GOOSE_BIN).
+    goose_bin = ""
     if agent_backend == "codex":
         codex_auth_mode = _prompt_choice(
             "Codex auth mode",
@@ -899,6 +917,30 @@ def _cmd_config() -> None:
         print("    <service_user> ~$ opencode auth login")
         print("  Kai writes the active model into OPENCODE_CONFIG_CONTENT at process spawn;")
         print("  OpenCode resolves it against the credentials in ~/.local/share/opencode/auth.json.")
+
+    # Goose setup: binary-path wizard prompt. Mirrors the opencode
+    # block above: the wizard-persisted path drives /etc/kai/env's
+    # GOOSE_BIN and the per-user sudoers SETENV rule from one source
+    # of truth, and resolve_oneshot_binary("goose") prefers it over
+    # PATH discovery at run time. Default suggestion uses `which
+    # goose` from the operator's PATH (Homebrew installs land there);
+    # falls back to the empty string when which finds nothing so the
+    # operator types the path explicitly rather than accepting a
+    # wrong default. Provider auth needs no extra reminder here: the
+    # provider prompt below collects the API key for key-based
+    # providers, and keychain auth via `goose configure` is per-user
+    # and out of band.
+    if agent_backend == "goose":
+        while True:
+            which_goose = shutil.which("goose") or ""
+            goose_bin = _prompt(
+                "Goose binary path",
+                existing_env.get("GOOSE_BIN", which_goose),
+                required=True,
+            )
+            if _validate_goose_bin(goose_bin):
+                break
+            print(f"  Path '{goose_bin}' does not exist or is not executable.")
 
     # Multi-provider backends (opencode, goose): operator picks the
     # provider that drives the (backend, provider, role) registry
@@ -1258,12 +1300,12 @@ def _cmd_config() -> None:
         "Enable semantic memory (Mem0 + Qdrant)",
         existing_env.get("MEMORY_ENABLED", "false").lower() in ("1", "true", "yes"),
     )
-    # Codex memory is supported. Both claude and codex agent backends
-    # can run semantic memory with a backend-matched reasoner; the
-    # reasoner_backend prompt below resolves which subprocess runs
-    # the extraction. The historical "codex disables memory" guard
-    # was removed once OneShotReasoner abstracted away the claude-
-    # only assumption in memory_extraction.
+    # Every backend in ONESHOT_REASONER_BACKENDS can run semantic
+    # memory with a backend-matched reasoner; extraction dispatches
+    # per user at runtime via memory_extraction._build_memory_reasoner.
+    # The historical "codex disables memory" guard was removed once
+    # OneShotReasoner abstracted away the claude-only assumption in
+    # memory_extraction.
     # Defaults match the dataclass values in config.py. Only non-defaults
     # (or memory_enabled=true itself) are written to the env dict below.
     memory_extraction_enabled = False
@@ -1360,6 +1402,24 @@ def _cmd_config() -> None:
                         if _validate_opencode_bin(opencode_bin):
                             break
                         print(f"  Path '{opencode_bin}' does not exist or is not executable.")
+                # Same defense-in-depth shape for the goose global
+                # backend: the global-goose block above collects
+                # goose_bin on the normal flow; this gate covers a
+                # future refactor that reaches the extraction prompts
+                # with goose_bin still empty. Defaults mirror the
+                # global block (`which goose`, else empty so the
+                # operator types the path explicitly).
+                if agent_backend == "goose" and not goose_bin:
+                    while True:
+                        which_goose = shutil.which("goose") or ""
+                        goose_bin = _prompt(
+                            "Goose binary path (required by goose memory reasoner)",
+                            existing_env.get("GOOSE_BIN", which_goose),
+                            required=True,
+                        )
+                        if _validate_goose_bin(goose_bin):
+                            break
+                        print(f"  Path '{goose_bin}' does not exist or is not executable.")
                 # Extraction timeout is the LLM-call hard cap inside
                 # memory_extraction.py:541. Default 10s is too aggressive
                 # for production - real extractions routinely take 20-30s
@@ -1563,6 +1623,12 @@ def _cmd_config() -> None:
     # two cannot drift.
     if opencode_bin:
         env["OPENCODE_BIN"] = opencode_bin
+    # Same gating shape again for goose: persist only when the wizard
+    # collected a value, so non-goose installs do not carry an empty
+    # GOOSE_BIN= line. The single emission drives both /etc/kai/env's
+    # GOOSE_BIN and the sudoers SETENV rule so the two cannot drift.
+    if goose_bin:
+        env["GOOSE_BIN"] = goose_bin
 
     # Remove stale renamed keys if present - leaving both the old and
     # new key causes silent confusion (the deprecation warning is
@@ -2319,6 +2385,7 @@ def _generate_sudoers(
     os_users: Iterable[str] = (),
     codex_bin: str | None = None,
     opencode_bin: str | None = None,
+    goose_bin: str | None = None,
 ) -> str:
     """
     Generate sudoers rules for the service user to read protected config files.
@@ -2332,7 +2399,7 @@ def _generate_sudoers(
     in the current PATH (e.g., when running in a minimal environment).
 
     Per-user `(target_user) SETENV: NOPASSWD:` rules for the claude, codex,
-    and opencode binaries (plus a `NOPASSWD: /bin/kill` rule for the
+    opencode, and goose binaries (plus a `NOPASSWD: /bin/kill` rule for the
     cross-user kill escalation) are emitted for every distinct `os_user`
     value in users.yaml. Users matching `service_user` are skipped (the
     runtime detects self-sudo via resolve_claude_user() and spawns the
@@ -2341,7 +2408,9 @@ def _generate_sudoers(
     env var at install time. The opencode rule uses the service user's
     `~/.local/bin/opencode` path (where the upstream installer drops the
     binary by default); operators with a custom install location can
-    override via OPENCODE_BIN.
+    override via OPENCODE_BIN. The goose rule defaults to
+    /opt/homebrew/bin/goose (the Homebrew cask location) with the same
+    GOOSE_BIN override shape.
 
     Args:
         service_user: The OS username that runs the Kai service.
@@ -2419,6 +2488,12 @@ def _generate_sudoers(
         # override via OPENCODE_BIN (the wizard prompts for and
         # persists the value the same way CODEX_BIN is handled).
         opencode_bin_resolved = opencode_bin or f"{svc_home}/.local/bin/opencode"
+        # Goose binary path. Homebrew's block-goose-cli cask drops the
+        # binary under /opt/homebrew/bin/goose on macOS; the wizard
+        # prompts for and persists GOOSE_BIN the same way CODEX_BIN
+        # and OPENCODE_BIN are handled, so the fallback fires only on
+        # a first-time install where the wizard has not run yet.
+        goose_bin_resolved = goose_bin or "/opt/homebrew/bin/goose"
         # kill(1) for the cross-user kill escalation (#456). The bot
         # runs `sudo -n -u <target> /bin/kill -<sig> <pid>` against
         # the inner claude grandchild because POSIX signal permissions
@@ -2434,9 +2509,9 @@ def _generate_sudoers(
         # rationale as the claude_bin fix in PR #455.
         kill_bin = "/bin/kill"
         # SETENV: allows the service user to pass env vars (e.g.,
-        # KAI_WEBHOOK_SECRET) through sudo to claude and codex.
-        # Scoped to the claude and codex rules; the kill rule does
-        # not need SETENV (kill ignores env entirely), and the
+        # KAI_WEBHOOK_SECRET, provider API keys) through sudo to the
+        # agent binaries. Scoped to the agent rules; the kill rule
+        # does not need SETENV (kill ignores env entirely), and the
         # cat/tee config-read rules above remain locked down.
         #
         # Scope note for the generated rules below (also surfaced
@@ -2457,10 +2532,10 @@ def _generate_sudoers(
         rules += textwrap.dedent("""\
 
             # Per-target sudoers rules for the cross-os-user inner agent spawn.
-            # The claude, codex, and opencode rules grant arbitrary code execution
-            # as <target> (all three agents have Bash/Read/Write tools); the kill
-            # rule grants signal delivery to any <target>-owned process. The kill
-            # rule's scope is broader than a PID-locked rule because sudoers
+            # The claude, codex, opencode, and goose rules grant arbitrary code
+            # execution as <target> (all four agents have shell/file tools); the
+            # kill rule grants signal delivery to any <target>-owned process. The
+            # kill rule's scope is broader than a PID-locked rule because sudoers
             # argument matching is not safe per sudo(8). The kill rule is a strict
             # subset of capabilities the agent rules already provide; the practical
             # delta is zero.
@@ -2469,6 +2544,7 @@ def _generate_sudoers(
             rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {claude_bin}\n"
             rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {codex_bin_resolved}\n"
             rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {opencode_bin_resolved}\n"
+            rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {goose_bin_resolved}\n"
             rules += f"{service_user} ALL=({target}) NOPASSWD: {kill_bin}\n"
 
     return rules
@@ -3658,6 +3734,11 @@ def _cmd_apply() -> None:
         env_opencode_bin = os.environ.get("OPENCODE_BIN")
         if env_opencode_bin and env.get("AGENT_BACKEND") == "opencode":
             env["OPENCODE_BIN"] = env_opencode_bin
+        # And for GOOSE_BIN, completing the per-backend trio. Same
+        # global-AGENT_BACKEND gating posture as the two above.
+        env_goose_bin = os.environ.get("GOOSE_BIN")
+        if env_goose_bin and env.get("AGENT_BACKEND") == "goose":
+            env["GOOSE_BIN"] = env_goose_bin
         # AGENT_TIMEOUT_SECONDS migration. Operators upgrading without
         # re-running the wizard carry the legacy CLAUDE_TIMEOUT_SECONDS
         # key in install.conf; rewrite to the canonical name at apply
@@ -3696,6 +3777,7 @@ def _cmd_apply() -> None:
             dry_run,
             codex_bin=env.get("CODEX_BIN"),
             opencode_bin=env.get("OPENCODE_BIN"),
+            goose_bin=env.get("GOOSE_BIN"),
             agent_backend=env.get("AGENT_BACKEND", "claude"),
         )
 
@@ -4807,6 +4889,7 @@ def _apply_sudoers(
     users_yaml_path: str | Path = "/etc/kai/users.yaml",
     codex_bin: str | None = None,
     opencode_bin: str | None = None,
+    goose_bin: str | None = None,
     agent_backend: str = "claude",
 ) -> None:
     """
@@ -4817,13 +4900,14 @@ def _apply_sudoers(
     matching SETENV: NOPASSWD: rule. Without this, hand-added per-user rules
     were silently wiped on every `sudo make install`.
 
-    `codex_bin` and `opencode_bin` are threaded from `_cmd_apply`'s env
-    dict (which sources them from install.conf, after the apply-time
-    env-var override block) so the SETENV rules pin the same absolute
-    paths the running bot will invoke. `codex_bin` falls back to
-    /opt/homebrew/bin/codex; `opencode_bin` falls back to the service
-    user's `~/.local/bin/opencode`. Both fallbacks fire only on first-
-    time installs where the wizard has not run yet.
+    `codex_bin`, `opencode_bin`, and `goose_bin` are threaded from
+    `_cmd_apply`'s env dict (which sources them from install.conf,
+    after the apply-time env-var override block) so the SETENV rules
+    pin the same absolute paths the running bot will invoke.
+    `codex_bin` falls back to /opt/homebrew/bin/codex; `opencode_bin`
+    falls back to the service user's `~/.local/bin/opencode`;
+    `goose_bin` falls back to /opt/homebrew/bin/goose. The fallbacks
+    fire only on first-time installs where the wizard has not run yet.
 
     `agent_backend` is the install's global backend (the env dict's
     AGENT_BACKEND, defaulting to claude when the key is absent, which
@@ -4842,6 +4926,7 @@ def _apply_sudoers(
         os_users,
         codex_bin=codex_bin,
         opencode_bin=opencode_bin,
+        goose_bin=goose_bin,
     )
 
     # Backstop check: each per-user rule pins a backend binary to a
@@ -4855,12 +4940,10 @@ def _apply_sudoers(
     # global agent_backend plus any per-user agent_backend overrides
     # in users.yaml): telling an opencode-only operator to install
     # claude would manufacture a requirement that does not exist and
-    # train operators to ignore the warning. Goose has no entry in the
-    # map because it has no per-user sudoers rule (it always runs as
-    # the service user). The rules themselves are still emitted for
-    # all three binaries: a rule pointing at an absent path is inert,
-    # and unconditional emission means a later backend switch cannot
-    # strand a user without a rule.
+    # train operators to ignore the warning. The rules themselves are
+    # still emitted for all four binaries: a rule pointing at an
+    # absent path is inert, and unconditional emission means a later
+    # backend switch cannot strand a user without a rule.
     if os_users:
         backends_in_use = {agent_backend} | _collect_backends_from_yaml(users_yaml_path)
         svc_home = _user_home(service_user)
@@ -4884,6 +4967,11 @@ def _apply_sudoers(
                 Path(opencode_bin or f"{svc_home}/.local/bin/opencode"),
                 "Re-run 'make config' and point OPENCODE_BIN at the actual "
                 "opencode install location to keep the rule and runtime in sync.",
+            ),
+            "goose": (
+                Path(goose_bin or "/opt/homebrew/bin/goose"),
+                "Re-run 'make config' and point GOOSE_BIN at the actual goose "
+                "install location to keep the rule and runtime in sync.",
             ),
         }
         for backend in sorted(backends_in_use & expected_bins.keys()):

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -35,6 +35,7 @@ from kai.oneshot import _SUBPROCESS_ENV_ALLOWLIST as _SUBPROCESS_ENV_ALLOWLIST
 from kai.oneshot import (
     ClaudeOneShotReasoner,
     CodexOneShotReasoner,
+    GooseOneShotReasoner,
     OneShotError,
     OneShotReasoner,
     OneShotSubprocessError,
@@ -1888,24 +1889,34 @@ def _resolve_effective_provider(user_id: str, config: Config) -> str:
     return user_cfg.llm_provider or config.llm_provider
 
 
-def _build_memory_reasoner(effective_backend: str, os_user: str | None = None) -> OneShotReasoner:
+def _build_memory_reasoner(
+    effective_backend: str,
+    os_user: str | None = None,
+    provider: str = "",
+) -> OneShotReasoner:
     """
     Build the one-shot reasoner matching the user's effective backend.
 
     Dispatches on the per-user `effective_backend` resolved by
-    `_resolve_effective_backend`. The valid set is "claude" / "codex" /
-    "opencode"; goose users do not reach this site (gated upstream in
-    `bot.py`). The RuntimeError branch is a defensive safety net for
-    a future regression where the upstream gate widens or changes -
-    surfacing as a runtime error rather than silently selecting
-    Claude keeps the failure visible.
+    `_resolve_effective_backend`. The valid set is
+    ONESHOT_REASONER_BACKENDS; the RuntimeError branch is a defensive
+    safety net for a future regression where the upstream gate widens
+    or changes - surfacing as a runtime error rather than silently
+    selecting Claude keeps the failure visible.
 
     `os_user` is resolved once at the top of `extract_and_store` and
-    threaded in. All three reasoners accept `os_user=None` and spawn
+    threaded in. Every reasoner accepts `os_user=None` and spawns
     in-process via the self-sudo-skip path; a non-bot value wraps
     the argv in `sudo -H -u <user>`. Tests monkeypatch this helper
     to inject fake reasoners; the parameters are accepted but not
     inspected on the test side because patches use `return_value=`.
+
+    `provider` is consumed by the goose reasoner only: goose's
+    one-shot argv carries an explicit `--provider` flag, while the
+    other backends encode the provider implicitly (claude/codex are
+    single-provider; opencode embeds it in the model string). The
+    other branches accept and ignore it so the call sites stay
+    uniform.
 
     Returning a fresh instance per call (rather than a module-level
     singleton) keeps the memory path stateless and mirrors the
@@ -1917,6 +1928,8 @@ def _build_memory_reasoner(effective_backend: str, os_user: str | None = None) -
         return CodexOneShotReasoner(os_user=os_user)
     if effective_backend == "opencode":
         return OpenCodeOneShotReasoner(os_user=os_user)
+    if effective_backend == "goose":
+        return GooseOneShotReasoner(os_user=os_user, provider=provider)
     raise RuntimeError(f"extraction reached _build_memory_reasoner for non-extraction backend: {effective_backend!r}")
 
 
@@ -2003,7 +2016,7 @@ async def _run_extractor(
     # returned on failure. JSON envelope parsing stays in this
     # function so memory-domain concerns (is_error, structured_output,
     # facts, has_episode) do not leak into the reasoner.
-    reasoner = _build_memory_reasoner(effective_backend, os_user=os_user)
+    reasoner = _build_memory_reasoner(effective_backend, os_user=os_user, provider=effective_provider)
     # Per-role resolution consults the full precedence chain
     # (per-user `models.memory_extraction` > Config.default_models >
     # MODEL_REGISTRY). Pre-resolved backend / provider are passed as
@@ -2208,7 +2221,7 @@ async def _run_episode_extractor(
     # `os_user` is the routing target resolved once at the top of
     # `extract_and_store` (per-user OS routing); stage 2 inherits the
     # same target so the policy boundary is enforced consistently.
-    reasoner = _build_memory_reasoner(effective_backend, os_user=os_user)
+    reasoner = _build_memory_reasoner(effective_backend, os_user=os_user, provider=effective_provider)
     try:
         result = await reasoner.run(
             prompt=payload_text,

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -42,6 +42,7 @@ from typing import Any, Protocol
 from kai.acp import drain_late_text, read_result, write_rpc
 from kai.codex_exec import extract_codex_text
 from kai.config import DATA_DIR, resolve_claude_user
+from kai.goose import goose_provider_id
 from kai.oneshot_binary import BinaryResolutionError, resolve_oneshot_binary
 from kai.opencode import (
     concat_opencode_text,
@@ -284,6 +285,13 @@ _OPENCODE_PRESERVED_AUTH_VARS: tuple[str, ...] = (
     "OPENROUTER_API_KEY",
     "DEEPSEEK_API_KEY",
 )
+# Goose authenticates per provider via env keys (or the target user's
+# keychain, which `sudo -H` reaches through the rewritten HOME), so
+# the preserve list is the same five provider keys opencode carries.
+# GOOSE_MODEL / GOOSE_PROVIDER are deliberately absent: the one-shot
+# passes model and provider as argv flags, so nothing model-related
+# rides the environment on this path.
+_GOOSE_PRESERVED_AUTH_VARS: tuple[str, ...] = _OPENCODE_PRESERVED_AUTH_VARS
 
 
 def _preserved_auth_vars_for(backend: str) -> tuple[str, ...]:
@@ -303,6 +311,8 @@ def _preserved_auth_vars_for(backend: str) -> tuple[str, ...]:
         return _CODEX_PRESERVED_AUTH_VARS
     if backend == "opencode":
         return _OPENCODE_PRESERVED_AUTH_VARS
+    if backend == "goose":
+        return _GOOSE_PRESERVED_AUTH_VARS
     raise ValueError(f"unknown backend for preserve-env: {backend!r}")
 
 
@@ -2111,3 +2121,316 @@ async def _shutdown_opencode_proc(
         proc.kill()
     with contextlib.suppress(BaseException):
         await asyncio.wait_for(proc.wait(), timeout=5)
+
+
+# ── Goose implementation ────────────────────────────────────────────
+
+
+# Env vars forwarded to the goose one-shot subprocess. Identical in
+# content to the opencode list: PATH for binary resolution, HOME for
+# the keychain / config state goose reads per user, and the five
+# provider API keys for env-key auth flows. GOOSE_MODEL and
+# GOOSE_PROVIDER are deliberately absent: the one-shot passes model
+# and provider as argv flags (unlike the conversational GooseBackend,
+# which delivers both via env), so the env surface stays minimal.
+# KAI_WEBHOOK_SECRET is likewise absent; one-shots never serve the
+# webhook API.
+_GOOSE_ENV_ALLOWLIST = (
+    "PATH",
+    "HOME",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "OPENROUTER_API_KEY",
+    "DEEPSEEK_API_KEY",
+)
+
+
+def _render_goose_stdin(system_prompt: str | None, prompt: str) -> str:
+    """
+    Build the stdin payload for a goose one-shot call.
+
+    `goose run -i -` reads the whole instruction text from stdin and
+    has no dedicated system-prompt slot this reasoner trusts: the
+    `--system` flag exists but its semantics relative to the
+    recipe/profile system prompt are unverified, so the system text
+    rides inside the stdin payload behind a randomized boundary
+    block, exactly the shape `_render_codex_stdin` and
+    `_render_opencode_session_prompt` use. The boundary entropy is
+    collision-avoidance, not a security barrier; matching the
+    sibling renderers keeps the three non-claude one-shot prompt
+    shapes symmetric.
+
+    A None or empty `system_prompt` returns the user prompt
+    unchanged, matching the no-system-prompt semantics callers get
+    from claude's `--system-prompt` flag being omitted.
+    """
+    if not system_prompt:
+        return prompt
+    begin, end = make_boundary("SYSTEM")
+    return f"{begin}\n{system_prompt}\n{end}\n\n{prompt}"
+
+
+class GooseOneShotReasoner:
+    """
+    Spawns `goose run -i -` once per call and returns either the raw
+    response text or, when a JSON schema is supplied, the normalized
+    `{"is_error": false, "structured_output": ...}` envelope string
+    that matches the shape memory_extraction.py already parses.
+
+    Goose differs from the siblings in three load-bearing ways:
+
+    - The provider is an explicit argv flag: goose is multi-provider
+      and the registry's goose model names are bare (no provider
+      prefix), so the constructor takes the Kai provider key and the
+      argv carries `--provider <goose_provider_id(provider)>`. The
+      wire-name translation matters: goose ships DeepSeek as
+      `custom_deepseek` and rejects the bare Kai key.
+    - No structured-output channel at all: like opencode, the JSON
+      instruction rides the caller's prompt and compliance is model
+      discipline, so the schema-backed path parses through
+      `_parse_schema_payload` (fence / prose tolerant) rather than a
+      bare `json.loads`.
+    - Plain stdout: `-q` prints only the model response, so the
+      response text is the stripped stdout with no event-stream
+      walking (unlike codex's NDJSON).
+
+    Flag rationale (all verified against `goose run --help` on
+    1.29.1): `-i -` reads the prompt from stdin; `-q` suppresses
+    non-response output; `--no-session` writes no session files;
+    `--no-profile` keeps the operator's default extensions out of a
+    bounded structured-output call; `--max-turns 1` prevents tool
+    loops (the one-shot asks for text, not actions).
+    """
+
+    def __init__(self, *, cwd: Path | None = None, os_user: str | None = None, provider: str = "") -> None:
+        """
+        Args:
+            cwd: Override for the subprocess working directory. Tests
+                pass a temp path so the run does not touch the real
+                DATA_DIR; production callers leave this unset and the
+                reasoner uses `_EXTRACTOR_CWD`.
+            os_user: Optional target OS user, symmetric with the
+                other reasoners: None (or a value resolve_claude_user
+                collapses to the current process user) spawns goose
+                in-process; a non-bot username wraps the argv in
+                `sudo -H -u <user>`.
+            provider: Kai provider key for the `--provider` flag
+                (translated to goose's wire name at argv build).
+                Empty omits the flag so goose falls back to its own
+                GOOSE_PROVIDER / config default; production callers
+                always pass the user's effective provider.
+        """
+        self._cwd = cwd if cwd is not None else _EXTRACTOR_CWD
+        self._os_user = os_user
+        self._provider = provider
+
+    async def run(
+        self,
+        *,
+        prompt: str,
+        system_prompt: str | None = None,
+        model: str | None = None,
+        timeout: float | None = None,
+        purpose: str,
+        json_schema: dict[str, Any] | None = None,
+    ) -> OneShotResult:
+        # Lazy mkdir + chmod: deferred from import time so a
+        # permission failure surfaces as a logged miss rather than
+        # crashing the bot at startup. The unconditional chmod
+        # self-heals a pre-existing tighter mode on the next call.
+        self._cwd.mkdir(parents=True, exist_ok=True)
+        self._cwd.chmod(0o755)
+
+        # Shared resolver so config validation, this argv, and the
+        # smoke output all see the same resolution result.
+        # BinaryResolutionError becomes OneShotRoutingError here so
+        # the existing memory_extraction `except OneShotError` catch
+        # surface is unchanged.
+        try:
+            resolved_binary = resolve_oneshot_binary("goose")
+        except BinaryResolutionError as e:
+            raise OneShotRoutingError(str(e)) from e
+        cmd: list[str] = [resolved_binary, "run", "-i", "-"]
+        if self._provider:
+            cmd.extend(["--provider", goose_provider_id(self._provider)])
+        if model is not None:
+            cmd.extend(["--model", model])
+        cmd.extend(["-q", "--no-session", "--no-profile", "--max-turns", "1"])
+
+        # Per-user OS routing. Same shape the sibling reasoners use:
+        # resolve_claude_user returns None when the target is unset
+        # OR matches the bot user (self-sudo-skip), and the direct
+        # spawn path is byte-identical to a no-os_user call. A
+        # non-None target wraps the argv in sudo with the goose
+        # preserve list.
+        effective_user = resolve_claude_user(self._os_user)
+        if effective_user is not None:
+            cmd = _wrap_cmd_for_user(cmd, effective_user, "goose")
+
+        # Allow-listed env: only forward keys present in the parent
+        # env. PATH is allow-listed so sudo can resolve the bare
+        # `goose` invocation against the bot user's PATH when
+        # GOOSE_BIN is unset; an explicit GOOSE_BIN puts the absolute
+        # path straight into argv.
+        subprocess_env: dict[str, str] = {key: os.environ[key] for key in _GOOSE_ENV_ALLOWLIST if key in os.environ}
+
+        stdin_payload = _render_goose_stdin(system_prompt, prompt)
+        os_user_field = _os_user_log_field(effective_user)
+
+        start = time.monotonic()
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(self._cwd),
+            env=subprocess_env,
+            start_new_session=bool(effective_user),
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=stdin_payload.encode("utf-8")),
+                timeout=timeout,
+            )
+        except TimeoutError:
+            # Wrap path: escalate via the target user's permission to
+            # signal its own process group so the whole descendant
+            # tree terminates before the wrapper is reaped. Direct
+            # path keeps the plain kill+await.
+            if effective_user is not None:
+                await _kill_target_user_tree(
+                    target_user=effective_user,
+                    pgid=proc.pid,
+                    purpose=purpose,
+                    backend="goose",
+                )
+            proc.kill()
+            await proc.wait()
+            duration_ms = int((time.monotonic() - start) * 1000)
+            log.info(
+                "oneshot_reasoner purpose=%s backend=goose model=%s duration_ms=%d outcome=timeout error_category=timeout os_user=%s",
+                purpose,
+                model,
+                duration_ms,
+                os_user_field,
+            )
+            raise OneShotTimeout() from None
+
+        duration_ms = int((time.monotonic() - start) * 1000)
+        returncode = proc.returncode if proc.returncode is not None else -1
+        if returncode != 0:
+            log.info(
+                "oneshot_reasoner purpose=%s backend=goose model=%s duration_ms=%d outcome=subprocess_error error_category=non_zero_exit returncode=%d os_user=%s",
+                purpose,
+                model,
+                duration_ms,
+                returncode,
+                os_user_field,
+            )
+            raise OneShotSubprocessError(returncode=returncode, stderr=stderr)
+
+        response_text = stdout.decode("utf-8", errors="replace").strip()
+        raw_metadata = {
+            "returncode": returncode,
+            "stderr": stderr,
+            "cwd": str(self._cwd),
+            # cmd is post-wrap (includes the sudo prefix on
+            # cross-user routing); resolved_binary is the pre-wrap
+            # agent path so the smoke output's "which binary ran"
+            # answer survives the wrap, where cmd[0] is "sudo".
+            "cmd": list(cmd),
+            "resolved_binary": resolved_binary,
+        }
+
+        # Free-form path: hand the response text back unchanged.
+        # Memory extraction always supplies a schema, so this branch
+        # exists only for future free-form callers; claude, codex,
+        # and opencode keep the symmetric branch.
+        if json_schema is None:
+            log.info(
+                "oneshot_reasoner purpose=%s backend=goose model=%s duration_ms=%d outcome=success returncode=0 os_user=%s",
+                purpose,
+                model,
+                duration_ms,
+                os_user_field,
+            )
+            return OneShotResult(
+                text=response_text,
+                backend="goose",
+                model=model,
+                raw_metadata=raw_metadata,
+                duration_ms=duration_ms,
+            )
+
+        # Schema-backed path. Mirrors the codex and opencode
+        # reasoners: the response text must carry a JSON object, with
+        # `_parse_schema_payload` tolerating fence / prose wrapping
+        # around it; anything it cannot recover is OneShotOutputError
+        # so memory extraction's caller-side mapping collapses it to
+        # the zero-state extraction result instead of letting a
+        # malformed payload reach the fact validator.
+        if not response_text:
+            log.info(
+                "oneshot_reasoner purpose=%s backend=goose model=%s duration_ms=%d outcome=output_error error_category=empty_response returncode=0 os_user=%s",
+                purpose,
+                model,
+                duration_ms,
+                os_user_field,
+            )
+            raise OneShotOutputError("goose produced no response text")
+        try:
+            payload = _parse_schema_payload(response_text)
+        except json.JSONDecodeError as exc:
+            log.info(
+                "oneshot_reasoner purpose=%s backend=goose model=%s duration_ms=%d outcome=output_error error_category=invalid_json returncode=0 os_user=%s",
+                purpose,
+                model,
+                duration_ms,
+                os_user_field,
+            )
+            raise OneShotOutputError(f"goose response text did not contain a JSON object: {exc}") from None
+
+        if not isinstance(payload, dict):
+            log.info(
+                "oneshot_reasoner purpose=%s backend=goose model=%s duration_ms=%d outcome=output_error error_category=non_object_json returncode=0 os_user=%s",
+                purpose,
+                model,
+                duration_ms,
+                os_user_field,
+            )
+            raise OneShotOutputError("goose response JSON was not an object")
+
+        required_fields = json_schema.get("required")
+        if isinstance(required_fields, list):
+            missing = [field for field in required_fields if field not in payload]
+            if missing:
+                log.info(
+                    "oneshot_reasoner purpose=%s backend=goose model=%s duration_ms=%d outcome=output_error error_category=missing_required_fields returncode=0 os_user=%s",
+                    purpose,
+                    model,
+                    duration_ms,
+                    os_user_field,
+                )
+                raise OneShotOutputError(f"goose response JSON missing required fields: {missing}")
+
+        # Wrap goose's schema-shaped payload in the same envelope
+        # claude emits natively (codex and opencode mirror it).
+        # memory_extraction.py already walks the `structured_output`
+        # field on a parsed dict; rewrapping keeps the parser path
+        # provider-neutral.
+        envelope = json.dumps({"is_error": False, "structured_output": payload})
+        log.info(
+            "oneshot_reasoner purpose=%s backend=goose model=%s duration_ms=%d outcome=success returncode=0 os_user=%s",
+            purpose,
+            model,
+            duration_ms,
+            os_user_field,
+        )
+        return OneShotResult(
+            text=envelope,
+            backend="goose",
+            model=model,
+            raw_metadata=raw_metadata,
+            duration_ms=duration_ms,
+        )

--- a/src/kai/oneshot_binary.py
+++ b/src/kai/oneshot_binary.py
@@ -1,13 +1,14 @@
 """
 Shared agent-binary resolver for the one-shot reasoner family.
 
-Single source of truth for "where is the claude/codex/opencode binary."
+Single source of truth for "where is the agent binary" across the
+one-shot backends (claude, codex, opencode, goose).
 `kai.config.load_config()` uses this to fail-fast at startup when the
-memory reasoner backend points at an unreachable binary;
-`kai.oneshot.{Claude,Codex,OpenCode}OneShotReasoner` uses it to build
-argv with the resolved absolute path; `kai.smoke.memory` reads the
-resolved binary from `OneShotResult.raw_metadata["resolved_binary"]`
-to show the operator which binary actually ran.
+memory reasoner backend points at an unreachable binary; the
+`kai.oneshot` reasoner classes use it to build argv with the resolved
+absolute path; `kai.smoke.memory` reads the resolved binary from
+`OneShotResult.raw_metadata["resolved_binary"]` to show the operator
+which binary actually ran.
 
 Module is a leaf by design: imports `os`, `shutil`, `pathlib` only.
 Neither `kai.config` nor `kai.oneshot` is imported here. The
@@ -144,6 +145,25 @@ def resolve_oneshot_binary(backend: str) -> str:
         resolved = shutil.which("opencode")
         if resolved is None:
             raise BinaryResolutionError("could not resolve opencode binary: OPENCODE_BIN unset, `opencode` not on PATH")
+        return resolved
+
+    if backend == "goose":
+        # Structural mirror of the codex / opencode arms. GOOSE_BIN,
+        # when set, is validated as a configuration error with no
+        # PATH fallback; unset falls through to PATH discovery, which
+        # covers the common Homebrew install where `goose` is already
+        # resolvable from the service user's shell.
+        override = os.environ.get("GOOSE_BIN")
+        if override:
+            override_path = Path(override)
+            if not override_path.is_file():
+                raise BinaryResolutionError(f"could not resolve goose binary: GOOSE_BIN={override!r} not-a-file")
+            if not os.access(str(override_path), os.X_OK):
+                raise BinaryResolutionError(f"could not resolve goose binary: GOOSE_BIN={override!r} not-executable")
+            return str(override_path)
+        resolved = shutil.which("goose")
+        if resolved is None:
+            raise BinaryResolutionError("could not resolve goose binary: GOOSE_BIN unset, `goose` not on PATH")
         return resolved
 
     # Unknown backend. Unlike a resolution miss this is a caller bug

--- a/src/kai/smoke/memory.py
+++ b/src/kai/smoke/memory.py
@@ -47,10 +47,10 @@ log = logging.getLogger("kai.smoke.memory")
 
 
 # Fixed two-turn conversation. The user-asserted preference is stable
-# enough that both claude and codex extractors reliably produce a
-# single fact referencing the anchor substring; the assistant turn
-# carries the conventional acknowledgement shape so the prompt's
-# extraction rules fire on familiar ground.
+# enough that every backend's extractor reliably produces a single
+# fact referencing the anchor substring; the assistant turn carries
+# the conventional acknowledgement shape so the prompt's extraction
+# rules fire on familiar ground.
 _SMOKE_USER_TEXT = "Quick note: I take my coffee with oat milk, no sugar."
 _SMOKE_ASSISTANT_TEXT = "Noted, coffee with oat milk and no sugar."
 _SMOKE_ANCHOR_SUBSTRING = "oat milk"

--- a/templates/.env
+++ b/templates/.env
@@ -19,7 +19,7 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 
 # LLM provider. Required when AGENT_BACKEND is a non-Claude backend.
 # Valid values depend on the backend:
-#   goose: anthropic, openai, google, openrouter, ollama
+#   goose: anthropic, deepseek, google, ollama, openai, openrouter
 #LLM_PROVIDER=anthropic
 
 # Provider API key. Set the one matching your LLM_PROVIDER.
@@ -30,6 +30,16 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 #OPENAI_API_KEY=sk-...
 #GOOGLE_API_KEY=...
 #OPENROUTER_API_KEY=sk-or-...
+#DEEPSEEK_API_KEY=sk-...
+
+# Agent binary paths. The wizard prompts for and persists these on
+# the matching backend; set them here only to override PATH discovery
+# (codex, opencode, and goose one-shot reasoners and the per-user
+# sudoers rules pin these exact paths). A set-but-wrong path is a
+# hard error at the first one-shot call, not a PATH fallback.
+#CODEX_BIN=/opt/homebrew/bin/codex
+#OPENCODE_BIN=~/.local/bin/opencode
+#GOOSE_BIN=/opt/homebrew/bin/goose
 
 # ── Global agent defaults ─────────────────────────────────────────
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3298,15 +3298,17 @@ class TestHandleResponse:
         extract_mock.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_extraction_skipped_for_goose_users(self, monkeypatch):
-        """Symmetric guard: goose users must NOT reach the extractor.
-        The gate widening for opencode must not have widened to goose
-        too; goose has no OneShotReasoner implementation, so an
-        extraction attempt would crash."""
+    async def test_extraction_skipped_for_non_reasoner_backend_users(self, monkeypatch):
+        """Symmetric guard: users whose effective backend has no
+        OneShotReasoner must NOT reach the extractor; an extraction
+        attempt would crash. Every real backend is a member today, so
+        the gate's negative branch is exercised by patching the
+        constant down rather than naming a real backend."""
         from kai.bot import _handle_response
         from kai.config import UserConfig
 
         monkeypatch.setattr("kai.memory.is_enabled", lambda: True)
+        monkeypatch.setattr("kai.bot.ONESHOT_REASONER_BACKENDS", frozenset({"claude", "codex"}))
         extract_mock = AsyncMock()
         monkeypatch.setattr("kai.memory_extraction.extract_and_store", extract_mock)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1722,14 +1722,29 @@ class TestExtractionEligibleBackendsHelper:
         eligible = _compute_extraction_eligible_backends("claude", configs, True)
         assert eligible == {"claude", "codex"}
 
-    def test_goose_users_filtered_out(self):
-        """A users.yaml entry with `agent_backend: goose` does NOT
-        contribute to the eligible set, mirroring the runtime gate
-        at bot.py that skips extraction for goose users. The
-        precondition/binary checks must not fire on a goose-only
-        user even when extraction is enabled globally."""
+    def test_goose_users_contribute_to_eligible_set(self):
+        """A users.yaml entry with `agent_backend: goose` contributes
+        to the eligible set now that goose ships a OneShotReasoner;
+        the config-load precondition / binary checks must fire for a
+        goose user the same way they do for the other backends."""
         from kai.config import UserConfig, _compute_extraction_eligible_backends
 
+        configs = {
+            1: UserConfig(telegram_id=1, name="alice", os_user="a"),
+            2: UserConfig(telegram_id=2, name="bob", os_user="b", agent_backend="goose", llm_provider="openai"),
+        }
+        eligible = _compute_extraction_eligible_backends("claude", configs, True)
+        assert eligible == {"claude", "goose"}
+
+    def test_non_reasoner_backends_filtered_out(self, monkeypatch):
+        """The membership gate itself: a backend outside the patched
+        constant does not contribute, even when extraction is enabled
+        globally. Patched rather than exemplified by a real backend
+        because every real backend is currently a member."""
+        import kai.config as config_module
+        from kai.config import UserConfig, _compute_extraction_eligible_backends
+
+        monkeypatch.setattr(config_module, "ONESHOT_REASONER_BACKENDS", frozenset({"claude", "codex"}))
         configs = {
             1: UserConfig(telegram_id=1, name="alice", os_user="a"),
             2: UserConfig(telegram_id=2, name="bob", os_user="b", agent_backend="goose", llm_provider="openai"),
@@ -3221,24 +3236,18 @@ class TestOneShotReasonerBackendsConstant:
     """
 
     def test_membership(self):
-        """Exactly claude, codex, and opencode have OneShotReasoner
-        implementations in `src/kai/oneshot.py` today. Goose is a
-        valid agent backend (retrieval-only memory installs work) but
-        has no `GooseOneShotReasoner`, so it must NOT be in the
-        constant.
+        """Every backend with a OneShotReasoner implementation in
+        `src/kai/oneshot.py` is a member: claude, codex, opencode,
+        and goose all ship one today.
         """
         assert "claude" in ONESHOT_REASONER_BACKENDS
         assert "codex" in ONESHOT_REASONER_BACKENDS
         assert "opencode" in ONESHOT_REASONER_BACKENDS
-        # Goose-exclusion is load-bearing: collapsing the goose
-        # backend into the one-shot-eligible set would force a goose
-        # operator into memory-extraction / review / triage paths
-        # that the goose backend cannot satisfy.
-        assert "goose" not in ONESHOT_REASONER_BACKENDS
+        assert "goose" in ONESHOT_REASONER_BACKENDS
         # Pin the exact contents so an accidental addition is caught
         # at test time; intentional additions update this assertion
         # in lockstep with the constant's definition.
-        assert frozenset({"claude", "codex", "opencode"}) == ONESHOT_REASONER_BACKENDS
+        assert frozenset({"claude", "codex", "goose", "opencode"}) == ONESHOT_REASONER_BACKENDS
 
     def test_is_frozenset(self):
         """The constant must be a `frozenset` so callers only do

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -957,14 +957,29 @@ class TestBackendAwareModelResolution:
             asyncio.run(behavioral._run_cli(args))
         return captured["config"]
 
-    def test_goose_unset_flag_falls_back_to_legacy_constant(self, tmp_path, monkeypatch):
+    def test_goose_unset_flag_uses_registry(self, tmp_path, monkeypatch):
         """
-        On a goose-backed install, an unset --judge-model must NOT trigger
-        get_model_for("goose", BEHAVIORAL_JUDGE) (no registry row, would
-        raise LookupError). The fallback path uses _DEFAULT_JUDGE_MODEL,
-        matching pre-Phase-1 behavior.
+        Goose is a registry-resolved backend: an unset flag resolves
+        through the (goose, provider, role) rows the same way claude
+        does. LLM_PROVIDER is required env on goose installs, so the
+        eval reads it the same way the runtime does.
         """
+        from kai.config import ModelRole, get_model_for
+
         monkeypatch.setenv("AGENT_BACKEND", "goose")
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        args = self._make_args(tmp_path)  # judge_model=None, gen_model=None
+        config = self._run_with_captured_config(args)
+        assert config.judge_model == get_model_for(ModelRole.BEHAVIORAL_JUDGE, "goose", "anthropic")
+        assert config.gen_model == get_model_for(ModelRole.BEHAVIORAL_GEN, "goose", "anthropic")
+
+    def test_unrecognized_backend_falls_back_to_legacy_constant(self, tmp_path, monkeypatch):
+        """
+        An AGENT_BACKEND env value the registry does not know must NOT
+        trigger get_model_for (no registry row, would raise
+        LookupError). The fallback path uses _DEFAULT_JUDGE_MODEL.
+        """
+        monkeypatch.setenv("AGENT_BACKEND", "nonexistent")
         args = self._make_args(tmp_path)  # judge_model=None, gen_model=None
         config = self._run_with_captured_config(args)
         assert config.judge_model == behavioral._DEFAULT_JUDGE_MODEL

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1409,6 +1409,7 @@ class TestCmdConfig:
                 "false",  # advanced user options
                 "polling",  # transport
                 "goose",  # agent backend (prompt shown because existing config has goose)
+                "/bin/sh",  # goose binary path (any existing executable)
                 "anthropic",  # goose provider
                 "sk-ant-test-key",  # ANTHROPIC_API_KEY
                 "sonnet",  # model
@@ -1439,16 +1440,17 @@ class TestCmdConfig:
         assert conf["env"]["AGENT_BACKEND"] == "goose"
         assert conf["env"]["LLM_PROVIDER"] == "anthropic"
         assert conf["env"]["ANTHROPIC_API_KEY"] == "sk-ant-test-key"
+        assert conf["env"]["GOOSE_BIN"] == "/bin/sh"
         # Memory was declined, so the retrieval-only note must not
         # print; it belongs only to the memory-enabled flow.
         out = capsys.readouterr().out
         assert "retrieval-only" not in out
 
-    def test_goose_memory_enabled_prints_retrieval_only_note(self, tmp_path, monkeypatch, capsys):
-        """Goose plus memory: the extraction prompts are skipped (no
-        OneShotReasoner), and the operator must be told the result is
-        retrieval-only rather than discovering it through facts never
-        accumulating."""
+    def test_goose_memory_enabled_walks_extraction_prompts(self, tmp_path, monkeypatch, capsys):
+        """Goose plus memory now walks the extraction prompts: goose
+        ships a OneShotReasoner, so the wizard treats it like the
+        other reasoner backends and the retrieval-only note does not
+        print."""
         monkeypatch.chdir(tmp_path)
         conf_path = tmp_path / "install.conf"
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
@@ -1459,40 +1461,50 @@ class TestCmdConfig:
         existing = {"version": 1, "env": {"AGENT_BACKEND": "goose"}}
         conf_path.write_text(json.dumps(existing))
 
-        inputs = iter(
-            [
-                "protected",  # deployment mode
-                "/opt/kai",  # install dir
-                "/var/lib/kai",  # data dir
-                "kai",  # service user
-                "darwin",  # platform
-                "fake-token",  # bot token
-                "12345",  # admin telegram ID
-                "admin",  # admin display name
-                "false",  # advanced user options
-                "polling",  # transport
-                "goose",  # agent backend
-                "anthropic",  # goose provider
-                "sk-ant-test-key",  # ANTHROPIC_API_KEY
-                "sonnet",  # model
-                "false",  # customize per-role models
-                "120",  # timeout
-                "0",  # max session age hours
-                "1800",  # idle eviction timeout seconds
-                "8080",  # port
-                "test-secret",  # webhook secret
-                "~/Projects",  # workspace base
-                "",  # allowed workspaces (empty)
-                "300",  # pr review cooldown (global resource control)
-                "900",  # pr review timeout
-                "false",  # voice
-                "false",  # tts
-                "true",  # memory enabled
-                "2000",  # memory token budget (extraction prompts skipped)
-                "10",  # memory search limit
-                "",  # perplexity key (empty)
-            ]
-        )
+        memory_block = [
+            "true",  # memory enabled
+            "true",  # memory extraction enabled (now prompted on goose)
+            "60",  # per-extraction timeout (non-default so it persists)
+            "8",  # consolidation candidates
+            "3",  # episode classifier context turns
+            "120",  # per-episode timeout
+            "0.9",  # paraphrase-dedup threshold
+            "2000",  # memory token budget
+            "10",  # memory search limit
+        ]
+        inputs = iter(self._base_inputs(memory_block, agent_backend="goose"))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        out = capsys.readouterr().out
+        assert "retrieval-only" not in out
+        conf = json.loads((tmp_path / "install.conf").read_text())
+        assert conf["env"]["MEMORY_ENABLED"] == "true"
+        assert conf["env"]["MEMORY_EXTRACTION_ENABLED"] == "true"
+        assert conf["env"]["MEMORY_EXTRACTION_TIMEOUT_S"] == "60"
+
+    def test_non_reasoner_backend_memory_prints_retrieval_only_note(self, tmp_path, monkeypatch, capsys):
+        """The retrieval-only note still prints for a backend outside
+        ONESHOT_REASONER_BACKENDS. Every real backend is a member
+        today, so the else branch is exercised by patching the
+        constant down; goose stands in as the excluded backend the
+        same way it did before it grew a reasoner."""
+        import kai.install as install_module
+
+        monkeypatch.chdir(tmp_path)
+        conf_path = tmp_path / "install.conf"
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(install_module, "ONESHOT_REASONER_BACKENDS", frozenset({"claude", "codex"}))
+        self._block_etc_kai(monkeypatch)
+        self._redirect_staging(monkeypatch, tmp_path)
+
+        existing = {"version": 1, "env": {"AGENT_BACKEND": "goose"}}
+        conf_path.write_text(json.dumps(existing))
+
+        memory_block = ["true", "2000", "10"]  # memory enabled; extraction prompts gated out
+        inputs = iter(self._base_inputs(memory_block, agent_backend="goose"))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
 
         _cmd_config()
@@ -1529,6 +1541,7 @@ class TestCmdConfig:
                 "false",  # advanced user options
                 "polling",  # transport
                 "goose",  # agent backend
+                "/bin/sh",  # goose binary path (any existing executable)
                 "ollama",  # goose provider (no key needed)
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
@@ -1663,8 +1676,14 @@ class TestCmdConfig:
             )
         # Wizard prompts for provider + API key only for non-claude
         # backends. The API key prompt itself is skipped when provider
-        # is "ollama" (local model, no auth).
+        # is "ollama" (local model, no auth). The goose backend block
+        # additionally prompts for the binary path before the provider
+        # prompt; /bin/sh is just an existing executable that passes
+        # the is-file + executable validation without depending on
+        # goose being installed on the test host.
         backend_block: list[str] = []
+        if agent_backend == "goose":
+            backend_block.append("/bin/sh")
         if agent_backend != "claude":
             backend_block.append(llm_provider)
             if llm_provider != "ollama":
@@ -2093,12 +2112,19 @@ class TestCmdConfig:
         for key in env:
             assert not key.startswith("MEMORY_"), f"stale memory key: {key}"
 
-    def test_non_claude_backend_drops_stale_extraction_keys(self, tmp_path, monkeypatch):
-        """Switching from claude to goose strips MEMORY_EXTRACTION_* keys."""
+    def test_non_reasoner_backend_drops_stale_extraction_keys(self, tmp_path, monkeypatch):
+        """Switching to a backend outside ONESHOT_REASONER_BACKENDS
+        strips MEMORY_EXTRACTION_* keys. Every real backend is a
+        member today, so the cleanup branch is exercised by patching
+        the constant down with goose standing in as the excluded
+        backend."""
+        import kai.install as install_module
+
         monkeypatch.chdir(tmp_path)
         conf_path = tmp_path / "install.conf"
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(install_module, "ONESHOT_REASONER_BACKENDS", frozenset({"claude", "codex"}))
         self._block_etc_kai(monkeypatch)
         self._redirect_staging(monkeypatch, tmp_path)
 
@@ -2129,6 +2155,7 @@ class TestCmdConfig:
                 "false",  # advanced user options
                 "polling",  # transport
                 "goose",  # agent backend (was claude)
+                "/bin/sh",  # goose binary path (any existing executable)
                 "anthropic",  # goose provider
                 "sk-ant-test-key",  # API key
                 "sonnet",  # model
@@ -2276,54 +2303,44 @@ class TestCmdConfig:
         # All defaults → key is absent.
         assert "EPISODE_CLASSIFIER_CONTEXT_TURNS" not in env
 
-    def test_episode_classifier_context_turns_skipped_on_goose_backend(self, tmp_path, monkeypatch):
-        """On agent_backend="goose", the entire memory-extraction
-        branch is gated out (the classifier only runs under claude
-        per bot.py's effective_backend == "claude" check). The wizard
-        does not prompt for the new key, the dataclass default
-        applies at startup, and the env file does not carry the key."""
+    def test_episode_classifier_context_turns_skipped_on_goose_extraction_declined(self, tmp_path, monkeypatch):
+        """On a goose install that declines extraction, the
+        extraction-enabled branch (including the classifier-window
+        prompt) does not fire: the dataclass default applies at
+        startup and the env file does not carry the key."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
         self._redirect_staging(monkeypatch, tmp_path)
 
-        # On goose, the extraction-enabled prompt itself is skipped, so
-        # memory_block is shaped like a no-extraction run. The entire
-        # extraction-enabled branch (including the new classifier-window
-        # prompt) does not fire.
-        memory_block = ["true", "2000", "10"]  # memory_enabled, token_budget, search_limit
+        # Goose now reaches the extraction-enabled prompt; declining it
+        # keeps the rest of the extraction branch (including the new
+        # classifier-window prompt) gated out.
+        memory_block = ["true", "false", "2000", "10"]  # memory on, extraction declined, budget, limit
         inputs = iter(self._base_inputs(memory_block, agent_backend="goose"))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
 
         _cmd_config()
 
         env = json.loads((tmp_path / "install.conf").read_text())["env"]
-        # Backend-cleanup pop in install.py drops the key under non-
-        # claude backends; pin the absence so a future regression
-        # that leaves a stale value in /etc/kai/env after a
-        # claude→goose flip surfaces here.
         assert "EPISODE_CLASSIFIER_CONTEXT_TURNS" not in env
 
     def test_goose_retrieval_only_does_not_persist_invalid_reasoner_backend(self, tmp_path, monkeypatch):
-        """v5 regression: a goose install accepting memory_enabled=true
-        with extraction disabled must NOT write MEMORY_REASONER_BACKEND
-        to the generated env. The wizard gates the prompt on
-        memory_extraction_enabled (the composed value), so on a
-        goose-backed install the prompt never fires and the key never
-        lands. Prevents the prior failure mode where the prompt fired
-        and `agent_backend=goose` as the default would have produced
-        MEMORY_REASONER_BACKEND=goose, failing load_config validation."""
+        """A goose install accepting memory_enabled=true and declining
+        extraction must NOT write MEMORY_REASONER_BACKEND or any
+        extraction config to the generated env: the retired reasoner
+        prompt never fires and extraction-off is the dataclass
+        default, so the delta-from-default emission suppresses both."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._block_etc_kai(monkeypatch)
         self._redirect_staging(monkeypatch, tmp_path)
 
-        # Goose install: extraction is gated out, so no reasoner prompt.
-        # Inputs match the existing goose-skip test shape (memory_enabled,
-        # token_budget, search_limit).
-        memory_block = ["true", "2000", "10"]
+        # Goose now reaches the extraction prompt; declining keeps the
+        # run retrieval-only.
+        memory_block = ["true", "false", "2000", "10"]
         inputs = iter(self._base_inputs(memory_block, agent_backend="goose"))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
 
@@ -2331,8 +2348,7 @@ class TestCmdConfig:
 
         env = json.loads((tmp_path / "install.conf").read_text())["env"]
         # The critical assertion: no invalid reasoner-backend value
-        # in the env. The cleanup block also drops it on non-supported
-        # backends as defense-in-depth.
+        # in the env.
         assert "MEMORY_REASONER_BACKEND" not in env
         # Extraction config is also absent on goose retrieval-only.
         assert "MEMORY_EXTRACTION_ENABLED" not in env
@@ -2916,6 +2932,7 @@ class TestCmdConfigDefaultModelDispatch:
             "fake-token",  # bot token
             "polling",  # transport
             "goose",  # agent backend
+            "/bin/sh",  # goose binary path (any existing executable)
             "openai",  # llm provider
             "openai-key",  # OPENAI_API_KEY
             # model prompt is handled by the _prompt_default_model mock

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7168,12 +7168,14 @@ class TestApplySudoersDryRun:
         assert "the claude sudoers rule" in captured.err
         assert "the opencode sudoers rule" not in captured.err
 
-    def test_goose_only_install_warns_about_nothing(self, tmp_path, capsys, monkeypatch):
-        """A goose-only install with os_users gets no missing-binary
-        warning at all: the backstop's binary map deliberately omits
-        goose because goose has no per-user sudoers rule (it always
-        runs as the service user), so there is no pinned binary path
-        that can drift out of sync with a rule."""
+    def test_goose_only_install_missing_binary_names_goose_bin(self, tmp_path, capsys, monkeypatch):
+        """A goose-only install with os_users warns when the goose
+        binary path does not exist, and the remedy names GOOSE_BIN:
+        goose now has a per-user sudoers rule with a pinned path, so
+        the backstop covers it the same way it covers the other
+        backends. The path is passed explicitly (never the host
+        fallback) so the assertion cannot flip on whether the test
+        host happens to have goose installed."""
         svc_home = tmp_path / "home" / "kai"
         svc_home.mkdir(parents=True)
         monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
@@ -7184,6 +7186,37 @@ class TestApplySudoersDryRun:
             "kai",
             dry_run=True,
             users_yaml_path=users_yaml,
+            goose_bin=str(tmp_path / "nope" / "goose"),
+            agent_backend="goose",
+        )
+
+        captured = capsys.readouterr()
+        assert "the goose sudoers rule" in captured.err
+        assert "GOOSE_BIN" in captured.err
+        # Scoping: a goose-only install must not be told about the
+        # other backends' binaries.
+        assert "the claude sudoers rule" not in captured.err
+        assert "the codex sudoers rule" not in captured.err
+
+    def test_goose_only_install_with_present_binary_warns_about_nothing(self, tmp_path, capsys, monkeypatch):
+        """A goose-only install whose pinned goose path exists gets no
+        missing-binary warning. Deterministic counterpart to the
+        missing-binary case above: the binary is a real executable
+        under tmp_path, so the check cannot depend on host state."""
+        svc_home = tmp_path / "home" / "kai"
+        svc_home.mkdir(parents=True)
+        monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
+        goose = tmp_path / "goose"
+        goose.write_text("#!/bin/sh\necho hi\n")
+        goose.chmod(0o755)
+
+        _apply_sudoers(
+            "kai",
+            dry_run=True,
+            users_yaml_path=users_yaml,
+            goose_bin=str(goose),
             agent_backend="goose",
         )
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1396,6 +1396,7 @@ class TestCmdConfig:
         existing = {"version": 1, "env": {"AGENT_BACKEND": "goose"}}
         conf_path.write_text(json.dumps(existing))
 
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = iter(
             [
                 "protected",  # deployment mode
@@ -1409,7 +1410,7 @@ class TestCmdConfig:
                 "false",  # advanced user options
                 "polling",  # transport
                 "goose",  # agent backend (prompt shown because existing config has goose)
-                "/bin/sh",  # goose binary path (any existing executable)
+                "/opt/homebrew/bin/goose",  # goose binary path (validator stubbed)
                 "anthropic",  # goose provider
                 "sk-ant-test-key",  # ANTHROPIC_API_KEY
                 "sonnet",  # model
@@ -1440,7 +1441,7 @@ class TestCmdConfig:
         assert conf["env"]["AGENT_BACKEND"] == "goose"
         assert conf["env"]["LLM_PROVIDER"] == "anthropic"
         assert conf["env"]["ANTHROPIC_API_KEY"] == "sk-ant-test-key"
-        assert conf["env"]["GOOSE_BIN"] == "/bin/sh"
+        assert conf["env"]["GOOSE_BIN"] == "/opt/homebrew/bin/goose"
         # Memory was declined, so the retrieval-only note must not
         # print; it belongs only to the memory-enabled flow.
         out = capsys.readouterr().out
@@ -1472,6 +1473,7 @@ class TestCmdConfig:
             "2000",  # memory token budget
             "10",  # memory search limit
         ]
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = iter(self._base_inputs(memory_block, agent_backend="goose"))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
 
@@ -1504,6 +1506,7 @@ class TestCmdConfig:
         conf_path.write_text(json.dumps(existing))
 
         memory_block = ["true", "2000", "10"]  # memory enabled; extraction prompts gated out
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = iter(self._base_inputs(memory_block, agent_backend="goose"))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
 
@@ -1528,6 +1531,7 @@ class TestCmdConfig:
         conf_path.write_text(json.dumps(existing))
 
         # No API key input after "ollama" - the prompt is skipped.
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = iter(
             [
                 "protected",  # deployment mode
@@ -1541,7 +1545,7 @@ class TestCmdConfig:
                 "false",  # advanced user options
                 "polling",  # transport
                 "goose",  # agent backend
-                "/bin/sh",  # goose binary path (any existing executable)
+                "/opt/homebrew/bin/goose",  # goose binary path (validator stubbed)
                 "ollama",  # goose provider (no key needed)
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
@@ -1678,12 +1682,12 @@ class TestCmdConfig:
         # backends. The API key prompt itself is skipped when provider
         # is "ollama" (local model, no auth). The goose backend block
         # additionally prompts for the binary path before the provider
-        # prompt; /bin/sh is just an existing executable that passes
-        # the is-file + executable validation without depending on
-        # goose being installed on the test host.
+        # prompt; goose callers stub `_validate_goose_bin` (the codex
+        # wizard-test precedent), so the literal path here never
+        # touches the host filesystem.
         backend_block: list[str] = []
         if agent_backend == "goose":
-            backend_block.append("/bin/sh")
+            backend_block.append("/opt/homebrew/bin/goose")
         if agent_backend != "claude":
             backend_block.append(llm_provider)
             if llm_provider != "ollama":
@@ -1811,6 +1815,7 @@ class TestCmdConfig:
         self._block_etc_kai(monkeypatch)
         self._redirect_staging(monkeypatch, tmp_path)
 
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = iter(self._base_inputs(["false"], agent_backend="goose"))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
 
@@ -1863,6 +1868,7 @@ class TestCmdConfig:
         conf_path.write_text(json.dumps(pre_existing))
 
         # Re-run wizard, switch to goose this time.
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = iter(self._base_inputs(["false"], agent_backend="goose"))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
 
@@ -2142,6 +2148,7 @@ class TestCmdConfig:
         }
         conf_path.write_text(json.dumps(existing))
 
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = iter(
             [
                 "protected",  # deployment mode
@@ -2155,7 +2162,7 @@ class TestCmdConfig:
                 "false",  # advanced user options
                 "polling",  # transport
                 "goose",  # agent backend (was claude)
-                "/bin/sh",  # goose binary path (any existing executable)
+                "/opt/homebrew/bin/goose",  # goose binary path (validator stubbed)
                 "anthropic",  # goose provider
                 "sk-ant-test-key",  # API key
                 "sonnet",  # model
@@ -2318,6 +2325,7 @@ class TestCmdConfig:
         # keeps the rest of the extraction branch (including the new
         # classifier-window prompt) gated out.
         memory_block = ["true", "false", "2000", "10"]  # memory on, extraction declined, budget, limit
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = iter(self._base_inputs(memory_block, agent_backend="goose"))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
 
@@ -2341,6 +2349,7 @@ class TestCmdConfig:
         # Goose now reaches the extraction prompt; declining keeps the
         # run retrieval-only.
         memory_block = ["true", "false", "2000", "10"]
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = iter(self._base_inputs(memory_block, agent_backend="goose"))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
 
@@ -2932,7 +2941,7 @@ class TestCmdConfigDefaultModelDispatch:
             "fake-token",  # bot token
             "polling",  # transport
             "goose",  # agent backend
-            "/bin/sh",  # goose binary path (any existing executable)
+            "/opt/homebrew/bin/goose",  # goose binary path (validator stubbed)
             "openai",  # llm provider
             "openai-key",  # OPENAI_API_KEY
             # model prompt is handled by the _prompt_default_model mock
@@ -2984,6 +2993,7 @@ class TestCmdConfigDefaultModelDispatch:
         in install.conf.
         """
         self._setup(monkeypatch, tmp_path, existing_env={"DEFAULT_MODEL": "sonnet"})
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         helper, env = self._run(
             monkeypatch,
             tmp_path,
@@ -3046,6 +3056,7 @@ class TestCmdConfigDefaultModelDispatch:
         re-prompts, helper fires with eff_provider equal to "openai".
         """
         self._setup(monkeypatch, tmp_path, existing_env={})
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         helper, env = self._run(
             monkeypatch,
             tmp_path,
@@ -3069,6 +3080,7 @@ class TestCmdConfigDefaultModelDispatch:
         the prefill, the operator pressing Enter would re-accept it.
         """
         self._setup(monkeypatch, tmp_path, existing_env={"DEFAULT_MODEL": "opus"})
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         helper, env = self._run(
             monkeypatch,
             tmp_path,
@@ -7634,6 +7646,44 @@ class TestValidateOpenCodeBin:
         f.write_text("#!/bin/sh\necho hi\n")
         f.chmod(0o755)
         assert _validate_opencode_bin(str(f)) is True
+
+
+class TestValidateGooseBin:
+    """goose binary path existence validator. Mirrors
+    `TestValidateCodexBin` and `TestValidateOpenCodeBin` exactly: same
+    five edge cases (empty, nonexistent, directory, non-executable
+    file, executable file), pinning the shared validator shape for
+    the third backend the same way it is pinned for the other two."""
+
+    def test_empty_value_rejected(self):
+        from kai.install import _validate_goose_bin
+
+        assert _validate_goose_bin("") is False
+
+    def test_nonexistent_path_rejected(self, tmp_path):
+        from kai.install import _validate_goose_bin
+
+        assert _validate_goose_bin(str(tmp_path / "does_not_exist")) is False
+
+    def test_directory_rejected(self, tmp_path):
+        from kai.install import _validate_goose_bin
+
+        assert _validate_goose_bin(str(tmp_path)) is False
+
+    def test_non_executable_file_rejected(self, tmp_path):
+        from kai.install import _validate_goose_bin
+
+        f = tmp_path / "fake_goose"
+        f.write_text("#!/bin/sh\necho hi\n")
+        assert _validate_goose_bin(str(f)) is False
+
+    def test_executable_file_accepted(self, tmp_path):
+        from kai.install import _validate_goose_bin
+
+        f = tmp_path / "fake_goose"
+        f.write_text("#!/bin/sh\necho hi\n")
+        f.chmod(0o755)
+        assert _validate_goose_bin(str(f)) is True
 
 
 class TestOpenCodeBinWizardPrompt:

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -2341,13 +2341,18 @@ class TestCommandDispatch:
 class TestDashboardBackendNote:
     """Users on a backend without a OneShotReasoner never get
     extraction; the dashboard must say so instead of letting the
-    user discover it through facts never accumulating."""
+    user discover it through facts never accumulating. Every real
+    backend is a member of ONESHOT_REASONER_BACKENDS today, so these
+    tests patch the module's constant down to exercise the
+    non-member branch without coupling to any specific excluded
+    backend name."""
 
     @pytest.mark.asyncio
     async def test_note_appended_for_non_reasoner_backend(
         self, monkeypatch, update_factory, context_factory, auth_config
     ):
         auth_config.agent_backend = "goose"
+        monkeypatch.setattr(memory_command, "ONESHOT_REASONER_BACKENDS", frozenset({"claude", "codex"}))
         monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
         monkeypatch.setattr(
             memory_command.memory,
@@ -2367,6 +2372,7 @@ class TestDashboardBackendNote:
         the note must appear there too, not only on populated
         dashboards."""
         auth_config.agent_backend = "goose"
+        monkeypatch.setattr(memory_command, "ONESHOT_REASONER_BACKENDS", frozenset({"claude", "codex"}))
         monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
         monkeypatch.setattr(
             memory_command.memory,
@@ -2404,6 +2410,7 @@ class TestDashboardBackendNote:
         user_cfg = MagicMock()
         user_cfg.agent_backend = "goose"
         auth_config.get_user_config.return_value = user_cfg
+        monkeypatch.setattr(memory_command, "ONESHOT_REASONER_BACKENDS", frozenset({"claude", "codex"}))
         monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
         monkeypatch.setattr(
             memory_command.memory,

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -3669,11 +3669,23 @@ class TestMemoryReasonerSelection:
         reasoner = memory_extraction._build_memory_reasoner("opencode")
         assert isinstance(reasoner, OpenCodeOneShotReasoner)
 
+    def test_goose_backend_builds_goose_reasoner(self):
+        """Goose dispatches to GooseOneShotReasoner with the provider
+        threaded through (goose's one-shot argv carries an explicit
+        --provider flag, unlike the other backends)."""
+        from kai.oneshot import GooseOneShotReasoner
+
+        reasoner = memory_extraction._build_memory_reasoner("goose", os_user=None, provider="deepseek")
+        assert isinstance(reasoner, GooseOneShotReasoner)
+        assert reasoner._provider == "deepseek"
+
     def test_unknown_backend_still_raises_defensive_runtime_error(self):
         """The defensive RuntimeError remains the safety net for any
-        backend the eligibility gate does not allow through."""
-        with pytest.raises(RuntimeError, match=r"non-extraction backend.*goose"):
-            memory_extraction._build_memory_reasoner("goose")
+        backend the eligibility gate does not allow through. Every
+        real backend dispatches now, so the guard is exercised with a
+        string no backend will ever use."""
+        with pytest.raises(RuntimeError, match=r"non-extraction backend.*nonexistent"):
+            memory_extraction._build_memory_reasoner("nonexistent")
 
 
 class TestRunExtractorWithCodexEnvelope:
@@ -3932,7 +3944,7 @@ class TestExtractAndStorePerUserDispatch:
                     duration_ms=1,
                 )
 
-        def _spy_build(effective_backend, os_user=None):
+        def _spy_build(effective_backend, os_user=None, provider=""):
             captured_backends.append(effective_backend)
             return _StubReasoner()
 
@@ -3984,7 +3996,7 @@ class TestExtractAndStorePerUserDispatch:
                     duration_ms=1,
                 )
 
-        def _build(effective_backend, os_user=None):
+        def _build(effective_backend, os_user=None, provider=""):
             return _ModelCapturingReasoner()
 
         monkeypatch.setattr(memory_extraction, "_build_memory_reasoner", _build)
@@ -4022,7 +4034,7 @@ class TestExtractAndStorePerUserDispatch:
 
         captured: list[str] = []
 
-        def _build(effective_backend, os_user=None):
+        def _build(effective_backend, os_user=None, provider=""):
             captured.append(effective_backend)
 
             class _R:
@@ -4069,7 +4081,7 @@ class TestExtractAndStorePerUserDispatch:
 
         captured: list[str] = []
 
-        def _build(effective_backend, os_user=None):
+        def _build(effective_backend, os_user=None, provider=""):
             captured.append(effective_backend)
 
             class _R:

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -19,10 +19,12 @@ import pytest
 
 from kai.oneshot import (
     _CODEX_ENV_ALLOWLIST,
+    _GOOSE_ENV_ALLOWLIST,
     _OPENCODE_PRESERVED_AUTH_VARS,
     _SUBPROCESS_ENV_ALLOWLIST,
     ClaudeOneShotReasoner,
     CodexOneShotReasoner,
+    GooseOneShotReasoner,
     OneShotOutputError,
     OneShotResult,
     OneShotRoutingError,
@@ -31,6 +33,7 @@ from kai.oneshot import (
     OpenCodeOneShotReasoner,
     _parse_schema_payload,
     _preserved_auth_vars_for,
+    _render_goose_stdin,
     _render_opencode_session_prompt,
 )
 
@@ -63,6 +66,8 @@ def _mock_binary_resolver():
             return "codex"
         if backend == "opencode":
             return "opencode"
+        if backend == "goose":
+            return "goose"
         raise ValueError(f"unknown backend: {backend!r}")
 
     with patch("kai.oneshot.resolve_oneshot_binary", side_effect=fake_resolve):
@@ -2827,3 +2832,294 @@ class TestOpenCodeOneShotReasonerSudoWrap:
 
         spawn_kwargs = mock_exec.call_args_list[0].kwargs
         assert spawn_kwargs["start_new_session"] is True
+
+
+# ── Goose reasoner tests ─────────────────────────────────────────────
+
+
+class TestGooseOneShotReasonerArgvAndEnv:
+    """Argv shape, provider wire-name translation, stdin payload, and
+    the env allow-list of the goose one-shot."""
+
+    @pytest.mark.asyncio
+    async def test_argv_shape_with_provider_translation(self, tmp_path):
+        """The full `goose run` argv, with the Kai provider key
+        translated to goose's wire name (deepseek is custom_deepseek
+        on the goose side) and the registry model untranslated."""
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="deepseek")
+        proc = _make_proc(stdout=b'{"facts": [], "has_episode": false}')
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                model="deepseek-v4-flash",
+                json_schema={"type": "object"},
+            )
+        cmd = list(mock_exec.call_args[0])
+        assert cmd == [
+            "goose",
+            "run",
+            "-i",
+            "-",
+            "--provider",
+            "custom_deepseek",
+            "--model",
+            "deepseek-v4-flash",
+            "-q",
+            "--no-session",
+            "--no-profile",
+            "--max-turns",
+            "1",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_argv_omits_provider_when_empty(self, tmp_path):
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user())
+        proc = _make_proc(stdout=b"{}")
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(prompt="p", purpose="fact_extraction", model="m", json_schema={"type": "object"})
+        cmd = list(mock_exec.call_args[0])
+        assert "--provider" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_argv_omits_model_when_none(self, tmp_path):
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="anthropic")
+        proc = _make_proc(stdout=b"{}")
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
+        cmd = list(mock_exec.call_args[0])
+        assert "--model" not in cmd
+        assert cmd[4] == "--provider"
+        assert cmd[5] == "anthropic"
+
+    @pytest.mark.asyncio
+    async def test_stdin_wraps_system_prompt_in_boundary(self, tmp_path):
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="anthropic")
+        proc = _make_proc(stdout=b"{}")
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            await reasoner.run(
+                prompt="USER TEXT",
+                system_prompt="SYSTEM TEXT",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+        payload = proc.communicate.call_args.kwargs["input"].decode("utf-8")
+        assert "--- BEGIN SYSTEM " in payload
+        assert "SYSTEM TEXT" in payload
+        assert payload.endswith("USER TEXT")
+
+    @pytest.mark.asyncio
+    async def test_stdin_omits_boundary_when_no_system_prompt(self, tmp_path):
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="anthropic")
+        proc = _make_proc(stdout=b"{}")
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            await reasoner.run(prompt="USER TEXT", purpose="fact_extraction", json_schema={"type": "object"})
+        payload = proc.communicate.call_args.kwargs["input"].decode("utf-8")
+        assert payload == "USER TEXT"
+
+    @pytest.mark.asyncio
+    async def test_env_contains_only_allowlisted_keys(self, tmp_path, monkeypatch):
+        """Secrets outside the allow-list must not reach the goose
+        subprocess; GOOSE_MODEL / GOOSE_PROVIDER stay out too because
+        the one-shot passes both as argv flags."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
+        monkeypatch.setenv("GOOSE_MODEL", "leak-model")
+        monkeypatch.setenv("GOOSE_PROVIDER", "leak-provider")
+        monkeypatch.setenv("KAI_WEBHOOK_SECRET", "leak-secret")
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "leak-token")
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="anthropic")
+        proc = _make_proc(stdout=b"{}")
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
+        env = mock_exec.call_args.kwargs["env"]
+        assert env["ANTHROPIC_API_KEY"] == "key"
+        assert set(env) <= set(_GOOSE_ENV_ALLOWLIST)
+        assert "GOOSE_MODEL" not in env
+        assert "GOOSE_PROVIDER" not in env
+        assert "KAI_WEBHOOK_SECRET" not in env
+        assert "TELEGRAM_BOT_TOKEN" not in env
+
+
+class TestGooseOneShotReasonerOutput:
+    """Free-form and schema-backed output contracts, mirroring the
+    codex / opencode reasoner suites."""
+
+    @pytest.mark.asyncio
+    async def test_non_schema_returns_stripped_text(self, tmp_path):
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="anthropic")
+        proc = _make_proc(stdout=b"  free-form review text  \n")
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(prompt="p", purpose="pr_review", json_schema=None)
+        assert isinstance(result, OneShotResult)
+        assert result.backend == "goose"
+        assert result.text == "free-form review text"
+
+    @pytest.mark.asyncio
+    async def test_schema_backed_success_returns_normalized_envelope(self, tmp_path):
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="deepseek")
+        payload = {"facts": [{"content": "x"}], "has_episode": False}
+        proc = _make_proc(stdout=json.dumps(payload).encode())
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                model="deepseek-v4-flash",
+                json_schema={"type": "object"},
+            )
+        envelope = json.loads(result.text)
+        assert envelope == {"is_error": False, "structured_output": payload}
+        assert result.raw_metadata["resolved_binary"] == "goose"
+
+    @pytest.mark.asyncio
+    async def test_schema_backed_recovers_fenced_payload_with_preamble(self, tmp_path):
+        """Goose has no structured-output channel, so models that
+        narrate and fence (deepseek-v4-flash does both) must still
+        reach the envelope via the tolerant parser."""
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="deepseek")
+        body = 'Let me analyze the exchange.\n\n```json\n{"facts": [], "has_episode": false}\n```'
+        proc = _make_proc(stdout=body.encode())
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object", "required": ["facts", "has_episode"]},
+            )
+        envelope = json.loads(result.text)
+        assert envelope == {
+            "is_error": False,
+            "structured_output": {"facts": [], "has_episode": False},
+        }
+
+    @pytest.mark.asyncio
+    async def test_empty_response_raises_output_error(self, tmp_path):
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="anthropic")
+        proc = _make_proc(stdout=b"   \n")
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotOutputError),
+        ):
+            await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_raises_output_error(self, tmp_path):
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="anthropic")
+        proc = _make_proc(stdout=b"not json at all")
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotOutputError),
+        ):
+            await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("non_object_payload", ['"a plain string"', "[]", "42", "true", "null"])
+    async def test_non_object_json_raises_output_error(self, tmp_path, non_object_payload):
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="anthropic")
+        proc = _make_proc(stdout=non_object_payload.encode())
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotOutputError),
+        ):
+            await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
+
+    @pytest.mark.asyncio
+    async def test_missing_required_fields_raises_output_error(self, tmp_path):
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="anthropic")
+        proc = _make_proc(stdout=b'{"facts": []}')
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotOutputError) as excinfo,
+        ):
+            await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object", "required": ["facts", "has_episode"]},
+            )
+        assert "has_episode" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_non_zero_exit_raises_subprocess_error(self, tmp_path):
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="anthropic")
+        proc = _make_proc(stdout=b"", stderr=b"boom", returncode=3)
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotSubprocessError) as excinfo,
+        ):
+            await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
+        assert excinfo.value.returncode == 3
+        assert excinfo.value.stderr == b"boom"
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_and_raises(self, tmp_path):
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="anthropic")
+        proc = _make_proc(raise_timeout=True)
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotTimeout),
+        ):
+            await reasoner.run(prompt="p", purpose="fact_extraction", timeout=0.01, json_schema={"type": "object"})
+        proc.kill.assert_called_once()
+        proc.wait.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_binary_resolution_failure_raises_routing_error(self, tmp_path):
+        from kai.oneshot_binary import BinaryResolutionError
+
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="anthropic")
+        with (
+            patch(
+                "kai.oneshot.resolve_oneshot_binary",
+                side_effect=BinaryResolutionError("could not resolve goose binary"),
+            ),
+            pytest.raises(OneShotRoutingError),
+        ):
+            await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
+
+
+class TestGooseStdinRender:
+    """`_render_goose_stdin` boundary contract."""
+
+    def test_none_system_prompt_returns_prompt_unchanged(self):
+        assert _render_goose_stdin(None, "hello") == "hello"
+
+    def test_empty_system_prompt_returns_prompt_unchanged(self):
+        assert _render_goose_stdin("", "hello") == "hello"
+
+    def test_system_prompt_rides_boundary_block(self):
+        rendered = _render_goose_stdin("SYS", "USER")
+        assert rendered.index("SYS") < rendered.index("USER")
+        assert "--- BEGIN SYSTEM " in rendered
+        assert "--- END SYSTEM " in rendered
+
+
+@pytest.mark.routing_test
+class TestGooseRouting:
+    """Sudo wrap and preserve-env contract for the goose one-shot,
+    mirroring the codex / opencode routing classes."""
+
+    @pytest.mark.asyncio
+    async def test_goose_runs_in_process_when_os_user_matches_bot(self, tmp_path):
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="anthropic")
+        proc = _make_proc(stdout=b"{}")
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
+        cmd = mock_exec.call_args[0]
+        assert cmd[0] != "sudo"
+        assert mock_exec.call_args.kwargs["start_new_session"] is False
+
+    @pytest.mark.asyncio
+    async def test_goose_wraps_with_preserve_env(self, tmp_path):
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user="other-user", provider="deepseek")
+        proc = _make_proc(stdout=b"{}")
+        with (
+            patch("kai.oneshot.resolve_claude_user", return_value="other-user"),
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec,
+        ):
+            await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
+        cmd = list(mock_exec.call_args[0])
+        assert cmd[:4] == ["sudo", "-H", "-u", "other-user"]
+        assert cmd[4] == (
+            "--preserve-env=ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,OPENROUTER_API_KEY,DEEPSEEK_API_KEY"
+        )
+        assert cmd[5] == "--"
+        assert cmd[6] == "goose"
+        assert mock_exec.call_args.kwargs["start_new_session"] is True

--- a/tests/test_oneshot_binary.py
+++ b/tests/test_oneshot_binary.py
@@ -195,6 +195,76 @@ class TestOpenCodeResolution:
         assert called == [], f"shutil.which should not be called when OPENCODE_BIN is set; got {called}"
 
 
+class TestGooseResolution:
+    """Goose arm mirrors the codex / opencode pattern: GOOSE_BIN
+    override validates as is-file plus executable with no PATH
+    fallback; no override falls back to shutil.which("goose")."""
+
+    def test_no_override_resolves_via_path(self, monkeypatch):
+        monkeypatch.delenv("GOOSE_BIN", raising=False)
+        monkeypatch.setattr(
+            "kai.oneshot_binary.shutil.which",
+            lambda name: "/fake/path/goose" if name == "goose" else None,
+        )
+        assert resolve_oneshot_binary("goose") == "/fake/path/goose"
+
+    def test_no_override_unreachable_raises_naming_both_candidates(self, monkeypatch):
+        monkeypatch.delenv("GOOSE_BIN", raising=False)
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", lambda name: None)
+        with pytest.raises(BinaryResolutionError) as exc:
+            resolve_oneshot_binary("goose")
+        message = str(exc.value)
+        assert "GOOSE_BIN" in message
+        assert "PATH" in message
+
+    def test_explicit_override_resolves_to_exact_path(self, tmp_path, monkeypatch):
+        fake = tmp_path / "goose-binary"
+        fake.write_text("#!/bin/sh\nexit 0\n")
+        fake.chmod(0o755)
+        monkeypatch.setenv("GOOSE_BIN", str(fake))
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", lambda name: "/other/goose")
+        assert resolve_oneshot_binary("goose") == str(fake)
+
+    def test_explicit_override_not_a_file_raises_not_a_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GOOSE_BIN", str(tmp_path / "does-not-exist"))
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", lambda name: "/should/not/be/returned")
+        with pytest.raises(BinaryResolutionError) as exc:
+            resolve_oneshot_binary("goose")
+        message = str(exc.value)
+        assert "not-a-file" in message
+        assert "does-not-exist" in message
+
+    def test_explicit_override_not_executable_raises_not_executable(self, tmp_path, monkeypatch):
+        fake = tmp_path / "goose-not-x"
+        fake.write_text("not-a-script")
+        fake.chmod(0o644)
+        monkeypatch.setenv("GOOSE_BIN", str(fake))
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", lambda name: "/should/not/be/returned")
+        with pytest.raises(BinaryResolutionError) as exc:
+            resolve_oneshot_binary("goose")
+        message = str(exc.value)
+        assert "not-executable" in message
+        assert str(fake) in message
+
+    def test_explicit_override_no_fallback_to_path(self, tmp_path, monkeypatch):
+        """GOOSE_BIN set to a bad path must NOT silently fall back to
+        shutil.which('goose'). Same regression guard as the codex and
+        opencode arms; a fallback would hide stale-config bugs from
+        the operator."""
+        monkeypatch.setenv("GOOSE_BIN", str(tmp_path / "missing"))
+
+        called: list[str] = []
+
+        def fake_which(name):
+            called.append(name)
+            return "/some/goose"
+
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", fake_which)
+        with pytest.raises(BinaryResolutionError):
+            resolve_oneshot_binary("goose")
+        assert called == [], f"shutil.which should not be called when GOOSE_BIN is set; got {called}"
+
+
 class TestUnknownBackend:
     def test_unknown_backend_raises_value_error(self):
         """An unknown backend string is a CALLER bug (config validation


### PR DESCRIPTION
Refs #611 (tranche A of two; per-user OS isolation for goose chat sessions follows separately and closes the issue).

## What

Goose joins `ONESHOT_REASONER_BACKENDS`: memory fact extraction and episode generation now run for goose-backed users exactly like the other backends, and the constant's membership comment changes meaning from "goose is the documented exclusion" to "membership asserts a reasoner exists".

## The reasoner

`GooseOneShotReasoner` in `src/kai/oneshot.py`, structurally mirroring the codex reasoner (plain subprocess) with opencode's output posture (no CLI-side structured-output channel):

- Argv: `goose run -i - --provider <wire-name> --model <registry model> -q --no-session --no-profile --max-turns 1`, all flags previously verified against the installed binary. The provider rides through `goose_provider_id`, so goose+DeepSeek works (`custom_deepseek` on the wire).
- The provider is a constructor parameter threaded from the extraction call sites (`_build_memory_reasoner` gains a `provider` kwarg); the other backends accept and ignore it, since they encode the provider implicitly.
- System prompt rides the stdin payload behind a randomized boundary (`make_boundary`), same scheme as the codex and opencode renders.
- Schema-backed output parses through the shared tolerant helper (`_parse_schema_payload`) and rewraps in the standard `structured_output` envelope; error categories, timeout handling, env allow-list shape, and sudo routing (`_wrap_cmd_for_user`, kill-tree escalation, preserve-env list) all mirror the siblings.

## Plumbing

- `GOOSE_BIN` end to end: resolver arm in `oneshot_binary.py` (override validated, no PATH fallback), wizard prompt in the goose backend block plus the extraction defense-in-depth re-prompt, install.conf/env persistence, apply-time passthrough, and a per-target-user sudoers rule pinned to the wizard-persisted path (warning-map entry included). Documented in the env template.
- Constant-flip surfaces verified one by one: bot extraction gate, config eligibility and binary validation, wizard extraction prompts (now shown on goose), smoke, the eval backend gate, and the retrieval-only notices, which are constant-gated and so stop firing for goose automatically while still covering any future non-reasoner backend.
- Stale goose-exclusion comments swept (config eligibility helper, extraction factory, sudoers warning map, smoke wording, the behavioral eval's resolution note, which also stops claiming goose models live outside the registry).

## Live verification

A no-auth run of the real reasoner against the installed goose binary with `provider="deepseek"` accepted every flag, delivered stdin, and surfaced the expected typed failure. One behavioral note from it: goose prints auth errors to stdout and exits 0, so a missing provider key surfaces as the `invalid_json` output-error category rather than a subprocess error; extraction's zero-state mapping absorbs both identically. Full end-to-end (a fact actually written) needs a provisioned key at deploy time.

## Tests

- Goose reasoner suite mirroring the codex/opencode classes: argv shape with wire-name translation, boundary render, env allow-list (model/provider env vars and secrets stay out), envelope success, fenced-preamble recovery, the four error categories, timeout kill, routing wrap with the exact preserve-env CSV.
- Resolver arm suite mirroring the opencode one (override valid / not-a-file / not-executable / no-fallback / PATH miss).
- Wizard: goose+memory walks the extraction prompts; the retrieval-only note coverage moves to a patched-constant test, as do the bot gate, eligibility helper, and dashboard-note negative branches; the stale-extraction-keys cleanup test keeps its semantics the same way.
- Dispatch: `_build_memory_reasoner` goose branch with provider threading; behavioral eval resolves goose from the registry, with the legacy-constant fallback pinned via an unrecognized backend string.
- Full suite: 3834 passed, 1 skipped. `ruff check` and `ruff format --check` clean.
