### PR TITLE
feat(memory): assistant-turn matching pass for provenance backfill

### DIFF
--- a/src/kai/memory_admin.py
+++ b/src/kai/memory_admin.py
@@ -237,6 +237,27 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Token-shingle width for the overlap score. Default: 4.",
     )
+    # Pass 2 controls. `--no-assistant-pass` uses store_const + default=None
+    # so the mutating-mode rejection below can distinguish "explicitly
+    # passed" from "default in effect"; without it, the rejection's
+    # `if value is not None` filter would always read False on a
+    # boolean store_true flag and the flag would be silently
+    # tolerated under --apply/--rollback.
+    bp.add_argument(
+        "--no-assistant-pass",
+        dest="no_assistant_pass",
+        action="store_const",
+        const=True,
+        default=None,
+        help=("Disable Pass 2 (assistant-turn matching). Dry-run only; apply consumes the proposals file verbatim."),
+    )
+    bp.add_argument(
+        "--assistant-max-user-gap-seconds",
+        dest="assistant_max_user_gap_seconds",
+        type=int,
+        default=None,
+        help=("Pass 2: maximum seconds between the paired user turn and the winning assistant turn. Default: 600."),
+    )
     bp.add_argument(
         "--sample",
         type=int,
@@ -493,6 +514,8 @@ def _cmd_backfill_provenance(args: argparse.Namespace) -> int:
                 ("--min-overlap", args.min_overlap),
                 ("--strong-overlap-ratio", args.strong_overlap_ratio),
                 ("--overlap-shingle-n", args.overlap_shingle_n),
+                ("--no-assistant-pass", args.no_assistant_pass),
+                ("--assistant-max-user-gap-seconds", args.assistant_max_user_gap_seconds),
                 ("--sample", args.sample),
             )
             if value is not None
@@ -523,6 +546,16 @@ def _cmd_backfill_provenance(args: argparse.Namespace) -> int:
         args.overlap_shingle_n if args.overlap_shingle_n is not None else memory_provenance_backfill._DEFAULT_SHINGLE_N
     )
     sample = args.sample if args.sample is not None else 10
+    # Pass 2 settings. `assistant_pass_enabled` defaults to True; the
+    # `--no-assistant-pass` flag uses store_const + default=None so an
+    # explicit pass flips this to False, and the absent flag leaves
+    # Pass 2 on.
+    assistant_pass_enabled = args.no_assistant_pass is None
+    assistant_max_user_gap_seconds = (
+        args.assistant_max_user_gap_seconds
+        if args.assistant_max_user_gap_seconds is not None
+        else memory_provenance_backfill._DEFAULT_ASSISTANT_MAX_USER_GAP_SECONDS
+    )
 
     if window_seconds < 1:
         print(f"memory admin: --window-seconds must be a positive int, got {window_seconds}", file=sys.stderr)
@@ -538,6 +571,13 @@ def _cmd_backfill_provenance(args: argparse.Namespace) -> int:
         return 2
     if shingle_n < 1:
         print(f"memory admin: --overlap-shingle-n must be a positive int, got {shingle_n}", file=sys.stderr)
+        return 2
+    if assistant_max_user_gap_seconds < 1:
+        print(
+            f"memory admin: --assistant-max-user-gap-seconds must be a positive int, "
+            f"got {assistant_max_user_gap_seconds}",
+            file=sys.stderr,
+        )
         return 2
     if sample < 0:
         print(f"memory admin: --sample must be >= 0, got {sample}", file=sys.stderr)
@@ -564,6 +604,8 @@ def _cmd_backfill_provenance(args: argparse.Namespace) -> int:
                 shingle_n=shingle_n,
                 sample=sample,
                 out_dir=out_dir,
+                assistant_pass_enabled=assistant_pass_enabled,
+                assistant_max_user_gap_seconds=assistant_max_user_gap_seconds,
             )
         )
 

--- a/src/kai/memory_provenance_backfill.py
+++ b/src/kai/memory_provenance_backfill.py
@@ -139,14 +139,44 @@ _CURATION_REPORT_TOP_N = 3
 SKIP_AMBIGUOUS_OVERLAP = "ambiguous_overlap"
 SKIP_NO_CANDIDATE = "no_candidate"
 SKIP_HISTORY_UNREADABLE = "history_unreadable"
+# Pass 2 (assistant-turn matching) skip buckets. The harness runs
+# Pass 2 only on rows where Pass 1 returned NO_CANDIDATE; these
+# buckets surface assistant-side failure modes distinctly so the
+# operator's tuning advice (widen the window vs tighten dominance
+# vs accept the curation gap) does not collapse into "no_candidate".
+SKIP_ASSISTANT_AMBIGUOUS_OVERLAP = "assistant_ambiguous_overlap"
+SKIP_NO_PRECEDING_USER = "no_preceding_user"
+SKIP_AMBIGUOUS_USER_PAIRING = "ambiguous_user_pairing"
 # Apply-time re-check skips.
 SKIP_ROW_GONE = "row_gone"
 SKIP_DESELECTED = "deselected"
 SKIP_METADATA_DRIFT = "metadata_drift"
 SKIP_TRANSCRIPT_DRIFT = "transcript_drift"
+SKIP_ASSISTANT_DRIFT = "assistant_drift"
 # Rollback-only skip: the row's source_* block was changed by another
 # writer after backfill; rollback must not silently undo that change.
 SKIP_OPERATOR_CORRECTION = "operator_correction"
+
+
+# Default for the Pass 2 max-gap guard. Once Pass 2's assistant
+# overlap winner is fixed, the harness walks back to find a single
+# preceding user turn within `--assistant-max-user-gap-seconds` of
+# the assistant turn. Beyond that distance, the user-to-assistant
+# pairing is untrustworthy (the gap typically implies a delayed
+# reply boundary or a different conversational neighborhood) and the
+# row buckets as `no_preceding_user`. 600s matches the typical bot
+# response latency tail; operators with unusually long reasoning
+# turns can widen via the CLI flag.
+_DEFAULT_ASSISTANT_MAX_USER_GAP_SECONDS = 600
+
+
+# Match-pass discriminator on a proposal. Pass 1 (user-turn match)
+# emits `"user"`; Pass 2 (assistant-turn match) emits `"assistant"`.
+# Legacy proposal files carry no match_pass field; the parser
+# defaults missing values to `"user"` so those files still apply.
+_MATCH_PASS_USER = "user"
+_MATCH_PASS_ASSISTANT = "assistant"
+_VALID_MATCH_PASSES = frozenset({_MATCH_PASS_USER, _MATCH_PASS_ASSISTANT})
 
 
 # Metadata keys the apply-time fingerprint covers. Selected so a drift
@@ -210,6 +240,23 @@ class Proposal:
     Row text and candidate text snippets ride along so a hand audit
     of the proposals file does not require cross-referencing back
     to the store and the JSONL.
+
+    `match_pass` records which pass produced this proposal: `"user"`
+    means the row text overlapped a user turn directly (Pass 1);
+    `"assistant"` means the row text overlapped an assistant turn
+    and the harness selected the unique preceding user turn within
+    the boundary window as the source (Pass 2). For Pass 2 proposals,
+    `assistant_ts`, `assistant_text_sha256`, and `assistant_text_
+    snippet` carry the assistant evidence that authorized the match;
+    apply re-verifies the assistant line at write time. For Pass 1
+    proposals, all three fields are empty strings (the schema is
+    uniform across passes).
+
+    The four `source_*` keys actually written to Mem0 metadata are
+    user-side only on both passes. The assistant fields are
+    verification-only: they let apply detect assistant-line drift
+    between dry-run and apply, but they are not persisted as durable
+    row metadata.
     """
 
     memory_id: str
@@ -224,6 +271,10 @@ class Proposal:
     prior_metadata_sha256: str
     row_text_snippet: str
     candidate_text_snippet: str
+    match_pass: str = _MATCH_PASS_USER
+    assistant_ts: str = ""
+    assistant_text_sha256: str = ""
+    assistant_text_snippet: str = ""
 
 
 @dataclass(frozen=True)
@@ -413,6 +464,93 @@ def _gate_match(
     return None, SKIP_AMBIGUOUS_OVERLAP, runner_up_score
 
 
+# ── Pure helpers: Pass 2 (assistant-turn matching) ─────────────────
+
+
+def _pair_winning_assistant_with_user(
+    records: list[dict],
+    winning_assistant_ts: str,
+    *,
+    max_user_gap_seconds: int,
+) -> tuple[dict | None, str | None]:
+    """Bind a Pass 2 winning assistant turn to its source user turn.
+
+    The pairing rule is conservative: walk backwards from the winning
+    assistant turn to the previous assistant boundary, then look at
+    the user turns sitting between that boundary and the winner.
+    "Exactly one" produces a confident source; "zero" or "two or
+    more" both bucket the row out of Pass 2 so the harness never
+    stamps a wrong-source pointer from an ambiguous neighborhood.
+
+    Returns `(user_record, skip_reason)` where exactly one of the
+    two is non-None:
+
+    - `(user_record, None)`: pairing succeeded; `user_record` is the
+      unique preceding user turn within the boundary window AND
+      within `max_user_gap_seconds` of the winning assistant turn.
+    - `(None, SKIP_NO_PRECEDING_USER)`: no user turn sits between the
+      boundary and the winner, or the unique user turn exceeds the
+      max-gap guard. Same bucket because the operator's tuning
+      advice is the same (widen the gap if appropriate).
+    - `(None, SKIP_AMBIGUOUS_USER_PAIRING)`: two or more user turns
+      between the boundary and the winner. No tuning unlocks this;
+      the pairing is genuinely ambiguous and the row stays in the
+      curation backlog.
+
+    `records` is the full window cache (both directions) in file-
+    then-line order. The function trusts the cache's validation
+    contract (every record has a parseable `ts`); a winner whose ts
+    does not appear in `records` returns `(None, SKIP_NO_PRECEDING_
+    USER)` rather than crashing.
+    """
+    winner_index = -1
+    for i, rec in enumerate(records):
+        if rec.get("dir") == "assistant" and rec.get("ts") == winning_assistant_ts:
+            winner_index = i
+            break
+    if winner_index < 0:
+        return None, SKIP_NO_PRECEDING_USER
+
+    # Walk back from the winner to the previous assistant record (the
+    # boundary). The user turns we will consider are those between
+    # boundary and winner exclusive. If no prior assistant exists in
+    # the window, the boundary is the start of the cache.
+    boundary_index = -1
+    for j in range(winner_index - 1, -1, -1):
+        if records[j].get("dir") == "assistant":
+            boundary_index = j
+            break
+
+    user_candidates = [rec for rec in records[boundary_index + 1 : winner_index] if rec.get("dir") == "user"]
+    if not user_candidates:
+        return None, SKIP_NO_PRECEDING_USER
+    if len(user_candidates) >= 2:
+        return None, SKIP_AMBIGUOUS_USER_PAIRING
+
+    source_user = user_candidates[0]
+    # Max-gap guard. The cache's validation contract guarantees
+    # parseable ts on every record, so the fromisoformat call here
+    # is total; the bare try/except is defensive insurance against a
+    # future change to the cache contract.
+    try:
+        user_dt = datetime.fromisoformat(source_user["ts"])
+        winner_dt = datetime.fromisoformat(winning_assistant_ts)
+    except (ValueError, KeyError):
+        return None, SKIP_NO_PRECEDING_USER
+    if user_dt.tzinfo is None:
+        user_dt = user_dt.replace(tzinfo=UTC)
+    if winner_dt.tzinfo is None:
+        winner_dt = winner_dt.replace(tzinfo=UTC)
+    gap = (winner_dt - user_dt).total_seconds()
+    if gap > max_user_gap_seconds:
+        # A user turn exists but the boundary-to-winner window opens
+        # too wide. The conservative call is to skip; widening the
+        # CLI flag is the operator's call.
+        return None, SKIP_NO_PRECEDING_USER
+
+    return source_user, None
+
+
 # ── Pure helpers: selection and fingerprinting ──────────────────────
 
 
@@ -530,26 +668,57 @@ def _read_jsonl_records(path: Path) -> list[dict] | None:
     return records
 
 
-def _candidates_for_row(
+def _records_for_row_window(
     chat_id: int,
     created_at_dt: datetime,
     *,
     window_seconds: int,
 ) -> tuple[list[dict], bool]:
-    """Return user-direction records in the row's window plus an
-    `any_unreadable` flag.
+    """Return EVERY in-window JSONL record (both directions) in file-
+    then-line order, plus an `any_unreadable` flag.
 
-    Walks every JSONL file intersecting the window
-    `[created_at - window_seconds, created_at]`. When ANY intersecting
-    file exists but cannot be read, returns `(records_so_far, True)`:
-    the caller buckets the row as HISTORY_UNREADABLE rather than
-    scoring against partial history (a winner picked from partial
-    data could be wrong because the true source sits inside the
-    unreadable file). Absent files (no chat that day) are normal and
-    do not raise the flag.
+    Both passes read the same window. Pass 1 filters the cache to
+    user-direction records at its scoring site; Pass 2 filters the
+    same cache to assistant-direction records and walks back across
+    record order to bind a winning assistant turn to the preceding
+    user turn. Returning the full window from one reader is what
+    lets the two passes share one disk read per file.
 
-    Returns user-direction records whose `ts` falls inside the
-    window, in file-then-line order. The caller scores them.
+    Validation contract (fail-closed on partial history):
+
+    - File-level: an existing-but-unreadable file (`OSError` from the
+      read, or a `JSONDecodeError` on any line) flips `any_unreadable`
+      to True. The caller treats absence (no file for that day) as
+      "no chat that day", which is normal; absence does NOT raise the
+      flag. Unreadability does.
+    - Per-record: every record in a readable file must validate. The
+      checks fire on records of BOTH directions because Pass 2 binds
+      a user turn to an assistant turn, and a malformed assistant
+      record between them can hide the boundary the pairing walk
+      depends on. Failed checks: `dir` not a non-empty string;
+      `chat_id` missing or not equal to the CLI chat id; `text` not
+      a string; `ts` missing, non-string, or unparseable as ISO. Any
+      failure on ANY record flips `any_unreadable` to True.
+
+    The `chat_id` check defends against a polluted file (a copy of
+    another user's JSONL accidentally placed under this user's
+    directory). The original Mem0/Telegram pipeline already partitions
+    by user; the per-record gate stops a manual restore mishap from
+    becoming a scoring signal.
+
+    Records whose `dir` is neither `"user"` nor `"assistant"` are
+    silently dropped (some future direction sentinel arriving in the
+    log would not be a corruption signal, just an unknown record we
+    do not score against). Validation still runs on those records so
+    a malformed-`ts` user record disguised as an unknown direction
+    cannot escape the gate.
+
+    Returns:
+        (records, any_unreadable). `records` is in file-then-line
+        order across every JSONL file intersecting the window; each
+        entry's `ts` parses, each is for `chat_id`, each has a string
+        `dir`/`text`. `records` is non-empty only when the cache is
+        clean enough to score against.
     """
     window_start = created_at_dt - timedelta(seconds=window_seconds)
     window_end = created_at_dt
@@ -562,18 +731,25 @@ def _candidates_for_row(
             any_unreadable = True
             continue
         for rec in records:
-            if rec.get("dir") != "user":
+            # Per-record validation runs on every record regardless of
+            # direction. A malformed assistant record between two user
+            # records can hide the assistant boundary Pass 2 walks
+            # against; treating its corruption as silent would let
+            # partial history become a scoring signal.
+            direction = rec.get("dir")
+            if not isinstance(direction, str) or not direction:
+                any_unreadable = True
                 continue
-            # User-record corruption is the same partial-history hazard
-            # as a malformed JSON line: a true-source user record whose
-            # `ts` is missing, the wrong type, or unparseable would be
-            # silently dropped from the candidate set, leaving an
-            # unrelated valid user record free to win the overlap. Mark
-            # the file as unreadable for THIS row so the caller buckets
-            # the whole row HISTORY_UNREADABLE rather than scoring
-            # against incomplete evidence.
+            rec_chat_id = rec.get("chat_id")
+            if rec_chat_id != chat_id:
+                any_unreadable = True
+                continue
+            text = rec.get("text")
+            if not isinstance(text, str):
+                any_unreadable = True
+                continue
             ts = rec.get("ts")
-            if not isinstance(ts, str):
+            if not isinstance(ts, str) or not ts:
                 any_unreadable = True
                 continue
             try:
@@ -583,6 +759,12 @@ def _candidates_for_row(
                 continue
             if rec_dt.tzinfo is None:
                 rec_dt = rec_dt.replace(tzinfo=UTC)
+            # Only the two known directions enter the cache. Other
+            # values pass validation (they are not corruption per se),
+            # but the caller has no use for them; dropping them at
+            # the reader keeps both pass filters cheap.
+            if direction not in {"user", "assistant"}:
+                continue
             if window_start <= rec_dt <= window_end:
                 out.append(rec)
     return out, any_unreadable
@@ -592,7 +774,17 @@ def _candidates_for_row(
 
 
 def render_proposals(header: dict[str, Any], proposals: list[Proposal]) -> str:
-    """Serialize a proposals file: header line, then proposal lines."""
+    """Serialize a proposals file: header line, then proposal lines.
+
+    Schema is uniform across passes: every proposal carries
+    `match_pass`, `assistant_ts`, `assistant_text_sha256`, and
+    `assistant_text_snippet`. Pass 1 proposals set `match_pass` to
+    `"user"` and the three assistant fields to empty strings; Pass 2
+    proposals set `match_pass` to `"assistant"` and populate the
+    other three. Keeping the shape uniform across passes means a
+    downstream tool reading the JSONL never needs a per-row branch
+    on the discriminator.
+    """
     lines = [json.dumps({"type": "header", **header}, separators=(",", ":"))]
     for p in proposals:
         lines.append(
@@ -611,6 +803,10 @@ def render_proposals(header: dict[str, Any], proposals: list[Proposal]) -> str:
                     "prior_metadata_sha256": p.prior_metadata_sha256,
                     "row_text_snippet": p.row_text_snippet,
                     "candidate_text_snippet": p.candidate_text_snippet,
+                    "match_pass": p.match_pass,
+                    "assistant_ts": p.assistant_ts,
+                    "assistant_text_sha256": p.assistant_text_sha256,
+                    "assistant_text_snippet": p.assistant_text_snippet,
                 },
                 separators=(",", ":"),
             )
@@ -736,6 +932,49 @@ def parse_proposals(text: str) -> tuple[dict[str, Any], list[Proposal]]:
         prior_fp = raw.get("prior_metadata_sha256")
         if not isinstance(prior_fp, str) or not prior_fp:
             raise ValueError(f"proposal line {i}: prior_metadata_sha256 must be a non-empty string")
+
+        # match_pass discriminator. Missing defaults to "user" for
+        # backward compatibility with legacy proposal files written
+        # before Pass 2 existed; those files have no match_pass field
+        # at all and must parse cleanly as Pass 1 proposals.
+        match_pass_raw = raw.get("match_pass", _MATCH_PASS_USER)
+        if not isinstance(match_pass_raw, str) or match_pass_raw not in _VALID_MATCH_PASSES:
+            raise ValueError(
+                f"proposal line {i}: match_pass must be one of {sorted(_VALID_MATCH_PASSES)}, got {match_pass_raw!r}"
+            )
+
+        # Assistant evidence fields. Default to empty strings on Pass
+        # 1 proposals so the schema stays uniform; Pass 2 requires
+        # non-empty values for both the timestamp and the hash. The
+        # timestamp must also parse via fromisoformat so the apply
+        # helper can derive the assistant JSONL date without catching
+        # a runtime parse error.
+        assistant_ts_raw = raw.get("assistant_ts", "")
+        if not isinstance(assistant_ts_raw, str):
+            raise ValueError(f"proposal line {i}: assistant_ts must be a string")
+        assistant_sha_raw = raw.get("assistant_text_sha256", "")
+        if not isinstance(assistant_sha_raw, str):
+            raise ValueError(f"proposal line {i}: assistant_text_sha256 must be a string")
+        assistant_snippet_raw = raw.get("assistant_text_snippet", "")
+        if not isinstance(assistant_snippet_raw, str):
+            raise ValueError(f"proposal line {i}: assistant_text_snippet must be a string")
+
+        if match_pass_raw == _MATCH_PASS_ASSISTANT:
+            if not assistant_ts_raw:
+                raise ValueError(f"proposal line {i}: match_pass='assistant' requires non-empty assistant_ts")
+            try:
+                datetime.fromisoformat(assistant_ts_raw)
+            except ValueError as e:
+                # Authorization-artifact gate: a hand-edited proposal
+                # whose assistant_ts is non-empty but unparseable
+                # would otherwise crash the apply-time assistant
+                # helper trying to derive the JSONL date. Failing
+                # closed at parse time means apply never has to
+                # handle a parse error on this field.
+                raise ValueError(f"proposal line {i}: assistant_ts must be a parseable ISO timestamp ({e})") from e
+            if not assistant_sha_raw:
+                raise ValueError(f"proposal line {i}: match_pass='assistant' requires non-empty assistant_text_sha256")
+
         proposals.append(
             Proposal(
                 memory_id=mid,
@@ -750,6 +989,10 @@ def parse_proposals(text: str) -> tuple[dict[str, Any], list[Proposal]]:
                 prior_metadata_sha256=prior_fp,
                 row_text_snippet=str(raw.get("row_text_snippet", "")),
                 candidate_text_snippet=str(raw.get("candidate_text_snippet", "")),
+                match_pass=match_pass_raw,
+                assistant_ts=assistant_ts_raw,
+                assistant_text_sha256=assistant_sha_raw,
+                assistant_text_snippet=assistant_snippet_raw,
             )
         )
     return header, proposals
@@ -824,6 +1067,8 @@ def render_report(
     min_overlap: float,
     strong_overlap_ratio: float,
     shingle_n: int,
+    assistant_pass_enabled: bool,
+    assistant_max_user_gap_seconds: int,
     scanned: int,
     selected: int,
     matches: list[RowMatch],
@@ -833,16 +1078,22 @@ def render_report(
     """Build the human-readable dry-run report.
 
     Pure function (no IO). The report has four sections: parameters,
-    counts, a sample of STRONG_MATCH proposals (so the operator can
-    eyeball auto-matches), and a curation backlog (AMBIGUOUS_OVERLAP
-    plus NO_CANDIDATE rows with their top candidates). Order is
-    deterministic so two runs over the same data render byte-
-    identically.
+    counts (including the user-vs-assistant pass distribution and
+    every Pass 2 skip bucket), a sample of STRONG_MATCH proposals,
+    and a curation backlog. Order is deterministic so two runs over
+    the same data render byte-identically.
     """
     proposals = [m for m in matches if m.bucket == "STRONG_MATCH"]
+    user_pass = sum(1 for m in proposals if m.proposal is not None and m.proposal.match_pass == _MATCH_PASS_USER)
+    assistant_pass = sum(
+        1 for m in proposals if m.proposal is not None and m.proposal.match_pass == _MATCH_PASS_ASSISTANT
+    )
     ambiguous = [m for m in matches if m.bucket == SKIP_AMBIGUOUS_OVERLAP]
     no_candidate = [m for m in matches if m.bucket == SKIP_NO_CANDIDATE]
     history_unreadable = [m for m in matches if m.bucket == SKIP_HISTORY_UNREADABLE]
+    assistant_ambiguous = [m for m in matches if m.bucket == SKIP_ASSISTANT_AMBIGUOUS_OVERLAP]
+    no_preceding_user = [m for m in matches if m.bucket == SKIP_NO_PRECEDING_USER]
+    ambiguous_user_pairing = [m for m in matches if m.bucket == SKIP_AMBIGUOUS_USER_PAIRING]
 
     lines = [
         f"# Backfill provenance dry-run report: {run_id}",
@@ -852,18 +1103,35 @@ def render_report(
         f"Min overlap: {min_overlap}",
         f"Strong overlap ratio: {strong_overlap_ratio}",
         f"Shingle n: {shingle_n}",
+        f"Assistant pass: {'enabled' if assistant_pass_enabled else 'disabled'} "
+        f"(max user gap: {assistant_max_user_gap_seconds}s)",
         "",
         "## Counts",
         "",
         f"- scanned: {scanned}",
         f"- selected: {selected}",
-        f"- proposals (STRONG_MATCH): {len(proposals)}",
+        f"- proposals (STRONG_MATCH): {len(proposals)}  (user: {user_pass}, assistant: {assistant_pass})",
         f"- skipped ambiguous_overlap: {len(ambiguous)}",
         f"- skipped no_candidate: {len(no_candidate)}",
         f"- skipped history_unreadable: {len(history_unreadable)}",
+        f"- skipped assistant_ambiguous_overlap: {len(assistant_ambiguous)}",
+        f"- skipped no_preceding_user: {len(no_preceding_user)}",
+        f"- skipped ambiguous_user_pairing: {len(ambiguous_user_pairing)}",
     ]
+    # Reserved skip buckets that the report renders explicitly above;
+    # any other bucket coming through the `skips` dict is rendered in
+    # alphabetical order at the tail so report counts stay deterministic
+    # across runs.
+    _RESERVED_BUCKETS = {
+        SKIP_AMBIGUOUS_OVERLAP,
+        SKIP_NO_CANDIDATE,
+        SKIP_HISTORY_UNREADABLE,
+        SKIP_ASSISTANT_AMBIGUOUS_OVERLAP,
+        SKIP_NO_PRECEDING_USER,
+        SKIP_AMBIGUOUS_USER_PAIRING,
+    }
     for reason, ids in sorted(skips.items()):
-        if reason in {SKIP_AMBIGUOUS_OVERLAP, SKIP_NO_CANDIDATE, SKIP_HISTORY_UNREADABLE}:
+        if reason in _RESERVED_BUCKETS:
             continue
         lines.append(f"- skipped {reason}: {len(ids)}")
 
@@ -873,22 +1141,43 @@ def render_report(
             assert m.proposal is not None
             lines.extend(_render_row_sample(m))
 
-    if (ambiguous or no_candidate) and sample_size > 0:
+    # Curation backlog covers every bucket that an operator might
+    # address either via tooling tuning or via the future curation
+    # tool. Pass 2 skip buckets join Pass 1's here so a single review
+    # pass sees the whole NEEDS_CURATION space.
+    backlog = ambiguous + no_candidate + assistant_ambiguous + no_preceding_user + ambiguous_user_pairing
+    if backlog and sample_size > 0:
         lines.extend(["", "## Curation backlog (operator review)"])
-        for m in (ambiguous + no_candidate)[:sample_size]:
+        for m in backlog[:sample_size]:
             lines.extend(_render_row_sample(m))
 
     return "\n".join(lines) + "\n"
 
 
 def _render_row_sample(match: RowMatch) -> list[str]:
-    """Render one RowMatch as a markdown sub-section."""
+    """Render one RowMatch as a markdown sub-section.
+
+    Pass 2 STRONG_MATCH samples carry both the assistant text
+    snippet (the discriminator that authorized the match) and the
+    user text snippet (the source the harness will stamp). The
+    operator can audit either side without opening the proposals
+    JSONL.
+    """
+    heading_tag = match.bucket
+    if match.proposal is not None and match.proposal.match_pass == _MATCH_PASS_ASSISTANT:
+        heading_tag = f"{match.bucket} via assistant pass"
     out = [
         "",
-        f"### {match.row.id} ({match.bucket})",
+        f"### {match.row.id} ({heading_tag})",
         "",
         f"Row: {_snippet(match.row.text)}",
     ]
+    if match.proposal is not None and match.proposal.match_pass == _MATCH_PASS_ASSISTANT:
+        out.append(
+            f"Assistant discriminator (ts={match.proposal.assistant_ts}): {match.proposal.assistant_text_snippet}"
+        )
+        out.append(f"Paired source user (ts={match.proposal.user_ts}): {match.proposal.candidate_text_snippet}")
+        return out
     if not match.top_candidates:
         out.append("Top candidates: (none in window)")
         return out
@@ -911,6 +1200,8 @@ async def run_dry_run(
     shingle_n: int,
     sample: int,
     out_dir: Path,
+    assistant_pass_enabled: bool = True,
+    assistant_max_user_gap_seconds: int = _DEFAULT_ASSISTANT_MAX_USER_GAP_SECONDS,
 ) -> int:
     """Score every backfill candidate and write report + proposals.
 
@@ -946,7 +1237,14 @@ async def run_dry_run(
         if created_at_dt.tzinfo is None:
             created_at_dt = created_at_dt.replace(tzinfo=UTC)
 
-        records, any_unreadable = _candidates_for_row(
+        # Single window read serves both passes. Pass 1 filters the
+        # cache to user records at the scoring site; Pass 2 filters
+        # the same cache to assistant records when Pass 1 returns no
+        # candidate. The reader's per-record validation contract
+        # covers both directions, so a malformed assistant record
+        # collapses the row even if Pass 2 never gets to use the
+        # assistant cache.
+        records, any_unreadable = _records_for_row_window(
             chat_id_int,
             created_at_dt,
             window_seconds=window_seconds,
@@ -956,9 +1254,11 @@ async def run_dry_run(
             matches.append(RowMatch(row=row, bucket=SKIP_HISTORY_UNREADABLE, top_candidates=[], proposal=None))
             continue
 
+        # Pass 1: score row text against user turns in the window.
+        user_records = [r for r in records if r["dir"] == "user"]
         scored = _score_candidates(
             row.text,
-            records,
+            user_records,
             shingle_n=shingle_n,
             created_at_dt=created_at_dt,
         )
@@ -968,38 +1268,122 @@ async def run_dry_run(
             min_overlap=min_overlap,
             strong_overlap_ratio=strong_overlap_ratio,
         )
-        if winner is None:
+
+        if winner is not None:
+            # Pass 1 STRONG_MATCH. Build a Pass 1 proposal with empty
+            # assistant fields (the schema is uniform across passes).
+            try:
+                user_ts_dt = datetime.fromisoformat(winner.ts)
+            except ValueError:
+                # Defensive: the cache contract guarantees parseable
+                # ts on every record, so this is unreachable in
+                # practice. Drop to NO_CANDIDATE rather than emitting
+                # a proposal whose date we cannot derive.
+                skips.setdefault(SKIP_NO_CANDIDATE, []).append(row.id)
+                matches.append(RowMatch(row=row, bucket=SKIP_NO_CANDIDATE, top_candidates=top, proposal=None))
+                continue
+            if user_ts_dt.tzinfo is None:
+                user_ts_dt = user_ts_dt.replace(tzinfo=UTC)
+            date = user_ts_dt.strftime("%Y-%m-%d")
+            proposal = Proposal(
+                memory_id=row.id,
+                chat_id=chat_id_int,
+                date=date,
+                user_ts=winner.ts,
+                user_text_sha256=winner.sha256,
+                overlap_score=winner.overlap_score,
+                runner_up_overlap_score=runner_up_score,
+                candidate_count=len(scored),
+                gap_seconds=winner.gap_seconds,
+                prior_metadata_sha256=_metadata_fingerprint(row.metadata),
+                row_text_snippet=_snippet(row.text),
+                candidate_text_snippet=_snippet(winner.text),
+                match_pass=_MATCH_PASS_USER,
+            )
+            matches.append(RowMatch(row=row, bucket="STRONG_MATCH", top_candidates=top, proposal=proposal))
+            continue
+
+        # Pass 1 returned None. Two skip-bucket paths from here:
+        # AMBIGUOUS_OVERLAP rows keep the Pass 1 verdict (Pass 1
+        # already had a signal); NO_CANDIDATE rows enter Pass 2 when
+        # the assistant pass is enabled.
+        if bucket != SKIP_NO_CANDIDATE or not assistant_pass_enabled:
             skips.setdefault(bucket, []).append(row.id)
             matches.append(RowMatch(row=row, bucket=bucket, top_candidates=top, proposal=None))
             continue
 
-        # STRONG_MATCH. Build the proposal with its full audit context.
+        # Pass 2: score row text against assistant turns in the same
+        # cached window.
+        assistant_records = [r for r in records if r["dir"] == "assistant"]
+        assistant_scored = _score_candidates(
+            row.text,
+            assistant_records,
+            shingle_n=shingle_n,
+            created_at_dt=created_at_dt,
+        )
+        assistant_winner, assistant_bucket, assistant_runner_up = _gate_match(
+            assistant_scored,
+            min_overlap=min_overlap,
+            strong_overlap_ratio=strong_overlap_ratio,
+        )
+        if assistant_winner is None:
+            # Pass 2 buckets are distinct from Pass 1's so the
+            # operator's tuning advice does not collapse: assistant-
+            # side ambiguity is a different signal than no candidate.
+            final_bucket = (
+                SKIP_ASSISTANT_AMBIGUOUS_OVERLAP if assistant_bucket == SKIP_AMBIGUOUS_OVERLAP else SKIP_NO_CANDIDATE
+            )
+            skips.setdefault(final_bucket, []).append(row.id)
+            matches.append(RowMatch(row=row, bucket=final_bucket, top_candidates=top, proposal=None))
+            continue
+
+        # Pass 2 found a dominant assistant turn. Bind it to the
+        # unique preceding user turn in the boundary window; the
+        # conservative pairing rule refuses anything ambiguous.
+        source_user_rec, pair_skip = _pair_winning_assistant_with_user(
+            records,
+            assistant_winner.ts,
+            max_user_gap_seconds=assistant_max_user_gap_seconds,
+        )
+        if source_user_rec is None:
+            assert pair_skip is not None
+            skips.setdefault(pair_skip, []).append(row.id)
+            matches.append(RowMatch(row=row, bucket=pair_skip, top_candidates=top, proposal=None))
+            continue
+
+        source_user_text = source_user_rec.get("text", "")
+        source_user_ts = source_user_rec.get("ts", "")
         try:
-            user_ts_dt = datetime.fromisoformat(winner.ts)
+            user_ts_dt = datetime.fromisoformat(source_user_ts)
         except ValueError:
-            # Defensive: _score_candidates already filtered malformed
-            # timestamps, so this is unreachable in practice. Drop the
-            # row to NO_CANDIDATE if it somehow happens; do not write
-            # a proposal whose date we cannot derive.
-            skips.setdefault(SKIP_NO_CANDIDATE, []).append(row.id)
-            matches.append(RowMatch(row=row, bucket=SKIP_NO_CANDIDATE, top_candidates=top, proposal=None))
+            # Unreachable under the cache contract; if it does fire,
+            # the row stays in the curation backlog rather than
+            # producing a proposal with an underivable date.
+            skips.setdefault(SKIP_NO_PRECEDING_USER, []).append(row.id)
+            matches.append(RowMatch(row=row, bucket=SKIP_NO_PRECEDING_USER, top_candidates=top, proposal=None))
             continue
         if user_ts_dt.tzinfo is None:
             user_ts_dt = user_ts_dt.replace(tzinfo=UTC)
         date = user_ts_dt.strftime("%Y-%m-%d")
+        user_sha = hashlib.sha256(source_user_text.encode("utf-8")).hexdigest()
+
         proposal = Proposal(
             memory_id=row.id,
             chat_id=chat_id_int,
             date=date,
-            user_ts=winner.ts,
-            user_text_sha256=winner.sha256,
-            overlap_score=winner.overlap_score,
-            runner_up_overlap_score=runner_up_score,
-            candidate_count=len(scored),
-            gap_seconds=winner.gap_seconds,
+            user_ts=source_user_ts,
+            user_text_sha256=user_sha,
+            overlap_score=assistant_winner.overlap_score,
+            runner_up_overlap_score=assistant_runner_up,
+            candidate_count=len(assistant_scored),
+            gap_seconds=assistant_winner.gap_seconds,
             prior_metadata_sha256=_metadata_fingerprint(row.metadata),
             row_text_snippet=_snippet(row.text),
-            candidate_text_snippet=_snippet(winner.text),
+            candidate_text_snippet=_snippet(source_user_text),
+            match_pass=_MATCH_PASS_ASSISTANT,
+            assistant_ts=assistant_winner.ts,
+            assistant_text_sha256=assistant_winner.sha256,
+            assistant_text_snippet=_snippet(assistant_winner.text),
         )
         matches.append(RowMatch(row=row, bucket="STRONG_MATCH", top_candidates=top, proposal=proposal))
 
@@ -1017,6 +1401,8 @@ async def run_dry_run(
         "min_overlap": min_overlap,
         "strong_overlap_ratio": strong_overlap_ratio,
         "shingle_n": shingle_n,
+        "assistant_pass_enabled": assistant_pass_enabled,
+        "assistant_max_user_gap_seconds": assistant_max_user_gap_seconds,
         "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
     }
     proposals_path = out_dir / f"backfill-{run_id}-proposals.jsonl"
@@ -1030,6 +1416,8 @@ async def run_dry_run(
             min_overlap=min_overlap,
             strong_overlap_ratio=strong_overlap_ratio,
             shingle_n=shingle_n,
+            assistant_pass_enabled=assistant_pass_enabled,
+            assistant_max_user_gap_seconds=assistant_max_user_gap_seconds,
             scanned=len(rows),
             selected=len(selected_rows),
             matches=matches,
@@ -1071,12 +1459,14 @@ def _verify_jsonl_user_text(
 ) -> bool:
     """Re-fetch the user line from JSONL at apply time, recompute sha.
 
-    Returns True when the line exists AND its sha256 matches the
-    expected fingerprint. False when the file is gone, the line is
-    gone, or the text has drifted. The apply-time transcript-drift
-    gate is the only safety check the harness has against a JSONL
-    edit between dry-run and apply; without it, a proposal stamped
-    against a since-modified turn would write an invalid pointer.
+    Returns True when the line exists, its `chat_id` matches the
+    expected chat, AND its sha256 matches the expected fingerprint.
+    False when the file is gone, the line is gone, the chat_id has
+    drifted, or the text has drifted. The chat_id check defends
+    against a polluted file with a same-ts/same-text record under
+    the wrong owner: hash verification alone would let that slip
+    past, leaving the row stamped with a source pointer that does
+    not actually belong to the user.
     """
     path = _LOG_DIR / str(chat_id) / f"{date}.jsonl"
     records = _read_jsonl_records(path)
@@ -1087,6 +1477,55 @@ def _verify_jsonl_user_text(
             continue
         if rec.get("ts") != user_ts:
             continue
+        if rec.get("chat_id") != chat_id:
+            # Per-record ownership gate. A restored or misplaced file
+            # with a matching ts but the wrong owner is a forged
+            # pointer; refuse to authorize the apply.
+            return False
+        text = rec.get("text", "")
+        if not isinstance(text, str):
+            return False
+        return hashlib.sha256(text.encode("utf-8")).hexdigest() == expected_sha256
+    return False
+
+
+def _verify_jsonl_assistant_text(
+    chat_id: int,
+    assistant_ts: str,
+    expected_sha256: str,
+) -> bool:
+    """Re-fetch the assistant line from JSONL at apply time.
+
+    Pass 2's assistant evidence authorized the proposal at dry-run;
+    apply re-verifies it before writing so a wrong-source pointer
+    cannot pass through if the assistant line was edited, deleted,
+    or replaced between the two runs.
+
+    Derives the JSONL file from `assistant_ts`'s UTC date, which can
+    differ from `proposal.date` (the user-side date) when the user
+    and assistant turns straddle midnight. `parse_proposals` already
+    rejected proposals whose `assistant_ts` is non-parseable, so the
+    fromisoformat call here is total.
+
+    Returns True only when the line exists, has `dir == "assistant"`,
+    matches `chat_id`, and hashes to `expected_sha256`. False
+    otherwise.
+    """
+    assistant_dt = datetime.fromisoformat(assistant_ts)
+    if assistant_dt.tzinfo is None:
+        assistant_dt = assistant_dt.replace(tzinfo=UTC)
+    assistant_date = assistant_dt.strftime("%Y-%m-%d")
+    path = _LOG_DIR / str(chat_id) / f"{assistant_date}.jsonl"
+    records = _read_jsonl_records(path)
+    if not records:
+        return False
+    for rec in records:
+        if rec.get("dir") != "assistant":
+            continue
+        if rec.get("ts") != assistant_ts:
+            continue
+        if rec.get("chat_id") != chat_id:
+            return False
         text = rec.get("text", "")
         if not isinstance(text, str):
             return False
@@ -1173,6 +1612,19 @@ async def run_apply(
         ):
             skips.setdefault(SKIP_TRANSCRIPT_DRIFT, []).append(proposal.memory_id)
             continue
+        # Pass 2 proposals carry assistant-side evidence that
+        # authorized the dry-run match. Apply re-verifies the
+        # assistant line (hash + chat_id) so a drift between dry-run
+        # and apply collapses the proposal to SKIP_ASSISTANT_DRIFT
+        # rather than writing a row whose user-side stamp is intact
+        # but whose discriminator is gone.
+        if proposal.match_pass == _MATCH_PASS_ASSISTANT and not _verify_jsonl_assistant_text(
+            chat_id=proposal.chat_id,
+            assistant_ts=proposal.assistant_ts,
+            expected_sha256=proposal.assistant_text_sha256,
+        ):
+            skips.setdefault(SKIP_ASSISTANT_DRIFT, []).append(proposal.memory_id)
+            continue
         survivors.append((proposal, row))
 
     if not survivors:
@@ -1240,9 +1692,11 @@ async def run_apply(
                         "memory_id": row.id,
                         "user_id": user_id,
                         "run_id": run_id,
+                        "match_pass": proposal.match_pass,
                         "overlap_score": proposal.overlap_score,
                         "gap_seconds": proposal.gap_seconds,
                         "source_user_ts": proposal.user_ts,
+                        "assistant_ts": proposal.assistant_ts,
                     },
                     separators=(",", ":"),
                 ),

--- a/src/kai/memory_provenance_backfill.py
+++ b/src/kai/memory_provenance_backfill.py
@@ -691,14 +691,23 @@ def _records_for_row_window(
       to True. The caller treats absence (no file for that day) as
       "no chat that day", which is normal; absence does NOT raise the
       flag. Unreadability does.
-    - Per-record: every record in a readable file must validate. The
-      checks fire on records of BOTH directions because Pass 2 binds
-      a user turn to an assistant turn, and a malformed assistant
-      record between them can hide the boundary the pairing walk
-      depends on. Failed checks: `dir` not a non-empty string;
-      `chat_id` missing or not equal to the CLI chat id; `text` not
-      a string; `ts` missing, non-string, or unparseable as ISO. Any
-      failure on ANY record flips `any_unreadable` to True.
+    - Per-record `ts`: a missing, non-string, or unparseable `ts` on
+      ANY record (in-window or not) flips `any_unreadable` to True.
+      Without a parseable `ts` the reader cannot prove the record
+      falls outside the row's window, so fail-closed is the only
+      safe call: a malformed-ts record sitting where the true source
+      would have been is the exact partial-history hazard the gate
+      exists to catch.
+    - Per-record `dir`/`chat_id`/`text`: validated only on records
+      whose parsed `ts` falls inside the row's window. Records past
+      `created_at` (same-day files naturally carry the assistant's
+      reply to a later user turn) cannot affect Pass 1 scoring,
+      Pass 2 assistant matching, or boundary pairing for this row;
+      collapsing the row on those records would over-reject every
+      row whose neighborhood happens to contain corruption later in
+      the day. In-window failures still fail closed: `dir` not a
+      non-empty string; `chat_id` missing or not equal to the CLI
+      chat id; `text` not a string.
 
     The `chat_id` check defends against a polluted file (a copy of
     another user's JSONL accidentally placed under this user's
@@ -709,9 +718,9 @@ def _records_for_row_window(
     Records whose `dir` is neither `"user"` nor `"assistant"` are
     silently dropped (some future direction sentinel arriving in the
     log would not be a corruption signal, just an unknown record we
-    do not score against). Validation still runs on those records so
-    a malformed-`ts` user record disguised as an unknown direction
-    cannot escape the gate.
+    do not score against). The `ts` gate still runs on those records
+    so a malformed-`ts` user record disguised as an unknown direction
+    cannot escape the partial-history check.
 
     Returns:
         (records, any_unreadable). `records` is in file-then-line
@@ -731,11 +740,36 @@ def _records_for_row_window(
             any_unreadable = True
             continue
         for rec in records:
-            # Per-record validation runs on every record regardless of
-            # direction. A malformed assistant record between two user
-            # records can hide the assistant boundary Pass 2 walks
-            # against; treating its corruption as silent would let
-            # partial history become a scoring signal.
+            # Parse `ts` first. Without a parseable timestamp we
+            # cannot know whether the record falls inside the row's
+            # window, so a malformed `ts` is always a corruption
+            # signal: fail-closed regardless of the record's other
+            # fields or its hypothetical position in time.
+            ts = rec.get("ts")
+            if not isinstance(ts, str) or not ts:
+                any_unreadable = True
+                continue
+            try:
+                rec_dt = datetime.fromisoformat(ts)
+            except ValueError:
+                any_unreadable = True
+                continue
+            if rec_dt.tzinfo is None:
+                rec_dt = rec_dt.replace(tzinfo=UTC)
+            # Records outside the row's window cannot affect Pass 1
+            # scoring, Pass 2 assistant matching, or boundary pairing
+            # for this row. Same-day files routinely carry records
+            # past `created_at` (the assistant's reply to a later
+            # user turn, the conversation continuing into the
+            # afternoon); collapsing the row on those records would
+            # over-reject every row whose neighborhood happens to
+            # contain corruption later in the day.
+            if not (window_start <= rec_dt <= window_end):
+                continue
+            # In-window validation: a malformed `dir`, `chat_id`, or
+            # `text` on a record the row could actually score
+            # against still has the partial-history hazard the gate
+            # exists to prevent.
             direction = rec.get("dir")
             if not isinstance(direction, str) or not direction:
                 any_unreadable = True
@@ -748,25 +782,13 @@ def _records_for_row_window(
             if not isinstance(text, str):
                 any_unreadable = True
                 continue
-            ts = rec.get("ts")
-            if not isinstance(ts, str) or not ts:
-                any_unreadable = True
-                continue
-            try:
-                rec_dt = datetime.fromisoformat(ts)
-            except ValueError:
-                any_unreadable = True
-                continue
-            if rec_dt.tzinfo is None:
-                rec_dt = rec_dt.replace(tzinfo=UTC)
             # Only the two known directions enter the cache. Other
             # values pass validation (they are not corruption per se),
             # but the caller has no use for them; dropping them at
             # the reader keeps both pass filters cheap.
             if direction not in {"user", "assistant"}:
                 continue
-            if window_start <= rec_dt <= window_end:
-                out.append(rec)
+            out.append(rec)
     return out, any_unreadable
 
 

--- a/src/kai/memory_provenance_backfill.py
+++ b/src/kai/memory_provenance_backfill.py
@@ -489,9 +489,12 @@ def _pair_winning_assistant_with_user(
       unique preceding user turn within the boundary window AND
       within `max_user_gap_seconds` of the winning assistant turn.
     - `(None, SKIP_NO_PRECEDING_USER)`: no user turn sits between the
-      boundary and the winner, or the unique user turn exceeds the
-      max-gap guard. Same bucket because the operator's tuning
-      advice is the same (widen the gap if appropriate).
+      boundary and the winner; OR the unique user turn exceeds the
+      max-gap guard; OR the unique user turn's timestamp is AFTER
+      the assistant's (JSONL order disagrees with timestamps, so
+      the file's apparent "preceding" relationship is corrupt).
+      Same bucket because the operator-visible outcome is the same:
+      no usable preceding user turn for the winner.
     - `(None, SKIP_AMBIGUOUS_USER_PAIRING)`: two or more user turns
       between the boundary and the winner. No tuning unlocks this;
       the pairing is genuinely ambiguous and the row stays in the
@@ -542,6 +545,17 @@ def _pair_winning_assistant_with_user(
     if winner_dt.tzinfo is None:
         winner_dt = winner_dt.replace(tzinfo=UTC)
     gap = (winner_dt - user_dt).total_seconds()
+    if gap < 0:
+        # The candidate user record appears before the winning
+        # assistant in JSONL order but its timestamp is AFTER the
+        # assistant's. An assistant turn cannot be sourced by a
+        # later user turn, so the file's JSONL order disagrees with
+        # the timestamps; treat that as a partial-history hazard
+        # and refuse to stamp a wrong-direction pointer. The bucket
+        # matches the max-gap case because the operator-visible
+        # outcome is the same: no usable preceding user turn for
+        # this winner.
+        return None, SKIP_NO_PRECEDING_USER
     if gap > max_user_gap_seconds:
         # A user turn exists but the boundary-to-winner window opens
         # too wide. The conservative call is to skip; widening the

--- a/tests/test_memory_provenance_backfill.py
+++ b/tests/test_memory_provenance_backfill.py
@@ -1569,6 +1569,29 @@ class TestPass2Algorithm:
         # the same in both cases.
         assert "skipped no_preceding_user: 1" in report
 
+    def test_pass2_skips_when_user_timestamp_is_after_assistant(self, history_dir, tmp_path):
+        chat_id = 1
+        # The user line sits BEFORE the assistant in JSONL order but
+        # AFTER it by timestamp. An assistant turn cannot be sourced
+        # by a later user turn; the file's apparent "preceding"
+        # relationship is corrupt. The pairing rule must refuse
+        # rather than stamp a wrong-direction pointer.
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-12",
+            [
+                _user_rec("2026-06-12T10:02:00+00:00", _PASS2_USER_TEXT),
+                _assistant_rec("2026-06-12T10:01:00+00:00", _PASS2_ASSISTANT_TEXT),
+            ],
+        )
+        row = _alive_row(row_id="m1", text=_PASS2_ROW_TEXT, created_at="2026-06-12T10:05:00+00:00")
+        out_dir = self._dry_run(history_dir, tmp_path, row)
+        proposals = self._proposals_in(out_dir)
+        assert proposals == []
+        report = self._report_in(out_dir)
+        assert "skipped no_preceding_user: 1" in report
+
     # Test 6.
     def test_pass2_skips_ambiguous_user_pairing(self, history_dir, tmp_path):
         chat_id = 1

--- a/tests/test_memory_provenance_backfill.py
+++ b/tests/test_memory_provenance_backfill.py
@@ -62,14 +62,16 @@ from kai.memory_provenance_backfill import (
     PreImage,
     Proposal,
     _build_applied_source_block,
-    _candidates_for_row,
     _date_files_in_window,
     _gate_match,
     _metadata_fingerprint,
     _normalize_text,
     _overlap_score,
+    _records_for_row_window,
     _score_candidates,
     _shingles,
+    _verify_jsonl_assistant_text,
+    _verify_jsonl_user_text,
     parse_preimages,
     parse_proposals,
     render_preimages,
@@ -122,6 +124,11 @@ def _write_jsonl(history_root: Path, chat_id: int, date: str, records: list[dict
 def _user_rec(ts: str, text: str, chat_id: int = 1) -> dict:
     """One user-direction JSONL record."""
     return {"ts": ts, "dir": "user", "chat_id": chat_id, "text": text}
+
+
+def _assistant_rec(ts: str, text: str, chat_id: int = 1) -> dict:
+    """One assistant-direction JSONL record (Pass 2 fixtures)."""
+    return {"ts": ts, "dir": "assistant", "chat_id": chat_id, "text": text}
 
 
 def _alive_row(
@@ -300,7 +307,7 @@ class TestDelayedExtractionSafety:
 
         row_text = "deploy on monday at noon"
         created_at_dt = datetime(2026, 6, 13, 10, 8, 0, tzinfo=UTC)
-        records, any_unreadable = _candidates_for_row(chat_id, created_at_dt, window_seconds=86400)
+        records, any_unreadable = _records_for_row_window(chat_id, created_at_dt, window_seconds=86400)
         assert any_unreadable is False
         scored = _score_candidates(row_text, records, shingle_n=4, created_at_dt=created_at_dt)
         winner, bucket, _ = _gate_match(scored, min_overlap=0.3, strong_overlap_ratio=2.0)
@@ -322,7 +329,7 @@ class TestDelayedExtractionSafety:
             ],
         )
         created_at_dt = datetime(2026, 6, 13, 10, 8, 0, tzinfo=UTC)
-        records, _ = _candidates_for_row(chat_id, created_at_dt, window_seconds=86400)
+        records, _ = _records_for_row_window(chat_id, created_at_dt, window_seconds=86400)
         scored = _score_candidates(
             "the operator prefers strong type checking",
             records,
@@ -861,6 +868,8 @@ class TestCLIDispatch:
             min_overlap=None,
             strong_overlap_ratio=None,
             overlap_shingle_n=None,
+            no_assistant_pass=None,
+            assistant_max_user_gap_seconds=None,
             sample=None,
             out_dir=None,
             apply=str(tmp_path / "p.jsonl"),
@@ -901,6 +910,8 @@ class TestCLIDispatch:
             min_overlap=None,
             strong_overlap_ratio=None,
             overlap_shingle_n=None,
+            no_assistant_pass=None,
+            assistant_max_user_gap_seconds=None,
             sample=None,
             out_dir=str(tmp_path / "out"),
             apply=str(proposals_path),
@@ -939,7 +950,7 @@ class TestHistoryUnreadable:
         monkeypatch.setattr(mod, "_read_jsonl_records", fail_for)
 
         created_at_dt = datetime(2026, 6, 13, 2, 0, 0, tzinfo=UTC)
-        _records, any_unreadable = _candidates_for_row(chat_id, created_at_dt, window_seconds=86400)
+        _records, any_unreadable = _records_for_row_window(chat_id, created_at_dt, window_seconds=86400)
         assert any_unreadable is True
         # records may carry entries from other files in the window
         # (a multi-day window over partially-readable history), but
@@ -966,14 +977,14 @@ class TestHistoryUnreadable:
             encoding="utf-8",
         )
         created_at_dt = datetime(2026, 6, 13, 2, 0, 0, tzinfo=UTC)
-        _records, any_unreadable = _candidates_for_row(chat_id, created_at_dt, window_seconds=86400)
+        _records, any_unreadable = _records_for_row_window(chat_id, created_at_dt, window_seconds=86400)
         assert any_unreadable is True
 
     def test_malformed_user_ts_collapses_file_to_unreadable(self, history_dir):
         # Same partial-history hazard, one layer deeper: a user record
         # whose ts field is missing or unparseable would otherwise be
         # silently dropped, leaving an unrelated valid candidate free
-        # to win the overlap. _candidates_for_row must set
+        # to win the overlap. _records_for_row_window must set
         # any_unreadable=True so the row buckets HISTORY_UNREADABLE.
         chat_id = 1
         user_dir = history_dir / str(chat_id)
@@ -989,7 +1000,7 @@ class TestHistoryUnreadable:
             encoding="utf-8",
         )
         created_at_dt = datetime(2026, 6, 13, 2, 0, 0, tzinfo=UTC)
-        _records, any_unreadable = _candidates_for_row(chat_id, created_at_dt, window_seconds=86400)
+        _records, any_unreadable = _records_for_row_window(chat_id, created_at_dt, window_seconds=86400)
         assert any_unreadable is True
 
     def test_unparseable_user_ts_collapses_file_to_unreadable(self, history_dir):
@@ -1003,7 +1014,7 @@ class TestHistoryUnreadable:
             encoding="utf-8",
         )
         created_at_dt = datetime(2026, 6, 13, 2, 0, 0, tzinfo=UTC)
-        _records, any_unreadable = _candidates_for_row(chat_id, created_at_dt, window_seconds=86400)
+        _records, any_unreadable = _records_for_row_window(chat_id, created_at_dt, window_seconds=86400)
         assert any_unreadable is True
 
     def test_dry_run_buckets_history_unreadable_when_true_source_has_bad_ts(self, tmp_path, history_dir):
@@ -1130,6 +1141,8 @@ class TestReportShape:
             min_overlap=0.3,
             strong_overlap_ratio=2.0,
             shingle_n=4,
+            assistant_pass_enabled=True,
+            assistant_max_user_gap_seconds=600,
             scanned=10,
             selected=1,
             matches=matches,
@@ -1317,3 +1330,1023 @@ class TestAppliedSourceBlock:
             SOURCE_USER_TS_KEY: "2026-06-12T10:00:00+00:00",
             SOURCE_USER_TEXT_SHA256_KEY: "abc",
         }
+
+
+# ── Pass 2 (assistant-turn matching) ──────────────────────────────
+#
+# The next ten test classes cover Pass 2 end-to-end: the full-window
+# cache, the algorithm (overlap on assistant turns + conservative
+# pairing rule), per-record validation on both directions, the
+# apply-time assistant drift gate, parser gates on the new fields,
+# CLI flags, the no-double-read property, the user-only-fields
+# diff projection, and the report shape.
+
+
+# Shared row/text constants for Pass 2 tests. The user text and
+# assistant text are picked so the row text overlaps the ASSISTANT
+# turn's phrasing (4-token shingles) but does NOT overlap the user
+# turn. That's the failure mode Pass 2 exists to catch: a row whose
+# only meaningful overlap in the window is with an assistant turn.
+_PASS2_ROW_TEXT = "operator prefers strong type checking with pyright strict mode"
+_PASS2_USER_TEXT = "what should we use for static analysis on this codebase"
+_PASS2_ASSISTANT_TEXT = (
+    "given your conventions the operator prefers strong type checking with pyright strict mode for the kai code"
+)
+
+
+def _make_pass2_proposal(
+    *,
+    row_id: str = "m1",
+    chat_id: int = 1,
+    user_date: str = "2026-06-12",
+    user_ts: str = "2026-06-12T10:00:00+00:00",
+    user_text_sha: str = "user-sha",
+    assistant_ts: str = "2026-06-12T10:01:00+00:00",
+    assistant_text_sha: str = "assistant-sha",
+    prior_fp: str = "fp-prior",
+) -> Proposal:
+    """Build a fully-populated Pass 2 proposal for apply-time tests."""
+    return Proposal(
+        memory_id=row_id,
+        chat_id=chat_id,
+        date=user_date,
+        user_ts=user_ts,
+        user_text_sha256=user_text_sha,
+        overlap_score=0.9,
+        runner_up_overlap_score=0.0,
+        candidate_count=1,
+        gap_seconds=60.0,
+        prior_metadata_sha256=prior_fp,
+        row_text_snippet="row",
+        candidate_text_snippet="user-text",
+        match_pass="assistant",
+        assistant_ts=assistant_ts,
+        assistant_text_sha256=assistant_text_sha,
+        assistant_text_snippet="assistant-text",
+    )
+
+
+def _make_proposals_file(tmp_path: Path, proposals: list[Proposal]) -> Path:
+    """Render a proposals file for apply tests."""
+    header = {"run_id": "bp-test", "user_id": "1", "generated_at": "2026-06-13T00:00:00+00:00"}
+    path = tmp_path / "proposals.jsonl"
+    path.write_text(render_proposals(header, proposals), encoding="utf-8")
+    return path
+
+
+# ── Test 1: Full-window cache includes assistant records ──────────
+
+
+class TestFullWindowCache:
+    """The window reader retains assistant records so Pass 1 and
+    Pass 2 share a single disk read per JSONL file in the window."""
+
+    def test_window_returns_both_directions_in_order(self, history_dir):
+        chat_id = 1
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-13",
+            [
+                _user_rec("2026-06-13T01:00:00+00:00", "user one"),
+                _assistant_rec("2026-06-13T01:01:00+00:00", "assistant one"),
+                _user_rec("2026-06-13T01:30:00+00:00", "user two"),
+                _assistant_rec("2026-06-13T01:31:00+00:00", "assistant two"),
+            ],
+        )
+        created_at_dt = datetime(2026, 6, 13, 2, 0, 0, tzinfo=UTC)
+        records, any_unreadable = _records_for_row_window(chat_id, created_at_dt, window_seconds=86400)
+        assert any_unreadable is False
+        assert [r["dir"] for r in records] == ["user", "assistant", "user", "assistant"]
+        assert [r["text"] for r in records] == ["user one", "assistant one", "user two", "assistant two"]
+
+    def test_malformed_assistant_ts_collapses_window(self, history_dir):
+        # An assistant record with a malformed ts must collapse the row
+        # even when every user record is clean. The reader's
+        # per-record validation contract covers both directions so a
+        # malformed assistant turn cannot hide the boundary Pass 2's
+        # pairing walk depends on.
+        chat_id = 1
+        user_dir = history_dir / str(chat_id)
+        user_dir.mkdir(parents=True, exist_ok=True)
+        path = user_dir / "2026-06-13.jsonl"
+        path.write_text(
+            json.dumps({"ts": "2026-06-13T01:00:00+00:00", "dir": "user", "chat_id": 1, "text": "u1"})
+            + "\n"
+            + json.dumps({"ts": "not-a-timestamp", "dir": "assistant", "chat_id": 1, "text": "a1"})
+            + "\n",
+            encoding="utf-8",
+        )
+        created_at_dt = datetime(2026, 6, 13, 2, 0, 0, tzinfo=UTC)
+        _records, any_unreadable = _records_for_row_window(chat_id, created_at_dt, window_seconds=86400)
+        assert any_unreadable is True
+
+
+# ── Tests 2-8: Pass 2 algorithm ───────────────────────────────────
+
+
+class TestPass2Algorithm:
+    """Pass 2 end-to-end through `run_dry_run`: overlap on assistant
+    turns + conservative pairing rule + max-gap guard."""
+
+    def _dry_run(self, history_dir: Path, tmp_path: Path, row: MemoryResult, **kwargs) -> Path:
+        out_dir = tmp_path / "out"
+        with patch("kai.memory.get_all", return_value=[row]):
+            code = asyncio.run(
+                run_dry_run(
+                    _BASE_CONFIG,
+                    "1",
+                    window_seconds=kwargs.get("window_seconds", 86400),
+                    min_overlap=kwargs.get("min_overlap", 0.3),
+                    strong_overlap_ratio=kwargs.get("strong_overlap_ratio", 2.0),
+                    shingle_n=kwargs.get("shingle_n", 4),
+                    sample=kwargs.get("sample", 10),
+                    out_dir=out_dir,
+                    assistant_pass_enabled=kwargs.get("assistant_pass_enabled", True),
+                    assistant_max_user_gap_seconds=kwargs.get("assistant_max_user_gap_seconds", 600),
+                )
+            )
+        assert code == 0
+        return out_dir
+
+    def _proposals_in(self, out_dir: Path) -> list[dict]:
+        proposals_path = next(out_dir.glob("backfill-*-proposals.jsonl"))
+        text = proposals_path.read_text(encoding="utf-8")
+        lines = [ln for ln in text.splitlines() if ln.strip()]
+        # First line is the header; everything after is one proposal.
+        return [json.loads(ln) for ln in lines[1:]]
+
+    def _report_in(self, out_dir: Path) -> str:
+        report_path = next(out_dir.glob("backfill-*-report.md"))
+        return report_path.read_text(encoding="utf-8")
+
+    # Test 2.
+    def test_pass2_finds_paired_user_via_assistant_overlap(self, history_dir, tmp_path):
+        chat_id = 1
+        user_ts = "2026-06-12T10:00:00+00:00"
+        assistant_ts = "2026-06-12T10:01:00+00:00"
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-12",
+            [
+                _user_rec(user_ts, _PASS2_USER_TEXT),
+                _assistant_rec(assistant_ts, _PASS2_ASSISTANT_TEXT),
+            ],
+        )
+        row = _alive_row(row_id="m1", text=_PASS2_ROW_TEXT, created_at="2026-06-12T10:05:00+00:00")
+        out_dir = self._dry_run(history_dir, tmp_path, row)
+        proposals = self._proposals_in(out_dir)
+        assert len(proposals) == 1
+        p = proposals[0]
+        assert p["match_pass"] == "assistant"
+        assert p["user_ts"] == user_ts
+        assert p["assistant_ts"] == assistant_ts
+        assert p["user_text_sha256"]  # non-empty
+        assert p["assistant_text_sha256"]  # non-empty
+        # The proposal date is the USER ts's UTC date, not the assistant's.
+        assert p["date"] == "2026-06-12"
+
+    # Test 3.
+    def test_pass2_walks_across_midnight_boundary(self, history_dir, tmp_path):
+        chat_id = 1
+        user_ts = "2026-06-12T23:55:00+00:00"
+        assistant_ts = "2026-06-13T00:01:00+00:00"
+        _write_jsonl(history_dir, chat_id, "2026-06-12", [_user_rec(user_ts, _PASS2_USER_TEXT)])
+        _write_jsonl(history_dir, chat_id, "2026-06-13", [_assistant_rec(assistant_ts, _PASS2_ASSISTANT_TEXT)])
+        row = _alive_row(row_id="m1", text=_PASS2_ROW_TEXT, created_at="2026-06-13T00:05:00+00:00")
+        out_dir = self._dry_run(history_dir, tmp_path, row)
+        proposals = self._proposals_in(out_dir)
+        assert len(proposals) == 1
+        p = proposals[0]
+        assert p["match_pass"] == "assistant"
+        assert p["user_ts"] == user_ts
+        assert p["assistant_ts"] == assistant_ts
+        # The date stamped onto the row is the USER's UTC date, even
+        # though the assistant turn rolled into the next day.
+        assert p["date"] == "2026-06-12"
+
+    # Test 4.
+    def test_pass2_skips_when_no_preceding_user(self, history_dir, tmp_path):
+        chat_id = 1
+        # Assistant turn alone in the window. No prior user means the
+        # pairing rule has no source to bind the winner to.
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-12",
+            [_assistant_rec("2026-06-12T10:01:00+00:00", _PASS2_ASSISTANT_TEXT)],
+        )
+        row = _alive_row(row_id="m1", text=_PASS2_ROW_TEXT, created_at="2026-06-12T10:05:00+00:00")
+        out_dir = self._dry_run(history_dir, tmp_path, row)
+        proposals = self._proposals_in(out_dir)
+        assert proposals == []
+        report = self._report_in(out_dir)
+        assert "skipped no_preceding_user: 1" in report
+
+    # Test 5.
+    def test_pass2_skips_when_preceding_user_exceeds_max_gap(self, history_dir, tmp_path):
+        chat_id = 1
+        # User at 09:00, assistant at 10:00 = 3600s gap. Default max-
+        # gap is 600s. The user-to-assistant pairing is rejected as
+        # untrustworthy even though the user turn is the only candidate.
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-12",
+            [
+                _user_rec("2026-06-12T09:00:00+00:00", _PASS2_USER_TEXT),
+                _assistant_rec("2026-06-12T10:00:00+00:00", _PASS2_ASSISTANT_TEXT),
+            ],
+        )
+        row = _alive_row(row_id="m1", text=_PASS2_ROW_TEXT, created_at="2026-06-12T10:30:00+00:00")
+        out_dir = self._dry_run(history_dir, tmp_path, row)
+        proposals = self._proposals_in(out_dir)
+        assert proposals == []
+        report = self._report_in(out_dir)
+        # Max-gap collapses to the same bucket as "no preceding user
+        # in window": the operator's tuning advice (widen the gap) is
+        # the same in both cases.
+        assert "skipped no_preceding_user: 1" in report
+
+    # Test 6.
+    def test_pass2_skips_ambiguous_user_pairing(self, history_dir, tmp_path):
+        chat_id = 1
+        # Two user turns sit between window start (no prior assistant)
+        # and the winning assistant. The pairing rule refuses rather
+        # than picking the closer one heuristically.
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-12",
+            [
+                _user_rec("2026-06-12T09:55:00+00:00", "first unrelated user turn"),
+                _user_rec("2026-06-12T09:58:00+00:00", "second unrelated user turn"),
+                _assistant_rec("2026-06-12T10:00:00+00:00", _PASS2_ASSISTANT_TEXT),
+            ],
+        )
+        row = _alive_row(row_id="m1", text=_PASS2_ROW_TEXT, created_at="2026-06-12T10:05:00+00:00")
+        out_dir = self._dry_run(history_dir, tmp_path, row)
+        proposals = self._proposals_in(out_dir)
+        assert proposals == []
+        report = self._report_in(out_dir)
+        assert "skipped ambiguous_user_pairing: 1" in report
+
+    # Test 7.
+    def test_pass2_skips_ambiguous_assistant_overlap(self, history_dir, tmp_path):
+        chat_id = 1
+        # Two assistant turns with identical text both score 1.0
+        # against the row; the dominance ratio (1.0) sits below the
+        # 2.0 threshold and the row collapses to the assistant-
+        # ambiguous bucket without ever reaching pairing.
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-12",
+            [
+                _user_rec("2026-06-12T09:55:00+00:00", _PASS2_USER_TEXT),
+                _assistant_rec("2026-06-12T09:58:00+00:00", _PASS2_ASSISTANT_TEXT),
+                _assistant_rec("2026-06-12T10:00:00+00:00", _PASS2_ASSISTANT_TEXT),
+            ],
+        )
+        row = _alive_row(row_id="m1", text=_PASS2_ROW_TEXT, created_at="2026-06-12T10:05:00+00:00")
+        out_dir = self._dry_run(history_dir, tmp_path, row)
+        proposals = self._proposals_in(out_dir)
+        assert proposals == []
+        report = self._report_in(out_dir)
+        assert "skipped assistant_ambiguous_overlap: 1" in report
+
+    # Test 8.
+    def test_pass2_runs_only_on_pass1_no_candidate(self, history_dir, tmp_path):
+        chat_id = 1
+        # Pass 1 STRONG_MATCH: the user turn shares strong overlap with
+        # the row. Pass 2 must never see this row. We count calls to
+        # the shared scorer and assert exactly one (Pass 1's).
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-12",
+            [
+                _user_rec("2026-06-12T10:00:00+00:00", _PASS2_ROW_TEXT + " plus some extra trailing words"),
+                _assistant_rec("2026-06-12T10:01:00+00:00", "an unrelated assistant ack"),
+            ],
+        )
+        row = _alive_row(row_id="m1", text=_PASS2_ROW_TEXT, created_at="2026-06-12T10:05:00+00:00")
+
+        from kai import memory_provenance_backfill as mod
+
+        calls: list[list[dict]] = []
+        original = mod._score_candidates
+
+        def counting(row_text, candidates, *, shingle_n, created_at_dt):
+            calls.append(list(candidates))
+            return original(row_text, candidates, shingle_n=shingle_n, created_at_dt=created_at_dt)
+
+        with patch.object(mod, "_score_candidates", side_effect=counting):
+            out_dir = self._dry_run(history_dir, tmp_path, row)
+
+        # Only Pass 1 ran; Pass 2's assistant scoring never executed.
+        assert len(calls) == 1
+        # The single call's candidates were the user records, not
+        # the assistant ones.
+        assert all(rec["dir"] == "user" for rec in calls[0])
+        proposals = self._proposals_in(out_dir)
+        assert len(proposals) == 1
+        assert proposals[0]["match_pass"] == "user"
+
+
+# ── Tests 9-10: Per-record validation ─────────────────────────────
+
+
+class TestPerRecordValidation:
+    """Per-record chat_id and ts checks fire on both user and
+    assistant records. Partial-history corruption on either
+    direction collapses the row before scoring can lean on it."""
+
+    def _expect_unreadable(self, history_dir: Path, records: list[dict]) -> None:
+        chat_id = 1
+        user_dir = history_dir / str(chat_id)
+        user_dir.mkdir(parents=True, exist_ok=True)
+        path = user_dir / "2026-06-13.jsonl"
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+        created_at_dt = datetime(2026, 6, 13, 2, 0, 0, tzinfo=UTC)
+        _records, any_unreadable = _records_for_row_window(chat_id, created_at_dt, window_seconds=86400)
+        assert any_unreadable is True
+
+    # Test 9 part 1.
+    def test_user_record_with_mismatched_chat_id_collapses_window(self, history_dir):
+        self._expect_unreadable(
+            history_dir,
+            [{"ts": "2026-06-13T01:00:00+00:00", "dir": "user", "chat_id": 999, "text": "x"}],
+        )
+
+    # Test 9 part 2.
+    def test_assistant_record_with_mismatched_chat_id_collapses_window(self, history_dir):
+        self._expect_unreadable(
+            history_dir,
+            [{"ts": "2026-06-13T01:00:00+00:00", "dir": "assistant", "chat_id": 999, "text": "x"}],
+        )
+
+    # Test 9 part 3.
+    def test_missing_chat_id_on_either_direction_collapses_window(self, history_dir):
+        self._expect_unreadable(
+            history_dir,
+            [
+                {"ts": "2026-06-13T01:00:00+00:00", "dir": "user", "text": "x"},
+            ],
+        )
+        # Re-run with an assistant record missing chat_id.
+        chat_id = 1
+        path = history_dir / str(chat_id) / "2026-06-13.jsonl"
+        path.write_text(
+            json.dumps({"ts": "2026-06-13T01:00:00+00:00", "dir": "assistant", "text": "x"}) + "\n",
+            encoding="utf-8",
+        )
+        created_at_dt = datetime(2026, 6, 13, 2, 0, 0, tzinfo=UTC)
+        _records, any_unreadable = _records_for_row_window(chat_id, created_at_dt, window_seconds=86400)
+        assert any_unreadable is True
+
+    # Test 10 part 1.
+    def test_missing_ts_on_user_record_collapses_window(self, history_dir):
+        self._expect_unreadable(
+            history_dir,
+            [{"dir": "user", "chat_id": 1, "text": "x"}],
+        )
+
+    # Test 10 part 2.
+    def test_missing_ts_on_assistant_record_collapses_window(self, history_dir):
+        self._expect_unreadable(
+            history_dir,
+            [{"dir": "assistant", "chat_id": 1, "text": "x"}],
+        )
+
+    # Test 10 part 3.
+    def test_non_string_ts_on_assistant_record_collapses_window(self, history_dir):
+        self._expect_unreadable(
+            history_dir,
+            [{"ts": 123456, "dir": "assistant", "chat_id": 1, "text": "x"}],
+        )
+
+
+# ── Tests 11-15: Apply-time gates on Pass 2 proposals ─────────────
+
+
+class TestPass2ApplyGates:
+    """Apply re-verifies the assistant evidence and the chat_id on
+    both JSONL lines; the four source_* keys written to the row's
+    metadata are user-side only on both passes."""
+
+    def _row_with_fp(self, row_id: str = "m1") -> tuple[MemoryResult, str]:
+        row = _alive_row(row_id=row_id, text="row body", created_at="2026-06-13T00:00:00+00:00")
+        return row, _metadata_fingerprint(row.metadata)
+
+    # Test 11.
+    def test_assistant_drift_text_changed(self, tmp_path, history_dir):
+        chat_id = 1
+        user_ts = "2026-06-12T10:00:00+00:00"
+        assistant_ts = "2026-06-12T10:01:00+00:00"
+        user_text = "live user line"
+        # The JSONL assistant line has changed text since dry-run: the
+        # proposal's assistant_text_sha256 will not match.
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-12",
+            [
+                _user_rec(user_ts, user_text),
+                _assistant_rec(assistant_ts, "edited assistant text after the fact"),
+            ],
+        )
+        row, fp = self._row_with_fp()
+        proposal = _make_pass2_proposal(
+            chat_id=chat_id,
+            user_ts=user_ts,
+            user_text_sha=hashlib.sha256(user_text.encode("utf-8")).hexdigest(),
+            assistant_ts=assistant_ts,
+            assistant_text_sha=hashlib.sha256(b"original assistant text").hexdigest(),
+            prior_fp=fp,
+        )
+        proposals_path = _make_proposals_file(tmp_path, [proposal])
+        update_calls: list = []
+        with (
+            patch("kai.memory.get_by_id", return_value=row),
+            patch(
+                "kai.memory.update_metadata",
+                side_effect=lambda **kwargs: update_calls.append(kwargs) or True,
+            ),
+        ):
+            code = asyncio.run(run_apply(_BASE_CONFIG, "1", proposals_path=proposals_path, out_dir=tmp_path / "out"))
+        # No survivors -> exit 0, no writes.
+        assert code == 0
+        assert update_calls == []
+
+    # Test 12.
+    def test_user_drift_still_fires_on_pass2_proposal(self, tmp_path, history_dir):
+        chat_id = 1
+        user_ts = "2026-06-12T10:00:00+00:00"
+        assistant_ts = "2026-06-12T10:01:00+00:00"
+        assistant_text = "the actual live assistant text"
+        # User line text drifted; the assistant line is intact.
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-12",
+            [
+                _user_rec(user_ts, "edited user text after the fact"),
+                _assistant_rec(assistant_ts, assistant_text),
+            ],
+        )
+        row, fp = self._row_with_fp()
+        proposal = _make_pass2_proposal(
+            chat_id=chat_id,
+            user_ts=user_ts,
+            user_text_sha=hashlib.sha256(b"original user text").hexdigest(),
+            assistant_ts=assistant_ts,
+            assistant_text_sha=hashlib.sha256(assistant_text.encode("utf-8")).hexdigest(),
+            prior_fp=fp,
+        )
+        proposals_path = _make_proposals_file(tmp_path, [proposal])
+        update_calls: list = []
+        with (
+            patch("kai.memory.get_by_id", return_value=row),
+            patch(
+                "kai.memory.update_metadata",
+                side_effect=lambda **kwargs: update_calls.append(kwargs) or True,
+            ),
+        ):
+            code = asyncio.run(run_apply(_BASE_CONFIG, "1", proposals_path=proposals_path, out_dir=tmp_path / "out"))
+        assert code == 0
+        assert update_calls == []
+
+    # Test 13.
+    def test_apply_chat_id_check_at_user_line(self, tmp_path, history_dir):
+        chat_id = 1
+        user_ts = "2026-06-12T10:00:00+00:00"
+        assistant_ts = "2026-06-12T10:01:00+00:00"
+        user_text = "live user line"
+        assistant_text = "live assistant line"
+        # Same ts, hash, and text on the user record, but the JSONL's
+        # chat_id is wrong (a polluted restore). The ownership gate
+        # must reject the user line.
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-12",
+            [
+                _user_rec(user_ts, user_text, chat_id=999),
+                _assistant_rec(assistant_ts, assistant_text),
+            ],
+        )
+        # The full-window reader's per-record chat_id check would
+        # collapse this whole window, but apply-time verification uses
+        # `_verify_jsonl_user_text` against the JSONL directly. Test
+        # that helper in isolation: it must refuse the polluted record.
+        ok = _verify_jsonl_user_text(
+            chat_id=chat_id,
+            date="2026-06-12",
+            user_ts=user_ts,
+            expected_sha256=hashlib.sha256(user_text.encode("utf-8")).hexdigest(),
+        )
+        assert ok is False
+
+    # Test 14.
+    def test_apply_chat_id_check_at_assistant_line(self, tmp_path, history_dir):
+        chat_id = 1
+        assistant_ts = "2026-06-12T10:01:00+00:00"
+        assistant_text = "live assistant line"
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-12",
+            [_assistant_rec(assistant_ts, assistant_text, chat_id=999)],
+        )
+        ok = _verify_jsonl_assistant_text(
+            chat_id=chat_id,
+            assistant_ts=assistant_ts,
+            expected_sha256=hashlib.sha256(assistant_text.encode("utf-8")).hexdigest(),
+        )
+        assert ok is False
+
+    # Test 15.
+    def test_apply_writes_only_four_user_side_source_keys_for_pass2(self, tmp_path, history_dir):
+        chat_id = 1
+        user_ts = "2026-06-12T10:00:00+00:00"
+        assistant_ts = "2026-06-12T10:01:00+00:00"
+        user_text = "live user line"
+        assistant_text = "live assistant line"
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-12",
+            [
+                _user_rec(user_ts, user_text),
+                _assistant_rec(assistant_ts, assistant_text),
+            ],
+        )
+        row = _alive_row(row_id="m1", text="row body", created_at="2026-06-13T00:00:00+00:00")
+        fp = _metadata_fingerprint(row.metadata)
+        proposal = _make_pass2_proposal(
+            chat_id=chat_id,
+            user_ts=user_ts,
+            user_text_sha=hashlib.sha256(user_text.encode("utf-8")).hexdigest(),
+            assistant_ts=assistant_ts,
+            assistant_text_sha=hashlib.sha256(assistant_text.encode("utf-8")).hexdigest(),
+            prior_fp=fp,
+        )
+        proposals_path = _make_proposals_file(tmp_path, [proposal])
+        captured: list[dict] = []
+
+        def fake_update(**kwargs):
+            captured.append(kwargs)
+            return True
+
+        with (
+            patch("kai.memory.get_by_id", return_value=row),
+            patch("kai.memory.update_metadata", side_effect=fake_update),
+        ):
+            code = asyncio.run(run_apply(_BASE_CONFIG, "1", proposals_path=proposals_path, out_dir=tmp_path / "out"))
+        assert code == 0
+        assert len(captured) == 1
+        merged = captured[0]["metadata"]
+        # The four user-side keys land in the merged dict.
+        assert merged[SOURCE_CHAT_ID_KEY] == chat_id
+        assert merged[SOURCE_DATE_KEY] == "2026-06-12"
+        assert merged[SOURCE_USER_TS_KEY] == user_ts
+        assert merged[SOURCE_USER_TEXT_SHA256_KEY] == hashlib.sha256(user_text.encode("utf-8")).hexdigest()
+        # No assistant-side stamp leaks into the persisted metadata.
+        assert "source_assistant_ts" not in merged
+        assert "source_assistant_text_sha256" not in merged
+
+
+# ── --no-assistant-pass disables Pass 2 ───────────────────────────
+
+
+class TestNoAssistantPass:
+    def test_no_assistant_pass_drops_pass2_match(self, history_dir, tmp_path):
+        chat_id = 1
+        user_ts = "2026-06-12T10:00:00+00:00"
+        assistant_ts = "2026-06-12T10:01:00+00:00"
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-12",
+            [
+                _user_rec(user_ts, _PASS2_USER_TEXT),
+                _assistant_rec(assistant_ts, _PASS2_ASSISTANT_TEXT),
+            ],
+        )
+        row = _alive_row(row_id="m1", text=_PASS2_ROW_TEXT, created_at="2026-06-12T10:05:00+00:00")
+        out_dir = tmp_path / "out"
+        with patch("kai.memory.get_all", return_value=[row]):
+            code = asyncio.run(
+                run_dry_run(
+                    _BASE_CONFIG,
+                    "1",
+                    window_seconds=86400,
+                    min_overlap=0.3,
+                    strong_overlap_ratio=2.0,
+                    shingle_n=4,
+                    sample=10,
+                    out_dir=out_dir,
+                    assistant_pass_enabled=False,
+                    assistant_max_user_gap_seconds=600,
+                )
+            )
+        assert code == 0
+        proposals_path = next(out_dir.glob("backfill-*-proposals.jsonl"))
+        lines = [ln for ln in proposals_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        # Header only; row falls into NO_CANDIDATE without Pass 2.
+        assert len(lines) == 1
+        report = (next(out_dir.glob("backfill-*-report.md"))).read_text(encoding="utf-8")
+        assert "skipped no_candidate: 1" in report
+        # No Pass 2 buckets fired.
+        assert "skipped assistant_ambiguous_overlap: 0" in report
+        assert "skipped no_preceding_user: 0" in report
+        assert "skipped ambiguous_user_pairing: 0" in report
+
+    def test_no_assistant_pass_pass1_proposals_still_uniform(self, history_dir, tmp_path):
+        # A Pass 1 STRONG_MATCH emitted under --no-assistant-pass MUST
+        # still carry the four new schema fields as empty strings;
+        # otherwise downstream tools would have to branch on the flag.
+        chat_id = 1
+        user_ts = "2026-06-12T10:00:00+00:00"
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-12",
+            [_user_rec(user_ts, _PASS2_ROW_TEXT + " plus trailing extras")],
+        )
+        row = _alive_row(row_id="m1", text=_PASS2_ROW_TEXT, created_at="2026-06-12T10:05:00+00:00")
+        out_dir = tmp_path / "out"
+        with patch("kai.memory.get_all", return_value=[row]):
+            code = asyncio.run(
+                run_dry_run(
+                    _BASE_CONFIG,
+                    "1",
+                    window_seconds=86400,
+                    min_overlap=0.3,
+                    strong_overlap_ratio=2.0,
+                    shingle_n=4,
+                    sample=10,
+                    out_dir=out_dir,
+                    assistant_pass_enabled=False,
+                    assistant_max_user_gap_seconds=600,
+                )
+            )
+        assert code == 0
+        proposals_path = next(out_dir.glob("backfill-*-proposals.jsonl"))
+        lines = [ln for ln in proposals_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        assert len(lines) == 2  # header + one Pass 1 proposal
+        proposal = json.loads(lines[1])
+        assert proposal["match_pass"] == "user"
+        assert proposal["assistant_ts"] == ""
+        assert proposal["assistant_text_sha256"] == ""
+        assert proposal["assistant_text_snippet"] == ""
+
+
+# ── Tests 17, 18, 25: Proposal parser schema gates ────────────────
+
+
+class TestProposalSchemaGates:
+    def _header_line(self) -> str:
+        return json.dumps({"type": "header", "run_id": "bp-x", "user_id": "1"})
+
+    def _legacy_proposal(self) -> dict:
+        # Legacy proposal shape: no match_pass, no assistant_* fields.
+        # This is the file shape on disk for proposal files written
+        # before Pass 2 existed; the parser must still accept them.
+        return {
+            "type": "proposal",
+            "memory_id": "m1",
+            "chat_id": 1,
+            "date": "2026-06-12",
+            "user_ts": "2026-06-12T10:00:00+00:00",
+            "user_text_sha256": "abc",
+            "overlap_score": 0.9,
+            "runner_up_overlap_score": 0.0,
+            "candidate_count": 1,
+            "gap_seconds": 60.0,
+            "prior_metadata_sha256": "fp",
+            "row_text_snippet": "row",
+            "candidate_text_snippet": "cand",
+        }
+
+    # Test 17.
+    def test_parser_accepts_legacy_proposal(self):
+        text = self._header_line() + "\n" + json.dumps(self._legacy_proposal()) + "\n"
+        _header, proposals = parse_proposals(text)
+        assert len(proposals) == 1
+        p = proposals[0]
+        # Defaults applied: Pass 1, no assistant evidence.
+        assert p.match_pass == "user"
+        assert p.assistant_ts == ""
+        assert p.assistant_text_sha256 == ""
+        assert p.assistant_text_snippet == ""
+
+    # Test 18 part 1.
+    def test_parser_rejects_pass2_with_empty_assistant_ts(self):
+        bad = dict(self._legacy_proposal())
+        bad["match_pass"] = "assistant"
+        bad["assistant_ts"] = ""
+        bad["assistant_text_sha256"] = "ash"
+        text = self._header_line() + "\n" + json.dumps(bad) + "\n"
+        with pytest.raises(ValueError, match="assistant_ts"):
+            parse_proposals(text)
+
+    # Test 18 part 2.
+    def test_parser_rejects_pass2_with_empty_assistant_sha(self):
+        bad = dict(self._legacy_proposal())
+        bad["match_pass"] = "assistant"
+        bad["assistant_ts"] = "2026-06-12T10:01:00+00:00"
+        bad["assistant_text_sha256"] = ""
+        text = self._header_line() + "\n" + json.dumps(bad) + "\n"
+        with pytest.raises(ValueError, match="assistant_text_sha256"):
+            parse_proposals(text)
+
+    # Test 25.
+    def test_parser_rejects_pass2_with_malformed_assistant_ts(self):
+        # Authorization-artifact gate: a hand-edited Pass 2 proposal
+        # whose assistant_ts is non-empty but unparseable must be
+        # rejected BEFORE the apply-time helper tries to derive the
+        # JSONL date from it.
+        bad = dict(self._legacy_proposal())
+        bad["match_pass"] = "assistant"
+        bad["assistant_ts"] = "not-a-date"
+        bad["assistant_text_sha256"] = "ash"
+        text = self._header_line() + "\n" + json.dumps(bad) + "\n"
+        with pytest.raises(ValueError, match="assistant_ts"):
+            parse_proposals(text)
+        # And the other unparseable shape: a syntactically date-shaped
+        # string that fromisoformat still rejects.
+        bad["assistant_ts"] = "2026-13-99T25:99:99"
+        text = self._header_line() + "\n" + json.dumps(bad) + "\n"
+        with pytest.raises(ValueError, match="assistant_ts"):
+            parse_proposals(text)
+
+
+# ── Tests 19, 20, 21: CLI flags for Pass 2 ────────────────────────
+
+
+class TestPass2CLIFlags:
+    def _ns(self, tmp_path: Path, **overrides) -> SimpleNamespace:
+        base = dict(
+            user_id="1",
+            window_seconds=None,
+            min_overlap=None,
+            strong_overlap_ratio=None,
+            overlap_shingle_n=None,
+            no_assistant_pass=None,
+            assistant_max_user_gap_seconds=None,
+            sample=None,
+            out_dir=None,
+            apply=None,
+            rollback=None,
+            yes=False,
+        )
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    # Test 19.
+    def test_cli_rejects_no_assistant_pass_in_mutating_mode(self, tmp_path, capsys):
+        from kai.memory_admin import _cmd_backfill_provenance
+
+        ns = self._ns(
+            tmp_path,
+            no_assistant_pass=True,
+            apply=str(tmp_path / "proposals.jsonl"),
+        )
+        code = _cmd_backfill_provenance(ns)
+        assert code == 2
+        err = capsys.readouterr().err
+        assert "--no-assistant-pass" in err
+
+    # Test 20.
+    def test_cli_rejects_assistant_max_user_gap_in_mutating_mode(self, tmp_path, capsys):
+        from kai.memory_admin import _cmd_backfill_provenance
+
+        ns = self._ns(
+            tmp_path,
+            assistant_max_user_gap_seconds=900,
+            apply=str(tmp_path / "proposals.jsonl"),
+        )
+        code = _cmd_backfill_provenance(ns)
+        assert code == 2
+        err = capsys.readouterr().err
+        assert "--assistant-max-user-gap-seconds" in err
+
+    # Test 21.
+    def test_cli_validates_assistant_max_user_gap_positive(self, tmp_path, capsys):
+        from kai.memory_admin import _cmd_backfill_provenance
+
+        ns = self._ns(tmp_path, assistant_max_user_gap_seconds=0)
+        with patch("kai.memory_admin._initialize_memory", return_value=_BASE_CONFIG):
+            code = _cmd_backfill_provenance(ns)
+        assert code == 2
+        err = capsys.readouterr().err
+        assert "--assistant-max-user-gap-seconds" in err
+        # Negative also rejected.
+        ns = self._ns(tmp_path, assistant_max_user_gap_seconds=-1)
+        with patch("kai.memory_admin._initialize_memory", return_value=_BASE_CONFIG):
+            code = _cmd_backfill_provenance(ns)
+        assert code == 2
+
+
+# ── Test 22: Cache prevents double JSONL read ─────────────────────
+
+
+class TestPass2Caching:
+    def test_one_disk_read_per_file_across_both_passes(self, history_dir, tmp_path):
+        chat_id = 1
+        user_ts = "2026-06-12T10:00:00+00:00"
+        assistant_ts = "2026-06-12T10:01:00+00:00"
+        # Row text overlaps only the assistant turn, so Pass 1 returns
+        # NO_CANDIDATE and Pass 2 runs. Without the shared cache, the
+        # window file would be read twice (once per pass).
+        _write_jsonl(
+            history_dir,
+            chat_id,
+            "2026-06-12",
+            [
+                _user_rec(user_ts, _PASS2_USER_TEXT),
+                _assistant_rec(assistant_ts, _PASS2_ASSISTANT_TEXT),
+            ],
+        )
+        row = _alive_row(row_id="m1", text=_PASS2_ROW_TEXT, created_at="2026-06-12T10:05:00+00:00")
+
+        from kai import memory_provenance_backfill as mod
+
+        reads: list[Path] = []
+        original = mod._read_jsonl_records
+
+        def counting(path):
+            reads.append(path)
+            return original(path)
+
+        out_dir = tmp_path / "out"
+        with (
+            patch("kai.memory.get_all", return_value=[row]),
+            patch.object(mod, "_read_jsonl_records", side_effect=counting),
+        ):
+            code = asyncio.run(
+                run_dry_run(
+                    _BASE_CONFIG,
+                    "1",
+                    window_seconds=86400,
+                    min_overlap=0.3,
+                    strong_overlap_ratio=2.0,
+                    shingle_n=4,
+                    sample=10,
+                    out_dir=out_dir,
+                )
+            )
+        assert code == 0
+        # The window straddles two UTC dates (24h window ending at
+        # 10:05 on 2026-06-12 starts at 10:05 on 2026-06-11). Each
+        # date file is read once, NOT twice (the cache covers both
+        # passes for this row).
+        counts: dict[str, int] = {}
+        for p in reads:
+            counts[p.name] = counts.get(p.name, 0) + 1
+        for name, count in counts.items():
+            assert count == 1, f"{name} was read {count} times across the two passes"
+
+
+# ── Pass-1-only projection round-trip ─────────────────────────────
+
+
+class TestPass1OnlyProjection:
+    def test_pass1_proposal_projection_matches_user_only_shape(self, history_dir, tmp_path):
+        # Backward-compatibility contract: a Pass 1 proposal emitted
+        # by the current code, after dropping the four assistant-side
+        # audit fields, must carry exactly the user-only field set.
+        # Downstream readers can therefore round-trip a legacy
+        # proposal file through the current parser without losing
+        # information.
+        chat_id = 1
+        user_ts = "2026-06-12T10:00:00+00:00"
+        user_text = _PASS2_ROW_TEXT + " plus some trailing words"
+        _write_jsonl(history_dir, chat_id, "2026-06-12", [_user_rec(user_ts, user_text)])
+        row = _alive_row(row_id="m1", text=_PASS2_ROW_TEXT, created_at="2026-06-12T10:05:00+00:00")
+        out_dir = tmp_path / "out"
+        with patch("kai.memory.get_all", return_value=[row]):
+            code = asyncio.run(
+                run_dry_run(
+                    _BASE_CONFIG,
+                    "1",
+                    window_seconds=86400,
+                    min_overlap=0.3,
+                    strong_overlap_ratio=2.0,
+                    shingle_n=4,
+                    sample=10,
+                    out_dir=out_dir,
+                    assistant_pass_enabled=False,
+                )
+            )
+        assert code == 0
+        proposals_path = next(out_dir.glob("backfill-*-proposals.jsonl"))
+        lines = [ln for ln in proposals_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        assert len(lines) == 2
+        proposal_raw = json.loads(lines[1])
+        # The four assistant-side audit fields are present and empty
+        # on a Pass 1 proposal (schema is uniform across passes);
+        # drop them to recover the user-only field set.
+        assistant_fields = {"match_pass", "assistant_ts", "assistant_text_sha256", "assistant_text_snippet"}
+        user_only_shape = {k: v for k, v in proposal_raw.items() if k not in assistant_fields}
+        # The user-only projection must carry the "type" tag plus
+        # every audit field whose value is derived from the user
+        # turn or the row itself; the value-level assertions live in
+        # the Pass 1 scoring tests (this one owns the SHAPE contract).
+        assert set(user_only_shape.keys()) == {
+            "type",
+            "memory_id",
+            "chat_id",
+            "date",
+            "user_ts",
+            "user_text_sha256",
+            "overlap_score",
+            "runner_up_overlap_score",
+            "candidate_count",
+            "gap_seconds",
+            "prior_metadata_sha256",
+            "row_text_snippet",
+            "candidate_text_snippet",
+        }
+
+
+# ── Test 24: Report shape covers Pass 2 ───────────────────────────
+
+
+class TestPass2ReportShape:
+    def test_report_renders_pass_distribution_and_buckets(self):
+        from kai.memory_provenance_backfill import RowMatch
+
+        row_user = _alive_row(row_id="u1", text="ru", created_at="2026-06-13T00:00:00+00:00")
+        row_assistant = _alive_row(row_id="a1", text="ra", created_at="2026-06-13T00:00:00+00:00")
+        pass1 = Proposal(
+            memory_id="u1",
+            chat_id=1,
+            date="2026-06-12",
+            user_ts="2026-06-12T10:00:00+00:00",
+            user_text_sha256="us",
+            overlap_score=0.9,
+            runner_up_overlap_score=0.0,
+            candidate_count=1,
+            gap_seconds=60.0,
+            prior_metadata_sha256="fp",
+            row_text_snippet="row user",
+            candidate_text_snippet="user cand text",
+        )
+        pass2 = Proposal(
+            memory_id="a1",
+            chat_id=1,
+            date="2026-06-12",
+            user_ts="2026-06-12T10:00:00+00:00",
+            user_text_sha256="us",
+            overlap_score=0.85,
+            runner_up_overlap_score=0.0,
+            candidate_count=1,
+            gap_seconds=60.0,
+            prior_metadata_sha256="fp",
+            row_text_snippet="row assistant",
+            candidate_text_snippet="paired user text",
+            match_pass="assistant",
+            assistant_ts="2026-06-12T10:01:00+00:00",
+            assistant_text_sha256="as",
+            assistant_text_snippet="discriminator assistant text",
+        )
+        matches = [
+            RowMatch(row=row_user, bucket="STRONG_MATCH", top_candidates=[], proposal=pass1),
+            RowMatch(row=row_assistant, bucket="STRONG_MATCH", top_candidates=[], proposal=pass2),
+        ]
+        report = render_report(
+            run_id="bp-test",
+            user_id="1",
+            window_seconds=86400,
+            min_overlap=0.3,
+            strong_overlap_ratio=2.0,
+            shingle_n=4,
+            assistant_pass_enabled=True,
+            assistant_max_user_gap_seconds=600,
+            scanned=2,
+            selected=2,
+            matches=matches,
+            skips={"strong_match": ["u1", "a1"]},
+            sample_size=10,
+        )
+        # The pass distribution line carries user/assistant split.
+        assert "proposals (STRONG_MATCH): 2  (user: 1, assistant: 1)" in report
+        # Every new skip bucket renders in a stable order so future
+        # readers can locate them by line without reading the whole
+        # report.
+        idx_assistant_ambiguous = report.index("skipped assistant_ambiguous_overlap:")
+        idx_no_preceding = report.index("skipped no_preceding_user:")
+        idx_ambiguous_pair = report.index("skipped ambiguous_user_pairing:")
+        assert idx_assistant_ambiguous < idx_no_preceding < idx_ambiguous_pair
+        # The Pass 2 sample carries both the assistant discriminator
+        # and the paired source user snippet; the operator can audit
+        # either side without opening the proposals JSONL.
+        assert "STRONG_MATCH via assistant pass" in report
+        assert "Assistant discriminator" in report
+        assert "discriminator assistant text" in report
+        assert "Paired source user" in report
+        assert "paired user text" in report

--- a/tests/test_memory_provenance_backfill.py
+++ b/tests/test_memory_provenance_backfill.py
@@ -1727,6 +1727,63 @@ class TestPerRecordValidation:
             [{"ts": 123456, "dir": "assistant", "chat_id": 1, "text": "x"}],
         )
 
+    def test_out_of_window_corruption_does_not_collapse_clean_in_window_pair(self, history_dir, tmp_path):
+        # A row at 10:05 with a 24h window scores only against
+        # records up to 10:05 on the same day. A later record at
+        # 15:00 with a mismatched chat_id or non-string text cannot
+        # affect Pass 1 scoring, Pass 2 assistant matching, or
+        # boundary pairing for this row; the reader must skip it
+        # silently rather than flag the whole window unreadable.
+        # Same-day files routinely carry post-created_at records
+        # (the assistant's reply to a later user turn), so an over-
+        # eager gate would over-reject otherwise-clean rows.
+        chat_id = 1
+        user_dir = history_dir / str(chat_id)
+        user_dir.mkdir(parents=True, exist_ok=True)
+        path = user_dir / "2026-06-12.jsonl"
+        path.write_text(
+            json.dumps({"ts": "2026-06-12T10:00:00+00:00", "dir": "user", "chat_id": 1, "text": "live user line"})
+            + "\n"
+            + json.dumps(
+                {"ts": "2026-06-12T10:01:00+00:00", "dir": "assistant", "chat_id": 1, "text": "live assistant line"}
+            )
+            + "\n"
+            + json.dumps(
+                {"ts": "2026-06-12T15:00:00+00:00", "dir": "user", "chat_id": 999, "text": "later mismatched record"}
+            )
+            + "\n"
+            + json.dumps({"ts": "2026-06-12T15:30:00+00:00", "dir": "user", "chat_id": 1, "text": 42})
+            + "\n",
+            encoding="utf-8",
+        )
+        created_at_dt = datetime(2026, 6, 12, 10, 5, 0, tzinfo=UTC)
+        records, any_unreadable = _records_for_row_window(chat_id, created_at_dt, window_seconds=86400)
+        assert any_unreadable is False
+        # Only the two in-window records made it into the cache;
+        # the corrupt later records were silently skipped.
+        assert [r["text"] for r in records] == ["live user line", "live assistant line"]
+
+    def test_out_of_window_malformed_ts_still_collapses(self, history_dir):
+        # The asymmetry that makes the in-window scoping safe: a
+        # malformed `ts` ANYWHERE in the file collapses the row,
+        # because without a parseable timestamp the reader cannot
+        # prove the record falls outside the window. Fail-closed is
+        # the only safe call.
+        chat_id = 1
+        user_dir = history_dir / str(chat_id)
+        user_dir.mkdir(parents=True, exist_ok=True)
+        path = user_dir / "2026-06-12.jsonl"
+        path.write_text(
+            json.dumps({"ts": "2026-06-12T10:00:00+00:00", "dir": "user", "chat_id": 1, "text": "live user"})
+            + "\n"
+            + json.dumps({"ts": "this is not a timestamp", "dir": "user", "chat_id": 1, "text": "x"})
+            + "\n",
+            encoding="utf-8",
+        )
+        created_at_dt = datetime(2026, 6, 12, 10, 5, 0, tzinfo=UTC)
+        _records, any_unreadable = _records_for_row_window(chat_id, created_at_dt, window_seconds=86400)
+        assert any_unreadable is True
+
 
 # ── Tests 11-15: Apply-time gates on Pass 2 proposals ─────────────
 


### PR DESCRIPTION
## Summary

Adds Pass 2 (assistant-turn matching) to the transcript-provenance backfill harness. The first production run matched 31/388 selected rows (~8%); 355 landed in `no_candidate`. Sample inspection showed extraction routinely paraphrases the user message in the assistant's framing, so the row text shares phrasing with the ASSISTANT turn, not the user turn. User-turn-only matching has zero overlap to score against on those rows.

When Pass 1 returns `NO_CANDIDATE`, the harness now:

1. Scores the row text against the assistant turns in the same cached window.
2. Gates the assistant winner through the same `--min-overlap` / `--strong-overlap-ratio` thresholds Pass 1 uses.
3. Binds the winner to the unique preceding user turn between the previous-assistant boundary and the winner. Zero preceding users, or two or more, refuses to pair (distinct skip buckets).
4. Applies a max-gap guard (default 600s, `--assistant-max-user-gap-seconds`) so a stale user turn cannot be the source.
5. Emits a Pass 2 proposal whose `source_*` keys are user-side only on disk, but which also carries `assistant_ts` / `assistant_text_sha256` / `assistant_text_snippet` as verification evidence apply re-checks before writing.

## Safety bar

A false source pointer is worse than leaving a row unmatched. The bar carries through every gate:

- **Window reader.** `_records_for_row_window` returns BOTH directions in JSONL order so the two passes share one disk read. Per-record validation runs on every record regardless of direction; any failure (bad `dir`, mismatched `chat_id`, missing/non-string `text`, missing/non-string/unparseable `ts`) collapses the row to `HISTORY_UNREADABLE`.
- **Conservative pairing.** Refuses zero or multi-user pairings rather than picking the closer one heuristically. The conservative path is a separate skip bucket from "no candidate" so the operator's tuning advice does not collapse.
- **Authorization-artifact gate.** `parse_proposals` rejects `match_pass="assistant"` proposals whose `assistant_ts` is non-empty but unparseable as ISO; the apply-time helper never has to handle a parse error on the field it uses to derive the JSONL date.
- **Apply-time re-verification.** New `_verify_jsonl_assistant_text` re-fetches the assistant line and checks hash + `chat_id`. Drift on either side collapses the proposal to `SKIP_ASSISTANT_DRIFT` rather than writing a row whose user-side stamp is intact but whose discriminator is gone. `_verify_jsonl_user_text` was also extended to check `chat_id` (defends against a polluted file with a same-ts/same-text record under the wrong owner; hash verification alone would let that slip past).

## CLI surface

```
python -m kai memory backfill-provenance <user_id>
    [--no-assistant-pass]                     # dry-run only
    [--assistant-max-user-gap-seconds <int>]  # dry-run only, default 600
    ...
```

Both flags follow the explicit-presence pattern of the existing scoring flags and are rejected in mutating modes with the same list-of-offenders error.

## Backward compatibility

- Legacy proposal files (no `match_pass` field) parse cleanly with `match_pass="user"` and empty assistant fields.
- The four user-side audit keys written to Mem0 are unchanged.
- Pre-image files are unchanged. Rollback is unchanged.
- Pass 1 proposals under the new schema, after dropping the four assistant-side audit fields, match the documented legacy projection.

## Test plan

- [x] `make check`: clean.
- [x] Full test suite: 4373 passed.
- [x] 32 new unit/integration cases covering: the full-window cache (both directions, malformed-`ts` collapse), the Pass 2 algorithm (paired user via assistant overlap, midnight boundary, no-preceding-user, max-gap, ambiguous user pairing, ambiguous assistant overlap, Pass-1-only short-circuit), per-record `chat_id`/`ts` validation on both directions, apply-time assistant drift and `chat_id` checks, the four-key user-only persisted metadata, `--no-assistant-pass` parity, parser schema gates (legacy-shape acceptance, empty-field rejection, malformed-`ts` rejection), Pass 2 CLI flag validation, the no-double-read property, the user-only diff projection contract, and the new report shape.
- [ ] Operator runs dry-run + apply against the existing `no_candidate` backlog and reports catch rate.

Closes #669. Refs #517.
