### PR TITLE
refactor(oneshot): fold claude/codex review/triage onto their reasoners

### DIFF
--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -222,6 +222,19 @@ class OneShotSubprocessError(OneShotError):
     returncode: int
     stderr: bytes
 
+    def __str__(self) -> str:
+        # The dataclass-generated __init__ never populates
+        # Exception.args, so the inherited str() renders empty and
+        # any caller embedding this error in a message (the review /
+        # triage RuntimeError collapse) would surface a bare prefix
+        # with no failure detail. Render the exit code plus a bounded
+        # stderr snippet instead, mirroring the shape stage 2 builds
+        # from the same fields.
+        snippet = self.stderr[:200].decode("utf-8", errors="replace").strip()
+        if snippet:
+            return f"exit {self.returncode}: {snippet}"
+        return f"exit {self.returncode}"
+
 
 class OneShotOutputError(OneShotError):
     """
@@ -454,15 +467,27 @@ def _parse_schema_payload(text: str) -> Any:
 
 class ClaudeOneShotReasoner:
     """
-    Spawns `claude --print` once per call and returns the raw stdout.
+    Spawns `claude --print` once per call and returns either the raw
+    JSON result envelope (schema mode) or the plain response text
+    (free-form mode).
 
-    The argv, env allow-list, neutral cwd, and timeout semantics are
-    lifted verbatim from the pre-refactor `_run_extractor` /
+    Schema mode (`json_schema` supplied): the argv carries
+    `--output-format json` plus `--json-schema`, and the raw stdout
+    (the CLI's JSON result envelope) is returned unparsed; envelope
+    parsing is the caller's contract (memory extraction). The argv,
+    env allow-list, neutral cwd, and timeout semantics of this mode
+    are lifted verbatim from the pre-refactor `_run_extractor` /
     `_run_episode_extractor` paths in `kai.memory_extraction`. That
     is the load-bearing invariant for the Phase 1 refactor: the
     Claude memory path must stay byte-identical to its prior
     behavior, so any future drift in this implementation is a
     semantic change and not a refactor.
+
+    Free-form mode (`json_schema=None`): the output-format flag is
+    omitted so `claude --print` emits the response text itself, and
+    the result text is the stripped stdout - the same free-form
+    contract the goose and opencode reasoners expose for the review
+    and triage callers.
 
     Flag rationale (carried over from the original site):
 
@@ -541,14 +566,17 @@ class ClaudeOneShotReasoner:
         cmd: list[str] = [resolved_binary, "--print"]
         if model is not None:
             cmd.extend(["--model", model])
-        cmd.extend(["--output-format", "json"])
         if json_schema is not None:
+            # Schema mode rides the JSON result envelope, so the
+            # output format is pinned alongside the schema flag;
+            # free-form callers get plain-text stdout instead.
             # `claude --print --json-schema <schema>` validates the
             # model's structured-output payload CLI-side. Stage 1 and
             # stage 2 both rely on this defense-in-depth gate; the
             # caller's Python validation is the primary contract, but
             # losing the CLI gate would let more malformed payloads
             # reach the parser.
+            cmd.extend(["--output-format", "json"])
             cmd.extend(["--json-schema", json.dumps(json_schema)])
         if system_prompt is not None:
             cmd.extend(["--system-prompt", system_prompt])
@@ -653,8 +681,16 @@ class ClaudeOneShotReasoner:
         # provider implementations may populate backend-specific
         # metadata, but current callers depend on nothing beyond
         # what is captured below.
+        text = stdout.decode("utf-8", errors="replace")
+        if json_schema is None:
+            # Free-form mode: stdout IS the response text (no JSON
+            # envelope to preserve), so strip the surrounding
+            # whitespace the same way the goose reasoner does. Schema
+            # mode stays unstripped to keep the envelope bytes the
+            # caller parses identical to the pre-refactor path.
+            text = text.strip()
         return OneShotResult(
-            text=stdout.decode("utf-8", errors="replace"),
+            text=text,
             backend="claude",
             model=model,
             raw_metadata={
@@ -903,12 +939,13 @@ class CodexOneShotReasoner:
       removes it on every exit path (success, timeout, non-zero exit,
       or output-parse failure).
     - NDJSON event output instead of a single envelope: stdout is a
-      sequence of `thread.*`, `turn.*`, and `item.*` events. The final
-      `agent_message` text is recovered via `extract_codex_text` with
-      `join_items=False`, which matches triage's "last completed
-      message only" contract for structured-output callers. A
-      preamble agent_message followed by a JSON body would otherwise
-      corrupt the parse.
+      sequence of `thread.*`, `turn.*`, and `item.*` events. The
+      `agent_message` text is recovered via `extract_codex_text`.
+      Schema mode always takes `join_items=False` ("last completed
+      message only"): a preamble agent_message glued ahead of the
+      JSON body would otherwise corrupt the parse. Free-form mode
+      takes the constructor's `join_items` flag so callers pick the
+      contract that matches their downstream parser.
 
     The schema-backed call always returns a wrapped envelope so the
     caller's nested-vs-root resolution path (the one already in
@@ -916,11 +953,11 @@ class CodexOneShotReasoner:
     sees the same `structured_output` shape it sees from Claude. The
     reasoner does not inspect fact / episode / tag / confidence
     fields; that contract stays with the caller. When no schema is
-    supplied (`json_schema is None`), the final agent_message text is
+    supplied (`json_schema is None`), the agent_message text is
     returned directly without wrapping; memory extraction always
     supplies a schema, so the wrap path is the production memory
-    path and the non-schema branch exists only for future free-form
-    callers.
+    path while the non-schema branch carries the free-form review
+    and triage callers.
 
     Flag rationale:
 
@@ -969,7 +1006,7 @@ class CodexOneShotReasoner:
     exception masking the original failure.
     """
 
-    def __init__(self, *, cwd: Path | None = None, os_user: str | None = None) -> None:
+    def __init__(self, *, cwd: Path | None = None, os_user: str | None = None, join_items: bool = False) -> None:
         """
         Args:
             cwd: Override for the subprocess working directory and the
@@ -990,9 +1027,21 @@ class CodexOneShotReasoner:
                 claude does. The persistent codex chat backend in
                 `src/kai/codex.py` already uses this resolution
                 shape; this reasoner now follows it.
+            join_items: Output-joining mode for the free-form
+                (no-schema) path. True joins every completed
+                agent_message with blank-line separators - the right
+                contract for free-form markdown callers like PR
+                review, where codex may emit a preamble message ahead
+                of the body and both must survive. False (the
+                default) returns only the last completed message,
+                which JSON-contract callers like triage need so a
+                preamble never gets glued ahead of the JSON object.
+                Schema-backed calls ignore this flag and always take
+                last-wins for the same reason.
         """
         self._cwd = cwd if cwd is not None else _EXTRACTOR_CWD
         self._os_user = os_user
+        self._join_items = join_items
 
     async def run(
         self,
@@ -1169,13 +1218,16 @@ class CodexOneShotReasoner:
                 raise OneShotSubprocessError(returncode=returncode, stderr=stderr)
 
             stdout_text = stdout.decode("utf-8", errors="replace")
-            # Triage's lesson carried over: structured-output callers
-            # want only the LAST completed agent_message so a preamble
-            # message does not get glued ahead of the JSON body. Memory
-            # extraction is the canonical structured caller here; the
-            # `join_items=True` (review/chat) path has no caller in
-            # #497 but the protocol leaves room for one.
-            final_text = extract_codex_text(stdout_text, join_items=False)
+            # Structured-output callers want only the LAST completed
+            # agent_message so a preamble message does not get glued
+            # ahead of the JSON body; schema mode therefore pins
+            # last-wins regardless of the constructor flag. Free-form
+            # callers pick their contract at construction: PR review
+            # joins every completed message (a preamble plus body must
+            # both survive in the posted markdown), triage keeps
+            # last-wins for its one-JSON-object parser.
+            join_items = self._join_items if json_schema is None else False
+            final_text = extract_codex_text(stdout_text, join_items=join_items)
 
             if json_schema is None:
                 # Free-form path: hand the final agent_message text

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -1,5 +1,5 @@
 """
-PR review agent - one-shot subprocess (Claude, Codex, or Goose) for automated code review.
+PR review agent - one-shot subprocess (Claude, Codex, Goose, or OpenCode) for automated code review.
 
 Provides functionality to:
 1. Fetch PR diffs and metadata via the GitHub CLI
@@ -13,33 +13,33 @@ Provides functionality to:
 
 The review agent stores no persistent state, but reads prior GitHub PR
 comments for conversational awareness within a single PR. Each review is
-a fresh Claude invocation with the full diff and any prior review thread
+a fresh LLM invocation with the full diff and any prior review thread
 in context, so issues that were already raised and dismissed are not
 repeated. If the relevant code has materially changed, the agent may
 re-evaluate a prior finding.
 
 The LLM subprocess runs in one-shot mode (non-interactive, no tools, no
-streaming): `claude --print` for Claude, `codex exec --json` for Codex,
-`goose run -i -` for Goose. The prompt goes in via stdin to handle
-large diffs without hitting shell argument length limits. Output is
-captured as plain text (NDJSON for codex; the agent_message text is
-extracted by kai.codex_exec.extract_codex_text).
+streaming) through the per-backend OneShotReasoner implementations in
+`kai.oneshot`, which own binary resolution, argv shape, per-user
+os_user routing, the allow-listed subprocess env, and timeout / kill
+semantics. The prompt goes in via stdin to handle large diffs without
+hitting shell argument length limits; every backend returns the review
+as a single text string.
 """
 
 import asyncio
 import glob as glob_mod
 import json
 import logging
-import os
-import signal
 from dataclasses import dataclass
 from pathlib import Path
 
 import aiohttp
 
-from kai.codex_exec import extract_codex_text
-from kai.config import ModelRole, get_model_for, resolve_claude_user
+from kai.config import ModelRole, get_model_for
 from kai.oneshot import (
+    ClaudeOneShotReasoner,
+    CodexOneShotReasoner,
     GooseOneShotReasoner,
     OneShotError,
     OneShotTimeout,
@@ -628,43 +628,38 @@ async def run_review(
     """
     Spawn a one-shot LLM subprocess to perform the review.
 
-    Dispatches by agent_backend: Claude (`claude --print`) and Codex
-    (`codex exec --json`) spawn inline; Goose and OpenCode dispatch
-    through their OneShotReasoner implementations in `kai.oneshot`.
-    All paths read the prompt and return a single string of review
-    text; the prompt and output handling are identical regardless of
-    backend.
+    Dispatches by agent_backend: every backend routes through its
+    OneShotReasoner implementation in `kai.oneshot`, which owns
+    binary resolution, the argv shape, per-OS-user routing via
+    `sudo -H -u <user>`, the allow-listed subprocess env, and
+    timeout / kill semantics. All paths read the prompt and return a
+    single string of review text, and all collapse typed reasoner
+    errors to RuntimeError so the caller's failure surface is
+    uniform across backends.
 
-    Claude path: supports sudo -u for OS-level isolation and process
-    group kills for cleanup.
+    Claude path: `ClaudeOneShotReasoner` in free-form mode (plain
+    `claude --print` text output, no tools, no session persistence,
+    neutral cwd).
 
-    Codex path: sudo -H -u when claude_user is set (codex needs
-    HOME pointing at the user's home so it reads the right
-    ~/.codex/auth.json); subprocess emits NDJSON which is collapsed
-    to the final agent_message text by extract_codex_text.
+    Codex path: `CodexOneShotReasoner` (`codex exec --json`); the
+    reasoner walks the NDJSON event stream and, with
+    `join_items=True`, joins every completed agent_message so a
+    multi-message review survives intact.
 
-    OpenCode path: dispatches through `OpenCodeOneShotReasoner` in
-    `kai.oneshot`, which spawns a fresh `opencode acp` JSON-RPC
-    subprocess per call, accumulates response text from
-    `session/update` notifications, and rejects any tool-permission
-    request mid-stream (review prompts must not execute tools). The
-    reasoner handles per-OS-user routing via `sudo -H -u <user>`
-    and timeout / error mapping; we collapse its typed errors to
-    RuntimeError below so the caller's existing failure surface is
-    unchanged.
+    OpenCode path: `OpenCodeOneShotReasoner`, which spawns a fresh
+    `opencode acp` JSON-RPC subprocess per call, accumulates
+    response text from `session/update` notifications, and rejects
+    any tool-permission request mid-stream (review prompts must not
+    execute tools).
 
-    Goose path: dispatches through `GooseOneShotReasoner` in
-    `kai.oneshot` (same shape as the OpenCode path), which owns the
-    `goose run -i - ... --max-turns 1` argv, GOOSE_BIN resolution,
-    per-OS-user routing via `sudo -H -u <user>`, the provider
-    wire-name translation, and the allow-listed subprocess env.
-    Typed errors collapse to RuntimeError below.
+    Goose path: `GooseOneShotReasoner`, which owns the
+    `goose run -i - ... --max-turns 1` argv and the provider
+    wire-name translation.
 
     Args:
         prompt: The complete review prompt (from build_review_prompt).
-        claude_user: Optional OS user to run the subprocess as (via
-            sudo -u for claude, sudo -H -u for codex / goose /
-            opencode).
+        claude_user: Optional OS user to run the subprocess as (the
+            reasoners apply the sudo -H -u wrap).
         agent_backend: Which LLM backend to use ("claude", "codex",
             "opencode", or "goose").
         provider: LLM provider name (e.g. "anthropic", "openai").
@@ -710,109 +705,36 @@ async def run_review(
         return result.text
 
     if agent_backend == "codex":
-        # Codex one-shot mode: --json emits NDJSON events on stdout
-        # (thread.started, turn.started, item.*, turn.completed,
-        # turn.failed, error). The final agent message text is
-        # recovered by walking the events and accumulating any text
-        # content; extract_codex_text in kai.codex_exec is the
-        # schema-defensive parser shared with triage.py.
-        # Per-user OAuth isolation: when claude_user is set (the
-        # webhook handler passes the same os_user value to both
-        # backends through this parameter), wrap the codex argv in
-        # `sudo -H -u <user>` so codex reads ~<user>/.codex/auth.json
-        # instead of the service user's home. The parameter name is
-        # claude-historical; rename is out of scope for this fix.
-        # No cost cap is passed: subscription auth has no per-call
-        # billing; runaway protection comes from timeout_s at the
-        # asyncio.wait_for below.
+        # Dispatch to the codex one-shot reasoner, which owns the
+        # `codex exec --json` argv (--skip-git-repo-check plus the
+        # --ephemeral / --ignore-rules sandboxing flags), CODEX_BIN
+        # resolution, per-user os_user routing via the shared
+        # sudo -H wrap, the allow-listed subprocess env, and the
+        # NDJSON event walk. join_items=True joins every completed
+        # agent_message so a preamble plus body both survive in the
+        # posted markdown; triage keeps the last-wins default for
+        # its one-JSON-object contract. Typed reasoner errors
+        # collapse to RuntimeError so the webhook handler's existing
+        # catch surface is unchanged.
         review_model = get_model_for(
             ModelRole.PR_REVIEW,
             agent_backend,
             provider,
             override=model_override,
         )
-        # Pin the absolute codex path when CODEX_BIN is set; same
-        # rationale as codex.py and triage.py - sudo cannot resolve
-        # bare `codex` when the binary lives in a per-os_user home
-        # that isn't on the service user's PATH. Falls back to bare
-        # "codex" for installs where codex is on PATH.
-        codex_bin = os.environ.get("CODEX_BIN") or "codex"
-        codex_cmd = [
-            codex_bin,
-            "exec",
-            "--json",
-            # `codex exec` refuses to spawn unless the cwd is on the
-            # user's trusted-directories list OR this flag is passed.
-            # Production review has worked only because the bot's cwd
-            # happened to be trusted; one-shot callers from any other
-            # cwd hit "Not inside a trusted directory" and rc=1. The
-            # safety check is meant for the interactive code-modifying
-            # path, not a non-interactive triage / review / eval call.
-            "--skip-git-repo-check",
-            "--model",
-            review_model,
-        ]
-
-        # Resolve self-sudo: skip the sudo wrap when claude_user
-        # matches the bot process user. Mirrors the triage codex
-        # branch's pattern.
-        effective_user = resolve_claude_user(claude_user)
-        if effective_user:
-            # -H sets HOME to <effective_user>'s pw entry so codex
-            # reads auth from the right home. --preserve-env passes
-            # KAI_WEBHOOK_SECRET through sudo's env_reset (the SETENV:
-            # sudoers rule allows this). Same shape claude uses.
-            cmd = [
-                "sudo",
-                "-H",
-                "-u",
-                effective_user,
-                "--preserve-env=KAI_WEBHOOK_SECRET",
-                "--",
-            ] + codex_cmd
-        else:
-            cmd = codex_cmd
-
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            # New session group in cross-user mode so killing sudo
-            # also kills the codex grandchild (mirrors claude branch
-            # and the triage codex branch).
-            start_new_session=bool(effective_user),
-        )
-
+        reasoner = CodexOneShotReasoner(os_user=claude_user, join_items=True)
         try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(input=prompt.encode()),
+            result = await reasoner.run(
+                prompt=prompt,
+                model=review_model,
                 timeout=timeout_s,
+                purpose="pr_review",
             )
-        except TimeoutError:
-            # Kill the subprocess tree if it exceeds the timeout. In
-            # cross-user mode (effective_user set) the process is in
-            # a new group (PGID == PID); kill the group so both sudo
-            # and the codex grandchild die, preventing orphans.
-            if effective_user:
-                try:
-                    os.killpg(proc.pid, signal.SIGKILL)
-                except ProcessLookupError:
-                    pass  # Already dead
-            else:
-                proc.kill()
-            await proc.wait()
-            raise RuntimeError(f"Review subprocess timed out after {timeout_s}s") from None
-
-        if proc.returncode != 0:
-            error = stderr.decode().strip()
-            raise RuntimeError(f"Review subprocess failed (exit {proc.returncode}): {error}")
-
-        # Codex emits NDJSON; extract the final agent message text and
-        # return it (mirrors the contract the claude / goose branches
-        # already satisfy: a single string the caller hands back to
-        # the webhook handler for posting as a PR comment).
-        return extract_codex_text(stdout.decode())
+        except OneShotTimeout as exc:
+            raise RuntimeError(f"Review subprocess timed out after {timeout_s}s") from exc
+        except OneShotError as exc:
+            raise RuntimeError(f"Codex review failed: {exc}") from exc
+        return result.text
 
     if agent_backend == "goose":
         if not provider:
@@ -849,78 +771,38 @@ async def run_review(
             raise RuntimeError(f"Goose review failed: {exc}") from exc
         return result.text
     else:
-        # Claude one-shot mode: --print reads from stdin, writes to stdout.
-        # No cost cap is passed: subscription auth has no real per-token
-        # cost. Runaway protection comes from `timeout_s` at the
-        # asyncio.wait_for call below.
-        # Model identifier comes from the per-role registry indexed
-        # by (backend, provider, role) so the codex backend (and any
-        # future backend) can override the mid-tier "sonnet" default
-        # without modifying this branch. The caller's per-user
-        # `models.pr_review` override (when set in users.yaml) wins
-        # via the `model_override` parameter; the load-time env-var
-        # seeding pass also routes deprecated PR_REVIEW_MODEL_*
-        # values through that same parameter.
+        # Claude (the default backend). Dispatch to the claude
+        # one-shot reasoner in free-form mode (json_schema=None):
+        # plain `claude --print` text output with no tools, no
+        # session persistence, a neutral cwd, the allow-listed
+        # subprocess env, and binary resolution shared with config
+        # validation. Per-user os_user routing rides the shared
+        # sudo -H wrap. The caller's per-user `models.pr_review`
+        # override (when set in users.yaml) wins via the
+        # `model_override` parameter; the load-time env-var seeding
+        # pass also routes deprecated PR_REVIEW_MODEL_* values
+        # through that same parameter. Typed reasoner errors
+        # collapse to RuntimeError so the webhook handler's existing
+        # catch surface is unchanged.
         review_model = get_model_for(
             ModelRole.PR_REVIEW,
             agent_backend,
             provider,
             override=model_override,
         )
-        cmd = [
-            "claude",
-            "--print",
-            "--model",
-            review_model,
-        ]
-
-        # Resolve self-sudo: skip sudo when claude_user matches the bot
-        # process user. Uses the resolved value for both the spawn command
-        # and the cleanup path below.
-        effective_user = resolve_claude_user(claude_user)
-
-        if effective_user:
-            # -H sets HOME to the target user's pw entry. Without it, claude
-            # reads OAuth creds from the caller's ~/.claude/.credentials.json
-            # and silently exits.
-            cmd = ["sudo", "-H", "-u", effective_user, "--"] + cmd
-
-        # When spawned via sudo, start in a new process group so the
-        # entire tree (sudo + claude) can be killed via os.killpg().
-        # Without this, killing sudo orphans the claude Node.js process.
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            start_new_session=bool(effective_user),
-        )
-
+        reasoner = ClaudeOneShotReasoner(os_user=claude_user)
         try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(input=prompt.encode()),
+            result = await reasoner.run(
+                prompt=prompt,
+                model=review_model,
                 timeout=timeout_s,
+                purpose="pr_review",
             )
-        except TimeoutError:
-            # Kill the subprocess tree if it exceeds the timeout.
-            # When effective_user is set, start_new_session=True puts the
-            # process in a new group (PGID == PID). Kill the group so
-            # both sudo and its claude child die, preventing orphans.
-            if effective_user:
-                try:
-                    os.killpg(proc.pid, signal.SIGKILL)
-                except ProcessLookupError:
-                    pass  # Already dead
-            else:
-                proc.kill()
-            await proc.wait()
-            raise RuntimeError(f"Review subprocess timed out after {timeout_s}s") from None
-
-    if proc.returncode != 0:
-        error = stderr.decode().strip()
-        raise RuntimeError(f"Review subprocess failed (exit {proc.returncode}): {error}")
-
-    return stdout.decode().strip()
+        except OneShotTimeout as exc:
+            raise RuntimeError(f"Review subprocess timed out after {timeout_s}s") from exc
+        except OneShotError as exc:
+            raise RuntimeError(f"Claude review failed: {exc}") from exc
+        return result.text
 
 
 async def post_review_comment(repo: str, pr_number: int, review: str) -> bool:

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -1,5 +1,5 @@
 """
-Issue triage agent - one-shot subprocess (Claude or Goose) for automated issue triage.
+Issue triage agent - one-shot subprocess (Claude, Codex, Goose, or OpenCode) for automated issue triage.
 
 Provides functionality to:
 1. Extract metadata from GitHub issue webhook payloads
@@ -11,33 +11,34 @@ Provides functionality to:
 7. Apply triage results: labels, project assignment, comments, notifications
 8. Orchestrate the full pipeline from webhook event to posted triage
 
-Follows the same fire-and-forget subprocess pattern established by the PR
-review agent (review.py). Each triage is a fresh LLM invocation with no
-persistent state. The subprocess runs in one-shot mode: `claude --print`
-for Claude, `goose run -i -` for Goose (non-interactive, no tools, no
-streaming).
+Follows the same fire-and-forget subprocess pattern established by the
+PR review agent (review.py). Each triage is a fresh LLM invocation with
+no persistent state. The subprocess runs in one-shot mode
+(non-interactive, no tools, no streaming) through the per-backend
+OneShotReasoner implementations in `kai.oneshot`, which own binary
+resolution, argv shape, per-user os_user routing, the allow-listed
+subprocess env, and timeout / kill semantics.
 
 Unlike the review agent (which returns free-form markdown), triage uses
-structured JSON output from Claude to drive automated actions (label
+structured JSON output from the model to drive automated actions (label
 application, project assignment). This requires parsing and validation
-of Claude's response before acting on it.
+of the model's response before acting on it.
 """
 
 import asyncio
 import json
 import logging
-import os
 import re
-import signal
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
 import aiohttp
 
-from kai.codex_exec import extract_codex_text
-from kai.config import ModelRole, get_model_for, resolve_claude_user
+from kai.config import ModelRole, get_model_for
 from kai.oneshot import (
+    ClaudeOneShotReasoner,
+    CodexOneShotReasoner,
     GooseOneShotReasoner,
     OneShotError,
     OneShotTimeout,
@@ -358,19 +359,22 @@ async def run_triage(
     """
     Spawn a one-shot LLM subprocess to perform the triage analysis.
 
-    Dispatches by agent_backend: Claude (`claude --print`) and Codex
-    (`codex exec --json`) spawn inline; Goose and OpenCode dispatch
-    through their OneShotReasoner implementations in `kai.oneshot`,
-    which own binary resolution, per-user os_user routing, and the
-    allow-listed subprocess env. All paths read the prompt and
-    return a single text string. Same pattern as run_review() in
-    review.py.
+    Dispatches by agent_backend: every backend routes through its
+    OneShotReasoner implementation in `kai.oneshot`, which owns
+    binary resolution, the argv shape, per-OS-user routing via
+    `sudo -H -u <user>`, the allow-listed subprocess env, and
+    timeout / kill semantics. All paths read the prompt, return a
+    single text string, and collapse typed reasoner errors to
+    RuntimeError. Same pattern as run_review() in review.py, with
+    one codex-side difference: triage keeps the reasoner's last-wins
+    default (`join_items=False`) because its downstream parser
+    expects exactly one JSON object, while review joins every
+    completed message for free-form markdown.
 
     Args:
         prompt: The complete triage prompt (from build_triage_prompt).
-        claude_user: Optional OS user to run the subprocess as (via
-            sudo -u for claude, sudo -H -u for codex / goose /
-            opencode).
+        claude_user: Optional OS user to run the subprocess as (the
+            reasoners apply the sudo -H -u wrap).
         agent_backend: Which LLM backend to use ("claude", "codex",
             "opencode", or "goose").
         provider: LLM provider name (e.g. "anthropic", "openai").
@@ -414,117 +418,38 @@ async def run_triage(
         return result.text
 
     if agent_backend == "codex":
-        # Codex one-shot mode: --json emits NDJSON events on stdout
-        # (thread.started, turn.started, item.*, turn.completed, error).
-        # The final agent message text is recovered by walking the
-        # events and accumulating any text content; see
-        # extract_codex_text (kai.codex_exec) is the schema-defensive parser.
-        # Per-user OAuth isolation: when claude_user is set (the
-        # webhook handler passes the same os_user value to both
-        # backends through this parameter), wrap the codex argv in
-        # `sudo -H -u <user>` so codex reads ~<user>/.codex/auth.json
-        # instead of the service user's home. The parameter name is
-        # claude-historical; rename is out of scope for this fix.
-        # No cost cap is passed: subscription auth has no per-call
-        # billing; runaway protection comes from _TRIAGE_TIMEOUT at
-        # the asyncio.wait_for below.
+        # Dispatch to the codex one-shot reasoner, which owns the
+        # `codex exec --json` argv (--skip-git-repo-check plus the
+        # --ephemeral / --ignore-rules sandboxing flags), CODEX_BIN
+        # resolution, per-user os_user routing via the shared
+        # sudo -H wrap, the allow-listed subprocess env, and the
+        # NDJSON event walk. The reasoner's last-wins default
+        # (join_items=False) is the right contract here: triage's
+        # downstream parser expects exactly one JSON object, and a
+        # preamble agent_message joined ahead of the JSON body would
+        # corrupt it (review.py passes join_items=True for its
+        # free-form markdown instead). Typed reasoner errors
+        # collapse to RuntimeError so the webhook handler's existing
+        # catch surface is unchanged.
         triage_model = get_model_for(
             ModelRole.ISSUE_TRIAGE,
             agent_backend,
             provider,
             override=model_override,
         )
-        # Pin the absolute codex path when CODEX_BIN is set; same
-        # rationale as codex.py - sudo cannot resolve bare `codex`
-        # when the binary lives in a per-os_user home that isn't on
-        # the service user's PATH. Falls back to bare "codex" for
-        # installs where codex is on PATH.
-        codex_bin = os.environ.get("CODEX_BIN") or "codex"
-        codex_cmd = [
-            codex_bin,
-            "exec",
-            "--json",
-            # `codex exec` refuses to spawn unless the cwd is on the
-            # user's trusted-directories list OR this flag is passed.
-            # Production worked at first only because the bot's cwd
-            # happened to be trusted; one-shot callers from any other
-            # cwd hit "Not inside a trusted directory" and rc=1. The
-            # safety check is meant for the interactive code-modifying
-            # path, not a non-interactive triage / review / eval call.
-            "--skip-git-repo-check",
-            "--model",
-            triage_model,
-        ]
-
-        # Resolve self-sudo: skip the sudo wrap when claude_user matches
-        # the bot process user. Mirrors the claude branch's pattern.
-        effective_user = resolve_claude_user(claude_user)
-        if effective_user:
-            # -H sets HOME to <effective_user>'s pw entry so codex
-            # reads auth from the right home. --preserve-env passes
-            # KAI_WEBHOOK_SECRET through sudo's env_reset (the SETENV:
-            # sudoers rule allows this). Same shape claude uses.
-            cmd = [
-                "sudo",
-                "-H",
-                "-u",
-                effective_user,
-                "--preserve-env=KAI_WEBHOOK_SECRET",
-                "--",
-            ] + codex_cmd
-        else:
-            cmd = codex_cmd
-
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            # New session group in cross-user mode so killing sudo
-            # also kills the codex grandchild (mirrors claude branch).
-            start_new_session=bool(effective_user),
-        )
-
+        reasoner = CodexOneShotReasoner(os_user=claude_user)
         try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(input=prompt.encode()),
+            result = await reasoner.run(
+                prompt=prompt,
+                model=triage_model,
                 timeout=_TRIAGE_TIMEOUT,
+                purpose="issue_triage",
             )
-        except TimeoutError:
-            # Kill the subprocess tree if it exceeds the timeout. In
-            # cross-user mode (effective_user set) the process is in
-            # a new group (PGID == PID); kill the group so both sudo
-            # and the codex grandchild die, preventing orphans.
-            if effective_user:
-                try:
-                    os.killpg(proc.pid, signal.SIGKILL)
-                except ProcessLookupError:
-                    pass  # Already dead
-            else:
-                proc.kill()
-            await proc.wait()
-            raise RuntimeError(f"Triage subprocess timed out after {_TRIAGE_TIMEOUT}s") from None
-
-        if proc.returncode != 0:
-            error = stderr.decode().strip()
-            raise RuntimeError(f"Triage subprocess failed (exit {proc.returncode}): {error}")
-
-        # Codex emits NDJSON; extract the final agent message text and
-        # return it (mirrors the contract the claude / goose branches
-        # already satisfy: a single string the caller hands to
-        # _parse_triage_json). extract_codex_text lives in codex_exec
-        # so review.py can share the same parser without importing
-        # from triage.py.
-        #
-        # join_items=False: triage's downstream contract is "exactly
-        # one JSON object." If codex emits a preamble agent_message
-        # followed by the JSON body as a separate agent_message,
-        # joining them would yield "preamble\n\n{json}" which
-        # _parse_triage_json's fence-stripping cannot recover from.
-        # Last-wins preserves the prior helper behavior and keeps the
-        # JSON contract intact; review.py (free-form markdown) uses
-        # the joining default instead.
-        return extract_codex_text(stdout.decode(), join_items=False)
+        except OneShotTimeout as exc:
+            raise RuntimeError(f"Triage subprocess timed out after {_TRIAGE_TIMEOUT}s") from exc
+        except OneShotError as exc:
+            raise RuntimeError(f"Codex triage failed: {exc}") from exc
+        return result.text
 
     if agent_backend == "goose":
         if not provider:
@@ -562,77 +487,39 @@ async def run_triage(
             raise RuntimeError(f"Goose triage failed: {exc}") from exc
         return result.text
     else:
-        # Claude one-shot mode: --print reads from stdin, writes to stdout.
-        # No cost cap is passed: subscription auth has no real per-token
-        # cost. Runaway protection comes from _TRIAGE_TIMEOUT at the
-        # asyncio.wait_for call below: a stuck subprocess cannot hold the
-        # executor longer than that timeout.
-        # Model identifier comes from the per-role registry indexed
-        # by (backend, provider, role). Caller's per-user
-        # `models.issue_triage` override (when set in users.yaml)
-        # wins via the `model_override` parameter; the load-time
-        # env-var seeding pass also routes deprecated
+        # Claude (the default backend). Dispatch to the claude
+        # one-shot reasoner in free-form mode (json_schema=None):
+        # plain `claude --print` text output with no tools, no
+        # session persistence, a neutral cwd, the allow-listed
+        # subprocess env, and binary resolution shared with config
+        # validation. Per-user os_user routing rides the shared
+        # sudo -H wrap. Triage's downstream parser owns the JSON
+        # contract, matching the other backends. The caller's
+        # per-user `models.issue_triage` override (when set in
+        # users.yaml) wins via the `model_override` parameter; the
+        # load-time env-var seeding pass also routes deprecated
         # ISSUE_TRIAGE_MODEL_* values through that same parameter.
+        # Typed reasoner errors collapse to RuntimeError so the
+        # webhook handler's existing catch surface is unchanged.
         triage_model = get_model_for(
             ModelRole.ISSUE_TRIAGE,
             agent_backend,
             provider,
             override=model_override,
         )
-        cmd = [
-            "claude",
-            "--print",
-            "--model",
-            triage_model,
-        ]
-
-        # Resolve self-sudo: skip sudo when claude_user matches the bot
-        # process user. Uses the resolved value for both the spawn command
-        # and the cleanup path below.
-        effective_user = resolve_claude_user(claude_user)
-
-        if effective_user:
-            # -H sets HOME to the target user's pw entry. Without it, claude
-            # reads OAuth creds from the caller's ~/.claude/.credentials.json
-            # and silently exits.
-            cmd = ["sudo", "-H", "-u", effective_user, "--"] + cmd
-
-        # When spawned via sudo, start in a new process group so the
-        # entire tree (sudo + claude) can be killed via os.killpg().
-        # Without this, killing sudo orphans the claude Node.js process.
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            start_new_session=bool(effective_user),
-        )
-
+        reasoner = ClaudeOneShotReasoner(os_user=claude_user)
         try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(input=prompt.encode()),
+            result = await reasoner.run(
+                prompt=prompt,
+                model=triage_model,
                 timeout=_TRIAGE_TIMEOUT,
+                purpose="issue_triage",
             )
-        except TimeoutError:
-            # Kill the subprocess tree if it exceeds the timeout.
-            # When effective_user is set, start_new_session=True puts the
-            # process in a new group (PGID == PID). Kill the group so
-            # both sudo and its claude child die, preventing orphans.
-            if effective_user:
-                try:
-                    os.killpg(proc.pid, signal.SIGKILL)
-                except ProcessLookupError:
-                    pass  # Already dead
-            else:
-                proc.kill()
-            await proc.wait()
-            raise RuntimeError(f"Triage subprocess timed out after {_TRIAGE_TIMEOUT}s") from None
-
-    if proc.returncode != 0:
-        error = stderr.decode().strip()
-        raise RuntimeError(f"Triage subprocess failed (exit {proc.returncode}): {error}")
-
-    return stdout.decode().strip()
+        except OneShotTimeout as exc:
+            raise RuntimeError(f"Triage subprocess timed out after {_TRIAGE_TIMEOUT}s") from exc
+        except OneShotError as exc:
+            raise RuntimeError(f"Claude triage failed: {exc}") from exc
+        return result.text
 
 
 def _parse_triage_json(raw: str) -> dict:

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -220,6 +220,22 @@ class TestClaudeOneShotReasonerArgv:
         cmd = mock_exec.call_args[0]
         assert "--json-schema" not in cmd
 
+    @pytest.mark.asyncio
+    async def test_output_format_omitted_in_free_form_mode(self, tmp_path):
+        """Free-form mode (json_schema=None) must not pass
+        --output-format json: stdout IS the response text, and the
+        review / triage callers hand it to their downstream consumers
+        without any envelope parse. Emitting the envelope here would
+        post raw JSON as a PR comment."""
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc()
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await reasoner.run(prompt="p", purpose="pr_review", json_schema=None)
+
+        cmd = mock_exec.call_args[0]
+        assert "--output-format" not in cmd
+
 
 class TestClaudeOneShotReasonerEnv:
     """The subprocess env must be allow-listed - the parent's full env
@@ -312,6 +328,25 @@ class TestClaudeOneShotReasonerSubprocessError:
         assert excinfo.value.stderr == b"oauth refused"
 
 
+class TestOneShotSubprocessErrorStr:
+    """str() must carry the exit code and a stderr snippet: review and
+    triage embed the exception in their RuntimeError messages, and the
+    dataclass-generated __init__ leaves Exception.args empty, which
+    would otherwise render a bare prefix with no failure detail."""
+
+    def test_str_includes_exit_code_and_stderr(self):
+        err = OneShotSubprocessError(returncode=2, stderr=b"  oauth refused\n")
+        assert str(err) == "exit 2: oauth refused"
+
+    def test_str_without_stderr_is_exit_code_only(self):
+        err = OneShotSubprocessError(returncode=1, stderr=b"")
+        assert str(err) == "exit 1"
+
+    def test_str_bounds_stderr_snippet(self):
+        err = OneShotSubprocessError(returncode=1, stderr=b"x" * 500)
+        assert str(err) == "exit 1: " + "x" * 200
+
+
 class TestClaudeOneShotReasonerSuccess:
     """A successful run returns a populated OneShotResult: decoded
     stdout, backend tag, model passthrough, raw_metadata with
@@ -354,6 +389,38 @@ class TestClaudeOneShotReasonerSuccess:
         # Phase 1 must keep raw_metadata free of envelope-parsed fields.
         for forbidden in ("is_error", "total_cost_usd", "subtype", "result", "structured_output"):
             assert forbidden not in result.raw_metadata
+
+    @pytest.mark.asyncio
+    async def test_free_form_text_is_stripped(self, tmp_path):
+        """Free-form mode (json_schema=None) returns the response text
+        itself, stripped of surrounding whitespace - the same
+        free-form contract the goose reasoner exposes, and what the
+        review / triage callers post or parse directly."""
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=b"  the review body  \n")
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(prompt="p", purpose="pr_review", json_schema=None)
+
+        assert result.text == "the review body"
+
+    @pytest.mark.asyncio
+    async def test_schema_mode_text_is_unstripped(self, tmp_path):
+        """Schema mode hands raw stdout back unmodified (no strip):
+        the envelope parse downstream is the caller's contract, and
+        the memory path must stay byte-identical to its pre-refactor
+        behavior."""
+        reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
+        proc = _make_proc(stdout=b'{"result": "x"}\n')
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object", "properties": {}},
+            )
+
+        assert result.text == '{"result": "x"}\n'
 
 
 class TestClaudeOneShotReasonerLogging:
@@ -1160,8 +1227,8 @@ class TestCodexOneShotReasonerSuccess:
     async def test_non_schema_success_returns_raw_text(self, tmp_path):
         """A None schema means the caller wants the free-form
         agent_message text back unchanged; no envelope wrapping
-        happens. Memory extraction never takes this branch, but the
-        protocol permits it for future callers."""
+        happens. Review and triage are the production callers of
+        this branch (memory extraction always supplies a schema)."""
         reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user=_current_user())
         stdout = _codex_event("agent_message", "free-form reply").encode("utf-8") + b"\n"
         proc = _make_proc(stdout=stdout, returncode=0)
@@ -1175,6 +1242,69 @@ class TestCodexOneShotReasonerSuccess:
 
         assert result.text == "free-form reply"
         assert result.backend == "codex"
+
+    @pytest.mark.asyncio
+    async def test_non_schema_default_keeps_last_message_only(self, tmp_path):
+        """Without join_items, the free-form path keeps the last-wins
+        extraction: triage's downstream parser expects exactly one
+        JSON object, and a preamble agent_message joined ahead of it
+        would corrupt the parse."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user=_current_user())
+        first = _codex_event("agent_message", "preamble text")
+        second = _codex_event("agent_message", '{"labels": []}')
+        proc = _make_proc(stdout=(first + "\n" + second + "\n").encode("utf-8"), returncode=0)
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(
+                prompt="p",
+                purpose="issue_triage",
+                json_schema=None,
+            )
+
+        assert result.text == '{"labels": []}'
+
+    @pytest.mark.asyncio
+    async def test_non_schema_join_items_joins_all_messages(self, tmp_path):
+        """With join_items=True, the free-form path joins every
+        completed agent_message with a blank-line separator. This is
+        the review contract: a turn that emits a preamble and then
+        the body must surface BOTH in the posted markdown; last-wins
+        would silently truncate the review to the final item."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user=_current_user(), join_items=True)
+        first = _codex_event("agent_message", "First finding: foo.py has a bug.")
+        second = _codex_event("agent_message", "Second finding: bar.py needs a docstring.")
+        proc = _make_proc(stdout=(first + "\n" + second + "\n").encode("utf-8"), returncode=0)
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(
+                prompt="p",
+                purpose="pr_review",
+                json_schema=None,
+            )
+
+        assert result.text == "First finding: foo.py has a bug.\n\nSecond finding: bar.py needs a docstring."
+
+    @pytest.mark.asyncio
+    async def test_schema_mode_ignores_join_items(self, tmp_path):
+        """Schema-backed calls pin last-wins even when the reasoner
+        was constructed with join_items=True: the JSON body must
+        never get a preamble glued ahead of it, regardless of how
+        the free-form flag is set."""
+        reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user=_current_user(), join_items=True)
+        preamble = _codex_event("agent_message", "preamble text, not JSON")
+        payload = {"facts": []}
+        final = _codex_event("agent_message", json.dumps(payload))
+        proc = _make_proc(stdout=(preamble + "\n" + final + "\n").encode("utf-8"), returncode=0)
+
+        with patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            result = await reasoner.run(
+                prompt="p",
+                purpose="fact_extraction",
+                json_schema={"type": "object"},
+            )
+
+        envelope = json.loads(result.text)
+        assert envelope == {"is_error": False, "structured_output": payload}
 
 
 class TestCodexOneShotReasonerLogging:

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,10 +1,7 @@
 """Tests for review.py PR review agent - metadata, prompts, subprocess, and output."""
 
 import json
-import os
-import pwd
 import re
-import signal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -496,295 +493,172 @@ class TestFetchPRDiff:
 # ── run_review ──────────────────────────────────────────────────────
 
 
-class TestRunReview:
+class TestRunReviewClaudeDispatch:
+    """
+    `run_review` with the default claude backend dispatches to
+    `ClaudeOneShotReasoner` (NOT an inline `claude --print` spawn).
+    The reasoner owns binary resolution, the free-form plain-text
+    argv, per-user os_user routing, and the allow-listed subprocess
+    env; this class pins the dispatch contract: ctor kwargs, registry
+    model resolution, override and timeout pass-through, raw-text
+    return, and the collapse of typed reasoner errors to
+    RuntimeError.
+    """
+
+    @staticmethod
+    def _fake_reasoner(text="review output"):
+        from kai.oneshot import OneShotResult
+
+        fake = MagicMock()
+        fake.run = AsyncMock(return_value=OneShotResult(text=text, backend="claude", model="sonnet"))
+        return fake
+
     @pytest.mark.asyncio
-    async def test_success(self):
-        """Successful Claude subprocess returns stripped review text."""
-        mock_proc = _mock_process(stdout=b"  Looks good, no issues found.  \n")
+    async def test_run_review_dispatches_to_claude_reasoner(self):
+        """The claude branch builds a ClaudeOneShotReasoner with the
+        os_user threaded through, awaits its run with the registry
+        model in free-form mode, and returns the reasoner's text."""
+        fake = self._fake_reasoner(text="review body from claude")
 
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            result = await run_review("review this code")
+        with (
+            patch("kai.review.ClaudeOneShotReasoner", return_value=fake) as ctor,
+            patch("kai.review.asyncio.create_subprocess_exec") as mock_exec,
+        ):
+            result = await run_review("review prompt", claude_user="someone")
 
-        assert result == "Looks good, no issues found."
-
-        # Verify the command structure: claude --print --model sonnet ...
-        call_args = mock_exec.call_args
-        cmd = call_args[0]
-        assert cmd[0] == "claude"
-        assert "--print" in cmd
-        assert "--model" in cmd
-        assert "sonnet" in cmd
+        assert result == "review body from claude"
+        ctor.assert_called_once()
+        assert ctor.call_args.kwargs == {"os_user": "someone"}
+        fake.run.assert_awaited_once()
+        run_kwargs = fake.run.call_args.kwargs
+        assert run_kwargs["prompt"] == "review prompt"
+        assert run_kwargs["model"] == "sonnet"
+        assert run_kwargs["purpose"] == "pr_review"
+        # Free-form mode: no json_schema kwarg reaches the reasoner,
+        # so the run stays on the plain-text path.
+        assert "json_schema" not in run_kwargs
+        mock_exec.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_model_override_param_wins_over_registry_default(self):
         """
         The `model_override` parameter (resolved by the caller in
-        webhook.py from `user_config.models[role.value]` and the
+        webhook.py from `user_config.models["pr_review"]` and the
         load-time legacy env-var seeding) wins over the registry
         default. Pins the wiring that lets per-user `models.pr_review`
-        reach dispatch without the historic env-var read at the call site.
+        reach dispatch without the historic env-var read at the call
+        site.
         """
-        mock_proc = _mock_process(stdout=b"ok")
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+        fake = self._fake_reasoner()
+
+        with patch("kai.review.ClaudeOneShotReasoner", return_value=fake):
             await run_review("prompt", model_override="opus")
-        cmd = mock_exec.call_args[0]
-        i = cmd.index("--model")
-        assert cmd[i + 1] == "opus"
+
+        assert fake.run.call_args.kwargs["model"] == "opus"
 
     @pytest.mark.asyncio
-    async def test_failure_raises(self):
-        """Non-zero exit from Claude subprocess raises RuntimeError."""
-        mock_proc = _mock_process(stderr=b"model not found", returncode=1)
+    async def test_timeout_s_passes_through_to_reasoner(self):
+        """run_review's timeout_s parameter becomes the reasoner's
+        per-call timeout (review diffs can need a larger cap than
+        the default)."""
+        fake = self._fake_reasoner()
+
+        with patch("kai.review.ClaudeOneShotReasoner", return_value=fake):
+            await run_review("prompt", timeout_s=777)
+
+        assert fake.run.call_args.kwargs["timeout"] == 777
+
+    @pytest.mark.asyncio
+    async def test_run_review_collapses_oneshot_timeout_to_runtime_error(self):
+        from kai.oneshot import OneShotTimeout
+
+        fake = MagicMock()
+        fake.run = AsyncMock(side_effect=OneShotTimeout())
 
         with (
-            patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc),
-            pytest.raises(RuntimeError, match=r"Review subprocess failed.*model not found"),
+            patch("kai.review.ClaudeOneShotReasoner", return_value=fake),
+            pytest.raises(RuntimeError, match=r"Review subprocess timed out"),
         ):
-            await run_review("review this code")
-
-    @pytest.mark.asyncio
-    async def test_timeout_raises(self):
-        """Hanging subprocess is killed and raises RuntimeError."""
-        mock_proc = AsyncMock()
-        mock_proc.pid = 12345
-        # communicate's return value doesn't matter here - wait_for is
-        # patched to raise TimeoutError before communicate is ever called.
-        mock_proc.kill = MagicMock()
-        mock_proc.wait = AsyncMock()
-
-        with (
-            patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc),
-            patch("kai.review.asyncio.wait_for", side_effect=TimeoutError()),
-            pytest.raises(RuntimeError, match="timed out"),
-        ):
-            await run_review("review this code")
-
-        # Without claude_user, kills the process directly
-        mock_proc.kill.assert_called_once()
-        mock_proc.wait.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_timeout_with_claude_user_kills_group(self):
-        """Timeout with claude_user kills the process group, not just sudo."""
-        mock_proc = AsyncMock()
-        mock_proc.pid = 12345
-        mock_proc.wait = AsyncMock()
-
-        with (
-            patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc),
-            patch("kai.review.asyncio.wait_for", side_effect=TimeoutError()),
-            patch("kai.review.os.killpg") as mock_killpg,
-            # Ensure resolve_claude_user doesn't skip sudo on this machine
-            patch("kai.config.pwd.getpwuid", return_value=MagicMock(pw_name="notkai")),
-            pytest.raises(RuntimeError, match="timed out"),
-        ):
-            await run_review("review this code", claude_user="kai")
-
-        # With claude_user, kills the entire process group
-        mock_killpg.assert_called_once_with(12345, signal.SIGKILL)
-        mock_proc.wait.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_claude_user_starts_new_session(self):
-        """claude_user spawns with start_new_session=True for group kill."""
-        mock_proc = _mock_process(stdout=b"review output")
-
-        with (
-            patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
-            patch("kai.config.pwd.getpwuid", return_value=MagicMock(pw_name="notkai")),
-        ):
-            await run_review("prompt", claude_user="kai")
-
-        kwargs = mock_exec.call_args[1]
-        assert kwargs.get("start_new_session") is True
-
-    @pytest.mark.asyncio
-    async def test_no_claude_user_no_new_session(self):
-        """Without claude_user, start_new_session is False."""
-        mock_proc = _mock_process(stdout=b"review output")
-
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
             await run_review("prompt")
 
-        kwargs = mock_exec.call_args[1]
-        assert kwargs.get("start_new_session") is False
-
     @pytest.mark.asyncio
-    async def test_with_claude_user(self):
-        """When claude_user is set, command is prefixed with sudo -H -u."""
-        mock_proc = _mock_process(stdout=b"review output")
+    async def test_run_review_collapses_oneshot_error_to_runtime_error(self):
+        from kai.oneshot import OneShotSubprocessError
+
+        fake = MagicMock()
+        fake.run = AsyncMock(side_effect=OneShotSubprocessError(returncode=1, stderr=b"model not found"))
 
         with (
-            patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
-            patch("kai.config.pwd.getpwuid", return_value=MagicMock(pw_name="notkai")),
+            patch("kai.review.ClaudeOneShotReasoner", return_value=fake),
+            # The collapsed message must keep the exit code and stderr
+            # detail; this is what reaches the Telegram failure notice.
+            pytest.raises(RuntimeError, match=r"Claude review failed: exit 1: model not found"),
         ):
-            await run_review("prompt", claude_user="kai")
-
-        cmd = mock_exec.call_args[0]
-        assert cmd[:5] == ("sudo", "-H", "-u", "kai", "--")
-        assert "claude" in cmd
-        assert "--print" in cmd
-
-    @pytest.mark.asyncio
-    async def test_without_claude_user(self):
-        """Without claude_user, command starts directly with claude."""
-        mock_proc = _mock_process(stdout=b"review output")
-
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
             await run_review("prompt")
-
-        cmd = mock_exec.call_args[0]
-        assert cmd[0] == "claude"
-        assert "sudo" not in cmd
-
-    @pytest.mark.asyncio
-    async def test_self_sudo_skipped(self):
-        """When claude_user matches bot user, review skips sudo."""
-        try:
-            current_user = pwd.getpwuid(os.getuid()).pw_name
-        except KeyError:
-            pytest.skip("UID has no passwd entry")
-        mock_proc = _mock_process(stdout=b"review output")
-
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_review("prompt", claude_user=current_user)
-
-        cmd = mock_exec.call_args[0]
-        assert cmd[0] != "sudo", "Self-sudo should be skipped"
-        assert cmd[0] == "claude"
-        kwargs = mock_exec.call_args[1]
-        assert kwargs["start_new_session"] is False
-
-    @pytest.mark.asyncio
-    async def test_self_sudo_timeout_kills_directly(self):
-        """When self-sudo is skipped, timeout kills proc directly (not killpg)."""
-        try:
-            current_user = pwd.getpwuid(os.getuid()).pw_name
-        except KeyError:
-            pytest.skip("UID has no passwd entry")
-        mock_proc = AsyncMock()
-        mock_proc.pid = 12345
-        mock_proc.wait = AsyncMock()
-
-        with (
-            patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc),
-            patch("kai.review.asyncio.wait_for", side_effect=TimeoutError()),
-            patch("kai.review.os.killpg") as mock_killpg,
-            pytest.raises(RuntimeError, match="timed out"),
-        ):
-            await run_review("prompt", claude_user=current_user)
-
-        # Should kill the process directly, not the process group
-        mock_proc.kill.assert_called_once()
-        mock_killpg.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_prompt_sent_via_stdin(self):
-        """The review prompt is sent to the subprocess via stdin, not as an argument."""
-        mock_proc = _mock_process(stdout=b"review output")
-
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
-            await run_review("the review prompt")
-
-        # communicate() should have been called with the prompt as input bytes
-        mock_proc.communicate.assert_called_once()
-        call_kwargs = mock_proc.communicate.call_args
-        # The input kwarg contains the encoded prompt
-        assert call_kwargs[1]["input"] == b"the review prompt"
 
 
 # ── run_review (Codex backend) ─────────────────────────────────────
 
 
-class TestRunReviewCodex:
+class TestRunReviewCodexDispatch:
     """
-    Tests for the codex branch of run_review.
-
-    Mirrors TestRunTriageCodex in test_triage.py: the two codex
-    branches share the same pattern (codex exec --json + sudo -H -u
-    wrap + NDJSON parse) and the same kai.codex_exec parser. Locks
-    the "no overlap" guarantee at the subprocess boundary - a codex-
-    backed review never spawns claude or goose.
+    `run_review` with `agent_backend="codex"` dispatches to
+    `CodexOneShotReasoner` (NOT an inline `codex exec` spawn). The
+    reasoner owns the `codex exec --json` argv, CODEX_BIN resolution,
+    per-user os_user routing, the allow-listed subprocess env, and
+    the NDJSON event walk; this class pins the dispatch contract:
+    ctor kwargs (including join_items=True), registry model
+    resolution, override and timeout pass-through, raw-text return,
+    and the collapse of typed reasoner errors to RuntimeError.
     """
 
     @staticmethod
-    def _codex_ndjson(text: str) -> bytes:
-        """
-        Build a minimal NDJSON stream that mirrors the real
-        `codex exec --json` schema: each event has a top-level `type`
-        tag; item.completed for an agent_message carries the full
-        consolidated `text` field. Returns bytes (the review tests'
-        _mock_process expects bytes via communicate()).
-        """
-        events = [
-            {"type": "thread.started", "thread_id": "thr_test"},
-            {"type": "turn.started"},
-            {
-                "type": "item.completed",
-                "item": {"id": "item_1", "type": "agent_message", "text": text},
-            },
-            {"type": "turn.completed", "usage": {"input_tokens": 0, "output_tokens": 0}},
-        ]
-        return ("\n".join(json.dumps(e) for e in events) + "\n").encode()
+    def _fake_reasoner(text="review output"):
+        from kai.oneshot import OneShotResult
+
+        fake = MagicMock()
+        fake.run = AsyncMock(return_value=OneShotResult(text=text, backend="codex", model="gpt-5.5"))
+        return fake
 
     @pytest.mark.asyncio
-    async def test_codex_argv_uses_codex_exec(self):
-        """
-        Argv is `codex exec --json --model <model>`, never claude or
-        goose. Locks the "no overlap" guarantee at the subprocess
-        boundary: the codex review branch never spawns claude.
-        """
-        mock_proc = _mock_process(stdout=self._codex_ndjson("review body"))
+    async def test_run_review_dispatches_to_codex_reasoner(self):
+        """The codex branch builds a CodexOneShotReasoner with the
+        os_user threaded through, awaits its run with the registry
+        model, and returns the reasoner's text."""
+        fake = self._fake_reasoner(text="review body from codex")
+
         with (
-            patch.dict(os.environ, {}, clear=False),
-            patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+            patch("kai.review.CodexOneShotReasoner", return_value=fake) as ctor,
+            patch("kai.review.asyncio.create_subprocess_exec") as mock_exec,
         ):
-            os.environ.pop("CODEX_BIN", None)
-            await run_review("prompt", agent_backend="codex")
-        cmd = mock_exec.call_args[0]
-        assert cmd[0] == "codex"
-        assert cmd[1] == "exec"
-        assert "--json" in cmd
-        # `--skip-git-repo-check` is load-bearing: codex exec refuses
-        # to spawn unless the cwd is on the user's trusted-directories
-        # list or this flag is passed. Production-only initial success
-        # was due to the bot's cwd happening to be trusted.
-        assert "--skip-git-repo-check" in cmd
-        assert "--print" not in cmd  # No claude flag
+            result = await run_review("review prompt", agent_backend="codex", claude_user="someone")
+
+        assert result == "review body from codex"
+        ctor.assert_called_once()
+        assert ctor.call_args.kwargs == {"os_user": "someone", "join_items": True}
+        fake.run.assert_awaited_once()
+        run_kwargs = fake.run.call_args.kwargs
+        assert run_kwargs["prompt"] == "review prompt"
+        assert run_kwargs["model"] == "gpt-5.5"
+        assert run_kwargs["purpose"] == "pr_review"
+        mock_exec.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_codex_argv_uses_codex_bin_env_var(self):
+    async def test_join_items_true_so_multi_message_reviews_survive(self):
         """
-        CODEX_BIN env var overrides bare "codex" in the review argv.
-        Same install-time lever the persistent backend and the codex
-        triage branch honor; needed for multi-user installs where
-        codex lives in a per-os_user home not on the service user's
-        PATH.
+        Review constructs the reasoner with join_items=True: a codex
+        turn can emit multiple agent_message items (preamble, then
+        body), and a last-wins extraction would silently truncate the
+        posted review to the final item. The joining behavior itself
+        is pinned at the reasoner layer in test_oneshot.py; this test
+        pins that review opts into it.
         """
-        mock_proc = _mock_process(stdout=self._codex_ndjson(""))
-        with (
-            patch.dict(os.environ, {"CODEX_BIN": "/Users/daniel/.npm-global/bin/codex"}),
-            patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
-        ):
-            await run_review("prompt", agent_backend="codex")
-        cmd = mock_exec.call_args[0]
-        assert cmd[0] == "/Users/daniel/.npm-global/bin/codex"
-        assert cmd[1] == "exec"
+        fake = self._fake_reasoner()
 
-    @pytest.mark.asyncio
-    async def test_codex_argv_uses_registry_model(self):
-        """
-        With agent_backend=codex and no override, the --model argv
-        slot matches the registry's (codex, openai, PR_REVIEW) row
-        (gpt-5.5, the current frontier). Locks the registry as the
-        source of truth for the codex side.
-        """
-        mock_proc = _mock_process(stdout=self._codex_ndjson(""))
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+        with patch("kai.review.CodexOneShotReasoner", return_value=fake) as ctor:
             await run_review("prompt", agent_backend="codex")
-        cmd = mock_exec.call_args[0]
-        i = cmd.index("--model")
-        assert cmd[i + 1] == "gpt-5.5"
+
+        assert ctor.call_args.kwargs["join_items"] is True
 
     @pytest.mark.asyncio
     async def test_codex_model_override_param_wins(self):
@@ -794,149 +668,49 @@ class TestRunReviewCodex:
         load-time legacy env-var seeding) wins over the registry
         default the same way it does on the claude branch.
         """
-        mock_proc = _mock_process(stdout=self._codex_ndjson(""))
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+        fake = self._fake_reasoner()
+
+        with patch("kai.review.CodexOneShotReasoner", return_value=fake):
             await run_review("prompt", agent_backend="codex", model_override="gpt-5.4")
-        cmd = mock_exec.call_args[0]
-        i = cmd.index("--model")
-        assert cmd[i + 1] == "gpt-5.4"
+
+        assert fake.run.call_args.kwargs["model"] == "gpt-5.4"
 
     @pytest.mark.asyncio
-    async def test_codex_no_sudo_when_user_unset(self):
-        """
-        With no claude_user passed, codex runs as the bot process
-        user directly: argv begins with "codex", no "sudo" wrap.
-        """
-        mock_proc = _mock_process(stdout=self._codex_ndjson(""))
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_review("prompt", agent_backend="codex")
-        cmd = mock_exec.call_args[0]
-        assert cmd[0] == "codex"
-        assert "sudo" not in cmd
+    async def test_timeout_s_passes_through_to_reasoner(self):
+        """run_review's timeout_s parameter becomes the reasoner's
+        per-call timeout on the codex branch too."""
+        fake = self._fake_reasoner()
+
+        with patch("kai.review.CodexOneShotReasoner", return_value=fake):
+            await run_review("prompt", agent_backend="codex", timeout_s=888)
+
+        assert fake.run.call_args.kwargs["timeout"] == 888
 
     @pytest.mark.asyncio
-    async def test_codex_wraps_sudo_when_user_set(self):
-        """
-        With claude_user set to a non-self user, codex argv is wrapped
-        in `sudo -H -u <user> --preserve-env=KAI_WEBHOOK_SECRET --`.
-        The per-user os_user lever is what makes a multi-user install
-        spawn codex as each user, reading their per-user
-        ~/.codex/auth.json.
+    async def test_run_review_collapses_oneshot_timeout_to_runtime_error(self):
+        from kai.oneshot import OneShotTimeout
 
-        Same fake-username trick as the triage codex tests: pass a
-        username implausible enough to never match the test runner's
-        user, so resolve_claude_user does NOT short-circuit to no-sudo.
-        """
-        mock_proc = _mock_process(stdout=self._codex_ndjson(""))
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_review("prompt", agent_backend="codex", claude_user="ci-fake-user")
-        cmd = mock_exec.call_args[0]
-        assert cmd[0] == "sudo"
-        assert "-H" in cmd
-        i = cmd.index("-u")
-        assert cmd[i + 1] == "ci-fake-user"
-        assert any(arg.startswith("--preserve-env=") and "KAI_WEBHOOK_SECRET" in arg for arg in cmd)
-        assert "codex" in cmd
-        codex_i = cmd.index("codex")
-        assert cmd[codex_i + 1] == "exec"
+        fake = MagicMock()
+        fake.run = AsyncMock(side_effect=OneShotTimeout())
 
-    @pytest.mark.asyncio
-    async def test_codex_extracts_final_text_from_ndjson(self):
-        """
-        Return value is the agent message text extracted from the
-        NDJSON event stream, not the raw stdout. The downstream
-        webhook handler posts the returned text directly as a PR
-        comment; it must not see multi-line NDJSON.
-        """
-        body = "## Review\n\nLooks good."
-        mock_proc = _mock_process(stdout=self._codex_ndjson(body))
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await run_review("prompt", agent_backend="codex")
-        assert result == body
-
-    @pytest.mark.asyncio
-    async def test_codex_multi_item_review_preserves_all_findings(self):
-        """
-        A codex review turn can emit multiple agent_message items
-        (preamble before a tool call, post-tool summary after). The
-        review path must surface ALL of them joined with a blank-line
-        separator; the prior parser dropped earlier completions and
-        only returned the last item's text, silently truncating
-        reviews. Regression guard for the multi-item truncation bug:
-        the prior parser returned only the last completed item, which
-        is the same class of failure as the persistent backend bug
-        fixed by PR #491.
-        """
-        # Build a two-item NDJSON stream by hand because the single-
-        # item _codex_ndjson helper above can't express it.
-        events = [
-            {"type": "thread.started", "thread_id": "thr_test"},
-            {"type": "turn.started"},
-            {
-                "type": "item.completed",
-                "item": {"id": "item_1", "type": "agent_message", "text": "First finding: foo.py has a bug."},
-            },
-            {
-                "type": "item.completed",
-                "item": {
-                    "id": "item_2",
-                    "type": "agent_message",
-                    "text": "Second finding: bar.py needs a docstring.",
-                },
-            },
-            {"type": "turn.completed", "usage": {"input_tokens": 0, "output_tokens": 0}},
-        ]
-        stream = ("\n".join(json.dumps(e) for e in events) + "\n").encode()
-        mock_proc = _mock_process(stdout=stream)
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await run_review("prompt", agent_backend="codex")
-        # Both findings present, blank-line separated. The prior
-        # "last wins" behavior would have returned only the second.
-        assert result == "First finding: foo.py has a bug.\n\nSecond finding: bar.py needs a docstring."
-
-    @pytest.mark.asyncio
-    async def test_codex_subprocess_failure_raises(self):
-        """Non-zero exit from codex raises RuntimeError with stderr."""
-        mock_proc = _mock_process(returncode=1, stderr=b"auth failed")
         with (
-            patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc),
-            pytest.raises(RuntimeError, match="auth failed"),
+            patch("kai.review.CodexOneShotReasoner", return_value=fake),
+            pytest.raises(RuntimeError, match=r"Review subprocess timed out"),
         ):
             await run_review("prompt", agent_backend="codex")
 
     @pytest.mark.asyncio
-    async def test_codex_timeout_kills_process_group(self):
-        """
-        On TimeoutError with claude_user set, the subprocess group is
-        killed via os.killpg(PID, SIGKILL) so both sudo and the codex
-        grandchild die. Mirror of the claude branch's process-group
-        teardown.
-        """
-        proc = AsyncMock()
-        proc.communicate = AsyncMock(side_effect=TimeoutError())
-        proc.kill = MagicMock()
-        proc.wait = AsyncMock()
-        proc.pid = 99999  # Fake PID for killpg
-        with (
-            patch("kai.review.asyncio.create_subprocess_exec", return_value=proc),
-            patch("kai.review.os.killpg") as mock_killpg,
-            pytest.raises(RuntimeError, match="timed out"),
-        ):
-            await run_review("prompt", agent_backend="codex", claude_user="ci-fake-user", timeout_s=1)
-        mock_killpg.assert_called_once_with(99999, signal.SIGKILL)
+    async def test_run_review_collapses_oneshot_error_to_runtime_error(self):
+        from kai.oneshot import OneShotSubprocessError
 
-    @pytest.mark.asyncio
-    async def test_codex_stdin_carries_prompt(self):
-        """
-        Codex one-shot mode reads the review prompt from stdin (the
-        prompt is too large for argv on real diffs). Mirrors the
-        existing claude- and goose-side stdin assertions.
-        """
-        mock_proc = _mock_process(stdout=self._codex_ndjson(""))
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc):
-            await run_review("the review prompt", agent_backend="codex")
-        mock_proc.communicate.assert_called_once()
-        assert mock_proc.communicate.call_args.kwargs["input"] == b"the review prompt"
+        fake = MagicMock()
+        fake.run = AsyncMock(side_effect=OneShotSubprocessError(returncode=1, stderr=b"auth failed"))
+
+        with (
+            patch("kai.review.CodexOneShotReasoner", return_value=fake),
+            pytest.raises(RuntimeError, match=r"Codex review failed"),
+        ):
+            await run_review("prompt", agent_backend="codex")
 
 
 # ── run_review (Goose backend) ─────────────────────────────────────
@@ -1061,15 +835,18 @@ class TestRunReviewGooseDispatch:
 
     @pytest.mark.asyncio
     async def test_default_backend_is_claude(self):
-        """Calling run_review with no backend args still uses Claude."""
-        mock_proc = _mock_process(stdout=b"review output")
+        """Calling run_review with no backend args still uses Claude
+        (dispatching to ClaudeOneShotReasoner, not goose)."""
+        from kai.oneshot import OneShotResult
 
-        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+        fake = MagicMock()
+        fake.run = AsyncMock(return_value=OneShotResult(text="ok", backend="claude", model="sonnet"))
+
+        with patch("kai.review.ClaudeOneShotReasoner", return_value=fake) as ctor:
             await run_review("prompt")
 
-        cmd = mock_exec.call_args[0]
-        assert cmd[0] == "claude"
-        assert "--print" in cmd
+        ctor.assert_called_once()
+        fake.run.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_empty_provider_raises(self):

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1,10 +1,7 @@
 """Tests for triage.py issue triage pipeline."""
 
 import json
-import os
-import pwd
 import re
-import signal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -302,34 +299,50 @@ class TestListProjects:
 # ── run_triage ──────────────────────────────────────────────────────
 
 
-class TestRunTriage:
-    @pytest.mark.asyncio
-    async def test_success(self):
-        """Successful Claude run returns stripped output."""
-        expected = '{"labels": ["bug"], "summary": "A bug."}'
-        mock_proc = _mock_subprocess(stdout=f"  {expected}  \n")
+class TestRunTriageClaudeDispatch:
+    """
+    `run_triage` with the default claude backend dispatches to
+    `ClaudeOneShotReasoner` (NOT an inline `claude --print` spawn).
+    The reasoner owns binary resolution, the free-form plain-text
+    argv, per-user os_user routing, and the allow-listed subprocess
+    env; this class pins the dispatch contract: ctor kwargs, registry
+    model resolution, override pass-through, raw-text return, and
+    the collapse of typed reasoner errors to RuntimeError.
+    """
 
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await run_triage("test prompt")
-        assert result == expected
+    @staticmethod
+    def _fake_reasoner(text='{"labels": []}'):
+        from kai.oneshot import OneShotResult
+
+        fake = MagicMock()
+        fake.run = AsyncMock(return_value=OneShotResult(text=text, backend="claude", model="sonnet"))
+        return fake
 
     @pytest.mark.asyncio
-    async def test_claude_argv_uses_registry_model(self):
-        """
-        With agent_backend=claude and no env override, the --model
-        argv slot matches the registry's (claude, ISSUE_TRIAGE) row.
-        Locks the Phase 1 byte-identical invariant at the call site:
-        Phase 1 removed the _TRIAGE_MODEL constant, so this test is
-        the place the resolved string is observable.
-        """
-        mock_proc = _mock_subprocess(returncode=0, stdout='{"labels": []}')
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage("prompt", agent_backend="claude")
-        cmd = mock_exec.call_args[0]
-        # --model is followed immediately by the model identifier in
-        # the argv vector; index +1 gives the actual model string.
-        i = cmd.index("--model")
-        assert cmd[i + 1] == "sonnet"
+    async def test_run_triage_dispatches_to_claude_reasoner(self):
+        """The claude branch builds a ClaudeOneShotReasoner with the
+        os_user threaded through, awaits its run with the registry
+        model in free-form mode, and returns the reasoner's text."""
+        fake = self._fake_reasoner(text='{"labels": ["bug"], "summary": "A bug."}')
+
+        with (
+            patch("kai.triage.ClaudeOneShotReasoner", return_value=fake) as ctor,
+            patch("kai.triage.asyncio.create_subprocess_exec") as mock_exec,
+        ):
+            result = await run_triage("triage prompt", claude_user="someone")
+
+        assert result == '{"labels": ["bug"], "summary": "A bug."}'
+        ctor.assert_called_once()
+        assert ctor.call_args.kwargs == {"os_user": "someone"}
+        fake.run.assert_awaited_once()
+        run_kwargs = fake.run.call_args.kwargs
+        assert run_kwargs["prompt"] == "triage prompt"
+        assert run_kwargs["model"] == "sonnet"
+        assert run_kwargs["purpose"] == "issue_triage"
+        # Free-form mode: no json_schema kwarg reaches the reasoner;
+        # triage's downstream parser owns the JSON contract.
+        assert "json_schema" not in run_kwargs
+        mock_exec.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_model_override_param_wins_over_registry_default(self):
@@ -341,141 +354,38 @@ class TestRunTriage:
         `models.issue_triage` reach dispatch without the historic
         ISSUE_TRIAGE_MODEL_CLAUDE env-var read at the call site.
         """
-        mock_proc = _mock_subprocess(returncode=0, stdout='{"labels": []}')
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage("prompt", agent_backend="claude", model_override="opus")
-        cmd = mock_exec.call_args[0]
-        i = cmd.index("--model")
-        assert cmd[i + 1] == "opus"
+        fake = self._fake_reasoner()
+
+        with patch("kai.triage.ClaudeOneShotReasoner", return_value=fake):
+            await run_triage("prompt", model_override="opus")
+
+        assert fake.run.call_args.kwargs["model"] == "opus"
 
     @pytest.mark.asyncio
-    async def test_timeout(self):
-        """Timed-out subprocess raises RuntimeError and kills the process."""
-        mock_proc = AsyncMock()
-        mock_proc.pid = 12345
-        mock_proc.communicate = AsyncMock(side_effect=TimeoutError)
-        mock_proc.kill = AsyncMock()
-        mock_proc.wait = AsyncMock()
+    async def test_run_triage_collapses_oneshot_timeout_to_runtime_error(self):
+        from kai.oneshot import OneShotTimeout
+
+        fake = MagicMock()
+        fake.run = AsyncMock(side_effect=OneShotTimeout())
 
         with (
-            patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc),
-            pytest.raises(RuntimeError, match="timed out"),
+            patch("kai.triage.ClaudeOneShotReasoner", return_value=fake),
+            pytest.raises(RuntimeError, match=r"Triage subprocess timed out"),
         ):
-            await run_triage("test prompt")
-        mock_proc.kill.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_timeout_with_claude_user_kills_group(self):
-        """Timeout with claude_user kills the process group."""
-        mock_proc = AsyncMock()
-        mock_proc.pid = 12345
-        mock_proc.communicate = AsyncMock(side_effect=TimeoutError)
-        mock_proc.wait = AsyncMock()
-
-        with (
-            patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc),
-            patch("kai.triage.os.killpg") as mock_killpg,
-            # Ensure resolve_claude_user doesn't skip sudo on this machine
-            patch("kai.config.pwd.getpwuid", return_value=MagicMock(pw_name="notkai")),
-            pytest.raises(RuntimeError, match="timed out"),
-        ):
-            await run_triage("test prompt", claude_user="kai")
-
-        mock_killpg.assert_called_once_with(12345, signal.SIGKILL)
-        mock_proc.wait.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_claude_user_starts_new_session(self):
-        """claude_user spawns with start_new_session=True."""
-        mock_proc = _mock_subprocess(returncode=0, stdout='{"labels": []}')
-
-        with (
-            patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
-            patch("kai.config.pwd.getpwuid", return_value=MagicMock(pw_name="notkai")),
-        ):
-            await run_triage("prompt", claude_user="kai")
-
-        kwargs = mock_exec.call_args[1]
-        assert kwargs.get("start_new_session") is True
-
-    @pytest.mark.asyncio
-    async def test_no_claude_user_no_new_session(self):
-        """Without claude_user, start_new_session is False."""
-        mock_proc = _mock_subprocess(returncode=0, stdout='{"labels": []}')
-
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
             await run_triage("prompt")
 
-        kwargs = mock_exec.call_args[1]
-        assert kwargs.get("start_new_session") is False
-
     @pytest.mark.asyncio
-    async def test_self_sudo_skipped(self):
-        """When claude_user matches bot user, triage skips sudo."""
-        try:
-            current_user = pwd.getpwuid(os.getuid()).pw_name
-        except KeyError:
-            pytest.skip("UID has no passwd entry")
-        mock_proc = _mock_subprocess(returncode=0, stdout='{"labels": [], "priority": "low", "summary": "test"}')
+    async def test_run_triage_collapses_oneshot_error_to_runtime_error(self):
+        from kai.oneshot import OneShotSubprocessError
 
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage("prompt", claude_user=current_user)
-
-        cmd = mock_exec.call_args[0]
-        assert cmd[0] != "sudo", "Self-sudo should be skipped"
-        assert cmd[0] == "claude"
-        kwargs = mock_exec.call_args[1]
-        assert kwargs["start_new_session"] is False
-
-    @pytest.mark.asyncio
-    async def test_self_sudo_timeout_kills_directly(self):
-        """When self-sudo is skipped, timeout kills proc directly (not killpg)."""
-        try:
-            current_user = pwd.getpwuid(os.getuid()).pw_name
-        except KeyError:
-            pytest.skip("UID has no passwd entry")
-        mock_proc = AsyncMock()
-        mock_proc.pid = 12345
-        mock_proc.wait = AsyncMock()
+        fake = MagicMock()
+        fake.run = AsyncMock(side_effect=OneShotSubprocessError(returncode=1, stderr=b"model error"))
 
         with (
-            patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc),
-            patch("kai.triage.asyncio.wait_for", side_effect=TimeoutError()),
-            patch("kai.triage.os.killpg") as mock_killpg,
-            pytest.raises(RuntimeError, match="timed out"),
+            patch("kai.triage.ClaudeOneShotReasoner", return_value=fake),
+            pytest.raises(RuntimeError, match=r"Claude triage failed"),
         ):
-            await run_triage("prompt", claude_user=current_user)
-
-        # Should kill the process directly, not the process group
-        mock_proc.kill.assert_called_once()
-        mock_killpg.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_nonzero_exit(self):
-        """Non-zero exit code raises RuntimeError."""
-        mock_proc = _mock_subprocess(returncode=1, stderr="model error")
-
-        with (
-            patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc),
-            pytest.raises(RuntimeError, match="exit 1"),
-        ):
-            await run_triage("test prompt")
-
-    @pytest.mark.asyncio
-    async def test_claude_user_sudo(self):
-        """When claude_user is set, command starts with sudo -H -u."""
-        mock_proc = _mock_subprocess(stdout='{"labels": []}')
-
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage("prompt", claude_user="testuser")
-
-        # First args should be sudo -H -u testuser --
-        args = mock_exec.call_args[0]
-        assert args[0] == "sudo"
-        assert args[1] == "-H"
-        assert args[2] == "-u"
-        assert args[3] == "testuser"
-        assert args[4] == "--"
+            await run_triage("prompt")
 
 
 # ── run_triage (Goose backend) ─────────────────────────────────────
@@ -588,15 +498,18 @@ class TestRunTriageGooseDispatch:
 
     @pytest.mark.asyncio
     async def test_default_backend_is_claude(self):
-        """Calling run_triage with no backend args still uses Claude."""
-        mock_proc = _mock_subprocess(stdout='{"labels": []}')
+        """Calling run_triage with no backend args still uses Claude
+        (dispatching to ClaudeOneShotReasoner, not goose)."""
+        from kai.oneshot import OneShotResult
 
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+        fake = MagicMock()
+        fake.run = AsyncMock(return_value=OneShotResult(text='{"labels": []}', backend="claude", model="sonnet"))
+
+        with patch("kai.triage.ClaudeOneShotReasoner", return_value=fake) as ctor:
             await run_triage("prompt")
 
-        cmd = mock_exec.call_args[0]
-        assert cmd[0] == "claude"
-        assert "--print" in cmd
+        ctor.assert_called_once()
+        fake.run.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_empty_provider_raises(self):
@@ -668,91 +581,65 @@ class TestRunTriageOpenCodeDispatch:
             await run_triage("prompt", agent_backend="opencode", provider="anthropic")
 
 
-class TestRunTriageCodex:
+class TestRunTriageCodexDispatch:
     """
-    Tests for the codex branch of run_triage.
-
-    The codex branch invokes `codex exec --json` and parses NDJSON
-    output via extract_codex_text. No sudo wrap; subscription auth
-    uses the service user's own ~/.codex/auth.json.
+    `run_triage` with `agent_backend="codex"` dispatches to
+    `CodexOneShotReasoner` (NOT an inline `codex exec` spawn). The
+    reasoner owns the `codex exec --json` argv, CODEX_BIN resolution,
+    per-user os_user routing, the allow-listed subprocess env, and
+    the NDJSON event walk; this class pins the dispatch contract:
+    ctor kwargs (no join_items override, so last-wins extraction
+    protects the one-JSON-object contract), registry model
+    resolution, override pass-through, raw-text return, and the
+    collapse of typed reasoner errors to RuntimeError.
     """
 
     @staticmethod
-    def _codex_ndjson(text: str) -> str:
-        """
-        Build a minimal NDJSON stream that mirrors the real
-        `codex exec --json` schema (codex-rs/exec/src/exec_events.rs):
-        each event has a top-level `type` tag; item.completed for an
-        agent_message item carries the full consolidated `text`.
-        """
-        events = [
-            {"type": "thread.started", "thread_id": "thr_test"},
-            {"type": "turn.started"},
-            {
-                "type": "item.completed",
-                "item": {"id": "item_1", "type": "agent_message", "text": text},
-            },
-            {"type": "turn.completed", "usage": {"input_tokens": 0, "output_tokens": 0}},
-        ]
-        return "\n".join(json.dumps(e) for e in events) + "\n"
+    def _fake_reasoner(text='{"labels": []}'):
+        from kai.oneshot import OneShotResult
+
+        fake = MagicMock()
+        fake.run = AsyncMock(return_value=OneShotResult(text=text, backend="codex", model="gpt-5.5"))
+        return fake
 
     @pytest.mark.asyncio
-    async def test_codex_argv_uses_codex_exec(self):
-        """
-        Argv is `codex exec --json --model <model>`, never claude or
-        goose. Locks the "no overlap" guarantee at the subprocess
-        boundary: the codex triage branch never spawns claude.
-        """
-        mock_proc = _mock_subprocess(stdout=self._codex_ndjson('{"labels": []}'))
+    async def test_run_triage_dispatches_to_codex_reasoner(self):
+        """The codex branch builds a CodexOneShotReasoner with the
+        os_user threaded through, awaits its run with the registry
+        model, and returns the reasoner's text."""
+        fake = self._fake_reasoner(text='{"labels": ["bug"], "summary": "A bug."}')
+
         with (
-            patch.dict(os.environ, {}, clear=False),
-            patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+            patch("kai.triage.CodexOneShotReasoner", return_value=fake) as ctor,
+            patch("kai.triage.asyncio.create_subprocess_exec") as mock_exec,
         ):
-            os.environ.pop("CODEX_BIN", None)
-            await run_triage("prompt", agent_backend="codex")
-        cmd = mock_exec.call_args[0]
-        assert cmd[0] == "codex"
-        assert cmd[1] == "exec"
-        assert "--json" in cmd
-        # `--skip-git-repo-check` is load-bearing: codex exec refuses
-        # to spawn unless the cwd is on the user's trusted-directories
-        # list or this flag is passed. Production-only initial success
-        # was due to the bot's cwd happening to be trusted.
-        assert "--skip-git-repo-check" in cmd
-        assert "--print" not in cmd  # No claude flag
+            result = await run_triage("triage prompt", agent_backend="codex", claude_user="someone")
+
+        assert result == '{"labels": ["bug"], "summary": "A bug."}'
+        ctor.assert_called_once()
+        assert ctor.call_args.kwargs == {"os_user": "someone"}
+        fake.run.assert_awaited_once()
+        run_kwargs = fake.run.call_args.kwargs
+        assert run_kwargs["prompt"] == "triage prompt"
+        assert run_kwargs["model"] == "gpt-5.5"
+        assert run_kwargs["purpose"] == "issue_triage"
+        mock_exec.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_codex_argv_uses_codex_bin_env_var(self):
+    async def test_join_items_not_passed_keeps_last_wins(self):
         """
-        CODEX_BIN env var overrides bare "codex" in the triage argv.
-        Same install-time lever the persistent backend honors; needed
-        for multi-user installs where codex lives in a per-os_user
-        home not on the service user's PATH.
+        Triage constructs the reasoner WITHOUT join_items, leaving
+        the last-wins default in place: the downstream parser expects
+        exactly one JSON object, and joining a preamble agent_message
+        ahead of the JSON body would corrupt it (review passes
+        join_items=True for its free-form markdown instead).
         """
-        mock_proc = _mock_subprocess(stdout=self._codex_ndjson("{}"))
-        with (
-            patch.dict(os.environ, {"CODEX_BIN": "/Users/daniel/.npm-global/bin/codex"}),
-            patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
-        ):
-            await run_triage("prompt", agent_backend="codex")
-        cmd = mock_exec.call_args[0]
-        assert cmd[0] == "/Users/daniel/.npm-global/bin/codex"
-        assert cmd[1] == "exec"
+        fake = self._fake_reasoner()
 
-    @pytest.mark.asyncio
-    async def test_codex_argv_uses_registry_model(self):
-        """
-        With agent_backend=codex and no override, the --model argv
-        slot matches the registry's (codex, openai, ISSUE_TRIAGE) row
-        (gpt-5.5, the current frontier). Locks the registry as the
-        source of truth for the codex side.
-        """
-        mock_proc = _mock_subprocess(stdout=self._codex_ndjson("{}"))
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+        with patch("kai.triage.CodexOneShotReasoner", return_value=fake) as ctor:
             await run_triage("prompt", agent_backend="codex")
-        cmd = mock_exec.call_args[0]
-        i = cmd.index("--model")
-        assert cmd[i + 1] == "gpt-5.5"
+
+        assert "join_items" not in ctor.call_args.kwargs
 
     @pytest.mark.asyncio
     async def test_codex_model_override_param_wins(self):
@@ -762,114 +649,38 @@ class TestRunTriageCodex:
         load-time legacy env-var seeding) wins over the registry
         default the same way it does on the claude branch.
         """
-        mock_proc = _mock_subprocess(stdout=self._codex_ndjson("{}"))
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+        fake = self._fake_reasoner()
+
+        with patch("kai.triage.CodexOneShotReasoner", return_value=fake):
             await run_triage("prompt", agent_backend="codex", model_override="gpt-5.4")
-        cmd = mock_exec.call_args[0]
-        i = cmd.index("--model")
-        assert cmd[i + 1] == "gpt-5.4"
+
+        assert fake.run.call_args.kwargs["model"] == "gpt-5.4"
 
     @pytest.mark.asyncio
-    async def test_codex_no_sudo_when_user_unset(self):
-        """
-        With no claude_user passed, codex runs as the bot process user
-        directly: argv begins with "codex", no "sudo" wrap.
-        """
-        mock_proc = _mock_subprocess(stdout=self._codex_ndjson("{}"))
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage("prompt", agent_backend="codex")
-        cmd = mock_exec.call_args[0]
-        assert cmd[0] == "codex"
-        assert "sudo" not in cmd
+    async def test_run_triage_collapses_oneshot_timeout_to_runtime_error(self):
+        from kai.oneshot import OneShotTimeout
 
-    @pytest.mark.asyncio
-    async def test_codex_wraps_sudo_when_user_set(self):
-        """
-        With claude_user set to a non-self user, codex argv is wrapped
-        in `sudo -H -u <user> --preserve-env=KAI_WEBHOOK_SECRET --`.
-        The per-user os_user lever is what makes a multi-user install
-        spawn codex as each user, reading their per-user ~/.codex/auth.json.
+        fake = MagicMock()
+        fake.run = AsyncMock(side_effect=OneShotTimeout())
 
-        The current process user is determined at runtime; this test
-        passes a username that cannot match the test runner's user
-        ("ci-fake-user") so resolve_claude_user does NOT short-circuit
-        to no-sudo. If the test runner happens to actually be named
-        "ci-fake-user", the test would self-sudo-skip; that name is
-        chosen to be implausible enough to avoid the collision.
-        """
-        mock_proc = _mock_subprocess(stdout=self._codex_ndjson("{}"))
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await run_triage("prompt", agent_backend="codex", claude_user="ci-fake-user")
-        cmd = mock_exec.call_args[0]
-        # Sudo wrap is present and points at the target user.
-        assert cmd[0] == "sudo"
-        assert "-H" in cmd
-        i = cmd.index("-u")
-        assert cmd[i + 1] == "ci-fake-user"
-        # KAI_WEBHOOK_SECRET preserved through sudo's env_reset.
-        assert any(arg.startswith("--preserve-env=") and "KAI_WEBHOOK_SECRET" in arg for arg in cmd)
-        # Codex binary still gets invoked after the sudo wrap.
-        assert "codex" in cmd
-        codex_i = cmd.index("codex")
-        assert cmd[codex_i + 1] == "exec"
-
-    @pytest.mark.asyncio
-    async def test_codex_extracts_final_text_from_ndjson(self):
-        """
-        Return value is the agent message text extracted from the
-        NDJSON event stream, not the raw stdout. The downstream
-        _parse_triage_json receives a single JSON object, not
-        multi-line NDJSON.
-        """
-        expected_json = '{"labels": ["bug"], "summary": "A bug."}'
-        mock_proc = _mock_subprocess(stdout=self._codex_ndjson(expected_json))
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await run_triage("prompt", agent_backend="codex")
-        # extract_codex_text strips, so the result is the expected
-        # JSON string with no leading/trailing whitespace.
-        assert result == expected_json
-
-    @pytest.mark.asyncio
-    async def test_codex_subprocess_failure_raises(self):
-        """Non-zero exit from codex raises RuntimeError with stderr."""
-        mock_proc = _mock_subprocess(returncode=1, stderr="auth failed")
         with (
-            patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc),
-            pytest.raises(RuntimeError, match="auth failed"),
+            patch("kai.triage.CodexOneShotReasoner", return_value=fake),
+            pytest.raises(RuntimeError, match=r"Triage subprocess timed out"),
         ):
             await run_triage("prompt", agent_backend="codex")
 
     @pytest.mark.asyncio
-    async def test_codex_completed_supersedes_updated(self):
-        """
-        End-to-end through run_triage: a stream that contains both
-        item.updated events (interim consolidated text) AND a final
-        item.completed returns the completed text exactly once,
-        parseable by _parse_triage_json.
+    async def test_run_triage_collapses_oneshot_error_to_runtime_error(self):
+        from kai.oneshot import OneShotSubprocessError
 
-        Without the completed-wins rule, the triage path could
-        accumulate or return stale interim text and the downstream
-        parser would fail on every codex run that streams.
-        """
-        expected_json = '{"labels": ["bug"], "summary": "ok"}'
-        events = [
-            {"type": "thread.started", "thread_id": "thr_test"},
-            {"type": "turn.started"},
-            {"type": "item.started", "item": {"id": "i1", "type": "agent_message", "text": ""}},
-            {"type": "item.updated", "item": {"id": "i1", "type": "agent_message", "text": '{"labels":'}},
-            {
-                "type": "item.updated",
-                "item": {"id": "i1", "type": "agent_message", "text": '{"labels": ["bug"], "summa'},
-            },
-            {"type": "item.completed", "item": {"id": "i1", "type": "agent_message", "text": expected_json}},
-            {"type": "turn.completed", "usage": {"input_tokens": 0, "output_tokens": 0}},
-        ]
-        stream = "\n".join(json.dumps(e) for e in events) + "\n"
-        mock_proc = _mock_subprocess(stdout=stream)
-        with patch("kai.triage.asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await run_triage("prompt", agent_backend="codex")
-        # Exactly the completed text, not interim updates concatenated.
-        assert result == expected_json
+        fake = MagicMock()
+        fake.run = AsyncMock(side_effect=OneShotSubprocessError(returncode=1, stderr=b"auth failed"))
+
+        with (
+            patch("kai.triage.CodexOneShotReasoner", return_value=fake),
+            pytest.raises(RuntimeError, match=r"Codex triage failed"),
+        ):
+            await run_triage("prompt", agent_backend="codex")
 
 
 class TestGooseTriageModelResolutionViaRegistry:


### PR DESCRIPTION
## Summary

`run_review` and `run_triage` now dispatch the claude and codex backends through their `OneShotReasoner` implementations in `kai.oneshot`, replacing the inline `claude --print` and `codex exec --json` subprocess spawns. This completes the pattern the goose and opencode branches already follow: all four backends share the same shape (registry model lookup, reasoner dispatch, typed errors collapsed to RuntimeError), and the reasoners own binary resolution, argv shape, per-user os_user routing, the allow-listed subprocess env, and timeout/kill semantics.

## Reasoner changes

- `ClaudeOneShotReasoner` gains a free-form mode: with `json_schema=None` the argv drops `--output-format json` and the result text is the stripped plain stdout, matching the goose/opencode free-form contract. The schema path used by memory extraction is unchanged byte-for-byte.
- `CodexOneShotReasoner` gains a `join_items` constructor flag for the free-form path: review passes `True` so multi-message reviews survive intact (a last-wins extraction would silently truncate the posted review to the final agent_message); triage and all schema-backed callers keep the last-wins default so a preamble never corrupts the JSON body.
- `OneShotSubprocessError` gains a `__str__` rendering `exit N: <stderr snippet>`. The dataclass-generated `__init__` leaves `Exception.args` empty, so the review/triage RuntimeError collapse previously rendered a bare prefix with no failure detail on the goose and opencode legs, and would have regressed claude/codex the same way.

## Behavior deltas on the folded legs (deliberate)

- Subprocess env is allow-listed instead of inheriting the full bot environment. The codex sudo wrap preserves the codex auth vars instead of the webhook secret; a one-shot review/triage call never calls back into the bot API.
- Claude one-shots gain `--tools ""`, `--no-session-persistence`, and the neutral extractor cwd, so reviews no longer pick up CLAUDE.md context from the bot's working directory or write per-call session dirs. Codex one-shots gain `--ephemeral`, `--ignore-rules`, and `--cd <neutral cwd>`.
- Both legs resolve their binary through `resolve_oneshot_binary`, so a bad `CLAUDE_BIN`/`CODEX_BIN` override fails loudly instead of silently falling back.
- Subprocess failures surface as `Claude/Codex review failed: exit N: <stderr>` through the shared typed-error collapse instead of the inline `Review subprocess failed (exit N)` strings.

## Tests

- The inline-subprocess test classes for the claude/codex review and triage branches were replaced with dispatch-style classes mirroring the goose/opencode ones (ctor kwargs, registry model resolution, override and timeout pass-through, raw-text return, error collapse).
- New reasoner-layer tests pin the claude free-form argv (no `--output-format`), the free-form strip vs schema-mode unstripped contract, the codex `join_items` joining/last-wins/schema-pins-last-wins matrix, and the `OneShotSubprocessError.__str__` rendering.
- Full suite: 3887 passed, 1 skipped; ruff check and format clean.
