### PR TITLE
feat(memory): serve live recall from scoped retrieval behind a config knob

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -1030,43 +1030,72 @@ async def assemble_turn_context(
     # / `run_scoped_recall_shadow` symbols) without import-order
     # surprises.
     if chat_id is not None and search_query.strip():
-        # Legacy recall is the live prompt content. The split
-        # introduced in #546 (format_context_with_recall_payload +
-        # _emit_recall_log) lets shadow-mode logging reuse the
-        # same legacy search and payload without re-running search;
-        # the wrapper format_context still exists for callers that
-        # do not need the payload, but assemble_turn_context owns
-        # the shadow-mode call site and so reads the payload
-        # directly. memory.recall stays "exactly one line per
-        # eligible turn" - emitted here, never twice.
         from kai.memory import (
             _emit_recall_log,
             format_context_with_recall_payload,
+            format_scoped_context_with_recall_payload,
+            is_scoped_recall_enabled,
             run_scoped_recall_shadow,
         )
 
-        legacy_recall = await format_context_with_recall_payload(search_query, user_id=str(chat_id))
-        _emit_recall_log(legacy_recall.recall_payload)
-        if legacy_recall.rendered_context:
-            prompt = prepend_to_prompt(prompt, legacy_recall.rendered_context)
+        if is_scoped_recall_enabled():
+            # Scoped recall IS the live prompt content. The helper is
+            # fail-closed internally: any scoped retrieval or
+            # rendering error collapses to an empty rendered block
+            # with reason="scoped_error" in the payload, so a read-
+            # path bug degrades to "no memory this turn" and never to
+            # unscoped fallback content. memory.recall stays "exactly
+            # one line per eligible turn" in both knob states -
+            # emitted here, never twice.
+            scoped_recall = await format_scoped_context_with_recall_payload(
+                search_query,
+                user_id=str(chat_id),
+                workspace=workspace,
+                backend_name=backend_name,
+                job_type=job_type,
+                session_id=session_id,
+            )
+            _emit_recall_log(scoped_recall.recall_payload)
+            if scoped_recall.rendered_context:
+                prompt = prepend_to_prompt(prompt, scoped_recall.rendered_context)
+            # No shadow while scoped recall is live: the comparison
+            # exists to validate scoped retrieval against legacy
+            # before cutover, and running legacy as a second query
+            # per turn buys nothing once scoped serves the prompt.
+            # The scoped_debug fields on the memory.recall line above
+            # carry the audit trail the shadow line used to provide.
+        else:
+            # Legacy recall is the live prompt content. The split
+            # introduced in #546 (format_context_with_recall_payload +
+            # _emit_recall_log) lets shadow-mode logging reuse the
+            # same legacy search and payload without re-running search;
+            # the wrapper format_context still exists for callers that
+            # do not need the payload, but assemble_turn_context owns
+            # the shadow-mode call site and so reads the payload
+            # directly. memory.recall stays "exactly one line per
+            # eligible turn" - emitted here, never twice.
+            legacy_recall = await format_context_with_recall_payload(search_query, user_id=str(chat_id))
+            _emit_recall_log(legacy_recall.recall_payload)
+            if legacy_recall.rendered_context:
+                prompt = prepend_to_prompt(prompt, legacy_recall.rendered_context)
 
-        # Shadow-mode comparison log (#546). Best-effort; the helper
-        # is failure-isolated internally and short-circuits when
-        # disabled, so the live prompt path above is unaffected by
-        # any scoped retrieval or rendering bug. Backends pass
-        # workspace/backend_name/job_type so the shadow log can
-        # detect the active project and identify the caller; tests
-        # that omit those kwargs land on the missing-workspace
-        # branch which still emits a uniform shadow line.
-        await run_scoped_recall_shadow(
-            query=search_query,
-            user_id=str(chat_id),
-            legacy_result=legacy_recall,
-            workspace=workspace,
-            backend_name=backend_name,
-            job_type=job_type,
-            session_id=session_id,
-        )
+            # Shadow-mode comparison log (#546). Best-effort; the helper
+            # is failure-isolated internally and short-circuits when
+            # disabled, so the live prompt path above is unaffected by
+            # any scoped retrieval or rendering bug. Backends pass
+            # workspace/backend_name/job_type so the shadow log can
+            # detect the active project and identify the caller; tests
+            # that omit those kwargs land on the missing-workspace
+            # branch which still emits a uniform shadow line.
+            await run_scoped_recall_shadow(
+                query=search_query,
+                user_id=str(chat_id),
+                legacy_result=legacy_recall,
+                workspace=workspace,
+                backend_name=backend_name,
+                job_type=job_type,
+                session_id=session_id,
+            )
 
     # Foreign-workspace reminder is built fresh by the caller on
     # every turn (it depends on the workspace state at call time).

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1277,6 +1277,18 @@ class Config:
     # is enabled (legacy recall provides the baseline to compare).
     memory_recall_shadow_enabled: bool = True
 
+    # Scoped-recall cutover. When True, the per-turn prompt context is
+    # served by scoped retrieval (filter-before-rank against the
+    # project registry, rendered as separate global/project sections)
+    # instead of legacy unscoped recall, and the shadow comparison is
+    # skipped (running legacy as a second query per turn buys nothing
+    # once scoped is live). Default-off is deliberate: shipping the
+    # switch disabled keeps the deploy behavior-neutral, and the
+    # operator flips it via `make config` once the shadow log has
+    # shown clean wrong-scope exclusions on real traffic. Like the
+    # shadow toggle, this is a sub-toggle of memory_enabled.
+    memory_scoped_recall_enabled: bool = False
+
     def get_workspace_config(self, workspace: Path) -> WorkspaceConfig | None:
         """
         Get per-workspace config for a path, or None for global defaults.
@@ -2779,6 +2791,15 @@ def load_config() -> Config:
     memory_recall_shadow_enabled = _shadow_raw.strip().lower() not in ("0", "false", "no")
     memory_recall_shadow_enabled = memory_recall_shadow_enabled and memory_enabled
 
+    # Scoped-recall cutover toggle. Default-off, normal parse (only the
+    # explicit enable strings turn it on), the OPPOSITE polarity of the
+    # shadow toggle above: shadow defaults on because it only observes,
+    # the cutover defaults off because it changes live prompt content.
+    # Composed with memory_enabled like every other memory sub-toggle.
+    _scoped_recall_raw = os.environ.get("MEMORY_SCOPED_RECALL_ENABLED", "")
+    memory_scoped_recall_enabled = _scoped_recall_raw.strip().lower() in ("1", "true", "yes")
+    memory_scoped_recall_enabled = memory_scoped_recall_enabled and memory_enabled
+
     # Deprecation warnings for the three retired memory env vars. The
     # reasoner and model used for memory extraction now derive entirely
     # from each user's effective `agent_backend` (per-user dispatch via
@@ -3133,6 +3154,7 @@ def load_config() -> Config:
         memory_embedding_model=memory_embedding_model,
         memory_extraction_enabled=memory_extraction_enabled,
         memory_recall_shadow_enabled=memory_recall_shadow_enabled,
+        memory_scoped_recall_enabled=memory_scoped_recall_enabled,
         memory_extraction_timeout_s=memory_extraction_timeout_s,
         episode_classifier_context_turns=episode_classifier_context_turns,
         memory_consolidation_candidates_n=memory_consolidation_candidates_n,

--- a/src/kai/eval/retrieval.py
+++ b/src/kai/eval/retrieval.py
@@ -14,13 +14,21 @@ reports the Pareto frontier of (precision, latency).
 Design rationale (the part that is not obvious from the code):
 
 - The harness scores against `format_context`, not `search` directly.
-  `format_context` is what production runs; scoring a reduced pipeline
-  (search without floor filtering or budget walking) would measure a
-  code path the agent never uses. `format_context` is already
-  instrumented with a structured `memory.recall` log line, so the
-  harness reads the log rather than wrapping retrieval. This doubles
-  as a regression test: if the log emit ever stops being parseable,
-  the harness fails loudly.
+  `format_context` is the LEGACY recall pipeline; scoring a reduced
+  pipeline (search without floor filtering or budget walking) would
+  measure a code path the agent never uses. `format_context` is
+  already instrumented with a structured `memory.recall` log line, so
+  the harness reads the log rather than wrapping retrieval. This
+  doubles as a regression test: if the log emit ever stops being
+  parseable, the harness fails loudly.
+
+- LEGACY-RECALL EVALUATOR ONLY: when `MEMORY_SCOPED_RECALL_ENABLED`
+  is on, production turns are served by scoped retrieval through
+  `assemble_turn_context`, which this harness does NOT exercise. The
+  harness warns at init when that knob is enabled, and its results
+  then describe a pipeline production no longer runs. A scoped-aware
+  evaluator (workspace-parameterized probes against the scoped live
+  helper) is future work tracked in the scoped-memory epic.
 
 - Probes whose expected fact has been deleted from the store between
   authoring and evaluation are bucketed as "probe-set drift" rather
@@ -1108,6 +1116,18 @@ def _initialize_memory() -> bool:
                 file=sys.stderr,
             )
             return False
+        # Loud divergence warning, not a hard stop: the legacy
+        # numbers are still meaningful for comparing against older
+        # baselines, but they no longer describe the live read path
+        # once the cutover knob is on. Anyone using this harness as
+        # post-cutover evidence needs to see this in the run output.
+        if config.memory_scoped_recall_enabled:
+            print(
+                "eval: WARNING: MEMORY_SCOPED_RECALL_ENABLED is on; production serves "
+                "scoped recall, but this harness measures the LEGACY pipeline only. "
+                "Do not use these results as evidence about the live read path.",
+                file=sys.stderr,
+            )
         return True
     except Exception as e:
         print(f"eval: init failed: {e}", file=sys.stderr)

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1612,6 +1612,11 @@ def _cmd_config() -> None:
     # default at runtime via load_config, so the env entry stays
     # suppressed by the delta-from-default check below.
     memory_duplicate_threshold = "0.9"
+    # Scoped-recall cutover pre-init. False matches the dataclass
+    # default so the true-only emission below suppresses the env
+    # entry when memory is disabled (prompt never reached) or the
+    # operator declines.
+    memory_scoped_recall_enabled = False
     if memory_enabled:
         # Memory extraction is supported on agent backends that ship a
         # OneShotReasoner. Every shipped backend is in
@@ -1856,6 +1861,16 @@ def _cmd_config() -> None:
             if _validate_positive_int(memory_search_limit):
                 break
             print("  Must be a positive integer.")
+        # Scoped-recall cutover (read path). Serves the per-turn
+        # memory context from project-aware scoped retrieval instead
+        # of legacy unscoped recall; wrong-project rows are excluded
+        # from the prompt regardless of semantic score. Default-off:
+        # the operator flips it after the shadow comparison log has
+        # shown clean wrong-scope exclusions on real traffic.
+        memory_scoped_recall_enabled = _prompt_bool(
+            "Serve memory recall from scoped retrieval (project-aware)",
+            existing_env.get("MEMORY_SCOPED_RECALL_ENABLED", "false").lower() in ("1", "true", "yes"),
+        )
     print()
 
     # -- External services --
@@ -2131,6 +2146,12 @@ def _cmd_config() -> None:
         # naturally drops this key via the surrounding if.
         if int(memory_search_limit) != 10:
             env["MEMORY_SEARCH_LIMIT"] = memory_search_limit
+        # Scoped-recall cutover. True-only emission: false is the
+        # dataclass default, and the env dict is rebuilt fresh each
+        # wizard run, so declining (or disabling memory) drops the
+        # key on the next /etc/kai/env regeneration.
+        if memory_scoped_recall_enabled:
+            env["MEMORY_SCOPED_RECALL_ENABLED"] = "true"
 
     # Drop the three deprecated memory env vars on every wizard run
     # (issue #515). Reasoner and model both derive per-user from each

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -538,7 +538,11 @@ class ScopedRetrievalContext:
         message: The raw user query to search against.
         workspace: Active workspace path. The helper resolves it
             through `detect_active_memory_project` to find the
-            active memory project.
+            active memory project. None skips detection entirely
+            and produces global-only retrieval, the same outcome
+            detection rule 4 gives an unregistered path; callers
+            without a workspace concept get safe behavior instead
+            of an error.
         job_type: Optional job-type tag (e.g. "interactive",
             "scheduled"). Recorded in debug metadata.
         backend_name: Optional backend identifier (e.g. "claude",
@@ -549,7 +553,7 @@ class ScopedRetrievalContext:
 
     chat_id: int | str
     message: str
-    workspace: Path
+    workspace: Path | None
     job_type: str | None = None
     backend_name: str | None = None
     session_id: str | None = None
@@ -1375,6 +1379,19 @@ def is_recall_shadow_enabled() -> bool:
     return _config is not None and _config.memory_recall_shadow_enabled
 
 
+def is_scoped_recall_enabled() -> bool:
+    """
+    True when the live prompt context should be served by scoped
+    retrieval instead of legacy recall.
+
+    Backed by `Config.memory_scoped_recall_enabled`, which defaults
+    off and is enabled via `MEMORY_SCOPED_RECALL_ENABLED=1`. The
+    composition with `memory_enabled` happens in `load_config`, the
+    same contract as `is_recall_shadow_enabled` above.
+    """
+    return _config is not None and _config.memory_scoped_recall_enabled
+
+
 def search(query: str, *, user_id: str, limit: int | None = None) -> list[MemoryResult]:
     """
     Search for memories semantically similar to the query.
@@ -1809,10 +1826,14 @@ async def retrieve_scoped_memories(
 
     # Step 2: detect active project. Function-local import keeps
     # config.py's import surface lean and matches the pattern from
-    # #543's lazy import of the scope constants.
+    # #543's lazy import of the scope constants. A None workspace
+    # skips detection: no path means no project authority, which
+    # collapses to the same global-only allowed scopes as an
+    # unregistered path (detection rule 4).
     from kai.memory_projects import detect_active_memory_project
 
-    active_project = detect_active_memory_project(context.workspace, _config.memory_projects)
+    if context.workspace is not None:
+        active_project = detect_active_memory_project(context.workspace, _config.memory_projects)
 
     # Step 3: build allowed scopes. Project scope is admitted only
     # when an active project is detected AND that project has
@@ -2371,6 +2392,117 @@ async def run_scoped_recall_shadow(
     base["scoped_rendered_chars"] = len(rendered)
 
     _emit_recall_shadow_log(base)
+
+
+@dataclass(frozen=True)
+class ScopedRecallResult:
+    """
+    Internal-only result type for `format_scoped_context_with_recall_payload`.
+
+    The scoped twin of `LegacyRecallResult`: the rendered two-section
+    memory block plus the `memory.recall` payload the caller emits
+    exactly once via `_emit_recall_log`. Separate type (not a reuse of
+    the legacy one) so call sites and tests state which pipeline
+    produced the value.
+
+    Attributes:
+        rendered_context: The scoped memory block ready to prepend to
+            the prompt, or `""` for every short-circuit and failure
+            path.
+        recall_payload: The fully populated `memory.recall` dict
+            (uniform base schema from `_base_recall_payload`, plus
+            the scoped debug fields under `scoped_debug`).
+    """
+
+    rendered_context: str
+    recall_payload: dict[str, object]
+
+
+# `memory.recall` reason for a scoped live-path failure. Lives beside
+# the scoped pipeline (not with the legacy reason constants) because
+# only the scoped live path can produce it; the legacy pipeline's
+# failure surface is inside Mem0 and collapses to no_results.
+_RECALL_REASON_SCOPED_ERROR = "scoped_error"
+
+
+async def format_scoped_context_with_recall_payload(
+    query: str,
+    *,
+    user_id: str,
+    workspace: Path | None,
+    backend_name: str | None = None,
+    job_type: str | None = None,
+    session_id: str | None = None,
+    token_budget: int | None = None,
+) -> ScopedRecallResult:
+    """
+    Run the scoped recall pipeline for LIVE prompt injection.
+
+    Composes `retrieve_scoped_memories` (filter-before-rank) and
+    `format_scoped_context` (two-section rendering) into the same
+    rendered-text-plus-payload shape the legacy
+    `format_context_with_recall_payload` returns, so the caller in
+    `assemble_turn_context` can switch pipelines without changing its
+    emit-once `memory.recall` contract.
+
+    FAIL CLOSED: every exception from scoped retrieval or rendering is
+    caught here and collapses to `rendered_context=""` with
+    `reason="scoped_error"` plus the error class and truncated message
+    in the payload. The epic's invariant is that a scoped read-path
+    bug must degrade to "less memory", never to unscoped fallback
+    content; returning empty (instead of raising or delegating to
+    legacy recall) is the enforcement point. The caller still emits
+    the payload, so the failing turn stays visible in the log stream.
+
+    A None `workspace` flows through to global-only retrieval (see
+    `ScopedRetrievalContext.workspace`); unlike the shadow path there
+    is no skip branch, because this IS the live content path and a
+    workspace-less caller still deserves its global memories.
+    """
+    payload = _base_recall_payload(user_id, query)
+
+    try:
+        context = ScopedRetrievalContext(
+            chat_id=user_id,
+            message=query,
+            workspace=workspace,
+            job_type=job_type,
+            backend_name=backend_name,
+            session_id=session_id,
+        )
+        budget = token_budget
+        if budget is None and _config is not None:
+            budget = _config.memory_token_budget
+        payload["budget_tokens"] = budget if budget is not None else 0
+        # latency_ms scopes the retrieval call only, mirroring the
+        # legacy payload's contract (embedding/query time, not
+        # rendering time).
+        t0 = time.perf_counter()
+        scoped_result = await retrieve_scoped_memories(context, token_budget=budget)
+        payload["latency_ms"] = int((time.perf_counter() - t0) * 1000)
+        rendered = format_scoped_context(scoped_result, token_budget=budget)
+    except Exception as exc:
+        payload["reason"] = _RECALL_REASON_SCOPED_ERROR
+        payload["scoped_error_type"] = type(exc).__name__
+        payload["scoped_error_message"] = _truncate(str(exc), _SHADOW_ERROR_MESSAGE_TRUNC)
+        payload["returned_empty"] = True
+        return ScopedRecallResult(rendered_context="", recall_payload=payload)
+
+    debug = scoped_result.debug
+    payload["reason"] = debug.reason
+    payload["fetch_limit"] = debug.fetch_limit
+    payload["floor"] = debug.floor
+    payload["hits_raw"] = debug.hits_raw
+    payload["hits_after_floor"] = debug.hits_after_floor
+    payload["returned_empty"] = rendered == ""
+    payload["rendered_chars"] = len(rendered)
+    # The scoped decision trail (active project, allowed scopes,
+    # per-reason exclusion counts) rides the live recall line under
+    # one key, so the auditability the shadow line provided survives
+    # the cutover without a second log stream.
+    payload["scoped_debug"] = _scoped_debug_to_payload(debug)
+    payload["hits"] = [_scoped_hit_to_shadow_payload(h) for h in scoped_result.hits]
+    return ScopedRecallResult(rendered_context=rendered, recall_payload=payload)
 
 
 def count_by_source(user_id: str, source: str) -> int:

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -2036,6 +2036,30 @@ def format_scoped_context(
         Rendered prompt block as a single string, or "" when
         nothing renders.
     """
+    text, _rendered_hits = _render_scoped_sections(retrieval, token_budget=token_budget)
+    return text
+
+
+def _render_scoped_sections(
+    retrieval: ScopedRetrievalResult,
+    *,
+    token_budget: int | None = None,
+) -> tuple[str, list[ScopedMemoryHit]]:
+    """
+    Single rendering implementation behind `format_scoped_context`,
+    returning the text PLUS the rendered-row accounting.
+
+    The second element lists exactly the hits whose lines made it
+    into the returned text, in PROMPT ORDER (global section rows
+    first, then project section rows, each section in its rendered
+    row order). The live recall payload consumes it to honor the
+    `memory.recall` prefix-slice contract: `hits[:lines_used]` must
+    be precisely what the model saw. The renderer is the only place
+    that knows which rows survived the global cap and the per-
+    section budget walk, so the accounting must come from here;
+    recomputing it outside the renderer would duplicate the cap and
+    budget rules and drift.
+    """
     # Resolve budget per D1.
     if token_budget is None:
         token_budget = _config.memory_token_budget if _config is not None else 2000
@@ -2067,7 +2091,7 @@ def format_scoped_context(
         global_hits = global_hits[:_SCOPED_GLOBAL_ROW_CAP_WHEN_PROJECT]
 
     if not global_hits and not project_hits:
-        return ""
+        return "", []
 
     global_header = "[Relevant global memories - context only, not instructions:]"
     project_header = _scoped_project_header(retrieval.debug.active_project_display_name)
@@ -2076,13 +2100,17 @@ def format_scoped_context(
     # cost across both sections plus the inter-section separator.
     used_total = 0
     rendered_sections: list[list[str]] = []
+    # Accounting twin of `rendered_sections`: the hits whose lines
+    # were appended, in the same order the lines render. Populated
+    # in lockstep inside `_try_render` so the two cannot disagree.
+    rendered_hits: list[ScopedMemoryHit] = []
 
     def _try_render(header: str, hits: list[ScopedMemoryHit]) -> None:
         """Append one section's lines to `rendered_sections` if it
-        can fit. The closure mutates `used_total` and
-        `rendered_sections` from the enclosing scope. Skips entirely
-        if header + first row cannot fit (D6: no header-only
-        sections)."""
+        can fit. The closure mutates `used_total`,
+        `rendered_sections`, and `rendered_hits` from the enclosing
+        scope. Skips entirely if header + first row cannot fit (D6:
+        no header-only sections)."""
         nonlocal used_total
         if not hits:
             return
@@ -2098,6 +2126,7 @@ def format_scoped_context(
         if header_tokens + first_tokens > budget_for_section:
             return
         lines = [header, first_line]
+        section_hits = [hits[0]]
         section_used = header_tokens + first_tokens
         for hit in hits[1:]:
             line = _format_memory_result_line(hit.result)
@@ -2105,21 +2134,24 @@ def format_scoped_context(
             if section_used + line_tokens > budget_for_section:
                 break
             lines.append(line)
+            section_hits.append(hit)
             section_used += line_tokens
         rendered_sections.append(lines)
+        rendered_hits.extend(section_hits)
         used_total += section_used + sep_cost
 
     _try_render(global_header, global_hits)
     _try_render(project_header, project_hits)
 
     if not rendered_sections:
-        return ""
+        return "", []
 
     # Blank line between sections gives the model a visible
     # boundary. join() over one section produces no separator;
     # over two it inserts a single blank line. Same separator
     # literal that the budget charge above used.
-    return _SCOPED_SECTION_SEPARATOR.join("\n".join(section) for section in rendered_sections)
+    text = _SCOPED_SECTION_SEPARATOR.join("\n".join(section) for section in rendered_sections)
+    return text, rendered_hits
 
 
 # ── Shadow-mode comparison logging (#546) ────────────────────────────
@@ -2480,7 +2512,7 @@ async def format_scoped_context_with_recall_payload(
         t0 = time.perf_counter()
         scoped_result = await retrieve_scoped_memories(context, token_budget=budget)
         payload["latency_ms"] = int((time.perf_counter() - t0) * 1000)
-        rendered = format_scoped_context(scoped_result, token_budget=budget)
+        rendered, rendered_hits = _render_scoped_sections(scoped_result, token_budget=budget)
     except Exception as exc:
         payload["reason"] = _RECALL_REASON_SCOPED_ERROR
         payload["scoped_error_type"] = type(exc).__name__
@@ -2501,7 +2533,21 @@ async def format_scoped_context_with_recall_payload(
     # one key, so the auditability the shadow line provided survives
     # the cutover without a second log stream.
     payload["scoped_debug"] = _scoped_debug_to_payload(debug)
-    payload["hits"] = [_scoped_hit_to_shadow_payload(h) for h in scoped_result.hits]
+    # Prefix-slice contract: downstream consumers (the retrieval
+    # eval harness and the backend gate) define "this fact reached
+    # the injected prompt" as rank <= lines_used over `hits`. The
+    # renderer is the only authority on which rows survived the
+    # global cap and the per-section budget walk, so `hits` lists
+    # the RENDERED rows first (prompt order: global section then
+    # project section) followed by admitted-but-not-rendered rows
+    # in adjusted-score order, and lines_used counts the rendered
+    # prefix. Within the prefix the order is prompt order, not
+    # ranking order; the slice membership is what the consumers'
+    # math depends on.
+    rendered_ids = {h.result.id for h in rendered_hits}
+    overflow_hits = [h for h in scoped_result.hits if h.result.id not in rendered_ids]
+    payload["hits"] = [_scoped_hit_to_shadow_payload(h) for h in rendered_hits + overflow_hits]
+    payload["lines_used"] = len(rendered_hits)
     return ScopedRecallResult(rendered_context=rendered, recall_payload=payload)
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1896,3 +1896,126 @@ class TestAssembleTurnContext:
         )
         assert legacy_mock.call_count == 1, "legacy recall must run exactly once"
         assert shadow_mock.call_count == 1, "shadow must run exactly once when enabled"
+
+
+class TestScopedRecallCutover:
+    """Knob-on behavior of `assemble_turn_context`: scoped retrieval
+    serves the live prompt content; legacy recall and the shadow
+    comparison are both skipped. The knob itself is read through
+    `is_scoped_recall_enabled`, patched here because backend tests
+    run without an initialized memory config."""
+
+    def _enable(self, monkeypatch):
+        monkeypatch.setattr("kai.memory.is_scoped_recall_enabled", lambda: True)
+
+    def _patch_scoped_recall(self, monkeypatch, *, rendered_context: str = "", recall_payload: dict | None = None):
+        """Scoped twin of `_patch_legacy_recall`."""
+        from kai.memory import ScopedRecallResult
+
+        payload = recall_payload if recall_payload is not None else {"reason": "ok"}
+        fake = AsyncMock(return_value=ScopedRecallResult(rendered_context=rendered_context, recall_payload=payload))
+        monkeypatch.setattr("kai.memory.format_scoped_context_with_recall_payload", fake)
+        return fake
+
+    async def test_scoped_serves_live_content_and_skips_legacy_and_shadow(self, monkeypatch):
+        """The cutover's core contract in one test: scoped output is
+        prepended, the legacy pipeline never runs (no second Mem0
+        search), the shadow comparison never runs, and memory.recall
+        is emitted exactly once with the scoped payload."""
+        from kai.backend import assemble_turn_context
+
+        self._enable(monkeypatch)
+        legacy_mock = _patch_legacy_recall(monkeypatch, rendered_context="[LEGACY BLOCK]")
+        shadow_mock = AsyncMock()
+        monkeypatch.setattr("kai.memory.run_scoped_recall_shadow", shadow_mock)
+        scoped_payload = {"reason": "ok", "scoped_debug": {"active_project_id": "kai"}}
+        scoped_mock = self._patch_scoped_recall(
+            monkeypatch,
+            rendered_context="[SCOPED BLOCK]",
+            recall_payload=scoped_payload,
+        )
+        emit_mock = MagicMock()
+        monkeypatch.setattr("kai.memory._emit_recall_log", emit_mock)
+
+        ws = Path("/tmp/test_workspace_scoped")
+        result = await assemble_turn_context(
+            "user message",
+            chat_id=42,
+            session_context="",
+            workspace_reminder="",
+            workspace=ws,
+            backend_name="claude_code",
+            job_type="interactive",
+            session_id="sess-1",
+        )
+
+        assert isinstance(result, str)
+        assert "[SCOPED BLOCK]" in result
+        assert "[LEGACY BLOCK]" not in result
+        legacy_mock.assert_not_called()
+        shadow_mock.assert_not_called()
+        assert scoped_mock.call_count == 1
+        assert scoped_mock.call_args.args[0] == "user message"
+        kwargs = scoped_mock.call_args.kwargs
+        assert kwargs["user_id"] == "42"
+        assert kwargs["workspace"] == ws
+        assert kwargs["backend_name"] == "claude_code"
+        assert kwargs["job_type"] == "interactive"
+        assert kwargs["session_id"] == "sess-1"
+        assert emit_mock.call_count == 1
+        assert emit_mock.call_args.args[0] is scoped_payload
+
+    async def test_scoped_empty_render_prepends_nothing_but_still_logs(self, monkeypatch):
+        """The fail-closed surface as the backend sees it: the helper
+        collapses every scoped failure (and every legitimate
+        no-content path) to rendered_context="". The backend must
+        prepend nothing and still emit the one memory.recall line so
+        the turn stays visible in the log stream."""
+        from kai.backend import assemble_turn_context
+
+        self._enable(monkeypatch)
+        _patch_legacy_recall(monkeypatch, rendered_context="[LEGACY BLOCK]")
+        monkeypatch.setattr("kai.memory.run_scoped_recall_shadow", AsyncMock())
+        self._patch_scoped_recall(monkeypatch, rendered_context="", recall_payload={"reason": "scoped_error"})
+        emit_mock = MagicMock()
+        monkeypatch.setattr("kai.memory._emit_recall_log", emit_mock)
+
+        result = await assemble_turn_context(
+            "user message",
+            chat_id=42,
+            session_context="",
+            workspace_reminder="",
+            workspace=Path("/tmp/ws"),
+        )
+
+        assert "[LEGACY BLOCK]" not in result
+        assert emit_mock.call_count == 1
+        assert emit_mock.call_args.args[0]["reason"] == "scoped_error"
+
+    async def test_knob_off_keeps_legacy_path_and_never_calls_scoped(self, monkeypatch):
+        """Disabled-state pin: with the knob explicitly off, the
+        scoped live helper is never invoked and the legacy + shadow
+        pair runs unchanged. Existing TestAssembleTurnContext tests
+        cover the legacy path's details; this test pins the
+        knob-off/scoped-helper boundary specifically."""
+        from kai.backend import assemble_turn_context
+
+        monkeypatch.setattr("kai.memory.is_scoped_recall_enabled", lambda: False)
+        legacy_mock = _patch_legacy_recall(monkeypatch, rendered_context="[LEGACY BLOCK]")
+        shadow_mock = AsyncMock()
+        monkeypatch.setattr("kai.memory.run_scoped_recall_shadow", shadow_mock)
+        scoped_mock = self._patch_scoped_recall(monkeypatch, rendered_context="[SCOPED BLOCK]")
+
+        result = await assemble_turn_context(
+            "user message",
+            chat_id=42,
+            session_context="",
+            workspace_reminder="",
+            workspace=Path("/tmp/ws"),
+        )
+
+        assert "[LEGACY BLOCK]" in result
+        assert "[SCOPED BLOCK]" not in result
+        scoped_mock.assert_not_called()
+        assert legacy_mock.call_count == 1
+        assert shadow_mock.call_count == 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,6 +67,7 @@ _CONFIG_ENV_VARS = [
     "LLM_PROVIDER",
     "MEMORY_ENABLED",
     "MEMORY_SEARCH_LIMIT",
+    "MEMORY_SCOPED_RECALL_ENABLED",
     "MEMORY_TOKEN_BUDGET",
     "MEMORY_EMBEDDING_MODEL",
     "MEMORY_REASONER_BACKEND",
@@ -3327,6 +3328,74 @@ class TestMemoryRecallShadowConfig:
         cfg = load_config()
         assert cfg.memory_enabled is False
         assert cfg.memory_recall_shadow_enabled is False
+
+
+class TestMemoryScopedRecallConfig:
+    """Tests for `Config.memory_scoped_recall_enabled` and its
+    `MEMORY_SCOPED_RECALL_ENABLED` env-var parse.
+
+    Default-off, the OPPOSITE polarity of the shadow toggle above:
+    shadow only observes, so it defaults on to collect evidence; the
+    cutover changes live prompt content, so it stays off until the
+    operator flips it deliberately."""
+
+    def _base_env(self, monkeypatch):
+        """Minimal env so load_config builds cleanly. Caller adds
+        MEMORY_SCOPED_RECALL_ENABLED on top to drive the test."""
+        for v in _CONFIG_ENV_VARS:
+            monkeypatch.delenv(v, raising=False)
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+        monkeypatch.setenv("ALLOWED_USER_IDS", "12345")
+        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+        monkeypatch.setenv("MEMORY_ENABLED", "true")  # gate for the sub-toggle
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n",
+        )
+
+    def test_scoped_recall_defaults_off(self, monkeypatch):
+        """Unset env var keeps the cutover off even with memory on;
+        the default-off posture is what makes shipping the switch
+        behavior-neutral."""
+        self._base_env(monkeypatch)
+        monkeypatch.delenv("MEMORY_SCOPED_RECALL_ENABLED", raising=False)
+        cfg = load_config()
+        assert cfg.memory_scoped_recall_enabled is False
+
+    def test_scoped_recall_enable_values(self, monkeypatch):
+        """Each explicit enable string turns the cutover on,
+        case-insensitively."""
+        for enable_value in ("1", "true", "yes", "TRUE", "Yes"):
+            self._base_env(monkeypatch)
+            monkeypatch.setenv("MEMORY_SCOPED_RECALL_ENABLED", enable_value)
+            cfg = load_config()
+            assert cfg.memory_scoped_recall_enabled is True, f"failed to enable with {enable_value!r}"
+
+    def test_scoped_recall_non_enable_values_stay_off(self, monkeypatch):
+        """Anything outside the enable set stays off; a typo must
+        not flip live prompt content."""
+        for off_value in ("0", "false", "no", "on", "enabled", "y"):
+            self._base_env(monkeypatch)
+            monkeypatch.setenv("MEMORY_SCOPED_RECALL_ENABLED", off_value)
+            cfg = load_config()
+            assert cfg.memory_scoped_recall_enabled is False, f"unexpectedly enabled with {off_value!r}"
+
+    def test_scoped_recall_disabled_when_memory_off(self, monkeypatch):
+        """Sub-toggle composition: scoped recall is gated on
+        memory_enabled even when its own env var is set."""
+        for v in _CONFIG_ENV_VARS:
+            monkeypatch.delenv(v, raising=False)
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+        monkeypatch.setenv("ALLOWED_USER_IDS", "12345")
+        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n",
+        )
+        monkeypatch.setenv("MEMORY_SCOPED_RECALL_ENABLED", "true")
+        cfg = load_config()
+        assert cfg.memory_enabled is False
+        assert cfg.memory_scoped_recall_enabled is False
 
 
 class TestOneShotReasonerBackendsConstant:

--- a/tests/test_eval_retrieval.py
+++ b/tests/test_eval_retrieval.py
@@ -729,3 +729,27 @@ class TestApplyOverride:
         assert pre_speaker_weights == mem_mod._SPEAKER_WEIGHTS
         assert pre_overfetch == mem_mod._SEARCH_OVERFETCH
         assert mem_mod._config is pre_config
+
+
+class TestLegacyOnlyWarning:
+    """This harness measures the legacy recall pipeline; when the
+    scoped-recall cutover knob is on, production serves a different
+    read path and the init step must say so loudly."""
+
+    def _init_with(self, monkeypatch, *, scoped_enabled: bool) -> bool:
+        cfg = MagicMock()
+        cfg.memory_scoped_recall_enabled = scoped_enabled
+        monkeypatch.setattr("kai.config.load_config", lambda: cfg)
+        monkeypatch.setattr("kai.memory.init_memory", lambda config: None)
+        monkeypatch.setattr("kai.memory.is_enabled", lambda: True)
+        return retrieval._initialize_memory()
+
+    def test_warns_when_scoped_recall_enabled(self, monkeypatch, capsys):
+        assert self._init_with(monkeypatch, scoped_enabled=True) is True
+        err = capsys.readouterr().err
+        assert "LEGACY pipeline only" in err
+
+    def test_silent_when_scoped_recall_disabled(self, monkeypatch, capsys):
+        assert self._init_with(monkeypatch, scoped_enabled=False) is True
+        err = capsys.readouterr().err
+        assert "LEGACY pipeline only" not in err

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1497,6 +1497,7 @@ class TestCmdConfig:
             "0.9",  # paraphrase-dedup threshold
             "2000",  # memory token budget
             "10",  # memory search limit
+            "false",  # scoped recall (default off)
         ]
         monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = iter(self._base_inputs(memory_block, agent_backend="goose"))
@@ -1529,7 +1530,12 @@ class TestCmdConfig:
         existing = {"version": 1, "env": {"AGENT_BACKEND": "goose"}}
         conf_path.write_text(json.dumps(existing))
 
-        memory_block = ["true", "2000", "10"]  # memory enabled; extraction prompts gated out
+        memory_block = [
+            "true",
+            "2000",
+            "10",
+            "false",
+        ]  # memory enabled; extraction prompts gated out; scoped recall declined
         monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = iter(self._base_inputs(memory_block, agent_backend="goose"))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
@@ -1933,6 +1939,7 @@ class TestCmdConfig:
             "0.85",  # paraphrase-dedup threshold (non-default, exercises emission)
             "3000",  # token budget
             "20",  # search limit (#345)
+            "false",  # scoped recall (default off)
         ]
         inputs = iter(self._base_inputs(memory_block))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
@@ -1964,6 +1971,53 @@ class TestCmdConfig:
         assert env["MEMORY_TOKEN_BUDGET"] == "3000"
         assert env["MEMORY_SEARCH_LIMIT"] == "20"
 
+    def test_scoped_recall_accepted_writes_env_entry(self, tmp_path, monkeypatch):
+        """Answering yes to the scoped-recall prompt emits
+        MEMORY_SCOPED_RECALL_ENABLED=true; the surrounding tests pin
+        the declined path's suppression (no key when false)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._redirect_staging(monkeypatch, tmp_path)
+
+        memory_block = [
+            "true",  # memory enabled
+            "false",  # extraction declined
+            "2000",  # token budget (default)
+            "10",  # search limit (default)
+            "true",  # scoped recall ACCEPTED
+        ]
+        inputs = iter(self._base_inputs(memory_block))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        env = json.loads((tmp_path / "install.conf").read_text())["env"]
+        assert env["MEMORY_SCOPED_RECALL_ENABLED"] == "true"
+
+    def test_scoped_recall_declined_suppresses_env_entry(self, tmp_path, monkeypatch):
+        """Declining keeps the key out of the env dict entirely; the
+        dataclass default (off) applies at load_config time."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._redirect_staging(monkeypatch, tmp_path)
+
+        memory_block = [
+            "true",  # memory enabled
+            "false",  # extraction declined
+            "2000",  # token budget (default)
+            "10",  # search limit (default)
+            "false",  # scoped recall declined
+        ]
+        inputs = iter(self._base_inputs(memory_block))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        env = json.loads((tmp_path / "install.conf").read_text())["env"]
+        assert "MEMORY_SCOPED_RECALL_ENABLED" not in env
+
     def test_memory_episode_defaults_suppress_emission(self, tmp_path, monkeypatch):
         """Operator who accepts every wizard default in the episode
         block produces no episode-specific env entries (the emission
@@ -1987,6 +2041,7 @@ class TestCmdConfig:
             "0.9",  # paraphrase-dedup threshold (dataclass default; suppressed)
             "2000",  # token budget (dataclass default; suppressed)
             "10",  # search limit (dataclass default; suppressed)
+            "false",  # scoped recall (default off)
         ]
         inputs = iter(self._base_inputs(memory_block))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
@@ -2017,7 +2072,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._redirect_staging(monkeypatch, tmp_path)
 
-        # Inputs in wizard order: enabled, ext enabled, timeout, consolidation, classifier-window, episode timeout, dedup threshold, token budget, search limit.
+        # Inputs in wizard order: enabled, ext enabled, timeout, consolidation, classifier-window, episode timeout, dedup threshold, token budget, search limit, scoped recall.
         # The memory reasoner backend and episode model prompts were
         # retired in issue #515.
         memory_block = [
@@ -2030,6 +2085,7 @@ class TestCmdConfig:
             "0.8",  # paraphrase-dedup threshold (non-default)
             "2500",
             "15",
+            "false",  # scoped recall (default off)
         ]
         inputs = iter(self._base_inputs(memory_block))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
@@ -2210,6 +2266,7 @@ class TestCmdConfig:
                 "true",  # memory enabled (extraction + timeout prompts skipped: non-claude)
                 "2000",  # token budget
                 "10",  # search limit
+                "false",  # scoped recall (default off)
                 "",  # perplexity key
             ]
         )
@@ -2249,6 +2306,7 @@ class TestCmdConfig:
             "false",  # extraction disabled (skips timeout + consolidation + episode block)
             "3000",  # token budget
             "20",  # search limit
+            "false",  # scoped recall (default off)
         ]
         inputs = iter(self._base_inputs(memory_block))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
@@ -2297,6 +2355,7 @@ class TestCmdConfig:
             "0.9",  # paraphrase-dedup threshold (default; suppressed)
             "2000",  # token budget (default; suppressed)
             "10",  # search limit (default; suppressed)
+            "false",  # scoped recall (default off)
         ]
         inputs = iter(self._base_inputs(memory_block))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
@@ -2326,6 +2385,7 @@ class TestCmdConfig:
             "0.9",  # paraphrase-dedup threshold (default)
             "2000",  # token budget (default)
             "10",  # search limit (default)
+            "false",  # scoped recall (default off)
         ]
         inputs = iter(self._base_inputs(memory_block))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
@@ -2349,7 +2409,13 @@ class TestCmdConfig:
         # Goose now reaches the extraction-enabled prompt; declining it
         # keeps the rest of the extraction branch (including the new
         # classifier-window prompt) gated out.
-        memory_block = ["true", "false", "2000", "10"]  # memory on, extraction declined, budget, limit
+        memory_block = [
+            "true",
+            "false",
+            "2000",
+            "10",
+            "false",
+        ]  # memory on, extraction declined, budget, limit, scoped recall declined
         monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = iter(self._base_inputs(memory_block, agent_backend="goose"))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
@@ -2372,7 +2438,7 @@ class TestCmdConfig:
 
         # Goose now reaches the extraction prompt; declining keeps the
         # run retrieval-only.
-        memory_block = ["true", "false", "2000", "10"]
+        memory_block = ["true", "false", "2000", "10", "false"]
         monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = iter(self._base_inputs(memory_block, agent_backend="goose"))
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
@@ -2553,6 +2619,7 @@ class TestCmdConfig:
                 "0.9",  # paraphrase-dedup threshold
                 "2000",  # token budget
                 "10",  # search limit
+                "false",  # scoped recall (default off)
                 "",  # perplexity key
             ]
         )
@@ -3181,6 +3248,7 @@ class TestCmdConfigDefaultModelDispatch:
             "0.9",  # paraphrase-dedup threshold (dataclass default)
             "2000",  # token budget (dataclass default)
             "10",  # search limit (dataclass default)
+            "false",  # scoped recall (default off)
         ]
         # Codex-subscription inputs sequence inserts memory_enabled
         # as the second-to-last entry (before the perplexity key).
@@ -8300,6 +8368,7 @@ class TestOpenCodeBinWizardPrompt:
             "0.9",  # paraphrase-dedup threshold
             "2000",  # token budget
             "10",  # search limit
+            "false",  # scoped recall (default off)
             "",  # perplexity key
         ]
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -6079,6 +6079,89 @@ class TestFormatScopedContextWithRecallPayload:
         assert payload["returned_empty"] is False
         assert payload["scoped_debug"]["active_project_id"] == "kai"
         assert list(payload["scoped_debug"]["allowed_scopes"]) == ["global", "project"]
+        # Prefix-slice contract: both rows rendered, so lines_used
+        # covers them, and the prefix is PROMPT order (global section
+        # first) rather than adjusted-score order (which would put
+        # the 0.9 project row first).
+        assert payload["lines_used"] == 2
+        assert [h["id"] for h in payload["hits"]] == ["g1", "p1"]
+
+    async def test_global_cap_drops_rows_out_of_prompt_prefix(self, tmp_path):
+        """With both sections populated, the renderer caps the global
+        section; capped rows must fall OUTSIDE hits[:lines_used] so
+        eval consumers do not count them as prompt-visible."""
+        import kai.memory as mem_mod
+        from kai.memory import _SCOPED_GLOBAL_ROW_CAP_WHEN_PROJECT, format_scoped_context_with_recall_payload
+
+        project_root = tmp_path / "kai"
+        project_root.mkdir()
+        n_globals = _SCOPED_GLOBAL_ROW_CAP_WHEN_PROJECT + 2
+        rows = [
+            _search_row(f"g{i}", f"global fact number {i}", 0.9 - i * 0.01, scope="global") for i in range(n_globals)
+        ]
+        rows.append(_search_row("p1", "kai project fact", 0.95, scope="project", project_id="kai"))
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {"results": rows}
+        mem_mod._memory = mock_mem
+        mem_mod._config = _mp_config(memory_projects={"kai": _mp("kai", project_root)})
+
+        result = await format_scoped_context_with_recall_payload(
+            "what is kai?",
+            user_id="123",
+            workspace=project_root,
+            token_budget=10_000,
+        )
+
+        payload = result.recall_payload
+        # Rendered prefix: capped global rows + the project row.
+        assert payload["lines_used"] == _SCOPED_GLOBAL_ROW_CAP_WHEN_PROJECT + 1
+        prefix_ids = {h["id"] for h in payload["hits"][: payload["lines_used"]]}
+        overflow_ids = {h["id"] for h in payload["hits"][payload["lines_used"] :]}
+        assert "p1" in prefix_ids
+        # The two cap-dropped globals are present but outside the prefix.
+        assert len(overflow_ids) == 2
+        assert overflow_ids.isdisjoint(prefix_ids)
+        # The structural invariant the eval consumers depend on:
+        # lines_used equals the number of rendered memory rows.
+        rendered_rows = [line for line in result.rendered_context.split("\n") if line.startswith("- ")]
+        assert payload["lines_used"] == len(rendered_rows)
+
+    async def test_budget_truncation_keeps_prefix_in_sync_with_render(self, tmp_path):
+        """A tight token budget truncates rendering; lines_used must
+        track exactly what rendered, with dropped rows after the
+        prefix."""
+        import kai.memory as mem_mod
+        from kai.memory import format_scoped_context_with_recall_payload
+
+        project_root = tmp_path / "kai"
+        project_root.mkdir()
+        rows = [
+            _search_row(f"g{i}", f"global fact number {i} with some extra words", 0.9 - i * 0.01, scope="global")
+            for i in range(6)
+        ]
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {"results": rows}
+        mem_mod._memory = mock_mem
+        mem_mod._config = _mp_config(memory_projects={"kai": _mp("kai", project_root)})
+
+        result = await format_scoped_context_with_recall_payload(
+            "what is kai?",
+            user_id="123",
+            workspace=project_root,
+            token_budget=40,
+        )
+
+        payload = result.recall_payload
+        rendered_rows = [line for line in result.rendered_context.split("\n") if line.startswith("- ")]
+        assert 0 < payload["lines_used"] < 6
+        assert payload["lines_used"] == len(rendered_rows)
+        # All six admitted rows stay visible in hits; the truncated
+        # ones sit after the prefix.
+        assert len(payload["hits"]) == 6
+        prefix_ids = [h["id"] for h in payload["hits"][: payload["lines_used"]]]
+        # Prefix follows render order, which for a single section is
+        # the adjusted-score order of its rows.
+        assert prefix_ids == [f"g{i}" for i in range(payload["lines_used"])]
 
     async def test_none_workspace_is_global_only(self, tmp_path):
         """A workspace-less caller still gets its global memories;

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -18,7 +18,7 @@ import os
 import re
 from dataclasses import replace
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -6017,3 +6017,141 @@ class TestRuntimeBackendsPassShadowContext:
         assert ClaudeCodeBackend.backend_name == "claude_code"
         assert CodexBackend.backend_name == "codex"
         assert GooseBackend.backend_name == "goose"
+
+
+class TestIsScopedRecallEnabled:
+    """The knob gate mirrors `is_recall_shadow_enabled`'s contract:
+    config-backed, False when memory was never initialized."""
+
+    def test_false_without_config(self):
+        import kai.memory as mem_mod
+        from kai.memory import is_scoped_recall_enabled
+
+        mem_mod._config = None
+        assert is_scoped_recall_enabled() is False
+
+    def test_reflects_config_flag(self):
+        import kai.memory as mem_mod
+        from kai.memory import is_scoped_recall_enabled
+
+        mem_mod._config = _make_config(memory_scoped_recall_enabled=True)
+        assert is_scoped_recall_enabled() is True
+        mem_mod._config = _make_config(memory_scoped_recall_enabled=False)
+        assert is_scoped_recall_enabled() is False
+
+
+class TestFormatScopedContextWithRecallPayload:
+    """The live scoped recall helper: composes scoped retrieval and
+    rendering into rendered-text-plus-payload, fail-closed."""
+
+    async def test_project_workspace_renders_sections_and_populates_payload(self, tmp_path):
+        import kai.memory as mem_mod
+        from kai.memory import format_scoped_context_with_recall_payload
+
+        project_root = tmp_path / "kai"
+        project_root.mkdir()
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {
+            "results": [
+                _search_row("g1", "global fact", 0.8, scope="global"),
+                _search_row("p1", "kai project fact", 0.9, scope="project", project_id="kai"),
+            ]
+        }
+        mem_mod._memory = mock_mem
+        mem_mod._config = _mp_config(memory_projects={"kai": _mp("kai", project_root)})
+
+        result = await format_scoped_context_with_recall_payload(
+            "what is kai?",
+            user_id="123",
+            workspace=project_root,
+            backend_name="claude_code",
+            job_type="interactive",
+            session_id="sess-1",
+        )
+
+        assert "global fact" in result.rendered_context
+        assert "kai project fact" in result.rendered_context
+        # Two-section shape: global header and the project header.
+        assert "[Relevant global memories" in result.rendered_context
+        assert "Kai project memories" in result.rendered_context
+        payload = result.recall_payload
+        assert payload["reason"] == "ok"
+        assert payload["returned_empty"] is False
+        assert payload["scoped_debug"]["active_project_id"] == "kai"
+        assert list(payload["scoped_debug"]["allowed_scopes"]) == ["global", "project"]
+
+    async def test_none_workspace_is_global_only(self, tmp_path):
+        """A workspace-less caller still gets its global memories;
+        detection is skipped and project rows are excluded. This is
+        the live-path behavior that distinguishes the cutover from
+        the shadow's missing_workspace skip."""
+        import kai.memory as mem_mod
+        from kai.memory import format_scoped_context_with_recall_payload
+
+        project_root = tmp_path / "kai"
+        project_root.mkdir()
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {
+            "results": [
+                _search_row("g1", "global fact", 0.8, scope="global"),
+                _search_row("p1", "kai project fact", 0.9, scope="project", project_id="kai"),
+            ]
+        }
+        mem_mod._memory = mock_mem
+        mem_mod._config = _mp_config(memory_projects={"kai": _mp("kai", project_root)})
+
+        result = await format_scoped_context_with_recall_payload(
+            "what is kai?",
+            user_id="123",
+            workspace=None,
+        )
+
+        assert "global fact" in result.rendered_context
+        assert "kai project fact" not in result.rendered_context
+        assert result.recall_payload["scoped_debug"]["active_project_id"] is None
+        assert list(result.recall_payload["scoped_debug"]["allowed_scopes"]) == ["global"]
+
+    async def test_retrieval_failure_fails_closed(self, monkeypatch, tmp_path):
+        """The epic's invariant at its enforcement point: a scoped
+        retrieval error returns empty rendered content (never raises,
+        never falls back to unscoped content) with the error recorded
+        in the payload."""
+        import kai.memory as mem_mod
+        from kai.memory import format_scoped_context_with_recall_payload
+
+        mem_mod._config = _mp_config()
+        monkeypatch.setattr(
+            "kai.memory.retrieve_scoped_memories",
+            AsyncMock(side_effect=RuntimeError("qdrant exploded")),
+        )
+
+        result = await format_scoped_context_with_recall_payload(
+            "what is kai?",
+            user_id="123",
+            workspace=tmp_path,
+        )
+
+        assert result.rendered_context == ""
+        payload = result.recall_payload
+        assert payload["reason"] == "scoped_error"
+        assert payload["scoped_error_type"] == "RuntimeError"
+        assert "qdrant exploded" in str(payload["scoped_error_message"])
+        assert payload["returned_empty"] is True
+
+    async def test_disabled_memory_short_circuits(self, tmp_path):
+        """Memory disabled flows through retrieve_scoped_memories'
+        disabled reason; rendered content stays empty."""
+        import kai.memory as mem_mod
+        from kai.memory import format_scoped_context_with_recall_payload
+
+        mem_mod._memory = None
+        mem_mod._config = None
+
+        result = await format_scoped_context_with_recall_payload(
+            "what is kai?",
+            user_id="123",
+            workspace=tmp_path,
+        )
+
+        assert result.rendered_context == ""
+        assert result.recall_payload["reason"] == "disabled"


### PR DESCRIPTION
## Summary

- Adds `MEMORY_SCOPED_RECALL_ENABLED` (default off, sub-toggle of `MEMORY_ENABLED`): dataclass field, validated parsing, wizard prompt with true-only env emission, `_CONFIG_ENV_VARS` entry.
- When enabled, `assemble_turn_context` serves the live memory context from the scoped pipeline (`retrieve_scoped_memories` + `format_scoped_context`) via a new `format_scoped_context_with_recall_payload` helper, driven by the same workspace/backend/job-type context the shadow call receives. The shadow comparison is skipped while enabled; the `memory.recall` line carries the scoped decision trail under `scoped_debug` instead.
- **Fail closed:** the helper catches every scoped retrieval/rendering error and returns an empty rendered block with `reason="scoped_error"` plus the error class and truncated message in the payload. A read-path bug degrades to "no memory this turn", never to unscoped fallback content, and the turn stays visible in the log stream (`memory.recall` still emits exactly once per eligible turn in both knob states).
- `ScopedRetrievalContext.workspace` now accepts `None`: detection is skipped and retrieval is global-only, so workspace-less callers keep their global memories on the live path (the shadow's missing-workspace skip is unchanged).
- Default-off means this deploy is behavior-neutral; enabling is a `make config` decision once the ghost log shows clean wrong-scope exclusions on real traffic.

## Testing

- Config: default-off, enable strings, typo-stays-off, memory-off composition; env var registered in `_CONFIG_ENV_VARS`.
- Memory: knob gate, live helper success shape (two sections, populated payload), None-workspace global-only, fail-closed on retrieval error, disabled short-circuit.
- Backend: knob-on serves scoped content and skips legacy and shadow entirely (with kwarg threading pinned), empty-render-still-logs, knob-off never touches the scoped helper.
- Wizard: accepted prompt emits the env entry, declined prompt suppresses it; all existing scripted wizard flows updated for the new prompt.
- Full suite: 4013 passed, 1 skipped. `make check` clean.

Closes #654
