### PR TITLE
Relocate unscoped recall-capture helpers

### DIFF
--- a/src/kai/eval/_unscoped_recall_capture.py
+++ b/src/kai/eval/_unscoped_recall_capture.py
@@ -1,0 +1,213 @@
+"""
+Unscoped recall-capture helpers.
+
+Buffers the structured `memory.recall` log line that
+`kai.memory.format_context` emits, parses it, and exposes
+`legacy_retrieve_hits` as the public entry point for callers that
+need the unscoped recall result for a single question rather than
+the aggregate metrics the legacy eval CLI in `kai.eval.retrieval`
+produces.
+
+Why a dedicated module:
+
+`kai.eval.retrieval` is deprecated (see its docstring). The
+collision-probe generator in `kai.eval.gen_collision_probes` still
+needs an unscoped verifier: when drafting a negative probe, the
+question is "does this look like a hit under the OLD unscoped
+gate?" and replacing the verifier with scoped retrieval would
+reject every good negative. The helpers live here, under a name
+that says what they are, so the eval CLI can be removed without
+taking the generator's verifier path with it.
+
+The capture machinery:
+
+`format_context` emits a structured log line prefixed
+`memory.recall ` (`_RECALL_PREFIX`) on every call. The capture
+handler buffers matching records on the `kai.memory` logger; drain
+returns the parsed JSON payloads. The handler is additive (the
+existing log destinations still receive the lines) and forces the
+logger's effective level to INFO at attach time so an operator
+running with `LOG_LEVEL=WARNING` does not silently drop the records
+the caller depends on.
+
+The attach / detach pair is symmetric. `legacy_retrieve_hits` wraps
+the full attach / format_context / drain / detach dance in a
+try/finally so the capture handler is removed on every exit path,
+including the case where `format_context` itself raises. A naive
+caller that attaches and forgets to detach pollutes the logger for
+the rest of the process and silently corrupts the next caller by
+delivering its `memory.recall` record to two handlers.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+# Greppable prefix on every memory.recall log line. Mirrored in
+# `kai.memory._emit_recall_log`; if either changes, the parser in
+# `_RecallLogCapture` must move with it. The trailing space is part
+# of the prefix so empty-payload edge cases still tokenize.
+_RECALL_PREFIX = "memory.recall "
+
+
+class _RecallLogCapture(logging.Handler):
+    """Buffer memory.recall log records for later draining.
+
+    Attached to the `kai.memory` logger so it sees every record the
+    module emits. Filters down to records whose message starts with
+    the `memory.recall ` prefix so unrelated info-level logs (init,
+    delete, etc.) are ignored. The handler keeps full records, not
+    just the parsed payloads, so per-record diagnostics (logger
+    name, timestamp) remain accessible if a future debug hook needs
+    them.
+
+    Carries `_saved_level` so the attach helper can restore the
+    `kai.memory` logger's effective level on detach. The attach
+    helper forces the level to INFO because operators may run with
+    LOG_LEVEL=WARNING in production - without the bump,
+    `memory.recall` records would never reach any handler and any
+    caller draining the buffer would see zero records and abort
+    with "expected one log, got zero."
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.INFO)
+        self._records: list[logging.LogRecord] = []
+        self._saved_level: int | None = None
+
+    def emit(self, record: logging.LogRecord) -> None:
+        # `getMessage()` is the documented stable API; `.message` is
+        # set as a side effect of Formatter.format() and is not
+        # guaranteed to be populated for every handler.
+        if record.getMessage().startswith(_RECALL_PREFIX):
+            self._records.append(record)
+
+    def drain(self) -> list[dict[str, Any]]:
+        """Return parsed payloads for every buffered record and clear.
+
+        Strips the `memory.recall ` prefix and decodes the remainder
+        as JSON. Callers expect exactly one record per call to
+        `format_context`; they assert on the count and abort loudly
+        on zero or more than one - the log-shape contract is the
+        only signal that the retrieval path ran as expected.
+        """
+        parsed: list[dict[str, Any]] = []
+        for r in self._records:
+            blob = r.getMessage()[len(_RECALL_PREFIX) :]
+            try:
+                payload = json.loads(blob)
+            except json.JSONDecodeError as e:
+                raise RuntimeError(f"unparseable memory.recall payload: {e.msg}") from e
+            parsed.append(payload)
+        self._records.clear()
+        return parsed
+
+
+def _attach_capture() -> _RecallLogCapture:
+    """Attach a recall-log capture handler to kai.memory's logger.
+
+    Caller is responsible for detaching after use (see
+    `_detach_capture`). The handler is additive (does NOT set
+    propagate=False on the logger) so existing log destinations
+    still receive the lines; the caller only intercepts a copy.
+
+    Forces the `kai.memory` logger level to INFO if it is currently
+    higher (e.g. WARNING in a quiet operator config). Without this,
+    info-level `memory.recall` records would be filtered out before
+    reaching any handler and the caller would abort with "expected
+    one log, got zero." The original level is saved on the capture
+    object so detach can restore it.
+    """
+    logger = logging.getLogger("kai.memory")
+    capture = _RecallLogCapture()
+    capture._saved_level = logger.level
+    if logger.level == logging.NOTSET or logger.level > logging.INFO:
+        logger.setLevel(logging.INFO)
+    logger.addHandler(capture)
+    return capture
+
+
+def _detach_capture(capture: _RecallLogCapture) -> None:
+    """Symmetric removal of the handler installed by _attach_capture.
+
+    Restores the `kai.memory` logger's pre-attach level so a
+    long-lived process running multiple capture sessions does not
+    slowly accumulate verbosity changes.
+    """
+    logger = logging.getLogger("kai.memory")
+    logger.removeHandler(capture)
+    if capture._saved_level is not None:
+        logger.setLevel(capture._saved_level)
+
+
+async def legacy_retrieve_hits(question: str, user_id: str) -> tuple[list[dict[str, Any]], int]:
+    """
+    Run the legacy recall pipeline for one question and return its hits.
+
+    Wraps the attach / format_context / drain / detach pattern so
+    external callers (the collision-probe generator in
+    `kai.eval.gen_collision_probes`) can reuse the legacy unscoped
+    pipeline as a verification gate without reaching into
+    `_attach_capture` / `_detach_capture` directly.
+
+    Why a public helper and not just exposing the capture:
+    callers need the attach / call / drain / detach invariant
+    intact. Three of the four steps are bookkeeping around one
+    awaited call that can raise; the only way to guarantee the
+    capture handler is removed from `kai.memory`'s logger on every
+    exit path is to keep the try/finally in one place. A naive
+    caller that attaches and forgets to detach pollutes the logger
+    for the rest of the process and silently corrupts the next
+    caller by delivering its `memory.recall` record to two
+    handlers.
+
+    The single-payload check matches `format_context`'s contract
+    (exactly one `memory.recall` line per call). Zero indicates the
+    logger never received the record (level filter, missing
+    handler, removed log statement); more than one indicates a
+    logging-discipline regression. Both are raised loudly because
+    silently picking one would make every downstream score wrong in
+    ways nothing else would catch.
+
+    Args:
+        question: The probe question text. Passed verbatim to
+            `kai.memory.format_context`.
+        user_id: Kai user id (Telegram chat id as a string for
+            production callers). Scopes the recall to one user.
+
+    Returns:
+        A 2-tuple of (hits, latency_ms) drawn from the captured
+        `memory.recall` payload. `hits` is the raw list of hit
+        dicts in the order the pipeline ranked them; `latency_ms`
+        is the end-to-end retrieval latency the pipeline measured.
+
+    Raises:
+        RuntimeError: If zero or more than one `memory.recall` log
+            records are captured for the call.
+    """
+    # Deferred import: `kai.memory` pulls in PyTorch /
+    # sentence-transformers when memory is enabled, which is too
+    # expensive to load at module-import time for callers that may
+    # not actually invoke the helper.
+    from kai.memory import format_context
+
+    capture = _attach_capture()
+    try:
+        await format_context(question, user_id=user_id)
+        payloads = capture.drain()
+        if len(payloads) != 1:
+            raise RuntimeError(
+                f"expected exactly one memory.recall log per probe, got {len(payloads)} for question {question!r}"
+            )
+        payload = payloads[0]
+        return list(payload.get("hits", [])), int(payload.get("latency_ms", 0))
+    finally:
+        # try/finally is the entire reason this helper exists. An
+        # exception inside `format_context` (or inside the count
+        # check) must NOT leave the capture handler attached to
+        # `kai.memory`'s logger; the next caller in the process
+        # would then double-capture and abort with "expected one
+        # log, got two."
+        _detach_capture(capture)

--- a/src/kai/eval/gen_collision_probes.py
+++ b/src/kai/eval/gen_collision_probes.py
@@ -90,7 +90,8 @@ from kai.config import (
     get_effective_provider,
     resolve_user_model,
 )
-from kai.eval.retrieval import compute_rank, legacy_retrieve_hits
+from kai.eval._unscoped_recall_capture import legacy_retrieve_hits
+from kai.eval.retrieval import compute_rank
 from kai.eval.retrieval_scoped import evaluate, load_probes
 from kai.oneshot import (
     ClaudeOneShotReasoner,

--- a/src/kai/eval/retrieval.py
+++ b/src/kai/eval/retrieval.py
@@ -16,13 +16,13 @@ production path and is workspace-aware, so it also evaluates
 cross-project collision behavior that this harness is structurally
 blind to.
 
-This CLI remains importable because the collision-probe generator
-(`kai.eval.gen_collision_probes`) uses the unscoped recall-capture
-helpers (`legacy_retrieve_hits`, `_RecallLogCapture`) from this
-module to verify drafted negative probes against the unscoped gate;
-replacing that verifier with scoped retrieval would reject every
-good negative. The helpers will be relocated so this CLI can be
-removed.
+This CLI remains importable as a transitional shim. The unscoped
+recall-capture helpers (`legacy_retrieve_hits`, `_RecallLogCapture`,
+`_attach_capture`, `_detach_capture`) live in
+`kai.eval._unscoped_recall_capture`; this module re-exports
+`legacy_retrieve_hits` under a `DeprecationWarning` for any caller
+that still imports the public name from here. New code should
+import from `_unscoped_recall_capture` directly.
 
 Given a probe set of `(question, expected_fact_id)` pairs, runs each
 probe through the live memory pipeline, parses the resulting
@@ -90,8 +90,47 @@ from pathlib import Path
 from typing import Any
 
 from kai.config import Config
+from kai.eval._unscoped_recall_capture import (
+    _attach_capture,
+    _detach_capture,
+    _RecallLogCapture,
+)
+from kai.eval._unscoped_recall_capture import (
+    legacy_retrieve_hits as _legacy_retrieve_hits_impl,
+)
 
 log = logging.getLogger(__name__)
+
+
+# ── Deprecated re-exports ──────────────────────────────────────────
+
+
+def __getattr__(name: str) -> Any:
+    """Module-level attribute access for deprecated public names.
+
+    `legacy_retrieve_hits` lives in
+    `kai.eval._unscoped_recall_capture`; external callers that
+    still import it from `kai.eval.retrieval` get a
+    `DeprecationWarning` so the migration is visible before this
+    CLI is removed. Internal call sites in this module use the
+    underscored alias `_legacy_retrieve_hits_impl` bound at the top
+    of the file and do not trip the warning. Internal helpers
+    (`_attach_capture`, `_detach_capture`, `_RecallLogCapture`) are
+    re-exported as ordinary module-level names because they have no
+    public surface to deprecate and the CLI's own probe loop still
+    uses them.
+    """
+    if name == "legacy_retrieve_hits":
+        import warnings
+
+        warnings.warn(
+            "kai.eval.retrieval.legacy_retrieve_hits is deprecated; "
+            "import from kai.eval._unscoped_recall_capture instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _legacy_retrieve_hits_impl
+    raise AttributeError(f"module 'kai.eval.retrieval' has no attribute {name!r}")
 
 
 # ── Constants ───────────────────────────────────────────────────────
@@ -130,13 +169,6 @@ _PRODUCTION_USER_WEIGHT = 0.85
 _PRODUCTION_ASSISTANT_WEIGHT = 0.8
 _PRODUCTION_EPISODE_SUMMARY_WEIGHT = 0.85
 _PRODUCTION_OVERFETCH = 20
-
-
-# Greppable prefix on every memory.recall log line. Mirrored in
-# `kai.memory._emit_recall_log`; if either ever changes, the parser
-# in `_RecallLogCapture` must move with it. The trailing space is
-# part of the prefix so empty-payload edge cases still tokenize.
-_RECALL_PREFIX = "memory.recall "
 
 
 # Schema version written into baseline JSON output. Bump when the
@@ -325,62 +357,6 @@ def probe_set_hash(probes: list[Probe]) -> str:
     pairs = sorted((p.question, p.expected_fact_id) for p in probes)
     blob = json.dumps(pairs, separators=(",", ":")).encode("utf-8")
     return "sha256:" + hashlib.sha256(blob).hexdigest()
-
-
-# ── Log capture ─────────────────────────────────────────────────────
-
-
-class _RecallLogCapture(logging.Handler):
-    """Buffer memory.recall log records for later draining.
-
-    Attached to the `kai.memory` logger so it sees every record the
-    module emits. Filters down to records whose message starts with
-    the `memory.recall ` prefix so unrelated info-level logs (init,
-    delete, etc.) are ignored. The handler keeps full records, not
-    just the parsed payloads, so per-record diagnostics (logger name,
-    timestamp) remain accessible if a future debug hook needs them.
-
-    Carries `_saved_level` so the attach helper can restore the
-    `kai.memory` logger's effective level on detach. The harness
-    forces the level to INFO at attach time because operators may
-    run with LOG_LEVEL=WARNING in production - without the bump,
-    `memory.recall` records would never reach any handler and the
-    harness would loudly fail with "expected one record, got zero."
-    """
-
-    def __init__(self) -> None:
-        super().__init__(level=logging.INFO)
-        self._records: list[logging.LogRecord] = []
-        self._saved_level: int | None = None
-
-    def emit(self, record: logging.LogRecord) -> None:
-        # `getMessage()` is the documented stable API; `.message` is
-        # set as a side effect of Formatter.format() and is not
-        # guaranteed to be populated for every handler. Test #4 round-
-        # trips against this exact path.
-        if record.getMessage().startswith(_RECALL_PREFIX):
-            self._records.append(record)
-
-    def drain(self) -> list[dict[str, Any]]:
-        """Return parsed payloads for every buffered record and clear.
-
-        Strips the `memory.recall ` prefix and decodes the remainder
-        as JSON. The harness expects exactly one record per call to
-        `format_context`; the caller (`_run_one_probe`) asserts on
-        the count and aborts loudly on zero or more-than-one - the
-        log-shape contract is the harness's only signal that the
-        retrieval path ran as expected.
-        """
-        parsed: list[dict[str, Any]] = []
-        for r in self._records:
-            blob = r.getMessage()[len(_RECALL_PREFIX) :]
-            try:
-                payload = json.loads(blob)
-            except json.JSONDecodeError as e:
-                raise RuntimeError(f"unparseable memory.recall payload: {e.msg}") from e
-            parsed.append(payload)
-        self._records.clear()
-        return parsed
 
 
 # ── Scoring math ────────────────────────────────────────────────────
@@ -644,113 +620,6 @@ async def _run_probes(
 
 
 # ── Single-config evaluation ──────────────────────────────────────
-
-
-def _attach_capture() -> _RecallLogCapture:
-    """Attach a recall-log capture handler to kai.memory's logger.
-
-    Caller is responsible for detaching after use (see
-    `_detach_capture`). The handler is additive (does NOT set
-    propagate=False on the logger) so existing log destinations
-    still receive the lines; the harness only intercepts a copy.
-
-    Forces the `kai.memory` logger level to INFO if it is currently
-    higher (e.g. WARNING in a quiet operator config). Without this,
-    info-level `memory.recall` records would be filtered out before
-    reaching any handler and the harness would abort with
-    "expected one log, got zero." The original level is saved on
-    the capture object so detach can restore it.
-    """
-    logger = logging.getLogger("kai.memory")
-    capture = _RecallLogCapture()
-    capture._saved_level = logger.level
-    if logger.level == logging.NOTSET or logger.level > logging.INFO:
-        logger.setLevel(logging.INFO)
-    logger.addHandler(capture)
-    return capture
-
-
-def _detach_capture(capture: _RecallLogCapture) -> None:
-    """Symmetric removal of the handler installed by _attach_capture.
-
-    Restores the `kai.memory` logger's pre-attach level so a
-    long-lived process running multiple harness invocations does
-    not slowly accumulate verbosity changes.
-    """
-    logger = logging.getLogger("kai.memory")
-    logger.removeHandler(capture)
-    if capture._saved_level is not None:
-        logger.setLevel(capture._saved_level)
-
-
-async def legacy_retrieve_hits(question: str, user_id: str) -> tuple[list[dict[str, Any]], int]:
-    """
-    Run the legacy recall pipeline for one question and return its hits.
-
-    Wraps the attach/format_context/drain/detach pattern used inside
-    `_run_one_probe` so external callers (e.g. the collision-probe
-    generator at `kai.eval.gen_collision_probes`) can reuse the
-    legacy harness as a verification gate without reaching into
-    `_attach_capture` / `_detach_capture` directly.
-
-    Why a public helper and not just exposing the captures:
-    callers need the attach / call / drain / detach invariant
-    intact. Three of the four steps are bookkeeping around one
-    awaited call that can raise; the only way to guarantee the
-    capture handler is removed from `kai.memory`'s logger on every
-    exit path is to keep the try/finally in one place. A naive caller
-    that attaches and forgets to detach pollutes the logger for the
-    rest of the process and silently corrupts the next probe by
-    delivering its `memory.recall` record to two handlers.
-
-    The single-payload check matches the legacy harness's contract
-    (`format_context` emits exactly one `memory.recall` line per
-    call). Zero indicates the logger never received the record
-    (level filter, missing handler, removed log statement); more
-    than one indicates a logging-discipline regression. Both are
-    raised loudly because silently picking one would make every
-    downstream score wrong in ways nothing else would catch.
-
-    Args:
-        question: The probe question text. Passed verbatim to
-            `kai.memory.format_context`.
-        user_id: Kai user id (Telegram chat id as a string for
-            production callers). Scopes the recall to one user.
-
-    Returns:
-        A 2-tuple of (hits, latency_ms) drawn from the captured
-        `memory.recall` payload. `hits` is the raw list of hit dicts
-        in the order the pipeline ranked them; `latency_ms` is the
-        end-to-end retrieval latency the pipeline measured.
-
-    Raises:
-        RuntimeError: If zero or more than one `memory.recall` log
-            records are captured for the call.
-    """
-    # Deferred import: mirrors `_run_one_probe`. `kai.memory` pulls in
-    # PyTorch / sentence-transformers when memory is enabled, which is
-    # too expensive to load at module-import time for callers that may
-    # not actually invoke the helper.
-    from kai.memory import format_context
-
-    capture = _attach_capture()
-    try:
-        await format_context(question, user_id=user_id)
-        payloads = capture.drain()
-        if len(payloads) != 1:
-            raise RuntimeError(
-                f"expected exactly one memory.recall log per probe, got {len(payloads)} for question {question!r}"
-            )
-        payload = payloads[0]
-        return list(payload.get("hits", [])), int(payload.get("latency_ms", 0))
-    finally:
-        # try/finally is the entire reason this helper exists. An
-        # exception inside `format_context` (or inside the count
-        # check) must NOT leave the capture handler attached to
-        # `kai.memory`'s logger; the next probe in the process would
-        # then double-capture and the harness would abort with
-        # "expected one log, got two."
-        _detach_capture(capture)
 
 
 async def _score_against_store(

--- a/tests/test_eval_retrieval.py
+++ b/tests/test_eval_retrieval.py
@@ -1,6 +1,6 @@
 """Tests for the Layer 1 retrieval eval harness (kai.eval.retrieval).
 
-Six test classes covering the harness's load-bearing seams:
+Covers the harness's load-bearing seams:
 
 1. TestMetricComputation - precision/recall/MRR math, including the
    drift-denominator contract (drift probes excluded from BOTH
@@ -10,13 +10,14 @@ Six test classes covering the harness's load-bearing seams:
    probe_set_hash invariance under reorder.
 3. TestSweepRestoration - run_sweep restores all three pieces of
    mutated module state when a probe raises mid-sweep.
-4. TestLogParserRoundTrip - capture a real memory.recall record via
-   format_context (with Mem0 mocked) and assert the per-hit `id`
-   field round-trips through the parser into compute_rank.
-5. TestDriftDetection - get_by_id returning None buckets a probe as
+4. TestDriftDetection - get_by_id returning None buckets a probe as
    drift; pareto_frontier dominates correctly on (precision@5, p50).
-6. TestEvaluateEndToEnd - drift detection + scoring composed through
+5. TestEvaluateEndToEnd - drift detection + scoring composed through
    evaluate(); confirms metrics use N_scored, not N_probes.
+
+The recall-capture machinery and the public `legacy_retrieve_hits`
+wrapper live in `kai.eval._unscoped_recall_capture`; their tests
+live alongside them in `tests/test_eval_unscoped_recall_capture.py`.
 
 Math tests are pure functions (no Mem0, no logging fixtures), so the
 file is fast to run independently of the heavyweight memory fixtures.
@@ -42,7 +43,6 @@ from kai.eval.retrieval import (
     compute_rank,
     detect_drift,
     evaluate,
-    legacy_retrieve_hits,
     load_probes,
     pareto_frontier,
     probe_set_hash,
@@ -390,72 +390,7 @@ class TestSweepRestoration:
         assert original_overfetch == mem_mod._SEARCH_OVERFETCH
 
 
-# ── Test 4: Log parser end-to-end (round-trip on `id` field) ──────
-
-
-class TestLogParserRoundTrip:
-    """Capture a real memory.recall record, parse it, assert id passthrough.
-
-    The harness's ranking logic depends on each per-hit dict in the
-    recall payload carrying `id` matching MemoryResult.id. This test
-    wires the harness's `_RecallLogCapture` to a real format_context
-    call (with a mocked Mem0 search) and confirms the id flows through
-    end-to-end via the structured log line, not via any side-channel.
-    """
-
-    def test_capture_and_parse_id_field(self):
-        import kai.memory as mem_mod
-        from kai.memory import format_context
-
-        # Mock Mem0 to return two rows with known IDs. The harness's
-        # log capture handler reads format_context's emit; the parsed
-        # payload must carry both IDs so a downstream `compute_rank`
-        # against expected_fact_id="row-b" returns 2 (not None).
-        mock_mem = MagicMock()
-        mock_mem.search.return_value = {
-            "results": [
-                {
-                    "id": "row-a",
-                    "memory": "Fact A text",
-                    "score": 0.9,
-                    "metadata": {"type": "fact", "source": "extracted"},
-                    "created_at": "2026-04-01T10:00:00",
-                },
-                {
-                    "id": "row-b",
-                    "memory": "Fact B text",
-                    "score": 0.8,
-                    "metadata": {"type": "fact", "source": "extracted"},
-                    "created_at": "2026-04-02T10:00:00",
-                },
-            ]
-        }
-        mem_mod._memory = mock_mem
-        mem_mod._config = _BASE_CONFIG
-
-        # Attach the harness's capture handler exactly the way the
-        # production code path does. _attach_capture also forces the
-        # kai.memory logger level to INFO if it was higher (test runs
-        # default to WARNING via pytest config), so the recall record
-        # is guaranteed to reach the handler.
-        capture = retrieval._attach_capture()
-        try:
-            asyncio.run(format_context("any query", user_id="42"))
-            payloads = capture.drain()
-        finally:
-            retrieval._detach_capture(capture)
-
-        assert len(payloads) == 1
-        payload = payloads[0]
-        ids = [h["id"] for h in payload["hits"]]
-        # IDs round-tripped via JSON; compute_rank must locate row-b
-        # at position 2 to score the prerequisite-dependent contract.
-        assert ids == ["row-a", "row-b"]
-        assert compute_rank(payload["hits"], "row-b") == 2
-        assert compute_rank(payload["hits"], "missing-id") is None
-
-
-# ── Test 5: Drift detection ────────────────────────────────────────
+# ── Test 4: Drift detection ────────────────────────────────────────
 
 
 class TestDriftDetection:
@@ -754,126 +689,3 @@ class TestLegacyOnlyWarning:
         assert self._init_with(monkeypatch, scoped_enabled=False) is True
         err = capsys.readouterr().err
         assert "LEGACY pipeline only" not in err
-
-
-# ── Test 7: legacy_retrieve_hits public helper ─────────────────────
-
-
-class TestLegacyRetrieveHits:
-    """The public wrapper around the attach/format/drain/detach dance.
-
-    `legacy_retrieve_hits` is the helper external callers (the
-    collision-probe generator in `kai.eval.gen_collision_probes`) use
-    to drive the legacy harness as a verification gate. The contract
-    is: one `memory.recall` line per call returns `(hits, latency_ms)`;
-    zero or more than one raises; the capture handler MUST be detached
-    on every exit path so a long-lived process running successive
-    probes does not silently double-capture later records.
-
-    Tests live here rather than in a new file because they share the
-    `_attach_capture` / `_RecallLogCapture` machinery already exercised
-    by `TestLogParserRoundTrip` above.
-    """
-
-    @staticmethod
-    def _emit_recall(payload: dict) -> None:
-        """Emit a single memory.recall log line.
-
-        Mirrors what `kai.memory.format_context` does internally so
-        tests can drive the capture without standing up Mem0. The
-        prefix and JSON-payload shape are the parser's contract; if
-        either changes, _RecallLogCapture.drain breaks first and
-        every harness test fails together, so we encode the prefix
-        inline rather than importing the private constant.
-        """
-        logging.getLogger("kai.memory").info("memory.recall " + json.dumps(payload))
-
-    def test_returns_hits_and_latency_from_single_payload(self, monkeypatch):
-        """Happy path: one captured payload returns its hits and latency."""
-
-        async def fake_format_context(query: str, *, user_id: str, token_budget=None):
-            self._emit_recall(
-                {
-                    "user_id": user_id,
-                    "query": query,
-                    "hits": [
-                        {"id": "row-a", "score": 0.9},
-                        {"id": "row-b", "score": 0.7},
-                    ],
-                    "latency_ms": 42,
-                    "lines_used": 2,
-                }
-            )
-
-        # `legacy_retrieve_hits` does a deferred `from kai.memory
-        # import format_context` inside the function body, so the
-        # patch must target the kai.memory attribute that the
-        # imported name resolves to, not the eval module.
-        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
-
-        hits, latency_ms = asyncio.run(legacy_retrieve_hits("any query", user_id="42"))
-
-        assert latency_ms == 42
-        assert [h["id"] for h in hits] == ["row-a", "row-b"]
-
-    def test_raises_when_zero_recall_lines_captured(self, monkeypatch):
-        """A format_context that emits no memory.recall line is a logging-discipline regression.
-
-        Picking "zero hits" silently would make every downstream
-        score wrong in ways no other test catches; raising loudly is
-        the documented contract from `_run_one_probe`, and the public
-        helper inherits it.
-        """
-
-        async def fake_format_context(query: str, *, user_id: str, token_budget=None):
-            # Deliberately no log emit. format_context returning
-            # nothing must surface as RuntimeError, not as an empty
-            # hits list.
-            return None
-
-        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
-
-        with pytest.raises(RuntimeError, match="got 0"):
-            asyncio.run(legacy_retrieve_hits("any query", user_id="42"))
-
-    def test_raises_when_multiple_recall_lines_captured(self, monkeypatch):
-        """Two emits in one call indicates a logging duplication regression."""
-
-        async def fake_format_context(query: str, *, user_id: str, token_budget=None):
-            self._emit_recall({"hits": [], "latency_ms": 1, "user_id": user_id, "query": query})
-            self._emit_recall({"hits": [], "latency_ms": 2, "user_id": user_id, "query": query})
-
-        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
-
-        with pytest.raises(RuntimeError, match="got 2"):
-            asyncio.run(legacy_retrieve_hits("any query", user_id="42"))
-
-    def test_detaches_capture_when_format_context_raises(self, monkeypatch):
-        """The try/finally that makes this helper exist.
-
-        If `format_context` raises, the capture handler MUST come off
-        `kai.memory`'s logger. Otherwise the next probe in the
-        process double-captures and aborts with "expected one log,
-        got two." Assertion: handler count on the kai.memory logger
-        is the same before and after the failing call.
-        """
-
-        async def fake_format_context(query: str, *, user_id: str, token_budget=None):
-            raise ValueError("simulated retrieval failure")
-
-        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
-
-        # Snapshot the logger's handler list before the call so the
-        # assertion does not depend on whether pytest itself attached
-        # any handlers; we only care that we did not LEAK one.
-        logger = logging.getLogger("kai.memory")
-        handlers_before = list(logger.handlers)
-
-        with pytest.raises(ValueError, match="simulated retrieval failure"):
-            asyncio.run(legacy_retrieve_hits("any query", user_id="42"))
-
-        handlers_after = list(logger.handlers)
-        assert handlers_after == handlers_before, (
-            "legacy_retrieve_hits leaked a capture handler on the kai.memory "
-            "logger; the next probe in the process would double-capture"
-        )

--- a/tests/test_eval_unscoped_recall_capture.py
+++ b/tests/test_eval_unscoped_recall_capture.py
@@ -1,0 +1,258 @@
+"""Tests for the unscoped recall-capture helpers.
+
+Covers `kai.eval._unscoped_recall_capture`: the buffer-and-drain
+machinery (`_RecallLogCapture`, `_attach_capture`, `_detach_capture`)
+that intercepts `memory.recall` log lines from
+`kai.memory.format_context`, and the `legacy_retrieve_hits` public
+wrapper the collision-probe generator uses as its unscoped
+verification gate.
+
+Two test classes:
+
+1. TestLogParserRoundTrip - drives a real `format_context` call with
+   Mem0 mocked, asserts the per-hit `id` field round-trips through
+   the parser into `compute_rank`. Confirms the log-line shape is
+   the only contract the capture handler depends on.
+2. TestLegacyRetrieveHits - exercises the public wrapper's three
+   load-bearing seams: happy path returns hits+latency, zero/two
+   captured records raise loudly, and an exception inside
+   `format_context` still detaches the capture handler (the
+   try/finally invariant that motivates the helper's existence).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from kai.config import Config
+from kai.eval._unscoped_recall_capture import (
+    _attach_capture,
+    _detach_capture,
+    legacy_retrieve_hits,
+)
+from kai.eval.retrieval import compute_rank
+
+# Minimal Config the recall path needs: memory enabled with a
+# production-shape budget and floor. The capture tests do not
+# exercise sweep knobs, so only the fields format_context reads
+# need to be populated.
+_BASE_CONFIG = Config(
+    telegram_bot_token="test-token",
+    allowed_user_ids={12345},
+    webhook_secret="test-secret",
+    memory_enabled=True,
+    memory_search_limit=10,
+    memory_token_budget=2000,
+    memory_search_floor=0.3,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_memory_state():
+    """Reset kai.memory module-level state between tests.
+
+    TestLogParserRoundTrip writes a MagicMock into `mem_mod._memory`
+    and a stub Config into `mem_mod._config`; leaving those in
+    place would silently couple later tests (here or in sibling
+    test files) to this file's fixtures.
+    """
+    import kai.memory as mem_mod
+
+    mem_mod._memory = None
+    mem_mod._config = None
+    yield
+    mem_mod._memory = None
+    mem_mod._config = None
+
+
+# ── Test 1: Log parser end-to-end (round-trip on `id` field) ──────
+
+
+class TestLogParserRoundTrip:
+    """Capture a real memory.recall record, parse it, assert id passthrough.
+
+    Downstream ranking logic depends on each per-hit dict in the
+    recall payload carrying `id` matching MemoryResult.id. This
+    test wires the capture handler to a real format_context call
+    (with a mocked Mem0 search) and confirms the id flows through
+    end-to-end via the structured log line, not via any
+    side-channel.
+    """
+
+    def test_capture_and_parse_id_field(self):
+        import kai.memory as mem_mod
+        from kai.memory import format_context
+
+        # Mock Mem0 to return two rows with known IDs. The capture
+        # handler reads format_context's emit; the parsed payload
+        # must carry both IDs so a downstream `compute_rank` against
+        # expected_fact_id="row-b" returns 2 (not None).
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {
+            "results": [
+                {
+                    "id": "row-a",
+                    "memory": "Fact A text",
+                    "score": 0.9,
+                    "metadata": {"type": "fact", "source": "extracted"},
+                    "created_at": "2026-04-01T10:00:00",
+                },
+                {
+                    "id": "row-b",
+                    "memory": "Fact B text",
+                    "score": 0.8,
+                    "metadata": {"type": "fact", "source": "extracted"},
+                    "created_at": "2026-04-02T10:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+        mem_mod._config = _BASE_CONFIG
+
+        # Attach the capture handler exactly the way the production
+        # code path does. _attach_capture also forces the kai.memory
+        # logger level to INFO if it was higher (test runs default
+        # to WARNING via pytest config), so the recall record is
+        # guaranteed to reach the handler.
+        capture = _attach_capture()
+        try:
+            asyncio.run(format_context("any query", user_id="42"))
+            payloads = capture.drain()
+        finally:
+            _detach_capture(capture)
+
+        assert len(payloads) == 1
+        payload = payloads[0]
+        ids = [h["id"] for h in payload["hits"]]
+        # IDs round-tripped via JSON; compute_rank must locate row-b
+        # at position 2 to score the prerequisite-dependent contract.
+        assert ids == ["row-a", "row-b"]
+        assert compute_rank(payload["hits"], "row-b") == 2
+        assert compute_rank(payload["hits"], "missing-id") is None
+
+
+# ── Test 2: legacy_retrieve_hits public helper ─────────────────────
+
+
+class TestLegacyRetrieveHits:
+    """The public wrapper around the attach/format/drain/detach dance.
+
+    `legacy_retrieve_hits` is the helper external callers (the
+    collision-probe generator in `kai.eval.gen_collision_probes`)
+    use to drive the unscoped recall pipeline as a verification
+    gate. The contract is: one `memory.recall` line per call
+    returns `(hits, latency_ms)`; zero or more than one raises;
+    the capture handler MUST be detached on every exit path so a
+    long-lived process running successive probes does not silently
+    double-capture later records.
+    """
+
+    @staticmethod
+    def _emit_recall(payload: dict) -> None:
+        """Emit a single memory.recall log line.
+
+        Mirrors what `kai.memory.format_context` does internally
+        so tests can drive the capture without standing up Mem0.
+        The prefix and JSON-payload shape are the parser's
+        contract; if either changes, `_RecallLogCapture.drain`
+        breaks first and every capture test fails together, so we
+        encode the prefix inline rather than importing the private
+        constant.
+        """
+        logging.getLogger("kai.memory").info("memory.recall " + json.dumps(payload))
+
+    def test_returns_hits_and_latency_from_single_payload(self, monkeypatch):
+        """Happy path: one captured payload returns its hits and latency."""
+
+        async def fake_format_context(query: str, *, user_id: str, token_budget=None):
+            self._emit_recall(
+                {
+                    "user_id": user_id,
+                    "query": query,
+                    "hits": [
+                        {"id": "row-a", "score": 0.9},
+                        {"id": "row-b", "score": 0.7},
+                    ],
+                    "latency_ms": 42,
+                    "lines_used": 2,
+                }
+            )
+
+        # `legacy_retrieve_hits` does a deferred `from kai.memory
+        # import format_context` inside the function body, so the
+        # patch must target the kai.memory attribute that the
+        # imported name resolves to, not the eval module.
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+
+        hits, latency_ms = asyncio.run(legacy_retrieve_hits("any query", user_id="42"))
+
+        assert latency_ms == 42
+        assert [h["id"] for h in hits] == ["row-a", "row-b"]
+
+    def test_raises_when_zero_recall_lines_captured(self, monkeypatch):
+        """A format_context that emits no memory.recall line is a logging-discipline regression.
+
+        Picking "zero hits" silently would make every downstream
+        score wrong in ways no other test catches; raising loudly
+        is the documented contract and the public helper inherits
+        it.
+        """
+
+        async def fake_format_context(query: str, *, user_id: str, token_budget=None):
+            # Deliberately no log emit. format_context returning
+            # nothing must surface as RuntimeError, not as an empty
+            # hits list.
+            return None
+
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+
+        with pytest.raises(RuntimeError, match="got 0"):
+            asyncio.run(legacy_retrieve_hits("any query", user_id="42"))
+
+    def test_raises_when_multiple_recall_lines_captured(self, monkeypatch):
+        """Two emits in one call indicates a logging duplication regression."""
+
+        async def fake_format_context(query: str, *, user_id: str, token_budget=None):
+            self._emit_recall({"hits": [], "latency_ms": 1, "user_id": user_id, "query": query})
+            self._emit_recall({"hits": [], "latency_ms": 2, "user_id": user_id, "query": query})
+
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+
+        with pytest.raises(RuntimeError, match="got 2"):
+            asyncio.run(legacy_retrieve_hits("any query", user_id="42"))
+
+    def test_detaches_capture_when_format_context_raises(self, monkeypatch):
+        """The try/finally that makes this helper exist.
+
+        If `format_context` raises, the capture handler MUST come
+        off `kai.memory`'s logger. Otherwise the next probe in the
+        process double-captures and aborts with "expected one log,
+        got two." Assertion: handler count on the kai.memory logger
+        is the same before and after the failing call.
+        """
+
+        async def fake_format_context(query: str, *, user_id: str, token_budget=None):
+            raise ValueError("simulated retrieval failure")
+
+        monkeypatch.setattr("kai.memory.format_context", fake_format_context)
+
+        # Snapshot the logger's handler list before the call so the
+        # assertion does not depend on whether pytest itself
+        # attached any handlers; we only care that we did not LEAK
+        # one.
+        logger = logging.getLogger("kai.memory")
+        handlers_before = list(logger.handlers)
+
+        with pytest.raises(ValueError, match="simulated retrieval failure"):
+            asyncio.run(legacy_retrieve_hits("any query", user_id="42"))
+
+        handlers_after = list(logger.handlers)
+        assert handlers_after == handlers_before, (
+            "legacy_retrieve_hits leaked a capture handler on the kai.memory "
+            "logger; the next probe in the process would double-capture"
+        )


### PR DESCRIPTION
## Summary

- New module `kai.eval._unscoped_recall_capture` owns the canonical `legacy_retrieve_hits`, `_RecallLogCapture`, `_attach_capture`, `_detach_capture`, and the `_RECALL_PREFIX` constant.
- `kai.eval.retrieval` keeps the helpers reachable: private ones are re-imported at module top for the CLI's own probe loop; `legacy_retrieve_hits` is exposed via a module `__getattr__` that emits a `DeprecationWarning` so callers still reaching for the public name from here get a visible signal.
- `kai.eval.gen_collision_probes` imports `legacy_retrieve_hits` from its new home directly; `compute_rank` still imports from `kai.eval.retrieval`.
- Tests for the moved symbols (the log-parser round-trip and the four `legacy_retrieve_hits` contract tests) move into `tests/test_eval_unscoped_recall_capture.py`; `tests/test_eval_retrieval.py` loses those two test classes and the corresponding numbered headers, and the module docstring is updated to reflect the smaller surface.

## Why

The deprecation notice on `kai.eval.retrieval` (PR #693) named these helpers as the only reason the deprecated CLI was still importable: the collision-probe generator imports them to verify drafted negative probes against the unscoped gate, and replacing that verifier with scoped retrieval would reject every good negative. Relocating the helpers under a name that says what they are decouples the verifier path from the CLI's lifetime so a follow-up can delete `kai.eval.retrieval` without taking the generator with it.

## What's not in this PR

- Deleting `src/kai/eval/retrieval.py` and `tests/test_eval_retrieval.py`. Closes the parent issue when it lands. Follow-up.

## Test plan

- [x] `make check` clean
- [x] `pytest tests/test_eval_retrieval.py tests/test_eval_unscoped_recall_capture.py tests/test_gen_collision_probes.py` clean (73 passed)
- [x] Full `pytest` suite clean (4557 passed, 1 skipped)
- [x] `from kai.eval.retrieval import legacy_retrieve_hits` fires `DeprecationWarning` with the migration hint
- [x] `from kai.eval._unscoped_recall_capture import legacy_retrieve_hits` does not warn (verified under `warnings.simplefilter('error', DeprecationWarning)`)
