### PR TITLE
fix(goose): route review/triage one-shots through the goose reasoner

### DIFF
--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -39,8 +39,12 @@ import aiohttp
 
 from kai.codex_exec import extract_codex_text
 from kai.config import ModelRole, get_model_for, resolve_claude_user
-from kai.goose import goose_provider_id
-from kai.oneshot import OneShotError, OneShotTimeout, OpenCodeOneShotReasoner
+from kai.oneshot import (
+    GooseOneShotReasoner,
+    OneShotError,
+    OneShotTimeout,
+    OpenCodeOneShotReasoner,
+)
 from kai.prompt_utils import make_boundary
 
 log = logging.getLogger(__name__)
@@ -624,11 +628,12 @@ async def run_review(
     """
     Spawn a one-shot LLM subprocess to perform the review.
 
-    Dispatches to Claude (`claude --print`), Codex (`codex exec
-    --json`), or Goose (`goose run -i -`) based on agent_backend.
-    All three read the prompt from stdin and return a single string
-    of review text; the prompt and output handling are identical
-    regardless of backend.
+    Dispatches by agent_backend: Claude (`claude --print`) and Codex
+    (`codex exec --json`) spawn inline; Goose and OpenCode dispatch
+    through their OneShotReasoner implementations in `kai.oneshot`.
+    All paths read the prompt and return a single string of review
+    text; the prompt and output handling are identical regardless of
+    backend.
 
     Claude path: supports sudo -u for OS-level isolation and process
     group kills for cleanup.
@@ -648,14 +653,18 @@ async def run_review(
     RuntimeError below so the caller's existing failure surface is
     unchanged.
 
-    Goose path: no sudo (Goose has no user isolation), simple
-    proc.kill() for cleanup, --max-turns 1 as the safety limit.
+    Goose path: dispatches through `GooseOneShotReasoner` in
+    `kai.oneshot` (same shape as the OpenCode path), which owns the
+    `goose run -i - ... --max-turns 1` argv, GOOSE_BIN resolution,
+    per-OS-user routing via `sudo -H -u <user>`, the provider
+    wire-name translation, and the allow-listed subprocess env.
+    Typed errors collapse to RuntimeError below.
 
     Args:
         prompt: The complete review prompt (from build_review_prompt).
         claude_user: Optional OS user to run the subprocess as (via
-            sudo -u for claude, sudo -H -u for codex / opencode).
-            Ignored when agent_backend is "goose".
+            sudo -u for claude, sudo -H -u for codex / goose /
+            opencode).
         agent_backend: Which LLM backend to use ("claude", "codex",
             "opencode", or "goose").
         provider: LLM provider name (e.g. "anthropic", "openai").
@@ -810,57 +819,35 @@ async def run_review(
             raise ValueError(
                 "agent_backend is 'goose' but provider is empty. Set LLM_PROVIDER in .env or per-user config."
             )
-        # Goose one-shot mode: read prompt from stdin, write response
-        # to stdout. -q suppresses non-response output, --no-session
-        # avoids creating session files, --no-profile skips user
-        # config, --max-turns 1 prevents runaway tool loops. Model
-        # comes from the unified (backend, provider, role) registry
-        # so a goose-on-deepseek install picks up the deepseek-shaped
-        # default; openrouter / ollama users set their per-user
-        # `models.pr_review` in users.yaml. The --provider value runs
-        # through `goose_provider_id` because goose's wire-level
-        # provider names can differ from Kai's keys (deepseek is
-        # custom_deepseek on the goose side).
-        model = get_model_for(
+        # Dispatch to the goose one-shot reasoner, which owns the
+        # `goose run -i - ... --max-turns 1` argv, GOOSE_BIN
+        # resolution (so the spawned binary matches the absolute path
+        # the per-user sudoers rule pins), per-user os_user routing
+        # via the shared sudo -H wrap, the provider wire-name
+        # translation, and the allow-listed subprocess env. With
+        # json_schema=None the reasoner returns raw review text (this
+        # function's contract); typed reasoner errors collapse to
+        # RuntimeError so the webhook handler's existing catch
+        # surface is unchanged.
+        review_model = get_model_for(
             ModelRole.PR_REVIEW,
             agent_backend,
             provider,
             override=model_override,
         )
-        cmd = [
-            "goose",
-            "run",
-            "-i",
-            "-",
-            "--provider",
-            goose_provider_id(provider),
-            "--model",
-            model,
-            "-q",
-            "--no-session",
-            "--no-profile",
-            "--max-turns",
-            "1",
-        ]
-
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            # No start_new_session - Goose doesn't use sudo,
-            # so there is no parent/child process tree to manage.
-        )
-
+        reasoner = GooseOneShotReasoner(os_user=claude_user, provider=provider)
         try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(input=prompt.encode()),
+            result = await reasoner.run(
+                prompt=prompt,
+                model=review_model,
                 timeout=timeout_s,
+                purpose="pr_review",
             )
-        except TimeoutError:
-            proc.kill()
-            await proc.wait()
-            raise RuntimeError(f"Review subprocess timed out after {timeout_s}s") from None
+        except OneShotTimeout as exc:
+            raise RuntimeError(f"Review subprocess timed out after {timeout_s}s") from exc
+        except OneShotError as exc:
+            raise RuntimeError(f"Goose review failed: {exc}") from exc
+        return result.text
     else:
         # Claude one-shot mode: --print reads from stdin, writes to stdout.
         # No cost cap is passed: subscription auth has no real per-token

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -37,8 +37,12 @@ import aiohttp
 
 from kai.codex_exec import extract_codex_text
 from kai.config import ModelRole, get_model_for, resolve_claude_user
-from kai.goose import goose_provider_id
-from kai.oneshot import OneShotError, OneShotTimeout, OpenCodeOneShotReasoner
+from kai.oneshot import (
+    GooseOneShotReasoner,
+    OneShotError,
+    OneShotTimeout,
+    OpenCodeOneShotReasoner,
+)
 from kai.prompt_utils import make_boundary
 
 log = logging.getLogger(__name__)
@@ -354,16 +358,19 @@ async def run_triage(
     """
     Spawn a one-shot LLM subprocess to perform the triage analysis.
 
-    Dispatches to either Claude (`claude --print`) or Goose
-    (`goose run -i -`) based on agent_backend. Both read from stdin
-    and write plain text to stdout. Same pattern as run_review()
-    in review.py.
+    Dispatches by agent_backend: Claude (`claude --print`) and Codex
+    (`codex exec --json`) spawn inline; Goose and OpenCode dispatch
+    through their OneShotReasoner implementations in `kai.oneshot`,
+    which own binary resolution, per-user os_user routing, and the
+    allow-listed subprocess env. All paths read the prompt and
+    return a single text string. Same pattern as run_review() in
+    review.py.
 
     Args:
         prompt: The complete triage prompt (from build_triage_prompt).
         claude_user: Optional OS user to run the subprocess as (via
-            sudo -u for claude, sudo -H -u for codex / opencode).
-            Ignored when agent_backend is "goose".
+            sudo -u for claude, sudo -H -u for codex / goose /
+            opencode).
         agent_backend: Which LLM backend to use ("claude", "codex",
             "opencode", or "goose").
         provider: LLM provider name (e.g. "anthropic", "openai").
@@ -524,57 +531,36 @@ async def run_triage(
             raise ValueError(
                 "agent_backend is 'goose' but provider is empty. Set LLM_PROVIDER in .env or per-user config."
             )
-        # Goose one-shot mode: read prompt from stdin, write response
-        # to stdout. -q suppresses non-response output, --no-session
-        # avoids creating session files, --no-profile skips user
-        # config, --max-turns 1 prevents runaway tool loops. Model
-        # resolution flows through the unified (backend, provider,
-        # role) registry so a goose-on-deepseek install picks up the
-        # deepseek-shaped default; openrouter / ollama users set
-        # their per-user `models.issue_triage` in users.yaml. The
-        # --provider value runs through `goose_provider_id` because
-        # goose's wire-level provider names can differ from Kai's
-        # keys (deepseek is custom_deepseek on the goose side).
-        model = get_model_for(
+        # Dispatch to the goose one-shot reasoner, which owns the
+        # `goose run -i - ... --max-turns 1` argv, GOOSE_BIN
+        # resolution (so the spawned binary matches the absolute path
+        # the per-user sudoers rule pins), per-user os_user routing
+        # via the shared sudo -H wrap, the provider wire-name
+        # translation, and the allow-listed subprocess env. With
+        # json_schema=None the reasoner returns raw text (triage's
+        # downstream parser owns the JSON contract, matching the
+        # other backends); typed reasoner errors collapse to
+        # RuntimeError so the webhook handler's existing catch
+        # surface is unchanged.
+        triage_model = get_model_for(
             ModelRole.ISSUE_TRIAGE,
             agent_backend,
             provider,
             override=model_override,
         )
-        cmd = [
-            "goose",
-            "run",
-            "-i",
-            "-",
-            "--provider",
-            goose_provider_id(provider),
-            "--model",
-            model,
-            "-q",
-            "--no-session",
-            "--no-profile",
-            "--max-turns",
-            "1",
-        ]
-
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            # No start_new_session - Goose doesn't use sudo,
-            # so there is no parent/child process tree to manage.
-        )
-
+        reasoner = GooseOneShotReasoner(os_user=claude_user, provider=provider)
         try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(input=prompt.encode()),
+            result = await reasoner.run(
+                prompt=prompt,
+                model=triage_model,
                 timeout=_TRIAGE_TIMEOUT,
+                purpose="issue_triage",
             )
-        except TimeoutError:
-            proc.kill()
-            await proc.wait()
-            raise RuntimeError(f"Triage subprocess timed out after {_TRIAGE_TIMEOUT}s") from None
+        except OneShotTimeout as exc:
+            raise RuntimeError(f"Triage subprocess timed out after {_TRIAGE_TIMEOUT}s") from exc
+        except OneShotError as exc:
+            raise RuntimeError(f"Goose triage failed: {exc}") from exc
+        return result.text
     else:
         # Claude one-shot mode: --print reads from stdin, writes to stdout.
         # No cost cap is passed: subscription auth has no real per-token

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -942,162 +942,122 @@ class TestRunReviewCodex:
 # ── run_review (Goose backend) ─────────────────────────────────────
 
 
-class TestRunReviewGoose:
-    """Tests for run_review() when agent_backend="goose"."""
+class TestRunReviewGooseDispatch:
+    """
+    `run_review` with `agent_backend="goose"` dispatches to
+    `GooseOneShotReasoner` (NOT a direct `goose run` subprocess
+    spawn). The reasoner owns the argv shape, GOOSE_BIN resolution,
+    provider wire-name translation, per-user os_user routing, and
+    the allow-listed subprocess env; this class pins the dispatch
+    contract: ctor kwargs, per-provider model resolution from the
+    registry, timeout pass-through, raw-text return, and the
+    collapse of typed reasoner errors to RuntimeError.
+    """
+
+    @staticmethod
+    def _fake_reasoner(text="review output"):
+        from kai.oneshot import OneShotResult
+
+        fake = MagicMock()
+        fake.run = AsyncMock(return_value=OneShotResult(text=text, backend="goose", model="claude-sonnet-4-6"))
+        return fake
 
     @pytest.mark.asyncio
-    async def test_goose_command_structure(self):
-        """Goose backend builds the correct command with provider and model."""
-        mock_proc = _mock_process(stdout=b"review output")
+    async def test_run_review_dispatches_to_goose_reasoner(self):
+        """The goose branch builds a GooseOneShotReasoner with the
+        os_user and Kai provider key threaded through, awaits its run
+        with the registry model, and returns the raw text."""
+        fake = self._fake_reasoner(text="review body from goose")
 
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+        with (
+            patch("kai.review.GooseOneShotReasoner", return_value=fake) as ctor,
+            patch("kai.review.asyncio.create_subprocess_exec") as mock_exec,
+        ):
             result = await run_review(
-                "review prompt",
-                agent_backend="goose",
-                provider="openai",
+                "review prompt", agent_backend="goose", provider="anthropic", claude_user="someone"
             )
 
-        assert result == "review output"
-
-        # Verify the full Goose command structure
-        cmd = mock_exec.call_args[0]
-        assert cmd == (
-            "goose",
-            "run",
-            "-i",
-            "-",
-            "--provider",
-            "openai",
-            "--model",
-            "gpt-5.5",
-            "-q",
-            "--no-session",
-            "--no-profile",
-            "--max-turns",
-            "1",
-        )
+        assert result == "review body from goose"
+        ctor.assert_called_once()
+        assert ctor.call_args.kwargs == {"os_user": "someone", "provider": "anthropic"}
+        fake.run.assert_awaited_once()
+        run_kwargs = fake.run.call_args.kwargs
+        assert run_kwargs["prompt"] == "review prompt"
+        assert run_kwargs["model"] == "claude-sonnet-4-6"
+        assert run_kwargs["purpose"] == "pr_review"
+        mock_exec.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_anthropic_model_mapping(self):
-        """Anthropic provider maps to full claude-sonnet-4-6 model ID."""
-        mock_proc = _mock_process(stdout=b"output")
+    @pytest.mark.parametrize(
+        ("provider", "expected_model"),
+        [
+            ("anthropic", "claude-sonnet-4-6"),
+            ("openai", "gpt-5.5"),
+            ("deepseek", "deepseek-v4-pro"),
+            ("ollama", "llama4:70b"),
+        ],
+    )
+    async def test_model_resolved_from_registry_per_provider(self, provider, expected_model):
+        """(goose, <provider>, PR_REVIEW) registry rows reach the
+        reasoner's model kwarg. The provider key passes through in
+        Kai form (deepseek stays deepseek); the reasoner owns the
+        custom_deepseek wire-name translation at argv build."""
+        fake = self._fake_reasoner()
 
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_review("prompt", agent_backend="goose", provider="anthropic")
+        with patch("kai.review.GooseOneShotReasoner", return_value=fake) as ctor:
+            await run_review("prompt", agent_backend="goose", provider=provider)
 
-        cmd = mock_exec.call_args[0]
-        assert "--model" in cmd
-        model_idx = cmd.index("--model")
-        assert cmd[model_idx + 1] == "claude-sonnet-4-6"
-
-    @pytest.mark.asyncio
-    async def test_deepseek_provider_translated_to_wire_name(self):
-        """Kai's "deepseek" key rides the argv as goose's
-        "custom_deepseek" wire name; goose rejects the bare key with
-        "Unknown provider: deepseek". The model name stays Kai's
-        registry value untranslated."""
-        mock_proc = _mock_process(stdout=b"output")
-
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_review("prompt", agent_backend="goose", provider="deepseek")
-
-        cmd = mock_exec.call_args[0]
-        provider_idx = cmd.index("--provider")
-        assert cmd[provider_idx + 1] == "custom_deepseek"
-        model_idx = cmd.index("--model")
-        assert cmd[model_idx + 1] == "deepseek-v4-pro"
+        assert ctor.call_args.kwargs["provider"] == provider
+        assert fake.run.call_args.kwargs["model"] == expected_model
 
     @pytest.mark.asyncio
-    async def test_successful_response_stripped(self):
-        """Goose output is returned with whitespace stripped."""
-        mock_proc = _mock_process(stdout=b"  review text with whitespace  \n")
-
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await run_review("prompt", agent_backend="goose", provider="anthropic")
-
-        assert result == "review text with whitespace"
-
-    @pytest.mark.asyncio
-    async def test_timeout_kills_directly(self):
-        """Goose timeout calls proc.kill(), not os.killpg()."""
-        mock_proc = AsyncMock()
-        mock_proc.pid = 99999
-        mock_proc.kill = MagicMock()
-        mock_proc.wait = AsyncMock()
-
-        with (
-            patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc),
-            patch("kai.review.asyncio.wait_for", side_effect=TimeoutError()),
-            patch("kai.review.os.killpg") as mock_killpg,
-            pytest.raises(RuntimeError, match="timed out"),
-        ):
-            await run_review("prompt", agent_backend="goose", provider="openai")
-
-        mock_proc.kill.assert_called_once()
-        mock_killpg.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_subprocess_failure(self):
-        """Non-zero exit from Goose subprocess raises RuntimeError."""
-        mock_proc = _mock_process(stderr=b"provider error", returncode=1)
-
-        with (
-            patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc),
-            pytest.raises(RuntimeError, match=r"Review subprocess failed.*provider error"),
-        ):
-            await run_review("prompt", agent_backend="goose", provider="openai")
-
-    @pytest.mark.asyncio
-    async def test_no_sudo_even_with_claude_user(self):
-        """Goose path never uses sudo, even when claude_user is set."""
-        mock_proc = _mock_process(stdout=b"output")
-
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_review(
-                "prompt",
-                claude_user="kai",
-                agent_backend="goose",
-                provider="anthropic",
-            )
-
-        cmd = mock_exec.call_args[0]
-        assert "sudo" not in cmd
-        assert cmd[0] == "goose"
-
-    @pytest.mark.asyncio
-    async def test_open_ended_provider_uses_registry_default(self):
-        """Goose+ollama resolves the PR_REVIEW row from the unified
-        registry. Operators override per-user via users.yaml
-        `models.pr_review`; the historic GOOSE_MODEL env path retired
-        with the `_GOOSE_AGENT_MODELS` fold-in."""
-        mock_proc = _mock_process(stdout=b"output")
-
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_review("prompt", agent_backend="goose", provider="ollama")
-
-        cmd = mock_exec.call_args[0]
-        model_idx = cmd.index("--model")
-        # Registry value for ("goose", "ollama", PR_REVIEW); see
-        # _BACKEND_PROVIDER_TIER_MODELS in config.py.
-        assert cmd[model_idx + 1] == "llama4:70b"
-
-    @pytest.mark.asyncio
-    async def test_open_ended_provider_with_model_override(self):
+    async def test_model_override_wins_over_registry(self):
         """Per-user `models.pr_review` override flows through
         `model_override` and wins over the registry default."""
-        mock_proc = _mock_process(stdout=b"output")
+        fake = self._fake_reasoner()
 
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_review(
-                "prompt",
-                agent_backend="goose",
-                provider="ollama",
-                model_override="qwen3:32b",
-            )
+        with patch("kai.review.GooseOneShotReasoner", return_value=fake):
+            await run_review("prompt", agent_backend="goose", provider="ollama", model_override="qwen3:32b")
 
-        cmd = mock_exec.call_args[0]
-        model_idx = cmd.index("--model")
-        assert cmd[model_idx + 1] == "qwen3:32b"
+        assert fake.run.call_args.kwargs["model"] == "qwen3:32b"
+
+    @pytest.mark.asyncio
+    async def test_timeout_s_passes_through_to_reasoner(self):
+        """run_review's timeout_s parameter becomes the reasoner's
+        per-call timeout (review diffs can need a larger cap than
+        the default)."""
+        fake = self._fake_reasoner()
+
+        with patch("kai.review.GooseOneShotReasoner", return_value=fake):
+            await run_review("prompt", agent_backend="goose", provider="anthropic", timeout_s=777)
+
+        assert fake.run.call_args.kwargs["timeout"] == 777
+
+    @pytest.mark.asyncio
+    async def test_run_review_collapses_oneshot_timeout_to_runtime_error(self):
+        from kai.oneshot import OneShotTimeout
+
+        fake = MagicMock()
+        fake.run = AsyncMock(side_effect=OneShotTimeout())
+
+        with (
+            patch("kai.review.GooseOneShotReasoner", return_value=fake),
+            pytest.raises(RuntimeError, match=r"Review subprocess timed out"),
+        ):
+            await run_review("prompt", agent_backend="goose", provider="anthropic")
+
+    @pytest.mark.asyncio
+    async def test_run_review_collapses_oneshot_error_to_runtime_error(self):
+        from kai.oneshot import OneShotSubprocessError
+
+        fake = MagicMock()
+        fake.run = AsyncMock(side_effect=OneShotSubprocessError(returncode=1, stderr=b"provider error"))
+
+        with (
+            patch("kai.review.GooseOneShotReasoner", return_value=fake),
+            pytest.raises(RuntimeError, match=r"Goose review failed"),
+        ):
+            await run_review("prompt", agent_backend="goose", provider="anthropic")
 
     @pytest.mark.asyncio
     async def test_default_backend_is_claude(self):

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -481,159 +481,110 @@ class TestRunTriage:
 # ── run_triage (Goose backend) ─────────────────────────────────────
 
 
-class TestRunTriageGoose:
-    """Tests for run_triage() when agent_backend="goose"."""
+class TestRunTriageGooseDispatch:
+    """
+    `run_triage` with `agent_backend="goose"` dispatches to
+    `GooseOneShotReasoner` (NOT a direct `goose run` subprocess
+    spawn). The reasoner owns the argv shape, GOOSE_BIN resolution,
+    provider wire-name translation, per-user os_user routing, and
+    the allow-listed subprocess env; this class pins the dispatch
+    contract: ctor kwargs, per-provider model resolution from the
+    registry, raw-text return, and the collapse of typed reasoner
+    errors to RuntimeError.
+    """
+
+    @staticmethod
+    def _fake_reasoner(text='{"labels": []}'):
+        from kai.oneshot import OneShotResult
+
+        fake = MagicMock()
+        fake.run = AsyncMock(return_value=OneShotResult(text=text, backend="goose", model="claude-sonnet-4-6"))
+        return fake
 
     @pytest.mark.asyncio
-    async def test_goose_command_structure(self):
-        """Goose backend builds the correct command with provider and model."""
-        mock_proc = _mock_subprocess(stdout='{"labels": ["bug"]}')
+    async def test_run_triage_dispatches_to_goose_reasoner(self):
+        """The goose branch builds a GooseOneShotReasoner with the
+        os_user and Kai provider key threaded through, awaits its run
+        with the registry model, and returns the raw text."""
+        fake = self._fake_reasoner(text='{"labels": ["bug"]}')
 
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+        with (
+            patch("kai.triage.GooseOneShotReasoner", return_value=fake) as ctor,
+            patch("kai.triage.asyncio.create_subprocess_exec") as mock_exec,
+        ):
             result = await run_triage(
-                "triage prompt",
-                agent_backend="goose",
-                provider="openai",
+                "triage prompt", agent_backend="goose", provider="anthropic", claude_user="someone"
             )
 
         assert result == '{"labels": ["bug"]}'
-
-        # Verify the full Goose command structure
-        cmd = mock_exec.call_args[0]
-        assert cmd == (
-            "goose",
-            "run",
-            "-i",
-            "-",
-            "--provider",
-            "openai",
-            "--model",
-            "gpt-5.5",
-            "-q",
-            "--no-session",
-            "--no-profile",
-            "--max-turns",
-            "1",
-        )
+        ctor.assert_called_once()
+        assert ctor.call_args.kwargs == {"os_user": "someone", "provider": "anthropic"}
+        fake.run.assert_awaited_once()
+        run_kwargs = fake.run.call_args.kwargs
+        assert run_kwargs["prompt"] == "triage prompt"
+        assert run_kwargs["model"] == "claude-sonnet-4-6"
+        assert run_kwargs["purpose"] == "issue_triage"
+        mock_exec.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_anthropic_model_mapping(self):
-        """Anthropic provider maps to full claude-sonnet-4-6 model ID."""
-        mock_proc = _mock_subprocess(stdout='{"labels": []}')
+    @pytest.mark.parametrize(
+        ("provider", "expected_model"),
+        [
+            ("anthropic", "claude-sonnet-4-6"),
+            ("openai", "gpt-5.5"),
+            ("deepseek", "deepseek-v4-pro"),
+            ("ollama", "llama4:70b"),
+        ],
+    )
+    async def test_model_resolved_from_registry_per_provider(self, provider, expected_model):
+        """(goose, <provider>, ISSUE_TRIAGE) registry rows reach the
+        reasoner's model kwarg. The provider key passes through in
+        Kai form (deepseek stays deepseek); the reasoner owns the
+        custom_deepseek wire-name translation at argv build."""
+        fake = self._fake_reasoner()
 
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage("prompt", agent_backend="goose", provider="anthropic")
+        with patch("kai.triage.GooseOneShotReasoner", return_value=fake) as ctor:
+            await run_triage("prompt", agent_backend="goose", provider=provider)
 
-        cmd = mock_exec.call_args[0]
-        assert "--model" in cmd
-        model_idx = cmd.index("--model")
-        assert cmd[model_idx + 1] == "claude-sonnet-4-6"
-
-    @pytest.mark.asyncio
-    async def test_deepseek_provider_translated_to_wire_name(self):
-        """Kai's "deepseek" key rides the argv as goose's
-        "custom_deepseek" wire name; goose rejects the bare key with
-        "Unknown provider: deepseek". The model name stays Kai's
-        registry value untranslated."""
-        mock_proc = _mock_subprocess(stdout='{"labels": []}')
-
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage("prompt", agent_backend="goose", provider="deepseek")
-
-        cmd = mock_exec.call_args[0]
-        provider_idx = cmd.index("--provider")
-        assert cmd[provider_idx + 1] == "custom_deepseek"
-        model_idx = cmd.index("--model")
-        assert cmd[model_idx + 1] == "deepseek-v4-pro"
+        assert ctor.call_args.kwargs["provider"] == provider
+        assert fake.run.call_args.kwargs["model"] == expected_model
 
     @pytest.mark.asyncio
-    async def test_successful_response_stripped(self):
-        """Goose output is returned with whitespace stripped."""
-        mock_proc = _mock_subprocess(stdout='  {"labels": ["feature"]}  \n')
-
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await run_triage("prompt", agent_backend="goose", provider="anthropic")
-
-        assert result == '{"labels": ["feature"]}'
-
-    @pytest.mark.asyncio
-    async def test_timeout_kills_directly(self):
-        """Goose timeout calls proc.kill(), not os.killpg()."""
-        mock_proc = AsyncMock()
-        mock_proc.pid = 99999
-        mock_proc.kill = MagicMock()
-        mock_proc.wait = AsyncMock()
-
-        with (
-            patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc),
-            patch("kai.triage.asyncio.wait_for", side_effect=TimeoutError()),
-            patch("kai.triage.os.killpg") as mock_killpg,
-            pytest.raises(RuntimeError, match="timed out"),
-        ):
-            await run_triage("prompt", agent_backend="goose", provider="openai")
-
-        mock_proc.kill.assert_called_once()
-        mock_killpg.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_subprocess_failure(self):
-        """Non-zero exit from Goose subprocess raises RuntimeError."""
-        mock_proc = _mock_subprocess(stderr="provider error", returncode=1)
-
-        with (
-            patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc),
-            pytest.raises(RuntimeError, match=r"Triage subprocess failed.*provider error"),
-        ):
-            await run_triage("prompt", agent_backend="goose", provider="openai")
-
-    @pytest.mark.asyncio
-    async def test_no_sudo_even_with_claude_user(self):
-        """Goose path never uses sudo, even when claude_user is set."""
-        mock_proc = _mock_subprocess(stdout='{"labels": []}')
-
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage(
-                "prompt",
-                claude_user="kai",
-                agent_backend="goose",
-                provider="anthropic",
-            )
-
-        cmd = mock_exec.call_args[0]
-        assert "sudo" not in cmd
-        assert cmd[0] == "goose"
-
-    @pytest.mark.asyncio
-    async def test_open_ended_provider_uses_registry_default(self):
-        """Goose+ollama resolves the ISSUE_TRIAGE row from the unified
-        registry. The historic GOOSE_MODEL env path retired with
-        the `_GOOSE_AGENT_MODELS` fold-in."""
-        mock_proc = _mock_subprocess(stdout='{"labels": []}')
-
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage("prompt", agent_backend="goose", provider="ollama")
-
-        cmd = mock_exec.call_args[0]
-        model_idx = cmd.index("--model")
-        assert cmd[model_idx + 1] == "llama4:70b"
-
-    @pytest.mark.asyncio
-    async def test_open_ended_provider_with_model_override(self):
+    async def test_model_override_wins_over_registry(self):
         """Per-user `models.issue_triage` override flows through
         `model_override` and wins over the registry default."""
-        mock_proc = _mock_subprocess(stdout='{"labels": []}')
+        fake = self._fake_reasoner()
 
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage(
-                "prompt",
-                agent_backend="goose",
-                provider="ollama",
-                model_override="qwen3:32b",
-            )
+        with patch("kai.triage.GooseOneShotReasoner", return_value=fake):
+            await run_triage("prompt", agent_backend="goose", provider="ollama", model_override="qwen3:32b")
 
-        cmd = mock_exec.call_args[0]
-        model_idx = cmd.index("--model")
-        assert cmd[model_idx + 1] == "qwen3:32b"
+        assert fake.run.call_args.kwargs["model"] == "qwen3:32b"
+
+    @pytest.mark.asyncio
+    async def test_run_triage_collapses_oneshot_timeout_to_runtime_error(self):
+        from kai.oneshot import OneShotTimeout
+
+        fake = MagicMock()
+        fake.run = AsyncMock(side_effect=OneShotTimeout())
+
+        with (
+            patch("kai.triage.GooseOneShotReasoner", return_value=fake),
+            pytest.raises(RuntimeError, match=r"Triage subprocess timed out"),
+        ):
+            await run_triage("prompt", agent_backend="goose", provider="anthropic")
+
+    @pytest.mark.asyncio
+    async def test_run_triage_collapses_oneshot_error_to_runtime_error(self):
+        from kai.oneshot import OneShotSubprocessError
+
+        fake = MagicMock()
+        fake.run = AsyncMock(side_effect=OneShotSubprocessError(returncode=1, stderr=b"provider error"))
+
+        with (
+            patch("kai.triage.GooseOneShotReasoner", return_value=fake),
+            pytest.raises(RuntimeError, match=r"Goose triage failed"),
+        ):
+            await run_triage("prompt", agent_backend="goose", provider="anthropic")
 
     @pytest.mark.asyncio
     async def test_default_backend_is_claude(self):


### PR DESCRIPTION
Closes #618.

PR review and issue triage on goose-backed users ran through inline `goose run -i -` spawns in `run_review` / `run_triage`, while the opencode branch already dispatched through its one-shot reasoner. The inline spawns dropped the `os_user` the webhook handler threads through (no per-user isolation), spawned bare `goose` (no `GOOSE_BIN` resolution, so installs that pin the binary path failed to spawn), and inherited the bot's full environment instead of an allow-list.

## Changes

- **Both goose branches fold onto `GooseOneShotReasoner`**, mirroring the opencode dispatch shape: model from the `(goose, provider, role)` registry row with the per-user `model_override` winning, the Kai provider key passed through (the reasoner owns the `custom_deepseek` wire-name translation at argv build), `os_user` threaded into the constructor, `json_schema=None` so the return stays raw text.
- **The model invocation is byte-equivalent.** The reasoner builds the identical `goose run -i - --provider X --model Y -q --no-session --no-profile --max-turns 1` argv and the same stdin payload (no system prompt, so the prompt rides unchanged). What changes: binary resolution (`GOOSE_BIN` validated, PATH fallback), the `sudo -H` wrap when `os_user` resolves to a non-service user, the allow-listed subprocess env (PATH, HOME, five provider keys), and the subprocess cwd (the reasoner's neutral working directory instead of the bot process cwd).
- **Caller surface unchanged.** Typed reasoner errors collapse to the existing `RuntimeError` contract; the timeout message is preserved verbatim. Webhook handlers need no changes.
- The claude and codex branches keep their inline spawns; folding those is the same debt family as #614 and stages separately.

## Tests

The inline-spawn goose test classes in test_review.py and test_triage.py convert to dispatch-contract classes: constructor kwargs (`os_user`, `provider`), per-provider registry model resolution (anthropic / openai / deepseek / ollama, parametrized), model override, review's `timeout_s` pass-through, raw-text return, error collapse, and the unchanged claude default. Argv shape, wire-name translation, env allow-list, and `GOOSE_BIN` handling remain pinned by the reasoner's own tests in test_oneshot.py. 3884 passed, 1 skipped; ruff clean.
