### PR TITLE
fix(backend): preserve auth and endpoint vars on the claude/codex chat wraps

### DIFF
--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -227,12 +227,26 @@ class ClaudeCodeBackend(AgentBackend):
             # applied to the subprocess env below survives sudo's
             # env_reset (see the TMPDIR block below for why the
             # anchoring exists).
+            #
+            # CLAUDE_CONFIG_DIR / ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL
+            # mirror the one-shot wrap's preserve list in kai.oneshot,
+            # so env-key auth and custom-endpoint routing behave the
+            # same on the chat leg as on extraction / review / triage
+            # for the same users.yaml entry; OAuth installs carry none
+            # of these vars and are unaffected.
+            #
+            # CLAUDE_AUTOCOMPACT_PCT_OVERRIDE is set into the
+            # subprocess env below when autocompact_pct > 0; without
+            # preservation, env_reset strips it and the per-user
+            # claude never sees the configured threshold.
             cmd = [
                 "sudo",
                 "-H",
                 "-u",
                 effective_claude_user,
-                "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR",
+                "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR,"
+                "CLAUDE_CONFIG_DIR,ANTHROPIC_API_KEY,ANTHROPIC_BASE_URL,"
+                "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE",
                 "--",
             ] + claude_cmd
         else:

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -361,15 +361,25 @@ class CodexBackend(AgentBackend):
         if effective_codex_user:
             # -H sets HOME to <codex_user>'s pw entry so codex reads
             # auth from ~<codex_user>/.codex/auth.json, not the bot's
-            # home. --preserve-env passes KAI_WEBHOOK_SECRET and
-            # TMPDIR through sudo's env_reset (the SETENV: sudoers
-            # rule allows this). Mirrors claude.py's sudo construction.
+            # home. --preserve-env passes the listed vars through
+            # sudo's env_reset (the SETENV: sudoers rule allows this).
+            # Mirrors claude.py's sudo construction.
+            #
+            # CODEX_HOME / OPENAI_API_KEY / OPENAI_BASE_URL mirror the
+            # one-shot wrap's preserve list in kai.oneshot, so env-key
+            # auth and custom-endpoint routing behave the same on the
+            # chat leg as on extraction / review / triage for the same
+            # users.yaml entry; subscription-OAuth installs carry none
+            # of these vars and are unaffected. CODEX_MODEL /
+            # CODEX_PROVIDER are deliberately NOT preserved: the
+            # authoritative model selection rides the per-turn
+            # protocol params, so the env mirrors are informational.
             argv: list[str] = [
                 "sudo",
                 "-H",
                 "-u",
                 effective_codex_user,
-                "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR",
+                "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR,CODEX_HOME,OPENAI_API_KEY,OPENAI_BASE_URL",
                 "--",
             ] + codex_argv
         else:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -154,7 +154,10 @@ class TestCommandConstruction:
             assert cmd[1] == "-H"
             assert cmd[2] == "-u"
             assert cmd[3] == "daniel"
-            assert cmd[4] == "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR"
+            assert (
+                cmd[4]
+                == "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR,CLAUDE_CONFIG_DIR,ANTHROPIC_API_KEY,ANTHROPIC_BASE_URL,CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"
+            )
             assert cmd[5] == "--"
             assert cmd[6] == "claude"
 
@@ -229,7 +232,10 @@ class TestCommandConstruction:
             assert cmd[1] == "-H"
             assert cmd[2] == "-u"
             assert cmd[3] == "some_other_user"
-            assert cmd[4] == "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR"
+            assert (
+                cmd[4]
+                == "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR,CLAUDE_CONFIG_DIR,ANTHROPIC_API_KEY,ANTHROPIC_BASE_URL,CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"
+            )
             assert cmd[5] == "--"
             assert args[1].get("start_new_session") is True
 
@@ -277,7 +283,10 @@ class TestCommandConstruction:
             await claude._ensure_started()
 
             cmd = mock_exec.call_args[0]
-            assert "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR" in cmd
+            assert (
+                "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR,CLAUDE_CONFIG_DIR,ANTHROPIC_API_KEY,ANTHROPIC_BASE_URL,CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"
+                in cmd
+            )
             # Secret is also in the env dict (unchanged behavior).
             env = mock_exec.call_args[1]["env"]
             assert env["KAI_WEBHOOK_SECRET"] == "s3cret"
@@ -326,7 +335,10 @@ class TestCommandConstruction:
             cmd = mock_exec.call_args[0]
             env = mock_exec.call_args[1]["env"]
             assert env["TMPDIR"] == str(DATA_DIR / "tmp" / "some_other_user")
-            assert "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR" in cmd
+            assert (
+                "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR,CLAUDE_CONFIG_DIR,ANTHROPIC_API_KEY,ANTHROPIC_BASE_URL,CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"
+                in cmd
+            )
 
     @pytest.mark.asyncio
     async def test_tmpdir_not_injected_in_single_user_mode(self, monkeypatch):

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1572,7 +1572,7 @@ class TestCodexUserSudoWrap:
     Verify the per-user OAuth isolation lever.
 
     When codex_user is set to a non-self user, the subprocess argv is
-    wrapped in `sudo -H -u <user> --preserve-env=KAI_WEBHOOK_SECRET,TMPDIR --`
+    wrapped in `sudo -H -u <user> --preserve-env=<csv> --`
     so codex runs as <codex_user> and reads
     ~<codex_user>/.codex/auth.json. This is what makes a multi-user
     install (e.g., users.yaml has os_user=daniel for one chat and
@@ -1608,10 +1608,12 @@ class TestCodexUserSudoWrap:
         assert "-H" in argv
         i = argv.index("-u")
         assert argv[i + 1] == "ci-fake-user"
-        # KAI_WEBHOOK_SECRET and TMPDIR preserved through sudo's env_reset.
-        assert any(
-            arg.startswith("--preserve-env=") and "KAI_WEBHOOK_SECRET" in arg and "TMPDIR" in arg for arg in argv
-        )
+        # Exact preserve CSV: the webhook secret and TMPDIR anchor,
+        # plus the auth / endpoint vars mirroring the one-shot wrap
+        # (CODEX_HOME, OPENAI_API_KEY, OPENAI_BASE_URL) so env-key
+        # auth and custom-endpoint routing behave the same on the
+        # chat leg as on extraction / review / triage.
+        assert "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR,CODEX_HOME,OPENAI_API_KEY,OPENAI_BASE_URL" in argv
         # Codex binary follows the sudo prologue.
         codex_i = argv.index("codex")
         assert argv[codex_i + 1] == "app-server"


### PR DESCRIPTION
## Summary

The conversational claude and codex sudo wraps preserved only `KAI_WEBHOOK_SECRET` and `TMPDIR` through sudo's `env_reset`, while their one-shot wraps (memory extraction, review, triage) preserve each backend's auth and endpoint-override vars. This PR aligns the chat wraps with the one-shot preserve lists, so every cross-user wrap in the codebase now preserves the same per-backend var set.

## What was broken

- **`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` was silently stripped on cross-user claude chat.** Kai sets this var into the chat subprocess env whenever `autocompact_pct` is configured, but `env_reset` dropped it before the per-user claude could read it, so multi-user installs ran without their configured autocompact threshold. Model selection was unaffected (it rides argv).
- **Env-key auth and custom endpoints worked on the one-shot legs but not on chat for the same users.yaml entry.** `ANTHROPIC_API_KEY`/`ANTHROPIC_BASE_URL` (claude) and `CODEX_HOME`/`OPENAI_API_KEY`/`OPENAI_BASE_URL` (codex) survive the one-shot wraps but were stripped on chat, so a cross-user install using env-key auth or a custom endpoint would extract and review correctly while chat silently hit the default endpoint or failed auth.

## Change

- Claude chat wrap now preserves `KAI_WEBHOOK_SECRET, TMPDIR, CLAUDE_CONFIG_DIR, ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL, CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`.
- Codex chat wrap now preserves `KAI_WEBHOOK_SECRET, TMPDIR, CODEX_HOME, OPENAI_API_KEY, OPENAI_BASE_URL`.
- `CODEX_MODEL` and `CODEX_PROVIDER` stay unpreserved deliberately: the authoritative model selection rides the per-turn protocol params, so the env mirrors are informational. The comment at the wrap site documents this.
- OAuth installs carry none of the auth vars and are unaffected. The `SETENV:` sudoers tag already authorizes the passthrough; no install-side changes.

## Tests

- The four exact `--preserve-env=` CSV pins in the claude chat tests updated to the new list.
- The codex wrap test's substring check replaced with an exact-CSV pin matching the claude test style.
- Full suite: 3887 passed, 1 skipped; ruff check and format clean.
