### PR TITLE
refactor(config): rename claude_timeout_seconds to agent_timeout_seconds

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -716,7 +716,7 @@ async def _show_settings(update: Update, context: ContextTypes.DEFAULT_TYPE, cha
 
     # Timeout
     yaml_timeout = user_config.timeout if user_config else None
-    timeout, timeout_src = _resolve("timeout", yaml_timeout, config.claude_timeout_seconds, lambda v: f"{int(v)}s")
+    timeout, timeout_src = _resolve("timeout", yaml_timeout, config.agent_timeout_seconds, lambda v: f"{int(v)}s")
 
     # Provider info - always show so users know their configuration.
     # Uses the shared helper that checks the running instance first,
@@ -768,7 +768,7 @@ def _revert_instance_field(pool: SubprocessPool, chat_id: int, field: str, confi
                     fallback = config.default_model
                 instance.model = fallback
     elif field == "timeout":
-        instance.timeout_seconds = user.timeout if user and user.timeout is not None else config.claude_timeout_seconds
+        instance.timeout_seconds = user.timeout if user and user.timeout is not None else config.agent_timeout_seconds
 
 
 async def _handle_settings_reset(
@@ -1454,7 +1454,7 @@ async def _show_workspace_config(
         elif user_config and user_config.timeout is not None:
             timeout, timeout_src = user_config.timeout, "users.yaml"
         else:
-            timeout, timeout_src = config.claude_timeout_seconds, "global default"
+            timeout, timeout_src = config.agent_timeout_seconds, "global default"
         lines.append(f"  Timeout: {timeout}s ({timeout_src})")
     except (ValueError, TypeError):
         lines.append("  Timeout: (corrupted - reset with /workspace config reset timeout)")

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -968,7 +968,8 @@ class Config:
             Only required in webhook mode. Defaults to WEBHOOK_SECRET if not explicitly set.
         allowed_user_ids: Set of Telegram user IDs permitted to interact with the bot (required)
         default_model: Default model name, provider-dependent (e.g. sonnet, gpt-5.5-pro, gemini-2.5-pro)
-        claude_timeout_seconds: Seconds before a Claude response is considered timed out
+        agent_timeout_seconds: Seconds before an agent response is considered timed
+            out, on every backend
         agent_max_session_hours: Hours before an agent subprocess is recycled, on every
             backend. Prevents unbounded memory growth in long-lived agent processes (the
             original motivator: V8 growth in the claude CLI triggering macOS Jetsam kernel
@@ -1005,7 +1006,7 @@ class Config:
     # MODEL_REGISTRY[(backend, provider, role)] (lowest) in the
     # resolution chain that `resolve_user_model` implements.
     default_models: dict[str, str] = field(default_factory=dict)
-    claude_timeout_seconds: int = 120
+    agent_timeout_seconds: int = 120
     # Backend-generic pool lifecycle tunables, matching the AGENT_-
     # prefixed env vars they load from: every backend's subprocess is
     # recycled by age and evicted when idle.
@@ -2567,7 +2568,7 @@ def load_config() -> Config:
         else:
             raw_timeout = "120"
     try:
-        claude_timeout_seconds = int(raw_timeout)
+        agent_timeout_seconds = int(raw_timeout)
     except ValueError:
         raise SystemExit("AGENT_TIMEOUT_SECONDS must be an integer") from None
     # AGENT_MAX_SESSION_HOURS / AGENT_IDLE_TIMEOUT are the canonical
@@ -3057,7 +3058,7 @@ def load_config() -> Config:
         allowed_user_ids=allowed_ids,
         default_model=default_model,
         default_models=default_models,
-        claude_timeout_seconds=claude_timeout_seconds,
+        agent_timeout_seconds=agent_timeout_seconds,
         agent_max_session_hours=agent_max_session_hours,
         agent_idle_timeout=agent_idle_timeout,
         claude_autocompact_pct=claude_autocompact_pct,

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -188,7 +188,7 @@ class SubprocessPool:
                 )
                 model = self._config.default_model
 
-        timeout = user.timeout if user and user.timeout is not None else self._config.claude_timeout_seconds
+        timeout = user.timeout if user and user.timeout is not None else self._config.agent_timeout_seconds
         # home_ws is what the backend treats as "home" for the foreign-
         # workspace reminder. Same resolution as the workspace above so
         # the two cannot drift; pre-#353 this took a different path that

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -721,7 +721,7 @@ async def resolve_user_defaults(
     except (ValueError, TypeError):
         timeout = None
     if timeout is None:
-        timeout = yaml_timeout if yaml_timeout is not None else config.claude_timeout_seconds
+        timeout = yaml_timeout if yaml_timeout is not None else config.agent_timeout_seconds
 
     return {
         "model": model,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -4289,7 +4289,7 @@ class TestHandleSettings:
             await handle_settings(update, ctx)
 
         assert instance.model == config.default_model
-        assert instance.timeout_seconds == config.claude_timeout_seconds
+        assert instance.timeout_seconds == config.agent_timeout_seconds
 
 
 # ── /github command ─────────────────────────────────────────────────

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -185,7 +185,7 @@ class TestLoadConfigDefaults:
         _set_required(monkeypatch)
         config = load_config()
         assert config.default_model == "sonnet"
-        assert config.claude_timeout_seconds == 120
+        assert config.agent_timeout_seconds == 120
         assert config.agent_max_session_hours == 0
         assert config.webhook_port == 8080
         # Without TELEGRAM_WEBHOOK_URL, defaults to polling mode
@@ -976,7 +976,7 @@ class TestMinimalEnvWithUsersYaml:
         config = load_config()
         # Uses dataclass defaults when no env var is set
         assert config.default_model == "sonnet"
-        assert config.claude_timeout_seconds == 120
+        assert config.agent_timeout_seconds == 120
         assert config.workspace_base is None
         assert config.allowed_workspaces == []
         # users.yaml IDs are the authorization surface
@@ -2675,19 +2675,19 @@ class TestAgentTimeoutSecondsRename:
             CLAUDE_TIMEOUT_SECONDS="60",
         )
         cfg = load_config()
-        assert cfg.claude_timeout_seconds == 180
+        assert cfg.agent_timeout_seconds == 180
 
     def test_legacy_only_falls_back_with_warning(self, monkeypatch, caplog):
         self._required_env(monkeypatch, CLAUDE_TIMEOUT_SECONDS="240")
         with caplog.at_level(logging.WARNING, logger="kai.config"):
             cfg = load_config()
-        assert cfg.claude_timeout_seconds == 240
+        assert cfg.agent_timeout_seconds == 240
         assert any("CLAUDE_TIMEOUT_SECONDS is deprecated" in r.message for r in caplog.records)
 
     def test_neither_set_defaults_to_120(self, monkeypatch):
         self._required_env(monkeypatch)
         cfg = load_config()
-        assert cfg.claude_timeout_seconds == 120
+        assert cfg.agent_timeout_seconds == 120
 
 
 class TestAgentSessionLifecycleRename:

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -43,7 +43,7 @@ def _make_config(**overrides) -> Config:
         "telegram_bot_token": "test",
         "allowed_user_ids": {111, 222},
         "default_model": "sonnet",
-        "claude_timeout_seconds": 30,
+        "agent_timeout_seconds": 30,
         "agent_max_session_hours": 0,
         "agent_idle_timeout": 1800,
         "webhook_port": 8080,
@@ -131,7 +131,7 @@ class TestInstanceCreation:
         config = _make_config(
             user_configs={111: user},
             default_model="haiku",
-            claude_timeout_seconds=60,
+            agent_timeout_seconds=60,
         )
         pool = SubprocessPool(config=config, services_info=[])
         instance = pool.get(111)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -551,7 +551,7 @@ class TestResolveUserDefaults:
             "telegram_bot_token": "test",
             "allowed_user_ids": {111},
             "default_model": "sonnet",
-            "claude_timeout_seconds": 120,
+            "agent_timeout_seconds": 120,
         }
         defaults.update(kwargs)
         if user_configs is not None:


### PR DESCRIPTION
## Summary

Renames the `Config.claude_timeout_seconds` dataclass field to `agent_timeout_seconds`. The field governs the per-response timeout on every backend and already loads from the `AGENT_TIMEOUT_SECONDS` env var (with `CLAUDE_TIMEOUT_SECONDS` as a warned legacy alias and apply-time migration of `/etc/kai/env`); the claude_ prefix on the Python field was the last generic claude_-prefixed Config field left behind by the `agent_max_session_hours` / `agent_idle_timeout` renames.

## Scope

- Pure field rename: env keys, wizard prompts, `.env.example`, and defaults are untouched, so no install-side changes are needed and existing installs are unaffected.
- Touches the dataclass field and docstring, the `load_config` local and constructor kwarg, the four consumer sites (pool, sessions, and the two bot resolution paths), and the four test files.
- The field docstring now reads "Seconds before an agent response is considered timed out, on every backend," matching its sibling entries.
- `claude_autocompact_pct` and `claude_effort_level` keep their prefix; both are genuinely claude-specific.

## Tests

Full suite: 3887 passed, 1 skipped; ruff check and format clean.
