### PR TITLE
fix(claude): surface non-ENOENT spawn failures as clean startup errors

### DIFF
--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -657,6 +657,18 @@ class ClaudeCodeBackend(AgentBackend):
                 response=AgentResponse(success=False, text="", error="claude CLI not found"),
             )
             return
+        except OSError as exc:
+            # Non-ENOENT spawn failures (EACCES on the binary, fork
+            # resource exhaustion, a bad cwd) surface as a clean error
+            # event, matching the codex and ACP backends' startup
+            # catch, instead of propagating an unhandled exception
+            # into the bot layer.
+            yield StreamEvent(
+                text_so_far="",
+                done=True,
+                response=AgentResponse(success=False, text="", error=f"Claude startup failed: {exc}"),
+            )
+            return
 
         # Per-turn prompt context. Build the fresh-session bootstrap
         # (MEMORY.md / PREFERENCES.md seed + session_context block)

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -211,9 +211,9 @@ class CodexBackend(AgentBackend):
         # emission and gates MEMORY.md inject in build_session_context.
         # Default False so direct test instantiations need not plumb
         # the kwarg; production callers (pool.py) always pass an
-        # explicit value. Codex installs run with memory disabled
-        # (the install wizard's guard forces MEMORY_ENABLED=false on
-        # codex), so this flag is effectively always False in v1.
+        # explicit value. Codex installs support full semantic memory:
+        # extraction dispatches per user through CodexOneShotReasoner,
+        # the same as every backend in ONESHOT_REASONER_BACKENDS.
         memory_enabled: bool = False,
         # Hours before the subprocess is recycled (0 = no limit).
         # Same contract as the claude and ACP backends: prevents

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1337,12 +1337,14 @@ def _cmd_config() -> None:
     memory_duplicate_threshold = "0.9"
     if memory_enabled:
         # Memory extraction is supported on agent backends that ship a
-        # OneShotReasoner. Goose retrieval-only installs accept
-        # memory_enabled but skip the extraction prompt because no
-        # GooseOneShotReasoner exists. The runtime eligibility gate at
-        # `bot._ingest_memory` and `config._compute_extraction_eligible_backends`
-        # read from the same constant; all sites stay in lockstep
-        # through it.
+        # OneShotReasoner. Every shipped backend is in
+        # ONESHOT_REASONER_BACKENDS, so the guard below always passes
+        # today; it stays so a future backend added without a reasoner
+        # degrades to retrieval-only (with the printed note in the
+        # else branch) instead of silently failing extraction. The
+        # runtime eligibility gate at `bot._ingest_memory` and
+        # `config._compute_extraction_eligible_backends` read from the
+        # same constant; all sites stay in lockstep through it.
         if agent_backend in ONESHOT_REASONER_BACKENDS:
             memory_extraction_enabled = _prompt_bool(
                 "Enable memory extraction (proactive memory writes)",

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1236,6 +1236,25 @@ class TestSendLockedErrors:
         assert "not found" in events[0].response.error
 
     @pytest.mark.asyncio
+    async def test_non_enoent_spawn_failure_yields_error_event(self):
+        """A non-ENOENT OSError from _ensure_started (EACCES on the
+        binary, fork resource exhaustion, a bad cwd) surfaces as a
+        clean error event, matching the codex and ACP backends'
+        startup catch, instead of propagating an unhandled exception
+        into the bot layer."""
+        claude = _make_claude()
+        claude._proc = None
+        claude._fresh_session = False
+
+        with patch.object(claude, "_ensure_started", side_effect=PermissionError("EACCES: claude")):
+            events = await _collect_events(claude)
+
+        assert len(events) == 1
+        assert events[0].done is True
+        assert "Claude startup failed" in events[0].response.error
+        assert "EACCES" in events[0].response.error
+
+    @pytest.mark.asyncio
     async def test_stdin_write_failure(self):
         """OSError on stdin.write kills the process and yields an error event."""
         proc = _make_mock_proc([])


### PR DESCRIPTION
Closes #625.

The codex and ACP chat backends catch `(OSError, RuntimeError, TimeoutError)` around startup and surface failures as a clean error event; claude caught only `FileNotFoundError`, so any other spawn-time `OSError` (EACCES on the binary, fork resource exhaustion, a bad cwd) propagated as an unhandled exception into the bot layer instead of producing an error reply.

## Changes

- **claude.py**: the startup catch keeps the specific "claude CLI not found" message for `FileNotFoundError` and surfaces every other `OSError` as "Claude startup failed: <exc>", matching the sibling backends' contract. Claude has no handshake, so the `RuntimeError`/`TimeoutError` arms the other backends need do not apply.
- **Stale comments corrected to present state** (no behavior change): codex.py claimed the install wizard forces `MEMORY_ENABLED=false` on codex installs (that guard no longer exists; codex dispatches memory extraction per user like every reasoner backend), and install.py's memory section claimed no `GooseOneShotReasoner` exists (it does; the comment now documents the future-backend degradation path the gate actually guards).

## Tests

New `test_non_enoent_spawn_failure_yields_error_event` mirrors the existing `test_cli_not_found` shape with a `PermissionError`, asserting a single done event carrying "Claude startup failed" rather than a propagated exception. 3899 passed, 1 skipped; ruff clean.
