### PR TITLE
Reject bool duplicate_of and bool entries in related

### DIFF
--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -837,14 +837,23 @@ async def apply_triage(
         labels = []
     labels = [lbl for lbl in labels if isinstance(lbl, str) and lbl.strip()]
 
+    # The `not isinstance(..., bool)` exclusion is load-bearing:
+    # Python's bool is a subclass of int, so a model that returns
+    # "duplicate_of": true would otherwise be accepted as a valid
+    # integer issue number and render as "Possible duplicate of: #True"
+    # in the public-facing comment. Same shape as the `blocked_by`
+    # guard above.
     duplicate_of = triage_result.get("duplicate_of")
-    if not isinstance(duplicate_of, int):
+    if not isinstance(duplicate_of, int) or isinstance(duplicate_of, bool):
         duplicate_of = None
 
     related = triage_result.get("related", [])
     if not isinstance(related, list):
         related = []
-    related = [n for n in related if isinstance(n, int)]
+    # Same bool-vs-int exclusion as `duplicate_of`: True/False values
+    # inside the list would otherwise pass `isinstance(n, int)` and
+    # render as "#True" / "#False".
+    related = [n for n in related if isinstance(n, int) and not isinstance(n, bool)]
 
     project = triage_result.get("project")
     if not isinstance(project, str) or not project.strip():

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1410,6 +1410,58 @@ class TestTriageActionability:
         # exists too so a future prompt edit cannot silently drop it.
         assert "SUGGESTION for human review, NOT a verdict" in prompt
 
+    # ── Bool-as-int guards on duplicate_of / related ────────────────
+
+    @pytest.mark.asyncio
+    async def test_bool_duplicate_of_normalizes_to_none(self):
+        """Python bool is a subclass of int; the parser must reject it on duplicate_of.
+
+        Without the explicit bool exclusion, `"duplicate_of": true`
+        from a malformed model response would be accepted as a valid
+        integer issue number (since `isinstance(True, int)` is True)
+        and render as "Possible duplicate of: #True" in the
+        public-facing comment. Same defect class the `blocked_by`
+        guard already protects against.
+        """
+        meta = _make_metadata()
+        result = _triage_result(
+            duplicate_of=True,
+            summary="Login broken on Safari.",
+            status="ready",
+            next_action="Start work.",
+            missing_info=[],
+        )
+        comment, telegram = await _apply_triage_capture(meta, result)
+        assert "**Possible duplicate of:**" not in comment
+        assert "Possible duplicate of" not in telegram
+        assert "#True" not in comment
+        assert "#True" not in telegram
+
+    @pytest.mark.asyncio
+    async def test_bool_entries_in_related_filter_out(self):
+        """Bool entries inside `related` must be filtered before rendering.
+
+        Same defect class as `duplicate_of`: True / False inside the
+        list would otherwise pass the per-entry `isinstance(n, int)`
+        filter and render as "#True" / "#False" in the public-facing
+        related-issues line.
+        """
+        meta = _make_metadata()
+        result = _triage_result(
+            related=[42, True, False, 100],
+            summary="Login broken on Safari.",
+            status="ready",
+            next_action="Start work.",
+            missing_info=[],
+        )
+        comment, telegram = await _apply_triage_capture(meta, result)
+        assert "**Related issues:** #42, #100" in comment
+        assert "Related: #42, #100" in telegram
+        assert "#True" not in comment
+        assert "#False" not in comment
+        assert "#True" not in telegram
+        assert "#False" not in telegram
+
     # ── Existing-behavior regression ────────────────────────────────
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Reject bool values in `duplicate_of`; bool entries inside `related` are filtered out.
- Two regression tests under `TestTriageActionability` confirm `"duplicate_of": true` no longer renders as "Possible duplicate of: #True" and that `[42, true, false, 100]` filters to `[42, 100]`.

## Why

Python's `bool` is a subclass of `int`, so `isinstance(True, int)` returns `True`. PR #697 caught and fixed this defect class on the new `blocked_by` parser. The same gap existed on the pre-existing `duplicate_of` and `related` parsers; the previous review pass only scoped the new code. A maliciously or carelessly malformed model response of `"duplicate_of": true` would have rendered as "Possible duplicate of: #True" in the public-facing triage comment.

## Test plan

- [x] `make check` clean.
- [x] `pytest tests/test_triage.py` clean (97 tests, was 95).
- [x] Two new tests confirm the bool guards: `test_bool_duplicate_of_normalizes_to_none`, `test_bool_entries_in_related_filter_out`.
