### PR TITLE
fix(install): launcher exits for restart when the agent never binds

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2858,16 +2858,36 @@ def _generate_launcher_script(install_dir: str, webhook_port: int = 8080) -> str
         # bash script instead, and we forward signals to the real Python.
         {install_dir}/venv/bin/python3 -m kai &
 
-        # Wait for Python to re-exec and start listening
-        sleep 2
-
-        # Find the actual Python process (the re-exec'd grandchild).
-        # lsof lives at /usr/sbin/ which may not be in the service PATH.
-        REAL_PID=$(/usr/sbin/lsof -ti :{webhook_port} -sTCP:LISTEN 2>/dev/null)
-        if [ -z "$REAL_PID" ]; then
-            # Hasn't bound yet; wait a bit more
-            sleep 3
+        # Find the actual Python process (the re-exec'd grandchild) by
+        # its listen port. lsof lives at /usr/sbin/ which may not be in
+        # the service PATH. Healthy startups bind in 15-25 seconds on
+        # this stack (the memory subsystem loads its embedding model
+        # before the webhook server starts), so poll for up to 120s.
+        # The direct child exits on the framework re-exec in normal
+        # operation, so child death alone is not a failure signal;
+        # only the port answers whether the agent came up.
+        REAL_PID=""
+        for _ in $(seq 1 60); do
             REAL_PID=$(/usr/sbin/lsof -ti :{webhook_port} -sTCP:LISTEN 2>/dev/null)
+            [ -n "$REAL_PID" ] && break
+            sleep 2
+        done
+
+        if [ -z "$REAL_PID" ]; then
+            # No listener after the window: startup is dead (a
+            # fail-closed config gate, a crash, or a hang that is
+            # indistinguishable from one). Exit non-zero so launchd's
+            # KeepAlive restarts the service - a throttled, visible
+            # retry loop instead of an eternal sleep that reports
+            # state=running with no agent behind it. Residual risk: a
+            # python that binds AFTER the window is orphaned by this
+            # exit and the restarted instance then fails its own bind
+            # with a visible address-in-use startup error; that beats
+            # silently supervising nothing, and no safe kill target
+            # exists here (the re-exec'd argv carries no install
+            # path to match on).
+            echo "kai launcher: no listener on :{webhook_port} after 120s; exiting so launchd restarts the service" >&2
+            exit 1
         fi
 
         cleanup() {{
@@ -2880,13 +2900,7 @@ def _generate_launcher_script(install_dir: str, webhook_port: int = 8080) -> str
         # Poll for the real Python process to exit.
         # kill -0 checks if PID exists without sending a signal.
         # This is macOS-compatible (no GNU tail --pid needed).
-        if [ -n "$REAL_PID" ]; then
-            while kill -0 "$REAL_PID" 2>/dev/null; do sleep 1; done
-        else
-            # Could not find the process; wait indefinitely.
-            # BSD sleep doesn't support "infinity", so loop with a long sleep.
-            while true; do sleep 86400; done
-        fi
+        while kill -0 "$REAL_PID" 2>/dev/null; do sleep 1; done
     """)
 
 

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2857,6 +2857,34 @@ def _generate_launcher_script(install_dir: str, webhook_port: int = 8080) -> str
         # creating a grandchild process with a new PID. Launchd tracks this
         # bash script instead, and we forward signals to the real Python.
         {install_dir}/venv/bin/python3 -m kai &
+        CHILD_PID=$!
+
+        cleanup() {{
+            # Ignore further TERM/INT while tearing down so the group
+            # signal below does not re-enter this handler.
+            trap '' TERM INT
+            # Signal the launcher's whole process group: launchd runs
+            # this script as its own group leader and non-interactive
+            # bash creates no job-control groups, so the python child,
+            # its re-exec'd grandchild, and any helper sleeps all share
+            # the group (fork and exec both preserve the pgid). The
+            # group signal is the only handle that reaches a python
+            # that has re-exec'd but not yet bound the port; in that
+            # window it has no individually resolvable pid. Fall back
+            # to the direct child if this shell is somehow not a group
+            # leader.
+            kill -TERM -- -$$ 2>/dev/null || kill -TERM "$CHILD_PID" 2>/dev/null
+            # Wait for the webhook port to be released so the stop is
+            # not reported complete while a dying python still holds
+            # the port a successor will need.
+            while [ -n "$(/usr/sbin/lsof -ti :{webhook_port} -sTCP:LISTEN 2>/dev/null)" ]; do sleep 0.5; done
+            exit 0
+        }}
+        # Installed BEFORE the bind poll: a service stop during the
+        # (up to 120s) startup window must still tear the agent down;
+        # with the default TERM action bash would exit alone and
+        # orphan the starting python.
+        trap cleanup TERM INT
 
         # Find the actual Python process (the re-exec'd grandchild) by
         # its listen port. lsof lives at /usr/sbin/ which may not be in
@@ -2876,26 +2904,17 @@ def _generate_launcher_script(install_dir: str, webhook_port: int = 8080) -> str
         if [ -z "$REAL_PID" ]; then
             # No listener after the window: startup is dead (a
             # fail-closed config gate, a crash, or a hang that is
-            # indistinguishable from one). Exit non-zero so launchd's
-            # KeepAlive restarts the service - a throttled, visible
-            # retry loop instead of an eternal sleep that reports
-            # state=running with no agent behind it. Residual risk: a
-            # python that binds AFTER the window is orphaned by this
-            # exit and the restarted instance then fails its own bind
-            # with a visible address-in-use startup error; that beats
-            # silently supervising nothing, and no safe kill target
-            # exists here (the re-exec'd argv carries no install
-            # path to match on).
+            # indistinguishable from one). Kill the process group so a
+            # python that would bind AFTER the window cannot linger as
+            # an orphan holding the port, then exit non-zero so
+            # launchd's KeepAlive restarts the service - a throttled,
+            # visible retry loop instead of an eternal sleep that
+            # reports state=running with no agent behind it.
             echo "kai launcher: no listener on :{webhook_port} after 120s; exiting so launchd restarts the service" >&2
+            trap '' TERM INT
+            kill -TERM -- -$$ 2>/dev/null || kill -TERM "$CHILD_PID" 2>/dev/null
             exit 1
         fi
-
-        cleanup() {{
-            kill -TERM "$REAL_PID" 2>/dev/null
-            # Poll until the process is gone (can't use wait on non-children)
-            while kill -0 "$REAL_PID" 2>/dev/null; do sleep 0.5; done
-        }}
-        trap cleanup TERM INT
 
         # Poll for the real Python process to exit.
         # kill -0 checks if PID exists without sending a signal.

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,10 +1,13 @@
 """Tests for the protected installation module (install.py)."""
 
+import contextlib
 import json
 import os
 import shutil
+import signal
 import stat
 import subprocess
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -5236,6 +5239,70 @@ class TestGenerateLauncherScript:
         script = _generate_launcher_script("/opt/kai")
         assert "seq 1 60" in script
         assert "sleep 2" in script
+
+    def test_trap_installed_before_bind_poll(self):
+        """The TERM trap must be armed before the launcher enters the
+        bind poll: a service stop during the startup window otherwise
+        exits bash alone with the default signal action and orphans
+        the starting python."""
+        script = _generate_launcher_script("/opt/kai")
+        assert script.index("trap cleanup TERM INT") < script.index("seq 1 60")
+
+    def test_sigterm_during_bind_poll_tears_down_the_child(self, tmp_path):
+        """Behavioral check on the generated script: SIGTERM arriving
+        while the launcher is still polling for the listener must
+        tear the spawned python down, not exit the wrapper alone. The
+        trap signals the launcher's process group, so the agent dies
+        even in the window where it has no resolvable pid; a wrapper
+        that exits alone leaves an orphan holding the webhook port,
+        which blocks the next boot's bind. Uses a real subprocess and
+        short real waits because the contract under test is bash
+        signal delivery, which cannot be mocked."""
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        pid_file = tmp_path / "fake.pid"
+        fake = venv_bin / "python3"
+        # The fake agent records its pid, then execs a sleep (same
+        # pid) without ever binding the port, pinning the launcher
+        # inside its bind poll.
+        fake.write_text(f"#!/bin/bash\necho $$ > {pid_file}\nexec sleep 30\n")
+        fake.chmod(0o755)
+
+        script_path = tmp_path / "run.sh"
+        # Port 1 is never listened on, so the poll cannot succeed.
+        script_path.write_text(_generate_launcher_script(str(tmp_path), webhook_port=1))
+        script_path.chmod(0o755)
+
+        # New session mirrors launchd: the wrapper is its own process
+        # group leader, the same topology the group signal relies on.
+        proc = subprocess.Popen(["/bin/bash", str(script_path)], start_new_session=True)
+        try:
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                if pid_file.exists() and pid_file.read_text().strip():
+                    break
+                time.sleep(0.1)
+            fake_pid = int(pid_file.read_text().strip())
+
+            proc.send_signal(signal.SIGTERM)
+            # The trap fires once the in-flight 2s poll sleep returns;
+            # allow margin beyond that for teardown.
+            deadline = time.time() + 8
+            while time.time() < deadline:
+                try:
+                    os.kill(fake_pid, 0)
+                except ProcessLookupError:
+                    break
+                time.sleep(0.2)
+            else:
+                pytest.fail("fake python survived SIGTERM to the launcher")
+        finally:
+            # EPERM joins ESRCH here: once the wrapper has exited and
+            # awaits reaping, macOS refuses killpg on the zombie-led
+            # group rather than reporting it gone.
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(proc.pid, signal.SIGKILL)
+            proc.wait(timeout=5)
 
 
 # ── _apply_source ────────────────────────────────────────────────────

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5215,6 +5215,28 @@ class TestGenerateLauncherScript:
         assert "trap" in script
         assert "TERM" in script
 
+    def test_no_listener_exits_nonzero_instead_of_sleeping(self):
+        """Python dying before it binds the webhook port must end the
+        launcher with a non-zero exit so launchd's KeepAlive restarts
+        the service (visible, throttled). Any unconditional-sleep
+        fallback would leave launchd reporting state=running with no
+        agent behind it and the TERM trap with nothing to signal."""
+        script = _generate_launcher_script("/opt/kai")
+        assert "exit 1" in script
+        assert "sleep 86400" not in script
+
+    def test_bind_poll_window_covers_slow_startups(self):
+        """The port poll must outlast a healthy startup's bind time
+        (15-25s on this stack; the memory subsystem loads its
+        embedding model before the webhook server starts). 60
+        iterations at 2s gives the 120s window the script comment
+        promises; a window shorter than the bind time expires on
+        every healthy boot and leaves the launcher supervising
+        nothing."""
+        script = _generate_launcher_script("/opt/kai")
+        assert "seq 1 60" in script
+        assert "sleep 2" in script
+
 
 # ── _apply_source ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #638.

`run.sh` located the re-exec'd python by polling the webhook port for a fixed ~5 seconds and, when the lookup came back empty, slept forever. Two failure modes landed in that branch and were masked:

1. **Python died at startup** (for example a fail-closed config gate): launchd reported `state = running` for the sleeping bash wrapper, KeepAlive never fired because nothing exited, and the bot was silently down until a human noticed; observed in production during the recent startup-gate incident.
2. **Healthy but slow bind**: normal startups take 15 to 25 seconds to bind (the memory subsystem loads its embedding model before the webhook server starts), so the 5-second window expired on *every healthy boot*. The launcher then supervised nothing: the TERM trap signaled an empty pid on shutdown, orphaning the real python, which then blocked the next boot's bind; the likely root of the historical address-in-use incidents.

## Change

- The port poll is now a bounded retry: 60 iterations at 2 seconds (120s total), covering healthy binds with margin.
- When the window expires with no listener, the launcher logs one line to stderr and exits non-zero, so launchd's KeepAlive (plain `true`, ThrottleInterval 10) produces a visible, throttled restart loop instead of an eternal sleep. The invariant from the issue holds: python exiting can no longer leave the service in a permanent "running" state with no agent behind it.
- The direct child's death is deliberately not used as a failure signal; it exits on the framework re-exec in normal operation, so only the port answers whether the agent came up.
- No kill is attempted on the no-listener path: the re-exec'd argv carries no install path to match safely (it is the framework `Python.app` binary plus `-m kai`, identical in shape to any operator-run python). The residual case, a python that binds after the window, surfaces as the restarted instance's address-in-use startup error, which the startup-error choke point from #639 makes visible in the main log.

## Tests

- The generated script contains the bounded retry (`seq 1 60`, 2s sleeps) and the non-zero exit; the unconditional-sleep fallback (`sleep 86400`) is asserted absent.
- Existing launcher assertions (shebang, install dir, port, TERM trap) unchanged.
- Full suite: 3921 passed, 1 skipped; ruff check and format clean.
