### PR TITLE
Migrate aiohttp app state to typed AppKey constants

### DIFF
--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -848,7 +848,7 @@ def _run_check() -> int:
     # Stats probe: 200 = enabled, 503 = disabled, anything else =
     # unexpected. Issue the request with NO `chat_id` query
     # parameter so the server falls back to its app-default
-    # (`request.app["chat_id"]` at webhook.py's _resolve_chat_id).
+    # (`request.app[CHAT_ID_KEY]` at webhook.py's _resolve_chat_id).
     # Earlier versions of this harness passed `chat_id=1` as a
     # placeholder, which fails: _resolve_chat_id runs after secret
     # auth but before the memory.is_enabled() branch, and rejects

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -55,12 +55,45 @@ from pathlib import Path
 
 from aiohttp import web
 from telegram import Bot, Update
+from telegram.ext import Application
 
 from kai import cron, memory, review, services, sessions, triage
 from kai.config import DATA_DIR, IMAGE_EXTENSIONS, Config, ModelRole, UserConfig, resolve_user_model
 from kai.telegram_utils import chunk_text
 
 log = logging.getLogger(__name__)
+
+
+# ── Application state keys ──────────────────────────────────────────
+#
+# Typed aiohttp AppKey constants for every value this module sets or
+# reads on the running Application. aiohttp 4.x is expected to make
+# string-key access (`app["foo"]`) an error rather than the current
+# NotAppKeyWarning; AppKey is the typed handle pattern that replaces
+# string keys. These constants live at module scope so the test
+# suite imports them from `kai.webhook` and accesses the same
+# Application via the same typed keys, avoiding the same warning at
+# test time.
+#
+# Keep the constants alphabetized by name. The runtime type argument
+# is omitted for Union-typed keys (AppKey accepts `type[T] | None`,
+# which cannot express `T | None` at runtime); the variable
+# annotation carries the type narrowing the call sites rely on.
+
+ALLOWED_USER_IDS_KEY: web.AppKey[set[int]] = web.AppKey("allowed_user_ids", set)
+ALLOWED_WORKSPACES_KEY: web.AppKey[list[str]] = web.AppKey("allowed_workspaces", list)
+CHAT_ID_KEY: web.AppKey[int] = web.AppKey("chat_id", int)
+CONFIG_KEY: web.AppKey[Config] = web.AppKey("config", Config)
+POOL_KEY: web.AppKey[object] = web.AppKey("pool", object)
+PR_REVIEW_COOLDOWN_KEY: web.AppKey[int] = web.AppKey("pr_review_cooldown", int)
+PR_REVIEW_TIMEOUT_S_KEY: web.AppKey[int] = web.AppKey("pr_review_timeout_s", int)
+SPEC_DIR_KEY: web.AppKey[str] = web.AppKey("spec_dir", str)
+TELEGRAM_APP_KEY: web.AppKey[Application] = web.AppKey("telegram_app", Application)
+TELEGRAM_BOT_KEY: web.AppKey[Bot] = web.AppKey("telegram_bot", Bot)
+TELEGRAM_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("telegram_webhook_secret", str)
+WEBHOOK_PORT_KEY: web.AppKey[int] = web.AppKey("webhook_port", int)
+WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("webhook_secret", str)
+WORKSPACE_BASE_KEY: web.AppKey[str | None] = web.AppKey("workspace_base")
 
 
 class UnauthorizedChatIdError(Exception):
@@ -226,14 +259,14 @@ async def _resolve_local_repo(repo_full_name: str, app: web.Application) -> str 
     repo_name = repo_full_name.split("/")[-1]
 
     # 1. WORKSPACE_BASE - scan immediate children for matching dir name
-    workspace_base = app.get("workspace_base")
+    workspace_base = app.get(WORKSPACE_BASE_KEY)
     if workspace_base:
         candidate = Path(workspace_base) / repo_name
         if candidate.is_dir():
             return str(candidate)
 
     # 2. ALLOWED_WORKSPACES - check each entry's directory name
-    for allowed in app.get("allowed_workspaces", []):
+    for allowed in app.get(ALLOWED_WORKSPACES_KEY, []):
         if Path(allowed).name == repo_name and Path(allowed).is_dir():
             return str(allowed)
 
@@ -275,7 +308,7 @@ def _require_secret(handler):
 
     @functools.wraps(handler)
     async def wrapper(request: web.Request) -> web.Response:
-        secret = request.app["webhook_secret"]
+        secret = request.app[WEBHOOK_SECRET_KEY]
         provided = request.headers.get("X-Webhook-Secret", "")
         if not hmac.compare_digest(provided, secret):
             log.warning("Auth failure on %s from %s", request.path, request.remote)
@@ -312,11 +345,11 @@ def _resolve_chat_id(request: web.Request, payload: dict) -> int:
         # Validate the resolved chat_id is an authorized user.
         # Without this, a prompt injection attack could make inner Claude
         # send messages to arbitrary Telegram users.
-        allowed = request.app.get("allowed_user_ids")
+        allowed = request.app.get(ALLOWED_USER_IDS_KEY)
         if allowed is not None and resolved not in allowed:
             raise UnauthorizedChatIdError(f"chat_id {resolved} is not an authorized user")
         return resolved
-    return request.app["chat_id"]
+    return request.app[CHAT_ID_KEY]
 
 
 # ── GitHub event formatters ───────────────────────────────────────────
@@ -472,7 +505,7 @@ async def _handle_telegram_update(request: web.Request) -> web.Response:
     on non-200 responses, so surfacing internal errors as HTTP errors would cause
     an infinite retry loop. Errors are logged instead.
     """
-    secret = request.app["telegram_webhook_secret"]
+    secret = request.app[TELEGRAM_WEBHOOK_SECRET_KEY]
     provided = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
     if not hmac.compare_digest(provided, secret):
         log.warning("Telegram update: invalid secret")
@@ -484,8 +517,8 @@ async def _handle_telegram_update(request: web.Request) -> web.Response:
         log.warning("Telegram update: malformed JSON")
         return web.Response(status=200)
 
-    telegram_app = request.app["telegram_app"]
-    bot = request.app["telegram_bot"]
+    telegram_app = request.app[TELEGRAM_APP_KEY]
+    bot = request.app[TELEGRAM_BOT_KEY]
 
     try:
         update = Update.de_json(data, bot)
@@ -513,7 +546,7 @@ async def _handle_github(request: web.Request) -> web.Response:
     Supported events: push, pull_request, issues, issue_comment, pull_request_review.
     Unsupported events are silently acknowledged with {"msg": "ignored"}.
     """
-    secret = request.app["webhook_secret"]
+    secret = request.app[WEBHOOK_SECRET_KEY]
 
     body = await request.read()
 
@@ -601,8 +634,8 @@ async def _process_github_event(request: web.Request, payload: dict, event_type:
     admin wildcard exists - for example, when no users.yaml is configured
     or when all admins have opted into specific repos only.
     """
-    bot = request.app["telegram_bot"]
-    config: Config = request.app["config"]
+    bot = request.app[TELEGRAM_BOT_KEY]
+    config: Config = request.app[CONFIG_KEY]
 
     # Extract the repo that triggered this event
     repo_full_name = payload.get("repository", {}).get("full_name", "")
@@ -627,7 +660,7 @@ async def _process_github_event(request: web.Request, payload: dict, event_type:
         # Fall back to the first admin in the app config so the event is
         # not silently dropped. Wrapped in try/except for consistency with
         # the fan-out path - a transient failure should return 200, not 500.
-        fallback_chat_id = request.app["chat_id"]
+        fallback_chat_id = request.app[CHAT_ID_KEY]
         try:
             await _process_github_event_for_user(
                 request,
@@ -738,7 +771,7 @@ async def _process_github_event_for_user(
             pr = payload.get("pull_request", {})
             pr_number = pr.get("number", 0)
             repo = payload.get("repository", {}).get("full_name", "")
-            cooldown = request.app.get("pr_review_cooldown", 300)
+            cooldown = request.app.get(PR_REVIEW_COOLDOWN_KEY, 300)
 
             # Cooldown is server-level, shared across all users.
             # One review per PR per cooldown window regardless of
@@ -766,15 +799,15 @@ async def _process_github_event_for_user(
             task = asyncio.create_task(
                 review.review_pr(
                     payload,
-                    webhook_port=request.app["webhook_port"],
-                    webhook_secret=request.app["webhook_secret"],
+                    webhook_port=request.app[WEBHOOK_PORT_KEY],
+                    webhook_secret=request.app[WEBHOOK_SECRET_KEY],
                     claude_user=claude_user,
                     local_repo_path=local_repo_path,
-                    spec_dir=request.app.get("spec_dir", "specs"),
+                    spec_dir=request.app.get(SPEC_DIR_KEY, "specs"),
                     notify_chat_id=target_chat_id,
                     agent_backend=agent_backend,
                     provider=provider,
-                    timeout_s=request.app["pr_review_timeout_s"],
+                    timeout_s=request.app[PR_REVIEW_TIMEOUT_S_KEY],
                     model_override=pr_review_model_override,
                 )
             )
@@ -816,8 +849,8 @@ async def _process_github_event_for_user(
             task = asyncio.create_task(
                 triage.triage_issue(
                     payload,
-                    webhook_port=request.app["webhook_port"],
-                    webhook_secret=request.app["webhook_secret"],
+                    webhook_port=request.app[WEBHOOK_PORT_KEY],
+                    webhook_secret=request.app[WEBHOOK_SECRET_KEY],
                     claude_user=claude_user,
                     notify_chat_id=target_chat_id,
                     agent_backend=agent_backend,
@@ -874,8 +907,8 @@ async def _handle_generic(request: web.Request) -> web.Response:
     payload) and forwards it to the Telegram chat. Truncates to Telegram's
     4096-char limit.
     """
-    bot = request.app["telegram_bot"]
-    chat_id = request.app["chat_id"]
+    bot = request.app[TELEGRAM_BOT_KEY]
+    chat_id = request.app[CHAT_ID_KEY]
 
     try:
         payload = await request.json()
@@ -1083,7 +1116,7 @@ async def _handle_schedule(request: web.Request) -> web.Response:
         return web.json_response({"error": "Failed to create job"}, status=500)
 
     # Register with APScheduler immediately so it starts firing
-    telegram_app = request.app["telegram_app"]
+    telegram_app = request.app[TELEGRAM_APP_KEY]
     await cron.register_job_by_id(telegram_app, job_id)
 
     log.info("Scheduled job %d '%s' via API (%s)", job_id, name, schedule_type)
@@ -1177,7 +1210,7 @@ async def _handle_delete_job(request: web.Request) -> web.Response:
     # Remove from APScheduler's in-memory queue. Daily jobs with multiple
     # times get suffixed names (e.g., cron_19_0, cron_19_1), so we match
     # both the exact name and the prefix pattern.
-    telegram_app = request.app["telegram_app"]
+    telegram_app = request.app[TELEGRAM_APP_KEY]
     jq = telegram_app.job_queue
     assert jq is not None
     prefix = f"cron_{job_id}"
@@ -1276,7 +1309,7 @@ async def _handle_update_job(request: web.Request) -> web.Response:
     schedule_changed = new_schedule_type is not None or schedule_data is not None
     if schedule_changed:
         # Remove old APScheduler entries
-        telegram_app = request.app["telegram_app"]
+        telegram_app = request.app[TELEGRAM_APP_KEY]
         jq = telegram_app.job_queue
         assert jq is not None
         prefix = f"cron_{job_id}"
@@ -1386,7 +1419,7 @@ async def _handle_send_message(request: web.Request) -> web.Response:
     if not text:
         return web.json_response({"error": "Missing required field: text"}, status=400)
 
-    bot = request.app["telegram_bot"]
+    bot = request.app[TELEGRAM_BOT_KEY]
     try:
         chat_id = _resolve_chat_id(request, payload)
     except ValueError as e:
@@ -1457,7 +1490,7 @@ async def _handle_send_file(request: web.Request) -> web.Response:
     # has their own per-user home workspace resolved from the pool (#353).
     # When the pool is unavailable (transient startup state) we refuse the
     # request rather than opening a global fallback path.
-    pool = request.app.get("pool")
+    pool = request.app.get(POOL_KEY)
     if pool is None:
         return web.json_response({"error": "No workspace configured"}, status=403)
     workspace = str(await pool.get_effective_workspace(chat_id))
@@ -1479,7 +1512,7 @@ async def _handle_send_file(request: web.Request) -> web.Response:
     if not path.is_file():
         return web.json_response({"error": f"File not found: {file_path}"}, status=404)
 
-    bot = request.app["telegram_bot"]
+    bot = request.app[TELEGRAM_BOT_KEY]
     caption = payload.get("caption", "")
 
     # Send images as photos (Telegram renders them inline) and everything
@@ -1560,7 +1593,7 @@ async def _handle_memory_add(request: web.Request) -> web.Response:
         tags: list[str], optional
         metadata: dict, optional (keys "type" and "tags" are reserved by
             add_structured; user values for those will be overwritten)
-        chat_id: int, optional, defaults to app["chat_id"]
+        chat_id: int, optional, defaults to the configured webhook chat_id
 
     Responses:
         200 {"id": "<mem0-uuid>"} on success
@@ -1688,7 +1721,7 @@ async def _handle_memory_search(request: web.Request) -> web.Response:
     Request body (JSON):
         query: str, required, non-empty after strip
         limit: int, optional (defaults to config.memory_search_limit)
-        chat_id: int, optional, defaults to app["chat_id"]
+        chat_id: int, optional, defaults to the configured webhook chat_id
 
     Responses:
         200 {"results": [<MemoryResult-dict>, ...]} on success (empty list
@@ -1774,7 +1807,7 @@ async def _handle_memory_stats(request: web.Request) -> web.Response:
     GET endpoint reads chat_id from query params, mirroring _handle_get_jobs.
 
     Query params:
-        chat_id: int, optional (defaults to app["chat_id"])
+        chat_id: int, optional (defaults to the configured webhook chat_id)
 
     Response is the MemoryStats object at the top level, NOT wrapped in
     {"results": ...} - single-object reads return the object bare per
@@ -1846,7 +1879,7 @@ async def _handle_memory_delete_all(request: web.Request) -> web.Response:
 
     Request body (JSON):
         confirm: str, required, must equal "delete-all-memories"
-        chat_id: int, optional, defaults to app["chat_id"]
+        chat_id: int, optional, defaults to the configured webhook chat_id
 
     Responses:
         200 {"status": "deleted"} on success
@@ -2048,9 +2081,9 @@ async def start(telegram_app, config) -> None:
     global _app, _runner, _webhook_registered, _health_monitor_task
 
     _app = web.Application()
-    _app["telegram_app"] = telegram_app
-    _app["telegram_bot"] = telegram_app.bot
-    _app["webhook_secret"] = config.webhook_secret
+    _app[TELEGRAM_APP_KEY] = telegram_app
+    _app[TELEGRAM_BOT_KEY] = telegram_app.bot
+    _app[WEBHOOK_SECRET_KEY] = config.webhook_secret
 
     # Set the default chat_id for API calls that don't specify a target.
     # users.yaml is mandatory so the first admin is the default; when
@@ -2058,7 +2091,7 @@ async def start(telegram_app, config) -> None:
     # (the same warning at config load time covers the no-admin case).
     admins = config.get_admins()
     if admins:
-        _app["chat_id"] = admins[0].telegram_id
+        _app[CHAT_ID_KEY] = admins[0].telegram_id
     else:
         fallback = next(iter(config.user_configs.values()))
         log.warning(
@@ -2068,46 +2101,46 @@ async def start(telegram_app, config) -> None:
             fallback.name,
             fallback.telegram_id,
         )
-        _app["chat_id"] = fallback.telegram_id
+        _app[CHAT_ID_KEY] = fallback.telegram_id
 
     # Store allowed user IDs for chat_id validation in _resolve_chat_id.
     # Prevents prompt injection from routing messages to arbitrary users.
-    _app["allowed_user_ids"] = config.allowed_user_ids
+    _app[ALLOWED_USER_IDS_KEY] = config.allowed_user_ids
 
     # Store config for GitHub actor routing in _handle_github()
-    _app["config"] = config
+    _app[CONFIG_KEY] = config
 
     # Store the subprocess pool for per-user workspace lookup in send-file.
     # Set by main.py after pool creation; may be None during init.
-    _app["pool"] = telegram_app.bot_data.get("pool")
+    _app[POOL_KEY] = telegram_app.bot_data.get("pool")
 
     # Server-level config for review/triage background tasks. Per-user
     # feature flags (pr_review, issue_triage) are resolved at event time
     # via sessions.resolve_github_settings(), not stored here.
-    _app["pr_review_cooldown"] = config.pr_review_cooldown
-    _app["pr_review_timeout_s"] = config.pr_review_timeout_s
-    _app["webhook_port"] = config.webhook_port
+    _app[PR_REVIEW_COOLDOWN_KEY] = config.pr_review_cooldown
+    _app[PR_REVIEW_TIMEOUT_S_KEY] = config.pr_review_timeout_s
+    _app[WEBHOOK_PORT_KEY] = config.webhook_port
 
     # Workspace config for review agent repo resolution. These let
     # _resolve_local_repo() match incoming PR webhook repos against
     # local checkouts without a hardcoded GITHUB_REPO setting.
-    _app["workspace_base"] = str(config.workspace_base) if config.workspace_base else None
-    _app["allowed_workspaces"] = [str(p) for p in config.allowed_workspaces]
-    _app["spec_dir"] = config.spec_dir
+    _app[WORKSPACE_BASE_KEY] = str(config.workspace_base) if config.workspace_base else None
+    _app[ALLOWED_WORKSPACES_KEY] = [str(p) for p in config.allowed_workspaces]
+    _app[SPEC_DIR_KEY] = config.spec_dir
 
     # Add per-user github_notify_chat_id values to allowed_user_ids
     # so review/triage agents can POST to /api/send-message with
     # these chat_ids. Loads from both users.yaml and DB.
     for uc in config.user_configs.values():
         if uc.github_notify_chat_id is not None:
-            _app["allowed_user_ids"].add(uc.github_notify_chat_id)
+            _app[ALLOWED_USER_IDS_KEY].add(uc.github_notify_chat_id)
     # Also add any DB-stored notify chat IDs (set via /github notify).
     # webhook.start() is already async so the await is fine.
     for uid in config.user_configs:
         val = await sessions.get_setting(f"github_notify_chat:{uid}")
         if val:
             try:
-                _app["allowed_user_ids"].add(int(val))
+                _app[ALLOWED_USER_IDS_KEY].add(int(val))
             except ValueError:
                 log.warning(
                     "Invalid github_notify_chat for user %s in DB: %s (ignoring)",
@@ -2119,7 +2152,7 @@ async def start(telegram_app, config) -> None:
     # Only register the Telegram webhook route in webhook mode. In polling mode,
     # there's no need for the endpoint and no secret to validate against.
     if config.telegram_webhook_url:
-        _app["telegram_webhook_secret"] = config.telegram_webhook_secret
+        _app[TELEGRAM_WEBHOOK_SECRET_KEY] = config.telegram_webhook_secret
         _app.router.add_post("/webhook/telegram", _handle_telegram_update)
 
     if config.webhook_secret:
@@ -2190,7 +2223,7 @@ async def start(telegram_app, config) -> None:
                 telegram_app.bot,
                 config.telegram_webhook_url,
                 config.telegram_webhook_secret,
-                _app["chat_id"],
+                _app[CHAT_ID_KEY],
             )
         )
 
@@ -2220,7 +2253,7 @@ async def stop() -> None:
 
     # Only deregister if we registered a webhook (i.e., webhook mode was active)
     if _webhook_registered and _app is not None:
-        telegram_bot = _app.get("telegram_bot")
+        telegram_bot = _app.get(TELEGRAM_BOT_KEY)
         if telegram_bot is not None:
             try:
                 await telegram_bot.delete_webhook()
@@ -2249,7 +2282,7 @@ def add_allowed_chat_id(chat_id: int) -> None:
     _resolve_chat_id() until the next restart.
     """
     if _app is not None:
-        allowed = _app.get("allowed_user_ids")
+        allowed = _app.get(ALLOWED_USER_IDS_KEY)
         if allowed is not None:
             allowed.add(chat_id)
 
@@ -2262,7 +2295,7 @@ def remove_allowed_chat_id(chat_id: int) -> None:
     Called by bot.py when /github notify reset clears a notification
     destination. A user's own telegram_id must never be removed.
 
-    Important: config.allowed_user_ids and _app["allowed_user_ids"]
+    Important: config.allowed_user_ids and _app[ALLOWED_USER_IDS_KEY]
     are the SAME set object (assigned by reference at start()). We
     cannot use config.allowed_user_ids as the guard because any
     chat_id we previously added via add_allowed_chat_id() would also
@@ -2270,12 +2303,12 @@ def remove_allowed_chat_id(chat_id: int) -> None:
     by telegram_id, populated at load time, never mutated at runtime).
     """
     if _app is not None:
-        allowed = _app.get("allowed_user_ids")
+        allowed = _app.get(ALLOWED_USER_IDS_KEY)
         if allowed is None:
             return
         # Never remove a chat_id that belongs to an actual user.
         # user_configs keys are telegram_ids of real users.
-        config = _app.get("config")
+        config = _app.get(CONFIG_KEY)
         if config and chat_id in config.user_configs:
             return
         allowed.discard(chat_id)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -13,6 +13,17 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from kai.config import UserConfig
 from kai.webhook import (
+    ALLOWED_USER_IDS_KEY,
+    ALLOWED_WORKSPACES_KEY,
+    CHAT_ID_KEY,
+    CONFIG_KEY,
+    PR_REVIEW_COOLDOWN_KEY,
+    PR_REVIEW_TIMEOUT_S_KEY,
+    SPEC_DIR_KEY,
+    TELEGRAM_BOT_KEY,
+    WEBHOOK_PORT_KEY,
+    WEBHOOK_SECRET_KEY,
+    WORKSPACE_BASE_KEY,
     _fmt_issue_comment,
     _fmt_issues,
     _fmt_pull_request,
@@ -404,24 +415,23 @@ def _build_test_app(
     Tests should mock sessions.resolve_github_settings to control these.
     """
     app = web.Application()
-    app["webhook_secret"] = _TEST_SECRET
-    app["pr_review_cooldown"] = cooldown
+    app[WEBHOOK_SECRET_KEY] = _TEST_SECRET
+    app[PR_REVIEW_COOLDOWN_KEY] = cooldown
     # Review subprocess resource limits (defaults match config.py).
-    app["pr_review_timeout_s"] = 900
+    app[PR_REVIEW_TIMEOUT_S_KEY] = 900
     # Config needed by review background tasks
-    app["webhook_port"] = 8080
-    app["claude_user"] = None
+    app[WEBHOOK_PORT_KEY] = 8080
     # Workspace config for review agent repo resolution. Tests that need
     # _resolve_local_repo() to return a specific path populate workspace_base
     # or allowed_workspaces; the default is empty so _mock_resolve_repo is
     # used for routing tests that don't care about the resolution result.
-    app["workspace_base"] = None
-    app["allowed_workspaces"] = []
-    app["spec_dir"] = "specs"
+    app[WORKSPACE_BASE_KEY] = None
+    app[ALLOWED_WORKSPACES_KEY] = []
+    app[SPEC_DIR_KEY] = "specs"
     # Mock bot that records sent messages
     mock_bot = AsyncMock()
-    app["telegram_bot"] = mock_bot
-    app["chat_id"] = 12345
+    app[TELEGRAM_BOT_KEY] = mock_bot
+    app[CHAT_ID_KEY] = 12345
     # Config for per-user routing. Default mock has no user_configs,
     # so all events fall through to admin chat_id.
     if config is None:
@@ -430,9 +440,9 @@ def _build_test_app(
         # get_user_config is synchronous in real Config; must not
         # return a coroutine. With no users configured, always None.
         mock_config.get_user_config = lambda uid: None
-        app["config"] = mock_config
+        app[CONFIG_KEY] = mock_config
     else:
-        app["config"] = config
+        app[CONFIG_KEY] = config
     app.router.add_post("/webhook/github", _handle_github)
     return app
 
@@ -510,7 +520,7 @@ class TestPRReviewRouting:
                 assert resp.status == 200
                 assert data["status"] == "ok"
                 # Should NOT have sent a Telegram notification (review task fires instead)
-                app["telegram_bot"].send_message.assert_not_called()
+                app[TELEGRAM_BOT_KEY].send_message.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_falls_through_when_disabled(self, _clear_cooldowns):
@@ -534,7 +544,7 @@ class TestPRReviewRouting:
                 assert resp.status == 200
                 # Falls through to _fmt_pull_request, which formats a notification
                 assert data.get("status") == "ok"
-                app["telegram_bot"].send_message.assert_called_once()
+                app[TELEGRAM_BOT_KEY].send_message.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_cooldown_skips_recent(self, _clear_cooldowns, _mock_resolve_repo):
@@ -629,7 +639,7 @@ class TestPRReviewRouting:
                 assert resp.status == 200
                 # Should fall through to _fmt_pull_request for the "closed" notification
                 assert data.get("status") == "ok"
-                app["telegram_bot"].send_message.assert_called_once()
+                app[TELEGRAM_BOT_KEY].send_message.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_synchronize_routed(self, _clear_cooldowns, _mock_resolve_repo):
@@ -703,8 +713,8 @@ class TestResolveLocalRepo:
         anvil_dir.mkdir()
 
         app = web.Application()
-        app["workspace_base"] = str(tmp_path)
-        app["allowed_workspaces"] = []
+        app[WORKSPACE_BASE_KEY] = str(tmp_path)
+        app[ALLOWED_WORKSPACES_KEY] = []
 
         result = await _resolve_local_repo("dcellison/anvil", app)
         assert result == str(anvil_dir)
@@ -716,8 +726,8 @@ class TestResolveLocalRepo:
         myrepo.mkdir()
 
         app = web.Application()
-        app["workspace_base"] = None
-        app["allowed_workspaces"] = [str(myrepo)]
+        app[WORKSPACE_BASE_KEY] = None
+        app[ALLOWED_WORKSPACES_KEY] = [str(myrepo)]
 
         result = await _resolve_local_repo("owner/myrepo", app)
         assert result == str(myrepo)
@@ -729,8 +739,8 @@ class TestResolveLocalRepo:
         history_repo.mkdir()
 
         app = web.Application()
-        app["workspace_base"] = None
-        app["allowed_workspaces"] = []
+        app[WORKSPACE_BASE_KEY] = None
+        app[ALLOWED_WORKSPACES_KEY] = []
 
         with patch(
             "kai.webhook.sessions.get_all_workspace_paths",
@@ -744,8 +754,8 @@ class TestResolveLocalRepo:
     async def test_no_match(self, tmp_path):
         """Returns None when no workspace matches the repo."""
         app = web.Application()
-        app["workspace_base"] = str(tmp_path)
-        app["allowed_workspaces"] = []
+        app[WORKSPACE_BASE_KEY] = str(tmp_path)
+        app[ALLOWED_WORKSPACES_KEY] = []
 
         with patch(
             "kai.webhook.sessions.get_all_workspace_paths",
@@ -759,8 +769,8 @@ class TestResolveLocalRepo:
     async def test_nonexistent_dir_skipped(self, tmp_path):
         """History entries pointing to deleted directories are skipped."""
         app = web.Application()
-        app["workspace_base"] = None
-        app["allowed_workspaces"] = []
+        app[WORKSPACE_BASE_KEY] = None
+        app[ALLOWED_WORKSPACES_KEY] = []
 
         with patch(
             "kai.webhook.sessions.get_all_workspace_paths",
@@ -777,8 +787,8 @@ class TestResolveLocalRepo:
         other_user_repo.mkdir()
 
         app = web.Application()
-        app["workspace_base"] = None
-        app["allowed_workspaces"] = []
+        app[WORKSPACE_BASE_KEY] = None
+        app[ALLOWED_WORKSPACES_KEY] = []
 
         with patch(
             "kai.webhook.sessions.get_all_workspace_paths",
@@ -872,7 +882,7 @@ class TestIssueTriageRouting:
                 assert resp.status == 200
                 assert data["status"] == "ok"
                 # Should NOT have sent a standard Telegram notification
-                app["telegram_bot"].send_message.assert_not_called()
+                app[TELEGRAM_BOT_KEY].send_message.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_falls_through_when_disabled(self, _clear_cooldowns):
@@ -895,7 +905,7 @@ class TestIssueTriageRouting:
                 await resp.json()
                 assert resp.status == 200
                 # Falls through to standard formatter, which sends a Telegram message
-                app["telegram_bot"].send_message.assert_called_once()
+                app[TELEGRAM_BOT_KEY].send_message.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_cooldown(self, _clear_cooldowns):
@@ -953,7 +963,7 @@ class TestIssueTriageRouting:
                 await resp.json()
                 assert resp.status == 200
                 # Closed events fall through to standard formatter
-                app["telegram_bot"].send_message.assert_called_once()
+                app[TELEGRAM_BOT_KEY].send_message.assert_called_once()
 
 
 # ── _handle_github exception handling ──────────────────────────────
@@ -967,7 +977,7 @@ class TestGitHubExceptionHandler:
         """An unhandled exception in event processing returns 500."""
         app = _build_test_app()
         # Remove telegram_bot to trigger KeyError in _process_github_event
-        del app["telegram_bot"]
+        del app[TELEGRAM_BOT_KEY]
         payload = {"action": "opened", "repository": {"full_name": "owner/repo"}}
         body = json.dumps(payload).encode()
         sig = _sign_payload(payload)
@@ -1176,7 +1186,7 @@ class TestGitHubNotifyGroup:
                 assert resp.status == 200
 
         # Notification should go to the group chat_id, not the default DM
-        call_args = app["telegram_bot"].send_message.call_args
+        call_args = app[TELEGRAM_BOT_KEY].send_message.call_args
         assert call_args[0][0] == -100999
 
     @pytest.mark.asyncio
@@ -1206,7 +1216,7 @@ class TestGitHubNotifyGroup:
                 assert resp.status == 200
 
         # Notification should go to the default admin DM (12345)
-        call_args = app["telegram_bot"].send_message.call_args
+        call_args = app[TELEGRAM_BOT_KEY].send_message.call_args
         assert call_args[0][0] == 12345
 
 
@@ -1467,7 +1477,7 @@ class TestPerUserRouting:
                 assert resp.status == 200
 
         # Notification should go to user 111, not the admin (12345)
-        call_args = app["telegram_bot"].send_message.call_args
+        call_args = app[TELEGRAM_BOT_KEY].send_message.call_args
         assert call_args[0][0] == 111
 
     @pytest.mark.asyncio
@@ -1517,8 +1527,8 @@ class TestPerUserRouting:
         # Resolver called once per subscribed user
         assert call_count == 2
         # Both users should receive notifications
-        assert app["telegram_bot"].send_message.call_count == 2
-        sent_to = {c[0][0] for c in app["telegram_bot"].send_message.call_args_list}
+        assert app[TELEGRAM_BOT_KEY].send_message.call_count == 2
+        sent_to = {c[0][0] for c in app[TELEGRAM_BOT_KEY].send_message.call_args_list}
         assert sent_to == {111, 222}
 
     @pytest.mark.asyncio
@@ -1551,7 +1561,7 @@ class TestPerUserRouting:
                 assert resp.status == 200
 
         # Should go to admin chat_id (12345), not user 111
-        call_args = app["telegram_bot"].send_message.call_args
+        call_args = app[TELEGRAM_BOT_KEY].send_message.call_args
         assert call_args[0][0] == 12345
 
     @pytest.mark.asyncio
@@ -1700,7 +1710,7 @@ class TestPerUserRouting:
                 assert resp.status == 200
 
         # Notification should go to the user's notify_chat_id, not their DM
-        call_args = app["telegram_bot"].send_message.call_args
+        call_args = app[TELEGRAM_BOT_KEY].send_message.call_args
         assert call_args[0][0] == -100999
 
     @pytest.mark.asyncio
@@ -1752,7 +1762,7 @@ class TestPerUserRouting:
         # Both users were attempted (resolve called twice)
         assert call_count == 2
         # User 2 still got their notification despite user 1's failure
-        call_args = app["telegram_bot"].send_message.call_args
+        call_args = app[TELEGRAM_BOT_KEY].send_message.call_args
         assert call_args[0][0] == 222
 
     # ── Per-user os_user resolution ─────────────────────────────
@@ -1875,7 +1885,7 @@ class TestPerUserRouting:
 
         # Return different notify_chat_id per caller so we can distinguish
         # wildcard routing (chat_id=111) from fallback routing (chat_id=12345).
-        # The fallback calls resolve_github_settings with app["chat_id"]=12345,
+        # The fallback calls resolve_github_settings with app[CHAT_ID_KEY]=12345,
         # the wildcard path calls with the admin's telegram_id=111.
         async def _per_caller_settings(chat_id, config):
             return {
@@ -1898,7 +1908,7 @@ class TestPerUserRouting:
                 assert resp.status == 200
 
         # Admin received the event via wildcard (111), not fallback (12345)
-        call_args = app["telegram_bot"].send_message.call_args
+        call_args = app[TELEGRAM_BOT_KEY].send_message.call_args
         assert call_args[0][0] == 111
 
     @pytest.mark.asyncio
@@ -1959,7 +1969,7 @@ class TestPerUserRouting:
                 assert resp.status == 200
 
         # Event goes to fallback admin (12345), not user 111
-        call_args = app["telegram_bot"].send_message.call_args
+        call_args = app[TELEGRAM_BOT_KEY].send_message.call_args
         assert call_args[0][0] == 12345
 
     @pytest.mark.asyncio
@@ -2081,12 +2091,12 @@ class TestAllowedChatIdMutations:
         import kai.webhook as wh
 
         app = web.Application()
-        app["allowed_user_ids"] = {100}
+        app[ALLOWED_USER_IDS_KEY] = {100}
         old_app = wh._app
         wh._app = app
         try:
             add_allowed_chat_id(999)
-            assert 999 in app["allowed_user_ids"]
+            assert 999 in app[ALLOWED_USER_IDS_KEY]
         finally:
             wh._app = old_app
 
@@ -2095,15 +2105,15 @@ class TestAllowedChatIdMutations:
         import kai.webhook as wh
 
         app = web.Application()
-        app["allowed_user_ids"] = {100}
+        app[ALLOWED_USER_IDS_KEY] = {100}
         old_app = wh._app
         wh._app = app
         try:
             add_allowed_chat_id(999)
             add_allowed_chat_id(999)
             # Sets don't have duplicates; just verify it's present
-            assert 999 in app["allowed_user_ids"]
-            assert len(app["allowed_user_ids"]) == 2  # {100, 999}
+            assert 999 in app[ALLOWED_USER_IDS_KEY]
+            assert len(app[ALLOWED_USER_IDS_KEY]) == 2  # {100, 999}
         finally:
             wh._app = old_app
 
@@ -2124,17 +2134,17 @@ class TestAllowedChatIdMutations:
         import kai.webhook as wh
 
         app = web.Application()
-        app["allowed_user_ids"] = {100, -100123}
+        app[ALLOWED_USER_IDS_KEY] = {100, -100123}
         # No config needed for this case - group IDs are never in user_configs
         mock_config = AsyncMock()
         mock_config.user_configs = {}
-        app["config"] = mock_config
+        app[CONFIG_KEY] = mock_config
         old_app = wh._app
         wh._app = app
         try:
             remove_allowed_chat_id(-100123)
-            assert -100123 not in app["allowed_user_ids"]
-            assert 100 in app["allowed_user_ids"]
+            assert -100123 not in app[ALLOWED_USER_IDS_KEY]
+            assert 100 in app[ALLOWED_USER_IDS_KEY]
         finally:
             wh._app = old_app
 
@@ -2147,14 +2157,14 @@ class TestAllowedChatIdMutations:
         mock_config.user_configs = {12345: user}
 
         app = web.Application()
-        app["allowed_user_ids"] = {12345, -100999}
-        app["config"] = mock_config
+        app[ALLOWED_USER_IDS_KEY] = {12345, -100999}
+        app[CONFIG_KEY] = mock_config
         old_app = wh._app
         wh._app = app
         try:
             remove_allowed_chat_id(12345)
             # 12345 is a real user - must NOT be removed
-            assert 12345 in app["allowed_user_ids"]
+            assert 12345 in app[ALLOWED_USER_IDS_KEY]
         finally:
             wh._app = old_app
 

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -12,6 +12,15 @@ from aiohttp import web
 from kai import sessions
 from kai.services import ServiceResponse
 from kai.webhook import (
+    ALLOWED_USER_IDS_KEY,
+    CHAT_ID_KEY,
+    CONFIG_KEY,
+    POOL_KEY,
+    PR_REVIEW_COOLDOWN_KEY,
+    TELEGRAM_APP_KEY,
+    TELEGRAM_BOT_KEY,
+    TELEGRAM_WEBHOOK_SECRET_KEY,
+    WEBHOOK_SECRET_KEY,
     _handle_delete_job,
     _handle_generic,
     _handle_get_job,
@@ -44,16 +53,16 @@ def mock_request():
     """Create a minimal mock request with app dict and helpers."""
     request = MagicMock(spec=web.Request)
     request.app = {
-        "webhook_secret": "test-secret",
-        "telegram_app": MagicMock(),
-        "telegram_bot": AsyncMock(),
-        "chat_id": 123,
-        "allowed_user_ids": {123, 456},
+        WEBHOOK_SECRET_KEY: "test-secret",
+        TELEGRAM_APP_KEY: MagicMock(),
+        TELEGRAM_BOT_KEY: AsyncMock(),
+        CHAT_ID_KEY: 123,
+        ALLOWED_USER_IDS_KEY: {123, 456},
     }
     # Mock the job_queue on the telegram app
     job_queue = MagicMock()
     job_queue.jobs = MagicMock(return_value=[])
-    request.app["telegram_app"].job_queue = job_queue
+    request.app[TELEGRAM_APP_KEY].job_queue = job_queue
     request.headers = {}
     request.match_info = {}
     # Multidict-like query object for GET parameter access
@@ -68,7 +77,7 @@ class TestScheduleJobType:
     async def test_invalid_job_type_returns_400(self, db, mock_request):
         """Schedule endpoint rejects unrecognized job_type values."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(
             return_value={
                 "name": "test",
@@ -89,8 +98,8 @@ class TestScheduleJobType:
     async def test_valid_job_type_accepted(self, db, mock_request):
         """Schedule endpoint accepts valid job_type values without error."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
-        mock_request.app["telegram_app"].job_queue = MagicMock()
+        mock_request.app[CHAT_ID_KEY] = 123
+        mock_request.app[TELEGRAM_APP_KEY].job_queue = MagicMock()
 
         # Mock register_job_by_id so we don't need a full APScheduler setup
         import kai.cron as cron_mod
@@ -333,10 +342,10 @@ def send_file_request(tmp_path):
     mock_pool.get_effective_workspace = AsyncMock(return_value=tmp_path)
     request = MagicMock(spec=web.Request)
     request.app = {
-        "webhook_secret": "test-secret",
-        "telegram_bot": AsyncMock(),
-        "chat_id": 123,
-        "pool": mock_pool,
+        WEBHOOK_SECRET_KEY: "test-secret",
+        TELEGRAM_BOT_KEY: AsyncMock(),
+        CHAT_ID_KEY: 123,
+        POOL_KEY: mock_pool,
     }
     request.headers = {"X-Webhook-Secret": "test-secret"}
     return request
@@ -355,7 +364,7 @@ class TestSendFile:
         body = json.loads(resp.body)
         assert body["status"] == "sent"
         assert body["file"] == "photo.jpg"
-        send_file_request.app["telegram_bot"].send_photo.assert_called_once()
+        send_file_request.app[TELEGRAM_BOT_KEY].send_photo.assert_called_once()
 
     async def test_send_document(self, tmp_path, send_file_request):
         """Non-image files are sent via send_document (as attachments)."""
@@ -368,7 +377,7 @@ class TestSendFile:
         assert resp.status == 200
         body = json.loads(resp.body)
         assert body["status"] == "sent"
-        send_file_request.app["telegram_bot"].send_document.assert_called_once()
+        send_file_request.app[TELEGRAM_BOT_KEY].send_document.assert_called_once()
 
     async def test_caption_forwarded_to_telegram(self, tmp_path, send_file_request):
         """Optional caption is passed through to the Telegram send call."""
@@ -379,7 +388,7 @@ class TestSendFile:
         resp = await _handle_send_file(send_file_request)
 
         assert resp.status == 200
-        call_kwargs = send_file_request.app["telegram_bot"].send_photo.call_args
+        call_kwargs = send_file_request.app[TELEGRAM_BOT_KEY].send_photo.call_args
         assert call_kwargs[1].get("caption") == "Here you go"
 
     async def test_missing_path_returns_400(self, send_file_request):
@@ -422,9 +431,9 @@ def send_message_request():
     """Create a mock request for the send-message endpoint."""
     request = MagicMock(spec=web.Request)
     request.app = {
-        "webhook_secret": "test-secret",
-        "telegram_bot": AsyncMock(),
-        "chat_id": 123,
+        WEBHOOK_SECRET_KEY: "test-secret",
+        TELEGRAM_BOT_KEY: AsyncMock(),
+        CHAT_ID_KEY: 123,
     }
     request.headers = {"X-Webhook-Secret": "test-secret"}
     return request
@@ -439,7 +448,7 @@ class TestSendMessage:
         assert resp.status == 200
         body = json.loads(resp.body)
         assert body["status"] == "sent"
-        send_message_request.app["telegram_bot"].send_message.assert_called_once_with(123, "Hello!")
+        send_message_request.app[TELEGRAM_BOT_KEY].send_message.assert_called_once_with(123, "Hello!")
 
     async def test_splits_long_message(self, send_message_request):
         """Messages exceeding 4096 chars are split into multiple sends."""
@@ -449,7 +458,7 @@ class TestSendMessage:
         resp = await _handle_send_message(send_message_request)
 
         assert resp.status == 200
-        bot = send_message_request.app["telegram_bot"]
+        bot = send_message_request.app[TELEGRAM_BOT_KEY]
         assert bot.send_message.call_count == 2
 
     async def test_missing_text_returns_400(self, send_message_request):
@@ -480,7 +489,7 @@ class TestSendMessage:
     async def test_telegram_error_returns_500(self, send_message_request):
         """Returns 500 when the Telegram send fails."""
         send_message_request.json = AsyncMock(return_value={"text": "Hello"})
-        send_message_request.app["telegram_bot"].send_message = AsyncMock(side_effect=RuntimeError("Boom"))
+        send_message_request.app[TELEGRAM_BOT_KEY].send_message = AsyncMock(side_effect=RuntimeError("Boom"))
         resp = await _handle_send_message(send_message_request)
         assert resp.status == 500
 
@@ -493,11 +502,11 @@ def telegram_request():
     """Create a mock request for the Telegram webhook endpoint."""
     request = MagicMock(spec=web.Request)
     request.app = {
-        "telegram_webhook_secret": "tg-secret",
-        "telegram_app": MagicMock(),
-        "telegram_bot": MagicMock(),
+        TELEGRAM_WEBHOOK_SECRET_KEY: "tg-secret",
+        TELEGRAM_APP_KEY: MagicMock(),
+        TELEGRAM_BOT_KEY: MagicMock(),
     }
-    request.app["telegram_app"].process_update = AsyncMock()
+    request.app[TELEGRAM_APP_KEY].process_update = AsyncMock()
     request.headers = {"X-Telegram-Bot-Api-Secret-Token": "tg-secret"}
     return request
 
@@ -516,7 +525,7 @@ class TestTelegramUpdate:
         # Telegram's webhook timeout). Yield to the event loop so the task
         # actually executes before we assert.
         await asyncio.sleep(0)
-        telegram_request.app["telegram_app"].process_update.assert_called_once_with(fake_update)
+        telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_called_once_with(fake_update)
 
     async def test_wrong_secret_returns_401(self, telegram_request):
         """Wrong secret token returns 401 without dispatching."""
@@ -525,7 +534,7 @@ class TestTelegramUpdate:
         resp = await _handle_telegram_update(telegram_request)
 
         assert resp.status == 401
-        telegram_request.app["telegram_app"].process_update.assert_not_called()
+        telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_not_called()
 
     async def test_missing_secret_returns_401(self, telegram_request):
         """Missing secret header returns 401."""
@@ -542,7 +551,7 @@ class TestTelegramUpdate:
         resp = await _handle_telegram_update(telegram_request)
 
         assert resp.status == 200
-        telegram_request.app["telegram_app"].process_update.assert_not_called()
+        telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_not_called()
 
     async def test_null_update_skips_dispatch(self, telegram_request, monkeypatch):
         """If Update.de_json returns None, process_update is not called."""
@@ -552,7 +561,7 @@ class TestTelegramUpdate:
         resp = await _handle_telegram_update(telegram_request)
 
         assert resp.status == 200
-        telegram_request.app["telegram_app"].process_update.assert_not_called()
+        telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_not_called()
 
 
 # ── GitHub webhook helpers ─────────────────────────────────────────
@@ -576,11 +585,11 @@ def github_request():
     mock_config.user_configs = {}
     request = MagicMock(spec=web.Request)
     request.app = {
-        "webhook_secret": "test-secret",
-        "telegram_bot": AsyncMock(),
-        "chat_id": 12345,
-        "config": mock_config,
-        "pr_review_cooldown": 300,
+        WEBHOOK_SECRET_KEY: "test-secret",
+        TELEGRAM_BOT_KEY: AsyncMock(),
+        CHAT_ID_KEY: 12345,
+        CONFIG_KEY: mock_config,
+        PR_REVIEW_COOLDOWN_KEY: 300,
     }
     request.headers = {}
     return request
@@ -634,7 +643,7 @@ class TestGitHubWebhook:
         resp = await _handle_github(github_request)
 
         assert resp.status == 200
-        bot = github_request.app["telegram_bot"]
+        bot = github_request.app[TELEGRAM_BOT_KEY]
         bot.send_message.assert_called_once()
         call_kwargs = bot.send_message.call_args
         assert call_kwargs.kwargs.get("parse_mode") == "Markdown" or call_kwargs[2] == "Markdown"
@@ -648,7 +657,7 @@ class TestGitHubWebhook:
             "X-Hub-Signature-256": _sign_body("test-secret", body),
             "X-GitHub-Event": "push",
         }
-        bot = github_request.app["telegram_bot"]
+        bot = github_request.app[TELEGRAM_BOT_KEY]
         # First call (Markdown) fails, second call (plain) succeeds
         bot.send_message = AsyncMock(side_effect=[Exception("parse error"), None])
 
@@ -671,7 +680,7 @@ class TestGitHubWebhook:
             "X-Hub-Signature-256": _sign_body("test-secret", body),
             "X-GitHub-Event": "push",
         }
-        bot = github_request.app["telegram_bot"]
+        bot = github_request.app[TELEGRAM_BOT_KEY]
         bot.send_message = AsyncMock(side_effect=Exception("always fails"))
 
         resp = await _handle_github(github_request)
@@ -692,7 +701,7 @@ class TestGitHubWebhook:
         resp = await _handle_github(github_request)
 
         assert resp.status == 401
-        github_request.app["telegram_bot"].send_message.assert_not_called()
+        github_request.app[TELEGRAM_BOT_KEY].send_message.assert_not_called()
 
     async def test_ping_event_returns_pong(self, github_request):
         """GitHub ping events are acknowledged without sending to Telegram."""
@@ -707,7 +716,7 @@ class TestGitHubWebhook:
 
         body_json = json.loads(resp.body.decode())
         assert body_json["msg"] == "pong"
-        github_request.app["telegram_bot"].send_message.assert_not_called()
+        github_request.app[TELEGRAM_BOT_KEY].send_message.assert_not_called()
 
     async def test_unknown_event_type_ignored(self, github_request):
         """Unsupported event types (e.g. 'star') are silently acknowledged."""
@@ -725,7 +734,7 @@ class TestGitHubWebhook:
         # Per-user routing always returns "ok" - the event is still
         # silently dropped (no formatter, no notification sent)
         assert body_json["status"] == "ok"
-        github_request.app["telegram_bot"].send_message.assert_not_called()
+        github_request.app[TELEGRAM_BOT_KEY].send_message.assert_not_called()
 
     async def test_filtered_action_ignored(self, github_request):
         """Known event type with filtered action (e.g. PR 'edited') is ignored."""
@@ -744,7 +753,7 @@ class TestGitHubWebhook:
         # Per-user routing always returns "ok" - the formatter returns
         # None for "edited" so no notification is sent
         assert body_json["status"] == "ok"
-        github_request.app["telegram_bot"].send_message.assert_not_called()
+        github_request.app[TELEGRAM_BOT_KEY].send_message.assert_not_called()
 
     async def test_invalid_json_after_valid_signature_returns_400(self, github_request):
         """Valid signature over malformed JSON body returns 400."""
@@ -769,9 +778,9 @@ def generic_request():
     """Create a mock request for the generic webhook endpoint."""
     request = MagicMock(spec=web.Request)
     request.app = {
-        "webhook_secret": "test-secret",
-        "telegram_bot": AsyncMock(),
-        "chat_id": 12345,
+        WEBHOOK_SECRET_KEY: "test-secret",
+        TELEGRAM_BOT_KEY: AsyncMock(),
+        CHAT_ID_KEY: 12345,
     }
     request.headers = {"X-Webhook-Secret": "test-secret"}
     return request
@@ -785,7 +794,7 @@ class TestGenericWebhook:
         resp = await _handle_generic(generic_request)
 
         assert resp.status == 200
-        generic_request.app["telegram_bot"].send_message.assert_called_once_with(12345, "Alert: disk full")
+        generic_request.app[TELEGRAM_BOT_KEY].send_message.assert_called_once_with(12345, "Alert: disk full")
 
     async def test_dumps_full_payload_when_no_message(self, generic_request):
         """Payload without 'message' sends the full JSON dump to Telegram."""
@@ -795,7 +804,7 @@ class TestGenericWebhook:
         resp = await _handle_generic(generic_request)
 
         assert resp.status == 200
-        sent_text = generic_request.app["telegram_bot"].send_message.call_args[0][1]
+        sent_text = generic_request.app[TELEGRAM_BOT_KEY].send_message.call_args[0][1]
         # Should be a pretty-printed JSON dump
         assert '"key": "value"' in sent_text
         assert '"count": 42' in sent_text
@@ -807,7 +816,7 @@ class TestGenericWebhook:
         resp = await _handle_generic(generic_request)
 
         assert resp.status == 200
-        sent_text = generic_request.app["telegram_bot"].send_message.call_args[0][1]
+        sent_text = generic_request.app[TELEGRAM_BOT_KEY].send_message.call_args[0][1]
         assert sent_text == ""
 
     async def test_long_message_truncated(self, generic_request):
@@ -818,7 +827,7 @@ class TestGenericWebhook:
         resp = await _handle_generic(generic_request)
 
         assert resp.status == 200
-        sent_text = generic_request.app["telegram_bot"].send_message.call_args[0][1]
+        sent_text = generic_request.app[TELEGRAM_BOT_KEY].send_message.call_args[0][1]
         assert len(sent_text) == 4096
         assert sent_text.endswith("...")
 
@@ -833,7 +842,7 @@ class TestGenericWebhook:
     async def test_send_failure_still_returns_ok(self, generic_request):
         """Telegram send failures are logged but the response is still 200/ok."""
         generic_request.json = AsyncMock(return_value={"message": "test"})
-        generic_request.app["telegram_bot"].send_message = AsyncMock(side_effect=RuntimeError("network error"))
+        generic_request.app[TELEGRAM_BOT_KEY].send_message = AsyncMock(side_effect=RuntimeError("network error"))
 
         resp = await _handle_generic(generic_request)
 
@@ -858,7 +867,7 @@ class TestGetJobs:
     async def test_returns_active_jobs(self, db, mock_request):
         """Returns a list of active jobs for the configured chat."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
 
         await sessions.create_job(
             chat_id=123,
@@ -888,7 +897,7 @@ class TestGetJobs:
     async def test_returns_empty_list_when_no_jobs(self, db, mock_request):
         """Returns an empty list when no jobs exist."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
 
         resp = await _handle_get_jobs(mock_request)
 
@@ -899,7 +908,7 @@ class TestGetJobs:
     async def test_missing_secret_returns_401(self, db, mock_request):
         """Missing webhook secret returns 401."""
         mock_request.headers = {}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
 
         resp = await _handle_get_jobs(mock_request)
 
@@ -967,7 +976,7 @@ class TestScheduleValidation:
     async def test_missing_required_fields_returns_400(self, db, mock_request):
         """Returns 400 when required fields are missing."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         # Missing prompt, schedule_type, and schedule_data
         mock_request.json = AsyncMock(return_value={"name": "incomplete"})
 
@@ -980,7 +989,7 @@ class TestScheduleValidation:
     async def test_invalid_schedule_type_returns_400(self, db, mock_request):
         """Returns 400 for unrecognized schedule_type."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(
             return_value={
                 "name": "test",
@@ -999,7 +1008,7 @@ class TestScheduleValidation:
     async def test_dict_schedule_data_serialized_to_json(self, db, mock_request):
         """schedule_data as a dict is serialized to a JSON string for DB storage."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(
             return_value={
                 "name": "dict test",
@@ -1022,7 +1031,7 @@ class TestScheduleValidation:
     async def test_string_schedule_data_passed_through(self, db, mock_request):
         """schedule_data as a pre-serialized string is stored as-is."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(
             return_value={
                 "name": "string test",
@@ -1043,7 +1052,7 @@ class TestScheduleValidation:
     async def test_invalid_string_schedule_data_returns_400(self, db, mock_request):
         """schedule_data as a non-JSON string is rejected with 400."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(
             return_value={
                 "name": "bad data",
@@ -1062,7 +1071,7 @@ class TestScheduleValidation:
     async def test_defaults_for_optional_fields(self, db, mock_request):
         """auto_remove defaults to False when omitted. job_type defaults to 'reminder'."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(
             return_value={
                 "name": "defaults test",
@@ -1084,7 +1093,7 @@ class TestScheduleValidation:
     async def test_db_failure_returns_500(self, db, mock_request):
         """Database create failure returns 500 with an error message."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(
             return_value={
                 "name": "fail test",
@@ -1107,7 +1116,7 @@ class TestScheduleValidation:
     async def test_successful_creation_registers_with_scheduler(self, db, mock_request):
         """Successful job creation calls register_job_by_id with the new ID."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(
             return_value={
                 "name": "scheduler test",
@@ -1121,12 +1130,12 @@ class TestScheduleValidation:
 
         assert resp.status == 200
         body = json.loads(resp.body.decode())
-        mock_register.assert_called_once_with(mock_request.app["telegram_app"], body["job_id"])
+        mock_register.assert_called_once_with(mock_request.app[TELEGRAM_APP_KEY], body["job_id"])
 
     async def test_invalid_json_returns_400(self, db, mock_request):
         """Malformed JSON body returns 400."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(side_effect=json.JSONDecodeError("test", "doc", 0))
 
         resp = await _handle_schedule(mock_request)
@@ -1136,7 +1145,7 @@ class TestScheduleValidation:
     async def test_once_missing_run_at_returns_400(self, db, mock_request):
         """schedule_data for 'once' without 'run_at' is rejected."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(
             return_value={
                 "name": "bad once",
@@ -1155,7 +1164,7 @@ class TestScheduleValidation:
     async def test_daily_missing_times_returns_400(self, db, mock_request):
         """schedule_data for 'daily' without 'times' is rejected."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(
             return_value={
                 "name": "bad daily",
@@ -1174,7 +1183,7 @@ class TestScheduleValidation:
     async def test_interval_missing_seconds_returns_400(self, db, mock_request):
         """schedule_data for 'interval' without 'seconds' is rejected."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(
             return_value={
                 "name": "bad interval",
@@ -1193,7 +1202,7 @@ class TestScheduleValidation:
     async def test_interval_negative_seconds_returns_400(self, db, mock_request):
         """schedule_data with non-positive seconds is rejected."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(
             return_value={
                 "name": "bad interval",
@@ -1212,7 +1221,7 @@ class TestScheduleValidation:
     async def test_daily_invalid_time_format_returns_400(self, db, mock_request):
         """schedule_data with a malformed time string is rejected."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(
             return_value={
                 "name": "bad time",
@@ -1231,7 +1240,7 @@ class TestScheduleValidation:
     async def test_once_invalid_datetime_returns_400(self, db, mock_request):
         """schedule_data with an unparseable run_at is rejected."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(
             return_value={
                 "name": "bad datetime",
@@ -1256,7 +1265,7 @@ class TestUpdateJobScheduleDataValidation:
         """PATCH with malformed schedule_data is rejected."""
         # Create a valid job first
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(
             return_value={
                 "name": "to update",
@@ -1288,7 +1297,7 @@ def service_request():
     """Create a mock request for the service proxy endpoint."""
     request = MagicMock(spec=web.Request)
     request.app = {
-        "webhook_secret": "test-secret",
+        WEBHOOK_SECRET_KEY: "test-secret",
     }
     request.headers = {"X-Webhook-Secret": "test-secret"}
     request.match_info = {"name": "perplexity"}
@@ -1379,7 +1388,7 @@ class TestResolveChatId:
     def _make_request(self, app_chat_id=12345):
         """Create a minimal mock request with an app-level chat_id."""
         request = MagicMock()
-        request.app = {"chat_id": app_chat_id}
+        request.app = {CHAT_ID_KEY: app_chat_id}
         return request
 
     def test_explicit_chat_id(self):
@@ -1426,7 +1435,7 @@ class TestGetJobsChatIdRouting:
     async def test_query_param_routes_to_user(self, db, mock_request):
         """GET /api/jobs?chat_id=456 returns jobs for that user."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.query = {"chat_id": "456"}
 
         # Create a job for user 456
@@ -1448,7 +1457,7 @@ class TestGetJobsChatIdRouting:
     async def test_invalid_query_param_returns_400(self, db, mock_request):
         """GET /api/jobs?chat_id=abc returns 400."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
+        mock_request.app[CHAT_ID_KEY] = 123
         mock_request.query = {"chat_id": "abc"}
 
         resp = await _handle_get_jobs(mock_request)
@@ -1460,9 +1469,9 @@ class TestScheduleChatIdRouting:
     async def test_explicit_chat_id_in_body(self, db, mock_request):
         """POST /api/schedule with chat_id routes job to that user."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["chat_id"] = 123
-        mock_request.app["telegram_app"].job_queue = MagicMock()
-        mock_request.app["telegram_app"].job_queue.jobs.return_value = []
+        mock_request.app[CHAT_ID_KEY] = 123
+        mock_request.app[TELEGRAM_APP_KEY].job_queue = MagicMock()
+        mock_request.app[TELEGRAM_APP_KEY].job_queue.jobs.return_value = []
 
         mock_request.json = AsyncMock(
             return_value={
@@ -1495,8 +1504,8 @@ class TestChatIdAuthorization:
     async def test_unauthorized_chat_id_returns_403(self, db, mock_request):
         """POST /api/schedule with chat_id not in allowed_user_ids returns 403."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["telegram_app"].job_queue = MagicMock()
-        mock_request.app["telegram_app"].job_queue.jobs.return_value = []
+        mock_request.app[TELEGRAM_APP_KEY].job_queue = MagicMock()
+        mock_request.app[TELEGRAM_APP_KEY].job_queue.jobs.return_value = []
 
         mock_request.json = AsyncMock(
             return_value={
@@ -1515,8 +1524,8 @@ class TestChatIdAuthorization:
     async def test_authorized_chat_id_accepted(self, db, mock_request):
         """POST /api/schedule with chat_id in allowed_user_ids succeeds."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        mock_request.app["telegram_app"].job_queue = MagicMock()
-        mock_request.app["telegram_app"].job_queue.jobs.return_value = []
+        mock_request.app[TELEGRAM_APP_KEY].job_queue = MagicMock()
+        mock_request.app[TELEGRAM_APP_KEY].job_queue.jobs.return_value = []
 
         mock_request.json = AsyncMock(
             return_value={
@@ -1554,7 +1563,7 @@ class TestChatIdAuthorization:
         from kai.webhook import UnauthorizedChatIdError
 
         request = MagicMock()
-        request.app = {"chat_id": 123, "allowed_user_ids": {123, 456}}
+        request.app = {CHAT_ID_KEY: 123, ALLOWED_USER_IDS_KEY: {123, 456}}
 
         with pytest.raises(UnauthorizedChatIdError):
             _resolve_chat_id(request, {"chat_id": 999999})
@@ -1562,7 +1571,7 @@ class TestChatIdAuthorization:
     def test_resolve_chat_id_no_allowed_list(self):
         """_resolve_chat_id skips validation when allowed_user_ids is not set."""
         request = MagicMock()
-        request.app = {"chat_id": 123}
+        request.app = {CHAT_ID_KEY: 123}
 
         # Should not raise even though 999 isn't in any allowed list
         result = _resolve_chat_id(request, {"chat_id": 999})
@@ -1667,7 +1676,7 @@ class TestGetJobsAuth:
     async def test_omitted_chat_id_defaults_to_admin(self, db, mock_request):
         """GET /api/jobs without chat_id falls back to admin, preserving backward compat."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        # No query param set; should fall back to app["chat_id"] = 123
+        # No query param set; should fall back to app[CHAT_ID_KEY] = 123
         await sessions.create_job(
             chat_id=123,
             name="Admin Job",
@@ -1728,7 +1737,7 @@ class TestGetJobAuth:
     async def test_omitted_chat_id_defaults_to_admin(self, db, mock_request):
         """GET /api/jobs/{id} without chat_id falls back to admin, preserving backward compat."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        # No query param set; should fall back to app["chat_id"] = 123
+        # No query param set; should fall back to app[CHAT_ID_KEY] = 123
         job_id = await sessions.create_job(
             chat_id=123,
             name="Admin Job",
@@ -1801,7 +1810,7 @@ class TestDeleteJobAuth:
     async def test_omitted_chat_id_defaults_to_admin(self, db, mock_request):
         """DELETE without chat_id falls back to admin, preserving backward compat."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        # No query param set; should fall back to app["chat_id"] = 123
+        # No query param set; should fall back to app[CHAT_ID_KEY] = 123
         job_id = await sessions.create_job(
             chat_id=123,
             name="Admin Job",
@@ -1882,7 +1891,7 @@ class TestUpdateJobAuth:
             schedule_data='{"run_at": "2026-06-01T12:00:00+00:00"}',
         )
         mock_request.match_info = {"id": str(job_id)}
-        # No chat_id in body; falls back to app["chat_id"] = 123
+        # No chat_id in body; falls back to app[CHAT_ID_KEY] = 123
         mock_request.json = AsyncMock(return_value={"name": "Updated"})
 
         resp = await _handle_update_job(mock_request)


### PR DESCRIPTION
## Summary

Migrates aiohttp app-state access in `src/kai/webhook.py` and its two test files to typed `web.AppKey` constants. aiohttp 4.x is expected to make string-key access (`app["foo"]`) an error rather than the current `NotAppKeyWarning`; this PR brings the production code onto the typed pattern while warnings are still soft, so the migration happens under no time pressure.

This is the first of the two PRs proposed in #532; the async-mock `RuntimeWarning` bucket in `test_claude.py` / `test_triage.py` is a separate, smaller PR (real test-hygiene fix, not forward-compat work). The `ResourceWarning` subprocess-teardown bucket stays untouched per the issue's "safest to leave alone" framing.

## Changes

- Add 14 typed `web.AppKey` constants in `src/kai/webhook.py` (alphabetized; module-scope) covering every app-state field this module sets or reads: `ALLOWED_USER_IDS_KEY`, `ALLOWED_WORKSPACES_KEY`, `CHAT_ID_KEY`, `CONFIG_KEY`, `POOL_KEY`, `PR_REVIEW_COOLDOWN_KEY`, `PR_REVIEW_TIMEOUT_S_KEY`, `SPEC_DIR_KEY`, `TELEGRAM_APP_KEY`, `TELEGRAM_BOT_KEY`, `TELEGRAM_WEBHOOK_SECRET_KEY`, `WEBHOOK_PORT_KEY`, `WEBHOOK_SECRET_KEY`, `WORKSPACE_BASE_KEY`.
- Add `from telegram.ext import Application` so `TELEGRAM_APP_KEY` carries the right runtime type.
- Rewrite 54 `app["..."]` / `request.app["..."]` / `_app["..."]` / `app.get("...")` sites in `webhook.py` to use the typed keys.
- Rewrite 54 sites in `tests/test_webhook.py` to import the keys from `kai.webhook` and access state through them.
- Rewrite 56 sites in `tests/test_webhook_api.py` (a third test file that builds the app via `request.app = {...}` dict literals in pytest fixtures). The dict-literal fixtures now use the AppKey constants as keys; otherwise the production code's typed reads would raise `KeyError` against string-keyed test fixtures (Python dict equality treats `AppKey("foo", T)` and `"foo"` as distinct keys).
- Drop a dead `app["claude_user"] = None` setup line in `tests/test_webhook.py`. No production code reads that key; `claude_user` is a function-local variable derived from `user_config.os_user`, not app state. The line was a fixture vestige.
- Update four `chat_id: int, optional, defaults to app["chat_id"]` docstring snippets to `defaults to the configured webhook chat_id` so the prose tracks the new access pattern.

## Why this approach

- Constants live in `src/kai/webhook.py` because that is the module that owns the Application lifecycle. Tests import from `kai.webhook` so the test app and production reads share the same typed handles.
- Runtime type arg supplied where it can be expressed as `type[T]` (e.g. `web.AppKey("config", Config)`); omitted for `WORKSPACE_BASE_KEY` (whose stored value is `str | None`, which is not a `type[]`).
- `POOL_KEY` uses `object` as the runtime type to avoid importing `SubprocessPool` into `webhook.py`; the value is set in init but never read by `webhook.py` itself, so a precise type would add a dependency for no real consumer.

## Out of scope

- Async-mock `RuntimeWarning` bucket (`test_claude.py` and `test_triage.py`). Separate PR per #532; that bucket is real test hygiene (discarded coroutines can bypass assertions), not a forward-compat chore.
- `ResourceWarning` subprocess-teardown bucket. Per #532, "mostly subprocess-teardown noise and hard to suppress without rewriting tests; safest to leave alone."
- A `filterwarnings` entry in `pyproject.toml` that would hide the warnings without doing the migration. #532 explicitly recommends doing the real migration; this PR does that.
- A CI gate on warning count. Worth considering once the async-mock bucket also lands; until then the floor is still moving.

## Warning count

| State | Total `make test` warnings | `NotAppKeyWarning` |
|---|---|---|
| Before | ~525 | ~475 |
| After  | 122  | 0 |

The 122 remaining warnings are entirely composed of the two buckets called out as out-of-scope above (subprocess-teardown `ResourceWarning` + async-mock `RuntimeWarning`, plus one `FutureWarning`). The actual count is higher than #532's `~50` estimate because the `ResourceWarning` bucket has grown larger than the 15-warning estimate in the issue body. Async-mock bucket is unchanged at ~30.

## Test plan

- [x] `make check` clean (lint + format)
- [x] `make test` passes (4547 passed, 1 skipped)
- [x] `tests/test_webhook.py` passes (100 tests)
- [x] `tests/test_webhook_api.py` passes (221 tests)
- [x] `make test 2>&1 | grep -c NotAppKeyWarning` returns 0
- [ ] Post-deploy: confirm `kai.log` shows no `NotAppKeyWarning` at startup

Refs #532
