### PR TITLE
fix(goose): unpin anthropic models from stale SKUs

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -643,6 +643,18 @@ def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> b
     operator typo (bare Anthropic names like "opus" or "sonnet" that
     are correct on other backends but unusable on OpenCode).
 
+    Goose-on-anthropic additionally accepts any `claude-*` ID
+    structurally, beyond the curated alias trio. Goose hands
+    GOOSE_MODEL verbatim to the Anthropic API, which accepts full
+    model IDs (current aliases like claude-opus-4-8 and dated SKUs
+    alike), so the alias map in goose.py going stale must never be a
+    ceiling on which SKUs a goose user can reach. A bogus claude-*
+    string fails at the provider with a clear API error, the same
+    contract opencode accepts for its structurally-validated IDs.
+    The claude backend keeps curated-only validation: its CLI
+    resolves the short aliases to the newest SKU itself, so the
+    alias surface does not pin generations there.
+
     Canonical model validator: every model-selection site in the
     codebase routes through this function so codex / goose / opencode
     share no fallback path.
@@ -651,6 +663,8 @@ def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> b
         return model in CODEX_MODELS
     if backend == "opencode":
         return is_opencode_model_shape(model)
+    if backend == "goose" and eff_provider == "anthropic" and model.startswith("claude-"):
+        return True
     return validate_model_for_provider(model, eff_provider)
 
 

--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -25,14 +25,20 @@ log = logging.getLogger(__name__)
 
 
 # Map Kai logical model names to Anthropic model IDs for GOOSE_MODEL.
-# These IDs will go stale as new model versions are released.
-# The .get(key, key) fallback passes unrecognized values through
-# unchanged, so full model IDs (e.g. "claude-opus-4-6") work without
-# being in the map.
+# Values are the API's undated alias forms, the same IDs the claude
+# CLI resolves its short aliases to, so the two backends agree on
+# which SKU a logical name means. The aliases pin a family version
+# (claude-opus-4-8 does not track a future 4.9), so this map needs a
+# bump on each Anthropic release. The .get(key, key) fallback passes
+# unrecognized values through unchanged, so full model IDs (e.g.
+# "claude-opus-4-7" to pin the previous generation) work without
+# being in the map; validate_model_for_backend admits any claude-*
+# ID on goose-on-anthropic so the pass-through is reachable from
+# /model and per-user config.
 _ANTHROPIC_MODEL_MAP: dict[str, str] = {
     "sonnet": "claude-sonnet-4-6",
-    "opus": "claude-opus-4-6",
-    "haiku": "claude-haiku-4-5-20251001",
+    "opus": "claude-opus-4-8",
+    "haiku": "claude-haiku-4-5",
 }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2446,6 +2446,43 @@ class TestValidateModelForBackend:
 
         assert validate_model_for_backend("opus", "claude", "anthropic") is True
 
+    def test_goose_anthropic_accepts_full_claude_ids(self):
+        """Goose hands GOOSE_MODEL verbatim to the Anthropic API, so any
+        claude-* ID passes structurally; a stale alias map must never be
+        a ceiling on which SKUs a goose user can reach."""
+        from kai.config import validate_model_for_backend
+
+        assert validate_model_for_backend("claude-opus-4-8", "goose", "anthropic") is True
+        assert validate_model_for_backend("claude-opus-4-7", "goose", "anthropic") is True
+        assert validate_model_for_backend("claude-haiku-4-5-20251001", "goose", "anthropic") is True
+        # The curated alias trio keeps working alongside the passthrough.
+        assert validate_model_for_backend("opus", "goose", "anthropic") is True
+        assert validate_model_for_backend("sonnet", "goose", "anthropic") is True
+
+    def test_goose_anthropic_rejects_non_claude_garbage(self):
+        """The structural passthrough is claude-* scoped; other strings
+        still validate against the curated provider surface."""
+        from kai.config import validate_model_for_backend
+
+        assert validate_model_for_backend("gpt-5.5", "goose", "anthropic") is False
+        assert validate_model_for_backend("clearly-bogus", "goose", "anthropic") is False
+
+    def test_claude_full_ids_stay_curated_only(self):
+        """The passthrough is goose-specific: the claude backend's CLI
+        resolves short aliases to the newest SKU itself, so its surface
+        stays the curated trio."""
+        from kai.config import validate_model_for_backend
+
+        assert validate_model_for_backend("claude-opus-4-8", "claude", "anthropic") is False
+
+    def test_goose_non_anthropic_providers_unaffected_by_passthrough(self):
+        """A claude-* string on goose-with-another-provider is not a
+        valid model for that provider's API; the passthrough must not
+        leak across providers."""
+        from kai.config import validate_model_for_backend
+
+        assert validate_model_for_backend("claude-opus-4-8", "goose", "openai") is False
+
     def test_opencode_accepts_provider_slash_model_shape(self):
         """OpenCode requires the `provider/model` structural shape."""
         from kai.config import validate_model_for_backend

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -201,14 +201,17 @@ class TestModelMapping:
     """Verify _ANTHROPIC_MODEL_MAP translates logical names to provider IDs."""
 
     def test_known_models(self):
-        """Logical names map to full Anthropic model IDs."""
+        """Logical names map to the current Anthropic API aliases (the
+        same SKUs the claude CLI resolves its short aliases to)."""
         assert _ANTHROPIC_MODEL_MAP["sonnet"] == "claude-sonnet-4-6"
-        assert _ANTHROPIC_MODEL_MAP["opus"] == "claude-opus-4-6"
-        assert _ANTHROPIC_MODEL_MAP["haiku"] == "claude-haiku-4-5-20251001"
+        assert _ANTHROPIC_MODEL_MAP["opus"] == "claude-opus-4-8"
+        assert _ANTHROPIC_MODEL_MAP["haiku"] == "claude-haiku-4-5"
 
     def test_passthrough_for_unknown(self):
-        """Unrecognized values pass through via .get(key, key) fallback."""
-        model_id = "claude-sonnet-4-5-20250514"
+        """Unrecognized values pass through via .get(key, key) fallback,
+        so full model IDs can pin a SKU the map does not list (e.g. the
+        previous-generation opus)."""
+        model_id = "claude-opus-4-7"
         assert _ANTHROPIC_MODEL_MAP.get(model_id, model_id) == model_id
 
 
@@ -375,7 +378,7 @@ class TestHandshake:
             await g._ensure_started()
 
         call_kwargs = mock_exec.call_args[1]
-        assert call_kwargs["env"]["GOOSE_MODEL"] == "claude-opus-4-6"
+        assert call_kwargs["env"]["GOOSE_MODEL"] == "claude-opus-4-8"
 
     @pytest.mark.asyncio
     async def test_model_passthrough_for_non_anthropic(self):


### PR DESCRIPTION
## Summary

Closes #608.

Goose-on-anthropic could not reach current Claude SKUs. Two mechanisms combined: the alias map in goose.py pinned `opus` to the previous generation, and the canonical validator rejected full `claude-*` IDs for goose-on-anthropic, closing the map's own documented pass-through.

- `_ANTHROPIC_MODEL_MAP` now carries the current API aliases: `opus` resolves to `claude-opus-4-8`, `sonnet` stays on `claude-sonnet-4-6`, and `haiku` moves from the dated snapshot to the `claude-haiku-4-5` alias so all three entries use the same undated form. The map comment now states the bump-per-release expectation explicitly.
- `validate_model_for_backend` admits any `claude-*` string structurally for goose-on-anthropic. Goose hands `GOOSE_MODEL` verbatim to the Anthropic API, which accepts full model IDs, so a stale alias map is no longer a ceiling; `/model claude-opus-4-7` (pinning the previous generation) and per-user full-ID overrides now work. This follows the opencode precedent: structural validation with the provider as the source of truth on which IDs resolve. Bogus `claude-*` strings fail at the provider with a clear API error.
- The claude backend deliberately keeps curated-only validation: its CLI resolves the short aliases to the newest SKU itself, so the alias surface never pins generations there.
- The `(goose, anthropic)` registry tier rows were re-checked against the current API surface: `claude-sonnet-4-6` (balanced) and `claude-haiku-4-5` (cheap) are both current accepted aliases and stand unchanged.

## Testing

- `make test`: 3881 passed, 1 skipped (4 new validator tests). `make check` clean.
- New coverage: full-ID acceptance on goose-on-anthropic (current alias, previous generation, dated SKU), curated trio still accepted, non-claude garbage still rejected, the passthrough not leaking to the claude backend or to goose on other providers, and the updated alias map values end to end through `build_env` (`GOOSE_MODEL`).
