### PR TITLE
feat(install): collect provider API keys for per-user goose entries

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -111,13 +111,18 @@ BACKENDS_NEEDING_PROVIDER_PROMPT: frozenset[str] = frozenset(b for b, ps in BACK
 
 # Maps LLM provider to its API key environment variable name.
 # Backend-agnostic - the API key for Anthropic is the same env var
-# regardless of which backend is using it.
+# regardless of which backend is using it. DEEPSEEK_API_KEY is the
+# var goose's declarative DeepSeek provider names as its api_key_env
+# (and the one the per-backend env allowlists / preserve lists
+# already forward), so deepseek-on-goose key collection routes
+# through the same map as every other provider.
 # Ollama is absent because it requires no API key (local inference).
 PROVIDER_KEY_VARS: dict[str, str] = {
     "anthropic": "ANTHROPIC_API_KEY",
     "openai": "OPENAI_API_KEY",
     "google": "GOOGLE_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
 }
 
 # ── Provider-aware model registry ──────────────────────────────────────

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -494,6 +494,58 @@ def _read_users_yaml_text(path: Path) -> str | None:
     return result.stdout
 
 
+def _users_yaml_goose_providers(users_yaml_path: Path, global_provider: str) -> list[str]:
+    """
+    Collect the distinct providers per-user goose entries need API
+    keys for.
+
+    Reads the canonical users.yaml via `_read_users_yaml_text` (sudo-
+    tolerant on protected installs) and returns the sorted set of
+    `llm_provider` values across entries whose `agent_backend` is
+    "goose", falling back to `global_provider` for entries that omit
+    the field - the same cascade the runtime applies. Goose is the
+    only backend whose per-user auth rides the daemon environment:
+    claude, codex, and opencode authenticate via per-OS-user on-disk
+    state managed outside the wizard, so entries on those backends
+    contribute nothing here.
+
+    A missing, unreadable, or malformed users.yaml degrades to an
+    empty list: the wizard then behaves as it does without per-user
+    goose entries, and the runtime's own users.yaml validation
+    surfaces any real misconfiguration at startup.
+
+    Deliberately NOT built on `_collect_backends_from_yaml`: that
+    sibling serves `_apply_sudoers` (apply side), reads the file
+    directly as root, raises on malformed YAML so the install fails
+    loudly, and returns backends without the provider pairing this
+    prompt needs. The wizard side runs as the operator account
+    (hence the sudo-tolerant reader) and must degrade rather than
+    crash mid-flow.
+    """
+    raw = _read_users_yaml_text(users_yaml_path)
+    if raw is None:
+        return []
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError:
+        return []
+    if not isinstance(data, dict):
+        return []
+    users = data.get("users")
+    if not isinstance(users, list):
+        return []
+    providers: set[str] = set()
+    for entry in users:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("agent_backend") != "goose":
+            continue
+        provider = entry.get("llm_provider") or global_provider
+        if isinstance(provider, str) and provider:
+            providers.add(provider)
+    return sorted(providers)
+
+
 # ── Config subcommand ────────────────────────────────────────────────
 
 
@@ -977,6 +1029,39 @@ def _cmd_config() -> None:
                 # goose path.
                 print(f"  {llm_provider} does not require an API key.")
     print()
+
+    # Per-user goose entries authenticate from the daemon environment
+    # (their provider keys are forwarded through the per-backend env
+    # allowlists and sudo preserve lists), and the wizard is the only
+    # owner of that environment. This is why goose key collection is
+    # per-user-aware while codex / opencode per-user overrides stay
+    # out-of-band: those backends authenticate via per-OS-user files
+    # (codex login, opencode auth login) the wizard does not manage,
+    # but a goose entry has no equivalent the operator could use -
+    # keys added to the env file by hand are wiped on regeneration.
+    # Scan users.yaml for goose entries and prompt for any provider
+    # key the global block above did not already collect; defaults
+    # come from the existing env so a re-run keeps stored values.
+    extra_provider_keys: dict[str, str] = {}
+    for peruser_provider in _users_yaml_goose_providers(
+        users_yaml_path,
+        llm_provider or existing_env.get("LLM_PROVIDER", ""),
+    ):
+        peruser_key_var = PROVIDER_KEY_VARS.get(peruser_provider, "")
+        if not peruser_key_var:
+            # Ollama and any other auth-less provider.
+            continue
+        if peruser_key_var == llm_api_key_var and llm_api_key:
+            # The global block already collected this exact var.
+            continue
+        print(f"  users.yaml has a goose entry on {peruser_provider}; the daemon env needs {peruser_key_var}.")
+        extra_provider_keys[peruser_key_var] = _prompt(
+            peruser_key_var,
+            existing_env.get(peruser_key_var, ""),
+            required=True,
+        )
+    if extra_provider_keys:
+        print()
 
     # -- Agent --
     # DEFAULT_MODEL and AGENT_TIMEOUT_SECONDS are
@@ -1602,6 +1687,30 @@ def _cmd_config() -> None:
             env["CODEX_AUTH_MODE"] = codex_auth_mode
         if codex_api_key:
             env["OPENAI_API_KEY"] = codex_api_key
+
+    # Keys collected for per-user goose entries. Required prompts, so
+    # values are non-empty whenever the scan found a keyed provider.
+    for peruser_key_var, peruser_key_value in sorted(extra_provider_keys.items()):
+        if peruser_key_value:
+            env[peruser_key_var] = peruser_key_value
+
+    # Provider keys already stored in the env survive regeneration
+    # even when this run's prompts did not fire, so a key collected
+    # once is never silently dropped by an unrelated re-run (the env
+    # dict is built fresh above; without this pass, only keys a
+    # prompt produced this session would be emitted). The one
+    # exception is OPENAI_API_KEY on a codex install: the codex auth
+    # block owns that var's lifecycle (api_key mode collects it,
+    # subscription mode deliberately sheds it), and preservation must
+    # not resurrect a key the operator just chose to retire.
+    for provider_key_var in sorted(set(PROVIDER_KEY_VARS.values())):
+        if provider_key_var in env:
+            continue
+        if agent_backend == "codex" and provider_key_var == "OPENAI_API_KEY":
+            continue
+        existing_key_value = existing_env.get(provider_key_var, "")
+        if existing_key_value:
+            env[provider_key_var] = existing_key_value
 
     # Persist the wizard-collected codex binary path whenever any
     # codex surface (agent backend or memory reasoner) is in play.

--- a/templates/.env
+++ b/templates/.env
@@ -25,7 +25,9 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 # Provider API key. Set the one matching your LLM_PROVIDER.
 # Ollama does not require an API key (local inference).
 # These are backend env vars, not Kai config fields - Kai
-# passes them through to the subprocess environment.
+# passes them through to the subprocess environment. The wizard
+# prompts for the keys goose needs (global backend or per-user
+# entries in users.yaml) and preserves stored keys across re-runs.
 #ANTHROPIC_API_KEY=sk-ant-...
 #OPENAI_API_KEY=sk-...
 #GOOGLE_API_KEY=...

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -50,6 +50,7 @@ from kai.install import (
     _start_service,
     _stop_service,
     _user_home,
+    _users_yaml_goose_providers,
     _validate_chat_id,
     _validate_display_name,
     _validate_os_user,
@@ -8758,3 +8759,210 @@ class TestBuildCodexLoginReminder:
 
         users_yaml = self._write_users_yaml(tmp_path, [])
         assert _build_codex_login_reminder({}, "kai", users_yaml_path=users_yaml) is None
+
+
+# ── Per-user goose provider keys ─────────────────────────────────────
+
+
+class TestUsersYamlGooseProviders:
+    """Direct tests for the wizard's per-user goose provider scan.
+
+    The helper reads the canonical users.yaml and returns the distinct
+    providers goose entries need API keys for; everything that is not
+    a well-formed goose entry degrades to an empty result so the
+    wizard never crashes mid-flow on user-owned YAML."""
+
+    @staticmethod
+    def _write(tmp_path, content: str) -> Path:
+        p = tmp_path / "users.yaml"
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_goose_entry_with_explicit_provider(self, tmp_path):
+        p = self._write(
+            tmp_path,
+            "users:\n  - telegram_id: 1\n    name: a\n    agent_backend: goose\n    llm_provider: deepseek\n",
+        )
+        assert _users_yaml_goose_providers(p, "") == ["deepseek"]
+
+    def test_falls_back_to_global_provider(self, tmp_path):
+        """An entry that omits llm_provider inherits the global
+        provider, mirroring the runtime cascade."""
+        p = self._write(tmp_path, "users:\n  - telegram_id: 1\n    name: a\n    agent_backend: goose\n")
+        assert _users_yaml_goose_providers(p, "deepseek") == ["deepseek"]
+
+    def test_no_global_fallback_yields_nothing(self, tmp_path):
+        """No llm_provider anywhere: the scan returns nothing and the
+        runtime's users.yaml validation owns the error."""
+        p = self._write(tmp_path, "users:\n  - telegram_id: 1\n    name: a\n    agent_backend: goose\n")
+        assert _users_yaml_goose_providers(p, "") == []
+
+    def test_distinct_providers_deduplicated_and_sorted(self, tmp_path):
+        p = self._write(
+            tmp_path,
+            "users:\n"
+            "  - telegram_id: 1\n    name: a\n    agent_backend: goose\n    llm_provider: openai\n"
+            "  - telegram_id: 2\n    name: b\n    agent_backend: goose\n    llm_provider: deepseek\n"
+            "  - telegram_id: 3\n    name: c\n    agent_backend: goose\n    llm_provider: deepseek\n",
+        )
+        assert _users_yaml_goose_providers(p, "") == ["deepseek", "openai"]
+
+    def test_non_goose_entries_contribute_nothing(self, tmp_path):
+        """claude / codex / opencode per-user auth is per-OS-user state
+        the wizard does not manage; only goose rides the daemon env."""
+        p = self._write(
+            tmp_path,
+            "users:\n"
+            "  - telegram_id: 1\n    name: a\n    agent_backend: opencode\n    llm_provider: deepseek\n"
+            "  - telegram_id: 2\n    name: b\n    agent_backend: codex\n"
+            "  - telegram_id: 3\n    name: c\n",
+        )
+        assert _users_yaml_goose_providers(p, "deepseek") == []
+
+    def test_missing_file_degrades_to_empty(self, tmp_path):
+        assert _users_yaml_goose_providers(tmp_path / "absent.yaml", "deepseek") == []
+
+    def test_malformed_yaml_degrades_to_empty(self, tmp_path):
+        p = self._write(tmp_path, "users: [unclosed\n")
+        assert _users_yaml_goose_providers(p, "deepseek") == []
+
+    def test_non_dict_entries_skipped(self, tmp_path):
+        p = self._write(tmp_path, "users:\n  - 42\n  - goose\n")
+        assert _users_yaml_goose_providers(p, "deepseek") == []
+
+
+class TestWizardPerUserGooseProviderKeys:
+    """Wizard collection of provider API keys for per-user goose
+    entries, the deepseek PROVIDER_KEY_VARS row, and the provider-key
+    preservation pass on env regeneration."""
+
+    PLAIN_USERS_YAML = "users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n"
+    GOOSE_DEEPSEEK_USERS_YAML = (
+        "users:\n"
+        "  - telegram_id: 1\n"
+        "    name: alice\n"
+        "    role: admin\n"
+        "  - telegram_id: 2\n"
+        "    name: bob\n"
+        "    agent_backend: goose\n"
+        "    llm_provider: deepseek\n"
+    )
+
+    @staticmethod
+    def _setup(monkeypatch, tmp_path, users_yaml: str, existing_env: dict | None = None) -> None:
+        """Wizard sandbox: users.yaml exists with the given content,
+        install.conf optionally seeded, model prompt mocked."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        TestCmdConfig._simulate_existing_etc_users_yaml(monkeypatch, users_yaml)
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            lambda backend, prov, default: "sonnet",
+        )
+        if existing_env is not None:
+            (tmp_path / "install.conf").write_text(json.dumps({"env": existing_env, "version": 1}))
+
+    @staticmethod
+    def _run(monkeypatch, tmp_path, inputs: list[str]) -> dict:
+        feed = iter(inputs)
+        monkeypatch.setattr("builtins.input", lambda prompt: next(feed))
+        _cmd_config()
+        return json.loads((tmp_path / "install.conf").read_text())["env"]
+
+    def test_deepseek_has_a_provider_key_var(self):
+        """The map row the whole goose-on-deepseek flow keys on: the
+        wizard prompt, the env emission, and refresh_models all
+        resolve the var through PROVIDER_KEY_VARS."""
+        from kai.config import PROVIDER_KEY_VARS
+
+        assert PROVIDER_KEY_VARS["deepseek"] == "DEEPSEEK_API_KEY"
+
+    def test_peruser_goose_entry_prompts_for_key(self, tmp_path, monkeypatch, capsys):
+        """Global claude install with a per-user goose+deepseek entry:
+        the wizard prompts for DEEPSEEK_API_KEY (inserted right after
+        the backend slot in the input chain) and emits it to env."""
+        self._setup(monkeypatch, tmp_path, self.GOOSE_DEEPSEEK_USERS_YAML)
+        inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
+        i = inputs.index("claude")
+        inputs = inputs[: i + 1] + ["sk-ds-peruser"] + inputs[i + 1 :]
+
+        env = self._run(monkeypatch, tmp_path, inputs)
+
+        assert env["DEEPSEEK_API_KEY"] == "sk-ds-peruser"
+        out = capsys.readouterr().out
+        assert "goose entry on deepseek" in out
+        assert "DEEPSEEK_API_KEY" in out
+
+    def test_no_goose_entries_means_no_prompt(self, tmp_path, monkeypatch):
+        """Plain users.yaml: the unmodified claude input chain must be
+        consumed exactly (an unexpected key prompt would raise
+        StopIteration), and no key lands in env."""
+        self._setup(monkeypatch, tmp_path, self.PLAIN_USERS_YAML)
+
+        env = self._run(monkeypatch, tmp_path, TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend())
+
+        assert "DEEPSEEK_API_KEY" not in env
+
+    def test_global_goose_deepseek_prompts_for_key(self, tmp_path, monkeypatch, capsys):
+        """Global goose+deepseek: the key prompt fires through the
+        global block now that deepseek has a PROVIDER_KEY_VARS row;
+        the auth-less fallback message must not appear."""
+        self._setup(monkeypatch, tmp_path, self.PLAIN_USERS_YAML)
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
+        inputs = list(TestCmdConfigDefaultModelDispatch._inputs_for_goose_openai())
+        inputs[inputs.index("openai")] = "deepseek"
+        inputs[inputs.index("openai-key")] = "sk-ds-global"
+
+        env = self._run(monkeypatch, tmp_path, inputs)
+
+        assert env["LLM_PROVIDER"] == "deepseek"
+        assert env["DEEPSEEK_API_KEY"] == "sk-ds-global"
+        assert "does not require an API key" not in capsys.readouterr().out
+
+    def test_peruser_key_already_collected_globally_not_reprompted(self, tmp_path, monkeypatch):
+        """Global goose+deepseek AND a per-user goose+deepseek entry:
+        the global block collects DEEPSEEK_API_KEY, so the per-user
+        scan must not prompt again (the unmodified goose chain is
+        consumed exactly)."""
+        self._setup(monkeypatch, tmp_path, self.GOOSE_DEEPSEEK_USERS_YAML)
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
+        inputs = list(TestCmdConfigDefaultModelDispatch._inputs_for_goose_openai())
+        inputs[inputs.index("openai")] = "deepseek"
+        inputs[inputs.index("openai-key")] = "sk-ds-once"
+
+        env = self._run(monkeypatch, tmp_path, inputs)
+
+        assert env["DEEPSEEK_API_KEY"] == "sk-ds-once"
+
+    def test_stored_key_survives_unrelated_regeneration(self, tmp_path, monkeypatch):
+        """A provider key already in the env survives a wizard re-run
+        whose prompts never fire (the env dict is rebuilt fresh, so
+        without the preservation pass the key would silently vanish)."""
+        self._setup(
+            monkeypatch,
+            tmp_path,
+            self.PLAIN_USERS_YAML,
+            existing_env={"TELEGRAM_BOT_TOKEN": "fake-token", "DEEPSEEK_API_KEY": "sk-stored"},
+        )
+
+        env = self._run(monkeypatch, tmp_path, TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend())
+
+        assert env["DEEPSEEK_API_KEY"] == "sk-stored"
+
+    def test_codex_subscription_does_not_resurrect_openai_key(self, tmp_path, monkeypatch):
+        """The preservation pass defers to the codex auth flow's
+        ownership of OPENAI_API_KEY: switching a codex install to
+        subscription mode sheds the stored key, and preservation must
+        not carry it back in."""
+        self._setup(
+            monkeypatch,
+            tmp_path,
+            self.PLAIN_USERS_YAML,
+            existing_env={"TELEGRAM_BOT_TOKEN": "fake-token", "OPENAI_API_KEY": "sk-old"},
+        )
+        monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
+
+        env = self._run(monkeypatch, tmp_path, TestCmdConfigDefaultModelDispatch._inputs_for_codex_subscription())
+
+        assert "OPENAI_API_KEY" not in env


### PR DESCRIPTION
## Summary

Closes #635.

Goose authenticates env-key providers from the daemon environment, and the runtime already forwards every provider key through the per-backend env allowlists and the sudo preserve lists; but the wizard could not collect those keys outside the global-goose path. This PR closes the three gaps from the issue.

## Changes

**`PROVIDER_KEY_VARS` gains a `deepseek` row.** `DEEPSEEK_API_KEY` is the var goose's declarative DeepSeek provider names as its `api_key_env`. A global goose+deepseek install now prompts for the key instead of falling into the auth-less branch and printing "deepseek does not require an API key". The map's other consumer (`refresh_models`) skips cleanly on an unset key, so the addition is safe there and only improves its coverage.

**Per-user-aware key collection.** After the global backend/provider prompts, the wizard scans the canonical users.yaml (via the existing sudo-tolerant reader) for entries with `agent_backend: goose` and prompts for any provider key the global block did not already collect. The entry's `llm_provider` falls back to the global provider, mirroring the runtime cascade. The new scan helper is deliberately not built on `_collect_backends_from_yaml`: that sibling serves the apply side (direct root read, raises on malformed YAML, returns backends without provider pairing), while the wizard side runs as the operator and must degrade rather than crash, so a missing, unreadable, or malformed users.yaml yields an empty scan and today's behavior.

Goose is per-user-aware where codex/opencode per-user overrides deliberately stay out-of-band: those backends authenticate via per-OS-user files (`codex login`, `opencode auth login`) the wizard does not manage, but goose env-key auth rides the daemon environment, which only the wizard owns; keys added to the env file by hand are wiped on regeneration.

**Provider keys survive regeneration.** The env dict is built fresh on each wizard run, so previously only keys a prompt produced that session were emitted. Stored `PROVIDER_KEY_VARS` values now carry forward. One exception: `OPENAI_API_KEY` on a codex install stays owned by the codex auth flow, where subscription mode deliberately sheds the key; preservation must not resurrect a key the operator just chose to retire.

**Docs.** The provider-key block in `templates/.env` notes that the wizard collects the keys goose needs and preserves stored keys across re-runs.

## Tests

- 8 direct tests on the scan helper (explicit provider, global fallback, no-provider degrade, dedupe and sort, non-goose entries ignored, missing file, malformed YAML, non-dict entries).
- 7 wizard-flow tests: per-user prompt fires and lands in env, no prompt without goose entries (input chain consumed exactly), global goose+deepseek prompt fires with no auth-less message, no double-prompt when the global block already collected the var, stored-key preservation, and the codex subscription ownership exception.
- Full suite: 3907 passed, 1 skipped; ruff check and format clean.
