### PR TITLE
Allocate the changed-files budget dynamically under a higher ceiling

### DIFF
--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -2097,14 +2097,22 @@ def _cap_patch(patch: str) -> tuple[str, list[BudgetNote]]:
 
 def _cap_changed_files(
     files: tuple[ChangedFile, ...],
+    *,
+    cap: int,
 ) -> tuple[tuple[ChangedFile, ...], list[BudgetNote]]:
-    """Truncate full file contents last; never drop the file entirely."""
+    """Truncate full file contents last; never drop the file entirely.
+
+    `cap` is the dynamic changed-files section cap computed by
+    `_compute_dynamic_changed_files_cap`. It is keyword-only so the
+    caller cannot accidentally pass the wrong constant; the caller is
+    responsible for floor enforcement before invoking this function.
+    """
     notes: list[BudgetNote] = []
     if not files:
         return ((), notes)
 
     total = sum(_measure_changed_file(f) for f in files)
-    if total <= _CHANGED_FILES_SECTION_FLOOR:
+    if total <= cap:
         return (files, notes)
 
     # Drop ladder rung 6: truncate the largest file contents first
@@ -2115,7 +2123,7 @@ def _cap_changed_files(
     indexed.sort(key=lambda item: _measure_changed_file(item[1]), reverse=True)
     truncated_paths: list[str] = []
     for idx, f in indexed:
-        if sum(_measure_changed_file(g) for g in [files[i] for i in range(len(files))]) <= _CHANGED_FILES_SECTION_FLOOR:
+        if sum(_measure_changed_file(g) for g in [files[i] for i in range(len(files))]) <= cap:
             break
         if f.content is None:
             continue
@@ -2164,6 +2172,38 @@ def _estimate_total_chars(ctx: PRReviewContext) -> int:
     return total
 
 
+def _compute_dynamic_changed_files_cap(ctx: PRReviewContext) -> int:
+    """Compute the section cap for changed_files given the rest of the bundle.
+
+    Constructs a measurement context with `changed_files=()` and reuses
+    `_estimate_total_chars` so any future change to per-section
+    measurement flows through here automatically. Floors at
+    `_CHANGED_FILES_SECTION_FLOOR` so pathological non-changed sections
+    never starve changed-files below the legacy static-cap behavior.
+    Holds `_OVERHEAD_RESERVE` back for rendered overhead the estimator
+    does not capture (per-section boundary tokens, BEGIN/END markers,
+    status lines).
+    """
+    measurement_ctx = PRReviewContext(
+        repo=ctx.repo,
+        pr_number=ctx.pr_number,
+        metadata=ctx.metadata,
+        linked_issues=ctx.linked_issues,
+        commits=ctx.commits,
+        patch=ctx.patch,
+        changed_files=(),
+        related_context=ctx.related_context,
+        spec=ctx.spec,
+        conventions=ctx.conventions,
+        prior_comments=ctx.prior_comments,
+        budget_notes=ctx.budget_notes,
+        collection_warnings=ctx.collection_warnings,
+    )
+    non_changed = _estimate_total_chars(measurement_ctx)
+    headroom = _MAX_REVIEW_CONTEXT_CHARS - non_changed - _OVERHEAD_RESERVE
+    return max(_CHANGED_FILES_SECTION_FLOOR, headroom)
+
+
 def budget_review_context(ctx: PRReviewContext) -> PRReviewContext:
     """
     Apply per-section caps and the drop ladder to a freshly-collected bundle.
@@ -2187,8 +2227,10 @@ def budget_review_context(ctx: PRReviewContext) -> PRReviewContext:
     """
     notes: list[BudgetNote] = list(ctx.budget_notes)
 
-    # Per-section caps. Run in fixed order so the result is
-    # deterministic for the same input.
+    # Per-section caps for the non-changed-files sections. Run in fixed
+    # order so the result is deterministic for the same input. The
+    # changed-files section runs after these so the dynamic allocator
+    # can size it against the measured weight of everything else.
     related, n = _cap_related(ctx.related_context)
     notes.extend(n)
     commits, n = _cap_commits(ctx.commits)
@@ -2197,11 +2239,11 @@ def budget_review_context(ctx: PRReviewContext) -> PRReviewContext:
     notes.extend(n)
     patch, n = _cap_patch(ctx.patch)
     notes.extend(n)
-    changed_files, n = _cap_changed_files(ctx.changed_files)
-    notes.extend(n)
 
     # Apply prior-comments cap (mirrors the existing
     # _MAX_PRIOR_COMMENTS_CHARS behavior for the legacy diff path).
+    # Capped before the dynamic allocator runs so its measurement
+    # reflects the post-cap size, not the pre-cap raw length.
     prior_comments = ctx.prior_comments
     if prior_comments and len(prior_comments) > _MAX_PRIOR_COMMENTS_CHARS:
         prior_comments = _truncate_with_marker(
@@ -2215,6 +2257,31 @@ def budget_review_context(ctx: PRReviewContext) -> PRReviewContext:
                 message="Prior review thread truncated to stay within cap.",
             )
         )
+
+    # Build a partial context with every non-changed-files section
+    # already capped; the allocator zeros out changed_files internally
+    # before measuring so the field value we pass here does not
+    # affect the result. Reuses `_estimate_total_chars` via the
+    # helper so any future change to per-section measurement flows
+    # through here automatically.
+    partial_ctx = PRReviewContext(
+        repo=ctx.repo,
+        pr_number=ctx.pr_number,
+        metadata=ctx.metadata,
+        linked_issues=linked_issues,
+        commits=commits,
+        patch=patch,
+        changed_files=ctx.changed_files,
+        related_context=related,
+        spec=ctx.spec,
+        conventions=ctx.conventions,
+        prior_comments=prior_comments,
+        budget_notes=tuple(notes),
+        collection_warnings=ctx.collection_warnings,
+    )
+    dynamic_cap = _compute_dynamic_changed_files_cap(partial_ctx)
+    changed_files, n = _cap_changed_files(ctx.changed_files, cap=dynamic_cap)
+    notes.extend(n)
 
     capped = PRReviewContext(
         repo=ctx.repo,

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -83,22 +83,40 @@ _MAX_PRIOR_COMMENTS_CHARS = 50_000
 # ── Bundle budget constants ──────────────────────────────────────────
 #
 # Per-section caps used by the deterministic budgeter that backs
-# build_pr_review_context() / build_review_prompt_from_context(). The
-# numbers target the realistic kai PR shape: a source module plus
-# its corresponding test file in the same change. Concretely, today's
-# `bot.py` is ~180K chars and `tests/test_bot.py` is ~246K chars; a
-# single-file rebalance is not enough because the budgeter measures
-# the COMBINED rendered size of the changed-files section, not each
-# file in isolation. The first production webhook review against the
-# previous cap set (250K changed-files / 360K global) saw ~426K
-# combined and dropped `test_bot.py` to a note even though both
-# files were inside the per-file cap. The current values admit the
-# two-large-file case so the bundle's full-file context survives
-# end-to-end. The cross-section drop ladder still enforces the
-# global ceiling when an unusually large PR overshoots.
-_MAX_REVIEW_CONTEXT_CHARS = 600_000
-_MAX_PATCH_CHARS = 80_000
-_MAX_CHANGED_FILES_CHARS = 450_000
+# build_pr_review_context() / build_review_prompt_from_context().
+#
+# The global ceiling sizes the bundle to admit a many-large-file PR's
+# full changed-file contents and full combined patch end-to-end. The
+# changed-files section runs a dynamic allocator
+# (`_compute_dynamic_changed_files_cap`) rather than a static cap:
+# the allocator measures the rendered weight of every other section,
+# subtracts that and `_OVERHEAD_RESERVE` from the global ceiling, and
+# floors at `_CHANGED_FILES_SECTION_FLOOR` so a pathological
+# non-changed payload never starves changed-files below the legacy
+# static-cap behavior. The cross-section drop ladder is defense in
+# depth for the two paths the allocator cannot prevent: floor-branch
+# saturation (non-changed weight exceeds the global ceiling minus
+# floor minus reserve) and estimator drift (rendered overhead
+# materially exceeds `_OVERHEAD_RESERVE`).
+#
+# The per-section caps for related-context, linked-issues, commits,
+# and prior-comments stay at their existing values: each one is
+# numerically dwarfed by the new global ceiling, and raising them
+# would consume headroom the dynamic allocator routes to
+# changed-files.
+_MAX_REVIEW_CONTEXT_CHARS = 3_500_000
+_MAX_PATCH_CHARS = 200_000
+# Minimum cap the dynamic changed-files allocator can produce. Matches
+# the legacy static cap so the safety net never regresses below
+# previously-shipped behavior, even when pathological non-changed
+# sections would otherwise drive the dynamic cap lower.
+_CHANGED_FILES_SECTION_FLOOR = 450_000
+# Headroom held back from the dynamic changed-files cap for rendered
+# overhead (per-section boundary tokens, BEGIN/END markers, status
+# lines) that `_estimate_total_chars` does not measure. Keeping the
+# reserve outside the section-cap arithmetic means the cross-section
+# ladder almost never has to fire on the typical headroom path.
+_OVERHEAD_RESERVE = 50_000
 _MAX_RELATED_CONTEXT_CHARS = 35_000
 _MAX_LINKED_ISSUES_CHARS = 30_000
 _MAX_COMMITS_CHARS = 20_000
@@ -1185,10 +1203,11 @@ async def fetch_linked_issues(
 # its drop ladder. Files over this cap are recorded with a `note`
 # instead of inline content. Sized to fit realistic kai-shaped
 # modules (the largest production files sit around 250K chars; the
-# largest test files reach ~250K) so the bundle's full-file context
-# is available on PRs that touch them. The per-section cap
-# (`_MAX_CHANGED_FILES_CHARS`) bounds how much of this any single PR
-# can claim.
+# largest test files reach ~412K) so the bundle's full-file context
+# is available on PRs that touch them. How much of this any one PR
+# can collectively claim is bounded by the dynamic changed-files
+# cap (`_compute_dynamic_changed_files_cap`), floored at
+# `_CHANGED_FILES_SECTION_FLOOR`.
 _MAX_CHANGED_FILE_BYTES = 500_000
 
 # File suffixes the changed-files fetcher refuses to fetch even when
@@ -2085,7 +2104,7 @@ def _cap_changed_files(
         return ((), notes)
 
     total = sum(_measure_changed_file(f) for f in files)
-    if total <= _MAX_CHANGED_FILES_CHARS:
+    if total <= _CHANGED_FILES_SECTION_FLOOR:
         return (files, notes)
 
     # Drop ladder rung 6: truncate the largest file contents first
@@ -2096,7 +2115,7 @@ def _cap_changed_files(
     indexed.sort(key=lambda item: _measure_changed_file(item[1]), reverse=True)
     truncated_paths: list[str] = []
     for idx, f in indexed:
-        if sum(_measure_changed_file(g) for g in [files[i] for i in range(len(files))]) <= _MAX_CHANGED_FILES_CHARS:
+        if sum(_measure_changed_file(g) for g in [files[i] for i in range(len(files))]) <= _CHANGED_FILES_SECTION_FLOOR:
             break
         if f.content is None:
             continue
@@ -2213,13 +2232,19 @@ def budget_review_context(ctx: PRReviewContext) -> PRReviewContext:
         collection_warnings=ctx.collection_warnings,
     )
 
-    # Cross-section drop ladder: if the per-section caps still leave
-    # the total above the global ceiling, walk the documented order
-    # (broad related hits, then test excerpts, then issue comments,
-    # then commit bodies, then patch, then changed files) until we
-    # fit. This branch is rarely taken in practice because the
-    # per-section caps sum within ~50K of the global cap; it exists
-    # so an outlier PR cannot blow the backend's context window.
+    # Cross-section drop ladder: if the bundle is still above the
+    # global ceiling after per-section caps and the dynamic
+    # changed-files cap, walk the documented order (broad related
+    # hits, then commit bodies, then issue comments, then prior
+    # thread, then spec / conventions, then patch, then changed
+    # files) until we fit. This branch is defense in depth under the
+    # lifted ceiling: the dynamic allocator's `_OVERHEAD_RESERVE`
+    # keeps the typical headroom-path bundle under the ceiling
+    # without it. The ladder still fires when non-changed weight
+    # drives the allocator down to `_CHANGED_FILES_SECTION_FLOOR`
+    # and the resulting bundle still overshoots, or when
+    # `_estimate_total_chars` materially under-counts rendered
+    # overhead.
     if _estimate_total_chars(capped) <= _MAX_REVIEW_CONTEXT_CHARS:
         return capped
     return _apply_cross_section_ladder(capped)

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -7,11 +7,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from kai.review import (
+    _CHANGED_FILES_SECTION_FLOOR,
+    _MAX_COMMITS_CHARS,
     _MAX_DIFF_CHARS,
+    _MAX_LINKED_ISSUES_CHARS,
     _MAX_PATCH_CHARS,
     _MAX_PRIOR_COMMENTS_CHARS,
     _MAX_RELATED_CONTEXT_CHARS,
     _MAX_REVIEW_CONTEXT_CHARS,
+    _OVERHEAD_RESERVE,
     _REVIEW_HEADER,
     BudgetNote,
     ChangedFile,
@@ -24,6 +28,7 @@ from kai.review import (
     PRReviewContext,
     PRReviewResult,
     RelatedExcerpt,
+    _compute_dynamic_changed_files_cap,
     _estimate_total_chars,
     _normalize_repo_from_remote,
     _resolve_workspace_remote_repo,
@@ -2431,6 +2436,74 @@ class TestBudgetHoldsTwoRealisticChangedFiles:
         assert _estimate_total_chars(out) <= _MAX_REVIEW_CONTEXT_CHARS
 
 
+# Pinned to the historical 23-file PR shape that motivated the ceiling
+# lift, totalling ~2.59 MB of inline content. Ten files reproduce the
+# largest paths and sizes from the source PR; thirteen padding files
+# fill out the count and bring the total within a few bytes of the
+# measured 2,591,737-byte sum. The fixture intentionally pins to
+# historical dimensions; if those files keep growing in main, the
+# fixture drifts, which is fine - this is a regression test for the
+# specific shape that motivated the lift, not for current state.
+_PINNED_LARGE_PR_FILE_SIZES: tuple[tuple[str, int], ...] = (
+    ("tests/test_install.py", 412_068),
+    ("src/kai/install.py", 276_246),
+    ("tests/test_memory.py", 240_705),
+    ("tests/test_memory_command.py", 170_555),
+    ("tests/test_config.py", 162_937),
+    ("src/kai/config.py", 150_270),
+    ("tests/test_claude.py", 149_319),
+    ("src/kai/memory.py", 145_436),
+    ("src/kai/memory_command.py", 113_414),
+    ("tests/test_review.py", 104_671),
+) + tuple(
+    # Thirteen smaller files fill out the 23-file count. Collective
+    # size 666,107 bytes lands within four bytes of the measured
+    # 666,116-byte balance from the real PR.
+    (f"src/kai/_padding_{i}.py", 51_239)
+    for i in range(13)
+)
+
+
+def _pinned_large_pr_files() -> tuple[ChangedFile, ...]:
+    """Build a changed-files tuple shaped like the lift-motivating PR.
+
+    Every file is below `_MAX_CHANGED_FILE_BYTES = 500_000`, so the
+    per-file cap never strips inline content even at the lifted
+    ceiling. Returns 23 entries totalling roughly 2.59 MB to match
+    the historical shape.
+    """
+    return tuple(
+        ChangedFile(
+            path=path,
+            status="modified",
+            content="x" * size,
+            note=None,
+        )
+        for path, size in _PINNED_LARGE_PR_FILE_SIZES
+    )
+
+
+def _changed_files_summing_to(n: int) -> tuple[ChangedFile, ...]:
+    """Return 10 ChangedFile entries whose contents sum to `n` bytes.
+
+    Distributes evenly across ten files (each well under the per-file
+    cap). The first file absorbs the remainder so the total lands
+    exactly on `n` even when `n` is not a multiple of ten.
+    """
+    file_count = 10
+    per_file = n // file_count
+    remainder = n - per_file * file_count
+    return tuple(
+        ChangedFile(
+            path=f"src/kai/sum_target_{i}.py",
+            status="modified",
+            content="x" * (per_file + (remainder if i == 0 else 0)),
+            note=None,
+        )
+        for i in range(file_count)
+    )
+
+
 class TestBudgetEnforcesGlobalCeiling:
     """
     After per-section caps, the final bundle must respect
@@ -2441,35 +2514,105 @@ class TestBudgetEnforcesGlobalCeiling:
     """
 
     def test_long_spec_and_conventions_trim_under_global_cap(self):
-        # Each section sits within its own cap but the sum overshoots.
-        long_spec = "spec line\n" * 8_000  # ~80K chars
-        long_conv = "convention line\n" * 8_000  # ~120K chars
+        # Build a bundle whose total pre-budget weight exceeds the
+        # global ceiling. The exact sizes are tuned to clear the
+        # ceiling with margin, but the pre-budget assertion below
+        # pins the fixture so a future cap change cannot silently
+        # turn this test into a non-ladder passthrough.
         long_issues = tuple(
             LinkedIssue(
                 number=n,
                 title=f"Issue {n}",
-                body="x" * 5_000,
+                body="x" * 90_000,
                 state="OPEN",
                 url="",
                 labels=(),
                 comments=(),
             )
-            for n in range(8)
+            for n in range(10)
         )
         ctx = _ctx(
-            spec=long_spec,
-            conventions=long_conv,
+            spec="A" * 1_500_000,
+            conventions="B" * 1_000_000,
+            patch="C" * 250_000,
             linked_issues=long_issues,
-            patch="diff " * 20_000,
         )
+
+        # Pre-budget assertion: the fixture's pre-budget bundle MUST
+        # exceed the global ceiling, otherwise the test does not
+        # exercise the ladder.
+        assert _estimate_total_chars(ctx) > _MAX_REVIEW_CONTEXT_CHARS
+
         out = budget_review_context(ctx)
+        # Post-budget invariant.
         assert _estimate_total_chars(out) <= _MAX_REVIEW_CONTEXT_CHARS, (
             f"global cap violated: {_estimate_total_chars(out)} > {_MAX_REVIEW_CONTEXT_CHARS}"
         )
-        # The reviewer should see what was trimmed.
-        sections = {n.section for n in out.budget_notes}
-        # At least one of SPEC, CONVENTIONS, PATCH appears in notes.
-        assert sections & {"SPEC", "CONVENTIONS", "PATCH"}
+        note_sections = {note.section for note in out.budget_notes}
+        # The 250K patch exceeds the new 200K per-section cap, so
+        # PATCH fires deterministically.
+        assert "PATCH" in note_sections
+        # The cross-section ladder trims spec / conventions because
+        # the post-cap bundle still overshoots; at least one fires.
+        assert "SPEC" in note_sections or "CONVENTIONS" in note_sections
+
+    def test_headroom_path_does_not_invoke_ladder(self):
+        # The pinned large-PR fixture (~2.59 MB of changed files) plus
+        # its 156 KB patch fit under the 3.5 MB ceiling with the
+        # typical headroom that the dynamic allocator's
+        # `_OVERHEAD_RESERVE` protects. The cross-section ladder must
+        # not fire on this path: no `CHANGED_FILES_AT_HEAD`
+        # cross-section note. The per-section `_cap_changed_files`
+        # note is allowed (separate message text).
+        ctx = _ctx(
+            changed_files=_pinned_large_pr_files(),
+            patch="P" * 156_000,
+        )
+        out = budget_review_context(ctx)
+        assert _estimate_total_chars(out) <= _MAX_REVIEW_CONTEXT_CHARS
+        cross_section_notes = [
+            n for n in out.budget_notes
+            if n.section == "CHANGED_FILES_AT_HEAD"
+            and "Cross-section ladder" in n.message
+        ]
+        assert cross_section_notes == [], (
+            "Cross-section ladder fired on a headroom-path bundle; "
+            "the dynamic allocator should have kept the bundle under "
+            "the ceiling without invoking the ladder."
+        )
+
+    def test_floor_branch_invokes_ladder(self):
+        # When non-changed weight exceeds
+        # `_MAX_REVIEW_CONTEXT_CHARS - _CHANGED_FILES_SECTION_FLOOR
+        # - _OVERHEAD_RESERVE`, the dynamic cap is forced to the
+        # floor. With the floor's section plus the non-changed
+        # weight still overshooting the global ceiling, the
+        # cross-section ladder runs as the last line of defense.
+        # The fixture's heavy spec and conventions exercise the
+        # earlier ladder rungs (spec / conventions trim) before
+        # Rung 7 would be reached, so this test only asserts that
+        # the ladder ran at all, not which specific rung fired.
+        ctx = _ctx(
+            spec="A" * 2_000_000,
+            conventions="B" * 1_200_000,
+            changed_files=_changed_files_summing_to(500_000),
+            patch="C" * 150_000,
+        )
+        # Pre-budget assertion: this fixture MUST overflow under
+        # the floor branch, otherwise the test does not exercise
+        # the ladder.
+        assert _estimate_total_chars(ctx) > _MAX_REVIEW_CONTEXT_CHARS
+
+        out = budget_review_context(ctx)
+        assert _estimate_total_chars(out) <= _MAX_REVIEW_CONTEXT_CHARS
+        cross_section_notes = [
+            n for n in out.budget_notes
+            if "Cross-section ladder" in n.message
+            or "under global ceiling" in n.message
+        ]
+        assert cross_section_notes, (
+            "Floor-branch path did not invoke the cross-section ladder."
+        )
 
     def test_pathological_bundle_emits_last_resort_note(self):
         # Forcing every section to overflow even after the ladder
@@ -2496,6 +2639,139 @@ class TestBudgetEnforcesGlobalCeiling:
         # last-resort BUDGET_NOTES entry (also acceptable).
         if _estimate_total_chars(out) > _MAX_REVIEW_CONTEXT_CHARS:
             assert "BUDGET_NOTES" in sections
+
+
+class TestDynamicChangedFilesBudget:
+    """The dynamic changed-files cap takes the global ceiling, subtracts
+    the non-changed-files weight and `_OVERHEAD_RESERVE`, and floors at
+    `_CHANGED_FILES_SECTION_FLOOR`. These tests pin the helper's
+    arithmetic against three reference shapes (quiet, busy, floor) plus
+    an end-to-end pinned-large-PR fixture.
+    """
+
+    def test_quiet_bundle_dynamic_cap_approaches_global_ceiling(self):
+        # Bare bundle with only the default metadata fields the `_ctx`
+        # helper provides. Non-changed weight collapses to the metadata
+        # estimate alone, so the dynamic cap sits within
+        # `_OVERHEAD_RESERVE + small metadata estimate` of the global
+        # ceiling.
+        ctx = _ctx()
+        cap = _compute_dynamic_changed_files_cap(ctx)
+        # Reproduce the helper's arithmetic against the same fixture
+        # so a future change to the metadata estimate flows through.
+        measurement_ctx = PRReviewContext(
+            repo=ctx.repo,
+            pr_number=ctx.pr_number,
+            metadata=ctx.metadata,
+            linked_issues=ctx.linked_issues,
+            commits=ctx.commits,
+            patch=ctx.patch,
+            changed_files=(),
+            related_context=ctx.related_context,
+            spec=ctx.spec,
+            conventions=ctx.conventions,
+            prior_comments=ctx.prior_comments,
+        )
+        non_changed = _estimate_total_chars(measurement_ctx)
+        assert cap == _MAX_REVIEW_CONTEXT_CHARS - non_changed - _OVERHEAD_RESERVE
+        # Order-of-magnitude check: the quiet cap is within 1 KB of
+        # `_MAX_REVIEW_CONTEXT_CHARS - _OVERHEAD_RESERVE`.
+        assert cap >= _MAX_REVIEW_CONTEXT_CHARS - _OVERHEAD_RESERVE - 1_000
+
+    def test_busy_bundle_dynamic_cap_shrinks_proportionally(self):
+        # Each non-changed section sits at (or near) its per-section
+        # cap; the dynamic cap shrinks by the sum of the caps plus the
+        # reserve. Sized so per-item measurement overhead stays inside
+        # the assertion tolerance.
+        related = tuple(
+            RelatedExcerpt(
+                path=f"src/{i}.py",
+                line=i,
+                symbol=f"s{i}",
+                kind="function",
+                reason="r",
+                excerpt="x" * 3_400,
+            )
+            for i in range(10)
+        )
+        commits = tuple(
+            Commit(oid=f"{i:040x}", headline="h", body="x" * 1_950)
+            for i in range(10)
+        )
+        big_issue = LinkedIssue(
+            number=1,
+            title="t",
+            body="x" * (_MAX_LINKED_ISSUES_CHARS - 100),
+            state="OPEN",
+            url="",
+            labels=(),
+            comments=(),
+        )
+        ctx = _ctx(
+            patch="P" * _MAX_PATCH_CHARS,
+            linked_issues=(big_issue,),
+            commits=commits,
+            related_context=related,
+            prior_comments="C" * _MAX_PRIOR_COMMENTS_CHARS,
+        )
+        cap = _compute_dynamic_changed_files_cap(ctx)
+        sum_of_caps = (
+            _MAX_PATCH_CHARS
+            + _MAX_RELATED_CONTEXT_CHARS
+            + _MAX_LINKED_ISSUES_CHARS
+            + _MAX_COMMITS_CHARS
+            + _MAX_PRIOR_COMMENTS_CHARS
+        )
+        expected = _MAX_REVIEW_CONTEXT_CHARS - sum_of_caps - _OVERHEAD_RESERVE
+        # Tolerate ~10K of measurement noise from per-item overheads
+        # and the metadata estimate.
+        assert abs(cap - expected) < 10_000
+
+    def test_floor_holds_when_other_sections_exceed_global_minus_floor(self):
+        # Drive non-changed weight past
+        # `_MAX_REVIEW_CONTEXT_CHARS - _CHANGED_FILES_SECTION_FLOOR
+        # - _OVERHEAD_RESERVE` so the raw computation would go below
+        # the floor; the helper must clamp to the floor.
+        ctx = _ctx(spec="A" * _MAX_REVIEW_CONTEXT_CHARS)
+        cap = _compute_dynamic_changed_files_cap(ctx)
+        assert cap == _CHANGED_FILES_SECTION_FLOOR
+
+    def test_pinned_large_pr_shape_no_changed_files_truncation(self):
+        # End-to-end: the pinned large-PR fixture goes through the
+        # full budgeter. With ~2.59 MB of changed files plus a 156 KB
+        # patch, the dynamic cap is large enough that
+        # `_cap_changed_files` keeps every file's content. No
+        # `CHANGED_FILES_AT_HEAD` budget note appears.
+        ctx = _ctx(
+            changed_files=_pinned_large_pr_files(),
+            patch="P" * 156_000,
+        )
+        out = budget_review_context(ctx)
+        changed_files_notes = [
+            n for n in out.budget_notes
+            if n.section == "CHANGED_FILES_AT_HEAD"
+        ]
+        assert changed_files_notes == [], (
+            f"Pinned large-PR fixture emitted CHANGED_FILES_AT_HEAD notes: "
+            f"{changed_files_notes}"
+        )
+        for f in out.changed_files:
+            assert f.content is not None, (
+                f"{f.path} content was dropped under the lifted ceiling"
+            )
+
+
+class TestBundleCapLifts:
+    """Pin the four bundle-budget constants that drive the current
+    budget model. A silent change to any of them re-shapes the bundle
+    in ways the rest of the test suite does not directly catch.
+    """
+
+    def test_lifted_constants_hold_expected_values(self):
+        assert _MAX_REVIEW_CONTEXT_CHARS == 3_500_000
+        assert _MAX_PATCH_CHARS == 200_000
+        assert _CHANGED_FILES_SECTION_FLOOR == 450_000
+        assert _OVERHEAD_RESERVE == 50_000
 
 
 class TestChangedFileURLEncoding:

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -2571,9 +2571,7 @@ class TestBudgetEnforcesGlobalCeiling:
         out = budget_review_context(ctx)
         assert _estimate_total_chars(out) <= _MAX_REVIEW_CONTEXT_CHARS
         cross_section_notes = [
-            n for n in out.budget_notes
-            if n.section == "CHANGED_FILES_AT_HEAD"
-            and "Cross-section ladder" in n.message
+            n for n in out.budget_notes if n.section == "CHANGED_FILES_AT_HEAD" and "Cross-section ladder" in n.message
         ]
         assert cross_section_notes == [], (
             "Cross-section ladder fired on a headroom-path bundle; "
@@ -2606,13 +2604,9 @@ class TestBudgetEnforcesGlobalCeiling:
         out = budget_review_context(ctx)
         assert _estimate_total_chars(out) <= _MAX_REVIEW_CONTEXT_CHARS
         cross_section_notes = [
-            n for n in out.budget_notes
-            if "Cross-section ladder" in n.message
-            or "under global ceiling" in n.message
+            n for n in out.budget_notes if "Cross-section ladder" in n.message or "under global ceiling" in n.message
         ]
-        assert cross_section_notes, (
-            "Floor-branch path did not invoke the cross-section ladder."
-        )
+        assert cross_section_notes, "Floor-branch path did not invoke the cross-section ladder."
 
     def test_pathological_bundle_emits_last_resort_note(self):
         # Forcing every section to overflow even after the ladder
@@ -2694,10 +2688,7 @@ class TestDynamicChangedFilesBudget:
             )
             for i in range(10)
         )
-        commits = tuple(
-            Commit(oid=f"{i:040x}", headline="h", body="x" * 1_950)
-            for i in range(10)
-        )
+        commits = tuple(Commit(oid=f"{i:040x}", headline="h", body="x" * 1_950) for i in range(10))
         big_issue = LinkedIssue(
             number=1,
             title="t",
@@ -2747,18 +2738,12 @@ class TestDynamicChangedFilesBudget:
             patch="P" * 156_000,
         )
         out = budget_review_context(ctx)
-        changed_files_notes = [
-            n for n in out.budget_notes
-            if n.section == "CHANGED_FILES_AT_HEAD"
-        ]
+        changed_files_notes = [n for n in out.budget_notes if n.section == "CHANGED_FILES_AT_HEAD"]
         assert changed_files_notes == [], (
-            f"Pinned large-PR fixture emitted CHANGED_FILES_AT_HEAD notes: "
-            f"{changed_files_notes}"
+            f"Pinned large-PR fixture emitted CHANGED_FILES_AT_HEAD notes: {changed_files_notes}"
         )
         for f in out.changed_files:
-            assert f.content is not None, (
-                f"{f.path} content was dropped under the lifted ceiling"
-            )
+            assert f.content is not None, f"{f.path} content was dropped under the lifted ceiling"
 
 
 class TestBundleCapLifts:

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -2457,8 +2457,8 @@ _PINNED_LARGE_PR_FILE_SIZES: tuple[tuple[str, int], ...] = (
     ("tests/test_review.py", 104_671),
 ) + tuple(
     # Thirteen smaller files fill out the 23-file count. Collective
-    # size 666,107 bytes lands within four bytes of the measured
-    # 666,116-byte balance from the real PR.
+    # size 666,107 bytes lands within nine bytes of the measured
+    # 666,116-byte balance from the source PR.
     (f"src/kai/_padding_{i}.py", 51_239)
     for i in range(13)
 )


### PR DESCRIPTION
## Summary

The PR review bundle's changed-files cap was a static `450_000` chars under a `600_000`-char global ceiling and an `80_000`-char patch cap. Multi-file PRs at the scale of recent refactors regularly exceeded those caps; the budgeter dropped large files to existence-only notes and the reviewer flagged residual risk from truncated changed-file contents.

This PR replaces the static cap with a dynamic value computed against the actually-measured weight of every other bundle section, and raises the global ceiling and combined-patch cap so a 23-file PR with ~2.59 MB of changed files plus a ~156 KB combined patch fits without per-file truncation.

## Changes

- Raise `_MAX_REVIEW_CONTEXT_CHARS` from `600_000` to `3_500_000` (5.8x).
- Raise `_MAX_PATCH_CHARS` from `80_000` to `200_000` (2.5x).
- Rename `_MAX_CHANGED_FILES_CHARS` to `_CHANGED_FILES_SECTION_FLOOR`, keep value `450_000`, role changes from static cap to dynamic-allocator floor.
- Add `_OVERHEAD_RESERVE = 50_000` held back from the dynamic cap for rendered overhead the estimator does not measure (boundary tokens, BEGIN/END markers, status lines).
- Add `_compute_dynamic_changed_files_cap(ctx)` which builds a measurement context with `changed_files=()`, reuses `_estimate_total_chars`, subtracts `_OVERHEAD_RESERVE`, and floors at `_CHANGED_FILES_SECTION_FLOOR`.
- Change `_cap_changed_files(files)` to `_cap_changed_files(files, *, cap)`; the caller is now responsible for the cap value.
- Reorder `budget_review_context()` so per-section caps for related, commits, linked-issues, patch, and prior-comments run first; then the dynamic cap is computed against the partially-capped bundle and applied to changed-files.
- Rewrite three stale source-comment blocks in `review.py` so they describe the dynamic-allocator model rather than the static-cap model: the bundle-budget constants block, the `_MAX_CHANGED_FILE_BYTES` comment, and the cross-section ladder comment inside `budget_review_context`.
- Tests: rewrite the existing `test_long_spec_and_conventions_trim_under_global_cap` so its fixture overshoots the new 3.5 MB ceiling, with a pre-budget assertion pinning the fixture against future cap changes. Add `TestDynamicChangedFilesBudget` (4 tests covering the quiet, busy, floor, and end-to-end paths). Add `test_headroom_path_does_not_invoke_ladder` and `test_floor_branch_invokes_ladder` for ladder coverage. Add `TestBundleCapLifts` to pin the four lifted constants.

## Out of scope (deliberately)

- The per-file cap `_MAX_CHANGED_FILE_BYTES = 500_000`. The largest file in the lift-motivating PR is `tests/test_install.py` at 412 KB, under the per-file cap. Worth re-examining when a 500 KB+ file appears in a future PR.
- The `_MAX_DIFF_CHARS = 100_000` diff cap used by the legacy single-prompt path.
- Per-section caps on related-context, linked-issues, commits, and prior-comments. Raising them would consume headroom the dynamic allocator routes to changed-files.
- A patch-plus-context fallback rendering of the changed-files section (Option C). Structural change; deferred.
- Switching the review reasoner, raising the model, or restructuring the bundle into AST summaries.
- Smart per-file priority in the changed-files drop ladder. The higher ceiling makes the existing drop-largest-first ladder rarely fire for realistic shapes.
- Pre-merge cost or latency validation. The lifted ceiling is roughly 800K input tokens at codex `gpt-5.5` rates; cost / latency tuning is a post-deploy concern, captured below.

## Post-deploy concerns

- **Cost / latency.** The 3.5 MB ceiling is 5.8x the prior value. Wall-clock latency and per-review dollar cost may regress on PRs that actually fill the new headroom. Measure both against a real PR review after deploy; if the regression is unacceptable, file a follow-up and revise rather than silently lowering the constant.
- **Residual-risk note.** On the first multi-large-file PR review after deploy, observe whether the reviewer still mentions "truncated or omitted changed-file contents." The phrase can persist for unrelated reasons (binary files, per-file cap notes), so absence is the useful signal.

## Test plan

- [x] `make check` clean
- [x] `make test` passes (4547 passed, 1 skipped)
- [x] `TestDynamicChangedFilesBudget` (4 new tests) passes
- [x] `TestBundleCapLifts::test_lifted_constants_hold_expected_values` passes
- [x] Rewritten `test_long_spec_and_conventions_trim_under_global_cap` exercises the ladder under the lifted ceiling with a pre-budget fixture pin
- [x] `test_headroom_path_does_not_invoke_ladder` and `test_floor_branch_invokes_ladder` cover the new ladder posture
- [ ] Post-deploy: observe cost and latency on the first multi-large-file PR review

Closes #701
