### PR TITLE
feat(opencode): per-user OS isolation for opencode chat via the ACP layer

### DIFF
--- a/src/kai/opencode.py
+++ b/src/kai/opencode.py
@@ -31,11 +31,15 @@ the active model into a one-shot JSON blob per process.
 Operator authentication is handled OUTSIDE Kai: `opencode auth login`
 writes credentials to `~/.local/share/opencode/auth.json`. The Kai
 installer prints a reminder; the wizard does not attempt to manage
-OpenCode auth state.
+OpenCode auth state. On installs with per-user OS isolation
+(users.yaml `os_user`), the login must be run AS each target user so
+the auth file lands under that user's home; the `sudo -H` wrap the
+shared AcpBackend applies points the subprocess at exactly that file.
 """
 
 import json
 import logging
+import os
 from typing import Literal
 
 from kai.acp import AcpBackend
@@ -245,14 +249,24 @@ class OpenCodeBackend(AcpBackend):
 
     def build_argv(self) -> list[str]:
         """
-        Static argv for `opencode acp`.
+        Argv for `opencode acp`.
 
         The CLI does not accept `--model` on argv; model selection
         flows through `OPENCODE_CONFIG_CONTENT` in `build_env`. `--cwd`
         is supplied via the subprocess `cwd=` argument in
         `AcpBackend._ensure_started`, not as an explicit argv entry.
+
+        OPENCODE_BIN pins an absolute binary path (mirrors codex's
+        CODEX_BIN and goose's GOOSE_BIN): when opencode is not on the
+        service user's PATH, or the spawn is sudo-wrapped for a
+        per-user os_user, the bare name either fails to resolve or
+        resolves to a path different from the one the sudoers rule
+        pins, and the spawn dies. Falls back to bare "opencode" so
+        installs with opencode on PATH keep working without the
+        override.
         """
-        return ["opencode", "acp"]
+        opencode_bin = os.environ.get("OPENCODE_BIN") or "opencode"
+        return [opencode_bin, "acp"]
 
     def build_env(self, base_env: dict[str, str]) -> dict[str, str]:
         """
@@ -274,6 +288,36 @@ class OpenCodeBackend(AcpBackend):
         if self.model:
             base_env["OPENCODE_CONFIG_CONTENT"] = json.dumps({"model": self.model})
         return base_env
+
+    def preserved_env_vars(self) -> tuple[str, ...]:
+        """
+        Env vars the cross-user sudo wrap forwards through env_reset.
+
+        OpenCode reads its model selection from OPENCODE_CONFIG_CONTENT
+        (set in build_env). claude and codex carry model selection
+        outside the environment (argv flag and per-turn protocol
+        params respectively), but for an env-driven backend sudo's
+        env_reset strips the model selection itself, not just auth,
+        and the wrapped opencode falls back to whatever its per-user
+        config files say.
+        The five provider key vars cover env-key auth flows centrally;
+        the primary auth store (`~/.local/share/opencode/auth.json`,
+        written by `opencode auth login` run as the target user) rides
+        the HOME rewrite from `sudo -H` instead and needs no
+        preservation. KAI_WEBHOOK_SECRET and TMPDIR mirror the
+        AcpBackend default (webhook callback auth and the per-os-user
+        temp anchor).
+        """
+        return (
+            "OPENCODE_CONFIG_CONTENT",
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_API_KEY",
+            "OPENROUTER_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "KAI_WEBHOOK_SECRET",
+            "TMPDIR",
+        )
 
     def build_initialize_params(self) -> dict:
         """

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -208,13 +208,14 @@ class SubprocessPool:
         home_ws = resolve_home_workspace(chat_id, self._config)
 
         # os_user for sudo -u isolation. None = run as bot user.
-        # Resolved here (rather than inside each branch) because the
-        # claude, codex, and goose backends all consume it for
-        # per-user subprocess isolation. OpenCode does not: its auth
-        # file (~/.local/share/opencode/auth.json) is per-OS-user and
-        # operator-provisioned via `opencode auth login` outside the
-        # wizard, so opencode chat stays on the service user until
-        # that provisioning story exists.
+        # Resolved here (rather than inside each branch) because all
+        # four backends consume it for per-user subprocess isolation.
+        # Each agent's auth state is per-OS-user and operator-
+        # provisioned under the target user's home (claude OAuth
+        # credentials, codex auth.json, goose keychain or env keys,
+        # opencode auth.json via `opencode auth login` run as that
+        # user); the `sudo -H` wrap each backend applies is what
+        # points the subprocess at the right home.
         os_user = user.os_user if user else None
 
         # Backend selection: "goose" uses Goose ACP, "opencode" uses
@@ -253,6 +254,7 @@ class SubprocessPool:
                 workspace_config=ws_config,
                 provider=effective_provider,
                 memory_enabled=self._config.memory_enabled,
+                os_user=os_user,
             )
 
         if backend == "codex":

--- a/templates/.env
+++ b/templates/.env
@@ -34,9 +34,10 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 
 # Agent binary paths. The wizard prompts for and persists these on
 # the matching backend; set them here only to override PATH discovery
-# (codex, opencode, and goose one-shot reasoners and the per-user
-# sudoers rules pin these exact paths). A set-but-wrong path is a
-# hard error at the first one-shot call, not a PATH fallback.
+# (the codex, opencode, and goose chat backends and one-shot reasoners
+# spawn these exact paths, and the per-user sudoers rules pin them).
+# A set-but-wrong path is a hard error at the first one-shot call,
+# not a PATH fallback.
 #CODEX_BIN=/opt/homebrew/bin/codex
 #OPENCODE_BIN=~/.local/bin/opencode
 #GOOSE_BIN=/opt/homebrew/bin/goose

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -5,7 +5,8 @@ Covers OpenCode-specific hook implementations on top of the shared
 AcpBackend layer:
 
 1. backend_name / backend_label class attributes
-2. Static argv `opencode acp` (no --model flag; flag is not accepted)
+2. Argv `opencode acp` with OPENCODE_BIN binary pinning (no --model
+   flag; flag is not accepted)
 3. build_env injects OPENCODE_CONFIG_CONTENT with the active model
 4. Integer protocolVersion in build_initialize_params (NOT string "v1")
 5. session/new params: cwd + empty mcpServers (same as Goose)
@@ -15,12 +16,14 @@ AcpBackend layer:
    allow_always (falls back through allow_once and the first option;
    returns None when no usable option is found)
 8. Other server-request methods return None (no auto-response)
+9. preserved_env_vars carries OPENCODE_CONFIG_CONTENT plus the
+   provider auth keys through the cross-user sudo wrap
 """
 
 import json
 import logging
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -36,6 +39,77 @@ def _make_opencode(**kwargs) -> OpenCodeBackend:
     }
     defaults.update(kwargs)
     return OpenCodeBackend(**defaults)
+
+
+def _json_line(obj: dict) -> bytes:
+    """Encode a dict as a JSON line (bytes with trailing newline)."""
+    return json.dumps(obj).encode() + b"\n"
+
+
+def _initialize_result() -> bytes:
+    """Build the server's response to an initialize request."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "protocolVersion": 1,
+                "agentCapabilities": {
+                    "loadSession": True,
+                    "promptCapabilities": {"image": True, "audio": False},
+                },
+            },
+        }
+    )
+
+
+def _session_new_result(session_id: str = "ses_test01") -> bytes:
+    """Build the server's response to a session/new request."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {"sessionId": session_id},
+        }
+    )
+
+
+def _handshake_lines(session_id: str = "ses_test01") -> list[bytes]:
+    """Return the two stdout lines for a successful handshake."""
+    return [_initialize_result(), _session_new_result(session_id)]
+
+
+def _make_mock_proc(stdout_lines: list[bytes]) -> MagicMock:
+    """
+    Build a mock subprocess that yields predefined stdout lines.
+
+    stdout_lines should be a list of bytes, each ending with b"\\n".
+    Once the list is exhausted, every further readline call returns
+    b"" (EOF), so tests do not need to count exactly how many reads
+    the caller performs. Same shape as the test_acp.py / test_goose.py
+    helpers; per-file duplication is the deliberate pattern there.
+    """
+    proc = MagicMock()
+    proc.returncode = None
+    proc.pid = 12345
+    proc.stdin = MagicMock()
+    proc.stdin.write = MagicMock()
+    proc.stdin.drain = AsyncMock()
+    proc.stdout = MagicMock()
+    queue = list(stdout_lines)
+
+    async def _readline() -> bytes:
+        if not queue:
+            return b""
+        return queue.pop(0)
+
+    proc.stdout.readline = _readline
+    proc.stderr = MagicMock()
+    proc.stderr.readline = AsyncMock(return_value=b"")
+    proc.wait = AsyncMock()
+    proc.kill = MagicMock()
+    proc.terminate = MagicMock()
+    return proc
 
 
 # ── Class attributes ────────────────────────────────────────────────
@@ -57,17 +131,35 @@ class TestClassAttributes:
 
 
 class TestBuildArgv:
-    """The CLI does not accept --model on argv; model flows through env."""
+    """The CLI does not accept --model on argv; model flows through
+    env. OPENCODE_BIN pins the binary path so a sudo-wrapped per-user
+    spawn matches the absolute path the sudoers rule names (mirrors
+    codex's CODEX_BIN and goose's GOOSE_BIN contract); bare "opencode"
+    remains the default for installs with opencode on PATH."""
 
-    def test_static_argv_no_model_flag(self):
+    def test_static_argv_no_model_flag(self, monkeypatch):
         """argv is exactly `opencode acp` regardless of self.model."""
+        monkeypatch.delenv("OPENCODE_BIN", raising=False)
         b = _make_opencode(model="anthropic/claude-sonnet-4-6")
         assert b.build_argv() == ["opencode", "acp"]
 
-    def test_argv_unchanged_with_empty_model(self):
+    def test_argv_unchanged_with_empty_model(self, monkeypatch):
         """Empty model still produces the same argv (model goes via env)."""
+        monkeypatch.delenv("OPENCODE_BIN", raising=False)
         b = _make_opencode(model="")
         assert b.build_argv() == ["opencode", "acp"]
+
+    def test_opencode_bin_override_pins_absolute_path(self, monkeypatch):
+        monkeypatch.setenv("OPENCODE_BIN", "/Users/svc/.local/bin/opencode")
+        b = _make_opencode()
+        assert b.build_argv() == ["/Users/svc/.local/bin/opencode", "acp"]
+
+    def test_empty_opencode_bin_falls_back_to_bare_name(self, monkeypatch):
+        """An empty-string OPENCODE_BIN (unset-but-present in /etc/kai/env)
+        must not produce an empty argv head."""
+        monkeypatch.setenv("OPENCODE_BIN", "")
+        b = _make_opencode()
+        assert b.build_argv()[0] == "opencode"
 
 
 # ── build_env ───────────────────────────────────────────────────────
@@ -731,3 +823,57 @@ class TestCombineTextChunksHook:
         # Sentence boundary that OpenCode would treat as a join site;
         # the default backend leaves it verbatim.
         assert backend.combine_text_chunks("End.", "Start") == "End.Start"
+
+
+# ── Cross-user preserve list ────────────────────────────────────────
+
+
+class TestPreservedEnvVars:
+    """The sudo wrap's --preserve-env list. OpenCode delivers model
+    selection via OPENCODE_CONFIG_CONTENT (build_env), so the override
+    must carry it through env_reset or the wrapped opencode silently
+    loses its model selection; the five provider keys cover env-key
+    auth, and KAI_WEBHOOK_SECRET / TMPDIR mirror the AcpBackend
+    default. The primary auth store (~/.local/share/opencode/auth.json)
+    rides the `sudo -H` HOME rewrite and needs no preservation."""
+
+    def test_content_exact(self):
+        b = _make_opencode()
+        assert b.preserved_env_vars() == (
+            "OPENCODE_CONFIG_CONTENT",
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_API_KEY",
+            "OPENROUTER_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "KAI_WEBHOOK_SECRET",
+            "TMPDIR",
+        )
+
+    @pytest.mark.asyncio
+    async def test_wrap_argv_carries_opencode_preserve_list(self, monkeypatch):
+        """End-to-end through _ensure_started: the opencode wrap's
+        --preserve-env CSV is the hook's list, not the base default."""
+        monkeypatch.delenv("OPENCODE_BIN", raising=False)
+        b = _make_opencode(os_user="oc-user")
+        captured: dict = {}
+
+        async def _fake_spawn(*args, **kwargs):
+            captured["argv"] = args
+            return _make_mock_proc(_handshake_lines())
+
+        with (
+            patch("kai.acp.resolve_claude_user", return_value="oc-user"),
+            patch("kai.acp.asyncio.create_subprocess_exec", side_effect=_fake_spawn),
+        ):
+            await b._ensure_started()
+
+        argv = list(captured["argv"])
+        assert argv[:4] == ["sudo", "-H", "-u", "oc-user"]
+        assert argv[4] == (
+            "--preserve-env=OPENCODE_CONFIG_CONTENT,ANTHROPIC_API_KEY,"
+            "OPENAI_API_KEY,GOOGLE_API_KEY,OPENROUTER_API_KEY,DEEPSEEK_API_KEY,"
+            "KAI_WEBHOOK_SECRET,TMPDIR"
+        )
+        assert argv[5] == "--"
+        assert argv[6:] == ["opencode", "acp"]

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -340,12 +340,13 @@ class TestPerUserBackendRouting:
         assert isinstance(instance, GooseBackend)
         assert instance.os_user == "alice-os"
 
-    def test_opencode_user_does_not_receive_os_user(self):
-        """OpenCode chat stays on the service user even when the
-        users.yaml entry carries an os_user: its auth file is
-        per-OS-user and operator-provisioned, so the pool does not
-        wire the isolation for opencode until that provisioning
-        story exists."""
+    def test_opencode_user_receives_os_user(self):
+        """An opencode user's os_user reaches OpenCodeBackend, which
+        wires the per-user sudo isolation in the shared ACP layer
+        (same contract claude_user / codex_user / goose's os_user
+        carry on their backends). Auth is operator-provisioned per
+        OS user (`opencode auth login` run as the target user); the
+        pool only threads the routing target."""
         from kai.opencode import OpenCodeBackend
 
         user = UserConfig(
@@ -359,7 +360,7 @@ class TestPerUserBackendRouting:
         pool = SubprocessPool(config=config, services_info=[])
         instance = pool.get(111)
         assert isinstance(instance, OpenCodeBackend)
-        assert instance.os_user is None
+        assert instance.os_user == "alice-os"
 
 
 # ── Per-user actions ────────────────────────────────────────────────


### PR DESCRIPTION
Closes #616.

OpenCode was the one chat backend that ignored `users.yaml` `os_user`: claude, codex, and goose chat all spawn the agent as the target OS account via `sudo -H -u`, while opencode chat stayed on the service user (its one-shots were already isolated). This wires the remaining gap through the shared ACP layer.

## Changes

- **pool.py** passes `os_user` to `OpenCodeBackend`. The `AcpBackend` capability (sudo `-H` wrap, per-os-user TMPDIR anchor, pgid kill escalation) is shared with goose and applies unchanged.
- **`OpenCodeBackend.build_argv` honors `OPENCODE_BIN`.** The wizard already collects the value and the generated per-user sudoers rule pins that exact absolute path, but the chat backend spawned bare `opencode`; under sudo the argv head must resolve to the same file the rule names or the spawn fails. Bare `opencode` remains the PATH fallback, mirroring the codex `CODEX_BIN` and goose `GOOSE_BIN` contract.
- **`preserved_env_vars` override.** OpenCode is env-driven: model selection rides `OPENCODE_CONFIG_CONTENT`, which sudo's `env_reset` would strip (the same failure mode the goose wiring solved for `GOOSE_MODEL` / `GOOSE_PROVIDER`). The list carries `OPENCODE_CONFIG_CONTENT`, the five provider API keys (matching the opencode one-shot preserve list), and the `KAI_WEBHOOK_SECRET` / `TMPDIR` base defaults.
- **Auth posture documented.** Operators run `opencode auth login` as each target OS user so `~/.local/share/opencode/auth.json` lands under that user's home; `sudo -H` points the subprocess at it. Same operator-provisioned contract codex uses for `~/.codex/auth.json`. The wizard does not manage opencode auth state.
- **templates/.env** comment updated: the binary-path overrides are honored by the chat backends as well as the one-shot reasoners.

No installer changes: the per-user sudoers rule for the opencode binary (with `SETENV:`) is already generated.

## Tests

Mirror the goose precedents: pool wiring (`os_user` reaches the instance), `OPENCODE_BIN` argv pinning including the empty-string fallback, exact preserve-list content, and an end-to-end assertion through `_ensure_started` that the wrap argv carries the full `--preserve-env` CSV. 3885 passed, 1 skipped; ruff clean.
