### PR TITLE
Add legacy_retrieve_hits and embed_texts public helpers

### DIFF
--- a/src/kai/eval/retrieval.py
+++ b/src/kai/eval/retrieval.py
@@ -662,6 +662,76 @@ def _detach_capture(capture: _RecallLogCapture) -> None:
         logger.setLevel(capture._saved_level)
 
 
+async def legacy_retrieve_hits(question: str, user_id: str) -> tuple[list[dict[str, Any]], int]:
+    """
+    Run the legacy recall pipeline for one question and return its hits.
+
+    Wraps the attach/format_context/drain/detach pattern used inside
+    `_run_one_probe` so external callers (e.g. the collision-probe
+    generator at `kai.eval.gen_collision_probes`) can reuse the
+    legacy harness as a verification gate without reaching into
+    `_attach_capture` / `_detach_capture` directly.
+
+    Why a public helper and not just exposing the captures:
+    callers need the attach / call / drain / detach invariant
+    intact. Three of the four steps are bookkeeping around one
+    awaited call that can raise; the only way to guarantee the
+    capture handler is removed from `kai.memory`'s logger on every
+    exit path is to keep the try/finally in one place. A naive caller
+    that attaches and forgets to detach pollutes the logger for the
+    rest of the process and silently corrupts the next probe by
+    delivering its `memory.recall` record to two handlers.
+
+    The single-payload check matches the legacy harness's contract
+    (`format_context` emits exactly one `memory.recall` line per
+    call). Zero indicates the logger never received the record
+    (level filter, missing handler, removed log statement); more
+    than one indicates a logging-discipline regression. Both are
+    raised loudly because silently picking one would make every
+    downstream score wrong in ways nothing else would catch.
+
+    Args:
+        question: The probe question text. Passed verbatim to
+            `kai.memory.format_context`.
+        user_id: Kai user id (Telegram chat id as a string for
+            production callers). Scopes the recall to one user.
+
+    Returns:
+        A 2-tuple of (hits, latency_ms) drawn from the captured
+        `memory.recall` payload. `hits` is the raw list of hit dicts
+        in the order the pipeline ranked them; `latency_ms` is the
+        end-to-end retrieval latency the pipeline measured.
+
+    Raises:
+        RuntimeError: If zero or more than one `memory.recall` log
+            records are captured for the call.
+    """
+    # Deferred import: mirrors `_run_one_probe`. `kai.memory` pulls in
+    # PyTorch / sentence-transformers when memory is enabled, which is
+    # too expensive to load at module-import time for callers that may
+    # not actually invoke the helper.
+    from kai.memory import format_context
+
+    capture = _attach_capture()
+    try:
+        await format_context(question, user_id=user_id)
+        payloads = capture.drain()
+        if len(payloads) != 1:
+            raise RuntimeError(
+                f"expected exactly one memory.recall log per probe, got {len(payloads)} for question {question!r}"
+            )
+        payload = payloads[0]
+        return list(payload.get("hits", [])), int(payload.get("latency_ms", 0))
+    finally:
+        # try/finally is the entire reason this helper exists. An
+        # exception inside `format_context` (or inside the count
+        # check) must NOT leave the capture handler attached to
+        # `kai.memory`'s logger; the next probe in the process would
+        # then double-capture and the harness would abort with
+        # "expected one log, got two."
+        _detach_capture(capture)
+
+
 async def _score_against_store(
     scored: list[Probe],
     drifted: list[Probe],

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -1529,6 +1529,75 @@ def is_scoped_recall_enabled() -> bool:
     return _config is not None and _config.memory_scoped_recall_enabled
 
 
+def _embed_via_configured_embedder(texts: list[str]) -> list[list[float]]:
+    """
+    Embed a batch of texts using the Mem0-wired embedder.
+
+    The ONLY function in the module that touches Mem0's private
+    `embedding_model` attribute. Every external caller goes through
+    `embed_texts` (below) so a future Mem0 upgrade that renames or
+    relocates the embedder attribute updates exactly one site.
+
+    Mem0's `HuggingFaceEmbedding.embed(text, memory_action=None)`
+    takes a single string and returns one vector per call; batching
+    is done client-side by looping. The underlying SentenceTransformer
+    could accept a list and batch internally, but reaching past Mem0's
+    `embed()` wrapper into `embedding_model.model.encode(...)` would
+    couple to two layers of internals instead of one. The loop is
+    fine: callers feed at most a few hundred texts per pair in the
+    collision-probe generator's centroid pass, and the embedder is
+    GPU-or-MPS-warm after the first call.
+
+    Precondition: `init_memory(config)` has run successfully and
+    `_memory` is set. The caller-facing `embed_texts` enforces this.
+    """
+    # Local alias to make the private-attribute hop explicit; reads
+    # better than chaining `_memory.embedding_model.embed(t)` inline.
+    embedder = _memory.embedding_model  # type: ignore[union-attr]
+    return [embedder.embed(t) for t in texts]
+
+
+def embed_texts(texts: list[str]) -> list[list[float]]:
+    """
+    Embed a batch of texts via the configured memory embedder.
+
+    Public boundary for external callers that need vectors in the
+    same embedding space the memory pipeline uses for search
+    (e.g. `kai.eval.gen_collision_probes` computing per-project
+    centroids for collision-candidate discovery). Going through this
+    helper keeps callers off Mem0 internals: the actual attribute
+    hop lives in `_embed_via_configured_embedder` so a future Mem0
+    rename touches one function, not every caller.
+
+    The vectors returned here use the same model as live recall
+    (`Config.memory_embedding_model`, validated at init for the
+    Qdrant 384-dim collection), so cosine similarities computed
+    over them are directly comparable to whatever the search
+    pipeline computes internally.
+
+    Args:
+        texts: List of text strings to embed. An empty list returns
+            an empty list (no embedder call).
+
+    Returns:
+        One embedding vector per input text, in the same order.
+
+    Raises:
+        RuntimeError: If `init_memory(config)` has not been called
+            (or failed). The same failure mode as every other
+            embedder-dependent function in this module, but raised
+            explicitly rather than silently returning an empty list,
+            because a caller asking for embeddings on a disabled
+            store should see the misconfiguration, not get vacuous
+            zero-vectors that silently corrupt downstream math.
+    """
+    if _memory is None:
+        raise RuntimeError("init_memory() not called; embed_texts cannot run")
+    if not texts:
+        return []
+    return _embed_via_configured_embedder(texts)
+
+
 def search(query: str, *, user_id: str, limit: int | None = None) -> list[MemoryResult]:
     """
     Search for memories semantically similar to the query.

--- a/tests/test_eval_retrieval.py
+++ b/tests/test_eval_retrieval.py
@@ -42,6 +42,7 @@ from kai.eval.retrieval import (
     compute_rank,
     detect_drift,
     evaluate,
+    legacy_retrieve_hits,
     load_probes,
     pareto_frontier,
     probe_set_hash,
@@ -753,3 +754,126 @@ class TestLegacyOnlyWarning:
         assert self._init_with(monkeypatch, scoped_enabled=False) is True
         err = capsys.readouterr().err
         assert "LEGACY pipeline only" not in err
+
+
+# ── Test 7: legacy_retrieve_hits public helper ─────────────────────
+
+
+class TestLegacyRetrieveHits:
+    """The public wrapper around the attach/format/drain/detach dance.
+
+    `legacy_retrieve_hits` is the helper external callers (the
+    collision-probe generator in `kai.eval.gen_collision_probes`) use
+    to drive the legacy harness as a verification gate. The contract
+    is: one `memory.recall` line per call returns `(hits, latency_ms)`;
+    zero or more than one raises; the capture handler MUST be detached
+    on every exit path so a long-lived process running successive
+    probes does not silently double-capture later records.
+
+    Tests live here rather than in a new file because they share the
+    `_attach_capture` / `_RecallLogCapture` machinery already exercised
+    by `TestLogParserRoundTrip` above.
+    """
+
+    @staticmethod
+    def _emit_recall(payload: dict) -> None:
+        """Emit a single memory.recall log line.
+
+        Mirrors what `kai.memory.format_context` does internally so
+        tests can drive the capture without standing up Mem0. The
+        prefix and JSON-payload shape are the parser's contract; if
+        either changes, _RecallLogCapture.drain breaks first and
+        every harness test fails together, so we encode the prefix
+        inline rather than importing the private constant.
+        """
+        logging.getLogger("kai.memory").info("memory.recall " + json.dumps(payload))
+
+    def test_returns_hits_and_latency_from_single_payload(self, monkeypatch):
+        """Happy path: one captured payload returns its hits and latency."""
+
+        async def fake_format_context(query: str, *, user_id: str, token_budget=None):
+            self._emit_recall(
+                {
+                    "user_id": user_id,
+                    "query": query,
+                    "hits": [
+                        {"id": "row-a", "score": 0.9},
+                        {"id": "row-b", "score": 0.7},
+                    ],
+                    "latency_ms": 42,
+                    "lines_used": 2,
+                }
+            )
+
+        # `legacy_retrieve_hits` does a deferred `from kai.memory
+        # import format_context` inside the function body, so the
+        # patch must target the kai.memory attribute that the
+        # imported name resolves to, not the eval module.
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+
+        hits, latency_ms = asyncio.run(legacy_retrieve_hits("any query", user_id="42"))
+
+        assert latency_ms == 42
+        assert [h["id"] for h in hits] == ["row-a", "row-b"]
+
+    def test_raises_when_zero_recall_lines_captured(self, monkeypatch):
+        """A format_context that emits no memory.recall line is a logging-discipline regression.
+
+        Picking "zero hits" silently would make every downstream
+        score wrong in ways no other test catches; raising loudly is
+        the documented contract from `_run_one_probe`, and the public
+        helper inherits it.
+        """
+
+        async def fake_format_context(query: str, *, user_id: str, token_budget=None):
+            # Deliberately no log emit. format_context returning
+            # nothing must surface as RuntimeError, not as an empty
+            # hits list.
+            return None
+
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+
+        with pytest.raises(RuntimeError, match="got 0"):
+            asyncio.run(legacy_retrieve_hits("any query", user_id="42"))
+
+    def test_raises_when_multiple_recall_lines_captured(self, monkeypatch):
+        """Two emits in one call indicates a logging duplication regression."""
+
+        async def fake_format_context(query: str, *, user_id: str, token_budget=None):
+            self._emit_recall({"hits": [], "latency_ms": 1, "user_id": user_id, "query": query})
+            self._emit_recall({"hits": [], "latency_ms": 2, "user_id": user_id, "query": query})
+
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+
+        with pytest.raises(RuntimeError, match="got 2"):
+            asyncio.run(legacy_retrieve_hits("any query", user_id="42"))
+
+    def test_detaches_capture_when_format_context_raises(self, monkeypatch):
+        """The try/finally that makes this helper exist.
+
+        If `format_context` raises, the capture handler MUST come off
+        `kai.memory`'s logger. Otherwise the next probe in the
+        process double-captures and aborts with "expected one log,
+        got two." Assertion: handler count on the kai.memory logger
+        is the same before and after the failing call.
+        """
+
+        async def fake_format_context(query: str, *, user_id: str, token_budget=None):
+            raise ValueError("simulated retrieval failure")
+
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+
+        # Snapshot the logger's handler list before the call so the
+        # assertion does not depend on whether pytest itself attached
+        # any handlers; we only care that we did not LEAK one.
+        logger = logging.getLogger("kai.memory")
+        handlers_before = list(logger.handlers)
+
+        with pytest.raises(ValueError, match="simulated retrieval failure"):
+            asyncio.run(legacy_retrieve_hits("any query", user_id="42"))
+
+        handlers_after = list(logger.handlers)
+        assert handlers_after == handlers_before, (
+            "legacy_retrieve_hits leaked a capture handler on the kai.memory "
+            "logger; the next probe in the process would double-capture"
+        )

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -6374,3 +6374,91 @@ class TestReadTranscriptProvenance:
         )
         assert same_day.date_end is None
         assert cross.date_end == "2026-06-14"
+
+
+class TestEmbedTexts:
+    """Public embedder boundary used by external callers.
+
+    `embed_texts` is the only path the rest of the codebase should
+    take to embed arbitrary strings (the collision-probe generator
+    uses it for per-project centroid computation). The internals it
+    delegates to (`_embed_via_configured_embedder`) reach into
+    Mem0's `embedding_model` attribute; these tests pin the public
+    contract so a future Mem0 upgrade that renames the attribute
+    only needs to update the one internal site without breaking
+    every caller's expectations.
+    """
+
+    def test_raises_runtime_error_when_init_memory_not_called(self):
+        """Memory disabled or never initialized must surface as RuntimeError.
+
+        Returning [] silently would let callers compute meaningful-
+        looking similarities over zero vectors and silently corrupt
+        downstream math (centroid of empty list, NaN cosine, etc).
+        Raising forces the misconfiguration to the caller.
+        """
+        import kai.memory as mem_mod
+
+        # `_clean_memory_state` autouse fixture sets `_memory = None`
+        # before each test, so we just assert the precondition fires.
+        assert mem_mod._memory is None
+        with pytest.raises(RuntimeError, match="init_memory"):
+            mem_mod.embed_texts(["any text"])
+
+    def test_empty_list_returns_empty_list_without_calling_embedder(self):
+        """The cheap-input fast path must NOT touch the embedder.
+
+        Callers passing [] should not pay the cost of allocating a
+        Mem0 embed call (and the empty-list path is the easiest place
+        for a silent IndexError to hide if the embedder is touched
+        anyway). MagicMock with a .called assertion catches both.
+        """
+        import kai.memory as mem_mod
+
+        mock_mem = MagicMock()
+        # Wire an embedder mock so we can assert it is NOT called for
+        # the empty-input case. The assertion is on the embed method,
+        # not on `embedding_model` access, because the attribute lookup
+        # is harmless; only an actual call would be the regression.
+        mock_mem.embedding_model.embed = MagicMock()
+        mem_mod._memory = mock_mem
+
+        try:
+            result = mem_mod.embed_texts([])
+            assert result == []
+            assert mock_mem.embedding_model.embed.call_count == 0
+        finally:
+            mem_mod._memory = None
+
+    def test_returns_one_vector_per_text_via_configured_embedder(self):
+        """Happy path: each text passes through Mem0's embed() and yields one vector."""
+        import kai.memory as mem_mod
+
+        # Mem0's HuggingFaceEmbedding.embed(text) returns a single
+        # vector per call (the public mem0.embeddings API; batching
+        # is client-side). Mock that shape so the test exercises the
+        # actual public contract we built `embed_texts` against, not
+        # a fictional batch interface.
+        mock_mem = MagicMock()
+
+        def fake_embed(text):
+            # Deterministic per-text vector so test asserts are stable
+            # and order-preservation is verifiable.
+            return [float(len(text)), 0.0, 0.0]
+
+        mock_mem.embedding_model.embed = MagicMock(side_effect=fake_embed)
+        mem_mod._memory = mock_mem
+
+        try:
+            vectors = mem_mod.embed_texts(["abc", "de", "fghi"])
+        finally:
+            mem_mod._memory = None
+
+        assert vectors == [
+            [3.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [4.0, 0.0, 0.0],
+        ]
+        # Order matters: callers (centroid computation) rely on
+        # vectors lining up with the input texts by index.
+        assert mock_mem.embedding_model.embed.call_count == 3


### PR DESCRIPTION
## Summary

Adds two public helpers the collision-probe corpus generator planned for #673 depends on. Both are pure additions; no existing call paths change.

### `kai.eval.retrieval.legacy_retrieve_hits(question, user_id) -> (hits, latency_ms)`

Wraps the `_attach_capture` / `format_context` / `drain` / `_detach_capture` pattern that `_run_one_probe` runs inline today. The whole reason for the helper is the `try/finally`: an exception inside `format_context`, or in the single-payload count check, must not leave the capture handler attached to `kai.memory`'s logger. A leaked handler would double-capture the next probe in the process and abort with "expected one log, got two."

The single-payload check (`len(payloads) != 1` raises `RuntimeError`) matches the legacy harness contract; zero or more than one is a logging-discipline regression, not a recoverable state.

### `kai.memory.embed_texts(texts) -> list[list[float]]`

Public boundary for embedding arbitrary text via the same Mem0 embedder live recall uses (`Config.memory_embedding_model`, validated to 384 dims at init for the Qdrant collection). Cosine similarities computed over these vectors are directly comparable to whatever the search pipeline computes internally.

The only function in the module that touches Mem0's `_memory.embedding_model` attribute is `_embed_via_configured_embedder`; every external caller goes through `embed_texts`. A future Mem0 upgrade that renames or relocates the embedder attribute updates exactly one site.

Behavior:
- `_memory is None` → `RuntimeError` (rather than `[]`, which would let callers silently compute meaningful-looking similarities over zero vectors).
- Empty input list → empty output without touching the embedder.

### Tests

- `tests/test_eval_retrieval.py::TestLegacyRetrieveHits` (4 tests): happy path, zero-payload raises, two-payload raises, capture is detached when `format_context` raises (the regression the `try/finally` exists to prevent).
- `tests/test_memory.py::TestEmbedTexts` (3 tests): uninitialized-store raises, empty input does not call the embedder, order-preserved one-vector-per-text via a mocked embedder.

Full suite: 4509 passed, 1 skipped, no new failures.

## Test plan

- [x] `make check` (ruff lint + format)
- [x] `make test` (full suite, 4509 passed)
- [x] `pytest tests/test_eval_retrieval.py::TestLegacyRetrieveHits tests/test_memory.py::TestEmbedTexts -v` (7 new tests pass)
