### PR TITLE
fix(codex): anchor per-os-user TMPDIR in cross-user chat

### DIFF
--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -325,7 +325,11 @@ class CodexBackend(AgentBackend):
         # 3. CODEX_PROVIDER (forward-compat placeholder; "openai" today)
         # 4. Per-workspace env_file values
         # 5. Per-workspace inline env values (override env_file)
-        # 6. Webhook secret (LAST - workspace env can't override it)
+        # 6. Webhook secret (workspace env can't override it)
+        # 7. Per-os-user TMPDIR anchor (cross-user mode only; set
+        #    below once the effective user is resolved, LAST so
+        #    workspace env cannot point one user's temp writes at
+        #    another's)
         env = os.environ.copy()
         if self.model:
             env["CODEX_MODEL"] = self.model
@@ -347,6 +351,17 @@ class CodexBackend(AgentBackend):
         # None when codex_user matches the bot's own user (skipping
         # an unnecessary self-sudo) and the value unchanged otherwise.
         effective_codex_user = resolve_claude_user(self.codex_user)
+
+        # Per-os-user TMPDIR anchor (cross-user mode only). Namespaces
+        # every codex temp write under <DATA_DIR>/tmp/<os_user>/ (per-
+        # user dir created and chowned by install.py `_apply_migrate`)
+        # so two os_users sharing /tmp cannot collide on same-named
+        # temp artifacts; the --preserve-env clause below carries
+        # TMPDIR through sudo's env_reset. Same posture as the claude
+        # and ACP backends. Single-user mode (no codex_user) inherits
+        # the system default temp directory.
+        if effective_codex_user:
+            env["TMPDIR"] = str(DATA_DIR / "tmp" / effective_codex_user)
 
         # Resolve the codex binary path. When `codex` is not on the
         # service user's PATH (multi-user installs where codex lives

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1767,8 +1767,10 @@ def _cmd_config() -> None:
         "TTS_ENABLED": str(tts_enabled).lower(),
     }
 
-    # Agent backend is truly global (one backend per deployment).
-    # Only write non-default values to keep the env file clean.
+    # AGENT_BACKEND is the global default backend; users.yaml entries
+    # can override it per user. Only write non-default values to keep
+    # the env file clean (the runtime defaults to claude when the key
+    # is absent).
     if agent_backend != "claude":
         env["AGENT_BACKEND"] = agent_backend
 
@@ -3784,8 +3786,8 @@ def _apply_migrate(
     # whose --settings JSON hashes to the same hex collide on the
     # default /tmp path; the first writer owns the file at mode
     # 0o644 and the second claude exits with EACCES on the
-    # write-open. The cross-user spawn paths (claude.py and the
-    # shared ACP layer in acp.py) anchor TMPDIR per-os_user under
+    # write-open. The cross-user spawn paths (claude.py, codex.py,
+    # and the shared ACP layer in acp.py) anchor TMPDIR per-os_user under
     # <DATA_DIR>/tmp/<os_user>/ so each identity has its own temp
     # namespace. Create those dirs here, mode 0o700 chowned to the
     # target os_user (only their owner needs to read them). Parent

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -1,9 +1,10 @@
 """
 Provider-agnostic one-shot reasoning boundary.
 
-Used by semantic memory extraction (and any future caller that needs a
-bounded, stateless model call) so the caller does not embed provider
-subprocess mechanics. Distinct from `kai.backend.AgentBackend`: that
+Used by semantic memory extraction, episode generation, PR review,
+and issue triage (and any caller that needs a bounded, stateless
+model call) so the caller does not embed provider subprocess
+mechanics. Distinct from `kai.backend.AgentBackend`: that
 abstraction is for persistent, interactive sessions that own a long-
 running subprocess and inject Kai's identity / memory / history
 context. A one-shot reasoner has different lifecycle requirements: no
@@ -11,12 +12,11 @@ persistent state, a hard per-call timeout, stdin-only prompt delivery,
 optional structured-output schema, and an envelope that the CALLER
 parses (the reasoner returns raw text, not parsed memory objects).
 
-Phase 1 ships exactly one implementation: `ClaudeOneShotReasoner`. Its
-argv, env allow-list, neutral cwd, and timeout semantics are lifted
-verbatim from `kai.memory_extraction`'s previous direct subprocess
-spawn so that the Claude memory path stays byte-identical to its
-pre-refactor behavior. Future Codex / OpenCode implementations of the
-same `OneShotReasoner` protocol live here as siblings.
+Four sibling implementations of the same `OneShotReasoner` protocol
+live here: `ClaudeOneShotReasoner`, `CodexOneShotReasoner`,
+`OpenCodeOneShotReasoner`, and `GooseOneShotReasoner`. Memory
+extraction, episode generation, PR review, and issue triage all
+dispatch onto this family by the user's effective backend.
 
 `_EXTRACTOR_CWD`, `_ensure_extractor_cwd`, and `_SUBPROCESS_ENV_ALLOWLIST`
 are canonical here, not in memory_extraction. The behavioral eval
@@ -120,9 +120,9 @@ class OneShotResult:
     Return value from a `OneShotReasoner.run()` call.
 
     Attributes:
-        text: The model's raw output text. For Claude in Phase 1 this
-            is the stdout of `claude --print`, which the caller parses
-            for the JSON envelope it expects (`is_error`,
+        text: The model's raw output text. For claude in schema mode
+            this is the stdout of `claude --print`, which the caller
+            parses for the JSON envelope it expects (`is_error`,
             `structured_output`, etc.). The reasoner does not parse
             the envelope; that contract lives in memory_extraction.
         backend: Provider tag ("claude", "codex", "goose", or
@@ -134,12 +134,12 @@ class OneShotResult:
             responsibility.
         raw_metadata: Subprocess-layer metadata only - returncode,
             stderr bytes, and optionally cmd / cwd for log forensics.
-            Phase 1 deliberately does NOT include parsed-envelope
+            The dict deliberately does NOT include parsed-envelope
             fields (is_error, total_cost_usd, etc.); those stay in
             memory_extraction so the envelope is parsed exactly once.
-            Future provider implementations may populate
-            backend-specific fields, but no Phase 1 caller depends on
-            anything beyond returncode and stderr.
+            Implementations may populate backend-specific fields, but
+            no caller depends on anything beyond returncode and
+            stderr.
         duration_ms: Wall-clock duration of the underlying provider
             call, measured around the subprocess spawn + wait. Used
             for structured logging and for operator-side latency
@@ -204,7 +204,7 @@ class OneShotError(Exception):
 
 class OneShotTimeout(OneShotError):
     """The provider subprocess exceeded the call's timeout and was
-    killed. No payload fields in Phase 1: stage 1 maps this to
+    killed. No payload fields: stage 1 maps this to
     `ExtractionResult(facts=[], has_episode=False)`, stage 2 to the
     literal reason `"timeout"`, neither of which needs additional
     context off the exception. If a future caller needs the elapsed
@@ -514,10 +514,9 @@ class ClaudeOneShotReasoner:
     env allow-list, neutral cwd, and timeout semantics of this mode
     are lifted verbatim from the pre-refactor `_run_extractor` /
     `_run_episode_extractor` paths in `kai.memory_extraction`. That
-    is the load-bearing invariant for the Phase 1 refactor: the
-    Claude memory path must stay byte-identical to its prior
-    behavior, so any future drift in this implementation is a
-    semantic change and not a refactor.
+    is the load-bearing invariant: the Claude memory path must stay
+    byte-identical to its prior behavior, so any future drift in
+    this implementation is a semantic change and not a refactor.
 
     Free-form mode (`json_schema=None`): the output-format flag is
     omitted so `claude --print` emits the response text itself, and

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -125,9 +125,9 @@ class OneShotResult:
             for the JSON envelope it expects (`is_error`,
             `structured_output`, etc.). The reasoner does not parse
             the envelope; that contract lives in memory_extraction.
-        backend: Provider tag ("claude" today; "codex" / "opencode" in
-            future implementations). Surfaces in structured logs and
-            run-record JSON so cross-backend comparisons are possible.
+        backend: Provider tag ("claude", "codex", "goose", or
+            "opencode"). Surfaces in structured logs and run-record
+            JSON so cross-backend comparisons are possible.
         model: Model name passed to the provider, or None when the
             caller did not request a specific model. The reasoner
             does not validate model strings; that is the caller's
@@ -171,6 +171,14 @@ class OneShotReasoner(Protocol):
     in structured logs only; the reasoner does not branch on it. The
     field is required (not optional) so log streams can always
     identify which caller spawned the subprocess.
+
+    Constructors are not part of this protocol and differ where the
+    underlying CLI demands it: `GooseOneShotReasoner` additionally
+    requires a `provider` argument (goose is multi-provider and its
+    argv carries the provider's wire-level name), while the claude /
+    codex / opencode reasoners derive their provider implicitly.
+    Callers constructing reasoners by backend name must thread the
+    user's effective provider when the backend is goose.
     """
 
     async def run(

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -37,7 +37,7 @@ import pytest
 
 from kai.backend import USER_MESSAGE_MARKER, StreamEvent
 from kai.codex import CodexBackend, write_turn_image_file
-from kai.config import WorkspaceConfig
+from kai.config import DATA_DIR, WorkspaceConfig
 
 # ── Shared helpers ──────────────────────────────────────────────────
 
@@ -1617,6 +1617,46 @@ class TestCodexUserSudoWrap:
         # Codex binary follows the sudo prologue.
         codex_i = argv.index("codex")
         assert argv[codex_i + 1] == "app-server"
+
+    @pytest.mark.asyncio
+    async def test_tmpdir_anchored_per_os_user_in_cross_user_mode(self):
+        """
+        When codex_user is set, the subprocess env must include
+        TMPDIR=<DATA_DIR>/tmp/<os_user>/ so every codex temp write
+        lands in a per-os-user namespace rather than the shared
+        system /tmp, where two distinct os_users can collide on
+        same-named temp artifacts. Mirrors the claude and ACP
+        backends' anchor; the per-user dirs are created and chowned
+        by the install.
+        """
+        c = _make_codex(codex_user="ci-fake-user")
+        proc = _make_mock_proc(_handshake_lines())
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await c._ensure_started()
+        env = mock_exec.call_args[1]["env"]
+        assert env["TMPDIR"] == str(DATA_DIR / "tmp" / "ci-fake-user")
+        # The anchor only matters if it survives sudo's env_reset.
+        argv = mock_exec.call_args[0]
+        assert any("TMPDIR" in str(a) for a in argv if str(a).startswith("--preserve-env="))
+
+    @pytest.mark.asyncio
+    async def test_tmpdir_not_injected_in_single_user_mode(self, monkeypatch):
+        """
+        Single-user mode (no codex_user, or codex_user == service
+        user) runs codex directly without sudo and has no cross-
+        os-user temp collision risk. TMPDIR must NOT be injected so
+        the inner codex inherits the system default.
+        """
+        # Ensure the parent env has no TMPDIR so any value showing up
+        # in the subprocess env can only have come from our code path.
+        monkeypatch.delenv("TMPDIR", raising=False)
+
+        c = _make_codex()  # no codex_user, no sudo wrapper
+        proc = _make_mock_proc(_handshake_lines())
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await c._ensure_started()
+        env = mock_exec.call_args[1]["env"]
+        assert "TMPDIR" not in env
 
     @pytest.mark.asyncio
     async def test_start_new_session_when_codex_user_set(self):


### PR DESCRIPTION
Implements the actionable batch from the backend parity sweep: the one code gap plus the two comment corrections.

## TMPDIR anchor (the code change)

The cross-user codex chat wrap preserved `TMPDIR` through sudo's `env_reset` but never set it, leaving codex the only backend whose cross-user temp writes landed on the shared system `/tmp` instead of the per-os-user namespace under `DATA_DIR/tmp/` that the install provisions for every distinct os_user. Harmless today (codex turn images live under `DATA_DIR/files/` with cross-user-readable modes), but the asymmetry was unexplained and the fix is the established pattern.

The anchor is set once the effective user is resolved, last in the env merge order so workspace env cannot point one user's temp writes at another's, mirroring `claude.py` and the shared ACP layer. Single-user mode still inherits the system default. The existing preserve-CSV test comment already described "the webhook secret and TMPDIR anchor"; the anchor now exists to match it.

Tests mirror the claude precedent pair: anchored in cross-user mode (with a preserve-clause assertion, since the anchor only matters if it survives `env_reset`), and not injected in single-user mode.

## Comment corrections

- install.py env emission: "Agent backend is truly global (one backend per deployment)" contradicted the shipped per-user `users.yaml` overrides; now states the global-default-plus-per-user-override contract and why only non-default values are written.
- install.py per-user tmp-dir block: the consumer enumeration now includes `codex.py`.
- oneshot.py `OneShotReasoner` protocol docstring: documents that `GooseOneShotReasoner` alone requires a `provider` constructor argument (goose is multi-provider; its argv carries the wire-level provider name), so callers constructing reasoners by backend name know to thread the user's effective provider.
- oneshot.py `OneShotResult.backend`: the tag list now names all four backends instead of describing codex and opencode as future implementations.

## Verification

3929 passed, 1 skipped; ruff clean. The two new tests pin the anchor behavior in both modes.
