### PR TITLE
Fix the async-mock RuntimeWarning bucket in triage and claude tests

### DIFF
--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -123,7 +123,8 @@ class TestCommandConstruction:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -143,7 +144,8 @@ class TestCommandConstruction:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -169,7 +171,8 @@ class TestCommandConstruction:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -189,7 +192,8 @@ class TestCommandConstruction:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             with caplog.at_level("WARNING", logger="kai.config"):
@@ -221,7 +225,8 @@ class TestCommandConstruction:
         ):
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -252,7 +257,8 @@ class TestCommandConstruction:
         ):
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -277,7 +283,8 @@ class TestCommandConstruction:
         ):
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -299,7 +306,8 @@ class TestCommandConstruction:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -327,7 +335,8 @@ class TestCommandConstruction:
         ):
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -357,7 +366,8 @@ class TestCommandConstruction:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -377,7 +387,8 @@ class TestCommandConstruction:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -395,7 +406,8 @@ class TestCommandConstruction:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -413,7 +425,8 @@ class TestCommandConstruction:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -434,7 +447,8 @@ class TestCommandConstruction:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -458,7 +472,8 @@ class TestCommandConstruction:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -485,7 +500,8 @@ class TestCommandConstruction:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -504,7 +520,8 @@ class TestCommandConstruction:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -529,7 +546,8 @@ class TestCommandConstruction:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -945,7 +963,8 @@ class TestEnsureStarted:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -969,7 +988,8 @@ class TestEnsureStarted:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -986,7 +1006,8 @@ class TestEnsureStarted:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             await claude._ensure_started()
@@ -1002,7 +1023,8 @@ class TestEnsureStarted:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
             mock_proc = MagicMock()
             mock_proc.returncode = None
-            mock_proc.stderr = AsyncMock()
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
             mock_exec.return_value = mock_proc
 
             before = time.monotonic()
@@ -1330,8 +1352,18 @@ class TestSendLockedErrors:
         claude._proc = proc
         claude._fresh_session = False
 
-        # Patch wait_for to propagate the TimeoutError
-        with patch("asyncio.wait_for", side_effect=TimeoutError):
+        # Production calls asyncio.wait_for(readline(), timeout=timeout);
+        # readline() has already constructed a coroutine by the time the
+        # patched wait_for runs. A bare `side_effect=TimeoutError` would
+        # raise without awaiting or closing that coroutine, leaking a
+        # never-awaited-coroutine warning. Close the supplied coroutine
+        # first, then raise. The *args/**kwargs shape tolerates
+        # production's keyword `timeout=` argument.
+        async def _timeout_after_closing(coro, *args, **kwargs):
+            coro.close()
+            raise TimeoutError
+
+        with patch("asyncio.wait_for", side_effect=_timeout_after_closing):
             events = await _collect_events(claude)
 
         assert events[-1].done is True

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1628,14 +1628,22 @@ class TestSendErrorNotification:
             labels=[],
         )
 
-        mock_session = AsyncMock()
-        mock_session.post = AsyncMock(side_effect=ConnectionError("refused"))
+        # session.post() is a sync call in production; the side effect
+        # must fire when the call itself runs, not when an awaited
+        # coroutine resumes. AsyncMock would queue the exception on
+        # the unawaited coroutine and never raise, letting the test
+        # pass for the wrong reason (and leaking a never-awaited
+        # coroutine warning). MagicMock raises synchronously.
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(side_effect=ConnectionError("refused"))
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
         with patch("kai.triage.aiohttp.ClientSession", return_value=mock_session):
             # Should not raise
             await _send_error_notification(metadata, "test error", 8080, "secret")
+
+        mock_session.post.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_does_not_raise_on_timeout(self):
@@ -1651,13 +1659,15 @@ class TestSendErrorNotification:
             labels=[],
         )
 
-        mock_session = AsyncMock()
-        mock_session.post = AsyncMock(side_effect=TimeoutError())
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(side_effect=TimeoutError())
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
         with patch("kai.triage.aiohttp.ClientSession", return_value=mock_session):
             await _send_error_notification(metadata, "test error", 8080, "secret")
+
+        mock_session.post.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_logs_warning_on_failure(self, caplog):
@@ -1672,8 +1682,8 @@ class TestSendErrorNotification:
             labels=[],
         )
 
-        mock_session = AsyncMock()
-        mock_session.post = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(side_effect=RuntimeError("boom"))
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
@@ -1683,6 +1693,7 @@ class TestSendErrorNotification:
         ):
             await _send_error_notification(metadata, "test error", 8080, "secret")
 
+        mock_session.post.assert_called_once()
         assert "Failed to send triage error notification" in caplog.text
 
     @pytest.mark.asyncio

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -85,6 +85,40 @@ def _mock_subprocess(stdout: str = "", returncode: int = 0, stderr: str = ""):
     return mock_proc
 
 
+def _mock_aiohttp_session_post(status: int = 200) -> tuple[MagicMock, MagicMock]:
+    """Build a mocked aiohttp ClientSession for the
+    `async with session, session.post(...)` pattern.
+
+    Returns (session, response). The session is a MagicMock so its
+    `.post(...)` call returns an object that supports the async
+    context manager protocol directly; the response is a MagicMock
+    with `.status` defaulted to the supplied value. Pair with a
+    `patch("kai.triage.aiohttp.ClientSession")` context manager and
+    wire the patched class via `_attach_session_to_class()`.
+
+    The bare `AsyncMock()` predecessor of this helper made
+    `session.post` itself an AsyncMock, so the production
+    `async with session.post(...) as resp:` evaluated `__aenter__`
+    on an unawaited coroutine and silently failed inside the
+    surrounding `try / except Exception:`. The helper uses a
+    MagicMock session so `.post(...)` returns a normal object whose
+    `__aenter__` resolves to the configured response.
+    """
+    session = MagicMock()
+    response = MagicMock()
+    response.status = status
+    session.post.return_value.__aenter__ = AsyncMock(return_value=response)
+    session.post.return_value.__aexit__ = AsyncMock(return_value=None)
+    return session, response
+
+
+def _attach_session_to_class(session: MagicMock, mock_cls: MagicMock) -> None:
+    """Wire a patched `aiohttp.ClientSession` mock class to yield
+    `session` from `async with aiohttp.ClientSession() as session:`."""
+    mock_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+
 # ── extract_issue_metadata ──────────────────────────────────────────
 
 

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -861,7 +861,7 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
@@ -892,7 +892,7 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
@@ -921,7 +921,7 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret", projects_json=projects_json)
 
@@ -946,7 +946,7 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
@@ -971,7 +971,7 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
@@ -993,7 +993,7 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
@@ -1024,7 +1024,7 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
@@ -1049,7 +1049,7 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
@@ -1084,7 +1084,7 @@ async def _apply_triage_capture(meta: IssueMetadata, result: dict, **kwargs) -> 
         patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
         patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
     ):
-        mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+        mock_session, _ = _mock_aiohttp_session_post(status=200)
         _attach_session_to_class(mock_session, mock_session_cls)
         await apply_triage(meta, result, 8080, "secret", **kwargs)
         if mock_session.post.called:
@@ -1161,7 +1161,7 @@ class TestTriageActionability:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
@@ -1551,7 +1551,7 @@ class TestTriageIssue:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
             await triage_issue(payload, 8080, "secret")
 
@@ -1575,7 +1575,7 @@ class TestTriageIssue:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
             # Should not raise
             await triage_issue(payload, 8080, "secret")
@@ -1599,7 +1599,7 @@ class TestTriageIssue:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
             await triage_issue(payload, 8080, "secret")
 

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -861,13 +861,11 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session = AsyncMock()
-            mock_resp = AsyncMock()
-            mock_resp.status = 200
-            mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
+        assert mock_session.post.called
         # Verify gh issue edit --add-label was called for both labels
         add_label_calls = [cmd for cmd in commands_run if "issue" in cmd and "edit" in cmd and "--add-label" in cmd]
         applied_labels = {cmd[list(cmd).index("--add-label") + 1] for cmd in add_label_calls}
@@ -894,13 +892,11 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session = AsyncMock()
-            mock_resp = AsyncMock()
-            mock_resp.status = 200
-            mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
+        assert mock_session.post.called
         # "bug" should not appear in any --add-label call
         add_label_calls = [cmd for cmd in commands_run if "issue" in cmd and "edit" in cmd and "--add-label" in cmd]
         for call in add_label_calls:
@@ -925,13 +921,11 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session = AsyncMock()
-            mock_resp = AsyncMock()
-            mock_resp.status = 200
-            mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret", projects_json=projects_json)
 
+        assert mock_session.post.called
         # Should have called gh project item-add
         item_add_calls = [cmd for cmd in commands_run if "project" in cmd and "item-add" in cmd]
         assert len(item_add_calls) > 0
@@ -952,13 +946,11 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session = AsyncMock()
-            mock_resp = AsyncMock()
-            mock_resp.status = 200
-            mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
+        assert mock_session.post.called
         # No project item-add calls
         item_add_calls = [cmd for cmd in commands_run if "project" in cmd and "item-add" in cmd]
         assert len(item_add_calls) == 0
@@ -979,13 +971,11 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session = AsyncMock()
-            mock_resp = AsyncMock()
-            mock_resp.status = 200
-            mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
+        assert mock_session.post.called
         # Should have called gh issue comment
         comment_calls = [cmd for cmd in commands_run if "issue" in cmd and "comment" in cmd]
         assert len(comment_calls) > 0
@@ -1003,11 +993,8 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session = AsyncMock()
-            mock_resp = AsyncMock()
-            mock_resp.status = 200
-            mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
         # Verify the send-message call
@@ -1037,13 +1024,11 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session = AsyncMock()
-            mock_resp = AsyncMock()
-            mock_resp.status = 200
-            mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
+        assert mock_session.post.called
         # Should have called gh label create
         create_calls = [cmd for cmd in commands_run if "label" in cmd and "create" in cmd]
         assert len(create_calls) > 0
@@ -1064,13 +1049,11 @@ class TestApplyTriage:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session = AsyncMock()
-            mock_resp = AsyncMock()
-            mock_resp.status = 200
-            mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
+        assert mock_session.post.called
         # No --add-label calls should have been made
         add_label_calls = [cmd for cmd in commands_run if "issue" in cmd and "edit" in cmd and "--add-label" in cmd]
         assert len(add_label_calls) == 0
@@ -1101,11 +1084,8 @@ async def _apply_triage_capture(meta: IssueMetadata, result: dict, **kwargs) -> 
         patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
         patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
     ):
-        mock_session = AsyncMock()
-        mock_resp = AsyncMock()
-        mock_resp.status = 200
-        mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+        _attach_session_to_class(mock_session, mock_session_cls)
         await apply_triage(meta, result, 8080, "secret", **kwargs)
         if mock_session.post.called:
             captured["telegram"] = mock_session.post.call_args[1]["json"]["text"]
@@ -1181,13 +1161,11 @@ class TestTriageActionability:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session = AsyncMock()
-            mock_resp = AsyncMock()
-            mock_resp.status = 200
-            mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret")
 
+        assert mock_session.post.called
         # Comment renders the status.
         comment_calls = [cmd for cmd in commands_run if "issue" in cmd and "comment" in cmd]
         assert len(comment_calls) == 1
@@ -1573,13 +1551,11 @@ class TestTriageIssue:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session = AsyncMock()
-            mock_resp = AsyncMock()
-            mock_resp.status = 200
-            mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_session_cls)
             await triage_issue(payload, 8080, "secret")
 
+        assert mock_session.post.called
         # Pipeline ran (multiple subprocess calls)
         assert call_count > 0
         # Telegram notification was sent
@@ -1599,11 +1575,8 @@ class TestTriageIssue:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session = AsyncMock()
-            mock_resp = AsyncMock()
-            mock_resp.status = 200
-            mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_session_cls)
             # Should not raise
             await triage_issue(payload, 8080, "secret")
 
@@ -1626,11 +1599,8 @@ class TestTriageIssue:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session = AsyncMock()
-            mock_resp = AsyncMock()
-            mock_resp.status = 200
-            mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session, mock_resp = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_session_cls)
             await triage_issue(payload, 8080, "secret")
 
         # Error notification was sent
@@ -1728,17 +1698,12 @@ class TestSendErrorNotification:
             labels=[],
         )
 
-        mock_resp = AsyncMock()
-        mock_resp.status = 200
-        mock_session = AsyncMock()
-        mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-        mock_session.post.return_value.__aexit__ = AsyncMock(return_value=False)
-
         with patch("kai.triage.aiohttp.ClientSession") as mock_cs:
-            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_cs)
             await _send_error_notification(metadata, "test error", 8080, "secret", notify_chat_id=-100999)
 
+        assert mock_session.post.called
         body = mock_session.post.call_args[1]["json"]
         assert body["chat_id"] == -100999
 
@@ -1755,17 +1720,12 @@ class TestSendErrorNotification:
             labels=[],
         )
 
-        mock_resp = AsyncMock()
-        mock_resp.status = 200
-        mock_session = AsyncMock()
-        mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-        mock_session.post.return_value.__aexit__ = AsyncMock(return_value=False)
-
         with patch("kai.triage.aiohttp.ClientSession") as mock_cs:
-            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_cs)
             await _send_error_notification(metadata, "test error", 8080, "secret", notify_chat_id=None)
 
+        assert mock_session.post.called
         body = mock_session.post.call_args[1]["json"]
         assert "chat_id" not in body
 
@@ -1791,13 +1751,8 @@ class TestApplyTriageNotifyChatId:
             patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
             patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
         ):
-            mock_session = AsyncMock()
-            mock_resp = AsyncMock()
-            mock_resp.status = 200
-            mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
-            mock_session.post.return_value.__aexit__ = AsyncMock(return_value=False)
-            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_session_cls)
             await apply_triage(meta, result, 8080, "secret", notify_chat_id=-100999)
 
         # The Telegram summary POST should include chat_id

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -39,8 +39,7 @@ def test_async_mock_warning_bucket_stays_empty():
     # would report zero leaks and the regression guard would pass for
     # the wrong reason.
     assert proc.returncode == 0, (
-        f"Subprocess pytest exited {proc.returncode}; warning count "
-        f"cannot be trusted. Captured output:\n{combined}"
+        f"Subprocess pytest exited {proc.returncode}; warning count cannot be trusted. Captured output:\n{combined}"
     )
     leaks = combined.count("AsyncMockMixin._execute_mock_call")
     assert leaks == 0, (

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,0 +1,50 @@
+"""Regression guard for the async-mock warning bucket from issue 532.
+
+When this test fails, a new test has reintroduced the
+`AsyncMockMixin._execute_mock_call was never awaited` pattern. Either
+fix the mock setup at the site that emits the warning, or remove this
+test if the maintenance burden is no longer worthwhile.
+
+The guard runs a focused pytest subprocess against the two files that
+historically carried the warning bucket. The subprocess form keeps the
+warning capture independent of the parent pytest's warning filters,
+which is necessary because pytest's `-W` flag at the outer level can
+otherwise mask the inner warnings.
+"""
+
+import subprocess
+import sys
+
+
+def test_async_mock_warning_bucket_stays_empty():
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-W",
+            "default",
+            "--quiet",
+            "tests/test_triage.py",
+            "tests/test_claude.py",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    combined = proc.stdout + proc.stderr
+    # The returncode check guards against a nested pytest invocation
+    # that exits early (collection error, import failure, unrelated
+    # test failure) and therefore never emits the warnings the count
+    # below is meant to catch. Without this gate, a broken nested run
+    # would report zero leaks and the regression guard would pass for
+    # the wrong reason.
+    assert proc.returncode == 0, (
+        f"Subprocess pytest exited {proc.returncode}; warning count "
+        f"cannot be trusted. Captured output:\n{combined}"
+    )
+    leaks = combined.count("AsyncMockMixin._execute_mock_call")
+    assert leaks == 0, (
+        f"{leaks} async-mock RuntimeWarning(s) detected. Each one "
+        "points at a test whose mock setup discards a coroutine.\n"
+        f"Captured output:\n{combined}"
+    )

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,22 +1,30 @@
 """Regression guard for the async-mock warning bucket from issue 532.
 
 When this test fails, a new test has reintroduced the
-`AsyncMockMixin._execute_mock_call was never awaited` pattern. Either
-fix the mock setup at the site that emits the warning, or remove this
-test if the maintenance burden is no longer worthwhile.
+`AsyncMockMixin._execute_mock_call was never awaited` pattern in the
+two files this guard covers. Either fix the mock setup at the site
+that emits the warning, or remove this test if the maintenance burden
+is no longer worthwhile.
 
-The guard runs a focused pytest subprocess against the two files that
-historically carried the warning bucket. The subprocess form keeps the
-warning capture independent of the parent pytest's warning filters,
-which is necessary because pytest's `-W` flag at the outer level can
-otherwise mask the inner warnings.
+The guard is scoped to `tests/test_triage.py` and
+`tests/test_claude.py`, which is where issue 532 surfaced the
+async-mock bucket and where this guard's accompanying migrations
+landed. Other files (notably `tests/test_webhook.py`) have a
+separate, aiohttp-fixture-teardown root cause and are tracked
+independently; do not extend this guard to cover them without first
+investigating that distinct shape.
+
+The guard runs a focused pytest subprocess so the warning capture
+stays independent of the parent pytest's warning filters, which is
+necessary because pytest's `-W` flag at the outer level can otherwise
+mask the inner warnings.
 """
 
 import subprocess
 import sys
 
 
-def test_async_mock_warning_bucket_stays_empty():
+def test_async_mock_warning_bucket_empty_in_triage_and_claude_tests():
     proc = subprocess.run(
         [
             sys.executable,


### PR DESCRIPTION
## Summary

Eliminates the async-mock `RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited` bucket from `tests/test_triage.py` and `tests/test_claude.py` (the scope called out in #532), and adds a subprocess regression guard that catches reintroduction in those two files.

This is the second of the two PRs proposed in #532. The first cleared the `NotAppKeyWarning` bucket in PR #703. The `ResourceWarning` subprocess-teardown bucket remains untouched per #532's "safest to leave alone" framing.

## Why these warnings matter

Each warning points at a test whose mock setup discards a coroutine, which means the production code's surrounding `try / except Exception:` silently swallows the resulting error and the test passes for the wrong reason. The failure mode is real test hygiene: the previously-vacuous passes are now explicit assertions on the same code paths the tests were nominally exercising.

## Changes

### Helpers and regression guard (commit 1)

- Add `_mock_aiohttp_session_post(status=200) -> (session, response)` and `_attach_session_to_class(session, mock_cls)` near the top of `tests/test_triage.py`. The two helpers build the canonical async-with-context-manager mock shape and wire a patched `ClientSession` class.
- Add `tests/test_warnings.py` with a single regression test that runs a focused pytest subprocess against `tests/test_triage.py tests/test_claude.py` and asserts both that the subprocess exits cleanly and that the captured output contains zero `AsyncMockMixin._execute_mock_call` occurrences. The `returncode == 0` gate guards against a nested run that exits early (collection error, import failure, unrelated test failure) and would otherwise report zero leaks for the wrong reason.

### Group 1: triage Shape A (commit 2)

The 16 success-path sites in `tests/test_triage.py` all built `session.post` via `mock_session = AsyncMock()`. That made `mock_session.post` itself an `AsyncMock` whose call returned a coroutine; production then evaluated `async with <coroutine> as resp:` which fails on `__aenter__`, the surrounding `try / except` swallowed the `AttributeError`, the coroutine was garbage-collected without being awaited, and the runtime emitted the warning. The test still passed because its assertions checked `gh` CLI calls via `kai.triage.asyncio.create_subprocess_exec`, not HTTP behavior.

- Replace the 5-line `AsyncMock` setup at all 16 sites with `_mock_aiohttp_session_post()` + `_attach_session_to_class()`.
- Add `assert mock_session.post.called` (or rely on an existing downstream `assert_called_once()` / `if mock_session.post.called:` check) at each site so the previously-vacuous HTTP step now carries a real assertion.
- Triage file warning count drops from 31 to 3.

### Group 2: triage Shape B (commit 3)

The 3 error-path sites at `test_does_not_raise_on_connection_error`, `test_does_not_raise_on_timeout`, and `test_logs_warning_on_failure` set `session.post = AsyncMock(side_effect=ConnectionError(...))` (or `TimeoutError()`, `RuntimeError("boom")`). Production calls `session.post(...)` synchronously, then evaluates `async with <result>`. `AsyncMock(side_effect=...)` attaches the exception to the unawaited coroutine the call returns; that coroutine is never awaited, so the side effect never fires, and the test's intended failure branch is not exercised.

- Rewrite each site to `MagicMock(side_effect=...)` on a sync `session.post`. MagicMock raises synchronously, which matches production's call shape and lets production's `try / except` actually catch the error.
- Add `mock_session.post.assert_called_once()` to each error-path test so the previously-vacuous pass now asserts the HTTP call actually ran.
- Triage file warning count drops from 3 to 0.

### Group 3: claude.py stderr + wait_for (commit 4)

Two shapes in `tests/test_claude.py`:

- **22 sites set `mock_proc.stderr = AsyncMock()` without configuring `stderr.readline`.** Production's `_drain_stderr()` background task loops on `await self._proc.stderr.readline()` then evaluates `text = line.decode().strip()`. With the bare `AsyncMock`, `stderr.readline` was an auto-generated `AsyncMock` whose await returned an `AsyncMock` instance (not bytes); the subsequent `line.decode()` triggered another auto-generated `AsyncMock` call that created a coroutine which was never awaited. The warning surfaced at file level because the GC happened during the file's teardown sweep rather than inside any one test.
  - Fix: replace each bare `mock_proc.stderr = AsyncMock()` with the configured pair `mock_proc.stderr = MagicMock()` + `mock_proc.stderr.readline = AsyncMock(return_value=b"")`.

- **1 site (`test_timeout`) patched `asyncio.wait_for` with `side_effect=TimeoutError`.** Production already constructed a coroutine via `self._proc.stdout.readline()` before passing it to `wait_for`; the mock raised without awaiting or closing that coroutine.
  - Fix: rewrite the patch with a local helper `async def _timeout_after_closing(coro, *args, **kwargs)` that closes the supplied coroutine before raising `TimeoutError`. The `*args, **kwargs` shape tolerates production's `timeout=` keyword argument; a narrower signature would raise `TypeError` and reintroduce the leak.

- Claude file warning count drops from 23 to 0.

### Format / lint cleanup (commit 5)

Drop unused `mock_resp` unpacking name in 13 sites (ruff RUF059); reformat the regression-guard assertion message line. No behavior change.

## Out of scope

- The `ResourceWarning` subprocess-teardown bucket. Per #532: "safest to leave alone."
- A `filterwarnings` entry suppressing `RuntimeWarning` from `unittest.mock`. The bucket masks real test-hygiene bugs; suppression defeats the purpose.
- A CI gate on overall warning count.
- The `claude_user="daniel"` test assumptions in `tests/test_claude.py` that fail in environments where the current OS user is `daniel`. Pre-existing, environment-dependent, surfaced by the spec reviews but not this PR's scope.
- Argument-level assertions on `session.post`.

## Findings during implementation (worth flagging)

The async-mock pattern exists outside the spec's declared scope as well. Live measurement against `make test`:

- `tests/test_webhook.py`: ~35 warnings (highest concentration outside the spec scope; same broken `session.post`-via-`AsyncMock` shape).
- `tests/test_review.py`: 1 warning.
- `tests/test_tts.py`: 1 warning.
- `tests/test_webhook_api.py`: 1 warning.

#532's issue body described the bucket as "`tests/test_claude.py` + `tests/test_triage.py`: ~30 warnings" but the real bucket is larger. The regression guard in `tests/test_warnings.py` is scoped to the spec's two files; reintroduction in `test_webhook.py` or the other files would not trip the guard. If clearing those is worth doing, it is the same shape of work and should land as a follow-up PR (or PRs).

## Warning count

| State | Total `make test` warnings | `AsyncMockMixin._execute_mock_call` |
|---|---|---|
| Before | 122 | 53 |
| After  | 59  | 0 in spec scope (`tests/test_triage.py` + `tests/test_claude.py`); ~38 remain in `tests/test_webhook.py` and 3 elsewhere |

## Test plan

- [x] `make check` clean (lint + format)
- [x] `make test` passes (4548 passed, 1 skipped)
- [x] `tests/test_triage.py` passes (97 tests, 0 async-mock warnings)
- [x] `tests/test_claude.py` passes (164 tests, 0 async-mock warnings)
- [x] `tests/test_warnings.py::test_async_mock_warning_bucket_stays_empty` passes
- [x] `.venv/bin/python -m pytest -W default tests/test_triage.py tests/test_claude.py 2>&1 | grep -c "AsyncMockMixin._execute_mock_call"` returns 0
- [ ] Post-deploy: confirm the daemon's runtime logs remain clean (no `AsyncMockMixin` chatter)

Refs #532
