### PR TITLE
Clear the async-mock RuntimeWarning bucket suite-wide

### DIFF
--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1024,9 +1024,9 @@ class TestSendReviewSummary:
         """Success summary includes PR link and title."""
         meta = _metadata(repo="owner/repo", number=42, title="Add feature X")
 
-        mock_resp = AsyncMock()
+        mock_resp = MagicMock()
         mock_resp.status = 200
-        mock_session = AsyncMock()
+        mock_session = MagicMock()
         mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
         mock_session.post.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -1036,6 +1036,7 @@ class TestSendReviewSummary:
             await send_review_summary(meta, True, 8080, "secret")
 
         # Verify the POST was made with correct URL and content
+        assert mock_session.post.called
         call_args = mock_session.post.call_args
         assert "localhost:8080/api/send-message" in call_args[0][0]
         body = call_args[1]["json"]
@@ -1048,9 +1049,9 @@ class TestSendReviewSummary:
         """Failure summary says 'Failed to review'."""
         meta = _metadata()
 
-        mock_resp = AsyncMock()
+        mock_resp = MagicMock()
         mock_resp.status = 200
-        mock_session = AsyncMock()
+        mock_session = MagicMock()
         mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
         mock_session.post.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -1059,6 +1060,7 @@ class TestSendReviewSummary:
             mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
             await send_review_summary(meta, False, 8080, "secret")
 
+        assert mock_session.post.called
         body = mock_session.post.call_args[1]["json"]
         assert "Failed to review" in body["text"]
 
@@ -1076,9 +1078,14 @@ class TestSendReviewSummary:
         """When notify_chat_id is set, chat_id is included in the POST body."""
         meta = _metadata()
 
-        mock_resp = AsyncMock()
+        # session.post() is a sync call returning an async context
+        # manager. MagicMock keeps the call return synchronous; an
+        # AsyncMock session would make .post() return a coroutine
+        # that production then tries to use as `async with`, leaking
+        # the AsyncMockMixin._execute_mock_call warning.
+        mock_resp = MagicMock()
         mock_resp.status = 200
-        mock_session = AsyncMock()
+        mock_session = MagicMock()
         mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
         mock_session.post.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -1087,6 +1094,7 @@ class TestSendReviewSummary:
             mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
             await send_review_summary(meta, True, 8080, "secret", notify_chat_id=-100123)
 
+        assert mock_session.post.called
         body = mock_session.post.call_args[1]["json"]
         assert body["chat_id"] == -100123
 
@@ -1095,9 +1103,9 @@ class TestSendReviewSummary:
         """When notify_chat_id is None, chat_id is NOT in the POST body."""
         meta = _metadata()
 
-        mock_resp = AsyncMock()
+        mock_resp = MagicMock()
         mock_resp.status = 200
-        mock_session = AsyncMock()
+        mock_session = MagicMock()
         mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
         mock_session.post.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -1106,6 +1114,7 @@ class TestSendReviewSummary:
             mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
             await send_review_summary(meta, True, 8080, "secret", notify_chat_id=None)
 
+        assert mock_session.post.called
         body = mock_session.post.call_args[1]["json"]
         assert "chat_id" not in body
 

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -64,9 +64,18 @@ class TestRun:
     async def test_timeout(self):
         """Timeout kills process and raises TranscriptionError."""
         proc = _make_proc()
+
+        async def _timeout_after_closing(coro, *args, **kwargs):
+            # Close the coroutine production created via proc.communicate()
+            # before raising; a bare side_effect=TimeoutError would leak
+            # the unawaited coroutine and surface as the
+            # AsyncMockMixin._execute_mock_call warning.
+            coro.close()
+            raise TimeoutError
+
         with (
             patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc),
-            patch("asyncio.wait_for", side_effect=TimeoutError),
+            patch("asyncio.wait_for", side_effect=_timeout_after_closing),
             pytest.raises(TranscriptionError, match="timed out"),
         ):
             await _run("ffmpeg", label="ffmpeg")

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -96,9 +96,18 @@ class TestSynthesizePiper:
     async def test_piper_timeout(self, tmp_path, tts_tmpdir):
         model_dir = _model_path(tmp_path)
         proc = _make_proc()
+
+        async def _timeout_after_closing(coro, *args, **kwargs):
+            # Close the coroutine production created via proc.communicate(...)
+            # before raising; a bare side_effect=TimeoutError would leak
+            # the unawaited coroutine and surface as the
+            # AsyncMockMixin._execute_mock_call warning.
+            coro.close()
+            raise TimeoutError
+
         with (
             patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc),
-            patch("asyncio.wait_for", side_effect=TimeoutError),
+            patch("asyncio.wait_for", side_effect=_timeout_after_closing),
             pytest.raises(TTSError, match="timed out"),
         ):
             await synthesize_speech("hello", model_dir)
@@ -174,7 +183,10 @@ class TestSynthesizeFfmpeg:
             if wait_for_count == 1:
                 # Piper's communicate - let it through
                 return await original_wait_for(coro, timeout=timeout)
-            # ffmpeg's communicate - timeout
+            # ffmpeg's communicate - timeout. Close the supplied
+            # coroutine before raising so the patched wait_for does
+            # not leak an unawaited AsyncMock coroutine.
+            coro.close()
             raise TimeoutError
 
         with (

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,18 +1,28 @@
-"""Regression guard for the async-mock warning bucket from issue 532.
+"""Regression guard for the async-mock warning bucket from issues 532 and 712.
 
 When this test fails, a new test has reintroduced the
-`AsyncMockMixin._execute_mock_call was never awaited` pattern in the
-two files this guard covers. Either fix the mock setup at the site
+`AsyncMockMixin._execute_mock_call was never awaited` pattern in one
+of the files this guard covers. Either fix the mock setup at the site
 that emits the warning, or remove this test if the maintenance burden
 is no longer worthwhile.
 
-The guard is scoped to `tests/test_triage.py` and
-`tests/test_claude.py`, which is where issue 532 surfaced the
-async-mock bucket and where this guard's accompanying migrations
-landed. Other files (notably `tests/test_webhook.py`) have a
-separate, aiohttp-fixture-teardown root cause and are tracked
-independently; do not extend this guard to cover them without first
-investigating that distinct shape.
+The guard is scoped to the test files where the bucket was identified
+and cleared (PR #711 for issue 532; the PR closing issue 712 for the
+remaining files). New files added to the suite that misuse AsyncMock
+will not be caught here automatically; extend the file list below
+when adding the same shape of fix elsewhere.
+
+The two recurring root shapes the guard catches:
+
+1. AsyncMock-where-MagicMock-was-needed: a sync interface (e.g. a
+   Config dataclass, an aiohttp.ClientSession's `.post(...)` call)
+   mocked with AsyncMock, so calling it returns an unawaited
+   coroutine that production then misuses (assigns to a value,
+   passes to `async with`, etc.).
+2. wait_for-leaks-coroutine: a patched `asyncio.wait_for` with a
+   bare `side_effect=TimeoutError` that raises without closing the
+   already-constructed coroutine production passed to it. The fix is
+   a coroutine-closing helper.
 
 The guard runs a focused pytest subprocess so the warning capture
 stays independent of the parent pytest's warning filters, which is
@@ -23,8 +33,20 @@ mask the inner warnings.
 import subprocess
 import sys
 
+# Files covered by the regression guard. Add a file here when a new
+# test in it gets fixed for the same async-mock leak pattern, so future
+# regressions surface immediately.
+_GUARDED_FILES = (
+    "tests/test_triage.py",
+    "tests/test_claude.py",
+    "tests/test_webhook.py",
+    "tests/test_review.py",
+    "tests/test_tts.py",
+    "tests/test_transcribe.py",
+)
 
-def test_async_mock_warning_bucket_empty_in_triage_and_claude_tests():
+
+def test_async_mock_warning_bucket_empty_across_guarded_files():
     proc = subprocess.run(
         [
             sys.executable,
@@ -33,8 +55,7 @@ def test_async_mock_warning_bucket_empty_in_triage_and_claude_tests():
             "-W",
             "default",
             "--quiet",
-            "tests/test_triage.py",
-            "tests/test_claude.py",
+            *_GUARDED_FILES,
         ],
         capture_output=True,
         text=True,

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -439,8 +439,19 @@ def _build_test_app(
         # every chained attribute call (e.g. config.default_models.get(...))
         # return a coroutine, which then leaks as the
         # AsyncMockMixin._execute_mock_call never-awaited warning.
+        #
+        # The dataclass-shaped attribute defaults below let
+        # resolve_user_model() return a real string (the registry
+        # default for the selected backend) rather than a chained
+        # MagicMock. Without them, model_override would silently flow
+        # through to review_pr / triage_issue as a MagicMock instance,
+        # which the mocked downstream callers accept but real code
+        # would not.
         mock_config = MagicMock()
         mock_config.user_configs = {}
+        mock_config.default_models = {}
+        mock_config.agent_backend = "claude"
+        mock_config.llm_provider = ""
         # get_user_config is synchronous in real Config; must not
         # return a coroutine. With no users configured, always None.
         mock_config.get_user_config = lambda uid: None
@@ -698,6 +709,13 @@ class TestPRReviewRouting:
             assert call_kwargs[0][0] == payload
             assert call_kwargs[1]["webhook_port"] == 8080
             assert call_kwargs[1]["webhook_secret"] == _TEST_SECRET
+            # model_override must be a real string, not a mock. The
+            # dataclass-shaped defaults on the fixture config let
+            # resolve_user_model return the registry default for the
+            # claude backend (`sonnet`); a bare MagicMock config would
+            # silently pass a MagicMock instance here, vacuously
+            # satisfying mocked review_pr but failing under real code.
+            assert isinstance(call_kwargs[1]["model_override"], str)
             # _resolve_local_repo is mocked to return None here;
             # dedicated tests for resolution logic are in TestResolveLocalRepo.
             assert call_kwargs[1]["local_repo_path"] is None
@@ -1253,9 +1271,17 @@ class TestGetSubscribedUsers:
 
         Config is a sync dataclass; AsyncMock would make chained
         attribute calls return coroutines that never get awaited.
+
+        The dataclass-shaped attribute defaults make
+        `resolve_user_model()` return a real registry string rather
+        than a chained MagicMock; without them, model_override would
+        flow through routing tests as an opaque mock.
         """
         config = MagicMock()
         config.user_configs = user_configs if user_configs is not None else {}
+        config.default_models = {}
+        config.agent_backend = "claude"
+        config.llm_provider = ""
         return config
 
     def _make_user(
@@ -1454,9 +1480,19 @@ class TestPerUserRouting:
         attribute calls like `config.default_models.get(...)` return a
         coroutine instead of a value, which then surfaces as the
         AsyncMockMixin._execute_mock_call never-awaited warning.
+
+        The dataclass-shaped attribute defaults make
+        `resolve_user_model()` return a real registry string rather
+        than a chained MagicMock; without them, the routing tests
+        would pass model_override as an opaque mock into review_pr /
+        triage_issue, hiding any future regression that depended on
+        the override being a real string.
         """
         config = MagicMock()
         config.user_configs = {u.telegram_id: u for u in users}
+        config.default_models = {}
+        config.agent_backend = "claude"
+        config.llm_provider = ""
         # get_user_config returns the UserConfig for a given ID
         config.get_user_config = lambda uid: config.user_configs.get(uid)
         return config

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -5,7 +5,7 @@ import dataclasses
 import hashlib
 import hmac
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
@@ -435,7 +435,11 @@ def _build_test_app(
     # Config for per-user routing. Default mock has no user_configs,
     # so all events fall through to admin chat_id.
     if config is None:
-        mock_config = AsyncMock()
+        # Config is a sync dataclass. Using AsyncMock here would make
+        # every chained attribute call (e.g. config.default_models.get(...))
+        # return a coroutine, which then leaks as the
+        # AsyncMockMixin._execute_mock_call never-awaited warning.
+        mock_config = MagicMock()
         mock_config.user_configs = {}
         # get_user_config is synchronous in real Config; must not
         # return a coroutine. With no users configured, always None.
@@ -1240,14 +1244,17 @@ class TestGetSubscribedUsers:
         with patch("kai.webhook.sessions.get_effective_repos", side_effect=_passthrough):
             yield
 
-    def _make_config(self, user_configs: dict | None = None) -> AsyncMock:
+    def _make_config(self, user_configs: dict | None = None) -> MagicMock:
         """Build a mock Config with the given user_configs dict.
 
         Post-#565 tranche A `Config.user_configs` is a non-optional
         dict; a None argument here is coerced to `{}` to preserve the
         empty-dict test ergonomics callers expect.
+
+        Config is a sync dataclass; AsyncMock would make chained
+        attribute calls return coroutines that never get awaited.
         """
-        config = AsyncMock()
+        config = MagicMock()
         config.user_configs = user_configs if user_configs is not None else {}
         return config
 
@@ -1440,9 +1447,15 @@ class TestPerUserRouting:
             role=role,
         )
 
-    def _make_config_with_users(self, users: list) -> AsyncMock:
-        """Build a mock Config with user_configs populated."""
-        config = AsyncMock()
+    def _make_config_with_users(self, users: list) -> MagicMock:
+        """Build a mock Config with user_configs populated.
+
+        Config is a sync dataclass; using AsyncMock would make chained
+        attribute calls like `config.default_models.get(...)` return a
+        coroutine instead of a value, which then surfaces as the
+        AsyncMockMixin._execute_mock_call never-awaited warning.
+        """
+        config = MagicMock()
         config.user_configs = {u.telegram_id: u for u in users}
         # get_user_config returns the UserConfig for a given ID
         config.get_user_config = lambda uid: config.user_configs.get(uid)
@@ -2136,7 +2149,7 @@ class TestAllowedChatIdMutations:
         app = web.Application()
         app[ALLOWED_USER_IDS_KEY] = {100, -100123}
         # No config needed for this case - group IDs are never in user_configs
-        mock_config = AsyncMock()
+        mock_config = MagicMock()
         mock_config.user_configs = {}
         app[CONFIG_KEY] = mock_config
         old_app = wh._app
@@ -2153,7 +2166,7 @@ class TestAllowedChatIdMutations:
         import kai.webhook as wh
 
         user = UserConfig(telegram_id=12345, name="alice")
-        mock_config = AsyncMock()
+        mock_config = MagicMock()
         mock_config.user_configs = {12345: user}
 
         app = web.Application()


### PR DESCRIPTION
## Summary

Clears the `AsyncMockMixin._execute_mock_call was never awaited` warning bucket from the rest of the test suite. PR #711 cleared the bucket inside its declared scope (`tests/test_triage.py` and `tests/test_claude.py`); issue #712 was filed based on my own analysis that said the rest of the bucket had a different root cause. That analysis was wrong: tracemalloc shows the same two root shapes everywhere.

## Why the original #712 framing was off

I traced one test in `tests/test_webhook.py` and stopped reading the stack one frame too early, at `aiohttp/web_protocol.py:510`. The actual leak was further down at `src/kai/config.py` inside `resolve_user_model()`, where production calls `config.default_models.get(role.value, "")`. The test fixture set `mock_config = AsyncMock()`; `Config` is a sync dataclass, so the chained attribute call returned a coroutine that was assigned to a local and discarded. Same shape as PR #711's triage fix.

I correct that here and close #712 instead of writing up new spec work.

## Changes

Two recurring root shapes:

### 1. AsyncMock where MagicMock was needed

Sync interfaces (`Config` dataclass; `aiohttp.ClientSession`'s sync `.post(...)`) mocked as `AsyncMock`. Every chained attribute call returns a coroutine production then misuses (assigns to a value, passes to `async with`).

- `tests/test_webhook.py`: five `mock_config = AsyncMock()` sites: the `_build_test_app` fixture, two helper functions (`_make_config`, `_make_config_with_users`), and two direct test setups in `TestAddRemoveAllowedChatId`. Swap to `MagicMock`. This single category cleared 35 warnings.
- `tests/test_review.py`: four sites in `TestSendReviewSummary` using the same broken `mock_resp = AsyncMock()` + `mock_session = AsyncMock()` shape as PR #711's triage Shape A. Swap to `MagicMock` and add `assert mock_session.post.called` so the previously-vacuous HTTP-send step carries a real assertion.

### 2. `wait_for` leaks coroutine

Patched `asyncio.wait_for` with a bare `side_effect=TimeoutError` raises without closing the coroutine production passed to it. Same shape as PR #711's `tests/test_claude.py::test_timeout`.

- `tests/test_tts.py::test_piper_timeout`: production calls `asyncio.wait_for(proc.communicate(input=text.encode()), timeout=120)`. Patch with `_timeout_after_closing(coro, *args, **kwargs)` that closes the coroutine before raising.
- `tests/test_transcribe.py::TestRun::test_timeout`: same shape, same fix.
- `tests/test_tts.py::test_ffmpeg_timeout`: already had a per-call `_wait_for_side_effect` helper; added `coro.close()` to its raise branch.

### Regression guard

Extend `tests/test_warnings.py` to cover the six files now cleaned (the original two from PR #711 plus the four cleaned up here). Rename the test from `..._empty_in_triage_and_claude_tests` to `..._empty_across_guarded_files`. Add a module-docstring section enumerating the two recurring root shapes so a future contributor can recognize them quickly. The file list is the load-bearing artifact; future contributors should add new files here when fixing the same pattern.

## Results

- **Async-mock bucket suite-wide:** 38 → 0.
- **Total `make test` warnings:** drops to ~3 (variable, ResourceWarning subprocess-teardown floor only).
- **Tests:** 4548 passed, 1 skipped. No new failures.
- **Regression guard runtime:** ~2 seconds (scoped to six known files; running the full suite would take ~35 seconds).

## Test plan

- [x] `make check` clean (lint + format)
- [x] `make test` passes (4548 passed, 1 skipped)
- [x] `tests/test_warnings.py::test_async_mock_warning_bucket_empty_across_guarded_files` passes
- [x] Each touched file passes in isolation with zero `AsyncMockMixin._execute_mock_call` occurrences
- [x] `.venv/bin/python -m pytest -W default 2>&1 | grep -c "AsyncMockMixin._execute_mock_call"` returns 0

## Out of scope

- `ResourceWarning` subprocess-teardown bucket (~3 warnings remaining). Per #532's "safest to leave alone" framing.
- CI gate on overall warning count. Worth revisiting now that the floor is much lower.

Closes #712
