### PR TITLE
feat(goose): per-user OS isolation for goose chat via the ACP layer

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -25,6 +25,7 @@ The hook surface:
     backend_label          : human-readable label for error messages
     build_argv()           : subprocess command vector (may include model)
     build_env(base_env)    : layer backend-specific env onto base_env
+    preserved_env_vars()   : env vars the cross-user sudo wrap preserves
     build_initialize_params() : params for the initialize JSON-RPC call
     build_session_new_params() : params for the session/new JSON-RPC call
     extract_session_id(result) : pull session ID from session/new result
@@ -35,9 +36,11 @@ The hook surface:
 """
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
+import subprocess
 import time
 from collections.abc import AsyncIterator, Callable
 from pathlib import Path
@@ -55,7 +58,7 @@ from kai.backend import (
     ensure_user_memory,
     ensure_user_preferences,
 )
-from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file
+from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
 
 log = logging.getLogger(__name__)
 
@@ -283,6 +286,214 @@ def convert_image_block(block: dict) -> dict | None:
     return {"type": "image", "mimeType": media_type, "data": data}
 
 
+# ── Shared cross-user subprocess helpers ─────────────────────────
+
+
+# Timeout (seconds) for the cross-user kill subprocess on the wrap
+# path. A hung kill must not stall the caller's own timeout cleanup
+# (a one-shot reasoner's typed-error path, or the conversational
+# backend's _kill/shutdown chain), so the cap is intentionally short
+# relative to the timeouts those callers run under.
+_CROSS_USER_KILL_TIMEOUT_S: float = 5.0
+
+
+def _stderr_is_esrch(stderr: bytes | None) -> bool:
+    """
+    True iff `stderr` carries the POSIX ESRCH diagnostic from
+    `/bin/kill` for a no-such-process condition.
+
+    Discriminates the benign race (the target tree already exited
+    between the caller's decision to kill and the signal delivery;
+    kill returns rc=1 with "No such process") from real failure
+    modes (sudoers misconfiguration, signal permission denied, kill
+    binary missing). The benign case logs at DEBUG; everything else
+    keeps the WARNING.
+
+    Substring match because BSD `/bin/kill` on macOS and util-linux
+    `kill` on Linux both emit `kill: <pid>: No such process`; the
+    prefix varies slightly but the "No such process" portion is the
+    stable POSIX `strerror(ESRCH)` text, fixed by libc and not
+    localized for these binaries on any production platform.
+
+    Returns False on `None` or empty bytes so a missing-stderr
+    rc!=0 (itself unusual and probably a real failure) keeps the
+    WARNING.
+    """
+    if not stderr:
+        return False
+    return b"No such process" in stderr
+
+
+def _log_cross_user_kill_result(
+    *,
+    rc: int,
+    stderr: bytes,
+    target_user: str,
+    pgid: int,
+    purpose: str,
+    backend: str,
+) -> None:
+    """
+    Log the outcome of a cross-user kill subprocess.
+
+    Shared by the async and sync kill variants so the rc/ESRCH
+    classification cannot drift between them: rc=0 is silent
+    success, ESRCH is the benign already-gone race at DEBUG, any
+    other non-zero rc is a WARNING an operator needs to see.
+    """
+    if rc == 0:
+        return
+    if _stderr_is_esrch(stderr):
+        log.debug(
+            "cross-user kill: process group already gone (purpose=%s backend=%s target=%s pgid=%d); benign race",
+            purpose,
+            backend,
+            target_user,
+            pgid,
+        )
+        return
+    log.warning(
+        "cross-user kill returned rc=%d (purpose=%s backend=%s target=%s pgid=%d stderr=%r)",
+        rc,
+        purpose,
+        backend,
+        target_user,
+        pgid,
+        stderr[:200],
+    )
+
+
+async def _kill_target_user_tree(
+    *,
+    target_user: str,
+    pgid: int,
+    purpose: str,
+    backend: str,
+) -> None:
+    """
+    Send SIGKILL to every target-user process in the spawn's group.
+
+    The sudo wrap leaves the bot holding the `sudo` process while
+    the agent (and any descendants like the npm-wrapped codex's
+    node/Rust child pair) runs under `target_user`. POSIX
+    permission rules prevent the service user from signaling those
+    descendants directly; the workaround is `sudo -n -u <target>
+    /bin/kill -KILL -<pgid>` which the target user CAN run
+    (authorized by the per-os_user `/bin/kill` rule
+    `install._generate_sudoers` already emits). The leading `-` on
+    the PID arg makes kill's target a process group; sending to the
+    negative group id signals every process the target user has
+    permission to signal in that group, covering descendants at
+    every tree depth without per-PID discovery.
+
+    Shared by the one-shot reasoners (timeout escalation) and the
+    conversational `AcpBackend` kill paths so the cross-user kill
+    semantics cannot drift between them. Bounded by
+    `_CROSS_USER_KILL_TIMEOUT_S` so a hung sudo or missing
+    `/bin/kill` does not stall the caller's own cleanup. Failures
+    (non-ESRCH rc, timeout, FileNotFoundError on sudo itself) are
+    logged and swallowed; the caller still reaps the wrapper
+    afterward, accepting the orphan risk for that deployment edge
+    case.
+    """
+    cmd = ["sudo", "-n", "-u", target_user, "/bin/kill", "-KILL", f"-{pgid}"]
+    try:
+        kill_proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        log.warning(
+            "cross-user kill spawn failed: sudo not found (purpose=%s backend=%s target=%s pgid=%d)",
+            purpose,
+            backend,
+            target_user,
+            pgid,
+        )
+        return
+    try:
+        _stdout, stderr = await asyncio.wait_for(kill_proc.communicate(), timeout=_CROSS_USER_KILL_TIMEOUT_S)
+    except TimeoutError:
+        kill_proc.kill()
+        with contextlib.suppress(BaseException):
+            await kill_proc.wait()
+        log.warning(
+            "cross-user kill timed out (purpose=%s backend=%s target=%s pgid=%d)",
+            purpose,
+            backend,
+            target_user,
+            pgid,
+        )
+        return
+    rc = kill_proc.returncode if kill_proc.returncode is not None else -1
+    _log_cross_user_kill_result(
+        rc=rc,
+        stderr=stderr,
+        target_user=target_user,
+        pgid=pgid,
+        purpose=purpose,
+        backend=backend,
+    )
+
+
+def _kill_target_user_tree_sync(
+    *,
+    target_user: str,
+    pgid: int,
+    purpose: str,
+    backend: str,
+) -> None:
+    """
+    Synchronous companion to `_kill_target_user_tree` for sync-only
+    callers.
+
+    `AgentBackend.force_kill` is a synchronous method (the pool's
+    last-resort path after `shutdown` failed or timed out), so it
+    cannot await the canonical async helper; the claude and codex
+    backends keep a sync signal path for exactly this reason. Same
+    argv, timeout bound, and rc/ESRCH log classification as the
+    async variant. Blocking the loop for up to
+    `_CROSS_USER_KILL_TIMEOUT_S` is accepted on this path: it only
+    runs when a graceful shutdown already failed and the
+    alternative is an orphaned target-user process tree.
+    """
+    cmd = ["sudo", "-n", "-u", target_user, "/bin/kill", "-KILL", f"-{pgid}"]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            timeout=_CROSS_USER_KILL_TIMEOUT_S,
+            check=False,
+        )
+    except FileNotFoundError:
+        log.warning(
+            "cross-user kill spawn failed: sudo not found (purpose=%s backend=%s target=%s pgid=%d)",
+            purpose,
+            backend,
+            target_user,
+            pgid,
+        )
+        return
+    except subprocess.TimeoutExpired:
+        log.warning(
+            "cross-user kill timed out (purpose=%s backend=%s target=%s pgid=%d)",
+            purpose,
+            backend,
+            target_user,
+            pgid,
+        )
+        return
+    _log_cross_user_kill_result(
+        rc=result.returncode,
+        stderr=result.stderr,
+        target_user=target_user,
+        pgid=pgid,
+        purpose=purpose,
+        backend=backend,
+    )
+
+
 # ── ACP base backend ──────────────────────────────────────────────
 
 
@@ -327,6 +538,13 @@ class AcpBackend(AgentBackend):
         # the kwarg; production callers (pool.py) always pass an
         # explicit value.
         memory_enabled: bool = False,
+        # Optional OS user to run the ACP subprocess as, via
+        # `sudo -H -u <user>`. None = run as the bot's process user.
+        # Same per-user isolation contract as claude_user / codex_user
+        # on the sibling backends; resolved through resolve_claude_user
+        # at spawn time so a value naming the bot's own user collapses
+        # to the direct-spawn path (self-sudo skip).
+        os_user: str | None = None,
     ):
         # ABC-required attributes (pool.py reads/writes these)
         self.model = model
@@ -336,6 +554,7 @@ class AcpBackend(AgentBackend):
         self.workspace_config = workspace_config
         self.provider = provider
         self.memory_enabled = memory_enabled
+        self.os_user = os_user
 
         # API context for session injection (passed to build_session_context).
         self._api_context = ApiContext(
@@ -363,6 +582,15 @@ class AcpBackend(AgentBackend):
         # Subprocess and session state.
         self._proc: asyncio.subprocess.Process | None = None
         self._session_id: str | None = None
+        # Cross-user spawn state, set per incarnation in
+        # _ensure_started. `_effective_os_user` is the resolved sudo
+        # target (None on the direct path); `_pgid` is the wrapper's
+        # process group id, recorded only on the wrap path so the
+        # kill paths know whether a sudo escalation is needed and
+        # which group to target. _kill nulls both so a recycled
+        # instance cannot carry stale routing into a fresh spawn.
+        self._effective_os_user: str | None = None
+        self._pgid: int | None = None
         # Whether the agent accepts image content blocks on
         # session/prompt, read from `promptCapabilities.image` in the
         # initialize result. False until a handshake completes so a
@@ -410,6 +638,30 @@ class AcpBackend(AgentBackend):
         it may mutate in place or return a different dict.
         """
         raise NotImplementedError
+
+    def preserved_env_vars(self) -> tuple[str, ...]:
+        """
+        Return the env var names the cross-user sudo wrap forwards
+        through sudo's env_reset (the `--preserve-env=<csv>` clause).
+
+        Only consulted on the wrap path (`os_user` resolved to a
+        non-bot user); the direct spawn hands the full env built in
+        `_ensure_started` to the subprocess unfiltered. The per-user
+        sudoers entries generated by `install._generate_sudoers`
+        carry the `SETENV:` tag that authorizes the passthrough.
+
+        Default mirrors claude.py's wrap: KAI_WEBHOOK_SECRET (the
+        per-session token the agent needs to call back into Kai's
+        webhook API) and TMPDIR (the per-os-user temp anchor set in
+        `_ensure_started`; without preservation env_reset strips the
+        anchor and the agent falls back to the shared /tmp).
+        Concrete adapters whose harness reads configuration or auth
+        from the environment must override and EXTEND this list -
+        sudo strips everything not named here, so an adapter that
+        delivers model selection via env (GooseBackend) loses it
+        silently otherwise.
+        """
+        return ("KAI_WEBHOOK_SECRET", "TMPDIR")
 
     def build_initialize_params(self) -> dict:
         """
@@ -558,18 +810,36 @@ class AcpBackend(AgentBackend):
         1. initialize - establishes protocol version and capabilities
         2. session/new - creates a session with backend-specific params
 
+        When `os_user` resolves to a non-bot user, the argv is wrapped
+        in `sudo -H -u <target> --preserve-env=<csv> --` so the agent
+        runs as that user (per-user OS isolation, same contract as the
+        claude and codex backends). `-H` rewrites HOME so the agent
+        reads its config and auth state under the target user's home;
+        the preserve list comes from the preserved_env_vars() hook.
+
         The process persists across prompts. Restarts (via /new or a
         workspace switch) re-run the handshake with a fresh session.
         """
         if self.is_alive:
             return
 
+        # Per-user OS routing. resolve_claude_user (named claude-
+        # historically; its body is backend-agnostic) returns None
+        # when os_user is unset OR matches the bot's own user, so the
+        # self-sudo-skip path is byte-identical to a no-os_user spawn.
+        effective_os_user = resolve_claude_user(self.os_user)
+
         # Build the subprocess environment. Layering order:
         # 1. Base environment (inherited from parent process)
         # 2. Backend-specific keys (via self.build_env)
         # 3. Per-workspace env_file values
         # 4. Per-workspace inline env values (override env_file)
-        # 5. Webhook secret (LAST - workspace env can't override it)
+        # 5. Webhook secret (workspace env can't override it)
+        # 6. Per-os-user TMPDIR anchor (cross-user mode only; LAST so
+        #    workspace env cannot point one user's temp writes at
+        #    another's). The per-user dirs under <DATA_DIR>/tmp/ are
+        #    created and chowned by install.py; TMPDIR survives
+        #    sudo's env_reset via the preserved_env_vars() default.
         env = self.build_env(os.environ.copy())
         if self.workspace_config:
             if self.workspace_config.env_file:
@@ -578,9 +848,32 @@ class AcpBackend(AgentBackend):
                 env.update(self.workspace_config.env)
         if self._api_context.webhook_secret:
             env["KAI_WEBHOOK_SECRET"] = self._api_context.webhook_secret
+        if effective_os_user:
+            env["TMPDIR"] = str(DATA_DIR / "tmp" / effective_os_user)
 
         argv = self.build_argv()
-        log.info("Starting persistent %s ACP process (model=%s)", self.backend_label, self.model)
+        if effective_os_user:
+            # The SETENV: tag on the per-os_user sudoers rule
+            # authorizes --preserve-env; the rule pins the absolute
+            # agent binary path, so sudo's PATH resolution of the
+            # argv head must land on the same file the rule names.
+            preserve = ",".join(self.preserved_env_vars())
+            argv = [
+                "sudo",
+                "-H",
+                "-u",
+                effective_os_user,
+                f"--preserve-env={preserve}",
+                "--",
+                *argv,
+            ]
+
+        log.info(
+            "Starting persistent %s ACP process (model=%s, user=%s)",
+            self.backend_label,
+            self.model,
+            effective_os_user or "(same as bot)",
+        )
 
         self._proc = await asyncio.create_subprocess_exec(
             *argv,
@@ -590,7 +883,19 @@ class AcpBackend(AgentBackend):
             cwd=str(self.workspace),
             env=env,
             limit=1024 * 1024,  # 1MB per-line buffer
+            # Cross-user mode: new session group so the sudo wrapper
+            # is the session leader (PGID == PID) and the kill paths
+            # can SIGKILL the whole target-user tree by negative
+            # group id. Direct mode keeps default semantics so a
+            # plain kill on _proc reaches the agent alone.
+            start_new_session=bool(effective_os_user),
         )
+        # PGID == PID for session leaders. Recorded now because
+        # os.getpgid() fails once the wrapper exits, while the group
+        # kill works as long as any member survives (the orphaned
+        # agent is exactly the member that survives the wrapper).
+        self._pgid = self._proc.pid if effective_os_user else None
+        self._effective_os_user = effective_os_user
         self._stderr_task = asyncio.create_task(self._drain_stderr())
 
         # Step 1: initialize - establish protocol version and read the
@@ -1062,8 +1367,25 @@ class AcpBackend(AgentBackend):
         Safe to call without holding the lock. Called by /stop to abort
         an in-flight response. Does NOT null _proc - full cleanup
         happens in _kill() when the read loop detects EOF.
+
+        Cross-user mode: _proc is the sudo wrapper, owned by the
+        service user; the agent underneath is owned by the target
+        user, and SIGKILL cannot be relayed by sudo. Killing only the
+        wrapper would orphan the agent, so the target-user process
+        group is sudo-escalated FIRST (sync variant; this method is
+        the pool's synchronous last resort). _pgid is nulled after
+        the escalation so the async kill paths that follow (read
+        loop EOF -> _kill) do not re-kill an already-dead group.
         """
         if self._proc is not None:
+            if self._effective_os_user is not None and self._pgid is not None:
+                _kill_target_user_tree_sync(
+                    target_user=self._effective_os_user,
+                    pgid=self._pgid,
+                    purpose="chat",
+                    backend=self.backend_name,
+                )
+                self._pgid = None
             try:
                 self._proc.kill()
             except OSError:
@@ -1077,9 +1399,21 @@ class AcpBackend(AgentBackend):
         Kill the subprocess and clean up all process state.
 
         Sends SIGKILL, waits up to 5 seconds for exit, then nulls all
-        process references. Idempotent.
+        process references. Idempotent. Cross-user mode escalates the
+        target-user group kill through the canonical async helper
+        BEFORE the wrapper is reaped, and nulls _pgid so the
+        force_kill() call below does not repeat the escalation
+        synchronously.
         """
         if self._proc:
+            if self._effective_os_user is not None and self._pgid is not None:
+                await _kill_target_user_tree(
+                    target_user=self._effective_os_user,
+                    pgid=self._pgid,
+                    purpose="chat",
+                    backend=self.backend_name,
+                )
+                self._pgid = None
             self.force_kill()
             try:
                 await asyncio.wait_for(self._proc.wait(), timeout=5)
@@ -1089,6 +1423,8 @@ class AcpBackend(AgentBackend):
             # None, so no additional cleanup needed here.
             self._proc = None
             self._session_id = None
+            self._pgid = None
+            self._effective_os_user = None
 
     async def restart(self) -> None:
         """
@@ -1134,6 +1470,14 @@ class AcpBackend(AgentBackend):
 
         Sends SIGTERM first and waits up to 5 seconds for clean exit.
         Falls back to SIGKILL if the process doesn't terminate in time.
+
+        Cross-user mode: the SIGTERM lands on the sudo wrapper, which
+        relays catchable signals to the target-user agent, so the
+        graceful path needs no escalation. The SIGKILL fallback DOES:
+        SIGKILL cannot be relayed, so the target-user group is
+        escalated through the canonical async helper before
+        force_kill() reaps the wrapper (with _pgid nulled so
+        force_kill skips its own sync escalation).
         """
         if self._proc:
             try:
@@ -1146,6 +1490,14 @@ class AcpBackend(AgentBackend):
                 try:
                     await asyncio.wait_for(self._proc.wait(), timeout=5)
                 except TimeoutError:
+                    if self._effective_os_user is not None and self._pgid is not None:
+                        await _kill_target_user_tree(
+                            target_user=self._effective_os_user,
+                            pgid=self._pgid,
+                            purpose="chat",
+                            backend=self.backend_name,
+                        )
+                        self._pgid = None
                     self.force_kill()
                     try:
                         await asyncio.wait_for(self._proc.wait(), timeout=5)
@@ -1156,3 +1508,5 @@ class AcpBackend(AgentBackend):
             self._stderr_task = None
         self._proc = None
         self._session_id = None
+        self._pgid = None
+        self._effective_os_user = None

--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -17,6 +17,7 @@ The Goose ACP protocol:
 """
 
 import logging
+import os
 
 from kai.acp import AcpBackend
 
@@ -89,12 +90,21 @@ class GooseBackend(AcpBackend):
 
     def build_argv(self) -> list[str]:
         """
-        Static argv for `goose acp` with the developer builtin enabled.
+        Argv for `goose acp` with the developer builtin enabled.
 
         Goose injects the model via GOOSE_MODEL env, not argv, so model
         does not appear here.
+
+        GOOSE_BIN pins an absolute binary path (mirrors codex's
+        CODEX_BIN): when goose is not on the service user's PATH, or
+        the spawn is sudo-wrapped for a per-user os_user, the bare
+        name either fails to resolve or resolves to a path different
+        from the one the sudoers rule pins, and the spawn dies. Falls
+        back to bare "goose" so installs with goose on PATH keep
+        working without the override.
         """
-        return ["goose", "acp", "--with-builtin", "developer"]
+        goose_bin = os.environ.get("GOOSE_BIN") or "goose"
+        return [goose_bin, "acp", "--with-builtin", "developer"]
 
     def build_env(self, base_env: dict[str, str]) -> dict[str, str]:
         """
@@ -130,6 +140,34 @@ class GooseBackend(AcpBackend):
         if self.provider:
             base_env["GOOSE_PROVIDER"] = goose_provider_id(self.provider)
         return base_env
+
+    def preserved_env_vars(self) -> tuple[str, ...]:
+        """
+        Env vars the cross-user sudo wrap forwards through env_reset.
+
+        Goose reads its model and provider selection from GOOSE_MODEL
+        / GOOSE_PROVIDER (set in build_env), unlike claude and codex,
+        which pass model on argv. Without preservation, sudo's
+        env_reset strips the model selection itself, not just auth,
+        and the wrapped goose falls back to whatever its per-user
+        config files say. The five provider key vars cover env-key
+        auth flows centrally; keychain-based auth (per-user
+        `goose configure`) rides the HOME rewrite from `sudo -H`
+        instead and needs no preservation. KAI_WEBHOOK_SECRET and
+        TMPDIR mirror the AcpBackend default (webhook callback auth
+        and the per-os-user temp anchor).
+        """
+        return (
+            "GOOSE_MODEL",
+            "GOOSE_PROVIDER",
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_API_KEY",
+            "OPENROUTER_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "KAI_WEBHOOK_SECRET",
+            "TMPDIR",
+        )
 
     def build_session_new_params(self) -> dict:
         """

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2207,6 +2207,71 @@ def _collect_backends_from_yaml(users_yaml_path: str | Path) -> set[str]:
     return backends
 
 
+def _collect_goose_os_users_from_yaml(
+    users_yaml_path: str | Path,
+    agent_backend: str,
+) -> list[str]:
+    """
+    Read users.yaml and return distinct, validated os_user values of
+    goose-backed users.
+
+    A user is goose-backed when their entry's `agent_backend` is
+    "goose", or when the entry carries no per-user backend and the
+    install's global backend (`agent_backend`) is goose - the same
+    inheritance contract the runtime applies. `_apply_goose_config`
+    deploys the goose config template into each such user's home:
+    the per-user `goose acp` spawn runs under `sudo -H`, so goose
+    resolves `~/.config/goose/config.yaml` beneath the TARGET user's
+    home, where the service-user deploy is invisible.
+
+    Same lightweight posture and failure behavior as
+    `_collect_os_users_from_yaml`: missing file, empty file, non-dict
+    document, or missing `users:` list yield an empty list; malformed
+    YAML raises; non-string / empty os_user values are skipped (those
+    users run as the service user, which gets its own deploy
+    unconditionally); os_user values failing username validation
+    raise ValueError before any filesystem path is built from them.
+    """
+    path = Path(users_yaml_path)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+    if not text.strip():
+        return []
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        return []
+    users = data.get("users")
+    if not isinstance(users, list):
+        return []
+    seen: set[str] = set()
+    result: list[str] = []
+    for entry in users:
+        if not isinstance(entry, dict):
+            continue
+        backend = entry.get("agent_backend")
+        # Non-string / empty per-user values mean "inherit the global
+        # backend" (PyYAML may parse unquoted scalars as non-strings;
+        # the runtime loader rejects those separately).
+        effective = backend.strip() if isinstance(backend, str) and backend.strip() else agent_backend
+        if effective != "goose":
+            continue
+        os_user = entry.get("os_user")
+        if not isinstance(os_user, str):
+            continue
+        normalized = os_user.strip()
+        if not normalized:
+            continue
+        if not _validate_os_user(normalized):
+            raise ValueError(f"Invalid os_user {normalized!r} in {path}: must match {_OS_USER_RE.pattern}")
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
 def _build_codex_login_reminder(
     env: dict[str, str],
     service_user: str,
@@ -3468,11 +3533,11 @@ def _apply_migrate(
     # whose --settings JSON hashes to the same hex collide on the
     # default /tmp path; the first writer owns the file at mode
     # 0o644 and the second claude exits with EACCES on the
-    # write-open. claude.py anchors TMPDIR per-os_user under
+    # write-open. The cross-user spawn paths (claude.py and the
+    # shared ACP layer in acp.py) anchor TMPDIR per-os_user under
     # <DATA_DIR>/tmp/<os_user>/ so each identity has its own temp
     # namespace. Create those dirs here, mode 0o700 chowned to the
-    # target os_user (only their owner needs to read them; they
-    # hold cache state for that user's claude.ai session). Parent
+    # target os_user (only their owner needs to read them). Parent
     # tmp/ is service-owned mode 0o755 so the per-user subdirs
     # are traversable for the sudo -u <os_user> subprocess.
     #
@@ -3767,9 +3832,19 @@ def _cmd_apply() -> None:
         env.pop("MEMORY_EPISODE_BUDGET_USD", None)
         _apply_secrets(env, dry_run, users_yaml_staging_path=users_yaml_staging_path)
 
-        # -- Step 6: Deploy Goose config (if backend=goose) --
-        if env.get("AGENT_BACKEND") == "goose":
-            _apply_goose_config(service_user, install_path, svc_uid, svc_gid, dry_run)
+        # -- Step 6: Deploy Goose config (if any goose-backed user) --
+        # The function gates itself: global AGENT_BACKEND=goose or a
+        # per-user agent_backend override in users.yaml both mean some
+        # session spawns `goose acp`; otherwise it no-ops.
+        agent_backend = env.get("AGENT_BACKEND", "claude")
+        _apply_goose_config(
+            service_user,
+            install_path,
+            svc_uid,
+            svc_gid,
+            dry_run,
+            agent_backend=agent_backend,
+        )
 
         # -- Step 7: Configure sudoers --
         _apply_sudoers(
@@ -3778,7 +3853,7 @@ def _cmd_apply() -> None:
             codex_bin=env.get("CODEX_BIN"),
             opencode_bin=env.get("OPENCODE_BIN"),
             goose_bin=env.get("GOOSE_BIN"),
-            agent_backend=env.get("AGENT_BACKEND", "claude"),
+            agent_backend=agent_backend,
         )
 
         # -- Step 8: Migrate runtime data --
@@ -4827,18 +4902,36 @@ def _apply_goose_config(
     svc_uid: int,
     svc_gid: int,
     dry_run: bool,
+    users_yaml_path: str | Path = "/etc/kai/users.yaml",
+    agent_backend: str = "claude",
 ) -> None:
     """
-    Deploy the Goose extension config to the service user's home.
+    Deploy the Goose extension config to every home goose runs from.
 
     Copies config/goose-config.yaml from the install tree to
-    `~/.config/goose/config.yaml` so that `goose acp` picks up the
-    right extension settings. The directory is created if it does
-    not exist. Only called when AGENT_BACKEND=goose.
+    `~/.config/goose/config.yaml` for the service user AND for each
+    distinct goose-backed `os_user` in users.yaml, so `goose acp`
+    picks up the right extension settings wherever it spawns. The
+    service-user copy covers goose-backed users with no os_user (they
+    run as the service user); the per-os_user copies cover isolated
+    users, whose spawn runs under `sudo -H` and therefore resolves
+    config beneath the target user's home. Directories are created if
+    missing, with each user's tree owned by that user.
+
+    `agent_backend` is the install's global backend; users.yaml
+    entries without a per-user override inherit it (same contract as
+    `_apply_sudoers`). No-ops when nothing in the install is
+    goose-backed - neither the global backend nor any users.yaml
+    override - so the apply pipeline can call it unconditionally and
+    a claude-only install is never blocked on the goose template.
     """
-    svc_home = Path(_user_home(service_user))
-    goose_dir = svc_home / ".config" / "goose"
-    dst = goose_dir / "config.yaml"
+    # Gate before the template check: a goose template is only a
+    # requirement when some session will spawn `goose acp`. users.yaml
+    # is canonical at /etc/kai by this step (the secrets step deploys
+    # any staged copy first).
+    if agent_backend != "goose" and "goose" not in _collect_backends_from_yaml(users_yaml_path):
+        return
+
     src = install_path / "config" / "goose-config.yaml"
 
     # Check before dry_run so a missing template is caught during
@@ -4846,9 +4939,39 @@ def _apply_goose_config(
     if not src.exists():
         raise SystemExit(f"Goose config template not found at {src}")
 
+    # Resolve every target home and its ownership BEFORE touching
+    # disk, so a users.yaml entry naming an os_user that does not
+    # exist on this host fails the whole step with a clear message
+    # instead of leaving a half-deployed set of homes (mirrors the
+    # pre-validation posture of _apply_migrate). The service user is
+    # always a target; its uid/gid arrive pre-resolved from the
+    # caller and its home resolves through _user_home like the rest
+    # of the installer's service-user paths.
+    targets: list[tuple[Path, int, int]] = [
+        (Path(_user_home(service_user)), svc_uid, svc_gid),
+    ]
+    for name in _collect_goose_os_users_from_yaml(users_yaml_path, agent_backend):
+        # An os_user matching the service user is already covered by
+        # the unconditional service-user deploy (the runtime self-
+        # sudo-skips that case anyway).
+        if name == service_user:
+            continue
+        try:
+            pwd_entry = pwd.getpwnam(name)
+        except KeyError as exc:
+            raise ValueError(
+                f"users.yaml names os_user {name!r}, which does not exist "
+                f"on this host. Source: {users_yaml_path}. Create the OS "
+                "account or correct the users.yaml entry, then re-run "
+                "sudo make install."
+            ) from exc
+        targets.append((Path(pwd_entry.pw_dir), pwd_entry.pw_uid, pwd_entry.pw_gid))
+
     if dry_run:
-        print(f"[DRY RUN] Would create: {goose_dir}")
-        print(f"[DRY RUN] Would copy: {src} -> {dst}")
+        for home, _uid, _gid in targets:
+            goose_dir = home / ".config" / "goose"
+            print(f"[DRY RUN] Would create: {goose_dir}")
+            print(f"[DRY RUN] Would copy: {src} -> {goose_dir / 'config.yaml'}")
         return
 
     # Warn if the goose binary isn't on PATH. Not fatal because the
@@ -4861,26 +4984,31 @@ def _apply_goose_config(
         print("  Kai will fail to start the Goose backend until goose is installed.")
         print("  See https://github.com/block/goose for installation instructions.")
 
-    # Track whether we're creating .config for the first time so we
-    # can set ownership on it below. mkdir(parents=True) creates both
-    # .config/ and .config/goose/ if needed.
-    config_dir = svc_home / ".config"
-    config_dir_is_new = not config_dir.exists()
+    for home, uid, gid in targets:
+        goose_dir = home / ".config" / "goose"
+        dst = goose_dir / "config.yaml"
 
-    goose_dir.mkdir(parents=True, exist_ok=True)
-    # Own the .config/goose tree by the service user so Goose can
-    # write runtime state (session logs, etc.) alongside the config.
-    _set_ownership(goose_dir, svc_uid, svc_gid)
-    # Only chown .config itself if we just created it. An existing
-    # .config may be shared with other tools and should keep its
-    # current ownership.
-    if config_dir_is_new:
-        _set_ownership(config_dir, svc_uid, svc_gid)
+        # Track whether we're creating .config for the first time so
+        # we can set ownership on it below. mkdir(parents=True)
+        # creates both .config/ and .config/goose/ if needed.
+        config_dir = home / ".config"
+        config_dir_is_new = not config_dir.exists()
 
-    shutil.copy2(src, dst)
-    os.chmod(dst, 0o644)
-    _set_ownership(dst, svc_uid, svc_gid)
-    print(f"  Deployed Goose config to {dst}")
+        goose_dir.mkdir(parents=True, exist_ok=True)
+        # Own the .config/goose tree by the home's user so Goose can
+        # write runtime state (session logs, etc.) alongside the
+        # config.
+        _set_ownership(goose_dir, uid, gid)
+        # Only chown .config itself if we just created it. An existing
+        # .config may be shared with other tools and should keep its
+        # current ownership.
+        if config_dir_is_new:
+            _set_ownership(config_dir, uid, gid)
+
+        shutil.copy2(src, dst)
+        os.chmod(dst, 0o644)
+        _set_ownership(dst, uid, gid)
+        print(f"  Deployed Goose config to {dst}")
 
 
 def _apply_sudoers(

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -39,7 +39,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
 
-from kai.acp import drain_late_text, read_result, write_rpc
+from kai.acp import _kill_target_user_tree, drain_late_text, read_result, write_rpc
 from kai.codex_exec import extract_codex_text
 from kai.config import DATA_DIR, resolve_claude_user
 from kai.goose import goose_provider_id
@@ -316,14 +316,6 @@ def _preserved_auth_vars_for(backend: str) -> tuple[str, ...]:
     raise ValueError(f"unknown backend for preserve-env: {backend!r}")
 
 
-# Timeout (seconds) for the cross-user kill subprocess on the wrap
-# path. Matches the persistent backend's `_async_sudo_kill` cap. A
-# hung kill must not stall the reasoner's own timeout cleanup, so
-# the cap is intentionally short relative to memory_extraction's
-# stage-1 / stage-2 timeouts.
-_CROSS_USER_KILL_TIMEOUT_S: float = 5.0
-
-
 # ── Shared wrap / kill helpers ──────────────────────────────────────
 
 
@@ -352,79 +344,6 @@ def _wrap_cmd_for_user(cmd: list[str], target_user: str, backend: str) -> list[s
         "--",
         *cmd,
     ]
-
-
-async def _kill_target_user_tree(
-    *,
-    target_user: str,
-    pgid: int,
-    purpose: str,
-    backend: str,
-) -> None:
-    """
-    Send SIGKILL to every target-user process in the spawn's group.
-
-    The sudo wrap leaves the bot holding the `sudo` process while
-    the agent (and any descendants like the npm-wrapped codex's
-    node/Rust child pair) runs under `target_user`. POSIX
-    permission rules prevent the service user from signaling those
-    descendants directly; the workaround is `sudo -n -u <target>
-    /bin/kill -KILL -<pgid>` which the target user CAN run
-    (authorized by the per-os_user `/bin/kill` rule
-    `_generate_sudoers` already emits). The leading `-` on the
-    PID arg makes kill's target a process group; sending to the
-    negative group id signals every process the target user has
-    permission to signal in that group, covering descendants at
-    every tree depth without per-PID discovery.
-
-    Bounded by `_CROSS_USER_KILL_TIMEOUT_S` so a hung sudo or
-    missing `/bin/kill` does not stall the reasoner's own timeout
-    cleanup. Failures (non-zero rc, timeout, FileNotFoundError on
-    sudo itself) are logged and swallowed; the caller still reaps
-    the wrapper afterward, accepting the orphan risk for that
-    deployment edge case.
-    """
-    cmd = ["sudo", "-n", "-u", target_user, "/bin/kill", "-KILL", f"-{pgid}"]
-    try:
-        kill_proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-    except FileNotFoundError:
-        log.warning(
-            "cross-user kill spawn failed: sudo not found (purpose=%s backend=%s target=%s pgid=%d)",
-            purpose,
-            backend,
-            target_user,
-            pgid,
-        )
-        return
-    try:
-        _stdout, stderr = await asyncio.wait_for(kill_proc.communicate(), timeout=_CROSS_USER_KILL_TIMEOUT_S)
-    except TimeoutError:
-        kill_proc.kill()
-        with contextlib.suppress(BaseException):
-            await kill_proc.wait()
-        log.warning(
-            "cross-user kill timed out (purpose=%s backend=%s target=%s pgid=%d)",
-            purpose,
-            backend,
-            target_user,
-            pgid,
-        )
-        return
-    rc = kill_proc.returncode if kill_proc.returncode is not None else -1
-    if rc != 0:
-        log.warning(
-            "cross-user kill returned rc=%d (purpose=%s backend=%s target=%s pgid=%d stderr=%r)",
-            rc,
-            purpose,
-            backend,
-            target_user,
-            pgid,
-            stderr[:200],
-        )
 
 
 def _os_user_log_field(effective_user: str | None) -> str:

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -207,6 +207,16 @@ class SubprocessPool:
         # clarity of two separate resolution calls is worth it.
         home_ws = resolve_home_workspace(chat_id, self._config)
 
+        # os_user for sudo -u isolation. None = run as bot user.
+        # Resolved here (rather than inside each branch) because the
+        # claude, codex, and goose backends all consume it for
+        # per-user subprocess isolation. OpenCode does not: its auth
+        # file (~/.local/share/opencode/auth.json) is per-OS-user and
+        # operator-provisioned via `opencode auth login` outside the
+        # wizard, so opencode chat stays on the service user until
+        # that provisioning story exists.
+        os_user = user.os_user if user else None
+
         # Backend selection: "goose" uses Goose ACP, "opencode" uses
         # OpenCode ACP, "codex" uses OpenAI Codex CLI's app-server
         # JSON-RPC protocol, anything else (including the default
@@ -223,6 +233,7 @@ class SubprocessPool:
                 workspace_config=ws_config,
                 provider=effective_provider,
                 memory_enabled=self._config.memory_enabled,
+                os_user=os_user,
             )
 
         if backend == "opencode":
@@ -243,16 +254,6 @@ class SubprocessPool:
                 provider=effective_provider,
                 memory_enabled=self._config.memory_enabled,
             )
-
-        # os_user for sudo -u isolation. None = run as bot user.
-        # Resolved here (rather than inside each branch) because both
-        # ClaudeCodeBackend and CodexBackend consume it for per-user
-        # subprocess isolation. Goose and OpenCode do not: both run as
-        # the service user. Goose bills against a single GOOSE_PROVIDER
-        # auth set in /etc/kai/env; OpenCode reads its auth from
-        # ~/.local/share/opencode/auth.json which is per-OS-user but
-        # operator-managed via `opencode auth login` outside the wizard.
-        os_user = user.os_user if user else None
 
         if backend == "codex":
             # Import locally so codex.py is only imported on a

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -34,6 +34,12 @@ Covers:
     initialize result, Anthropic-to-ACP block conversion, forwarding
     when supported, drop notice in the reply text when not, and the
     EOF-after-drop path staying an error
+19. os_user routing: direct spawn vs sudo -H wrap, preserve-env CSV
+    from the preserved_env_vars() hook, per-os-user TMPDIR anchor
+20. Cross-user kill escalation on force_kill / _kill / shutdown /
+    in-stream timeout when wrapped, and its absence when direct
+21. The shared _kill_target_user_tree helpers (argv shape, ESRCH
+    demotion, timeout bound)
 """
 
 import asyncio
@@ -1687,3 +1693,483 @@ class TestReadResultFreeFunction:
             backend_label="OpenCode",
         )
         assert result == {"ok": True}
+
+
+# ── Cross-user os_user routing ──────────────────────────────────────
+
+
+class TestOsUserRouting:
+    """`os_user` controls the sudo wrap in _ensure_started, mirroring
+    the claude/codex routing contract: an unset (or bot-matching)
+    target spawns the agent directly; a non-bot target wraps the argv
+    in `sudo -H -u <target> --preserve-env=<csv> --`, runs the spawn
+    in a new session group, and records the escalation target + pgid
+    the kill paths need."""
+
+    @pytest.mark.asyncio
+    async def test_direct_spawn_when_os_user_none(self):
+        """No os_user: argv is the bare build_argv() vector, no new
+        session group, no escalation state recorded."""
+        b = _make_fake()
+        captured: dict = {}
+
+        async def _fake_spawn(*args, **kwargs):
+            captured["argv"] = args
+            captured.update(kwargs)
+            return _make_mock_proc(_handshake_lines())
+
+        with patch("kai.acp.asyncio.create_subprocess_exec", side_effect=_fake_spawn):
+            await b._ensure_started()
+
+        assert captured["argv"][0] == "fake_acp_binary"
+        assert "sudo" not in captured["argv"]
+        assert captured["start_new_session"] is False
+        assert b._pgid is None
+        assert b._effective_os_user is None
+
+    @pytest.mark.asyncio
+    async def test_self_sudo_skip_spawns_direct(self):
+        """An os_user that resolve_claude_user collapses to None (the
+        bot's own user) takes the byte-identical direct path. The
+        resolver is patched so the assertion does not depend on which
+        OS user the test runner happens to be."""
+        b = _make_fake(os_user="bot-user-itself")
+        captured: dict = {}
+
+        async def _fake_spawn(*args, **kwargs):
+            captured["argv"] = args
+            captured.update(kwargs)
+            return _make_mock_proc(_handshake_lines())
+
+        with (
+            patch("kai.acp.resolve_claude_user", return_value=None) as mock_resolve,
+            patch("kai.acp.asyncio.create_subprocess_exec", side_effect=_fake_spawn),
+        ):
+            await b._ensure_started()
+
+        mock_resolve.assert_called_once_with("bot-user-itself")
+        assert captured["argv"][0] == "fake_acp_binary"
+        assert captured["start_new_session"] is False
+        assert b._pgid is None
+        assert b._effective_os_user is None
+
+    @pytest.mark.asyncio
+    async def test_wrap_argv_preserve_env_and_state(self):
+        """A non-bot os_user wraps the argv with -H and the default
+        preserve list, spawns a new session group, and records pgid
+        (== wrapper pid for session leaders) plus the resolved target
+        for the kill paths."""
+        b = _make_fake(os_user="other-user")
+        captured: dict = {}
+
+        async def _fake_spawn(*args, **kwargs):
+            captured["argv"] = args
+            captured.update(kwargs)
+            return _make_mock_proc(_handshake_lines())
+
+        with (
+            patch("kai.acp.resolve_claude_user", return_value="other-user"),
+            patch("kai.acp.asyncio.create_subprocess_exec", side_effect=_fake_spawn),
+        ):
+            await b._ensure_started()
+
+        argv = list(captured["argv"])
+        assert argv[:4] == ["sudo", "-H", "-u", "other-user"]
+        # Preserve-env CSV exact contract: the AcpBackend default
+        # (webhook callback auth + per-os-user temp anchor). Backends
+        # that need more override preserved_env_vars(); see the
+        # hook-driven test below.
+        assert argv[4] == "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR"
+        assert argv[5] == "--"
+        assert argv[6] == "fake_acp_binary"
+        assert captured["start_new_session"] is True
+        # _make_mock_proc pins pid=12345; PGID == PID for session
+        # leaders, recorded at spawn time.
+        assert b._pgid == 12345
+        assert b._effective_os_user == "other-user"
+
+    @pytest.mark.asyncio
+    async def test_preserve_env_csv_comes_from_hook(self):
+        """The CSV is whatever preserved_env_vars() returns, so a
+        concrete adapter (GooseBackend) can extend the list without
+        the shared layer hardcoding backend specifics."""
+
+        class _CustomPreserve(_FakeAcp):
+            def preserved_env_vars(self) -> tuple[str, ...]:
+                return ("ALPHA", "BETA")
+
+        b = _CustomPreserve(model="sonnet", workspace=Path("/tmp/test-workspace"), os_user="other-user")
+        captured: dict = {}
+
+        async def _fake_spawn(*args, **kwargs):
+            captured["argv"] = args
+            return _make_mock_proc(_handshake_lines())
+
+        with (
+            patch("kai.acp.resolve_claude_user", return_value="other-user"),
+            patch("kai.acp.asyncio.create_subprocess_exec", side_effect=_fake_spawn),
+        ):
+            await b._ensure_started()
+
+        assert captured["argv"][4] == "--preserve-env=ALPHA,BETA"
+
+    @pytest.mark.asyncio
+    async def test_tmpdir_anchored_per_os_user_on_wrap(self):
+        """Cross-user mode anchors TMPDIR under <DATA_DIR>/tmp/<user>
+        so each os_user has its own temp namespace; the anchor is
+        applied AFTER workspace env so a workspace cannot point one
+        user's temp writes at another's."""
+        from kai.config import DATA_DIR
+
+        b = _make_fake(os_user="other-user")
+        captured: dict = {}
+
+        async def _fake_spawn(*args, **kwargs):
+            captured.update(kwargs)
+            return _make_mock_proc(_handshake_lines())
+
+        with (
+            patch("kai.acp.resolve_claude_user", return_value="other-user"),
+            patch("kai.acp.asyncio.create_subprocess_exec", side_effect=_fake_spawn),
+        ):
+            await b._ensure_started()
+
+        assert captured["env"]["TMPDIR"] == str(DATA_DIR / "tmp" / "other-user")
+
+    @pytest.mark.asyncio
+    async def test_tmpdir_not_anchored_on_direct_spawn(self):
+        """Direct mode keeps the inherited TMPDIR (or its absence):
+        no cross-user collision is possible when everything runs as
+        the bot user, matching the claude backend's contract."""
+        import os as _os
+
+        b = _make_fake()
+        captured: dict = {}
+
+        async def _fake_spawn(*args, **kwargs):
+            captured.update(kwargs)
+            return _make_mock_proc(_handshake_lines())
+
+        with patch("kai.acp.asyncio.create_subprocess_exec", side_effect=_fake_spawn):
+            await b._ensure_started()
+
+        assert captured["env"].get("TMPDIR") == _os.environ.get("TMPDIR")
+
+
+# ── Cross-user kill escalation ──────────────────────────────────────
+
+
+class TestCrossUserKillEscalation:
+    """When the spawn is wrapped, _proc is the service-user-owned sudo
+    wrapper and the agent underneath is target-user-owned; plain
+    SIGKILL on the wrapper would orphan the agent. force_kill, _kill,
+    and shutdown therefore escalate a group kill through the target
+    user first - and never do so on the direct path, where _proc IS
+    the agent."""
+
+    def _wrapped_backend(self) -> tuple[_FakeAcp, MagicMock]:
+        """Backend in post-spawn cross-user state, without a real
+        spawn: _proc is a live-looking wrapper mock and the routing
+        state is what _ensure_started records on the wrap path."""
+        b = _make_fake()
+        proc = MagicMock()
+        proc.returncode = None
+        proc.pid = 4242
+        proc.kill = MagicMock()
+        proc.terminate = MagicMock()
+        proc.wait = AsyncMock()
+        b._proc = proc
+        b._effective_os_user = "other-user"
+        b._pgid = 4242
+        b._stderr_task = None
+        return b, proc
+
+    def test_force_kill_escalates_sync_then_kills_wrapper(self):
+        """force_kill (sync, the pool's last resort) runs the sync
+        group-kill variant before SIGKILLing the wrapper, and nulls
+        _pgid so the async paths that follow (read loop EOF -> _kill)
+        do not re-kill the already-dead group."""
+        b, proc = self._wrapped_backend()
+
+        with patch("kai.acp._kill_target_user_tree_sync") as mock_sync:
+            b.force_kill()
+
+        mock_sync.assert_called_once_with(
+            target_user="other-user",
+            pgid=4242,
+            purpose="chat",
+            backend="fake",
+        )
+        proc.kill.assert_called_once()
+        assert b._pgid is None
+        # force_kill does NOT null _proc; _kill owns full cleanup.
+        assert b._proc is proc
+
+    def test_force_kill_direct_no_escalation(self):
+        """Direct mode: no escalation subprocess, just the SIGKILL."""
+        b = _make_fake()
+        proc = MagicMock()
+        proc.kill = MagicMock()
+        b._proc = proc
+        b._stderr_task = None
+
+        with patch("kai.acp._kill_target_user_tree_sync") as mock_sync:
+            b.force_kill()
+
+        mock_sync.assert_not_called()
+        proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_kill_escalates_async_once(self):
+        """_kill escalates through the canonical async helper, then
+        falls through to force_kill - which must NOT re-escalate
+        (the _pgid nulling between the two is the dedup)."""
+        b, proc = self._wrapped_backend()
+
+        with (
+            patch("kai.acp._kill_target_user_tree", new=AsyncMock()) as mock_async,
+            patch("kai.acp._kill_target_user_tree_sync") as mock_sync,
+        ):
+            await b._kill()
+
+        mock_async.assert_awaited_once_with(
+            target_user="other-user",
+            pgid=4242,
+            purpose="chat",
+            backend="fake",
+        )
+        mock_sync.assert_not_called()
+        proc.kill.assert_called_once()
+        # Full cleanup: a recycled instance must not carry stale
+        # routing state into a fresh spawn.
+        assert b._proc is None
+        assert b._pgid is None
+        assert b._effective_os_user is None
+
+    @pytest.mark.asyncio
+    async def test_kill_direct_no_escalation(self):
+        """Direct mode _kill: SIGKILL + reap only."""
+        b = _make_fake()
+        proc = MagicMock()
+        proc.returncode = None
+        proc.kill = MagicMock()
+        proc.wait = AsyncMock()
+        b._proc = proc
+        b._stderr_task = None
+
+        with patch("kai.acp._kill_target_user_tree", new=AsyncMock()) as mock_async:
+            await b._kill()
+
+        mock_async.assert_not_awaited()
+        proc.kill.assert_called_once()
+        assert b._proc is None
+
+    @pytest.mark.asyncio
+    async def test_response_timeout_escalates_when_wrapped(self):
+        """The in-stream timeout path (response/idle timeouts both
+        funnel into _kill) escalates for a wrapped backend, so an
+        eviction or hung turn cannot orphan the target-user agent."""
+        b, proc = self._wrapped_backend()
+        b.timeout_seconds = 1
+        proc.stdout = MagicMock()
+        proc.stdout.readline = AsyncMock(side_effect=TimeoutError())
+        proc.stdin = MagicMock()
+        proc.stdin.write = MagicMock()
+        proc.stdin.drain = AsyncMock()
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        with patch("kai.acp._kill_target_user_tree", new=AsyncMock()) as mock_async:
+            events = await _collect_events(b, prompt="hi")
+
+        assert events[-1].done is True
+        assert events[-1].response is not None
+        assert events[-1].response.success is False
+        mock_async.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_graceful_path_no_escalation(self):
+        """SIGTERM lands on the sudo wrapper, which relays catchable
+        signals to the agent; when the wait succeeds there is nothing
+        left to escalate."""
+        b, proc = self._wrapped_backend()
+        proc.wait = AsyncMock(return_value=None)
+
+        with patch("kai.acp._kill_target_user_tree", new=AsyncMock()) as mock_async:
+            await b.shutdown()
+
+        mock_async.assert_not_awaited()
+        proc.terminate.assert_called_once()
+        proc.kill.assert_not_called()
+        assert b._proc is None
+        assert b._pgid is None
+        assert b._effective_os_user is None
+
+    @pytest.mark.asyncio
+    async def test_shutdown_timeout_escalates_before_sigkill(self):
+        """When SIGTERM is ignored, the group escalation runs BEFORE
+        force_kill reaps the wrapper, mirroring the one-shot
+        reasoners' kill ordering (target tree first, wrapper reap
+        after). The sync variant must not fire: the _pgid nulling
+        between escalation and force_kill is the dedup."""
+        b, proc = self._wrapped_backend()
+        proc.wait = AsyncMock(side_effect=[TimeoutError(), None])
+        order: list[str] = []
+
+        async def _fake_tree_kill(**kwargs) -> None:
+            order.append("escalate")
+
+        proc.kill = MagicMock(side_effect=lambda: order.append("sigkill"))
+
+        with (
+            patch("kai.acp._kill_target_user_tree", side_effect=_fake_tree_kill),
+            patch("kai.acp._kill_target_user_tree_sync") as mock_sync,
+        ):
+            await b.shutdown()
+
+        assert order == ["escalate", "sigkill"]
+        mock_sync.assert_not_called()
+        assert b._proc is None
+
+
+# ── Cross-user kill helper free functions ───────────────────────────
+
+
+class TestKillTargetUserTreeFreeFunctions:
+    """The canonical cross-user group-kill helpers shared by the
+    one-shot reasoners and the conversational AcpBackend. Argv shape,
+    bounded wait, and the rc/ESRCH log classification (benign
+    already-gone race demotes to DEBUG; real failures keep WARNING)."""
+
+    @pytest.mark.asyncio
+    async def test_async_kill_argv_shape(self):
+        from kai.acp import _kill_target_user_tree
+
+        kill_proc = MagicMock()
+        kill_proc.communicate = AsyncMock(return_value=(b"", b""))
+        kill_proc.returncode = 0
+        captured: dict = {}
+
+        async def _fake_exec(*args, **kwargs):
+            captured["argv"] = args
+            return kill_proc
+
+        with patch("kai.acp.asyncio.create_subprocess_exec", side_effect=_fake_exec):
+            await _kill_target_user_tree(
+                target_user="other-user",
+                pgid=777,
+                purpose="chat",
+                backend="goose",
+            )
+
+        # Negative-PGID group kill through the target user's /bin/kill
+        # sudoers permission; -n so a missing rule fails fast instead
+        # of prompting.
+        assert list(captured["argv"]) == ["sudo", "-n", "-u", "other-user", "/bin/kill", "-KILL", "-777"]
+
+    @pytest.mark.asyncio
+    async def test_async_kill_esrch_demotes_to_debug(self, caplog):
+        """rc=1 with the POSIX ESRCH diagnostic is the benign race
+        (tree already exited); it must not pollute the WARNING
+        stream the operator watches for real sudoers failures."""
+        from kai.acp import _kill_target_user_tree
+
+        kill_proc = MagicMock()
+        kill_proc.communicate = AsyncMock(return_value=(b"", b"kill: -777: No such process"))
+        kill_proc.returncode = 1
+
+        with (
+            patch("kai.acp.asyncio.create_subprocess_exec", AsyncMock(return_value=kill_proc)),
+            caplog.at_level(logging.DEBUG, logger="kai.acp"),
+        ):
+            await _kill_target_user_tree(
+                target_user="other-user",
+                pgid=777,
+                purpose="chat",
+                backend="goose",
+            )
+
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert not warnings
+        debugs = [r for r in caplog.records if "benign race" in r.getMessage()]
+        assert debugs
+
+    @pytest.mark.asyncio
+    async def test_async_kill_real_failure_keeps_warning(self, caplog):
+        """A non-ESRCH rc!=0 (sudoers misconfiguration, permission
+        denied) keeps the WARNING so the orphan risk is visible."""
+        from kai.acp import _kill_target_user_tree
+
+        kill_proc = MagicMock()
+        kill_proc.communicate = AsyncMock(return_value=(b"", b"sudo: a password is required"))
+        kill_proc.returncode = 1
+
+        with (
+            patch("kai.acp.asyncio.create_subprocess_exec", AsyncMock(return_value=kill_proc)),
+            caplog.at_level(logging.WARNING, logger="kai.acp"),
+        ):
+            await _kill_target_user_tree(
+                target_user="other-user",
+                pgid=777,
+                purpose="chat",
+                backend="goose",
+            )
+
+        warnings = [r for r in caplog.records if "cross-user kill returned rc=1" in r.getMessage()]
+        assert warnings
+
+    def test_sync_kill_argv_and_esrch_classification(self, caplog):
+        """The sync companion (force_kill path) shares the argv shape
+        and the ESRCH demotion with the async canonical helper."""
+        from kai.acp import _kill_target_user_tree_sync
+
+        captured: dict = {}
+
+        def _fake_run(cmd, **kwargs):
+            captured["argv"] = cmd
+            result = MagicMock()
+            result.returncode = 1
+            result.stderr = b"kill: -888: No such process"
+            return result
+
+        with (
+            patch("kai.acp.subprocess.run", side_effect=_fake_run),
+            caplog.at_level(logging.DEBUG, logger="kai.acp"),
+        ):
+            _kill_target_user_tree_sync(
+                target_user="other-user",
+                pgid=888,
+                purpose="chat",
+                backend="goose",
+            )
+
+        assert captured["argv"] == ["sudo", "-n", "-u", "other-user", "/bin/kill", "-KILL", "-888"]
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert not warnings
+        debugs = [r for r in caplog.records if "benign race" in r.getMessage()]
+        assert debugs
+
+    def test_sync_kill_timeout_logs_warning(self, caplog):
+        """A hung sudo is bounded and logged; the caller's cleanup
+        must not stall behind the escalation."""
+        import subprocess as _subprocess
+
+        from kai.acp import _kill_target_user_tree_sync
+
+        with (
+            patch(
+                "kai.acp.subprocess.run",
+                side_effect=_subprocess.TimeoutExpired(cmd="sudo", timeout=5.0),
+            ),
+            caplog.at_level(logging.WARNING, logger="kai.acp"),
+        ):
+            _kill_target_user_tree_sync(
+                target_user="other-user",
+                pgid=999,
+                purpose="chat",
+                backend="goose",
+            )
+
+        warnings = [r for r in caplog.records if "cross-user kill timed out" in r.getMessage()]
+        assert warnings

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -1221,3 +1221,95 @@ class TestSendLock:
             events.append(event)
         assert not g._lock.locked()
         assert len(events) > 0
+
+
+# ── Argv binary resolution ──────────────────────────────────────────
+
+
+class TestBuildArgv:
+    """GOOSE_BIN pins the binary path so a sudo-wrapped per-user spawn
+    matches the absolute path the sudoers rule names (mirrors codex's
+    CODEX_BIN contract); bare "goose" remains the default for installs
+    with goose on PATH."""
+
+    def test_bare_goose_without_override(self, monkeypatch):
+        monkeypatch.delenv("GOOSE_BIN", raising=False)
+        g = _make_goose()
+        assert g.build_argv() == ["goose", "acp", "--with-builtin", "developer"]
+
+    def test_goose_bin_override_pins_absolute_path(self, monkeypatch):
+        monkeypatch.setenv("GOOSE_BIN", "/opt/homebrew/bin/goose")
+        g = _make_goose()
+        assert g.build_argv() == ["/opt/homebrew/bin/goose", "acp", "--with-builtin", "developer"]
+
+    def test_empty_goose_bin_falls_back_to_bare_name(self, monkeypatch):
+        """An empty-string GOOSE_BIN (unset-but-present in /etc/kai/env)
+        must not produce an empty argv head."""
+        monkeypatch.setenv("GOOSE_BIN", "")
+        g = _make_goose()
+        assert g.build_argv()[0] == "goose"
+
+
+# ── Cross-user preserve list ────────────────────────────────────────
+
+
+class TestPreservedEnvVars:
+    """The sudo wrap's --preserve-env list. Goose delivers model and
+    provider selection via env vars (GOOSE_MODEL / GOOSE_PROVIDER in
+    build_env), so the override must carry them through env_reset or
+    the wrapped goose silently loses its model selection; the five
+    provider keys cover env-key auth, and KAI_WEBHOOK_SECRET / TMPDIR
+    mirror the AcpBackend default."""
+
+    def test_content_exact(self):
+        g = _make_goose()
+        assert g.preserved_env_vars() == (
+            "GOOSE_MODEL",
+            "GOOSE_PROVIDER",
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_API_KEY",
+            "OPENROUTER_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "KAI_WEBHOOK_SECRET",
+            "TMPDIR",
+        )
+
+    @pytest.mark.asyncio
+    async def test_wrap_argv_carries_goose_preserve_list(self, monkeypatch):
+        """End-to-end through _ensure_started: the goose wrap's
+        --preserve-env CSV is the hook's list, not the base default."""
+        monkeypatch.delenv("GOOSE_BIN", raising=False)
+        g = _make_goose(os_user="goose-user", provider="anthropic")
+        captured: dict = {}
+
+        async def _fake_spawn(*args, **kwargs):
+            captured["argv"] = args
+            proc = MagicMock()
+            proc.returncode = None
+            proc.pid = 11111
+            proc.stdin = MagicMock()
+            proc.stdin.write = MagicMock()
+            proc.stdin.drain = AsyncMock()
+            proc.stdout = MagicMock()
+            lines = [_initialize_result(), _session_new_result()]
+            proc.stdout.readline = AsyncMock(side_effect=lambda: lines.pop(0) if lines else b"")
+            proc.stderr = MagicMock()
+            proc.stderr.readline = AsyncMock(return_value=b"")
+            return proc
+
+        with (
+            patch("kai.acp.resolve_claude_user", return_value="goose-user"),
+            patch("kai.acp.asyncio.create_subprocess_exec", side_effect=_fake_spawn),
+        ):
+            await g._ensure_started()
+
+        argv = list(captured["argv"])
+        assert argv[:4] == ["sudo", "-H", "-u", "goose-user"]
+        assert argv[4] == (
+            "--preserve-env=GOOSE_MODEL,GOOSE_PROVIDER,ANTHROPIC_API_KEY,"
+            "OPENAI_API_KEY,GOOGLE_API_KEY,OPENROUTER_API_KEY,DEEPSEEK_API_KEY,"
+            "KAI_WEBHOOK_SECRET,TMPDIR"
+        )
+        assert argv[5] == "--"
+        assert argv[6:] == ["goose", "acp", "--with-builtin", "developer"]

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -1285,18 +1285,7 @@ class TestPreservedEnvVars:
 
         async def _fake_spawn(*args, **kwargs):
             captured["argv"] = args
-            proc = MagicMock()
-            proc.returncode = None
-            proc.pid = 11111
-            proc.stdin = MagicMock()
-            proc.stdin.write = MagicMock()
-            proc.stdin.drain = AsyncMock()
-            proc.stdout = MagicMock()
-            lines = [_initialize_result(), _session_new_result()]
-            proc.stdout.readline = AsyncMock(side_effect=lambda: lines.pop(0) if lines else b"")
-            proc.stderr = MagicMock()
-            proc.stderr.readline = AsyncMock(return_value=b"")
-            return proc
+            return _make_mock_proc(_handshake_lines())
 
         with (
             patch("kai.acp.resolve_claude_user", return_value="goose-user"),

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7273,7 +7273,13 @@ class TestApplyServiceDryRun:
 
 
 class TestApplyGooseConfig:
-    """Tests for _apply_goose_config() goose binary check."""
+    """Tests for _apply_goose_config() goose binary check.
+
+    Every call passes an explicit (absent) users_yaml_path so the
+    assertions cannot flip on the host's real /etc/kai/users.yaml;
+    an absent file means no goose-backed os_users, i.e. the
+    service-user-only deploy these tests pin.
+    """
 
     def _setup(self, tmp_path):
         """Create a minimal install tree with the goose config template."""
@@ -7295,7 +7301,15 @@ class TestApplyGooseConfig:
 
         uid = os.getuid()
         gid = os.getgid()
-        _apply_goose_config("kai", install_path, uid, gid, dry_run=False)
+        _apply_goose_config(
+            "kai",
+            install_path,
+            uid,
+            gid,
+            dry_run=False,
+            users_yaml_path=tmp_path / "absent-users.yaml",
+            agent_backend="goose",
+        )
 
         output = capsys.readouterr().out
         assert "WARNING" in output
@@ -7311,7 +7325,15 @@ class TestApplyGooseConfig:
 
         uid = os.getuid()
         gid = os.getgid()
-        _apply_goose_config("kai", install_path, uid, gid, dry_run=True)
+        _apply_goose_config(
+            "kai",
+            install_path,
+            uid,
+            gid,
+            dry_run=True,
+            users_yaml_path=tmp_path / "absent-users.yaml",
+            agent_backend="goose",
+        )
 
         output = capsys.readouterr().out
         assert "WARNING" not in output
@@ -7329,10 +7351,288 @@ class TestApplyGooseConfig:
 
         uid = os.getuid()
         gid = os.getgid()
-        _apply_goose_config("kai", install_path, uid, gid, dry_run=False)
+        _apply_goose_config(
+            "kai",
+            install_path,
+            uid,
+            gid,
+            dry_run=False,
+            users_yaml_path=tmp_path / "absent-users.yaml",
+            agent_backend="goose",
+        )
 
         output = capsys.readouterr().out
         assert "WARNING" not in output
+
+    def test_deploys_to_each_goose_backed_os_user(self, tmp_path, monkeypatch):
+        """The config lands in the service user's home AND in each
+        distinct goose-backed os_user's home, each file owned by its
+        home's user (the per-user `goose acp` spawn runs under
+        `sudo -H` and resolves config beneath the target home)."""
+        import types
+
+        install_path = self._setup(tmp_path)
+        svc_home = tmp_path / "home" / "kai"
+        svc_home.mkdir(parents=True)
+        alice_home = tmp_path / "home" / "alice"
+        alice_home.mkdir(parents=True)
+        monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/local/bin/goose")
+
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            "users:\n"
+            "  - telegram_id: 1\n"
+            "    name: alice\n"
+            "    agent_backend: goose\n"
+            "    os_user: alice\n"
+            # Duplicate os_user entry: the deploy must dedupe.
+            "  - telegram_id: 2\n"
+            "    name: alice2\n"
+            "    agent_backend: goose\n"
+            "    os_user: alice\n"
+            # Non-goose user with an os_user: not a deploy target.
+            "  - telegram_id: 3\n"
+            "    name: bob\n"
+            "    agent_backend: codex\n"
+            "    os_user: bob\n"
+        )
+
+        # Fake passwd database so the os_user lookup does not depend
+        # on accounts existing on the test host.
+        def _fake_getpwnam(name):
+            if name == "alice":
+                return types.SimpleNamespace(pw_dir=str(alice_home), pw_uid=2001, pw_gid=2001)
+            raise KeyError(name)
+
+        monkeypatch.setattr("kai.install.pwd", types.SimpleNamespace(getpwnam=_fake_getpwnam))
+
+        # Record chowns instead of performing them: the test runner
+        # cannot chown to arbitrary uids, and the recorded calls ARE
+        # the ownership contract under test.
+        chowns: list[tuple[str, int, int]] = []
+        monkeypatch.setattr(
+            "kai.install._set_ownership",
+            lambda path, uid, gid, recursive=False: chowns.append((str(path), uid, gid)),
+        )
+
+        _apply_goose_config(
+            "kai",
+            install_path,
+            1001,
+            1001,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+            agent_backend="claude",
+        )
+
+        # Both homes got the template.
+        assert (svc_home / ".config" / "goose" / "config.yaml").exists()
+        assert (alice_home / ".config" / "goose" / "config.yaml").exists()
+        # Exactly one per-os_user deploy (deduped), none for bob.
+        assert not (tmp_path / "home" / "bob").exists()
+        # Ownership followed each home's user.
+        svc_cfg = str(svc_home / ".config" / "goose" / "config.yaml")
+        alice_cfg = str(alice_home / ".config" / "goose" / "config.yaml")
+        assert (svc_cfg, 1001, 1001) in chowns
+        assert (alice_cfg, 2001, 2001) in chowns
+
+    def test_global_goose_install_deploys_to_os_users_without_override(self, tmp_path, monkeypatch):
+        """On a global goose install, users.yaml entries with no
+        per-user agent_backend inherit goose and their os_user homes
+        are deploy targets."""
+        import types
+
+        install_path = self._setup(tmp_path)
+        svc_home = tmp_path / "home" / "kai"
+        svc_home.mkdir(parents=True)
+        carol_home = tmp_path / "home" / "carol"
+        carol_home.mkdir(parents=True)
+        monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/local/bin/goose")
+
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 1\n    name: carol\n    os_user: carol\n")
+
+        monkeypatch.setattr(
+            "kai.install.pwd",
+            types.SimpleNamespace(
+                getpwnam=lambda name: types.SimpleNamespace(pw_dir=str(carol_home), pw_uid=2002, pw_gid=2002)
+            ),
+        )
+        monkeypatch.setattr(
+            "kai.install._set_ownership",
+            lambda path, uid, gid, recursive=False: None,
+        )
+
+        _apply_goose_config(
+            "kai",
+            install_path,
+            1001,
+            1001,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+            agent_backend="goose",
+        )
+
+        assert (carol_home / ".config" / "goose" / "config.yaml").exists()
+
+    def test_dry_run_lists_every_target(self, tmp_path, capsys, monkeypatch):
+        """Dry run prints the create/copy pair for the service user
+        and each goose-backed os_user, mutating nothing."""
+        import types
+
+        install_path = self._setup(tmp_path)
+        svc_home = tmp_path / "home" / "kai"
+        svc_home.mkdir(parents=True)
+        alice_home = tmp_path / "home" / "alice"
+        monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            "users:\n  - telegram_id: 1\n    name: alice\n    agent_backend: goose\n    os_user: alice\n"
+        )
+        monkeypatch.setattr(
+            "kai.install.pwd",
+            types.SimpleNamespace(
+                getpwnam=lambda name: types.SimpleNamespace(pw_dir=str(alice_home), pw_uid=2001, pw_gid=2001)
+            ),
+        )
+
+        _apply_goose_config(
+            "kai",
+            install_path,
+            1001,
+            1001,
+            dry_run=True,
+            users_yaml_path=users_yaml,
+            agent_backend="claude",
+        )
+
+        output = capsys.readouterr().out
+        assert f"[DRY RUN] Would create: {svc_home / '.config' / 'goose'}" in output
+        assert f"[DRY RUN] Would create: {alice_home / '.config' / 'goose'}" in output
+        # Nothing was written.
+        assert not (svc_home / ".config").exists()
+        assert not alice_home.exists()
+
+    def test_noop_when_nothing_goose_backed(self, tmp_path, capsys):
+        """A claude-only install (no global goose, no per-user goose
+        override) deploys nothing and is never blocked on the goose
+        template - the apply pipeline calls this unconditionally."""
+        # Deliberately NO template in the install tree: the gate must
+        # return before the template existence check.
+        install_path = tmp_path / "opt" / "kai"
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - {telegram_id: 1, name: a, agent_backend: codex, os_user: bob}\n")
+
+        _apply_goose_config(
+            "kai",
+            install_path,
+            1001,
+            1001,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+            agent_backend="claude",
+        )
+
+        assert capsys.readouterr().out == ""
+
+    def test_unknown_os_user_fails_before_any_deploy(self, tmp_path, monkeypatch):
+        """An os_user missing from the passwd database aborts the
+        whole step BEFORE the service-user copy, so a typo cannot
+        leave a half-deployed set of homes."""
+        import types
+
+        install_path = self._setup(tmp_path)
+        svc_home = tmp_path / "home" / "kai"
+        svc_home.mkdir(parents=True)
+        monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            "users:\n  - telegram_id: 1\n    name: ghost\n    agent_backend: goose\n    os_user: ghost\n"
+        )
+
+        def _raise_keyerror(name):
+            raise KeyError(name)
+
+        monkeypatch.setattr("kai.install.pwd", types.SimpleNamespace(getpwnam=_raise_keyerror))
+
+        with pytest.raises(ValueError, match="does not exist"):
+            _apply_goose_config(
+                "kai",
+                install_path,
+                1001,
+                1001,
+                dry_run=False,
+                users_yaml_path=users_yaml,
+                agent_backend="claude",
+            )
+
+        assert not (svc_home / ".config").exists()
+
+
+class TestCollectGooseOsUsersFromYaml:
+    """The goose-backed os_user collector behind _apply_goose_config:
+    per-user overrides and global-backend inheritance select entries;
+    empty/absent os_users are skipped (service-user deploy covers
+    them); validation failures raise before any path is built."""
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        from kai.install import _collect_goose_os_users_from_yaml
+
+        assert _collect_goose_os_users_from_yaml(tmp_path / "nope.yaml", "goose") == []
+
+    def test_per_user_override_selected_on_non_goose_global(self, tmp_path):
+        from kai.install import _collect_goose_os_users_from_yaml
+
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            "users:\n"
+            "  - {telegram_id: 1, name: a, agent_backend: goose, os_user: alice}\n"
+            "  - {telegram_id: 2, name: b, agent_backend: codex, os_user: bob}\n"
+            "  - {telegram_id: 3, name: c, os_user: carol}\n"
+        )
+        assert _collect_goose_os_users_from_yaml(path, "claude") == ["alice"]
+
+    def test_global_goose_inherited_by_unset_entries(self, tmp_path):
+        from kai.install import _collect_goose_os_users_from_yaml
+
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            "users:\n"
+            "  - {telegram_id: 1, name: a, os_user: alice}\n"
+            "  - {telegram_id: 2, name: b, agent_backend: claude, os_user: bob}\n"
+        )
+        assert _collect_goose_os_users_from_yaml(path, "goose") == ["alice"]
+
+    def test_entries_without_os_user_skipped(self, tmp_path):
+        from kai.install import _collect_goose_os_users_from_yaml
+
+        path = tmp_path / "users.yaml"
+        path.write_text("users:\n  - {telegram_id: 1, name: a, agent_backend: goose}\n")
+        assert _collect_goose_os_users_from_yaml(path, "claude") == []
+
+    def test_duplicates_deduped_preserving_order(self, tmp_path):
+        from kai.install import _collect_goose_os_users_from_yaml
+
+        path = tmp_path / "users.yaml"
+        path.write_text(
+            "users:\n"
+            "  - {telegram_id: 1, name: a, agent_backend: goose, os_user: alice}\n"
+            "  - {telegram_id: 2, name: b, agent_backend: goose, os_user: dana}\n"
+            "  - {telegram_id: 3, name: c, agent_backend: goose, os_user: alice}\n"
+        )
+        assert _collect_goose_os_users_from_yaml(path, "claude") == ["alice", "dana"]
+
+    def test_invalid_os_user_raises(self, tmp_path):
+        from kai.install import _collect_goose_os_users_from_yaml
+
+        path = tmp_path / "users.yaml"
+        path.write_text('users:\n  - {telegram_id: 1, name: a, agent_backend: goose, os_user: "bad)user"}\n')
+        with pytest.raises(ValueError, match="Invalid os_user"):
+            _collect_goose_os_users_from_yaml(path, "claude")
 
 
 # ── _apply_migrate per-os-user tmp dir (issue #454) ────────────────────

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -1460,14 +1460,13 @@ class TestRoutingTimeoutCleanup:
 
     @pytest.mark.asyncio
     async def test_cross_user_kill_failure_logs_and_reaps(self, tmp_path, caplog):
-        """A kill subprocess returning rc != 0 (e.g., the agent
-        already exited between TimeoutError and the kill spawn)
-        logs a warning, still reaps the wrapper, and still raises
-        OneShotTimeout."""
+        """A kill subprocess failing for a real reason (sudoers
+        misconfiguration, permission denied) logs a warning, still
+        reaps the wrapper, and still raises OneShotTimeout."""
         reasoner = ClaudeOneShotReasoner(cwd=tmp_path, os_user="other-user")
         proc = _make_proc(raise_timeout=True)
         proc.pid = 999
-        kill_proc = _make_proc(stdout=b"", stderr=b"No such process", returncode=1)
+        kill_proc = _make_proc(stdout=b"", stderr=b"sudo: a password is required", returncode=1)
 
         async def _fake_exec(*args, **kwargs):
             if args[0] == "sudo" and len(args) > 4 and args[4] == "/bin/kill":
@@ -1477,7 +1476,7 @@ class TestRoutingTimeoutCleanup:
         with (
             patch("kai.oneshot.resolve_claude_user", return_value="other-user"),
             patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(side_effect=_fake_exec)),
-            caplog.at_level(logging.WARNING, logger="kai.oneshot"),
+            caplog.at_level(logging.WARNING, logger="kai.acp"),
             pytest.raises(OneShotTimeout),
         ):
             await reasoner.run(prompt="p", purpose="fact_extraction", timeout=0.1)
@@ -1485,6 +1484,37 @@ class TestRoutingTimeoutCleanup:
         proc.kill.assert_called_once()
         warnings = [r for r in caplog.records if "cross-user kill returned rc=1" in r.getMessage()]
         assert warnings, "expected a warning about the failing kill subprocess"
+
+    @pytest.mark.asyncio
+    async def test_cross_user_kill_esrch_is_benign(self, tmp_path, caplog):
+        """rc=1 with the POSIX ESRCH diagnostic means the agent
+        already exited between TimeoutError and the kill spawn: a
+        benign race that must NOT hit the WARNING stream an operator
+        watches for real sudoers failures. Still reaps the wrapper
+        and still raises OneShotTimeout."""
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path, os_user="other-user")
+        proc = _make_proc(raise_timeout=True)
+        proc.pid = 999
+        kill_proc = _make_proc(stdout=b"", stderr=b"kill: -999: No such process", returncode=1)
+
+        async def _fake_exec(*args, **kwargs):
+            if args[0] == "sudo" and len(args) > 4 and args[4] == "/bin/kill":
+                return kill_proc
+            return proc
+
+        with (
+            patch("kai.oneshot.resolve_claude_user", return_value="other-user"),
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(side_effect=_fake_exec)),
+            caplog.at_level(logging.DEBUG, logger="kai.acp"),
+            pytest.raises(OneShotTimeout),
+        ):
+            await reasoner.run(prompt="p", purpose="fact_extraction", timeout=0.1)
+
+        proc.kill.assert_called_once()
+        warnings = [r for r in caplog.records if "cross-user kill" in r.getMessage() and r.levelno >= logging.WARNING]
+        assert not warnings, "ESRCH must demote to DEBUG, not WARNING"
+        debugs = [r for r in caplog.records if "benign race" in r.getMessage()]
+        assert debugs
 
     @pytest.mark.asyncio
     async def test_direct_spawn_does_not_run_cross_user_kill(self, tmp_path):

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -322,6 +322,45 @@ class TestPerUserBackendRouting:
         assert instance.model == "gpt-5.5"
         assert instance.provider == "openai"
 
+    def test_goose_user_receives_os_user(self):
+        """A goose user's os_user reaches GooseBackend, which wires
+        the per-user sudo isolation in the shared ACP layer (same
+        contract claude_user / codex_user carry on their backends)."""
+        user = UserConfig(
+            telegram_id=111,
+            name="alice",
+            agent_backend="goose",
+            llm_provider="anthropic",
+            model="sonnet",
+            os_user="alice-os",
+        )
+        config = _make_config(user_configs={111: user})
+        pool = SubprocessPool(config=config, services_info=[])
+        instance = pool.get(111)
+        assert isinstance(instance, GooseBackend)
+        assert instance.os_user == "alice-os"
+
+    def test_opencode_user_does_not_receive_os_user(self):
+        """OpenCode chat stays on the service user even when the
+        users.yaml entry carries an os_user: its auth file is
+        per-OS-user and operator-provisioned, so the pool does not
+        wire the isolation for opencode until that provisioning
+        story exists."""
+        from kai.opencode import OpenCodeBackend
+
+        user = UserConfig(
+            telegram_id=111,
+            name="alice",
+            agent_backend="opencode",
+            model="anthropic/claude-sonnet-4-6",
+            os_user="alice-os",
+        )
+        config = _make_config(user_configs={111: user})
+        pool = SubprocessPool(config=config, services_info=[])
+        instance = pool.get(111)
+        assert isinstance(instance, OpenCodeBackend)
+        assert instance.os_user is None
+
 
 # ── Per-user actions ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #611.

Goose chat sessions now honor `os_user` from users.yaml, completing per-user OS isolation for the goose backend. Claude and codex already had it for chat; goose one-shots gained it in #612.

- `AcpBackend` gains `os_user`: when it resolves to a non-bot user, the spawn is wrapped in `sudo -H -u <target> --preserve-env=<csv> --`, TMPDIR is anchored to the per-os-user temp dir, and the wrapper runs as a session leader so the kill paths can target the process group.
- A new `preserved_env_vars()` hook supplies the preserve list (default `KAI_WEBHOOK_SECRET,TMPDIR`). `GooseBackend` extends it with `GOOSE_MODEL`, `GOOSE_PROVIDER`, and the five provider API key vars: goose reads model and provider selection from the environment, so sudo's env_reset would otherwise strip the model selection itself, not just auth.
- `force_kill`, `_kill`, and `shutdown` escalate a cross-user group kill (`sudo -n -u <target> /bin/kill -KILL -<pgid>`) before reaping the sudo wrapper, so a stop, an eviction, or a hung turn cannot orphan the target-user goose process.
- The canonical cross-user kill helper `_kill_target_user_tree` moves from `oneshot.py` into `acp.py`; `oneshot` already imports shared helpers from `acp`, so the reverse import would cycle. A sync companion covers the synchronous `force_kill` path. Both variants demote the benign ESRCH "No such process" race to DEBUG; real failures (sudoers misconfiguration, permission denied) keep WARNING.
- `GooseBackend.build_argv` honors `GOOSE_BIN` so the wrapped argv resolves to the same absolute path the sudoers rule pins (mirrors the `CODEX_BIN` contract).
- The pool wires `os_user` for goose only. OpenCode chat stays on the service user: its auth file (`~/.local/share/opencode/auth.json`) is per-OS-user and operator-provisioned, so wiring it is a separate decision.
- The installer deploys the goose config template to each distinct goose-backed os_user home in addition to the service user, with ownership following each home. The gate moved inside `_apply_goose_config` (fires on a global goose backend or any per-user goose override), so claude-only installs never block on the template.

## Operator notes

Each goose `os_user` needs provider auth reachable from their environment. The preserved env keys cover central env-key auth; keychain-based auth (`goose configure`) is per-user, out of band, and rides the `sudo -H` HOME rewrite.

## Testing

- `make test`: 3877 passed, 1 skipped (37 new tests). `make check` clean.
- New coverage: AcpBackend wrap argv, preserve-env CSV from the hook, self-sudo skip, TMPDIR anchoring, kill escalation on force_kill / _kill / shutdown / in-stream timeout (and its absence on the direct path), the relocated kill helpers (argv shape, ESRCH demotion, timeout bound), GooseBackend preserve list and GOOSE_BIN argv, pool wiring (goose receives os_user, opencode does not), installer per-os_user deploy, dry-run shape, unknown-os_user pre-validation, the goose-backed os_user collector, and a no-op gate check for claude-only installs.
