### PR TITLE
Show Codex effort level choices in make config

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -197,6 +197,82 @@ def _prompt_choice(label: str, choices: list[str], default: str = "") -> str:
         print(f"  Please choose one of: {choices_str}")
 
 
+def _prompt_optional_choice(
+    label: str,
+    choices: list[str],
+    default: str = "",
+    empty_hint: str = "empty = default",
+) -> str:
+    """
+    Prompt the user to pick from a list of valid choices, with empty
+    input promoted to a first-class valid answer.
+
+    Use for set-or-absent settings where absence has its own meaning:
+    omitting the variable from install.conf is the signal to let the
+    downstream consumer use its own default. The Codex effort prompt
+    is the seed call site; absence means CodexBackend skips the
+    `-c model_reasoning_effort` override and codex falls back to the
+    per-OS-user `~/.codex/config.toml` or the model default.
+
+    The prefill is normalized via `.strip().lower()` before the `in
+    choices` check, mirroring the runtime config parser's tolerance
+    for copy-paste-shaped values. A prefill that lands in `choices`
+    after normalization round-trips on Enter and is displayed in its
+    canonical lowercased form. A prefill that does not match after
+    normalization is treated as no prefill: the inline hint advertises
+    the empty-default path, and Enter returns "".
+
+    Display:
+        - With a usable prefill:    `label (a/b/c) [b]: `
+        - Without a usable prefill: `label (a/b/c, empty = default): `
+
+    Args:
+        label: The prompt text shown to the user.
+        choices: List of valid string values. Membership is checked
+            case-sensitively after the caller's input is lowercased,
+            so `choices` should contain canonical lowercase entries.
+        default: Prefill candidate. Normalized via `.strip().lower()`
+            before the membership check. An out-of-list value after
+            normalization is treated as no default.
+        empty_hint: Phrase shown inline next to the choices in the
+            no-prefill display path, and repeated in the re-prompt on
+            invalid input. Default "empty = default" is generic;
+            callers should pass a site-specific phrase like
+            "empty = codex default" so the operator sees the semantics
+            in their own terms.
+
+    Returns:
+        The chosen value (guaranteed to be in `choices`), or "" when
+        the operator explicitly leaves the answer empty AND there is
+        no usable prefill.
+    """
+    choices_str = "/".join(choices)
+    # Match the runtime config parser's tolerance for copy-paste-shaped
+    # values (pinned by test_uppercase_and_whitespace_normalized in the
+    # codex-effort config tests) so a re-run of `make config` with a
+    # value like "  HIGH " sitting in /etc/kai/env keeps the existing
+    # setting instead of silently treating it as out-of-list and
+    # dropping it.
+    effective_default = default.strip().lower()
+    if effective_default in choices:
+        prompt_text = f"{label} ({choices_str}) [{effective_default}]: "
+    else:
+        # No usable prefill: advertise the empty-default path inline
+        # so a first-time operator does not have to guess that empty
+        # is a valid answer. The empty hint never appears alongside
+        # `[prefill]` so the prompt does not give two different
+        # "what happens on Enter" answers at once.
+        prompt_text = f"{label} ({choices_str}, {empty_hint}): "
+        effective_default = ""
+    while True:
+        value = input(prompt_text).strip().lower()
+        if not value:
+            return effective_default
+        if value in choices:
+            return value
+        print(f"  Must be one of {choices_str}, or {empty_hint}.")
+
+
 def _prompt_bool(label: str, default: bool = False) -> bool:
     """
     Prompt the user for a yes/no answer.
@@ -1448,31 +1524,24 @@ def _cmd_config() -> None:
         print()
 
     # CODEX_EFFORT_LEVEL mirrors the claude effort prompt for the
-    # codex backend with one contract difference: the default is empty
-    # (set-or-absent). Empty means CodexBackend passes no
+    # codex backend with one contract difference: empty is a valid
+    # answer (set-or-absent). Empty means CodexBackend passes no
     # `-c model_reasoning_effort` override and codex falls back to the
     # per-OS-user ~/.codex/config.toml or the model default, which is
     # the right posture because codex config is per-OS-user and
     # operator-owned, and xhigh availability is model-dependent.
-    # _prompt_choice cannot express "empty means skip", so this is a
-    # validated free-text prompt: empty accepted, anything else must
-    # be in CODEX_EFFORT_LEVELS (the same allow-list config.py
-    # enforces at load, so install.conf cannot carry a value that
-    # fails at service startup).
+    # _prompt_optional_choice exists to express that contract: it
+    # validates non-empty input against the same allow-list config.py
+    # enforces at load so install.conf cannot carry a value that fails
+    # at service startup, while accepting "" as the no-override signal.
     codex_effort_level = ""
     if agent_backend == "codex":
-        while True:
-            codex_effort_level = (
-                _prompt(
-                    "Codex reasoning effort (empty = codex default)",
-                    existing_env.get("CODEX_EFFORT_LEVEL", ""),
-                )
-                .strip()
-                .lower()
-            )
-            if not codex_effort_level or codex_effort_level in CODEX_EFFORT_LEVELS:
-                break
-            print(f"  Must be one of {', '.join(CODEX_EFFORT_LEVELS)}, or empty for the codex default.")
+        codex_effort_level = _prompt_optional_choice(
+            "Codex reasoning effort",
+            list(CODEX_EFFORT_LEVELS),
+            existing_env.get("CODEX_EFFORT_LEVEL", ""),
+            empty_hint="empty = codex default",
+        )
         print()
 
     # -- Webhook server --

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -270,7 +270,16 @@ def _prompt_optional_choice(
             return effective_default
         if value in choices:
             return value
-        print(f"  Must be one of {choices_str}, or {empty_hint}.")
+        # The recovery message has to match what Enter actually does
+        # at this point in the loop. With a usable prefill, Enter
+        # round-trips that prefill (NOT the downstream default), so
+        # advertising the empty-default hint here would be a lie and
+        # would mislead the operator into thinking they can clear the
+        # override by pressing Enter on the re-prompt.
+        if effective_default:
+            print(f"  Must be one of {choices_str}, or empty to keep {effective_default}.")
+        else:
+            print(f"  Must be one of {choices_str}, or {empty_hint}.")
 
 
 def _prompt_bool(label: str, default: bool = False) -> bool:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -46,6 +46,7 @@ from kai.install import (
     _generate_users_yaml,
     _migrate_identity_to_claude_md,
     _prompt_choice,
+    _prompt_optional_choice,
     _read_users_yaml_text,
     _retire_install_home_claude,
     _retire_install_home_dir,
@@ -1059,6 +1060,161 @@ class TestPromptChoice:
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
         result = _prompt_choice("Pick", ["a", "b"], default="A")
         assert result == "a"
+
+
+class TestPromptOptionalChoice:
+    """
+    `_prompt_optional_choice` covers the set-or-absent prompt shape:
+    empty input is a first-class valid answer, the prefill is normalized
+    via `.strip().lower()` before the `in choices` check, and the inline
+    empty-default hint is shown only when there is no usable prefill.
+
+    The Codex effort prompt is the seed call site; these tests pin the
+    helper's contract independently of any specific caller.
+    """
+
+    @staticmethod
+    def _record(monkeypatch, inputs: list[str]) -> list[str]:
+        """
+        Install an `input` stub that records every prompt string and
+        returns the next scripted answer. Returned list is the live
+        prompts buffer; assertions read it after the helper returns.
+        """
+        recorded_prompts: list[str] = []
+        it = iter(inputs)
+
+        def mock_input(prompt: str) -> str:
+            recorded_prompts.append(prompt)
+            return next(it)
+
+        monkeypatch.setattr("builtins.input", mock_input)
+        return recorded_prompts
+
+    def test_empty_input_returns_empty_when_default_empty(self, monkeypatch):
+        """
+        With no prefill, pressing Enter is the operator's "use the
+        downstream default" signal and the helper returns "". The
+        inline hint advertising the empty-default path is also shown
+        in the prompt so a first-time operator sees it.
+        """
+        prompts = self._record(monkeypatch, [""])
+        result = _prompt_optional_choice("Pick", ["a", "b", "c"], default="", empty_hint="empty = pick default")
+        assert result == ""
+        assert "a/b/c" in prompts[0]
+        assert "empty = pick default" in prompts[0]
+
+    def test_empty_input_returns_default_when_default_in_choices(self, monkeypatch):
+        """
+        A valid prefill round-trips on Enter. The empty-default hint is
+        suppressed in the prompt so the operator does not see two
+        different "what happens on Enter" answers at once.
+        """
+        prompts = self._record(monkeypatch, [""])
+        result = _prompt_optional_choice("Pick", ["a", "b", "c"], default="b", empty_hint="empty = pick default")
+        assert result == "b"
+        assert "[b]" in prompts[0]
+        assert "empty = pick default" not in prompts[0]
+
+    def test_empty_input_returns_normalized_default_when_default_case_or_whitespace_differs(self, monkeypatch):
+        """
+        A copy-pasted prefill like "  HIGH " in /etc/kai/env round-trips
+        to its canonical "high" form on Enter, matching the runtime
+        config parser's tolerance for case and whitespace. The displayed
+        suffix shows the normalized value, never the raw input.
+
+        Regression guard: a raw `in choices` check would treat
+        "  HIGH " as out-of-list and erase the env var during
+        reconfiguration. The normalization happens inside the helper
+        so the operator's existing setting is preserved.
+        """
+        prompts = self._record(monkeypatch, [""])
+        result = _prompt_optional_choice("Pick", ["low", "medium", "high"], default="  HIGH ")
+        assert result == "high"
+        assert "[high]" in prompts[0]
+        assert "[  HIGH ]" not in prompts[0]
+
+    def test_empty_input_returns_empty_when_default_not_in_choices(self, monkeypatch):
+        """
+        A prefill that does not match any choice after normalization is
+        treated as no prefill: the suffix reverts to the inline empty-
+        default hint and Enter returns "". `"max"` is deliberately
+        chosen as a value that does not normalize into any allowed
+        entry so this test exercises only the out-of-list branch, not
+        the case-and-whitespace normalization branch.
+        """
+        prompts = self._record(monkeypatch, [""])
+        result = _prompt_optional_choice(
+            "Pick",
+            ["low", "medium", "high"],
+            default="max",
+            empty_hint="empty = pick default",
+        )
+        assert result == ""
+        assert "empty = pick default" in prompts[0]
+        assert "[max]" not in prompts[0]
+
+    def test_in_list_input_returned_lowercased(self, monkeypatch):
+        """
+        Typed input is normalized via `.strip().lower()` before the
+        membership check, so the operator can type "HIGH" or " high "
+        and the function returns the canonical "high". Mirrors the
+        same normalization `_prompt_choice` applies to its input.
+        """
+        self._record(monkeypatch, ["HIGH"])
+        result = _prompt_optional_choice("Pick", ["low", "medium", "high"], default="")
+        assert result == "high"
+
+    def test_invalid_input_reprompts_with_choices_and_empty_hint(self, monkeypatch, capsys):
+        """
+        On an out-of-list typed answer the helper re-prompts and the
+        notice on stdout includes both the allowed choices and the
+        empty-default hint, so the operator can recover by retyping
+        OR by pressing Enter.
+        """
+        self._record(monkeypatch, ["bogus", "low"])
+        result = _prompt_optional_choice(
+            "Pick",
+            ["low", "medium", "high"],
+            default="",
+            empty_hint="empty = pick default",
+        )
+        assert result == "low"
+        captured = capsys.readouterr().out
+        assert "low/medium/high" in captured
+        assert "empty = pick default" in captured
+
+    def test_whitespace_only_input_treated_as_empty(self, monkeypatch):
+        """
+        `.strip()` on typed input collapses a whitespace-only answer to
+        "", which then takes the empty-input branch. With no prefill
+        the helper returns "". Pins parity with how the runtime config
+        parser treats `CODEX_EFFORT_LEVEL="   "` as effectively unset.
+        """
+        self._record(monkeypatch, ["   "])
+        result = _prompt_optional_choice("Pick", ["a", "b", "c"], default="")
+        assert result == ""
+
+    def test_custom_empty_hint_appears_in_prompt(self, monkeypatch):
+        """
+        The Codex call site passes `empty_hint="empty = codex default"`
+        so the operator sees the semantics in their own terms. This
+        test pins that the custom hint reaches the prompt verbatim in
+        the no-prefill display path.
+
+        Uses CODEX_EFFORT_LEVELS rather than a hand-written copy of the
+        tuple so the canonical effort vocabulary stays single-sourced
+        in `kai.config`.
+        """
+        from kai.config import CODEX_EFFORT_LEVELS
+
+        prompts = self._record(monkeypatch, [""])
+        _prompt_optional_choice(
+            "Codex reasoning effort",
+            list(CODEX_EFFORT_LEVELS),
+            default="",
+            empty_hint="empty = codex default",
+        )
+        assert "empty = codex default" in prompts[0]
 
 
 # ── Config subcommand ────────────────────────────────────────────────
@@ -3051,6 +3207,48 @@ class TestCmdConfigDefaultModelDispatch:
         base[idx - 1] = "HIGH"
         _, env = self._run(monkeypatch, tmp_path, base, helper_return="gpt-5.5")
         assert env.get("CODEX_EFFORT_LEVEL") == "high"
+
+    def test_codex_effort_prompt_displays_choices(self, tmp_path, monkeypatch):
+        """
+        The Codex effort prompt advertises the allowed values and the
+        empty-default semantics BEFORE accepting input, so the operator
+        does not have to guess the vocabulary.
+
+        Replaces the default `lambda prompt: next(inputs_iter)` stub
+        with a recording variant so the test can inspect every prompt
+        string the wizard issues, then asserts that the prompt issued
+        for the codex effort slot contains every value in
+        CODEX_EFFORT_LEVELS plus the `empty = codex default` hint.
+        """
+        from unittest.mock import MagicMock
+
+        from kai.config import CODEX_EFFORT_LEVELS
+
+        self._setup(monkeypatch, tmp_path)
+        helper_mock = MagicMock(return_value="gpt-5.5")
+        monkeypatch.setattr("kai.install._prompt_default_model", helper_mock)
+        monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
+
+        recorded_prompts: list[str] = []
+        inputs_iter = iter(self._inputs_for_codex_subscription())
+
+        def mock_input(prompt: str) -> str:
+            recorded_prompts.append(prompt)
+            return next(inputs_iter)
+
+        monkeypatch.setattr("builtins.input", mock_input)
+        _cmd_config()
+
+        # Find the prompt issued for the Codex effort slot. The label
+        # "Codex reasoning effort" is unique in the wizard chain so a
+        # substring match identifies the right prompt without coupling
+        # to its position in the input list.
+        codex_prompts = [p for p in recorded_prompts if "Codex reasoning effort" in p]
+        assert len(codex_prompts) == 1, f"expected exactly one Codex effort prompt, got {codex_prompts!r}"
+        prompt = codex_prompts[0]
+        for level in CODEX_EFFORT_LEVELS:
+            assert level in prompt, f"codex effort prompt missing level {level!r}; prompt={prompt!r}"
+        assert "empty = codex default" in prompt
 
     def test_reprompts_on_provider_flip_with_users_yaml(self, tmp_path, monkeypatch):
         """

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1183,6 +1183,32 @@ class TestPromptOptionalChoice:
         assert "low/medium/high" in captured
         assert "empty = pick default" in captured
 
+    def test_invalid_input_reprompt_does_not_advertise_empty_default_when_prefill_present(self, monkeypatch, capsys):
+        """
+        With a usable prefill, Enter returns the prefill, not "". The
+        recovery message must match that: advertise that empty keeps
+        the prefill, NOT that empty means the downstream default. The
+        latter would mislead the operator into thinking they can clear
+        the override by pressing Enter at the re-prompt.
+
+        Inputs are `["bogus", ""]`: the first answer triggers the
+        recovery message, the second answer (empty) takes the prefill-
+        round-trip branch. Asserts the recovery text omits the
+        `empty_hint` and the final return is the prefill.
+        """
+        self._record(monkeypatch, ["bogus", ""])
+        result = _prompt_optional_choice(
+            "Pick",
+            ["low", "medium", "high"],
+            default="high",
+            empty_hint="empty = pick default",
+        )
+        assert result == "high"
+        captured = capsys.readouterr().out
+        assert "low/medium/high" in captured
+        assert "high" in captured
+        assert "empty = pick default" not in captured
+
     def test_whitespace_only_input_treated_as_empty(self, monkeypatch):
         """
         `.strip()` on typed input collapses a whitespace-only answer to


### PR DESCRIPTION
## Summary

- Adds `_prompt_optional_choice(...)` in `src/kai/install.py`. It mirrors `_prompt_choice`'s display surface (`label (a/b/c) [b]:` with a prefill, `label (a/b/c, empty = default):` without) but promotes empty input to a first-class valid answer, for set-or-absent settings where absence has its own meaning.
- Swaps the Codex effort prompt at `src/kai/install.py` from the `_prompt(...) + while True` validation loop to a single call to the new helper, so `make config` now shows `Codex reasoning effort (minimal/low/medium/high/xhigh, empty = codex default):` before accepting input.
- Normalizes the prefill via `.strip().lower()` before the `in choices` check, matching the runtime config parser's tolerance for copy-paste-shaped values (a `CODEX_EFFORT_LEVEL="  HIGH "` in `/etc/kai/env` round-trips as `[high]` rather than being silently treated as out-of-list and dropped on Enter).

The `CODEX_EFFORT_LEVEL` set-or-absent contract is unchanged: empty input still omits the variable from `install.conf`, and a chosen tier still round-trips lowercased.

Closes #704

## Test plan

- [x] `make check` (ruff + format) clean
- [x] `make test` clean (4557 passed, 1 skipped)
- [x] New `TestPromptOptionalChoice` (8 cases) pins the helper's display, normalization, empty-input, re-prompt, and out-of-list-default behavior
- [x] New wizard-level `test_codex_effort_prompt_displays_choices` asserts every `CODEX_EFFORT_LEVELS` value and the `empty = codex default` hint appear in the actual prompt the wizard issues
- [x] Pre-existing `test_codex_effort_default_omits_env_key` and `test_codex_effort_non_default_writes_env_key` still pass unchanged, pinning the set-or-absent contract
