### PR TITLE
Add actionability assessment to issue triage

### DIFF
--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -321,7 +321,11 @@ def build_triage_prompt(
         '  "related": [list of related issue numbers],',
         '  "project": null or "project title" if this clearly belongs on a board,',
         '  "summary": "1-2 sentence assessment of the issue",',
-        '  "priority": "low" | "medium" | "high" | "critical"',
+        '  "priority": "low" | "medium" | "high" | "critical",',
+        '  "status": "ready" | "needs_info" | "wontfix_candidate" | "blocked",',
+        '  "next_action": "single concrete recommendation for what the maintainer should do next",',
+        '  "missing_info": [list of specific questions to ask the reporter],',
+        '  "blocked_by": null or issue number (int) or short string describing the blocker',
         "}",
         "",
         "Label guidelines:",
@@ -338,6 +342,49 @@ def build_triage_prompt(
         "For project: only assign if one of the available projects clearly matches the "
         "issue's scope based on the project title/description. When in doubt, leave null. "
         "Do not force a match.",
+        "",
+        "Status guidelines:",
+        '- "ready": the issue is clear enough for a maintainer or contributor to start work. '
+        'Confirmed duplicates also use "ready"; the next_action is the close-as-duplicate step.',
+        '- "needs_info": the issue is not actionable until the reporter answers one or more '
+        "questions in missing_info. Use this when the report omits a stack trace, "
+        "reproduction steps, configuration details, or any specific information you would need "
+        "to make progress.",
+        '- "wontfix_candidate": the issue appears outside the project\'s scope or conflicts with '
+        "documented behavior. This is a SUGGESTION for human review, NOT a verdict. The "
+        "maintainer decides. Use sparingly and only when the misalignment is concrete and "
+        "named in summary / next_action.",
+        '- "blocked": the issue is valid but cannot move forward until another issue, upstream '
+        'dependency, or external decision is resolved. When you set status to "blocked", you '
+        "MUST populate blocked_by with the specific blocker.",
+        "",
+        "next_action guidelines:",
+        "- A single sentence, written for a maintainer reading the issue.",
+        '- Concrete and specific. Examples: "Ask the reporter for the exact command, expected '
+        'output, and actual output." / "Confirm whether this should be handled by the existing '
+        'project-board cleanup work." / "Start with the webhook routing tests, then update the '
+        'issue triage prompt contract." / "Track the upstream SDK release, then revisit this '
+        'issue." / "Confirm against #123 and close as duplicate." / "Confirm scope, then close '
+        'or apply the wontfix label."',
+        "- next_action describes what the MAINTAINER should do. Maintainer-driven close, "
+        "assign, label, and milestone recommendations are fine and often the right answer "
+        "(close as duplicate, close as wontfix, apply a needs-info label after asking the "
+        "reporter). Do NOT claim Kai will perform any of these automatically; Kai's mutation "
+        "surface is additive labels, optional project assignment, the triage comment, and the "
+        "Telegram notification, full stop.",
+        "",
+        "missing_info guidelines:",
+        '- Each entry is a specific question, not a vague phrase like "more details needed."',
+        '- Empty list when status is anything other than "needs_info".',
+        "- Two to four entries is typical; more than five usually means the issue is "
+        "wontfix_candidate or blocked, not needs_info.",
+        "",
+        "blocked_by guidelines:",
+        '- null for every status except "blocked".',
+        '- For "blocked", give the maintainer a handle: an issue number (preferred, when the '
+        'blocker is tracked in this repo), a short string like "upstream pytest fix" or '
+        '"operator decision on memory backend", or a URL.',
+        '- Do NOT leave blocked_by null when status is "blocked"; the maintainer would have no handle to follow up.',
     ]
 
     return "\n".join(parts)
@@ -675,6 +722,112 @@ async def apply_triage(
     # Type-guard Claude's response fields. Claude may return wrong types
     # (e.g., "labels": "bug" instead of ["bug"], or ["bug", 42, null]).
     # Filter at extraction so downstream code can assume correct types.
+    #
+    # Ordering for the actionability block (status / next_action /
+    # missing_info / blocked_by) is load-bearing: capture
+    # raw_summary_has_content from the raw model dict BEFORE the
+    # summary normalization below rewrites a missing or empty summary
+    # to "No summary provided." A status fallback that inspected the
+    # post-normalization summary would always see content and always
+    # pick "ready"; the raw signal is what makes the fallback honest.
+    # Then normalize missing_info BEFORE computing the status
+    # fallback so a scalar / dict / int / None missing_info collapses
+    # to [] and is captured in a warning log rather than influencing
+    # the status decision.
+    raw_summary_has_content = isinstance(triage_result.get("summary"), str) and triage_result["summary"].strip() != ""
+
+    missing_info_raw = triage_result.get("missing_info", [])
+    if not isinstance(missing_info_raw, list):
+        # Matches the existing list-field guard pattern for labels and
+        # related: non-list becomes []. Iterating a string would render
+        # one bullet per character; iterating a dict would render its
+        # keys; neither matches the intent.
+        log.warning(
+            "Triage: missing_info is %s (expected list); normalizing to []",
+            type(missing_info_raw).__name__,
+        )
+        missing_info: list[str] = []
+    else:
+        missing_info = [q.strip() for q in missing_info_raw if isinstance(q, str) and q.strip()]
+
+    # Status fallback uses raw_summary_has_content plus normalized
+    # missing_info per spec section 8. If the model returned a real
+    # summary AND no real questions, the issue is actionable enough to
+    # mark ready; otherwise default to needs_info so a maintainer
+    # reading the comment knows the model could not classify cleanly.
+    _ALLOWED_STATUSES = ("ready", "needs_info", "wontfix_candidate", "blocked")
+    status_raw = triage_result.get("status")
+    if status_raw in _ALLOWED_STATUSES:
+        status = status_raw
+    else:
+        if status_raw is not None:
+            log.warning(
+                "Triage: invalid status %r (expected one of %s); falling back",
+                status_raw,
+                _ALLOWED_STATUSES,
+            )
+        status = "ready" if (raw_summary_has_content and not missing_info) else "needs_info"
+
+    # blocked_by accepts int (preferred when the blocker is tracked
+    # in the repo), non-empty string (a short label or URL), or None.
+    # Any other type collapses to None.
+    blocked_by_raw = triage_result.get("blocked_by")
+    if isinstance(blocked_by_raw, int):
+        blocked_by: int | str | None = blocked_by_raw
+    elif isinstance(blocked_by_raw, str) and blocked_by_raw.strip():
+        blocked_by = blocked_by_raw.strip()
+    else:
+        blocked_by = None
+
+    # Consistency checks per spec section 8. A "blocked" label with no
+    # handle is worse than "ready" because the maintainer has nothing
+    # to follow up on; downgrade to ready and let the summary explain
+    # the situation. Conversely, rendering "Blocked by: X" alongside a
+    # non-blocked status would confuse the maintainer; drop blocked_by.
+    if status == "blocked" and blocked_by is None:
+        log.warning("Triage: status=blocked with null blocked_by; downgrading to ready")
+        status = "ready"
+    elif status != "blocked" and blocked_by is not None:
+        log.warning(
+            "Triage: blocked_by populated but status is %s; ignoring blocked_by",
+            status,
+        )
+        blocked_by = None
+
+    # next_action per-status fallback. The defaults match spec
+    # section 8 so a missing or empty next_action still renders a
+    # useful sentence in the comment instead of an empty line.
+    _NEXT_ACTION_DEFAULTS = {
+        "ready": "Review the issue and assign or start work.",
+        "needs_info": "Ask the reporter the questions in Missing information.",
+        "wontfix_candidate": ("Confirm the scope assessment and either close or apply a wontfix label."),
+        "blocked": "Track the blocking dependency and revisit this issue when it resolves.",
+    }
+    next_action_raw = triage_result.get("next_action")
+    if isinstance(next_action_raw, str) and next_action_raw.strip():
+        next_action = next_action_raw.strip()
+    else:
+        if next_action_raw is not None:
+            log.warning(
+                "Triage: next_action is %r; falling back to per-status default",
+                next_action_raw,
+            )
+        next_action = _NEXT_ACTION_DEFAULTS[status]
+
+    # Missing info edge cases: status mismatch with question count is
+    # logged but the questions render anyway when present, so the
+    # maintainer sees the model's intent even when its status decision
+    # was off. A needs_info status with no questions also logs so the
+    # operator can spot model misbehavior in the daemon log.
+    if status != "needs_info" and missing_info:
+        log.warning(
+            "Triage: status=%s but missing_info has %d question(s); rendering anyway",
+            status,
+            len(missing_info),
+        )
+    elif status == "needs_info" and not missing_info:
+        log.warning("Triage: status=needs_info but missing_info is empty; comment will lack specific questions")
+
     labels = triage_result.get("labels", [])
     if not isinstance(labels, list):
         labels = []
@@ -786,12 +939,27 @@ async def apply_triage(
 
     # Step 3: Post triage comment
     labels_str = ", ".join(new_labels) if new_labels else "(none added)"
+    # Render order per spec section 9: Triage summary, blank line,
+    # Status (always), Blocked by (only when status=blocked), Priority,
+    # Labels applied, optional duplicate / related / project, Next
+    # action (always), Missing information block (only when
+    # missing_info has at least one question). blocked_by renders as
+    # "#<n>" when an int (matches the existing "Possible duplicate of"
+    # rendering) and as the raw string otherwise.
     comment_parts = [
         f"**Triage summary:** {summary}",
         "",
-        f"**Priority:** {priority}",
-        f"**Labels applied:** {labels_str}",
+        f"**Status:** {status}",
     ]
+    if status == "blocked" and blocked_by is not None:
+        blocked_by_display = f"#{blocked_by}" if isinstance(blocked_by, int) else blocked_by
+        comment_parts.append(f"**Blocked by:** {blocked_by_display}")
+    comment_parts.extend(
+        [
+            f"**Priority:** {priority}",
+            f"**Labels applied:** {labels_str}",
+        ]
+    )
     if duplicate_of:
         comment_parts.append(f"**Possible duplicate of:** #{duplicate_of}")
     if related:
@@ -799,6 +967,11 @@ async def apply_triage(
         comment_parts.append(f"**Related issues:** {related_str}")
     if project:
         comment_parts.append(f"**Added to project:** {project}")
+    comment_parts.append(f"**Next action:** {next_action}")
+    if missing_info:
+        comment_parts.append("**Missing information:**")
+        for question in missing_info:
+            comment_parts.append(f"- {question}")
 
     comment_body = _TRIAGE_HEADER + "\n".join(comment_parts)
 
@@ -833,12 +1006,23 @@ async def apply_triage(
             log.info("Posted triage comment on %s#%d", metadata.repo, metadata.number)
 
     # Step 4: Send Telegram notification
+    # Render order per spec section 9: header, title, Status (always),
+    # Priority, Labels, Next (always, single line), optional Needs
+    # info count (questions live on the GitHub comment, not duplicated
+    # here), optional duplicate / related / project, optional Blocked
+    # by (only when status=blocked), url. blocked_by renders as
+    # "#<n>" for ints and as the raw string otherwise.
     telegram_parts = [
         f"Issue #{metadata.number} triaged in {metadata.repo}",
         metadata.title,
+        f"Status: {status}",
         f"Priority: {priority}",
         f"Labels: {', '.join(new_labels) if new_labels else '(none added)'}",
+        f"Next: {next_action}",
     ]
+    if missing_info:
+        question_word = "question" if len(missing_info) == 1 else "questions"
+        telegram_parts.append(f"Needs info: {len(missing_info)} {question_word}")
     if duplicate_of:
         telegram_parts.append(f"Possible duplicate of #{duplicate_of}")
     if related:
@@ -846,6 +1030,9 @@ async def apply_triage(
         telegram_parts.append(f"Related: {related_str}")
     if project:
         telegram_parts.append(f"Project: {project}")
+    if status == "blocked" and blocked_by is not None:
+        blocked_by_display = f"#{blocked_by}" if isinstance(blocked_by, int) else blocked_by
+        telegram_parts.append(f"Blocked by: {blocked_by_display}")
     telegram_parts.append(metadata.url)
 
     text = "\n".join(telegram_parts)

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -770,9 +770,13 @@ async def apply_triage(
 
     # blocked_by accepts int (preferred when the blocker is tracked
     # in the repo), non-empty string (a short label or URL), or None.
-    # Any other type collapses to None.
+    # Any other type collapses to None. The `not isinstance(..., bool)`
+    # exclusion is load-bearing: Python's bool is a subclass of int,
+    # so a model that returns "blocked_by": true would otherwise be
+    # accepted as a valid integer blocker and render as "Blocked by:
+    # #True" in the public-facing comment.
     blocked_by_raw = triage_result.get("blocked_by")
-    if isinstance(blocked_by_raw, int):
+    if isinstance(blocked_by_raw, int) and not isinstance(blocked_by_raw, bool):
         blocked_by: int | str | None = blocked_by_raw
     elif isinstance(blocked_by_raw, str) and blocked_by_raw.strip():
         blocked_by = blocked_by_raw.strip()

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1208,6 +1208,34 @@ class TestTriageActionability:
         assert any("blocked with null blocked_by" in r.message for r in caplog.records)
 
     @pytest.mark.asyncio
+    async def test_blocked_status_with_bool_blocked_by_rejects_and_downgrades(self, caplog):
+        """Python bool is a subclass of int; the parser must reject it explicitly.
+
+        Without the explicit bool exclusion, `"blocked_by": true` from
+        a malformed model response would be accepted as a valid
+        integer blocker (since `isinstance(True, int)` is True) and
+        render as "Blocked by: #True" in the public-facing comment.
+        The parser rejects the bool, leaving `blocked_by` None, which
+        then triggers the blocked-with-null consistency check and
+        downgrades status to ready.
+        """
+        meta = _make_metadata()
+        result = _triage_result(
+            status="blocked",
+            next_action="Track the dependency.",
+            missing_info=[],
+            blocked_by=True,
+        )
+        with caplog.at_level("WARNING", logger="kai.triage"):
+            comment, telegram = await _apply_triage_capture(meta, result)
+        assert "**Status:** ready" in comment
+        assert "**Blocked by:**" not in comment
+        assert "Blocked by:" not in telegram
+        assert "#True" not in comment
+        assert "#True" not in telegram
+        assert any("blocked with null blocked_by" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
     async def test_non_blocked_status_with_blocked_by_ignores_blocked_by(self, caplog):
         meta = _make_metadata()
         result = _triage_result(

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1039,6 +1040,382 @@ class TestApplyTriage:
         # No --add-label calls should have been made
         add_label_calls = [cmd for cmd in commands_run if "issue" in cmd and "edit" in cmd and "--add-label" in cmd]
         assert len(add_label_calls) == 0
+
+
+# ── apply_triage actionability fields (#690) ────────────────────────
+
+
+async def _apply_triage_capture(meta: IssueMetadata, result: dict, **kwargs) -> tuple[str, str]:
+    """Run apply_triage and capture the rendered comment / Telegram bodies.
+
+    Reads the comment body from the tempfile path passed to
+    `gh issue comment --body-file`; the tempfile is still live inside
+    the mocked subprocess callback so we can read it before
+    apply_triage's `with tempfile.TemporaryDirectory(...)` block
+    cleans up. Reads the Telegram body from the mocked aiohttp post
+    call's json payload.
+    """
+    captured: dict[str, str | None] = {"comment": None, "telegram": None}
+
+    async def mock_exec(*args, **_kwargs):
+        if "issue" in args and "comment" in args and "--body-file" in args:
+            body_path = args[list(args).index("--body-file") + 1]
+            captured["comment"] = Path(body_path).read_text()
+        return _mock_subprocess(stdout="[]")
+
+    with (
+        patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
+        patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
+    ):
+        mock_session = AsyncMock()
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        await apply_triage(meta, result, 8080, "secret", **kwargs)
+        if mock_session.post.called:
+            captured["telegram"] = mock_session.post.call_args[1]["json"]["text"]
+
+    assert captured["comment"] is not None, "apply_triage did not post a comment"
+    assert captured["telegram"] is not None, "apply_triage did not send a Telegram summary"
+    return captured["comment"], captured["telegram"]
+
+
+class TestTriageActionability:
+    """#690: status / next_action / missing_info / blocked_by output fields."""
+
+    # ── Happy path: one fixture per status value ────────────────────
+
+    @pytest.mark.asyncio
+    async def test_ready_status_renders_status_and_next_action(self):
+        meta = _make_metadata()
+        result = _triage_result(
+            status="ready",
+            next_action="Start work on the foo module.",
+            missing_info=[],
+            blocked_by=None,
+        )
+        comment, telegram = await _apply_triage_capture(meta, result)
+        assert "**Status:** ready" in comment
+        assert "**Next action:** Start work on the foo module." in comment
+        assert "**Missing information:**" not in comment
+        assert "**Blocked by:**" not in comment
+        assert "Status: ready" in telegram
+        assert "Next: Start work on the foo module." in telegram
+        assert "Needs info:" not in telegram
+        assert "Blocked by:" not in telegram
+
+    @pytest.mark.asyncio
+    async def test_needs_info_renders_missing_info_block(self):
+        meta = _make_metadata()
+        questions = [
+            "What is the exact command you ran?",
+            "What was the expected vs actual output?",
+        ]
+        result = _triage_result(
+            status="needs_info",
+            next_action="Ask the reporter for reproduction details.",
+            missing_info=questions,
+            blocked_by=None,
+        )
+        comment, telegram = await _apply_triage_capture(meta, result)
+        assert "**Status:** needs_info" in comment
+        assert "**Missing information:**" in comment
+        for question in questions:
+            assert f"- {question}" in comment
+        assert "Status: needs_info" in telegram
+        assert "Needs info: 2 questions" in telegram
+
+    @pytest.mark.asyncio
+    async def test_wontfix_candidate_renders_status(self):
+        meta = _make_metadata()
+        result = _triage_result(
+            status="wontfix_candidate",
+            next_action="Confirm scope, then close or apply the wontfix label.",
+            missing_info=[],
+            blocked_by=None,
+        )
+        commands_run = []
+
+        async def mock_exec(*args, **_kwargs):
+            commands_run.append(args)
+            if "issue" in args and "comment" in args and "--body-file" in args:
+                pass
+            return _mock_subprocess(stdout="[]")
+
+        with (
+            patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
+            patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
+        ):
+            mock_session = AsyncMock()
+            mock_resp = AsyncMock()
+            mock_resp.status = 200
+            mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            await apply_triage(meta, result, 8080, "secret")
+
+        # Comment renders the status.
+        comment_calls = [cmd for cmd in commands_run if "issue" in cmd and "comment" in cmd]
+        assert len(comment_calls) == 1
+        # No automatic close: gh issue close must NEVER be invoked.
+        close_calls = [cmd for cmd in commands_run if "issue" in cmd and "close" in cmd]
+        assert close_calls == []
+
+    @pytest.mark.asyncio
+    async def test_blocked_status_renders_blocked_by_int(self):
+        meta = _make_metadata()
+        result = _triage_result(
+            status="blocked",
+            next_action="Track #42, then revisit.",
+            missing_info=[],
+            blocked_by=42,
+        )
+        comment, telegram = await _apply_triage_capture(meta, result)
+        assert "**Status:** blocked" in comment
+        assert "**Blocked by:** #42" in comment
+        assert "Status: blocked" in telegram
+        assert "Blocked by: #42" in telegram
+
+    @pytest.mark.asyncio
+    async def test_blocked_status_renders_blocked_by_string(self):
+        meta = _make_metadata()
+        result = _triage_result(
+            status="blocked",
+            next_action="Track the upstream pytest fix, then revisit.",
+            missing_info=[],
+            blocked_by="upstream pytest fix",
+        )
+        comment, telegram = await _apply_triage_capture(meta, result)
+        assert "**Status:** blocked" in comment
+        assert "**Blocked by:** upstream pytest fix" in comment
+        assert "Blocked by: upstream pytest fix" in telegram
+
+    # ── Consistency fallback tests ──────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_blocked_status_with_null_blocked_by_downgrades_to_ready(self, caplog):
+        meta = _make_metadata()
+        result = _triage_result(
+            status="blocked",
+            next_action="Track the dependency.",
+            missing_info=[],
+            blocked_by=None,
+        )
+        with caplog.at_level("WARNING", logger="kai.triage"):
+            comment, _telegram = await _apply_triage_capture(meta, result)
+        assert "**Status:** ready" in comment
+        assert "**Blocked by:**" not in comment
+        assert any("blocked with null blocked_by" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_non_blocked_status_with_blocked_by_ignores_blocked_by(self, caplog):
+        meta = _make_metadata()
+        result = _triage_result(
+            status="ready",
+            next_action="Start work.",
+            missing_info=[],
+            blocked_by=42,
+        )
+        with caplog.at_level("WARNING", logger="kai.triage"):
+            comment, telegram = await _apply_triage_capture(meta, result)
+        assert "**Status:** ready" in comment
+        assert "**Blocked by:**" not in comment
+        assert "Blocked by:" not in telegram
+        assert any("blocked_by populated but status is ready" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_invalid_status_falls_back_to_ready_with_raw_summary(self):
+        meta = _make_metadata()
+        result = _triage_result(
+            status="frobnicate",
+            summary="The login button is misaligned on Safari 17.",
+            missing_info=[],
+        )
+        comment, _telegram = await _apply_triage_capture(meta, result)
+        assert "**Status:** ready" in comment
+
+    @pytest.mark.asyncio
+    async def test_invalid_status_falls_back_to_needs_info_with_questions(self):
+        meta = _make_metadata()
+        result = _triage_result(
+            status="frobnicate",
+            summary="The login button is misaligned on Safari 17.",
+            missing_info=["What version of Safari?"],
+        )
+        comment, _telegram = await _apply_triage_capture(meta, result)
+        assert "**Status:** needs_info" in comment
+        assert "- What version of Safari?" in comment
+
+    @pytest.mark.asyncio
+    async def test_invalid_status_with_missing_summary_and_empty_missing_info_falls_back_to_needs_info(self):
+        """W-1 regression guard: status fallback uses RAW summary, not the post-normalization default.
+
+        With status="frobnicate", summary="", and missing_info=[], the
+        raw summary has no content, so the fallback selects
+        needs_info. A naive implementation that checked the
+        post-normalization summary would always see "No summary
+        provided." (non-empty) and wrongly pick "ready".
+        """
+        meta = _make_metadata()
+        result = _triage_result(
+            status="frobnicate",
+            summary="",
+            missing_info=[],
+        )
+        comment, _telegram = await _apply_triage_capture(meta, result)
+        assert "**Status:** needs_info" in comment
+
+    # ── Malformed field tests ───────────────────────────────────────
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "status,expected_default",
+        [
+            ("ready", "Review the issue and assign or start work."),
+            ("needs_info", "Ask the reporter the questions in Missing information."),
+            (
+                "wontfix_candidate",
+                "Confirm the scope assessment and either close or apply a wontfix label.",
+            ),
+            ("blocked", "Track the blocking dependency and revisit this issue when it resolves."),
+        ],
+    )
+    async def test_missing_next_action_falls_back_per_status(self, status, expected_default):
+        meta = _make_metadata()
+        # blocked needs blocked_by populated, otherwise the consistency
+        # check downgrades status to "ready" and the fallback default
+        # changes underneath the test. Provide one so the status sticks.
+        result = _triage_result(
+            status=status,
+            next_action=None,
+            missing_info=["question?"] if status == "needs_info" else [],
+            blocked_by=42 if status == "blocked" else None,
+        )
+        comment, _telegram = await _apply_triage_capture(meta, result)
+        assert f"**Next action:** {expected_default}" in comment
+
+    @pytest.mark.asyncio
+    async def test_missing_info_with_non_string_entries_filters(self):
+        meta = _make_metadata()
+        result = _triage_result(
+            status="needs_info",
+            next_action="Ask the reporter.",
+            missing_info=["valid?", 42, None, "another?"],
+        )
+        comment, _telegram = await _apply_triage_capture(meta, result)
+        assert "- valid?" in comment
+        assert "- another?" in comment
+        assert "- 42" not in comment
+        assert "- None" not in comment
+
+    @pytest.mark.asyncio
+    async def test_missing_info_scalar_normalizes_to_empty_list(self, caplog):
+        """W-2 regression guard: non-list missing_info collapses to []."""
+        meta = _make_metadata()
+        result = _triage_result(
+            status="needs_info",
+            next_action="Ask the reporter.",
+            missing_info="steps?",
+        )
+        with caplog.at_level("WARNING", logger="kai.triage"):
+            comment, telegram = await _apply_triage_capture(meta, result)
+        assert "**Missing information:**" not in comment
+        assert "Needs info:" not in telegram
+        assert any("missing_info is str" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_scalar_missing_info_with_invalid_status_falls_back_to_ready(self):
+        """W-1 v3 regression guard: scalar missing_info normalizes before status fallback.
+
+        With status="frobnicate", a non-empty raw summary, and scalar
+        missing_info, the parser normalizes missing_info to [] before
+        the status fallback inspects it. Combined with the non-empty
+        raw summary, this lands as status="ready" (not "needs_info",
+        which would treat the malformed scalar as a real question
+        signal).
+        """
+        meta = _make_metadata()
+        result = _triage_result(
+            status="frobnicate",
+            summary="The login button is misaligned on Safari 17.",
+            missing_info="steps?",
+        )
+        comment, _telegram = await _apply_triage_capture(meta, result)
+        assert "**Status:** ready" in comment
+
+    @pytest.mark.asyncio
+    async def test_missing_info_when_status_is_not_needs_info_still_renders(self, caplog):
+        meta = _make_metadata()
+        result = _triage_result(
+            status="ready",
+            next_action="Start work.",
+            missing_info=["edge case to confirm?"],
+        )
+        with caplog.at_level("WARNING", logger="kai.triage"):
+            comment, telegram = await _apply_triage_capture(meta, result)
+        assert "**Status:** ready" in comment
+        assert "- edge case to confirm?" in comment
+        assert "Needs info: 1 question" in telegram
+        assert any("status=ready but missing_info has 1 question" in r.message for r in caplog.records)
+
+    # ── Prompt contract test (B-1 regression guard) ─────────────────
+
+    def test_prompt_allows_close_recommendation_in_next_action(self):
+        """B-1 regression guard: prompt permits maintainer-driven close recommendations.
+
+        The v1 spec had a prompt prohibition ("Do NOT recommend
+        closing, assigning, or setting milestones") that contradicted
+        the duplicate and wontfix_candidate fallbacks (which DO
+        recommend closing, since the maintainer is the one closing).
+        The v2 fix distinguishes maintainer-driven recommendations
+        (allowed) from claims about Kai's automatic behavior (still
+        forbidden). The prompt must contain phrasing that supports the
+        distinction; assert on the load-bearing fragments here.
+        """
+        meta = _make_metadata()
+        prompt = build_triage_prompt(meta, related_issues="[]", projects="[]")
+        assert "next_action describes what the MAINTAINER should do" in prompt
+        assert "Maintainer-driven close, assign, label, and milestone recommendations are fine" in prompt
+        assert "Do NOT claim Kai will perform any of these automatically" in prompt
+        # The wontfix_candidate framing as suggestion-not-verdict is
+        # the load-bearing phrase for false-positive risk; assert it
+        # exists too so a future prompt edit cannot silently drop it.
+        assert "SUGGESTION for human review, NOT a verdict" in prompt
+
+    # ── Existing-behavior regression ────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_existing_fields_still_render(self):
+        """Adding the new fields does not displace the existing comment lines."""
+        meta = _make_metadata(labels=[])
+        result = _triage_result(
+            labels=["bug", "enhancement"],
+            duplicate_of=99,
+            related=[100, 101],
+            project="Sprint 1",
+            summary="Login broken on Safari.",
+            priority="high",
+            status="ready",
+            next_action="Start work on the login fix.",
+            missing_info=[],
+            blocked_by=None,
+        )
+        projects_json = json.dumps({"projects": [{"title": "Sprint 1", "number": 1}]})
+        comment, telegram = await _apply_triage_capture(meta, result, projects_json=projects_json)
+        # All existing fields render.
+        assert "**Triage summary:** Login broken on Safari." in comment
+        assert "**Priority:** high" in comment
+        assert "**Labels applied:** bug, enhancement" in comment
+        assert "**Possible duplicate of:** #99" in comment
+        assert "**Related issues:** #100, #101" in comment
+        assert "**Added to project:** Sprint 1" in comment
+        # New fields render too.
+        assert "**Status:** ready" in comment
+        assert "**Next action:** Start work on the login fix." in comment
+        # Telegram surfaces the new and existing summary bits.
+        assert "Status: ready" in telegram
+        assert "Priority: high" in telegram
+        assert "Next: Start work on the login fix." in telegram
 
 
 # ── triage_issue (full pipeline) ────────────────────────────────────


### PR DESCRIPTION
Closes #690.

## Summary

- New triage output fields: `status` (`ready` / `needs_info` / `wontfix_candidate` / `blocked`), `next_action` (single concrete recommendation), `missing_info` (specific questions for the reporter), and `blocked_by` (handle for the blocker when `status = "blocked"`).
- The new fields land on the GitHub triage comment so a maintainer scanning a freshly triaged issue knows the next human move in one read instead of inferring it from labels and a summary line.
- Telegram summary picks up a compact form (status, next action, optional needs-info count, optional blocked-by line) without duplicating the `missing_info` questions, which live on the GitHub comment.

## Why

The current triage one-shot classifies an issue across six axes (labels, duplicate detection, related, project, summary, priority) but stops one step short of being actionable. A maintainer reading "## Triage by Kai" learns priority and labels but still has to read the issue body to decide whether to start work, ask the reporter a question, mark it as a duplicate, or punt because it's blocked on an external dependency. This PR closes that gap.

## How

The prompt edit adds the four new fields to the JSON shape and appends four guidance paragraphs. The `wontfix_candidate` framing is the load-bearing phrase: the model is told to treat it as "a SUGGESTION for human review, NOT a verdict" so it does not over-claim scope judgments without project context. The `next_action` guidance permits maintainer-driven close / assign / label recommendations (which are often the right answer for duplicates and wontfix candidates) while still forbidding claims about Kai's own automatic behavior.

Parser ordering is load-bearing:

1. Capture `raw_summary_has_content` from the raw model dict before the existing summary normalization rewrites a missing summary to a fallback string. A status fallback that inspected the post-normalization summary would always see content and always pick `"ready"`.
2. Normalize `missing_info` to a filtered list (non-list scalars to `[]`, drop non-string and empty entries) before the status fallback inspects it. A scalar `missing_info` therefore collapses to `[]` and contributes nothing to the status decision.
3. Compute the invalid-status fallback from `raw_summary_has_content` plus the normalized `missing_info`: ready if both signals match an actionable issue, otherwise needs_info.
4. Two consistency checks: `blocked` + null `blocked_by` downgrades to `ready` (a blocked label with no handle is worse than ready), and non-`blocked` + populated `blocked_by` drops `blocked_by` (rendering "Blocked by: X" alongside `status = "ready"` would confuse the maintainer). Both inconsistencies log at WARNING.

The mutation surface is unchanged. Kai still does additive labels, optional project assignment, the triage comment, and the Telegram notification, full stop. No auto-close, no auto-assign, no milestone setting, no label removal.

## Test plan

- [x] `make check` clean.
- [x] `pytest tests/test_triage.py` clean (94 tests, was 74). 20 new tests under `TestTriageActionability`:
  - 5 per-status happy paths
  - 5 consistency-fallback guards (blocked + null blocked_by downgrades, non-blocked + populated blocked_by drops, invalid status fallback under three input shapes including the W-1 raw-summary regression guard)
  - 5 malformed-field guards (non-list `missing_info`, non-string entries inside a list, scalar + invalid status falls back to ready, status mismatch with question count renders anyway and logs)
  - 1 parametrized per-status `next_action` default test
  - 1 prompt-contract assertion that the maintainer-driven close-recommendation distinction stays in the prompt body and that the `wontfix_candidate` "suggestion for human review, NOT a verdict" framing remains intact
  - 1 existing-behavior regression confirming the new fields do not displace existing comment lines
- [x] Full `pytest` suite clean (4564 passed, 1 skipped).
- [x] Wiki page updated separately on the `kai.wiki.git` repo: new triage output fields documented with rendered comment examples for `ready`, `needs_info`, and `blocked`; the two adjacent stale claims (XML-delimited prompts, Claude-only execution) corrected to match current code state.

## Deferred follow-ups

These belong to separate issues:

- Reply to the reporter directly when `status = "needs_info"` (post a second comment asking the listed `missing_info` questions). Expands the mutation surface; out of scope here.
- Automated close-as-duplicate flow when `duplicate_of` is non-null, gated on operator approval. Expands the mutation surface; out of scope here.
- Status-driven label additions (e.g. auto-adding a `needs-info` or `blocked` label when the status enum matches). Possible but invites label-soup; defer.
