### PR TITLE
fix(bot): stable-prefix filter for live Telegram streaming updates

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -322,6 +322,18 @@ _CLOSE_PUNCT_CHARS = frozenset("\"')]`")
 # Markdown list-item line shapes.
 _LIST_LINE_WITH_CONTENT_RE = re.compile(r"^[ ]*([-*+]|\d+\.)\s+\S")
 _LIST_LINE_RE = re.compile(r"^[ ]*([-*+]|\d+\.)(\s|$)")
+# Ordered-list marker at the start of a line. Used in _sentence_cuts to
+# advance past the marker period; without this, `1. Item one` would
+# treat the `.` in `1.` as a sentence boundary and publish a bare
+# numbered marker as if it were a completed sentence.
+_ORDERED_LIST_MARKER_RE = re.compile(r"^[ ]*\d+\.(\s|$)")
+# Looser pattern that also matches a forming next-item marker. The
+# stream may have emitted just the digits of the next ordered-list
+# marker (`3`) before the period and following text arrive; treating
+# the partial marker as a list-item signal lets list_item cuts fire on
+# the previous complete items even while the next marker is still
+# mid-emission.
+_LIST_LINE_FORMING_RE = re.compile(r"^[ ]*(\d+\.?|[-*+])(\s|$)")
 # Minimum length for the long-span fallback to fire. Picked to be long
 # enough that a coherent paragraph is likely visible, but short enough
 # that streamed paragraphs reach it before the user gives up watching.
@@ -546,8 +558,15 @@ def _sentence_cuts(working: str) -> list[int]:
         if _is_fence_line(line):
             in_fence = not in_fence
         elif not in_fence:
-            j = 0
             line_len = len(line)
+            # Advance past an ordered-list marker so its period isn't
+            # treated as a sentence terminator. The marker `.` is
+            # followed by whitespace and would otherwise satisfy the
+            # sentence-end predicate, letting `1.` publish as if it
+            # were a complete sentence while the list item is still
+            # being typed.
+            list_match = _ORDERED_LIST_MARKER_RE.match(line)
+            j = list_match.end() if list_match else 0
             while j < line_len:
                 if line[j] in _SENTENCE_END_CHARS:
                     # Extend the cut through any closing-punctuation or
@@ -602,12 +621,15 @@ def _list_item_cuts(working: str) -> list[int]:
         if i + 1 >= len(lines):
             continue
         next_line = lines[i + 1]
-        # A list-item boundary fires only when the next line is either
-        # blank or itself a list-item line. That keeps prose paragraphs
-        # after a list intact (the paragraph boundary handles them) and
-        # avoids cutting a list short when the next line is still
-        # building.
-        if not next_line.strip() or _LIST_LINE_RE.match(next_line):
+        # A list-item boundary fires when the next line is either
+        # blank, a fully-formed list-item line, or a still-forming
+        # marker (bare digits like `3` before the period arrives, a
+        # lone bullet character). That keeps prose paragraphs after a
+        # list intact (the paragraph boundary handles them), avoids
+        # cutting a list short when the next line is still building,
+        # and accepts the partial next-item marker as evidence that
+        # the previous item is complete.
+        if not next_line.strip() or _LIST_LINE_FORMING_RE.match(next_line):
             cuts.append(starts[i] + len(line))
     return cuts
 

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -297,6 +297,400 @@ def _truncate_for_telegram(text: str, max_len: int = 4096) -> str:
     return text[: max_len - 4] + "\n..."
 
 
+# ── Streaming publishable-prefix filter ──────────────────────────────
+#
+# Telegram's live message edits operate on raw accumulated text from each
+# StreamEvent. Backend chunks arrive at protocol boundaries (tokens,
+# model-defined messages) which rarely line up with human boundaries. The
+# helper below answers "is there a stable prefix of this accumulated text
+# I can publish right now?" and returns the longest such prefix or None.
+#
+# The transport layer (_handle_response) consults this helper for every
+# streamed update; a None answer means "withhold this update; the final
+# response path will still deliver everything at completion". A non-None
+# answer is the candidate text to create or edit the live message with.
+# Backends are untouched - this is purely a Telegram-side policy.
+
+# Triple-backtick fence delimiter, allowing up to three leading spaces
+# (CommonMark allows 0-3) before the opening sequence.
+_FENCE_LINE_RE = re.compile(r"^[ ]{0,3}```")
+# Sentence terminators.
+_SENTENCE_END_CHARS = frozenset(".?!")
+# Closing punctuation that may follow a sentence terminator and stay part
+# of the same sentence (quote-then-period style).
+_CLOSE_PUNCT_CHARS = frozenset("\"')]`")
+# Markdown list-item line shapes.
+_LIST_LINE_WITH_CONTENT_RE = re.compile(r"^[ ]*([-*+]|\d+\.)\s+\S")
+_LIST_LINE_RE = re.compile(r"^[ ]*([-*+]|\d+\.)(\s|$)")
+_LIST_LINE_EMPTY_MARKER_RE = re.compile(r"^[ ]*([-*+]|\d+\.)\s*$")
+# Setext-style ATX headings; we care about the bare-marker case where the
+# stream paused after the hashes but before any title text arrived.
+_HEADING_EMPTY_MARKER_RE = re.compile(r"^#{1,6}\s*$")
+# Minimum length for the long-span fallback to fire. Picked to be long
+# enough that a coherent paragraph is likely visible, but short enough
+# that streamed paragraphs reach it before the user gives up watching.
+_LONG_SPAN_MIN_CHARS = 240
+# Candidate kinds ordered by preference when two kinds resolve to the
+# same cut position. Lower number = stronger boundary, evaluated first.
+_KIND_PRIORITY = {
+    "sentence": 1,
+    "paragraph": 2,
+    "list_item": 3,
+    "closed_fence": 4,
+    "long_span": 5,
+    "full": 6,
+}
+
+
+def _is_fence_line(line: str) -> bool:
+    return bool(_FENCE_LINE_RE.match(line))
+
+
+def _has_open_fenced_code(text: str) -> bool:
+    """True iff `text` has an odd number of triple-backtick fence lines.
+
+    An odd count means the last fence opened is still unclosed; the helper
+    must not publish through an open fenced block because the next chunk
+    is going to land inside it.
+    """
+    fences = sum(1 for line in text.splitlines() if _is_fence_line(line))
+    return (fences % 2) == 1
+
+
+def _segments_outside_fences(text: str) -> str:
+    """Return the lines of `text` that sit outside fenced code blocks.
+
+    Used by the inline-Markdown checks: backticks and brackets inside a
+    fenced code block are content, not Markdown delimiters, and must not
+    affect the balance counts.
+    """
+    parts = []
+    in_fence = False
+    for line in text.splitlines(keepends=True):
+        if _is_fence_line(line.rstrip("\n")):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            parts.append(line)
+    return "".join(parts)
+
+
+def _has_unbalanced_inline_markdown(text: str) -> bool:
+    """True iff `text` has an unbalanced inline-code span or link.
+
+    Checks (all candidate-wide per spec §6 D6 N-4 fix):
+      - Odd count of unescaped single backticks outside fenced regions.
+      - Unmatched `[` (no later `]`) anywhere outside fenced regions.
+      - Unmatched `](` (no later closing `)`) anywhere outside fenced
+        regions, which catches links whose target was cut mid-stream.
+    """
+    outside = _segments_outside_fences(text)
+    n = len(outside)
+
+    # Backtick parity, skipping backslash-escaped chars.
+    backticks = 0
+    i = 0
+    while i < n:
+        if outside[i] == "\\" and i + 1 < n:
+            i += 2
+            continue
+        if outside[i] == "`":
+            backticks += 1
+        i += 1
+    if backticks % 2 == 1:
+        return True
+
+    # Bracket + link-target balance. A `[label]` reference link closes
+    # cleanly; `[label](target)` opens a target on the matching `]` and
+    # tracks paren depth until it closes. An unbalanced state at end of
+    # text means the stream cut inside an open link.
+    open_brackets = 0
+    in_link_target = False
+    paren_depth = 0
+    i = 0
+    while i < n:
+        if outside[i] == "\\" and i + 1 < n:
+            i += 2
+            continue
+        c = outside[i]
+        if not in_link_target:
+            if c == "[":
+                open_brackets += 1
+            elif c == "]" and open_brackets > 0:
+                open_brackets -= 1
+                if i + 1 < n and outside[i + 1] == "(":
+                    in_link_target = True
+                    paren_depth = 1
+                    i += 2
+                    continue
+        else:
+            if c == "(":
+                paren_depth += 1
+            elif c == ")":
+                paren_depth -= 1
+                if paren_depth == 0:
+                    in_link_target = False
+        i += 1
+    return open_brackets > 0 or in_link_target
+
+
+def _line_ends_inside_unmatched_inline(line: str) -> bool:
+    """True iff `line` has an odd backtick count or open `[`."""
+    bt = 0
+    open_brackets = 0
+    i = 0
+    n = len(line)
+    while i < n:
+        if line[i] == "\\" and i + 1 < n:
+            i += 2
+            continue
+        c = line[i]
+        if c == "`":
+            bt += 1
+        elif c == "[":
+            open_brackets += 1
+        elif c == "]" and open_brackets > 0:
+            open_brackets -= 1
+        i += 1
+    return (bt % 2 == 1) or open_brackets > 0
+
+
+def _has_dangling_final_line(candidate: str, kind: str) -> bool:
+    """True iff the final visible line of `candidate` is a dangling fragment.
+
+    For non-`full` candidates the boundary collection in Phase 2 already
+    validated the final line as a stable unit (a complete sentence,
+    paragraph end, list item, etc.), so only the unmatched-inline-Markdown
+    rule on the final line runs. For `full` candidates the cut sits at
+    the stream's tail and the full §D5 guard applies: bare list/heading
+    markers, short or single-word lines without sentence punctuation, and
+    mid-line broken inline Markdown all reject.
+    """
+    stripped = candidate.rstrip()
+    if not stripped:
+        return False
+    lines = stripped.splitlines()
+    final_line = lines[-1] if lines else ""
+    final_stripped = final_line.strip()
+    if not final_stripped:
+        return False
+
+    # Look past trailing closing punctuation runs to find the true
+    # terminator. `He said "Yes."` ends with `"` but the real terminator
+    # is the `.`; that distinction lets compound endings like `?!` and
+    # quote-wrapped sentences satisfy the "ends in sentence punctuation"
+    # check below.
+    last_real = final_stripped
+    while last_real and last_real[-1] in _CLOSE_PUNCT_CHARS:
+        last_real = last_real[:-1]
+    ends_in_sentence = bool(last_real) and last_real[-1] in _SENTENCE_END_CHARS
+
+    if kind == "full":
+        words = final_stripped.split()
+        # Rule 1: single word without sentence punctuation.
+        if len(words) == 1 and not ends_in_sentence:
+            return True
+        # Rule 2: short line without sentence punctuation.
+        if len(final_stripped) < 24 and not ends_in_sentence:
+            return True
+        # Rule 3: bare list-item marker (no content after).
+        if _LIST_LINE_EMPTY_MARKER_RE.match(final_line):
+            return True
+        # Rule 4: bare heading marker (no content after hashes).
+        if _HEADING_EMPTY_MARKER_RE.match(final_line):
+            return True
+        # Rule 6: dangling tail after a sentence terminator on the final
+        # line. A line like `Sentence. Two` clears rule 2 by total length
+        # but the actual cut tail (`Two`) is still a fragment. Catching
+        # this lets Phase 3 fall back to the earlier sentence-boundary
+        # candidate instead of publishing the mid-sentence continuation.
+        last_term_pos = max(
+            (final_stripped.rfind(c) for c in _SENTENCE_END_CHARS),
+            default=-1,
+        )
+        if last_term_pos >= 0:
+            end = last_term_pos + 1
+            while end < len(final_stripped) and (
+                final_stripped[end] in _CLOSE_PUNCT_CHARS or final_stripped[end] in _SENTENCE_END_CHARS
+            ):
+                end += 1
+            tail = final_stripped[end:].strip()
+            if tail:
+                tail_ends_in_sentence = tail[-1] in _SENTENCE_END_CHARS
+                tail_words = tail.split()
+                if len(tail_words) == 1 and not tail_ends_in_sentence:
+                    return True
+                if len(tail) < 24 and not tail_ends_in_sentence:
+                    return True
+
+    # Rule 5 applies to every candidate kind: an open inline span on the
+    # final line is broken Markdown regardless of cut origin.
+    if _is_fence_line(final_line):
+        # Triple-backtick fence delimiter; the trailing backticks are the
+        # closing fence marker, not an unclosed inline code span. Without
+        # this carve-out, closed-fence candidates get rejected for ending
+        # with three "unmatched" backticks.
+        return False
+    return _line_ends_inside_unmatched_inline(final_line)
+
+
+def _paragraph_cuts(working: str) -> list[int]:
+    """Positions of `\\n\\n` separators that are followed by more content."""
+    cuts: list[int] = []
+    i = 0
+    n = len(working)
+    while True:
+        j = working.find("\n\n", i)
+        if j < 0:
+            break
+        if working[j + 2 : n].strip():
+            cuts.append(j)
+        i = j + 1
+    return cuts
+
+
+def _sentence_cuts(working: str) -> list[int]:
+    """End-of-sentence positions outside any open fenced code block."""
+    cuts: list[int] = []
+    in_fence = False
+    pos = 0
+    n = len(working)
+    while pos < n:
+        nl = working.find("\n", pos)
+        line_end = nl if nl >= 0 else n
+        line = working[pos:line_end]
+        if _is_fence_line(line):
+            in_fence = not in_fence
+        elif not in_fence:
+            j = 0
+            while j < len(line):
+                if line[j] in _SENTENCE_END_CHARS:
+                    # Extend the cut through any closing-punctuation or
+                    # compound sentence-end run so `Yes."` and `?!` keep
+                    # the closer as part of the published prefix.
+                    k = j + 1
+                    while k < len(line) and (line[k] in _CLOSE_PUNCT_CHARS or line[k] in _SENTENCE_END_CHARS):
+                        k += 1
+                    cuts.append(pos + k)
+                    j = k
+                else:
+                    j += 1
+        pos = line_end + 1 if nl >= 0 else line_end
+    return cuts
+
+
+def _closed_fence_cuts(working: str) -> list[int]:
+    """Positions immediately after each closing fence line."""
+    cuts: list[int] = []
+    in_fence = False
+    pos = 0
+    n = len(working)
+    while pos < n:
+        nl = working.find("\n", pos)
+        line_end = nl if nl >= 0 else n
+        line = working[pos:line_end]
+        if _is_fence_line(line):
+            in_fence = not in_fence
+            if not in_fence:
+                cuts.append(line_end)
+        pos = line_end + 1 if nl >= 0 else line_end
+    return cuts
+
+
+def _list_item_cuts(working: str) -> list[int]:
+    """End-of-line positions where a complete list item closes."""
+    cuts: list[int] = []
+    lines = working.splitlines()
+    if not lines:
+        return cuts
+    starts = [0]
+    for line in lines[:-1]:
+        starts.append(starts[-1] + len(line) + 1)
+    for i, line in enumerate(lines):
+        if not _LIST_LINE_WITH_CONTENT_RE.match(line):
+            continue
+        if i + 1 >= len(lines):
+            continue
+        next_line = lines[i + 1]
+        # A list-item boundary fires only when the next line is either
+        # blank or itself a list-item line. That keeps prose paragraphs
+        # after a list intact (the paragraph boundary handles them) and
+        # avoids cutting a list short when the next line is still
+        # building.
+        if not next_line.strip() or _LIST_LINE_RE.match(next_line):
+            cuts.append(starts[i] + len(line))
+    return cuts
+
+
+def _long_span_cut(working: str) -> int | None:
+    """Cut at the last whitespace before the final line, when ≥ threshold.
+
+    Long-form responses without obvious paragraph breaks (a single long
+    monologue) still need a streaming surface so the user sees progress.
+    This fallback releases prefixes that contain at least 240 visible
+    characters and end before the final line, which preserves the
+    dangling-line guard's protection on the final visible line.
+    """
+    last_nl = working.rfind("\n")
+    if last_nl < 0:
+        return None
+    prefix = working[:last_nl].rstrip()
+    if len(prefix) >= _LONG_SPAN_MIN_CHARS:
+        return last_nl
+    return None
+
+
+def _stream_publishable_prefix(text: str) -> str | None:
+    """
+    Return the longest stable prefix of `text` safe for a live Telegram
+    update, or None when no stable prefix exists yet.
+
+    Stable means the prefix ends at a coherent boundary (paragraph,
+    sentence, closed fenced code block, list-item boundary, or a long
+    whitespace-aligned span) and its final visible line is not a
+    dangling fragment. The helper is pure and deterministic; transport
+    callers may invoke it on every streamed update and either publish
+    the returned prefix or wait for the next event.
+    """
+    if not text or not text.strip():
+        return None
+    working = text.rstrip()
+    if not working:
+        return None
+
+    candidates: list[tuple[int, str]] = []
+    candidates.extend((p, "paragraph") for p in _paragraph_cuts(working))
+    candidates.extend((p, "sentence") for p in _sentence_cuts(working))
+    candidates.extend((p, "closed_fence") for p in _closed_fence_cuts(working))
+    candidates.extend((p, "list_item") for p in _list_item_cuts(working))
+    ls = _long_span_cut(working)
+    if ls is not None:
+        candidates.append((ls, "long_span"))
+    candidates.append((len(working), "full"))
+
+    # Evaluate longest-first; when two kinds resolve to the same cut
+    # position, prefer the stronger boundary so the dangling-line guard
+    # runs in its lighter mode for the chosen candidate.
+    candidates.sort(key=lambda pk: (-pk[0], _KIND_PRIORITY[pk[1]]))
+
+    seen_positions: set[int] = set()
+    for cut, kind in candidates:
+        if cut in seen_positions:
+            continue
+        seen_positions.add(cut)
+        candidate = working[:cut].rstrip()
+        if not candidate:
+            continue
+        if _has_open_fenced_code(candidate):
+            continue
+        if _has_unbalanced_inline_markdown(candidate):
+            continue
+        if _has_dangling_final_line(candidate, kind):
+            continue
+        return candidate
+    return None
+
+
 async def _reply_safe(msg: Message, text: str) -> Message:
     """
     Reply with Markdown formatting, falling back to plain text on parse failure.
@@ -3668,16 +4062,25 @@ async def _handle_response(
             if not event.text_so_far:
                 continue
 
-            # Create the live message on first text, then edit periodically
+            # Stable-prefix gate: only create or edit the live message
+            # when the accumulated text has a coherent prefix to show.
+            # Withholding unstable chunks here means /stop, final
+            # delivery, and edit suppression always operate against text
+            # Telegram actually saw, which is the invariant the rest of
+            # this function relies on. `last_edit_text` is the last
+            # PUBLISHED stable prefix, never raw accumulated text.
+            publishable = _stream_publishable_prefix(event.text_so_far)
+            if publishable is None or publishable == last_edit_text:
+                continue
+
             if live_msg is None:
-                truncated = _truncate_for_telegram(event.text_so_far)
-                live_msg = await _reply_safe(update.message, truncated)
+                live_msg = await _reply_safe(update.message, _truncate_for_telegram(publishable))
                 last_edit_time = now
-                last_edit_text = event.text_so_far
-            elif now - last_edit_time >= EDIT_INTERVAL and event.text_so_far != last_edit_text:
-                await _edit_message_safe(live_msg, event.text_so_far)
+                last_edit_text = publishable
+            elif now - last_edit_time >= EDIT_INTERVAL:
+                await _edit_message_safe(live_msg, publishable)
                 last_edit_time = now
-                last_edit_text = event.text_so_far
+                last_edit_text = publishable
     finally:
         # Always cancel the typing indicator, even if the streaming loop
         # exits with an exception. Without this, a leaked _keep_typing task

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -322,10 +322,6 @@ _CLOSE_PUNCT_CHARS = frozenset("\"')]`")
 # Markdown list-item line shapes.
 _LIST_LINE_WITH_CONTENT_RE = re.compile(r"^[ ]*([-*+]|\d+\.)\s+\S")
 _LIST_LINE_RE = re.compile(r"^[ ]*([-*+]|\d+\.)(\s|$)")
-_LIST_LINE_EMPTY_MARKER_RE = re.compile(r"^[ ]*([-*+]|\d+\.)\s*$")
-# Setext-style ATX headings; we care about the bare-marker case where the
-# stream paused after the hashes but before any title text arrived.
-_HEADING_EMPTY_MARKER_RE = re.compile(r"^#{1,6}\s*$")
 # Minimum length for the long-span fallback to fire. Picked to be long
 # enough that a coherent paragraph is likely visible, but short enough
 # that streamed paragraphs reach it before the user gives up watching.
@@ -485,43 +481,19 @@ def _has_dangling_final_line(candidate: str, kind: str) -> bool:
         last_real = last_real[:-1]
     ends_in_sentence = bool(last_real) and last_real[-1] in _SENTENCE_END_CHARS
 
-    if kind == "full":
-        words = final_stripped.split()
-        # Rule 1: single word without sentence punctuation.
-        if len(words) == 1 and not ends_in_sentence:
-            return True
-        # Rule 2: short line without sentence punctuation.
-        if len(final_stripped) < 24 and not ends_in_sentence:
-            return True
-        # Rule 3: bare list-item marker (no content after).
-        if _LIST_LINE_EMPTY_MARKER_RE.match(final_line):
-            return True
-        # Rule 4: bare heading marker (no content after hashes).
-        if _HEADING_EMPTY_MARKER_RE.match(final_line):
-            return True
-        # Rule 6: dangling tail after a sentence terminator on the final
-        # line. A line like `Sentence. Two` clears rule 2 by total length
-        # but the actual cut tail (`Two`) is still a fragment. Catching
-        # this lets Phase 3 fall back to the earlier sentence-boundary
-        # candidate instead of publishing the mid-sentence continuation.
-        last_term_pos = max(
-            (final_stripped.rfind(c) for c in _SENTENCE_END_CHARS),
-            default=-1,
-        )
-        if last_term_pos >= 0:
-            end = last_term_pos + 1
-            while end < len(final_stripped) and (
-                final_stripped[end] in _CLOSE_PUNCT_CHARS or final_stripped[end] in _SENTENCE_END_CHARS
-            ):
-                end += 1
-            tail = final_stripped[end:].strip()
-            if tail:
-                tail_ends_in_sentence = tail[-1] in _SENTENCE_END_CHARS
-                tail_words = tail.split()
-                if len(tail_words) == 1 and not tail_ends_in_sentence:
-                    return True
-                if len(tail) < 24 and not tail_ends_in_sentence:
-                    return True
+    # The `full` candidate sits at the very tail of the accumulated
+    # buffer; it has no preceding boundary marker to vouch for it. It
+    # is safe to publish only when the final visible line ends in
+    # sentence punctuation (with optional closing quotes/parens). Any
+    # other tail shape (bare list/heading markers, mid-sentence prose
+    # of any length, a dangling fragment after an earlier sentence on
+    # the same line) risks shipping unstable text that the next stream
+    # chunk will overwrite. Other stable boundary kinds (paragraph,
+    # sentence, closed_fence, list_item) produce their own candidates
+    # at lower or equal cut positions and win via the priority sort
+    # when they coincide.
+    if kind == "full" and not ends_in_sentence:
+        return True
 
     # Rule 5 applies to every candidate kind: an open inline span on the
     # final line is broken Markdown regardless of cut origin.
@@ -550,7 +522,19 @@ def _paragraph_cuts(working: str) -> list[int]:
 
 
 def _sentence_cuts(working: str) -> list[int]:
-    """End-of-sentence positions outside any open fenced code block."""
+    """End-of-sentence positions outside any open fenced code block.
+
+    A `.?!` run (optionally followed by closing punctuation like quotes
+    or parens) qualifies as a sentence boundary only when the run ends
+    at end-of-line or is followed by whitespace. Mid-token periods
+    (decimals like `3.13`, version strings like `v1.2.3`, file paths
+    like `src/bot.py`, domain names) are NOT sentence ends; cutting at
+    them would publish a misleading prefix that splits the token in
+    half (e.g. `Use Python 3.` while the stream still has `13` to come).
+    The next stream chunk would then overwrite the visible message with
+    the correctly-joined text, but the user has already seen the wrong
+    prefix flash by.
+    """
     cuts: list[int] = []
     in_fence = False
     pos = 0
@@ -563,15 +547,21 @@ def _sentence_cuts(working: str) -> list[int]:
             in_fence = not in_fence
         elif not in_fence:
             j = 0
-            while j < len(line):
+            line_len = len(line)
+            while j < line_len:
                 if line[j] in _SENTENCE_END_CHARS:
                     # Extend the cut through any closing-punctuation or
                     # compound sentence-end run so `Yes."` and `?!` keep
                     # the closer as part of the published prefix.
                     k = j + 1
-                    while k < len(line) and (line[k] in _CLOSE_PUNCT_CHARS or line[k] in _SENTENCE_END_CHARS):
+                    while k < line_len and (line[k] in _CLOSE_PUNCT_CHARS or line[k] in _SENTENCE_END_CHARS):
                         k += 1
-                    cuts.append(pos + k)
+                    # Sentence-boundary predicate: the run must land at
+                    # end-of-line or be followed by a whitespace
+                    # separator. Anything else means the punctuation is
+                    # internal to a token and should not become a cut.
+                    if k == line_len or line[k].isspace():
+                        cuts.append(pos + k)
                     j = k
                 else:
                     j += 1
@@ -623,20 +613,42 @@ def _list_item_cuts(working: str) -> list[int]:
 
 
 def _long_span_cut(working: str) -> int | None:
-    """Cut at the last whitespace before the final line, when ≥ threshold.
+    """Cut at a whitespace boundary in long unpunctuated prose.
 
-    Long-form responses without obvious paragraph breaks (a single long
-    monologue) still need a streaming surface so the user sees progress.
-    This fallback releases prefixes that contain at least 240 visible
-    characters and end before the final line, which preserves the
-    dangling-line guard's protection on the final visible line.
+    Long-form responses without paragraph or sentence breaks still need
+    a streaming surface so the user sees progress. Two shapes are
+    handled:
+
+      1. Multi-line: when a newline exists and the prefix before the
+         final newline already holds at least ``_LONG_SPAN_MIN_CHARS``
+         of content, cut before the final newline. This preserves the
+         dangling-line guard's protection on the final (possibly
+         in-progress) line.
+      2. Single-line: when no newline exists, cut at the rightmost
+         whitespace whose position is at or beyond the threshold.
+         Without this fallback, an inner-Claude monologue streamed as
+         one long unpunctuated paragraph would have no stable prefix
+         until a sentence terminator finally appears; the user sees a
+         stalled message for the entire run.
     """
     last_nl = working.rfind("\n")
-    if last_nl < 0:
+    if last_nl >= 0:
+        prefix = working[:last_nl].rstrip()
+        if len(prefix) >= _LONG_SPAN_MIN_CHARS:
+            return last_nl
         return None
-    prefix = working[:last_nl].rstrip()
-    if len(prefix) >= _LONG_SPAN_MIN_CHARS:
-        return last_nl
+    # Single-line fallback. Scan right-to-left for a whitespace at
+    # position ≥ threshold; the word immediately before such a
+    # whitespace is guaranteed complete (it has a separator after it),
+    # whereas the final word at the buffer tail may still be growing.
+    n = len(working)
+    if n <= _LONG_SPAN_MIN_CHARS:
+        return None
+    for i in range(n - 1, _LONG_SPAN_MIN_CHARS - 1, -1):
+        if working[i].isspace():
+            prefix = working[:i].rstrip()
+            if len(prefix) >= _LONG_SPAN_MIN_CHARS:
+                return i
     return None
 
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -394,6 +394,30 @@ class TestStreamPublishablePrefix:
 
         assert _stream_publishable_prefix("Use Python 3.13.") == "Use Python 3.13."
 
+    def test_ordered_list_marker_is_not_sentence_boundary(self):
+        """The dot in ``1.`` is a list marker, not a sentence end. A
+        single in-progress numbered item must not publish as the bare
+        marker; with the previous sentence-cut rules it would have
+        produced ``"1."`` because the marker period is followed by
+        whitespace and therefore satisfied the new sentence predicate.
+        """
+        from kai.bot import _stream_publishable_prefix
+
+        assert _stream_publishable_prefix("1. Item one") is None
+
+    def test_forming_next_marker_releases_previous_items(self):
+        """Numbered items publish as a list once the next item's marker
+        starts emitting, even before the period and content arrive.
+        Without forming-marker awareness, an in-progress next item
+        (just the digits ``3``) would not count as a boundary and the
+        helper would publish only ``1. Item one`` instead of the full
+        ``1. Item one\\n2. Item two``.
+        """
+        from kai.bot import _stream_publishable_prefix
+
+        text = "1. Item one\n2. Item two\n3"
+        assert _stream_publishable_prefix(text) == "1. Item one\n2. Item two"
+
 
 # ── _save_upload ────────────────────────────────────────────────────
 
@@ -3638,6 +3662,44 @@ class TestHandleResponse:
         published_texts = [c.args[1] for c in mock_reply.call_args_list]
         assert "One" not in published_texts
         assert any("One final answer." in t for t in published_texts)
+
+    @pytest.mark.asyncio
+    async def test_does_not_create_live_message_for_bare_numbered_marker(self):
+        """First non-empty partial is a single in-progress numbered item;
+        the stable-prefix gate must withhold the live message. Without
+        the ordered-list-aware sentence cut, the gate would publish the
+        bare marker ``1.`` as if it were a complete sentence.
+        """
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        claude = _make_mock_claude()
+        claude.send = MagicMock(
+            return_value=_fake_stream(
+                _text_event("1. Item one"),
+                _done_event("1. Item one\n2. Item two\n3. Item three"),
+            )
+        )
+        ctx = _make_context(claude=claude)
+
+        with (
+            patch.multiple("kai.bot", **self._base_patches()),
+            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply,
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock) as mock_edit,
+        ):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        # No live message edit ever fired; the unstable single in-progress
+        # item never produced a stable-prefix candidate, so the live
+        # message was never created mid-stream.
+        mock_edit.assert_not_called()
+        published_texts = [c.args[1] for c in mock_reply.call_args_list]
+        # The bare marker is the worst Telegram artifact this PR
+        # prevents; no published text may show it.
+        assert "1." not in published_texts
+        assert "1. Item one" not in published_texts
+        # Final delivery still carries the complete answer via _reply_safe.
+        assert any("3. Item three" in t for t in published_texts)
 
     @pytest.mark.asyncio
     async def test_publishes_completed_prefix_not_dangling_suffix(self):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -337,6 +337,63 @@ class TestStreamPublishablePrefix:
         assert result is not None
         assert result == prose.rstrip()
 
+    def test_full_rejects_long_unfinished_final_paragraph(self):
+        """A completed paragraph followed by a long mid-sentence fragment
+        must publish only the completed paragraph. The full candidate is
+        longer than the paragraph cut, so without a tight final-line guard
+        it would win the priority sort and ship the in-progress fragment.
+        """
+        from kai.bot import _stream_publishable_prefix
+
+        text = "Complete paragraph.\n\nOne hard inconsistency is emerging"
+        assert _stream_publishable_prefix(text) == "Complete paragraph."
+
+    def test_long_span_handles_single_line_prose(self):
+        """A long unpunctuated single-line monologue must still produce a
+        streaming surface. Without the single-line fallback in
+        ``_long_span_cut`` the helper has nothing to publish (no
+        paragraph, sentence, list, or fence boundary) and the user sees
+        a stalled live message until a sentence terminator arrives.
+        """
+        from kai.bot import _stream_publishable_prefix
+
+        text = ("alpha beta " * 30).rstrip()
+        result = _stream_publishable_prefix(text)
+        assert result is not None
+        # Threshold is 240; the long-span cut must land on a whitespace
+        # at or beyond that, leaving a substantive prefix.
+        assert len(result) >= 240
+        # The cut lands at a whitespace, so the published prefix never
+        # ends with the in-progress trailing word.
+        assert not result.endswith(" ")
+
+    def test_sentence_cut_rejects_mid_token_decimal(self):
+        """A period inside a decimal is not a sentence boundary; the
+        helper must not publish ``"Use Python 3."`` while the stream is
+        still emitting ``"13"``.
+        """
+        from kai.bot import _stream_publishable_prefix
+
+        assert _stream_publishable_prefix("Use Python 3.13") is None
+
+    def test_sentence_cut_rejects_mid_token_path(self):
+        """A period inside a file path (``bot.py``) is not a sentence
+        boundary; the helper must not publish ``"Open src/kai/bot."``
+        while the stream is still emitting ``"py"``.
+        """
+        from kai.bot import _stream_publishable_prefix
+
+        assert _stream_publishable_prefix("Open src/kai/bot.py") is None
+
+    def test_terminating_period_after_internal_dots_is_sentence_end(self):
+        """A period followed by end-of-string IS a sentence boundary,
+        even when the preceding token contains internal dots. The
+        complete version-string sentence publishes as a unit.
+        """
+        from kai.bot import _stream_publishable_prefix
+
+        assert _stream_publishable_prefix("Use Python 3.13.") == "Use Python 3.13."
+
 
 # ── _save_upload ────────────────────────────────────────────────────
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -258,6 +258,86 @@ class TestTruncateForTelegram:
         assert _truncate_for_telegram(text, 50) == text
 
 
+# ── _stream_publishable_prefix ──────────────────────────────────────
+
+
+class TestStreamPublishablePrefix:
+    """
+    Stability filter applied to live streaming updates. The helper
+    returns the longest stable prefix of the accumulated text, or None
+    when nothing in the buffer is safe to publish yet. Backends keep
+    emitting; the transport just waits for a coherent boundary.
+    """
+
+    def test_rejects_empty_text(self):
+        from kai.bot import _stream_publishable_prefix
+
+        assert _stream_publishable_prefix("") is None
+        assert _stream_publishable_prefix("   \n  \t  ") is None
+
+    def test_rejects_single_initial_word(self):
+        from kai.bot import _stream_publishable_prefix
+
+        assert _stream_publishable_prefix("One") is None
+
+    def test_cuts_dangling_suffix_to_paragraph(self):
+        from kai.bot import _stream_publishable_prefix
+
+        assert _stream_publishable_prefix("Complete paragraph.\n\nOne") == "Complete paragraph."
+
+    def test_allows_complete_sentence(self):
+        from kai.bot import _stream_publishable_prefix
+
+        assert _stream_publishable_prefix("One complete sentence.") == "One complete sentence."
+
+    def test_includes_closing_sentence_punctuation(self):
+        from kai.bot import _stream_publishable_prefix
+
+        assert _stream_publishable_prefix('He said "Yes."') == 'He said "Yes."'
+
+    def test_cuts_dangling_list_item_to_previous_item(self):
+        from kai.bot import _stream_publishable_prefix
+
+        text = "- Item one\n- Item two\n- Three"
+        assert _stream_publishable_prefix(text) == "- Item one\n- Item two"
+
+    def test_rejects_open_fenced_code_block(self):
+        from kai.bot import _stream_publishable_prefix
+
+        assert _stream_publishable_prefix("```python\nprint('hi')") is None
+
+    def test_allows_closed_fenced_code_block(self):
+        from kai.bot import _stream_publishable_prefix
+
+        text = "```python\nprint('hi')\n```"
+        assert _stream_publishable_prefix(text) == text
+
+    def test_rejects_open_inline_code(self):
+        from kai.bot import _stream_publishable_prefix
+
+        # Single unmatched backtick mid-final-line is dangling.
+        assert _stream_publishable_prefix("Use the `cmd flag") is None
+
+    def test_rejects_open_link(self):
+        from kai.bot import _stream_publishable_prefix
+
+        # Final line has an unmatched `[` so the link target is mid-stream.
+        assert _stream_publishable_prefix("See [the docs") is None
+
+    def test_long_span_fallback_when_no_smaller_boundary(self):
+        from kai.bot import _stream_publishable_prefix
+
+        # 240+ chars of prose on one line, then a newline and a final
+        # tiny dangling word. No paragraph break, no sentence end inside
+        # the prose, no list. Long-span fallback must release the prose
+        # block while withholding the dangling final line.
+        prose = "alpha beta gamma " * 16  # 272 chars
+        text = prose + "\nOne"
+        result = _stream_publishable_prefix(text)
+        assert result is not None
+        assert result == prose.rstrip()
+
+
 # ── _save_upload ────────────────────────────────────────────────────
 
 
@@ -3474,6 +3554,210 @@ class TestHandleResponse:
         # the patched attribute path; the assertions read from the
         # re-imported `_pending_memory_tasks` reference.
         _ = bot
+
+    # ── Stable-prefix streaming gate ─────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_does_not_create_live_message_for_initial_single_word(self):
+        """First non-empty partial is a single word; gate withholds live message."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        claude = _make_mock_claude()
+        claude.send = MagicMock(return_value=_fake_stream(_text_event("One"), _done_event("One final answer.")))
+        ctx = _make_context(claude=claude)
+
+        with (
+            patch.multiple("kai.bot", **self._base_patches()),
+            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply,
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock) as mock_edit,
+        ):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        # No live edit ever fired; final answer arrived through _reply_safe
+        # via _send_response. The unstable "One" partial never created a
+        # live message.
+        mock_edit.assert_not_called()
+        published_texts = [c.args[1] for c in mock_reply.call_args_list]
+        assert "One" not in published_texts
+        assert any("One final answer." in t for t in published_texts)
+
+    @pytest.mark.asyncio
+    async def test_publishes_completed_prefix_not_dangling_suffix(self):
+        """Live message uses the completed paragraph, never the dangling word."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        claude = _make_mock_claude()
+        claude.send = MagicMock(
+            return_value=_fake_stream(
+                _text_event("Complete paragraph.\n\nOne"),
+                _done_event("Complete paragraph.\n\nOne final answer."),
+            )
+        )
+        ctx = _make_context(claude=claude)
+
+        with (
+            patch.multiple("kai.bot", **self._base_patches()),
+            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply,
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock) as mock_edit,
+        ):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        # The live message creation received the completed paragraph
+        # without the dangling "One" suffix.
+        live_create_texts = [c.args[1] for c in mock_reply.call_args_list]
+        assert "Complete paragraph." in live_create_texts
+        # No reply / edit ever showed the bare "Complete paragraph.\n\nOne"
+        # intermediate. (The final delivery edit carries the complete
+        # final answer, not the dangling intermediate.)
+        edit_texts = [c.args[1] for c in mock_edit.call_args_list]
+        assert "Complete paragraph.\n\nOne" not in edit_texts
+        assert "Complete paragraph.\n\nOne" not in live_create_texts
+
+    @pytest.mark.asyncio
+    async def test_edits_only_when_publishable_prefix_advances(self):
+        """A dangling suffix after a stable sentence does not trigger an edit."""
+        from kai.bot import EDIT_INTERVAL, _handle_response
+
+        update = _make_update()
+        live_msg = MagicMock()
+        live_msg.edit_text = AsyncMock()
+        update.message.reply_text = AsyncMock(return_value=live_msg)
+
+        claude = _make_mock_claude()
+        claude.send = MagicMock(
+            return_value=_fake_stream(
+                _text_event("One complete sentence."),
+                _text_event("One complete sentence. Two"),  # dangling suffix
+                _done_event("One complete sentence. Two complete sentences."),
+            )
+        )
+        ctx = _make_context(claude=claude)
+
+        # Patch monotonic so the second event is past EDIT_INTERVAL.
+        times = iter([0.0, EDIT_INTERVAL + 1.0, EDIT_INTERVAL + 2.0, EDIT_INTERVAL + 3.0])
+        with (
+            patch.multiple("kai.bot", **self._base_patches()),
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock) as mock_edit,
+            patch("kai.bot.time.monotonic", side_effect=lambda: next(times)),
+        ):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        # No edit ever published a dangling "Two" mid-stream.
+        edit_texts = [c.args[1] for c in mock_edit.call_args_list]
+        assert not any(t.endswith(" Two") for t in edit_texts)
+        # Final edit carries the complete final text (not the dangling
+        # intermediate).
+        if edit_texts:
+            assert "Two complete sentences." in edit_texts[-1]
+
+    @pytest.mark.asyncio
+    async def test_stop_before_stable_live_message_sends_no_fragment(self):
+        """Stop while only unstable partials seen: no fragment reply, no error reply, stop logged."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        stop_event = asyncio.Event()
+
+        async def _streaming(*args):
+            yield _text_event("One")
+            stop_event.set()
+            yield _text_event("One more")  # still unstable
+            yield _done_event("Should not reach")
+
+        claude = _make_mock_claude()
+        claude.send = MagicMock(return_value=_streaming())
+        ctx = _make_context(claude=claude)
+
+        patches = self._base_patches()
+        log_message_mock = patches["log_message"]
+
+        with (
+            patch.multiple("kai.bot", **patches),
+            patch("kai.bot.get_stop_event", return_value=stop_event),
+            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply,
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock) as mock_edit,
+        ):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        # The unstable "One" partial never created a live message.
+        mock_edit.assert_not_called()
+        # Error fallback was NOT sent. update.message.reply_text is the
+        # entry point for the bare "Error: No response from agent" path
+        # (it bypasses _reply_safe).
+        error_calls = [
+            c
+            for c in update.message.reply_text.call_args_list
+            if c.args and "Error: No response from agent" in c.args[0]
+        ]
+        assert not error_calls
+        # _reply_safe was never called with "One" or "One more".
+        reply_texts = [c.args[1] for c in mock_reply.call_args_list]
+        assert "One" not in reply_texts
+        assert "One more" not in reply_texts
+        # The stop was logged with the canonical marker.
+        stop_log_calls = [c for c in log_message_mock.call_args_list if c.kwargs.get("text") == "[stopped by user]"]
+        assert stop_log_calls, "expected '[stopped by user]' log entry"
+
+    @pytest.mark.asyncio
+    async def test_final_delivery_after_withheld_live_updates(self):
+        """Stream only unstable partials; final delivery still sends the complete answer."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        claude = _make_mock_claude()
+        claude.send = MagicMock(
+            return_value=_fake_stream(
+                _text_event("One"),
+                _text_event("One more"),
+                _done_event("One final complete response."),
+            )
+        )
+        ctx = _make_context(claude=claude)
+
+        with (
+            patch.multiple("kai.bot", **self._base_patches()),
+            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply,
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock) as mock_edit,
+        ):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        # No live edits, no fragment replies; only the final delivery.
+        mock_edit.assert_not_called()
+        published_texts = [c.args[1] for c in mock_reply.call_args_list]
+        assert any("One final complete response." in t for t in published_texts)
+
+    @pytest.mark.asyncio
+    async def test_publishes_completed_list_items_not_dangling_next(self):
+        """Live message receives `- Item one\\n- Item two`; the dangling `- Three` is withheld."""
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        claude = _make_mock_claude()
+        claude.send = MagicMock(
+            return_value=_fake_stream(
+                _text_event("- Item one\n- Item two\n- Three"),
+                _done_event("- Item one\n- Item two\n- Three is complete."),
+            )
+        )
+        ctx = _make_context(claude=claude)
+
+        with (
+            patch.multiple("kai.bot", **self._base_patches()),
+            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply,
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock) as mock_edit,
+        ):
+            await _handle_response(update, ctx, 12345, "test", claude, "sonnet")
+
+        live_create_texts = [c.args[1] for c in mock_reply.call_args_list]
+        edit_texts = [c.args[1] for c in mock_edit.call_args_list]
+
+        # The live message carried the completed pair, never the
+        # dangling next item.
+        assert "- Item one\n- Item two" in live_create_texts
+        assert "- Item one\n- Item two\n- Three" not in live_create_texts
+        assert "- Item one\n- Item two\n- Three" not in edit_texts
 
 
 # ── _notify_if_queued ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `_stream_publishable_prefix` to `src/kai/bot.py`: a pure helper that returns the longest stable prefix of the accumulated streamed text, or None when nothing is safe to publish yet
- Update `_handle_response`'s streaming loop to consult the helper instead of publishing raw `event.text_so_far`; the live message is created or edited only when the candidate prefix advances
- Track `last_edit_text` as the last published prefix, never raw accumulated text, so `/stop`, final delivery, and edit suppression operate against what Telegram actually saw

Closes #680.

## Test plan

- [x] `make check` (ruff check + format) green
- [x] `make test` green (4406 passed, 1 skipped)
- [x] `tests/test_bot.py::TestStreamPublishablePrefix` covers 11 boundary states: empty/whitespace, single-word initial, dangling-suffix paragraph cut, complete sentence, quote-wrapped sentence (`He said "Yes."`), list-item boundary, open and closed fenced code blocks, open inline code, open link target, and the 240-char long-span fallback
- [x] `tests/test_bot.py::TestHandleResponse` adds six integration cases that exercise the new gate: unstable first fragment (no live message), completed-paragraph cut, prefix-advance-only edits, stop-before-stable-live-message (with `[stopped by user]` log assertion), final delivery after withheld updates, and the list-streaming flow
- [x] Existing `TestHandleResponse` cases still pass; the short-fragment streams (`Hello`, `Done`, `Partial`, `Hi`) now route through final delivery, and the existing assertions remain satisfied
- [ ] Manual smoke: send a long-running Kai prompt that previously stuttered with dangling final words; confirm live updates only publish at coherent boundaries and the final answer renders as today
- [ ] Manual smoke: send a list-generating prompt; confirm streaming advances item-by-item without ever showing a half-typed marker
