### PR TITLE
Size review caps to hold both files in a realistic kai PR

### DIFF
--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -84,22 +84,21 @@ _MAX_PRIOR_COMMENTS_CHARS = 50_000
 #
 # Per-section caps used by the deterministic budgeter that backs
 # build_pr_review_context() / build_review_prompt_from_context(). The
-# v1 numbers (240K global / 90K changed-files / 200K per-file) were
-# tuned conservatively, and a manual acceptance pass against a real
-# kai PR (3 commits touching `bot.py` and `test_bot.py`) showed both
-# changed files dropped to notes: `test_bot.py` exceeded the 200K
-# per-file cap and `bot.py` exceeded the 90K section cap. That left
-# the bundle reviewer relying on the patch alone for the very files
-# the bundle was supposed to broaden context around. The realistic
-# kai codebase has several modules in the 150-220K-char range
-# (`bot.py`, `webhook.py`, `config.py`, `sessions.py`, `review.py`,
-# `pool.py`, the larger test files); any PR touching one of those
-# would hit the same drop. Caps are rebalanced here so realistic PRs
-# carry full file contents through to the reviewer, with the
-# cross-section drop ladder still enforcing the global ceiling.
-_MAX_REVIEW_CONTEXT_CHARS = 360_000
+# numbers target the realistic kai PR shape: a source module plus
+# its corresponding test file in the same change. Concretely, today's
+# `bot.py` is ~180K chars and `tests/test_bot.py` is ~246K chars; a
+# single-file rebalance is not enough because the budgeter measures
+# the COMBINED rendered size of the changed-files section, not each
+# file in isolation. The first production webhook review against the
+# previous cap set (250K changed-files / 360K global) saw ~426K
+# combined and dropped `test_bot.py` to a note even though both
+# files were inside the per-file cap. The current values admit the
+# two-large-file case so the bundle's full-file context survives
+# end-to-end. The cross-section drop ladder still enforces the
+# global ceiling when an unusually large PR overshoots.
+_MAX_REVIEW_CONTEXT_CHARS = 600_000
 _MAX_PATCH_CHARS = 80_000
-_MAX_CHANGED_FILES_CHARS = 250_000
+_MAX_CHANGED_FILES_CHARS = 450_000
 _MAX_RELATED_CONTEXT_CHARS = 35_000
 _MAX_LINKED_ISSUES_CHARS = 30_000
 _MAX_COMMITS_CHARS = 20_000

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -2369,6 +2369,56 @@ class TestRelatedContextDropsByPriority:
         assert "src/b.py" not in paths
 
 
+class TestBudgetHoldsTwoRealisticChangedFiles:
+    """
+    The realistic kai PR shape touches a source module and its test
+    file together. Both files have to survive the changed-files
+    section cap; if either gets dropped to a note, the bundle's
+    full-file context promise is broken for the very pattern users
+    rely on. The cap numbers must hold the COMBINED rendered size,
+    not just each file in isolation - the budgeter measures the
+    sum, not the max.
+    """
+
+    def test_both_realistic_files_inline_unchanged(self):
+        bot_size = 180_000
+        test_size = 246_000
+        files = (
+            ChangedFile(
+                path="src/kai/bot.py",
+                status="modified",
+                content="b" * bot_size,
+                note=None,
+            ),
+            ChangedFile(
+                path="tests/test_bot.py",
+                status="modified",
+                content="t" * test_size,
+                note=None,
+            ),
+        )
+        ctx = _ctx(
+            changed_files=files,
+            patch="diff " * 1000,
+        )
+        out = budget_review_context(ctx)
+        # No CHANGED_FILES_AT_HEAD truncation note - both files
+        # survive the per-section cap.
+        sections = {n.section for n in out.budget_notes}
+        assert "CHANGED_FILES_AT_HEAD" not in sections, (
+            f"changed-files were trimmed: {[n for n in out.budget_notes if n.section == 'CHANGED_FILES_AT_HEAD']}"
+        )
+        # Both files keep their full content.
+        kept_paths = {f.path: f.content for f in out.changed_files}
+        assert kept_paths["src/kai/bot.py"] is not None
+        assert kept_paths["tests/test_bot.py"] is not None
+        assert len(kept_paths["src/kai/bot.py"]) == bot_size
+        assert len(kept_paths["tests/test_bot.py"]) == test_size
+        # And the result stays under the global cap so the cross-section
+        # ladder does not have to fire.
+        assert _estimate_total_chars(out) <= _MAX_REVIEW_CONTEXT_CHARS
+
+
 class TestBudgetEnforcesGlobalCeiling:
     """
     After per-section caps, the final bundle must respect


### PR DESCRIPTION
## Summary

- The production webhook bot's first bundle review on PR #685 caught a real gap I missed: the prior cap rebalance promised both `src/kai/bot.py` and `tests/test_bot.py` would inline together, but `_cap_changed_files()` measures the **combined** rendered size of the changed-files section, not each file in isolation. 180K + 246K + per-file overhead = ~426K, which still overshoots the 250K section cap.
- The acceptance test I added in PR #685 only exercised the fetcher path for a single 180K file, so it never crossed the budgeter and missed the production failure mode.
- Bump section cap to 450K and global cap to 600K so the realistic kai PR shape (a source module plus its test file) actually fits. Per-file cap stays at 500K.

## What changed

`src/kai/review.py`:

- `_MAX_CHANGED_FILES_CHARS`: 250K → 450K
- `_MAX_REVIEW_CONTEXT_CHARS`: 360K → 600K
- Comment block updated to record the two-file failure mode the production webhook bot surfaced.

`tests/test_review.py`:

- New `TestBudgetHoldsTwoRealisticChangedFiles.test_both_realistic_files_inline_unchanged` runs the actual budgeter against a 180K-char source file and a 246K-char test file, asserts no `CHANGED_FILES_AT_HEAD` truncation note, asserts both files keep their full content, and asserts the bundle stays under the global cap.

## Test plan

- [x] `make check` clean.
- [x] `make test`: 4477 passed (4476 baseline + 1 new), 1 skipped.

Refs #666
