### PR TITLE
feat(memory): legacy scope reclassification CLI

### DIFF
--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -381,6 +381,19 @@ _BUILDER_SCOPE_SOURCES: frozenset[str] = frozenset(
     }
 )
 
+# Structured-log event name for scope reassignments. Shared by the
+# /memory scope tools (operator moves) and the reclassification CLI
+# (classifier runs and rollbacks) so log readers key on one event
+# regardless of which writer changed the row.
+SCOPE_CHANGE_EVENT = "memory.scope_change"
+
+# Metadata key stamped by classifier writes, carrying the run id that
+# ties a row's scope assignment back to its dry-run report, proposals
+# file, and pre-image dump. Not part of the canonical five scope keys
+# (`build_scope_metadata` does not emit it); the reclassification
+# apply step adds it alongside them.
+SCOPE_RUN_ID_KEY = "scope_run_id"
+
 
 @dataclass(frozen=True)
 class ResolvedMemoryScope:

--- a/src/kai/memory_admin.py
+++ b/src/kai/memory_admin.py
@@ -9,6 +9,13 @@ dropping into an ad-hoc Python shell.
 Scope (spec §16 + Phase 4 of spec 320):
 - `purge <user_id> --source <source>`: scoped deletion. Leaves rows
   whose metadata.source does not match untouched.
+- `reclassify-scope <user_id> [...]`: guarded scope reclassification
+  of unreviewed global rows. Dry-run by default (report + proposals
+  file, no store writes); `--apply` writes a reviewed proposals file
+  with pre-images dumped first; `--rollback` restores a pre-image
+  file. The pass logic lives in `src/kai/memory_reclassify.py`; this
+  module owns only argument parsing, the authorization gates, and
+  dispatch.
 
 Commands that modify the store require an explicit `--yes` flag. When
 `--yes` is absent, the command prints the action it WOULD take and
@@ -26,8 +33,10 @@ future incident requires the nuclear option, add it as a separate
 `nuke` subcommand with its own review.
 
 This module should NOT import `kai.bot`, `kai.pool`, or other
-bot-runtime code, so the CLI stays cheap to invoke. Only the memory
-and config modules are needed.
+bot-runtime code, so the CLI stays cheap to invoke. The reclassify
+handler imports `kai.memory_reclassify` (which pulls the one-shot
+reasoner stack) inside the function for the same reason: a plain
+`purge` invocation never pays that import.
 """
 
 from __future__ import annotations
@@ -36,6 +45,10 @@ import argparse
 import asyncio
 import logging
 import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kai.config import Config
 
 log = logging.getLogger(__name__)
 
@@ -88,16 +101,105 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Confirm deletion. Without this flag the command prints the planned action and exits with status 2.",
     )
+
+    # Lazy import: the choices list is the only config dependency at
+    # parser-build time. Importing it here (not at module top) keeps
+    # `import kai.memory_admin` itself free of kai.config, preserving
+    # the module's zero-kai-imports surface for test collection.
+    from kai.config import ONESHOT_REASONER_BACKENDS
+
+    rec = sub.add_parser(
+        "reclassify-scope",
+        help="Reclassify unreviewed global memory rows (dry-run by default)",
+        description=(
+            "Classify rows whose resolved scope is global with legacy or "
+            "extraction-default provenance. Dry-run (the default) writes a "
+            "report plus a proposals file and never touches the store. "
+            "--apply writes a reviewed proposals file after re-checks, "
+            "dumping pre-images first. --rollback restores rows from a "
+            "pre-image file. The daemon must be stopped; the embedded "
+            "store is single-process."
+        ),
+    )
+    rec.add_argument(
+        "user_id",
+        help="Telegram chat id (as a string) whose rows to reclassify.",
+    )
+    # Classification flags default to None (not their documented
+    # defaults) so the mutating-mode rejection below can tell "flag
+    # explicitly passed" from "default in effect"; the dry-run driver
+    # applies the real defaults.
+    rec.add_argument(
+        "--backend",
+        choices=sorted(ONESHOT_REASONER_BACKENDS),
+        default=None,
+        help="Reasoner backend. Default: the target user's effective backend.",
+    )
+    rec.add_argument(
+        "--os-user",
+        dest="os_user",
+        default=None,
+        help="OS user whose provider auth runs the reasoner. Default: the target user's os_user mapping.",
+    )
+    rec.add_argument(
+        "--provider",
+        default=None,
+        help="Provider wire name (goose only). Default: the target user's effective provider.",
+    )
+    rec.add_argument(
+        "--threshold",
+        type=float,
+        default=None,
+        help="Confidence gate for both verdict directions. Default: 0.8.",
+    )
+    rec.add_argument(
+        "--sample",
+        type=int,
+        default=None,
+        help="Eyeball-sample size in the dry-run report. Default: 10.",
+    )
+    rec.add_argument(
+        "--out-dir",
+        dest="out_dir",
+        default=None,
+        help="Artifact directory. Default: <DATA_DIR>/home/<user_id>/docs/reclassify/.",
+    )
+    mode = rec.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--apply",
+        metavar="PROPOSALS",
+        default=None,
+        help="Apply a reviewed proposals file (requires --yes).",
+    )
+    mode.add_argument(
+        "--rollback",
+        metavar="PREIMAGES",
+        default=None,
+        help="Restore rows from a pre-image file (requires --yes).",
+    )
+    rec.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm a mutating mode. Without it, --apply/--rollback print the planned change count and exit with status 2.",
+    )
     return parser
 
 
-def _initialize_memory() -> bool:
-    """Load config and call `init_memory()`; return True on success.
+def _initialize_memory() -> Config | None:
+    """Load config and call `init_memory()`; return the Config on success.
 
     The admin CLI reuses the same init path as the bot so the same
     embedding model, Qdrant directory, and history DB settings are in
     effect. A failure here (missing optional deps, unreadable Qdrant
     dir) is reported to stderr; the caller exits with status 1.
+
+    Returns the loaded Config (truthy) rather than a bare True so
+    subcommands that need config values (reclassify-scope reads the
+    session DB path, project registry, and model settings) do not
+    load the environment twice; `purge`'s `if not _initialize_memory()`
+    check is unaffected. None signals failure. The embedded store is
+    single-process, so a failure here while the daemon is running is
+    expected; stop the service first.
     """
     try:
         from kai.config import load_config
@@ -111,14 +213,15 @@ def _initialize_memory() -> bool:
             # etc.). Both cases print a warning during init_memory; we
             # just stop the command from proceeding.
             print(
-                "memory admin: memory is not enabled. Set MEMORY_ENABLED=true and verify the store is readable.",
+                "memory admin: memory is not enabled. Set MEMORY_ENABLED=true, verify the store is "
+                "readable, and make sure the daemon is stopped (the embedded store is single-process).",
                 file=sys.stderr,
             )
-            return False
-        return True
+            return None
+        return config
     except Exception as e:
         print(f"memory admin: init failed: {e}", file=sys.stderr)
-        return False
+        return None
 
 
 def _cmd_purge(args: argparse.Namespace) -> int:
@@ -176,6 +279,100 @@ def _cmd_purge(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_reclassify(args: argparse.Namespace) -> int:
+    """Execute the `reclassify-scope` subcommand. Returns an exit code.
+
+    Gate order, deliberately:
+    1. Classification flags are rejected in mutating modes before
+       anything else; a typo must not silently change apply
+       semantics.
+    2. Memory init runs before the --yes gate (same rationale as
+       purge: the no-yes plan doubles as a smoke test).
+    3. Mutating modes parse and header-validate their artifact
+       BEFORE the --yes gate, so the plan shows the real change
+       count and a wrong-user file fails loudly up front.
+    The pass logic lives in kai.memory_reclassify; this function owns
+    only the gates and dispatch, per the module-docstring split.
+    """
+    mutating = args.apply is not None or args.rollback is not None
+    if mutating:
+        # The None defaults exist precisely for this check: any
+        # non-None value was explicitly passed.
+        offenders = [
+            name
+            for name, value in (
+                ("--backend", args.backend),
+                ("--os-user", args.os_user),
+                ("--provider", args.provider),
+                ("--threshold", args.threshold),
+                ("--sample", args.sample),
+            )
+            if value is not None
+        ]
+        if offenders:
+            print(
+                f"memory admin: {', '.join(offenders)} only apply to dry-run classification; "
+                "remove them when using --apply/--rollback.",
+                file=sys.stderr,
+            )
+            return 2
+
+    threshold = args.threshold if args.threshold is not None else 0.8
+    if not (0.0 <= threshold <= 1.0):
+        print(f"memory admin: --threshold must be in [0.0, 1.0], got {threshold}", file=sys.stderr)
+        return 2
+
+    config = _initialize_memory()
+    if config is None:
+        return 1
+
+    from pathlib import Path
+
+    from kai import memory_reclassify
+    from kai.config import DATA_DIR
+
+    out_dir = Path(args.out_dir) if args.out_dir else DATA_DIR / "home" / args.user_id / "docs" / "reclassify"
+
+    if not mutating:
+        sample = args.sample if args.sample is not None else 10
+        return asyncio.run(
+            memory_reclassify.run_dry_run(
+                config,
+                args.user_id,
+                backend=args.backend,
+                os_user=args.os_user,
+                provider=args.provider,
+                threshold=threshold,
+                sample=sample,
+                out_dir=out_dir,
+            )
+        )
+
+    artifact_path = Path(args.apply if args.apply is not None else args.rollback)
+    row_type = "proposal" if args.apply is not None else "preimage"
+    try:
+        header, rows = memory_reclassify.parse_artifact(artifact_path.read_text(encoding="utf-8"), row_type=row_type)
+    except (OSError, ValueError) as e:
+        print(f"memory admin: cannot read {row_type} file: {e}", file=sys.stderr)
+        return 1
+    error = memory_reclassify.validate_header(header, user_id=args.user_id)
+    if error is not None:
+        print(f"memory admin: {error}", file=sys.stderr)
+        return 1
+
+    if not args.yes:
+        verb = "apply" if args.apply is not None else "roll back"
+        print(f"memory admin: would {verb} {len(rows)} row(s) from run {header['run_id']} for user {args.user_id}.")
+        print("memory admin: re-run with --yes to execute.")
+        return 2
+
+    if args.apply is not None:
+        return asyncio.run(
+            memory_reclassify.run_apply(config, args.user_id, proposals_path=artifact_path, out_dir=out_dir)
+        )
+    return asyncio.run(memory_reclassify.run_rollback(config, args.user_id, preimages_path=artifact_path))
+
+
 def cli(argv: list[str]) -> None:
     """Dispatch entry point. Called from `__main__.py` with argv[2:].
 
@@ -187,6 +384,8 @@ def cli(argv: list[str]) -> None:
 
     if args.command == "purge":
         sys.exit(_cmd_purge(args))
+    if args.command == "reclassify-scope":
+        sys.exit(_cmd_reclassify(args))
     # argparse's required=True on the subparsers guarantees a known
     # command reaches this point, so the else branch is unreachable
     # under normal invocation. Guarded anyway in case a future

--- a/src/kai/memory_admin.py
+++ b/src/kai/memory_admin.py
@@ -321,6 +321,13 @@ def _cmd_reclassify(args: argparse.Namespace) -> int:
     if not (0.0 <= threshold <= 1.0):
         print(f"memory admin: --threshold must be in [0.0, 1.0], got {threshold}", file=sys.stderr)
         return 2
+    sample = args.sample if args.sample is not None else 10
+    # A negative sample would survive until report rendering and kill
+    # the run AFTER every reasoner call has been paid for; reject the
+    # typo up front. Zero is valid (no sample section).
+    if sample < 0:
+        print(f"memory admin: --sample must be >= 0, got {sample}", file=sys.stderr)
+        return 2
 
     config = _initialize_memory()
     if config is None:
@@ -334,7 +341,6 @@ def _cmd_reclassify(args: argparse.Namespace) -> int:
     out_dir = Path(args.out_dir) if args.out_dir else DATA_DIR / "home" / args.user_id / "docs" / "reclassify"
 
     if not mutating:
-        sample = args.sample if args.sample is not None else 10
         return asyncio.run(
             memory_reclassify.run_dry_run(
                 config,
@@ -348,10 +354,18 @@ def _cmd_reclassify(args: argparse.Namespace) -> int:
             )
         )
 
+    # Typed parsers, not the generic artifact reader: a hand-edited
+    # row with a bad verdict or confidence fails HERE, in the plan
+    # path, before --yes and before any store access. The driver
+    # re-validates the same way, so both entries share one contract.
     artifact_path = Path(args.apply if args.apply is not None else args.rollback)
     row_type = "proposal" if args.apply is not None else "preimage"
     try:
-        header, rows = memory_reclassify.parse_artifact(artifact_path.read_text(encoding="utf-8"), row_type=row_type)
+        text = artifact_path.read_text(encoding="utf-8")
+        if args.apply is not None:
+            header, rows = memory_reclassify.parse_proposals(text)
+        else:
+            header, rows = memory_reclassify.parse_preimages(text)
     except (OSError, ValueError) as e:
         print(f"memory admin: cannot read {row_type} file: {e}", file=sys.stderr)
         return 1

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -2072,7 +2072,8 @@ async def _apply_scope_change(
         # scope_source after an operator move is always "operator",
         # so only the before value is recorded.
         log.info(
-            "memory.scope_change %s",
+            "%s %s",
+            memory.SCOPE_CHANGE_EVENT,
             json.dumps(
                 {
                     "memory_id": memory_id,

--- a/src/kai/memory_reclassify.py
+++ b/src/kai/memory_reclassify.py
@@ -434,6 +434,79 @@ def validate_header(header: dict[str, Any], *, user_id: str) -> str | None:
     return None
 
 
+def parse_proposals(text: str) -> tuple[dict[str, Any], list[Proposal]]:
+    """Parse a proposals file into fully validated Proposal objects.
+
+    Strict by design: a proposals file is a hand-editable
+    authorization artifact, and apply mutates the store row by row.
+    A row that only fails AT WRITE TIME would crash the run after
+    earlier rows were already updated, so every field is validated
+    here, before any store access. Raises ValueError naming the
+    offending line; the caller aborts the whole apply.
+    """
+    header, raws = parse_artifact(text, row_type="proposal")
+    proposals: list[Proposal] = []
+    for i, raw in enumerate(raws, start=2):
+        mid = raw.get("memory_id")
+        if not isinstance(mid, str) or not mid:
+            raise ValueError(f"proposal line {i}: memory_id must be a non-empty string")
+        verdict = raw.get("verdict")
+        if verdict not in (memory.SCOPE_GLOBAL, memory.SCOPE_PROJECT):
+            raise ValueError(f"proposal line {i}: verdict must be 'global' or 'project', got {verdict!r}")
+        project_id = raw.get("project_id")
+        if verdict == memory.SCOPE_PROJECT:
+            if not isinstance(project_id, str) or not project_id:
+                raise ValueError(f"proposal line {i}: project verdict requires a non-empty project_id")
+        else:
+            # Normalize, matching the gate: a global re-stamp never
+            # carries a target, whatever a hand edit left behind.
+            project_id = None
+        confidence = raw.get("confidence")
+        if not isinstance(confidence, int | float) or not (0.0 <= float(confidence) <= 1.0):
+            raise ValueError(f"proposal line {i}: confidence must be a number in [0.0, 1.0], got {confidence!r}")
+        sha = raw.get("text_sha256")
+        if not isinstance(sha, str) or not sha:
+            raise ValueError(f"proposal line {i}: text_sha256 must be a non-empty string")
+        reason = raw.get("reason")
+        proposals.append(
+            Proposal(
+                memory_id=mid,
+                verdict=verdict,
+                project_id=project_id,
+                confidence=float(confidence),
+                reason=reason if isinstance(reason, str) else "",
+                prior_scope_source=str(raw.get("prior_scope_source", "")),
+                text_sha256=sha,
+            )
+        )
+    return header, proposals
+
+
+def parse_preimages(text: str) -> tuple[dict[str, Any], list[PreImage]]:
+    """Parse a pre-image file into fully validated PreImage objects.
+
+    Same strictness rationale as `parse_proposals`: rollback writes
+    the dumped text and metadata back verbatim, so a malformed row
+    (text missing, metadata not a dict) would either crash mid-run
+    or silently restore an empty row. Raises ValueError naming the
+    offending line; the caller aborts the whole rollback.
+    """
+    header, raws = parse_artifact(text, row_type="preimage")
+    preimages: list[PreImage] = []
+    for i, raw in enumerate(raws, start=2):
+        mid = raw.get("memory_id")
+        if not isinstance(mid, str) or not mid:
+            raise ValueError(f"preimage line {i}: memory_id must be a non-empty string")
+        pre_text = raw.get("text")
+        if not isinstance(pre_text, str) or not pre_text:
+            raise ValueError(f"preimage line {i}: text must be a non-empty string")
+        metadata = raw.get("metadata")
+        if not isinstance(metadata, dict):
+            raise ValueError(f"preimage line {i}: metadata must be an object")
+        preimages.append(PreImage(memory_id=mid, text=pre_text, metadata=metadata))
+    return header, preimages
+
+
 # ── Pure helpers: report rendering ──────────────────────────────────
 
 
@@ -726,11 +799,15 @@ async def run_apply(config: Config, user_id: str, *, proposals_path: Path, out_d
     """Apply a reviewed proposals file with per-row re-checks.
 
     Never re-runs classification: the reviewed file IS the change
-    set. Pre-images are dumped (and fsynced) before the first store
-    write; a dump failure aborts with zero changes.
+    set. Every proposal row is schema-validated up front (a
+    hand-edited row must abort the run BEFORE any write, not crash
+    it midway). Pre-images are dumped (and fsynced) before the first
+    store write; a dump failure aborts with zero changes, and an
+    existing pre-image file is never truncated because it may be the
+    only rollback material from an earlier apply of the same run.
     """
     try:
-        header, raw_rows = parse_artifact(proposals_path.read_text(encoding="utf-8"), row_type="proposal")
+        header, proposals = parse_proposals(proposals_path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as e:
         print(f"memory admin: cannot read proposals: {e}")
         return 1
@@ -746,13 +823,12 @@ async def run_apply(config: Config, user_id: str, *, proposals_path: Path, out_d
     # and registry as they are NOW. The pairs that survive carry
     # their fresh row so the pre-image dump and the write use the
     # same fetched state.
-    survivors: list[tuple[dict[str, Any], MemoryResult, ResolvedMemoryScope]] = []
+    survivors: list[tuple[Proposal, MemoryResult, ResolvedMemoryScope]] = []
     skips: dict[str, list[str]] = {}
-    for raw in raw_rows:
-        mid = raw.get("memory_id", "")
-        row = memory.get_by_id(user_id=user_id, memory_id=mid)
+    for proposal in proposals:
+        row = memory.get_by_id(user_id=user_id, memory_id=proposal.memory_id)
         if row is None:
-            skips.setdefault(SKIP_ROW_GONE, []).append(mid)
+            skips.setdefault(SKIP_ROW_GONE, []).append(proposal.memory_id)
             continue
         resolved = memory.resolve_memory_scope(row.metadata)
         still_selected = (
@@ -764,24 +840,37 @@ async def run_apply(config: Config, user_id: str, *, proposals_path: Path, out_d
             # Covers the operator-moved-it-since-dry-run case: an
             # operator (or earlier classifier) write changes the
             # provenance, which deselects the row here.
-            skips.setdefault(SKIP_DESELECTED, []).append(mid)
+            skips.setdefault(SKIP_DESELECTED, []).append(proposal.memory_id)
             continue
-        if _text_sha256(row.text) != raw.get("text_sha256"):
-            skips.setdefault(SKIP_TEXT_DRIFT, []).append(mid)
+        if _text_sha256(row.text) != proposal.text_sha256:
+            skips.setdefault(SKIP_TEXT_DRIFT, []).append(proposal.memory_id)
             continue
-        if raw.get("verdict") == memory.SCOPE_PROJECT:
-            pid = raw.get("project_id")
-            if not isinstance(pid, str) or pid not in registry:
-                skips.setdefault(SKIP_UNREGISTERED_TARGET, []).append(mid)
+        if proposal.verdict == memory.SCOPE_PROJECT:
+            pid = proposal.project_id
+            if pid is None or pid not in registry:
+                skips.setdefault(SKIP_UNREGISTERED_TARGET, []).append(proposal.memory_id)
                 continue
             if not registry[pid].memory_enabled:
-                skips.setdefault(SKIP_DISABLED_TARGET, []).append(mid)
+                skips.setdefault(SKIP_DISABLED_TARGET, []).append(proposal.memory_id)
                 continue
-        survivors.append((raw, row, resolved))
+        survivors.append((proposal, row, resolved))
 
-    # Pre-image dump before any write; abort on failure. fsync so a
-    # crash mid-apply cannot leave changed rows with rollback
-    # material trapped in the page cache.
+    # Nothing to write means nothing to roll back: stop before the
+    # pre-image step entirely. Writing a header-only file here would
+    # at best be noise and at worst (same run id re-applied after a
+    # successful first pass) truncate the previous run's rollback
+    # material into an empty shell.
+    if not survivors:
+        skip_summary = ", ".join(f"{len(ids)} {reason}" for reason, ids in sorted(skips.items())) or "none"
+        print(f"memory admin: apply {run_id}: nothing to apply; skipped: {skip_summary}.")
+        return 0
+
+    # Pre-image dump before any write; abort on failure. Exclusive
+    # creation ("x"): the path derives from the run id, so a re-run
+    # of the same apply would otherwise silently overwrite the only
+    # copy of the original rows. fsync so a crash mid-apply cannot
+    # leave changed rows with rollback material trapped in the page
+    # cache.
     preimage_path = out_dir / f"reclassify-{run_id}-preimages.jsonl"
     preimage_header = {
         "run_id": run_id,
@@ -794,25 +883,30 @@ async def run_apply(config: Config, user_id: str, *, proposals_path: Path, out_d
     ]
     try:
         out_dir.mkdir(parents=True, exist_ok=True)
-        with open(preimage_path, "w", encoding="utf-8") as f:
+        with open(preimage_path, "x", encoding="utf-8") as f:
             f.write(render_preimages(preimage_header, preimages))
             f.flush()
             os.fsync(f.fileno())
+    except FileExistsError:
+        print(
+            f"memory admin: pre-image file already exists for run {run_id}: {preimage_path}\n"
+            "memory admin: refusing to overwrite rollback material; move it aside first "
+            "(or use it with --rollback)."
+        )
+        return 1
     except OSError as e:
         print(f"memory admin: pre-image dump failed, aborting with no changes: {e}")
         return 1
 
     applied = 0
     failed = 0
-    for raw, row, resolved in survivors:
-        verdict = raw["verdict"]
-        pid = raw.get("project_id") if verdict == memory.SCOPE_PROJECT else None
+    for proposal, row, resolved in survivors:
         merged = dict(row.metadata or {})
         merged.update(
             memory.build_scope_metadata(
-                scope=verdict,
-                project_id=pid,
-                scope_confidence=float(raw.get("confidence", 1.0)),
+                scope=proposal.verdict,
+                project_id=proposal.project_id,
+                scope_confidence=proposal.confidence,
                 scope_source=memory.SCOPE_SOURCE_CLASSIFIER,
             )
         )
@@ -824,8 +918,8 @@ async def run_apply(config: Config, user_id: str, *, proposals_path: Path, out_d
                 memory_id=row.id,
                 user_id=user_id,
                 from_resolved=resolved,
-                to_scope=verdict,
-                to_project_id=pid,
+                to_scope=proposal.verdict,
+                to_project_id=proposal.project_id,
                 run_id=run_id,
             )
         else:
@@ -847,13 +941,16 @@ async def run_rollback(config: Config, user_id: str, *, preimages_path: Path) ->
 
     Restores text and metadata exactly as dumped; Mem0 recomputes
     the embedding from the restored text, so the row returns to its
-    prior retrieval behavior. Rows whose CURRENT provenance is
-    operator are skipped: the pre-image file is rollback material
-    for classifier writes, not a time machine over later operator
-    intent.
+    prior retrieval behavior. Every pre-image row is schema-validated
+    up front (same rationale as apply: a malformed row in a
+    hand-editable restore artifact must abort the run before any
+    write, not crash it midway or silently restore an empty row).
+    Rows whose CURRENT provenance is operator are skipped: the
+    pre-image file is rollback material for classifier writes, not a
+    time machine over later operator intent.
     """
     try:
-        header, raw_rows = parse_artifact(preimages_path.read_text(encoding="utf-8"), row_type="preimage")
+        header, preimages = parse_preimages(preimages_path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as e:
         print(f"memory admin: cannot read pre-images: {e}")
         return 1
@@ -866,27 +963,21 @@ async def run_rollback(config: Config, user_id: str, *, preimages_path: Path) ->
     restored = 0
     failed = 0
     skips: dict[str, list[str]] = {}
-    for raw in raw_rows:
-        mid = raw.get("memory_id", "")
-        pre_text = raw.get("text", "")
-        pre_metadata = raw.get("metadata")
-        if not isinstance(pre_metadata, dict):
-            skips.setdefault(SKIP_MALFORMED_OUTPUT, []).append(mid)
-            continue
-        current = memory.get_by_id(user_id=user_id, memory_id=mid)
+    for pre in preimages:
+        current = memory.get_by_id(user_id=user_id, memory_id=pre.memory_id)
         if current is None:
-            skips.setdefault(SKIP_ROW_GONE, []).append(mid)
+            skips.setdefault(SKIP_ROW_GONE, []).append(pre.memory_id)
             continue
         current_resolved = memory.resolve_memory_scope(current.metadata)
         if current_resolved.scope_source == memory.SCOPE_SOURCE_OPERATOR:
-            skips.setdefault(SKIP_OPERATOR_CORRECTION, []).append(mid)
+            skips.setdefault(SKIP_OPERATOR_CORRECTION, []).append(pre.memory_id)
             continue
-        ok = memory.update_metadata(user_id=user_id, memory_id=mid, data=pre_text, metadata=pre_metadata)
+        ok = memory.update_metadata(user_id=user_id, memory_id=pre.memory_id, data=pre.text, metadata=pre.metadata)
         if ok:
             restored += 1
-            pre_resolved = memory.resolve_memory_scope(pre_metadata)
+            pre_resolved = memory.resolve_memory_scope(pre.metadata)
             _emit_scope_change(
-                memory_id=mid,
+                memory_id=pre.memory_id,
                 user_id=user_id,
                 from_resolved=current_resolved,
                 to_scope=pre_resolved.scope,

--- a/src/kai/memory_reclassify.py
+++ b/src/kai/memory_reclassify.py
@@ -1,0 +1,905 @@
+"""
+Offline scope reclassification for the semantic memory store.
+
+Backs the `python -m kai memory reclassify-scope` subcommand. The
+pass targets the scope-debt backlog: rows whose resolved scope is
+global only because nothing ever classified them (resolver
+`legacy_default`), plus rows written global by extraction before
+their project was registered (`extraction_default`). A one-shot
+reasoner proposes per-row verdicts; high-confidence verdicts become a
+reviewable proposals file; a separate apply invocation writes only
+what the operator reviewed, with pre-images dumped first and a
+rollback mode that consumes them.
+
+Three modes, three drivers:
+1. `run_dry_run`: enumerate, classify, write report + proposals.
+   No store writes.
+2. `run_apply`: re-check and apply a reviewed proposals file;
+   pre-image dump before the first write.
+3. `run_rollback`: restore rows from a pre-image file, refusing to
+   overwrite later operator corrections.
+
+Architectural shape mirrors `memory_command.py`: pure helpers
+(selection, verdict gating, file (de)serialization, report
+rendering, header validation) do no I/O and are unit-testable
+without Mem0 or subprocesses; the three async drivers own store
+access, reasoner calls, and file writes. The ENFORCEMENT of every
+safety gate (registry bootstrap, acting on a header-validation
+failure, exit-code policy) happens in the drivers and the CLI
+layer, never inside a pure helper, so the gates stay visible at the
+orchestration layer.
+
+Conservatism contract (the spec's load-bearing properties):
+- Selection admits ONLY user-visible rows resolving to global with
+  legacy/extraction-default provenance. Operator rows are
+  authoritative, classifier rows must not flip-flop across runs,
+  and invalid rows would have their corruption masked by a
+  classifier write.
+- Both verdict directions are threshold-gated; everything ambiguous
+  stays exactly as it is.
+- Apply consumes the reviewed proposals file verbatim; it never
+  re-runs classification, so what the operator eyeballed is what
+  gets written.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import random
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from kai import memory, sessions
+from kai.config import Config, MemoryProjectConfig, ModelRole, resolve_user_model
+from kai.memory import MemoryResult, ResolvedMemoryScope
+from kai.memory_extraction import (
+    _build_memory_reasoner,
+    _resolve_effective_backend,
+    _resolve_effective_provider,
+    _resolve_os_user,
+    _resolve_user_config,
+)
+from kai.memory_projects import load_db_registry, merged_registry
+from kai.oneshot import OneShotError
+
+log = logging.getLogger(__name__)
+
+
+# ── Constants ───────────────────────────────────────────────────────
+
+# Provenance values eligible for reclassification. Everything else is
+# shielded: operator rows are authoritative, classifier rows would
+# flip-flop, invalid rows need repair (not masking), and non-global
+# rows are out of population by definition.
+_ELIGIBLE_SCOPE_SOURCES: frozenset[str] = frozenset(
+    {memory.SCOPE_SOURCE_LEGACY_DEFAULT, memory.SCOPE_SOURCE_EXTRACTION_DEFAULT}
+)
+
+# Stable skip-reason keys. They appear in reports and summaries, so
+# renames are reader-visible; treat like log vocabulary.
+SKIP_BELOW_THRESHOLD = "below_threshold"
+SKIP_UNREGISTERED_TARGET = "unregistered_target"
+SKIP_DISABLED_TARGET = "disabled_target"
+SKIP_REASONER_FAILURE = "reasoner_failure"
+SKIP_MALFORMED_OUTPUT = "malformed_output"
+# Apply-time re-check skips.
+SKIP_ROW_GONE = "row_gone"
+SKIP_DESELECTED = "deselected"
+SKIP_TEXT_DRIFT = "text_drift"
+# Rollback-only skip: the row was corrected by the operator after the
+# pre-image was taken; rollback must not overwrite that intent.
+SKIP_OPERATOR_CORRECTION = "operator_correction"
+
+# Consecutive reasoner-failure ceiling for the dry-run abort guard. A
+# dead backend (wrong os-user, missing auth, stopped provider) fails
+# every call; five in a row is unambiguous death, while scattered
+# failures from a live backend never accumulate because any success
+# resets the counter.
+_CONSECUTIVE_FAILURE_ABORT = 5
+
+# JSON Schema enforced on every classification call. Mirrors the
+# extraction pattern: the reasoner passes it to the provider's schema
+# mode, and the envelope parser still validates defensively because
+# the root-fallback path can deliver unvalidated payloads.
+_SCOPE_VERDICT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "scope": {"type": "string", "enum": ["global", "project"]},
+        "project_id": {"type": ["string", "null"]},
+        "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+        "reason": {"type": "string", "maxLength": 200},
+    },
+    "required": ["scope", "project_id", "confidence", "reason"],
+    "additionalProperties": False,
+}
+
+# Classification prompt scaffolding. Assembled by `_render_prompt`
+# with plain concatenation (never str.format) because row text is
+# user-originated and routinely contains braces.
+_PROMPT_HEAD = (
+    "You are classifying one stored memory for scope.\n"
+    "\n"
+    'Scope model: a "global" memory applies to the operator\'s work everywhere. '
+    'A "project" memory only matters inside one specific project.\n'
+    "\n"
+    "Registered projects:\n"
+)
+_PROMPT_RULES = (
+    "\n"
+    "Rules:\n"
+    '- Choose "project" only when the memory is about that project\'s code, issues, design, tests, or conventions.\n'
+    '- Operator identity, preferences, environment, tooling habits, people, and cross-project workflow are "global".\n'
+    '- If unsure, choose "global" with low confidence.\n'
+    '- "project_id" must be one of the registered ids above, or null when scope is "global".\n'
+    "\n"
+    'Respond with JSON only: {"scope": "global"|"project", "project_id": <id or null>, '
+    '"confidence": 0.0-1.0, "reason": "<one line>"}\n'
+    "\n"
+    "Memory:\n"
+)
+
+
+# ── Data shapes ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Proposal:
+    """One reviewable scope-change proposal from a dry run.
+
+    Attributes:
+        memory_id: Target row id.
+        verdict: "project" (move) or "global" (provenance re-stamp).
+        project_id: Move target for project verdicts; None for
+            global re-stamps.
+        confidence: Reasoner confidence, carried into
+            `scope_confidence` at apply time so the stored row
+            reflects the classifier's actual certainty.
+        reason: The reasoner's one-line justification, surfaced in
+            the report for eyeballing.
+        prior_scope_source: Resolved provenance at classification
+            time ("legacy_default" or "extraction_default");
+            report-only context.
+        text_sha256: SHA-256 of the row text at classification time.
+            Apply skips the row when this no longer matches, because
+            the verdict was rendered for content that has since
+            changed.
+    """
+
+    memory_id: str
+    verdict: str
+    project_id: str | None
+    confidence: float
+    reason: str
+    prior_scope_source: str
+    text_sha256: str
+
+
+@dataclass(frozen=True)
+class PreImage:
+    """One row's full pre-apply state, dumped for rollback."""
+
+    memory_id: str
+    text: str
+    metadata: dict[str, Any]
+
+
+def _text_sha256(text: str) -> str:
+    """Content-drift fingerprint for a row's text."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+# ── Pure helpers: selection ─────────────────────────────────────────
+
+
+def select_rows(rows: list[MemoryResult]) -> list[tuple[MemoryResult, ResolvedMemoryScope]]:
+    """Filter the corpus down to the reclassification population.
+
+    A row is selected iff its source is user-visible, its RESOLVED
+    scope is global, and its resolved provenance is legacy_default or
+    extraction_default. Resolution always goes through
+    `resolve_memory_scope`, never raw metadata, so corrupted rows
+    land in the resolver's invalid arm and are excluded here rather
+    than misread as eligible.
+
+    Returns (row, resolved) pairs so downstream steps never
+    re-resolve the same metadata.
+    """
+    selected: list[tuple[MemoryResult, ResolvedMemoryScope]] = []
+    for row in rows:
+        if (row.metadata or {}).get("source") not in memory.USER_VISIBLE_SOURCES:
+            continue
+        resolved = memory.resolve_memory_scope(row.metadata)
+        if resolved.scope != memory.SCOPE_GLOBAL:
+            continue
+        # invalid_defaulted rows can resolve to global too; the
+        # provenance check excludes them because their stored
+        # metadata is malformed and a classifier overlay would mask
+        # the corruption instead of surfacing it.
+        if resolved.scope_source not in _ELIGIBLE_SCOPE_SOURCES:
+            continue
+        selected.append((row, resolved))
+    return selected
+
+
+# ── Pure helpers: verdict gating ────────────────────────────────────
+
+
+def gate_verdict(
+    verdict: Any,
+    *,
+    row: MemoryResult,
+    resolved: ResolvedMemoryScope,
+    registry: dict[str, MemoryProjectConfig],
+    threshold: float,
+) -> tuple[Proposal | None, str | None]:
+    """Turn one parsed reasoner verdict into a proposal or a skip.
+
+    Returns exactly one of (proposal, None) or (None, skip_reason).
+
+    Validation here is defensive even though the call carries a JSON
+    Schema: the envelope's root-fallback path can deliver payloads
+    the provider never validated, and a malformed verdict must
+    become a counted skip, not an exception that kills the run.
+
+    Gates (conservative in both directions; threshold applies to
+    both):
+    - project verdict: confidence >= threshold AND the target is a
+      registered, memory-enabled project. Disabled projects are not
+      valid targets because their rows are unretrievable; moving a
+      row there would park it invisibly.
+    - global verdict: confidence >= threshold. Proposes a provenance
+      re-stamp so the legacy bucket converges toward genuinely
+      unreviewed rows.
+    - everything else: skip with a stable reason.
+    """
+    if not isinstance(verdict, dict):
+        return None, SKIP_MALFORMED_OUTPUT
+    scope = verdict.get("scope")
+    confidence = verdict.get("confidence")
+    project_id = verdict.get("project_id")
+    reason = verdict.get("reason")
+    if scope not in (memory.SCOPE_GLOBAL, memory.SCOPE_PROJECT):
+        return None, SKIP_MALFORMED_OUTPUT
+    if not isinstance(confidence, int | float) or not (0.0 <= float(confidence) <= 1.0):
+        return None, SKIP_MALFORMED_OUTPUT
+    if not isinstance(reason, str):
+        reason = ""
+
+    if float(confidence) < threshold:
+        return None, SKIP_BELOW_THRESHOLD
+
+    if scope == memory.SCOPE_PROJECT:
+        if not isinstance(project_id, str) or project_id not in registry:
+            return None, SKIP_UNREGISTERED_TARGET
+        if not registry[project_id].memory_enabled:
+            return None, SKIP_DISABLED_TARGET
+    else:
+        # Global re-stamps never carry a target, whatever the model
+        # emitted alongside the verdict.
+        project_id = None
+
+    return (
+        Proposal(
+            memory_id=row.id,
+            verdict=scope,
+            project_id=project_id,
+            confidence=float(confidence),
+            reason=reason,
+            prior_scope_source=resolved.scope_source,
+            text_sha256=_text_sha256(row.text),
+        ),
+        None,
+    )
+
+
+# ── Pure helpers: prompt ────────────────────────────────────────────
+
+
+def _render_prompt(registry: dict[str, MemoryProjectConfig], text: str) -> str:
+    """Assemble the classification prompt for one row.
+
+    Only memory-enabled projects appear in the vocabulary: a
+    disabled project is not a valid verdict target, so offering it
+    to the model would invite proposals the gate must then reject.
+    """
+    project_lines = "".join(
+        f"{pid}: {cfg.display_name}\n" for pid, cfg in sorted(registry.items()) if cfg.memory_enabled
+    )
+    return _PROMPT_HEAD + project_lines + _PROMPT_RULES + text
+
+
+# ── Pure helpers: envelope parsing ──────────────────────────────────
+
+
+def parse_verdict_envelope(raw_text: str) -> dict[str, Any] | None:
+    """Parse one reasoner response into a verdict dict, or None.
+
+    Mirrors the extraction parse block: strict `json.loads`, reject
+    non-dict, reject `is_error: true`, prefer the
+    `structured_output` nesting (the claude schema-mode envelope)
+    and fall back to the root for providers that emit the payload
+    directly. Returns None for every rejection; the caller counts it
+    as a malformed-output skip.
+    """
+    try:
+        parsed = json.loads(raw_text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    if parsed.get("is_error") is True:
+        return None
+    structured = parsed.get("structured_output")
+    if isinstance(structured, dict) and "scope" in structured:
+        return structured
+    if "scope" in parsed:
+        return parsed
+    return None
+
+
+# ── Pure helpers: file formats ──────────────────────────────────────
+#
+# Both artifact formats are header-then-rows JSONL. The header makes
+# every file self-describing (run id, target user) so apply and
+# rollback never derive identity from filenames, and a wrong-user
+# file fails validation before any store access.
+
+
+def render_proposals(header: dict[str, Any], proposals: list[Proposal]) -> str:
+    """Serialize a proposals file: header line, then proposal lines."""
+    lines = [json.dumps({"type": "header", **header}, separators=(",", ":"))]
+    for p in proposals:
+        lines.append(
+            json.dumps(
+                {
+                    "type": "proposal",
+                    "memory_id": p.memory_id,
+                    "verdict": p.verdict,
+                    "project_id": p.project_id,
+                    "confidence": p.confidence,
+                    "reason": p.reason,
+                    "prior_scope_source": p.prior_scope_source,
+                    "text_sha256": p.text_sha256,
+                },
+                separators=(",", ":"),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def render_preimages(header: dict[str, Any], preimages: list[PreImage]) -> str:
+    """Serialize a pre-image file: header line, then row lines."""
+    lines = [json.dumps({"type": "header", **header}, separators=(",", ":"))]
+    for p in preimages:
+        lines.append(
+            json.dumps(
+                {"type": "preimage", "memory_id": p.memory_id, "text": p.text, "metadata": p.metadata},
+                separators=(",", ":"),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def parse_artifact(text: str, *, row_type: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Parse a header-then-rows JSONL artifact.
+
+    Shared by proposals (`row_type="proposal"`) and pre-images
+    (`row_type="preimage"`). Raises ValueError with a readable
+    message on structural problems (missing/invalid header, a line
+    that is not JSON, a row of the wrong type); the CLI surfaces the
+    message and exits non-zero. Strictness is deliberate: these
+    files authorize store writes, so a half-parsed file must never
+    be silently half-applied.
+    """
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        raise ValueError("artifact is empty")
+    try:
+        header = json.loads(lines[0])
+    except json.JSONDecodeError as e:
+        raise ValueError(f"header line is not valid JSON: {e}") from e
+    if not isinstance(header, dict) or header.get("type") != "header":
+        raise ValueError("first line is not a header object")
+    rows: list[dict[str, Any]] = []
+    for i, ln in enumerate(lines[1:], start=2):
+        try:
+            row = json.loads(ln)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"line {i} is not valid JSON: {e}") from e
+        if not isinstance(row, dict) or row.get("type") != row_type:
+            raise ValueError(f"line {i} is not a {row_type} row")
+        rows.append(row)
+    return header, rows
+
+
+def validate_header(header: dict[str, Any], *, user_id: str) -> str | None:
+    """Check an artifact header against the CLI invocation.
+
+    Returns an error message, or None when valid. The user check is
+    the guard that makes a wrong-user apply/rollback fail loudly up
+    front instead of dwindling into per-row ownership skips that
+    read as a benign empty run.
+    """
+    run_id = header.get("run_id")
+    if not isinstance(run_id, str) or not run_id:
+        return "artifact header has no run_id"
+    header_user = header.get("user_id")
+    if header_user != user_id:
+        return f"artifact was generated for user {header_user!r}, not {user_id!r}"
+    return None
+
+
+# ── Pure helpers: report rendering ──────────────────────────────────
+
+
+def render_report(
+    *,
+    run_id: str,
+    user_id: str,
+    backend: str,
+    threshold: float,
+    scanned: int,
+    selected: int,
+    proposals: list[Proposal],
+    skips: dict[str, list[str]],
+    sample_size: int,
+    texts: dict[str, str],
+) -> str:
+    """Render the dry-run report markdown.
+
+    `texts` maps memory_id to row text for display; row text lives
+    only in the report (the proposals file carries the sha) so the
+    machine-readable artifact stays small while the human-readable
+    one shows what was actually classified.
+
+    The eyeball sample is drawn with `random.Random(run_id)` so
+    re-rendering the same run reproduces the same sample; the
+    operator's quick look and any later re-read see identical rows.
+    """
+    moves = sum(1 for p in proposals if p.verdict == memory.SCOPE_PROJECT)
+    restamps = len(proposals) - moves
+    skip_summary = ", ".join(f"{len(ids)} {reason}" for reason, ids in sorted(skips.items()) if ids) or "none"
+
+    lines = [
+        f"# Scope reclassification dry-run {run_id}",
+        "",
+        f"user: {user_id}  backend: {backend}  threshold: {threshold}",
+        f"rows scanned: {scanned}   selected: {selected}",
+        f"proposals: {moves} project moves, {restamps} global re-stamps",
+        f"skipped: {skip_summary}",
+        "",
+    ]
+
+    if proposals:
+        sample = random.Random(run_id).sample(proposals, min(sample_size, len(proposals)))
+        lines.append(f"## Eyeball sample ({len(sample)} of {len(proposals)})")
+        for i, p in enumerate(sample, start=1):
+            target = f"project {p.project_id}" if p.verdict == memory.SCOPE_PROJECT else "global"
+            text = _truncate(texts.get(p.memory_id, ""), 80)
+            lines.append(f'{i}. [{target} {p.confidence:.2f}] "{text}" (was {p.prior_scope_source})')
+            lines.append(f"   reason: {p.reason}")
+        lines.append("")
+        lines.append("## All proposals")
+        lines.append("| id | verdict | conf | was | text |")
+        lines.append("|----|---------|------|-----|------|")
+        for p in proposals:
+            target = p.project_id if p.verdict == memory.SCOPE_PROJECT else "global"
+            text = _truncate(texts.get(p.memory_id, ""), 60)
+            lines.append(f"| {p.memory_id} | {target} | {p.confidence:.2f} | {p.prior_scope_source} | {text} |")
+        lines.append("")
+
+    lines.append("## Skips")
+    any_skips = False
+    for reason, ids in sorted(skips.items()):
+        for mid in ids:
+            lines.append(f"- {mid}: {reason}")
+            any_skips = True
+    if not any_skips:
+        lines.append("- none")
+    return "\n".join(lines) + "\n"
+
+
+def _truncate(text: str, limit: int) -> str:
+    """Single-line truncation for report table cells."""
+    flat = text.replace("\n", " ").replace("|", "/")
+    if len(flat) <= limit:
+        return flat
+    return flat[: max(limit - 1, 0)] + "…"
+
+
+# ── Structured logging ──────────────────────────────────────────────
+
+
+def _emit_scope_change(
+    *,
+    memory_id: str,
+    user_id: str,
+    from_resolved: ResolvedMemoryScope,
+    to_scope: str,
+    to_project_id: str | None,
+    run_id: str,
+    rollback: bool = False,
+) -> None:
+    """Emit one scope-change audit line.
+
+    Same event name and field names as the /memory scope tools'
+    emitter, plus run_id (and rollback when applicable), so one log
+    query covers every writer that reassigns scope. The chat_id
+    field carries the CLI's user_id string.
+    """
+    payload: dict[str, Any] = {
+        "memory_id": memory_id,
+        "chat_id": user_id,
+        "from_scope": from_resolved.scope,
+        "from_project_id": from_resolved.project_id,
+        "from_scope_source": from_resolved.scope_source,
+        "to_scope": to_scope,
+        "to_project_id": to_project_id,
+        "run_id": run_id,
+    }
+    if rollback:
+        payload["rollback"] = True
+    log.info("%s %s", memory.SCOPE_CHANGE_EVENT, json.dumps(payload, separators=(",", ":")))
+
+
+# ── Drivers ─────────────────────────────────────────────────────────
+
+
+async def load_project_registry(config: Config) -> dict[str, MemoryProjectConfig]:
+    """Bootstrap the merged project registry in a fresh CLI process.
+
+    Mirrors daemon startup exactly: session-DB init, bulk-load the
+    chat-registered rows into the detection cache, then merge under
+    the operator-pinned YAML layer. Runs in BOTH dry-run and apply
+    (apply re-checks target registration, so an apply without this
+    load would skip every chat-registered target as unregistered,
+    which is the exact failure the re-check exists to prevent).
+    Rollback restores dumped state wholesale and does not need it.
+    """
+    await sessions.init_db(config.session_db_path)
+    load_db_registry(await sessions.get_memory_project_rows())
+    return merged_registry(config.memory_projects)
+
+
+def resolve_classification_settings(
+    config: Config,
+    user_id: str,
+    *,
+    backend: str | None,
+    os_user: str | None,
+    provider: str | None,
+) -> tuple[str, str | None, str] | str:
+    """Resolve effective (backend, os_user, provider) for a dry run.
+
+    Flags override; defaults follow the TARGET USER's effective
+    resolution (the same cascade memory extraction walks), because
+    classification quality and provider auth are per-user
+    properties, not install-wide ones. Returns the resolved triple,
+    or an error message string when the effective backend cannot run
+    a one-shot reasoner and no explicit flag was given; the command
+    must fail rather than silently substitute another backend.
+    """
+    from kai.config import ONESHOT_REASONER_BACKENDS
+
+    effective_backend = backend or _resolve_effective_backend(user_id, config)
+    if effective_backend not in ONESHOT_REASONER_BACKENDS:
+        return (
+            f"effective backend {effective_backend!r} cannot run one-shot classification; "
+            f"pass --backend (one of {sorted(ONESHOT_REASONER_BACKENDS)})"
+        )
+    effective_os_user = os_user if os_user is not None else _resolve_os_user(user_id, config)
+    effective_provider = provider or _resolve_effective_provider(user_id, config)
+    return effective_backend, effective_os_user, effective_provider
+
+
+async def run_dry_run(
+    config: Config,
+    user_id: str,
+    *,
+    backend: str | None,
+    os_user: str | None,
+    provider: str | None,
+    threshold: float,
+    sample: int,
+    out_dir: Path,
+) -> int:
+    """Classify the target population and write report + proposals.
+
+    Writes nothing to the store. Returns a process exit code: 0 on a
+    completed pass (even an all-skip one; the report is the
+    product), non-zero on settings errors or the abort guard.
+    """
+    settings = resolve_classification_settings(config, user_id, backend=backend, os_user=os_user, provider=provider)
+    if isinstance(settings, str):
+        print(f"memory admin: {settings}")
+        return 2
+    effective_backend, effective_os_user, effective_provider = settings
+
+    registry = await load_project_registry(config)
+    rows = memory.get_all(user_id=user_id, limit=None)
+    selected = select_rows(rows)
+
+    run_id = datetime.now(UTC).strftime("rs-%Y%m%d-%H%M%S")
+    reasoner = _build_memory_reasoner(effective_backend, os_user=effective_os_user, provider=effective_provider)
+    user_cfg = _resolve_user_config(user_id, config)
+    model = resolve_user_model(
+        ModelRole.MEMORY_EXTRACTION,
+        user_cfg,
+        config,
+        backend=effective_backend,
+        provider=effective_provider,
+    )
+
+    proposals: list[Proposal] = []
+    skips: dict[str, list[str]] = {}
+    consecutive_failures = 0
+    for row, resolved in selected:
+        try:
+            result = await reasoner.run(
+                prompt=_render_prompt(registry, row.text),
+                system_prompt=None,
+                model=model,
+                timeout=config.memory_extraction_timeout_s,
+                purpose="scope_reclassification",
+                json_schema=_SCOPE_VERDICT_SCHEMA,
+            )
+        except OneShotError:
+            # All typed reasoner failures (timeout, subprocess,
+            # output) collapse to the same counted skip; the log
+            # carries the detail for forensics.
+            log.warning("reclassify: reasoner failed for %s", row.id, exc_info=True)
+            skips.setdefault(SKIP_REASONER_FAILURE, []).append(row.id)
+            consecutive_failures += 1
+            if consecutive_failures >= _CONSECUTIVE_FAILURE_ABORT:
+                print(
+                    f"memory admin: aborting after {consecutive_failures} consecutive reasoner "
+                    "failures; the backend looks dead (auth? os-user? provider?)."
+                )
+                return 1
+            continue
+        verdict = parse_verdict_envelope(result.text)
+        if verdict is None:
+            skips.setdefault(SKIP_MALFORMED_OUTPUT, []).append(row.id)
+            # Malformed output counts toward the abort guard: a
+            # backend emitting garbage every call is as dead as one
+            # that times out.
+            consecutive_failures += 1
+            if consecutive_failures >= _CONSECUTIVE_FAILURE_ABORT:
+                print(
+                    f"memory admin: aborting after {consecutive_failures} consecutive reasoner "
+                    "failures; the backend looks dead (auth? os-user? provider?)."
+                )
+                return 1
+            continue
+        consecutive_failures = 0
+        proposal, skip_reason = gate_verdict(
+            verdict, row=row, resolved=resolved, registry=registry, threshold=threshold
+        )
+        if proposal is not None:
+            proposals.append(proposal)
+        else:
+            assert skip_reason is not None
+            skips.setdefault(skip_reason, []).append(row.id)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    header = {
+        "run_id": run_id,
+        "user_id": user_id,
+        "threshold": threshold,
+        "backend": effective_backend,
+        "registry_ids": sorted(registry),
+        "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
+    }
+    proposals_path = out_dir / f"reclassify-{run_id}-proposals.jsonl"
+    proposals_path.write_text(render_proposals(header, proposals), encoding="utf-8")
+    report = render_report(
+        run_id=run_id,
+        user_id=user_id,
+        backend=effective_backend,
+        threshold=threshold,
+        scanned=len(rows),
+        selected=len(selected),
+        proposals=proposals,
+        skips=skips,
+        sample_size=sample,
+        texts={row.id: row.text for row, _ in selected},
+    )
+    report_path = out_dir / f"reclassify-{run_id}-report.md"
+    report_path.write_text(report, encoding="utf-8")
+
+    moves = sum(1 for p in proposals if p.verdict == memory.SCOPE_PROJECT)
+    print(
+        f"memory admin: dry-run {run_id}: scanned {len(rows)}, selected {len(selected)}, "
+        f"proposed {moves} moves + {len(proposals) - moves} re-stamps."
+    )
+    print(f"memory admin: report:    {report_path}")
+    print(f"memory admin: proposals: {proposals_path}")
+    return 0
+
+
+async def run_apply(config: Config, user_id: str, *, proposals_path: Path, out_dir: Path) -> int:
+    """Apply a reviewed proposals file with per-row re-checks.
+
+    Never re-runs classification: the reviewed file IS the change
+    set. Pre-images are dumped (and fsynced) before the first store
+    write; a dump failure aborts with zero changes.
+    """
+    try:
+        header, raw_rows = parse_artifact(proposals_path.read_text(encoding="utf-8"), row_type="proposal")
+    except (OSError, ValueError) as e:
+        print(f"memory admin: cannot read proposals: {e}")
+        return 1
+    error = validate_header(header, user_id=user_id)
+    if error is not None:
+        print(f"memory admin: {error}")
+        return 1
+    run_id: str = header["run_id"]
+
+    registry = await load_project_registry(config)
+
+    # Re-check phase: every proposal is verified against the store
+    # and registry as they are NOW. The pairs that survive carry
+    # their fresh row so the pre-image dump and the write use the
+    # same fetched state.
+    survivors: list[tuple[dict[str, Any], MemoryResult, ResolvedMemoryScope]] = []
+    skips: dict[str, list[str]] = {}
+    for raw in raw_rows:
+        mid = raw.get("memory_id", "")
+        row = memory.get_by_id(user_id=user_id, memory_id=mid)
+        if row is None:
+            skips.setdefault(SKIP_ROW_GONE, []).append(mid)
+            continue
+        resolved = memory.resolve_memory_scope(row.metadata)
+        still_selected = (
+            (row.metadata or {}).get("source") in memory.USER_VISIBLE_SOURCES
+            and resolved.scope == memory.SCOPE_GLOBAL
+            and resolved.scope_source in _ELIGIBLE_SCOPE_SOURCES
+        )
+        if not still_selected:
+            # Covers the operator-moved-it-since-dry-run case: an
+            # operator (or earlier classifier) write changes the
+            # provenance, which deselects the row here.
+            skips.setdefault(SKIP_DESELECTED, []).append(mid)
+            continue
+        if _text_sha256(row.text) != raw.get("text_sha256"):
+            skips.setdefault(SKIP_TEXT_DRIFT, []).append(mid)
+            continue
+        if raw.get("verdict") == memory.SCOPE_PROJECT:
+            pid = raw.get("project_id")
+            if not isinstance(pid, str) or pid not in registry:
+                skips.setdefault(SKIP_UNREGISTERED_TARGET, []).append(mid)
+                continue
+            if not registry[pid].memory_enabled:
+                skips.setdefault(SKIP_DISABLED_TARGET, []).append(mid)
+                continue
+        survivors.append((raw, row, resolved))
+
+    # Pre-image dump before any write; abort on failure. fsync so a
+    # crash mid-apply cannot leave changed rows with rollback
+    # material trapped in the page cache.
+    preimage_path = out_dir / f"reclassify-{run_id}-preimages.jsonl"
+    preimage_header = {
+        "run_id": run_id,
+        "user_id": user_id,
+        "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "proposal_file": proposals_path.name,
+    }
+    preimages = [
+        PreImage(memory_id=row.id, text=row.text, metadata=dict(row.metadata or {})) for _, row, _ in survivors
+    ]
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        with open(preimage_path, "w", encoding="utf-8") as f:
+            f.write(render_preimages(preimage_header, preimages))
+            f.flush()
+            os.fsync(f.fileno())
+    except OSError as e:
+        print(f"memory admin: pre-image dump failed, aborting with no changes: {e}")
+        return 1
+
+    applied = 0
+    failed = 0
+    for raw, row, resolved in survivors:
+        verdict = raw["verdict"]
+        pid = raw.get("project_id") if verdict == memory.SCOPE_PROJECT else None
+        merged = dict(row.metadata or {})
+        merged.update(
+            memory.build_scope_metadata(
+                scope=verdict,
+                project_id=pid,
+                scope_confidence=float(raw.get("confidence", 1.0)),
+                scope_source=memory.SCOPE_SOURCE_CLASSIFIER,
+            )
+        )
+        merged[memory.SCOPE_RUN_ID_KEY] = run_id
+        ok = memory.update_metadata(user_id=user_id, memory_id=row.id, data=row.text, metadata=merged)
+        if ok:
+            applied += 1
+            _emit_scope_change(
+                memory_id=row.id,
+                user_id=user_id,
+                from_resolved=resolved,
+                to_scope=verdict,
+                to_project_id=pid,
+                run_id=run_id,
+            )
+        else:
+            failed += 1
+
+    skip_summary = ", ".join(f"{len(ids)} {reason}" for reason, ids in sorted(skips.items())) or "none"
+    print(f"memory admin: apply {run_id}: applied {applied}, failed {failed}, skipped: {skip_summary}.")
+    print(f"memory admin: pre-images: {preimage_path}")
+    # Exit 1 only when the run attempted writes and none landed; an
+    # all-benign-skip run is a valid outcome (everything changed or
+    # was corrected since the dry run).
+    if survivors and applied == 0:
+        return 1
+    return 0
+
+
+async def run_rollback(config: Config, user_id: str, *, preimages_path: Path) -> int:
+    """Restore rows from a pre-image file.
+
+    Restores text and metadata exactly as dumped; Mem0 recomputes
+    the embedding from the restored text, so the row returns to its
+    prior retrieval behavior. Rows whose CURRENT provenance is
+    operator are skipped: the pre-image file is rollback material
+    for classifier writes, not a time machine over later operator
+    intent.
+    """
+    try:
+        header, raw_rows = parse_artifact(preimages_path.read_text(encoding="utf-8"), row_type="preimage")
+    except (OSError, ValueError) as e:
+        print(f"memory admin: cannot read pre-images: {e}")
+        return 1
+    error = validate_header(header, user_id=user_id)
+    if error is not None:
+        print(f"memory admin: {error}")
+        return 1
+    run_id: str = header["run_id"]
+
+    restored = 0
+    failed = 0
+    skips: dict[str, list[str]] = {}
+    for raw in raw_rows:
+        mid = raw.get("memory_id", "")
+        pre_text = raw.get("text", "")
+        pre_metadata = raw.get("metadata")
+        if not isinstance(pre_metadata, dict):
+            skips.setdefault(SKIP_MALFORMED_OUTPUT, []).append(mid)
+            continue
+        current = memory.get_by_id(user_id=user_id, memory_id=mid)
+        if current is None:
+            skips.setdefault(SKIP_ROW_GONE, []).append(mid)
+            continue
+        current_resolved = memory.resolve_memory_scope(current.metadata)
+        if current_resolved.scope_source == memory.SCOPE_SOURCE_OPERATOR:
+            skips.setdefault(SKIP_OPERATOR_CORRECTION, []).append(mid)
+            continue
+        ok = memory.update_metadata(user_id=user_id, memory_id=mid, data=pre_text, metadata=pre_metadata)
+        if ok:
+            restored += 1
+            pre_resolved = memory.resolve_memory_scope(pre_metadata)
+            _emit_scope_change(
+                memory_id=mid,
+                user_id=user_id,
+                from_resolved=current_resolved,
+                to_scope=pre_resolved.scope,
+                to_project_id=pre_resolved.project_id,
+                run_id=run_id,
+                rollback=True,
+            )
+        else:
+            failed += 1
+
+    skip_summary = ", ".join(f"{len(ids)} {reason}" for reason, ids in sorted(skips.items())) or "none"
+    print(f"memory admin: rollback {run_id}: restored {restored}, failed {failed}, skipped: {skip_summary}.")
+    attempted = restored + failed
+    if attempted and restored == 0:
+        return 1
+    return 0

--- a/tests/test_memory_admin.py
+++ b/tests/test_memory_admin.py
@@ -349,6 +349,39 @@ class TestReclassifyGates:
         init_mock.assert_not_called()
         assert "[0.0, 1.0]" in capsys.readouterr().err
 
+    def test_negative_sample_rejected_before_init(self, capsys):
+        """A negative sample would only blow up at report rendering,
+        after every reasoner call has been paid for; the typo must
+        die before memory init."""
+        args = self._args(["100", "--sample", "-1"])
+        with patch.object(memory_admin, "_initialize_memory") as init_mock:
+            code = memory_admin._cmd_reclassify(args)
+        assert code == 2
+        init_mock.assert_not_called()
+        assert ">= 0" in capsys.readouterr().err
+
+    def test_zero_sample_accepted(self):
+        args = self._args(["100", "--sample", "0"])
+        run_dry_run = AsyncMock(return_value=0)
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=MagicMock()),
+            patch("kai.memory_reclassify.run_dry_run", run_dry_run),
+        ):
+            code = memory_admin._cmd_reclassify(args)
+        assert code == 0
+        assert run_dry_run.call_args.kwargs["sample"] == 0
+
+    def test_apply_plan_path_rejects_malformed_rows(self, tmp_path, capsys):
+        """The no-yes plan path uses the same strict row validation as
+        the driver, so a hand-edited file fails before authorization."""
+        path = _write_proposals(tmp_path)
+        path.write_text(path.read_text().replace('"verdict":"global"', '"verdict":"oops"'))
+        args = self._args(["100", "--apply", str(path)])
+        with patch.object(memory_admin, "_initialize_memory", return_value=MagicMock()):
+            code = memory_admin._cmd_reclassify(args)
+        assert code == 1
+        assert "verdict" in capsys.readouterr().err
+
     def test_init_failure_returns_1(self):
         args = self._args(["100"])
         with patch.object(memory_admin, "_initialize_memory", return_value=None):

--- a/tests/test_memory_admin.py
+++ b/tests/test_memory_admin.py
@@ -203,7 +203,7 @@ class TestInitializeMemory:
     """Isolated tests for the init helper. The CLI tests above patch
     this helper out; these ensure its own branches are exercised."""
 
-    def test_returns_false_when_is_enabled_false(self, capsys):
+    def test_returns_none_when_is_enabled_false(self, capsys):
         """init_memory ran but memory stays disabled (e.g. MEMORY_ENABLED=
         false or dimension mismatch). The CLI must not proceed."""
         with (
@@ -212,25 +212,28 @@ class TestInitializeMemory:
             patch("kai.memory.is_enabled", return_value=False),
         ):
             ok = memory_admin._initialize_memory()
-        assert ok is False
+        assert ok is None
         err = capsys.readouterr().err
         assert "not enabled" in err
 
-    def test_returns_true_on_success(self):
+    def test_returns_config_on_success(self):
+        """Success hands back the loaded Config (truthy) so subcommands
+        that need config values do not load the environment twice."""
+        cfg = MagicMock()
         with (
-            patch("kai.config.load_config", return_value=MagicMock()),
+            patch("kai.config.load_config", return_value=cfg),
             patch("kai.memory.init_memory"),
             patch("kai.memory.is_enabled", return_value=True),
         ):
             ok = memory_admin._initialize_memory()
-        assert ok is True
+        assert ok is cfg
 
-    def test_returns_false_on_exception(self, capsys):
+    def test_returns_none_on_exception(self, capsys):
         """load_config raising (bad env, missing file) surfaces as a
-        stderr message and False, not a crash."""
+        stderr message and None, not a crash."""
         with patch("kai.config.load_config", side_effect=RuntimeError("bad env")):
             ok = memory_admin._initialize_memory()
-        assert ok is False
+        assert ok is None
         err = capsys.readouterr().err
         assert "init failed" in err
 
@@ -259,3 +262,161 @@ class TestCliDispatch:
         with patch.object(memory_admin, "_cmd_purge", return_value=2), pytest.raises(SystemExit) as exc_info:
             memory_admin.cli(["purge", "12345", "--source", "extracted"])
         assert exc_info.value.code == 2
+
+    def test_dispatch_calls_reclassify(self):
+        with (
+            patch.object(memory_admin, "_cmd_reclassify", return_value=0) as cmd_mock,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            memory_admin.cli(["reclassify-scope", "100"])
+        assert exc_info.value.code == 0
+        assert cmd_mock.call_args[0][0].user_id == "100"
+
+
+# ── reclassify-scope: parser ─────────────────────────────────────────
+
+
+class TestReclassifyParser:
+    def test_modes_are_mutually_exclusive(self):
+        parser = memory_admin._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["reclassify-scope", "100", "--apply", "a.jsonl", "--rollback", "b.jsonl"])
+
+    def test_classification_flags_default_to_none(self):
+        """None defaults are load-bearing: the mutating-mode rejection
+        distinguishes explicitly-passed flags from defaults by None."""
+        parser = memory_admin._build_parser()
+        args = parser.parse_args(["reclassify-scope", "100"])
+        assert args.backend is None
+        assert args.os_user is None
+        assert args.provider is None
+        assert args.threshold is None
+        assert args.sample is None
+        assert args.out_dir is None
+        assert args.apply is None
+        assert args.rollback is None
+        assert args.yes is False
+
+    def test_backend_choices_reject_unknown(self):
+        parser = memory_admin._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["reclassify-scope", "100", "--backend", "acp"])
+
+
+# ── reclassify-scope: gates ──────────────────────────────────────────
+
+
+def _write_proposals(tmp_path, *, user_id="100", run_id="rs-1", n=2):
+    """A minimal valid proposals file for gate tests."""
+    from kai import memory_reclassify
+
+    proposals = [
+        memory_reclassify.Proposal(
+            memory_id=f"m{i}",
+            verdict="global",
+            project_id=None,
+            confidence=0.9,
+            reason="r",
+            prior_scope_source="legacy_default",
+            text_sha256="ab",
+        )
+        for i in range(n)
+    ]
+    path = tmp_path / "proposals.jsonl"
+    path.write_text(memory_reclassify.render_proposals({"run_id": run_id, "user_id": user_id}, proposals))
+    return path
+
+
+class TestReclassifyGates:
+    def _args(self, argv):
+        return memory_admin._build_parser().parse_args(["reclassify-scope", *argv])
+
+    def test_classification_flags_rejected_in_mutating_mode(self, tmp_path, capsys):
+        """A typo'd dry-run flag must not silently change apply
+        semantics; it is rejected before memory init runs."""
+        args = self._args(["100", "--apply", str(tmp_path / "p.jsonl"), "--threshold", "0.9"])
+        with patch.object(memory_admin, "_initialize_memory") as init_mock:
+            code = memory_admin._cmd_reclassify(args)
+        assert code == 2
+        init_mock.assert_not_called()
+        assert "--threshold" in capsys.readouterr().err
+
+    def test_threshold_out_of_range_rejected(self, capsys):
+        args = self._args(["100", "--threshold", "1.5"])
+        with patch.object(memory_admin, "_initialize_memory") as init_mock:
+            code = memory_admin._cmd_reclassify(args)
+        assert code == 2
+        init_mock.assert_not_called()
+        assert "[0.0, 1.0]" in capsys.readouterr().err
+
+    def test_init_failure_returns_1(self):
+        args = self._args(["100"])
+        with patch.object(memory_admin, "_initialize_memory", return_value=None):
+            code = memory_admin._cmd_reclassify(args)
+        assert code == 1
+
+    def test_apply_without_yes_prints_count_and_exits_2(self, tmp_path, capsys):
+        path = _write_proposals(tmp_path, n=3)
+        args = self._args(["100", "--apply", str(path)])
+        with patch.object(memory_admin, "_initialize_memory", return_value=MagicMock()):
+            code = memory_admin._cmd_reclassify(args)
+        assert code == 2
+        out = capsys.readouterr().out
+        assert "3 row(s)" in out
+        assert "rs-1" in out
+        assert "--yes" in out
+
+    def test_apply_wrong_user_header_aborts(self, tmp_path, capsys):
+        path = _write_proposals(tmp_path, user_id="200")
+        args = self._args(["100", "--apply", str(path), "--yes"])
+        with patch.object(memory_admin, "_initialize_memory", return_value=MagicMock()):
+            code = memory_admin._cmd_reclassify(args)
+        assert code == 1
+        assert "200" in capsys.readouterr().err
+
+    def test_apply_with_yes_dispatches_run_apply(self, tmp_path):
+        path = _write_proposals(tmp_path)
+        args = self._args(["100", "--apply", str(path), "--yes"])
+        run_apply = AsyncMock(return_value=0)
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=MagicMock()),
+            patch("kai.memory_reclassify.run_apply", run_apply),
+        ):
+            code = memory_admin._cmd_reclassify(args)
+        assert code == 0
+        run_apply.assert_awaited_once()
+        assert run_apply.call_args.kwargs["proposals_path"] == path
+
+    def test_rollback_with_yes_dispatches_run_rollback(self, tmp_path):
+        from kai import memory_reclassify
+
+        path = tmp_path / "pre.jsonl"
+        path.write_text(
+            memory_reclassify.render_preimages(
+                {"run_id": "rs-1", "user_id": "100"},
+                [memory_reclassify.PreImage(memory_id="a", text="t", metadata={})],
+            )
+        )
+        args = self._args(["100", "--rollback", str(path), "--yes"])
+        run_rollback = AsyncMock(return_value=0)
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=MagicMock()),
+            patch("kai.memory_reclassify.run_rollback", run_rollback),
+        ):
+            code = memory_admin._cmd_reclassify(args)
+        assert code == 0
+        run_rollback.assert_awaited_once()
+
+    def test_dry_run_dispatches_with_documented_defaults(self):
+        args = self._args(["100"])
+        run_dry_run = AsyncMock(return_value=0)
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=MagicMock()),
+            patch("kai.memory_reclassify.run_dry_run", run_dry_run),
+        ):
+            code = memory_admin._cmd_reclassify(args)
+        assert code == 0
+        kwargs = run_dry_run.call_args.kwargs
+        assert kwargs["threshold"] == 0.8
+        assert kwargs["sample"] == 10
+        assert kwargs["backend"] is None

--- a/tests/test_memory_reclassify.py
+++ b/tests/test_memory_reclassify.py
@@ -1,0 +1,759 @@
+"""
+Unit tests for `src/kai/memory_reclassify.py`.
+
+Covers the spec's test plan: selection, verdict gating, envelope
+parsing, the dry-run (no store writes, artifacts, abort guard,
+defaults resolution), apply (header guard, re-checks, pre-images,
+write shape, audit lines), and rollback (header guard, exact restore,
+operator shielding).
+
+No real Mem0, no real subprocesses, no real timeouts. The reasoner is
+a fake object whose `run` pops canned outcomes; memory primitives are
+monkeypatched; artifacts land in `tmp_path`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import kai.memory_projects as mp_mod
+from kai import memory, memory_reclassify
+from kai.config import MemoryProjectConfig
+from kai.memory import MemoryResult
+from kai.oneshot import OneShotResult, OneShotTimeout
+
+# ── Fixture builders ────────────────────────────────────────────────
+
+
+def _row(
+    rid: str,
+    text: str = "some stored fact",
+    *,
+    source: str = "extracted",
+    scope_md: dict[str, Any] | None = None,
+) -> MemoryResult:
+    """A MemoryResult with optional scope metadata overlaid."""
+    metadata: dict[str, Any] = {"type": "fact", "source": source, "tags": ["t"], "confidence": 0.9}
+    if scope_md is not None:
+        metadata.update(scope_md)
+    return MemoryResult(id=rid, text=text, score=0.0, memory_type="fact", metadata=metadata, created_at="")
+
+
+def _legacy(rid: str, text: str = "some stored fact") -> MemoryResult:
+    """A legacy row: no scope keys at all."""
+    return _row(rid, text)
+
+
+def _extraction_global(rid: str) -> MemoryResult:
+    return _row(rid, scope_md={"scope": "global", "scope_source": "extraction_default"})
+
+
+def _project_cfg(pid: str, *, enabled: bool = True) -> MemoryProjectConfig:
+    return MemoryProjectConfig(
+        project_id=pid,
+        display_name=pid,
+        workspace_roots=(Path("/work") / pid,),
+        memory_enabled=enabled,
+        default_scope_for_new_facts="project",
+    )
+
+
+_REGISTRY = {"kai": _project_cfg("kai"), "anvil": _project_cfg("anvil")}
+
+
+def _verdict(scope: str, *, project_id: str | None = None, confidence: float = 0.9, reason: str = "r") -> dict:
+    return {"scope": scope, "project_id": project_id, "confidence": confidence, "reason": reason}
+
+
+def _envelope(verdict: dict) -> str:
+    """Wrap a verdict the way the claude schema-mode envelope does."""
+    return json.dumps({"is_error": False, "structured_output": verdict})
+
+
+class FakeReasoner:
+    """Pops one canned outcome per run() call.
+
+    Outcomes are either exceptions (raised) or strings (returned as
+    OneShotResult.text). Records every prompt for assertions.
+    """
+
+    def __init__(self, outcomes: list[Any]):
+        self.outcomes = list(outcomes)
+        self.prompts: list[str] = []
+
+    async def run(self, *, prompt, system_prompt, model, timeout, purpose, json_schema):
+        self.prompts.append(prompt)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return OneShotResult(text=outcome, backend="claude", model=model)
+
+
+def _config(tmp_path: Path) -> MagicMock:
+    cfg = MagicMock()
+    cfg.memory_projects = {}
+    cfg.user_configs = {}
+    cfg.agent_backend = "claude"
+    cfg.llm_provider = ""
+    cfg.memory_extraction_timeout_s = 60
+    cfg.session_db_path = tmp_path / "kai.db"
+    return cfg
+
+
+@pytest.fixture
+def dry_run_env(monkeypatch, tmp_path):
+    """Common monkeypatching for run_dry_run tests.
+
+    Returns a dict of mutable knobs the test can adjust before
+    calling `run()`: rows, registry, reasoner outcomes.
+    """
+    env: dict[str, Any] = {
+        "rows": [],
+        "registry": dict(_REGISTRY),
+        "outcomes": [],
+        "config": _config(tmp_path),
+        "out_dir": tmp_path / "out",
+    }
+
+    async def fake_registry(config):
+        return env["registry"]
+
+    monkeypatch.setattr(memory_reclassify, "load_project_registry", fake_registry)
+    monkeypatch.setattr(memory_reclassify.memory, "get_all", lambda *, user_id, limit: env["rows"])
+    monkeypatch.setattr(memory_reclassify, "resolve_user_model", lambda *a, **k: "model-x")
+    env["reasoner"] = None
+
+    def fake_build(backend, *, os_user=None, provider=""):
+        env["reasoner"] = FakeReasoner(env["outcomes"])
+        return env["reasoner"]
+
+    monkeypatch.setattr(memory_reclassify, "_build_memory_reasoner", fake_build)
+    update_mock = MagicMock(return_value=True)
+    monkeypatch.setattr(memory_reclassify.memory, "update_metadata", update_mock)
+    env["update_metadata"] = update_mock
+
+    async def run(**overrides):
+        kwargs = {
+            "backend": "claude",
+            "os_user": None,
+            "provider": "",
+            "threshold": 0.8,
+            "sample": 10,
+            "out_dir": env["out_dir"],
+        }
+        kwargs.update(overrides)
+        return await memory_reclassify.run_dry_run(env["config"], "100", **kwargs)
+
+    env["run"] = run
+    return env
+
+
+# ── Selection ───────────────────────────────────────────────────────
+
+
+class TestSelectRows:
+    def test_admits_legacy_and_extraction_default_global(self):
+        rows = [_legacy("a"), _extraction_global("b")]
+        selected = memory_reclassify.select_rows(rows)
+        assert [r.id for r, _ in selected] == ["a", "b"]
+
+    @pytest.mark.parametrize(
+        "row",
+        [
+            # Operator and classifier provenance are shielded.
+            _row("op", scope_md={"scope": "global", "scope_source": "operator"}),
+            _row("cl", scope_md={"scope": "global", "scope_source": "classifier"}),
+            # Invalid arm: corrupted scope value resolves global but
+            # invalid_defaulted, and must not be masked.
+            _row("inv", scope_md={"scope": "bogus"}),
+            # Valid scope without provenance: also the invalid arm.
+            _row("noprov", scope_md={"scope": "global"}),
+            # Non-global rows are out of population.
+            _row("proj", scope_md={"scope": "project", "project_id": "kai", "scope_source": "operator"}),
+            _row("task", scope_md={"scope": "task", "scope_source": "extraction_default"}),
+            # Non-user-visible sources never appear.
+            _row("raw", source="user_raw"),
+            _row("nosrc", source=""),
+        ],
+    )
+    def test_excludes_everything_else(self, row):
+        assert memory_reclassify.select_rows([row]) == []
+
+
+# ── Verdict gating ──────────────────────────────────────────────────
+
+
+class TestGateVerdict:
+    def _gate(self, verdict, *, registry=None, threshold=0.8, row=None):
+        row = row or _legacy("a")
+        resolved = memory.resolve_memory_scope(row.metadata)
+        return memory_reclassify.gate_verdict(
+            verdict,
+            row=row,
+            resolved=resolved,
+            registry=_REGISTRY if registry is None else registry,
+            threshold=threshold,
+        )
+
+    def test_project_verdict_at_threshold_proposes(self):
+        proposal, skip = self._gate(_verdict("project", project_id="kai", confidence=0.8))
+        assert skip is None
+        assert proposal is not None
+        assert proposal.verdict == "project"
+        assert proposal.project_id == "kai"
+        assert proposal.prior_scope_source == "legacy_default"
+        assert proposal.text_sha256
+
+    def test_project_below_threshold_skips(self):
+        proposal, skip = self._gate(_verdict("project", project_id="kai", confidence=0.79))
+        assert proposal is None
+        assert skip == memory_reclassify.SKIP_BELOW_THRESHOLD
+
+    def test_unregistered_target_skips(self):
+        proposal, skip = self._gate(_verdict("project", project_id="ghost"))
+        assert proposal is None
+        assert skip == memory_reclassify.SKIP_UNREGISTERED_TARGET
+
+    def test_disabled_target_skips(self):
+        registry = {"kai": _project_cfg("kai", enabled=False)}
+        proposal, skip = self._gate(_verdict("project", project_id="kai"), registry=registry)
+        assert proposal is None
+        assert skip == memory_reclassify.SKIP_DISABLED_TARGET
+
+    def test_global_verdict_proposes_restamp(self):
+        proposal, skip = self._gate(_verdict("global"))
+        assert skip is None
+        assert proposal is not None
+        assert proposal.verdict == "global"
+        assert proposal.project_id is None
+
+    def test_global_below_threshold_skips(self):
+        proposal, skip = self._gate(_verdict("global", confidence=0.5))
+        assert proposal is None
+        assert skip == memory_reclassify.SKIP_BELOW_THRESHOLD
+
+    def test_global_verdict_discards_stray_target(self):
+        proposal, _ = self._gate(_verdict("global", project_id="kai"))
+        assert proposal is not None
+        assert proposal.project_id is None
+
+    @pytest.mark.parametrize(
+        "verdict",
+        [
+            None,
+            "not a dict",
+            {"scope": "task", "project_id": None, "confidence": 0.9, "reason": "r"},
+            {"scope": "project", "project_id": "kai", "confidence": "high", "reason": "r"},
+            {"scope": "project", "project_id": "kai", "confidence": 1.7, "reason": "r"},
+        ],
+    )
+    def test_malformed_verdicts_skip(self, verdict):
+        proposal, skip = self._gate(verdict)
+        assert proposal is None
+        assert skip == memory_reclassify.SKIP_MALFORMED_OUTPUT
+
+
+# ── Envelope parsing ────────────────────────────────────────────────
+
+
+class TestParseVerdictEnvelope:
+    def test_structured_output_nesting_preferred(self):
+        v = memory_reclassify.parse_verdict_envelope(_envelope(_verdict("global")))
+        assert v is not None and v["scope"] == "global"
+
+    def test_root_fallback(self):
+        v = memory_reclassify.parse_verdict_envelope(json.dumps(_verdict("project", project_id="kai")))
+        assert v is not None and v["project_id"] == "kai"
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "not json at all",
+            json.dumps(["a", "list"]),
+            json.dumps({"is_error": True, "structured_output": {"scope": "global"}}),
+            json.dumps({"unrelated": 1}),
+        ],
+    )
+    def test_rejections_return_none(self, raw):
+        assert memory_reclassify.parse_verdict_envelope(raw) is None
+
+
+# ── Artifact formats ────────────────────────────────────────────────
+
+
+class TestArtifactFormats:
+    def _proposal(self) -> memory_reclassify.Proposal:
+        return memory_reclassify.Proposal(
+            memory_id="m1",
+            verdict="project",
+            project_id="kai",
+            confidence=0.9,
+            reason="r",
+            prior_scope_source="legacy_default",
+            text_sha256="ab",
+        )
+
+    def test_proposals_round_trip(self):
+        text = memory_reclassify.render_proposals({"run_id": "rs-1", "user_id": "100"}, [self._proposal()])
+        header, rows = memory_reclassify.parse_artifact(text, row_type="proposal")
+        assert header["run_id"] == "rs-1"
+        assert rows[0]["memory_id"] == "m1"
+        assert rows[0]["text_sha256"] == "ab"
+
+    def test_preimages_round_trip(self):
+        pre = memory_reclassify.PreImage(memory_id="m1", text="t", metadata={"source": "extracted"})
+        text = memory_reclassify.render_preimages({"run_id": "rs-1", "user_id": "100"}, [pre])
+        header, rows = memory_reclassify.parse_artifact(text, row_type="preimage")
+        assert header["run_id"] == "rs-1"
+        assert rows[0]["metadata"] == {"source": "extracted"}
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "",
+            "not json\n",
+            json.dumps({"type": "proposal"}) + "\n",
+            json.dumps({"type": "header", "run_id": "rs-1"}) + "\n" + json.dumps({"type": "preimage"}),
+        ],
+    )
+    def test_structural_problems_raise(self, text):
+        with pytest.raises(ValueError):
+            memory_reclassify.parse_artifact(text, row_type="proposal")
+
+    def test_validate_header_user_mismatch(self):
+        err = memory_reclassify.validate_header({"run_id": "rs-1", "user_id": "200"}, user_id="100")
+        assert err is not None and "200" in err
+
+    def test_validate_header_missing_run_id(self):
+        err = memory_reclassify.validate_header({"user_id": "100"}, user_id="100")
+        assert err is not None and "run_id" in err
+
+    def test_validate_header_ok(self):
+        assert memory_reclassify.validate_header({"run_id": "rs-1", "user_id": "100"}, user_id="100") is None
+
+
+# ── Report rendering ────────────────────────────────────────────────
+
+
+class TestRenderReport:
+    def _render(self, run_id: str = "rs-test") -> str:
+        proposals = [
+            memory_reclassify.Proposal(
+                memory_id=f"m{i}",
+                verdict="project" if i % 2 else "global",
+                project_id="kai" if i % 2 else None,
+                confidence=0.9,
+                reason=f"reason {i}",
+                prior_scope_source="legacy_default",
+                text_sha256="ab",
+            )
+            for i in range(6)
+        ]
+        return memory_reclassify.render_report(
+            run_id=run_id,
+            user_id="100",
+            backend="claude",
+            threshold=0.8,
+            scanned=10,
+            selected=8,
+            proposals=proposals,
+            skips={"below_threshold": ["m9"], "reasoner_failure": []},
+            sample_size=3,
+            texts={f"m{i}": f"text of row {i}" for i in range(6)},
+        )
+
+    def test_report_contains_counts_sample_and_proposals(self):
+        report = self._render()
+        assert "rows scanned: 10   selected: 8" in report
+        assert "3 project moves, 3 global re-stamps" in report
+        assert "1 below_threshold" in report
+        assert "## Eyeball sample (3 of 6)" in report
+        assert "text of row" in report
+        assert "## All proposals" in report
+        assert "- m9: below_threshold" in report
+
+    def test_sample_is_reproducible_per_run_id(self):
+        assert self._render("rs-a") == self._render("rs-a")
+        # Different run ids draw different samples (statistically;
+        # with 6 choose 3 the two seeds used here differ).
+        assert self._render("rs-a") != self._render("rs-b")
+
+
+# ── Defaults resolution ─────────────────────────────────────────────
+
+
+class TestResolveClassificationSettings:
+    def test_user_overrides_win_over_global(self, tmp_path):
+        cfg = _config(tmp_path)
+        user = MagicMock()
+        user.agent_backend = "codex"
+        user.llm_provider = "deepseek"
+        user.os_user = "alice"
+        cfg.user_configs = {100: user}
+        settings = memory_reclassify.resolve_classification_settings(
+            cfg, "100", backend=None, os_user=None, provider=None
+        )
+        assert settings == ("codex", "alice", "deepseek")
+
+    def test_unsupported_effective_backend_errors(self, tmp_path):
+        cfg = _config(tmp_path)
+        cfg.agent_backend = "not-a-reasoner-backend"
+        settings = memory_reclassify.resolve_classification_settings(
+            cfg, "100", backend=None, os_user=None, provider=None
+        )
+        assert isinstance(settings, str)
+        assert "--backend" in settings
+
+    def test_explicit_flags_override_resolution(self, tmp_path):
+        cfg = _config(tmp_path)
+        user = MagicMock()
+        user.agent_backend = "codex"
+        user.llm_provider = "deepseek"
+        user.os_user = "alice"
+        cfg.user_configs = {100: user}
+        settings = memory_reclassify.resolve_classification_settings(
+            cfg, "100", backend="claude", os_user="bob", provider="p"
+        )
+        assert settings == ("claude", "bob", "p")
+
+
+# ── Dry run ─────────────────────────────────────────────────────────
+
+
+class TestDryRun:
+    @pytest.mark.asyncio
+    async def test_writes_artifacts_and_no_store_writes(self, dry_run_env):
+        env = dry_run_env
+        env["rows"] = [_legacy("a", "kai webhook internals"), _extraction_global("b")]
+        env["outcomes"] = [
+            _envelope(_verdict("project", project_id="kai", confidence=0.93)),
+            _envelope(_verdict("global", confidence=0.85)),
+        ]
+        code = await env["run"]()
+        assert code == 0
+        env["update_metadata"].assert_not_called()
+        files = sorted(p.name for p in env["out_dir"].iterdir())
+        assert any(name.endswith("-proposals.jsonl") for name in files)
+        assert any(name.endswith("-report.md") for name in files)
+        proposals_text = next(p for p in env["out_dir"].iterdir() if p.name.endswith(".jsonl")).read_text()
+        header, rows = memory_reclassify.parse_artifact(proposals_text, row_type="proposal")
+        assert header["user_id"] == "100"
+        assert header["backend"] == "claude"
+        assert {r["memory_id"] for r in rows} == {"a", "b"}
+
+    @pytest.mark.asyncio
+    async def test_prompt_carries_enabled_projects_only(self, dry_run_env):
+        env = dry_run_env
+        env["registry"] = {"kai": _project_cfg("kai"), "off": _project_cfg("off", enabled=False)}
+        env["rows"] = [_legacy("a")]
+        env["outcomes"] = [_envelope(_verdict("global"))]
+        await env["run"]()
+        prompt = env["reasoner"].prompts[0]
+        assert "kai: kai" in prompt
+        assert "off" not in prompt.split("Rules:")[0].split("Registered projects:")[1]
+
+    @pytest.mark.asyncio
+    async def test_abort_after_five_consecutive_failures(self, dry_run_env):
+        env = dry_run_env
+        env["rows"] = [_legacy(f"r{i}") for i in range(8)]
+        env["outcomes"] = [OneShotTimeout() for _ in range(5)] + [_envelope(_verdict("global"))] * 3
+        code = await env["run"]()
+        assert code == 1
+        # The sixth row was never classified: the guard fired first.
+        assert len(env["reasoner"].prompts) == 5
+
+    @pytest.mark.asyncio
+    async def test_four_failures_then_success_continues(self, dry_run_env):
+        env = dry_run_env
+        env["rows"] = [_legacy(f"r{i}") for i in range(6)]
+        env["outcomes"] = [OneShotTimeout() for _ in range(4)] + [_envelope(_verdict("global"))] * 2
+        code = await env["run"]()
+        assert code == 0
+        assert len(env["reasoner"].prompts) == 6
+
+    @pytest.mark.asyncio
+    async def test_malformed_output_counts_toward_abort(self, dry_run_env):
+        env = dry_run_env
+        env["rows"] = [_legacy(f"r{i}") for i in range(6)]
+        env["outcomes"] = ["garbage"] * 5 + [_envelope(_verdict("global"))]
+        code = await env["run"]()
+        assert code == 1
+
+    @pytest.mark.asyncio
+    async def test_unsupported_backend_exits_2(self, dry_run_env):
+        env = dry_run_env
+        env["config"].agent_backend = "not-a-reasoner-backend"
+        code = await env["run"](backend=None)
+        assert code == 2
+
+
+# ── Apply ───────────────────────────────────────────────────────────
+
+
+def _proposals_file(
+    tmp_path: Path, rows: list[MemoryResult], *, run_id: str = "rs-apply", user_id: str = "100"
+) -> Path:
+    """Write a proposals file moving every row to project kai."""
+    proposals = [
+        memory_reclassify.Proposal(
+            memory_id=r.id,
+            verdict="project",
+            project_id="kai",
+            confidence=0.9,
+            reason="r",
+            prior_scope_source="legacy_default",
+            text_sha256=memory_reclassify._text_sha256(r.text),
+        )
+        for r in rows
+    ]
+    path = tmp_path / "proposals.jsonl"
+    path.write_text(
+        memory_reclassify.render_proposals({"run_id": run_id, "user_id": user_id}, proposals), encoding="utf-8"
+    )
+    return path
+
+
+@pytest.fixture
+def apply_env(monkeypatch, tmp_path):
+    """Common monkeypatching for run_apply / run_rollback tests."""
+    env: dict[str, Any] = {
+        "store": {},
+        "registry": dict(_REGISTRY),
+        "config": _config(tmp_path),
+        "out_dir": tmp_path / "out",
+        "updates": [],
+        "update_ok": True,
+    }
+
+    async def fake_registry(config):
+        return env["registry"]
+
+    monkeypatch.setattr(memory_reclassify, "load_project_registry", fake_registry)
+    monkeypatch.setattr(
+        memory_reclassify.memory,
+        "get_by_id",
+        lambda *, user_id, memory_id: env["store"].get(memory_id),
+    )
+
+    def fake_update(*, user_id, memory_id, data, metadata):
+        env["updates"].append({"user_id": user_id, "memory_id": memory_id, "data": data, "metadata": metadata})
+        return env["update_ok"]
+
+    monkeypatch.setattr(memory_reclassify.memory, "update_metadata", fake_update)
+    return env
+
+
+class TestApply:
+    @pytest.mark.asyncio
+    async def test_happy_path_write_shape_and_preimages(self, apply_env, tmp_path, caplog):
+        env = apply_env
+        row = _legacy("a", "kai internals")
+        env["store"] = {"a": row}
+        path = _proposals_file(tmp_path, [row])
+        with caplog.at_level(logging.INFO, logger="kai.memory_reclassify"):
+            code = await memory_reclassify.run_apply(env["config"], "100", proposals_path=path, out_dir=env["out_dir"])
+        assert code == 0
+        # Write shape: full prior metadata preserved, scope keys
+        # overlaid, run id stamped, verdict confidence carried.
+        update = env["updates"][0]
+        assert update["user_id"] == "100"
+        assert update["data"] == row.text
+        md = update["metadata"]
+        for key, value in row.metadata.items():
+            if key not in {"scope", "project_id", "workspace_root", "scope_confidence", "scope_source"}:
+                assert md[key] == value
+        assert md["scope"] == "project"
+        assert md["project_id"] == "kai"
+        assert md["scope_source"] == "classifier"
+        assert md["scope_confidence"] == 0.9
+        assert md[memory.SCOPE_RUN_ID_KEY] == "rs-apply"
+        # Pre-image dump: headed, complete, prior state exact.
+        pre_path = env["out_dir"] / "reclassify-rs-apply-preimages.jsonl"
+        header, rows = memory_reclassify.parse_artifact(pre_path.read_text(), row_type="preimage")
+        assert header["run_id"] == "rs-apply"
+        assert header["user_id"] == "100"
+        assert rows[0]["metadata"] == row.metadata
+        # One audit line with the run id.
+        line = next(r.message for r in caplog.records if r.message.startswith(memory.SCOPE_CHANGE_EVENT))
+        assert '"run_id":"rs-apply"' in line
+        assert '"from_scope_source":"legacy_default"' in line
+        assert '"to_project_id":"kai"' in line
+
+    @pytest.mark.asyncio
+    async def test_header_user_mismatch_aborts_before_store(self, apply_env, tmp_path, monkeypatch):
+        env = apply_env
+        row = _legacy("a")
+        path = _proposals_file(tmp_path, [row], user_id="200")
+        fetches: list[str] = []
+        monkeypatch.setattr(
+            memory_reclassify.memory,
+            "get_by_id",
+            lambda *, user_id, memory_id: fetches.append(memory_id),
+        )
+        code = await memory_reclassify.run_apply(env["config"], "100", proposals_path=path, out_dir=env["out_dir"])
+        assert code == 1
+        assert fetches == []
+        assert env["updates"] == []
+
+    @pytest.mark.asyncio
+    async def test_recheck_skips(self, apply_env, tmp_path):
+        env = apply_env
+        gone = _legacy("gone")
+        moved = _row("moved", scope_md={"scope": "project", "project_id": "kai", "scope_source": "operator"})
+        drifted_orig = _legacy("drift", "original text")
+        drifted_now = _legacy("drift", "edited text")
+        ok = _legacy("ok")
+        env["store"] = {"moved": moved, "drift": drifted_now, "ok": ok}
+        path = _proposals_file(tmp_path, [gone, _legacy("moved"), drifted_orig, ok])
+        code = await memory_reclassify.run_apply(env["config"], "100", proposals_path=path, out_dir=env["out_dir"])
+        assert code == 0
+        # Only the clean row was written; the operator-moved row was
+        # deselected, the drifted row hash-mismatched, the gone row
+        # vanished.
+        assert [u["memory_id"] for u in env["updates"]] == ["ok"]
+        # Pre-images contain only the surviving row.
+        pre_path = env["out_dir"] / "reclassify-rs-apply-preimages.jsonl"
+        _, rows = memory_reclassify.parse_artifact(pre_path.read_text(), row_type="preimage")
+        assert [r["memory_id"] for r in rows] == ["ok"]
+
+    @pytest.mark.asyncio
+    async def test_session_db_only_project_applies(self, apply_env, tmp_path, monkeypatch):
+        """Pins the mode-neutral registry bootstrap: a target that only
+        the DB layer knows applies when the bootstrap loaded it, and
+        skips as unregistered when the registry is empty."""
+        env = apply_env
+        row = _legacy("a")
+        env["store"] = {"a": row}
+        path = _proposals_file(tmp_path, [row])
+
+        env["registry"] = {"kai": _project_cfg("kai")}
+        code = await memory_reclassify.run_apply(env["config"], "100", proposals_path=path, out_dir=env["out_dir"])
+        assert code == 0
+        assert len(env["updates"]) == 1
+
+        env["updates"].clear()
+        env["registry"] = {}
+        code = await memory_reclassify.run_apply(env["config"], "100", proposals_path=path, out_dir=env["out_dir"])
+        assert code == 0
+        assert env["updates"] == []
+
+    @pytest.mark.asyncio
+    async def test_load_project_registry_mirrors_daemon_startup(self, monkeypatch, tmp_path):
+        """The real bootstrap loads session-DB rows through the same
+        cache loader daemon startup uses and merges under YAML."""
+        init_db = AsyncMock()
+        rows = AsyncMock(
+            return_value=[
+                {
+                    "project_id": "dbproj",
+                    "display_name": "dbproj",
+                    "workspace_root": str(tmp_path / "dbproj"),
+                    "memory_enabled": True,
+                    "default_scope_for_new_facts": "project",
+                    "created_by": 100,
+                }
+            ]
+        )
+        monkeypatch.setattr(memory_reclassify.sessions, "init_db", init_db)
+        monkeypatch.setattr(memory_reclassify.sessions, "get_memory_project_rows", rows)
+        monkeypatch.setattr(mp_mod, "_db_registry", {})
+        monkeypatch.setattr(mp_mod, "_db_creators", {})
+        cfg = _config(tmp_path)
+        registry = await memory_reclassify.load_project_registry(cfg)
+        init_db.assert_awaited_once_with(cfg.session_db_path)
+        assert "dbproj" in registry
+
+    @pytest.mark.asyncio
+    async def test_preimage_dump_failure_aborts_with_no_writes(self, apply_env, tmp_path):
+        env = apply_env
+        row = _legacy("a")
+        env["store"] = {"a": row}
+        path = _proposals_file(tmp_path, [row])
+        # out_dir is an existing FILE: mkdir(exist_ok=True) raises,
+        # which must abort before any store write.
+        blocked = tmp_path / "blocked"
+        blocked.write_text("")
+        code = await memory_reclassify.run_apply(env["config"], "100", proposals_path=path, out_dir=blocked)
+        assert code == 1
+        assert env["updates"] == []
+
+    @pytest.mark.asyncio
+    async def test_all_writes_failing_exits_1(self, apply_env, tmp_path):
+        env = apply_env
+        row = _legacy("a")
+        env["store"] = {"a": row}
+        env["update_ok"] = False
+        path = _proposals_file(tmp_path, [row])
+        code = await memory_reclassify.run_apply(env["config"], "100", proposals_path=path, out_dir=env["out_dir"])
+        assert code == 1
+
+
+# ── Rollback ────────────────────────────────────────────────────────
+
+
+def _preimage_file(tmp_path: Path, preimages: list[memory_reclassify.PreImage], *, user_id: str = "100") -> Path:
+    path = tmp_path / "preimages.jsonl"
+    path.write_text(
+        memory_reclassify.render_preimages({"run_id": "rs-orig", "user_id": user_id}, preimages), encoding="utf-8"
+    )
+    return path
+
+
+class TestRollback:
+    @pytest.mark.asyncio
+    async def test_restores_text_and_metadata_exactly(self, apply_env, tmp_path, caplog):
+        env = apply_env
+        # Current state: classifier-moved row. Pre-image: the legacy
+        # original.
+        current = _row(
+            "a", "kai internals", scope_md={"scope": "project", "project_id": "kai", "scope_source": "classifier"}
+        )
+        env["store"] = {"a": current}
+        original = _legacy("a", "kai internals")
+        path = _preimage_file(
+            tmp_path, [memory_reclassify.PreImage(memory_id="a", text=original.text, metadata=original.metadata)]
+        )
+        with caplog.at_level(logging.INFO, logger="kai.memory_reclassify"):
+            code = await memory_reclassify.run_rollback(env["config"], "100", preimages_path=path)
+        assert code == 0
+        update = env["updates"][0]
+        assert update["data"] == original.text
+        assert update["metadata"] == original.metadata
+        line = next(r.message for r in caplog.records if r.message.startswith(memory.SCOPE_CHANGE_EVENT))
+        assert '"run_id":"rs-orig"' in line
+        assert '"rollback":true' in line
+
+    @pytest.mark.asyncio
+    async def test_operator_corrected_rows_are_skipped(self, apply_env, tmp_path):
+        env = apply_env
+        current = _row("a", scope_md={"scope": "project", "project_id": "anvil", "scope_source": "operator"})
+        env["store"] = {"a": current}
+        path = _preimage_file(tmp_path, [memory_reclassify.PreImage(memory_id="a", text="t", metadata={})])
+        code = await memory_reclassify.run_rollback(env["config"], "100", preimages_path=path)
+        assert code == 0
+        assert env["updates"] == []
+
+    @pytest.mark.asyncio
+    async def test_header_user_mismatch_aborts(self, apply_env, tmp_path):
+        env = apply_env
+        path = _preimage_file(
+            tmp_path, [memory_reclassify.PreImage(memory_id="a", text="t", metadata={})], user_id="200"
+        )
+        code = await memory_reclassify.run_rollback(env["config"], "100", preimages_path=path)
+        assert code == 1
+        assert env["updates"] == []
+
+    @pytest.mark.asyncio
+    async def test_missing_rows_skip_counted(self, apply_env, tmp_path):
+        env = apply_env
+        env["store"] = {}
+        path = _preimage_file(tmp_path, [memory_reclassify.PreImage(memory_id="ghost", text="t", metadata={})])
+        code = await memory_reclassify.run_rollback(env["config"], "100", preimages_path=path)
+        assert code == 0
+        assert env["updates"] == []

--- a/tests/test_memory_reclassify.py
+++ b/tests/test_memory_reclassify.py
@@ -338,6 +338,82 @@ class TestArtifactFormats:
         assert memory_reclassify.validate_header({"run_id": "rs-1", "user_id": "100"}, user_id="100") is None
 
 
+class TestParseProposals:
+    """Strict row validation: a hand-edited proposals file must fail
+    parsing as a whole, never crash apply midway through writes."""
+
+    def _line(self, **overrides) -> str:
+        row = {
+            "type": "proposal",
+            "memory_id": "m1",
+            "verdict": "project",
+            "project_id": "kai",
+            "confidence": 0.9,
+            "reason": "r",
+            "prior_scope_source": "legacy_default",
+            "text_sha256": "ab",
+        }
+        row.update(overrides)
+        header = json.dumps({"type": "header", "run_id": "rs-1", "user_id": "100"})
+        return header + "\n" + json.dumps(row)
+
+    def test_valid_round_trip(self):
+        header, proposals = memory_reclassify.parse_proposals(self._line())
+        assert header["run_id"] == "rs-1"
+        assert proposals[0].verdict == "project"
+        assert proposals[0].confidence == 0.9
+
+    def test_global_verdict_normalizes_stray_target(self):
+        _, proposals = memory_reclassify.parse_proposals(self._line(verdict="global", project_id="kai"))
+        assert proposals[0].project_id is None
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"memory_id": ""},
+            {"memory_id": 7},
+            {"verdict": "task"},
+            {"verdict": "oops"},
+            {"project_id": None},
+            {"confidence": "high"},
+            {"confidence": 1.7},
+            {"text_sha256": None},
+        ],
+    )
+    def test_invalid_rows_raise_with_line_number(self, overrides):
+        with pytest.raises(ValueError, match="line 2"):
+            memory_reclassify.parse_proposals(self._line(**overrides))
+
+
+class TestParsePreimages:
+    """Same strictness for the restore artifact: a malformed pre-image
+    row could otherwise silently restore an empty row."""
+
+    def _line(self, **overrides) -> str:
+        row = {"type": "preimage", "memory_id": "m1", "text": "t", "metadata": {"source": "extracted"}}
+        row.update(overrides)
+        header = json.dumps({"type": "header", "run_id": "rs-1", "user_id": "100"})
+        return header + "\n" + json.dumps(row)
+
+    def test_valid_round_trip(self):
+        _, preimages = memory_reclassify.parse_preimages(self._line())
+        assert preimages[0].metadata == {"source": "extracted"}
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"memory_id": ""},
+            {"text": ""},
+            {"text": None},
+            {"metadata": "not a dict"},
+            {"metadata": None},
+        ],
+    )
+    def test_invalid_rows_raise_with_line_number(self, overrides):
+        with pytest.raises(ValueError, match="line 2"):
+            memory_reclassify.parse_preimages(self._line(**overrides))
+
+
 # ── Report rendering ────────────────────────────────────────────────
 
 
@@ -693,6 +769,59 @@ class TestApply:
         code = await memory_reclassify.run_apply(env["config"], "100", proposals_path=path, out_dir=env["out_dir"])
         assert code == 1
 
+    @pytest.mark.asyncio
+    async def test_existing_preimage_file_is_never_truncated(self, apply_env, tmp_path):
+        """A re-run of the same apply must not overwrite the first
+        run's rollback material; the path derives from the run id, so
+        only exclusive creation protects it."""
+        env = apply_env
+        row = _legacy("a")
+        env["store"] = {"a": row}
+        path = _proposals_file(tmp_path, [row])
+        env["out_dir"].mkdir(parents=True)
+        existing = env["out_dir"] / "reclassify-rs-apply-preimages.jsonl"
+        existing.write_text("rollback material from the first apply\n")
+        code = await memory_reclassify.run_apply(env["config"], "100", proposals_path=path, out_dir=env["out_dir"])
+        assert code == 1
+        assert env["updates"] == []
+        assert existing.read_text() == "rollback material from the first apply\n"
+
+    @pytest.mark.asyncio
+    async def test_no_survivors_writes_no_preimage_file(self, apply_env, tmp_path):
+        """The accidental-re-apply shape: every row was reclassified
+        by the first run, so the re-check deselects all of them. The
+        second run must not leave a header-only pre-image file where
+        the first run's rollback material lives."""
+        env = apply_env
+        reclassified = _row("a", scope_md={"scope": "project", "project_id": "kai", "scope_source": "classifier"})
+        env["store"] = {"a": reclassified}
+        path = _proposals_file(tmp_path, [_legacy("a")])
+        code = await memory_reclassify.run_apply(env["config"], "100", proposals_path=path, out_dir=env["out_dir"])
+        assert code == 0
+        assert env["updates"] == []
+        assert not (env["out_dir"] / "reclassify-rs-apply-preimages.jsonl").exists()
+
+    @pytest.mark.asyncio
+    async def test_malformed_proposal_row_aborts_before_store(self, apply_env, tmp_path, monkeypatch):
+        """A hand-edited row with an invalid verdict must abort the
+        whole apply during parsing, before any fetch or write."""
+        env = apply_env
+        row = _legacy("a")
+        good = _proposals_file(tmp_path, [row]).read_text()
+        corrupted = good.replace('"verdict":"project"', '"verdict":"task"')
+        bad_path = tmp_path / "edited.jsonl"
+        bad_path.write_text(corrupted)
+        fetches: list[str] = []
+        monkeypatch.setattr(
+            memory_reclassify.memory,
+            "get_by_id",
+            lambda *, user_id, memory_id: fetches.append(memory_id),
+        )
+        code = await memory_reclassify.run_apply(env["config"], "100", proposals_path=bad_path, out_dir=env["out_dir"])
+        assert code == 1
+        assert fetches == []
+        assert env["updates"] == []
+
 
 # ── Rollback ────────────────────────────────────────────────────────
 
@@ -756,4 +885,24 @@ class TestRollback:
         path = _preimage_file(tmp_path, [memory_reclassify.PreImage(memory_id="ghost", text="t", metadata={})])
         code = await memory_reclassify.run_rollback(env["config"], "100", preimages_path=path)
         assert code == 0
+        assert env["updates"] == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_preimage_row_aborts_before_store(self, apply_env, tmp_path, monkeypatch):
+        """A pre-image row without text must abort the whole rollback
+        during parsing; writing it back would wipe the row's content."""
+        env = apply_env
+        good = _preimage_file(tmp_path, [memory_reclassify.PreImage(memory_id="a", text="t", metadata={})]).read_text()
+        corrupted = good.replace('"text":"t"', '"text":""')
+        bad_path = tmp_path / "edited.jsonl"
+        bad_path.write_text(corrupted)
+        fetches: list[str] = []
+        monkeypatch.setattr(
+            memory_reclassify.memory,
+            "get_by_id",
+            lambda *, user_id, memory_id: fetches.append(memory_id),
+        )
+        code = await memory_reclassify.run_rollback(env["config"], "100", preimages_path=bad_path)
+        assert code == 1
+        assert fetches == []
         assert env["updates"] == []


### PR DESCRIPTION
## Summary

Offline, guarded reclassification of unreviewed global memory rows. Closes #664.

- New `reclassify-scope` subcommand on the memory admin CLI (`python -m kai memory ...`) with three modes, following the CLI's `--yes`/exit-2 conventions. The pass logic lives in a new `memory_reclassify` module (pure helpers for selection, gating, formats, and report; async drivers for store access, reasoner calls, and file writes); the admin module owns only parsing, gates, and dispatch, and imports the module function-locally so `purge` stays cheap.
- Dry-run (default): selects rows whose RESOLVED scope is global with `legacy_default` or `extraction_default` provenance (operator, classifier, and invalid rows are never touched), classifies each with a one-shot reasoner using the target user's effective backend/provider/os-user/model resolution (flags override; an unsupported effective backend errors rather than substituting), and writes a markdown report (reproducible eyeball sample) plus a header-led proposals JSONL. Both verdict directions are threshold-gated: high-confidence project verdicts propose moves; high-confidence global verdicts propose a provenance re-stamp so the legacy bucket converges to genuinely unreviewed rows; everything ambiguous stays untouched. Five consecutive reasoner failures abort the run.
- Apply: consumes the reviewed proposals file verbatim (never re-classifies), validates the header user before store access, re-checks every row (existence, still-selected, text-hash drift, target registered and memory-enabled), dumps a header-led fsynced pre-image file before the first write, then writes read-merge-write through `build_scope_metadata(scope_source="classifier")` with the verdict confidence and a `scope_run_id` stamp, emitting one `memory.scope_change` line per change. The project-registry bootstrap (session DB into the merged registry) runs in BOTH dry-run and apply, so proposals targeting chat-registered projects survive the fresh-process re-check.
- Rollback: restores text and metadata exactly from a pre-image file, validates the header user before store access, logs the originating run id from the header (never the filename), and refuses to overwrite rows whose current provenance is `operator`.
- The scope-change event name and run-id metadata key are shared constants in `memory.py`, consumed by both the `/memory` scope tools and this CLI so the two writers cannot drift. `_initialize_memory` now returns the loaded Config (truthy) so subcommands needing config values do not load the environment twice; `purge` semantics are unchanged.

Operational note: the embedded store is single-process, so the command runs while the daemon is stopped, same as `purge`.

## Testing

- 70 new tests: selection arms, two-direction gating (incl. unregistered and disabled targets), envelope parsing (nesting, root fallback, `is_error`, garbage), abort guard (five abort, four continue, malformed counts), per-user defaults resolution with flag overrides, dry-run artifact contents with zero store writes, apply header guard and re-check skips, pre-image completeness and dump-failure abort, write shape (non-scope metadata preserved byte-identical, confidence and run id stamped), session-DB-only-target bootstrap pin, rollback exact restore with operator shielding, and the CLI parser/gate matrix.
- Full suite: 4177 passed, 1 skipped. `make check` clean.
