### PR TITLE
feat(oneshot): preserve goose endpoint-override vars across the sudo wrap

### DIFF
--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -159,9 +159,15 @@ class GooseBackend(AcpBackend):
         config files say. The five provider key vars cover env-key
         auth flows centrally; keychain-based auth (per-user
         `goose configure`) rides the HOME rewrite from `sudo -H`
-        instead and needs no preservation. KAI_WEBHOOK_SECRET and
-        TMPDIR mirror the AcpBackend default (webhook callback auth
-        and the per-os-user temp anchor).
+        instead and needs no preservation. The endpoint-override vars
+        (ANTHROPIC_HOST, OPENAI_HOST plus OPENAI_BASE_PATH,
+        OLLAMA_HOST; verified against goose's provider docs) keep a
+        custom-endpoint install routed at its proxy or gateway under
+        the wrap, mirroring the claude / codex precedent of
+        preserving each backend's base-URL override. DeepSeek and
+        google have no host vars and ride their API keys alone.
+        KAI_WEBHOOK_SECRET and TMPDIR mirror the AcpBackend default
+        (webhook callback auth and the per-os-user temp anchor).
         """
         return (
             "GOOSE_MODEL",
@@ -171,6 +177,10 @@ class GooseBackend(AcpBackend):
             "GOOGLE_API_KEY",
             "OPENROUTER_API_KEY",
             "DEEPSEEK_API_KEY",
+            "ANTHROPIC_HOST",
+            "OPENAI_HOST",
+            "OPENAI_BASE_PATH",
+            "OLLAMA_HOST",
             "KAI_WEBHOOK_SECRET",
             "TMPDIR",
         )

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -287,11 +287,22 @@ _CODEX_PRESERVED_AUTH_VARS: tuple[str, ...] = (
 # resolves automatically; what must survive `env_reset` are the per-
 # provider API keys operators commonly export when their auth flow
 # does not use the on-disk auth.json (e.g., a CI secret, a per-shell
-# `direnv` injection, or a temporary key from a vault). HOME and PATH
-# are NOT listed here for the same reason they are omitted from the
-# claude / codex lists: PATH comes through the subprocess env allow-
-# list and HOME is rewritten by `sudo -H`.
+# `direnv` injection, or a temporary key from a vault).
+# OPENCODE_CONFIG_CONTENT is the reasoner's model-selection channel
+# (set into the subprocess env at run time, the same mechanism the
+# conversational backend uses); without preservation, sudo's
+# env_reset strips the model selection itself and the wrapped
+# opencode silently falls back to the target user's config defaults.
+# No endpoint-override vars exist for opencode: custom base URLs are
+# config-file state (`provider.<id>.options.baseURL` in
+# opencode.json), which reaches the agent through the per-user
+# config under the rewritten HOME or through this same
+# OPENCODE_CONFIG_CONTENT channel. HOME and PATH are NOT listed here
+# for the same reason they are omitted from the claude / codex
+# lists: PATH comes through the subprocess env allow-list and HOME
+# is rewritten by `sudo -H`.
 _OPENCODE_PRESERVED_AUTH_VARS: tuple[str, ...] = (
+    "OPENCODE_CONFIG_CONTENT",
     "ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
     "GOOGLE_API_KEY",
@@ -300,11 +311,28 @@ _OPENCODE_PRESERVED_AUTH_VARS: tuple[str, ...] = (
 )
 # Goose authenticates per provider via env keys (or the target user's
 # keychain, which `sudo -H` reaches through the rewritten HOME), so
-# the preserve list is the same five provider keys opencode carries.
-# GOOSE_MODEL / GOOSE_PROVIDER are deliberately absent: the one-shot
-# passes model and provider as argv flags, so nothing model-related
-# rides the environment on this path.
-_GOOSE_PRESERVED_AUTH_VARS: tuple[str, ...] = _OPENCODE_PRESERVED_AUTH_VARS
+# the preserve list carries the same five provider keys opencode
+# does, plus goose's endpoint-override vars: goose reads custom
+# endpoints from the environment (ANTHROPIC_HOST, OPENAI_HOST plus
+# OPENAI_BASE_PATH, OLLAMA_HOST; verified against goose's provider
+# docs), so a custom-endpoint install loses its routing under
+# env_reset without them. DeepSeek has no host var (goose ships it
+# as a declarative provider with a fixed base_url) and google has no
+# documented host var; both ride their API keys alone. GOOSE_MODEL /
+# GOOSE_PROVIDER are deliberately absent: the one-shot passes model
+# and provider as argv flags, so nothing model-related rides the
+# environment on this path.
+_GOOSE_PRESERVED_AUTH_VARS: tuple[str, ...] = (
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "OPENROUTER_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "ANTHROPIC_HOST",
+    "OPENAI_HOST",
+    "OPENAI_BASE_PATH",
+    "OLLAMA_HOST",
+)
 
 
 def _preserved_auth_vars_for(backend: str) -> tuple[str, ...]:
@@ -1396,11 +1424,15 @@ class CodexOneShotReasoner:
 # Env vars forwarded to the opencode one-shot subprocess. Distinct from
 # the claude / codex allow-lists because opencode does not consume
 # CLAUDE_CONFIG_DIR or CODEX_HOME; it has its own auth state under
-# ~/.local/share/opencode/. The provider API keys mirror
-# `_OPENCODE_PRESERVED_AUTH_VARS` exactly because the same vars that
-# survive sudo's env_reset are the ones the in-process spawn also
-# needs (no-wrap path is the bot user; cross-user path is the target
-# user with the same per-provider key contract). PATH is required so
+# ~/.local/share/opencode/. The provider API keys mirror the key
+# entries of `_OPENCODE_PRESERVED_AUTH_VARS` because the same vars
+# that survive sudo's env_reset are the ones the in-process spawn
+# also needs (no-wrap path is the bot user; cross-user path is the
+# target user with the same per-provider key contract).
+# OPENCODE_CONFIG_CONTENT is deliberately NOT forwarded from the
+# parent env: the reasoner constructs that var itself for model
+# selection, and forwarding the daemon's own value would shadow the
+# per-call model. PATH is required so
 # opencode resolves its own bundled helpers and any subprocesses it
 # spawns. HOME is required so opencode finds `~/.local/share/opencode/
 # auth.json`; on the wrap path `sudo -H` rewrites HOME to the target
@@ -2110,13 +2142,16 @@ async def _shutdown_opencode_proc(
 # ── Goose implementation ────────────────────────────────────────────
 
 
-# Env vars forwarded to the goose one-shot subprocess. Identical in
-# content to the opencode list: PATH for binary resolution, HOME for
-# the keychain / config state goose reads per user, and the five
-# provider API keys for env-key auth flows. GOOSE_MODEL and
-# GOOSE_PROVIDER are deliberately absent: the one-shot passes model
-# and provider as argv flags (unlike the conversational GooseBackend,
-# which delivers both via env), so the env surface stays minimal.
+# Env vars forwarded to the goose one-shot subprocess: PATH for
+# binary resolution, HOME for the keychain / config state goose reads
+# per user, the five provider API keys for env-key auth flows, and
+# goose's endpoint-override vars (ANTHROPIC_HOST, OPENAI_HOST plus
+# OPENAI_BASE_PATH, OLLAMA_HOST) so a custom-endpoint install routes
+# correctly on the in-process spawn path too, not just through the
+# sudo wrap's preserve list. GOOSE_MODEL and GOOSE_PROVIDER are
+# deliberately absent: the one-shot passes model and provider as
+# argv flags (unlike the conversational GooseBackend, which delivers
+# both via env), so the env surface stays minimal.
 # KAI_WEBHOOK_SECRET is likewise absent; one-shots never serve the
 # webhook API.
 _GOOSE_ENV_ALLOWLIST = (
@@ -2127,6 +2162,10 @@ _GOOSE_ENV_ALLOWLIST = (
     "GOOGLE_API_KEY",
     "OPENROUTER_API_KEY",
     "DEEPSEEK_API_KEY",
+    "ANTHROPIC_HOST",
+    "OPENAI_HOST",
+    "OPENAI_BASE_PATH",
+    "OLLAMA_HOST",
 )
 
 

--- a/src/kai/opencode.py
+++ b/src/kai/opencode.py
@@ -304,7 +304,12 @@ class OpenCodeBackend(AcpBackend):
         the primary auth store (`~/.local/share/opencode/auth.json`,
         written by `opencode auth login` run as the target user) rides
         the HOME rewrite from `sudo -H` instead and needs no
-        preservation. KAI_WEBHOOK_SECRET and TMPDIR mirror the
+        preservation. No endpoint-override vars appear here because
+        opencode has none: custom base URLs are config-file state
+        (`provider.<id>.options.baseURL` in opencode.json), which
+        reaches the agent through the per-user config under the
+        rewritten HOME or through OPENCODE_CONFIG_CONTENT, both
+        already covered. KAI_WEBHOOK_SECRET and TMPDIR mirror the
         AcpBackend default (webhook callback auth and the per-os-user
         temp anchor).
         """

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -1261,8 +1261,10 @@ class TestPreservedEnvVars:
     provider selection via env vars (GOOSE_MODEL / GOOSE_PROVIDER in
     build_env), so the override must carry them through env_reset or
     the wrapped goose silently loses its model selection; the five
-    provider keys cover env-key auth, and KAI_WEBHOOK_SECRET / TMPDIR
-    mirror the AcpBackend default."""
+    provider keys cover env-key auth, the endpoint-override vars
+    (ANTHROPIC_HOST, OPENAI_HOST, OPENAI_BASE_PATH, OLLAMA_HOST) keep
+    a custom-endpoint install routed at its gateway under the wrap,
+    and KAI_WEBHOOK_SECRET / TMPDIR mirror the AcpBackend default."""
 
     def test_content_exact(self):
         g = _make_goose()
@@ -1274,6 +1276,10 @@ class TestPreservedEnvVars:
             "GOOGLE_API_KEY",
             "OPENROUTER_API_KEY",
             "DEEPSEEK_API_KEY",
+            "ANTHROPIC_HOST",
+            "OPENAI_HOST",
+            "OPENAI_BASE_PATH",
+            "OLLAMA_HOST",
             "KAI_WEBHOOK_SECRET",
             "TMPDIR",
         )
@@ -1301,6 +1307,7 @@ class TestPreservedEnvVars:
         assert argv[4] == (
             "--preserve-env=GOOSE_MODEL,GOOSE_PROVIDER,ANTHROPIC_API_KEY,"
             "OPENAI_API_KEY,GOOGLE_API_KEY,OPENROUTER_API_KEY,DEEPSEEK_API_KEY,"
+            "ANTHROPIC_HOST,OPENAI_HOST,OPENAI_BASE_PATH,OLLAMA_HOST,"
             "KAI_WEBHOOK_SECRET,TMPDIR"
         )
         assert argv[5] == "--"

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -20,6 +20,7 @@ import pytest
 from kai.oneshot import (
     _CODEX_ENV_ALLOWLIST,
     _GOOSE_ENV_ALLOWLIST,
+    _GOOSE_PRESERVED_AUTH_VARS,
     _OPENCODE_PRESERVED_AUTH_VARS,
     _SUBPROCESS_ENV_ALLOWLIST,
     ClaudeOneShotReasoner,
@@ -2463,9 +2464,51 @@ class TestOpenCodePreservedAuthVars:
     def test_returns_opencode_specific_list(self):
         assert _preserved_auth_vars_for("opencode") == _OPENCODE_PRESERVED_AUTH_VARS
 
+    def test_config_content_survives_the_wrap(self):
+        """OPENCODE_CONFIG_CONTENT is the reasoner's model-selection
+        channel; without it in the preserve list, sudo's env_reset
+        strips the per-call model on the cross-user path and the
+        wrapped opencode silently falls back to the target user's
+        config defaults (the conversational backend has always
+        preserved it; the one-shot must match)."""
+        assert "OPENCODE_CONFIG_CONTENT" in _OPENCODE_PRESERVED_AUTH_VARS
+
     def test_unknown_backend_still_raises(self):
         with pytest.raises(ValueError):
             _preserved_auth_vars_for("nonsense")
+
+
+class TestGoosePreservedAuthVars:
+    """`_preserved_auth_vars_for("goose")` carries the five provider
+    keys plus goose's endpoint-override vars. The goose list is no
+    longer an alias of the opencode one: opencode has no endpoint
+    env vars (custom base URLs are opencode.json config state), while
+    goose reads its custom endpoints from the environment."""
+
+    def test_returns_goose_specific_list(self):
+        assert _preserved_auth_vars_for("goose") == _GOOSE_PRESERVED_AUTH_VARS
+
+    def test_endpoint_override_vars_survive_the_wrap(self):
+        """ANTHROPIC_HOST / OPENAI_HOST / OPENAI_BASE_PATH /
+        OLLAMA_HOST are how goose points a provider at a proxy or
+        gateway; a custom-endpoint install loses its routing under
+        env_reset without them (the claude / codex lists preserve
+        their base-URL overrides the same way)."""
+        for var in ("ANTHROPIC_HOST", "OPENAI_HOST", "OPENAI_BASE_PATH", "OLLAMA_HOST"):
+            assert var in _GOOSE_PRESERVED_AUTH_VARS
+
+    def test_endpoint_override_vars_forwarded_in_process(self):
+        """The same endpoint vars ride the subprocess env allow-list
+        so the in-process (no-wrap) spawn routes correctly too; the
+        preserve list only matters cross-user."""
+        for var in ("ANTHROPIC_HOST", "OPENAI_HOST", "OPENAI_BASE_PATH", "OLLAMA_HOST"):
+            assert var in _GOOSE_ENV_ALLOWLIST
+
+    def test_opencode_config_content_not_in_goose_list(self):
+        """The alias split must not leak opencode's config-content
+        channel into the goose list; goose delivers nothing through
+        OPENCODE_CONFIG_CONTENT."""
+        assert "OPENCODE_CONFIG_CONTENT" not in _GOOSE_PRESERVED_AUTH_VARS
 
 
 class TestOpenCodeOneShotReasonerArgvAndEnv:
@@ -3294,7 +3337,8 @@ class TestGooseRouting:
         cmd = list(mock_exec.call_args[0])
         assert cmd[:4] == ["sudo", "-H", "-u", "other-user"]
         assert cmd[4] == (
-            "--preserve-env=ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,OPENROUTER_API_KEY,DEEPSEEK_API_KEY"
+            "--preserve-env=ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,OPENROUTER_API_KEY,DEEPSEEK_API_KEY,"
+            "ANTHROPIC_HOST,OPENAI_HOST,OPENAI_BASE_PATH,OLLAMA_HOST"
         )
         assert cmd[5] == "--"
         assert cmd[6] == "goose"


### PR DESCRIPTION
## Summary

Adds goose's endpoint-override env vars to the cross-user preserve lists and the one-shot env allowlist, mirroring the claude/codex precedent of preserving each backend's base-URL override. Also fixes an adjacent gap on the opencode one-shot leg where the per-call model selection was silently stripped on the cross-user path.

## Goose

Goose reads custom provider endpoints from the environment: `ANTHROPIC_HOST`, `OPENAI_HOST`, `OPENAI_BASE_PATH`, and `OLLAMA_HOST` (verified against the providers documentation in the goose repo). Previously a custom-endpoint install lost its routing in two places: sudo's `env_reset` stripped the vars on the cross-user wrap, and the one-shot env allowlist stripped them even on the in-process spawn. All three goose lists now carry the four vars:

- `_GOOSE_ENV_ALLOWLIST` (one-shot subprocess env)
- `_GOOSE_PRESERVED_AUTH_VARS` (one-shot sudo wrap)
- `GooseBackend.preserved_env_vars()` (conversational sudo wrap)

DeepSeek and google gain nothing: goose ships DeepSeek as a declarative provider with a hardcoded `base_url` (only `DEEPSEEK_API_KEY` is read), and no google host var is documented.

## OpenCode

OpenCode has no endpoint env vars at all: custom base URLs are config-file state (`provider.<id>.options.baseURL` in opencode.json), which reaches the agent through the per-user config under `sudo -H`'s HOME rewrite or through `OPENCODE_CONFIG_CONTENT`. Its lists therefore gain no endpoint entries, and the asymmetry is documented at every list site so it reads as deliberate rather than an omission. Splitting the goose preserve list from its former opencode alias was required for the divergence.

## Adjacent fix: opencode one-shot model selection

The opencode one-shot reasoner delivers its per-call model through `OPENCODE_CONFIG_CONTENT` in the subprocess env, but the one-shot preserve list never carried that var. On the cross-user wrap path, sudo's `env_reset` silently dropped the model and the wrapped opencode fell back to the target user's config defaults. The conversational backend has always preserved it; the one-shot list now matches. The env allowlist deliberately does NOT forward `OPENCODE_CONFIG_CONTENT` from the parent env, since the reasoner constructs that var itself and a forwarded daemon value would shadow the per-call model.

## Deliberately excluded

`OPENAI_ORGANIZATION`, `OPENAI_PROJECT`, and `OPENAI_CUSTOM_HEADERS` are tenancy/auth knobs rather than endpoint overrides; the codex preserve list does not carry its equivalents either.

## Tests

- Exact-content pins updated for the goose chat hook and both hardcoded `--preserve-env=` CSV assertions (chat and one-shot wrap argv).
- New `TestGoosePreservedAuthVars` covering the endpoint vars in both goose lists and the alias split; new pin that `OPENCODE_CONFIG_CONTENT` survives the opencode one-shot wrap.
- Full suite: 3892 passed, 1 skipped; ruff check and format clean.
