### PR TITLE
feat(memory): add write-scope routing for memory extraction

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -3548,10 +3548,19 @@ async def _handle_response(
                         session_id=final_response.session_id,
                         config=config,
                         prior_pairs=prior_pairs,
+                        workspace=ingest_workspace,
                     )
             except Exception:
                 log.warning("Memory ingestion failed", exc_info=True)
 
+        # Workspace for write-scope routing, captured BEFORE the
+        # fire-and-forget task is scheduled. The exchange being
+        # extracted happened in THIS workspace; reading
+        # pool.get_workspace inside the task instead would let a
+        # /workspace switch that lands during the ingestion delay
+        # re-route the exchange's facts to a project the conversation
+        # never touched.
+        ingest_workspace = str(pool.get_workspace(chat_id))
         task = asyncio.create_task(_ingest_memory())
         _pending_memory_tasks.add(task)
         task.add_done_callback(_pending_memory_tasks.discard)

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1792,14 +1792,72 @@ def _validate_facts(
     return validated
 
 
-def _paraphrase_neighbor(content: str, user_id: str, threshold: float) -> MemoryResult | None:
-    """
-    Top-1 semantic-search dedup gate.
+# Fetch width for the dedup gate's neighbor search. The gate's
+# decision needs only the nearest ADMISSIBLE neighbor, but a wrong-
+# scope row can occupy rank 1 and mask an admissible duplicate right
+# below it, so the gate scans a small descending-score window instead
+# of trusting top-1. Five covers the realistic case (a handful of
+# near-identical rows split across projects) without turning the gate
+# into a full retrieval.
+_DEDUP_NEIGHBOR_FETCH_N: int = 5
 
-    Returns the nearest existing user-scoped memory when its cosine
-    score meets or exceeds `threshold` against `content`. Returns None
-    when no neighbor reaches the threshold, when the store is empty,
-    when memory is disabled, or when the search call raises.
+
+def _allowed_write_project_id(active_project: ActiveMemoryProject | None) -> str | None:
+    """
+    The project id whose project-scoped rows have authority over this
+    extraction run's write-time reads, or None for global-only.
+
+    None covers both "no detected project" and "detected project with
+    memory disabled", matching the read side's admission contract
+    (`memory._scoped_memory_admission_reason` treats a None
+    allowed_project_id as project-scope-not-allowed). Centralized so
+    the consolidation-candidate filter and the dedup gate cannot
+    drift on the memory-disabled rule.
+    """
+    if active_project is None or not active_project.memory_enabled:
+        return None
+    return active_project.project_id
+
+
+def _scope_admitted(metadata: dict | None, allowed_project_id: str | None) -> bool:
+    """
+    True when a stored row has authority in this extraction run.
+
+    Thin composition of the read side's resolver and admission helper
+    so write-time reads (consolidation candidates, the dedup gate)
+    apply EXACTLY the rule retrieval uses: global always admitted
+    (including legacy rows), project rows only under a matching
+    allowed_project_id, task rows never. Write-time reads control
+    deletion (`update_of`) and suppression (`skip_redundant`, dedup),
+    so their candidate authority must be at least as scoped as the
+    write authority they gate.
+    """
+    resolved = memory.resolve_memory_scope(metadata)
+    return memory._scoped_memory_admission_reason(resolved, allowed_project_id=allowed_project_id) is None
+
+
+def _paraphrase_neighbor(
+    content: str,
+    user_id: str,
+    threshold: float,
+    active_project: ActiveMemoryProject | None = None,
+) -> MemoryResult | None:
+    """
+    Nearest-admissible-neighbor semantic-search dedup gate.
+
+    Returns the nearest existing user-scoped memory that is ADMITTED
+    under the active scope policy when its cosine score meets or
+    exceeds `threshold` against `content`. Returns None when no
+    admissible neighbor reaches the threshold, when the store is
+    empty, when memory is disabled, or when the search call raises.
+
+    Scope admission (`_scope_admitted`) is applied before the
+    threshold test: a near-verbatim row belonging to ANOTHER project
+    must not suppress this project's write, because the row has no
+    authority here even at cosine 1.0. Results arrive in descending
+    score order, so the first admitted hit IS the nearest admissible
+    neighbor; if its score is below threshold, every later admissible
+    hit's score is too, and the gate does not fire.
 
     Returning the matched `MemoryResult` (vs the prior `bool`) lets the
     caller log the neighbor's id and cosine score on a fire without
@@ -1828,14 +1886,17 @@ def _paraphrase_neighbor(content: str, user_id: str, threshold: float) -> Memory
         # at the public-API layer; this helper is called from inside
         # the semaphore block of `extract_and_store` which already
         # runs off the hot path, so a direct sync call is fine here.
-        results = memory.search(content, user_id=user_id, limit=1)
+        results = memory.search(content, user_id=user_id, limit=_DEDUP_NEIGHBOR_FETCH_N)
     except Exception:
         log.debug("_paraphrase_neighbor: search failed; treating as non-duplicate", exc_info=True)
         return None
-    if not results:
+    allowed_project_id = _allowed_write_project_id(active_project)
+    for result in results or []:
+        if not _scope_admitted(result.metadata, allowed_project_id):
+            continue
+        if result.score >= threshold:
+            return result
         return None
-    if results[0].score >= threshold:
-        return results[0]
     return None
 
 
@@ -2485,8 +2546,11 @@ async def _generate_episode(
                     # Write-scope routing, same consumption shape as
                     # the fact path in _store_facts: the generator's
                     # scope_hint is routed (never stored raw) and the
-                    # resulting scope fields land in metadata.
-                    extra.update(_route_write_scope(episode.get("scope_hint"), active_project))
+                    # resulting scope fields land in metadata. Kept in
+                    # a named variable because the post-store scope
+                    # log below reports the routed outcome.
+                    scope_meta = _route_write_scope(episode.get("scope_hint"), active_project)
+                    extra.update(scope_meta)
                     # add_structured is sync (Mem0 is sync). Run off
                     # the event loop so the embedding step does not
                     # block other stage-2 tasks queued behind this
@@ -2512,6 +2576,21 @@ async def _generate_episode(
                         outcome = "stored"
                         memory_id = mem_id
                         reason = None
+                        # Episode-side scope log, emitted only for a
+                        # row that actually landed (mirrors the fact
+                        # side's stored-rows-only tally). Episodes are
+                        # orthogonal to facts, so without this line an
+                        # episode-only run would write scoped metadata
+                        # with no memory.extract.scope record at all.
+                        _emit_scope_log(
+                            user_id=user_id,
+                            source="episode",
+                            active_project=active_project,
+                            hinted=1 if scope_meta["scope_source"] == memory.SCOPE_SOURCE_CLASSIFIER else 0,
+                            defaulted=0 if scope_meta["scope_source"] == memory.SCOPE_SOURCE_CLASSIFIER else 1,
+                            stored_global=1 if scope_meta["scope"] == memory.SCOPE_GLOBAL else 0,
+                            stored_project=1 if scope_meta["scope"] == memory.SCOPE_PROJECT else 0,
+                        )
                     else:
                         outcome = "store_failed"
                         reason = "add_structured returned None"
@@ -2550,6 +2629,50 @@ _SCOPE_CONFIDENCE_DEFAULTED: float = 0.6
 # schema regression that lets a stray string through) is treated as
 # "no hint" rather than rejected or guessed.
 _VALID_SCOPE_HINTS: frozenset[str] = frozenset({memory.SCOPE_GLOBAL, memory.SCOPE_PROJECT})
+
+
+def _emit_scope_log(
+    *,
+    user_id: str,
+    source: str,
+    active_project: ActiveMemoryProject | None,
+    hinted: int,
+    defaulted: int,
+    stored_global: int,
+    stored_project: int,
+) -> None:
+    """
+    Emit one memory.extract.scope JSON line for a set of scoped writes.
+
+    Shared by the fact path (`_store_facts`, source="facts", once per
+    run with that run's tallies) and the episode path
+    (`_generate_episode`, source="episode", once per stored episode).
+    Episodes are orthogonal to facts (a run can store an episode with
+    zero facts), so a single fact-side emission would leave
+    episode-only scoped writes invisible; the `source` discriminator
+    is what lets a log reader attribute a scoped row to the path that
+    wrote it. `active_project_id` reports the DETECTED project even
+    when memory_enabled is false (routing then forces global); the
+    `project_memory_enabled` field is what distinguishes the two
+    states, mirroring the detector's diagnostics contract.
+    """
+    log.info(
+        "memory.extract.scope %s",
+        json.dumps(
+            {
+                "user_id": user_id,
+                "source": source,
+                "active_project_id": active_project.project_id if active_project else None,
+                "matched_root": str(active_project.matched_root) if active_project else None,
+                "project_memory_enabled": active_project.memory_enabled if active_project else None,
+                "hinted": hinted,
+                "defaulted": defaulted,
+                "stored_global": stored_global,
+                "stored_project": stored_project,
+            },
+            separators=(",", ":"),
+        ),
+    )
 
 
 def _route_write_scope(
@@ -2827,6 +2950,7 @@ def _store_facts(
             content,
             user_id,
             threshold=config.memory_duplicate_threshold,
+            active_project=active_project,
         )
         if neighbor is not None:
             log.debug("_store_facts: skipping duplicate %r", content[:80])
@@ -2888,29 +3012,20 @@ def _store_facts(
                 replaced_id=None,
                 outcome="dropped_backend",
             )
-    # One scope-routing line per extraction run (this function is
-    # called at most once per run, and only when the validated fact
-    # list is non-empty). The fixed-shape JSON record lets shadow-log
-    # analysis trace a scoped row back to the write-time decision that
-    # produced it. `active_project_id` reports the DETECTED project
-    # even when memory_enabled is false (routing then forces global);
-    # the `project_memory_enabled` field is what distinguishes the two
-    # states, mirroring the detector's diagnostics contract.
-    log.info(
-        "memory.extract.scope %s",
-        json.dumps(
-            {
-                "user_id": user_id,
-                "active_project_id": active_project.project_id if active_project else None,
-                "matched_root": str(active_project.matched_root) if active_project else None,
-                "project_memory_enabled": active_project.memory_enabled if active_project else None,
-                "hinted": scope_hinted,
-                "defaulted": scope_defaulted,
-                "stored_global": stored_by_scope.get(memory.SCOPE_GLOBAL, 0),
-                "stored_project": stored_by_scope.get(memory.SCOPE_PROJECT, 0),
-            },
-            separators=(",", ":"),
-        ),
+    # One fact-side scope-routing line per extraction run (this
+    # function is called at most once per run, and only when the
+    # validated fact list is non-empty). The fixed-shape JSON record
+    # lets shadow-log analysis trace a scoped row back to the
+    # write-time decision that produced it; episode-side writes emit
+    # their own line from `_generate_episode`.
+    _emit_scope_log(
+        user_id=user_id,
+        source="facts",
+        active_project=active_project,
+        hinted=scope_hinted,
+        defaulted=scope_defaulted,
+        stored_global=stored_by_scope.get(memory.SCOPE_GLOBAL, 0),
+        stored_project=stored_by_scope.get(memory.SCOPE_PROJECT, 0),
     )
     return stored, replaced, skipped
 
@@ -3068,6 +3183,24 @@ async def extract_and_store(
                 # `or []` collapses both None and a falsy empty result
                 # to the documented contract (a list).
                 candidates = candidates or []
+            # Scope admission for consolidation candidates. The fetch
+            # above is user-wide; without this filter, a project row
+            # from ANOTHER project can enter the EXISTING FACTS block,
+            # where an `update_of` would delete-and-rewrite it under
+            # the current project's scope and a `skip_redundant` would
+            # suppress a valid current-project write. Consolidation is
+            # a write-time read that controls deletion and storage, so
+            # its candidate authority must match the write authority:
+            # the same admission rule retrieval uses, keyed on the
+            # detected project. Excluded candidates also never reach
+            # `candidate_id_set`, so an extractor that hallucinates a
+            # filtered id falls into the existing hallucinated-id drop.
+            excluded_by_scope = 0
+            if candidates:
+                write_project_id = _allowed_write_project_id(active_project)
+                admitted = [c for c in candidates if _scope_admitted(c.metadata, write_project_id)]
+                excluded_by_scope = len(candidates) - len(admitted)
+                candidates = admitted
             candidate_id_set: set[str] = {c.id for c in candidates}
             # Per-id metadata lookup for `_validate_facts` Rule 4b
             # (issue #414): the rule needs the existing row's stored
@@ -3089,6 +3222,7 @@ async def extract_and_store(
                         "user_id": user_id,
                         "n_candidates": len(candidates),
                         "candidate_ids": [c.id for c in candidates],
+                        "excluded_by_scope": excluded_by_scope,
                     },
                     separators=(",", ":"),
                 ),
@@ -3233,6 +3367,7 @@ __all__ = [
     "_ALLOWED_TYPES",
     "_CONFIRMATION_QUOTE_MIN_CHARS",
     "_CONSOLIDATION_INTENTS",
+    "_DEDUP_NEIGHBOR_FETCH_N",
     "_EXTRACTION_PROMPT_VERSION",
     "_EXTRACTION_SYSTEM_PROMPT",
     "_EXTRACTOR_CWD",
@@ -3242,9 +3377,11 @@ __all__ = [
     "_SCOPE_CONFIDENCE_DEFAULTED",
     "_SCOPE_CONFIDENCE_HINTED",
     "_SEMAPHORE_CAP",
+    "_allowed_write_project_id",
     "_build_extraction_payload",
     "_capped_assistant",
     "_emit_intent_log",
+    "_emit_scope_log",
     "_get_semaphore",
     "_paraphrase_neighbor",
     "_per_user_semaphores",
@@ -3252,6 +3389,7 @@ __all__ = [
     "_render_candidate_source",
     "_route_write_scope",
     "_run_extractor",
+    "_scope_admitted",
     "_store_facts",
     "_strip_role_labels",
     "_validate_episode",

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -26,10 +26,12 @@ import re
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
+from pathlib import Path
 
 from kai import memory
 from kai.config import Config, ModelRole, resolve_user_model
 from kai.memory import MemoryResult
+from kai.memory_projects import ActiveMemoryProject, detect_active_memory_project
 from kai.oneshot import _EXTRACTOR_CWD as _EXTRACTOR_CWD
 from kai.oneshot import _SUBPROCESS_ENV_ALLOWLIST as _SUBPROCESS_ENV_ALLOWLIST
 from kai.oneshot import (
@@ -142,14 +144,20 @@ log = logging.getLogger(__name__)
 # extractor classified the same probe correctly. Schema unchanged;
 # the bump lets post-rollout log analysis partition facts produced
 # after the merge-PR negative landed from those produced before it.
-_EXTRACTION_PROMPT_VERSION: str = "11"
+# v12 (2026-06-12): added the scope_hint FORMAT field (global vs
+# project write-scope judgment for the scoped-memory routing path),
+# with worked examples. The fact schema gains the matching optional
+# scope_hint enum.
+_EXTRACTION_PROMPT_VERSION: str = "12"
 
 # Sibling of _EXTRACTION_PROMPT_VERSION for stage-2 episode generation.
 # Stored in each episode's metadata so future cleanups can target a
 # specific episode-prompt revision the same way fact prompt versions
 # are tracked. Bump on any substantive edit to _EPISODE_SYSTEM_PROMPT
 # or _EPISODE_SCHEMA.
-_EPISODE_PROMPT_VERSION: str = "1"
+# v2 (2026-06-12): added the optional scope_hint field (global vs
+# project write-scope judgment for the scoped-memory routing path).
+_EPISODE_PROMPT_VERSION: str = "2"
 
 # Memory `type` values this module writes. Track 1 writes "exchange"
 # from memory.py; Track 2 writes "fact" from here. Any other type value
@@ -362,6 +370,17 @@ _FACT_SCHEMA: dict = {
                         "type": "string",
                         "enum": ["user", "assistant"],
                     },
+                    # Optional write-scope judgment. NOT in `required`:
+                    # the prompt tells the model to omit the field when
+                    # neither value clearly applies, and the routing
+                    # helper treats absence as "use policy default".
+                    # A required field would push the model toward
+                    # guessing a scope, which is exactly the failure
+                    # mode scoped memory exists to prevent.
+                    "scope_hint": {
+                        "type": "string",
+                        "enum": ["global", "project"],
+                    },
                 },
                 "required": ["content", "tags", "confidence", "intent", "speaker"],
                 "additionalProperties": False,
@@ -535,6 +554,29 @@ FORMAT each fact as:
   confirms the action, minimum 20 characters, and must reference
   the action specifically (not a generic "thanks"). If no such
   quote exists, do not emit the fact.
+- scope_hint: OPTIONAL. Either "global" or "project". Emit "global"
+  when the fact would hold for this user in ANY project context:
+  identity, location, timezone, stable preferences, working style,
+  hardware, cross-project constraints. Emit "project" when the fact
+  is specific to the project being worked on in this conversation:
+  implementation details, repo or module specifics, project-local
+  conventions, decisions whose authority ends at the project
+  boundary. OMIT the field when neither clearly applies; an omitted
+  scope_hint falls back to a safe policy default, and omitting is
+  always better than guessing.
+
+  Worked examples:
+
+  - "User prefers Celsius" -> scope_hint: "global". True in every
+    project.
+  - "The webhook secret is read from the WEBHOOK_SECRET env var"
+    -> scope_hint: "project". An implementation detail of the
+    project under discussion; in a different project the same
+    sentence could be false.
+  - "User decided the parser rewrite ships behind a feature flag"
+    -> scope_hint: "project". A durable decision, but its
+    authority ends at this project's boundary.
+  - "User works in Eastern Time" -> scope_hint: "global".
 
 EPISODE CLASSIFICATION (windowed):
 Decide whether the CURRENT exchange (marked with >>>) is the closing
@@ -711,6 +753,14 @@ _EPISODE_SCHEMA: dict = {
                     "minItems": 1,
                     "maxItems": 10,
                 },
+                # Optional write-scope judgment, mirroring the fact
+                # schema's scope_hint. Absence means "use policy
+                # default"; see the fact-schema comment for why the
+                # field must not be required.
+                "scope_hint": {
+                    "type": "string",
+                    "enum": ["global", "project"],
+                },
             },
             "required": [
                 "goal",
@@ -792,6 +842,14 @@ FIELDS (required unless noted):
   GitHub login or service name for an external actor, or a PR or
   issue number (e.g. "PR #360", "#306") for an artifact that was
   central to the situation.
+
+- scope_hint: OPTIONAL. Either "global" or "project". Emit
+  "project" when the situation is specific to the project being
+  worked on (an implementation arc, a debugging session in one
+  codebase, a repo-local decision). Emit "global" when the
+  situation's lesson would apply to this user's work in any
+  project. OMIT the field when neither clearly applies; omitting
+  is always better than guessing.
 
 GUIDELINES:
 - Prefer specificity over generality. An episode that could fit
@@ -2284,6 +2342,7 @@ async def _generate_episode(
     effective_backend: str,
     effective_provider: str,
     os_user: str | None = None,
+    active_project: ActiveMemoryProject | None = None,
 ) -> None:
     """
     Stage-2 task body: generate one episode record and store it.
@@ -2299,6 +2358,11 @@ async def _generate_episode(
     extraction semaphore) so concurrent stage-2 calls for the same user
     serialize. Stage 1 calls for the same user proceed in parallel
     because stage 2 is by design out-of-band.
+
+    `active_project` is the run-level detection result threaded from
+    `extract_and_store` (same single-resolution contract as `os_user`
+    and the backend triple); `_route_write_scope` consumes it with the
+    generated episode's `scope_hint` at the metadata-build site below.
     """
     sem = _get_episode_semaphore(user_id)
     # Pre-acquire fallback so the post-try _emit_episode_log call
@@ -2418,6 +2482,11 @@ async def _generate_episode(
                     }
                     if "lessons" in episode:
                         extra["lessons"] = episode["lessons"]
+                    # Write-scope routing, same consumption shape as
+                    # the fact path in _store_facts: the generator's
+                    # scope_hint is routed (never stored raw) and the
+                    # resulting scope fields land in metadata.
+                    extra.update(_route_write_scope(episode.get("scope_hint"), active_project))
                     # add_structured is sync (Mem0 is sync). Run off
                     # the event loop so the embedding step does not
                     # block other stage-2 tasks queued behind this
@@ -2465,12 +2534,103 @@ async def _generate_episode(
     )
 
 
+# Write-time scope-assignment confidence. Hinted assignments carry the
+# extractor's content judgment; defaulted assignments are mechanical
+# policy fallbacks with no judgment behind them. The gap between the
+# two values is what lets a later audit (or a reclassification pass)
+# find the defaulted rows without parsing scope_source strings. No
+# retrieval ranking weights scope_confidence yet (the read-time
+# resolver only carries it through); these values are write-side
+# provenance only.
+_SCOPE_CONFIDENCE_HINTED: float = 0.9
+_SCOPE_CONFIDENCE_DEFAULTED: float = 0.6
+
+# Hint values the routing helper accepts. Mirrors the scope_hint enum
+# in _FACT_SCHEMA and _EPISODE_SCHEMA; anything else (including a
+# schema regression that lets a stray string through) is treated as
+# "no hint" rather than rejected or guessed.
+_VALID_SCOPE_HINTS: frozenset[str] = frozenset({memory.SCOPE_GLOBAL, memory.SCOPE_PROJECT})
+
+
+def _route_write_scope(
+    hint: object,
+    active_project: ActiveMemoryProject | None,
+) -> dict[str, object]:
+    """
+    Apply the write-scope routing rules and return scope metadata.
+
+    The returned dict comes from `memory.build_scope_metadata()` and
+    merges into a row's metadata before `add_structured()`. Routing is
+    fail-safe: every path that cannot justify project scope lands on
+    global, and an unusable hint is discarded (the FACT is kept; only
+    the hint is ignored). Never raises on bad input; an exception here
+    would bubble through `_store_facts` into the run-level catch and
+    lose the whole validated batch over its least important field.
+
+    Rules, in precedence order:
+
+    1. No detected project, or the detected project has
+       `memory_enabled: false`: global, `scope_source=extraction_default`.
+       Hints are ignored in this state; there is no project to attach
+       project scope to, and honoring a "global" hint here would
+       record classifier provenance for a decision the classifier did
+       not actually make.
+    2. Detected project and a valid hint: the hint wins,
+       `scope_source=classifier`. Project-scoped rows take their
+       `project_id` and `workspace_root` from detection, never from
+       the model.
+    3. Detected project, missing or invalid hint: the registry's
+       `default_scope_for_new_facts` when set, else global;
+       `scope_source=extraction_default`.
+
+    Defaulted assignments (rules 1 and 3) carry
+    `_SCOPE_CONFIDENCE_DEFAULTED`; hinted assignments (rule 2) carry
+    `_SCOPE_CONFIDENCE_HINTED`.
+    """
+    if active_project is None or not active_project.memory_enabled:
+        return memory.build_scope_metadata(
+            scope=memory.SCOPE_GLOBAL,
+            scope_source=memory.SCOPE_SOURCE_EXTRACTION_DEFAULT,
+            scope_confidence=_SCOPE_CONFIDENCE_DEFAULTED,
+        )
+
+    if isinstance(hint, str) and hint in _VALID_SCOPE_HINTS:
+        if hint == memory.SCOPE_PROJECT:
+            return memory.build_scope_metadata(
+                scope=memory.SCOPE_PROJECT,
+                project_id=active_project.project_id,
+                workspace_root=str(active_project.matched_root),
+                scope_source=memory.SCOPE_SOURCE_CLASSIFIER,
+                scope_confidence=_SCOPE_CONFIDENCE_HINTED,
+            )
+        return memory.build_scope_metadata(
+            scope=memory.SCOPE_GLOBAL,
+            scope_source=memory.SCOPE_SOURCE_CLASSIFIER,
+            scope_confidence=_SCOPE_CONFIDENCE_HINTED,
+        )
+
+    if active_project.default_scope_for_new_facts == memory.SCOPE_PROJECT:
+        return memory.build_scope_metadata(
+            scope=memory.SCOPE_PROJECT,
+            project_id=active_project.project_id,
+            workspace_root=str(active_project.matched_root),
+            scope_source=memory.SCOPE_SOURCE_EXTRACTION_DEFAULT,
+            scope_confidence=_SCOPE_CONFIDENCE_DEFAULTED,
+        )
+    return memory.build_scope_metadata(
+        scope=memory.SCOPE_GLOBAL,
+        scope_source=memory.SCOPE_SOURCE_EXTRACTION_DEFAULT,
+        scope_confidence=_SCOPE_CONFIDENCE_DEFAULTED,
+    )
+
+
 def _store_facts(
     facts: list[dict],
     *,
     user_id: str,
     session_id: str | None,
     config: Config,
+    active_project: ActiveMemoryProject | None = None,
 ) -> tuple[int, int, int]:
     """
     Persist validated facts via memory.add_structured, branching on intent.
@@ -2492,6 +2652,14 @@ def _store_facts(
     rather than re-loaded here so a test or a per-call override can
     flow through the same code path; also avoids an in-loop
     `load_config()` cost.
+
+    `active_project` is the workspace-detection result threaded from
+    `extract_and_store`; `_route_write_scope` consumes it (with each
+    fact's `scope_hint`) to merge scope metadata into every stored
+    row. None routes all facts global, which is both the no-workspace
+    state and the not-in-a-registered-project state. The function
+    emits one `memory.extract.scope` JSON line per call recording the
+    detection result and the routing tallies for rows that landed.
 
     Each intent branch emits exactly one `memory.consolidate.intent`
     line via `_emit_intent_log`. The `intent="new"` branch keeps the
@@ -2515,6 +2683,22 @@ def _store_facts(
     stored = 0
     replaced = 0
     skipped = 0
+    # Per-run scope routing tallies for the memory.extract.scope log
+    # line. `hinted`/`defaulted` count rows that LANDED (not proposed
+    # facts), keyed off the routed scope_source, so the log reflects
+    # what actually entered the store.
+    scope_hinted = 0
+    scope_defaulted = 0
+    stored_by_scope: dict[str, int] = {memory.SCOPE_GLOBAL: 0, memory.SCOPE_PROJECT: 0}
+
+    def _tally_scope(scope_meta: dict[str, object]) -> None:
+        nonlocal scope_hinted, scope_defaulted
+        if scope_meta["scope_source"] == memory.SCOPE_SOURCE_CLASSIFIER:
+            scope_hinted += 1
+        else:
+            scope_defaulted += 1
+        scope = str(scope_meta["scope"])
+        stored_by_scope[scope] = stored_by_scope.get(scope, 0) + 1
 
     for fact in facts:
         content = fact.get("content")
@@ -2553,6 +2737,13 @@ def _store_facts(
         # by the time _validate_facts has run.
         if "confirmation_quote" in fact:
             extra["confirmation_quote"] = fact["confirmation_quote"]
+        # Write-scope routing. The model's scope_hint is consumed here
+        # and deliberately NOT copied into metadata: the routed result
+        # (scope, project_id, workspace_root, scope_confidence,
+        # scope_source) is the durable record; the raw hint adds no
+        # information beyond what scope_source already encodes.
+        scope_meta = _route_write_scope(fact.get("scope_hint"), active_project)
+        extra.update(scope_meta)
 
         if intent == "skip_redundant":
             # No storage call. The intent log is the only side effect
@@ -2622,6 +2813,7 @@ def _store_facts(
             )
             stored += 1
             replaced += 1
+            _tally_scope(scope_meta)
             continue
 
         # intent == "new" (rule-1 already rejected anything else, but
@@ -2680,6 +2872,7 @@ def _store_facts(
                 outcome="stored",
             )
             stored += 1
+            _tally_scope(scope_meta)
         else:
             # `dropped_backend`: storage disabled OR backend swallowed
             # the call (Mem0 add() has an internal try/except that turns
@@ -2695,6 +2888,30 @@ def _store_facts(
                 replaced_id=None,
                 outcome="dropped_backend",
             )
+    # One scope-routing line per extraction run (this function is
+    # called at most once per run, and only when the validated fact
+    # list is non-empty). The fixed-shape JSON record lets shadow-log
+    # analysis trace a scoped row back to the write-time decision that
+    # produced it. `active_project_id` reports the DETECTED project
+    # even when memory_enabled is false (routing then forces global);
+    # the `project_memory_enabled` field is what distinguishes the two
+    # states, mirroring the detector's diagnostics contract.
+    log.info(
+        "memory.extract.scope %s",
+        json.dumps(
+            {
+                "user_id": user_id,
+                "active_project_id": active_project.project_id if active_project else None,
+                "matched_root": str(active_project.matched_root) if active_project else None,
+                "project_memory_enabled": active_project.memory_enabled if active_project else None,
+                "hinted": scope_hinted,
+                "defaulted": scope_defaulted,
+                "stored_global": stored_by_scope.get(memory.SCOPE_GLOBAL, 0),
+                "stored_project": stored_by_scope.get(memory.SCOPE_PROJECT, 0),
+            },
+            separators=(",", ":"),
+        ),
+    )
     return stored, replaced, skipped
 
 
@@ -2710,6 +2927,7 @@ async def extract_and_store(
     config: Config | None = None,
     prior_pairs: list[tuple[str, str]] | None = None,
     os_user_override: str | None = None,
+    workspace: str | None = None,
 ) -> int:
     """
     Run Haiku extraction on an exchange and store the resulting facts.
@@ -2736,6 +2954,17 @@ async def extract_and_store(
     fetches it from `history.get_recent_pairs` and threads it through;
     None preserves the pre-#392 single-turn behavior for any caller
     (notably the existing test suite) that does not yet pass it.
+
+    The optional `workspace` parameter is the user's active workspace
+    path, threaded by bot.py from the same per-user state the recall
+    path uses. It drives write-scope routing: the path is matched
+    against the memory project registry once per run and the result
+    flows into both stages' storage writes. None (the default) skips
+    detection and routes every row global, which keeps callers that
+    predate scoped memory (notably the eval replay harness, whose
+    extractor input must stay byte-equivalent across replays) on
+    exactly the pre-routing write shape apart from the now-explicit
+    scope metadata.
     """
     if config is None:
         from kai.config import load_config
@@ -2768,6 +2997,17 @@ async def extract_and_store(
     # mirrors `_resolve_effective_backend`.
     effective_backend = _resolve_effective_backend(user_id, config)
     effective_provider = _resolve_effective_provider(user_id, config)
+
+    # Active-project detection, ONCE per run, threaded into both
+    # stages like os_user and the backend triple above so a single
+    # exchange's fact rows and episode row can never disagree on
+    # which project they belong to. The detector is pure and cheap
+    # (longest-prefix match over the registry), but running it per
+    # fact would still invite drift if a future edit moved the two
+    # write paths apart.
+    active_project: ActiveMemoryProject | None = None
+    if workspace:
+        active_project = detect_active_memory_project(Path(workspace), config.memory_projects)
 
     sem = _get_semaphore(user_id)
     # Pre-initialize the storage counters so the post-try summary log
@@ -2902,6 +3142,7 @@ async def extract_and_store(
                         user_id=user_id,
                         session_id=session_id,
                         config=config,
+                        active_project=active_project,
                     ),
                 )
             else:
@@ -2939,6 +3180,7 @@ async def extract_and_store(
                         effective_backend=effective_backend,
                         effective_provider=effective_provider,
                         os_user=os_user,
+                        active_project=active_project,
                     ),
                     name=f"episode-{user_id}",
                 )
@@ -2997,6 +3239,8 @@ __all__ = [
     "_FACT_SCHEMA",
     "_GENERIC_CONFIRMATION_RE",
     "_ROLE_LABEL_RE",
+    "_SCOPE_CONFIDENCE_DEFAULTED",
+    "_SCOPE_CONFIDENCE_HINTED",
     "_SEMAPHORE_CAP",
     "_build_extraction_payload",
     "_capped_assistant",
@@ -3006,6 +3250,7 @@ __all__ = [
     "_per_user_semaphores",
     "_render_candidate_line",
     "_render_candidate_source",
+    "_route_write_scope",
     "_run_extractor",
     "_store_facts",
     "_strip_role_labels",

--- a/tests/test_extraction_prompt.py
+++ b/tests/test_extraction_prompt.py
@@ -113,7 +113,7 @@ def test_store_block_does_not_reference_durability_test():
 
 def test_prompt_version_bumped():
     """Version stamp matches the prompt revision."""
-    assert _EXTRACTION_PROMPT_VERSION == "11"
+    assert _EXTRACTION_PROMPT_VERSION == "12"
 
 
 def test_no_em_or_en_dashes_in_quality_test_block():

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -425,7 +425,7 @@ class TestStage2Trigger:
         causal correlation in logs."""
         order: list[str] = []
 
-        def _store_recorder(facts, *, user_id, session_id, config):
+        def _store_recorder(facts, *, user_id, session_id, config, active_project=None):
             order.append("store_facts")
             return (len(facts), 0, 0)
 

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -4414,6 +4414,7 @@ class TestStoreFactsScopeMetadata:
         scope_lines = [r.message for r in caplog.records if r.message.startswith("memory.extract.scope ")]
         assert len(scope_lines) == 1
         payload = json.loads(scope_lines[0].split(" ", 1)[1])
+        assert payload["source"] == "facts"
         assert payload["active_project_id"] == "kai"
         assert payload["matched_root"] == "/work/kai"
         assert payload["project_memory_enabled"] is True
@@ -4511,6 +4512,92 @@ class TestEpisodeScopeMetadata:
         assert captured_metadata["scope"] == "global"
         assert captured_metadata["scope_source"] == "extraction_default"
 
+    @pytest.mark.asyncio
+    async def test_episode_only_store_emits_scope_log(self, monkeypatch, caplog):
+        """An episode can store with zero facts (the two outputs are
+        orthogonal), and `_store_facts` never runs on that path; the
+        episode-side emission is what keeps episode-only scoped writes
+        visible in the memory.extract.scope stream."""
+        episode_payload = {
+            "goal": "Lock per-user home workspace as the canonical layout",
+            "context": "ctx",
+            "approach": "ap",
+            "outcome": "out",
+            "outcome_quality": "success",
+            "tags": ["t1"],
+            "actors": ["user"],
+            "scope_hint": "project",
+        }
+
+        async def _fake_runner(payload, config, **kwargs):
+            return episode_payload, None
+
+        monkeypatch.setattr(memory_extraction, "_run_episode_extractor", _fake_runner)
+        monkeypatch.setattr(memory_extraction, "_emit_episode_log", lambda **kw: None)
+        from kai import memory as memory_module
+
+        monkeypatch.setattr(memory_module, "add_structured", lambda *a, **kw: "stored-mem-id")
+
+        with caplog.at_level("INFO", logger="kai.memory_extraction"):
+            await memory_extraction._generate_episode(
+                user_text="propose home layout",
+                assistant_text="locked: per-user home workspace",
+                user_id="u-int",
+                session_id="s-1",
+                config=_cfg(),
+                effective_backend="claude",
+                effective_provider="anthropic",
+                active_project=_active_project(),
+            )
+
+        scope_lines = [r.message for r in caplog.records if r.message.startswith("memory.extract.scope ")]
+        assert len(scope_lines) == 1
+        payload = json.loads(scope_lines[0].split(" ", 1)[1])
+        assert payload["source"] == "episode"
+        assert payload["active_project_id"] == "kai"
+        assert payload["hinted"] == 1
+        assert payload["stored_project"] == 1
+        assert payload["stored_global"] == 0
+
+    @pytest.mark.asyncio
+    async def test_failed_episode_store_emits_no_scope_log(self, monkeypatch, caplog):
+        """The scope log reports rows that LANDED; an add_structured
+        failure must not emit one (mirroring the fact side's
+        stored-rows-only tally)."""
+        episode_payload = {
+            "goal": "Lock per-user home workspace as the canonical layout",
+            "context": "ctx",
+            "approach": "ap",
+            "outcome": "out",
+            "outcome_quality": "success",
+            "tags": ["t1"],
+            "actors": ["user"],
+        }
+
+        async def _fake_runner(payload, config, **kwargs):
+            return episode_payload, None
+
+        monkeypatch.setattr(memory_extraction, "_run_episode_extractor", _fake_runner)
+        monkeypatch.setattr(memory_extraction, "_emit_episode_log", lambda **kw: None)
+        from kai import memory as memory_module
+
+        monkeypatch.setattr(memory_module, "add_structured", lambda *a, **kw: None)
+
+        with caplog.at_level("INFO", logger="kai.memory_extraction"):
+            await memory_extraction._generate_episode(
+                user_text="propose home layout",
+                assistant_text="locked: per-user home workspace",
+                user_id="u-int",
+                session_id="s-1",
+                config=_cfg(),
+                effective_backend="claude",
+                effective_provider="anthropic",
+                active_project=_active_project(),
+            )
+
+        scope_lines = [r.message for r in caplog.records if r.message.startswith("memory.extract.scope ")]
+        assert scope_lines == []
+
 
 class TestWorkspaceThreading:
     """`extract_and_store` detects the active project from the
@@ -4606,3 +4693,202 @@ class TestScopeHintSchema:
         props = memory_extraction._EPISODE_SCHEMA["properties"]["episode"]["properties"]
         assert props["scope_hint"]["enum"] == ["global", "project"]
         assert "scope_hint" not in memory_extraction._EPISODE_SCHEMA["properties"]["episode"]["required"]
+
+
+def _mem_result(mem_id: str, metadata: dict, score: float = 0.9) -> MemoryResult:
+    """Build a MemoryResult with real (dict) metadata for scope tests."""
+    return MemoryResult(
+        id=mem_id,
+        text="t",
+        score=score,
+        memory_type="fact",
+        metadata=metadata,
+        created_at="2026-06-12T00:00:00",
+    )
+
+
+# Scope-carrying metadata shapes used by the write-time-read tests.
+# `scope_source` must be a write-path value or the resolver flags the
+# row invalid_defaulted; classifier is the realistic shape for rows
+# written by the routing path.
+_OTHER_PROJECT_META = {"scope": "project", "project_id": "other", "scope_source": "classifier"}
+_KAI_PROJECT_META = {"scope": "project", "project_id": "kai", "scope_source": "classifier"}
+
+
+class TestScopeAdmittedWriteReads:
+    """Unit tests for `_scope_admitted`, the write-time-read admission
+    rule shared by the consolidation-candidate filter and the dedup
+    gate. Composes the read side's resolver and admission helper, so
+    these tests pin the composition (which rows a write-time read may
+    act on), not the helpers' internals."""
+
+    def test_legacy_row_admitted_everywhere(self):
+        assert memory_extraction._scope_admitted({}, None) is True
+        assert memory_extraction._scope_admitted({}, "kai") is True
+
+    def test_matching_project_row_admitted(self):
+        assert memory_extraction._scope_admitted(_KAI_PROJECT_META, "kai") is True
+
+    def test_wrong_project_row_rejected(self):
+        assert memory_extraction._scope_admitted(_OTHER_PROJECT_META, "kai") is False
+
+    def test_project_row_rejected_without_project_authority(self):
+        """allowed_project_id None covers both no-detected-project and
+        memory-disabled-project; in either state a project row has no
+        write-time-read authority."""
+        assert memory_extraction._scope_admitted(_KAI_PROJECT_META, None) is False
+
+    def test_task_row_rejected(self):
+        meta = {"scope": "task", "scope_source": "classifier"}
+        assert memory_extraction._scope_admitted(meta, "kai") is False
+
+    def test_allowed_write_project_id_requires_memory_enabled(self):
+        assert memory_extraction._allowed_write_project_id(None) is None
+        assert memory_extraction._allowed_write_project_id(_active_project(memory_enabled=False)) is None
+        assert memory_extraction._allowed_write_project_id(_active_project()) == "kai"
+
+
+class TestConsolidationCandidateScope:
+    """Wrong-project rows must never enter the consolidation candidate
+    set: an `update_of` against such a row deletes and rewrites another
+    project's memory under the current project, and a `skip_redundant`
+    suppresses a valid current-project write. The filter removes them
+    BEFORE the candidate block is rendered and before
+    `candidate_id_set` is built, so the extractor can neither see nor
+    legally cite them."""
+
+    @pytest.mark.asyncio
+    async def test_wrong_project_candidate_filtered_from_extractor_input(self, monkeypatch, tmp_path, caplog):
+        root = (tmp_path / "kai").resolve()
+        root.mkdir()
+        cfg = _cfg(
+            memory_consolidation_candidates_n=8,
+            memory_projects={
+                "kai": MemoryProjectConfig(
+                    project_id="kai",
+                    display_name="Kai",
+                    workspace_roots=(root,),
+                    memory_enabled=True,
+                    default_scope_for_new_facts=None,
+                )
+            },
+        )
+        candidates = [
+            _mem_result("legacy-row", {}),
+            _mem_result("kai-row", dict(_KAI_PROJECT_META)),
+            _mem_result("other-row", dict(_OTHER_PROJECT_META)),
+        ]
+        monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: list(candidates))
+
+        seen: dict = {}
+
+        async def _fake_extractor(payload, config, **kwargs):
+            seen["candidate_ids"] = kwargs.get("candidate_ids")
+            seen["payload"] = payload
+            result = MagicMock()
+            result.facts = []
+            result.has_episode = False
+            return result
+
+        monkeypatch.setattr(memory_extraction, "_run_extractor", _fake_extractor)
+
+        with caplog.at_level("INFO", logger="kai.memory_extraction"):
+            await extract_and_store(
+                user_text="u",
+                assistant_text="a",
+                user_id="1",
+                config=cfg,
+                workspace=str(root),
+            )
+
+        # The wrong-project row is gone from both the citable id set
+        # and the rendered payload; admissible rows survive.
+        assert seen["candidate_ids"] == {"legacy-row", "kai-row"}
+        assert "other-row" not in seen["payload"]
+        # The candidate log line reports the exclusion so an operator
+        # can see scope filtering acting on write-time reads.
+        cand_lines = [r.message for r in caplog.records if r.message.startswith("memory.consolidate.candidates ")]
+        assert len(cand_lines) == 1
+        payload = json.loads(cand_lines[0].split(" ", 1)[1])
+        assert payload["excluded_by_scope"] == 1
+        assert payload["n_candidates"] == 2
+
+    @pytest.mark.asyncio
+    async def test_no_project_excludes_all_project_candidates(self, monkeypatch):
+        """Outside any registered project, project-scoped rows from
+        EVERY project lose candidate authority; only global/legacy
+        rows remain citable."""
+        cfg = _cfg(memory_consolidation_candidates_n=8)
+        candidates = [
+            _mem_result("legacy-row", {}),
+            _mem_result("kai-row", dict(_KAI_PROJECT_META)),
+        ]
+        monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: list(candidates))
+
+        seen: dict = {}
+
+        async def _fake_extractor(payload, config, **kwargs):
+            seen["candidate_ids"] = kwargs.get("candidate_ids")
+            result = MagicMock()
+            result.facts = []
+            result.has_episode = False
+            return result
+
+        monkeypatch.setattr(memory_extraction, "_run_extractor", _fake_extractor)
+
+        await extract_and_store(user_text="u", assistant_text="a", user_id="1", config=cfg)
+
+        assert seen["candidate_ids"] == {"legacy-row"}
+
+
+class TestDedupGateScope:
+    """`_paraphrase_neighbor` must not let a wrong-project row
+    suppress a current-project write, and must not let a wrong-project
+    row at rank 1 mask an admissible duplicate below it."""
+
+    def _searches(self, monkeypatch, results: list[MemoryResult]) -> None:
+        monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
+        monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: list(results))
+
+    def test_wrong_project_neighbor_does_not_suppress(self, monkeypatch):
+        self._searches(monkeypatch, [_mem_result("other-row", dict(_OTHER_PROJECT_META), score=0.99)])
+        neighbor = _paraphrase_neighbor("x", "u1", threshold=0.9, active_project=_active_project())
+        assert neighbor is None
+
+    def test_admissible_duplicate_below_wrong_project_row_still_fires(self, monkeypatch):
+        """Rank 1 is wrong-project; rank 2 is an admissible duplicate
+        above threshold. The gate must skip rank 1 and fire on rank 2;
+        the pre-fix top-1 fetch would have returned the wrong-project
+        row and (post-admission) missed the real duplicate."""
+        self._searches(
+            monkeypatch,
+            [
+                _mem_result("other-row", dict(_OTHER_PROJECT_META), score=0.99),
+                _mem_result("kai-row", dict(_KAI_PROJECT_META), score=0.95),
+            ],
+        )
+        neighbor = _paraphrase_neighbor("x", "u1", threshold=0.9, active_project=_active_project())
+        assert neighbor is not None
+        assert neighbor.id == "kai-row"
+
+    def test_nearest_admissible_below_threshold_does_not_fire(self, monkeypatch):
+        """The first admitted hit is the nearest admissible neighbor;
+        if it is below threshold the gate must not fire, and later
+        (lower-scored) hits must not be consulted."""
+        self._searches(
+            monkeypatch,
+            [
+                _mem_result("other-row", dict(_OTHER_PROJECT_META), score=0.99),
+                _mem_result("kai-row", dict(_KAI_PROJECT_META), score=0.7),
+            ],
+        )
+        neighbor = _paraphrase_neighbor("x", "u1", threshold=0.9, active_project=_active_project())
+        assert neighbor is None
+
+    def test_legacy_neighbor_still_fires_without_project(self, monkeypatch):
+        """The pre-scoping behavior is preserved for the global-only
+        state: a legacy row above threshold suppresses the duplicate."""
+        self._searches(monkeypatch, [_mem_result("legacy-row", {}, score=0.95)])
+        neighbor = _paraphrase_neighbor("x", "u1", threshold=0.9)
+        assert neighbor is not None
+        assert neighbor.id == "legacy-row"

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -17,12 +17,13 @@ from __future__ import annotations
 import asyncio
 import json
 from dataclasses import replace
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from kai import memory_extraction
-from kai.config import Config
+from kai.config import Config, MemoryProjectConfig
 from kai.memory import MemoryResult
 from kai.memory_extraction import (
     _CONFIRMATION_QUOTE_MIN_CHARS,
@@ -32,6 +33,8 @@ from kai.memory_extraction import (
     _FACT_SCHEMA,
     _GENERIC_CONFIRMATION_RE,
     _RULE_6_REJECTIONS,
+    _SCOPE_CONFIDENCE_DEFAULTED,
+    _SCOPE_CONFIDENCE_HINTED,
     _WORKFLOW_EVENT_RE,
     _WORKFLOW_SELF_ANNOUNCEMENT_QUOTE_RE,
     _build_extraction_payload,
@@ -41,6 +44,7 @@ from kai.memory_extraction import (
     _paraphrase_neighbor,
     _render_candidate_line,
     _render_candidate_source,
+    _route_write_scope,
     _store_facts,
     _strip_role_labels,
     _validate_episode,
@@ -48,6 +52,7 @@ from kai.memory_extraction import (
     extract_and_store,
     get_extractor_stats,
 )
+from kai.memory_projects import ActiveMemoryProject
 
 # ── Fixtures ─────────────────────────────────────────────────────────
 
@@ -2602,7 +2607,7 @@ class TestExtractionPromptSoftVocab:
     def test_extraction_prompt_version_bumped(self):
         """The version stamp on every fact's metadata; bumped
         whenever the schema or prompt changes meaningfully."""
-        assert _EXTRACTION_PROMPT_VERSION == "11"
+        assert _EXTRACTION_PROMPT_VERSION == "12"
 
     def test_extraction_prompt_version_history_extended(self):
         """The prompt-version history comment block (the sequence
@@ -2646,6 +2651,11 @@ class TestExtractionPromptSoftVocab:
         # at the current head of the version sequence.
         assert "v11 (2026-05-24)" in src
         assert "user-announced completed workflow actions" in src
+        # v12 entry: scope_hint write-scope judgment field. Pinning
+        # the literal date plus the distinguishing phrase keeps the
+        # rule honest at the current head of the version sequence.
+        assert "v12 (2026-06-12)" in src
+        assert "scope_hint FORMAT field" in src
 
 
 class TestRule6WorkflowEventRegex:
@@ -4157,3 +4167,442 @@ class TestExtractAndStorePerUserDispatch:
         # Stage 2 inherits the codex backend stage 1 resolved.
         assert captured_episode_kwargs.get("effective_backend") == "codex"
         assert captured_episode_kwargs.get("os_user") == "alice_os"
+
+
+# ── Write-scope routing (scoped-memory epic) ─────────────────────────
+
+
+def _active_project(**overrides) -> ActiveMemoryProject:
+    """Build an ActiveMemoryProject with test defaults.
+
+    Mirrors what detect_active_memory_project returns for a registered
+    root; tests override individual fields to exercise each routing
+    rule without re-running detection.
+    """
+    defaults: dict = {
+        "project_id": "kai",
+        "display_name": "Kai",
+        "matched_root": Path("/work/kai"),
+        "memory_enabled": True,
+        "default_scope_for_new_facts": None,
+    }
+    defaults.update(overrides)
+    return ActiveMemoryProject(**defaults)
+
+
+class TestRouteWriteScope:
+    """Unit tests for `_route_write_scope`, one per routing rule.
+
+    The helper is pure (hint + detection result in, scope-metadata
+    dict out), so every rule is pinned directly without mocks. The
+    dict shape itself is produced by `memory.build_scope_metadata`,
+    whose validation is covered in test_memory.py; these tests assert
+    the ROUTING decisions (scope, source, confidence, id propagation),
+    not the builder's field mechanics.
+    """
+
+    def test_no_project_routes_global_default(self):
+        meta = _route_write_scope("project", None)
+        assert meta["scope"] == "global"
+        assert meta["scope_source"] == "extraction_default"
+        assert meta["scope_confidence"] == _SCOPE_CONFIDENCE_DEFAULTED
+        assert meta["project_id"] is None
+
+    def test_memory_disabled_project_routes_global_and_ignores_hint(self):
+        """A detectable project with memory_enabled=false must behave
+        exactly like no project: global scope, default source, hint
+        ignored. This mirrors the read side's "known project, memory
+        disabled" rule so write and read authority cannot disagree."""
+        project = _active_project(memory_enabled=False)
+        meta = _route_write_scope("project", project)
+        assert meta["scope"] == "global"
+        assert meta["scope_source"] == "extraction_default"
+        assert meta["project_id"] is None
+
+    def test_project_hint_wins_with_detection_identity(self):
+        """A valid "project" hint takes project scope, but the
+        project_id and workspace_root come from DETECTION, never from
+        anything the model produced. The identity fields are the
+        authority boundary; the model only judges which side of it
+        the content falls on."""
+        project = _active_project()
+        meta = _route_write_scope("project", project)
+        assert meta["scope"] == "project"
+        assert meta["scope_source"] == "classifier"
+        assert meta["scope_confidence"] == _SCOPE_CONFIDENCE_HINTED
+        assert meta["project_id"] == "kai"
+        assert meta["workspace_root"] == "/work/kai"
+
+    def test_global_hint_wins_inside_project(self):
+        """An operator-identity fact extracted inside a project
+        workspace stays global when the model says global; the
+        active project must not leak into its identity fields."""
+        project = _active_project()
+        meta = _route_write_scope("global", project)
+        assert meta["scope"] == "global"
+        assert meta["scope_source"] == "classifier"
+        assert meta["scope_confidence"] == _SCOPE_CONFIDENCE_HINTED
+        assert meta["project_id"] is None
+
+    def test_missing_hint_falls_back_to_registry_project_default(self):
+        project = _active_project(default_scope_for_new_facts="project")
+        meta = _route_write_scope(None, project)
+        assert meta["scope"] == "project"
+        assert meta["scope_source"] == "extraction_default"
+        assert meta["scope_confidence"] == _SCOPE_CONFIDENCE_DEFAULTED
+        assert meta["project_id"] == "kai"
+
+    def test_missing_hint_falls_back_to_registry_global_default(self):
+        project = _active_project(default_scope_for_new_facts="global")
+        meta = _route_write_scope(None, project)
+        assert meta["scope"] == "global"
+        assert meta["scope_source"] == "extraction_default"
+
+    def test_missing_hint_with_no_registry_default_routes_global(self):
+        project = _active_project(default_scope_for_new_facts=None)
+        meta = _route_write_scope(None, project)
+        assert meta["scope"] == "global"
+        assert meta["scope_source"] == "extraction_default"
+
+    @pytest.mark.parametrize("bad_hint", ["task", "Project", "GLOBAL", "", 42, ["project"], {"scope": "project"}])
+    def test_invalid_hint_treated_as_missing(self, bad_hint):
+        """Every malformed hint shape takes the missing-hint path: the
+        registry default applies and the source stays
+        extraction_default. The schema enum should prevent these from
+        ever arriving, but a schema regression must degrade to policy
+        defaulting, never to guessing or to dropping the fact."""
+        project = _active_project(default_scope_for_new_facts="project")
+        meta = _route_write_scope(bad_hint, project)
+        assert meta["scope"] == "project"
+        assert meta["scope_source"] == "extraction_default"
+        assert meta["scope_confidence"] == _SCOPE_CONFIDENCE_DEFAULTED
+
+
+class TestStoreFactsScopeMetadata:
+    """Integration of `_route_write_scope` into `_store_facts`: the
+    routed fields land in add_structured metadata, the raw hint does
+    not, and the per-run memory.extract.scope log line carries the
+    routing tallies."""
+
+    def _captured_store(self, monkeypatch) -> list[dict]:
+        """Stub the storage boundary; return the captured metadata
+        list (one entry per add_structured call, in call order)."""
+        captured: list[dict] = []
+        monkeypatch.setattr(
+            "kai.memory_extraction._paraphrase_neighbor",
+            lambda *a, **kw: None,
+        )
+        monkeypatch.setattr(
+            "kai.memory_extraction.memory.add_structured",
+            lambda content, **kw: captured.append(kw.get("metadata") or {}) or f"id-{len(captured)}",
+        )
+        return captured
+
+    def test_project_hint_lands_in_metadata(self, monkeypatch):
+        captured = self._captured_store(monkeypatch)
+        facts = [
+            {
+                "content": "The retry queue drains via the cron worker",
+                "tags": ["fact"],
+                "confidence": 0.9,
+                "intent": "new",
+                "speaker": "assistant",
+                "scope_hint": "project",
+            }
+        ]
+        stored, _, _ = _store_facts(
+            facts,
+            user_id="u1",
+            session_id="s1",
+            config=_cfg(),
+            active_project=_active_project(),
+        )
+        assert stored == 1
+        meta = captured[0]
+        assert meta["scope"] == "project"
+        assert meta["project_id"] == "kai"
+        assert meta["workspace_root"] == "/work/kai"
+        assert meta["scope_source"] == "classifier"
+        # The raw hint is consumed by routing, never persisted: the
+        # routed fields plus scope_source already encode everything
+        # the hint said.
+        assert "scope_hint" not in meta
+
+    def test_default_active_project_none_routes_global(self, monkeypatch):
+        """Callers that do not pass active_project (the replay
+        harness, any pre-scoped-memory call site) get explicit global
+        scope metadata on every row, which is the same authority the
+        legacy-default read path already assigned them implicitly."""
+        captured = self._captured_store(monkeypatch)
+        facts = [
+            {
+                "content": "User prefers Celsius",
+                "tags": ["preference"],
+                "confidence": 0.9,
+                "intent": "new",
+                "speaker": "user",
+            }
+        ]
+        stored, _, _ = _store_facts(facts, user_id="u1", session_id="s1", config=_cfg())
+        assert stored == 1
+        meta = captured[0]
+        assert meta["scope"] == "global"
+        assert meta["scope_source"] == "extraction_default"
+        assert meta["project_id"] is None
+
+    def test_update_of_branch_routes_scope_too(self, monkeypatch):
+        """The update_of branch shares the metadata bundle with the
+        new branch; pin it separately so a refactor that splits the
+        bundle cannot silently drop scope from replacements."""
+        captured = self._captured_store(monkeypatch)
+        monkeypatch.setattr(
+            "kai.memory_extraction.memory.delete_by_id",
+            lambda *, user_id, memory_id: True,
+        )
+        facts = [
+            {
+                "content": "The retry queue drains via the async worker",
+                "tags": ["fact"],
+                "confidence": 0.9,
+                "intent": "update_of",
+                "existing_id": "old-id",
+                "speaker": "assistant",
+                "scope_hint": "project",
+            }
+        ]
+        stored, replaced, _ = _store_facts(
+            facts,
+            user_id="u1",
+            session_id="s1",
+            config=_cfg(),
+            active_project=_active_project(),
+        )
+        assert (stored, replaced) == (1, 1)
+        assert captured[0]["scope"] == "project"
+        assert captured[0]["project_id"] == "kai"
+
+    def test_scope_log_line_carries_tallies(self, monkeypatch, caplog):
+        """One memory.extract.scope line per run: hinted vs defaulted
+        counts and per-scope stored tallies must reflect rows that
+        actually landed."""
+        self._captured_store(monkeypatch)
+        facts = [
+            {
+                "content": "The retry queue drains via the cron worker",
+                "tags": ["fact"],
+                "confidence": 0.9,
+                "intent": "new",
+                "speaker": "assistant",
+                "scope_hint": "project",
+            },
+            {
+                "content": "User prefers Celsius",
+                "tags": ["preference"],
+                "confidence": 0.9,
+                "intent": "new",
+                "speaker": "user",
+            },
+        ]
+        with caplog.at_level("INFO", logger="kai.memory_extraction"):
+            _store_facts(
+                facts,
+                user_id="u1",
+                session_id="s1",
+                config=_cfg(),
+                active_project=_active_project(),
+            )
+        scope_lines = [r.message for r in caplog.records if r.message.startswith("memory.extract.scope ")]
+        assert len(scope_lines) == 1
+        payload = json.loads(scope_lines[0].split(" ", 1)[1])
+        assert payload["active_project_id"] == "kai"
+        assert payload["matched_root"] == "/work/kai"
+        assert payload["project_memory_enabled"] is True
+        assert payload["hinted"] == 1
+        assert payload["defaulted"] == 1
+        assert payload["stored_project"] == 1
+        assert payload["stored_global"] == 1
+
+
+class TestEpisodeScopeMetadata:
+    """Episode writes route scope under the same rules as facts."""
+
+    @pytest.mark.asyncio
+    async def test_episode_scope_hint_lands_in_metadata(self, monkeypatch):
+        episode_payload = {
+            "goal": "Lock per-user home workspace as the canonical layout",
+            "context": "ctx",
+            "approach": "ap",
+            "outcome": "out",
+            "outcome_quality": "success",
+            "tags": ["t1"],
+            "actors": ["user"],
+            "scope_hint": "project",
+        }
+
+        async def _fake_runner(payload, config, **kwargs):
+            return episode_payload, None
+
+        captured_metadata: dict = {}
+
+        def _fake_add_structured(*args, **kwargs):
+            captured_metadata.update(kwargs.get("metadata") or {})
+            return "stored-mem-id"
+
+        monkeypatch.setattr(memory_extraction, "_run_episode_extractor", _fake_runner)
+        monkeypatch.setattr(memory_extraction, "_emit_episode_log", lambda **kw: None)
+        from kai import memory as memory_module
+
+        monkeypatch.setattr(memory_module, "add_structured", _fake_add_structured)
+
+        await memory_extraction._generate_episode(
+            user_text="propose home layout",
+            assistant_text="locked: per-user home workspace",
+            user_id="u-int",
+            session_id="s-1",
+            config=_cfg(),
+            effective_backend="claude",
+            effective_provider="anthropic",
+            active_project=_active_project(),
+        )
+
+        assert captured_metadata["scope"] == "project"
+        assert captured_metadata["project_id"] == "kai"
+        assert captured_metadata["scope_source"] == "classifier"
+        assert "scope_hint" not in captured_metadata
+
+    @pytest.mark.asyncio
+    async def test_episode_without_active_project_routes_global(self, monkeypatch):
+        episode_payload = {
+            "goal": "Lock per-user home workspace as the canonical layout",
+            "context": "ctx",
+            "approach": "ap",
+            "outcome": "out",
+            "outcome_quality": "success",
+            "tags": ["t1"],
+            "actors": ["user"],
+            "scope_hint": "project",
+        }
+
+        async def _fake_runner(payload, config, **kwargs):
+            return episode_payload, None
+
+        captured_metadata: dict = {}
+
+        def _fake_add_structured(*args, **kwargs):
+            captured_metadata.update(kwargs.get("metadata") or {})
+            return "stored-mem-id"
+
+        monkeypatch.setattr(memory_extraction, "_run_episode_extractor", _fake_runner)
+        monkeypatch.setattr(memory_extraction, "_emit_episode_log", lambda **kw: None)
+        from kai import memory as memory_module
+
+        monkeypatch.setattr(memory_module, "add_structured", _fake_add_structured)
+
+        await memory_extraction._generate_episode(
+            user_text="propose home layout",
+            assistant_text="locked: per-user home workspace",
+            user_id="u-int",
+            session_id="s-1",
+            config=_cfg(),
+            effective_backend="claude",
+            effective_provider="anthropic",
+        )
+
+        assert captured_metadata["scope"] == "global"
+        assert captured_metadata["scope_source"] == "extraction_default"
+
+
+class TestWorkspaceThreading:
+    """`extract_and_store` detects the active project from the
+    `workspace` parameter once per run and threads the result into
+    `_store_facts`."""
+
+    def _fact(self) -> dict:
+        return {
+            "content": "User prefers Celsius",
+            "tags": ["preference"],
+            "confidence": 0.9,
+            "intent": "new",
+            "speaker": "user",
+        }
+
+    def _result(self) -> MagicMock:
+        result = MagicMock()
+        result.facts = [self._fact()]
+        result.has_episode = False
+        return result
+
+    @pytest.mark.asyncio
+    async def test_workspace_inside_registered_root_detects_project(self, monkeypatch, tmp_path):
+        root = (tmp_path / "kai").resolve()
+        root.mkdir()
+        cfg = _cfg(
+            memory_projects={
+                "kai": MemoryProjectConfig(
+                    project_id="kai",
+                    display_name="Kai",
+                    workspace_roots=(root,),
+                    memory_enabled=True,
+                    default_scope_for_new_facts=None,
+                )
+            }
+        )
+        monkeypatch.setattr(memory_extraction, "_run_extractor", AsyncMock(return_value=self._result()))
+        seen: dict = {}
+
+        def _fake_store(facts, *, user_id, session_id, config, active_project=None):
+            seen["active_project"] = active_project
+            return (1, 0, 0)
+
+        monkeypatch.setattr(memory_extraction, "_store_facts", _fake_store)
+
+        await extract_and_store(
+            user_text="u",
+            assistant_text="a",
+            user_id="1",
+            config=cfg,
+            workspace=str(root / "src"),
+        )
+
+        assert seen["active_project"] is not None
+        assert seen["active_project"].project_id == "kai"
+        assert seen["active_project"].matched_root == root
+
+    @pytest.mark.asyncio
+    async def test_no_workspace_skips_detection(self, monkeypatch):
+        """The default-None path (replay harness, legacy callers) must
+        not even consult the registry; routing sees active_project
+        None and writes global."""
+        monkeypatch.setattr(memory_extraction, "_run_extractor", AsyncMock(return_value=self._result()))
+        monkeypatch.setattr(
+            memory_extraction,
+            "detect_active_memory_project",
+            lambda *a, **kw: pytest.fail("detection must not run without a workspace"),
+        )
+        seen: dict = {}
+
+        def _fake_store(facts, *, user_id, session_id, config, active_project=None):
+            seen["active_project"] = active_project
+            return (1, 0, 0)
+
+        monkeypatch.setattr(memory_extraction, "_store_facts", _fake_store)
+
+        await extract_and_store(user_text="u", assistant_text="a", user_id="1", config=_cfg())
+
+        assert seen["active_project"] is None
+
+
+class TestScopeHintSchema:
+    """Pin the scope_hint contract in both extractor schemas."""
+
+    def test_fact_schema_scope_hint_optional_enum(self):
+        props = _FACT_SCHEMA["properties"]["facts"]["items"]["properties"]
+        assert props["scope_hint"]["enum"] == ["global", "project"]
+        # NOT required: omission is the model's "neither clearly
+        # applies" signal and must stay schema-legal.
+        assert "scope_hint" not in _FACT_SCHEMA["properties"]["facts"]["items"]["required"]
+
+    def test_episode_schema_scope_hint_optional_enum(self):
+        props = memory_extraction._EPISODE_SCHEMA["properties"]["episode"]["properties"]
+        assert props["scope_hint"]["enum"] == ["global", "project"]
+        assert "scope_hint" not in memory_extraction._EPISODE_SCHEMA["properties"]["episode"]["required"]


### PR DESCRIPTION
## Summary

- Threads the user's active workspace from `bot.py`'s ingestion path into `extract_and_store()`, captured at message-handling time so a `/workspace` switch racing the fire-and-forget task cannot re-route the exchange's facts.
- Detects the active memory project once per extraction run and threads the result into both stages (facts and episode), mirroring the existing single-resolution contract for `os_user` and the backend triple.
- Adds an optional `scope_hint` (`global` | `project`) to the fact and episode extraction contracts: prompt sections with worked examples (extraction prompt v12, episode prompt v2) plus matching optional schema enums. Omission is the model's "neither clearly applies" signal.
- New `_route_write_scope()` helper applies the routing rules with fail-safe precedence: no project / memory-disabled project routes global (`extraction_default`); a valid hint wins (`classifier`) with `project_id`/`workspace_root` taken from detection, never from the model; missing or invalid hints fall back to the registry's `default_scope_for_new_facts`, else global. Defaulted assignments carry lower `scope_confidence` (0.6) than hinted ones (0.9). Every write goes through `build_scope_metadata()`; the raw hint is never persisted.
- Emits one `memory.extract.scope` JSON line per run (detected project, hinted/defaulted counts, per-scope stored tallies) so shadow-log diffs trace back to write-time decisions.
- Replay harness and any caller not passing `workspace` route everything global, which makes their prior implicit (legacy-default) write authority explicit without changing it.

## Prompt/schema diff (the risky surface)

The extraction system prompt gains one FORMAT bullet (`scope_hint`) with four worked examples; the episode prompt gains one FIELDS bullet. Both schemas add the same optional two-value enum, not in `required`. No existing prompt section was modified, so fact-quality behavior should be unchanged apart from the added field.

## Testing

- 24 new tests: one per routing rule (including invalid-hint shapes parameterized), `_store_facts` metadata integration for both `new` and `update_of` branches, hint non-persistence, the scope log tallies, episode routing with and without a project, workspace threading with a real registry detection, the no-workspace-skips-detection contract, and schema pins for both `scope_hint` enums.
- Full suite: 3984 passed, 1 skipped. `make check` clean.
- Not yet run: the live before/after eval-replay comparison to confirm extraction quality is unaffected by the prompt change; flagged for the deploy step.

Closes #652
