### PR TITLE
feat(memory): operator scope tools for /memory

### DIFF
--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -500,6 +500,22 @@ class MemoryStats:
     confidence_below_0_6: int = 0
     confirmation_quote_count: int = 0
     by_prompt_version: dict[str, int] = field(default_factory=dict)
+    # Scope distribution over USER-VISIBLE rows (extracted, episode,
+    # migration), unlike the extracted-only aggregates above: scope
+    # applies to every user-visible source, so restricting the
+    # distribution to extracted rows would hide mis-scoped episodes
+    # and understate the legacy-default backlog that reclassification
+    # needs to measure. Keys are stable bucket identifiers consumed
+    # by the /memory stats renderer:
+    #   "global"             - explicit valid global rows
+    #   "global_legacy"      - rows resolved global via legacy_default
+    #   "invalid"            - rows flagged invalid_defaulted by the
+    #                          resolver (corrupted scope or provenance)
+    #   "project:<id>"       - valid project rows, one bucket per id
+    #   "project_missing_id" - valid project rows with no project_id
+    #   "task"               - valid task rows
+    # Buckets are present only when non-zero.
+    by_scope: dict[str, int] = field(default_factory=dict)
 
 
 # ── Scoped retrieval helper data shapes ──────────────────────────────
@@ -3243,6 +3259,7 @@ def get_stats(*, user_id: str) -> MemoryStats:
     extracted: list[MemoryResult] = []
     episode_count = 0
     migration_count = 0
+    by_scope: dict[str, int] = {}
     for m in memories:
         src = m.metadata.get("source")
         if src == "extracted":
@@ -3251,6 +3268,28 @@ def get_stats(*, user_id: str) -> MemoryStats:
             episode_count += 1
         elif src == "migration":
             migration_count += 1
+        # Scope distribution covers every user-visible source, not
+        # just extracted: scope is a cross-source axis and the
+        # legacy-default bucket is the operator's running measure of
+        # reclassification debt. Legacy ""-source rows are excluded
+        # for the same reason they are invisible in the browse UI.
+        if src in USER_VISIBLE_SOURCES:
+            resolved = resolve_memory_scope(m.metadata)
+            if resolved.invalid_defaulted:
+                bucket = "invalid"
+            elif resolved.legacy_defaulted:
+                bucket = "global_legacy"
+            elif resolved.scope == SCOPE_PROJECT:
+                # Valid project rows missing an id get their own
+                # bucket rather than folding into "invalid": the
+                # resolver deliberately preserves them as project
+                # rows (it does not guess), and retrieval excludes
+                # them with a distinct admission reason, so the
+                # stats view keeps the same boundary visible.
+                bucket = f"project:{resolved.project_id}" if resolved.project_id else "project_missing_id"
+            else:
+                bucket = resolved.scope
+            by_scope[bucket] = by_scope.get(bucket, 0) + 1
 
     by_tag: dict[str, int] = {}
     by_prompt_version: dict[str, int] = {}
@@ -3331,4 +3370,5 @@ def get_stats(*, user_id: str) -> MemoryStats:
         confidence_below_0_6=confidence_below_0_6,
         confirmation_quote_count=confirmation_count,
         by_prompt_version=by_prompt_version,
+        by_scope=by_scope,
     )

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -52,6 +52,7 @@ enumeration.
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 from dataclasses import dataclass, field
@@ -62,13 +63,14 @@ from telegram.error import BadRequest
 from telegram.ext import ContextTypes
 
 from kai import memory
-from kai.config import ONESHOT_REASONER_BACKENDS, Config
-from kai.memory import MemoryResult, MemoryStats
+from kai.config import ONESHOT_REASONER_BACKENDS, Config, MemoryProjectConfig
+from kai.memory import MemoryResult, MemoryStats, ResolvedMemoryScope
+from kai.memory_projects import ActiveMemoryProject, detect_active_memory_project, merged_registry
 
 if TYPE_CHECKING:
     # Only used for type hints; importing at runtime would create a
     # cycle since bot.py imports this module.
-    pass
+    from kai.pool import SubprocessPool
 
 log = logging.getLogger(__name__)
 
@@ -121,6 +123,19 @@ class _ScreenCache:
     on dispatch. Storing the structured form (rather than a callback
     string) means the back-target representation can change without
     needing to reparse stale entries.
+
+    `scope_targets` backs the scope screen the same way `memory_ids`
+    backs the list views: each entry is a (kind, project_id) tuple
+    where kind is "global" (project_id None) or "project". The target
+    buttons carry only the integer index, so a long project id can
+    never push callback data over the Telegram 64-byte ceiling. A
+    project id stored here may also collide with no reserved word:
+    the tuple's kind discriminator is what distinguishes "move to
+    the project named 'global'" from "make global".
+
+    `scope_target` is the entry the user tapped, carried from the
+    scope screen to its confirm step so the apply verb needs no
+    callback arguments at all.
     """
 
     screen: str
@@ -128,6 +143,8 @@ class _ScreenCache:
     page: int = 0
     query: str | None = None
     return_to: tuple[str, list[str]] | None = None
+    scope_targets: list[tuple[str, str | None]] = field(default_factory=list)
+    scope_target: tuple[str, str | None] | None = None
     created_at: float = field(default_factory=time.monotonic)
 
 
@@ -340,6 +357,167 @@ def _browse_score(fact: MemoryResult) -> float:
     arithmetic does not require a parallel edit in the browse path.
     """
     return memory._speaker_weight(fact)
+
+
+# ── Scope helpers ───────────────────────────────────────────────────
+#
+# Row-level scope inspection and correction. Reads go through
+# `memory.resolve_memory_scope` so legacy and corrupted rows render
+# their read-time interpretation (the same one retrieval acts on)
+# rather than echoing raw metadata. The retrievability verdict reuses
+# `memory._scoped_memory_admission_reason` - the exact admission rule
+# scoped retrieval applies - so the detail view can never disagree
+# with what retrieval would actually do. Writes go through
+# `memory.build_scope_metadata` (validated shape, operator
+# provenance) merged over the row's existing metadata, because
+# `memory.update_metadata` replaces the metadata dict wholesale and
+# a partial dict would silently destroy every unlisted field.
+
+
+@dataclass(frozen=True)
+class _ScopeView:
+    """Pre-rendered scope strings for the detail and scope screens.
+
+    Built once per render by `_build_scope_view` and passed into the
+    pure builders, so the builders stay free of registry and
+    detection I/O.
+
+    Attributes:
+        resolved: The row's read-time scope interpretation; kept so
+            the scope screen can derive transition targets without
+            re-resolving.
+        scope_label: Operator-facing scope value, e.g. "global" or
+            "project 'kai'", with an unregistered-project or
+            missing-id marker when applicable.
+        source_label: Scope provenance with confidence, e.g.
+            "operator (confidence 1.00)". Values render raw
+            (legacy_default, extraction_default, ...) so the screen
+            greps against the same vocabulary the logs use.
+        retrievable_label: "yes", or "no (<admission reason>)" with
+            the stable exclusion-reason key retrieval logs carry.
+    """
+
+    resolved: ResolvedMemoryScope
+    scope_label: str
+    source_label: str
+    retrievable_label: str
+
+
+def _build_scope_view(
+    fact: MemoryResult,
+    registry: dict[str, MemoryProjectConfig],
+    active: ActiveMemoryProject | None,
+) -> _ScopeView:
+    """Resolve a row's scope into operator-facing display strings.
+
+    `registry` is the merged project registry (operator-pinned YAML
+    over chat-registered rows) and `active` is the project detected
+    for the caller's current workspace, or None. Both come from
+    `_scope_inputs`; tests can pass fixtures directly.
+
+    The allowed-project derivation mirrors scoped retrieval exactly:
+    project authority exists only when a project is detected AND has
+    memory enabled. Keeping the two predicates identical is what the
+    admission-parity guarantee rests on.
+    """
+    resolved = memory.resolve_memory_scope(fact.metadata)
+
+    # Scope label. Project rows render their id plus the registered
+    # display name when it differs; a project id that is no longer
+    # in the registry is flagged rather than hidden, because the row
+    # is still movable and the operator needs to see why it stopped
+    # being retrievable anywhere.
+    if resolved.scope == memory.SCOPE_PROJECT:
+        pid = resolved.project_id
+        if pid is None:
+            scope_label = "project (no project id)"
+        elif pid in registry:
+            display = registry[pid].display_name
+            scope_label = f"project '{pid}'" if display == pid else f"project '{pid}' ({display})"
+        else:
+            scope_label = f"project '{pid}' (not registered)"
+    else:
+        scope_label = resolved.scope
+
+    source_label = f"{resolved.scope_source} (confidence {resolved.scope_confidence:.2f})"
+
+    # Retrievability verdict: same allowed-project derivation and
+    # same admission rule as scoped retrieval. The two enriched
+    # arms add the context an operator cannot reconstruct from the
+    # bare reason key (which two projects mismatched; whether "not
+    # allowed" means no project here or a disabled one).
+    allowed = active.project_id if active is not None and active.memory_enabled else None
+    reason = memory._scoped_memory_admission_reason(resolved, allowed_project_id=allowed)
+    if reason is None:
+        retrievable_label = "yes"
+    elif reason == memory._ADMISSION_PROJECT_ID_MISMATCH:
+        retrievable_label = f"no ({reason}: row '{resolved.project_id}', here '{allowed}')"
+    elif reason == memory._ADMISSION_PROJECT_SCOPE_NOT_ALLOWED:
+        detail = "project memory disabled here" if active is not None else "no active project here"
+        retrievable_label = f"no ({reason}: {detail})"
+    else:
+        retrievable_label = f"no ({reason})"
+
+    return _ScopeView(
+        resolved=resolved,
+        scope_label=scope_label,
+        source_label=source_label,
+        retrievable_label=retrievable_label,
+    )
+
+
+def _scope_change_targets(
+    resolved: ResolvedMemoryScope,
+    registry: dict[str, MemoryProjectConfig],
+) -> list[tuple[str, str | None]]:
+    """Derive the scope transitions offered for a row.
+
+    Returns (kind, project_id) tuples in render order: the global
+    target first when offered, then project targets sorted by id for
+    deterministic keyboards.
+
+    Rules:
+    - "Make global" is offered unless the row is already explicitly
+      global with valid provenance. Legacy-default and invalid rows
+      DO get the global target even though they already resolve to
+      global: applying it stamps explicit operator provenance, which
+      converts an auditable-debt row into a deliberate assignment.
+    - Every registered project is a move target except the row's own
+      project - unless the row is invalid-flagged, where re-assigning
+      the same project is meaningful because it repairs the broken
+      provenance while keeping the assignment.
+    """
+    targets: list[tuple[str, str | None]] = []
+    already_explicit_global = (
+        resolved.scope == memory.SCOPE_GLOBAL and not resolved.legacy_defaulted and not resolved.invalid_defaulted
+    )
+    if not already_explicit_global:
+        targets.append(("global", None))
+    for pid in sorted(registry):
+        if pid == resolved.project_id and not resolved.invalid_defaulted:
+            continue
+        targets.append(("project", pid))
+    return targets
+
+
+def _scope_inputs(
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+) -> tuple[dict[str, MemoryProjectConfig], ActiveMemoryProject | None]:
+    """Fetch the merged registry and the caller's active project.
+
+    The workspace comes from the subprocess pool (the same per-user
+    workspace scoped retrieval sees on the next turn). A missing
+    pool collapses to no-workspace semantics: no path means no
+    project authority, the same global-only posture scoped retrieval
+    takes for a None workspace.
+    """
+    config: Config = context.bot_data["config"]
+    registry = merged_registry(config.memory_projects)
+    pool: SubprocessPool | None = context.bot_data.get("pool")
+    if pool is None:
+        return registry, None
+    return registry, detect_active_memory_project(pool.get_workspace(chat_id), registry)
 
 
 # ── Builder: dashboard ──────────────────────────────────────────────
@@ -666,6 +844,7 @@ def _build_facts_list_view(
 def _build_fact_view(
     fact: MemoryResult,
     return_to: tuple[str, list[str]] | None,
+    scope_view: _ScopeView | None = None,
 ) -> tuple[str, InlineKeyboardMarkup]:
     """Render the fact detail screen (spec §6.3).
 
@@ -693,7 +872,15 @@ def _build_fact_view(
     `return_to` encodes where the back button should land. It can be
     None for callers (e.g., tests) that don't care; in that case the
     back button defaults to the dashboard. The keyboard is the same
-    (back / forget) across all three sources.
+    (back / scope / forget) across all three sources.
+
+    `scope_view` carries the pre-rendered scope block (scope value,
+    provenance, retrievability verdict). Every production caller
+    passes it; None omits the block so direct builder callers that
+    are not exercising scope rendering need no registry fixture.
+    All three source arms render the same three scope rows because
+    scope is a cross-source axis - an episode is just as capable of
+    being mis-scoped as a fact.
     """
     md = fact.metadata or {}
     tags = md.get("tags") or []
@@ -787,6 +974,14 @@ def _build_fact_view(
         if confidence_line is not None:
             footer_lines.append(confidence_line)
         footer_lines.append(f"Date:  {_format_date(fact.created_at, with_time=True)}")
+        # Scope block trails the Date row so the existing tail
+        # convention (date last among the legacy fields) stays
+        # recognizable while the three scope rows read as one
+        # appended unit.
+        if scope_view is not None:
+            footer_lines.append(f"Scope:  {scope_view.scope_label}")
+            footer_lines.append(f"Scope source:  {scope_view.source_label}")
+            footer_lines.append(f"Retrievable here:  {scope_view.retrievable_label}")
         lines = [
             header,
             "",
@@ -822,6 +1017,16 @@ def _build_fact_view(
         # without re-validating.
         confirmation_line = confirmation if confirmation else "n/a"
 
+        # Scope block sits with the other classification rows (after
+        # the extractor provenance, before the Confirmation block)
+        # using the same 18-column label alignment as the rows above.
+        scope_rows: list[str] = []
+        if scope_view is not None:
+            scope_rows = [
+                f"Scope:            {scope_view.scope_label}",
+                f"Scope source:     {scope_view.source_label}",
+                f"Retrievable here: {scope_view.retrievable_label}",
+            ]
         lines = [
             "Fact",
             "",
@@ -833,6 +1038,7 @@ def _build_fact_view(
             f"Date:             {_format_date(fact.created_at, with_time=True)}",
             f"Session:          {session_id or '(none)'}",
             f"Prompt version:   {prompt_version or '(none)'}",
+            *scope_rows,
             "",
             f"Confirmation:     {confirmation_line}",
         ]
@@ -843,6 +1049,7 @@ def _build_fact_view(
         [
             [
                 InlineKeyboardButton("back", callback_data=back_callback),
+                InlineKeyboardButton("scope", callback_data=_encode_callback("scp")),
                 InlineKeyboardButton("forget", callback_data=_encode_callback("ffc")),
             ]
         ]
@@ -870,14 +1077,108 @@ def _build_forget_fact_confirm(fact: MemoryResult) -> tuple[str, InlineKeyboardM
     deploy transition could in principle slip a different source
     through).
     """
-    source = (fact.metadata or {}).get("source", "")
-    label = {"extracted": "fact", "episode": "episode", "migration": "fact"}.get(source, "memory")
+    label = _source_noun(fact)
     text = f'Forget this {label}?\n\n"{fact.text}"\n\nThis cannot be undone.'
     kb = InlineKeyboardMarkup(
         [
             [
                 InlineKeyboardButton("confirm forget", callback_data=_encode_callback("ffd")),
                 InlineKeyboardButton("cancel", callback_data=_encode_callback("fview")),
+            ]
+        ]
+    )
+    return text, kb
+
+
+def _source_noun(fact: MemoryResult) -> str:
+    """Operator-facing noun for a row, keyed on `metadata.source`.
+
+    Extracted and migration share "fact" because the UI does not
+    surface that distinction; the generic "memory" fallback covers
+    an unknown source slipping through a stale cache during a deploy
+    transition (same defensive posture as the forget flow).
+    """
+    source = (fact.metadata or {}).get("source", "")
+    return {"extracted": "fact", "episode": "episode", "migration": "fact"}.get(source, "memory")
+
+
+# ── Builder: scope screen and confirm ───────────────────────────────
+
+
+def _build_scope_screen(
+    fact: MemoryResult,
+    scope_view: _ScopeView,
+    targets: list[tuple[str, str | None]],
+) -> tuple[str, InlineKeyboardMarkup]:
+    """Render the scope screen: current assignment plus transitions.
+
+    The body repeats the detail view's scope block (in the two-space
+    label style) above the transition prompt so the operator decides
+    with the current assignment in front of them, not from memory of
+    the previous screen.
+
+    Keyboard shape: one target button per row. Project ids are
+    operator-chosen and can be long; packing several per row would
+    truncate labels on a phone, and the target count is bounded by
+    the registry size, which is small by construction. The nav row
+    holds a single back button to the fact view.
+
+    Targets render by cache index (`sct:<idx>`), never by id, for
+    the same 64-byte-ceiling reason the list views use indexed
+    `fact` callbacks.
+    """
+    lines = [
+        "Scope",
+        "",
+        f'"{fact.text}"',
+        "",
+        f"Scope:  {scope_view.scope_label}",
+        f"Scope source:  {scope_view.source_label}",
+        f"Retrievable here:  {scope_view.retrievable_label}",
+        "",
+    ]
+    if targets:
+        lines.append("Choose a new scope:")
+    else:
+        # Reachable when the row is explicitly global and no projects
+        # are registered: nothing to move to, nothing to re-stamp.
+        lines.append("No scope changes available (no registered projects).")
+    text = "\n".join(lines)
+
+    rows: list[list[InlineKeyboardButton]] = []
+    for idx, (kind, pid) in enumerate(targets):
+        label = "Make global" if kind == "global" else f"Move to '{pid}'"
+        rows.append([InlineKeyboardButton(label, callback_data=_encode_callback("sct", str(idx)))])
+    rows.append([InlineKeyboardButton("back", callback_data=_encode_callback("fview"))])
+    return text, InlineKeyboardMarkup(rows)
+
+
+def _build_scope_confirm(
+    fact: MemoryResult,
+    target: tuple[str, str | None],
+) -> tuple[str, InlineKeyboardMarkup]:
+    """Render the scope-change confirmation.
+
+    Mirrors the forget confirmation's shape (question, quoted row
+    text, confirm/cancel row) but drops the irreversibility warning:
+    a scope change can be reversed by moving the row back. The
+    confirm step exists anyway because the prior assignment is not
+    visible after the change lands - a fat-fingered tap would leave
+    the operator unsure what the row's scope used to be.
+
+    Cancel returns to the scope screen (the screen the tap came
+    from), matching the forget flow's own convention of cancelling
+    back one step rather than to a fixed screen.
+    """
+    kind, pid = target
+    noun = _source_noun(fact)
+    question = f"Make this {noun} global?" if kind == "global" else f"Move this {noun} to project '{pid}'?"
+    text = f'{question}\n\n"{fact.text}"'
+    kb = InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("confirm", callback_data=_encode_callback("scd")),
+                InlineKeyboardButton("cancel", callback_data=_encode_callback("scp")),
             ]
         ]
     )
@@ -929,6 +1230,53 @@ def _build_search_results(
 # ── Builder: stats (spec §6.6) ──────────────────────────────────────
 
 
+# Display labels and render order for the fixed (non-project) scope
+# buckets emitted by `memory.get_stats`. Projects render between
+# global_legacy and task, sorted by count descending with id as the
+# tiebreaker, matching the prompt-version table's determinism rule.
+_SCOPE_BUCKET_ORDER: list[tuple[str, str]] = [
+    ("global", "global"),
+    ("global_legacy", "global (legacy)"),
+    ("task", "task"),
+    ("project_missing_id", "project (no project id)"),
+    ("invalid", "invalid"),
+]
+
+
+def _scope_distribution_lines(by_scope: dict[str, int]) -> list[str]:
+    """Format the scope-distribution rows for the stats screen.
+
+    Fixed buckets keep a stable position so repeated /memory stats
+    reads scan the same way; project buckets (keys prefixed
+    `project:`) slot in after the two global rows. Only non-zero
+    buckets appear because `get_stats` never emits zero counts.
+    """
+    project_items = sorted(
+        ((key.removeprefix("project:"), count) for key, count in by_scope.items() if key.startswith("project:")),
+        key=lambda item: (-item[1], item[0]),
+    )
+    rows: list[tuple[str, int]] = []
+    for key, label in _SCOPE_BUCKET_ORDER[:2]:
+        if key in by_scope:
+            rows.append((label, by_scope[key]))
+    rows.extend((f"project '{pid}'", count) for pid, count in project_items)
+    for key, label in _SCOPE_BUCKET_ORDER[2:]:
+        if key in by_scope:
+            rows.append((label, by_scope[key]))
+
+    # Any bucket key this renderer does not recognize renders raw at
+    # the end rather than silently vanishing: a distribution that
+    # hides rows misrepresents the corpus, and the raw key is enough
+    # signal that the renderer and the aggregator have drifted.
+    known = {key for key, _ in _SCOPE_BUCKET_ORDER}
+    rows.extend(
+        (key, count) for key, count in sorted(by_scope.items()) if key not in known and not key.startswith("project:")
+    )
+
+    width = max(len(label) for label, _ in rows)
+    return [f"  {label.ljust(width)}  {count:>3}" for label, count in rows]
+
+
 def _build_stats(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup]:
     """Render the read-only stats dashboard.
 
@@ -963,6 +1311,17 @@ def _build_stats(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup]:
         lines.append(f"Total facts:      {total_facts}")
     if stats.episode_count:
         lines.append(f"Total episodes:   {stats.episode_count}")
+
+    # Scope distribution over all user-visible rows. Sits right after
+    # the headline because (unlike the extracted-only sections below)
+    # it spans every user-visible source. The global_legacy row is
+    # the operator's running measure of reclassification debt - rows
+    # that retrieval treats as global only because nothing has
+    # classified them yet.
+    if stats.by_scope:
+        lines.append("")
+        lines.append("Scope:")
+        lines.extend(_scope_distribution_lines(stats.by_scope))
 
     # The three extracted-shaped sections below all read extractor-only
     # metadata (confidence, confirmation_quote, prompt_version). For
@@ -1109,7 +1468,14 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
       stats             - re-render stats
       ffc               - forget single fact confirm
       ffd               - forget single fact: do delete
-      fview             - cancel forget; return to fact view (same id)
+      fview             - return to fact view (same id); cancel target
+                          of the forget confirm, back target of the
+                          scope screen
+      scp               - scope screen for the cached fact; cancel
+                          target of the scope confirm
+      sct <idx>         - scope target tapped (resolved against
+                          cache.scope_targets); renders confirm
+      scd               - scope change confirmed: apply
     """
     # PTB CallbackQueryHandler guarantees both callback_query and
     # query.data are present, but `python -O` strips asserts; use
@@ -1274,6 +1640,53 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
             else:
                 await _send_dashboard(update, context, chat_id, edit=True)
             await query.answer("Forgotten." if ok else "Not found.")
+            return
+        if verb == "scp":
+            # Scope screen for the fact in cache. Reached from the
+            # fact view's scope button and from the confirm screen's
+            # cancel button; both leave the fact id at memory_ids[0].
+            cache = _get_cache(chat_id)
+            if cache is None or not cache.memory_ids:
+                await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
+                return
+            await _send_scope_screen(update, context, chat_id, cache.memory_ids[0])
+            await query.answer()
+            return
+        if verb == "sct":
+            # Scope target tapped. The integer arg indexes
+            # cache.scope_targets (set by _send_scope_screen); any
+            # decode or range failure routes through the standard
+            # session-expired fallback like the fact verb does.
+            cache = _get_cache(chat_id)
+            if cache is None or not cache.memory_ids or not args:
+                await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
+                return
+            try:
+                idx = int(args[0])
+            except ValueError:
+                await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
+                return
+            if idx < 0 or idx >= len(cache.scope_targets):
+                await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
+                return
+            await _send_scope_confirm(update, context, chat_id, cache.memory_ids[0], cache.scope_targets[idx])
+            await query.answer()
+            return
+        if verb == "scd":
+            # Scope change confirmed. The selected target rode the
+            # cache from the confirm screen, so the callback carries
+            # no arguments to validate.
+            cache = _get_cache(chat_id)
+            if cache is None or not cache.memory_ids or cache.scope_target is None:
+                await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
+                return
+            answer = await _apply_scope_change(update, context, chat_id, cache.memory_ids[0], cache.scope_target)
+            await query.answer(answer)
             return
     except Exception as exc:
         # Spec §8: never let a Mem0 exception surface as a stack trace.
@@ -1459,7 +1872,9 @@ async def _send_fact_view(
         # non-extracted source, Mem0 fetch error).
         await _send_or_edit(update, "This memory no longer exists.", None, edit=True)
         return
-    text, kb = _build_fact_view(fact, return_to)
+    registry, active = _scope_inputs(context, chat_id)
+    scope_view = _build_scope_view(fact, registry, active)
+    text, kb = _build_fact_view(fact, return_to, scope_view)
     # Cache holds only this fact's id so the forget flow knows what to
     # delete without re-encoding the id into callback data.
     _set_cache(
@@ -1502,6 +1917,151 @@ async def _send_forget_fact_confirm(
         ),
     )
     await _send_or_edit(update, text, kb, edit=True)
+
+
+async def _send_scope_screen(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    memory_id: str,
+) -> None:
+    """Render the scope screen for a fact.
+
+    Re-fetches the row and re-derives the targets on every render
+    (including the cancel path back from the confirm screen), so the
+    screen always reflects the registry and the row as they are now,
+    not as they were when the fact view was first opened.
+    """
+    fact = memory.get_by_id(user_id=str(chat_id), memory_id=memory_id)
+    if fact is None:
+        await _send_or_edit(update, "This memory no longer exists.", None, edit=True)
+        return
+    registry, active = _scope_inputs(context, chat_id)
+    scope_view = _build_scope_view(fact, registry, active)
+    targets = _scope_change_targets(scope_view.resolved, registry)
+    text, kb = _build_scope_screen(fact, scope_view, targets)
+    # Preserve return_to so the eventual back-nav from the fact view
+    # still lands on the originating list screen after a round trip
+    # through the scope flow.
+    cache = _get_cache(chat_id)
+    return_to = cache.return_to if cache is not None else None
+    _set_cache(
+        chat_id,
+        _ScreenCache(
+            screen="scope",
+            memory_ids=[memory_id],
+            return_to=return_to,
+            scope_targets=targets,
+        ),
+    )
+    await _send_or_edit(update, text, kb, edit=True)
+
+
+async def _send_scope_confirm(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    memory_id: str,
+    target: tuple[str, str | None],
+) -> None:
+    """Render the scope-change confirmation for a tapped target.
+
+    The selected target moves into `cache.scope_target` so the apply
+    verb (`scd`) needs no callback arguments. `scope_targets` is NOT
+    carried forward: the confirm screen has no target buttons, so an
+    empty list is the honest cache state, and a stale `sct` tap from
+    an older message in chat history falls into the standard
+    session-expired path instead of resolving against a list the
+    user is no longer looking at.
+    """
+    fact = memory.get_by_id(user_id=str(chat_id), memory_id=memory_id)
+    if fact is None:
+        await _send_or_edit(update, "This memory no longer exists.", None, edit=True)
+        return
+    text, kb = _build_scope_confirm(fact, target)
+    cache = _get_cache(chat_id)
+    return_to = cache.return_to if cache is not None else None
+    _set_cache(
+        chat_id,
+        _ScreenCache(
+            screen="scope_confirm",
+            memory_ids=[memory_id],
+            return_to=return_to,
+            scope_target=target,
+        ),
+    )
+    await _send_or_edit(update, text, kb, edit=True)
+
+
+async def _apply_scope_change(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    memory_id: str,
+    target: tuple[str, str | None],
+) -> str:
+    """Apply a confirmed scope change and re-render the fact view.
+
+    Returns the toast string for the callback answer (the caller
+    answers after this helper's sends complete, preserving the
+    answer-after-send pattern).
+
+    Write shape: the row's existing metadata is copied and the five
+    scope keys are overlaid from `build_scope_metadata`, because
+    `memory.update_metadata` REPLACES the metadata dict wholesale -
+    passing only the scope keys would destroy tags, confidence,
+    episode fields, and every other stored field. Operator moves
+    carry `scope_source="operator"`, full confidence, and no
+    `workspace_root`: that field records write-time workspace
+    provenance, which a retarget from chat does not have.
+    """
+    fact = memory.get_by_id(user_id=str(chat_id), memory_id=memory_id)
+    if fact is None:
+        await _send_or_edit(update, "This memory no longer exists.", None, edit=True)
+        return "Not found."
+    old = memory.resolve_memory_scope(fact.metadata)
+    kind, pid = target
+    scope_md = memory.build_scope_metadata(
+        scope=memory.SCOPE_GLOBAL if kind == "global" else memory.SCOPE_PROJECT,
+        project_id=pid,
+        scope_confidence=1.0,
+        scope_source=memory.SCOPE_SOURCE_OPERATOR,
+    )
+    merged = dict(fact.metadata or {})
+    merged.update(scope_md)
+    ok = memory.update_metadata(
+        user_id=str(chat_id),
+        memory_id=memory_id,
+        data=fact.text,
+        metadata=merged,
+    )
+    if ok:
+        # Structured audit line, one per applied change. The before
+        # values come from the resolver (not raw metadata) so legacy
+        # rows log the same global-interpretation retrieval acted on;
+        # scope_source after an operator move is always "operator",
+        # so only the before value is recorded.
+        log.info(
+            "memory.scope_change %s",
+            json.dumps(
+                {
+                    "memory_id": memory_id,
+                    "chat_id": chat_id,
+                    "from_scope": old.scope,
+                    "from_project_id": old.project_id,
+                    "from_scope_source": old.scope_source,
+                    "to_scope": scope_md["scope"],
+                    "to_project_id": scope_md["project_id"],
+                },
+                separators=(",", ":"),
+            ),
+        )
+    # Re-render the fact view either way: on success it shows the new
+    # scope block; on failure it re-fetches and shows whatever state
+    # the row is actually in (including "no longer exists" if the row
+    # vanished mid-flow).
+    await _send_fact_view(update, context, chat_id, memory_id)
+    return "Scope updated." if ok else "Update failed."
 
 
 async def _send_search(

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -367,7 +367,13 @@ def _browse_score(fact: MemoryResult) -> float:
 # rather than echoing raw metadata. The retrievability verdict reuses
 # `memory._scoped_memory_admission_reason` - the exact admission rule
 # scoped retrieval applies - so the detail view can never disagree
-# with what retrieval would actually do. Writes go through
+# with what scoped retrieval would do. The verdict is also honest
+# about the cutover state: while the scoped-recall knob is off, the
+# live prompt path is legacy recall, which applies NO scope admission
+# before rendering rows into the injected memory block, so a scoped
+# yes/no would be false for the system actually serving prompts. In
+# that state the verdict renders a "scope not enforced" label instead
+# of a prediction only scoped mode would honor. Writes go through
 # `memory.build_scope_metadata` (validated shape, operator
 # provenance) merged over the row's existing metadata, because
 # `memory.update_metadata` replaces the metadata dict wholesale and
@@ -395,6 +401,10 @@ class _ScopeView:
             greps against the same vocabulary the logs use.
         retrievable_label: "yes", or "no (<admission reason>)" with
             the stable exclusion-reason key retrieval logs carry.
+            While scoped recall is disabled, a constant
+            "yes (scope not enforced: scoped recall disabled)"
+            because legacy recall serves prompts without scope
+            admission and every user-visible row stays eligible.
     """
 
     resolved: ResolvedMemoryScope
@@ -407,6 +417,8 @@ def _build_scope_view(
     fact: MemoryResult,
     registry: dict[str, MemoryProjectConfig],
     active: ActiveMemoryProject | None,
+    *,
+    scoped_recall_enabled: bool,
 ) -> _ScopeView:
     """Resolve a row's scope into operator-facing display strings.
 
@@ -414,6 +426,15 @@ def _build_scope_view(
     over chat-registered rows) and `active` is the project detected
     for the caller's current workspace, or None. Both come from
     `_scope_inputs`; tests can pass fixtures directly.
+
+    `scoped_recall_enabled` is the live cutover-knob state; production
+    callers pass `memory.is_scoped_recall_enabled()`. It is required
+    (no default) because the retrievability verdict is only truthful
+    relative to the branch actually serving prompts: scoped admission
+    when the knob is on, no scope filtering at all when it is off. A
+    defaulted value here would let a future caller silently render
+    scoped predictions while legacy recall still injects wrong-scope
+    rows.
 
     The allowed-project derivation mirrors scoped retrieval exactly:
     project authority exists only when a project is detected AND has
@@ -441,22 +462,31 @@ def _build_scope_view(
 
     source_label = f"{resolved.scope_source} (confidence {resolved.scope_confidence:.2f})"
 
-    # Retrievability verdict: same allowed-project derivation and
-    # same admission rule as scoped retrieval. The two enriched
-    # arms add the context an operator cannot reconstruct from the
-    # bare reason key (which two projects mismatched; whether "not
-    # allowed" means no project here or a disabled one).
-    allowed = active.project_id if active is not None and active.memory_enabled else None
-    reason = memory._scoped_memory_admission_reason(resolved, allowed_project_id=allowed)
-    if reason is None:
-        retrievable_label = "yes"
-    elif reason == memory._ADMISSION_PROJECT_ID_MISMATCH:
-        retrievable_label = f"no ({reason}: row '{resolved.project_id}', here '{allowed}')"
-    elif reason == memory._ADMISSION_PROJECT_SCOPE_NOT_ALLOWED:
-        detail = "project memory disabled here" if active is not None else "no active project here"
-        retrievable_label = f"no ({reason}: {detail})"
+    # Retrievability verdict. With the knob off, the live prompt path
+    # is legacy recall, which never consults scope, so every
+    # user-visible row stays eligible regardless of its assignment;
+    # rendering the scoped yes/no in that state would tell the
+    # operator a wrong-scope row cannot reach the prompt while legacy
+    # recall can still inject it. With the knob on: same
+    # allowed-project derivation and same admission rule as scoped
+    # retrieval. The two enriched arms add the context an operator
+    # cannot reconstruct from the bare reason key (which two projects
+    # mismatched; whether "not allowed" means no project here or a
+    # disabled one).
+    if not scoped_recall_enabled:
+        retrievable_label = "yes (scope not enforced: scoped recall disabled)"
     else:
-        retrievable_label = f"no ({reason})"
+        allowed = active.project_id if active is not None and active.memory_enabled else None
+        reason = memory._scoped_memory_admission_reason(resolved, allowed_project_id=allowed)
+        if reason is None:
+            retrievable_label = "yes"
+        elif reason == memory._ADMISSION_PROJECT_ID_MISMATCH:
+            retrievable_label = f"no ({reason}: row '{resolved.project_id}', here '{allowed}')"
+        elif reason == memory._ADMISSION_PROJECT_SCOPE_NOT_ALLOWED:
+            detail = "project memory disabled here" if active is not None else "no active project here"
+            retrievable_label = f"no ({reason}: {detail})"
+        else:
+            retrievable_label = f"no ({reason})"
 
     return _ScopeView(
         resolved=resolved,
@@ -1873,7 +1903,7 @@ async def _send_fact_view(
         await _send_or_edit(update, "This memory no longer exists.", None, edit=True)
         return
     registry, active = _scope_inputs(context, chat_id)
-    scope_view = _build_scope_view(fact, registry, active)
+    scope_view = _build_scope_view(fact, registry, active, scoped_recall_enabled=memory.is_scoped_recall_enabled())
     text, kb = _build_fact_view(fact, return_to, scope_view)
     # Cache holds only this fact's id so the forget flow knows what to
     # delete without re-encoding the id into callback data.
@@ -1937,7 +1967,7 @@ async def _send_scope_screen(
         await _send_or_edit(update, "This memory no longer exists.", None, edit=True)
         return
     registry, active = _scope_inputs(context, chat_id)
-    scope_view = _build_scope_view(fact, registry, active)
+    scope_view = _build_scope_view(fact, registry, active, scoped_recall_enabled=memory.is_scoped_recall_enabled())
     targets = _scope_change_targets(scope_view.resolved, registry)
     text, kb = _build_scope_screen(fact, scope_view, targets)
     # Preserve return_to so the eventual back-nav from the fact view

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -6238,3 +6238,75 @@ class TestFormatScopedContextWithRecallPayload:
 
         assert result.rendered_context == ""
         assert result.recall_payload["reason"] == "disabled"
+
+
+class TestGetStatsScopeDistribution:
+    """`MemoryStats.by_scope` buckets resolved scope over user-visible
+    rows. Resolution goes through `resolve_memory_scope`, so legacy and
+    corrupted rows land in their audit buckets instead of echoing raw
+    metadata."""
+
+    def _stats_with(self, rows):
+        """Helper: install a mock returning `rows` and call get_stats."""
+        import kai.memory as mem_mod
+        from kai.memory import get_stats
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.return_value = {"results": rows}
+        mem_mod._memory = mock_mem
+        return get_stats(user_id="123")
+
+    @staticmethod
+    def _row(rid: str, source: str, scope_md: dict | None = None) -> dict:
+        metadata: dict = {"type": "fact", "source": source}
+        if scope_md is not None:
+            metadata.update(scope_md)
+        return {"id": rid, "memory": f"row {rid}", "score": 0.0, "metadata": metadata, "created_at": ""}
+
+    def test_buckets_cover_all_resolver_arms(self):
+        stats = self._stats_with(
+            [
+                # Legacy: no scope key at all.
+                self._row("1", "extracted"),
+                # Explicit valid global.
+                self._row("2", "extracted", {"scope": "global", "scope_source": "extraction_default"}),
+                # Valid project rows, two for kai and one for anvil.
+                self._row("3", "extracted", {"scope": "project", "project_id": "kai", "scope_source": "classifier"}),
+                self._row("4", "episode", {"scope": "project", "project_id": "kai", "scope_source": "operator"}),
+                self._row("5", "extracted", {"scope": "project", "project_id": "anvil", "scope_source": "operator"}),
+                # Corrupted scope value.
+                self._row("6", "migration", {"scope": "bogus"}),
+                # Valid project scope but provenance missing: invalid arm.
+                self._row("7", "extracted", {"scope": "project", "project_id": "kai"}),
+                # Valid project scope, valid provenance, no id.
+                self._row("8", "extracted", {"scope": "project", "scope_source": "operator"}),
+                # Valid task row.
+                self._row("9", "extracted", {"scope": "task", "scope_source": "extraction_default"}),
+            ]
+        )
+        assert stats.by_scope == {
+            "global_legacy": 1,
+            "global": 1,
+            "project:kai": 2,
+            "project:anvil": 1,
+            "invalid": 2,
+            "project_missing_id": 1,
+            "task": 1,
+        }
+
+    def test_non_user_visible_rows_are_excluded(self):
+        stats = self._stats_with(
+            [
+                # Track 1 / legacy "" sources never reach the
+                # distribution, matching their invisibility in the
+                # browse UI.
+                self._row("1", "user_raw", {"scope": "global", "scope_source": "extraction_default"}),
+                {"id": "2", "memory": "no source", "score": 0.0, "metadata": {"type": "exchange"}, "created_at": ""},
+                self._row("3", "extracted"),
+            ]
+        )
+        assert stats.by_scope == {"global_legacy": 1}
+
+    def test_empty_corpus_yields_empty_distribution(self):
+        stats = self._stats_with([])
+        assert stats.by_scope == {}

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -2987,20 +2987,20 @@ class TestBuildScopeView:
     """Rendering of the resolver arms into operator-facing labels."""
 
     def test_explicit_global(self):
-        view = memory_command._build_scope_view(_scoped_fact("global"), {}, None)
+        view = memory_command._build_scope_view(_scoped_fact("global"), {}, None, scoped_recall_enabled=True)
         assert view.scope_label == "global"
         assert view.source_label == "extraction_default (confidence 1.00)"
         assert view.retrievable_label == "yes"
 
     def test_legacy_row_defaults_global_with_legacy_source(self):
-        view = memory_command._build_scope_view(_scoped_fact(None), {}, None)
+        view = memory_command._build_scope_view(_scoped_fact(None), {}, None, scoped_recall_enabled=True)
         assert view.scope_label == "global"
         assert view.resolved.legacy_defaulted is True
         assert "legacy_default" in view.source_label
         assert view.retrievable_label == "yes"
 
     def test_invalid_scope_value_renders_invalid_source(self):
-        view = memory_command._build_scope_view(_scoped_fact("bogus"), {}, None)
+        view = memory_command._build_scope_view(_scoped_fact("bogus"), {}, None, scoped_recall_enabled=True)
         assert view.scope_label == "global"
         assert view.resolved.invalid_defaulted is True
         assert "invalid_default" in view.source_label
@@ -3008,19 +3008,19 @@ class TestBuildScopeView:
     def test_project_row_registered_same_display(self):
         registry = {"kai": _project_cfg("kai")}
         fact = _scoped_fact("project", project_id="kai", scope_source="classifier", scope_confidence=0.8)
-        view = memory_command._build_scope_view(fact, registry, None)
+        view = memory_command._build_scope_view(fact, registry, None, scoped_recall_enabled=True)
         assert view.scope_label == "project 'kai'"
         assert view.source_label == "classifier (confidence 0.80)"
 
     def test_project_row_registered_distinct_display(self):
         registry = {"kai": _project_cfg("kai", display="Kai Assistant")}
         fact = _scoped_fact("project", project_id="kai", scope_source="operator")
-        view = memory_command._build_scope_view(fact, registry, None)
+        view = memory_command._build_scope_view(fact, registry, None, scoped_recall_enabled=True)
         assert view.scope_label == "project 'kai' (Kai Assistant)"
 
     def test_project_row_unregistered_is_flagged(self):
         fact = _scoped_fact("project", project_id="ghost", scope_source="operator")
-        view = memory_command._build_scope_view(fact, {}, None)
+        view = memory_command._build_scope_view(fact, {}, None, scoped_recall_enabled=True)
         assert view.scope_label == "project 'ghost' (not registered)"
 
     def test_project_row_missing_id(self):
@@ -3028,20 +3028,22 @@ class TestBuildScopeView:
         # verdict reaches the missing-id arm instead of stopping at
         # project_scope_not_allowed.
         fact = _scoped_fact("project", project_id=None, scope_source="operator")
-        view = memory_command._build_scope_view(fact, {}, _active_project("kai"))
+        view = memory_command._build_scope_view(fact, {}, _active_project("kai"), scoped_recall_enabled=True)
         assert view.scope_label == "project (no project id)"
         assert "project_scope_missing_project_id" in view.retrievable_label
 
     def test_task_row(self):
         fact = _scoped_fact("task", scope_source="extraction_default")
-        view = memory_command._build_scope_view(fact, {}, None)
+        view = memory_command._build_scope_view(fact, {}, None, scoped_recall_enabled=True)
         assert view.scope_label == "task"
         assert "task_scope_not_supported" in view.retrievable_label
 
 
 class TestScopeViewAdmissionParity:
-    """The retrievability verdict must match scoped retrieval's own
-    admission rule under the same allowed-project derivation."""
+    """With scoped recall enabled, the retrievability verdict must
+    match scoped retrieval's own admission rule under the same
+    allowed-project derivation. (Knob-off behavior is pinned in
+    TestScopeViewCutoverKnob.)"""
 
     @pytest.mark.parametrize(
         "fact,active",
@@ -3060,7 +3062,7 @@ class TestScopeViewAdmissionParity:
         ],
     )
     def test_verdict_matches_admission_reason(self, fact, active):
-        view = memory_command._build_scope_view(fact, {}, active)
+        view = memory_command._build_scope_view(fact, {}, active, scoped_recall_enabled=True)
         allowed = active.project_id if active is not None and active.memory_enabled else None
         reason = memory._scoped_memory_admission_reason(
             memory.resolve_memory_scope(fact.metadata),
@@ -3074,14 +3076,16 @@ class TestScopeViewAdmissionParity:
 
     def test_mismatch_names_both_projects(self):
         fact = _scoped_fact("project", project_id="anvil", scope_source="operator")
-        view = memory_command._build_scope_view(fact, {}, _active_project("kai"))
+        view = memory_command._build_scope_view(fact, {}, _active_project("kai"), scoped_recall_enabled=True)
         assert "row 'anvil'" in view.retrievable_label
         assert "here 'kai'" in view.retrievable_label
 
     def test_disabled_project_distinguished_from_no_project(self):
         fact = _scoped_fact("project", project_id="kai", scope_source="operator")
-        disabled = memory_command._build_scope_view(fact, {}, _active_project("kai", enabled=False))
-        nowhere = memory_command._build_scope_view(fact, {}, None)
+        disabled = memory_command._build_scope_view(
+            fact, {}, _active_project("kai", enabled=False), scoped_recall_enabled=True
+        )
+        nowhere = memory_command._build_scope_view(fact, {}, None, scoped_recall_enabled=True)
         assert "project memory disabled here" in disabled.retrievable_label
         assert "no active project here" in nowhere.retrievable_label
 
@@ -3122,7 +3126,7 @@ class TestBuildScopeScreen:
     def test_renders_scope_block_and_targets(self):
         registry = {"kai": _project_cfg("kai")}
         fact = _scoped_fact(None)
-        view = memory_command._build_scope_view(fact, registry, None)
+        view = memory_command._build_scope_view(fact, registry, None, scoped_recall_enabled=True)
         targets = memory_command._scope_change_targets(view.resolved, registry)
         text, kb = memory_command._build_scope_screen(fact, view, targets)
         assert '"Scoped fact text."' in text
@@ -3138,7 +3142,7 @@ class TestBuildScopeScreen:
 
     def test_no_targets_renders_empty_message(self):
         fact = _scoped_fact("global")
-        view = memory_command._build_scope_view(fact, {}, None)
+        view = memory_command._build_scope_view(fact, {}, None, scoped_recall_enabled=True)
         text, kb = memory_command._build_scope_screen(fact, view, [])
         assert "No scope changes available" in text
         assert [row[0].text for row in kb.inline_keyboard] == ["back"]
@@ -3171,7 +3175,9 @@ class TestBuildScopeConfirm:
 class TestFactViewScopeBlock:
     def test_extracted_arm_renders_aligned_scope_rows(self):
         fact = _scoped_fact("project", project_id="kai", scope_source="classifier", scope_confidence=0.7)
-        view = memory_command._build_scope_view(fact, {"kai": _project_cfg("kai")}, _active_project("kai"))
+        view = memory_command._build_scope_view(
+            fact, {"kai": _project_cfg("kai")}, _active_project("kai"), scoped_recall_enabled=True
+        )
         text, _ = memory_command._build_fact_view(fact, return_to=None, scope_view=view)
         assert "Scope:            project 'kai'" in text
         assert "Scope source:     classifier (confidence 0.70)" in text
@@ -3179,7 +3185,7 @@ class TestFactViewScopeBlock:
 
     def test_episode_arm_renders_scope_rows(self):
         fact = _episode_fact()
-        view = memory_command._build_scope_view(fact, {}, None)
+        view = memory_command._build_scope_view(fact, {}, None, scoped_recall_enabled=True)
         text, _ = memory_command._build_fact_view(fact, return_to=None, scope_view=view)
         assert "Scope:  global" in text
         assert "Scope source:  legacy_default (confidence 1.00)" in text
@@ -3489,3 +3495,64 @@ class TestScopeCallbackCodec:
         # the project id itself never enters callback data.
         encoded = memory_command._encode_callback("sct", "999")
         assert len(encoded.encode("utf-8")) <= 64
+
+
+class TestScopeViewCutoverKnob:
+    """While scoped recall is disabled, the live prompt path is legacy
+    recall, which applies no scope admission, so the verdict must say
+    scope is not enforced instead of predicting a scoped yes/no that
+    the serving branch would not honor."""
+
+    _NOT_ENFORCED = "yes (scope not enforced: scoped recall disabled)"
+
+    def test_knob_off_renders_not_enforced_for_wrong_project_row(self):
+        # The exact transition-state hazard: a wrong-project row that
+        # scoped admission would exclude is still injectable by legacy
+        # recall, so the verdict must not claim "no".
+        fact = _scoped_fact("project", project_id="anvil", scope_source="operator")
+        view = memory_command._build_scope_view(fact, {}, _active_project("kai"), scoped_recall_enabled=False)
+        assert view.retrievable_label == self._NOT_ENFORCED
+        assert "project_id_mismatch" not in view.retrievable_label
+
+    def test_knob_off_renders_not_enforced_for_task_row(self):
+        fact = _scoped_fact("task")
+        view = memory_command._build_scope_view(fact, {}, None, scoped_recall_enabled=False)
+        assert view.retrievable_label == self._NOT_ENFORCED
+
+    def test_knob_off_keeps_scope_and_source_labels(self):
+        # The inspection half stays fully informative with the knob
+        # off: the assignment and provenance still render, only the
+        # verdict switches to the not-enforced form.
+        fact = _scoped_fact("project", project_id="anvil", scope_source="classifier", scope_confidence=0.8)
+        view = memory_command._build_scope_view(
+            fact, {"anvil": _project_cfg("anvil")}, None, scoped_recall_enabled=False
+        )
+        assert view.scope_label == "project 'anvil'"
+        assert view.source_label == "classifier (confidence 0.80)"
+
+    @pytest.mark.asyncio
+    async def test_fact_view_send_helper_passes_live_knob(self, monkeypatch, update_factory, context_factory):
+        """Live-injection parity at the send-helper level: the detail
+        render consults `memory.is_scoped_recall_enabled()` so the
+        verdict follows the branch actually serving prompts."""
+        import kai.memory_projects as mp_mod
+
+        monkeypatch.setattr(mp_mod, "_db_registry", {})
+        fact = _scoped_fact("project", project_id="anvil", scope_source="operator")
+        monkeypatch.setattr(memory_command.memory, "get_by_id", lambda *, user_id, memory_id: fact)
+        sent = {}
+
+        async def fake_send(update, text, kb, edit):
+            sent["text"] = text
+
+        monkeypatch.setattr(memory_command, "_send_or_edit", fake_send)
+        ctx = context_factory()
+        ctx.bot_data["config"].memory_projects = {}
+
+        monkeypatch.setattr(memory_command.memory, "is_scoped_recall_enabled", lambda: False)
+        await memory_command._send_fact_view(update_factory(callback_data="mem:fview"), ctx, 100, "scoped1")
+        assert self._NOT_ENFORCED in sent["text"]
+
+        monkeypatch.setattr(memory_command.memory, "is_scoped_recall_enabled", lambda: True)
+        await memory_command._send_fact_view(update_factory(callback_data="mem:fview"), ctx, 100, "scoped1")
+        assert "no (project_scope_not_allowed" in sent["text"]

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -19,14 +19,18 @@ No real Mem0 instance is involved. The handler tests that drive
 
 from __future__ import annotations
 
+import logging
 import time
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from kai import memory_command
+from kai import memory, memory_command
+from kai.config import MemoryProjectConfig
 from kai.memory import MemoryResult, MemoryStats
+from kai.memory_projects import ActiveMemoryProject
 
 # ── Fixture builders ────────────────────────────────────────────────
 
@@ -305,9 +309,9 @@ class TestBuildFactView:
         assert "v3" in text
         # No confirmation quote on a non-confirmed_action fact.
         assert "n/a" in text
-        # Two buttons in one row: back + forget.
+        # Three buttons in one row: back + scope + forget.
         row = kb.inline_keyboard[0]
-        assert [btn.text for btn in row] == ["back", "forget"]
+        assert [btn.text for btn in row] == ["back", "scope", "forget"]
 
     def test_back_button_routes_to_return_to(self):
         f = _fact("id1", "x", ["preference"])
@@ -2923,3 +2927,565 @@ class TestTagBrowseAxisRetired:
         assert "Tags:" in text
         assert "migration" in text
         assert "/backend" in text
+
+
+# ── Scope tools ─────────────────────────────────────────────────────
+#
+# Fixture builders for the scope-tool tests. Scope metadata rides the
+# existing extracted-fact shape; the helpers below overlay the five
+# scope keys (or deliberately corrupt them) on top of `_fact`.
+
+
+def _scoped_fact(
+    scope: str | None,
+    *,
+    project_id: str | None = None,
+    scope_source: str | None = "extraction_default",
+    scope_confidence: float = 1.0,
+    workspace_root: str | None = None,
+) -> MemoryResult:
+    """An extracted fact carrying explicit scope metadata.
+
+    `scope=None` omits the scope keys entirely (legacy shape);
+    `scope_source=None` writes scope without provenance (the
+    resolver's invalid arm for malformed writes).
+    """
+    f = _fact("scoped1", "Scoped fact text.", ["preference"])
+    if scope is not None:
+        f.metadata["scope"] = scope
+        f.metadata["project_id"] = project_id
+        f.metadata["workspace_root"] = workspace_root
+        f.metadata["scope_confidence"] = scope_confidence
+        if scope_source is not None:
+            f.metadata["scope_source"] = scope_source
+    return f
+
+
+def _project_cfg(pid: str, *, display: str | None = None, enabled: bool = True) -> MemoryProjectConfig:
+    """A registry entry with a synthetic root under /work."""
+    return MemoryProjectConfig(
+        project_id=pid,
+        display_name=display if display is not None else pid,
+        workspace_roots=(Path("/work") / pid,),
+        memory_enabled=enabled,
+        default_scope_for_new_facts="project",
+    )
+
+
+def _active_project(pid: str, *, enabled: bool = True) -> ActiveMemoryProject:
+    """An active-project detection result for `pid`."""
+    return ActiveMemoryProject(
+        project_id=pid,
+        display_name=pid,
+        matched_root=Path("/work") / pid,
+        memory_enabled=enabled,
+        default_scope_for_new_facts="project",
+    )
+
+
+class TestBuildScopeView:
+    """Rendering of the resolver arms into operator-facing labels."""
+
+    def test_explicit_global(self):
+        view = memory_command._build_scope_view(_scoped_fact("global"), {}, None)
+        assert view.scope_label == "global"
+        assert view.source_label == "extraction_default (confidence 1.00)"
+        assert view.retrievable_label == "yes"
+
+    def test_legacy_row_defaults_global_with_legacy_source(self):
+        view = memory_command._build_scope_view(_scoped_fact(None), {}, None)
+        assert view.scope_label == "global"
+        assert view.resolved.legacy_defaulted is True
+        assert "legacy_default" in view.source_label
+        assert view.retrievable_label == "yes"
+
+    def test_invalid_scope_value_renders_invalid_source(self):
+        view = memory_command._build_scope_view(_scoped_fact("bogus"), {}, None)
+        assert view.scope_label == "global"
+        assert view.resolved.invalid_defaulted is True
+        assert "invalid_default" in view.source_label
+
+    def test_project_row_registered_same_display(self):
+        registry = {"kai": _project_cfg("kai")}
+        fact = _scoped_fact("project", project_id="kai", scope_source="classifier", scope_confidence=0.8)
+        view = memory_command._build_scope_view(fact, registry, None)
+        assert view.scope_label == "project 'kai'"
+        assert view.source_label == "classifier (confidence 0.80)"
+
+    def test_project_row_registered_distinct_display(self):
+        registry = {"kai": _project_cfg("kai", display="Kai Assistant")}
+        fact = _scoped_fact("project", project_id="kai", scope_source="operator")
+        view = memory_command._build_scope_view(fact, registry, None)
+        assert view.scope_label == "project 'kai' (Kai Assistant)"
+
+    def test_project_row_unregistered_is_flagged(self):
+        fact = _scoped_fact("project", project_id="ghost", scope_source="operator")
+        view = memory_command._build_scope_view(fact, {}, None)
+        assert view.scope_label == "project 'ghost' (not registered)"
+
+    def test_project_row_missing_id(self):
+        # The active project makes project scope allowed, so the
+        # verdict reaches the missing-id arm instead of stopping at
+        # project_scope_not_allowed.
+        fact = _scoped_fact("project", project_id=None, scope_source="operator")
+        view = memory_command._build_scope_view(fact, {}, _active_project("kai"))
+        assert view.scope_label == "project (no project id)"
+        assert "project_scope_missing_project_id" in view.retrievable_label
+
+    def test_task_row(self):
+        fact = _scoped_fact("task", scope_source="extraction_default")
+        view = memory_command._build_scope_view(fact, {}, None)
+        assert view.scope_label == "task"
+        assert "task_scope_not_supported" in view.retrievable_label
+
+
+class TestScopeViewAdmissionParity:
+    """The retrievability verdict must match scoped retrieval's own
+    admission rule under the same allowed-project derivation."""
+
+    @pytest.mark.parametrize(
+        "fact,active",
+        [
+            (_scoped_fact("global"), None),
+            (_scoped_fact(None), _active_project("kai")),
+            (_scoped_fact("project", project_id="kai", scope_source="operator"), _active_project("kai")),
+            (_scoped_fact("project", project_id="anvil", scope_source="operator"), _active_project("kai")),
+            (_scoped_fact("project", project_id="kai", scope_source="operator"), None),
+            (
+                _scoped_fact("project", project_id="kai", scope_source="operator"),
+                _active_project("kai", enabled=False),
+            ),
+            (_scoped_fact("project", project_id=None, scope_source="operator"), _active_project("kai")),
+            (_scoped_fact("task"), _active_project("kai")),
+        ],
+    )
+    def test_verdict_matches_admission_reason(self, fact, active):
+        view = memory_command._build_scope_view(fact, {}, active)
+        allowed = active.project_id if active is not None and active.memory_enabled else None
+        reason = memory._scoped_memory_admission_reason(
+            memory.resolve_memory_scope(fact.metadata),
+            allowed_project_id=allowed,
+        )
+        if reason is None:
+            assert view.retrievable_label == "yes"
+        else:
+            assert view.retrievable_label.startswith("no (")
+            assert reason in view.retrievable_label
+
+    def test_mismatch_names_both_projects(self):
+        fact = _scoped_fact("project", project_id="anvil", scope_source="operator")
+        view = memory_command._build_scope_view(fact, {}, _active_project("kai"))
+        assert "row 'anvil'" in view.retrievable_label
+        assert "here 'kai'" in view.retrievable_label
+
+    def test_disabled_project_distinguished_from_no_project(self):
+        fact = _scoped_fact("project", project_id="kai", scope_source="operator")
+        disabled = memory_command._build_scope_view(fact, {}, _active_project("kai", enabled=False))
+        nowhere = memory_command._build_scope_view(fact, {}, None)
+        assert "project memory disabled here" in disabled.retrievable_label
+        assert "no active project here" in nowhere.retrievable_label
+
+
+class TestScopeChangeTargets:
+    """Transition derivation per current scope and registry."""
+
+    _REGISTRY = {"anvil": _project_cfg("anvil"), "kai": _project_cfg("kai")}
+
+    def _resolved(self, fact):
+        return memory.resolve_memory_scope(fact.metadata)
+
+    def test_explicit_global_offers_projects_only(self):
+        targets = memory_command._scope_change_targets(self._resolved(_scoped_fact("global")), self._REGISTRY)
+        assert targets == [("project", "anvil"), ("project", "kai")]
+
+    def test_legacy_global_offers_global_stamp_and_projects(self):
+        targets = memory_command._scope_change_targets(self._resolved(_scoped_fact(None)), self._REGISTRY)
+        assert targets == [("global", None), ("project", "anvil"), ("project", "kai")]
+
+    def test_project_row_excludes_own_project(self):
+        fact = _scoped_fact("project", project_id="kai", scope_source="operator")
+        targets = memory_command._scope_change_targets(self._resolved(fact), self._REGISTRY)
+        assert targets == [("global", None), ("project", "anvil")]
+
+    def test_invalid_project_row_includes_own_project_for_repair(self):
+        # scope present and valid, but no scope_source: invalid arm.
+        fact = _scoped_fact("project", project_id="kai", scope_source=None)
+        targets = memory_command._scope_change_targets(self._resolved(fact), self._REGISTRY)
+        assert targets == [("global", None), ("project", "anvil"), ("project", "kai")]
+
+    def test_explicit_global_empty_registry_offers_nothing(self):
+        targets = memory_command._scope_change_targets(self._resolved(_scoped_fact("global")), {})
+        assert targets == []
+
+
+class TestBuildScopeScreen:
+    def test_renders_scope_block_and_targets(self):
+        registry = {"kai": _project_cfg("kai")}
+        fact = _scoped_fact(None)
+        view = memory_command._build_scope_view(fact, registry, None)
+        targets = memory_command._scope_change_targets(view.resolved, registry)
+        text, kb = memory_command._build_scope_screen(fact, view, targets)
+        assert '"Scoped fact text."' in text
+        assert "Scope:  global" in text
+        assert "legacy_default" in text
+        assert "Choose a new scope:" in text
+        # One button per target row, then the nav row.
+        labels = [row[0].text for row in kb.inline_keyboard]
+        assert labels == ["Make global", "Move to 'kai'", "back"]
+        assert kb.inline_keyboard[0][0].callback_data == "mem:sct:0"
+        assert kb.inline_keyboard[1][0].callback_data == "mem:sct:1"
+        assert kb.inline_keyboard[-1][0].callback_data == "mem:fview"
+
+    def test_no_targets_renders_empty_message(self):
+        fact = _scoped_fact("global")
+        view = memory_command._build_scope_view(fact, {}, None)
+        text, kb = memory_command._build_scope_screen(fact, view, [])
+        assert "No scope changes available" in text
+        assert [row[0].text for row in kb.inline_keyboard] == ["back"]
+
+
+class TestBuildScopeConfirm:
+    def test_global_target_question(self):
+        fact = _scoped_fact("project", project_id="kai", scope_source="operator")
+        text, kb = memory_command._build_scope_confirm(fact, ("global", None))
+        assert text.startswith("Make this fact global?")
+        assert '"Scoped fact text."' in text
+        # Reversible action: no irreversibility warning.
+        assert "cannot be undone" not in text
+        row = kb.inline_keyboard[0]
+        assert [btn.text for btn in row] == ["confirm", "cancel"]
+        assert row[0].callback_data == "mem:scd"
+        assert row[1].callback_data == "mem:scp"
+
+    def test_project_target_question(self):
+        fact = _scoped_fact("global")
+        text, _ = memory_command._build_scope_confirm(fact, ("project", "anvil"))
+        assert text.startswith("Move this fact to project 'anvil'?")
+
+    def test_episode_noun(self):
+        fact = _episode_fact()
+        text, _ = memory_command._build_scope_confirm(fact, ("project", "kai"))
+        assert text.startswith("Move this episode to project 'kai'?")
+
+
+class TestFactViewScopeBlock:
+    def test_extracted_arm_renders_aligned_scope_rows(self):
+        fact = _scoped_fact("project", project_id="kai", scope_source="classifier", scope_confidence=0.7)
+        view = memory_command._build_scope_view(fact, {"kai": _project_cfg("kai")}, _active_project("kai"))
+        text, _ = memory_command._build_fact_view(fact, return_to=None, scope_view=view)
+        assert "Scope:            project 'kai'" in text
+        assert "Scope source:     classifier (confidence 0.70)" in text
+        assert "Retrievable here: yes" in text
+
+    def test_episode_arm_renders_scope_rows(self):
+        fact = _episode_fact()
+        view = memory_command._build_scope_view(fact, {}, None)
+        text, _ = memory_command._build_fact_view(fact, return_to=None, scope_view=view)
+        assert "Scope:  global" in text
+        assert "Scope source:  legacy_default (confidence 1.00)" in text
+        assert "Retrievable here:  yes" in text
+
+    def test_no_scope_view_omits_block(self):
+        text, _ = memory_command._build_fact_view(_fact("a", "x", ["t"]), return_to=None)
+        assert "Scope:" not in text
+        assert "Retrievable here" not in text
+
+
+class TestScopeCallbackDispatch:
+    """scp / sct / scd verb routing and session-expired guards."""
+
+    @pytest.mark.asyncio
+    async def test_scp_without_cache_expires(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        sent = {}
+
+        async def fake_dash(update, context, chat_id, edit=False):
+            sent["dash"] = True
+
+        monkeypatch.setattr(memory_command, "_send_dashboard", fake_dash)
+        upd = update_factory(callback_data="mem:scp")
+        await memory_command.handle_memory_callback(upd, context_factory())
+        assert sent.get("dash") is True
+        upd.callback_query.answer.assert_awaited_once_with(memory_command._MSG_SESSION_EXPIRED)
+
+    @pytest.mark.asyncio
+    async def test_scp_with_cached_fact_opens_scope_screen(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        sent = {}
+
+        async def fake_scope_screen(update, context, chat_id, memory_id):
+            sent["memory_id"] = memory_id
+
+        monkeypatch.setattr(memory_command, "_send_scope_screen", fake_scope_screen)
+        memory_command._set_cache(100, memory_command._ScreenCache(screen="fact", memory_ids=["m1"]))
+        upd = update_factory(callback_data="mem:scp")
+        await memory_command.handle_memory_callback(upd, context_factory())
+        assert sent["memory_id"] == "m1"
+
+    @pytest.mark.asyncio
+    async def test_sct_out_of_range_expires(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        sent = {}
+
+        async def fake_dash(update, context, chat_id, edit=False):
+            sent["dash"] = True
+
+        monkeypatch.setattr(memory_command, "_send_dashboard", fake_dash)
+        memory_command._set_cache(
+            100,
+            memory_command._ScreenCache(screen="scope", memory_ids=["m1"], scope_targets=[("global", None)]),
+        )
+        upd = update_factory(callback_data="mem:sct:5")
+        await memory_command.handle_memory_callback(upd, context_factory())
+        assert sent.get("dash") is True
+
+    @pytest.mark.asyncio
+    async def test_sct_valid_index_opens_confirm(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        sent = {}
+
+        async def fake_confirm(update, context, chat_id, memory_id, target):
+            sent["target"] = target
+
+        monkeypatch.setattr(memory_command, "_send_scope_confirm", fake_confirm)
+        memory_command._set_cache(
+            100,
+            memory_command._ScreenCache(
+                screen="scope",
+                memory_ids=["m1"],
+                scope_targets=[("global", None), ("project", "kai")],
+            ),
+        )
+        upd = update_factory(callback_data="mem:sct:1")
+        await memory_command.handle_memory_callback(upd, context_factory())
+        assert sent["target"] == ("project", "kai")
+
+    @pytest.mark.asyncio
+    async def test_scd_without_selected_target_expires(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        sent = {}
+
+        async def fake_dash(update, context, chat_id, edit=False):
+            sent["dash"] = True
+
+        monkeypatch.setattr(memory_command, "_send_dashboard", fake_dash)
+        memory_command._set_cache(100, memory_command._ScreenCache(screen="scope_confirm", memory_ids=["m1"]))
+        upd = update_factory(callback_data="mem:scd")
+        await memory_command.handle_memory_callback(upd, context_factory())
+        assert sent.get("dash") is True
+
+    @pytest.mark.asyncio
+    async def test_scd_applies_selected_target(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        applied = {}
+
+        async def fake_apply(update, context, chat_id, memory_id, target):
+            applied["memory_id"] = memory_id
+            applied["target"] = target
+            return "Scope updated."
+
+        monkeypatch.setattr(memory_command, "_apply_scope_change", fake_apply)
+        memory_command._set_cache(
+            100,
+            memory_command._ScreenCache(
+                screen="scope_confirm",
+                memory_ids=["m1"],
+                scope_target=("project", "kai"),
+            ),
+        )
+        upd = update_factory(callback_data="mem:scd")
+        await memory_command.handle_memory_callback(upd, context_factory())
+        assert applied == {"memory_id": "m1", "target": ("project", "kai")}
+        upd.callback_query.answer.assert_awaited_once_with("Scope updated.")
+
+
+class TestApplyScopeChange:
+    """Read-merge-write apply path: field preservation, provenance,
+    ownership pass-through, failure modes, audit log line."""
+
+    def _run_apply(self, monkeypatch, fact, *, update_ok=True):
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(memory_command.memory, "get_by_id", lambda *, user_id, memory_id: fact)
+
+        def fake_update(*, user_id, memory_id, data, metadata):
+            captured.update(user_id=user_id, memory_id=memory_id, data=data, metadata=metadata)
+            return update_ok
+
+        monkeypatch.setattr(memory_command.memory, "update_metadata", fake_update)
+
+        async def fake_fact_view(update, context, chat_id, memory_id):
+            captured["rerendered"] = memory_id
+
+        monkeypatch.setattr(memory_command, "_send_fact_view", fake_fact_view)
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_preserves_every_non_scope_field(self, monkeypatch, update_factory, context_factory):
+        fact = _scoped_fact("project", project_id="anvil", scope_source="classifier", scope_confidence=0.6)
+        original = dict(fact.metadata)
+        captured = self._run_apply(monkeypatch, fact)
+        answer = await memory_command._apply_scope_change(
+            update_factory(callback_data="mem:scd"), context_factory(), 100, "scoped1", ("project", "kai")
+        )
+        assert answer == "Scope updated."
+        md = captured["metadata"]
+        # Every non-scope key survives byte-identically.
+        scope_keys = {"scope", "project_id", "workspace_root", "scope_confidence", "scope_source"}
+        for key, value in original.items():
+            if key not in scope_keys:
+                assert md[key] == value
+        # The five scope keys carry the operator write shape.
+        assert md["scope"] == "project"
+        assert md["project_id"] == "kai"
+        assert md["workspace_root"] is None
+        assert md["scope_confidence"] == 1.0
+        assert md["scope_source"] == "operator"
+        # Mem0 update requires the row text; ownership rides user_id.
+        assert captured["data"] == fact.text
+        assert captured["user_id"] == "100"
+        assert captured["rerendered"] == "scoped1"
+
+    @pytest.mark.asyncio
+    async def test_make_global_discards_project_fields(self, monkeypatch, update_factory, context_factory):
+        fact = _scoped_fact("project", project_id="anvil", scope_source="operator", workspace_root="/work/anvil")
+        captured = self._run_apply(monkeypatch, fact)
+        answer = await memory_command._apply_scope_change(
+            update_factory(callback_data="mem:scd"), context_factory(), 100, "scoped1", ("global", None)
+        )
+        assert answer == "Scope updated."
+        md = captured["metadata"]
+        assert md["scope"] == "global"
+        assert md["project_id"] is None
+        assert md["workspace_root"] is None
+
+    @pytest.mark.asyncio
+    async def test_missing_row_returns_not_found(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command.memory, "get_by_id", lambda *, user_id, memory_id: None)
+        sent = {}
+
+        async def fake_send(update, text, kb, edit):
+            sent["text"] = text
+
+        monkeypatch.setattr(memory_command, "_send_or_edit", fake_send)
+        answer = await memory_command._apply_scope_change(
+            update_factory(callback_data="mem:scd"), context_factory(), 100, "gone", ("global", None)
+        )
+        assert answer == "Not found."
+        assert sent["text"] == "This memory no longer exists."
+
+    @pytest.mark.asyncio
+    async def test_update_failure_reports_and_rerenders(self, monkeypatch, update_factory, context_factory):
+        fact = _scoped_fact("global")
+        captured = self._run_apply(monkeypatch, fact, update_ok=False)
+        answer = await memory_command._apply_scope_change(
+            update_factory(callback_data="mem:scd"), context_factory(), 100, "scoped1", ("project", "kai")
+        )
+        assert answer == "Update failed."
+        assert captured["rerendered"] == "scoped1"
+
+    @pytest.mark.asyncio
+    async def test_emits_scope_change_log_line(self, monkeypatch, update_factory, context_factory, caplog):
+        fact = _scoped_fact("project", project_id="anvil", scope_source="classifier")
+        self._run_apply(monkeypatch, fact)
+        with caplog.at_level(logging.INFO, logger="kai.memory_command"):
+            await memory_command._apply_scope_change(
+                update_factory(callback_data="mem:scd"), context_factory(), 100, "scoped1", ("global", None)
+            )
+        line = next(r.message for r in caplog.records if r.message.startswith("memory.scope_change"))
+        assert '"from_scope":"project"' in line
+        assert '"from_project_id":"anvil"' in line
+        assert '"to_scope":"global"' in line
+        assert '"to_project_id":null' in line
+
+    @pytest.mark.asyncio
+    async def test_failed_update_emits_no_log_line(self, monkeypatch, update_factory, context_factory, caplog):
+        fact = _scoped_fact("global")
+        self._run_apply(monkeypatch, fact, update_ok=False)
+        with caplog.at_level(logging.INFO, logger="kai.memory_command"):
+            await memory_command._apply_scope_change(
+                update_factory(callback_data="mem:scd"), context_factory(), 100, "scoped1", ("project", "kai")
+            )
+        assert not any(r.message.startswith("memory.scope_change") for r in caplog.records)
+
+
+class TestScopeInputs:
+    def test_missing_pool_collapses_to_no_active_project(self, context_factory, monkeypatch):
+        import kai.memory_projects as mp_mod
+
+        monkeypatch.setattr(mp_mod, "_db_registry", {})
+        ctx = context_factory()
+        ctx.bot_data["config"].memory_projects = {"kai": _project_cfg("kai")}
+        registry, active = memory_command._scope_inputs(ctx, 100)
+        assert "kai" in registry
+        assert active is None
+
+    def test_pool_workspace_drives_detection(self, context_factory, monkeypatch, tmp_path):
+        import kai.memory_projects as mp_mod
+
+        monkeypatch.setattr(mp_mod, "_db_registry", {})
+        root = tmp_path / "kai"
+        root.mkdir()
+        cfg = MemoryProjectConfig(
+            project_id="kai",
+            display_name="kai",
+            workspace_roots=(root.resolve(),),
+            memory_enabled=True,
+            default_scope_for_new_facts="project",
+        )
+        ctx = context_factory()
+        ctx.bot_data["config"].memory_projects = {"kai": cfg}
+        pool = MagicMock()
+        pool.get_workspace.return_value = root
+        ctx.bot_data["pool"] = pool
+        _registry, active = memory_command._scope_inputs(ctx, 100)
+        assert active is not None and active.project_id == "kai"
+        pool.get_workspace.assert_called_once_with(100)
+
+
+class TestStatsScopeSection:
+    def test_distribution_renders_in_fixed_order(self):
+        base = _stats(extracted_count=5)
+        stats = MemoryStats(
+            **{**base.__dict__, "by_scope": {"project:kai": 2, "global": 1, "global_legacy": 9, "invalid": 1}}
+        )
+        text, _ = memory_command._build_stats(stats)
+        assert "Scope:" in text
+        idx_global = text.index("global ")
+        idx_legacy = text.index("global (legacy)")
+        idx_project = text.index("project 'kai'")
+        idx_invalid = text.index("invalid")
+        assert idx_global < idx_legacy < idx_project < idx_invalid
+
+    def test_projects_sort_by_count_then_id(self):
+        lines = memory_command._scope_distribution_lines({"project:kai": 1, "project:anvil": 1, "project:phi": 4})
+        rendered = "\n".join(lines)
+        assert rendered.index("'phi'") < rendered.index("'anvil'") < rendered.index("'kai'")
+
+    def test_unknown_bucket_renders_raw(self):
+        lines = memory_command._scope_distribution_lines({"global": 1, "mystery_bucket": 2})
+        assert any("mystery_bucket" in line for line in lines)
+
+    def test_no_by_scope_omits_section(self):
+        text, _ = memory_command._build_stats(_stats(extracted_count=3))
+        assert "Scope:" not in text
+
+
+class TestScopeCallbackCodec:
+    def test_scope_verbs_round_trip(self):
+        for encoded, verb, args in [
+            ("mem:scp", "scp", []),
+            ("mem:sct:7", "sct", ["7"]),
+            ("mem:scd", "scd", []),
+        ]:
+            assert memory_command._encode_callback(verb, *args) == encoded
+            action = memory_command._decode_callback(encoded)
+            assert action is not None
+            assert action.verb == verb
+            assert action.args == args
+
+    def test_sct_index_stays_under_ceiling(self):
+        # Target indices are bounded by registry size; even an absurd
+        # three-digit index stays far below the 64-byte limit because
+        # the project id itself never enters callback data.
+        encoded = memory_command._encode_callback("sct", "999")
+        assert len(encoded.encode("utf-8")) <= 64


### PR DESCRIPTION
## Summary

Row-level scope inspection and correction from the existing `/memory` browse UI. Closes #662.

- Detail views (extracted, episode, migration) render a scope block via `resolve_memory_scope`: scope value with the registered display name (or a not-registered marker), `scope_source` with confidence, and a retrievability verdict for the caller's current workspace. The verdict follows the branch actually serving prompts: with scoped recall enabled it reuses the same admission helper scoped retrieval applies, under the same allowed-project derivation (detected project AND memory enabled); with the cutover knob off it renders `yes (scope not enforced: scoped recall disabled)`, because legacy recall applies no scope admission and a scoped yes/no would be false in that state.
- A `scope` button on the detail keyboard opens a scope screen with transition targets derived from the merged registry: `Make global` plus `Move to '<project>'`. Targets are referenced by integer index into the per-chat screen cache (the existing `memory_ids` pattern), keeping callback data under the Telegram 64-byte ceiling regardless of project id length. A confirm step mirrors the forget flow; cancel steps back one screen.
- Apply is read-merge-write: the row's full metadata is overlaid with `build_scope_metadata(scope_source="operator", scope_confidence=1.0)` and written through `update_metadata` with the row's text, since the underlying update replaces metadata wholesale. `workspace_root` is cleared on operator moves; the field records write-time workspace provenance, which a retarget from chat does not have. Each applied change emits one structured `memory.scope_change` log line (before and after assignments, acting chat id).
- `/memory stats` gains a scope distribution over all user-visible rows; the `global (legacy)` bucket is the running measure of reclassification debt for the upcoming legacy reclassification pass.

Design notes:

- Legacy-default and invalid rows get a `Make global` target even though they already resolve to global: applying it stamps explicit operator provenance and retires the row from the reclassification backlog. An invalid-flagged project row also keeps its own project as a target, because re-assigning it repairs the broken provenance while keeping the assignment.
- Ownership needs no new code: `update_metadata` routes through `get_by_id`, which already gates on row ownership, so users can only retarget their own rows.

## Testing

- 55 new tests: resolver-arm rendering, an admission-parity matrix against the retrieval helper, transition derivation (including the invalid-row repair case and the empty-registry empty state), non-scope metadata preservation across a move, operator write shape, ownership pass-through, failure paths, audit-line emission and suppression, stats aggregation and rendering order, callback codec round-trips and ceiling.
- Full suite: 4103 passed, 1 skipped. `make check` clean.
