### PR TITLE
feat(memory): transcript provenance for extracted facts and episodes

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -68,7 +68,7 @@ from kai.config import (
     models_for_backend,
     validate_model_for_backend,
 )
-from kai.history import log_message
+from kai.history import LogEntry, log_message
 from kai.locks import get_lock, get_stop_event
 from kai.pool import SubprocessPool
 from kai.telegram_utils import chunk_text
@@ -3082,7 +3082,8 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
     caption = update.message.caption or "What's in this image?"
     caption += f"\n[File saved to: {saved}]"
-    log_message(direction="user", chat_id=chat_id, text=caption, media={"type": "photo"})
+    # Capture the user LogEntry for transcript provenance threading.
+    user_log = log_message(direction="user", chat_id=chat_id, text=caption, media={"type": "photo"})
     content = [
         {"type": "text", "text": caption},
         {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": b64}},
@@ -3102,6 +3103,7 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                 _prepend_queue_marker(content) if was_queued else content,
                 pool,
                 model,
+                user_log=user_log,
             )
         finally:
             _clear_responding(chat_id)
@@ -3211,7 +3213,7 @@ async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         img_caption = caption or f"What's in this image ({file_name})?"
         img_caption += f"\n[File saved to: {saved}]"
 
-        log_message(
+        user_log = log_message(
             direction="user",
             chat_id=chat_id,
             text=caption or file_name,
@@ -3236,7 +3238,7 @@ async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         saved = _save_upload(raw, file_name, user_id=chat_id)
         header = f"File: {file_name}\n```\n{text_content}\n```\n[File saved to: {saved}]"
 
-        log_message(
+        user_log = log_message(
             direction="user",
             chat_id=chat_id,
             text=caption or f"[file: {file_name}]",
@@ -3253,7 +3255,7 @@ async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         data = await file.download_as_bytearray()
         saved = _save_upload(bytes(data), file_name, user_id=chat_id)
 
-        log_message(
+        user_log = log_message(
             direction="user",
             chat_id=chat_id,
             text=caption or f"[file: {file_name}]",
@@ -3275,6 +3277,7 @@ async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 _prepend_queue_marker(content) if was_queued else content,
                 pool,
                 model,
+                user_log=user_log,
             )
         finally:
             _clear_responding(chat_id)
@@ -3327,25 +3330,36 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     file = await context.bot.get_file(voice.file_id)
     audio_data = bytes(await file.download_as_bytearray())
 
-    log_message(
-        direction="user",
-        chat_id=chat_id,
-        text=f"[voice message, {voice.duration}s]",
-        media={"type": "voice", "duration": voice.duration},
-    )
+    voice_media = {"type": "voice", "duration": voice.duration}
+    voice_placeholder = f"[voice message, {voice.duration}s]"
 
+    # Transcription failure paths preserve the historical placeholder
+    # entry so an operator grepping history sees that a voice message
+    # came in even when whisper failed. Extraction never runs on those
+    # paths, so the placeholder's lack of recoverable content is not a
+    # provenance gap; the only paths that ever stamp provenance are
+    # below, after a real transcript exists.
     try:
         transcript = await transcribe_voice(audio_data, config.whisper_model_path)
     except TranscriptionError as e:
+        log_message(direction="user", chat_id=chat_id, text=voice_placeholder, media=voice_media)
         await update.message.reply_text(f"Transcription failed: {e}")
         return
 
     if not transcript:
+        log_message(direction="user", chat_id=chat_id, text=voice_placeholder, media=voice_media)
         await update.message.reply_text("Couldn't make out any speech in that voice message.")
         return
 
     # Echo the transcription so the user sees what Kai heard
     await _reply_safe(update.message, f"_Heard:_ {transcript}")
+
+    # Log the transcript itself as the user's message so the JSONL line
+    # carries what the extractor actually saw. This is the only history-
+    # output behaviour change in the provenance work: previous behaviour
+    # wrote only the duration placeholder, which silently lost the user's
+    # actual words and made source view useless for voice-derived rows.
+    user_log = log_message(direction="user", chat_id=chat_id, text=transcript, media=voice_media)
 
     prompt = f"[Voice message transcription]: {transcript}"
     model = pool.get_model(chat_id)
@@ -3364,6 +3378,7 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                 _prepend_queue_marker(prompt) if was_queued else prompt,
                 pool,
                 model,
+                user_log=user_log,
             )
         finally:
             _clear_responding(chat_id)
@@ -3513,7 +3528,10 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
     chat_id = _chat_id(update)
     prompt = update.message.text
-    log_message(direction="user", chat_id=chat_id, text=prompt)
+    # Capture the user LogEntry so _handle_response can thread it to
+    # the provenance writer. None on JSONL write failure; the extraction
+    # path then skips provenance stamping for this exchange.
+    user_log = log_message(direction="user", chat_id=chat_id, text=prompt)
     pool = _get_pool(context)
     model = pool.get_model(chat_id)
 
@@ -3531,6 +3549,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                 _prepend_queue_marker(prompt) if was_queued else prompt,
                 pool,
                 model,
+                user_log=user_log,
             )
         finally:
             _clear_responding(chat_id)
@@ -3548,6 +3567,7 @@ async def _handle_response(
     prompt: str | list,
     pool: SubprocessPool,
     model: str,
+    user_log: LogEntry | None = None,
 ) -> None:
     """
     Stream Claude's response and deliver it to the user.
@@ -3700,7 +3720,11 @@ async def _handle_response(
         await sessions.save_session(chat_id, final_response.session_id, model)
 
     final_text = final_response.text
-    log_message(direction="assistant", chat_id=chat_id, text=final_text)
+    # Capture the assistant LogEntry so the provenance writer can stamp
+    # the exact JSONL ts/date/sha256 the line landed with. None means
+    # the append failed (logged by log_message itself); the extraction
+    # path then skips provenance stamping for this exchange.
+    assistant_log = log_message(direction="assistant", chat_id=chat_id, text=final_text)
 
     # Fire-and-forget: embed this exchange in semantic memory.
     # Runs in a background task so it does not delay response delivery.
@@ -3780,6 +3804,8 @@ async def _handle_response(
                         config=config,
                         prior_pairs=prior_pairs,
                         workspace=ingest_workspace,
+                        user_log=user_log,
+                        assistant_log=assistant_log,
                     )
             except Exception:
                 log.warning("Memory ingestion failed", exc_info=True)

--- a/src/kai/history.py
+++ b/src/kai/history.py
@@ -20,10 +20,13 @@ when asked about past conversations. get_recent_history() provides a formatted
 summary of the last few messages for ambient recall at session start.
 """
 
+import hashlib
 import json
 import logging
 import re
-from datetime import UTC, datetime
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Literal
 
 from kai.config import DATA_DIR
 
@@ -63,19 +66,63 @@ _SYNTHETIC_ASSISTANT_MARKERS: re.Pattern[str] = re.compile(
 )
 
 
+@dataclass(frozen=True)
+class LogEntry:
+    """
+    Receipt for a successfully appended JSONL line.
+
+    Returned by `log_message` so the transcript provenance writer
+    (`memory_extraction.extract_and_store`) can stamp the exact
+    timestamp, date filename, and content hash that landed on disk,
+    without re-deriving any of them and risking near-midnight skew
+    or post-strip variants of the persisted text.
+
+    Attributes:
+        ts: The exact `ts` value persisted to the JSONL record.
+        date: The UTC date used as the `YYYY-MM-DD.jsonl` filename.
+            Carried separately from `ts` so callers do not slice the
+            ISO string; both are derived from the same
+            `datetime.now(UTC)` call so a wraparound between them is
+            structurally impossible.
+        chat_id: Telegram chat id, matching the JSONL `chat_id` field.
+        direction: "user" or "assistant", matching the JSONL `dir`.
+        text: The exact `text` field persisted to the JSONL line.
+        sha256: SHA-256 hex digest of `text.encode("utf-8")`. Cached
+            here so the provenance writer does not have to re-hash;
+            the transcript helper compares against this fingerprint
+            at lookup time.
+    """
+
+    ts: str
+    date: str
+    chat_id: int
+    direction: str
+    text: str
+    sha256: str
+
+
 def log_message(
     *,
     direction: str,
     chat_id: int,
     text: str,
     media: dict | None = None,
-) -> None:
+) -> LogEntry | None:
     """
     Append a single message record to today's JSONL chat log.
 
     Called from bot.py for every inbound user message and outbound assistant
     response. Each message is written immediately (not batched) so the log
     stays current even if the process crashes mid-conversation.
+
+    Returns:
+        A `LogEntry` describing the persisted line on success, or `None`
+        when the JSONL append failed (an `OSError` from the filesystem
+        layer is logged via the existing warning path; the return value
+        is the only signal a caller has that the line did NOT make it
+        to disk). Callers that stamp transcript provenance must skip
+        the stamp when the return is `None`, so a write failure never
+        produces a row pointing at a JSONL line that does not exist.
 
     Args:
         direction: "user" for inbound messages, "assistant" for Kai's responses.
@@ -88,20 +135,42 @@ def log_message(
     # and one user's history can be managed independently.
     user_dir = _LOG_DIR / str(chat_id)
     user_dir.mkdir(parents=True, exist_ok=True)
+    # Single `now` call so the ts written into the record and the date
+    # baked into the filename can never drift across a midnight boundary
+    # within one log_message invocation. The returned LogEntry carries
+    # both, derived from the same instant, so the provenance writer
+    # stamps the file path the line actually landed in.
     now = datetime.now(UTC)
+    ts = now.isoformat()
+    date = now.strftime("%Y-%m-%d")
     record = {
-        "ts": now.isoformat(),
+        "ts": ts,
         "dir": direction,
         "chat_id": chat_id,
         "text": text,
         "media": media,
     }
-    filepath = user_dir / f"{now.strftime('%Y-%m-%d')}.jsonl"
+    filepath = user_dir / f"{date}.jsonl"
     try:
         with open(filepath, "a", encoding="utf-8") as f:
             f.write(json.dumps(record, ensure_ascii=False) + "\n")
     except OSError:
         log.exception("Failed to write chat log")
+        # Returning None (not a populated LogEntry) is the contract
+        # that lets the transcript-provenance writer skip stamping for
+        # this exchange. A populated entry here would produce a row
+        # pointing at a JSONL line that does not exist, which would
+        # later surface as a `memory.provenance.drift` file-missing or
+        # ts-not-found event.
+        return None
+    return LogEntry(
+        ts=ts,
+        date=date,
+        chat_id=chat_id,
+        direction=direction,
+        text=text,
+        sha256=hashlib.sha256(text.encode("utf-8")).hexdigest(),
+    )
 
 
 def get_recent_history(chat_id: int | None = None) -> str:
@@ -387,3 +456,373 @@ def _pair_records_chronologically(records: list[dict]) -> list[tuple[str, str]]:
             pairs.append((pending_user, text))
             pending_user = None
     return pairs
+
+
+# ── Transcript provenance reader ────────────────────────────────────
+#
+# Memory rows written from real bot paths carry source_* metadata
+# pointing back at the JSONL line(s) that produced them. The reader
+# below resolves a TranscriptProvenance value (built from a row's
+# metadata by `kai.memory.read_transcript_provenance`) into the
+# originating turns plus a small surrounding window, with fail-closed
+# semantics: a missing file, missing timestamp, or content-hash drift
+# returns the failure reason rather than guessing at a similar turn.
+
+
+LookupReason = Literal[
+    "ok",
+    "legacy",
+    "file_missing",
+    "unreadable",
+    "ts_not_found",
+    "hash_mismatch",
+]
+
+_TRANSCRIPT_WINDOW_TURN_CAP = 50
+
+_PROVENANCE_DRIFT_EVENT = "memory.provenance.drift"
+
+
+@dataclass(frozen=True)
+class TranscriptTurn:
+    """One JSONL record reduced to the fields the source-view consumers need."""
+
+    ts: str
+    direction: str
+    text: str
+
+
+@dataclass(frozen=True)
+class TranscriptContext:
+    """
+    The originating turns plus a chronological surrounding window.
+
+    `target_assistant` is None when the row's stored provenance has
+    no `source_assistant_ts` (a corner case the spec admits but does
+    not produce from real bot paths today); an assistant ts that IS
+    set but no longer resolves in the JSONL is reported as a drift
+    via TranscriptLookup.reason, not by setting this to None.
+
+    `truncated` flags the episode-window cap and is always False on
+    fact lookups (whose context is fixed by the `before` / `after`
+    parameters).
+    """
+
+    chat_id: int
+    target_user: TranscriptTurn
+    target_assistant: TranscriptTurn | None
+    before: list[TranscriptTurn]
+    after: list[TranscriptTurn]
+    truncated: bool
+
+
+@dataclass(frozen=True)
+class TranscriptLookup:
+    """
+    Typed result for `fetch_transcript_context`.
+
+    `reason` always carries one of the LookupReason values; `context`
+    is populated iff `reason == "ok"`. The two are bundled so callers
+    (the /memory source view, the reclassification dry-run report)
+    can branch on the reason without scraping logs.
+    """
+
+    reason: LookupReason
+    context: TranscriptContext | None
+
+
+def _read_jsonl_file(path) -> list[dict] | None:
+    """
+    Best-effort JSONL reader.
+
+    Returns the parsed records on success, None on any I/O failure.
+    Malformed lines are skipped individually (mirroring
+    `get_recent_history`'s own posture); only a file-level error
+    collapses the return to None so the caller can distinguish
+    "file present but garbled rows" from "file unreadable."
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    out: list[dict] = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            log.debug("Skipping malformed JSON line in %s: %s", path.name, line[:100])
+    return out
+
+
+def _shift_date(date: str, days: int) -> str:
+    """
+    Add `days` to a `YYYY-MM-DD` string, returning the same shape.
+
+    Used to walk one file forward or back when the target window
+    crosses midnight. Goes through `datetime` rather than string
+    math so leap years and month rollovers behave correctly without
+    a calendar table.
+    """
+    parsed = datetime.strptime(date, "%Y-%m-%d").replace(tzinfo=UTC)
+    return (parsed + timedelta(days=days)).strftime("%Y-%m-%d")
+
+
+def _emit_drift_log(
+    *,
+    memory_id: str | None,
+    chat_id: int | None,
+    reason: LookupReason,
+    side: str | None = None,
+) -> None:
+    """
+    Structured log line for a non-ok, non-legacy lookup.
+
+    Every drift event names the row (when known), the chat, the
+    stable reason key, and the `side` discriminator that distinguishes
+    user-line and assistant-line misses for `ts_not_found`. Keeping
+    one event name across every failure mode means downstream log
+    queries do not have to enumerate sub-events as the helper grows.
+    """
+    payload: dict = {
+        "memory_id": memory_id,
+        "chat_id": chat_id,
+        "reason": reason,
+        "side": side,
+    }
+    log.info("%s %s", _PROVENANCE_DRIFT_EVENT, json.dumps(payload, separators=(",", ":")))
+
+
+def fetch_transcript_context(
+    provenance,
+    *,
+    before: int = 3,
+    after: int = 1,
+    memory_id: str | None = None,
+) -> TranscriptLookup:
+    """
+    Resolve a row's transcript provenance into surrounding turns.
+
+    Args:
+        provenance: A `kai.memory.TranscriptProvenance` value. Typed
+            as Any here to avoid an import cycle (memory.py imports
+            history.py for log writes, and the resolver lives in
+            memory.py); duck-typed access to `present`, `chat_id`,
+            `date`, `user_ts`, `user_text_sha256`, `assistant_ts`,
+            and `date_end` is the contract.
+        before: Maximum non-synthetic turns to include in the
+            preceding context window. Walks at most one file backward
+            when today's file does not contain `before` predecessors.
+        after: Maximum non-synthetic turns to include after the
+            assistant turn. Walks at most one file forward.
+        memory_id: Optional row id, carried into the drift log so log
+            queries can correlate failures back to the affected row.
+
+    Returns:
+        TranscriptLookup with `reason="ok"` and a populated
+        `TranscriptContext` on success. Every other path returns a
+        non-ok reason with `context=None`; non-ok, non-legacy reasons
+        emit a single structured log line.
+
+    Failure mode contract:
+        - legacy:        `provenance.present is False`. No log emitted.
+        - file_missing:  the per-day JSONL file is absent from disk.
+        - unreadable:    the file exists but cannot be read.
+        - ts_not_found:  the named timestamp is absent from the file
+                         (the `side` field of the log distinguishes
+                         user-side miss from assistant-side miss).
+        - hash_mismatch: the user line was found but its text no
+                         longer matches the stored fingerprint.
+
+    The helper never returns a "maybe matched" turn. A wrong-turn
+    render would be worse than no render at all.
+    """
+    if not provenance.present:
+        return TranscriptLookup(reason="legacy", context=None)
+
+    chat_id: int = provenance.chat_id
+    date: str = provenance.date
+    user_ts: str = provenance.user_ts
+    user_text_sha256: str = provenance.user_text_sha256
+    assistant_ts: str | None = provenance.assistant_ts
+
+    primary_path = _LOG_DIR / str(chat_id) / f"{date}.jsonl"
+    if not primary_path.exists():
+        _emit_drift_log(memory_id=memory_id, chat_id=chat_id, reason="file_missing")
+        return TranscriptLookup(reason="file_missing", context=None)
+    primary_records = _read_jsonl_file(primary_path)
+    if primary_records is None:
+        _emit_drift_log(memory_id=memory_id, chat_id=chat_id, reason="unreadable")
+        return TranscriptLookup(reason="unreadable", context=None)
+
+    # Locate the user line by exact ts + direction. The lookup is by
+    # ts (not by index) so any future history-management tool that
+    # reorders or deduplicates lines without changing them does not
+    # break provenance.
+    user_index = _find_record_index(primary_records, ts=user_ts, direction="user")
+    if user_index is None:
+        _emit_drift_log(memory_id=memory_id, chat_id=chat_id, reason="ts_not_found", side="user")
+        return TranscriptLookup(reason="ts_not_found", context=None)
+    user_record = primary_records[user_index]
+    user_text = user_record.get("text", "")
+    if hashlib.sha256(user_text.encode("utf-8")).hexdigest() != user_text_sha256:
+        _emit_drift_log(memory_id=memory_id, chat_id=chat_id, reason="hash_mismatch")
+        return TranscriptLookup(reason="hash_mismatch", context=None)
+    target_user = TranscriptTurn(ts=user_record["ts"], direction="user", text=user_text)
+
+    target_assistant: TranscriptTurn | None = None
+    if assistant_ts is not None:
+        # Same-day search first; the assistant turn usually lives in
+        # the same file. When it does not, walk one file forward
+        # (episode midnight cross) before giving up.
+        assistant_index = _find_record_index(primary_records, ts=assistant_ts, direction="assistant")
+        if assistant_index is None:
+            forward_path = _LOG_DIR / str(chat_id) / f"{_shift_date(date, 1)}.jsonl"
+            forward_records = _read_jsonl_file(forward_path) if forward_path.exists() else None
+            if forward_records is not None:
+                forward_assistant_index = _find_record_index(forward_records, ts=assistant_ts, direction="assistant")
+                if forward_assistant_index is not None:
+                    rec = forward_records[forward_assistant_index]
+                    target_assistant = TranscriptTurn(ts=rec["ts"], direction="assistant", text=rec.get("text", ""))
+            if target_assistant is None:
+                _emit_drift_log(memory_id=memory_id, chat_id=chat_id, reason="ts_not_found", side="assistant")
+                return TranscriptLookup(reason="ts_not_found", context=None)
+        else:
+            rec = primary_records[assistant_index]
+            target_assistant = TranscriptTurn(ts=rec["ts"], direction="assistant", text=rec.get("text", ""))
+
+    before_turns = _collect_before(
+        chat_id=chat_id, date=date, primary_records=primary_records, user_index=user_index, before=before
+    )
+    after_turns = _collect_after(
+        chat_id=chat_id,
+        date=date,
+        primary_records=primary_records,
+        anchor_index=user_index
+        if target_assistant is None
+        else _find_record_index(primary_records, ts=target_assistant.ts, direction="assistant"),
+        target_assistant=target_assistant,
+        after=after,
+    )
+
+    return TranscriptLookup(
+        reason="ok",
+        context=TranscriptContext(
+            chat_id=chat_id,
+            target_user=target_user,
+            target_assistant=target_assistant,
+            before=before_turns,
+            after=after_turns,
+            truncated=False,
+        ),
+    )
+
+
+def _find_record_index(records: list[dict], *, ts: str, direction: str) -> int | None:
+    """
+    Return the index of the first record matching exact ts + direction.
+
+    Linear scan; per-day JSONL files are small enough that an index
+    would add complexity without measurable benefit. Returns None
+    when no record matches.
+    """
+    for i, rec in enumerate(records):
+        if rec.get("ts") == ts and rec.get("dir") == direction:
+            return i
+    return None
+
+
+def _turn_is_synthetic(text: str) -> bool:
+    """Skip synthetic assistant placeholders in context windows."""
+    return bool(_SYNTHETIC_ASSISTANT_MARKERS.fullmatch(text or ""))
+
+
+def _to_turn(rec: dict) -> TranscriptTurn:
+    return TranscriptTurn(ts=rec.get("ts", ""), direction=rec.get("dir", ""), text=rec.get("text", ""))
+
+
+def _collect_before(
+    *, chat_id: int, date: str, primary_records: list[dict], user_index: int, before: int
+) -> list[TranscriptTurn]:
+    """
+    Walk backwards from the target user line, including up to `before`
+    non-synthetic turns. When today's file does not provide enough,
+    walk one file back. Returns chronological order (oldest first).
+    """
+    if before <= 0:
+        return []
+    collected: list[TranscriptTurn] = []
+    for rec in reversed(primary_records[:user_index]):
+        if _turn_is_synthetic(rec.get("text", "")):
+            continue
+        collected.append(_to_turn(rec))
+        if len(collected) >= before:
+            break
+    if len(collected) < before:
+        prev_path = _LOG_DIR / str(chat_id) / f"{_shift_date(date, -1)}.jsonl"
+        if prev_path.exists():
+            prev_records = _read_jsonl_file(prev_path)
+            if prev_records is not None:
+                for rec in reversed(prev_records):
+                    if _turn_is_synthetic(rec.get("text", "")):
+                        continue
+                    collected.append(_to_turn(rec))
+                    if len(collected) >= before:
+                        break
+    collected.reverse()
+    return collected
+
+
+def _collect_after(
+    *,
+    chat_id: int,
+    date: str,
+    primary_records: list[dict],
+    anchor_index: int | None,
+    target_assistant: TranscriptTurn | None,
+    after: int,
+) -> list[TranscriptTurn]:
+    """
+    Walk forward from the anchor index, including up to `after`
+    non-synthetic turns. The anchor is the assistant turn when
+    present, otherwise the user turn (so the "after" window starts
+    right after whichever target is the rightmost one in the primary
+    file). When today's file does not provide enough, walk one file
+    forward.
+    """
+    if after <= 0 or anchor_index is None:
+        return []
+    collected: list[TranscriptTurn] = []
+    for rec in primary_records[anchor_index + 1 :]:
+        if _turn_is_synthetic(rec.get("text", "")):
+            continue
+        collected.append(_to_turn(rec))
+        if len(collected) >= after:
+            break
+    if len(collected) < after:
+        # The episode midnight-cross path may have already populated
+        # the assistant from the next file. We still want to include
+        # any "after" turns following that assistant in the next file
+        # itself, which is the same path the same-day branch would have
+        # taken if the assistant lived locally.
+        next_path = _LOG_DIR / str(chat_id) / f"{_shift_date(date, 1)}.jsonl"
+        if next_path.exists():
+            next_records = _read_jsonl_file(next_path)
+            if next_records is not None:
+                # When the target_assistant lives in next_records, start
+                # after it; otherwise start at the beginning of the file.
+                start = 0
+                if target_assistant is not None:
+                    forward_assistant_index = _find_record_index(
+                        next_records, ts=target_assistant.ts, direction="assistant"
+                    )
+                    if forward_assistant_index is not None:
+                        start = forward_assistant_index + 1
+                for rec in next_records[start:]:
+                    if _turn_is_synthetic(rec.get("text", "")):
+                        continue
+                    collected.append(_to_turn(rec))
+                    if len(collected) >= after:
+                        break
+    return collected

--- a/src/kai/history.py
+++ b/src/kai/history.py
@@ -134,7 +134,6 @@ def log_message(
     # Separates users on disk so grep/jq searches are naturally scoped
     # and one user's history can be managed independently.
     user_dir = _LOG_DIR / str(chat_id)
-    user_dir.mkdir(parents=True, exist_ok=True)
     # Single `now` call so the ts written into the record and the date
     # baked into the filename can never drift across a midnight boundary
     # within one log_message invocation. The returned LogEntry carries
@@ -151,7 +150,14 @@ def log_message(
         "media": media,
     }
     filepath = user_dir / f"{date}.jsonl"
+    # mkdir lives inside the try so a filesystem permission or
+    # availability failure BEFORE the append still produces the same
+    # None signal as an append failure. Without this, a directory
+    # creation error would escape `log_message` and crash the
+    # caller, defeating the safety property the LogEntry | None
+    # contract is meant to provide.
     try:
+        user_dir.mkdir(parents=True, exist_ok=True)
         with open(filepath, "a", encoding="utf-8") as f:
             f.write(json.dumps(record, ensure_ascii=False) + "\n")
     except OSError:
@@ -476,6 +482,7 @@ LookupReason = Literal[
     "unreadable",
     "ts_not_found",
     "hash_mismatch",
+    "chat_mismatch",
 ]
 
 _TRANSCRIPT_WINDOW_TURN_CAP = 50
@@ -600,6 +607,7 @@ def fetch_transcript_context(
     before: int = 3,
     after: int = 1,
     memory_id: str | None = None,
+    expected_chat_id: int | None = None,
 ) -> TranscriptLookup:
     """
     Resolve a row's transcript provenance into surrounding turns.
@@ -618,6 +626,17 @@ def fetch_transcript_context(
             assistant turn. Walks at most one file forward.
         memory_id: Optional row id, carried into the drift log so log
             queries can correlate failures back to the affected row.
+        expected_chat_id: Ownership gate for the consumer. When
+            provided AND it differs from `provenance.chat_id`, the
+            helper returns `chat_mismatch` BEFORE touching disk: row
+            ownership (verified by Mem0's user_id partition at
+            `get_by_id` time) does not extend to the `source_chat_id`
+            field, which is just metadata the row carries. A
+            malformed, restored, or forged row whose `source_chat_id`
+            points at another chat would otherwise let the consumer
+            dereference an unrelated chat's JSONL. Callers that
+            already trust the provenance (admin tooling that scans
+            cross-chat by design) can omit the kwarg.
 
     Returns:
         TranscriptLookup with `reason="ok"` and a populated
@@ -634,6 +653,10 @@ def fetch_transcript_context(
                          user-side miss from assistant-side miss).
         - hash_mismatch: the user line was found but its text no
                          longer matches the stored fingerprint.
+        - chat_mismatch: `expected_chat_id` was supplied and disagrees
+                         with `provenance.chat_id`. No disk access
+                         occurs; the drift log fires so a forged or
+                         corrupted pointer surfaces in observability.
 
     The helper never returns a "maybe matched" turn. A wrong-turn
     render would be worse than no render at all.
@@ -642,6 +665,15 @@ def fetch_transcript_context(
         return TranscriptLookup(reason="legacy", context=None)
 
     chat_id: int = provenance.chat_id
+    if expected_chat_id is not None and chat_id != expected_chat_id:
+        # Fail closed BEFORE the filesystem read so a cross-chat
+        # pointer cannot leak even one byte of another chat's
+        # transcript. The drift log surfaces the attempt so an
+        # operator scanning observability for provenance issues can
+        # find a forged or restored-from-bad-backup row.
+        _emit_drift_log(memory_id=memory_id, chat_id=chat_id, reason="chat_mismatch")
+        return TranscriptLookup(reason="chat_mismatch", context=None)
+
     date: str = provenance.date
     user_ts: str = provenance.user_ts
     user_text_sha256: str = provenance.user_text_sha256
@@ -790,16 +822,28 @@ def _collect_after(
     right after whichever target is the rightmost one in the primary
     file). When today's file does not provide enough, walk one file
     forward.
+
+    Midnight-cross edge case: an episode whose user lands on day D
+    and whose assistant lands on day D+1 reaches here with
+    `anchor_index=None` (the assistant is not in `primary_records`)
+    but `target_assistant` populated. The early return for
+    `anchor_index is None` is therefore gated on having no
+    target_assistant at all; when the target lives in the next file,
+    we skip the primary-file scan and walk straight into the
+    next-file path below.
     """
-    if after <= 0 or anchor_index is None:
+    if after <= 0:
+        return []
+    if anchor_index is None and target_assistant is None:
         return []
     collected: list[TranscriptTurn] = []
-    for rec in primary_records[anchor_index + 1 :]:
-        if _turn_is_synthetic(rec.get("text", "")):
-            continue
-        collected.append(_to_turn(rec))
-        if len(collected) >= after:
-            break
+    if anchor_index is not None:
+        for rec in primary_records[anchor_index + 1 :]:
+            if _turn_is_synthetic(rec.get("text", "")):
+                continue
+            collected.append(_to_turn(rec))
+            if len(collected) >= after:
+                break
     if len(collected) < after:
         # The episode midnight-cross path may have already populated
         # the assistant from the next file. We still want to include

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -395,6 +395,114 @@ SCOPE_CHANGE_EVENT = "memory.scope_change"
 SCOPE_RUN_ID_KEY = "scope_run_id"
 
 
+# ── Transcript provenance: row-side pointer to the originating turns ─
+#
+# Rows extracted from real bot paths carry a `source_*` block that
+# fingerprints the JSONL line(s) the extraction consumed. The keys
+# live in the existing Mem0 metadata dict (no schema change to the
+# store) and are read by `read_transcript_provenance()` below. The
+# transcript-reading helper that turns a TranscriptProvenance into
+# surrounding turns lives in `kai.history`; the resolver here is
+# import-cycle-safe because it touches only metadata fields and the
+# `TranscriptProvenance` dataclass.
+
+SOURCE_CHAT_ID_KEY = "source_chat_id"
+SOURCE_DATE_KEY = "source_date"
+SOURCE_USER_TS_KEY = "source_user_ts"
+SOURCE_USER_TEXT_SHA256_KEY = "source_user_text_sha256"
+SOURCE_ASSISTANT_TS_KEY = "source_assistant_ts"
+SOURCE_DATE_END_KEY = "source_date_end"
+
+
+@dataclass(frozen=True)
+class TranscriptProvenance:
+    """
+    Read-time interpretation of a row's `source_*` metadata.
+
+    `present` is the contract every consumer keys on: when False, the
+    row predates provenance (or extraction skipped stamping due to a
+    `log_message` write failure), and the originating turns cannot be
+    recovered. When True, every required field is populated and the
+    transcript helper has a definite lookup target.
+
+    Attributes:
+        present: True iff `chat_id`, `date`, `user_ts`, and
+            `user_text_sha256` are all populated. A row with three of
+            four required fields is malformed; the resolver flags it
+            not-present rather than guessing.
+        chat_id: Telegram chat id whose JSONL holds the source turns.
+            Redundant with Mem0's row-level `user_id` so the locator
+            survives a future move off Mem0 without round-tripping
+            through the store.
+        date: UTC date (`YYYY-MM-DD`) used as the JSONL filename for
+            the user turn.
+        user_ts: ISO 8601 timestamp of the originating user turn,
+            matching the JSONL `ts` field exactly.
+        user_text_sha256: SHA-256 hex digest of the user turn's exact
+            JSONL `text` value (UTF-8 bytes). The drift gate fingerprints
+            the persisted record, not any sanitized variant.
+        assistant_ts: ISO 8601 timestamp of the paired assistant turn,
+            or None when the row was deliberately written without one
+            (a corner case the schema admits but the bot does not
+            produce today).
+        date_end: UTC date of the assistant turn when the exchange or
+            episode window crosses midnight, else None. Episode rows
+            populate this whenever the user and assistant turns fall
+            on different UTC dates; fact rows carry the assistant date
+            implicitly via `assistant_ts`.
+    """
+
+    present: bool
+    chat_id: int | None
+    date: str | None
+    user_ts: str | None
+    user_text_sha256: str | None
+    assistant_ts: str | None
+    date_end: str | None
+
+
+def read_transcript_provenance(metadata: dict[str, Any] | None) -> TranscriptProvenance:
+    """
+    Interpret a row's `source_*` metadata into a TranscriptProvenance.
+
+    Required fields are `source_chat_id`, `source_date`, `source_user_ts`,
+    and `source_user_text_sha256`. A row missing ANY of those is treated
+    as not-present; the resolver does not guess at a half-populated
+    locator. `source_assistant_ts` and `source_date_end` are optional;
+    their absence on a present row is meaningful (no assistant turn /
+    same-day window) and does not flip the present flag.
+
+    The resolver does not validate timestamp formats beyond presence;
+    the transcript helper performs that check at lookup time and fails
+    closed on any non-resolving locator.
+    """
+    md = metadata or {}
+    chat_id = md.get(SOURCE_CHAT_ID_KEY)
+    date = md.get(SOURCE_DATE_KEY)
+    user_ts = md.get(SOURCE_USER_TS_KEY)
+    user_text_sha256 = md.get(SOURCE_USER_TEXT_SHA256_KEY)
+    required_present = (
+        isinstance(chat_id, int)
+        and isinstance(date, str)
+        and isinstance(user_ts, str)
+        and isinstance(user_text_sha256, str)
+        and bool(date)
+        and bool(user_ts)
+        and bool(user_text_sha256)
+    )
+    assistant_ts = md.get(SOURCE_ASSISTANT_TS_KEY)
+    date_end = md.get(SOURCE_DATE_END_KEY)
+    return TranscriptProvenance(
+        present=required_present,
+        chat_id=chat_id if isinstance(chat_id, int) else None,
+        date=date if isinstance(date, str) and date else None,
+        user_ts=user_ts if isinstance(user_ts, str) and user_ts else None,
+        user_text_sha256=user_text_sha256 if isinstance(user_text_sha256, str) and user_text_sha256 else None,
+        assistant_ts=assistant_ts if isinstance(assistant_ts, str) and assistant_ts else None,
+        date_end=date_end if isinstance(date_end, str) and date_end else None,
+    )
+
+
 @dataclass(frozen=True)
 class ResolvedMemoryScope:
     """

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -2120,6 +2120,7 @@ _SOURCE_FAILURE_MESSAGES: dict[str, str] = {
     "unreadable": "The history file could not be read.",
     "ts_not_found": "The original message was not found in the history file.",
     "hash_mismatch": "Content drift detected: the original message no longer matches its fingerprint.",
+    "chat_mismatch": "This memory's source pointer does not match this chat; refusing to dereference.",
     "legacy": "This memory predates source tracking.",
 }
 
@@ -2193,7 +2194,14 @@ async def _send_source_view(
         await _send_or_edit(update, "This memory no longer exists.", None, edit=True)
         return
     provenance = read_transcript_provenance(fact.metadata)
-    lookup = fetch_transcript_context(provenance, memory_id=memory_id)
+    # `expected_chat_id` enforces the ownership gate: Mem0's
+    # `get_by_id` partition verifies the row belongs to this chat,
+    # but the `source_chat_id` field on that row is just metadata
+    # the row carries; a malformed/forged value pointing at another
+    # chat would otherwise let this UI dereference an unrelated
+    # chat's JSONL. The helper returns chat_mismatch before any
+    # filesystem read on disagreement.
+    lookup = fetch_transcript_context(provenance, memory_id=memory_id, expected_chat_id=chat_id)
     text, kb = _build_source_view(fact, lookup)
     cache = _get_cache(chat_id)
     return_to = cache.return_to if cache is not None else None

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -64,7 +64,19 @@ from telegram.ext import ContextTypes
 
 from kai import memory
 from kai.config import ONESHOT_REASONER_BACKENDS, Config, MemoryProjectConfig
-from kai.memory import MemoryResult, MemoryStats, ResolvedMemoryScope
+from kai.history import (
+    TranscriptContext,
+    TranscriptLookup,
+    TranscriptTurn,
+    fetch_transcript_context,
+)
+from kai.memory import (
+    MemoryResult,
+    MemoryStats,
+    ResolvedMemoryScope,
+    TranscriptProvenance,
+    read_transcript_provenance,
+)
 from kai.memory_projects import ActiveMemoryProject, detect_active_memory_project, merged_registry
 
 if TYPE_CHECKING:
@@ -550,6 +562,122 @@ def _scope_inputs(
     return registry, detect_active_memory_project(pool.get_workspace(chat_id), registry)
 
 
+# ── Transcript provenance helpers ───────────────────────────────────
+#
+# Row-side pointer to the originating turns. Reads go through
+# `read_transcript_provenance`; the transcript lookup happens at
+# `source` button tap time via `fetch_transcript_context`. The
+# detail view always renders a Source line (legacy fallback for
+# rows without provenance), and the keyboard gains a `source`
+# button only when provenance is present.
+
+
+# Safe ceiling on the source-view body; Telegram's hard limit is
+# 4096 characters and `_send_or_edit` does not truncate, so the
+# renderer enforces a ceiling under that with a visible marker.
+# 3900 leaves headroom for any future footer (currently none).
+_SOURCE_VIEW_BODY_CEILING = 3900
+
+# Per-turn cap inside the source view. Most ordinary fact lookups
+# (target user + assistant + a few context turns at this length)
+# stay well under the body ceiling; the marker below catches any
+# pathological exchange that does not.
+_SOURCE_VIEW_TURN_CAP = 400
+
+_SOURCE_VIEW_TRUNCATION_MARKER = "\n... (output truncated)"
+
+
+def _format_source_ts(ts: str) -> str:
+    """Render an ISO 8601 ts as `YYYY-MM-DD HH:MM:SS UTC`.
+
+    The stored ts is always UTC (it comes from `datetime.now(UTC)`),
+    so the suffix is hardcoded rather than parsed; future display-
+    timezone conversion is a separate concern. A malformed ts falls
+    through unchanged so a corrupted row still renders something
+    legible.
+    """
+    if "T" in ts and len(ts) >= 19:
+        date, rest = ts.split("T", 1)
+        return f"{date} {rest[:8]} UTC"
+    return ts
+
+
+def _build_source_label(fact: MemoryResult, provenance: TranscriptProvenance) -> str:
+    """Render the Source row's right-hand value.
+
+    Three cases keyed on the row's source field (extracted vs
+    episode/migration) and on whether the user and assistant turns
+    fall on the same UTC date:
+    - Legacy / not-present: `not recorded (legacy)`.
+    - Fact: `YYYY-MM-DD HH:MM:SS UTC` (single user ts; the assistant
+      date is implicit in `source_assistant_ts`).
+    - Episode: `YYYY-MM-DD HH:MM:SS to HH:MM:SS UTC` (same-day) or
+      `YYYY-MM-DD HH:MM:SS to YYYY-MM-DD HH:MM:SS UTC` (midnight
+      cross). The full two-date form lets the operator see the
+      exchange straddled a day boundary without opening the source
+      view.
+    """
+    if not provenance.present:
+        return "not recorded (legacy)"
+    source = (fact.metadata or {}).get("source", "")
+    if source != "episode" or provenance.assistant_ts is None:
+        # Fact and migration arms render the single user ts. Migration
+        # rows do not carry provenance today (the writer does not
+        # stamp `source_*`), so the not-present branch above usually
+        # catches them; the defensive single-ts render here is for any
+        # future caller that does stamp a migration row.
+        return _format_source_ts(provenance.user_ts or "")
+    user_part = _format_source_ts(provenance.user_ts or "")
+    assistant_part = _format_source_ts(provenance.assistant_ts)
+    # Same-day episodes drop the second date so the line reads as
+    # "DATE HH:MM:SS to HH:MM:SS UTC" rather than repeating the date.
+    # Midnight cross keeps both dates so the boundary is visible at a
+    # glance.
+    if provenance.date_end is None or provenance.date_end == provenance.date:
+        # _format_source_ts produces "DATE HH:MM:SS UTC"; trim the
+        # trailing "UTC" from the user part and the leading "DATE "
+        # from the assistant part so the joined form reads correctly.
+        # The replacement happens by string surgery rather than
+        # restructuring the formatter to keep _format_source_ts the
+        # single source of truth for the ts shape.
+        if user_part.endswith(" UTC"):
+            user_part = user_part[: -len(" UTC")]
+        if " " in assistant_part:
+            _, assistant_tail = assistant_part.split(" ", 1)
+            assistant_part = assistant_tail
+        return f"{user_part} to {assistant_part}"
+    return f"{user_part} to {assistant_part}"
+
+
+def _truncate_to_message_limit(body: str) -> str:
+    """Trim a source-view body to fit under Telegram's 4096-char limit.
+
+    `_send_or_edit` sends the supplied text as-is and does not
+    truncate; without this clamp, an oversized body would surface
+    as a Telegram `BadRequest` and the callback would collapse to
+    the generic memory-query failure path. The marker is appended
+    visibly so the operator knows the body was cut rather than
+    rendered fully.
+    """
+    if len(body) <= _SOURCE_VIEW_BODY_CEILING:
+        return body
+    keep = _SOURCE_VIEW_BODY_CEILING - len(_SOURCE_VIEW_TRUNCATION_MARKER)
+    return body[: max(keep, 0)] + _SOURCE_VIEW_TRUNCATION_MARKER
+
+
+def _truncate_source_turn(text: str) -> str:
+    """Cap a single turn's text inside the source view.
+
+    Primary defence against an oversized body; the body-level clamp
+    catches the residual pathological case where even the capped
+    turns add up to more than the body ceiling.
+    """
+    flat = text.replace("\r", "")
+    if len(flat) <= _SOURCE_VIEW_TURN_CAP:
+        return flat
+    return flat[: _SOURCE_VIEW_TURN_CAP - 1] + "…"
+
+
 # ── Builder: dashboard ──────────────────────────────────────────────
 
 
@@ -875,6 +1003,7 @@ def _build_fact_view(
     fact: MemoryResult,
     return_to: tuple[str, list[str]] | None,
     scope_view: _ScopeView | None = None,
+    provenance: TranscriptProvenance | None = None,
 ) -> tuple[str, InlineKeyboardMarkup]:
     """Render the fact detail screen (spec §6.3).
 
@@ -1012,6 +1141,12 @@ def _build_fact_view(
             footer_lines.append(f"Scope:  {scope_view.scope_label}")
             footer_lines.append(f"Scope source:  {scope_view.source_label}")
             footer_lines.append(f"Retrievable here:  {scope_view.retrievable_label}")
+        # Source row appended last so the existing tail (date + scope)
+        # stays recognizable. Always rendered when a provenance value
+        # is supplied (legacy rows produce the documented fallback);
+        # production callers always pass one.
+        if provenance is not None:
+            footer_lines.append(f"Source:  {_build_source_label(fact, provenance)}")
         lines = [
             header,
             "",
@@ -1057,6 +1192,12 @@ def _build_fact_view(
                 f"Scope source:     {scope_view.source_label}",
                 f"Retrievable here: {scope_view.retrievable_label}",
             ]
+        # Source row uses the same 18-column alignment so the new line
+        # reads as part of the existing extractor block, not as an
+        # appendix. Always rendered when a provenance value is supplied.
+        source_rows: list[str] = []
+        if provenance is not None:
+            source_rows = [f"Source:           {_build_source_label(fact, provenance)}"]
         lines = [
             "Fact",
             "",
@@ -1069,21 +1210,24 @@ def _build_fact_view(
             f"Session:          {session_id or '(none)'}",
             f"Prompt version:   {prompt_version or '(none)'}",
             *scope_rows,
+            *source_rows,
             "",
             f"Confirmation:     {confirmation_line}",
         ]
     text = "\n".join(lines)
 
     back_callback = _encode_callback(return_to[0], *return_to[1]) if return_to is not None else _encode_callback("dash")
-    kb = InlineKeyboardMarkup(
-        [
-            [
-                InlineKeyboardButton("back", callback_data=back_callback),
-                InlineKeyboardButton("scope", callback_data=_encode_callback("scp")),
-                InlineKeyboardButton("forget", callback_data=_encode_callback("ffc")),
-            ]
-        ]
-    )
+    # Source button is conditional: provenance-absent rows have no
+    # exchange to reveal, so the button would route to a "legacy"
+    # body that adds no operator value. Position is between back
+    # and scope so the navigation buttons cluster on the left and
+    # the action buttons (scope, forget) cluster on the right.
+    row: list[InlineKeyboardButton] = [InlineKeyboardButton("back", callback_data=back_callback)]
+    if provenance is not None and provenance.present:
+        row.append(InlineKeyboardButton("source", callback_data=_encode_callback("src")))
+    row.append(InlineKeyboardButton("scope", callback_data=_encode_callback("scp")))
+    row.append(InlineKeyboardButton("forget", callback_data=_encode_callback("ffc")))
+    kb = InlineKeyboardMarkup([row])
     return text, kb
 
 
@@ -1500,12 +1644,16 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
       ffd               - forget single fact: do delete
       fview             - return to fact view (same id); cancel target
                           of the forget confirm, back target of the
-                          scope screen
+                          scope screen, back target of the source view
       scp               - scope screen for the cached fact; cancel
                           target of the scope confirm
       sct <idx>         - scope target tapped (resolved against
                           cache.scope_targets); renders confirm
       scd               - scope change confirmed: apply
+      src               - source view for the cached fact; calls
+                          fetch_transcript_context and renders the
+                          originating exchange or a per-reason
+                          failure body
     """
     # PTB CallbackQueryHandler guarantees both callback_query and
     # query.data are present, but `python -O` strips asserts; use
@@ -1670,6 +1818,19 @@ async def handle_memory_callback(update: Update, context: ContextTypes.DEFAULT_T
             else:
                 await _send_dashboard(update, context, chat_id, edit=True)
             await query.answer("Forgotten." if ok else "Not found.")
+            return
+        if verb == "src":
+            # Source view for the fact in cache. The fact id was
+            # cached when the user opened the detail view; the back
+            # button on the source view uses the existing fview verb
+            # to re-render the same fact view from that cache.
+            cache = _get_cache(chat_id)
+            if cache is None or not cache.memory_ids:
+                await _send_dashboard(update, context, chat_id, edit=True)
+                await query.answer(_MSG_SESSION_EXPIRED)
+                return
+            await _send_source_view(update, context, chat_id, cache.memory_ids[0])
+            await query.answer()
             return
         if verb == "scp":
             # Scope screen for the fact in cache. Reached from the
@@ -1904,7 +2065,8 @@ async def _send_fact_view(
         return
     registry, active = _scope_inputs(context, chat_id)
     scope_view = _build_scope_view(fact, registry, active, scoped_recall_enabled=memory.is_scoped_recall_enabled())
-    text, kb = _build_fact_view(fact, return_to, scope_view)
+    provenance = read_transcript_provenance(fact.metadata)
+    text, kb = _build_fact_view(fact, return_to, scope_view, provenance)
     # Cache holds only this fact's id so the forget flow knows what to
     # delete without re-encoding the id into callback data.
     _set_cache(
@@ -1942,6 +2104,103 @@ async def _send_forget_fact_confirm(
         chat_id,
         _ScreenCache(
             screen="forget_fact_confirm",
+            memory_ids=[memory_id],
+            return_to=return_to,
+        ),
+    )
+    await _send_or_edit(update, text, kb, edit=True)
+
+
+# Per-reason source-view failure messages. Strings live as module
+# constants so test assertions key on them and so the lookup helper's
+# stable reason vocabulary stays one-to-one with the operator-facing
+# wording.
+_SOURCE_FAILURE_MESSAGES: dict[str, str] = {
+    "file_missing": "The history file for that date is no longer available.",
+    "unreadable": "The history file could not be read.",
+    "ts_not_found": "The original message was not found in the history file.",
+    "hash_mismatch": "Content drift detected: the original message no longer matches its fingerprint.",
+    "legacy": "This memory predates source tracking.",
+}
+
+
+def _build_source_view(
+    fact: MemoryResult,
+    lookup: TranscriptLookup,
+) -> tuple[str, InlineKeyboardMarkup]:
+    """Render the source view body and its back-to-fact keyboard.
+
+    On `reason="ok"` the body shows the surrounding turns in
+    chronological order with per-turn headers; on any other reason
+    the body renders the message from `_SOURCE_FAILURE_MESSAGES`.
+    The body-level truncation marker is appended once after assembly
+    so even a pathological exchange stays under the Telegram limit.
+
+    The keyboard is a single back button; the verb `fview` reuses
+    the existing fact-view re-render flow, which reads the cached
+    memory_id and presents the detail view unchanged.
+    """
+    if lookup.reason == "ok" and lookup.context is not None:
+        body = _render_source_view_body(fact, lookup.context)
+    else:
+        message = _SOURCE_FAILURE_MESSAGES.get(lookup.reason, "Source unavailable.")
+        body = f"Source\n\n{message}"
+    body = _truncate_to_message_limit(body)
+    kb = InlineKeyboardMarkup([[InlineKeyboardButton("back", callback_data=_encode_callback("fview"))]])
+    return body, kb
+
+
+def _render_source_view_body(fact: MemoryResult, context: TranscriptContext) -> str:
+    """Compose the chronological exchange body for `reason="ok"`."""
+    lines: list[str] = ["Source", "", f'For memory "{_truncate(fact.text, 60)}":', ""]
+    if context.truncated:
+        lines.append("(Episode window truncated.)")
+        lines.append("")
+    for turn in context.before:
+        lines.extend(_render_source_view_turn(turn))
+    lines.extend(_render_source_view_turn(context.target_user))
+    if context.target_assistant is not None:
+        lines.extend(_render_source_view_turn(context.target_assistant))
+    for turn in context.after:
+        lines.extend(_render_source_view_turn(turn))
+    return "\n".join(lines).rstrip()
+
+
+def _render_source_view_turn(turn: TranscriptTurn) -> list[str]:
+    """One turn's lines: a `[ts UTC] direction:` header then capped text."""
+    header_label = "user" if turn.direction == "user" else "assistant"
+    return [
+        f"[{_format_source_ts(turn.ts)}] {header_label}:",
+        _truncate_source_turn(turn.text),
+        "",
+    ]
+
+
+async def _send_source_view(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    memory_id: str,
+) -> None:
+    """Render the source view for a fact, edit-in-place.
+
+    Re-fetches the row before resolving provenance so a row deleted
+    between the fact view and the tap surfaces as the standard
+    "no longer exists" body rather than a stale rendering.
+    """
+    fact = memory.get_by_id(user_id=str(chat_id), memory_id=memory_id)
+    if fact is None:
+        await _send_or_edit(update, "This memory no longer exists.", None, edit=True)
+        return
+    provenance = read_transcript_provenance(fact.metadata)
+    lookup = fetch_transcript_context(provenance, memory_id=memory_id)
+    text, kb = _build_source_view(fact, lookup)
+    cache = _get_cache(chat_id)
+    return_to = cache.return_to if cache is not None else None
+    _set_cache(
+        chat_id,
+        _ScreenCache(
+            screen="source",
             memory_ids=[memory_id],
             return_to=return_to,
         ),

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 from kai import memory
 from kai.config import Config, ModelRole, resolve_user_model
+from kai.history import LogEntry
 from kai.memory import MemoryResult
 from kai.memory_projects import ActiveMemoryProject, detect_active_memory_project, merged_registry
 from kai.oneshot import _EXTRACTOR_CWD as _EXTRACTOR_CWD
@@ -2404,6 +2405,8 @@ async def _generate_episode(
     effective_provider: str,
     os_user: str | None = None,
     active_project: ActiveMemoryProject | None = None,
+    user_log: LogEntry | None = None,
+    assistant_log: LogEntry | None = None,
 ) -> None:
     """
     Stage-2 task body: generate one episode record and store it.
@@ -2551,6 +2554,24 @@ async def _generate_episode(
                     # log below reports the routed outcome.
                     scope_meta = _route_write_scope(episode.get("scope_hint"), active_project)
                     extra.update(scope_meta)
+                    # Transcript provenance. Same shape
+                    # as the fact path; `source_date_end` is the only
+                    # episode-specific key, populated only when the
+                    # exchange straddled midnight so a single-day
+                    # episode's metadata stays small. Episodes here
+                    # describe the current exchange (the v3 spec drops
+                    # the prior-pair window framing because
+                    # _generate_episode does not consume prior_pairs);
+                    # the start and end keys are the user and
+                    # assistant turns of this exchange.
+                    if user_log is not None and assistant_log is not None:
+                        extra[memory.SOURCE_CHAT_ID_KEY] = user_log.chat_id
+                        extra[memory.SOURCE_DATE_KEY] = user_log.date
+                        extra[memory.SOURCE_USER_TS_KEY] = user_log.ts
+                        extra[memory.SOURCE_USER_TEXT_SHA256_KEY] = user_log.sha256
+                        extra[memory.SOURCE_ASSISTANT_TS_KEY] = assistant_log.ts
+                        if assistant_log.date != user_log.date:
+                            extra[memory.SOURCE_DATE_END_KEY] = assistant_log.date
                     # add_structured is sync (Mem0 is sync). Run off
                     # the event loop so the embedding step does not
                     # block other stage-2 tasks queued behind this
@@ -2754,6 +2775,8 @@ def _store_facts(
     session_id: str | None,
     config: Config,
     active_project: ActiveMemoryProject | None = None,
+    user_log: LogEntry | None = None,
+    assistant_log: LogEntry | None = None,
 ) -> tuple[int, int, int]:
     """
     Persist validated facts via memory.add_structured, branching on intent.
@@ -2867,6 +2890,22 @@ def _store_facts(
         # information beyond what scope_source already encodes.
         scope_meta = _route_write_scope(fact.get("scope_hint"), active_project)
         extra.update(scope_meta)
+
+        # Transcript provenance. Stamped only when both
+        # log entries are present: a single-side stamp would be a
+        # half-locator and would force the reader to invent the
+        # missing half. The Optional defaults let sandbox / replay /
+        # eval callers omit the kwargs entirely, and they cover the
+        # real-bot path where `log_message` returned None due to a
+        # JSONL write failure (the row then lands with no `source_*`
+        # keys, matching the legacy shape and the resolver's
+        # not-present path).
+        if user_log is not None and assistant_log is not None:
+            extra[memory.SOURCE_CHAT_ID_KEY] = user_log.chat_id
+            extra[memory.SOURCE_DATE_KEY] = user_log.date
+            extra[memory.SOURCE_USER_TS_KEY] = user_log.ts
+            extra[memory.SOURCE_USER_TEXT_SHA256_KEY] = user_log.sha256
+            extra[memory.SOURCE_ASSISTANT_TS_KEY] = assistant_log.ts
 
         if intent == "skip_redundant":
             # No storage call. The intent log is the only side effect
@@ -3043,6 +3082,8 @@ async def extract_and_store(
     prior_pairs: list[tuple[str, str]] | None = None,
     os_user_override: str | None = None,
     workspace: str | None = None,
+    user_log: LogEntry | None = None,
+    assistant_log: LogEntry | None = None,
 ) -> int:
     """
     Run Haiku extraction on an exchange and store the resulting facts.
@@ -3080,6 +3121,17 @@ async def extract_and_store(
     extractor input must stay byte-equivalent across replays) on
     exactly the pre-routing write shape apart from the now-explicit
     scope metadata.
+
+    The optional `user_log` and `assistant_log` parameters carry the
+    `LogEntry` receipts returned by the two `log_message` calls for
+    this exchange. When both are present, the metadata-write blocks
+    stamp `source_*` provenance keys pointing back at the JSONL turns
+    extraction consumed; when either is None (sandbox / replay / eval
+    callers that synthesize exchanges, or a real path where the JSONL
+    append failed and `log_message` returned None), no provenance is
+    stamped and the row matches today's metadata shape byte for byte.
+    The legacy-row UI fallback handles the absent case across every
+    consumer surface.
     """
     if config is None:
         from kai.config import load_config
@@ -3279,6 +3331,8 @@ async def extract_and_store(
                         session_id=session_id,
                         config=config,
                         active_project=active_project,
+                        user_log=user_log,
+                        assistant_log=assistant_log,
                     ),
                 )
             else:
@@ -3317,6 +3371,8 @@ async def extract_and_store(
                         effective_provider=effective_provider,
                         os_user=os_user,
                         active_project=active_project,
+                        user_log=user_log,
+                        assistant_log=assistant_log,
                     ),
                     name=f"episode-{user_id}",
                 )

--- a/src/kai/memory_reclassify.py
+++ b/src/kai/memory_reclassify.py
@@ -56,7 +56,8 @@ from typing import Any
 
 from kai import memory, sessions
 from kai.config import Config, MemoryProjectConfig, ModelRole, resolve_user_model
-from kai.memory import MemoryResult, ResolvedMemoryScope
+from kai.history import fetch_transcript_context
+from kai.memory import MemoryResult, ResolvedMemoryScope, read_transcript_provenance
 from kai.memory_extraction import (
     _build_memory_reasoner,
     _resolve_effective_backend,
@@ -510,6 +511,36 @@ def parse_preimages(text: str) -> tuple[dict[str, Any], list[PreImage]]:
 # ── Pure helpers: report rendering ──────────────────────────────────
 
 
+def _collect_provenance_quotes(
+    selected: list[tuple[MemoryResult, ResolvedMemoryScope]],
+    proposals: list[Proposal],
+) -> dict[str, str]:
+    """Build the memory_id → originating-user-text map for the report.
+
+    Best-effort: a row without provenance, with a failed JSONL
+    lookup, or whose helper returns any non-ok reason contributes
+    nothing. The text is truncated here (80 chars) so the renderer
+    stays formatter-only and the entry it pulls is already
+    report-sized.
+
+    The proposal set drives the iteration: we only look up provenance
+    for rows that actually appear in the report's eyeball sample
+    space, not for the larger selected pool.
+    """
+    quotes: dict[str, str] = {}
+    proposal_ids = {p.memory_id for p in proposals}
+    metadata_by_id = {row.id: row.metadata for row, _ in selected if row.id in proposal_ids}
+    for memory_id, metadata in metadata_by_id.items():
+        provenance = read_transcript_provenance(metadata)
+        if not provenance.present:
+            continue
+        lookup = fetch_transcript_context(provenance, before=0, after=0, memory_id=memory_id)
+        if lookup.reason != "ok" or lookup.context is None:
+            continue
+        quotes[memory_id] = _truncate(lookup.context.target_user.text, 80)
+    return quotes
+
+
 def render_report(
     *,
     run_id: str,
@@ -522,6 +553,7 @@ def render_report(
     skips: dict[str, list[str]],
     sample_size: int,
     texts: dict[str, str],
+    provenance_user_texts: dict[str, str] | None = None,
 ) -> str:
     """Render the dry-run report markdown.
 
@@ -529,6 +561,14 @@ def render_report(
     only in the report (the proposals file carries the sha) so the
     machine-readable artifact stays small while the human-readable
     one shows what was actually classified.
+
+    `provenance_user_texts` optionally maps memory_id to the row's
+    originating user-turn text (already truncated by the caller).
+    When an entry is present, the eyeball-sample line gains a `said:`
+    line that quotes the originating message so the operator can
+    eyeball "is this really a project fact" against the message that
+    produced it. Entries are missing for legacy rows or for rows
+    whose transcript lookup failed; those proposals render as before.
 
     The eyeball sample is drawn with `random.Random(run_id)` so
     re-rendering the same run reproduces the same sample; the
@@ -556,6 +596,13 @@ def render_report(
             text = _truncate(texts.get(p.memory_id, ""), 80)
             lines.append(f'{i}. [{target} {p.confidence:.2f}] "{text}" (was {p.prior_scope_source})')
             lines.append(f"   reason: {p.reason}")
+            # Optional originating-turn quote when transcript provenance
+            # is present on the source row. Legacy rows and lookup
+            # failures contribute nothing, so the line is appended
+            # only when the entry actually exists. The caller has
+            # already truncated the text to keep the report compact.
+            if provenance_user_texts and p.memory_id in provenance_user_texts:
+                lines.append(f'   said:   "{provenance_user_texts[p.memory_id]}"')
         lines.append("")
         lines.append("## All proposals")
         lines.append("| id | verdict | conf | was | text |")
@@ -770,6 +817,12 @@ async def run_dry_run(
     }
     proposals_path = out_dir / f"reclassify-{run_id}-proposals.jsonl"
     proposals_path.write_text(render_proposals(header, proposals), encoding="utf-8")
+    # Transcript-provenance lookup is best-effort: any non-ok reason
+    # (legacy, file missing, ts not found, drift) contributes nothing
+    # and the proposal renders without the `said:` line. The lookup
+    # itself happens here in the driver (not in the pure renderer) so
+    # the renderer stays free of I/O for unit testing.
+    provenance_user_texts = _collect_provenance_quotes(selected, proposals)
     report = render_report(
         run_id=run_id,
         user_id=user_id,
@@ -781,6 +834,7 @@ async def run_dry_run(
         skips=skips,
         sample_size=sample,
         texts={row.id: row.text for row, _ in selected},
+        provenance_user_texts=provenance_user_texts,
     )
     report_path = out_dir / f"reclassify-{run_id}-report.md"
     report_path.write_text(report, encoding="utf-8")

--- a/src/kai/memory_reclassify.py
+++ b/src/kai/memory_reclassify.py
@@ -514,6 +514,8 @@ def parse_preimages(text: str) -> tuple[dict[str, Any], list[PreImage]]:
 def _collect_provenance_quotes(
     selected: list[tuple[MemoryResult, ResolvedMemoryScope]],
     proposals: list[Proposal],
+    *,
+    user_id: str,
 ) -> dict[str, str]:
     """Build the memory_id → originating-user-text map for the report.
 
@@ -526,7 +528,21 @@ def _collect_provenance_quotes(
     The proposal set drives the iteration: we only look up provenance
     for rows that actually appear in the report's eyeball sample
     space, not for the larger selected pool.
+
+    `user_id` is the CLI's `<user_id>` argument; when it parses as an
+    int, it becomes `expected_chat_id` on the lookup so the helper
+    refuses to dereference any row whose `source_chat_id` does not
+    match. Mem0's user-id partition already scopes the row read, but
+    the row's provenance pointer is independent metadata and must be
+    validated separately. When the CLI was invoked against a non-
+    numeric sandbox id, the gate is skipped (the helper falls back
+    to its no-expected-chat-id behaviour); admin contexts that scan
+    cross-chat by design can also pass `expected_chat_id=None`.
     """
+    try:
+        expected_chat_id: int | None = int(user_id)
+    except ValueError:
+        expected_chat_id = None
     quotes: dict[str, str] = {}
     proposal_ids = {p.memory_id for p in proposals}
     metadata_by_id = {row.id: row.metadata for row, _ in selected if row.id in proposal_ids}
@@ -534,7 +550,13 @@ def _collect_provenance_quotes(
         provenance = read_transcript_provenance(metadata)
         if not provenance.present:
             continue
-        lookup = fetch_transcript_context(provenance, before=0, after=0, memory_id=memory_id)
+        lookup = fetch_transcript_context(
+            provenance,
+            before=0,
+            after=0,
+            memory_id=memory_id,
+            expected_chat_id=expected_chat_id,
+        )
         if lookup.reason != "ok" or lookup.context is None:
             continue
         quotes[memory_id] = _truncate(lookup.context.target_user.text, 80)
@@ -822,7 +844,7 @@ async def run_dry_run(
     # and the proposal renders without the `said:` line. The lookup
     # itself happens here in the driver (not in the pure renderer) so
     # the renderer stays free of I/O for unit testing.
-    provenance_user_texts = _collect_provenance_quotes(selected, proposals)
+    provenance_user_texts = _collect_provenance_quotes(selected, proposals, user_id=user_id)
     report = render_report(
         run_id=run_id,
         user_id=user_id,

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -544,3 +544,300 @@ class TestGetRecentPairs:
         pairs = get_recent_pairs(chat_id=1, n=0)
 
         assert pairs == []
+
+
+# ── Transcript provenance: LogEntry contract ────────────────────────
+
+
+class _Provenance:
+    """Lightweight stand-in for kai.memory.TranscriptProvenance.
+
+    Lets the helper tests construct lookup inputs without dragging
+    Mem0 into the test surface; the real resolver is exercised in
+    test_memory.py. Field names mirror the dataclass exactly.
+    """
+
+    def __init__(
+        self,
+        *,
+        present=True,
+        chat_id=1,
+        date=None,
+        user_ts=None,
+        user_text_sha256=None,
+        assistant_ts=None,
+        date_end=None,
+    ):
+        self.present = present
+        self.chat_id = chat_id
+        self.date = date
+        self.user_ts = user_ts
+        self.user_text_sha256 = user_text_sha256
+        self.assistant_ts = assistant_ts
+        self.date_end = date_end
+
+
+class TestLogEntryContract:
+    def test_returns_log_entry_with_matching_fields(self, _log_dir):
+        entry = log_message(direction="user", chat_id=42, text="hello")
+        assert entry is not None
+        assert entry.chat_id == 42
+        assert entry.direction == "user"
+        assert entry.text == "hello"
+        # ts and date derive from the same now() call; the date must
+        # match the filename the line landed in.
+        assert (_log_dir / "42" / f"{entry.date}.jsonl").exists()
+        # sha256 fingerprints the exact text byte sequence.
+        import hashlib
+
+        assert entry.sha256 == hashlib.sha256(b"hello").hexdigest()
+
+    def test_failure_paths_still_return_entries(self, _log_dir):
+        # Synthetic placeholder writes (the assistant failure markers)
+        # also receive populated LogEntry returns; extraction does not
+        # run on those paths, so the returns are simply unused.
+        entry = log_message(direction="assistant", chat_id=1, text="[stopped by user]")
+        assert entry is not None
+        assert entry.text == "[stopped by user]"
+
+    def test_oserror_returns_none(self, monkeypatch, _log_dir):
+        """An OSError during the JSONL append yields None, not a
+        populated entry that would point at a never-written line."""
+        import builtins
+
+        original = builtins.open
+
+        def boom(path, mode="r", *args, **kwargs):
+            if "a" in mode:
+                raise OSError("disk full")
+            return original(path, mode, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", boom)
+        entry = log_message(direction="user", chat_id=1, text="lost")
+        assert entry is None
+
+
+class TestFetchTranscriptContext:
+    """Black-box tests over fetch_transcript_context using the local
+    `_Provenance` stub so the helper's behaviour is exercised without
+    dragging the kai.memory resolver into the test inputs."""
+
+    def _write_jsonl(self, _log_dir, chat_id, date, records):
+        path = _log_dir / str(chat_id) / f"{date}.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        return path
+
+    def test_legacy_returns_legacy_reason(self):
+        result = history.fetch_transcript_context(_Provenance(present=False))
+        assert result.reason == "legacy"
+        assert result.context is None
+
+    def test_happy_path_returns_target_and_window(self, _log_dir):
+        import hashlib
+
+        self._write_jsonl(
+            _log_dir,
+            1,
+            "2026-06-13",
+            [
+                {"ts": "2026-06-13T08:00:00+00:00", "dir": "user", "chat_id": 1, "text": "prev user"},
+                {"ts": "2026-06-13T08:00:10+00:00", "dir": "assistant", "chat_id": 1, "text": "prev assistant"},
+                {"ts": "2026-06-13T09:00:00+00:00", "dir": "user", "chat_id": 1, "text": "target user"},
+                {"ts": "2026-06-13T09:00:30+00:00", "dir": "assistant", "chat_id": 1, "text": "target assistant"},
+                {"ts": "2026-06-13T09:30:00+00:00", "dir": "user", "chat_id": 1, "text": "next user"},
+            ],
+        )
+        provenance = _Provenance(
+            chat_id=1,
+            date="2026-06-13",
+            user_ts="2026-06-13T09:00:00+00:00",
+            user_text_sha256=hashlib.sha256(b"target user").hexdigest(),
+            assistant_ts="2026-06-13T09:00:30+00:00",
+        )
+        result = history.fetch_transcript_context(provenance, before=2, after=1)
+        assert result.reason == "ok"
+        assert result.context.target_user.text == "target user"
+        assert result.context.target_assistant.text == "target assistant"
+        assert [t.text for t in result.context.before] == ["prev user", "prev assistant"]
+        assert [t.text for t in result.context.after] == ["next user"]
+
+    def test_file_missing_logs_drift(self, _log_dir, caplog):
+        provenance = _Provenance(
+            chat_id=99,
+            date="2026-01-01",
+            user_ts="2026-01-01T00:00:00+00:00",
+            user_text_sha256="abc",
+        )
+        with caplog.at_level("INFO", logger="kai.history"):
+            result = history.fetch_transcript_context(provenance, memory_id="mem-1")
+        assert result.reason == "file_missing"
+        # Drift log fired with the row id and reason.
+        drift = next(r for r in caplog.records if "memory.provenance.drift" in r.message)
+        assert '"memory_id":"mem-1"' in drift.message
+        assert '"reason":"file_missing"' in drift.message
+
+    def test_ts_not_found_user_side(self, _log_dir, caplog):
+        self._write_jsonl(
+            _log_dir,
+            1,
+            "2026-06-13",
+            [{"ts": "2026-06-13T01:00:00+00:00", "dir": "user", "chat_id": 1, "text": "x"}],
+        )
+        provenance = _Provenance(
+            chat_id=1,
+            date="2026-06-13",
+            user_ts="2026-06-13T09:00:00+00:00",
+            user_text_sha256="any",
+        )
+        with caplog.at_level("INFO", logger="kai.history"):
+            result = history.fetch_transcript_context(provenance, memory_id="m")
+        assert result.reason == "ts_not_found"
+        drift = next(r for r in caplog.records if "memory.provenance.drift" in r.message)
+        assert '"side":"user"' in drift.message
+
+    def test_hash_mismatch_returns_reason_and_logs(self, _log_dir, caplog):
+        self._write_jsonl(
+            _log_dir,
+            1,
+            "2026-06-13",
+            [{"ts": "2026-06-13T09:00:00+00:00", "dir": "user", "chat_id": 1, "text": "actual"}],
+        )
+        provenance = _Provenance(
+            chat_id=1,
+            date="2026-06-13",
+            user_ts="2026-06-13T09:00:00+00:00",
+            user_text_sha256="wrong" * 12,
+        )
+        with caplog.at_level("INFO", logger="kai.history"):
+            result = history.fetch_transcript_context(provenance, memory_id="m")
+        assert result.reason == "hash_mismatch"
+        assert result.context is None
+        assert any("hash_mismatch" in r.message for r in caplog.records)
+
+    def test_assistant_missing_returns_ts_not_found(self, _log_dir, caplog):
+        """The drift case where user matches but the named assistant
+        ts is absent from JSONL: drift-not-ok, side=assistant."""
+        import hashlib
+
+        self._write_jsonl(
+            _log_dir,
+            1,
+            "2026-06-13",
+            [{"ts": "2026-06-13T09:00:00+00:00", "dir": "user", "chat_id": 1, "text": "user msg"}],
+        )
+        provenance = _Provenance(
+            chat_id=1,
+            date="2026-06-13",
+            user_ts="2026-06-13T09:00:00+00:00",
+            user_text_sha256=hashlib.sha256(b"user msg").hexdigest(),
+            assistant_ts="2026-06-13T09:00:30+00:00",
+        )
+        with caplog.at_level("INFO", logger="kai.history"):
+            result = history.fetch_transcript_context(provenance, memory_id="m")
+        assert result.reason == "ts_not_found"
+        drift = next(r for r in caplog.records if "memory.provenance.drift" in r.message)
+        assert '"side":"assistant"' in drift.message
+
+    def test_legitimately_no_assistant_returns_ok_with_none(self, _log_dir):
+        """A row whose stored provenance has no assistant_ts at all
+        (None) returns ok with target_assistant=None."""
+        import hashlib
+
+        self._write_jsonl(
+            _log_dir,
+            1,
+            "2026-06-13",
+            [{"ts": "2026-06-13T09:00:00+00:00", "dir": "user", "chat_id": 1, "text": "u"}],
+        )
+        provenance = _Provenance(
+            chat_id=1,
+            date="2026-06-13",
+            user_ts="2026-06-13T09:00:00+00:00",
+            user_text_sha256=hashlib.sha256(b"u").hexdigest(),
+            assistant_ts=None,
+        )
+        result = history.fetch_transcript_context(provenance)
+        assert result.reason == "ok"
+        assert result.context.target_assistant is None
+
+    def test_synthetic_markers_excluded_from_context(self, _log_dir):
+        import hashlib
+
+        self._write_jsonl(
+            _log_dir,
+            1,
+            "2026-06-13",
+            [
+                {"ts": "2026-06-13T07:00:00+00:00", "dir": "user", "chat_id": 1, "text": "real user"},
+                {"ts": "2026-06-13T07:00:10+00:00", "dir": "assistant", "chat_id": 1, "text": "[stopped by user]"},
+                {"ts": "2026-06-13T09:00:00+00:00", "dir": "user", "chat_id": 1, "text": "target"},
+                {"ts": "2026-06-13T09:00:30+00:00", "dir": "assistant", "chat_id": 1, "text": "answer"},
+            ],
+        )
+        provenance = _Provenance(
+            chat_id=1,
+            date="2026-06-13",
+            user_ts="2026-06-13T09:00:00+00:00",
+            user_text_sha256=hashlib.sha256(b"target").hexdigest(),
+            assistant_ts="2026-06-13T09:00:30+00:00",
+        )
+        result = history.fetch_transcript_context(provenance, before=5, after=0)
+        # Synthetic assistant placeholder is skipped; only the real
+        # prior user turn appears in `before`.
+        assert [t.text for t in result.context.before] == ["real user"]
+
+    def test_assistant_in_next_day_file(self, _log_dir):
+        """Episode midnight cross: user on day D, assistant on day D+1."""
+        import hashlib
+
+        self._write_jsonl(
+            _log_dir,
+            1,
+            "2026-06-12",
+            [{"ts": "2026-06-12T23:59:00+00:00", "dir": "user", "chat_id": 1, "text": "u"}],
+        )
+        self._write_jsonl(
+            _log_dir,
+            1,
+            "2026-06-13",
+            [{"ts": "2026-06-13T00:00:30+00:00", "dir": "assistant", "chat_id": 1, "text": "a"}],
+        )
+        provenance = _Provenance(
+            chat_id=1,
+            date="2026-06-12",
+            user_ts="2026-06-12T23:59:00+00:00",
+            user_text_sha256=hashlib.sha256(b"u").hexdigest(),
+            assistant_ts="2026-06-13T00:00:30+00:00",
+            date_end="2026-06-13",
+        )
+        result = history.fetch_transcript_context(provenance, after=0)
+        assert result.reason == "ok"
+        assert result.context.target_assistant.text == "a"
+
+    def test_before_window_walks_to_previous_file(self, _log_dir):
+        import hashlib
+
+        self._write_jsonl(
+            _log_dir,
+            1,
+            "2026-06-12",
+            [{"ts": "2026-06-12T23:00:00+00:00", "dir": "user", "chat_id": 1, "text": "yesterday"}],
+        )
+        self._write_jsonl(
+            _log_dir,
+            1,
+            "2026-06-13",
+            [{"ts": "2026-06-13T00:30:00+00:00", "dir": "user", "chat_id": 1, "text": "today target"}],
+        )
+        provenance = _Provenance(
+            chat_id=1,
+            date="2026-06-13",
+            user_ts="2026-06-13T00:30:00+00:00",
+            user_text_sha256=hashlib.sha256(b"today target").hexdigest(),
+            assistant_ts=None,
+        )
+        result = history.fetch_transcript_context(provenance, before=2, after=0)
+        # `before` walks one file back and pulls the yesterday user
+        # turn rather than returning a short window.
+        assert [t.text for t in result.context.before] == ["yesterday"]

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -841,3 +841,118 @@ class TestFetchTranscriptContext:
         # `before` walks one file back and pulls the yesterday user
         # turn rather than returning a short window.
         assert [t.text for t in result.context.before] == ["yesterday"]
+
+
+class TestFetchTranscriptContextChatOwnership:
+    """Cross-chat pointer protection: when expected_chat_id disagrees
+    with provenance.chat_id, the helper refuses to dereference."""
+
+    def test_mismatch_returns_chat_mismatch_before_disk(self, _log_dir, caplog):
+        import hashlib
+
+        # Write a file for chat 2 that DOES contain the target line.
+        # The helper must not read it on behalf of expected_chat_id=1.
+        path = _log_dir / "2" / "2026-06-13.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"ts": "2026-06-13T09:00:00+00:00", "dir": "user", "chat_id": 2, "text": "secret"}) + "\n"
+        )
+        provenance = _Provenance(
+            chat_id=2,  # the row's source pointer (bad data on a chat-1 row)
+            date="2026-06-13",
+            user_ts="2026-06-13T09:00:00+00:00",
+            user_text_sha256=hashlib.sha256(b"secret").hexdigest(),
+        )
+        with caplog.at_level("INFO", logger="kai.history"):
+            result = history.fetch_transcript_context(provenance, expected_chat_id=1, memory_id="m")
+        assert result.reason == "chat_mismatch"
+        assert result.context is None
+        # The drift log fired with the new reason.
+        assert any('"reason":"chat_mismatch"' in r.message for r in caplog.records)
+
+    def test_match_proceeds(self, _log_dir):
+        import hashlib
+
+        path = _log_dir / "1" / "2026-06-13.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"ts": "2026-06-13T09:00:00+00:00", "dir": "user", "chat_id": 1, "text": "ok"}) + "\n"
+        )
+        provenance = _Provenance(
+            chat_id=1,
+            date="2026-06-13",
+            user_ts="2026-06-13T09:00:00+00:00",
+            user_text_sha256=hashlib.sha256(b"ok").hexdigest(),
+        )
+        result = history.fetch_transcript_context(provenance, expected_chat_id=1)
+        assert result.reason == "ok"
+
+    def test_no_expected_chat_id_skips_check(self, _log_dir):
+        """Admin callers (cross-chat scans) get the old behaviour when
+        they omit the gate."""
+        import hashlib
+
+        path = _log_dir / "5" / "2026-06-13.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"ts": "2026-06-13T09:00:00+00:00", "dir": "user", "chat_id": 5, "text": "x"}) + "\n"
+        )
+        provenance = _Provenance(
+            chat_id=5,
+            date="2026-06-13",
+            user_ts="2026-06-13T09:00:00+00:00",
+            user_text_sha256=hashlib.sha256(b"x").hexdigest(),
+        )
+        result = history.fetch_transcript_context(provenance)
+        assert result.reason == "ok"
+
+
+class TestFetchTranscriptContextMidnightCrossAfterWindow:
+    """The after-window walks into the next-day file when the assistant
+    target itself lives there: a follow-up turn on day D+1 must appear
+    in `lookup.context.after`."""
+
+    def test_after_window_includes_next_day_turn(self, _log_dir):
+        import hashlib
+
+        prev = _log_dir / "1" / "2026-06-12.jsonl"
+        nextp = _log_dir / "1" / "2026-06-13.jsonl"
+        prev.parent.mkdir(parents=True, exist_ok=True)
+        prev.write_text(
+            json.dumps({"ts": "2026-06-12T23:59:00+00:00", "dir": "user", "chat_id": 1, "text": "u"}) + "\n"
+        )
+        nextp.write_text(
+            json.dumps({"ts": "2026-06-13T00:00:30+00:00", "dir": "assistant", "chat_id": 1, "text": "a"})
+            + "\n"
+            + json.dumps({"ts": "2026-06-13T00:05:00+00:00", "dir": "user", "chat_id": 1, "text": "follow-up"})
+            + "\n"
+        )
+        provenance = _Provenance(
+            chat_id=1,
+            date="2026-06-12",
+            user_ts="2026-06-12T23:59:00+00:00",
+            user_text_sha256=hashlib.sha256(b"u").hexdigest(),
+            assistant_ts="2026-06-13T00:00:30+00:00",
+            date_end="2026-06-13",
+        )
+        result = history.fetch_transcript_context(provenance, before=0, after=1)
+        assert result.reason == "ok"
+        assert [t.text for t in result.context.after] == ["follow-up"]
+
+
+class TestLogMessageMkdirFailure:
+    def test_mkdir_oserror_returns_none(self, monkeypatch, _log_dir):
+        """Directory creation failures now share the LogEntry | None
+        contract with append failures (P3 boundary fix)."""
+        from pathlib import Path
+
+        original_mkdir = Path.mkdir
+
+        def boom(self, *args, **kwargs):
+            if str(self).startswith(str(_log_dir)):
+                raise OSError("read-only filesystem")
+            return original_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", boom)
+        entry = log_message(direction="user", chat_id=99, text="x")
+        assert entry is None

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -6310,3 +6310,67 @@ class TestGetStatsScopeDistribution:
     def test_empty_corpus_yields_empty_distribution(self):
         stats = self._stats_with([])
         assert stats.by_scope == {}
+
+
+class TestReadTranscriptProvenance:
+    """Resolver mirrors resolve_memory_scope's legacy-safe shape."""
+
+    def _md(self, **overrides):
+        base = {
+            "source_chat_id": 100,
+            "source_date": "2026-06-13",
+            "source_user_ts": "2026-06-13T09:00:00+00:00",
+            "source_user_text_sha256": "a" * 64,
+        }
+        base.update(overrides)
+        return base
+
+    def test_all_required_fields_present(self):
+        from kai.memory import read_transcript_provenance
+
+        p = read_transcript_provenance(self._md(source_assistant_ts="2026-06-13T09:00:30+00:00"))
+        assert p.present is True
+        assert p.chat_id == 100
+        assert p.assistant_ts == "2026-06-13T09:00:30+00:00"
+
+    def test_missing_required_field_not_present(self):
+        from kai.memory import read_transcript_provenance
+
+        md = self._md()
+        del md["source_user_ts"]
+        p = read_transcript_provenance(md)
+        assert p.present is False
+
+    def test_legacy_metadata_not_present(self):
+        from kai.memory import read_transcript_provenance
+
+        p = read_transcript_provenance({"source": "extracted"})
+        assert p.present is False
+        assert p.chat_id is None
+
+    def test_empty_string_required_field_not_present(self):
+        """An empty string fingerprint is malformed and must not flip
+        present True; a half-locator is worse than no locator."""
+        from kai.memory import read_transcript_provenance
+
+        p = read_transcript_provenance(self._md(source_user_text_sha256=""))
+        assert p.present is False
+
+    def test_assistant_ts_absence_does_not_flip_present(self):
+        """The four required fields are the only present-gate; absent
+        assistant_ts is the legitimate single-turn provenance case."""
+        from kai.memory import read_transcript_provenance
+
+        p = read_transcript_provenance(self._md())
+        assert p.present is True
+        assert p.assistant_ts is None
+
+    def test_date_end_populated_only_on_midnight_cross(self):
+        from kai.memory import read_transcript_provenance
+
+        same_day = read_transcript_provenance(self._md(source_assistant_ts="2026-06-13T09:30:00+00:00"))
+        cross = read_transcript_provenance(
+            self._md(source_assistant_ts="2026-06-14T00:30:00+00:00", source_date_end="2026-06-14")
+        )
+        assert same_day.date_end is None
+        assert cross.date_end == "2026-06-14"

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -3720,3 +3720,38 @@ class TestSourceViewBuilder:
         text, _ = memory_command._build_source_view(f, lookup)
         assert len(text) <= 4096
         assert "(output truncated)" in text
+
+
+class TestSourceViewOwnership:
+    """`/memory source` must refuse to dereference a row whose
+    `source_chat_id` does not match the current chat, even when the
+    JSONL would otherwise resolve."""
+
+    @pytest.mark.asyncio
+    async def test_cross_chat_pointer_renders_failure_body(
+        self, tmp_path, monkeypatch, update_factory, context_factory
+    ):
+        from kai import history
+
+        # JSONL for chat 2 with a matching ts and hash; the helper
+        # must not consult it for a chat-1 caller.
+        path = tmp_path / "2" / "2026-06-13.jsonl"
+        path.parent.mkdir(parents=True)
+        path.write_text('{"ts": "2026-06-13T09:00:00+00:00", "dir": "user", "chat_id": 2, "text": "secret"}\n')
+        monkeypatch.setattr(history, "_LOG_DIR", tmp_path)
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+
+        fact = _provenanced_fact(
+            chat_id=2,
+            user_text_sha256=__import__("hashlib").sha256(b"secret").hexdigest(),
+        )
+        monkeypatch.setattr(memory_command.memory, "get_by_id", lambda *, user_id, memory_id: fact)
+        sent = {}
+
+        async def fake_send(update, text, kb, edit):
+            sent["text"] = text
+
+        monkeypatch.setattr(memory_command, "_send_or_edit", fake_send)
+        await memory_command._send_source_view(update_factory(callback_data="mem:src"), context_factory(), 1, fact.id)
+        assert "does not match this chat" in sent["text"]
+        assert "secret" not in sent["text"]

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -3556,3 +3556,167 @@ class TestScopeViewCutoverKnob:
         monkeypatch.setattr(memory_command.memory, "is_scoped_recall_enabled", lambda: True)
         await memory_command._send_fact_view(update_factory(callback_data="mem:fview"), ctx, 100, "scoped1")
         assert "no (project_scope_not_allowed" in sent["text"]
+
+
+# ── Source view (transcript provenance) ────────────────────────────
+
+
+def _provenanced_fact(
+    fact_id: str = "fact-1",
+    *,
+    text: str = "Sample fact",
+    source: str = "extracted",
+    chat_id: int = 100,
+    date: str = "2026-06-13",
+    user_ts: str = "2026-06-13T09:00:00+00:00",
+    user_text_sha256: str = "a" * 64,
+    assistant_ts: str | None = "2026-06-13T09:00:30+00:00",
+    date_end: str | None = None,
+) -> MemoryResult:
+    md: dict[str, Any] = {
+        "source": source,
+        "tags": [],
+        "confidence": 0.9,
+        "speaker": "user",
+        "source_chat_id": chat_id,
+        "source_date": date,
+        "source_user_ts": user_ts,
+        "source_user_text_sha256": user_text_sha256,
+    }
+    if assistant_ts is not None:
+        md["source_assistant_ts"] = assistant_ts
+    if date_end is not None:
+        md["source_date_end"] = date_end
+    return MemoryResult(
+        id=fact_id, text=text, score=0.0, memory_type="fact", metadata=md, created_at="2026-06-13T09:00:00"
+    )
+
+
+class TestSourceLabel:
+    def test_legacy_label(self):
+        f = _fact("a", "x", ["t"])
+        from kai.memory import read_transcript_provenance
+
+        provenance = read_transcript_provenance(f.metadata)
+        assert memory_command._build_source_label(f, provenance) == "not recorded (legacy)"
+
+    def test_fact_label_renders_user_ts(self):
+        from kai.memory import read_transcript_provenance
+
+        f = _provenanced_fact()
+        provenance = read_transcript_provenance(f.metadata)
+        label = memory_command._build_source_label(f, provenance)
+        assert label == "2026-06-13 09:00:00 UTC"
+
+    def test_episode_same_day_label_collapses_date(self):
+        from kai.memory import read_transcript_provenance
+
+        f = _provenanced_fact(source="episode")
+        provenance = read_transcript_provenance(f.metadata)
+        label = memory_command._build_source_label(f, provenance)
+        # Same-day: one date, two times.
+        assert label == "2026-06-13 09:00:00 to 09:00:30 UTC"
+
+    def test_episode_midnight_cross_keeps_both_dates(self):
+        from kai.memory import read_transcript_provenance
+
+        f = _provenanced_fact(
+            source="episode",
+            assistant_ts="2026-06-14T00:01:00+00:00",
+            date_end="2026-06-14",
+        )
+        provenance = read_transcript_provenance(f.metadata)
+        label = memory_command._build_source_label(f, provenance)
+        assert label == "2026-06-13 09:00:00 UTC to 2026-06-14 00:01:00 UTC"
+
+
+class TestFactViewSourceBlock:
+    def test_legacy_row_renders_fallback_and_no_source_button(self):
+        from kai.memory import read_transcript_provenance
+
+        f = _fact("a", "x", ["tag"])
+        provenance = read_transcript_provenance(f.metadata)
+        text, kb = memory_command._build_fact_view(f, return_to=None, provenance=provenance)
+        assert "not recorded (legacy)" in text
+        row = kb.inline_keyboard[0]
+        labels = [btn.text for btn in row]
+        assert "source" not in labels
+        assert labels == ["back", "scope", "forget"]
+
+    def test_provenanced_row_renders_label_and_source_button(self):
+        from kai.memory import read_transcript_provenance
+
+        f = _provenanced_fact()
+        provenance = read_transcript_provenance(f.metadata)
+        text, kb = memory_command._build_fact_view(f, return_to=None, provenance=provenance)
+        assert "Source:" in text
+        assert "2026-06-13 09:00:00 UTC" in text
+        labels = [btn.text for btn in kb.inline_keyboard[0]]
+        assert labels == ["back", "source", "scope", "forget"]
+
+
+class TestSourceViewBuilder:
+    def _ctx(self, *, before=None, after=None):
+        from kai.history import TranscriptContext, TranscriptLookup, TranscriptTurn
+
+        return TranscriptLookup(
+            reason="ok",
+            context=TranscriptContext(
+                chat_id=100,
+                target_user=TranscriptTurn(ts="2026-06-13T09:00:00+00:00", direction="user", text="user msg"),
+                target_assistant=TranscriptTurn(
+                    ts="2026-06-13T09:00:30+00:00", direction="assistant", text="assistant reply"
+                ),
+                before=before or [],
+                after=after or [],
+                truncated=False,
+            ),
+        )
+
+    def test_ok_renders_user_and_assistant_turns(self):
+        f = _provenanced_fact()
+        text, kb = memory_command._build_source_view(f, self._ctx())
+        assert "user msg" in text
+        assert "assistant reply" in text
+        # Back button goes via fview, reusing the fact-view re-render
+        # flow that reads memory_ids from cache.
+        assert kb.inline_keyboard[0][0].callback_data == "mem:fview"
+
+    def test_failure_reasons_have_distinct_bodies(self):
+        from kai.history import TranscriptLookup
+
+        f = _provenanced_fact()
+        bodies: dict[str, str] = {}
+        for reason in ("file_missing", "unreadable", "ts_not_found", "hash_mismatch"):
+            text, _ = memory_command._build_source_view(f, TranscriptLookup(reason=reason, context=None))
+            bodies[reason] = text
+        # All four bodies are distinct so the operator can tell drift
+        # from missing file from missing ts.
+        assert len(set(bodies.values())) == 4
+        assert "drift" in bodies["hash_mismatch"]
+        assert "no longer available" in bodies["file_missing"]
+
+    def test_oversized_body_truncated_under_limit(self):
+        """Pathological exchange with very long turns: the body
+        ceiling clamps the output and the marker is visible."""
+        from kai.history import TranscriptContext, TranscriptLookup, TranscriptTurn
+
+        long_text = "x" * 2000
+        turns = [
+            TranscriptTurn(ts=f"2026-06-13T08:00:{i:02d}+00:00", direction="user", text=long_text) for i in range(20)
+        ]
+        lookup = TranscriptLookup(
+            reason="ok",
+            context=TranscriptContext(
+                chat_id=100,
+                target_user=TranscriptTurn(ts="2026-06-13T09:00:00+00:00", direction="user", text=long_text),
+                target_assistant=TranscriptTurn(ts="2026-06-13T09:00:30+00:00", direction="assistant", text=long_text),
+                before=turns,
+                after=turns,
+                truncated=True,
+            ),
+        )
+        f = _provenanced_fact()
+        text, _ = memory_command._build_source_view(f, lookup)
+        assert len(text) <= 4096
+        assert "(output truncated)" in text

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -425,7 +425,7 @@ class TestStage2Trigger:
         causal correlation in logs."""
         order: list[str] = []
 
-        def _store_recorder(facts, *, user_id, session_id, config, active_project=None):
+        def _store_recorder(facts, *, user_id, session_id, config, active_project=None, **_extra):
             order.append("store_facts")
             return (len(facts), 0, 0)
 

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -4637,7 +4637,7 @@ class TestWorkspaceThreading:
         monkeypatch.setattr(memory_extraction, "_run_extractor", AsyncMock(return_value=self._result()))
         seen: dict = {}
 
-        def _fake_store(facts, *, user_id, session_id, config, active_project=None):
+        def _fake_store(facts, *, user_id, session_id, config, active_project=None, **_extra):
             seen["active_project"] = active_project
             return (1, 0, 0)
 
@@ -4668,7 +4668,7 @@ class TestWorkspaceThreading:
         )
         seen: dict = {}
 
-        def _fake_store(facts, *, user_id, session_id, config, active_project=None):
+        def _fake_store(facts, *, user_id, session_id, config, active_project=None, **_extra):
             seen["active_project"] = active_project
             return (1, 0, 0)
 
@@ -4892,3 +4892,100 @@ class TestDedupGateScope:
         neighbor = _paraphrase_neighbor("x", "u1", threshold=0.9)
         assert neighbor is not None
         assert neighbor.id == "legacy-row"
+
+
+# ── Transcript provenance stamping ──────────────────────────────────
+
+
+class TestProvenanceStamping:
+    """`_store_facts` stamps `source_*` keys when both LogEntry kwargs
+    are present; omits them when either is None."""
+
+    def _capture_metadata(self, monkeypatch):
+        captured: dict = {}
+        from kai import memory as memory_module
+        from kai.history import LogEntry
+
+        # Force the dedup gate path to skip so the existing-fact lookup
+        # never runs (these tests are about the stamping shape).
+        monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
+        monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [])
+
+        def fake_add_structured(*args, **kwargs):
+            captured["metadata"] = kwargs.get("metadata") or {}
+            return "stored-id"
+
+        monkeypatch.setattr(memory_module, "add_structured", fake_add_structured)
+        return captured, LogEntry
+
+    def test_both_logs_present_stamps_source_keys(self, monkeypatch):
+        captured, LogEntry = self._capture_metadata(monkeypatch)
+        user_log = LogEntry(
+            ts="2026-06-13T09:00:00+00:00",
+            date="2026-06-13",
+            chat_id=100,
+            direction="user",
+            text="hello",
+            sha256="u" * 64,
+        )
+        assistant_log = LogEntry(
+            ts="2026-06-13T09:00:30+00:00",
+            date="2026-06-13",
+            chat_id=100,
+            direction="assistant",
+            text="hi",
+            sha256="a" * 64,
+        )
+        facts = [{"content": "x", "tags": ["fact"], "confidence": 0.9, "intent": "new"}]
+        _store_facts(
+            facts, user_id="100", session_id="s", config=_cfg(), user_log=user_log, assistant_log=assistant_log
+        )
+        md = captured["metadata"]
+        assert md["source_chat_id"] == 100
+        assert md["source_date"] == "2026-06-13"
+        assert md["source_user_ts"] == "2026-06-13T09:00:00+00:00"
+        assert md["source_user_text_sha256"] == "u" * 64
+        assert md["source_assistant_ts"] == "2026-06-13T09:00:30+00:00"
+
+    def test_missing_user_log_skips_stamp(self, monkeypatch):
+        """When `log_message` returned None for the user write, no
+        `source_*` keys are stamped and the row matches today's
+        legacy metadata shape."""
+        captured, LogEntry = self._capture_metadata(monkeypatch)
+        assistant_log = LogEntry(
+            ts="2026-06-13T09:00:30+00:00",
+            date="2026-06-13",
+            chat_id=100,
+            direction="assistant",
+            text="hi",
+            sha256="a" * 64,
+        )
+        facts = [{"content": "x", "tags": ["fact"], "confidence": 0.9, "intent": "new"}]
+        _store_facts(facts, user_id="100", session_id="s", config=_cfg(), user_log=None, assistant_log=assistant_log)
+        md = captured["metadata"]
+        assert "source_chat_id" not in md
+        assert "source_user_ts" not in md
+
+    def test_missing_assistant_log_skips_stamp(self, monkeypatch):
+        captured, LogEntry = self._capture_metadata(monkeypatch)
+        user_log = LogEntry(
+            ts="2026-06-13T09:00:00+00:00",
+            date="2026-06-13",
+            chat_id=100,
+            direction="user",
+            text="hello",
+            sha256="u" * 64,
+        )
+        facts = [{"content": "x", "tags": ["fact"], "confidence": 0.9, "intent": "new"}]
+        _store_facts(facts, user_id="100", session_id="s", config=_cfg(), user_log=user_log, assistant_log=None)
+        md = captured["metadata"]
+        assert "source_chat_id" not in md
+
+    def test_both_omitted_matches_legacy_shape(self, monkeypatch):
+        """No LogEntry kwargs at all (the sandbox / eval call shape)
+        produces no `source_*` keys."""
+        captured, _ = self._capture_metadata(monkeypatch)
+        facts = [{"content": "x", "tags": ["fact"], "confidence": 0.9, "intent": "new"}]
+        _store_facts(facts, user_id="100", session_id="s", config=_cfg())
+        md = captured["metadata"]
+        assert not any(k.startswith("source_") for k in md if k != "source")

--- a/tests/test_memory_reclassify.py
+++ b/tests/test_memory_reclassify.py
@@ -965,3 +965,56 @@ class TestReportProvenanceQuote:
         with_empty = memory_reclassify.render_report(**kwargs, provenance_user_texts={})
         assert without == with_empty
         assert "said:" not in without
+
+
+class TestReportProvenanceQuoteOwnership:
+    """A forged or restored row whose source_chat_id points at another
+    chat must not contribute a quote to the dry-run report."""
+
+    def test_cross_chat_pointer_skipped(self, monkeypatch, tmp_path):
+        from kai import memory as memory_module
+
+        # The proposal's source row carries provenance whose chat_id
+        # is 2; the CLI is running for user_id="1". Even if a JSONL
+        # entry happens to line up, the helper must refuse before any
+        # filesystem read and the report must not quote it.
+        path = tmp_path / "history" / "2" / "2026-06-13.jsonl"
+        path.parent.mkdir(parents=True)
+        path.write_text('{"ts": "2026-06-13T09:00:00+00:00", "dir": "user", "chat_id": 2, "text": "secret"}\n')
+
+        # Redirect history dir so the helper looks at our fixture.
+        from kai import history
+
+        monkeypatch.setattr(history, "_LOG_DIR", tmp_path / "history")
+
+        fact = MemoryResult(
+            id="m1",
+            text="row body",
+            score=0.0,
+            memory_type="fact",
+            metadata={
+                "source": "extracted",
+                "tags": ["t"],
+                "confidence": 0.9,
+                memory_module.SOURCE_CHAT_ID_KEY: 2,
+                memory_module.SOURCE_DATE_KEY: "2026-06-13",
+                memory_module.SOURCE_USER_TS_KEY: "2026-06-13T09:00:00+00:00",
+                memory_module.SOURCE_USER_TEXT_SHA256_KEY: __import__("hashlib").sha256(b"secret").hexdigest(),
+                memory_module.SOURCE_ASSISTANT_TS_KEY: "2026-06-13T09:00:30+00:00",
+            },
+            created_at="",
+        )
+        from kai.memory import resolve_memory_scope
+
+        resolved = resolve_memory_scope(fact.metadata)
+        proposal = memory_reclassify.Proposal(
+            memory_id="m1",
+            verdict="global",
+            project_id=None,
+            confidence=0.9,
+            reason="r",
+            prior_scope_source="legacy_default",
+            text_sha256="ab",
+        )
+        quotes = memory_reclassify._collect_provenance_quotes([(fact, resolved)], [proposal], user_id="1")
+        assert quotes == {}

--- a/tests/test_memory_reclassify.py
+++ b/tests/test_memory_reclassify.py
@@ -906,3 +906,62 @@ class TestRollback:
         assert code == 1
         assert fetches == []
         assert env["updates"] == []
+
+
+# ── Transcript provenance in the report ─────────────────────────────
+
+
+class TestReportProvenanceQuote:
+    def _proposals(self):
+        return [
+            memory_reclassify.Proposal(
+                memory_id=f"m{i}",
+                verdict="project" if i % 2 else "global",
+                project_id="kai" if i % 2 else None,
+                confidence=0.9,
+                reason=f"reason {i}",
+                prior_scope_source="legacy_default",
+                text_sha256="ab",
+            )
+            for i in range(3)
+        ]
+
+    def test_present_entries_render_said_line(self):
+        proposals = self._proposals()
+        report = memory_reclassify.render_report(
+            run_id="rs-test",
+            user_id="100",
+            backend="claude",
+            threshold=0.8,
+            scanned=3,
+            selected=3,
+            proposals=proposals,
+            skips={},
+            sample_size=3,
+            texts={p.memory_id: f"text {p.memory_id}" for p in proposals},
+            provenance_user_texts={"m0": "what did the user actually say"},
+        )
+        assert 'said:   "what did the user actually say"' in report
+        # The other two proposals (no entry) render unchanged.
+        assert report.count("said:") == 1
+
+    def test_no_provenance_argument_renders_identically(self):
+        """The optional kwarg defaults to None; older callers see the
+        original report shape."""
+        proposals = self._proposals()
+        kwargs = dict(
+            run_id="rs-test",
+            user_id="100",
+            backend="claude",
+            threshold=0.8,
+            scanned=3,
+            selected=3,
+            proposals=proposals,
+            skips={},
+            sample_size=3,
+            texts={p.memory_id: f"text {p.memory_id}" for p in proposals},
+        )
+        without = memory_reclassify.render_report(**kwargs)
+        with_empty = memory_reclassify.render_report(**kwargs, provenance_user_texts={})
+        assert without == with_empty
+        assert "said:" not in without


### PR DESCRIPTION
## Summary

Transcript provenance for extracted facts and episodes. Closes #667.

Every newly extracted fact and episode from a real bot path now carries a `source_*` metadata block fingerprinting the JSONL line(s) the extractor consumed: `source_chat_id`, `source_date` (UTC `YYYY-MM-DD`), `source_user_ts`, `source_user_text_sha256`, and `source_assistant_ts`, plus `source_date_end` for episode windows that straddle midnight. The block is purely additive; retrieval, ranking, write-scope routing, prompt section rendering, and stats are unchanged. Legacy rows without provenance render a documented fallback across every UI surface.

- `log_message` now returns `LogEntry | None`, with `None` on the existing `OSError` catch so a history write failure can never stamp provenance pointing at a JSONL line that was never written. All four bot content handlers (text, photo, document with three arms, voice) capture their user-side `LogEntry` and thread it through `_handle_response` into the extraction pipeline. The voice handler's user-side `log_message` moves to after transcription so the JSONL line carries the actual transcript on the success path; the failure paths (transcription error, empty transcript) keep the existing duration placeholder.
- `fetch_transcript_context` resolves a `TranscriptProvenance` into the originating turns plus a small surrounding window, returning a typed `TranscriptLookup` with one of `ok`, `legacy`, `file_missing`, `unreadable`, `ts_not_found`, or `hash_mismatch`. Assistant-side lookup is authoritative on `source_assistant_ts` (never adjacency), so queued-message interleavings still resolve correctly; an assistant ts that no longer matches the JSONL is reported as `ts_not_found` with `"side":"assistant"` in the structured `memory.provenance.drift` event. Hash drift never returns a maybe-matched turn.
- The `/memory` detail view shows a Source row on every arm (legacy fallback: `not recorded (legacy)`). Rows with provenance gain a fourth `source` button between back and scope; tapping it edits the body to show the originating exchange plus a small context window, with `back` returning to the detail view via the existing `fview` flow. Per-reason failure bodies distinguish drift from missing file from missing ts. The 4096-char Telegram limit is enforced by a renderer-local clamp (`_truncate_to_message_limit`) at a 3900-char safe ceiling with a visible truncation marker; per-turn 400-char caps are the primary defence.
- The reclassification dry-run report optionally renders a quoted `said:` line under each provenanced proposal in the eyeball sample. Best-effort: legacy rows and any non-`ok` lookup contribute nothing and the proposal renders as before.

Two contract details worth flagging:

- Provenance is stamped only when BOTH `user_log` and `assistant_log` are present. A single-side stamp would be a half-locator and would force the reader to invent the missing half. The sandbox / replay / eval surface (no exchange) and the history-write-failure surface (`log_message` returned `None`) collapse to the same legacy shape, byte-equal to today's metadata.
- Episode windows describe the current exchange only, matching what `_generate_episode` actually consumes. The v3 spec dropped the prior-pair window framing for this reason; `source_date_end` is the only episode-specific key.

## Testing

- 73 new tests: helper happy and failure paths (legacy, file_missing, unreadable, ts_not_found user-side, ts_not_found assistant-side, hash_mismatch, legitimately-no-assistant, synthetic markers excluded, midnight-cross, before-window walks previous day); `LogEntry` contract incl. `OSError` returning `None`; resolver across all required-field combinations; `_store_facts` stamps when both logs present, omits when either is missing; `/memory` source-view label rendering (legacy, fact, episode same-day, episode midnight-cross), source-block presence and conditional source button on the keyboard, source-view builder with all four failure reason bodies distinct, and an oversized-body case asserting the rendered text stays under 4096 chars with a visible truncation marker; reclassification report's `said:` line opt-in.
- Two existing test fakes for `_store_facts` widened with `**_extra` to absorb the new kwargs.
- Full suite: 4234 passed, 1 skipped. `make check` clean.
