### PR TITLE
feat(pool): session-age recycling on every backend

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -660,6 +660,11 @@ class AcpBackend(AgentBackend):
         # at spawn time so a value naming the bot's own user collapses
         # to the direct-spawn path (self-sudo skip).
         os_user: str | None = None,
+        # Hours before the subprocess is recycled (0 = no limit).
+        # Same contract as the claude and codex backends: prevents
+        # unbounded memory growth in a long-lived agent subprocess.
+        # The pool passes Config.agent_max_session_hours.
+        max_session_hours: float = 0,
     ):
         # ABC-required attributes (pool.py reads/writes these)
         self.model = model
@@ -670,6 +675,9 @@ class AcpBackend(AgentBackend):
         self.provider = provider
         self.memory_enabled = memory_enabled
         self.os_user = os_user
+        # Session-age recycling limit (ABC surface; checked by the
+        # inherited _should_recycle at the top of _send_locked).
+        self.max_session_hours = max_session_hours
 
         # API context for session injection (passed to build_session_context).
         self._api_context = ApiContext(
@@ -697,6 +705,9 @@ class AcpBackend(AgentBackend):
         # Subprocess and session state.
         self._proc: asyncio.subprocess.Process | None = None
         self._session_id: str | None = None
+        # time.monotonic() at process start; drives the inherited
+        # session-age recycling helpers. Nulled on kill/shutdown.
+        self._session_started_at: float | None = None
         # Cross-user spawn state, set per incarnation in
         # _ensure_started. `_effective_os_user` is the resolved sudo
         # target (None on the direct path); `_pgid` is the wrapper's
@@ -1011,6 +1022,7 @@ class AcpBackend(AgentBackend):
         # agent is exactly the member that survives the wrapper).
         self._pgid = self._proc.pid if effective_os_user else None
         self._effective_os_user = effective_os_user
+        self._session_started_at = time.monotonic()
         self._stderr_task = asyncio.create_task(self._drain_stderr())
 
         # Step 1: initialize - establish protocol version and read the
@@ -1143,6 +1155,23 @@ class AcpBackend(AgentBackend):
         JSON-RPC session/prompt dispatch, and streaming response
         accumulation from session/update notifications.
         """
+        # Recycle the session if it has exceeded the configured age
+        # limit. Prevents unbounded memory growth in a long-lived
+        # agent subprocess. Checked only before starting a new
+        # interaction, never during one, so in-flight responses
+        # complete normally. No save-prompt equivalent exists on the
+        # ACP protocol; the kill is immediate, and _ensure_started()
+        # below respawns with a fresh handshake (which also re-marks
+        # the session fresh for context injection).
+        if self._should_recycle():
+            log.info(
+                "%s session age %.1f hours exceeds limit of %.1f hours; recycling",
+                self.backend_label,
+                self._session_age_hours(),
+                self.max_session_hours,
+            )
+            await self._kill()
+
         try:
             await self._ensure_started()
         except (OSError, RuntimeError, TimeoutError) as exc:
@@ -1540,6 +1569,7 @@ class AcpBackend(AgentBackend):
             self._session_id = None
             self._pgid = None
             self._effective_os_user = None
+            self._session_started_at = None
 
     async def restart(self) -> None:
         """
@@ -1625,3 +1655,4 @@ class AcpBackend(AgentBackend):
         self._session_id = None
         self._pgid = None
         self._effective_os_user = None
+        self._session_started_at = None

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -17,6 +17,7 @@ prompt assembly that is identical across all backends.
 import logging
 import os
 import shutil
+import time
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -148,9 +149,9 @@ class AgentBackend(ABC):
         workspace_config, provider
 
     Backend-specific attributes (NOT on the ABC) stay on the concrete
-    class. For ClaudeCodeBackend these include: claude_user,
-    max_session_hours, autocompact_pct. The pool never touches these
-    directly; they are set at construction by _create_instance().
+    class. For ClaudeCodeBackend these include: claude_user and
+    autocompact_pct. The pool never touches these directly; they are
+    set at construction by _create_instance().
     """
 
     # These are plain instance attributes, not abstract properties,
@@ -164,6 +165,18 @@ class AgentBackend(ABC):
     timeout_seconds: int
     workspace_config: WorkspaceConfig | None
     provider: str
+
+    # Session-age recycling surface, shared by every concrete
+    # backend. __init__ sets max_session_hours (the pool passes
+    # Config.agent_max_session_hours; 0 = no limit) and the backend
+    # stamps _session_started_at with time.monotonic() at subprocess
+    # spawn, nulling it on kill/shutdown. The recycle CHECK stays
+    # backend-owned at the top of each _send_locked because the
+    # surrounding lifecycle differs (claude runs a save-prompt before
+    # the kill; the others kill immediately and respawn on the same
+    # send).
+    max_session_hours: float
+    _session_started_at: float | None
 
     # Stable identifier the shadow-mode logger (#546) and any future
     # backend-aware code path can read off the instance. Concrete
@@ -214,6 +227,18 @@ class AgentBackend(ABC):
     def session_id(self) -> str | None:
         """Current session identifier."""
         ...
+
+    # ── Session-age recycling helpers ─────────────────────────────
+
+    def _session_age_hours(self) -> float:
+        """Hours elapsed since the current subprocess started."""
+        if self._session_started_at is None:
+            return 0.0
+        return (time.monotonic() - self._session_started_at) / 3600
+
+    def _should_recycle(self) -> bool:
+        """True if the session has exceeded the configured age limit."""
+        return self.max_session_hours > 0 and self.is_alive and self._session_age_hours() >= self.max_session_hours
 
 
 # ── Context injection functions ─────────────────────────────────────

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -114,10 +114,12 @@ class ClaudeCodeBackend(AgentBackend):
         # below for the pattern that DOES need a default shadow).
         self.claude_effort_level = claude_effort_level
         self.provider = "anthropic"  # Claude CLI always uses Anthropic
+        # Session-age recycling limit (ABC surface; checked by the
+        # inherited _should_recycle at the top of _send_locked).
+        self.max_session_hours = max_session_hours
 
         # Claude-Code-specific attributes (not on the ABC)
         self.claude_user = claude_user
-        self.max_session_hours = max_session_hours
         self.autocompact_pct = autocompact_pct
         self.memory_enabled = memory_enabled
 
@@ -162,16 +164,6 @@ class ClaudeCodeBackend(AgentBackend):
     def session_id(self) -> str | None:
         """The current Claude session ID, or None if no session is active."""
         return self._session_id
-
-    def _session_age_hours(self) -> float:
-        """Hours elapsed since the current session started."""
-        if self._session_started_at is None:
-            return 0.0
-        return (time.monotonic() - self._session_started_at) / 3600
-
-    def _should_recycle(self) -> bool:
-        """True if the session has exceeded the configured age limit."""
-        return self.max_session_hours > 0 and self.is_alive and self._session_age_hours() >= self.max_session_hours
 
     async def _ensure_started(self) -> None:
         """

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -215,6 +215,11 @@ class CodexBackend(AgentBackend):
         # (the install wizard's guard forces MEMORY_ENABLED=false on
         # codex), so this flag is effectively always False in v1.
         memory_enabled: bool = False,
+        # Hours before the subprocess is recycled (0 = no limit).
+        # Same contract as the claude and ACP backends: prevents
+        # unbounded memory growth in a long-lived agent subprocess.
+        # The pool passes Config.agent_max_session_hours.
+        max_session_hours: float = 0,
     ):
         # ABC-required attributes (pool.py reads/writes these)
         self.model = model
@@ -225,6 +230,9 @@ class CodexBackend(AgentBackend):
         self.provider = provider  # ABC-mandated; bot.py reads this
         self.codex_user = codex_user
         self.memory_enabled = memory_enabled
+        # Session-age recycling limit (ABC surface; checked by the
+        # inherited _should_recycle at the top of _send_locked).
+        self.max_session_hours = max_session_hours
 
         # API context for session injection (passed to build_session_context)
         self._api_context = ApiContext(
@@ -251,6 +259,9 @@ class CodexBackend(AgentBackend):
         # Subprocess and session state
         self._proc: asyncio.subprocess.Process | None = None
         self._session_id: str | None = None
+        # time.monotonic() at process start; drives the inherited
+        # session-age recycling helpers. Nulled on kill/shutdown.
+        self._session_started_at: float | None = None
         self._next_id: int = 1  # Monotonically increasing JSON-RPC request ID
         self._lock = asyncio.Lock()  # Serializes all message sends
         self._fresh_session: bool = True  # True until the first message is sent
@@ -403,6 +414,7 @@ class CodexBackend(AgentBackend):
             # 16MB ceiling is itself observed in practice.
             limit=16 * 1024 * 1024,
         )
+        self._session_started_at = time.monotonic()
         self._stderr_task = asyncio.create_task(self._drain_stderr())
 
         # Save the process group ID for reliable signal delivery.
@@ -636,6 +648,22 @@ class CodexBackend(AgentBackend):
         content-block format, session/prompt dispatch, and streaming
         response accumulation from session/update notifications.
         """
+        # Recycle the session if it has exceeded the configured age
+        # limit. Prevents unbounded memory growth in a long-lived
+        # agent subprocess. Checked only before starting a new
+        # interaction, never during one, so in-flight responses
+        # complete normally. No save-prompt equivalent exists on the
+        # codex CLI; the kill is immediate, and _ensure_started()
+        # below respawns with a fresh handshake (which also re-marks
+        # the session fresh for context injection).
+        if self._should_recycle():
+            log.info(
+                "Codex session age %.1f hours exceeds limit of %.1f hours; recycling",
+                self._session_age_hours(),
+                self.max_session_hours,
+            )
+            await self._kill()
+
         try:
             await self._ensure_started()
         except (OSError, RuntimeError, TimeoutError) as exc:
@@ -1398,6 +1426,7 @@ class CodexBackend(AgentBackend):
             self._pgid = None
             self._inner_codex_pids = []
             self._effective_codex_user = None
+            self._session_started_at = None
 
     async def restart(self) -> None:
         """
@@ -1465,3 +1494,4 @@ class CodexBackend(AgentBackend):
         self._pgid = None
         self._inner_codex_pids = []
         self._effective_codex_user = None
+        self._session_started_at = None

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -968,8 +968,10 @@ class Config:
         allowed_user_ids: Set of Telegram user IDs permitted to interact with the bot (required)
         default_model: Default model name, provider-dependent (e.g. sonnet, gpt-5.5-pro, gemini-2.5-pro)
         claude_timeout_seconds: Seconds before a Claude response is considered timed out
-        claude_max_session_hours: Hours before the inner agent subprocess is recycled. Prevents
-            unbounded V8 memory growth that can trigger macOS Jetsam kernel panics. 0 = no limit.
+        agent_max_session_hours: Hours before an agent subprocess is recycled, on every
+            backend. Prevents unbounded memory growth in long-lived agent processes (the
+            original motivator: V8 growth in the claude CLI triggering macOS Jetsam kernel
+            panics). 0 = no limit.
         session_db_path: Path to the SQLite database for sessions, jobs, and settings
         webhook_port: Port for the local aiohttp server (webhooks + scheduling API)
         webhook_secret: HMAC secret for verifying incoming webhook payloads
@@ -1003,8 +1005,11 @@ class Config:
     # resolution chain that `resolve_user_model` implements.
     default_models: dict[str, str] = field(default_factory=dict)
     claude_timeout_seconds: int = 120
-    claude_max_session_hours: float = 0  # 0 = no limit
-    claude_idle_timeout: int = 1800  # seconds before idle subprocess eviction; 0 = no eviction
+    # Backend-generic pool lifecycle tunables, matching the AGENT_-
+    # prefixed env vars they load from: every backend's subprocess is
+    # recycled by age and evicted when idle.
+    agent_max_session_hours: float = 0  # 0 = no limit
+    agent_idle_timeout: int = 1800  # seconds before idle subprocess eviction; 0 = no eviction
 
     # Autocompact tuning helps control token usage on the claude
     # backend. 0 = use the Claude Code default (~83% threshold).
@@ -2576,14 +2581,14 @@ def load_config() -> Config:
     if not raw_session_hours:
         raw_session_hours = os.environ.get("CLAUDE_MAX_SESSION_HOURS", "").strip() or "0"
     try:
-        claude_max_session_hours = float(raw_session_hours)
+        agent_max_session_hours = float(raw_session_hours)
     except ValueError:
         raise SystemExit("AGENT_MAX_SESSION_HOURS must be a number") from None
     raw_idle_timeout = os.environ.get("AGENT_IDLE_TIMEOUT", "").strip()
     if not raw_idle_timeout:
         raw_idle_timeout = os.environ.get("CLAUDE_IDLE_TIMEOUT", "").strip() or "1800"
     try:
-        claude_idle_timeout = int(raw_idle_timeout)
+        agent_idle_timeout = int(raw_idle_timeout)
     except ValueError:
         raise SystemExit("AGENT_IDLE_TIMEOUT must be an integer") from None
     try:
@@ -3052,8 +3057,8 @@ def load_config() -> Config:
         default_model=default_model,
         default_models=default_models,
         claude_timeout_seconds=claude_timeout_seconds,
-        claude_max_session_hours=claude_max_session_hours,
-        claude_idle_timeout=claude_idle_timeout,
+        agent_max_session_hours=agent_max_session_hours,
+        agent_idle_timeout=agent_idle_timeout,
         claude_autocompact_pct=claude_autocompact_pct,
         claude_effort_level=claude_effort_level,
         codex_auth_mode=codex_auth_mode,

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -235,6 +235,7 @@ class SubprocessPool:
                 provider=effective_provider,
                 memory_enabled=self._config.memory_enabled,
                 os_user=os_user,
+                max_session_hours=self._config.agent_max_session_hours,
             )
 
         if backend == "opencode":
@@ -255,6 +256,7 @@ class SubprocessPool:
                 provider=effective_provider,
                 memory_enabled=self._config.memory_enabled,
                 os_user=os_user,
+                max_session_hours=self._config.agent_max_session_hours,
             )
 
         if backend == "codex":
@@ -276,6 +278,7 @@ class SubprocessPool:
                 provider="openai",
                 codex_user=os_user,
                 memory_enabled=self._config.memory_enabled,
+                max_session_hours=self._config.agent_max_session_hours,
             )
 
         return ClaudeCodeBackend(
@@ -287,7 +290,7 @@ class SubprocessPool:
             timeout_seconds=timeout,
             services_info=self._services_info,
             claude_user=os_user,
-            max_session_hours=self._config.claude_max_session_hours,
+            max_session_hours=self._config.agent_max_session_hours,
             workspace_config=ws_config,
             autocompact_pct=self._config.claude_autocompact_pct,
             claude_effort_level=self._config.claude_effort_level,
@@ -554,12 +557,12 @@ class SubprocessPool:
 
     def start(self) -> None:
         """Start the eviction background task (if eviction is enabled)."""
-        if self._config.claude_idle_timeout > 0:
+        if self._config.agent_idle_timeout > 0:
             self._eviction_task = asyncio.create_task(self._eviction_loop())
 
     async def _eviction_loop(self) -> None:
         """Periodically kill idle subprocesses to free memory."""
-        idle_timeout = self._config.claude_idle_timeout
+        idle_timeout = self._config.agent_idle_timeout
         while True:
             await asyncio.sleep(_EVICTION_CHECK_INTERVAL)
             now = time.monotonic()

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -46,6 +46,7 @@ import asyncio
 import json
 import logging
 import signal
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -2306,3 +2307,76 @@ class TestSignalTargetUserPidFreeFunctions:
         assert not warnings
         debugs = [r for r in caplog.records if "benign race" in r.getMessage()]
         assert debugs
+
+
+class TestSessionAgeRecycling:
+    """Session-age recycling on the shared ACP layer. The age helpers
+    (_session_age_hours / _should_recycle) are inherited from
+    AgentBackend; these tests pin that AcpBackend wires the surface
+    (max_session_hours kwarg, _session_started_at stamp on handshake,
+    null on kill) and that _send_locked kills an expired subprocess
+    before _ensure_started respawns it."""
+
+    def test_should_recycle_expired_session(self):
+        b = _make_fake(max_session_hours=4)
+        proc = MagicMock()
+        proc.returncode = None
+        b._proc = proc
+        b._session_started_at = time.monotonic() - 18000  # 5 hours
+        assert b._should_recycle() is True
+
+    def test_should_recycle_disabled_by_default(self):
+        """max_session_hours defaults to 0 (no limit); an old live
+        session is never recycled unless the pool passes a limit."""
+        b = _make_fake()
+        proc = MagicMock()
+        proc.returncode = None
+        b._proc = proc
+        b._session_started_at = time.monotonic() - 999999
+        assert b._should_recycle() is False
+
+    @pytest.mark.asyncio
+    async def test_handshake_stamps_session_start_and_kill_nulls_it(self):
+        """_ensure_started records time.monotonic() so the age helpers
+        have a base; _kill nulls it so a recycled instance does not
+        inherit a stale age."""
+        b = _make_fake()
+        proc = _make_mock_proc(_handshake_lines())
+        with patch("kai.acp.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            await b._ensure_started()
+        assert b._session_started_at is not None
+        await b._kill()
+        assert b._session_started_at is None
+
+    @pytest.mark.asyncio
+    async def test_send_recycles_expired_before_ensure_started(self):
+        """_send_locked() kills the expired process before
+        _ensure_started() respawns it (the claude backend's recycle
+        contract, minus the save-prompt ACP has no equivalent of)."""
+        b = _make_fake(max_session_hours=1)
+
+        async def fake_ensure_started():
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stdin = MagicMock()
+            mock_proc.stdin.write = MagicMock()
+            mock_proc.stdin.drain = AsyncMock()
+            mock_proc.stdout = MagicMock()
+            mock_proc.stdout.readline = AsyncMock(return_value=b"")  # EOF
+            b._proc = mock_proc
+            b._session_id = "sess-recycled"
+            b._fresh_session = False
+
+        with (
+            patch.object(b, "_should_recycle", return_value=True),
+            patch.object(b, "_kill", new_callable=AsyncMock) as mock_kill,
+            patch.object(b, "_ensure_started", side_effect=fake_ensure_started),
+            patch.object(b, "_session_age_hours", return_value=2.5),
+        ):
+            events = []
+            async for event in b._send_locked("test"):
+                events.append(event)
+
+        # _kill fires at least once for the recycle (and again from
+        # the streaming loop's EOF handler, which is expected).
+        assert mock_kill.await_count >= 1

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -29,6 +29,7 @@ import inspect
 import json
 import os
 import signal
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -2183,3 +2184,64 @@ class TestStartupFailureSurface:
         # tells the operator which backend failed, not just "spawn error".
         assert final.response.error is not None
         assert "Codex startup failed:" in final.response.error
+
+
+class TestSessionAgeRecycling:
+    """Session-age recycling on the codex backend. The age helpers
+    (_session_age_hours / _should_recycle) are inherited from
+    AgentBackend; these tests pin that CodexBackend wires the surface
+    (max_session_hours kwarg, _session_started_at stamp) and that
+    _send_locked kills an expired subprocess before _ensure_started
+    respawns it."""
+
+    def test_should_recycle_expired_session(self):
+        c = _make_codex(max_session_hours=4)
+        proc = MagicMock()
+        proc.returncode = None
+        c._proc = proc
+        c._session_started_at = time.monotonic() - 18000  # 5 hours
+        assert c._should_recycle() is True
+
+    def test_should_recycle_disabled_by_default(self):
+        """max_session_hours defaults to 0 (no limit); an old live
+        session is never recycled unless the pool passes a limit."""
+        c = _make_codex()
+        proc = MagicMock()
+        proc.returncode = None
+        c._proc = proc
+        c._session_started_at = time.monotonic() - 999999
+        assert c._should_recycle() is False
+
+    @pytest.mark.asyncio
+    async def test_send_recycles_expired_before_ensure_started(self):
+        """_send_locked() kills the expired process before
+        _ensure_started() respawns it (the claude backend's recycle
+        contract, minus the save-prompt the codex CLI has no
+        equivalent of)."""
+        c = _make_codex(max_session_hours=1)
+
+        async def fake_ensure_started():
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stdin = MagicMock()
+            mock_proc.stdin.write = MagicMock()
+            mock_proc.stdin.drain = AsyncMock()
+            mock_proc.stdout = MagicMock()
+            mock_proc.stdout.readline = AsyncMock(return_value=b"")  # EOF
+            c._proc = mock_proc
+            c._session_id = "thread-recycled"
+            c._fresh_session = False
+
+        with (
+            patch.object(c, "_should_recycle", return_value=True),
+            patch.object(c, "_kill", new_callable=AsyncMock) as mock_kill,
+            patch.object(c, "_ensure_started", side_effect=fake_ensure_started),
+            patch.object(c, "_session_age_hours", return_value=2.5),
+        ):
+            events = []
+            async for event in c._send_locked("test"):
+                events.append(event)
+
+        # _kill fires at least once for the recycle (and again from
+        # the streaming loop's EOF handler, which is expected).
+        assert mock_kill.await_count >= 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -186,7 +186,7 @@ class TestLoadConfigDefaults:
         config = load_config()
         assert config.default_model == "sonnet"
         assert config.claude_timeout_seconds == 120
-        assert config.claude_max_session_hours == 0
+        assert config.agent_max_session_hours == 0
         assert config.webhook_port == 8080
         # Without TELEGRAM_WEBHOOK_URL, defaults to polling mode
         assert config.telegram_webhook_url is None
@@ -266,7 +266,7 @@ class TestLoadConfigErrors:
         _set_required(monkeypatch)
         monkeypatch.setenv("AGENT_MAX_SESSION_HOURS", "4.5")
         config = load_config()
-        assert config.claude_max_session_hours == 4.5
+        assert config.agent_max_session_hours == 4.5
 
     def test_invalid_autocompact_pct(self, monkeypatch):
         _set_required(monkeypatch)
@@ -2710,8 +2710,8 @@ class TestAgentSessionLifecycleRename:
             CLAUDE_IDLE_TIMEOUT="300",
         )
         cfg = load_config()
-        assert cfg.claude_max_session_hours == 6
-        assert cfg.claude_idle_timeout == 900
+        assert cfg.agent_max_session_hours == 6
+        assert cfg.agent_idle_timeout == 900
 
     def test_legacy_only_falls_back_with_warning(self, monkeypatch, caplog):
         self._required_env(
@@ -2721,8 +2721,8 @@ class TestAgentSessionLifecycleRename:
         )
         with caplog.at_level(logging.WARNING, logger="kai.config"):
             cfg = load_config()
-        assert cfg.claude_max_session_hours == 4.5
-        assert cfg.claude_idle_timeout == 600
+        assert cfg.agent_max_session_hours == 4.5
+        assert cfg.agent_idle_timeout == 600
         messages = [r.getMessage() for r in caplog.records]
         assert any("CLAUDE_MAX_SESSION_HOURS in env is deprecated" in m for m in messages)
         assert any("CLAUDE_IDLE_TIMEOUT in env is deprecated" in m for m in messages)
@@ -2730,8 +2730,8 @@ class TestAgentSessionLifecycleRename:
     def test_neither_set_uses_defaults(self, monkeypatch):
         self._required_env(monkeypatch)
         cfg = load_config()
-        assert cfg.claude_max_session_hours == 0
-        assert cfg.claude_idle_timeout == 1800
+        assert cfg.agent_max_session_hours == 0
+        assert cfg.agent_idle_timeout == 1800
 
     def test_invalid_idle_timeout_names_canonical_key(self, monkeypatch):
         """A bad value fails fast naming the canonical key, including

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -44,8 +44,8 @@ def _make_config(**overrides) -> Config:
         "allowed_user_ids": {111, 222},
         "default_model": "sonnet",
         "claude_timeout_seconds": 30,
-        "claude_max_session_hours": 0,
-        "claude_idle_timeout": 1800,
+        "agent_max_session_hours": 0,
+        "agent_idle_timeout": 1800,
         "webhook_port": 8080,
         "webhook_secret": "secret",
     }
@@ -340,6 +340,34 @@ class TestPerUserBackendRouting:
         assert isinstance(instance, GooseBackend)
         assert instance.os_user == "alice-os"
 
+    def test_all_backends_receive_max_session_hours(self):
+        """Config.agent_max_session_hours reaches every backend type:
+        session-age recycling is pool-generic, matching the AGENT_
+        env prefix, not a claude-only lever."""
+        from kai.claude import ClaudeCodeBackend
+        from kai.codex import CodexBackend
+        from kai.opencode import OpenCodeBackend
+
+        users = {
+            111: UserConfig(
+                telegram_id=111, name="a", agent_backend="claude", llm_provider="anthropic", model="sonnet"
+            ),
+            222: UserConfig(telegram_id=222, name="b", agent_backend="codex"),
+            333: UserConfig(telegram_id=333, name="c", agent_backend="goose", llm_provider="anthropic", model="sonnet"),
+            444: UserConfig(telegram_id=444, name="d", agent_backend="opencode", model="anthropic/claude-sonnet-4-6"),
+        }
+        config = _make_config(agent_max_session_hours=6.5, user_configs=users)
+        pool = SubprocessPool(config=config, services_info=[])
+        for chat_id, expected_type in [
+            (111, ClaudeCodeBackend),
+            (222, CodexBackend),
+            (333, GooseBackend),
+            (444, OpenCodeBackend),
+        ]:
+            instance = pool.get(chat_id)
+            assert isinstance(instance, expected_type)
+            assert instance.max_session_hours == 6.5
+
     def test_opencode_user_receives_os_user(self):
         """An opencode user's os_user reaches OpenCodeBackend, which
         wires the per-user sudo isolation in the shared ACP layer
@@ -476,7 +504,7 @@ class TestPropertyAccessors:
 class TestIdleEviction:
     def test_idle_instance_identified_for_eviction(self):
         """Instance idle past timeout is identified for eviction."""
-        config = _make_config(claude_idle_timeout=1)
+        config = _make_config(agent_idle_timeout=1)
         pool = SubprocessPool(config=config, services_info=[])
         pool.get(111)
 
@@ -487,13 +515,13 @@ class TestIdleEviction:
         to_evict = [
             cid
             for cid, last in pool._last_activity.items()
-            if now - last > config.claude_idle_timeout and cid in pool._pool
+            if now - last > config.agent_idle_timeout and cid in pool._pool
         ]
         assert 111 in to_evict
 
     def test_active_not_evicted(self):
         """User with recent activity is not evicted."""
-        config = _make_config(claude_idle_timeout=3600)
+        config = _make_config(agent_idle_timeout=3600)
         pool = SubprocessPool(config=config, services_info=[])
         pool.get(111)  # creates and sets last_activity to now
 
@@ -910,7 +938,7 @@ class TestGetIfExists:
 class TestEvictionTOCTOU:
     def test_toctou_guard_skips_recently_active(self):
         """TOCTOU guard skips user who became active between list build and eviction."""
-        config = _make_config(claude_idle_timeout=1)
+        config = _make_config(agent_idle_timeout=1)
         pool = SubprocessPool(config=config, services_info=[])
         pool.get(111)
 
@@ -922,7 +950,7 @@ class TestEvictionTOCTOU:
         to_evict = [
             cid
             for cid, last in pool._last_activity.items()
-            if sweep_now - last > config.claude_idle_timeout and cid in pool._pool and cid not in pool._in_flight
+            if sweep_now - last > config.agent_idle_timeout and cid in pool._pool and cid not in pool._in_flight
         ]
         assert 111 in to_evict  # user is in the evict list
 
@@ -937,7 +965,7 @@ class TestEvictionTOCTOU:
     @pytest.mark.asyncio
     async def test_toctou_guard_skips_in_flight(self):
         """TOCTOU guard skips user who entered send() between snapshot and eviction."""
-        config = _make_config(claude_idle_timeout=1)
+        config = _make_config(agent_idle_timeout=1)
         pool = SubprocessPool(config=config, services_info=[])
 
         # Two idle users: A's shutdown is the yield point, B gets the TOCTOU change.
@@ -982,7 +1010,7 @@ class TestEvictionTOCTOU:
     @pytest.mark.asyncio
     async def test_toctou_guard_skips_removed_from_pool(self):
         """TOCTOU guard skips user removed from pool between snapshot and eviction."""
-        config = _make_config(claude_idle_timeout=1)
+        config = _make_config(agent_idle_timeout=1)
         pool = SubprocessPool(config=config, services_info=[])
 
         # get() order determines to_evict order (dict insertion order); 111 must
@@ -1025,7 +1053,7 @@ class TestEvictionTOCTOU:
     @pytest.mark.asyncio
     async def test_eviction_proceeds_when_all_checks_pass(self):
         """User passing all three re-checks is evicted normally."""
-        config = _make_config(claude_idle_timeout=1)
+        config = _make_config(agent_idle_timeout=1)
         pool = SubprocessPool(config=config, services_info=[])
 
         instance = pool.get(111)
@@ -1059,7 +1087,7 @@ class TestEvictionTOCTOU:
     @pytest.mark.asyncio
     async def test_eviction_failure_triggers_sigkill_fallback(self):
         """Failed shutdown() in eviction loop triggers force_kill fallback."""
-        config = _make_config(claude_idle_timeout=1)
+        config = _make_config(agent_idle_timeout=1)
         pool = SubprocessPool(config=config, services_info=[])
 
         instance = pool.get(111)
@@ -1096,7 +1124,7 @@ class TestEvictionTOCTOU:
     @pytest.mark.asyncio
     async def test_eviction_pops_after_shutdown(self):
         """Instance stays in pool during shutdown, removed only after success."""
-        config = _make_config(claude_idle_timeout=1)
+        config = _make_config(agent_idle_timeout=1)
         pool = SubprocessPool(config=config, services_info=[])
 
         instance = pool.get(111)


### PR DESCRIPTION
Closes #621.

`AGENT_MAX_SESSION_HOURS` recycled only the claude subprocess, even though the env var's `AGENT_` prefix and the env-template text ("applies to every backend's subprocess pool") both promise generic behavior; the sibling `AGENT_IDLE_TIMEOUT` genuinely is generic, masking the asymmetry. This makes the documented behavior true: all four backends now recycle by session age.

## Changes

- **Age helpers move to the ABC.** `_session_age_hours` and `_should_recycle` become concrete methods on `AgentBackend`; claude's copies retire. The recycle check itself stays backend-owned at the top of each `_send_locked` because the surrounding lifecycle differs: claude runs its save-prompt before the kill, the others kill immediately and respawn on the same send (the next `_ensure_started` re-runs the handshake and re-marks the session fresh for context injection, so a recycled session re-receives identity/memory/history exactly like a new one).
- **`AcpBackend` (goose + opencode) and `CodexBackend`** gain the `max_session_hours` kwarg, stamp `_session_started_at` at spawn, null it on kill/shutdown, and recycle expired sessions before `_ensure_started`. The check fires only between interactions, never mid-stream, same as claude.
- **pool.py** passes `Config.agent_max_session_hours` to all four constructors.
- **Config field renames**: `claude_max_session_hours` → `agent_max_session_hours`, `claude_idle_timeout` → `agent_idle_timeout`, matching the canonical env vars they load from. Mechanical: env vars, wizard prompts, and the legacy `CLAUDE_*` fallbacks are all unchanged. (`claude_timeout_seconds` keeps its name; it is not part of the recycling/eviction pair this PR touches.)

No env, wizard, template, or installer changes; the existing documentation was already written for the generic behavior.

## Tests

Recycle-helper and send-path recycle tests for the ACP layer and codex, mirroring claude's existing test shapes (`_should_recycle` expired/disabled, kill-before-`_ensure_started` through `_send_locked`); a handshake-stamps/kill-nulls lifecycle test on the ACP layer; a pool wiring test asserting all four backend types receive the config value; and the mechanical fixture renames in test_config/test_pool. Claude's existing recycle suite passes unchanged against the inherited helpers. 3896 passed, 1 skipped; ruff clean.
