### PR TITLE
fix(backend): 16 MiB stream line limit on claude plus the ACP layer

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -1008,7 +1008,17 @@ class AcpBackend(AgentBackend):
             stderr=asyncio.subprocess.PIPE,
             cwd=str(self.workspace),
             env=env,
-            limit=1024 * 1024,  # 1MB per-line buffer
+            # A single ACP notification line can carry a large payload
+            # (a tool result echoed into a chunk, a long final
+            # message). The asyncio.StreamReader default limit is
+            # 64KB, and a 1MB ceiling is too tight for PR-review-sized
+            # payloads (readline raises "Separator is not found, and
+            # chunk exceed the limit", killing the turn). 16MB matches
+            # the codex backend's ceiling so the per-line headroom is
+            # uniform across backends: well above any plausible
+            # single-event payload while still bounding memory on a
+            # runaway line.
+            limit=16 * 1024 * 1024,
             # Cross-user mode: new session group so the sudo wrapper
             # is the session leader (PGID == PID) and the kill paths
             # can SIGKILL the whole target-user tree by negative

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -299,7 +299,16 @@ class ClaudeCodeBackend(AgentBackend):
             stderr=asyncio.subprocess.PIPE,
             cwd=str(self.workspace),
             env=env,
-            limit=1024 * 1024,  # 1 MiB; default 64 KiB too small for large tool results
+            # A single stream-json line can inline the full text of a
+            # large tool result. The asyncio.StreamReader default
+            # limit is 64KB, and a 1MB ceiling is too tight for
+            # PR-review-sized payloads (readline raises "Separator is
+            # not found, and chunk exceed the limit", killing the
+            # turn). 16MB matches the codex backend's ceiling so the
+            # per-line headroom is uniform across backends: well above
+            # any plausible single-event payload while still bounding
+            # memory on a runaway line.
+            limit=16 * 1024 * 1024,
             # When spawned via sudo, start in a new process group so we can
             # kill the entire tree (sudo + claude) via os.killpg(). Without
             # this, killing sudo may orphan the claude process.

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -2380,3 +2380,26 @@ class TestSessionAgeRecycling:
         # _kill fires at least once for the recycle (and again from
         # the streaming loop's EOF handler, which is expected).
         assert mock_kill.await_count >= 1
+
+
+class TestStreamLineLimit:
+    """The asyncio.StreamReader limit on the ACP subprocess stdout."""
+
+    @pytest.mark.asyncio
+    async def test_subprocess_limit_is_at_least_16mb(self):
+        """
+        A single notification line must fit any plausible payload; a
+        1MB ceiling is too tight for PR-review-sized tool results
+        (readline raises "Separator is not found, and chunk exceed
+        the limit", killing the turn). Lock the lower bound, matching
+        the codex backend's pin, so a future shrinkback gets caught
+        here rather than on a live operator turn.
+        """
+        b = _make_fake()
+        proc = _make_mock_proc(_handshake_lines())
+
+        with patch("kai.acp.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await b._ensure_started()
+
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["limit"] >= 16 * 1024 * 1024

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -904,6 +904,30 @@ class TestEnsureStarted:
             assert call_kwargs["env"]["KAI_WEBHOOK_SECRET"] == "my-secret"
 
     @pytest.mark.asyncio
+    async def test_subprocess_limit_is_at_least_16mb(self):
+        """
+        The asyncio.StreamReader limit on stdout must be large enough
+        for any single stream-json event payload; a 1MB ceiling is too
+        tight for PR-review-sized tool results (readline raises
+        "Separator is not found, and chunk exceed the limit", killing
+        the turn). Lock the lower bound, matching the codex backend's
+        pin, so a future shrinkback gets caught here rather than on a
+        live operator turn.
+        """
+        claude = _make_claude()
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = AsyncMock()
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["limit"] >= 16 * 1024 * 1024
+
+    @pytest.mark.asyncio
     async def test_sets_fresh_session(self):
         """_fresh_session is True after starting a new process."""
         claude = _make_claude()


### PR DESCRIPTION
Closes #623.

The codex backend reads subprocess stdout with a 16 MiB `asyncio.StreamReader` line limit because real PR-review turns broke the earlier 1 MiB ceiling: a single event line carrying an inlined tool result made `readline` raise "Separator is not found, and chunk exceed the limit," killing the turn. The claude backend and the shared ACP layer (goose + opencode) still read at 1 MiB, so the identical oversized payload kills the turn on three backends while succeeding on codex.

## Changes

- `claude.py` and `acp.py` spawn with `limit=16 * 1024 * 1024`, matching codex; the comments at both sites carry the rationale.
- Tests pin the 16 MiB lower bound on the claude and ACP spawn paths, mirroring the codex suite's existing pin, so a future shrinkback gets caught in CI rather than on a live operator turn.

3890 passed, 1 skipped; ruff clean.
