### PR TITLE
Telegram /review manual command using shared bundle

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -3387,6 +3387,7 @@ _REVIEW_TMP_DIR = Path("/tmp")
 
 
 async def _resolve_review_repo(
+    actor_id: int,
     chat_id: int,
     pool: "SubprocessPool",
     config: Config,
@@ -3406,10 +3407,17 @@ async def _resolve_review_repo(
 
     No fallback to ``Config.github_repo`` (deprecated), no
     first-of-list, and no new workspace-to-repo mapping.
+
+    Args:
+        actor_id: The authorized Telegram user id; drives user-scoped
+            config and effective-repo lookups so a group chat does
+            not read the wrong user's settings.
+        chat_id: The chat id; drives workspace resolution (workspaces
+            are chat-scoped via the pool).
     """
-    user_config = config.get_user_config(chat_id)
+    user_config = config.get_user_config(actor_id)
     yaml_repos = user_config.github_repos if user_config else []
-    effective_repos = await sessions.get_effective_repos(chat_id, yaml_repos)
+    effective_repos = await sessions.get_effective_repos(actor_id, yaml_repos)
     effective_lower = {r.lower() for r in effective_repos}
 
     workspace = str(await pool.get_effective_workspace(chat_id))
@@ -3457,6 +3465,14 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
     if not await _check_totp(update, context):
         return
 
+    # `actor_id` drives every user-scoped lookup (config, effective
+    # repos, backend, provider, model override); `chat_id` drives
+    # chat-scoped state (workspace path, per-chat file staging, the
+    # reply target, document upload). In a notification group the two
+    # differ: chat_id is the group's id and would silently miss the
+    # authorized operator's user config if it were used for the
+    # user-scoped reads, dropping the review onto global defaults.
+    actor_id = _user_id(update)
     chat_id = _chat_id(update)
     config: Config = context.bot_data["config"]
     pool = _get_pool(context)
@@ -3474,7 +3490,7 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
         except ValueError:
             await update.message.reply_text(usage)
             return
-        repo = await _resolve_review_repo(chat_id, pool, config)
+        repo = await _resolve_review_repo(actor_id, chat_id, pool, config)
         if not repo:
             await update.message.reply_text(
                 f"{usage}\n"
@@ -3498,18 +3514,14 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
         return
 
     # Per-user backend / provider / claude-user / model-override
-    # resolution mirrors the webhook PR review path so a manual
-    # review behaves the same as the automatic one for the same user.
-    user_config = config.get_user_config(chat_id)
+    # resolution. Use the shared `get_user_backend_and_provider`
+    # helper so a manual /review picks up exactly the same effective
+    # backend the rest of the bot uses for this user; hand-rolling
+    # the fallback would drift if config.py's resolution rules ever
+    # change.
+    user_config = config.get_user_config(actor_id)
     claude_user = user_config.os_user if user_config and user_config.os_user else None
-    if user_config and user_config.agent_backend:
-        agent_backend = user_config.agent_backend
-    else:
-        agent_backend = config.agent_backend
-    if user_config and user_config.llm_provider:
-        provider = user_config.llm_provider
-    else:
-        provider = config.llm_provider
+    agent_backend, provider = get_user_backend_and_provider(user_config, config)
     model_override = resolve_user_model(ModelRole.PR_REVIEW, user_config, config)
     workspace = str(await pool.get_effective_workspace(chat_id))
 
@@ -3557,7 +3569,11 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
     # can read the full review. The staged file is the upload source
     # rather than /tmp because the send-file allowlist may reject
     # /tmp and the staged path lives under the configured per-chat
-    # data area.
+    # data area. Failure is non-fatal (the canonical /tmp artifact is
+    # already written) but it is NOT silent: a phone-only operator
+    # cannot read /tmp, so the final reply must say the attachment
+    # failed if it did.
+    upload_failed = False
     try:
         with open(staged, "rb") as f:
             await context.bot.send_document(
@@ -3567,20 +3583,21 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
                 filename=f"pr-{pr_number}-review.md",
             )
     except Exception:
-        # Document upload is best-effort; the canonical /tmp path is
-        # always available so the reviewer can read the review even
-        # if the attachment fails (Telegram size limits, network
-        # blips, etc.).
+        upload_failed = True
         log.exception("Failed to upload staged review document for %s#%d", repo, pr_number)
 
     # Reply with the absolute path so the operator can open it in
     # the chat-review-loop convention, plus any collection warnings
-    # so they know what context was incomplete.
+    # so they know what context was incomplete, plus an explicit
+    # note if the document attachment failed.
+    reply_lines: list[str] = [f"Review written to {canonical}"]
+    if upload_failed:
+        reply_lines.append("Attachment failed; open the file at the path above.")
     if result.collection_warnings:
-        warnings_text = "\n".join(f"  [{w.source}] {w.message}" for w in result.collection_warnings)
-        await update.message.reply_text(f"Review written to {canonical}\nWarnings:\n{warnings_text}")
-    else:
-        await update.message.reply_text(f"Review written to {canonical}")
+        reply_lines.append("Warnings:")
+        for w in result.collection_warnings:
+            reply_lines.append(f"  [{w.source}] {w.message}")
+    await update.message.reply_text("\n".join(reply_lines))
 
 
 @_require_auth

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -54,7 +54,7 @@ from telegram.ext import (
     filters,
 )
 
-from kai import github_api, memory_command, services, sessions, webhook
+from kai import github_api, memory_command, review, services, sessions, webhook
 from kai.backend import resolve_home_workspace
 from kai.config import (
     DATA_DIR,
@@ -62,10 +62,12 @@ from kai.config import (
     OPEN_ENDED_PROVIDERS,
     PROVIDER_DEFAULTS,
     Config,
+    ModelRole,
     WorkspaceConfig,
     get_effective_provider,
     get_user_backend_and_provider,
     models_for_backend,
+    resolve_user_model,
     validate_model_for_backend,
 )
 from kai.history import LogEntry, log_message
@@ -3375,6 +3377,212 @@ async def handle_webhooks(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     await update.message.reply_text("\n".join(lines))
 
 
+# Canonical local directory for the /review command's review artifact.
+# The path `/tmp/pr-<N>-review.md` is a deliberate echo of the
+# operator's chat-review-loop convention so manual and product-generated
+# review artifacts land where the operator already expects them. Kept
+# as a module-level constant so tests can redirect to a tmp_path
+# without colliding with locally-owned `/tmp/pr-<N>-review.md` files.
+_REVIEW_TMP_DIR = Path("/tmp")
+
+
+async def _resolve_review_repo(
+    chat_id: int,
+    pool: "SubprocessPool",
+    config: Config,
+) -> str:
+    """
+    Resolve the short-form `/review <pr-number>` to an `owner/name` repo.
+
+    Walks the conservative ladder per the spec:
+
+    1. If the active workspace is a git checkout whose `origin` remote
+       normalizes to exactly one repo in the user's effective GitHub
+       repo list, return that repo.
+    2. Otherwise, if the user's effective GitHub repo list contains
+       exactly one repo, return that repo.
+    3. Otherwise, return the empty string so the caller can prompt
+       for the explicit `owner/repo` form.
+
+    No fallback to ``Config.github_repo`` (deprecated), no
+    first-of-list, and no new workspace-to-repo mapping.
+    """
+    user_config = config.get_user_config(chat_id)
+    yaml_repos = user_config.github_repos if user_config else []
+    effective_repos = await sessions.get_effective_repos(chat_id, yaml_repos)
+    effective_lower = {r.lower() for r in effective_repos}
+
+    workspace = str(await pool.get_effective_workspace(chat_id))
+    workspace_remote = await review._resolve_workspace_remote_repo(workspace)
+    if workspace_remote and workspace_remote.lower() in effective_lower:
+        return workspace_remote.lower()
+
+    if len(effective_repos) == 1:
+        return effective_repos[0].lower()
+
+    return ""
+
+
+@_require_auth
+async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """
+    Handle the /review command; run a deep PR review on demand.
+
+    Shapes:
+
+        /review <pr-number>              repository is inferred from
+                                         the active workspace's git
+                                         remote (when it matches one
+                                         of the user's effective
+                                         GitHub repos) or from the
+                                         sole effective repo.
+        /review <owner/repo> <pr-number> explicit repository.
+
+    Auth + TOTP gate mirrors content-invoking commands. The review
+    runs inside the update handler (per the spec: not a detached
+    background task). On success the review text lands at
+    ``/tmp/pr-<N>-review.md`` as the canonical artifact, a
+    timestamped copy is staged under the chat's file area via
+    ``_save_upload()``, and the staged copy is uploaded to Telegram
+    as a document attachment so phone-only use can read the full
+    review. No GitHub comment is posted; the webhook cooldown map is
+    untouched.
+    """
+    assert update.message is not None
+
+    # TOTP gate: same precedent as content-invoking commands that run
+    # a user-scoped backend subprocess (handle_photo, handle_document,
+    # handle_voice). The review backend consumes the user's
+    # OAuth-authed subprocess, so the gate applies here too.
+    if not await _check_totp(update, context):
+        return
+
+    chat_id = _chat_id(update)
+    config: Config = context.bot_data["config"]
+    pool = _get_pool(context)
+
+    args = list(context.args or [])
+    usage = "Usage: /review [owner/repo] <pr-number>"
+
+    # Two shapes: one arg (PR number, inferred repo) or two args
+    # (explicit repo + PR number). Anything else is a usage error.
+    repo: str = ""
+    pr_number: int = 0
+    if len(args) == 1:
+        try:
+            pr_number = int(args[0])
+        except ValueError:
+            await update.message.reply_text(usage)
+            return
+        repo = await _resolve_review_repo(chat_id, pool, config)
+        if not repo:
+            await update.message.reply_text(
+                f"{usage}\n"
+                "Could not infer the repository from your active workspace or your "
+                "effective GitHub repo list."
+            )
+            return
+    elif len(args) == 2:
+        candidate = args[0].lower()
+        if not _REPO_PATTERN.match(candidate):
+            await update.message.reply_text("Invalid repo format. Expected: owner/repo (e.g., dcellison/kai)")
+            return
+        repo = candidate
+        try:
+            pr_number = int(args[1])
+        except ValueError:
+            await update.message.reply_text(usage)
+            return
+    else:
+        await update.message.reply_text(usage)
+        return
+
+    # Per-user backend / provider / claude-user / model-override
+    # resolution mirrors the webhook PR review path so a manual
+    # review behaves the same as the automatic one for the same user.
+    user_config = config.get_user_config(chat_id)
+    claude_user = user_config.os_user if user_config and user_config.os_user else None
+    if user_config and user_config.agent_backend:
+        agent_backend = user_config.agent_backend
+    else:
+        agent_backend = config.agent_backend
+    if user_config and user_config.llm_provider:
+        provider = user_config.llm_provider
+    else:
+        provider = config.llm_provider
+    model_override = resolve_user_model(ModelRole.PR_REVIEW, user_config, config)
+    workspace = str(await pool.get_effective_workspace(chat_id))
+
+    # Start ack: always sent before the backend invocation; a single
+    # review can run up to PR_REVIEW_TIMEOUT_S seconds and silent
+    # Telegram during that wait would be confusing.
+    await update.message.reply_text(f"Reviewing {repo}#{pr_number}…")
+
+    try:
+        result = await review.generate_pr_review(
+            repo,
+            pr_number,
+            local_repo_path=workspace,
+            spec_dir=config.spec_dir,
+            include_prior_comments=True,
+            claude_user=claude_user,
+            agent_backend=agent_backend,
+            provider=provider,
+            timeout_s=config.pr_review_timeout_s,
+            model_override=model_override,
+        )
+    except Exception as exc:
+        log.exception("Manual review failed for %s#%d", repo, pr_number)
+        await update.message.reply_text(f"Review failed for {repo}#{pr_number}: {exc}")
+        return
+
+    if not result.review_text.strip():
+        await update.message.reply_text(f"Review returned no output for {repo}#{pr_number}.")
+        return
+
+    # File body: short metadata header in front of the raw review
+    # text so the standalone artifact identifies the PR it covers.
+    body = f"# PR #{pr_number} review\n\nRepository: {repo}\nURL: {result.pr_url}\n\n{result.review_text}\n"
+
+    canonical = _REVIEW_TMP_DIR / f"pr-{pr_number}-review.md"
+    canonical.write_text(body)
+
+    # Stage a timestamped copy under DATA_DIR/files/<chat_id>/ using
+    # the existing upload-file naming convention so the staged
+    # artifact composes with the per-chat file area and never
+    # overwrites a previous review's staged copy.
+    staged = _save_upload(body.encode(), f"pr-{pr_number}-review.md", user_id=chat_id)
+
+    # Upload the staged Markdown file to Telegram so phone-only use
+    # can read the full review. The staged file is the upload source
+    # rather than /tmp because the send-file allowlist may reject
+    # /tmp and the staged path lives under the configured per-chat
+    # data area.
+    try:
+        with open(staged, "rb") as f:
+            await context.bot.send_document(
+                chat_id,
+                document=f,
+                caption=f"PR #{pr_number} review\n{canonical}",
+                filename=f"pr-{pr_number}-review.md",
+            )
+    except Exception:
+        # Document upload is best-effort; the canonical /tmp path is
+        # always available so the reviewer can read the review even
+        # if the attachment fails (Telegram size limits, network
+        # blips, etc.).
+        log.exception("Failed to upload staged review document for %s#%d", repo, pr_number)
+
+    # Reply with the absolute path so the operator can open it in
+    # the chat-review-loop convention, plus any collection warnings
+    # so they know what context was incomplete.
+    if result.collection_warnings:
+        warnings_text = "\n".join(f"  [{w.source}] {w.message}" for w in result.collection_warnings)
+        await update.message.reply_text(f"Review written to {canonical}\nWarnings:\n{warnings_text}")
+    else:
+        await update.message.reply_text(f"Review written to {canonical}")
+
+
 @_require_auth
 async def handle_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle /help — show all available commands."""
@@ -3415,6 +3623,8 @@ async def handle_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         "/github token [<token>] - Manage access token\n"
         "/github add <repo> - Watch a repo\n"
         "/github remove <repo> - Unwatch a repo\n"
+        "/review <pr-number> - Review a PR on the inferred repo\n"
+        "/review <owner/repo> <pr-number> - Review an explicit PR\n"
         "\n"
         "/memory - Browse remembered facts and episodes\n"
         "/memory search <q> - Semantic search over memories\n"
@@ -4363,6 +4573,7 @@ def create_bot(config: Config, *, use_webhook: bool = True) -> Application:
     app.add_handler(CommandHandler("voices", handle_voices))
     app.add_handler(CommandHandler("webhooks", handle_webhooks))
     app.add_handler(CommandHandler("github", handle_github))
+    app.add_handler(CommandHandler("review", handle_review_command))
     app.add_handler(CommandHandler("memory", memory_command.handle_memory_command))
     app.add_handler(CommandHandler("stop", handle_stop))
 

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -3557,47 +3557,74 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
     body = f"# PR #{pr_number} review\n\nRepository: {repo}\nURL: {result.pr_url}\n\n{result.review_text}\n"
 
     canonical = _REVIEW_TMP_DIR / f"pr-{pr_number}-review.md"
-    canonical.write_text(body)
+    try:
+        canonical.write_text(body)
+    except OSError as exc:
+        # The canonical artifact is the contract: if we cannot write
+        # it the review effectively does not exist for the operator
+        # (no /tmp file to read, nothing to stage or upload). Surface
+        # the failure as a clear chat error so the operator does not
+        # see only the "Reviewing…" ack and silence.
+        log.exception("Failed to write canonical review artifact for %s#%d", repo, pr_number)
+        await update.message.reply_text(f"Review backend succeeded but writing {canonical} failed: {exc}")
+        return
 
     # Stage a timestamped copy under DATA_DIR/files/<chat_id>/ using
     # the existing upload-file naming convention so the staged
     # artifact composes with the per-chat file area and never
-    # overwrites a previous review's staged copy.
-    staged = _save_upload(body.encode(), f"pr-{pr_number}-review.md", user_id=chat_id)
+    # overwrites a previous review's staged copy. Staging failure
+    # is non-fatal: the canonical /tmp artifact still exists and
+    # the reply will surface the staging gap explicitly.
+    staged: Path | None = None
+    staging_failed = False
+    try:
+        staged = _save_upload(body.encode(), f"pr-{pr_number}-review.md", user_id=chat_id)
+    except OSError:
+        staging_failed = True
+        log.exception("Failed to stage review copy for %s#%d", repo, pr_number)
 
     # Upload the staged Markdown file to Telegram so phone-only use
     # can read the full review. The staged file is the upload source
     # rather than /tmp because the send-file allowlist may reject
     # /tmp and the staged path lives under the configured per-chat
-    # data area. Failure is non-fatal (the canonical /tmp artifact is
-    # already written) but it is NOT silent: a phone-only operator
-    # cannot read /tmp, so the final reply must say the attachment
-    # failed if it did.
+    # data area. Failure is non-fatal (the canonical /tmp artifact
+    # is already written) but it is NOT silent: a phone-only
+    # operator cannot read /tmp, so the final reply must say the
+    # attachment failed if it did.
     upload_failed = False
-    try:
-        with open(staged, "rb") as f:
-            await context.bot.send_document(
-                chat_id,
-                document=f,
-                caption=f"PR #{pr_number} review\n{canonical}",
-                filename=f"pr-{pr_number}-review.md",
-            )
-    except Exception:
-        upload_failed = True
-        log.exception("Failed to upload staged review document for %s#%d", repo, pr_number)
+    if staged is not None:
+        try:
+            with open(staged, "rb") as f:
+                await context.bot.send_document(
+                    chat_id,
+                    document=f,
+                    caption=f"PR #{pr_number} review\n{canonical}",
+                    filename=f"pr-{pr_number}-review.md",
+                )
+        except Exception:
+            upload_failed = True
+            log.exception("Failed to upload staged review document for %s#%d", repo, pr_number)
 
-    # Reply with the absolute path so the operator can open it in
-    # the chat-review-loop convention, plus any collection warnings
-    # so they know what context was incomplete, plus an explicit
-    # note if the document attachment failed.
-    reply_lines: list[str] = [f"Review written to {canonical}"]
-    if upload_failed:
-        reply_lines.append("Attachment failed; open the file at the path above.")
+    # Reply 1: short status line. Always sent first so the operator
+    # sees the canonical path immediately, before any potentially
+    # long warning block. Per the spec the status comes before
+    # warnings, and per Telegram's 4096-char message limit it has to
+    # stand alone so a flood of warnings does not crowd it out.
+    status_lines = [f"Review written to {canonical}"]
+    if staging_failed:
+        status_lines.append("Staging copy failed; document attachment skipped.")
+    elif upload_failed:
+        status_lines.append("Attachment failed; open the file at the path above.")
+    await update.message.reply_text("\n".join(status_lines))
+
+    # Reply 2+: collection warnings, chunked so the Telegram message
+    # limit (4096 chars) cannot truncate the final reply when a
+    # large bundle emits many file/fetch failures. chunk_text breaks
+    # at paragraph or line boundaries when possible.
     if result.collection_warnings:
-        reply_lines.append("Warnings:")
-        for w in result.collection_warnings:
-            reply_lines.append(f"  [{w.source}] {w.message}")
-    await update.message.reply_text("\n".join(reply_lines))
+        warnings_block = "Warnings:\n" + "\n".join(f"  [{w.source}] {w.message}" for w in result.collection_warnings)
+        for chunk in chunk_text(warnings_block):
+            await update.message.reply_text(chunk)
 
 
 @_require_auth

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -3388,12 +3388,11 @@ _REVIEW_TMP_DIR = Path("/tmp")
 
 async def _resolve_review_repo(
     actor_id: int,
-    chat_id: int,
-    pool: "SubprocessPool",
+    workspace: str,
     config: Config,
-) -> str:
+) -> tuple[str, str]:
     """
-    Resolve the short-form `/review <pr-number>` to an `owner/name` repo.
+    Resolve the short-form `/review <pr-number>` to ``(repo, workspace_remote)``.
 
     Walks the conservative ladder per the spec:
 
@@ -3408,27 +3407,38 @@ async def _resolve_review_repo(
     No fallback to ``Config.github_repo`` (deprecated), no
     first-of-list, and no new workspace-to-repo mapping.
 
+    The second tuple element is the normalized workspace `origin`
+    remote (or "" when the workspace is not a GitHub checkout). The
+    caller compares it to the chosen repo to decide whether the
+    workspace is safe to pass as ``local_repo_path``; passing a
+    workspace that does not match the target repo would surface the
+    wrong spec / conventions / surrounding-code excerpts into the
+    review, regardless of which ladder rung produced the repo.
+
     Args:
         actor_id: The authorized Telegram user id; drives user-scoped
             config and effective-repo lookups so a group chat does
             not read the wrong user's settings.
-        chat_id: The chat id; drives workspace resolution (workspaces
-            are chat-scoped via the pool).
+        workspace: The active workspace path (already resolved via
+            the pool); kept as a parameter so the caller can also
+            check workspace-matches in the explicit-repo branch
+            without re-fetching.
     """
     user_config = config.get_user_config(actor_id)
     yaml_repos = user_config.github_repos if user_config else []
     effective_repos = await sessions.get_effective_repos(actor_id, yaml_repos)
     effective_lower = {r.lower() for r in effective_repos}
 
-    workspace = str(await pool.get_effective_workspace(chat_id))
-    workspace_remote = await review._resolve_workspace_remote_repo(workspace)
-    if workspace_remote and workspace_remote.lower() in effective_lower:
-        return workspace_remote.lower()
+    workspace_remote_raw = await review._resolve_workspace_remote_repo(workspace)
+    workspace_remote = workspace_remote_raw.lower() if workspace_remote_raw else ""
+
+    if workspace_remote and workspace_remote in effective_lower:
+        return workspace_remote, workspace_remote
 
     if len(effective_repos) == 1:
-        return effective_repos[0].lower()
+        return effective_repos[0].lower(), workspace_remote
 
-    return ""
+    return "", workspace_remote
 
 
 @_require_auth
@@ -3476,13 +3486,18 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
     chat_id = _chat_id(update)
     config: Config = context.bot_data["config"]
     pool = _get_pool(context)
+    workspace = str(await pool.get_effective_workspace(chat_id))
 
     args = list(context.args or [])
     usage = "Usage: /review [owner/repo] <pr-number>"
 
     # Two shapes: one arg (PR number, inferred repo) or two args
     # (explicit repo + PR number). Anything else is a usage error.
+    # `workspace_remote` captures the normalized active-workspace
+    # `origin` so the post-parse step can decide whether the
+    # workspace is safe to pass as local_repo_path.
     repo: str = ""
+    workspace_remote: str = ""
     pr_number: int = 0
     if len(args) == 1:
         try:
@@ -3490,7 +3505,7 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
         except ValueError:
             await update.message.reply_text(usage)
             return
-        repo = await _resolve_review_repo(actor_id, chat_id, pool, config)
+        repo, workspace_remote = await _resolve_review_repo(actor_id, workspace, config)
         if not repo:
             await update.message.reply_text(
                 f"{usage}\n"
@@ -3509,6 +3524,8 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
         except ValueError:
             await update.message.reply_text(usage)
             return
+        workspace_remote_raw = await review._resolve_workspace_remote_repo(workspace)
+        workspace_remote = workspace_remote_raw.lower() if workspace_remote_raw else ""
     else:
         await update.message.reply_text(usage)
         return
@@ -3523,7 +3540,16 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
     claude_user = user_config.os_user if user_config and user_config.os_user else None
     agent_backend, provider = get_user_backend_and_provider(user_config, config)
     model_override = resolve_user_model(ModelRole.PR_REVIEW, user_config, config)
-    workspace = str(await pool.get_effective_workspace(chat_id))
+
+    # Only pass the workspace as `local_repo_path` when its `origin`
+    # remote actually matches the target repo. Otherwise the bundle
+    # would load spec/conventions from an unrelated checkout and
+    # the surrounding-code search would either misdirect (rare path
+    # collisions) or emit a noisy unavailable warning even though
+    # the workspace and the PR repo are intentionally unrelated.
+    # Passing None makes the bundle skip spec, conventions, and
+    # related-context cleanly.
+    local_repo_path = workspace if workspace_remote == repo else None
 
     # Start ack: always sent before the backend invocation; a single
     # review can run up to PR_REVIEW_TIMEOUT_S seconds and silent
@@ -3534,7 +3560,7 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
         result = await review.generate_pr_review(
             repo,
             pr_number,
-            local_repo_path=workspace,
+            local_repo_path=local_repo_path,
             spec_dir=config.spec_dir,
             include_prior_comments=True,
             claude_user=claude_user,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -6374,3 +6374,140 @@ class TestHandleReviewCommand:
         combined = "\n".join(replies)
         for w in warnings:
             assert w.source in combined
+
+    @pytest.mark.asyncio
+    async def test_explicit_form_with_mismatched_workspace_passes_none(self, tmp_path, monkeypatch):
+        # Operator is sitting in workspace whose origin points at a
+        # different repo (e.g. /Users/op/some-other-repo) and runs
+        # `/review dcellison/kai 681`. The bundle must NOT load
+        # local spec / conventions / surrounding-code from the
+        # unrelated checkout; the only safe choice is to pass
+        # local_repo_path=None so the bundle skips local lookups
+        # entirely.
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            # Active workspace's origin resolves to a different repo.
+            patch(
+                "kai.review._resolve_workspace_remote_repo",
+                new=AsyncMock(return_value="dcellison/other-repo"),
+            ),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        assert mock_generate.call_args.kwargs["local_repo_path"] is None
+
+    @pytest.mark.asyncio
+    async def test_explicit_form_with_matching_workspace_passes_workspace(self, tmp_path, monkeypatch):
+        # Same as above but the workspace IS the target repo's
+        # checkout. The bundle gets the workspace so spec /
+        # conventions / surrounding-code search can use it.
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.review._resolve_workspace_remote_repo",
+                new=AsyncMock(return_value="dcellison/kai"),
+            ),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        assert mock_generate.call_args.kwargs["local_repo_path"] == "/home/workspace"
+
+    @pytest.mark.asyncio
+    async def test_short_form_sole_effective_with_mismatched_workspace_passes_none(self, tmp_path, monkeypatch):
+        # Short form falls back to the sole effective repo because
+        # the workspace remote does not match it (or is empty).
+        # local_repo_path must be None in that case for the same
+        # reason as the explicit form: the workspace and the
+        # inferred repo are intentionally unrelated.
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        config = _make_config(
+            user_configs={
+                12345: UserConfig(
+                    telegram_id=12345,
+                    name="op",
+                    github_repos=["dcellison/kai"],
+                ),
+            }
+        )
+        ctx = _make_context(config=config, args=["681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            # No GitHub remote at all (e.g. a plain non-git
+            # workspace) - the sole-effective fallback fires but
+            # the workspace must not propagate.
+            patch("kai.review._resolve_workspace_remote_repo", new=AsyncMock(return_value="")),
+            patch(
+                "kai.sessions.get_effective_repos",
+                new=AsyncMock(return_value=["dcellison/kai"]),
+            ),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        assert mock_generate.call_args.kwargs["local_repo_path"] is None
+
+    @pytest.mark.asyncio
+    async def test_short_form_workspace_match_passes_workspace(self, tmp_path, monkeypatch):
+        # Belt and braces for the happy path: short form picks up
+        # the workspace remote AND the workspace flows through as
+        # local_repo_path so the bundle's full-context path runs.
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        config = _make_config(
+            user_configs={
+                12345: UserConfig(
+                    telegram_id=12345,
+                    name="op",
+                    github_repos=["dcellison/kai", "dcellison/other"],
+                ),
+            }
+        )
+        ctx = _make_context(config=config, args=["681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.review._resolve_workspace_remote_repo",
+                new=AsyncMock(return_value="dcellison/kai"),
+            ),
+            patch(
+                "kai.sessions.get_effective_repos",
+                new=AsyncMock(return_value=["dcellison/kai", "dcellison/other"]),
+            ),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        assert mock_generate.call_args.kwargs["local_repo_path"] == "/home/workspace"

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -6185,3 +6185,86 @@ class TestHandleReviewCommand:
         mock_generate.assert_not_called()
         replies = [c.args[0] for c in update.message.reply_text.call_args_list]
         assert any("Usage: /review" in r for r in replies)
+
+    @pytest.mark.asyncio
+    async def test_group_chat_uses_user_id_for_user_scoped_lookups(self, tmp_path, monkeypatch):
+        # In a notification group the message arrives on a group
+        # chat_id but the actor is the operator. User-scoped lookups
+        # (user_config, effective repos) must key on user_id, NOT
+        # chat_id, so the review picks up the operator's settings.
+        # Without this split, get_user_config(group_chat_id) returns
+        # None, github_repos is [], and the resolution silently
+        # collapses to the global defaults.
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update(chat_id=-100888, user_id=12345)
+        # User config keyed by user_id (12345), not chat_id (-100888).
+        config = _make_config(
+            user_configs={
+                12345: UserConfig(
+                    telegram_id=12345,
+                    name="op",
+                    github_repos=["dcellison/kai"],
+                    agent_backend="codex",
+                    llm_provider="openai",
+                    os_user="daniel",
+                ),
+            },
+            allowed_user_ids={12345},
+        )
+        ctx = _make_context(config=config, args=["681"])
+        ctx.bot.send_document = AsyncMock()
+
+        mock_effective = AsyncMock(return_value=["dcellison/kai"])
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch("kai.review._resolve_workspace_remote_repo", new=AsyncMock(return_value="")),
+            patch("kai.sessions.get_effective_repos", new=mock_effective),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        # effective-repos lookup uses the actor (user) id, not the
+        # group chat id - this is the load-bearing assertion.
+        assert mock_effective.await_args.args[0] == 12345
+        # The review actually runs with the operator's resolved
+        # settings (codex / openai / daniel), not the global
+        # defaults that would apply if the lookup had used the
+        # group chat id.
+        kwargs = mock_generate.call_args.kwargs
+        assert kwargs["agent_backend"] == "codex"
+        assert kwargs["provider"] == "openai"
+        assert kwargs["claude_user"] == "daniel"
+        # And the inferred repo is the operator's (sole) effective
+        # repo, not empty.
+        assert mock_generate.call_args.args == ("dcellison/kai", 681)
+
+    @pytest.mark.asyncio
+    async def test_upload_failure_is_surfaced_in_reply(self, tmp_path, monkeypatch):
+        # Phone-only operators cannot read /tmp; if the document
+        # upload fails the final chat reply must say so rather than
+        # silently telling them to open a file they can't reach.
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update(chat_id=12345)
+        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx.bot.send_document = AsyncMock(side_effect=RuntimeError("file too large"))
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ),
+        ):
+            await handle_review_command(update, ctx)
+
+        replies = [c.args[0] for c in update.message.reply_text.call_args_list]
+        # The canonical path is still surfaced...
+        assert any("Review written to" in r for r in replies)
+        # ...AND the failure is visible.
+        assert any("Attachment failed" in r for r in replies)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -59,6 +59,7 @@ from kai.bot import (
     handle_models,
     handle_new,
     handle_photo,
+    handle_review_command,
     handle_settings,
     handle_start,
     handle_stats,
@@ -74,6 +75,7 @@ from kai.bot import (
     handle_workspaces,
 )
 from kai.config import PROVIDER_MODELS, Config, UserConfig
+from kai.review import CollectionWarning, PRReviewResult
 from kai.tts import DEFAULT_VOICE, VOICES
 from kai.workspace_utils import is_workspace_allowed
 
@@ -426,12 +428,14 @@ class TestSaveUpload:
     def test_creates_files_directory(self, tmp_path, monkeypatch):
         """Automatically creates the files/ subdirectory if missing."""
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         _save_upload(b"hello", "test.txt")
         assert (tmp_path / "files").is_dir()
 
     def test_saves_content_correctly(self, tmp_path, monkeypatch):
         """Written bytes match the input exactly."""
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         data = b"binary content here"
         result = _save_upload(data, "doc.pdf")
         assert result.read_bytes() == data
@@ -439,12 +443,14 @@ class TestSaveUpload:
     def test_filename_contains_original_name(self, tmp_path, monkeypatch):
         """Saved filename preserves the original name after the timestamp."""
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         result = _save_upload(b"x", "report.pdf")
         assert "report.pdf" in result.name
 
     def test_timestamp_prefix_format(self, tmp_path, monkeypatch):
         """Filename starts with YYYYMMDD_HHMMSS_ffffff timestamp."""
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         result = _save_upload(b"x", "file.txt")
         # Format: YYYYMMDD_HHMMSS_ffffff_file.txt
         parts = result.name.split("_", 3)
@@ -455,6 +461,7 @@ class TestSaveUpload:
     def test_sanitizes_slashes_and_spaces(self, tmp_path, monkeypatch):
         """Slashes and spaces in filenames are replaced with underscores."""
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         result = _save_upload(b"x", "my file/name.txt")
         assert "/" not in result.name
         assert " " not in result.name
@@ -462,6 +469,7 @@ class TestSaveUpload:
     def test_returns_absolute_path(self, tmp_path, monkeypatch):
         """Returned path is absolute and points to an existing file."""
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         result = _save_upload(b"x", "test.txt")
         assert result.is_absolute()
         assert result.is_file()
@@ -5781,3 +5789,399 @@ class TestWorkspaceNewAutoRegister:
         switch.assert_awaited_once()
         replies = [c.args[0] for c in update.message.reply_text.call_args_list]
         assert any("memory project not registered" in r for r in replies)
+
+
+# ── handle_review_command (Telegram manual review) ─────────────────────
+
+
+def _review_result(text: str = "review output", warnings=()) -> PRReviewResult:
+    """Build a PRReviewResult fixture for the manual command tests."""
+    return PRReviewResult(
+        repo="dcellison/kai",
+        pr_number=681,
+        pr_title="Test PR",
+        pr_url="https://github.com/dcellison/kai/pull/681",
+        review_text=text,
+        collection_warnings=tuple(warnings),
+    )
+
+
+class TestHandleReviewCommand:
+    """
+    Manual /review command. The handler shares the bundle path with
+    the webhook bot via generate_pr_review(); these tests cover the
+    Telegram-specific surface (repo resolution, start ack, file
+    staging, document upload, no-GitHub-comment, no-cooldown-touch,
+    warning surfacing).
+    """
+
+    @pytest.mark.asyncio
+    async def test_short_form_uses_workspace_git_remote_match(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        config = _make_config(
+            user_configs={
+                12345: UserConfig(
+                    telegram_id=12345,
+                    name="op",
+                    github_repos=["dcellison/kai", "dcellison/other"],
+                ),
+            }
+        )
+        ctx = _make_context(config=config, args=["681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.review._resolve_workspace_remote_repo",
+                new=AsyncMock(return_value="dcellison/kai"),
+            ),
+            patch(
+                "kai.sessions.get_effective_repos",
+                new=AsyncMock(return_value=["dcellison/kai", "dcellison/other"]),
+            ),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        assert mock_generate.call_args.args == ("dcellison/kai", 681)
+
+    @pytest.mark.asyncio
+    async def test_short_form_falls_back_to_sole_effective_repo(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        # Workspace remote doesn't match the single effective repo;
+        # the sole-effective fallback kicks in.
+        config = _make_config(
+            user_configs={
+                12345: UserConfig(
+                    telegram_id=12345,
+                    name="op",
+                    github_repos=["dcellison/kai"],
+                ),
+            }
+        )
+        ctx = _make_context(config=config, args=["681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch("kai.review._resolve_workspace_remote_repo", new=AsyncMock(return_value="")),
+            patch(
+                "kai.sessions.get_effective_repos",
+                new=AsyncMock(return_value=["dcellison/kai"]),
+            ),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        assert mock_generate.call_args.args == ("dcellison/kai", 681)
+
+    @pytest.mark.asyncio
+    async def test_short_form_usage_error_when_unresolved(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        # Multi-repo + no workspace match → usage error.
+        config = _make_config(
+            user_configs={
+                12345: UserConfig(
+                    telegram_id=12345,
+                    name="op",
+                    github_repos=["dcellison/kai", "dcellison/other"],
+                ),
+            }
+        )
+        ctx = _make_context(config=config, args=["681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch("kai.review._resolve_workspace_remote_repo", new=AsyncMock(return_value="")),
+            patch(
+                "kai.sessions.get_effective_repos",
+                new=AsyncMock(return_value=["dcellison/kai", "dcellison/other"]),
+            ),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(),
+            ) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        mock_generate.assert_not_called()
+        replies = [c.args[0] for c in update.message.reply_text.call_args_list]
+        assert any("Usage: /review" in r for r in replies)
+
+    @pytest.mark.asyncio
+    async def test_explicit_owner_repo_form(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        assert mock_generate.call_args.args == ("dcellison/kai", 681)
+
+    @pytest.mark.asyncio
+    async def test_invalid_repo_format_returns_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        ctx = _make_context(args=["not-a-repo", "681"])
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(),
+            ) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        mock_generate.assert_not_called()
+        replies = [c.args[0] for c in update.message.reply_text.call_args_list]
+        assert any("Invalid repo format" in r for r in replies)
+
+    @pytest.mark.asyncio
+    async def test_invalid_pr_number_returns_usage(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        ctx = _make_context(args=["dcellison/kai", "not-a-number"])
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(),
+            ) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        mock_generate.assert_not_called()
+        replies = [c.args[0] for c in update.message.reply_text.call_args_list]
+        assert any("Usage: /review" in r for r in replies)
+
+    @pytest.mark.asyncio
+    async def test_start_ack_before_backend(self, tmp_path, monkeypatch):
+        # The start ack must fire BEFORE generate_pr_review returns.
+        # We assert ordering by checking the reply_text call sequence.
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx.bot.send_document = AsyncMock()
+
+        ack_at_call: list[int] = []
+
+        async def _capture(*_args, **_kwargs):
+            # Snapshot reply count at the moment the backend runs.
+            ack_at_call.append(len(update.message.reply_text.call_args_list))
+            return _review_result()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch("kai.bot.review.generate_pr_review", new=AsyncMock(side_effect=_capture)),
+        ):
+            await handle_review_command(update, ctx)
+
+        assert ack_at_call == [1], "start ack must be sent before generate_pr_review runs"
+
+    @pytest.mark.asyncio
+    async def test_writes_canonical_tmp_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result(text="bundle review body")),
+            ),
+        ):
+            await handle_review_command(update, ctx)
+
+        canonical = tmp_path / "pr-681-review.md"
+        assert canonical.exists()
+        body = canonical.read_text()
+        assert "bundle review body" in body
+        assert "Repository: dcellison/kai" in body
+
+    @pytest.mark.asyncio
+    async def test_stages_timestamped_copy_under_chat_files(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update(chat_id=12345)
+        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ),
+        ):
+            await handle_review_command(update, ctx)
+
+        staged_dir = tmp_path / "files" / "12345"
+        assert staged_dir.is_dir()
+        staged = list(staged_dir.glob("*_pr-681-review.md"))
+        assert len(staged) == 1, f"expected one timestamped staged copy, got {staged}"
+
+    @pytest.mark.asyncio
+    async def test_uploads_staged_file_to_telegram(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update(chat_id=12345)
+        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ),
+        ):
+            await handle_review_command(update, ctx)
+
+        ctx.bot.send_document.assert_awaited_once()
+        kwargs = ctx.bot.send_document.await_args.kwargs
+        assert kwargs["filename"] == "pr-681-review.md"
+        caption = kwargs["caption"]
+        assert "pr-681-review.md" in caption
+
+    @pytest.mark.asyncio
+    async def test_does_not_post_to_github(self, tmp_path, monkeypatch):
+        # post_review_comment lives in review.py; the manual command
+        # must never call it directly. The webhook path goes through
+        # review_pr; the Telegram path must NOT.
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ),
+            patch("kai.review.post_review_comment", new=AsyncMock()) as mock_post,
+        ):
+            await handle_review_command(update, ctx)
+
+        mock_post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_touch_webhook_cooldown(self, tmp_path, monkeypatch):
+        # The webhook cooldown map is private to webhook.py. The
+        # manual command runs as explicit user action and must not
+        # update it; a manual review at T must not suppress an
+        # automatic review on a later push.
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx.bot.send_document = AsyncMock()
+
+        from kai.webhook import _review_cooldowns
+
+        baseline = dict(_review_cooldowns)
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ),
+        ):
+            await handle_review_command(update, ctx)
+
+        assert dict(_review_cooldowns) == baseline
+
+    @pytest.mark.asyncio
+    async def test_collection_warnings_surface_in_reply(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx.bot.send_document = AsyncMock()
+
+        warnings = (CollectionWarning(source="related_search", message="search unavailable for repo"),)
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result(warnings=warnings)),
+            ),
+        ):
+            await handle_review_command(update, ctx)
+
+        replies = [c.args[0] for c in update.message.reply_text.call_args_list]
+        assert any("Warnings:" in r and "search unavailable" in r for r in replies)
+
+    @pytest.mark.asyncio
+    async def test_backend_failure_replies_with_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(side_effect=RuntimeError("backend timeout")),
+            ),
+        ):
+            await handle_review_command(update, ctx)
+
+        replies = [c.args[0] for c in update.message.reply_text.call_args_list]
+        assert any("Review failed" in r for r in replies)
+        ctx.bot.send_document.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_args_returns_usage(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        ctx = _make_context(args=[])
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(),
+            ) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        mock_generate.assert_not_called()
+        replies = [c.args[0] for c in update.message.reply_text.call_args_list]
+        assert any("Usage: /review" in r for r in replies)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -6268,3 +6268,109 @@ class TestHandleReviewCommand:
         assert any("Review written to" in r for r in replies)
         # ...AND the failure is visible.
         assert any("Attachment failed" in r for r in replies)
+
+    @pytest.mark.asyncio
+    async def test_canonical_write_failure_is_surfaced(self, tmp_path, monkeypatch):
+        # If the canonical /tmp/pr-N-review.md write fails (permission
+        # denied, disk full, etc.), the contract is broken: there is
+        # no artifact for the operator to read. The operator must see
+        # a clear chat error, not just the initial "Reviewing…" ack
+        # and silence.
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        # Point _REVIEW_TMP_DIR at a path that does NOT exist so the
+        # write_text call raises OSError without touching real /tmp.
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path / "does-not-exist")
+        update = _make_update()
+        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ),
+        ):
+            await handle_review_command(update, ctx)
+
+        replies = [c.args[0] for c in update.message.reply_text.call_args_list]
+        assert any("writing" in r and "failed" in r for r in replies)
+        ctx.bot.send_document.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_staging_failure_surfaces_in_status(self, tmp_path, monkeypatch):
+        # Staging is non-fatal (canonical /tmp still exists) but the
+        # operator should know the attachment will not arrive so they
+        # can fetch the file another way.
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ),
+            patch("kai.bot._save_upload", side_effect=OSError("read-only filesystem")),
+        ):
+            await handle_review_command(update, ctx)
+
+        replies = [c.args[0] for c in update.message.reply_text.call_args_list]
+        assert any("Staging copy failed" in r for r in replies)
+        # send_document must NOT fire when staging failed because
+        # there is no staged path to upload from.
+        ctx.bot.send_document.assert_not_awaited()
+        # Canonical path is still surfaced.
+        assert any("Review written to" in r for r in replies)
+
+    @pytest.mark.asyncio
+    async def test_many_warnings_chunked_under_telegram_limit(self, tmp_path, monkeypatch):
+        # A bundle that hits many file fetch failures can produce
+        # dozens of warnings. Concatenating them all into a single
+        # reply with the status line can blow past Telegram's 4096-
+        # char limit and cause the final reply to fail silently.
+        # Status and warnings are split across separate replies,
+        # each kept under the limit by chunk_text.
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx.bot.send_document = AsyncMock()
+
+        # Build warnings whose combined size exceeds 4096 chars.
+        warnings = tuple(
+            CollectionWarning(
+                source=f"changed_file:src/module_{i}.py",
+                message="content fetch failed: " + ("x" * 200),
+            )
+            for i in range(30)
+        )
+        assert sum(len(w.message) for w in warnings) > 4096
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result(warnings=warnings)),
+            ),
+        ):
+            await handle_review_command(update, ctx)
+
+        replies = [c.args[0] for c in update.message.reply_text.call_args_list]
+        # Telegram's hard limit is 4096; every reply must respect it.
+        for r in replies:
+            assert len(r) <= 4096, f"reply exceeds Telegram message limit: {len(r)} chars"
+        # Skip past the "Reviewing…" start ack to the post-backend
+        # replies; the canonical status line is the first post-
+        # backend reply and stands alone.
+        post_backend = [r for r in replies if not r.startswith("Reviewing ")]
+        assert post_backend[0].startswith("Review written to")
+        assert "Warnings:" not in post_backend[0]
+        assert any("Warnings:" in r for r in post_backend[1:])
+        # All warning sources appeared somewhere.
+        combined = "\n".join(replies)
+        for w in warnings:
+            assert w.source in combined


### PR DESCRIPTION
## Summary

- Phase 2 of the #666 epic: expose the shared review bundle through a Telegram `/review` command so the operator can request a deep PR review on demand from any chat (phone-only use included). The webhook bot was phase 1.
- Shapes: `/review <pr-number>` (repo inferred from the active workspace's `origin` remote when it matches an effective repo, else from the sole effective repo, else a usage error asking for the explicit form) and `/review <owner/repo> <pr-number>` (explicit).
- Auth + TOTP gate mirrors content-invoking commands. Review runs inside the update handler; a "Reviewing repo#N…" ack always goes out before the backend so a 5-15 minute wait does not look like the bot hung. Canonical artifact at `/tmp/pr-<N>-review.md` (deliberate echo of the chat-review-loop convention), timestamped staging copy under `DATA_DIR/files/<chat_id>/`, document upload of the staged copy. No GitHub comment posted; webhook cooldown untouched.

## What changed

`src/kai/bot.py`:

- `_resolve_review_repo` (private helper) for the short-form ladder: workspace `origin` ∩ effective repos → sole effective repo → empty (caller prompts for explicit form). No fallback to deprecated `Config.github_repo`, no first-of-list.
- `handle_review_command` registered as `CommandHandler("review", ...)`. Auth via `_require_auth`; TOTP via `_check_totp` (same precedent as `handle_photo`).
- `_REVIEW_TMP_DIR` module constant so tests can redirect the canonical `/tmp/pr-<N>-review.md` path to `tmp_path` without colliding with locally-owned `/tmp/pr-<N>-review.md` files from the operator's chat-review-loop scrollback.
- `/review` help text added to `handle_help`.

`tests/test_bot.py`:

- 15 tests in `TestHandleReviewCommand` covering the resolution ladder, invalid-format / usage paths, start-ack ordering (ack must arrive before the backend call), canonical `/tmp` write, timestamped staging under `<data-dir>/files/<chat-id>/`, document upload via `context.bot.send_document`, no-`post_review_comment` invariant, no-cooldown-touch invariant, collection-warning surfacing, and backend-failure reply.

## Test plan

- [x] `make check` clean.
- [x] `make test`: 4491 passed, 1 skipped (4476 baseline + 15 new).
- [ ] After merge + deploy: invoke `/review <pr-number>` on a real PR from Telegram and confirm the start ack, the canonical `/tmp` write, the timestamped staging copy, the Telegram document upload, and that no GitHub comment is posted on the target PR.

Closes #683
Closes #666
