### PR TITLE
feat(eval): probe-corpus coverage check for scoped retrieval evaluator

### DIFF
--- a/src/kai/eval/probe_corpus_check.py
+++ b/src/kai/eval/probe_corpus_check.py
@@ -22,6 +22,15 @@ What this is NOT:
 - A check on the live legacy backlog. Coverage is measured against
   the operator's authoring intent, not against the actual /memory
   state for any user.
+- A complete corpus authoring gate. The "at least N legacy-default
+  probes" minimum from the original issue body cannot be enforced
+  here: distinguishing a legacy-default-targeting probe from any
+  other positive probe requires reading the expected_fact_id row's
+  `scope_source` from the live store. The check covers STRUCTURAL
+  minimums (collision count, positive-only count, non-project count,
+  unregistered-workspace gate); legacy-default coverage is verified
+  separately by running the scoped evaluator and inspecting the
+  per-probe `scoped_reason` distribution.
 
 Exit codes mirror the admin-CLI convention:
 - 0: corpus meets every documented minimum
@@ -151,6 +160,8 @@ def check_corpus_coverage(
     probes: list[ScopedProbe],
     registry: dict[str, MemoryProjectConfig],
     minimums: CoverageMinimums,
+    *,
+    non_project_only: bool = False,
 ) -> CoverageReport:
     """Compute the coverage report for a probe corpus.
 
@@ -159,29 +170,46 @@ def check_corpus_coverage(
     codes; unit tests exercise this function directly with hand-
     constructed registries and probe lists.
 
-    Algorithm:
-        1. Initialize an empty ProjectCoverage for every registered
-           project so the report names zero-coverage projects
-           explicitly.
-        2. For each probe, detect its active project via the same
-           rule the scoped evaluator uses, bucket it, and classify.
-        3. After bucketing, walk every project and compute the
-           shortfall list against the minimums.
+    Registry filtering: only projects with `memory_enabled=True`
+    contribute to per-project minimums. The scoped retrieval helper
+    treats a detected disabled project as global-only at admission
+    (it carries the active-project debug metadata but produces
+    `allowed_scopes=("global",)`), so requiring collision probes
+    against a disabled project would assert a property the scope
+    filter does not enforce. Disabled projects do appear in the
+    report's diagnostics so the operator sees they exist; they just
+    do not block coverage.
 
-    Workspace=null probes contribute to `non_project_count` only.
-    Workspaces that match no registered project contribute to
-    `unregistered_workspace_count` and are NOT counted against any
-    per-project minimum (because they cannot be: an unregistered
-    workspace can never have collision probes for a project that
-    does not exist).
+    Non-project-only mode: when set, per-project minimums are
+    suppressed and an empty memory-enabled registry stops being a
+    shortfall. The mode exists for corpora that deliberately exercise
+    only the global section (e.g. a smoke test corpus for the
+    global-only retrieval posture). Without the mode, an empty
+    memory-enabled registry is a shortfall (the tool's primary job
+    is per-project safety coverage; "nothing to check" is not a
+    meaningful pass).
+
+    Unregistered workspace probes (workspace set but matching no
+    registered project) are always a shortfall. Either the operator
+    forgot to pin a chat-registered project in YAML, or the
+    workspace path is stale. Silent counting would let the corpus
+    exercise zero active projects while automation read exit 0.
     """
-    per_project_total: dict[str, int] = {pid: 0 for pid in registry}
-    per_project_collision: dict[str, int] = {pid: 0 for pid in registry}
-    per_project_positive: dict[str, int] = {pid: 0 for pid in registry}
+    enabled_registry = {pid: cfg for pid, cfg in registry.items() if cfg.memory_enabled}
+
+    per_project_total: dict[str, int] = {pid: 0 for pid in enabled_registry}
+    per_project_collision: dict[str, int] = {pid: 0 for pid in enabled_registry}
+    per_project_positive: dict[str, int] = {pid: 0 for pid in enabled_registry}
     non_project_count = 0
     unregistered_workspace_count = 0
 
     for probe in probes:
+        # Detection runs against the FULL registry (including disabled
+        # projects) so a probe pinned to a disabled project's workspace
+        # is bucketed correctly as "matched a registered project",
+        # then dropped from the enabled-registry per-project counts.
+        # Without this, a disabled-project probe would falsely land in
+        # the unregistered bucket and trip the unregistered shortfall.
         bucket = _detect_probe_active_project(probe, registry)
         is_collision, is_positive_only = _classify_probe(probe)
 
@@ -190,6 +218,13 @@ def check_corpus_coverage(
                 non_project_count += 1
             else:
                 unregistered_workspace_count += 1
+            continue
+
+        if bucket not in enabled_registry:
+            # Disabled project: counted as matched-but-not-required.
+            # The probe is not a corpus authoring mistake (the path is
+            # registered), but it cannot contribute to the safety
+            # signal because the scope filter would admit global only.
             continue
 
         per_project_total[bucket] = per_project_total.get(bucket, 0) + 1
@@ -205,23 +240,40 @@ def check_corpus_coverage(
             collision_probes=per_project_collision[pid],
             positive_only_probes=per_project_positive[pid],
         )
-        for pid in sorted(registry)
+        for pid in sorted(enabled_registry)
     }
 
     shortfalls: list[str] = []
-    for pid in sorted(registry):
-        cov = per_project[pid]
-        if cov.collision_probes < minimums.min_collision_per_project:
+    if not non_project_only:
+        if not enabled_registry:
             shortfalls.append(
-                f"project {pid!r}: {cov.collision_probes} collision probes (need {minimums.min_collision_per_project})"
+                "registry has no memory-enabled projects to check per-project coverage "
+                "against (pass --non-project-only if the corpus is deliberately global-only)"
             )
-        if cov.positive_only_probes < minimums.min_positive_per_project:
-            shortfalls.append(
-                f"project {pid!r}: {cov.positive_only_probes} positive-only probes "
-                f"(need {minimums.min_positive_per_project})"
-            )
+        for pid in sorted(enabled_registry):
+            cov = per_project[pid]
+            if cov.collision_probes < minimums.min_collision_per_project:
+                shortfalls.append(
+                    f"project {pid!r}: {cov.collision_probes} collision probes "
+                    f"(need {minimums.min_collision_per_project})"
+                )
+            if cov.positive_only_probes < minimums.min_positive_per_project:
+                shortfalls.append(
+                    f"project {pid!r}: {cov.positive_only_probes} positive-only probes "
+                    f"(need {minimums.min_positive_per_project})"
+                )
     if non_project_count < minimums.min_non_project:
         shortfalls.append(f"non-project (workspace=null): {non_project_count} probes (need {minimums.min_non_project})")
+    if unregistered_workspace_count > 0:
+        # Unregistered workspaces are always a shortfall: either the
+        # operator forgot to pin chat-registered projects into YAML
+        # (the registry layer this tool reads), or the workspace path
+        # is stale. Silent counting would let the corpus exercise zero
+        # active projects while the tool reported green.
+        shortfalls.append(
+            f"unregistered workspace: {unregistered_workspace_count} probes with workspace "
+            "paths that match no registered project (pin in YAML or fix the paths)"
+        )
 
     return CoverageReport(
         per_project=per_project,
@@ -320,6 +372,17 @@ def _build_parser() -> argparse.ArgumentParser:
         default=_DEFAULT_MIN_NON_PROJECT,
         help=(f"Minimum probes whose workspace is null (non-project assertions). Default: {_DEFAULT_MIN_NON_PROJECT}."),
     )
+    parser.add_argument(
+        "--non-project-only",
+        action="store_true",
+        help=(
+            "Skip the per-project minimums entirely; only the --min-non-project "
+            "threshold gates the result. Use for corpora that deliberately exercise "
+            "only the global section. Without this flag, an empty memory-enabled "
+            "registry is a shortfall (the tool's primary job is per-project safety "
+            "coverage, and 'nothing to check' would be a meaningless pass)."
+        ),
+    )
     return parser
 
 
@@ -374,7 +437,12 @@ def _run_cli(args: argparse.Namespace) -> int:
         min_positive_per_project=args.min_positive_per_project,
         min_non_project=args.min_non_project,
     )
-    report = check_corpus_coverage(probes, registry, minimums)
+    report = check_corpus_coverage(
+        probes,
+        registry,
+        minimums,
+        non_project_only=args.non_project_only,
+    )
     print(render_report(report))
     return 2 if report.shortfalls else 0
 

--- a/src/kai/eval/probe_corpus_check.py
+++ b/src/kai/eval/probe_corpus_check.py
@@ -29,8 +29,12 @@ What this is NOT:
   `scope_source` from the live store. The check covers STRUCTURAL
   minimums (collision count, positive-only count, non-project count,
   unregistered-workspace gate); legacy-default coverage is verified
-  separately by running the scoped evaluator and inspecting the
-  per-probe `scoped_reason` distribution.
+  out of band, by inspecting each candidate expected_fact_id row's
+  `scope_source` directly (via `/memory` or a get_by_id call), then
+  running the scoped evaluator to confirm the chosen probes surface
+  end to end. The evaluator's `scoped_reason` distribution describes
+  the retrieval outcome (ok / no_results_after_scope / etc.), NOT
+  the row's scope_source; the two signals are independent.
 
 Exit codes mirror the admin-CLI convention:
 - 0: corpus meets every documented minimum

--- a/src/kai/eval/probe_corpus_check.py
+++ b/src/kai/eval/probe_corpus_check.py
@@ -1,0 +1,394 @@
+"""
+Probe-corpus coverage check for the scoped retrieval evaluator.
+
+Reachable as `python -m kai.eval.probe_corpus_check <probes-path>`.
+
+Given an operator-authored probe file under the scoped evaluator's
+v2 schema, reports whether the corpus exercises the cross-scope
+safety property the scoped evaluator measures. The evaluator's
+`exclusion_pass_in_prompt` metric is meaningful only when probes
+carry `expected_excluded_fact_ids`; without those, the safety axis
+is invisible. This tool tells the operator, at corpus-authoring
+time, whether the file they wrote covers every active project with
+enough collision probes to make the metric trustworthy.
+
+What this is NOT:
+- A probe-file format validator. The scoped evaluator's `load_probes`
+  is the structural gate; this tool reuses it and exits early on any
+  load error. v2 schema fields are validated there, not here.
+- A retrieval evaluator. It does not call Mem0, score anything, or
+  touch the live store. The check is purely structural over the probe
+  file plus the project registry.
+- A check on the live legacy backlog. Coverage is measured against
+  the operator's authoring intent, not against the actual /memory
+  state for any user.
+
+Exit codes mirror the admin-CLI convention:
+- 0: corpus meets every documented minimum
+- 1: IO or config-init failure
+- 2: corpus loaded but one or more minimums are not met (the report
+  names every shortfall by project so the operator can author the
+  missing probes)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from kai.config import Config, MemoryProjectConfig
+from kai.eval.retrieval_scoped import ScopedProbe, _detect_probe_active_project, load_probes
+
+# Sentinel bucket keys for probes whose workspace does not resolve to
+# a registered project. `_NONE_PROJECT_KEY` matches the scoped
+# evaluator's own sentinel so the two tools render the same bucket
+# name. `_UNREGISTERED_KEY` is distinct from non-project: a probe
+# with a workspace path that the operator registered nowhere is an
+# authoring mistake (likely a stale path), while a workspace=null
+# probe is a deliberate non-project assertion.
+_NONE_PROJECT_KEY = "__none__"
+_UNREGISTERED_KEY = "__unregistered__"
+
+
+# Default coverage minimums. Tunable via CLI; the defaults match the
+# corpus shape the scoped evaluator's safety metric needs to be load-
+# bearing: five collision probes per active project to give the
+# negative denominator enough signal, two positive-only per project
+# to keep the IR family meaningful in the same run, and three non-
+# project probes to surface the `__none__` bucket.
+_DEFAULT_MIN_COLLISION_PER_PROJECT = 5
+_DEFAULT_MIN_POSITIVE_PER_PROJECT = 2
+_DEFAULT_MIN_NON_PROJECT = 3
+
+
+# ── Data shapes ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CoverageMinimums:
+    """The thresholds the coverage check measures against.
+
+    Carried alongside the report so the rendered output names the
+    exact minimums in effect (an operator running with non-default
+    flags should not have to cross-reference what they passed).
+    """
+
+    min_collision_per_project: int
+    min_positive_per_project: int
+    min_non_project: int
+
+
+@dataclass(frozen=True)
+class ProjectCoverage:
+    """Per-project coverage counts.
+
+    `total_probes` is every probe whose workspace resolves to this
+    project, regardless of polarity. `collision_probes` is the
+    subset whose `expected_excluded_fact_ids` is non-empty (the
+    safety signal); `positive_only_probes` is the subset with an
+    `expected_fact_id` and no exclusions (the IR signal). A probe
+    can be both polarities at once; it contributes to `total_probes`
+    once and to `collision_probes` whenever the exclusion list is
+    non-empty.
+    """
+
+    project_id: str
+    total_probes: int
+    collision_probes: int
+    positive_only_probes: int
+
+
+@dataclass(frozen=True)
+class CoverageReport:
+    """Structured coverage result over a probe corpus.
+
+    `per_project` is keyed on registered project ids; an entry exists
+    for every project in the registry even if its coverage is zero
+    (so the report explicitly names the gap). `non_project_count` is
+    workspace=null probes. `unregistered_workspace_count` is probes
+    whose workspace path matches no registered project; those are
+    authoring mistakes and surfaced separately so the operator can
+    fix or remove them.
+
+    `shortfalls` lists every minimum that was not met, one human-
+    readable line per gap. An empty list means the corpus meets every
+    minimum and the check exits 0.
+    """
+
+    per_project: dict[str, ProjectCoverage]
+    non_project_count: int
+    unregistered_workspace_count: int
+    total_probes: int
+    minimums: CoverageMinimums
+    shortfalls: list[str]
+
+
+# ── Pure helpers ───────────────────────────────────────────────────
+
+
+def _classify_probe(probe: ScopedProbe) -> tuple[bool, bool]:
+    """Return `(is_collision, is_positive_only)` for one probe.
+
+    The two flags are independent: a probe can be a collision probe
+    with a positive assertion (both `expected_fact_id` AND
+    `expected_excluded_fact_ids` set), or a pure collision (exclusion
+    only), or a pure positive (no exclusions), or neither (the loader
+    rejects "neither" so this branch is unreachable here, but the
+    classifier returns it cleanly for completeness).
+
+    `positive_only` is True when the probe has a positive id AND no
+    exclusions; the "only" qualifier reflects that this probe carries
+    the IR signal but does NOT contribute to the safety signal.
+    """
+    has_positive = probe.expected_fact_id is not None
+    has_exclusion = bool(probe.expected_excluded_fact_ids)
+    return has_exclusion, (has_positive and not has_exclusion)
+
+
+def check_corpus_coverage(
+    probes: list[ScopedProbe],
+    registry: dict[str, MemoryProjectConfig],
+    minimums: CoverageMinimums,
+) -> CoverageReport:
+    """Compute the coverage report for a probe corpus.
+
+    Pure function: takes a list of probes and a project registry,
+    returns the structured report. The CLI layer owns IO and exit
+    codes; unit tests exercise this function directly with hand-
+    constructed registries and probe lists.
+
+    Algorithm:
+        1. Initialize an empty ProjectCoverage for every registered
+           project so the report names zero-coverage projects
+           explicitly.
+        2. For each probe, detect its active project via the same
+           rule the scoped evaluator uses, bucket it, and classify.
+        3. After bucketing, walk every project and compute the
+           shortfall list against the minimums.
+
+    Workspace=null probes contribute to `non_project_count` only.
+    Workspaces that match no registered project contribute to
+    `unregistered_workspace_count` and are NOT counted against any
+    per-project minimum (because they cannot be: an unregistered
+    workspace can never have collision probes for a project that
+    does not exist).
+    """
+    per_project_total: dict[str, int] = {pid: 0 for pid in registry}
+    per_project_collision: dict[str, int] = {pid: 0 for pid in registry}
+    per_project_positive: dict[str, int] = {pid: 0 for pid in registry}
+    non_project_count = 0
+    unregistered_workspace_count = 0
+
+    for probe in probes:
+        bucket = _detect_probe_active_project(probe, registry)
+        is_collision, is_positive_only = _classify_probe(probe)
+
+        if bucket is None:
+            if probe.workspace is None:
+                non_project_count += 1
+            else:
+                unregistered_workspace_count += 1
+            continue
+
+        per_project_total[bucket] = per_project_total.get(bucket, 0) + 1
+        if is_collision:
+            per_project_collision[bucket] = per_project_collision.get(bucket, 0) + 1
+        if is_positive_only:
+            per_project_positive[bucket] = per_project_positive.get(bucket, 0) + 1
+
+    per_project: dict[str, ProjectCoverage] = {
+        pid: ProjectCoverage(
+            project_id=pid,
+            total_probes=per_project_total[pid],
+            collision_probes=per_project_collision[pid],
+            positive_only_probes=per_project_positive[pid],
+        )
+        for pid in sorted(registry)
+    }
+
+    shortfalls: list[str] = []
+    for pid in sorted(registry):
+        cov = per_project[pid]
+        if cov.collision_probes < minimums.min_collision_per_project:
+            shortfalls.append(
+                f"project {pid!r}: {cov.collision_probes} collision probes (need {minimums.min_collision_per_project})"
+            )
+        if cov.positive_only_probes < minimums.min_positive_per_project:
+            shortfalls.append(
+                f"project {pid!r}: {cov.positive_only_probes} positive-only probes "
+                f"(need {minimums.min_positive_per_project})"
+            )
+    if non_project_count < minimums.min_non_project:
+        shortfalls.append(f"non-project (workspace=null): {non_project_count} probes (need {minimums.min_non_project})")
+
+    return CoverageReport(
+        per_project=per_project,
+        non_project_count=non_project_count,
+        unregistered_workspace_count=unregistered_workspace_count,
+        total_probes=len(probes),
+        minimums=minimums,
+        shortfalls=shortfalls,
+    )
+
+
+def render_report(report: CoverageReport) -> str:
+    """Human-readable rendering of the coverage report.
+
+    Plain text, no color codes. The output is meant to be pastable
+    into a chat or commit message without ANSI escapes. Sections in
+    stable order: a summary line, per-project counts (with the
+    minimums next to each cell so an operator scanning the table
+    sees both the actual and the target at the same column), the
+    sentinel buckets, and the shortfall list.
+
+    When the corpus meets every minimum, the shortfall section
+    renders as a single "All minimums met." line; this lets a quick
+    eyeball of the bottom of the report answer the operator's first
+    question ("am I done authoring?") without scrolling through the
+    counts.
+    """
+    lines = [
+        "Probe corpus coverage report",
+        "",
+        f"Total probes: {report.total_probes}",
+        f"Non-project (workspace=null): {report.non_project_count} (need {report.minimums.min_non_project})",
+        f"Unregistered workspace: {report.unregistered_workspace_count}",
+        "",
+        "Per-project coverage:",
+    ]
+    if not report.per_project:
+        lines.append("  (registry is empty; nothing to check)")
+    for pid, cov in report.per_project.items():
+        lines.append(
+            f"  {pid}: total={cov.total_probes} collision={cov.collision_probes}"
+            f"/{report.minimums.min_collision_per_project} "
+            f"positive_only={cov.positive_only_probes}"
+            f"/{report.minimums.min_positive_per_project}"
+        )
+
+    lines.append("")
+    if report.shortfalls:
+        lines.append("Shortfalls:")
+        for sf in report.shortfalls:
+            lines.append(f"  - {sf}")
+    else:
+        lines.append("All minimums met.")
+    return "\n".join(lines)
+
+
+# ── CLI ────────────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Top-level argparse for `python -m kai.eval.probe_corpus_check`."""
+    parser = argparse.ArgumentParser(
+        prog="python -m kai.eval.probe_corpus_check",
+        description=(
+            "Structural coverage check for scoped-evaluator probe corpora. "
+            "Reports per-project collision and positive-only counts against "
+            "documented minimums and exits non-zero when any shortfall is found."
+        ),
+    )
+    parser.add_argument(
+        "probes",
+        type=Path,
+        help="Path to the probe corpus (JSONL, scoped evaluator v2 schema).",
+    )
+    parser.add_argument(
+        "--min-collision-per-project",
+        type=int,
+        default=_DEFAULT_MIN_COLLISION_PER_PROJECT,
+        help=(
+            "Minimum collision probes (expected_excluded_fact_ids non-empty) "
+            f"per registered project. Default: {_DEFAULT_MIN_COLLISION_PER_PROJECT}."
+        ),
+    )
+    parser.add_argument(
+        "--min-positive-per-project",
+        type=int,
+        default=_DEFAULT_MIN_POSITIVE_PER_PROJECT,
+        help=(
+            "Minimum positive-only probes (expected_fact_id set, no exclusions) "
+            f"per registered project. Default: {_DEFAULT_MIN_POSITIVE_PER_PROJECT}."
+        ),
+    )
+    parser.add_argument(
+        "--min-non-project",
+        type=int,
+        default=_DEFAULT_MIN_NON_PROJECT,
+        help=(f"Minimum probes whose workspace is null (non-project assertions). Default: {_DEFAULT_MIN_NON_PROJECT}."),
+    )
+    return parser
+
+
+def _load_config_registry() -> tuple[Config, dict[str, MemoryProjectConfig]] | None:
+    """Load config and return the YAML project registry.
+
+    Returns `(config, registry)` on success or None on failure (the
+    caller exits 1). Uses the YAML registry directly rather than
+    `load_project_registry` so the check does NOT require the daemon
+    to be stopped: it never touches the session DB or the Mem0 store.
+    Chat-registered projects (DB layer) are invisible here; an
+    operator who has only chat-registered projects must add a
+    matching YAML entry for the duration of the check or run
+    against the live registry by stopping the daemon and using the
+    scoped evaluator's own flags.
+    """
+    try:
+        from kai.config import load_config
+
+        config = load_config()
+    except Exception as e:
+        print(f"probe-corpus-check: config init failed: {e}", file=sys.stderr)
+        return None
+    return config, config.memory_projects
+
+
+def _run_cli(args: argparse.Namespace) -> int:
+    """CLI dispatch.
+
+    Returns process exit code: 0 on success (all minimums met), 1 on
+    init or IO failure, 2 on a successful load with shortfalls.
+    """
+    try:
+        probes = load_probes(args.probes)
+    except (OSError, ValueError) as e:
+        print(f"probe-corpus-check: failed to load probes: {e}", file=sys.stderr)
+        return 1
+    if not probes:
+        print(
+            f"probe-corpus-check: no probes loaded from {args.probes}",
+            file=sys.stderr,
+        )
+        return 1
+
+    loaded = _load_config_registry()
+    if loaded is None:
+        return 1
+    _config, registry = loaded
+
+    minimums = CoverageMinimums(
+        min_collision_per_project=args.min_collision_per_project,
+        min_positive_per_project=args.min_positive_per_project,
+        min_non_project=args.min_non_project,
+    )
+    report = check_corpus_coverage(probes, registry, minimums)
+    print(render_report(report))
+    return 2 if report.shortfalls else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entrypoint for `python -m kai.eval.probe_corpus_check`.
+
+    `argv` defaults to `sys.argv[1:]`. Returns the exit code for the
+    caller; the `__main__` block below propagates it via sys.exit.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return _run_cli(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_eval_probe_corpus_check.py
+++ b/tests/test_eval_probe_corpus_check.py
@@ -1,0 +1,316 @@
+"""Tests for the scoped-evaluator probe-corpus coverage check.
+
+Three layers:
+
+1. TestClassify - pure-function classification of a single probe
+   (collision / positive-only / both / neither).
+2. TestCoverageReport - bucketing per project, minimums and shortfalls,
+   the `__none__` vs `__unregistered__` distinction, the empty-registry
+   degenerate case.
+3. TestRenderReport - the rendered output names every section in
+   stable order and surfaces shortfalls verbatim.
+4. TestCLIExitCodes - end-to-end exit code for met-all / shortfalls /
+   load-failure paths.
+
+The check is a pure structural pass over (probes, registry); no Mem0,
+no filesystem outside the CLI smoke. Coverage minimums in the tests
+are tuned to small numbers so the fixtures stay readable.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from kai.config import MemoryProjectConfig
+from kai.eval.probe_corpus_check import (
+    CoverageMinimums,
+    ProjectCoverage,
+    _classify_probe,
+    check_corpus_coverage,
+    main,
+    render_report,
+)
+from kai.eval.retrieval_scoped import ScopedProbe
+
+# ── Shared fixtures ────────────────────────────────────────────────
+
+
+def _probe(
+    *,
+    line: int = 1,
+    expected_fact_id: str | None = "fact-a",
+    expected_excluded_fact_ids: tuple[str, ...] = (),
+    workspace: str | None = None,
+) -> ScopedProbe:
+    return ScopedProbe(
+        question="q",
+        expected_fact_id=expected_fact_id,
+        expected_excluded_fact_ids=expected_excluded_fact_ids,
+        workspace=workspace,
+        line_number=line,
+    )
+
+
+def _registry(tmp_path: Path, *project_ids: str) -> dict[str, MemoryProjectConfig]:
+    """Build a registry whose project roots live under tmp_path/<project_id>."""
+    registry: dict[str, MemoryProjectConfig] = {}
+    for pid in project_ids:
+        root = tmp_path / pid
+        root.mkdir(parents=True, exist_ok=True)
+        registry[pid] = MemoryProjectConfig(
+            project_id=pid,
+            display_name=pid,
+            workspace_roots=(root.resolve(),),
+            memory_enabled=True,
+            default_scope_for_new_facts="project",
+        )
+    return registry
+
+
+_MINIMUMS = CoverageMinimums(
+    min_collision_per_project=2,
+    min_positive_per_project=1,
+    min_non_project=1,
+)
+
+
+# ── Test 1: Classify ───────────────────────────────────────────────
+
+
+class TestClassify:
+    def test_positive_only_when_no_exclusions(self):
+        is_collision, is_positive_only = _classify_probe(_probe(expected_fact_id="x", expected_excluded_fact_ids=()))
+        assert is_collision is False
+        assert is_positive_only is True
+
+    def test_collision_only_when_no_positive(self):
+        is_collision, is_positive_only = _classify_probe(
+            _probe(expected_fact_id=None, expected_excluded_fact_ids=("bad",))
+        )
+        assert is_collision is True
+        assert is_positive_only is False
+
+    def test_both_when_positive_and_exclusion(self):
+        is_collision, is_positive_only = _classify_probe(
+            _probe(expected_fact_id="x", expected_excluded_fact_ids=("bad",))
+        )
+        # Both polarities present. positive_only is False because the
+        # probe contributes to the safety signal too; it is NOT a
+        # "positive only" probe.
+        assert is_collision is True
+        assert is_positive_only is False
+
+
+# ── Test 2: Coverage report ────────────────────────────────────────
+
+
+class TestCoverageReport:
+    def test_per_project_bucketing(self, tmp_path):
+        registry = _registry(tmp_path, "kai", "anvil")
+        kai_root = str(registry["kai"].workspace_roots[0])
+        anvil_root = str(registry["anvil"].workspace_roots[0])
+        probes = [
+            _probe(line=1, expected_fact_id="x", expected_excluded_fact_ids=("y",), workspace=kai_root),
+            _probe(line=2, expected_fact_id=None, expected_excluded_fact_ids=("z",), workspace=kai_root),
+            _probe(line=3, expected_fact_id="p", workspace=anvil_root),
+        ]
+        report = check_corpus_coverage(probes, registry, _MINIMUMS)
+        assert report.per_project["kai"] == ProjectCoverage(
+            project_id="kai",
+            total_probes=2,
+            collision_probes=2,
+            # Both kai probes carry exclusions; neither is positive-only.
+            positive_only_probes=0,
+        )
+        assert report.per_project["anvil"] == ProjectCoverage(
+            project_id="anvil",
+            total_probes=1,
+            collision_probes=0,
+            positive_only_probes=1,
+        )
+
+    def test_non_project_vs_unregistered(self, tmp_path):
+        registry = _registry(tmp_path, "kai")
+        probes = [
+            # workspace=null is deliberate non-project.
+            _probe(line=1, expected_fact_id="x", workspace=None),
+            # workspace set but not registered: authoring mistake.
+            _probe(line=2, expected_fact_id="y", workspace=str(tmp_path / "other")),
+        ]
+        report = check_corpus_coverage(probes, registry, _MINIMUMS)
+        assert report.non_project_count == 1
+        assert report.unregistered_workspace_count == 1
+        # Neither contributed to kai's counts.
+        assert report.per_project["kai"].total_probes == 0
+
+    def test_empty_registry_renders_no_per_project_entries(self):
+        report = check_corpus_coverage([], {}, _MINIMUMS)
+        assert report.per_project == {}
+        # Non-project minimum still fires when the corpus is empty.
+        assert report.shortfalls == [
+            "non-project (workspace=null): 0 probes (need 1)",
+        ]
+
+    def test_shortfalls_name_every_gap(self, tmp_path):
+        registry = _registry(tmp_path, "kai")
+        kai_root = str(registry["kai"].workspace_roots[0])
+        probes = [
+            # One collision probe; need two.
+            _probe(line=1, expected_fact_id=None, expected_excluded_fact_ids=("y",), workspace=kai_root),
+            # Two non-project probes; need one. Satisfied.
+            _probe(line=2, expected_fact_id="z", workspace=None),
+        ]
+        # Note: no positive-only probes for kai project.
+        report = check_corpus_coverage(probes, registry, _MINIMUMS)
+        assert "collision" in report.shortfalls[0]
+        assert "positive-only" in report.shortfalls[1]
+        # Non-project minimum is met (2 >= 1) so no shortfall there.
+        assert all("non-project" not in s for s in report.shortfalls)
+
+    def test_all_minimums_met_produces_empty_shortfalls(self, tmp_path):
+        registry = _registry(tmp_path, "kai")
+        kai_root = str(registry["kai"].workspace_roots[0])
+        probes = [
+            _probe(line=1, expected_fact_id=None, expected_excluded_fact_ids=("y",), workspace=kai_root),
+            _probe(line=2, expected_fact_id=None, expected_excluded_fact_ids=("z",), workspace=kai_root),
+            _probe(line=3, expected_fact_id="p", workspace=kai_root),
+            _probe(line=4, expected_fact_id="q", workspace=None),
+        ]
+        report = check_corpus_coverage(probes, registry, _MINIMUMS)
+        assert report.shortfalls == []
+
+
+# ── Test 3: Render report ──────────────────────────────────────────
+
+
+class TestRenderReport:
+    def test_met_all_minimums_renders_clean_summary(self, tmp_path):
+        registry = _registry(tmp_path, "kai")
+        kai_root = str(registry["kai"].workspace_roots[0])
+        probes = [
+            _probe(line=1, expected_fact_id=None, expected_excluded_fact_ids=("y",), workspace=kai_root),
+            _probe(line=2, expected_fact_id=None, expected_excluded_fact_ids=("z",), workspace=kai_root),
+            _probe(line=3, expected_fact_id="p", workspace=kai_root),
+            _probe(line=4, expected_fact_id="q", workspace=None),
+        ]
+        report = check_corpus_coverage(probes, registry, _MINIMUMS)
+        out = render_report(report)
+        assert "Probe corpus coverage report" in out
+        assert "Total probes: 4" in out
+        assert "Non-project (workspace=null): 1 (need 1)" in out
+        assert "All minimums met." in out
+
+    def test_shortfall_lines_render(self, tmp_path):
+        registry = _registry(tmp_path, "kai")
+        probes = []  # nothing.
+        report = check_corpus_coverage(probes, registry, _MINIMUMS)
+        out = render_report(report)
+        assert "Shortfalls:" in out
+        # Per-project AND non-project shortfalls both surface.
+        assert "collision probes" in out
+        assert "positive-only probes" in out
+        assert "non-project" in out
+
+
+# ── Test 4: CLI exit codes ─────────────────────────────────────────
+
+
+def _write_probes(path: Path, probes: list[dict]) -> None:
+    """Write a v2 probe file the scoped loader will accept."""
+    with open(path, "w", encoding="utf-8") as f:
+        for p in probes:
+            f.write(json.dumps(p) + "\n")
+
+
+class TestCLIExitCodes:
+    def test_exit_zero_when_minimums_met(self, tmp_path, capsys):
+        registry = _registry(tmp_path, "kai")
+        kai_root = str(registry["kai"].workspace_roots[0])
+        probes_path = tmp_path / "probes.jsonl"
+        _write_probes(
+            probes_path,
+            [
+                {"question": "q1", "expected_excluded_fact_ids": ["y"], "workspace": kai_root},
+                {"question": "q2", "expected_excluded_fact_ids": ["z"], "workspace": kai_root},
+                {"question": "q3", "expected_fact_id": "p", "workspace": kai_root},
+                {"question": "q4", "expected_fact_id": "q"},
+            ],
+        )
+        # Patch load_config to return a config whose memory_projects
+        # is our test registry. The CLI uses the YAML registry, so we
+        # do not need to touch the session DB or Mem0.
+        fake_config = type(
+            "FakeConfig",
+            (),
+            {"memory_projects": registry},
+        )()
+        with patch("kai.config.load_config", return_value=fake_config):
+            code = main(
+                [
+                    str(probes_path),
+                    "--min-collision-per-project",
+                    "2",
+                    "--min-positive-per-project",
+                    "1",
+                    "--min-non-project",
+                    "1",
+                ]
+            )
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "All minimums met." in out
+
+    def test_exit_two_when_shortfalls_present(self, tmp_path, capsys):
+        registry = _registry(tmp_path, "kai")
+        kai_root = str(registry["kai"].workspace_roots[0])
+        probes_path = tmp_path / "probes.jsonl"
+        _write_probes(
+            probes_path,
+            # Only one collision probe; needs two. No non-project probe.
+            [{"question": "q1", "expected_excluded_fact_ids": ["y"], "workspace": kai_root}],
+        )
+        fake_config = type("FakeConfig", (), {"memory_projects": registry})()
+        with patch("kai.config.load_config", return_value=fake_config):
+            code = main(
+                [
+                    str(probes_path),
+                    "--min-collision-per-project",
+                    "2",
+                    "--min-positive-per-project",
+                    "1",
+                    "--min-non-project",
+                    "1",
+                ]
+            )
+        assert code == 2
+        out = capsys.readouterr().out
+        assert "Shortfalls:" in out
+
+    def test_exit_one_when_probes_load_fails(self, tmp_path, capsys):
+        # File that exists but contains invalid JSONL: the scoped
+        # loader raises ValueError; the CLI must exit 1 (IO/load
+        # failure) and NOT exit 2 (which is "loaded but shortfalls").
+        probes_path = tmp_path / "probes.jsonl"
+        probes_path.write_text("this is not json at all\n", encoding="utf-8")
+        code = main([str(probes_path)])
+        assert code == 1
+        err = capsys.readouterr().err
+        assert "failed to load probes" in err
+
+    def test_exit_one_when_probes_file_missing(self, tmp_path, capsys):
+        # Nonexistent path: the loader raises OSError; CLI exits 1.
+        code = main([str(tmp_path / "missing.jsonl")])
+        assert code == 1
+        err = capsys.readouterr().err
+        assert "failed to load probes" in err
+
+    def test_exit_one_when_probes_file_empty(self, tmp_path, capsys):
+        # Probe file with only comment lines; loader returns [].
+        probes_path = tmp_path / "probes.jsonl"
+        probes_path.write_text("# just a comment\n", encoding="utf-8")
+        code = main([str(probes_path)])
+        assert code == 1
+        err = capsys.readouterr().err
+        assert "no probes loaded" in err

--- a/tests/test_eval_probe_corpus_check.py
+++ b/tests/test_eval_probe_corpus_check.py
@@ -145,13 +145,96 @@ class TestCoverageReport:
         # Neither contributed to kai's counts.
         assert report.per_project["kai"].total_probes == 0
 
-    def test_empty_registry_renders_no_per_project_entries(self):
+    def test_empty_registry_is_a_shortfall_by_default(self):
+        # The tool's primary job is per-project safety coverage; an
+        # empty memory-enabled registry plus no per-project shortfalls
+        # would have been a meaningless "all met" before. Now it
+        # surfaces an explicit shortfall so the operator either fixes
+        # the registry or opts in to --non-project-only.
         report = check_corpus_coverage([], {}, _MINIMUMS)
         assert report.per_project == {}
-        # Non-project minimum still fires when the corpus is empty.
-        assert report.shortfalls == [
-            "non-project (workspace=null): 0 probes (need 1)",
+        assert any("registry has no memory-enabled projects" in s for s in report.shortfalls)
+        # The non-project minimum still fires too because the corpus
+        # is empty.
+        assert any("non-project (workspace=null)" in s for s in report.shortfalls)
+
+    def test_empty_registry_passes_under_non_project_only(self, tmp_path):
+        # Corpus deliberately exercises only the global section; the
+        # non-project minimum is the only check that applies.
+        probes = [_probe(line=1, expected_fact_id="x", workspace=None)]
+        report = check_corpus_coverage([*probes], {}, _MINIMUMS, non_project_only=True)
+        assert report.shortfalls == []
+
+    def test_disabled_project_not_required_for_coverage(self, tmp_path):
+        # A YAML-pinned project with memory_enabled=False: production
+        # scope filter returns global-only at admission, so per-project
+        # collision probes against it would assert a property retrieval
+        # does not enforce. The coverage check filters disabled
+        # projects out of per-project minimums.
+        registry = _registry(tmp_path, "kai")
+        disabled_root = tmp_path / "disabled"
+        disabled_root.mkdir(parents=True, exist_ok=True)
+        registry["disabled"] = MemoryProjectConfig(
+            project_id="disabled",
+            display_name="disabled",
+            workspace_roots=(disabled_root.resolve(),),
+            memory_enabled=False,
+            default_scope_for_new_facts="project",
+        )
+        # Corpus exercises kai correctly but has nothing for the
+        # disabled project; this should pass without complaint about
+        # the disabled project.
+        kai_root = str(registry["kai"].workspace_roots[0])
+        probes = [
+            _probe(line=1, expected_fact_id=None, expected_excluded_fact_ids=("y",), workspace=kai_root),
+            _probe(line=2, expected_fact_id=None, expected_excluded_fact_ids=("z",), workspace=kai_root),
+            _probe(line=3, expected_fact_id="p", workspace=kai_root),
+            _probe(line=4, expected_fact_id="q", workspace=None),
         ]
+        report = check_corpus_coverage(probes, registry, _MINIMUMS)
+        # `disabled` does not appear in per_project (filtered out).
+        assert "disabled" not in report.per_project
+        # No shortfall mentions the disabled project.
+        assert all("disabled" not in s for s in report.shortfalls)
+        # And the run is otherwise clean.
+        assert report.shortfalls == []
+
+    def test_probe_pinned_to_disabled_project_does_not_count_as_unregistered(self, tmp_path):
+        # A probe whose workspace matches a disabled project's root
+        # should NOT be bucketed as unregistered (the path IS
+        # registered); it just does not contribute to coverage.
+        registry = _registry(tmp_path, "kai")
+        disabled_root = tmp_path / "disabled"
+        disabled_root.mkdir(parents=True, exist_ok=True)
+        registry["disabled"] = MemoryProjectConfig(
+            project_id="disabled",
+            display_name="disabled",
+            workspace_roots=(disabled_root.resolve(),),
+            memory_enabled=False,
+            default_scope_for_new_facts="project",
+        )
+        probes = [_probe(line=1, expected_fact_id="x", workspace=str(disabled_root))]
+        report = check_corpus_coverage(probes, registry, _MINIMUMS, non_project_only=False)
+        assert report.unregistered_workspace_count == 0
+
+    def test_unregistered_workspace_is_a_shortfall(self, tmp_path):
+        # Probe with a workspace path that no registered project
+        # matches: the operator forgot to pin a chat-registered project
+        # or the path is stale. The check must surface this.
+        registry = _registry(tmp_path, "kai")
+        kai_root = str(registry["kai"].workspace_roots[0])
+        probes = [
+            # Coverage for kai is fine.
+            _probe(line=1, expected_fact_id=None, expected_excluded_fact_ids=("y",), workspace=kai_root),
+            _probe(line=2, expected_fact_id=None, expected_excluded_fact_ids=("z",), workspace=kai_root),
+            _probe(line=3, expected_fact_id="p", workspace=kai_root),
+            _probe(line=4, expected_fact_id="q", workspace=None),
+            # One probe targeting an unregistered path.
+            _probe(line=5, expected_fact_id="r", workspace=str(tmp_path / "stale")),
+        ]
+        report = check_corpus_coverage(probes, registry, _MINIMUMS)
+        assert report.unregistered_workspace_count == 1
+        assert any("unregistered workspace" in s for s in report.shortfalls)
 
     def test_shortfalls_name_every_gap(self, tmp_path):
         registry = _registry(tmp_path, "kai")
@@ -305,6 +388,47 @@ class TestCLIExitCodes:
         assert code == 1
         err = capsys.readouterr().err
         assert "failed to load probes" in err
+
+    def test_exit_two_when_registry_empty_without_non_project_only(self, tmp_path, capsys):
+        # Empty YAML registry plus a corpus that satisfies the non-
+        # project minimum: under the old behavior this exited 0 (false
+        # green); under the new behavior the empty registry is itself
+        # a shortfall and exit is 2.
+        probes_path = tmp_path / "probes.jsonl"
+        _write_probes(probes_path, [{"question": "q", "expected_fact_id": "x"}])
+        fake_config = type("FakeConfig", (), {"memory_projects": {}})()
+        with patch("kai.config.load_config", return_value=fake_config):
+            code = main(
+                [
+                    str(probes_path),
+                    "--min-collision-per-project",
+                    "2",
+                    "--min-positive-per-project",
+                    "1",
+                    "--min-non-project",
+                    "1",
+                ]
+            )
+        assert code == 2
+        out = capsys.readouterr().out
+        assert "registry has no memory-enabled projects" in out
+
+    def test_exit_zero_under_non_project_only_with_empty_registry(self, tmp_path, capsys):
+        # Same setup as above but the operator opts in to non-project-
+        # only: empty registry is no longer a shortfall.
+        probes_path = tmp_path / "probes.jsonl"
+        _write_probes(probes_path, [{"question": "q", "expected_fact_id": "x"}])
+        fake_config = type("FakeConfig", (), {"memory_projects": {}})()
+        with patch("kai.config.load_config", return_value=fake_config):
+            code = main(
+                [
+                    str(probes_path),
+                    "--non-project-only",
+                    "--min-non-project",
+                    "1",
+                ]
+            )
+        assert code == 0
 
     def test_exit_one_when_probes_file_empty(self, tmp_path, capsys):
         # Probe file with only comment lines; loader returns [].


### PR DESCRIPTION
## Summary

- New `kai.eval.probe_corpus_check` module backs `python -m kai.eval.probe_corpus_check <probes-path>`. Structural pass over the operator-authored probe corpus that reports per-project collision and positive-only counts against documented minimums; exits 0 when all minimums are met, 2 on shortfalls (with named per-gap lines), 1 on probe-file IO or load failure.
- Pairs with the scoped retrieval evaluator's safety axis: `exclusion_pass_in_prompt` is meaningful only when the corpus carries enough collision probes per active project. The check tells the operator that at corpus-authoring time rather than forcing a full evaluator run against the live store.
- Read-only by design. Reads the YAML project registry from `config.memory_projects` rather than `load_project_registry`, so the daemon can stay running and no Mem0 or session-DB access happens. Chat-registered projects (added via `/project register` at runtime) are intentionally invisible here; the operator either pins them in YAML for the duration of the authoring session or runs the scoped evaluator's own filters against the live registry.
- Companion authoring guide lives in the operator docs tree (not in the public repo): coverage minimums + rationale, candidate-id sourcing patterns, what makes a good collision probe, validation workflow, an example abbreviated probe file.

This is the code part of the corpus-authoring work. The corpus content itself is operator data and is not produced by this PR.

Refs #517. Refs #673.

## Test plan

- [x] `make check` clean
- [x] `make test` passes (4335 passed, 1 skipped)
- [x] New `tests/test_eval_probe_corpus_check.py` (15 tests) covers probe classification (collision / positive-only / both), per-project bucketing via the existing scoped detector, `__none__` vs `__unregistered__` distinction, empty-registry degenerate case, shortfall naming, render-output stable sections, and CLI exit codes (`0` met-all, `2` shortfalls, `1` load failure / file missing / empty).
- [ ] Manual: run against a real probe corpus once one is authored, verify the per-project counts match expectations.
