### PR TITLE
feat(install): collect agent binary paths for per-user backend entries

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -3984,28 +3984,31 @@ def _cmd_apply() -> None:
         # without round-tripping through the wizard. Apply-time env
         # wins over any value already in install.conf.
         #
-        # Gate on the global AGENT_BACKEND only. The wizard and the
-        # apply-time CODEX_BIN env pass-through are both scoped to
-        # global Codex installs. A per-user `agent_backend: codex`
-        # entry on a non-Codex global install is operator-managed:
-        # ensure Codex is installed and authenticated out of band for
-        # that user's os_user; the runtime startup-failure event
-        # surfaces missing tooling at first message.
+        # Gate the apply-time shell env pass-through on the global
+        # AGENT_BACKEND only: it is an ad-hoc escape hatch for global
+        # backend installs (`sudo CODEX_BIN=... kai install apply`).
+        # Per-user backend entries do NOT need it; their binary paths
+        # are collected by the `make config` per-user backend scan
+        # and arrive here through install.conf, which `_apply_sudoers`
+        # consumes below. Codex AUTH for per-user entries stays
+        # out-of-band (per-OS-user `codex login`).
         env_codex_bin = os.environ.get("CODEX_BIN")
         if env_codex_bin and env.get("AGENT_BACKEND") == "codex":
             env["CODEX_BIN"] = env_codex_bin
         # Mirror the same env pass-through for OPENCODE_BIN so an
         # `sudo OPENCODE_BIN=... kai install apply` invocation pins
         # the same path the running bot will resolve via
-        # resolve_oneshot_binary("opencode"). Gating on the global
-        # AGENT_BACKEND keeps per-user opencode overrides
-        # operator-managed (the runtime surfaces missing tooling on
-        # first message), same posture as CODEX_BIN.
+        # resolve_oneshot_binary("opencode"). Same scoping as
+        # CODEX_BIN above: global installs only; per-user opencode
+        # entries get their path from the wizard scan via
+        # install.conf, with auth out-of-band (`opencode auth login`).
         env_opencode_bin = os.environ.get("OPENCODE_BIN")
         if env_opencode_bin and env.get("AGENT_BACKEND") == "opencode":
             env["OPENCODE_BIN"] = env_opencode_bin
         # And for GOOSE_BIN, completing the per-backend trio. Same
-        # global-AGENT_BACKEND gating posture as the two above.
+        # split as the two above: shell env override for global goose
+        # installs, install.conf from the wizard scan for per-user
+        # entries.
         env_goose_bin = os.environ.get("GOOSE_BIN")
         if env_goose_bin and env.get("AGENT_BACKEND") == "goose":
             env["GOOSE_BIN"] = env_goose_bin

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -494,33 +494,23 @@ def _read_users_yaml_text(path: Path) -> str | None:
     return result.stdout
 
 
-def _users_yaml_goose_providers(users_yaml_path: Path, global_provider: str) -> list[str]:
+def _users_yaml_entries(users_yaml_path: Path) -> list[dict]:
     """
-    Collect the distinct providers per-user goose entries need API
-    keys for.
+    Read the canonical users.yaml and return its well-formed user
+    entries for wizard-side scans.
 
-    Reads the canonical users.yaml via `_read_users_yaml_text` (sudo-
-    tolerant on protected installs) and returns the sorted set of
-    `llm_provider` values across entries whose `agent_backend` is
-    "goose", falling back to `global_provider` for entries that omit
-    the field - the same cascade the runtime applies. Goose is the
-    only backend whose per-user auth rides the daemon environment:
-    claude, codex, and opencode authenticate via per-OS-user on-disk
-    state managed outside the wizard, so entries on those backends
-    contribute nothing here.
-
-    A missing, unreadable, or malformed users.yaml degrades to an
-    empty list: the wizard then behaves as it does without per-user
-    goose entries, and the runtime's own users.yaml validation
-    surfaces any real misconfiguration at startup.
+    Reads via `_read_users_yaml_text` (sudo-tolerant on protected
+    installs) because the wizard runs as the operator account. A
+    missing, unreadable, or malformed file, a non-dict document, a
+    missing or non-list `users` key, and non-dict list items all
+    degrade to an empty result: wizard scans must never crash
+    mid-flow on user-owned YAML, and the runtime's own users.yaml
+    validation surfaces any real misconfiguration at startup.
 
     Deliberately NOT built on `_collect_backends_from_yaml`: that
     sibling serves `_apply_sudoers` (apply side), reads the file
-    directly as root, raises on malformed YAML so the install fails
-    loudly, and returns backends without the provider pairing this
-    prompt needs. The wizard side runs as the operator account
-    (hence the sudo-tolerant reader) and must degrade rather than
-    crash mid-flow.
+    directly as root, and raises on malformed YAML so the install
+    fails loudly - the opposite degrade posture from the wizard.
     """
     raw = _read_users_yaml_text(users_yaml_path)
     if raw is None:
@@ -534,16 +524,54 @@ def _users_yaml_goose_providers(users_yaml_path: Path, global_provider: str) -> 
     users = data.get("users")
     if not isinstance(users, list):
         return []
+    return [entry for entry in users if isinstance(entry, dict)]
+
+
+def _users_yaml_goose_providers(users_yaml_path: Path, global_provider: str) -> list[str]:
+    """
+    Collect the distinct providers per-user goose entries need API
+    keys for.
+
+    Returns the sorted set of `llm_provider` values across entries
+    whose `agent_backend` is "goose", falling back to
+    `global_provider` for entries that omit the field - the same
+    cascade the runtime applies. Goose is the only backend whose
+    per-user auth rides the daemon environment: claude, codex, and
+    opencode authenticate via per-OS-user on-disk state managed
+    outside the wizard, so entries on those backends contribute
+    nothing here. Parsing and degrade behavior live in
+    `_users_yaml_entries` (empty result on any malformed input).
+    """
     providers: set[str] = set()
-    for entry in users:
-        if not isinstance(entry, dict):
-            continue
+    for entry in _users_yaml_entries(users_yaml_path):
         if entry.get("agent_backend") != "goose":
             continue
         provider = entry.get("llm_provider") or global_provider
         if isinstance(provider, str) and provider:
             providers.add(provider)
     return sorted(providers)
+
+
+def _users_yaml_agent_backends(users_yaml_path: Path) -> set[str]:
+    """
+    Collect the distinct per-user `agent_backend` values for
+    wizard-side binary collection.
+
+    A users.yaml entry on a non-global backend makes that backend's
+    binary load-bearing at runtime (the chat spawn and the per-user
+    memory-extraction dispatch both route by each user's effective
+    backend, and the fail-closed startup gate refuses to boot when
+    an extraction-eligible user routes to an unresolvable binary),
+    so the wizard must know which backends are in play beyond the
+    global one. Parsing and degrade behavior live in
+    `_users_yaml_entries` (empty result on any malformed input).
+    """
+    backends: set[str] = set()
+    for entry in _users_yaml_entries(users_yaml_path):
+        backend = entry.get("agent_backend")
+        if isinstance(backend, str) and backend.strip():
+            backends.add(backend.strip())
+    return backends
 
 
 # ── Config subcommand ────────────────────────────────────────────────
@@ -1062,6 +1090,59 @@ def _cmd_config() -> None:
         )
     if extra_provider_keys:
         print()
+
+    # Per-user entries on a non-global backend make that backend's
+    # binary load-bearing: the chat spawn and the per-user memory-
+    # extraction dispatch both route by each user's effective
+    # backend, and the fail-closed startup gate refuses to boot when
+    # an extraction-eligible user routes to an unresolvable binary.
+    # The blocks above collect a binary only for the global backend,
+    # so collect here for every other backend per-user entries put
+    # in play; the values flow into the same codex_bin / opencode_bin
+    # / goose_bin variables, so the existing persistence (env var,
+    # install.conf, sudoers SETENV rule) needs no new emission sites.
+    # Claude is exempt: it has no *_BIN wizard surface and resolves
+    # through the service PATH the launchd plist pins. Prompt loops
+    # mirror the global blocks, including each backend's default
+    # posture (codex falls back to Homebrew; goose and opencode
+    # force an explicit path when `which` finds nothing).
+    peruser_backends = _users_yaml_agent_backends(users_yaml_path)
+    if "codex" in peruser_backends and not codex_bin:
+        print("  users.yaml has a codex entry; the daemon needs a resolvable codex binary.")
+        while True:
+            which_codex = shutil.which("codex") or "/opt/homebrew/bin/codex"
+            codex_bin = _prompt(
+                "Codex binary path",
+                existing_env.get("CODEX_BIN", which_codex),
+                required=True,
+            )
+            if _validate_codex_bin(codex_bin):
+                break
+            print(f"  Path '{codex_bin}' does not exist or is not executable.")
+    if "opencode" in peruser_backends and not opencode_bin:
+        print("  users.yaml has an opencode entry; the daemon needs a resolvable opencode binary.")
+        while True:
+            which_opencode = shutil.which("opencode") or ""
+            opencode_bin = _prompt(
+                "OpenCode binary path",
+                existing_env.get("OPENCODE_BIN", which_opencode),
+                required=True,
+            )
+            if _validate_opencode_bin(opencode_bin):
+                break
+            print(f"  Path '{opencode_bin}' does not exist or is not executable.")
+    if "goose" in peruser_backends and not goose_bin:
+        print("  users.yaml has a goose entry; the daemon needs a resolvable goose binary.")
+        while True:
+            which_goose = shutil.which("goose") or ""
+            goose_bin = _prompt(
+                "Goose binary path",
+                existing_env.get("GOOSE_BIN", which_goose),
+                required=True,
+            )
+            if _validate_goose_bin(goose_bin):
+                break
+            print(f"  Path '{goose_bin}' does not exist or is not executable.")
 
     # -- Agent --
     # DEFAULT_MODEL and AGENT_TIMEOUT_SECONDS are

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -544,11 +544,16 @@ def _users_yaml_goose_providers(users_yaml_path: Path, global_provider: str) -> 
     """
     providers: set[str] = set()
     for entry in _users_yaml_entries(users_yaml_path):
-        if entry.get("agent_backend") != "goose":
+        # Normalize the same way the runtime loader does
+        # (str.strip().lower()): mixed-case `Goose` / `DeepSeek`
+        # values are valid at runtime, so the scan must not let a
+        # casing difference skip a key the daemon will demand.
+        backend = entry.get("agent_backend")
+        if not isinstance(backend, str) or backend.strip().lower() != "goose":
             continue
         provider = entry.get("llm_provider") or global_provider
-        if isinstance(provider, str) and provider:
-            providers.add(provider)
+        if isinstance(provider, str) and provider.strip():
+            providers.add(provider.strip().lower())
     return sorted(providers)
 
 
@@ -569,8 +574,14 @@ def _users_yaml_agent_backends(users_yaml_path: Path) -> set[str]:
     backends: set[str] = set()
     for entry in _users_yaml_entries(users_yaml_path):
         backend = entry.get("agent_backend")
+        # Normalize the same way the runtime loader does
+        # (str.strip().lower()): mixed-case values like `Codex` are
+        # valid at runtime and route the user, so the scan must
+        # produce the canonical form the prompt gates compare
+        # against. Non-string values are skipped here; the runtime
+        # loader rejects them loudly at startup.
         if isinstance(backend, str) and backend.strip():
-            backends.add(backend.strip())
+            backends.add(backend.strip().lower())
     return backends
 
 
@@ -904,10 +915,10 @@ def _cmd_config() -> None:
     #
     # Gate on the global `agent_backend` selection only. Per-user
     # `agent_backend: codex` overrides in users.yaml do NOT trigger
-    # codex setup here; the operator is responsible for installing /
-    # authenticating codex out-of-band for those users, and the
-    # runtime surfaces a chat-visible startup-failure event when
-    # tooling is missing.
+    # the auth-mode setup here; codex AUTH for those users stays
+    # out-of-band (per-OS-user `codex login`). Their BINARY path is
+    # collected by the per-user backend scan after the provider
+    # block, which feeds this same codex_bin variable.
     codex_auth_mode = ""
     codex_api_key = ""
     codex_bin = ""
@@ -967,9 +978,11 @@ def _cmd_config() -> None:
     # a free-text prompt for a full `provider/model` ID.
     #
     # Gate on the global `agent_backend` selection only. Per-user
-    # `agent_backend: opencode` overrides in users.yaml do NOT trigger
-    # opencode setup here; the operator handles those installs and
-    # auth out-of-band.
+    # `agent_backend: opencode` overrides in users.yaml do NOT
+    # trigger the setup here; opencode AUTH for those users stays
+    # out-of-band (`opencode auth login` per OS user). Their BINARY
+    # path is collected by the per-user backend scan after the
+    # provider block, which feeds this same opencode_bin variable.
     if agent_backend == "opencode":
         # OpenCode binary path: wizard-prompted and persisted in
         # install.conf so `make install` writes both /etc/kai/env's

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -50,6 +50,7 @@ from kai.install import (
     _start_service,
     _stop_service,
     _user_home,
+    _users_yaml_agent_backends,
     _users_yaml_goose_providers,
     _validate_chat_id,
     _validate_display_name,
@@ -8880,16 +8881,19 @@ class TestWizardPerUserGooseProviderKeys:
 
     def test_peruser_goose_entry_prompts_for_key(self, tmp_path, monkeypatch, capsys):
         """Global claude install with a per-user goose+deepseek entry:
-        the wizard prompts for DEEPSEEK_API_KEY (inserted right after
-        the backend slot in the input chain) and emits it to env."""
+        the wizard prompts for DEEPSEEK_API_KEY and then the goose
+        binary path (both inserted right after the backend slot in
+        the input chain) and emits both to env."""
         self._setup(monkeypatch, tmp_path, self.GOOSE_DEEPSEEK_USERS_YAML)
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
         i = inputs.index("claude")
-        inputs = inputs[: i + 1] + ["sk-ds-peruser"] + inputs[i + 1 :]
+        inputs = inputs[: i + 1] + ["sk-ds-peruser", "/opt/homebrew/bin/goose"] + inputs[i + 1 :]
 
         env = self._run(monkeypatch, tmp_path, inputs)
 
         assert env["DEEPSEEK_API_KEY"] == "sk-ds-peruser"
+        assert env["GOOSE_BIN"] == "/opt/homebrew/bin/goose"
         out = capsys.readouterr().out
         assert "goose entry on deepseek" in out
         assert "DEEPSEEK_API_KEY" in out
@@ -8966,3 +8970,142 @@ class TestWizardPerUserGooseProviderKeys:
         env = self._run(monkeypatch, tmp_path, TestCmdConfigDefaultModelDispatch._inputs_for_codex_subscription())
 
         assert "OPENAI_API_KEY" not in env
+
+
+# ── Per-user backend binary collection ───────────────────────────────
+
+
+class TestUsersYamlAgentBackends:
+    """Direct tests for the wizard's per-user backend scan; parsing
+    and degrade behavior are shared with `_users_yaml_entries`."""
+
+    @staticmethod
+    def _write(tmp_path, content: str) -> Path:
+        p = tmp_path / "users.yaml"
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_collects_distinct_backends(self, tmp_path):
+        p = self._write(
+            tmp_path,
+            "users:\n"
+            "  - telegram_id: 1\n    name: a\n    agent_backend: goose\n"
+            "  - telegram_id: 2\n    name: b\n    agent_backend: codex\n"
+            "  - telegram_id: 3\n    name: c\n    agent_backend: codex\n"
+            "  - telegram_id: 4\n    name: d\n",
+        )
+        assert _users_yaml_agent_backends(p) == {"goose", "codex"}
+
+    def test_strips_whitespace_skips_non_strings(self, tmp_path):
+        p = self._write(
+            tmp_path,
+            "users:\n  - telegram_id: 1\n    name: a\n    agent_backend: ' codex '\n  - telegram_id: 2\n    name: b\n    agent_backend: 7\n",
+        )
+        assert _users_yaml_agent_backends(p) == {"codex"}
+
+    def test_missing_file_degrades_to_empty(self, tmp_path):
+        assert _users_yaml_agent_backends(tmp_path / "absent.yaml") == set()
+
+    def test_malformed_yaml_degrades_to_empty(self, tmp_path):
+        p = self._write(tmp_path, "users: [unclosed\n")
+        assert _users_yaml_agent_backends(p) == set()
+
+
+class TestWizardPerUserBackendBinaries:
+    """Wizard collection of agent binary paths when per-user entries
+    use a backend other than the global one. Mirrors the provider-key
+    collection: scan users.yaml, prompt only for binaries the global
+    blocks did not already collect, flow into the existing
+    persistence variables."""
+
+    CODEX_USERS_YAML = (
+        "users:\n"
+        "  - telegram_id: 1\n"
+        "    name: alice\n"
+        "    role: admin\n"
+        "  - telegram_id: 2\n"
+        "    name: bob\n"
+        "    agent_backend: codex\n"
+    )
+    PLAIN_USERS_YAML = "users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n"
+
+    @staticmethod
+    def _setup(monkeypatch, tmp_path, users_yaml: str, existing_env: dict | None = None) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        TestCmdConfig._simulate_existing_etc_users_yaml(monkeypatch, users_yaml)
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            lambda backend, prov, default: "sonnet",
+        )
+        if existing_env is not None:
+            (tmp_path / "install.conf").write_text(json.dumps({"env": existing_env, "version": 1}))
+
+    @staticmethod
+    def _run(monkeypatch, tmp_path, inputs: list[str]) -> dict:
+        feed = iter(inputs)
+        monkeypatch.setattr("builtins.input", lambda prompt: next(feed))
+        _cmd_config()
+        return json.loads((tmp_path / "install.conf").read_text())["env"]
+
+    def test_peruser_codex_entry_prompts_for_binary(self, tmp_path, monkeypatch, capsys):
+        """Global claude install with a per-user codex entry: the
+        wizard prompts for the codex binary path and CODEX_BIN lands
+        in env, so the fail-closed extraction gate can resolve codex
+        at startup. This is the incident shape: per-user codex on a
+        non-codex global install previously had no collection path
+        and the daemon exited at boot."""
+        self._setup(monkeypatch, tmp_path, self.CODEX_USERS_YAML)
+        monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
+        inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
+        i = inputs.index("claude")
+        inputs = inputs[: i + 1] + ["/per-user/npm/bin/codex"] + inputs[i + 1 :]
+
+        env = self._run(monkeypatch, tmp_path, inputs)
+
+        assert env["CODEX_BIN"] == "/per-user/npm/bin/codex"
+        assert "codex entry" in capsys.readouterr().out
+
+    def test_global_codex_does_not_reprompt(self, tmp_path, monkeypatch):
+        """Global codex install with a per-user codex entry: the
+        global block already collected codex_bin, so the per-user
+        block must not prompt again (the unmodified codex chain is
+        consumed exactly)."""
+        self._setup(monkeypatch, tmp_path, self.CODEX_USERS_YAML)
+        monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
+
+        env = self._run(monkeypatch, tmp_path, TestCmdConfigDefaultModelDispatch._inputs_for_codex_subscription())
+
+        assert env["CODEX_BIN"] == "/usr/local/bin/codex"
+
+    def test_plain_users_yaml_no_binary_prompt(self, tmp_path, monkeypatch):
+        """No per-user backend entries: the unmodified claude chain is
+        consumed exactly and no binary key lands in env."""
+        self._setup(monkeypatch, tmp_path, self.PLAIN_USERS_YAML)
+
+        env = self._run(monkeypatch, tmp_path, TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend())
+
+        assert "CODEX_BIN" not in env
+        assert "GOOSE_BIN" not in env
+        assert "OPENCODE_BIN" not in env
+
+    def test_stored_binary_offered_as_default(self, tmp_path, monkeypatch):
+        """Re-run with a stored CODEX_BIN: the prompt fires again for
+        the still-present codex entry and pressing Enter keeps the
+        stored path."""
+        self._setup(
+            monkeypatch,
+            tmp_path,
+            self.CODEX_USERS_YAML,
+            existing_env={"TELEGRAM_BOT_TOKEN": "fake-token", "CODEX_BIN": "/stored/bin/codex"},
+        )
+        monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
+        inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
+        i = inputs.index("claude")
+        # Empty answer accepts the prompt default (the stored path).
+        inputs = inputs[: i + 1] + [""] + inputs[i + 1 :]
+
+        env = self._run(monkeypatch, tmp_path, inputs)
+
+        assert env["CODEX_BIN"] == "/stored/bin/codex"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -8786,6 +8786,17 @@ class TestUsersYamlGooseProviders:
         )
         assert _users_yaml_goose_providers(p, "") == ["deepseek"]
 
+    def test_mixed_case_normalized_like_runtime(self, tmp_path):
+        """Mixed-case `Goose` / `DeepSeek` are valid at runtime (the
+        loader lowercases both fields before validation), so the scan
+        must match the backend case-insensitively and emit the
+        canonical provider form PROVIDER_KEY_VARS is keyed on."""
+        p = self._write(
+            tmp_path,
+            "users:\n  - telegram_id: 1\n    name: a\n    agent_backend: Goose\n    llm_provider: DeepSeek\n",
+        )
+        assert _users_yaml_goose_providers(p, "") == ["deepseek"]
+
     def test_falls_back_to_global_provider(self, tmp_path):
         """An entry that omits llm_provider inherits the global
         provider, mirroring the runtime cascade."""
@@ -9003,6 +9014,17 @@ class TestUsersYamlAgentBackends:
         )
         assert _users_yaml_agent_backends(p) == {"codex"}
 
+    def test_mixed_case_normalized_like_runtime(self, tmp_path):
+        """The runtime loader accepts `agent_backend` case-insensitively
+        (str.strip().lower() before validation), so mixed-case entries
+        route users at runtime; the scan must produce the canonical
+        lower-case form or the prompt gates silently miss them."""
+        p = self._write(
+            tmp_path,
+            "users:\n  - telegram_id: 1\n    name: a\n    agent_backend: Codex\n  - telegram_id: 2\n    name: b\n    agent_backend: ' GOOSE '\n",
+        )
+        assert _users_yaml_agent_backends(p) == {"codex", "goose"}
+
     def test_missing_file_degrades_to_empty(self, tmp_path):
         assert _users_yaml_agent_backends(tmp_path / "absent.yaml") == set()
 
@@ -9109,3 +9131,53 @@ class TestWizardPerUserBackendBinaries:
         env = self._run(monkeypatch, tmp_path, inputs)
 
         assert env["CODEX_BIN"] == "/stored/bin/codex"
+
+    def test_mixed_case_codex_entry_still_prompts(self, tmp_path, monkeypatch):
+        """`agent_backend: Codex` is valid at runtime (the loader
+        lowercases before validation) and routes the user, so the
+        scan must normalize the same way; a casing difference must
+        not skip the binary prompt and reintroduce the startup-gate
+        failure."""
+        mixed_yaml = (
+            "users:\n"
+            "  - telegram_id: 1\n"
+            "    name: alice\n"
+            "    role: admin\n"
+            "  - telegram_id: 2\n"
+            "    name: bob\n"
+            "    agent_backend: Codex\n"
+        )
+        self._setup(monkeypatch, tmp_path, mixed_yaml)
+        monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
+        inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
+        i = inputs.index("claude")
+        inputs = inputs[: i + 1] + ["/per-user/npm/bin/codex"] + inputs[i + 1 :]
+
+        env = self._run(monkeypatch, tmp_path, inputs)
+
+        assert env["CODEX_BIN"] == "/per-user/npm/bin/codex"
+
+    def test_peruser_opencode_entry_prompts_for_binary(self, tmp_path, monkeypatch, capsys):
+        """Global claude install with a per-user opencode entry: the
+        wizard prompts for the opencode binary path and OPENCODE_BIN
+        lands in env, completing the acceptance triple (codex, goose,
+        opencode) on the per-user scan."""
+        opencode_yaml = (
+            "users:\n"
+            "  - telegram_id: 1\n"
+            "    name: alice\n"
+            "    role: admin\n"
+            "  - telegram_id: 2\n"
+            "    name: bob\n"
+            "    agent_backend: opencode\n"
+        )
+        self._setup(monkeypatch, tmp_path, opencode_yaml)
+        monkeypatch.setattr("kai.install._validate_opencode_bin", lambda p: bool(p))
+        inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
+        i = inputs.index("claude")
+        inputs = inputs[: i + 1] + ["/custom/bin/opencode"] + inputs[i + 1 :]
+
+        env = self._run(monkeypatch, tmp_path, inputs)
+
+        assert env["OPENCODE_BIN"] == "/custom/bin/opencode"
+        assert "opencode entry" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Closes #637.

A users.yaml entry on a non-global backend makes that backend's binary load-bearing at runtime: the chat spawn and the per-user memory-extraction dispatch both route by each user's effective backend, and the fail-closed startup gate refuses to boot when an extraction-eligible user routes to an unresolvable binary. Every wizard site that collects `CODEX_BIN` / `OPENCODE_BIN` / `GOOSE_BIN` (the three main blocks and the three memory-gate defense re-prompts) was gated on the global `AGENT_BACKEND`, so a per-user entry on a foreign backend had no collection path, and a hand-added env line is wiped on regeneration. Observed in production as a startup-gate exit when a codex entry was activated on an opencode-global install: codex lived in a per-user npm prefix not on the daemon PATH, `CODEX_BIN` was unset, and the daemon exited at boot while the launcher masked the death (#638 tracks that part).

## Change

- The wizard scans the canonical users.yaml for the distinct per-user `agent_backend` values and runs the same validator prompt loops the global blocks use for any backend in play whose binary was not already collected. Each prompt is guarded on the existing `codex_bin` / `opencode_bin` / `goose_bin` variable, so global installs never double-prompt, and the collected values flow into those same variables; env emission, install.conf persistence, and the sudoers SETENV rule all work unchanged.
- Default posture mirrors the global blocks per backend: codex falls back to its Homebrew path when `which` finds nothing, goose and opencode force an explicit path.
- Claude stays exempt: it has no `*_BIN` wizard surface and resolves through the service PATH the launchd plist pins.
- Shared users.yaml parsing extracted into `_users_yaml_entries` (sudo-tolerant read, degrade-to-empty on any malformed input), now reused by both the provider-key scan and the new backend scan. The apply-side `_collect_backends_from_yaml` keeps its separate fail-loudly posture, as before.

## Tests

- Direct tests for the backend scan: distinct backends collected, whitespace stripped, non-string values skipped, missing file and malformed YAML degrade to empty.
- Wizard-flow tests: the incident shape (per-user codex entry on a non-codex global install prompts for the binary and `CODEX_BIN` lands in env), no double-prompt on a global-codex install, no prompts with a plain users.yaml (input chain consumed exactly), and stored paths offered back as prompt defaults on re-runs.
- The per-user goose provider-key test now also pins the goose binary prompt that fires for the same entry.
- Targeted classes pass (23 tests); ruff check and format clean. Note for local runs only: 7 pre-existing `TestCmdApply*` failures reproduce identically on clean main; they stem from apply-side tests reading the host's real `/etc/kai/users.yaml` (separate test-isolation bug, to be filed), and do not occur in CI.
