### PR TITLE
fix(main): mirror fail-closed startup exits into the main log

### DIFF
--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -187,13 +187,37 @@ def main() -> None:
     """
     Top-level entry point for the Kai bot.
 
-    Sets up logging, loads configuration, and delegates to an async
-    initialization function that manages the full application lifecycle.
-    Catches KeyboardInterrupt for clean Ctrl+C shutdown and logs any
-    unexpected crashes.
+    Sets up logging, then delegates the entire startup and run
+    lifecycle to `_start` under a single SystemExit choke point: the
+    fail-closed startup gates (config validation, binary resolution,
+    users.yaml validation) raise SystemExit with an actionable
+    message, but that text only reaches stderr, which launchd
+    redirects to a separate file. Without the CRITICAL re-log, the
+    main log ends mid-startup with no explanation and a gate exit
+    reads as a hang to anyone tailing it. The re-raise keeps the
+    exit code and stderr behavior unchanged; clean exits (None or
+    integer codes) stay silent.
     """
     setup_logging()
 
+    try:
+        _start()
+    except SystemExit as e:
+        if isinstance(e.code, str) and e.code.strip():
+            logging.critical("Startup failed: %s", e.code)
+        raise
+
+
+def _start() -> None:
+    """
+    Load configuration and run the application lifecycle.
+
+    Loads configuration, then delegates to an async initialization
+    function that manages the full application lifecycle. Catches
+    KeyboardInterrupt for clean Ctrl+C shutdown and logs any
+    unexpected crashes. SystemExit propagates to `main`'s choke
+    point, which mirrors gate messages into the main log.
+    """
     config = load_config()
     logging.info("Kai starting (model=%s, users=%s)", config.default_model, config.allowed_user_ids)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -336,3 +336,47 @@ class TestFileCleanupLoop:
         # Error was logged
         mock_log.assert_called()
         # Should not raise - error is counted, not propagated
+
+
+# ── main() startup-error choke point ─────────────────────────────────
+
+
+class TestMainStartupErrorLogging:
+    """main()'s SystemExit choke point mirrors fail-closed gate
+    messages into the standard logger. Without it the message reaches
+    only stderr, which launchd redirects away from the main log, so a
+    gate exit reads as a hang to anyone tailing kai.log."""
+
+    def test_gate_message_logged_critical(self, caplog, monkeypatch):
+        from kai.main import main
+
+        monkeypatch.setattr("kai.main.setup_logging", lambda: None)
+        monkeypatch.setattr(
+            "kai.main.load_config",
+            lambda: (_ for _ in ()).throw(SystemExit("codex binary unreachable")),
+        )
+
+        with caplog.at_level(logging.CRITICAL), pytest.raises(SystemExit, match="codex binary unreachable"):
+            main()
+
+        assert any(
+            r.levelno == logging.CRITICAL and "codex binary unreachable" in r.getMessage() for r in caplog.records
+        )
+
+    @pytest.mark.parametrize("code", [None, 0, 2])
+    def test_clean_or_numeric_exits_stay_silent(self, caplog, monkeypatch, code):
+        """SystemExit with no message (clean shutdowns, numeric exit
+        codes) must not produce a CRITICAL line; only the string-
+        message gate exits carry a diagnostic worth mirroring."""
+        from kai.main import main
+
+        monkeypatch.setattr("kai.main.setup_logging", lambda: None)
+        monkeypatch.setattr(
+            "kai.main.load_config",
+            lambda: (_ for _ in ()).throw(SystemExit(code)),
+        )
+
+        with caplog.at_level(logging.CRITICAL), pytest.raises(SystemExit):
+            main()
+
+        assert not [r for r in caplog.records if r.levelno == logging.CRITICAL]


### PR DESCRIPTION
## Summary

Closes #639.

The fail-closed startup gates raise `SystemExit` with an actionable message (for example the memory-extraction binary gate), but that text only reaches stderr, which launchd redirects to the separate stderr log. The main log ends with an ordinary INFO line from mid-startup, so a gate exit reads as a hang to anyone tailing `kai.log`; during the recent startup-gate incident the diagnosis required knowing to check the stderr file, and a log watcher matching `ERROR|Traceback|SystemExit` on the main log saw nothing.

## Change

`main()` now runs the entire startup and run lifecycle (`_start()`) under a single `SystemExit` choke point: string messages are re-logged at CRITICAL through the configured logger, then the exception re-raises so the exit code and stderr behavior stay unchanged. `setup_logging()` runs before the try block, so the handler always exists by the time a gate can fire. Clean exits (`None` or numeric codes) stay silent.

This is option 2 from the issue: one choke point covering every present and future gate, instead of asking each `raise SystemExit(...)` site to remember to log first.

## Tests

- Gate exits with a string message produce a CRITICAL record carrying the message, and the `SystemExit` still propagates.
- `SystemExit(None)`, `SystemExit(0)`, and `SystemExit(2)` produce no CRITICAL record.
- Full suite: 3923 passed, 1 skipped; ruff check and format clean.
