### PR TITLE
fix(install): add sudoers read rule for memory-projects.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # User and workspace config (contains user IDs and local paths)
 /users.yaml
 /workspaces.yaml
+/memory-projects.yaml
 
 # Python
 __pycache__/

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2839,6 +2839,7 @@ def _generate_sudoers(
         {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/services.yaml
         {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/users.yaml
         {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/workspaces.yaml
+        {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/memory-projects.yaml
         {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/totp.secret
         {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/totp.attempts
         {service_user} ALL=(root) NOPASSWD: {tee_path} /etc/kai/totp.attempts

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -326,6 +326,7 @@ class TestGenerateSudoers:
         assert f"{cat_path} /etc/kai/services.yaml" in result
         assert f"{cat_path} /etc/kai/users.yaml" in result
         assert f"{cat_path} /etc/kai/workspaces.yaml" in result
+        assert f"{cat_path} /etc/kai/memory-projects.yaml" in result
         assert f"{cat_path} /etc/kai/totp.secret" in result
         assert f"{cat_path} /etc/kai/totp.attempts" in result
 


### PR DESCRIPTION
## Summary

- Adds the missing `sudo cat` rule for `/etc/kai/memory-projects.yaml` to `_generate_sudoers`, alongside the existing config-read rules.
- Without it, the registry loader's protected-path read fails with a denial that is indistinguishable from "file absent", so a correctly authored registry was silently ignored, the project registry stayed empty, and every scoped-retrieval shadow log reported `active_project_id: null`. The shadow-mode comparison cannot produce signal on a protected install until this rule exists.
- Adds `/memory-projects.yaml` to `.gitignore`, mirroring `/users.yaml` and `/workspaces.yaml`, so a dev-checkout registry is not committable by accident.

## Testing

- `test_contains_cat_rules` now pins the new rule line.
- Full suite: 3960 passed, 1 skipped. `make check` clean.

Closes #650
