### PR TITLE
feat(config): accept full claude-* model IDs on the claude backend

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -643,17 +643,16 @@ def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> b
     operator typo (bare Anthropic names like "opus" or "sonnet" that
     are correct on other backends but unusable on OpenCode).
 
-    Goose-on-anthropic additionally accepts any `claude-*` ID
-    structurally, beyond the curated alias trio. Goose hands
-    GOOSE_MODEL verbatim to the Anthropic API, which accepts full
-    model IDs (current aliases like claude-opus-4-8 and dated SKUs
-    alike), so the alias map in goose.py going stale must never be a
-    ceiling on which SKUs a goose user can reach. A bogus claude-*
-    string fails at the provider with a clear API error, the same
-    contract opencode accepts for its structurally-validated IDs.
-    The claude backend keeps curated-only validation: its CLI
-    resolves the short aliases to the newest SKU itself, so the
-    alias surface does not pin generations there.
+    The claude backend and goose-on-anthropic additionally accept
+    any `claude-*` ID structurally, beyond the curated alias trio.
+    Both hand the model string verbatim to a surface that resolves
+    full IDs (the claude CLI's --model flag; the Anthropic API via
+    GOOSE_MODEL), so the curated aliases must never be a ceiling on
+    which SKUs a user can reach: pinning a previous generation (e.g.
+    claude-opus-4-7) is a real operator need when the newest SKU
+    misbehaves. A bogus claude-* string fails at the CLI or provider
+    with a clear error on the next message, the same contract
+    opencode accepts for its structurally-validated IDs.
 
     Canonical model validator: every model-selection site in the
     codebase routes through this function so codex / goose / opencode
@@ -663,6 +662,8 @@ def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> b
         return model in CODEX_MODELS
     if backend == "opencode":
         return is_opencode_model_shape(model)
+    if backend == "claude" and model.startswith("claude-"):
+        return True
     if backend == "goose" and eff_provider == "anthropic" and model.startswith("claude-"):
         return True
     return validate_model_for_provider(model, eff_provider)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2467,13 +2467,26 @@ class TestValidateModelForBackend:
         assert validate_model_for_backend("gpt-5.5", "goose", "anthropic") is False
         assert validate_model_for_backend("clearly-bogus", "goose", "anthropic") is False
 
-    def test_claude_full_ids_stay_curated_only(self):
-        """The passthrough is goose-specific: the claude backend's CLI
-        resolves short aliases to the newest SKU itself, so its surface
-        stays the curated trio."""
+    def test_claude_accepts_full_claude_ids(self):
+        """The claude CLI's --model flag resolves full model IDs, so
+        any claude-* string passes structurally alongside the curated
+        alias trio; pinning a previous generation must not require a
+        backend switch."""
         from kai.config import validate_model_for_backend
 
-        assert validate_model_for_backend("claude-opus-4-8", "claude", "anthropic") is False
+        assert validate_model_for_backend("claude-opus-4-8", "claude", "anthropic") is True
+        assert validate_model_for_backend("claude-opus-4-7", "claude", "anthropic") is True
+        assert validate_model_for_backend("claude-haiku-4-5-20251001", "claude", "anthropic") is True
+        # The curated alias trio keeps working alongside the passthrough.
+        assert validate_model_for_backend("sonnet", "claude", "anthropic") is True
+
+    def test_claude_rejects_non_claude_garbage(self):
+        """The structural passthrough is claude-* scoped; other strings
+        still validate against the curated provider surface."""
+        from kai.config import validate_model_for_backend
+
+        assert validate_model_for_backend("gpt-5.5", "claude", "anthropic") is False
+        assert validate_model_for_backend("clearly-bogus", "claude", "anthropic") is False
 
     def test_goose_non_anthropic_providers_unaffected_by_passthrough(self):
         """A claude-* string on goose-with-another-provider is not a


### PR DESCRIPTION
Closes #627.

Pinning a full Claude model ID (for example `claude-opus-4-7` to hold the previous generation when the newest SKU misbehaves) worked on goose-on-anthropic and opencode but was rejected on the claude backend itself, whose `--model` flag resolves full IDs natively. `/model claude-opus-4-7` succeeding for a goose user while failing for a claude user was backwards.

## Changes

- `validate_model_for_backend` extends the structural `claude-*` passthrough to the claude backend, alongside the existing goose-on-anthropic arm. The curated alias trio keeps working; non-`claude-*` strings still validate against the curated provider surface; the goose-on-other-providers behavior is unchanged.
- The `/models` keyboard stays curated; full IDs are typed via `/model <id>`, matching how goose-on-anthropic already works. A bogus `claude-*` string fails at the CLI with a clear error on the next message, the same contract the other structurally-validated surfaces accept.

## Tests

The test pinning curated-only claude validation flips to its mirror of the goose passthrough suite: full current/previous/dated IDs accepted, the alias trio still accepted, and `claude-*`-scoped rejection of garbage strings preserved. 3900 passed, 1 skipped; ruff clean.
