### PR TITLE
feat(codex): add a CODEX_EFFORT_LEVEL reasoning-effort knob

### DIFF
--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -220,6 +220,14 @@ class CodexBackend(AgentBackend):
         # unbounded memory growth in a long-lived agent subprocess.
         # The pool passes Config.agent_max_session_hours.
         max_session_hours: float = 0,
+        # Reasoning effort forwarded as a `-c model_reasoning_effort=
+        # <value>` config override on the spawn argv. Empty (default)
+        # passes no override: codex falls back to the per-OS-user
+        # ~/.codex/config.toml or the model default. Set-or-absent by
+        # design (see Config.codex_effort_level); validated at config
+        # load, so any non-empty value reaching this point is one of
+        # the CLI's accepted tiers.
+        codex_effort_level: str = "",
     ):
         # ABC-required attributes (pool.py reads/writes these)
         self.model = model
@@ -230,6 +238,7 @@ class CodexBackend(AgentBackend):
         self.provider = provider  # ABC-mandated; bot.py reads this
         self.codex_user = codex_user
         self.memory_enabled = memory_enabled
+        self.codex_effort_level = codex_effort_level
         # Session-age recycling limit (ABC surface; checked by the
         # inherited _should_recycle at the top of _send_locked).
         self.max_session_hours = max_session_hours
@@ -372,7 +381,17 @@ class CodexBackend(AgentBackend):
         # rule also names exactly. Falls back to bare "codex" so
         # single-user installs with codex on PATH still work.
         codex_bin = os.environ.get("CODEX_BIN") or "codex"
-        codex_argv = [codex_bin, "app-server"]
+        codex_argv = [codex_bin]
+        # The reasoning-effort override rides BEFORE the subcommand
+        # token: `-c key=value` is defined at the codex CLI root
+        # (flattened into the multitool parser and propagated to every
+        # subcommand), so root position is the form the CLI's own
+        # structure guarantees. Set-or-absent: no flag at all when the
+        # knob is empty, leaving the per-OS-user config.toml or the
+        # model default in charge of reasoning effort.
+        if self.codex_effort_level:
+            codex_argv += ["-c", f"model_reasoning_effort={self.codex_effort_level}"]
+        codex_argv.append("app-server")
         if effective_codex_user:
             # -H sets HOME to <codex_user>'s pw entry so codex reads
             # auth from ~<codex_user>/.codex/auth.json, not the bot's

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -565,6 +565,17 @@ def get_effective_provider(backend: str, llm_provider: str) -> str:
 EFFORT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 _VALID_EFFORT_LEVELS: frozenset[str] = frozenset(EFFORT_LEVELS)
 
+# Valid values for the codex `model_reasoning_effort` config override,
+# taken verbatim from the upstream codex configuration reference
+# (xhigh is model-dependent; the override applies to Responses-API
+# models). Same two-shape pattern as EFFORT_LEVELS above: ordered
+# tuple for operator-facing listings in intensity order, derived
+# frozenset for O(1) membership checks. The vocabularies are
+# CLI-specific and deliberately not shared: codex has "minimal" and
+# no "max"; claude has "max" and no "minimal".
+CODEX_EFFORT_LEVELS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
+_VALID_CODEX_EFFORT_LEVELS: frozenset[str] = frozenset(CODEX_EFFORT_LEVELS)
+
 
 def validate_model_for_provider(model: str, provider: str) -> bool:
     """Check if a model is valid for a provider.
@@ -1042,6 +1053,19 @@ class Config:
     # same way goose+openai does. Only consulted when AGENT_BACKEND=codex;
     # ignored on every other backend.
     codex_auth_mode: str = "subscription"
+
+    # Reasoning effort passed to the inner codex as a
+    # `-c model_reasoning_effort=<value>` config override on the
+    # app-server argv. Empty string (default) passes nothing: codex
+    # then falls back to each OS user's own ~/.codex/config.toml or
+    # the model default. That asymmetry with claude_effort_level
+    # (which always passes a value) is deliberate: codex config is
+    # per-OS-user and operator-owned, and xhigh availability is
+    # model-dependent, so a global override is opt-in rather than
+    # silently replacing a user's own setting. Validated at config
+    # load against _VALID_CODEX_EFFORT_LEVELS so a typo fails fast.
+    # Only consulted when the user's effective backend is codex.
+    codex_effort_level: str = ""
 
     # Database - uses DATA_DIR so the db lands in the writable data directory
     session_db_path: Path = field(default_factory=lambda: DATA_DIR / "kai.db")
@@ -2639,6 +2663,17 @@ def load_config() -> Config:
         # expects to see in an error string.
         raise SystemExit(f"CLAUDE_EFFORT_LEVEL must be one of {list(EFFORT_LEVELS)}, got {claude_effort_level!r}")
 
+    # CODEX_EFFORT_LEVEL: same strip/lower + membership shape as the
+    # claude block above, with one contract difference: empty / unset
+    # stays empty (set-or-absent). Empty means CodexBackend passes no
+    # `-c model_reasoning_effort` override and codex falls back to the
+    # per-OS-user ~/.codex/config.toml or the model default.
+    codex_effort_level = os.environ.get("CODEX_EFFORT_LEVEL", "").strip().lower()
+    if codex_effort_level and codex_effort_level not in _VALID_CODEX_EFFORT_LEVELS:
+        raise SystemExit(
+            f"CODEX_EFFORT_LEVEL must be one of {list(CODEX_EFFORT_LEVELS)} or empty, got {codex_effort_level!r}"
+        )
+
     # PR review agent config. The global `pr_review` toggle now lives
     # per-user in users.yaml; PR_REVIEW_COOLDOWN / PR_REVIEW_TIMEOUT_S
     # remain as global resource controls.
@@ -3071,6 +3106,7 @@ def load_config() -> Config:
         claude_autocompact_pct=claude_autocompact_pct,
         claude_effort_level=claude_effort_level,
         codex_auth_mode=codex_auth_mode,
+        codex_effort_level=codex_effort_level,
         webhook_port=webhook_port,
         webhook_secret=os.environ.get("WEBHOOK_SECRET", ""),
         voice_enabled=os.environ.get("VOICE_ENABLED", "").lower() in ("1", "true", "yes"),

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -43,6 +43,7 @@ from kai.config import (
     BACKEND_PROVIDERS,
     BACKENDS_NEEDING_PROVIDER_PROMPT,
     CODEX_DEFAULT_MODEL,
+    CODEX_EFFORT_LEVELS,
     CODEX_MODELS,
     EFFORT_LEVELS,
     MODEL_REGISTRY,
@@ -1437,6 +1438,34 @@ def _cmd_config() -> None:
         )
         print()
 
+    # CODEX_EFFORT_LEVEL mirrors the claude effort prompt for the
+    # codex backend with one contract difference: the default is empty
+    # (set-or-absent). Empty means CodexBackend passes no
+    # `-c model_reasoning_effort` override and codex falls back to the
+    # per-OS-user ~/.codex/config.toml or the model default, which is
+    # the right posture because codex config is per-OS-user and
+    # operator-owned, and xhigh availability is model-dependent.
+    # _prompt_choice cannot express "empty means skip", so this is a
+    # validated free-text prompt: empty accepted, anything else must
+    # be in CODEX_EFFORT_LEVELS (the same allow-list config.py
+    # enforces at load, so install.conf cannot carry a value that
+    # fails at service startup).
+    codex_effort_level = ""
+    if agent_backend == "codex":
+        while True:
+            codex_effort_level = (
+                _prompt(
+                    "Codex reasoning effort (empty = codex default)",
+                    existing_env.get("CODEX_EFFORT_LEVEL", ""),
+                )
+                .strip()
+                .lower()
+            )
+            if not codex_effort_level or codex_effort_level in CODEX_EFFORT_LEVELS:
+                break
+            print(f"  Must be one of {', '.join(CODEX_EFFORT_LEVELS)}, or empty for the codex default.")
+        print()
+
     # -- Webhook server --
     print("-- Webhook server --")
     while True:
@@ -1994,6 +2023,13 @@ def _cmd_config() -> None:
     # allow-list config.py uses, so no re-validation here.
     if claude_effort_level != "high":
         env["CLAUDE_EFFORT_LEVEL"] = claude_effort_level
+
+    # CODEX_EFFORT_LEVEL: same delta-from-defaults posture. The
+    # default is empty (codex's own config rules), so any non-empty
+    # value is operator intent worth persisting; empty stays out of
+    # install.conf entirely.
+    if codex_effort_level:
+        env["CODEX_EFFORT_LEVEL"] = codex_effort_level
 
     # Conditionally add optional values
     if transport == "webhook":

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -279,6 +279,7 @@ class SubprocessPool:
                 codex_user=os_user,
                 memory_enabled=self._config.memory_enabled,
                 max_session_hours=self._config.agent_max_session_hours,
+                codex_effort_level=self._config.codex_effort_level,
             )
 
         return ClaudeCodeBackend(

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1567,6 +1567,37 @@ class TestSubprocessConstruction:
 # ── Per-user OAuth isolation (codex_user / sudo wrap) ─────────────
 
 
+class TestCodexEffortArgv:
+    """codex_effort_level rides the spawn argv as a root-position
+    `-c model_reasoning_effort=<value>` config override (the -c
+    argument is defined at the codex CLI root and propagated to every
+    subcommand), and is set-or-absent: no flag at all when the knob
+    is empty, leaving the per-OS-user config.toml or model default in
+    charge."""
+
+    @pytest.mark.asyncio
+    async def test_effort_override_rides_before_subcommand(self):
+        c = _make_codex(codex_effort_level="high")
+        proc = _make_mock_proc(_handshake_lines())
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await c._ensure_started()
+        argv = list(mock_exec.call_args[0])
+        i = argv.index("-c")
+        assert argv[i + 1] == "model_reasoning_effort=high"
+        # Root position: the override precedes the subcommand token.
+        assert i < argv.index("app-server")
+
+    @pytest.mark.asyncio
+    async def test_no_override_when_unset(self):
+        c = _make_codex()
+        proc = _make_mock_proc(_handshake_lines())
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await c._ensure_started()
+        argv = list(mock_exec.call_args[0])
+        assert "-c" not in argv
+        assert "app-server" in argv
+
+
 class TestCodexUserSudoWrap:
     """
     Verify the per-user OAuth isolation lever.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,6 +58,7 @@ _CONFIG_ENV_VARS = [
     "CLAUDE_MAX_CONTEXT_WINDOW",
     "CLAUDE_AUTOCOMPACT_PCT",
     "CLAUDE_EFFORT_LEVEL",
+    "CODEX_EFFORT_LEVEL",
     "TOTP_SESSION_MINUTES",
     "TOTP_CHALLENGE_SECONDS",
     "TOTP_LOCKOUT_ATTEMPTS",
@@ -1227,6 +1228,62 @@ class TestClaudeEffortLevel:
         monkeypatch.setenv("CLAUDE_EFFORT_LEVEL", "   ")
         config = load_config()
         assert config.claude_effort_level == "high"
+
+
+# ── CODEX_EFFORT_LEVEL config ────────────────────────────────────────
+
+
+class TestCodexEffortLevel:
+    """Coverage for the CODEX_EFFORT_LEVEL env var: same strip/lower +
+    allow-list shape as CLAUDE_EFFORT_LEVEL with one contract
+    difference, the set-or-absent default. Empty / unset stays empty,
+    meaning CodexBackend passes no `-c model_reasoning_effort`
+    override and codex falls back to the per-OS-user config.toml or
+    the model default."""
+
+    def test_default_empty_when_unset(self, monkeypatch):
+        # Unset must stay empty, NOT fall back to a tier. An invented
+        # default would silently override every codex user's own
+        # config.toml effort setting from a knob the operator never
+        # touched.
+        _set_required(monkeypatch)
+        config = load_config()
+        assert config.codex_effort_level == ""
+
+    def test_valid_value_parses(self, monkeypatch):
+        # All five upstream values must round-trip. If codex adds a
+        # tier, CODEX_EFFORT_LEVELS in config.py and this list must
+        # move together.
+        _set_required(monkeypatch)
+        for value in ["minimal", "low", "medium", "high", "xhigh"]:
+            monkeypatch.setenv("CODEX_EFFORT_LEVEL", value)
+            config = load_config()
+            assert config.codex_effort_level == value, f"value {value!r} did not round-trip"
+
+    def test_invalid_value_raises(self, monkeypatch):
+        # Outside the allow-list must SystemExit at config load; a
+        # bad value reaching the spawn argv would fail at the codex
+        # subprocess instead, burning a chat session to discover.
+        _set_required(monkeypatch)
+        monkeypatch.setenv("CODEX_EFFORT_LEVEL", "max")
+        with pytest.raises(SystemExit, match="CODEX_EFFORT_LEVEL"):
+            load_config()
+
+    def test_uppercase_and_whitespace_normalized(self, monkeypatch):
+        # Same copy-paste absorption as the claude parser: case and
+        # surrounding whitespace must not cause an opaque rejection.
+        _set_required(monkeypatch)
+        monkeypatch.setenv("CODEX_EFFORT_LEVEL", "  HIGH ")
+        config = load_config()
+        assert config.codex_effort_level == "high"
+
+    def test_whitespace_only_stays_empty(self, monkeypatch):
+        # Whitespace-only is effectively unset: it must collapse to
+        # empty (no override) rather than hit the allow-list check.
+        _set_required(monkeypatch)
+        monkeypatch.setenv("CODEX_EFFORT_LEVEL", "   ")
+        config = load_config()
+        assert config.codex_effort_level == ""
 
 
 # ── Memory extraction config (spec §6.4, §13.1) ─────────────────────

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2532,7 +2532,8 @@ class TestCmdConfig:
                 "120",  # agent timeout
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
-                # autocompact + effort skipped on non-claude backend
+                # autocompact + claude effort skipped on non-claude backend
+                "",  # codex reasoning effort (empty = codex default)
                 "8080",  # webhook port
                 "test-secret",  # webhook secret
                 "",  # workspace base
@@ -2940,7 +2941,8 @@ class TestCmdConfigDefaultModelDispatch:
             "120",  # agent timeout (global default)
             "0",  # max session age hours (0 = no limit)
             "1800",  # idle eviction timeout seconds
-            # No autocompact_pct / effort_level prompts (claude-only)
+            # No autocompact_pct / claude effort prompts (claude-only)
+            "",  # codex reasoning effort (empty = codex default)
             "8080",  # webhook port
             "test-secret",  # webhook secret
             "~/Projects",  # workspace base (global default)
@@ -2973,7 +2975,9 @@ class TestCmdConfigDefaultModelDispatch:
             "120",  # agent timeout (global default)
             "0",  # max session age hours (0 = no limit)
             "1800",  # idle eviction timeout seconds
-            # autocompact_pct / effort_level prompts are claude-only (gated)
+            # autocompact_pct / effort prompts are backend-gated
+            # (claude tunables and the codex effort prompt all skip
+            # on goose)
             "8080",  # webhook port
             "test-secret",  # webhook secret
             "~/Projects",  # workspace base (global default)
@@ -3009,6 +3013,34 @@ class TestCmdConfigDefaultModelDispatch:
         _cmd_config()
         conf = json.loads((tmp_path / "install.conf").read_text())
         return helper_mock, conf["env"]
+
+    def test_codex_effort_default_omits_env_key(self, tmp_path, monkeypatch):
+        """Accepting the empty default leaves CODEX_EFFORT_LEVEL out
+        of install.conf entirely: the set-or-absent contract means
+        absence IS the 'use codex's own config' signal. Pairs with
+        the non-default test below to pin both emission branches."""
+        self._setup(monkeypatch, tmp_path)
+        _, env = self._run(
+            monkeypatch,
+            tmp_path,
+            self._inputs_for_codex_subscription(),
+            helper_return="gpt-5.5",
+        )
+        assert "CODEX_EFFORT_LEVEL" not in env
+
+    def test_codex_effort_non_default_writes_env_key(self, tmp_path, monkeypatch):
+        """A chosen effort tier round-trips from the wizard prompt
+        into install.conf, lowercased by the prompt's normalization
+        (mixed case pins the .strip().lower() behavior)."""
+        self._setup(monkeypatch, tmp_path)
+        base = list(self._inputs_for_codex_subscription())
+        idx = base.index("8080")
+        # The slot immediately before the webhook port is the codex
+        # effort answer in this chain.
+        assert base[idx - 1] == ""
+        base[idx - 1] = "HIGH"
+        _, env = self._run(monkeypatch, tmp_path, base, helper_return="gpt-5.5")
+        assert env.get("CODEX_EFFORT_LEVEL") == "high"
 
     def test_reprompts_on_provider_flip_with_users_yaml(self, tmp_path, monkeypatch):
         """


### PR DESCRIPTION
Implements the codex effort knob from the backend parity sweep's backfill list, per the agreed decisions: set-or-absent default, chat-only scope.

## What

`CODEX_EFFORT_LEVEL` gives codex installs the reasoning-depth knob claude installs have had, via the codex CLI's `model_reasoning_effort` config key (accepted values `minimal | low | medium | high | xhigh`; xhigh is model-dependent, per the upstream configuration reference). The standard env-var pattern end to end: Config field, validated load-time parsing against a new `CODEX_EFFORT_LEVELS` allow-list (ordered-tuple plus frozenset, the EFFORT_LEVELS shape), pool threading to CodexBackend, wizard prompt gated on the codex backend, delta-from-defaults emission.

## The deliberate asymmetry with CLAUDE_EFFORT_LEVEL

The claude knob defaults to "high" and always passes `--effort`. This knob defaults to empty and passes nothing when empty: codex then falls back to each OS user's own `~/.codex/config.toml` or the model default. Codex config is per-OS-user and operator-owned, and xhigh availability varies by model, so a global override is opt-in rather than a silent replacement of a user's own setting. The wizard prompt is validated free text with empty accepted (a choice prompt cannot express "empty means skip"); the load-time parser accepts empty or one of the five tiers and SystemExits on anything else.

## Mechanism

The override rides the spawn argv at root position: `codex -c model_reasoning_effort=<value> app-server`. Root position is the form the CLI's own structure guarantees: the `-c key=value` argument is clap-flattened into the codex multitool root parser and explicitly propagated to every subcommand, app-server included (verified in the upstream CLI source). The key name and value set are verified against the upstream configuration reference. One residual check did not run in-session because the Bash permission classifier was in an outage window: a live smoke of the installed binary. It is a two-second check:

```
codex -c model_reasoning_effort=high app-server --help; echo $?
```

Exit 0 with normal help output confirms the installed 0.139.0 binary accepts the root-position override (the `-c` root flag long predates this codex version, so the risk is theoretical).

## Scope

Chat-only, matching the claude knob: the one-shot reasoners (extraction, episodes, review, triage) are unaffected. Global, not per-user, also matching.

## Tests

Nine new tests mirroring the claude effort precedents: the five-case config parsing class (default-empty, round-trip, rejection, normalization, whitespace-only), the argv pair (override present at root position; absent when unset), and the wizard emission pair (empty omits the key; a chosen tier round-trips lowercased). Codex wizard input chains gained the new prompt's answer. 3956 passed, 1 skipped; ruff clean.
