### PR TITLE
fix(oneshot): carry a response snippet in invalid_json errors

### DIFF
--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -1237,7 +1237,13 @@ class CodexOneShotReasoner:
                     duration_ms,
                     os_user_field,
                 )
-                raise OneShotOutputError(f"codex final text did not contain a JSON object: {exc}") from None
+                # Carry a snippet of the offending text so non-JSON
+                # output is self-diagnosing in the operator log (e.g.
+                # a provider that prints its error text to stdout and
+                # exits 0).
+                raise OneShotOutputError(
+                    f"codex final text did not contain a JSON object: {exc}; response begins: {final_text[:200]!r}"
+                ) from None
 
             # Codex's `--output-schema` enforcement is best-effort:
             # the CLI does not hard-reject a final message that
@@ -1689,7 +1695,14 @@ class OpenCodeOneShotReasoner:
                     duration_ms,
                     os_user_field,
                 )
-                raise OneShotOutputError(f"opencode accumulated text did not contain a JSON object: {exc}") from None
+                # Carry a snippet of the offending text so non-JSON
+                # output is self-diagnosing in the operator log (e.g.
+                # a provider that prints its error text to stdout and
+                # exits 0).
+                raise OneShotOutputError(
+                    f"opencode accumulated text did not contain a JSON object: {exc}; "
+                    f"response begins: {accumulated[:200]!r}"
+                ) from None
 
             if not isinstance(payload, dict):
                 log.info(
@@ -2308,7 +2321,15 @@ class GooseOneShotReasoner:
                 duration_ms,
                 os_user_field,
             )
-            raise OneShotOutputError(f"goose response text did not contain a JSON object: {exc}") from None
+            # Carry a snippet of the offending text so non-JSON output
+            # is self-diagnosing in the operator log. This is the
+            # goose auth-failure surface: goose prints auth errors to
+            # stdout and exits 0, so without the snippet an expired or
+            # missing credential reads as a bare position-only JSON
+            # parse error with no pointer to the real cause.
+            raise OneShotOutputError(
+                f"goose response text did not contain a JSON object: {exc}; response begins: {response_text[:200]!r}"
+            ) from None
 
         if not isinstance(payload, dict):
             log.info(

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -3041,6 +3041,22 @@ class TestGooseOneShotReasonerOutput:
             await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
 
     @pytest.mark.asyncio
+    async def test_invalid_json_error_carries_response_snippet(self, tmp_path):
+        """The invalid_json error message carries the start of the
+        offending text so non-JSON output is self-diagnosing in the
+        operator log. This is the goose auth-failure surface: goose
+        prints auth errors to stdout and exits 0, so without the
+        snippet an expired credential reads as a bare position-only
+        parse error."""
+        reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="anthropic")
+        proc = _make_proc(stdout=b"Error: no credentials configured for provider anthropic")
+        with (
+            patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            pytest.raises(OneShotOutputError, match=r"no credentials configured"),
+        ):
+            await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("non_object_payload", ['"a plain string"', "[]", "42", "true", "null"])
     async def test_non_object_json_raises_output_error(self, tmp_path, non_object_payload):
         reasoner = GooseOneShotReasoner(cwd=tmp_path, os_user=_current_user(), provider="anthropic")


### PR DESCRIPTION
Closes #629.

Goose prints auth errors to stdout and exits 0, so a one-shot call with an expired or missing credential surfaced as an `invalid_json` output error carrying only the JSON decoder's position information ("Expecting value: line 1 column 1"); the operator saw a bare parse failure with no pointer to the real cause.

## Changes

Pattern-matching goose's auth-error text would be version-brittle, so the fix is generic: the three fence-tolerant schema parse sites in the one-shot reasoners (codex, opencode, goose) append a 200-character repr snippet of the offending output to their `invalid_json` `OneShotOutputError` messages. The snippet flows wherever the typed error already goes (extraction failure reasons, the review/triage RuntimeError collapse), so any non-JSON response is self-diagnosing in the operator log, auth errors included. The structured `oneshot_reasoner ... error_category=invalid_json` log line is unchanged.

## Tests

New goose test feeds an auth-error-shaped stdout (`Error: no credentials configured for provider anthropic`) and asserts the raised error message carries the text; the existing invalid_json/non-object suites pass unchanged. 3900 passed, 1 skipped; ruff clean.
