### PR TITLE
feat(memory): user-facing project registration

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -2214,8 +2214,12 @@ async def handle_workspace(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         # first exchange routes its memories to the project instead
         # of leaking them global. Failure warns but never blocks the
         # creation; the workspace is fully usable unregistered, and
-        # /project register remains the manual path.
-        registered, register_note = await _register_memory_project_for(config, chat_id, resolved, name)
+        # /project register remains the manual path. The BASENAME,
+        # not the raw argument: /workspace new accepts relative
+        # subpaths ("sub/project"), whose separator would fail the
+        # project-id slug validation; the final path component
+        # matches /project register's default for the same directory.
+        registered, register_note = await _register_memory_project_for(config, chat_id, resolved, resolved.name)
         await _switch_workspace(update, context, resolved)
         if registered:
             await update.message.reply_text(register_note)

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -1960,48 +1960,56 @@ async def _register_memory_project_for(
         db_registry_upsert,
         detect_active_memory_project,
         merged_registry,
+        registry_mutation_lock,
     )
 
     project_id = raw_name.strip().lower()
     if not _PROJECT_ID_RE.match(project_id):
         return False, f"Invalid project name {raw_name!r}: use letters, digits, - or _ (max 64 chars)."
 
-    merged = merged_registry(config.memory_projects)
-    owner = detect_active_memory_project(root, merged)
-    if owner is not None:
-        return False, f"This workspace is already inside project '{owner.project_id}'."
-    if project_id in merged:
-        return False, f"Project id '{project_id}' is already registered; pick another name."
+    # Guard + persist + cache update under the registry mutation
+    # lock: the guards read the merged view, and without the lock a
+    # second registration can pass its own guards against the same
+    # stale view while this one is awaiting the DB insert, committing
+    # a parent/child pair the nested-root guard exists to prevent.
+    async with registry_mutation_lock:
+        merged = merged_registry(config.memory_projects)
+        owner = detect_active_memory_project(root, merged)
+        if owner is not None:
+            return False, f"This workspace is already inside project '{owner.project_id}'."
+        if project_id in merged:
+            return False, f"Project id '{project_id}' is already registered; pick another name."
 
-    resolved_root = root.expanduser().resolve()
-    row = {
-        "project_id": project_id,
-        "display_name": raw_name.strip(),
-        "workspace_root": str(resolved_root),
-        "memory_enabled": True,
-        "default_scope_for_new_facts": "project",
-        "created_by": chat_id,
-    }
-    try:
-        await sessions.register_memory_project(
-            project_id=project_id,
-            display_name=raw_name.strip(),
-            workspace_root=str(resolved_root),
-            created_by=chat_id,
-        )
-    except Exception as e:
-        # IntegrityError covers the registration race (two users, one
-        # id or root); anything else is a DB-layer failure. Both
-        # collapse to a user-facing message because the caller may be
-        # the auto-hook, which must not raise.
-        log.warning("memory project registration failed for %r: %s", project_id, e)
-        return False, f"Could not register project '{project_id}': {e}"
-    if not db_registry_upsert(row):
-        # The handler validated every field above, so a cache
-        # rejection here means validation drift between this guard
-        # and _row_to_config; the row is persisted and will load on
-        # next restart regardless.
-        log.error("memory project cache rejected validated row %r", project_id)
+        resolved_root = root.expanduser().resolve()
+        row = {
+            "project_id": project_id,
+            "display_name": raw_name.strip(),
+            "workspace_root": str(resolved_root),
+            "memory_enabled": True,
+            "default_scope_for_new_facts": "project",
+            "created_by": chat_id,
+        }
+        try:
+            await sessions.register_memory_project(
+                project_id=project_id,
+                display_name=raw_name.strip(),
+                workspace_root=str(resolved_root),
+                created_by=chat_id,
+            )
+        except Exception as e:
+            # IntegrityError covers id/root collisions that raced a
+            # restart-era row the cache never saw; anything else is a
+            # DB-layer failure. Both collapse to a user-facing message
+            # because the caller may be the auto-hook, which must not
+            # raise.
+            log.warning("memory project registration failed for %r: %s", project_id, e)
+            return False, f"Could not register project '{project_id}': {e}"
+        if not db_registry_upsert(row):
+            # The handler validated every field above, so a cache
+            # rejection here means validation drift between this guard
+            # and _row_to_config; the row is persisted and will load on
+            # next restart regardless.
+            log.error("memory project cache rejected validated row %r", project_id)
     log.info(
         "memory.project.registry %s",
         json.dumps(
@@ -2073,8 +2081,13 @@ async def handle_project(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                 f"Project '{project_id}' was registered by another user; only they or an admin can unregister it."
             )
             return
-        removed = await sessions.unregister_memory_project(project_id)
-        db_registry_remove(project_id)
+        # Same mutation lock as registration: a register guard must
+        # never read the merged view mid-unregister.
+        from kai.memory_projects import registry_mutation_lock
+
+        async with registry_mutation_lock:
+            removed = await sessions.unregister_memory_project(project_id)
+            db_registry_remove(project_id)
         log.info(
             "memory.project.registry %s",
             json.dumps(

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -1924,6 +1924,193 @@ async def _handle_workspace_allowed(
 _NO_BASE_MSG = "No workspace base configured. Set workspace_base in users.yaml or WORKSPACE_BASE in .env."
 
 
+# Project ids are retrieval-time labels stored in memory rows, so
+# they get the same conservative shape discipline as tag slugs:
+# lowercase, digits, hyphen/underscore, no leading separator, 64-char
+# ceiling. Display names keep the user's original casing.
+_PROJECT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+async def _register_memory_project_for(
+    config: Config,
+    chat_id: int,
+    root: Path,
+    raw_name: str,
+) -> tuple[bool, str]:
+    """
+    Shared registration core for /project register and the
+    /workspace new auto-hook. Returns (ok, user_message); never
+    raises, because the auto-hook must not fail workspace creation
+    over a registration problem.
+
+    Guards, in order:
+    - project_id shape (lowercased raw_name must match _PROJECT_ID_RE).
+    - nested-root guard: if ANY registered project (merged view)
+      already owns this root, including via containment, the
+      registration is rejected naming the owner. A nested project
+      would steal scope from its parent through longest-prefix
+      detection.
+    - id collision against the merged view.
+
+    On success the row is persisted AND pushed into the detection
+    cache, so the user's next message in the workspace routes to the
+    new project with no restart.
+    """
+    from kai.memory_projects import (
+        db_registry_upsert,
+        detect_active_memory_project,
+        merged_registry,
+    )
+
+    project_id = raw_name.strip().lower()
+    if not _PROJECT_ID_RE.match(project_id):
+        return False, f"Invalid project name {raw_name!r}: use letters, digits, - or _ (max 64 chars)."
+
+    merged = merged_registry(config.memory_projects)
+    owner = detect_active_memory_project(root, merged)
+    if owner is not None:
+        return False, f"This workspace is already inside project '{owner.project_id}'."
+    if project_id in merged:
+        return False, f"Project id '{project_id}' is already registered; pick another name."
+
+    resolved_root = root.expanduser().resolve()
+    row = {
+        "project_id": project_id,
+        "display_name": raw_name.strip(),
+        "workspace_root": str(resolved_root),
+        "memory_enabled": True,
+        "default_scope_for_new_facts": "project",
+        "created_by": chat_id,
+    }
+    try:
+        await sessions.register_memory_project(
+            project_id=project_id,
+            display_name=raw_name.strip(),
+            workspace_root=str(resolved_root),
+            created_by=chat_id,
+        )
+    except Exception as e:
+        # IntegrityError covers the registration race (two users, one
+        # id or root); anything else is a DB-layer failure. Both
+        # collapse to a user-facing message because the caller may be
+        # the auto-hook, which must not raise.
+        log.warning("memory project registration failed for %r: %s", project_id, e)
+        return False, f"Could not register project '{project_id}': {e}"
+    if not db_registry_upsert(row):
+        # The handler validated every field above, so a cache
+        # rejection here means validation drift between this guard
+        # and _row_to_config; the row is persisted and will load on
+        # next restart regardless.
+        log.error("memory project cache rejected validated row %r", project_id)
+    log.info(
+        "memory.project.registry %s",
+        json.dumps(
+            {"action": "register", "project_id": project_id, "root": str(resolved_root), "by": chat_id},
+            separators=(",", ":"),
+        ),
+    )
+    return True, f"Registered memory project '{project_id}' for this workspace."
+
+
+@_require_auth
+async def handle_project(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """
+    Handle /project - register, unregister, or list memory projects.
+
+    Subcommands:
+        /project                    - list registered projects
+        /project list               - same
+        /project register [name]    - register the CURRENT workspace
+                                      (name defaults to its directory name)
+        /project unregister <name>  - remove a chat-registered project
+
+    Operator-pinned projects (from the host-side registry file) are
+    visible in the listing but cannot be unregistered from chat.
+    """
+    from kai.memory_projects import (
+        db_registry_creator,
+        db_registry_remove,
+        detect_active_memory_project,
+        merged_registry,
+    )
+
+    assert update.message is not None
+    chat_id = _chat_id(update)
+    pool = _get_pool(context)
+    config: Config = context.bot_data["config"]
+
+    args = context.args or []
+    sub = args[0].lower() if args else "list"
+
+    if sub == "register":
+        current = Path(pool.get_workspace(chat_id))
+        raw_name = args[1] if len(args) > 1 else current.name
+        # The message text alone distinguishes success from rejection
+        # for the user; the boolean exists for the /workspace new
+        # auto-hook, which prefixes failures with a "Note:" wrapper.
+        _ok, message = await _register_memory_project_for(config, chat_id, current, raw_name)
+        await update.message.reply_text(message)
+        return
+
+    if sub == "unregister":
+        if len(args) < 2:
+            await update.message.reply_text("Usage: /project unregister <name>")
+            return
+        project_id = args[1].strip().lower()
+        if project_id in config.memory_projects:
+            await update.message.reply_text(
+                f"Project '{project_id}' is operator-pinned; it cannot be unregistered from chat."
+            )
+            return
+        creator = db_registry_creator(project_id)
+        if creator is None:
+            await update.message.reply_text(f"No chat-registered project named '{project_id}'.")
+            return
+        user = config.get_user_config(chat_id)
+        is_admin = user is not None and user.role == "admin"
+        if chat_id != creator and not is_admin:
+            await update.message.reply_text(
+                f"Project '{project_id}' was registered by another user; only they or an admin can unregister it."
+            )
+            return
+        removed = await sessions.unregister_memory_project(project_id)
+        db_registry_remove(project_id)
+        log.info(
+            "memory.project.registry %s",
+            json.dumps(
+                {"action": "unregister", "project_id": project_id, "by": chat_id},
+                separators=(",", ":"),
+            ),
+        )
+        if removed:
+            await update.message.reply_text(f"Unregistered memory project '{project_id}'.")
+        else:
+            await update.message.reply_text(f"Project '{project_id}' was already gone.")
+        return
+
+    if sub != "list":
+        await update.message.reply_text("Usage: /project [list | register [name] | unregister <name>]")
+        return
+
+    merged = merged_registry(config.memory_projects)
+    if not merged:
+        await update.message.reply_text(
+            "No memory projects registered.\nUse /project register [name] in a workspace to create one."
+        )
+        return
+    current = Path(pool.get_workspace(chat_id))
+    active = detect_active_memory_project(current, merged)
+    lines = ["Memory projects:"]
+    for project_id in sorted(merged):
+        cfg = merged[project_id]
+        provenance = "pinned" if project_id in config.memory_projects else "user"
+        marker = " (active)" if active is not None and active.project_id == project_id else ""
+        lines.append(f"- {project_id} [{provenance}]{marker}")
+        for project_root in cfg.workspace_roots:
+            lines.append(f"    {project_root}")
+    await update.message.reply_text("\n".join(lines))
+
+
 @_require_auth
 async def handle_workspace(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -2021,7 +2208,19 @@ async def handle_workspace(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             await update.message.reply_text(
                 f"Warning: git init failed (exit code {rc}). The workspace was created but has no git repo."
             )
+        # Auto-register the new workspace as a memory project:
+        # /workspace new is an explicit "starting a project here"
+        # signal, and registering at creation time means the very
+        # first exchange routes its memories to the project instead
+        # of leaking them global. Failure warns but never blocks the
+        # creation; the workspace is fully usable unregistered, and
+        # /project register remains the manual path.
+        registered, register_note = await _register_memory_project_for(config, chat_id, resolved, name)
         await _switch_workspace(update, context, resolved)
+        if registered:
+            await update.message.reply_text(register_note)
+        else:
+            await update.message.reply_text(f"Note: memory project not registered: {register_note}")
         return
 
     # "config" keyword: view or modify workspace settings.
@@ -2728,6 +2927,9 @@ async def handle_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         "/workspace <name> - Switch by name\n"
         "/workspace home - Return to default\n"
         "/workspace new <name> - Create + git init + switch\n"
+        "/project - List memory projects\n"
+        "/project register [name] - Register current workspace as a memory project\n"
+        "/project unregister <name> - Remove a chat-registered project\n"
         "/workspace allow <path> - Add an allowed workspace\n"
         "/workspace deny <path> - Remove an allowed workspace\n"
         "/workspace allowed - List your workspaces\n"
@@ -3650,6 +3852,7 @@ def create_bot(config: Config, *, use_webhook: bool = True) -> Application:
     app.add_handler(CommandHandler("job", handle_job))
     app.add_handler(CommandHandler("jobs", handle_jobs))
     app.add_handler(CommandHandler("settings", handle_settings))
+    app.add_handler(CommandHandler("project", handle_project))
     app.add_handler(CommandHandler("workspace", handle_workspace))
     app.add_handler(CommandHandler("ws", handle_workspace))
     app.add_handler(CommandHandler("workspaces", handle_workspaces))

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -1972,7 +1972,7 @@ async def _register_memory_project_for(
     # second registration can pass its own guards against the same
     # stale view while this one is awaiting the DB insert, committing
     # a parent/child pair the nested-root guard exists to prevent.
-    async with registry_mutation_lock:
+    async with registry_mutation_lock():
         merged = merged_registry(config.memory_projects)
         owner = detect_active_memory_project(root, merged)
         if owner is not None:
@@ -2065,29 +2065,41 @@ async def handle_project(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             await update.message.reply_text("Usage: /project unregister <name>")
             return
         project_id = args[1].strip().lower()
-        if project_id in config.memory_projects:
-            await update.message.reply_text(
-                f"Project '{project_id}' is operator-pinned; it cannot be unregistered from chat."
-            )
-            return
-        creator = db_registry_creator(project_id)
-        if creator is None:
-            await update.message.reply_text(f"No chat-registered project named '{project_id}'.")
-            return
-        user = config.get_user_config(chat_id)
-        is_admin = user is not None and user.role == "admin"
-        if chat_id != creator and not is_admin:
-            await update.message.reply_text(
-                f"Project '{project_id}' was registered by another user; only they or an admin can unregister it."
-            )
-            return
-        # Same mutation lock as registration: a register guard must
-        # never read the merged view mid-unregister.
         from kai.memory_projects import registry_mutation_lock
 
-        async with registry_mutation_lock:
-            removed = await sessions.unregister_memory_project(project_id)
-            db_registry_remove(project_id)
+        # The role comes from static config and cannot go stale;
+        # everything keyed on the registry row must be read under the
+        # mutation lock below.
+        user = config.get_user_config(chat_id)
+        is_admin = user is not None and user.role == "admin"
+
+        # Pinned check, creator lookup, authorization, AND the delete
+        # all under the registry mutation lock: a creator read before
+        # the lock can authorize against a row that an earlier queued
+        # mutation deletes and a different user re-registers under
+        # the same id, letting stale authorization delete the new
+        # owner's project. The denial is computed inside the lock and
+        # replied outside it, so Telegram I/O never holds the lock.
+        denial: str | None = None
+        removed = False
+        async with registry_mutation_lock():
+            if project_id in config.memory_projects:
+                denial = f"Project '{project_id}' is operator-pinned; it cannot be unregistered from chat."
+            else:
+                creator = db_registry_creator(project_id)
+                if creator is None:
+                    denial = f"No chat-registered project named '{project_id}'."
+                elif chat_id != creator and not is_admin:
+                    denial = (
+                        f"Project '{project_id}' was registered by another user; "
+                        "only they or an admin can unregister it."
+                    )
+                else:
+                    removed = await sessions.unregister_memory_project(project_id)
+                    db_registry_remove(project_id)
+        if denial is not None:
+            await update.message.reply_text(denial)
+            return
         log.info(
             "memory.project.registry %s",
             json.dumps(

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -244,6 +244,17 @@ def _start() -> None:
         use_webhook = config.telegram_webhook_url is not None
 
         await sessions.init_db(config.session_db_path)
+
+        # Load user-registered memory projects into the detection
+        # cache. Must follow init_db (the rows live in the session
+        # DB) and precede message handling, because both detection
+        # call sites read the merged registry on the very first
+        # turn. After startup the /project handlers keep the cache
+        # in lockstep with the DB; this is the only bulk load.
+        from kai.memory_projects import load_db_registry
+
+        load_db_registry(await sessions.get_memory_project_rows())
+
         app = create_bot(config, use_webhook=use_webhook)
 
         # Determine the default user (admin or first user) for per-user

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -1829,11 +1829,13 @@ async def retrieve_scoped_memories(
     # #543's lazy import of the scope constants. A None workspace
     # skips detection: no path means no project authority, which
     # collapses to the same global-only allowed scopes as an
-    # unregistered path (detection rule 4).
-    from kai.memory_projects import detect_active_memory_project
+    # unregistered path (detection rule 4). Detection consults the
+    # MERGED registry (operator-pinned YAML over user-registered DB
+    # rows) so chat registrations take effect without a restart.
+    from kai.memory_projects import detect_active_memory_project, merged_registry
 
     if context.workspace is not None:
-        active_project = detect_active_memory_project(context.workspace, _config.memory_projects)
+        active_project = detect_active_memory_project(context.workspace, merged_registry(_config.memory_projects))
 
     # Step 3: build allowed scopes. Project scope is admitted only
     # when an active project is detected AND that project has

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from kai import memory
 from kai.config import Config, ModelRole, resolve_user_model
 from kai.memory import MemoryResult
-from kai.memory_projects import ActiveMemoryProject, detect_active_memory_project
+from kai.memory_projects import ActiveMemoryProject, detect_active_memory_project, merged_registry
 from kai.oneshot import _EXTRACTOR_CWD as _EXTRACTOR_CWD
 from kai.oneshot import _SUBPROCESS_ENV_ALLOWLIST as _SUBPROCESS_ENV_ALLOWLIST
 from kai.oneshot import (
@@ -3119,10 +3119,12 @@ async def extract_and_store(
     # which project they belong to. The detector is pure and cheap
     # (longest-prefix match over the registry), but running it per
     # fact would still invite drift if a future edit moved the two
-    # write paths apart.
+    # write paths apart. Detection consults the MERGED registry
+    # (operator-pinned YAML over user-registered DB rows) so chat
+    # registrations route writes without a restart.
     active_project: ActiveMemoryProject | None = None
     if workspace:
-        active_project = detect_active_memory_project(Path(workspace), config.memory_projects)
+        active_project = detect_active_memory_project(Path(workspace), merged_registry(config.memory_projects))
 
     sem = _get_semaphore(user_id)
     # Pre-initialize the storage counters so the post-try summary log

--- a/src/kai/memory_projects.py
+++ b/src/kai/memory_projects.py
@@ -38,6 +38,7 @@ later issues in the scoped-memory epic.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -170,6 +171,18 @@ _VALID_DEFAULT_SCOPES: frozenset[str] = frozenset({"global", "project"})
 
 _db_registry: dict[str, MemoryProjectConfig] = {}
 _db_creators: dict[str, int] = {}
+
+# Serializes registry mutations (guard + DB write + cache update).
+# The nested-root and collision guards are reads of the merged view
+# taken BEFORE an awaited DB insert; under concurrent command
+# handling, two registrations can both pass their guards against the
+# same stale view and commit a parent/child pair that the guards
+# exist to prevent (the child then steals its parent's subtree via
+# longest-prefix detection). The DB's uniqueness constraints only
+# cover exact id/root equality, not containment, so the stable-view
+# property must come from serialization. Mutations are rare,
+# operator-driven events; a single registry-wide lock costs nothing.
+registry_mutation_lock = asyncio.Lock()
 
 
 def _row_to_config(row: dict) -> MemoryProjectConfig | None:

--- a/src/kai/memory_projects.py
+++ b/src/kai/memory_projects.py
@@ -149,3 +149,147 @@ def detect_active_memory_project(
         memory_enabled=best_project.memory_enabled,
         default_scope_for_new_facts=best_project.default_scope_for_new_facts,
     )
+
+
+# ── User-registered registry (DB layer) ─────────────────────────────
+# Chat-registered projects live in the session DB (kai.sessions owns
+# persistence) and in this module-level cache (this module owns the
+# merged detection view). The daemon is the only writer: command
+# handlers mutate the DB and this cache in the same turn, so the
+# cache never goes stale and detection sees changes on the next
+# message with no restart. All mutation happens on the event loop,
+# never in an executor, so no locking is needed.
+
+# Mirrors the canonical SCOPE_GLOBAL / SCOPE_PROJECT constants in
+# kai.memory. Duplicated as literals so this pure-detection module's
+# import surface stays at kai.config only; importing kai.memory here
+# would pull the whole storage stack into every consumer of the
+# detector. The YAML loader makes the same trade with its own lazy
+# import of the constants.
+_VALID_DEFAULT_SCOPES: frozenset[str] = frozenset({"global", "project"})
+
+_db_registry: dict[str, MemoryProjectConfig] = {}
+_db_creators: dict[str, int] = {}
+
+
+def _row_to_config(row: dict) -> MemoryProjectConfig | None:
+    """
+    Validate one DB row into a MemoryProjectConfig, or None.
+
+    Applies the same per-entry rules as the YAML loader in
+    kai.config (non-empty id and display name, real boolean
+    memory_enabled, recognized default scope, resolvable root) so a
+    row that would have been skipped as a YAML entry is skipped as a
+    DB row too. Fail-closed: a malformed row never reaches
+    detection.
+    """
+    project_id = row.get("project_id")
+    display_name = row.get("display_name")
+    if not isinstance(project_id, str) or not project_id.strip():
+        log.warning("memory_projects db row skipped: bad project_id %r", project_id)
+        return None
+    if not isinstance(display_name, str) or not display_name.strip():
+        log.warning("memory_projects db row %r skipped: bad display_name", project_id)
+        return None
+    memory_enabled = row.get("memory_enabled")
+    if not isinstance(memory_enabled, bool):
+        log.warning("memory_projects db row %r skipped: bad memory_enabled %r", project_id, memory_enabled)
+        return None
+    default_scope = row.get("default_scope_for_new_facts")
+    if default_scope is not None and default_scope not in _VALID_DEFAULT_SCOPES:
+        log.warning("memory_projects db row %r skipped: bad default scope %r", project_id, default_scope)
+        return None
+    raw_root = row.get("workspace_root")
+    if not isinstance(raw_root, str) or not raw_root.strip():
+        log.warning("memory_projects db row %r skipped: bad workspace_root %r", project_id, raw_root)
+        return None
+    try:
+        resolved = Path(raw_root).expanduser().resolve()
+    except (OSError, ValueError) as e:
+        log.warning("memory_projects db row %r skipped: cannot resolve root %r: %s", project_id, raw_root, e)
+        return None
+    return MemoryProjectConfig(
+        project_id=project_id.strip(),
+        display_name=display_name.strip(),
+        workspace_roots=(resolved,),
+        memory_enabled=memory_enabled,
+        default_scope_for_new_facts=default_scope,
+    )
+
+
+def load_db_registry(rows: list[dict]) -> None:
+    """
+    Replace the cache from persisted rows (startup load).
+
+    Intra-DB duplicates cannot exist (PRIMARY KEY and UNIQUE root
+    constraints), so this is a straight validated load; conflicts
+    with the YAML layer are handled per-lookup in merged_registry,
+    not here, so an operator pinning a YAML entry over an existing
+    DB row needs no DB cleanup.
+    """
+    _db_registry.clear()
+    _db_creators.clear()
+    for row in rows:
+        cfg = _row_to_config(row)
+        if cfg is None:
+            continue
+        _db_registry[cfg.project_id] = cfg
+        created_by = row.get("created_by")
+        if isinstance(created_by, int):
+            _db_creators[cfg.project_id] = created_by
+
+
+def db_registry_upsert(row: dict) -> bool:
+    """Add one registered project to the cache (post-DB-write hook
+    for the register handler). Returns False when validation rejects
+    the row; the handler treats that as an internal error since it
+    validated the inputs before writing."""
+    cfg = _row_to_config(row)
+    if cfg is None:
+        return False
+    _db_registry[cfg.project_id] = cfg
+    created_by = row.get("created_by")
+    if isinstance(created_by, int):
+        _db_creators[cfg.project_id] = created_by
+    return True
+
+
+def db_registry_remove(project_id: str) -> None:
+    """Drop one registered project from the cache (post-DB-delete
+    hook for the unregister handler)."""
+    _db_registry.pop(project_id, None)
+    _db_creators.pop(project_id, None)
+
+
+def db_registry_creator(project_id: str) -> int | None:
+    """chat_id that registered a project, for the unregister
+    permission check. None for YAML-pinned or unknown projects."""
+    return _db_creators.get(project_id)
+
+
+def merged_registry(yaml_projects: dict[str, MemoryProjectConfig]) -> dict[str, MemoryProjectConfig]:
+    """
+    The detection view: user-registered projects under the
+    operator-pinned YAML layer.
+
+    YAML wins every conflict, on project_id AND on workspace-root
+    ownership, mirroring the YAML loader's own first-wins duplicate
+    rules; a user registration can never shadow or steal scope from
+    an operator-pinned project. Returns the yaml dict unchanged when
+    no DB rows exist, so the pre-registration call sites behave
+    byte-identically.
+    """
+    if not _db_registry:
+        return yaml_projects
+    yaml_roots = {root for project in yaml_projects.values() for root in project.workspace_roots}
+    merged: dict[str, MemoryProjectConfig] = {}
+    for project_id, cfg in _db_registry.items():
+        if project_id in yaml_projects:
+            log.debug("memory_projects: db project %r shadowed by yaml id", project_id)
+            continue
+        if any(root in yaml_roots for root in cfg.workspace_roots):
+            log.debug("memory_projects: db project %r root owned by yaml layer", project_id)
+            continue
+        merged[project_id] = cfg
+    merged.update(yaml_projects)
+    return merged

--- a/src/kai/memory_projects.py
+++ b/src/kai/memory_projects.py
@@ -282,12 +282,24 @@ def merged_registry(yaml_projects: dict[str, MemoryProjectConfig]) -> dict[str, 
     if not _db_registry:
         return yaml_projects
     yaml_roots = {root for project in yaml_projects.values() for root in project.workspace_roots}
+
+    def _yaml_owned(root: Path) -> bool:
+        # Equality OR containment, matching the detector's own
+        # containment model: a DB root INSIDE a YAML root would win
+        # that subtree via longest-prefix matching, so a later
+        # operator pin of the parent must evict the persisted child,
+        # not coexist with it. The inverse (a YAML root inside a DB
+        # root) is ordinary nested-project coexistence: the deeper
+        # YAML root already owns its subtree through longest-prefix,
+        # exactly like nested YAML entries.
+        return any(root == yaml_root or root.is_relative_to(yaml_root) for yaml_root in yaml_roots)
+
     merged: dict[str, MemoryProjectConfig] = {}
     for project_id, cfg in _db_registry.items():
         if project_id in yaml_projects:
             log.debug("memory_projects: db project %r shadowed by yaml id", project_id)
             continue
-        if any(root in yaml_roots for root in cfg.workspace_roots):
+        if any(_yaml_owned(root) for root in cfg.workspace_roots):
             log.debug("memory_projects: db project %r root owned by yaml layer", project_id)
             continue
         merged[project_id] = cfg

--- a/src/kai/memory_projects.py
+++ b/src/kai/memory_projects.py
@@ -42,6 +42,7 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from pathlib import Path
+from weakref import WeakKeyDictionary
 
 from kai.config import MemoryProjectConfig
 
@@ -182,7 +183,24 @@ _db_creators: dict[str, int] = {}
 # cover exact id/root equality, not containment, so the stable-view
 # property must come from serialization. Mutations are rare,
 # operator-driven events; a single registry-wide lock costs nothing.
-registry_mutation_lock = asyncio.Lock()
+#
+# Per-loop factory rather than a module-level Lock: asyncio locks
+# bind to the event loop that first acquires them and raise when
+# acquired from another loop. The daemon runs one loop forever, so
+# production sees a single lock; the factory exists so any context
+# with a different loop lifecycle (tests, future tooling) gets a
+# lock bound to ITS loop instead of a cross-loop RuntimeError.
+_registry_mutation_locks: WeakKeyDictionary = WeakKeyDictionary()
+
+
+def registry_mutation_lock() -> asyncio.Lock:
+    """The registry mutation lock for the running event loop."""
+    loop = asyncio.get_running_loop()
+    lock = _registry_mutation_locks.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _registry_mutation_locks[loop] = lock
+    return lock
 
 
 def _row_to_config(row: dict) -> MemoryProjectConfig | None:

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -150,6 +150,26 @@ async def init_db(db_path: Path) -> None:
                 PRIMARY KEY (path, chat_id)
             )
         """)
+        # User-registered memory projects (the DB layer under the
+        # operator-pinned memory-projects.yaml). One root per row:
+        # chat-registered projects are single-root by design; only
+        # YAML entries support multi-root. workspace_root is UNIQUE
+        # because the detector's longest-prefix match needs a single
+        # owner per root, mirroring the YAML loader's cross-project
+        # duplicate-root rule. created_by drives the unregister
+        # permission check (registering user or admin).
+        log.debug("Creating memory_projects table")
+        await _get_db().execute("""
+            CREATE TABLE IF NOT EXISTS memory_projects (
+                project_id TEXT PRIMARY KEY,
+                display_name TEXT NOT NULL,
+                workspace_root TEXT NOT NULL UNIQUE,
+                memory_enabled INTEGER NOT NULL DEFAULT 1,
+                default_scope_for_new_facts TEXT,
+                created_by INTEGER NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
 
         # Schema evolution: migrate old workspace_history tables (path-only
         # PK) to the new composite PK (path, chat_id). SQLite does not
@@ -739,6 +759,78 @@ async def upsert_workspace_history(path: str, chat_id: int) -> None:
         (path, chat_id),
     )
     await _get_db().commit()
+
+
+# ── Memory project registry (DB layer) ─────────────────────────────
+# User-registered memory projects. The in-memory merge with the
+# operator-pinned YAML registry lives in kai.memory_projects; these
+# accessors are the persistence layer only.
+
+
+async def register_memory_project(
+    *,
+    project_id: str,
+    display_name: str,
+    workspace_root: str,
+    created_by: int,
+    memory_enabled: bool = True,
+    default_scope_for_new_facts: str | None = "project",
+) -> None:
+    """Insert a user-registered memory project row.
+
+    Plain INSERT, not upsert: registration collisions are a user
+    error surfaced by the command handler (which checks the merged
+    registry first), and the PRIMARY KEY / UNIQUE constraints are
+    the backstop against a race between two concurrent registrations.
+    Raises sqlite's IntegrityError on collision; the caller maps it
+    to a user-facing message.
+    """
+    await _get_db().execute(
+        "INSERT INTO memory_projects (project_id, display_name, workspace_root, memory_enabled, default_scope_for_new_facts, created_by) VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            project_id,
+            display_name,
+            workspace_root,
+            1 if memory_enabled else 0,
+            default_scope_for_new_facts,
+            created_by,
+        ),
+    )
+    await _get_db().commit()
+
+
+async def unregister_memory_project(project_id: str) -> bool:
+    """Delete a user-registered project row. Returns True when a row
+    was actually removed, so the handler can distinguish "gone" from
+    "never existed" without a second query."""
+    cursor = await _get_db().execute("DELETE FROM memory_projects WHERE project_id = ?", (project_id,))
+    await _get_db().commit()
+    return cursor.rowcount > 0
+
+
+async def get_memory_project_rows() -> list[dict]:
+    """All user-registered project rows as plain dicts.
+
+    Consumed by kai.memory_projects at startup (cache load) and by
+    the /project list handler. Returns dicts rather than dataclass
+    instances so validation stays in one place (the cache loader),
+    matching the YAML path where the loader validates raw dicts.
+    """
+    async with _get_db().execute(
+        "SELECT project_id, display_name, workspace_root, memory_enabled, default_scope_for_new_facts, created_by FROM memory_projects"
+    ) as cursor:
+        rows = await cursor.fetchall()
+        return [
+            {
+                "project_id": row["project_id"],
+                "display_name": row["display_name"],
+                "workspace_root": row["workspace_root"],
+                "memory_enabled": bool(row["memory_enabled"]),
+                "default_scope_for_new_facts": row["default_scope_for_new_facts"],
+                "created_by": row["created_by"],
+            }
+            for row in rows
+        ]
 
 
 async def get_all_workspace_paths(limit: int = 100) -> list[str]:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5099,6 +5099,49 @@ class TestHandleProject:
         reply = update.message.reply_text.call_args.args[0]
         assert "Unregistered" in reply
 
+    async def test_concurrent_parent_child_registration_serialized(self, tmp_path):
+        """The nested-root guard reads the merged view BEFORE an
+        awaited DB insert; without the registry mutation lock, two
+        concurrent registrations both pass their guards against the
+        same stale view and commit a parent/child pair (the child
+        then steals the parent's subtree via longest-prefix
+        detection). With the lock, the second registration observes
+        the first and is rejected. The persist stub yields to the
+        event loop to force the interleaving the lock must close."""
+        from kai.bot import _register_memory_project_for
+        from kai.memory_projects import detect_active_memory_project, merged_registry
+
+        parent = tmp_path / "parent"
+        child = parent / "child"
+        child.mkdir(parents=True)
+        config = _make_config()
+
+        async def _yielding_persist(**kwargs):
+            await asyncio.sleep(0)
+
+        with patch(
+            "kai.bot.sessions.register_memory_project",
+            new=AsyncMock(side_effect=_yielding_persist),
+        ):
+            results = await asyncio.gather(
+                _register_memory_project_for(config, 12345, parent, "parent"),
+                _register_memory_project_for(config, 12345, child, "child"),
+            )
+
+        successes = [message for ok, message in results if ok]
+        rejections = [message for ok, message in results if not ok]
+        assert len(successes) == 1
+        assert len(rejections) == 1
+        assert "already inside project" in rejections[0]
+        # The merged registry must never contain nested DB-owned
+        # roots: detection from inside the child resolves to the
+        # single registered project.
+        merged = merged_registry({})
+        assert len(merged) == 1
+        active = detect_active_memory_project(child, merged)
+        assert active is not None
+        assert active.project_id == "parent"
+
     async def test_list_shows_provenance_and_active_marker(self, tmp_path):
         from kai.bot import handle_project
         from kai.memory_projects import load_db_registry

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5099,6 +5099,72 @@ class TestHandleProject:
         reply = update.message.reply_text.call_args.args[0]
         assert "Unregistered" in reply
 
+    async def test_stale_unregister_authorization_rechecked_under_lock(self, tmp_path):
+        """Unregister authorization must be read under the mutation
+        lock: a creator read before the lock can authorize against a
+        row that earlier queued mutations delete and a different
+        user re-registers under the same id. The test holds the lock,
+        starts the stale unregister so it queues, swaps the row's
+        owner while it waits, and asserts the recheck denies the
+        deletion and the new owner's project survives."""
+        from kai.bot import handle_project
+        from kai.memory_projects import (
+            db_registry_remove,
+            db_registry_upsert,
+            load_db_registry,
+            merged_registry,
+            registry_mutation_lock,
+        )
+
+        root_old = tmp_path / "phi-old"
+        root_old.mkdir()
+        root_new = tmp_path / "phi-new"
+        root_new.mkdir()
+        # phi originally registered by chat 999 (the stale caller).
+        load_db_registry(
+            [
+                {
+                    "project_id": "phi",
+                    "display_name": "Phi",
+                    "workspace_root": str(root_old),
+                    "memory_enabled": True,
+                    "default_scope_for_new_facts": "project",
+                    "created_by": 999,
+                }
+            ]
+        )
+        update = _make_update("/project unregister phi", chat_id=999)
+        ctx = _make_context(args=["unregister", "phi"])
+
+        with patch("kai.bot.sessions.unregister_memory_project", new_callable=AsyncMock) as remove:
+            async with registry_mutation_lock():
+                # The stale unregister starts and queues behind the
+                # held lock BEFORE the ownership swap below.
+                task = asyncio.create_task(handle_project(update, ctx))
+                await asyncio.sleep(0)
+                # Earlier queued mutations, simulated under the held
+                # lock: the old phi goes away and a different user
+                # re-registers the id.
+                db_registry_remove("phi")
+                db_registry_upsert(
+                    {
+                        "project_id": "phi",
+                        "display_name": "Phi",
+                        "workspace_root": str(root_new),
+                        "memory_enabled": True,
+                        "default_scope_for_new_facts": "project",
+                        "created_by": 12345,
+                    }
+                )
+            await task
+
+        remove.assert_not_awaited()
+        reply = update.message.reply_text.call_args.args[0]
+        assert "registered by another user" in reply
+        # The new owner's project survives with its new root.
+        merged = merged_registry({})
+        assert merged["phi"].workspace_roots == (root_new.resolve(),)
+
     async def test_concurrent_parent_child_registration_serialized(self, tmp_path):
         """The nested-root guard reads the merged view BEFORE an
         awaited DB insert; without the registry mutation lock, two

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -4912,3 +4912,285 @@ class TestCommandMenu:
             f"Added: {menu_commands - EXPECTED_MENU_COMMANDS}, "
             f"Removed: {EXPECTED_MENU_COMMANDS - menu_commands}"
         )
+
+
+# ── /project command and workspace auto-registration ────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_project_registry_cache():
+    """The DB project registry cache in kai.memory_projects is
+    module-level state; /project handler tests mutate it and must
+    not leak into each other."""
+    from kai.memory_projects import load_db_registry
+
+    load_db_registry([])
+    yield
+    load_db_registry([])
+
+
+def _mp_yaml(project_id: str, root: Path):
+    """Operator-pinned registry entry for handler tests."""
+    from kai.config import MemoryProjectConfig
+
+    return MemoryProjectConfig(
+        project_id=project_id,
+        display_name=project_id.capitalize(),
+        workspace_roots=(root.resolve(),),
+        memory_enabled=True,
+        default_scope_for_new_facts="project",
+    )
+
+
+class TestHandleProject:
+    async def test_register_current_workspace(self, tmp_path):
+        from kai.bot import handle_project
+        from kai.memory_projects import db_registry_creator, merged_registry
+
+        ws = tmp_path / "phi"
+        ws.mkdir()
+        update = _make_update("/project register")
+        ctx = _make_context(
+            pool=_make_mock_claude(workspace=ws),
+            args=["register"],
+        )
+        with patch("kai.bot.sessions.register_memory_project", new_callable=AsyncMock) as persist:
+            await handle_project(update, ctx)
+
+        persist.assert_awaited_once()
+        assert persist.call_args.kwargs["project_id"] == "phi"
+        assert persist.call_args.kwargs["created_by"] == 12345
+        # Restart-free contract: the cache sees the project immediately.
+        assert "phi" in merged_registry({})
+        assert db_registry_creator("phi") == 12345
+        reply = update.message.reply_text.call_args.args[0]
+        assert "Registered memory project 'phi'" in reply
+
+    async def test_register_explicit_name_overrides_dir_name(self, tmp_path):
+        from kai.bot import handle_project
+        from kai.memory_projects import merged_registry
+
+        ws = tmp_path / "some-checkout"
+        ws.mkdir()
+        update = _make_update("/project register Anvil")
+        ctx = _make_context(pool=_make_mock_claude(workspace=ws), args=["register", "Anvil"])
+        with patch("kai.bot.sessions.register_memory_project", new_callable=AsyncMock):
+            await handle_project(update, ctx)
+
+        merged = merged_registry({})
+        assert "anvil" in merged
+        # Display name keeps the user's casing; the id is the slug.
+        assert merged["anvil"].display_name == "Anvil"
+
+    async def test_register_inside_existing_project_rejected(self, tmp_path):
+        from kai.bot import handle_project
+
+        root = tmp_path / "kai"
+        sub = root / "subdir"
+        sub.mkdir(parents=True)
+        config = _make_config(memory_projects={"kai": _mp_yaml("kai", root)})
+        update = _make_update("/project register")
+        ctx = _make_context(config=config, pool=_make_mock_claude(workspace=sub), args=["register"])
+        with patch("kai.bot.sessions.register_memory_project", new_callable=AsyncMock) as persist:
+            await handle_project(update, ctx)
+
+        persist.assert_not_awaited()
+        reply = update.message.reply_text.call_args.args[0]
+        assert "already inside project 'kai'" in reply
+
+    async def test_register_duplicate_id_rejected(self, tmp_path):
+        from kai.bot import handle_project
+
+        yaml_root = tmp_path / "elsewhere"
+        yaml_root.mkdir()
+        ws = tmp_path / "kai"
+        ws.mkdir()
+        config = _make_config(memory_projects={"kai": _mp_yaml("kai", yaml_root)})
+        update = _make_update("/project register kai")
+        ctx = _make_context(config=config, pool=_make_mock_claude(workspace=ws), args=["register", "kai"])
+        with patch("kai.bot.sessions.register_memory_project", new_callable=AsyncMock) as persist:
+            await handle_project(update, ctx)
+
+        persist.assert_not_awaited()
+        reply = update.message.reply_text.call_args.args[0]
+        assert "already registered" in reply
+
+    async def test_register_invalid_name_rejected(self, tmp_path):
+        from kai.bot import handle_project
+
+        ws = tmp_path / "phi"
+        ws.mkdir()
+        update = _make_update("/project register 'bad name!'")
+        ctx = _make_context(pool=_make_mock_claude(workspace=ws), args=["register", "bad name!"])
+        with patch("kai.bot.sessions.register_memory_project", new_callable=AsyncMock) as persist:
+            await handle_project(update, ctx)
+
+        persist.assert_not_awaited()
+        reply = update.message.reply_text.call_args.args[0]
+        assert "Invalid project name" in reply
+
+    async def test_unregister_pinned_project_refused(self, tmp_path):
+        from kai.bot import handle_project
+
+        root = tmp_path / "kai"
+        root.mkdir()
+        config = _make_config(memory_projects={"kai": _mp_yaml("kai", root)})
+        update = _make_update("/project unregister kai")
+        ctx = _make_context(config=config, args=["unregister", "kai"])
+        with patch("kai.bot.sessions.unregister_memory_project", new_callable=AsyncMock) as remove:
+            await handle_project(update, ctx)
+
+        remove.assert_not_awaited()
+        reply = update.message.reply_text.call_args.args[0]
+        assert "operator-pinned" in reply
+
+    async def test_unregister_by_other_user_refused(self, tmp_path):
+        from kai.bot import handle_project
+        from kai.memory_projects import load_db_registry
+
+        root = tmp_path / "phi"
+        root.mkdir()
+        load_db_registry(
+            [
+                {
+                    "project_id": "phi",
+                    "display_name": "Phi",
+                    "workspace_root": str(root),
+                    "memory_enabled": True,
+                    "default_scope_for_new_facts": "project",
+                    "created_by": 777,
+                }
+            ]
+        )
+        update = _make_update("/project unregister phi")
+        ctx = _make_context(args=["unregister", "phi"])
+        with patch("kai.bot.sessions.unregister_memory_project", new_callable=AsyncMock) as remove:
+            await handle_project(update, ctx)
+
+        remove.assert_not_awaited()
+        reply = update.message.reply_text.call_args.args[0]
+        assert "registered by another user" in reply
+
+    async def test_unregister_by_creator_succeeds(self, tmp_path):
+        from kai.bot import handle_project
+        from kai.memory_projects import load_db_registry, merged_registry
+
+        root = tmp_path / "phi"
+        root.mkdir()
+        load_db_registry(
+            [
+                {
+                    "project_id": "phi",
+                    "display_name": "Phi",
+                    "workspace_root": str(root),
+                    "memory_enabled": True,
+                    "default_scope_for_new_facts": "project",
+                    "created_by": 12345,
+                }
+            ]
+        )
+        update = _make_update("/project unregister phi")
+        ctx = _make_context(args=["unregister", "phi"])
+        with patch("kai.bot.sessions.unregister_memory_project", new_callable=AsyncMock, return_value=True) as remove:
+            await handle_project(update, ctx)
+
+        remove.assert_awaited_once_with("phi")
+        assert merged_registry({}) == {}
+        reply = update.message.reply_text.call_args.args[0]
+        assert "Unregistered" in reply
+
+    async def test_list_shows_provenance_and_active_marker(self, tmp_path):
+        from kai.bot import handle_project
+        from kai.memory_projects import load_db_registry
+
+        yaml_root = tmp_path / "kai"
+        yaml_root.mkdir()
+        db_root = tmp_path / "phi"
+        db_root.mkdir()
+        load_db_registry(
+            [
+                {
+                    "project_id": "phi",
+                    "display_name": "Phi",
+                    "workspace_root": str(db_root),
+                    "memory_enabled": True,
+                    "default_scope_for_new_facts": "project",
+                    "created_by": 12345,
+                }
+            ]
+        )
+        config = _make_config(memory_projects={"kai": _mp_yaml("kai", yaml_root)})
+        update = _make_update("/project")
+        ctx = _make_context(config=config, pool=_make_mock_claude(workspace=db_root), args=[])
+        await handle_project(update, ctx)
+
+        reply = update.message.reply_text.call_args.args[0]
+        assert "kai [pinned]" in reply
+        assert "phi [user] (active)" in reply
+
+
+class TestWorkspaceNewAutoRegister:
+    async def test_workspace_new_registers_project(self, tmp_path):
+        """/workspace new is the strong project signal: the created
+        directory is registered automatically and the user is told."""
+        from kai.bot import handle_workspace
+        from kai.memory_projects import merged_registry
+
+        update = _make_update("/workspace new myproj")
+        ctx = _make_context(args=["new", "myproj"])
+
+        proc = MagicMock()
+        proc.wait = AsyncMock(return_value=0)
+        with (
+            _mock_resolve(base=tmp_path),
+            patch("kai.bot.asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc),
+            patch("kai.bot._switch_workspace", new_callable=AsyncMock),
+            patch("kai.bot.sessions.register_memory_project", new_callable=AsyncMock) as persist,
+        ):
+            await handle_workspace(update, ctx)
+
+        persist.assert_awaited_once()
+        assert persist.call_args.kwargs["project_id"] == "myproj"
+        assert "myproj" in merged_registry({})
+        replies = [c.args[0] for c in update.message.reply_text.call_args_list]
+        assert any("Registered memory project 'myproj'" in r for r in replies)
+
+    async def test_workspace_new_registration_failure_does_not_block(self, tmp_path):
+        """A registration failure warns but the workspace creation
+        and switch still happen."""
+        from kai.bot import handle_workspace
+        from kai.memory_projects import load_db_registry
+
+        # Pre-register the SAME id so the auto-hook hits the
+        # duplicate-id rejection.
+        other_root = tmp_path / "elsewhere"
+        other_root.mkdir()
+        load_db_registry(
+            [
+                {
+                    "project_id": "myproj",
+                    "display_name": "Myproj",
+                    "workspace_root": str(other_root),
+                    "memory_enabled": True,
+                    "default_scope_for_new_facts": "project",
+                    "created_by": 777,
+                }
+            ]
+        )
+        update = _make_update("/workspace new myproj")
+        ctx = _make_context(args=["new", "myproj"])
+
+        proc = MagicMock()
+        proc.wait = AsyncMock(return_value=0)
+        with (
+            _mock_resolve(base=tmp_path),
+            patch("kai.bot.asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc),
+            patch("kai.bot._switch_workspace", new_callable=AsyncMock) as switch,
+            patch("kai.bot.sessions.register_memory_project", new_callable=AsyncMock) as persist,
+        ):
+            await handle_workspace(update, ctx)
+
+        persist.assert_not_awaited()
+        switch.assert_awaited_once()
+        replies = [c.args[0] for c in update.message.reply_text.call_args_list]
+        assert any("memory project not registered" in r for r in replies)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5155,6 +5155,31 @@ class TestWorkspaceNewAutoRegister:
         replies = [c.args[0] for c in update.message.reply_text.call_args_list]
         assert any("Registered memory project 'myproj'" in r for r in replies)
 
+    async def test_workspace_new_subpath_registers_basename(self, tmp_path):
+        """/workspace new accepts relative subpaths; the auto-hook
+        must register the created directory's BASENAME, since the
+        raw argument's separator would fail slug validation and
+        silently skip registration on a perfectly valid creation."""
+        from kai.bot import handle_workspace
+        from kai.memory_projects import merged_registry
+
+        update = _make_update("/workspace new sub/project")
+        ctx = _make_context(args=["new", "sub/project"])
+
+        proc = MagicMock()
+        proc.wait = AsyncMock(return_value=0)
+        with (
+            _mock_resolve(base=tmp_path),
+            patch("kai.bot.asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc),
+            patch("kai.bot._switch_workspace", new_callable=AsyncMock),
+            patch("kai.bot.sessions.register_memory_project", new_callable=AsyncMock) as persist,
+        ):
+            await handle_workspace(update, ctx)
+
+        persist.assert_awaited_once()
+        assert persist.call_args.kwargs["project_id"] == "project"
+        assert "project" in merged_registry({})
+
     async def test_workspace_new_registration_failure_does_not_block(self, tmp_path):
         """A registration failure warns but the workspace creation
         and switch still happen."""

--- a/tests/test_memory_projects.py
+++ b/tests/test_memory_projects.py
@@ -275,6 +275,39 @@ class TestDbRegistryCache:
         assert "kai-imposter" not in merged
         assert set(merged) == {"kai"}
 
+    def test_yaml_parent_evicts_persisted_db_child_root(self, tmp_path):
+        """Containment, not just equality: a persisted DB root INSIDE
+        a later-pinned YAML root would win that subtree via
+        longest-prefix detection, so the merge must evict it. The
+        register-time nested guard cannot catch this ordering (the
+        DB row predates the YAML pin); the merge is the only gate."""
+        parent = tmp_path / "parent"
+        child = parent / "child"
+        deep = child / "src"
+        deep.mkdir(parents=True)
+        load_db_registry([_row("child", child)])
+        merged = merged_registry({"parent": _project("parent", parent)})
+        assert "child" not in merged
+        active = detect_active_memory_project(deep, merged)
+        assert active is not None
+        assert active.project_id == "parent"
+
+    def test_yaml_child_inside_db_parent_coexists(self, tmp_path):
+        """The inverse direction is ordinary nested-project
+        coexistence: a deeper YAML root owns its subtree through
+        longest-prefix while the DB parent keeps the surrounding
+        area, exactly like nested YAML entries."""
+        parent = tmp_path / "parent"
+        child = parent / "child"
+        child.mkdir(parents=True)
+        load_db_registry([_row("parent", parent)])
+        merged = merged_registry({"child": _project("child", child)})
+        assert set(merged) == {"parent", "child"}
+        inside_child = detect_active_memory_project(child, merged)
+        assert inside_child is not None and inside_child.project_id == "child"
+        inside_parent = detect_active_memory_project(parent, merged)
+        assert inside_parent is not None and inside_parent.project_id == "parent"
+
     def test_upsert_and_remove_visible_immediately(self, tmp_path):
         """Restart-free contract: cache mutations show up in the very
         next merged_registry call."""

--- a/tests/test_memory_projects.py
+++ b/tests/test_memory_projects.py
@@ -198,3 +198,126 @@ class TestActiveMemoryProjectDataclass:
         assert active.matched_root == root
         assert active.memory_enabled is True
         assert active.default_scope_for_new_facts == "project"
+
+
+# ── DB registry cache and merge ──────────────────────────────────────
+
+
+from kai.memory_projects import (  # noqa: E402
+    db_registry_creator,
+    db_registry_remove,
+    db_registry_upsert,
+    load_db_registry,
+    merged_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_db_registry():
+    """The DB registry cache is module-level state; tests must not
+    leak entries into each other (or into the detector tests above,
+    which assume a YAML-only world)."""
+    load_db_registry([])
+    yield
+    load_db_registry([])
+
+
+def _row(project_id: str, root, *, created_by: int = 123, **overrides) -> dict:
+    row = {
+        "project_id": project_id,
+        "display_name": project_id.capitalize(),
+        "workspace_root": str(root),
+        "memory_enabled": True,
+        "default_scope_for_new_facts": "project",
+        "created_by": created_by,
+    }
+    row.update(overrides)
+    return row
+
+
+class TestDbRegistryCache:
+    def test_load_and_merge_with_empty_yaml(self, tmp_path):
+        root = tmp_path / "phi"
+        root.mkdir()
+        load_db_registry([_row("phi", root)])
+        merged = merged_registry({})
+        assert set(merged) == {"phi"}
+        assert merged["phi"].workspace_roots == (root.resolve(),)
+        assert merged["phi"].default_scope_for_new_facts == "project"
+        assert db_registry_creator("phi") == 123
+
+    def test_empty_db_returns_yaml_dict_unchanged(self, tmp_path):
+        """The pre-registration call sites must behave byte-
+        identically: with no DB rows the merge returns the exact
+        yaml dict object, not a copy."""
+        root = tmp_path / "kai"
+        root.mkdir()
+        yaml_projects = {"kai": _project("kai", root)}
+        assert merged_registry(yaml_projects) is yaml_projects
+
+    def test_yaml_wins_on_project_id(self, tmp_path):
+        yaml_root = tmp_path / "kai-yaml"
+        yaml_root.mkdir()
+        db_root = tmp_path / "kai-db"
+        db_root.mkdir()
+        load_db_registry([_row("kai", db_root)])
+        merged = merged_registry({"kai": _project("kai", yaml_root)})
+        assert merged["kai"].workspace_roots == (yaml_root.resolve(),)
+
+    def test_yaml_wins_on_root_ownership(self, tmp_path):
+        """A DB project whose root is already owned by a YAML project
+        is dropped entirely; a user registration can never steal an
+        operator-pinned root under a different id."""
+        root = tmp_path / "kai"
+        root.mkdir()
+        load_db_registry([_row("kai-imposter", root)])
+        merged = merged_registry({"kai": _project("kai", root)})
+        assert "kai-imposter" not in merged
+        assert set(merged) == {"kai"}
+
+    def test_upsert_and_remove_visible_immediately(self, tmp_path):
+        """Restart-free contract: cache mutations show up in the very
+        next merged_registry call."""
+        root = tmp_path / "anvil"
+        root.mkdir()
+        assert db_registry_upsert(_row("anvil", root, created_by=456)) is True
+        assert "anvil" in merged_registry({})
+        assert db_registry_creator("anvil") == 456
+        db_registry_remove("anvil")
+        assert merged_registry({}) == {}
+        assert db_registry_creator("anvil") is None
+
+    @pytest.mark.parametrize(
+        "bad_overrides",
+        [
+            {"project_id": ""},
+            {"project_id": None},
+            {"display_name": ""},
+            {"memory_enabled": "true"},
+            {"default_scope_for_new_facts": "task"},
+            {"workspace_root": ""},
+        ],
+    )
+    def test_malformed_rows_skipped_fail_closed(self, tmp_path, bad_overrides):
+        """Validation parity with the YAML loader: a row the loader
+        would have skipped never reaches detection, and never
+        crashes the load."""
+        root = tmp_path / "phi"
+        root.mkdir()
+        row = _row("phi", root)
+        row.update(bad_overrides)
+        load_db_registry([row])
+        assert merged_registry({}) == {}
+
+    def test_detection_through_merged_registry(self, tmp_path):
+        """End-to-end with the detector: a cached DB project is
+        detectable exactly like a YAML one."""
+        root = tmp_path / "phi"
+        root.mkdir()
+        sub = root / "src"
+        sub.mkdir()
+        load_db_registry([_row("phi", root)])
+        active = detect_active_memory_project(sub, merged_registry({}))
+        assert active is not None
+        assert active.project_id == "phi"
+        assert active.matched_root == root.resolve()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,5 +1,6 @@
 """Tests for sessions.py async database CRUD."""
 
+import sqlite3
 from pathlib import Path
 
 import aiosqlite
@@ -50,6 +51,75 @@ class TestSessions:
 
     async def test_get_stats_unknown(self, db):
         assert await sessions.get_stats(999) is None
+
+
+class TestMemoryProjectRows:
+    """Persistence layer for chat-registered memory projects. The
+    merge/validation logic lives in kai.memory_projects; these tests
+    pin the CRUD contract and the DB-level uniqueness backstops."""
+
+    async def test_register_and_list_roundtrip(self, db):
+        await sessions.register_memory_project(
+            project_id="phi",
+            display_name="Phi",
+            workspace_root="/work/phi",
+            created_by=123,
+        )
+        rows = await sessions.get_memory_project_rows()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["project_id"] == "phi"
+        assert row["display_name"] == "Phi"
+        assert row["workspace_root"] == "/work/phi"
+        assert row["memory_enabled"] is True
+        assert row["default_scope_for_new_facts"] == "project"
+        assert row["created_by"] == 123
+
+    async def test_unregister_returns_whether_row_existed(self, db):
+        await sessions.register_memory_project(
+            project_id="phi",
+            display_name="Phi",
+            workspace_root="/work/phi",
+            created_by=123,
+        )
+        assert await sessions.unregister_memory_project("phi") is True
+        assert await sessions.unregister_memory_project("phi") is False
+        assert await sessions.get_memory_project_rows() == []
+
+    async def test_duplicate_project_id_raises(self, db):
+        """PRIMARY KEY backstop for the registration race; the
+        handler checks the merged registry first, but two concurrent
+        registrations must not both land."""
+        await sessions.register_memory_project(
+            project_id="phi",
+            display_name="Phi",
+            workspace_root="/work/phi",
+            created_by=123,
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            await sessions.register_memory_project(
+                project_id="phi",
+                display_name="Phi Again",
+                workspace_root="/work/elsewhere",
+                created_by=456,
+            )
+
+    async def test_duplicate_root_raises(self, db):
+        """UNIQUE(workspace_root) backstop: the detector needs a
+        single owner per root."""
+        await sessions.register_memory_project(
+            project_id="phi",
+            display_name="Phi",
+            workspace_root="/work/phi",
+            created_by=123,
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            await sessions.register_memory_project(
+                project_id="phi2",
+                display_name="Phi Two",
+                workspace_root="/work/phi",
+                created_by=456,
+            )
 
 
 # ── Jobs ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **DB registry layer:** a `memory_projects` table in the session DB persists chat-registered projects (one root per row, UNIQUE root + PRIMARY KEY id as race backstops). An in-memory cache loads at startup and is mutated in lockstep by the handlers, so registrations are visible to detection on the next message with no restart.
- **Merged detection view:** `merged_registry()` layers user-registered projects under the operator-pinned YAML registry; YAML wins every conflict, on `project_id` and on workspace-root ownership, mirroring the YAML loader's own duplicate rules. With no DB rows it returns the YAML dict unchanged, keeping pre-registration call sites byte-identical. Both detection call sites (scoped retrieval, extraction write-routing) now consult the merged view. DB rows pass the same per-entry validation as YAML entries, fail-closed.
- **`/project` command:** `register [name]` (current workspace; slug-validated id; nested-root guard so a child registration cannot steal its parent's scope via longest-prefix detection), `unregister <name>` (registering user or admin; YAML-pinned entries immune), `list` (provenance plus active-project marker).
- **Auto-registration:** `/workspace new` registers the created directory as a project; creation is an explicit "starting a project here" signal, and registering at birth keeps the first exchanges from leaking global. Failure warns without blocking creation. Plain switches deliberately do not auto-register.
- Registry mutations emit a structured `memory.project.registry` log line.

## Testing

- Sessions: CRUD roundtrip, unregister existed/absent, duplicate-id and duplicate-root IntegrityError backstops.
- Registry cache: merge precedence on id and root, byte-identical empty-DB shortcut, restart-free upsert/remove visibility, malformed-row fail-closed parametrized over every validation rule, end-to-end detection through the merged view.
- Handlers: register (default and explicit name, casing split between id and display name), nested-root and duplicate-id and invalid-name rejections, unregister permission matrix (pinned/other-user/creator), list output, auto-register on `/workspace new` plus its failure-does-not-block contract.
- Full suite: 4044 passed, 1 skipped. `make check` clean.

Closes #660
