### PR TITLE
Rebalance bundle caps for realistic kai file sizes

### DIFF
--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -83,18 +83,23 @@ _MAX_PRIOR_COMMENTS_CHARS = 50_000
 # ── Bundle budget constants ──────────────────────────────────────────
 #
 # Per-section caps used by the deterministic budgeter that backs
-# build_pr_review_context() / build_review_prompt_from_context(). These
-# are v1 guardrails sized to keep the rendered prompt within the
-# common-case context window of every configured review backend; the
-# numbers are not magic-correct values and can be tuned later. The
-# drop ladder (see _apply_budget_ladder) decides the order in which
-# sections are reduced when the rendered prompt would otherwise
-# exceed _MAX_REVIEW_CONTEXT_CHARS. Backend dispatch is symmetric;
-# per-backend ceilings are only introduced if a configured backend
-# cannot fit the shared one.
-_MAX_REVIEW_CONTEXT_CHARS = 240_000
+# build_pr_review_context() / build_review_prompt_from_context(). The
+# v1 numbers (240K global / 90K changed-files / 200K per-file) were
+# tuned conservatively, and a manual acceptance pass against a real
+# kai PR (3 commits touching `bot.py` and `test_bot.py`) showed both
+# changed files dropped to notes: `test_bot.py` exceeded the 200K
+# per-file cap and `bot.py` exceeded the 90K section cap. That left
+# the bundle reviewer relying on the patch alone for the very files
+# the bundle was supposed to broaden context around. The realistic
+# kai codebase has several modules in the 150-220K-char range
+# (`bot.py`, `webhook.py`, `config.py`, `sessions.py`, `review.py`,
+# `pool.py`, the larger test files); any PR touching one of those
+# would hit the same drop. Caps are rebalanced here so realistic PRs
+# carry full file contents through to the reviewer, with the
+# cross-section drop ladder still enforcing the global ceiling.
+_MAX_REVIEW_CONTEXT_CHARS = 360_000
 _MAX_PATCH_CHARS = 80_000
-_MAX_CHANGED_FILES_CHARS = 90_000
+_MAX_CHANGED_FILES_CHARS = 250_000
 _MAX_RELATED_CONTEXT_CHARS = 35_000
 _MAX_LINKED_ISSUES_CHARS = 30_000
 _MAX_COMMITS_CHARS = 20_000
@@ -1179,8 +1184,13 @@ async def fetch_linked_issues(
 # stops a single 900 KiB JSON fixture from eating the entire
 # changed-files budget before the deterministic budgeter can apply
 # its drop ladder. Files over this cap are recorded with a `note`
-# instead of inline content.
-_MAX_CHANGED_FILE_BYTES = 200_000
+# instead of inline content. Sized to fit realistic kai-shaped
+# modules (the largest production files sit around 250K chars; the
+# largest test files reach ~250K) so the bundle's full-file context
+# is available on PRs that touch them. The per-section cap
+# (`_MAX_CHANGED_FILES_CHARS`) bounds how much of this any single PR
+# can claim.
+_MAX_CHANGED_FILE_BYTES = 500_000
 
 # File suffixes the changed-files fetcher refuses to fetch even when
 # GitHub would happily return them. Inline base64 of a font, image, or

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1972,8 +1972,8 @@ class TestFetchChangedFilesAtHead:
 
     @pytest.mark.asyncio
     async def test_too_large_file_gets_note(self):
-        # API returns size above the cap; the content is requested but
-        # we record the omission note without inlining.
+        # API reports a size well beyond the per-file cap; the
+        # content is requested but recorded as a note without inlining.
         import base64
 
         big_body = b"x" * 50
@@ -1981,7 +1981,7 @@ class TestFetchChangedFilesAtHead:
             {
                 "type": "file",
                 "encoding": "base64",
-                "size": 500_000,
+                "size": 800_000,
                 "content": base64.b64encode(big_body).decode(),
             }
         ).encode()
@@ -2000,6 +2000,34 @@ class TestFetchChangedFilesAtHead:
             files, _ = await fetch_changed_files_at_head(meta)
         assert files[0].content is None
         assert "fetch failed" in (files[0].note or "")
+
+    @pytest.mark.asyncio
+    async def test_realistic_kai_module_inlines(self):
+        # 180K chars matches the order of magnitude of `bot.py` /
+        # `webhook.py` / `config.py` in the kai repo. With the
+        # previous 200K per-file cap these files inlined sometimes
+        # and dropped to notes when the GitHub API size field crept
+        # past the threshold; the new cap admits the realistic case
+        # comfortably so the bundle's full-file context promise
+        # holds for typical PRs.
+        import base64
+
+        body = b"# kai module\n" + (b"x" * 180_000)
+        payload = json.dumps(
+            {
+                "type": "file",
+                "encoding": "base64",
+                "size": len(body),
+                "content": base64.b64encode(body).decode(),
+            }
+        ).encode()
+        meta = self._meta((("src/kai/bot.py", "modified"),))
+        proc = _mock_process(stdout=payload)
+        with patch("asyncio.create_subprocess_exec", return_value=proc):
+            files, _ = await fetch_changed_files_at_head(meta)
+        assert files[0].content is not None
+        assert files[0].note is None
+        assert len(files[0].content) > 100_000
 
 
 # ── budget_review_context ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Manual acceptance pass against PR #681 showed the bundle's headline value-add (full changed-file contents at the PR head) did not actually reach the reviewer for either changed file: `tests/test_bot.py` (246K bytes) exceeded the per-file cap; `src/kai/bot.py` (180K bytes) exceeded the changed-files section cap. The reviewer ended up working from the patch + 11 related excerpts only, which is the pre-bundle review surface.
- Several kai modules sit in the same 150-220K-char range (`webhook.py`, `config.py`, `sessions.py`, `pool.py`, `review.py` post-#666), so this is not a one-off PR shape.
- Rebalance the per-file cap (200K -> 500K), per-section cap (90K -> 250K), and global ceiling (240K -> 360K) so realistic kai-shaped PRs carry full file contents through to the reviewer. The cross-section drop ladder added in the previous round still enforces the global cap; these numbers stop the ladder firing for the realistic case.

## Test plan

- [x] `make check` clean.
- [x] `make test`: 4476 passed (4475 baseline + 1 new), 1 skipped.
- [ ] Re-run the manual acceptance pass against the same PR (#681) after merge and confirm `bot.py` and `test_bot.py` both inline with no `[CHANGED_FILES_AT_HEAD]` budget notes (deferred to post-merge).

Refs #666
