### PR TITLE
fix(pool): restore saved workspace before command and API reads

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -509,6 +509,13 @@ async def _switch_model(context: ContextTypes.DEFAULT_TYPE, chat_id: int, model:
     it survives restarts (behavior change from session-only).
     """
     pool = _get_pool(context)
+    # Resolve the effective workspace BEFORE setting the model. The
+    # resolver may switch the live instance into the saved workspace
+    # which resets `instance.model` to the default and reapplies any
+    # workspace-level override; doing that after set_model would undo
+    # the just-set model. With this ordering, set_model operates on
+    # the already-restored instance and the model assignment sticks.
+    workspace = str(await pool.get_effective_workspace(chat_id))
     pool.set_model(chat_id, model)
     # Persist to settings table so the choice survives restarts
     await sessions.set_user_setting(chat_id, "model", model)
@@ -516,7 +523,6 @@ async def _switch_model(context: ContextTypes.DEFAULT_TYPE, chat_id: int, model:
     # takes effect. Without this, a prior /workspace config model entry
     # shadows the user setting (workspace config has higher precedence)
     # and the model would revert on the next service restart.
-    workspace = str(pool.get_workspace(chat_id))
     await sessions.delete_workspace_config_setting(chat_id, workspace, "model")
     await pool.restart(chat_id)
     await _end_session(chat_id)
@@ -1192,7 +1198,8 @@ async def _do_switch_workspace(context: ContextTypes.DEFAULT_TYPE, chat_id: int,
     ws_config = await sessions.build_workspace_config(yaml_config, path, chat_id)
     await pool.change_workspace(chat_id, path, workspace_config=ws_config)
     # Per-user file confinement is handled at request time in webhook.py
-    # via pool.get_workspace(chat_id), so no global update needed here.
+    # via pool.get_effective_workspace(chat_id), so no global update needed
+    # here.
     await _end_session(chat_id)
 
     if path == home:
@@ -1218,7 +1225,7 @@ async def _switch_workspace(update: Update, context: ContextTypes.DEFAULT_TYPE, 
     # for THIS user, not a shared default.
     home = resolve_home_workspace(_chat_id(update), config)
 
-    if path == pool.get_workspace(_chat_id(update)):
+    if path == await pool.get_effective_workspace(_chat_id(update)):
         await update.message.reply_text("Already in that workspace.")
         return
 
@@ -1326,7 +1333,7 @@ async def _handle_workspace_config(
     chat_id = _chat_id(update)
     pool = _get_pool(context)
     config: Config = context.bot_data["config"]
-    workspace = pool.get_workspace(chat_id)
+    workspace = await pool.get_effective_workspace(chat_id)
     workspace_str = str(workspace)
 
     # Parse: "config [field] [value...]"
@@ -1634,7 +1641,7 @@ async def handle_workspaces(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     base, allowed = await sessions.resolve_workspace_access(chat_id, config)
     history = await sessions.get_workspace_history(chat_id)
     pool = _get_pool(context)
-    current = str(pool.get_workspace(chat_id))
+    current = str(await pool.get_effective_workspace(chat_id))
     # Per-user home for the listing's "Home" pin and the empty-state
     # short-circuit below.
     home = str(resolve_home_workspace(chat_id, config))
@@ -1716,7 +1723,9 @@ async def handle_workspace_callback(update: Update, context: ContextTypes.DEFAUL
             await sessions.delete_workspace_history(str(path), chat_id)
             await query.answer("That workspace is no longer allowed.")
             history = await sessions.get_workspace_history(chat_id)
-            keyboard = _workspaces_keyboard(history, str(pool.get_workspace(chat_id)), str(home), base, allowed)
+            keyboard = _workspaces_keyboard(
+                history, str(await pool.get_effective_workspace(chat_id)), str(home), base, allowed
+            )
             await query.edit_message_reply_markup(reply_markup=keyboard)
             return
         # Remove stale entries where the directory no longer exists
@@ -1724,13 +1733,15 @@ async def handle_workspace_callback(update: Update, context: ContextTypes.DEFAUL
             await sessions.delete_workspace_history(str(path), chat_id)
             await query.answer("That workspace no longer exists.")
             history = await sessions.get_workspace_history(chat_id)
-            keyboard = _workspaces_keyboard(history, str(pool.get_workspace(chat_id)), str(home), base, allowed)
+            keyboard = _workspaces_keyboard(
+                history, str(await pool.get_effective_workspace(chat_id)), str(home), base, allowed
+            )
             await query.edit_message_reply_markup(reply_markup=keyboard)
             return
         label = _short_workspace_name(str(path), base)
 
     # Already there — dismiss the keyboard
-    if path == pool.get_workspace(chat_id):
+    if path == await pool.get_effective_workspace(chat_id):
         await query.answer()
         await query.edit_message_text("No change.", reply_markup=InlineKeyboardMarkup([]))
         return
@@ -2051,7 +2062,7 @@ async def handle_project(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     sub = args[0].lower() if args else "list"
 
     if sub == "register":
-        current = Path(pool.get_workspace(chat_id))
+        current = Path(await pool.get_effective_workspace(chat_id))
         raw_name = args[1] if len(args) > 1 else current.name
         # The message text alone distinguishes success from rejection
         # for the user; the boolean exists for the /workspace new
@@ -2123,7 +2134,7 @@ async def handle_project(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             "No memory projects registered.\nUse /project register [name] in a workspace to create one."
         )
         return
-    current = Path(pool.get_workspace(chat_id))
+    current = Path(await pool.get_effective_workspace(chat_id))
     active = detect_active_memory_project(current, merged)
     lines = ["Memory projects:"]
     for project_id in sorted(merged):
@@ -2166,7 +2177,7 @@ async def handle_workspace(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
     # No args: show current workspace
     if not context.args:
-        current = pool.get_workspace(chat_id)
+        current = await pool.get_effective_workspace(chat_id)
         short = _short_workspace_name(str(current), base)
         if current == home:
             short = "Home"
@@ -3813,11 +3824,11 @@ async def _handle_response(
         # Workspace for write-scope routing, captured BEFORE the
         # fire-and-forget task is scheduled. The exchange being
         # extracted happened in THIS workspace; reading
-        # pool.get_workspace inside the task instead would let a
-        # /workspace switch that lands during the ingestion delay
-        # re-route the exchange's facts to a project the conversation
-        # never touched.
-        ingest_workspace = str(pool.get_workspace(chat_id))
+        # pool.get_effective_workspace inside the task instead would
+        # let a /workspace switch that lands during the ingestion
+        # delay re-route the exchange's facts to a project the
+        # conversation never touched.
+        ingest_workspace = str(await pool.get_effective_workspace(chat_id))
         task = asyncio.create_task(_ingest_memory())
         _pending_memory_tasks.add(task)
         task.add_done_callback(_pending_memory_tasks.discard)

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -359,8 +359,8 @@ def _start() -> None:
             # In webhook mode, this also registers the Telegram webhook with the API.
             await webhook.start(app, config)
             # Phase 3: per-user file confinement is handled at request
-            # time via pool.get_workspace(chat_id) in webhook.py. No
-            # global workspace sync needed at startup.
+            # time via pool.get_effective_workspace(chat_id) in
+            # webhook.py. No global workspace sync needed at startup.
 
             # Start the subprocess pool's idle eviction task.
             app.bot_data["pool"].start()

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -542,24 +542,29 @@ def _scope_change_targets(
     return targets
 
 
-def _scope_inputs(
+async def _scope_inputs(
     context: ContextTypes.DEFAULT_TYPE,
     chat_id: int,
 ) -> tuple[dict[str, MemoryProjectConfig], ActiveMemoryProject | None]:
     """Fetch the merged registry and the caller's active project.
 
-    The workspace comes from the subprocess pool (the same per-user
-    workspace scoped retrieval sees on the next turn). A missing
-    pool collapses to no-workspace semantics: no path means no
-    project authority, the same global-only posture scoped retrieval
-    takes for a None workspace.
+    The workspace comes from the subprocess pool's effective resolver
+    (the same per-user workspace scoped retrieval sees on the next
+    turn). Calling the resolver here rather than the sync getter
+    means the saved workspace gets restored eagerly when needed, so
+    /memory's scope detection lines up with the user's settings
+    instead of the home default the lazy pool would otherwise show.
+    A missing pool collapses to no-workspace semantics: no path
+    means no project authority, the same global-only posture scoped
+    retrieval takes for a None workspace.
     """
     config: Config = context.bot_data["config"]
     registry = merged_registry(config.memory_projects)
     pool: SubprocessPool | None = context.bot_data.get("pool")
     if pool is None:
         return registry, None
-    return registry, detect_active_memory_project(pool.get_workspace(chat_id), registry)
+    workspace = await pool.get_effective_workspace(chat_id)
+    return registry, detect_active_memory_project(workspace, registry)
 
 
 # ── Transcript provenance helpers ───────────────────────────────────
@@ -2063,7 +2068,7 @@ async def _send_fact_view(
         # non-extracted source, Mem0 fetch error).
         await _send_or_edit(update, "This memory no longer exists.", None, edit=True)
         return
-    registry, active = _scope_inputs(context, chat_id)
+    registry, active = await _scope_inputs(context, chat_id)
     scope_view = _build_scope_view(fact, registry, active, scoped_recall_enabled=memory.is_scoped_recall_enabled())
     provenance = read_transcript_provenance(fact.metadata)
     text, kb = _build_fact_view(fact, return_to, scope_view, provenance)
@@ -2233,7 +2238,7 @@ async def _send_scope_screen(
     if fact is None:
         await _send_or_edit(update, "This memory no longer exists.", None, edit=True)
         return
-    registry, active = _scope_inputs(context, chat_id)
+    registry, active = await _scope_inputs(context, chat_id)
     scope_view = _build_scope_view(fact, registry, active, scoped_recall_enabled=memory.is_scoped_recall_enabled())
     targets = _scope_change_targets(scope_view.resolved, registry)
     text, kb = _build_scope_screen(fact, scope_view, targets)

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -71,7 +71,15 @@ class SubprocessPool:
         self._services_info = services_info
         self._pool: dict[int, AgentBackend] = {}
         self._last_activity: dict[int, float] = {}
-        self._needs_workspace_restore: set[int] = set()
+        # Pending one-time setup for a freshly-created backend instance.
+        # Split into two flags so a command-path workspace resolver call
+        # can finish the workspace half without suppressing the DB-
+        # settings half that only the first send() applies. A conflated
+        # marker would let a /memory or /workspace read clear the
+        # pending state before send() ever had a chance to push the
+        # user's stored model/timeout into the new subprocess.
+        self._pending_workspace_restore: set[int] = set()
+        self._pending_settings_restore: set[int] = set()
         self._in_flight: set[int] = set()  # chat_ids with active send()
         self._eviction_task: asyncio.Task | None = None
 
@@ -88,7 +96,12 @@ class SubprocessPool:
         if chat_id not in self._pool:
             instance = self._create_instance(chat_id)
             self._pool[chat_id] = instance
-            self._needs_workspace_restore.add(chat_id)
+            # Mark both one-time setup steps as pending. The split
+            # matters at command-path callers that finish the workspace
+            # half via get_effective_workspace; settings still need to
+            # land on the first ordinary send().
+            self._pending_workspace_restore.add(chat_id)
+            self._pending_settings_restore.add(chat_id)
         self._last_activity[chat_id] = time.monotonic()
         return self._pool[chat_id]
 
@@ -106,7 +119,7 @@ class SubprocessPool:
         2. Global config defaults (from .env)
 
         Per-user DB overrides (set via /settings or /model) are applied
-        in _restore_workspace() since they require async DB access.
+        in _apply_user_db_settings() since they require async DB access.
         """
         user = self._config.get_user_config(chat_id)
 
@@ -305,13 +318,21 @@ class SubprocessPool:
         Route a prompt to the user's subprocess.
 
         On the first call for a newly created instance, restores the
-        user's saved workspace from the database before sending.
+        user's saved workspace and applies DB-stored model/timeout
+        before sending. Each piece runs only if the corresponding
+        pending flag is set, so a command-path resolver call that
+        already handled the workspace half does not duplicate work
+        here and a workspace-handled-but-settings-pending instance
+        still gets its DB settings on first send.
+
         Marks the user as in-flight to prevent eviction mid-stream.
         """
         instance = self.get(chat_id)
-        if chat_id in self._needs_workspace_restore:
-            await self._restore_workspace(chat_id, instance)
-            self._needs_workspace_restore.discard(chat_id)
+        if chat_id in self._pending_workspace_restore:
+            await self._attempt_workspace_restore(chat_id, instance)
+        if chat_id in self._pending_settings_restore:
+            await self._apply_user_db_settings(chat_id, instance)
+            self._pending_settings_restore.discard(chat_id)
         self._last_activity[chat_id] = time.monotonic()
         self._in_flight.add(chat_id)
         try:
@@ -321,16 +342,27 @@ class SubprocessPool:
             self._in_flight.discard(chat_id)
             self._last_activity[chat_id] = time.monotonic()
 
-    async def _restore_workspace(self, chat_id: int, instance: AgentBackend) -> None:
-        """Restore a user's saved workspace from the database.
+    async def _attempt_workspace_restore(self, chat_id: int, instance: AgentBackend) -> Path:
+        """Restore the saved workspace into a live instance.
 
-        Validates that the saved workspace is still an allowed path
-        using per-user workspace access (workspace_base from users.yaml,
-        allowed list from DB + global ALLOWED_WORKSPACES). An admin who
-        removes a path should not have users silently bypass the
-        restriction on their next message.
+        Reads `settings.workspace:<chat_id>`, validates path existence
+        and per-user workspace access (workspace_base from users.yaml,
+        allowed list from DB + global ALLOWED_WORKSPACES), and switches
+        the instance into the saved path when valid. Stale rows (path
+        gone or no longer allowed) are deleted so an admin removing a
+        path does not have users silently bypass the restriction.
+
+        Always clears the workspace-restore flag for `chat_id` before
+        returning, regardless of whether the saved row was valid,
+        stale, or absent. This is the invariant the command-path
+        resolver relies on: a single decision finalizes the effective
+        workspace for the live instance.
+
+        Returns the effective workspace path (saved when valid,
+        otherwise the user's home workspace).
         """
         saved = await sessions.get_setting(f"workspace:{chat_id}")
+        effective: Path | None = None
         if saved:
             ws_path = Path(saved)
             if not ws_path.is_dir():
@@ -341,7 +373,6 @@ class SubprocessPool:
                 )
                 await sessions.delete_setting(f"workspace:{chat_id}")
             else:
-                # Resolve per-user workspace access for the allowed check
                 base, allowed = await sessions.resolve_workspace_access(chat_id, self._config)
                 if not is_workspace_allowed(ws_path, base, allowed):
                     log.warning(
@@ -351,89 +382,109 @@ class SubprocessPool:
                     )
                     await sessions.delete_setting(f"workspace:{chat_id}")
                 else:
-                    # Layer DB overrides on top of YAML baseline so user's
-                    # per-workspace config (set via /workspace config) is
-                    # applied on startup, not just after explicit switches.
+                    # Layer DB overrides on top of YAML baseline so the
+                    # user's per-workspace config (set via /workspace
+                    # config) is applied on startup, not just after
+                    # explicit switches.
                     yaml_config = self._config.get_workspace_config(ws_path)
                     ws_config = await sessions.build_workspace_config(yaml_config, ws_path, chat_id)
                     await instance.change_workspace(ws_path, workspace_config=ws_config)
                     log.info("Restored workspace for user %d: %s", chat_id, ws_path)
+                    effective = ws_path
 
-        # Apply per-user DB overrides (set via /settings or /model).
-        # _create_instance() already applied users.yaml baselines, so we
-        # only need the DB layer here. Workspace config takes precedence
-        # over user settings (more specific wins).
+        self._pending_workspace_restore.discard(chat_id)
+        if effective is not None:
+            return effective
+        return resolve_home_workspace(chat_id, self._config)
+
+    async def _apply_user_db_settings(self, chat_id: int, instance: AgentBackend) -> None:
+        """Apply per-user DB-stored settings to a live instance.
+
+        Covers the model and timeout overrides set via /settings or
+        /model. _create_instance() already applied the users.yaml
+        baselines, so this layer only handles the DB tier. Workspace
+        config takes precedence over user settings (more specific
+        wins).
+
+        Called from send() on the first ordinary text turn after
+        instance creation. The command-path resolver never invokes
+        this helper: settings need a subprocess restart to take
+        effect when the model changes, which would interrupt any UI
+        operation that just wanted to read the effective workspace.
+        """
         db_settings = await sessions.get_user_settings(chat_id)
-        if db_settings:
-            # Track whether any flag-level setting changed (requires restart
-            # because the value is baked into the CLI command at startup)
-            needs_restart = False
+        if not db_settings:
+            return
 
-            # Read the backend identifier off the instance. Every
-            # concrete backend sets `backend_name` as a class attribute
-            # (claude_code / goose / codex / opencode). The ABC default
-            # is the empty string, so a test double or legacy stub that
-            # never overrides falls through to "claude" with a warning;
-            # this preserves the historical default for unknown shapes
-            # while keeping real backends out of the class-name if-chain
-            # that previously had to be extended for every new backend.
-            # Hoisted out of the DB-model branch because the ws_model
-            # guard below also needs it.
-            instance_backend = instance.backend_name
-            if not instance_backend:
-                log.warning(
-                    "Instance %s has empty backend_name; falling back to 'claude'. "
-                    "Concrete backends must set the backend_name class attribute.",
-                    type(instance).__name__,
-                )
-                instance_backend = "claude"
+        # Track whether any flag-level setting changed (requires restart
+        # because the value is baked into the CLI command at startup)
+        needs_restart = False
 
-            # Model: only apply if workspace config has a VALID model
-            # for this backend. A workspaces.yaml entry like
-            # `model: gpt-5.4-nano` applied to a codex instance is
-            # rejected by apply_workspace_model() at backend __init__
-            # time (the helper returns the current model and logs a
-            # warning), but the original WorkspaceConfig - still
-            # carrying the invalid model field - remains stored on
-            # instance.workspace_config. Treating any non-empty
-            # workspace_config.model as precedence-bearing therefore
-            # blocks a valid per-user DB model (e.g. gpt-5.4-mini)
-            # even though the workspace override was never applied.
-            # Re-run the same validation here so the precedence guard
-            # matches what was actually applied to instance.model.
-            ws_model_raw = instance.workspace_config.model if instance.workspace_config else None
-            ws_model_applied = bool(
-                ws_model_raw and validate_model_for_backend(ws_model_raw, instance_backend, instance.provider)
+        # Read the backend identifier off the instance. Every concrete
+        # backend sets `backend_name` as a class attribute (claude_code
+        # / goose / codex / opencode). The ABC default is the empty
+        # string, so a test double or legacy stub that never overrides
+        # falls through to "claude" with a warning; this preserves the
+        # historical default for unknown shapes while keeping real
+        # backends out of the class-name if-chain that previously had
+        # to be extended for every new backend. Hoisted out of the
+        # DB-model branch because the ws_model guard below also needs
+        # it.
+        instance_backend = instance.backend_name
+        if not instance_backend:
+            log.warning(
+                "Instance %s has empty backend_name; falling back to 'claude'. "
+                "Concrete backends must set the backend_name class attribute.",
+                type(instance).__name__,
             )
-            if not ws_model_applied and "model" in db_settings and db_settings["model"] != instance.model:
-                stored_model = db_settings["model"]
-                if validate_model_for_backend(stored_model, instance_backend, instance.provider):
-                    instance.model = stored_model
-                    needs_restart = True
-                else:
-                    log.warning(
-                        "Ignoring stored model '%s' for user %d (invalid for backend '%s'/provider '%s')",
-                        stored_model,
-                        chat_id,
-                        instance_backend,
-                        instance.provider,
-                    )
+            instance_backend = "claude"
 
-            # Timeout: workspace config timeout overrides user default
-            ws_timeout = instance.workspace_config.timeout if instance.workspace_config else None
-            if ws_timeout is None and "timeout" in db_settings:
-                try:
-                    instance.timeout_seconds = int(db_settings["timeout"])
-                except (ValueError, TypeError):
-                    log.warning("Corrupt timeout in DB for user %d", chat_id)
+        # Model: only apply if workspace config has a VALID model for
+        # this backend. A workspaces.yaml entry like
+        # `model: gpt-5.4-nano` applied to a codex instance is rejected
+        # by apply_workspace_model() at backend __init__ time (the
+        # helper returns the current model and logs a warning), but
+        # the original WorkspaceConfig still carrying the invalid
+        # model field remains stored on instance.workspace_config.
+        # Treating any non-empty workspace_config.model as
+        # precedence-bearing therefore blocks a valid per-user DB
+        # model (e.g. gpt-5.4-mini) even though the workspace override
+        # was never applied. Re-run the same validation here so the
+        # precedence guard matches what was actually applied to
+        # instance.model.
+        ws_model_raw = instance.workspace_config.model if instance.workspace_config else None
+        ws_model_applied = bool(
+            ws_model_raw and validate_model_for_backend(ws_model_raw, instance_backend, instance.provider)
+        )
+        if not ws_model_applied and "model" in db_settings and db_settings["model"] != instance.model:
+            stored_model = db_settings["model"]
+            if validate_model_for_backend(stored_model, instance_backend, instance.provider):
+                instance.model = stored_model
+                needs_restart = True
+            else:
+                log.warning(
+                    "Ignoring stored model '%s' for user %d (invalid for backend '%s'/provider '%s')",
+                    stored_model,
+                    chat_id,
+                    instance_backend,
+                    instance.provider,
+                )
 
-            # restart() kills the subprocess and spawns a new one, but
-            # the backend *object* is preserved. Mutations made
-            # above (timeout, model) survive the
-            # restart because the new subprocess reads from self.* attrs.
-            if needs_restart:
-                log.info("Restarting process for user %d: per-user DB overrides differ", chat_id)
-                await instance.restart()
+        # Timeout: workspace config timeout overrides user default
+        ws_timeout = instance.workspace_config.timeout if instance.workspace_config else None
+        if ws_timeout is None and "timeout" in db_settings:
+            try:
+                instance.timeout_seconds = int(db_settings["timeout"])
+            except (ValueError, TypeError):
+                log.warning("Corrupt timeout in DB for user %d", chat_id)
+
+        # restart() kills the subprocess and spawns a new one, but the
+        # backend *object* is preserved. Mutations made above (timeout,
+        # model) survive the restart because the new subprocess reads
+        # from self.* attrs.
+        if needs_restart:
+            log.info("Restarting process for user %d: per-user DB overrides differ", chat_id)
+            await instance.restart()
 
     # ── Per-user actions ────────────────────────────────────────────
 
@@ -492,8 +543,11 @@ class SubprocessPool:
         instance = self.get(chat_id)
         # Explicit workspace change supersedes any pending restore.
         # Without this, the next send() would restore the old saved
-        # workspace over the one just set.
-        self._needs_workspace_restore.discard(chat_id)
+        # workspace over the one just set. Settings-restore stays
+        # pending: an explicit /workspace switch carries no signal
+        # about user-level model or timeout preferences, and pre-split
+        # behavior accidentally suppressed the DB-settings job here.
+        self._pending_workspace_restore.discard(chat_id)
         await instance.change_workspace(new_workspace, workspace_config=workspace_config)
 
     async def restart(self, chat_id: int) -> None:
@@ -532,17 +586,73 @@ class SubprocessPool:
         instance = self.get(chat_id)
         instance.model = model
 
-    def get_workspace(self, chat_id: int) -> Path:
+    async def get_effective_workspace(self, chat_id: int) -> Path:
         """
-        Get the active workspace for a user.
+        Get the effective workspace for a user, eagerly restoring the
+        saved workspace into the live instance when one exists.
 
-        When no backend instance exists yet (user has not sent their
-        first message in this process lifetime) we resolve the per-user
-        home directory rather than the removed global default. This
-        matches what _build_backend would do on first send().
+        All user-visible workspace decisions (command displays,
+        equality checks, scope detection, file confinement) flow
+        through this method so command-path callers cannot observe
+        the home default while `settings.workspace:<chat_id>` points
+        at a valid saved path. The matching send-path restore stays
+        as a backstop.
+
+        Resolution order:
+
+        1. If a live instance exists AND has no pending workspace
+           restore: return its current workspace.
+        2. Else read `settings.workspace:<chat_id>`. If unset: return
+           the user's home workspace. If an instance exists, discard
+           the workspace-restore flag (the effective path IS home).
+        3. If set, validate path existence and per-user workspace
+           access. If invalid: delete the stale row, return home,
+           and discard the workspace-restore flag on any pre-existing
+           instance.
+        4. If valid: create or reuse the instance, then delegate to
+           `_attempt_workspace_restore` which performs the switch,
+           clears the flag, and returns the saved path.
+
+        The resolver only touches the workspace-restore flag.
+        `_pending_settings_restore` is the send path's responsibility,
+        so user-level model/timeout overrides still land on the first
+        ordinary text turn even if a command-path resolver call
+        already finalized the workspace half.
         """
-        instance = self.get_if_exists(chat_id)
-        return instance.workspace if instance else resolve_home_workspace(chat_id, self._config)
+        instance = self._pool.get(chat_id)
+        if instance is not None and chat_id not in self._pending_workspace_restore:
+            return instance.workspace
+
+        saved = await sessions.get_setting(f"workspace:{chat_id}")
+        if not saved:
+            if instance is not None:
+                self._pending_workspace_restore.discard(chat_id)
+            return resolve_home_workspace(chat_id, self._config)
+
+        ws_path = Path(saved)
+        base, allowed = await sessions.resolve_workspace_access(chat_id, self._config)
+        if not ws_path.is_dir() or not is_workspace_allowed(ws_path, base, allowed):
+            log.warning(
+                "Saved workspace for user %d invalid; clearing: %s",
+                chat_id,
+                saved,
+            )
+            await sessions.delete_setting(f"workspace:{chat_id}")
+            if instance is not None:
+                self._pending_workspace_restore.discard(chat_id)
+            return resolve_home_workspace(chat_id, self._config)
+
+        # Only now do we materialize an instance. Avoiding instance
+        # creation in the no-saved-row and stale-row branches keeps
+        # the resolver cheap for cold reads that just want to confirm
+        # "home is the right answer."
+        instance = self.get(chat_id)
+        # Re-validate inside _attempt_workspace_restore via its own
+        # DB read so a concurrent writer that cleared the setting
+        # between this check and the helper call is still handled
+        # correctly (it returns home instead of trying to switch to a
+        # since-deleted target).
+        return await self._attempt_workspace_restore(chat_id, instance)
 
     def is_alive(self, chat_id: int) -> bool:
         """True if this user's subprocess is running."""

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -1460,7 +1460,7 @@ async def _handle_send_file(request: web.Request) -> web.Response:
     pool = request.app.get("pool")
     if pool is None:
         return web.json_response({"error": "No workspace configured"}, status=403)
-    workspace = str(pool.get_workspace(chat_id))
+    workspace = str(await pool.get_effective_workspace(chat_id))
     # Allow files from either the workspace or DATA_DIR/files/.
     # DATA_DIR/files/ is where uploaded files now live (PR #145).
     # Confinement to DATA_DIR/"files" (not all of DATA_DIR) is deliberate;

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -557,7 +557,7 @@ def _make_mock_claude(model="sonnet", workspace=None, is_alive=True, provider="a
     pool.get_model = MagicMock(return_value=model)
     pool.get_effective_model = AsyncMock(return_value=model)
     pool.set_model = MagicMock()
-    pool.get_workspace = MagicMock(return_value=ws)
+    pool.get_effective_workspace = AsyncMock(return_value=ws)
     pool.is_alive = MagicMock(return_value=is_alive)
     pool.get_session_id = MagicMock(return_value=None)
     pool.restart = AsyncMock()
@@ -1296,6 +1296,54 @@ class TestHandleModelCallback:
         # Model switch must clear workspace config override to prevent
         # the stale entry from shadowing the user setting on restart.
         mock_delete.assert_called_once_with(ANY, ANY, "model")
+
+    @pytest.mark.asyncio
+    async def test_switch_model_resolver_runs_before_set_model(self, tmp_path):
+        """
+        /model x against a saved non-home workspace must leave the live
+        instance carrying "x", not a workspace-level override.
+
+        The resolver runs change_workspace under the hood, which resets
+        the live model to the default and re-applies any workspace-
+        level model override from the cached WorkspaceConfig. If the
+        resolver fires AFTER set_model, that reset clobbers the user's
+        chosen model with the stale override. Pin the ordering by
+        emulating the change_workspace side effect on the mock pool.
+        """
+        from kai.bot import _switch_model
+
+        pool = _make_mock_claude(model="default")
+        instance = pool.get_if_exists.return_value
+        saved_ws = tmp_path / "foo"
+
+        async def resolver_side_effect(_chat_id):
+            # change_workspace inside the resolver resets the live
+            # model to the default and re-applies the workspace's
+            # stale override.
+            instance.model = "old-override"
+            return saved_ws
+
+        def set_model_side_effect(_chat_id, model):
+            instance.model = model
+
+        pool.get_effective_workspace.side_effect = resolver_side_effect
+        pool.set_model.side_effect = set_model_side_effect
+
+        ctx = _make_context(claude=pool)
+        with (
+            patch("kai.bot.sessions.clear_session", new_callable=AsyncMock),
+            patch("kai.bot.sessions.set_user_setting", new_callable=AsyncMock),
+            patch("kai.bot.sessions.delete_workspace_config_setting", new_callable=AsyncMock) as mock_delete,
+        ):
+            await _switch_model(ctx, 12345, "x")
+
+        # Live instance carries the user's choice, not the workspace's
+        # stale override. Catches a regression where set_model runs
+        # before the resolver.
+        assert instance.model == "x"
+        # Delete targets the saved workspace, not home, because the
+        # resolver returned the saved path before delete was called.
+        mock_delete.assert_called_once_with(12345, str(saved_ws), "model")
 
 
 # ── handle_voice_command ─────────────────────────────────────────────
@@ -3759,7 +3807,7 @@ class TestHandleWorkspaceConfig:
 
         # Should persist the model setting
         mock_sessions.set_workspace_config_setting.assert_called_once_with(
-            12345, str(pool.get_workspace(12345)), "model", "opus"
+            12345, str(pool.get_effective_workspace.return_value), "model", "opus"
         )
         # Should apply config change (rebuild + change_workspace)
         mock_sessions.build_workspace_config.assert_called_once()
@@ -3783,7 +3831,7 @@ class TestHandleWorkspaceConfig:
             await _handle_workspace_config(update, ctx, "config timeout 300")
 
         mock_sessions.set_workspace_config_setting.assert_called_once_with(
-            12345, str(pool.get_workspace(12345)), "timeout", "300"
+            12345, str(pool.get_effective_workspace.return_value), "timeout", "300"
         )
         reply = update.message.reply_text.call_args[0][0]
         assert "300" in reply
@@ -3827,7 +3875,7 @@ class TestHandleWorkspaceConfig:
 
         # Should delete the env key entirely (empty dict -> delete)
         mock_sessions.delete_workspace_config_setting.assert_called_once_with(
-            12345, str(pool.get_workspace(12345)), "env"
+            12345, str(pool.get_effective_workspace.return_value), "env"
         )
         reply = update.message.reply_text.call_args[0][0]
         assert "Removed" in reply
@@ -3867,7 +3915,7 @@ class TestHandleWorkspaceConfig:
             await _handle_workspace_config(update, ctx, "config prompt Hello world")
 
         mock_sessions.set_workspace_config_setting.assert_called_once_with(
-            12345, str(pool.get_workspace(12345)), "prompt", "Hello world"
+            12345, str(pool.get_effective_workspace.return_value), "prompt", "Hello world"
         )
         pool.change_workspace.assert_called_once()
 
@@ -3886,7 +3934,7 @@ class TestHandleWorkspaceConfig:
             await _handle_workspace_config(update, ctx, "config prompt clear")
 
         mock_sessions.delete_workspace_config_setting.assert_called_once_with(
-            12345, str(pool.get_workspace(12345)), "prompt"
+            12345, str(pool.get_effective_workspace.return_value), "prompt"
         )
         pool.change_workspace.assert_called_once()
 
@@ -3904,7 +3952,9 @@ class TestHandleWorkspaceConfig:
         with self._patches(mock_sessions):
             await _handle_workspace_config(update, ctx, "config reset")
 
-        mock_sessions.delete_all_workspace_config.assert_called_once_with(12345, str(pool.get_workspace(12345)))
+        mock_sessions.delete_all_workspace_config.assert_called_once_with(
+            12345, str(pool.get_effective_workspace.return_value)
+        )
         pool.change_workspace.assert_called_once()
         reply = update.message.reply_text.call_args[0][0]
         assert "global defaults" in reply.lower()
@@ -3924,7 +3974,7 @@ class TestHandleWorkspaceConfig:
             await _handle_workspace_config(update, ctx, "config reset model")
 
         mock_sessions.delete_workspace_config_setting.assert_called_once_with(
-            12345, str(pool.get_workspace(12345)), "model"
+            12345, str(pool.get_effective_workspace.return_value), "model"
         )
         pool.change_workspace.assert_called_once()
         reply = update.message.reply_text.call_args[0][0]

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -3415,17 +3415,19 @@ class TestApplyScopeChange:
 
 
 class TestScopeInputs:
-    def test_missing_pool_collapses_to_no_active_project(self, context_factory, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_missing_pool_collapses_to_no_active_project(self, context_factory, monkeypatch):
         import kai.memory_projects as mp_mod
 
         monkeypatch.setattr(mp_mod, "_db_registry", {})
         ctx = context_factory()
         ctx.bot_data["config"].memory_projects = {"kai": _project_cfg("kai")}
-        registry, active = memory_command._scope_inputs(ctx, 100)
+        registry, active = await memory_command._scope_inputs(ctx, 100)
         assert "kai" in registry
         assert active is None
 
-    def test_pool_workspace_drives_detection(self, context_factory, monkeypatch, tmp_path):
+    @pytest.mark.asyncio
+    async def test_pool_workspace_drives_detection(self, context_factory, monkeypatch, tmp_path):
         import kai.memory_projects as mp_mod
 
         monkeypatch.setattr(mp_mod, "_db_registry", {})
@@ -3441,11 +3443,11 @@ class TestScopeInputs:
         ctx = context_factory()
         ctx.bot_data["config"].memory_projects = {"kai": cfg}
         pool = MagicMock()
-        pool.get_workspace.return_value = root
+        pool.get_effective_workspace = AsyncMock(return_value=root)
         ctx.bot_data["pool"] = pool
-        _registry, active = memory_command._scope_inputs(ctx, 100)
+        _registry, active = await memory_command._scope_inputs(ctx, 100)
         assert active is not None and active.project_id == "kai"
-        pool.get_workspace.assert_called_once_with(100)
+        pool.get_effective_workspace.assert_awaited_once_with(100)
 
 
 class TestStatsScopeSection:

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -229,7 +229,7 @@ class TestPerUserBackendRouting:
             patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value=db_settings),
             patch.object(instance, "restart", new_callable=AsyncMock),
         ):
-            await pool._restore_workspace(111, instance)
+            await pool._apply_user_db_settings(111, instance)
             # "opus" is invalid for openai - should be ignored, model stays at gpt-5.4
             assert instance.model == "gpt-5.4"
 
@@ -480,17 +480,23 @@ class TestPropertyAccessors:
         ):
             assert await pool.get_effective_model(999) == "opus"
 
-    def test_get_workspace_no_instance(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_get_effective_workspace_no_instance_no_saved(self, tmp_path, monkeypatch):
         """
-        get_workspace returns the per-user default when no instance exists.
+        get_effective_workspace falls back to the per-user home when no
+        instance exists and no saved workspace setting is recorded.
 
-        Post-#353 the fallback resolves through resolve_home_workspace
-        instead of the removed global Config field, landing the user in
-        DATA_DIR/home/<chat_id>/.
+        The fallback resolves through resolve_home_workspace, landing the
+        user in DATA_DIR/home/<chat_id>/.
         """
         monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+
+        async def _no_setting(key: str) -> str | None:
+            return None
+
+        monkeypatch.setattr("kai.pool.sessions.get_setting", _no_setting)
         pool = SubprocessPool(config=_make_config(), services_info=[])
-        assert pool.get_workspace(999) == tmp_path / "home" / "999"
+        assert await pool.get_effective_workspace(999) == tmp_path / "home" / "999"
 
     def test_is_alive_no_instance(self):
         """is_alive returns False when no instance exists."""
@@ -587,8 +593,12 @@ class TestWorkspaceRestoration:
                 yield  # make it a generator
 
             mock_send.side_effect = empty_send
-            async for _ in pool.send("test", chat_id=111):
-                pass
+            # send() calls _apply_user_db_settings after the workspace half;
+            # patch get_user_settings so the second helper finds no overrides
+            # and the send path completes without restarting the subprocess.
+            with patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value={}):
+                async for _ in pool.send("test", chat_id=111):
+                    pass
             mock_change.assert_called_once()
 
     @pytest.mark.asyncio
@@ -607,11 +617,10 @@ class TestWorkspaceRestoration:
         # Simulate DB overrides: user set model=opus
         db_settings = {"model": "opus"}
         with (
-            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
             patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value=db_settings),
             patch.object(instance, "restart", new_callable=AsyncMock) as mock_restart,
         ):
-            await pool._restore_workspace(111, instance)
+            await pool._apply_user_db_settings(111, instance)
             # Model is a CLI flag, so changing it triggers restart
             assert instance.model == "opus"
             mock_restart.assert_called_once()
@@ -623,11 +632,10 @@ class TestWorkspaceRestoration:
         instance = pool.get(111)
 
         with (
-            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
             patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value={}),
             patch.object(instance, "restart", new_callable=AsyncMock) as mock_restart,
         ):
-            await pool._restore_workspace(111, instance)
+            await pool._apply_user_db_settings(111, instance)
             mock_restart.assert_not_called()
 
     @pytest.mark.asyncio
@@ -645,7 +653,7 @@ class TestWorkspaceRestoration:
             patch("kai.pool.sessions.delete_setting", new_callable=AsyncMock) as mock_delete,
         ):
             # The restore should detect the path doesn't exist and delete
-            await pool._restore_workspace(111, pool.get(111))
+            await pool._attempt_workspace_restore(111, pool.get(111))
             mock_delete.assert_called_once_with("workspace:111")
 
     @pytest.mark.asyncio
@@ -665,10 +673,9 @@ class TestWorkspaceRestoration:
                 return_value=(None, [ws]),
             ),
             patch("kai.pool.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
-            patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value={}),
             patch.object(instance, "change_workspace", new_callable=AsyncMock) as mock_change,
         ):
-            await pool._restore_workspace(111, instance)
+            await pool._attempt_workspace_restore(111, instance)
             mock_change.assert_called_once()
 
     @pytest.mark.asyncio
@@ -690,9 +697,8 @@ class TestWorkspaceRestoration:
                 return_value=(other_base, []),
             ),
             patch("kai.pool.sessions.delete_setting", new_callable=AsyncMock) as mock_delete,
-            patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value={}),
         ):
-            await pool._restore_workspace(111, pool.get(111))
+            await pool._attempt_workspace_restore(111, pool.get(111))
             mock_delete.assert_called_once_with("workspace:111")
 
     @pytest.mark.asyncio
@@ -703,7 +709,7 @@ class TestWorkspaceRestoration:
         rejects) is dropped by apply_workspace_model() but the original
         WorkspaceConfig object is still stored on instance.workspace_config
         with the invalid model field. The precedence guard in
-        _restore_workspace must NOT treat that stored field as
+        _apply_user_db_settings must NOT treat that stored field as
         "workspace model applied"; otherwise a perfectly valid per-user
         DB model (gpt-5.4-mini) gets silently suppressed by a never-
         applied workspace override. Re-validate ws_model against the
@@ -746,11 +752,10 @@ class TestWorkspaceRestoration:
         # DB has a valid per-user model override: gpt-5.4-mini.
         db_settings = {"model": "gpt-5.4-mini"}
         with (
-            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
             patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value=db_settings),
             patch.object(instance, "restart", new_callable=AsyncMock) as mock_restart,
         ):
-            await pool._restore_workspace(111, instance)
+            await pool._apply_user_db_settings(111, instance)
             # The DB model wins because the workspace model was never
             # actually applied (rejected by apply_workspace_model).
             assert instance.model == "gpt-5.4-mini"
@@ -774,10 +779,9 @@ class TestWorkspaceRestoration:
                 return_value=(base, []),
             ),
             patch("kai.pool.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
-            patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value={}),
             patch.object(instance, "change_workspace", new_callable=AsyncMock) as mock_change,
         ):
-            await pool._restore_workspace(111, instance)
+            await pool._attempt_workspace_restore(111, instance)
             mock_change.assert_called_once()
 
 
@@ -786,10 +790,11 @@ class TestWorkspaceRestoration:
 
 class TestRestoreBackendNameDispatch:
     """
-    _restore_workspace reads the backend identifier off `instance.backend_name`
-    instead of inspecting the concrete class name. Pin each real backend's
-    value plus the falsy fallback so an OpenCode (or any future) backend
-    cannot regress the dispatch by setting backend_name incorrectly.
+    _apply_user_db_settings reads the backend identifier off
+    `instance.backend_name` instead of inspecting the concrete class
+    name. Pin each real backend's value plus the falsy fallback so an
+    OpenCode (or any future) backend cannot regress the dispatch by
+    setting backend_name incorrectly.
     """
 
     @pytest.mark.asyncio
@@ -808,12 +813,11 @@ class TestRestoreBackendNameDispatch:
 
         db_settings = {"model": "gpt-5.4-mini"}
         with (
-            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
             patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value=db_settings),
             patch("kai.pool.validate_model_for_backend", return_value=True) as mock_validate,
             patch.object(instance, "restart", new_callable=AsyncMock),
         ):
-            await pool._restore_workspace(111, instance)
+            await pool._apply_user_db_settings(111, instance)
             # Validator received the instance's backend_name, not "claude".
             # validate_model_for_backend may also be called for ws_model_raw,
             # but ws_model_raw is None here so the only invocation is for
@@ -836,12 +840,11 @@ class TestRestoreBackendNameDispatch:
         db_settings = {"model": "opus"}
         with (
             caplog.at_level(logging.WARNING, logger="kai.pool"),
-            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
             patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value=db_settings),
             patch("kai.pool.validate_model_for_backend", return_value=True) as mock_validate,
             patch.object(instance, "restart", new_callable=AsyncMock),
         ):
-            await pool._restore_workspace(111, instance)
+            await pool._apply_user_db_settings(111, instance)
             # Fallback string is "claude".
             mock_validate.assert_called_once_with("opus", "claude", "anthropic")
         # Warning was logged about the empty backend_name.
@@ -1160,3 +1163,332 @@ class TestEvictionTOCTOU:
         assert in_pool_during_shutdown == [True]
         # Removed after shutdown completed
         assert 111 not in pool._pool
+
+
+# ── Effective workspace resolver ────────────────────────────────────
+
+
+class TestGetEffectiveWorkspace:
+    """
+    The resolver replaces the sync home-biased pool.get_workspace.
+    Command and API surfaces consult it to find the user's effective
+    workspace; the resolver eagerly restores the saved workspace into
+    a live instance so callers cannot observe the home default while
+    a valid saved row exists.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_instance_no_saved_returns_home(self, tmp_path, monkeypatch):
+        """Cold state, no saved row -> home; no instance materialized."""
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        with patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None):
+            result = await pool.get_effective_workspace(999)
+        assert result == tmp_path / "home" / "999"
+        assert 999 not in pool._pool
+
+    @pytest.mark.asyncio
+    async def test_no_instance_saved_valid_returns_saved_and_restores(self, tmp_path, monkeypatch):
+        """Cold state, saved row valid -> saved path; instance created and switched."""
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+        ws = tmp_path / "foo"
+        ws.mkdir()
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        with (
+            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=str(ws)),
+            patch(
+                "kai.pool.sessions.resolve_workspace_access",
+                new_callable=AsyncMock,
+                return_value=(None, [ws]),
+            ),
+            patch("kai.pool.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
+            patch.object(SubprocessPool, "_create_instance") as mock_create,
+        ):
+            stub = MagicMock()
+            stub.change_workspace = AsyncMock()
+            mock_create.return_value = stub
+            result = await pool.get_effective_workspace(999)
+        assert result == ws
+        assert 999 in pool._pool
+        stub.change_workspace.assert_awaited_once()
+        # Workspace half done; settings half stays pending for the
+        # first send().
+        assert 999 not in pool._pending_workspace_restore
+        assert 999 in pool._pending_settings_restore
+
+    @pytest.mark.asyncio
+    async def test_no_instance_saved_missing_clears_and_returns_home(self, tmp_path, monkeypatch):
+        """Cold state, saved row pointing to a deleted dir -> home; setting deleted; no instance."""
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        with (
+            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=str(tmp_path / "gone")),
+            patch(
+                "kai.pool.sessions.resolve_workspace_access",
+                new_callable=AsyncMock,
+                return_value=(None, []),
+            ),
+            patch("kai.pool.sessions.delete_setting", new_callable=AsyncMock) as mock_delete,
+        ):
+            result = await pool.get_effective_workspace(999)
+        assert result == tmp_path / "home" / "999"
+        mock_delete.assert_awaited_once_with("workspace:999")
+        assert 999 not in pool._pool
+
+    @pytest.mark.asyncio
+    async def test_no_instance_saved_disallowed_clears_and_returns_home(self, tmp_path, monkeypatch):
+        """Cold state, saved row valid path but disallowed -> home; setting deleted; no instance."""
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+        ws = tmp_path / "evicted"
+        ws.mkdir()
+        other_base = tmp_path / "base"
+        other_base.mkdir()
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        with (
+            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=str(ws)),
+            patch(
+                "kai.pool.sessions.resolve_workspace_access",
+                new_callable=AsyncMock,
+                return_value=(other_base, []),
+            ),
+            patch("kai.pool.sessions.delete_setting", new_callable=AsyncMock) as mock_delete,
+        ):
+            result = await pool.get_effective_workspace(999)
+        assert result == tmp_path / "home" / "999"
+        mock_delete.assert_awaited_once_with("workspace:999")
+        assert 999 not in pool._pool
+
+    @pytest.mark.asyncio
+    async def test_instance_not_pending_returns_instance_workspace(self, tmp_path, monkeypatch):
+        """Warm instance with no pending flag -> short-circuit to instance.workspace, no DB read."""
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        instance = pool.get(111)
+        # Simulate a previous resolver/send having finalized the
+        # workspace half.
+        pool._pending_workspace_restore.discard(111)
+        with patch("kai.pool.sessions.get_setting", new_callable=AsyncMock) as mock_setting:
+            result = await pool.get_effective_workspace(111)
+        assert result == instance.workspace
+        mock_setting.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pending_instance_saved_valid_switches_and_clears(self, tmp_path, monkeypatch):
+        """Pending instance with saved valid row gets switched and the workspace-pending flag clears."""
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+        ws = tmp_path / "foo"
+        ws.mkdir()
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        instance = pool.get(111)
+        assert 111 in pool._pending_workspace_restore
+        assert 111 in pool._pending_settings_restore
+        with (
+            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=str(ws)),
+            patch(
+                "kai.pool.sessions.resolve_workspace_access",
+                new_callable=AsyncMock,
+                return_value=(None, [ws]),
+            ),
+            patch("kai.pool.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
+            patch.object(instance, "change_workspace", new_callable=AsyncMock) as mock_change,
+        ):
+            result = await pool.get_effective_workspace(111)
+        assert result == ws
+        mock_change.assert_awaited_once()
+        assert 111 not in pool._pending_workspace_restore
+        # Settings half MUST stay pending so the next send() applies
+        # DB-stored model/timeout. Splitting the marker is the entire
+        # point of the resolver vs send-path separation.
+        assert 111 in pool._pending_settings_restore
+
+    @pytest.mark.asyncio
+    async def test_pending_instance_saved_missing_clears_and_returns_home(self, tmp_path, monkeypatch):
+        """Pending instance with saved row pointing nowhere -> home, setting deleted, pending cleared."""
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        pool.get(111)
+        with (
+            patch(
+                "kai.pool.sessions.get_setting",
+                new_callable=AsyncMock,
+                return_value=str(tmp_path / "gone"),
+            ),
+            patch(
+                "kai.pool.sessions.resolve_workspace_access",
+                new_callable=AsyncMock,
+                return_value=(None, []),
+            ),
+            patch("kai.pool.sessions.delete_setting", new_callable=AsyncMock) as mock_delete,
+        ):
+            result = await pool.get_effective_workspace(111)
+        assert result == tmp_path / "home" / "111"
+        mock_delete.assert_awaited_once_with("workspace:111")
+        assert 111 not in pool._pending_workspace_restore
+        assert 111 in pool._pending_settings_restore
+
+    @pytest.mark.asyncio
+    async def test_pending_instance_saved_disallowed_clears_and_returns_home(self, tmp_path, monkeypatch):
+        """Pending instance with saved path no longer allowed -> home, setting deleted, pending cleared."""
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+        ws = tmp_path / "evicted"
+        ws.mkdir()
+        other_base = tmp_path / "base"
+        other_base.mkdir()
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        pool.get(111)
+        with (
+            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=str(ws)),
+            patch(
+                "kai.pool.sessions.resolve_workspace_access",
+                new_callable=AsyncMock,
+                return_value=(other_base, []),
+            ),
+            patch("kai.pool.sessions.delete_setting", new_callable=AsyncMock) as mock_delete,
+        ):
+            result = await pool.get_effective_workspace(111)
+        assert result == tmp_path / "home" / "111"
+        mock_delete.assert_awaited_once_with("workspace:111")
+        assert 111 not in pool._pending_workspace_restore
+        assert 111 in pool._pending_settings_restore
+
+    @pytest.mark.asyncio
+    async def test_pending_instance_no_saved_clears_and_returns_home(self, tmp_path, monkeypatch):
+        """Pending instance with no saved row -> home, no setting writes, pending cleared."""
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        pool.get(111)
+        with patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None):
+            result = await pool.get_effective_workspace(111)
+        assert result == tmp_path / "home" / "111"
+        assert 111 not in pool._pending_workspace_restore
+        assert 111 in pool._pending_settings_restore
+
+
+# ── send() after resolver: P1 guard for DB-settings restore ─────────
+
+
+class TestSendAppliesSettingsAfterResolverCall:
+    """
+    Calling get_effective_workspace before send() must NOT suppress the
+    DB-settings restore that send() owns. The pending marker is split
+    so the resolver only clears the workspace half; the first send()
+    still picks up and applies the user's stored model/timeout.
+
+    If a future refactor accidentally re-conflates the markers, these
+    tests catch the regression.
+    """
+
+    @pytest.mark.asyncio
+    async def test_resolver_then_send_applies_db_model(self, tmp_path, monkeypatch):
+        """Resolver call before send still leaves DB model application for send."""
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+        ws = tmp_path / "foo"
+        ws.mkdir()
+        user = UserConfig(telegram_id=111, name="alice")
+        config = _make_config(user_configs={111: user})
+        pool = SubprocessPool(config=config, services_info=[])
+
+        with (
+            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=str(ws)),
+            patch(
+                "kai.pool.sessions.resolve_workspace_access",
+                new_callable=AsyncMock,
+                return_value=(None, [ws]),
+            ),
+            patch("kai.pool.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
+        ):
+            # Step 1: command-path resolver call finishes the workspace
+            # half early.
+            await pool.get_effective_workspace(111)
+
+        instance = pool.get(111)
+        # The resolver applied change_workspace via the real instance
+        # method which resets self.model; bring it back to the global
+        # default so the DB model differs.
+        instance.model = "sonnet"
+        assert 111 not in pool._pending_workspace_restore
+        assert 111 in pool._pending_settings_restore
+
+        with (
+            patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value={"model": "opus"}),
+            patch.object(instance, "restart", new_callable=AsyncMock) as mock_restart,
+            patch.object(instance, "send", new_callable=MagicMock) as mock_send,
+        ):
+
+            async def empty_send(*args, **kwargs):
+                return
+                yield
+
+            mock_send.side_effect = empty_send
+            async for _ in pool.send("hello", chat_id=111):
+                pass
+
+        # Step 2: send() picked up the still-pending settings flag and
+        # applied the DB model. If the resolver had wrongly cleared
+        # _pending_settings_restore, this assertion would fail.
+        assert instance.model == "opus"
+        mock_restart.assert_awaited_once()
+        assert 111 not in pool._pending_settings_restore
+
+    @pytest.mark.asyncio
+    async def test_resolver_then_send_applies_db_timeout(self, tmp_path, monkeypatch):
+        """Resolver call before send still leaves DB timeout application for send."""
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+        ws = tmp_path / "foo"
+        ws.mkdir()
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+
+        with (
+            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=str(ws)),
+            patch(
+                "kai.pool.sessions.resolve_workspace_access",
+                new_callable=AsyncMock,
+                return_value=(None, [ws]),
+            ),
+            patch("kai.pool.sessions.build_workspace_config", new_callable=AsyncMock, return_value=None),
+        ):
+            await pool.get_effective_workspace(111)
+
+        instance = pool.get(111)
+        assert 111 not in pool._pending_workspace_restore
+        assert 111 in pool._pending_settings_restore
+
+        with (
+            patch(
+                "kai.pool.sessions.get_user_settings",
+                new_callable=AsyncMock,
+                return_value={"timeout": "120"},
+            ),
+            patch.object(instance, "restart", new_callable=AsyncMock),
+            patch.object(instance, "send", new_callable=MagicMock) as mock_send,
+        ):
+
+            async def empty_send(*args, **kwargs):
+                return
+                yield
+
+            mock_send.side_effect = empty_send
+            async for _ in pool.send("hello", chat_id=111):
+                pass
+
+        assert instance.timeout_seconds == 120
+        assert 111 not in pool._pending_settings_restore
+
+    @pytest.mark.asyncio
+    async def test_change_workspace_keeps_settings_pending(self, tmp_path, monkeypatch):
+        """An explicit /workspace switch must NOT suppress the DB-settings restore."""
+        monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+        ws = tmp_path / "foo"
+        ws.mkdir()
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        with patch("kai.pool.SubprocessPool._create_instance") as mock_create:
+            stub = MagicMock()
+            stub.change_workspace = AsyncMock()
+            mock_create.return_value = stub
+            await pool.change_workspace(111, ws)
+        # Workspace flag cleared by the explicit switch...
+        assert 111 not in pool._pending_workspace_restore
+        # ...but settings flag is preserved so the next send applies
+        # DB-stored model/timeout. Pre-split behavior accidentally
+        # cleared both here.
+        assert 111 in pool._pending_settings_restore

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -325,11 +325,12 @@ class TestUpdateJob:
 @pytest.fixture
 def send_file_request(tmp_path):
     """Create a mock request for the send-file endpoint with workspace confinement."""
-    # Post-#353 send-file resolves the workspace via pool.get_workspace(chat_id)
+    # Send-file resolves the workspace via pool.get_effective_workspace(chat_id)
     # rather than a global app["workspace"] slot. The fixture supplies a mock
-    # pool whose get_workspace() returns tmp_path so path confinement passes.
+    # pool whose get_effective_workspace() returns tmp_path so path confinement
+    # passes.
     mock_pool = MagicMock()
-    mock_pool.get_workspace = MagicMock(return_value=tmp_path)
+    mock_pool.get_effective_workspace = AsyncMock(return_value=tmp_path)
     request = MagicMock(spec=web.Request)
     request.app = {
         "webhook_secret": "test-secret",


### PR DESCRIPTION
## Summary

- Replace `pool.get_workspace` (sync, home-biased) with `async pool.get_effective_workspace` so command and API surfaces no longer observe the home default while `settings.workspace:<chat_id>` points at a valid saved path
- Split the single pending-restore marker into separate workspace and DB-settings flags so a command-path resolver call cannot suppress the first-send application of stored model and timeout overrides
- Reorder `_switch_model` to resolve the effective workspace before mutating the live model, preventing the resolver's `change_workspace` from undoing the user's `/model` choice via a stale workspace-level override
- Convert `memory_command._scope_inputs` from sync to async so `/memory` scope detection sees the resolver's restored workspace
- Add nine resolver state-table tests plus regression tests for the marker split, `_switch_model` ordering, and explicit `change_workspace` settings preservation

Closes #677.

## Test plan

- [x] `make check` (ruff check + format) green
- [x] `make test` green (4389 passed, 1 skipped)
- [x] `tests/test_pool.py::TestGetEffectiveWorkspace` covers no-instance, instance-pending, and instance-not-pending state combinations against unset, valid, missing, and disallowed saved rows
- [x] `tests/test_pool.py::TestSendAppliesSettingsAfterResolverCall` locks the marker-split regression for model + timeout + explicit switch
- [x] `tests/test_bot.py::TestHandleModelCallback::test_switch_model_resolver_runs_before_set_model` locks the `/model` ordering against a stale workspace-level override
- [ ] Manual smoke: restart the service, run `/workspace` against a saved non-home workspace, confirm the saved path renders (not home)
- [ ] Manual smoke: same setup, run `/memory` and confirm the project scope detection matches the saved workspace
- [ ] Manual smoke: same setup, run `/model x`, restart the service, confirm the model setting persists
