### PR TITLE
feat(install): add a CLAUDE_BIN override for the claude binary

### DIFF
--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -184,9 +184,19 @@ class ClaudeCodeBackend(AgentBackend):
         if self.is_alive:
             return
 
+        # Resolve the claude binary path. The CLAUDE_BIN env var lets
+        # the install (or operator) pin an absolute path; the sudoers
+        # rule for cross-user spawns names the same file, and sudo's
+        # PATH resolution of a bare name must land on exactly that
+        # file for the rule to match. Falls back to bare "claude" so
+        # installs with claude on the service user's PATH and no
+        # override keep working. Mirrors the CODEX_BIN handling in
+        # codex.py.
+        claude_bin = os.environ.get("CLAUDE_BIN") or "claude"
+
         # Build the Claude command arguments.
         claude_cmd = [
-            "claude",
+            claude_bin,
             "--input-format",
             "stream-json",
             "--output-format",

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -2920,10 +2920,11 @@ def load_config() -> Config:
     # _check_model_registry_complete() call is self-driving over every
     # (backend, provider) pair in BACKEND_PROVIDERS, so registry rows
     # are already validated for every backend including per-user
-    # overrides. `resolve_oneshot_binary` is per-backend (CODEX_BIN
-    # location, opencode binary path) so it stays in the loop;
-    # a missing CODEX_BIN on a deployment where any user routes to
-    # codex fails fast at startup instead of at the first extraction.
+    # overrides. `resolve_oneshot_binary` is per-backend (each backend
+    # honors its *_BIN override, falling back to PATH) so it stays in
+    # the loop; a missing binary on a deployment where any user routes
+    # to that backend fails fast at startup instead of at the first
+    # extraction.
     if memory_extraction_enabled and extraction_eligible_backends:
         from kai.oneshot_binary import BinaryResolutionError, resolve_oneshot_binary
 
@@ -2934,8 +2935,9 @@ def load_config() -> Config:
                 raise SystemExit(
                     f"Memory extraction requires the {_backend!r} binary to be reachable "
                     f"at startup (at least one extraction-eligible user routes to it), but "
-                    f"{e}. Set CODEX_BIN (for codex) or fix PATH (for either backend); "
-                    f"rerun the wizard if you no longer want memory extraction enabled."
+                    f"{e}. Set {_backend.upper()}_BIN to the binary's absolute path or "
+                    f"fix PATH; rerun the wizard if you no longer want memory extraction "
+                    f"enabled."
                 ) from None
 
     # Renamed env vars: warn when the legacy name is present so the

--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -410,8 +410,12 @@ def _build_judge_cmd(config: BehavioralConfig) -> list[str]:
     probe as judge_error with no diagnostic. Re-run the verification
     if upgrading the CLI past 2.x.
     """
+    # CLAUDE_BIN env override is honored same as triage/review and the
+    # one-shot resolver, so the eval spawns the same binary the rest
+    # of the system pins.
+    claude_bin = os.environ.get("CLAUDE_BIN") or "claude"
     return [
-        "claude",
+        claude_bin,
         "--print",
         "--model",
         config.judge_model,
@@ -450,8 +454,10 @@ def _build_gen_cmd(config: BehavioralConfig) -> list[str]:
       `claude_cli_version` field in the output JSON lets cross-run
       comparisons detect drift in that residual.
     """
+    # Same CLAUDE_BIN precedence as the judge builder above.
+    claude_bin = os.environ.get("CLAUDE_BIN") or "claude"
     return [
-        "claude",
+        claude_bin,
         "--print",
         "--model",
         config.gen_model,
@@ -1717,11 +1723,12 @@ def _capture_agent_cli_version(backend: str) -> tuple[str, str]:
     is the most likely cause of a swing in win-rate that does not
     correspond to any code change in Kai or in the probe set.
 
-    The codex branch honors `CODEX_BIN`. Recording the version of
-    `codex` from PATH when the eval subprocess actually spawned
-    `$CODEX_BIN` would be a debugging trap: an operator chasing a
-    schema-drift bug would see the wrong version string. The
-    `--version` flag goes to the same binary the eval will spawn.
+    Both branches honor their binary override (`CLAUDE_BIN` /
+    `CODEX_BIN`). Recording the version of the PATH binary when the
+    eval subprocess actually spawned the override would be a
+    debugging trap: an operator chasing a schema-drift bug would see
+    the wrong version string. The `--version` flag goes to the same
+    binary the eval will spawn.
 
     Best-effort: if the CLI is missing, mis-aliased, or `--version`
     fails for any reason, the value is the literal "unknown". The
@@ -1734,10 +1741,11 @@ def _capture_agent_cli_version(backend: str) -> tuple[str, str]:
         codex_bin = os.environ.get("CODEX_BIN") or "codex"
         argv = [codex_bin, "--version"]
     else:
-        # claude (and any unknown backend, by design) - preserve the
-        # historical lookup.
+        # claude (and any unknown backend, by design) - same binary
+        # precedence as the judge / generator builders.
         field_name = "claude_cli_version"
-        argv = ["claude", "--version"]
+        claude_bin = os.environ.get("CLAUDE_BIN") or "claude"
+        argv = [claude_bin, "--version"]
     try:
         result = subprocess.run(
             argv,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -352,6 +352,20 @@ def _validate_chat_id(value: str) -> bool:
         return False
 
 
+def _validate_claude_bin(value: str) -> bool:
+    """Return True when the path exists and is executable.
+
+    Required by the claude wizard prompt; the path is baked into both
+    the runtime CLAUDE_BIN env var and the sudoers rule that allows
+    cross-os_user claude spawns, so a non-existent path here would
+    surface as a confusing 'a password is required' at first message.
+    """
+    if not value:
+        return False
+    p = Path(value)
+    return p.is_file() and os.access(p, os.X_OK)
+
+
 def _validate_codex_bin(value: str) -> bool:
     """Return True when the path exists and is executable.
 
@@ -941,6 +955,34 @@ def _cmd_config() -> None:
     # opencode above (global-goose block, extraction defense-in-depth
     # re-prompt, empty-skip persistence gate for GOOSE_BIN).
     goose_bin = ""
+    # Claude binary path: same collection and persistence shape as
+    # opencode (global-claude block, extraction defense-in-depth
+    # re-prompt, empty-skip persistence gate for CLAUDE_BIN).
+    claude_bin = ""
+    if agent_backend == "claude":
+        # Claude binary path: wizard-prompted and persisted in
+        # install.conf so `make install` writes both /etc/kai/env's
+        # CLAUDE_BIN and the sudoers SETENV rule from the same source
+        # of truth. Default suggestion uses `which claude` from the
+        # operator's PATH; falls back to the empty string when which
+        # finds nothing (claude has two canonical install locations,
+        # the native installer's ~/.local/bin/claude and the Homebrew
+        # cask's /opt/homebrew/bin/claude, so an empty default forces
+        # the operator to type the path explicitly rather than accept
+        # a wrong guess between the two). The _cmd_apply env
+        # passthrough (`sudo CLAUDE_BIN=... make install`) still works
+        # as the ad-hoc deploy escape hatch; the wizard path is the
+        # canonical source of truth.
+        while True:
+            which_claude = shutil.which("claude") or ""
+            claude_bin = _prompt(
+                "Claude binary path",
+                existing_env.get("CLAUDE_BIN", which_claude),
+                required=True,
+            )
+            if _validate_claude_bin(claude_bin):
+                break
+            print(f"  Path '{claude_bin}' does not exist or is not executable.")
     if agent_backend == "codex":
         codex_auth_mode = _prompt_choice(
             "Codex auth mode",
@@ -1122,12 +1164,22 @@ def _cmd_config() -> None:
     # in play; the values flow into the same codex_bin / opencode_bin
     # / goose_bin variables, so the existing persistence (env var,
     # install.conf, sudoers SETENV rule) needs no new emission sites.
-    # Claude is exempt: it has no *_BIN wizard surface and resolves
-    # through the service PATH the launchd plist pins. Prompt loops
-    # mirror the global blocks, including each backend's default
-    # posture (codex falls back to Homebrew; goose and opencode
-    # force an explicit path when `which` finds nothing).
+    # Prompt loops mirror the global blocks, including each backend's
+    # default posture (codex falls back to Homebrew; claude, goose,
+    # and opencode force an explicit path when `which` finds nothing).
     peruser_backends = _users_yaml_agent_backends(users_yaml_path)
+    if "claude" in peruser_backends and not claude_bin:
+        print("  users.yaml has a claude entry; the daemon needs a resolvable claude binary.")
+        while True:
+            which_claude = shutil.which("claude") or ""
+            claude_bin = _prompt(
+                "Claude binary path",
+                existing_env.get("CLAUDE_BIN", which_claude),
+                required=True,
+            )
+            if _validate_claude_bin(claude_bin):
+                break
+            print(f"  Path '{claude_bin}' does not exist or is not executable.")
     if "codex" in peruser_backends and not codex_bin:
         print("  users.yaml has a codex entry; the daemon needs a resolvable codex binary.")
         while True:
@@ -1609,6 +1661,25 @@ def _cmd_config() -> None:
                         if _validate_goose_bin(goose_bin):
                             break
                         print(f"  Path '{goose_bin}' does not exist or is not executable.")
+                # Same defense-in-depth shape for the claude global
+                # backend, completing the four-backend set: the
+                # global-claude block above collects claude_bin on
+                # the normal flow; this gate covers a future refactor
+                # that reaches the extraction prompts with claude_bin
+                # still empty. Defaults mirror the global block
+                # (`which claude`, else empty so the operator types
+                # the path explicitly).
+                if agent_backend == "claude" and not claude_bin:
+                    while True:
+                        which_claude = shutil.which("claude") or ""
+                        claude_bin = _prompt(
+                            "Claude binary path (required by claude memory reasoner)",
+                            existing_env.get("CLAUDE_BIN", which_claude),
+                            required=True,
+                        )
+                        if _validate_claude_bin(claude_bin):
+                            break
+                        print(f"  Path '{claude_bin}' does not exist or is not executable.")
                 # Extraction timeout is the LLM-call hard cap inside
                 # memory_extraction.py:541. Default 10s is too aggressive
                 # for production - real extractions routinely take 20-30s
@@ -1844,6 +1915,13 @@ def _cmd_config() -> None:
     # GOOSE_BIN and the sudoers SETENV rule so the two cannot drift.
     if goose_bin:
         env["GOOSE_BIN"] = goose_bin
+    # Same gating shape again for claude: persist only when the wizard
+    # collected a value, so installs that never collected one carry no
+    # CLAUDE_BIN= line and keep resolving claude via the service PATH.
+    # The single emission drives both /etc/kai/env's CLAUDE_BIN and
+    # the sudoers SETENV rule so the two cannot drift.
+    if claude_bin:
+        env["CLAUDE_BIN"] = claude_bin
 
     # Remove stale renamed keys if present - leaving both the old and
     # new key causes silent confusion (the deprecation warning is
@@ -2663,6 +2741,7 @@ def _collect_user_home_overrides(users_yaml_path: str | Path) -> dict[int, Path]
 def _generate_sudoers(
     service_user: str,
     os_users: Iterable[str] = (),
+    claude_bin: str | None = None,
     codex_bin: str | None = None,
     opencode_bin: str | None = None,
     goose_bin: str | None = None,
@@ -2683,14 +2762,17 @@ def _generate_sudoers(
     cross-user kill escalation) are emitted for every distinct `os_user`
     value in users.yaml. Users matching `service_user` are skipped (the
     runtime detects self-sudo via resolve_claude_user() and spawns the
-    agent directly without sudo). The codex binary path defaults to
-    /opt/homebrew/bin/codex; Linux installs override with the CODEX_BIN
-    env var at install time. The opencode rule uses the service user's
-    `~/.local/bin/opencode` path (where the upstream installer drops the
-    binary by default); operators with a custom install location can
-    override via OPENCODE_BIN. The goose rule defaults to
-    /opt/homebrew/bin/goose (the Homebrew cask location) with the same
-    GOOSE_BIN override shape.
+    agent directly without sudo). The claude rule defaults to the
+    service user's `~/.local/bin/claude` (the native installer
+    location); operators with a custom install location (e.g. the
+    Homebrew cask) override via CLAUDE_BIN. The codex binary path
+    defaults to /opt/homebrew/bin/codex; Linux installs override with
+    the CODEX_BIN env var at install time. The opencode rule uses the
+    service user's `~/.local/bin/opencode` path (where the upstream
+    installer drops the binary by default); operators with a custom
+    install location can override via OPENCODE_BIN. The goose rule
+    defaults to /opt/homebrew/bin/goose (the Homebrew cask location)
+    with the same GOOSE_BIN override shape.
 
     Args:
         service_user: The OS username that runs the Kai service.
@@ -2739,18 +2821,19 @@ def _generate_sudoers(
         target_users.append(candidate)
 
     if target_users:
-        # Anchor the rule path to the SERVICE user's claude install. The
-        # bot spawns `sudo -u <target> -- claude` and sudo resolves the
-        # bare `claude` against the caller's PATH (the service user's,
-        # not the target's), so the rule must reference the service
-        # user's binary. shutil.which("claude") used to be the first
-        # half of this expression but resolved against whatever PATH
-        # root happened to have when `sudo make install` ran - which
-        # picked up any user's `~/.local/bin/claude` that happened to
-        # be on PATH at install time, baking the wrong path into the
-        # rule and breaking the bot's sudo dispatch.
+        # Anchor the rule path to the wizard-collected CLAUDE_BIN when
+        # present, else the SERVICE user's native-installer location.
+        # The runtime spawn uses the same precedence (claude.py reads
+        # CLAUDE_BIN, else spawns bare `claude` which sudo resolves
+        # against the caller's PATH, the service user's), so the rule
+        # references the same binary the bot invokes. We deliberately
+        # do NOT call shutil.which here: resolving against whatever
+        # PATH root has when `sudo make install` runs can pick up any
+        # user's `~/.local/bin/claude` that happens to be on PATH at
+        # install time, baking the wrong path into the rule and
+        # breaking the bot's sudo dispatch.
         svc_home = _user_home(service_user)
-        claude_bin = f"{svc_home}/.local/bin/claude"
+        claude_bin_resolved = claude_bin or f"{svc_home}/.local/bin/claude"
         # Codex binary path is now threaded as an argument. The wizard
         # prompts for and persists the value in install.conf; _cmd_apply
         # passes it to _apply_sudoers which passes it here. We
@@ -2821,7 +2904,7 @@ def _generate_sudoers(
             # delta is zero.
         """)
         for target in target_users:
-            rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {claude_bin}\n"
+            rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {claude_bin_resolved}\n"
             rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {codex_bin_resolved}\n"
             rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {opencode_bin_resolved}\n"
             rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {goose_bin_resolved}\n"
@@ -4060,6 +4143,12 @@ def _cmd_apply() -> None:
         env_goose_bin = os.environ.get("GOOSE_BIN")
         if env_goose_bin and env.get("AGENT_BACKEND") == "goose":
             env["GOOSE_BIN"] = env_goose_bin
+        # And for CLAUDE_BIN, completing the per-backend set. The
+        # AGENT_BACKEND gate compares against the runtime default
+        # because the wizard omits the key on claude installs.
+        env_claude_bin = os.environ.get("CLAUDE_BIN")
+        if env_claude_bin and env.get("AGENT_BACKEND", "claude") == "claude":
+            env["CLAUDE_BIN"] = env_claude_bin
         # AGENT_TIMEOUT_SECONDS migration. Operators upgrading without
         # re-running the wizard carry the legacy CLAUDE_TIMEOUT_SECONDS
         # key in install.conf; rewrite to the canonical name at apply
@@ -4106,6 +4195,7 @@ def _cmd_apply() -> None:
         _apply_sudoers(
             service_user,
             dry_run,
+            claude_bin=env.get("CLAUDE_BIN"),
             codex_bin=env.get("CODEX_BIN"),
             opencode_bin=env.get("OPENCODE_BIN"),
             goose_bin=env.get("GOOSE_BIN"),
@@ -5278,6 +5368,7 @@ def _apply_sudoers(
     service_user: str,
     dry_run: bool,
     users_yaml_path: str | Path | None = None,
+    claude_bin: str | None = None,
     codex_bin: str | None = None,
     opencode_bin: str | None = None,
     goose_bin: str | None = None,
@@ -5292,14 +5383,16 @@ def _apply_sudoers(
     SETENV: NOPASSWD: rule. Without this, hand-added per-user rules
     were silently wiped on every `sudo make install`.
 
-    `codex_bin`, `opencode_bin`, and `goose_bin` are threaded from
-    `_cmd_apply`'s env dict (which sources them from install.conf,
-    after the apply-time env-var override block) so the SETENV rules
-    pin the same absolute paths the running bot will invoke.
+    `claude_bin`, `codex_bin`, `opencode_bin`, and `goose_bin` are
+    threaded from `_cmd_apply`'s env dict (which sources them from
+    install.conf, after the apply-time env-var override block) so the
+    SETENV rules pin the same absolute paths the running bot will
+    invoke. `claude_bin` falls back to the service user's
+    `~/.local/bin/claude` (the native installer location);
     `codex_bin` falls back to /opt/homebrew/bin/codex; `opencode_bin`
     falls back to the service user's `~/.local/bin/opencode`;
     `goose_bin` falls back to /opt/homebrew/bin/goose. The fallbacks
-    fire only on first-time installs where the wizard has not run yet.
+    fire only on installs where the wizard has not collected a value.
 
     `agent_backend` is the install's global backend (the env dict's
     AGENT_BACKEND, defaulting to claude when the key is absent, which
@@ -5323,6 +5416,7 @@ def _apply_sudoers(
     sudoers_content = _generate_sudoers(
         service_user,
         os_users,
+        claude_bin=claude_bin,
         codex_bin=codex_bin,
         opencode_bin=opencode_bin,
         goose_bin=goose_bin,
@@ -5351,11 +5445,9 @@ def _apply_sudoers(
         # backend with a sudoers rule needs an entry in both places.
         expected_bins: dict[str, tuple[Path, str]] = {
             "claude": (
-                Path(f"{svc_home}/.local/bin/claude"),
-                "The bot's runtime spawn resolves bare `claude` against the "
-                "service user's PATH - install claude via the native installer "
-                "(`~/.local/bin/claude`) or symlink your existing install there "
-                "to keep the rule and runtime in sync.",
+                Path(claude_bin or f"{svc_home}/.local/bin/claude"),
+                "Re-run 'make config' and point CLAUDE_BIN at the actual claude "
+                "install location to keep the rule and runtime in sync.",
             ),
             "codex": (
                 Path(codex_bin or "/opt/homebrew/bin/codex"),

--- a/src/kai/oneshot_binary.py
+++ b/src/kai/oneshot_binary.py
@@ -55,9 +55,11 @@ def resolve_oneshot_binary(backend: str) -> str:
     Return the absolute path of the agent binary the OneShotReasoner
     of `backend` will invoke.
 
-    `backend == "claude"`: `shutil.which("claude")`. Resolution
-    sequence: claude on PATH only. Failure message names that
-    sequence.
+    `backend == "claude"`: branch on `CLAUDE_BIN` with the same
+    is-file plus executable validation pattern as the codex arm.
+    Unset falls through to `shutil.which("claude")`, which covers
+    the native-installer layout where the launcher is already on
+    the service user's PATH.
 
     `backend == "codex"`: branch on `CODEX_BIN`.
       - Explicit override: when `CODEX_BIN` is set, resolve to that
@@ -91,13 +93,24 @@ def resolve_oneshot_binary(backend: str) -> str:
     bug, not the operator's PATH.
     """
     if backend == "claude":
-        # Resolution: claude on PATH only. No explicit-override
-        # variable for claude (CLAUDE_CONFIG_DIR controls auth state,
-        # not binary discovery). A future CLAUDE_BIN override would
-        # land here as the second branch.
+        # Structural mirror of the codex / opencode / goose arms.
+        # CLAUDE_BIN, when set, is validated as a configuration error
+        # with no PATH fallback; unset falls through to PATH
+        # discovery, which covers the native-installer layout where
+        # `~/.local/bin/claude` is already on the service user's
+        # PATH. (CLAUDE_CONFIG_DIR controls auth state, not binary
+        # discovery; it is unrelated to this resolution.)
+        override = os.environ.get("CLAUDE_BIN")
+        if override:
+            override_path = Path(override)
+            if not override_path.is_file():
+                raise BinaryResolutionError(f"could not resolve claude binary: CLAUDE_BIN={override!r} not-a-file")
+            if not os.access(str(override_path), os.X_OK):
+                raise BinaryResolutionError(f"could not resolve claude binary: CLAUDE_BIN={override!r} not-executable")
+            return str(override_path)
         resolved = shutil.which("claude")
         if resolved is None:
-            raise BinaryResolutionError("could not resolve claude binary: `claude` not on PATH")
+            raise BinaryResolutionError("could not resolve claude binary: CLAUDE_BIN unset, `claude` not on PATH")
         return resolved
 
     if backend == "codex":

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -366,6 +366,44 @@ class TestCommandConstruction:
             assert "TMPDIR" not in env
 
     @pytest.mark.asyncio
+    async def test_claude_bin_override_pins_absolute_path(self, monkeypatch):
+        """CLAUDE_BIN pins the argv head so a sudo-wrapped per-user
+        spawn matches the absolute path the sudoers rule names
+        (mirrors codex's CODEX_BIN and opencode's OPENCODE_BIN
+        contract)."""
+        monkeypatch.setenv("CLAUDE_BIN", "/opt/homebrew/bin/claude")
+        claude = _make_claude()
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = AsyncMock()
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+            cmd = mock_exec.call_args[0]
+            assert cmd[0] == "/opt/homebrew/bin/claude"
+
+    @pytest.mark.asyncio
+    async def test_empty_claude_bin_falls_back_to_bare_name(self, monkeypatch):
+        """An empty-string CLAUDE_BIN (unset-but-present in
+        /etc/kai/env) must not produce an empty argv head."""
+        monkeypatch.setenv("CLAUDE_BIN", "")
+        claude = _make_claude()
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = AsyncMock()
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+            cmd = mock_exec.call_args[0]
+            assert cmd[0] == "claude"
+
+    @pytest.mark.asyncio
     async def test_no_settings_flag_in_cmd(self):
         """The argv carries no --settings flag: the context window
         setting was removed, and no other knob routes through the

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -1521,6 +1521,27 @@ class TestBuildGenCmdCodex:
         assert cmd[0] == "/tmp/fake-codex"
 
 
+class TestClaudeBinOverride:
+    """The claude judge / generator builders honor CLAUDE_BIN the
+    same way the codex builders honor CODEX_BIN, so the eval spawns
+    the binary the rest of the system pins."""
+
+    def test_judge_cmd_honors_claude_bin(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_BIN", "/tmp/fake-claude")
+        cmd = _build_judge_cmd(_make_config())
+        assert cmd[0] == "/tmp/fake-claude"
+
+    def test_gen_cmd_honors_claude_bin(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_BIN", "/tmp/fake-claude")
+        cmd = _build_gen_cmd(_make_config())
+        assert cmd[0] == "/tmp/fake-claude"
+
+    def test_unset_claude_bin_uses_bare_name(self, monkeypatch):
+        monkeypatch.delenv("CLAUDE_BIN", raising=False)
+        assert _build_judge_cmd(_make_config())[0] == "claude"
+        assert _build_gen_cmd(_make_config())[0] == "claude"
+
+
 class TestRenderCodexStdin:
     """The stdin renderer prepends a boundary-delimited SYSTEM block when
     a system prompt is set, and emits the user payload unchanged when
@@ -1663,6 +1684,7 @@ class TestCaptureAgentCliVersionCodex:
 
     def test_claude_branch_uses_claude_version(self, monkeypatch):
         monkeypatch.delenv("CODEX_BIN", raising=False)
+        monkeypatch.delenv("CLAUDE_BIN", raising=False)
         fake_result = MagicMock()
         fake_result.returncode = 0
         fake_result.stdout = "claude 2.1.118\n"
@@ -1671,6 +1693,16 @@ class TestCaptureAgentCliVersionCodex:
         assert field == "claude_cli_version"
         assert value == "claude 2.1.118"
         assert mock_run.call_args[0][0] == ["claude", "--version"]
+
+    def test_claude_branch_honors_claude_bin(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_BIN", "/tmp/fake-claude")
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = "claude 2.1.118\n"
+        with patch("kai.eval.behavioral.subprocess.run", return_value=fake_result) as mock_run:
+            field, _value = _capture_agent_cli_version("claude")
+        assert field == "claude_cli_version"
+        assert mock_run.call_args[0][0] == ["/tmp/fake-claude", "--version"]
 
     def test_codex_branch_uses_codex_version(self, monkeypatch):
         monkeypatch.delenv("CODEX_BIN", raising=False)
@@ -1695,6 +1727,7 @@ class TestCaptureAgentCliVersionCodex:
 
     def test_unknown_backend_falls_back_to_claude(self, monkeypatch):
         monkeypatch.delenv("CODEX_BIN", raising=False)
+        monkeypatch.delenv("CLAUDE_BIN", raising=False)
         fake_result = MagicMock()
         fake_result.returncode = 0
         fake_result.stdout = "claude 2.1.118\n"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -382,6 +382,15 @@ class TestGenerateSudoers:
         assert "/home/kai/.local/bin/claude" in result
         assert "/some/other/users/local/bin/claude" not in result
 
+    def test_claude_bin_arg_overrides_default(self, monkeypatch):
+        """An explicit claude_bin (the wizard-collected CLAUDE_BIN)
+        replaces the service-home fallback in the per-user rule, so
+        the rule names the same binary the runtime spawn pins."""
+        monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
+        result = _generate_sudoers("kai", os_users=["alice"], claude_bin="/opt/homebrew/bin/claude")
+        assert "kai ALL=(alice) SETENV: NOPASSWD: /opt/homebrew/bin/claude" in result
+        assert "/home/kai/.local/bin/claude" not in result
+
     # -- Issue #341: per-user rules from users.yaml -----------------------
 
     def test_no_per_user_rule_when_os_users_empty(self, monkeypatch):
@@ -1114,6 +1123,7 @@ class TestCmdConfig:
                 "false",  # advanced user options
                 "polling",  # transport
                 "claude",  # agent backend
+                "/usr/bin/true",  # claude binary path
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
@@ -1162,6 +1172,25 @@ class TestCmdConfig:
         assert data["users"][0]["telegram_id"] == 12345
         assert data["users"][0]["role"] == "admin"
 
+    def test_claude_install_emits_claude_bin(self, tmp_path, monkeypatch):
+        """The wizard-collected claude binary path lands in
+        install.conf's env as CLAUDE_BIN, so `make install` writes
+        /etc/kai/env's CLAUDE_BIN and the sudoers SETENV rule from the
+        same source of truth (the same contract CODEX_BIN /
+        OPENCODE_BIN / GOOSE_BIN follow)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._redirect_staging(monkeypatch, tmp_path)
+
+        inputs = iter(self._base_inputs(["false"]))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        conf = json.loads((tmp_path / "install.conf").read_text())
+        assert conf["env"]["CLAUDE_BIN"] == "/usr/bin/true"
+
     def test_advanced_user_options(self, tmp_path, monkeypatch):
         """
         Advanced path writes os_user and skips CLAUDE_USER.
@@ -1192,6 +1221,7 @@ class TestCmdConfig:
                 # no home_workspace prompt post-#353
                 "polling",  # transport
                 "claude",  # agent backend
+                "/usr/bin/true",  # claude binary path
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
@@ -1273,6 +1303,7 @@ class TestCmdConfig:
                 "false",  # advanced user options -> no os_user, no home prompt
                 "polling",  # transport
                 "claude",  # agent backend
+                "/usr/bin/true",  # claude binary path
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
@@ -1342,6 +1373,7 @@ class TestCmdConfig:
                 "testuser",  # os_user (no home_workspace prompt should follow)
                 "polling",
                 "claude",
+                "/usr/bin/true",  # claude binary path
                 "sonnet",
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",
@@ -1593,8 +1625,13 @@ class TestCmdConfig:
         existing_users_yaml = "users:\n  - telegram_id: 999\n    name: existing\n    role: admin\n"
         self._simulate_existing_etc_users_yaml(monkeypatch, existing_users_yaml)
 
-        # Press Enter for everything (accept all defaults)
-        monkeypatch.setattr("builtins.input", lambda prompt: "")
+        # Press Enter for everything except the claude binary prompt,
+        # whose default depends on the runner's PATH (`which claude`);
+        # an explicit answer keeps the test host-independent.
+        monkeypatch.setattr(
+            "builtins.input",
+            lambda prompt: "/usr/bin/true" if "Claude binary path" in prompt else "",
+        )
 
         _cmd_config()
 
@@ -1676,6 +1713,13 @@ class TestCmdConfig:
         # wizard-test precedent), so the literal path here never
         # touches the host filesystem.
         backend_block: list[str] = []
+        if agent_backend == "claude":
+            # The global-claude block prompts for the binary path
+            # right after backend selection. /usr/bin/true exists and
+            # is executable on macOS and Linux CI runners alike, so
+            # the real _validate_claude_bin passes without a claude
+            # install on the host and without a validator stub.
+            backend_block.append("/usr/bin/true")
         if agent_backend == "goose":
             backend_block.append("/opt/homebrew/bin/goose")
         if agent_backend != "claude":
@@ -2050,9 +2094,13 @@ class TestCmdConfig:
         conf_path.write_text(json.dumps(existing))
         # users.yaml is simulated above via _simulate_existing_etc_users_yaml,
         # which keeps the wizard on the existing-config branch and skips
-        # the per-user prompts that lack defaults.
-
-        monkeypatch.setattr("builtins.input", lambda prompt: "")
+        # the per-user prompts that lack defaults. The claude binary
+        # prompt gets an explicit answer because its default depends
+        # on the runner's PATH (`which claude`).
+        monkeypatch.setattr(
+            "builtins.input",
+            lambda prompt: "/usr/bin/true" if "Claude binary path" in prompt else "",
+        )
 
         _cmd_config()
 
@@ -2844,6 +2892,7 @@ class TestCmdConfigDefaultModelDispatch:
             "fake-token",  # bot token
             "polling",  # transport
             "claude",  # agent backend
+            "/usr/bin/true",  # claude binary path
             # model prompt is handled by the _prompt_default_model mock
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout (global default)
@@ -6460,6 +6509,7 @@ class TestCmdConfigCanonicalUsersYaml:
             "false",  # advanced
             "polling",
             "claude",
+            "/usr/bin/true",  # claude binary path
             "sonnet",
             "false",  # customize per-role models (decline)
             "120",
@@ -6809,6 +6859,7 @@ class TestCmdConfigSingleUserMode:
             "false",  # advanced
             "polling",  # transport
             "claude",  # backend
+            "/usr/bin/true",  # claude binary path
             "sonnet",  # model
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # timeout
@@ -7948,6 +7999,42 @@ class TestApplyMigratePerOsUserTmpdir:
 # ── Codex wizard hardening: validators and apply-time checks ─────────
 
 
+class TestValidateClaudeBin:
+    """claude binary path existence validator. Mirrors
+    `TestValidateCodexBin` exactly: same five edge cases (empty,
+    nonexistent, directory, non-executable file, executable file)."""
+
+    def test_empty_value_rejected(self):
+        from kai.install import _validate_claude_bin
+
+        assert _validate_claude_bin("") is False
+
+    def test_nonexistent_path_rejected(self, tmp_path):
+        from kai.install import _validate_claude_bin
+
+        assert _validate_claude_bin(str(tmp_path / "does_not_exist")) is False
+
+    def test_directory_rejected(self, tmp_path):
+        from kai.install import _validate_claude_bin
+
+        assert _validate_claude_bin(str(tmp_path)) is False
+
+    def test_non_executable_file_rejected(self, tmp_path):
+        from kai.install import _validate_claude_bin
+
+        f = tmp_path / "fake_claude"
+        f.write_text("#!/bin/sh\necho hi\n")
+        assert _validate_claude_bin(str(f)) is False
+
+    def test_executable_file_accepted(self, tmp_path):
+        from kai.install import _validate_claude_bin
+
+        f = tmp_path / "fake_claude"
+        f.write_text("#!/bin/sh\necho hi\n")
+        f.chmod(0o755)
+        assert _validate_claude_bin(str(f)) is True
+
+
 class TestValidateCodexBin:
     """codex binary path existence validator."""
 
@@ -8915,12 +9002,12 @@ class TestWizardPerUserGooseProviderKeys:
     def test_peruser_goose_entry_prompts_for_key(self, tmp_path, monkeypatch, capsys):
         """Global claude install with a per-user goose+deepseek entry:
         the wizard prompts for DEEPSEEK_API_KEY and then the goose
-        binary path (both inserted right after the backend slot in
-        the input chain) and emits both to env."""
+        binary path (both inserted right after the global claude-
+        binary slot in the input chain) and emits both to env."""
         self._setup(monkeypatch, tmp_path, self.GOOSE_DEEPSEEK_USERS_YAML)
         monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
-        i = inputs.index("claude")
+        i = inputs.index("/usr/bin/true")
         inputs = inputs[: i + 1] + ["sk-ds-peruser", "/opt/homebrew/bin/goose"] + inputs[i + 1 :]
 
         env = self._run(monkeypatch, tmp_path, inputs)
@@ -9071,6 +9158,15 @@ class TestWizardPerUserBackendBinaries:
         "    name: bob\n"
         "    agent_backend: codex\n"
     )
+    CLAUDE_USERS_YAML = (
+        "users:\n"
+        "  - telegram_id: 1\n"
+        "    name: alice\n"
+        "    role: admin\n"
+        "  - telegram_id: 2\n"
+        "    name: bob\n"
+        "    agent_backend: claude\n"
+    )
     PLAIN_USERS_YAML = "users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n"
 
     @staticmethod
@@ -9103,13 +9199,30 @@ class TestWizardPerUserBackendBinaries:
         self._setup(monkeypatch, tmp_path, self.CODEX_USERS_YAML)
         monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
         inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
-        i = inputs.index("claude")
+        i = inputs.index("/usr/bin/true")
         inputs = inputs[: i + 1] + ["/per-user/npm/bin/codex"] + inputs[i + 1 :]
 
         env = self._run(monkeypatch, tmp_path, inputs)
 
         assert env["CODEX_BIN"] == "/per-user/npm/bin/codex"
         assert "codex entry" in capsys.readouterr().out
+
+    def test_peruser_claude_entry_prompts_for_binary(self, tmp_path, monkeypatch, capsys):
+        """Global goose install with a per-user claude entry: the
+        wizard prompts for the claude binary path and CLAUDE_BIN
+        lands in env, the same collection contract the other three
+        backends follow. The answer is a real executable so the
+        unstubbed _validate_claude_bin passes on any runner."""
+        self._setup(monkeypatch, tmp_path, self.CLAUDE_USERS_YAML)
+        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
+        inputs = list(TestCmdConfigDefaultModelDispatch._inputs_for_goose_openai())
+        i = inputs.index("openai-key")
+        inputs = inputs[: i + 1] + ["/usr/bin/true"] + inputs[i + 1 :]
+
+        env = self._run(monkeypatch, tmp_path, inputs)
+
+        assert env["CLAUDE_BIN"] == "/usr/bin/true"
+        assert "claude entry" in capsys.readouterr().out
 
     def test_global_codex_does_not_reprompt(self, tmp_path, monkeypatch):
         """Global codex install with a per-user codex entry: the
@@ -9146,7 +9259,7 @@ class TestWizardPerUserBackendBinaries:
         )
         monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
         inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
-        i = inputs.index("claude")
+        i = inputs.index("/usr/bin/true")
         # Empty answer accepts the prompt default (the stored path).
         inputs = inputs[: i + 1] + [""] + inputs[i + 1 :]
 
@@ -9172,7 +9285,7 @@ class TestWizardPerUserBackendBinaries:
         self._setup(monkeypatch, tmp_path, mixed_yaml)
         monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
         inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
-        i = inputs.index("claude")
+        i = inputs.index("/usr/bin/true")
         inputs = inputs[: i + 1] + ["/per-user/npm/bin/codex"] + inputs[i + 1 :]
 
         env = self._run(monkeypatch, tmp_path, inputs)
@@ -9196,7 +9309,7 @@ class TestWizardPerUserBackendBinaries:
         self._setup(monkeypatch, tmp_path, opencode_yaml)
         monkeypatch.setattr("kai.install._validate_opencode_bin", lambda p: bool(p))
         inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
-        i = inputs.index("claude")
+        i = inputs.index("/usr/bin/true")
         inputs = inputs[: i + 1] + ["/custom/bin/opencode"] + inputs[i + 1 :]
 
         env = self._run(monkeypatch, tmp_path, inputs)

--- a/tests/test_oneshot_binary.py
+++ b/tests/test_oneshot_binary.py
@@ -3,7 +3,8 @@ config validation, the OneShotReasoner argv builders, and the smoke
 command.
 
 Resolution rules under test:
-- claude: shutil.which("claude") only.
+- claude: branches on CLAUDE_BIN with the same override semantics as
+  the codex arm; no override falls back to shutil.which.
 - codex: branches on CODEX_BIN. Explicit override validates as
   is-file plus executable, no PATH fallback. No override falls back
   to shutil.which.
@@ -19,24 +20,84 @@ from kai.oneshot_binary import BinaryResolutionError, resolve_oneshot_binary
 
 
 class TestClaudeResolution:
+    """Claude arm mirrors the codex pattern: CLAUDE_BIN override
+    validates with no PATH fallback; unset resolves via PATH."""
+
     def test_resolves_via_path(self, monkeypatch):
         """shutil.which returning a path means the resolver returns it
         verbatim. Pinned via monkeypatch so the test does not depend
         on the host having claude installed."""
+        monkeypatch.delenv("CLAUDE_BIN", raising=False)
         monkeypatch.setattr(
             "kai.oneshot_binary.shutil.which", lambda name: "/fake/path/claude" if name == "claude" else None
         )
         assert resolve_oneshot_binary("claude") == "/fake/path/claude"
 
-    def test_raises_when_unreachable(self, monkeypatch):
+    def test_raises_when_unreachable_naming_both_candidates(self, monkeypatch):
         """No claude on PATH must raise BinaryResolutionError, NOT
-        return a fallback or empty string. The message names the
-        candidate so the operator can fix it."""
+        return a fallback or empty string. The message names both
+        candidates (CLAUDE_BIN unset, claude not on PATH) so the
+        operator does not have to guess which branch fired."""
+        monkeypatch.delenv("CLAUDE_BIN", raising=False)
         monkeypatch.setattr("kai.oneshot_binary.shutil.which", lambda name: None)
         with pytest.raises(BinaryResolutionError) as exc:
             resolve_oneshot_binary("claude")
-        assert "claude" in str(exc.value)
-        assert "PATH" in str(exc.value)
+        message = str(exc.value)
+        assert "CLAUDE_BIN" in message
+        assert "PATH" in message
+
+    def test_explicit_override_resolves_to_exact_path(self, tmp_path, monkeypatch):
+        """A real executable file at CLAUDE_BIN resolves to that exact
+        path, NOT a shutil.which lookup of its name."""
+        fake = tmp_path / "claude-binary"
+        fake.write_text("#!/bin/sh\nexit 0\n")
+        fake.chmod(0o755)
+        monkeypatch.setenv("CLAUDE_BIN", str(fake))
+        # Even if PATH would also resolve claude, the override wins.
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", lambda name: "/other/claude")
+        assert resolve_oneshot_binary("claude") == str(fake)
+
+    def test_explicit_override_not_a_file_raises_not_a_file(self, tmp_path, monkeypatch):
+        """CLAUDE_BIN pointing at a nonexistent path raises with
+        'not-a-file' in the message; no PATH fallback fires."""
+        monkeypatch.setenv("CLAUDE_BIN", str(tmp_path / "does-not-exist"))
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", lambda name: "/should/not/be/returned")
+        with pytest.raises(BinaryResolutionError) as exc:
+            resolve_oneshot_binary("claude")
+        message = str(exc.value)
+        assert "not-a-file" in message
+        assert "does-not-exist" in message
+
+    def test_explicit_override_not_executable_raises_not_executable(self, tmp_path, monkeypatch):
+        """CLAUDE_BIN pointing at a non-executable file raises with
+        'not-executable' in the message."""
+        fake = tmp_path / "claude-not-x"
+        fake.write_text("not-a-script")
+        fake.chmod(0o644)  # no execute bit
+        monkeypatch.setenv("CLAUDE_BIN", str(fake))
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", lambda name: "/should/not/be/returned")
+        with pytest.raises(BinaryResolutionError) as exc:
+            resolve_oneshot_binary("claude")
+        message = str(exc.value)
+        assert "not-executable" in message
+        assert str(fake) in message
+
+    def test_explicit_override_no_fallback_to_path(self, tmp_path, monkeypatch):
+        """When CLAUDE_BIN is set and resolves to a bad path, the
+        resolver MUST NOT silently fall back to shutil.which; the
+        fallback would hide stale-config bugs from the operator."""
+        monkeypatch.setenv("CLAUDE_BIN", str(tmp_path / "missing"))
+
+        called = []
+
+        def fake_which(name):
+            called.append(name)
+            return "/some/claude"
+
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", fake_which)
+        with pytest.raises(BinaryResolutionError):
+            resolve_oneshot_binary("claude")
+        assert called == [], f"shutil.which should not be called when CLAUDE_BIN is set; got {called}"
 
 
 class TestCodexResolution:


### PR DESCRIPTION
Phase 1 of moving the last backend binary to a global install: give claude the same binary-override contract the other three backends already have.

## Problem

Claude was the only backend without a `*_BIN` variable. The sudoers generator hardcoded the service user's `~/.local/bin/claude` into the cross-user rule, the chat argv spawned bare `claude` resolved off the daemon's PATH, and the one-shot resolver was PATH-only with the override explicitly documented as a future slot. An install whose claude moves to the Homebrew cask (`/opt/homebrew/bin/claude`) had no supported way to keep the rule, the spawns, and the binary in agreement; the no-hand-edits rule makes the wizard the required vehicle.

## Change

`CLAUDE_BIN` mirrors the `CODEX_BIN` pattern at every surface:

- **Resolver** (`oneshot_binary.py`): claude arm gains the validated override branch (is-file plus executable, no PATH fallback on a bad override; unset still resolves via PATH). This covers extraction, episodes, review, triage, and smoke, which all route through the resolver.
- **Chat argv** (`claude.py`): `CLAUDE_BIN` pins the argv head so the sudo-wrapped per-user spawn lands on the exact file the sudoers rule names; bare `claude` remains the unset fallback.
- **Eval** (`eval/behavioral.py`): judge, generator, and version capture honor the override, mirroring the codex branches.
- **Wizard** (`install.py`): claude installs now prompt for the binary path (default `which claude`; empty default forces an explicit path when which finds nothing, the opencode posture, since claude has two canonical locations: the native installer and the Homebrew cask). Per-user re-prompt fires when users.yaml puts claude in play on a non-claude global install, plus the defense-in-depth re-prompt at the memory gate. Emission is gated on a collected value, so existing install.confs without the key are untouched.
- **Apply**: `sudo CLAUDE_BIN=... make install` shell passthrough, and `_apply_sudoers` / `_generate_sudoers` thread the value into the per-user rule, with the service-home path retained as the unset fallback. The missing-binary backstop's claude remedy now says to re-run the wizard instead of suggesting a native-installer symlink.
- **Startup gate** (`config.py`): the fail-closed extraction message names each backend's own `*_BIN` variable instead of suggesting `CODEX_BIN` for every backend.

## Compatibility

Unset `CLAUDE_BIN` keeps today's behavior at every site: PATH resolution for spawns and the resolver, service-home fallback for the sudoers rule. The one operator-visible change is a new wizard prompt on claude-backend installs, defaulting to the operator's `which claude`.

## Tests

Eighteen new tests mirror the existing precedents: the resolver's codex-shaped override suite for the claude arm, chat argv pinning and empty-string fallback, the five-case validator class, sudoers threading and fallback, wizard emission, the per-user claude re-prompt, and the eval override trio. Wizard input chains answer the new prompt with `/usr/bin/true`, which exists and is executable on macOS and Linux CI runners alike, so the real validator runs unstubbed and test outcomes stay host-independent. 3947 passed, 1 skipped; ruff clean.
