### PR TITLE
Add model discovery layer with OpenRouter as the seed provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Responses stream into Telegram in real time, updating the message every 2 second
 
 Switch models via `/models` (interactive picker) or `/model <name>` (direct). Available models depend on the configured backend: Claude Code offers Opus, Sonnet, and Haiku; Goose offers whatever the user's configured provider supports; Codex offers the Codex CLI's curated model list; OpenCode accepts free-text `provider/model` IDs (for example `anthropic/claude-sonnet-4-6`) that OpenCode resolves at runtime against the credentials in `~/.local/share/opencode/auth.json`. Changing models restarts the session.
 
+Models flow through three layers: providers are **registered** in code (auth, env vars, validation), the per-(backend, provider) model list is **discovered** dynamically where the upstream catalogue is reliable (currently OpenRouter via background refresh of an on-disk cache; other providers stay curated until later phases bring them in), and **defaults** are curated separately and never changed automatically by discovery. The admin command `python -m kai.refresh_models` audits curated providers' `/v1/models` endpoints and forces a one-shot refresh of the discovery cache; the runtime freshness mechanism is `/models`'s own background refresh.
+
 ### Voice input
 
 Voice notes are transcribed locally using [whisper.cpp](https://github.com/ggerganov/whisper.cpp) and forwarded to the agent. Requires `ffmpeg` and `whisper-cpp`. Disabled by default - set `VOICE_ENABLED=true` after installing dependencies. See the [Voice Setup](https://github.com/dcellison/kai/wiki/Voice-Setup) wiki page.

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -59,17 +59,18 @@ from kai.backend import resolve_home_workspace
 from kai.config import (
     DATA_DIR,
     ONESHOT_REASONER_BACKENDS,
-    OPEN_ENDED_PROVIDERS,
     PROVIDER_DEFAULTS,
     Config,
     ModelRole,
     WorkspaceConfig,
     get_effective_provider,
     get_user_backend_and_provider,
+    model_source_for_backend,
     models_for_backend,
     resolve_user_model,
     validate_model_for_backend,
 )
+from kai.discovery import ProviderModelSource
 from kai.history import LogEntry, log_message
 from kai.locks import get_lock, get_stop_event
 from kai.pool import SubprocessPool
@@ -868,39 +869,134 @@ def _get_user_provider(pool: SubprocessPool, chat_id: int, config: Config) -> st
     return provider
 
 
-def _get_user_models(pool: SubprocessPool, chat_id: int, config: Config) -> dict[str, str] | None:
-    """Get the curated model dict for a user's backend/provider, or None if open-ended.
+# Keyboard pagination cutoff for the /models inline keyboard. Doubles
+# as the cutoff above which `/model`, `/settings model`, and
+# `/workspace config model` no-args usage strings collapse to a short
+# generic sentence instead of enumerating every id. Sharing the
+# constant guarantees the operator never sees a flat keyboard but a
+# long usage string, or vice versa.
+_MODELS_PAGE_SIZE = 20
 
-    Codex installs see CODEX_MODELS; other backends see PROVIDER_MODELS
-    for their effective provider. None means open-ended (no keyboard).
-    The codex-side surface is fully separate from PROVIDER_MODELS["openai"]
-    so a codex install never offers a goose-only model.
+
+def _get_user_model_source(
+    pool: SubprocessPool,
+    chat_id: int,
+    config: Config,
+    *,
+    schedule_refresh: bool = True,
+) -> ProviderModelSource:
+    """Resolve the user's runtime model surface.
+
+    Wraps `model_source_for_backend` with the per-user (backend,
+    provider) cascade. Returns a `ProviderModelSource` whose `.kind`
+    tells callers how to render: discovered/discovered_stale come with
+    a `cache_gen` for callback binding; curated wraps the static
+    dicts; open_ended drives the text-prompt fallback.
     """
     backend, provider = _get_user_backend_provider(pool, chat_id, config)
-    models = models_for_backend(backend, provider)
-    if models is None and backend != "codex" and backend != "opencode" and provider not in OPEN_ENDED_PROVIDERS:
-        # Provider is not open-ended but has no curated list. This means
-        # PROVIDER_MODELS is missing an entry for a valid provider -
-        # programming oversight, not user error. OpenCode is excluded
-        # alongside codex because its None return is intentional (full
-        # provider/model IDs are open-ended, not a missing registry
-        # entry), and the global llm_provider for opencode is usually
-        # empty so the OPEN_ENDED_PROVIDERS check above would not catch
-        # it.
-        log.warning(
-            "Provider '%s' has no curated model list; falling back to text input",
-            provider,
-        )
-    return models
+    return model_source_for_backend(backend, provider, schedule_refresh=schedule_refresh)
 
 
-def _models_keyboard(current: str, models: dict[str, str]) -> InlineKeyboardMarkup:
-    """Build an inline keyboard with model choices, highlighting the current model."""
-    buttons = []
-    for key, name in models.items():
-        label = f"{name} \U0001f7e2" if key == current else name
-        buttons.append([InlineKeyboardButton(label, callback_data=f"model:{key}")])
+def _get_user_models(pool: SubprocessPool, chat_id: int, config: Config) -> dict[str, str] | None:
+    """Get the curated/discovered model dict, or None if open-ended.
+
+    Thin wrapper around `_get_user_model_source` retained for callers
+    that only need the id->display map (display lookup after a model
+    switch, usage strings for curated-and-small sources).
+    """
+    source = _get_user_model_source(pool, chat_id, config)
+    if source.kind == "open_ended":
+        return None
+    return dict(source.models)
+
+
+def _short_usage(cmd: str) -> str:
+    """Short generic usage sentence for `/model`, `/settings model`,
+    and `/workspace config model` when the model source is discovered
+    or too large to enumerate inline. Telegram's per-message limit is
+    4096 chars; a 340-model OpenRouter catalog joined with ` | ` is
+    ~9 KB."""
+    return f"Usage: {cmd} <model_id>. Use /models to browse available models."
+
+
+def _should_short_usage(source: ProviderModelSource) -> bool:
+    """Collapse usage to the short generic form when the source is
+    discovered (regardless of size; the operator should be steered to
+    /models for the live catalog) or has more entries than fit in a
+    single keyboard page."""
+    if source.kind in ("discovered", "discovered_stale"):
+        return True
+    return len(source.models) > _MODELS_PAGE_SIZE
+
+
+def _render_models_keyboard(
+    current: str,
+    source: ProviderModelSource,
+    *,
+    page: int = 0,
+) -> InlineKeyboardMarkup:
+    """Build the inline keyboard for /models.
+
+    Curated sources at or below page size render flat with direct
+    `model:<id>` callbacks (the historical UX). Discovered sources
+    render alphabetically-sorted in pages of `_MODELS_PAGE_SIZE`,
+    using indirect `model_pick:<cache_gen>:<index>` callback_data so
+    OpenRouter IDs that exceed Telegram's 64-byte callback limit stay
+    selectable. A `cache_gen` mismatch at click time means a
+    background refresh landed between render and click; the click
+    handler rejects with a `catalogue changed` message instead of
+    selecting the wrong model.
+    """
+    if source.kind == "curated":
+        buttons = []
+        for key, name in source.models.items():
+            label = f"{name} \U0001f7e2" if key == current else name
+            buttons.append([InlineKeyboardButton(label, callback_data=f"model:{key}")])
+        return InlineKeyboardMarkup(buttons)
+
+    # Discovered / discovered_stale. cache_gen is set for both kinds.
+    assert source.cache_gen is not None, "discovered source must carry cache_gen"
+    ids = sorted(source.models.keys())
+    start = page * _MODELS_PAGE_SIZE
+    end = start + _MODELS_PAGE_SIZE
+    page_ids = ids[start:end]
+    buttons: list[list[InlineKeyboardButton]] = []
+    for offset, model_id in enumerate(page_ids):
+        absolute_index = start + offset
+        # 3-digit zero-padded index; OpenRouter is at 340 today, well
+        # under 1000. P2 raises the width if a provider exceeds.
+        callback = f"model_pick:{source.cache_gen}:{absolute_index:03d}"
+        display = source.models.get(model_id, model_id)
+        label = f"{display} \U0001f7e2" if model_id == current else display
+        buttons.append([InlineKeyboardButton(label, callback_data=callback)])
+    if len(ids) > _MODELS_PAGE_SIZE:
+        nav: list[InlineKeyboardButton] = []
+        if page > 0:
+            nav.append(
+                InlineKeyboardButton(
+                    "« prev",
+                    callback_data=f"models_page:{source.cache_gen}:{page - 1}",
+                )
+            )
+        if end < len(ids):
+            nav.append(
+                InlineKeyboardButton(
+                    "next »",
+                    callback_data=f"models_page:{source.cache_gen}:{page + 1}",
+                )
+            )
+        if nav:
+            buttons.append(nav)
     return InlineKeyboardMarkup(buttons)
+
+
+def _models_title(source: ProviderModelSource) -> str:
+    """Title text above the keyboard. Stale sources tell the operator a
+    background refresh is in flight so they understand why the
+    catalog might change between visits."""
+    if source.kind == "discovered_stale":
+        return "Choose a model (catalogue updating in background):"
+    return "Choose a model:"
 
 
 @_require_auth
@@ -910,22 +1006,22 @@ async def handle_models(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     pool = _get_pool(context)
     chat_id = _chat_id(update)
     config: Config = context.bot_data["config"]
-    models = _get_user_models(pool, chat_id, config)
+    source = _get_user_model_source(pool, chat_id, config)
 
-    if models is None:
-        # Open-ended provider - no keyboard, show current model.
-        # Use get_effective_model() so the displayed model reflects
-        # persisted settings even before the first message (when no
-        # subprocess instance exists yet after a service restart).
-        current = await pool.get_effective_model(chat_id)
+    # get_effective_model() reflects persisted settings even before
+    # the first message (when no subprocess instance exists yet after
+    # a service restart).
+    current = await pool.get_effective_model(chat_id)
+
+    if source.kind == "open_ended":
         await update.message.reply_text(
             f"Current model: {current}\nUse /model <id> to switch to any model your provider supports."
         )
         return
 
     await update.message.reply_text(
-        "Choose a model:",
-        reply_markup=_models_keyboard(await pool.get_effective_model(chat_id), models),
+        _models_title(source),
+        reply_markup=_render_models_keyboard(current, source, page=0),
     )
 
 
@@ -1002,6 +1098,127 @@ async def handle_model_callback(update: Update, context: ContextTypes.DEFAULT_TY
     )
 
 
+_CATALOGUE_CHANGED_MSG = "Catalogue changed; please re-open /models."
+
+
+async def handle_model_pick_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """
+    Handle inline keyboard model selection for discovered sources.
+
+    Callback shape: `model_pick:<cache_gen>:<index>` where
+    `<cache_gen>` is the 8-hex-char snapshot hash from the rendered
+    keyboard and `<index>` is the 3-digit alphabetical index into the
+    cached model list. The handler re-reads the discovery cache and
+    rejects the click if the catalog has changed or the cache is
+    missing/malformed/truncated, so a background refresh that lands
+    between render and click cannot route the click to the wrong
+    model.
+    """
+    assert update.callback_query is not None
+    query = update.callback_query
+    config: Config = context.bot_data["config"]
+    if not _is_authorized(config, _user_id(update)):
+        await query.answer("Not authorized.")
+        return
+    assert query.data is not None
+    parts = query.data.split(":", 2)
+    if len(parts) != 3:
+        await query.answer(_CATALOGUE_CHANGED_MSG)
+        return
+    _, click_gen, index_str = parts
+    try:
+        index = int(index_str)
+    except ValueError:
+        await query.answer(_CATALOGUE_CHANGED_MSG)
+        return
+
+    pool = _get_pool(context)
+    chat_id = _chat_id(update)
+    # schedule_refresh=False on the click path: we want to resolve
+    # against the current cache and either succeed or reject. If the
+    # cache is stale, a separate background refresh from the initial
+    # /models render is already in flight (or will be scheduled by the
+    # next /models). Avoids piling refresh tasks per click.
+    source = _get_user_model_source(pool, chat_id, config, schedule_refresh=False)
+    if source.kind not in ("discovered", "discovered_stale"):
+        await query.answer()
+        await query.edit_message_text(_CATALOGUE_CHANGED_MSG, reply_markup=InlineKeyboardMarkup([]))
+        return
+    if source.cache_gen != click_gen:
+        await query.answer()
+        await query.edit_message_text(_CATALOGUE_CHANGED_MSG, reply_markup=InlineKeyboardMarkup([]))
+        return
+    ids = sorted(source.models.keys())
+    if index < 0 or index >= len(ids):
+        await query.answer()
+        await query.edit_message_text(_CATALOGUE_CHANGED_MSG, reply_markup=InlineKeyboardMarkup([]))
+        return
+    model = ids[index]
+
+    backend, provider = _get_user_backend_provider(pool, chat_id, config)
+    if not validate_model_for_backend(model, backend, provider):
+        await query.answer("Invalid model.")
+        return
+
+    if model == await pool.get_effective_model(chat_id):
+        await query.answer()
+        await query.edit_message_text("No change.", reply_markup=InlineKeyboardMarkup([]))
+        return
+
+    await query.answer()
+    await _switch_model(context, chat_id, model)
+    display = source.models.get(model, model)
+    await query.edit_message_text(
+        f"Switched to {display}. Session restarted.",
+        reply_markup=InlineKeyboardMarkup([]),
+    )
+
+
+async def handle_models_page_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """
+    Handle pagination navigation on the /models keyboard.
+
+    Callback shape: `models_page:<cache_gen>:<page>`. Same cache-gen
+    binding as `handle_model_pick_callback`; a refresh that changes
+    the catalog between render and click rejects the page-flip and
+    asks the operator to re-open /models.
+    """
+    assert update.callback_query is not None
+    query = update.callback_query
+    config: Config = context.bot_data["config"]
+    if not _is_authorized(config, _user_id(update)):
+        await query.answer("Not authorized.")
+        return
+    assert query.data is not None
+    parts = query.data.split(":", 2)
+    if len(parts) != 3:
+        await query.answer(_CATALOGUE_CHANGED_MSG)
+        return
+    _, click_gen, page_str = parts
+    try:
+        page = int(page_str)
+    except ValueError:
+        await query.answer(_CATALOGUE_CHANGED_MSG)
+        return
+
+    pool = _get_pool(context)
+    chat_id = _chat_id(update)
+    source = _get_user_model_source(pool, chat_id, config, schedule_refresh=False)
+    if source.kind not in ("discovered", "discovered_stale") or source.cache_gen != click_gen:
+        await query.answer()
+        await query.edit_message_text(_CATALOGUE_CHANGED_MSG, reply_markup=InlineKeyboardMarkup([]))
+        return
+    if page < 0:
+        await query.answer(_CATALOGUE_CHANGED_MSG)
+        return
+
+    current = await pool.get_effective_model(chat_id)
+    await query.answer()
+    await query.edit_message_reply_markup(
+        reply_markup=_render_models_keyboard(current, source, page=page),
+    )
+
+
 @_require_auth
 async def handle_model(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle /model <name> - switch model directly via text command."""
@@ -1011,12 +1228,17 @@ async def handle_model(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     config: Config = context.bot_data["config"]
 
     if not context.args:
-        models = _get_user_models(pool, chat_id, config)
-        if models:
-            opts = " | ".join(sorted(models.keys()))
-            await update.message.reply_text(f"Usage: /model <{opts}>")
-        else:
+        # schedule_refresh=False on a usage-only path: the operator
+        # asked for help, not to browse. /models is where refresh
+        # scheduling belongs.
+        source = _get_user_model_source(pool, chat_id, config, schedule_refresh=False)
+        if source.kind == "open_ended":
             await update.message.reply_text("Usage: /model <model_id>")
+        elif _should_short_usage(source):
+            await update.message.reply_text(_short_usage("/model"))
+        else:
+            opts = " | ".join(sorted(source.models.keys()))
+            await update.message.reply_text(f"Usage: /model <{opts}>")
         return
 
     model = context.args[0].lower()
@@ -1070,12 +1292,14 @@ async def handle_settings(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     if field == "model":
         pool = _get_pool(context)
         if not value:
-            user_models = _get_user_models(pool, chat_id, config)
-            if user_models:
-                opts = " | ".join(sorted(user_models.keys()))
-                await update.message.reply_text(f"Usage: /settings model <{opts}>")
-            else:
+            source = _get_user_model_source(pool, chat_id, config, schedule_refresh=False)
+            if source.kind == "open_ended":
                 await update.message.reply_text("Usage: /settings model <model_id>")
+            elif _should_short_usage(source):
+                await update.message.reply_text(_short_usage("/settings model"))
+            else:
+                opts = " | ".join(sorted(source.models.keys()))
+                await update.message.reply_text(f"Usage: /settings model <{opts}>")
             return
 
         model_key = value.lower()
@@ -1793,12 +2017,14 @@ async def _handle_workspace_config(
     if field == "model":
         pool = _get_pool(context)
         if not value:
-            user_models = _get_user_models(pool, chat_id, config)
-            if user_models:
-                opts = " | ".join(sorted(user_models.keys()))
-                await update.message.reply_text(f"Usage: /workspace config model <{opts}>")
-            else:
+            source = _get_user_model_source(pool, chat_id, config, schedule_refresh=False)
+            if source.kind == "open_ended":
                 await update.message.reply_text("Usage: /workspace config model <model_id>")
+            elif _should_short_usage(source):
+                await update.message.reply_text(_short_usage("/workspace config model"))
+            else:
+                opts = " | ".join(sorted(source.models.keys()))
+                await update.message.reply_text(f"Usage: /workspace config model <{opts}>")
             return
         # Backend-aware validation
         backend, provider = _get_user_backend_provider(pool, chat_id, config)
@@ -4649,6 +4875,8 @@ def create_bot(config: Config, *, use_webhook: bool = True) -> Application:
 
     # Callback query handlers for inline keyboards (pattern-matched)
     app.add_handler(CallbackQueryHandler(handle_model_callback, pattern=r"^model:"))
+    app.add_handler(CallbackQueryHandler(handle_model_pick_callback, pattern=r"^model_pick:"))
+    app.add_handler(CallbackQueryHandler(handle_models_page_callback, pattern=r"^models_page:"))
     app.add_handler(CallbackQueryHandler(handle_voice_callback, pattern=r"^voice:"))
     app.add_handler(CallbackQueryHandler(handle_workspace_callback, pattern=r"^ws:"))
     app.add_handler(CallbackQueryHandler(memory_command.handle_memory_callback, pattern=r"^mem:"))

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -1208,8 +1208,15 @@ async def handle_models_page_callback(update: Update, context: ContextTypes.DEFA
         await query.answer()
         await query.edit_message_text(_CATALOGUE_CHANGED_MSG, reply_markup=InlineKeyboardMarkup([]))
         return
-    if page < 0:
-        await query.answer(_CATALOGUE_CHANGED_MSG)
+    # Bound the page against the current catalog size with the same
+    # defensive shape `handle_model_pick_callback` uses for indices.
+    # Without this guard, a stale or tampered `models_page:<gen>:999`
+    # whose cache_gen still matches would slice to an empty page and
+    # blank the keyboard without any explanation to the operator.
+    max_page = max(0, (len(source.models) - 1) // _MODELS_PAGE_SIZE)
+    if page < 0 or page > max_page:
+        await query.answer()
+        await query.edit_message_text(_CATALOGUE_CHANGED_MSG, reply_markup=InlineKeyboardMarkup([]))
         return
 
     current = await pool.get_effective_model(chat_id)

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -19,9 +19,17 @@ import subprocess
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
 from dotenv import load_dotenv
+
+if TYPE_CHECKING:
+    # Static-analysis-only import. `kai.discovery` imports `DATA_DIR`
+    # from this module; a runtime `from kai.discovery import ...` here
+    # would create a cycle. `model_source_for_backend` does the
+    # runtime import inside its body where the cycle is harmless.
+    from kai.discovery import ProviderModelSource
 
 log = logging.getLogger(__name__)
 
@@ -707,6 +715,91 @@ def models_for_backend(agent_backend: str, eff_provider: str) -> dict[str, str] 
     if eff_provider in OPEN_ENDED_PROVIDERS:
         return None
     return PROVIDER_MODELS.get(eff_provider)
+
+
+def model_source_for_backend(
+    agent_backend: str,
+    eff_provider: str,
+    *,
+    schedule_refresh: bool = True,
+) -> "ProviderModelSource":
+    """Runtime model surface for the given (backend, provider) pair.
+
+    Bot/UI-only sibling to `models_for_backend`. Consults the model
+    discovery cache for discoverable providers (currently openrouter)
+    and may schedule a background refresh on an absent or stale read.
+    Synchronous; never blocks on HTTP.
+
+    Returns a `ProviderModelSource` whose `.kind` tells the caller how
+    to render: "discovered" / "discovered_stale" come with a cached
+    model dict and a `cache_gen` suitable for binding callback_data;
+    "curated" wraps the same dicts `models_for_backend` returns for
+    static providers; "open_ended" is the free-text fallback.
+
+    Do NOT call from install.py. The installer uses
+    `models_for_backend` so it stays free of event-loop / cache
+    assumptions.
+
+    Args:
+        agent_backend: Active backend (claude / codex / goose / opencode).
+        eff_provider: Effective provider for non-codex backends.
+        schedule_refresh: When False, never schedule a background
+            refresh even on an absent or stale cache. Used by the
+            admin refresh CLI, which drives the refresh itself and
+            does not want a duplicate task on the bot's loop.
+
+    Returns:
+        ProviderModelSource describing the current surface.
+    """
+    # Local imports so the module-level `from kai.config import DATA_DIR`
+    # in kai.discovery does not become a cycle. config.py is loaded
+    # first (its DATA_DIR is referenced by discovery's top-level
+    # import); discovery is imported lazily here when the function
+    # actually runs.
+    from kai.discovery import ProviderModelSource, get_provider_model_source
+
+    if agent_backend == "codex":
+        return ProviderModelSource(
+            kind="curated",
+            models=CODEX_MODELS,
+            refreshed_at=None,
+            cache_gen=None,
+        )
+    if agent_backend == "opencode":
+        return ProviderModelSource(
+            kind="open_ended",
+            models={},
+            refreshed_at=None,
+            cache_gen=None,
+        )
+    if eff_provider == "openrouter":
+        return get_provider_model_source("openrouter", schedule_refresh=schedule_refresh)
+    if eff_provider in OPEN_ENDED_PROVIDERS:
+        # ollama in P1; Phase 2a brings it into discovery.
+        return ProviderModelSource(
+            kind="open_ended",
+            models={},
+            refreshed_at=None,
+            cache_gen=None,
+        )
+    curated = PROVIDER_MODELS.get(eff_provider)
+    if curated is None:
+        # Unknown provider with no curated list. Mirrors the
+        # `models_for_backend` "None" branch so the keyboard handler
+        # falls through to the text-input UI rather than rendering an
+        # empty keyboard.
+        return ProviderModelSource(
+            kind="open_ended",
+            models={},
+            refreshed_at=None,
+            cache_gen=None,
+        )
+    return ProviderModelSource(
+        kind="curated",
+        models=curated,
+        refreshed_at=None,
+        cache_gen=None,
+    )
 
 
 def get_user_backend_and_provider(user_config: "UserConfig | None", config: "Config") -> tuple[str, str]:

--- a/src/kai/discovery.py
+++ b/src/kai/discovery.py
@@ -456,20 +456,20 @@ async def refresh_provider_models(
     prior = _read_cache(provider)
     prior_models = prior[0] if prior is not None else {}
 
-    # An empty fetch result against a non-empty prior cache is almost
-    # always an upstream incident (the catalog endpoint returned an
-    # empty `data` array, or a row-shape change dropped every entry
-    # past the per-row id filter). Preserving the prior snapshot here
-    # is the same "operator-visible model list survives a transient
-    # outage" contract the network-failure path enforces. Without this
-    # guard the runtime path would commit the empty result, /models
-    # would render an empty keyboard, and the operator would lose
-    # access to the stale catalog they could have kept selecting from.
-    if not new_models and prior_models:
-        raise RefreshError(
-            f"{provider}: fetch returned an empty catalog while a prior cache "
-            f"with {len(prior_models)} models exists; refusing to overwrite"
-        )
+    # An empty fetch result is treated as an upstream fault, never as
+    # a steady state. Two failure modes this rejects:
+    #   - Non-empty prior cache: writing `{}` would destroy a working
+    #     catalog the operator was still selecting from.
+    #   - No prior cache (first run): writing `{}` would lock in
+    #     `kind="discovered"` against an empty map for one TTL,
+    #     rendering an empty keyboard instead of the open-ended
+    #     fallback that lets the operator type a model id while the
+    #     provider recovers.
+    # Discoverable providers in P1 (openrouter) never legitimately
+    # report zero models; raise so the cache stays absent or unchanged
+    # and the next scheduled refresh has a chance to recover.
+    if not new_models:
+        raise RefreshError(f"{provider}: fetch returned an empty catalog; refusing to write")
 
     added = sorted(set(new_models) - set(prior_models))
     removed = sorted(set(prior_models) - set(new_models))

--- a/src/kai/discovery.py
+++ b/src/kai/discovery.py
@@ -455,6 +455,22 @@ async def refresh_provider_models(
 
     prior = _read_cache(provider)
     prior_models = prior[0] if prior is not None else {}
+
+    # An empty fetch result against a non-empty prior cache is almost
+    # always an upstream incident (the catalog endpoint returned an
+    # empty `data` array, or a row-shape change dropped every entry
+    # past the per-row id filter). Preserving the prior snapshot here
+    # is the same "operator-visible model list survives a transient
+    # outage" contract the network-failure path enforces. Without this
+    # guard the runtime path would commit the empty result, /models
+    # would render an empty keyboard, and the operator would lose
+    # access to the stale catalog they could have kept selecting from.
+    if not new_models and prior_models:
+        raise RefreshError(
+            f"{provider}: fetch returned an empty catalog while a prior cache "
+            f"with {len(prior_models)} models exists; refusing to overwrite"
+        )
+
     added = sorted(set(new_models) - set(prior_models))
     removed = sorted(set(prior_models) - set(new_models))
 

--- a/src/kai/discovery.py
+++ b/src/kai/discovery.py
@@ -1,0 +1,470 @@
+"""
+Provider model discovery: cached on disk, refreshed in the background,
+falls back gracefully when a provider catalog is unreachable.
+
+Phase 1 supports a single discoverable provider (`openrouter`) and the
+synchronous open-ended fallback for the rest. Other providers are still
+served by the curated `PROVIDER_MODELS` / `CODEX_MODELS` constants in
+`kai.config`; this module is the place new fetchers land in later
+phases without touching the curated surfaces.
+
+The runtime contract:
+
+1. `get_provider_model_source(provider)` is the synchronous read. It
+   never blocks on HTTP. On an absent or stale cache for a
+   discoverable provider it schedules a background refresh and
+   returns the current (possibly empty) cache contents tagged with
+   `kind` so the UI can label it.
+2. `refresh_provider_models(provider)` is the async writer. It is
+   called from the background scheduler and from
+   `python -m kai.refresh_models`. On failure it raises
+   `RefreshError`; the on-disk cache is untouched so a transient
+   outage cannot corrupt the operator-visible model list.
+
+Validation lives in `kai.config.validate_model_for_backend`; this
+module never decides whether a model id is acceptable, only what the
+catalog says is on offer right now.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import tempfile
+import time
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import aiohttp
+
+from kai.config import DATA_DIR
+
+log = logging.getLogger(__name__)
+
+
+# ── Constants ────────────────────────────────────────────────────────
+
+
+# Bump when the cache file shape changes in a way the reader cannot
+# tolerate. Cache files with a mismatched version are treated as
+# absent and overwritten by the next refresh; no hand-migration step.
+_SCHEMA_VERSION = 1
+
+# 24 hours. OpenRouter publishes new models on the order of days, not
+# seconds; a sub-day TTL would burn API budget without UX benefit.
+_DISCOVERY_TTL_SECONDS = 86_400
+
+# Per-call timeout for a provider catalog fetch. The fetchers are
+# called from a background task; an unresponsive provider should not
+# pile up tasks waiting for a timeout that never arrives.
+_REFRESH_TIMEOUT_SECONDS = 10.0
+
+# Hex characters of the cache snapshot hash that get embedded in
+# Telegram callback_data. 8 hex chars = 32 bits of entropy, plenty
+# for catching a between-render-and-click cache change, and short
+# enough to fit comfortably under Telegram's 64-byte callback limit
+# alongside the `model_pick:` prefix and a 3-digit index.
+_CACHE_GEN_LEN = 8
+
+
+# ── Public types ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ProviderModelSource:
+    """
+    Resolved model surface for one provider at the time of read.
+
+    `kind` tells the UI how to render:
+        - "discovered": cached models within TTL.
+        - "discovered_stale": cached models past TTL; a background
+          refresh is in flight (or was just scheduled) and the next
+          read after it completes will return "discovered".
+        - "curated": static list from PROVIDER_MODELS / CODEX_MODELS.
+        - "open_ended": no list available; UI should prompt for free
+          text and the validator will accept any string.
+
+    `cache_gen` is a short hash over the `models` map, used by the
+    /models keyboard to bind callback_data to a specific catalog
+    snapshot so a refresh that lands between render and click can be
+    detected and rejected with a "catalogue changed" message.
+
+    Attributes:
+        kind: One of "discovered", "discovered_stale", "curated",
+            "open_ended".
+        models: id -> display label. Empty for "open_ended".
+        refreshed_at: Unix timestamp of the cached fetch, or None for
+            non-discovered kinds.
+        cache_gen: 8-hex-char snapshot hash, or None for non-discovered
+            kinds.
+    """
+
+    kind: Literal["discovered", "discovered_stale", "curated", "open_ended"]
+    models: Mapping[str, str]
+    refreshed_at: float | None
+    cache_gen: str | None
+
+
+@dataclass(frozen=True)
+class RefreshResult:
+    """
+    Successful outcome of `refresh_provider_models`.
+
+    Returned only on success. On failure the function raises
+    `RefreshError`; callers can rely on this dataclass never carrying
+    an error state.
+
+    Attributes:
+        provider: Provider whose cache was refreshed.
+        models_added: Ids present in the new fetch and absent from the
+            prior cache (empty if no prior cache existed; the entire
+            new list lives in `models` on disk).
+        models_removed: Ids present in the prior cache and absent from
+            the new fetch.
+        total: Total ids in the new fetch.
+        refreshed_at: Unix timestamp written to the new cache file.
+    """
+
+    provider: str
+    models_added: list[str]
+    models_removed: list[str]
+    total: int
+    refreshed_at: float
+
+
+class RefreshError(Exception):
+    """
+    Raised by `refresh_provider_models` on any failure path.
+
+    Wraps network errors, timeouts, non-2xx responses, and response
+    parse failures into a single exception class so callers do not
+    need to enumerate every aiohttp / asyncio error type. The on-disk
+    cache is guaranteed untouched when this is raised.
+    """
+
+
+# ── Module state ─────────────────────────────────────────────────────
+
+
+# Per-provider fetcher dispatch. Populated below as each fetcher is
+# defined. A provider absent from this map is non-discoverable: reads
+# get the synchronous fallback and no refresh is ever scheduled.
+_FETCHERS: dict[str, Callable[[float], Awaitable[dict[str, str]]]] = {}
+
+
+# Background-refresh dedupe. A `/models` spam from one chat would
+# otherwise stack identical fetches against the upstream provider.
+# Tasks self-evict in `_evict` so a poisoned entry cannot block the
+# scheduler forever.
+_refresh_tasks: dict[str, asyncio.Task[RefreshResult]] = {}
+
+
+# ── Cache file IO ────────────────────────────────────────────────────
+
+
+def _cache_dir() -> Path:
+    """
+    Return the discovery cache directory, creating it on first use.
+
+    Mode 0o755 so the bot (running as the `kai` service user) can read
+    and write, and other users on the host can read for debugging.
+    """
+    d = DATA_DIR / "discovery"
+    d.mkdir(mode=0o755, parents=True, exist_ok=True)
+    return d
+
+
+def _cache_path(provider: str) -> Path:
+    """Filesystem path for one provider's cache file."""
+    return _cache_dir() / f"{provider}.json"
+
+
+def _compute_cache_gen(models: Mapping[str, str]) -> str:
+    """
+    Short hash that binds a rendered keyboard to a catalog snapshot.
+
+    Sorting the items before serialization is load-bearing: dict
+    iteration order is insertion order, so two semantically identical
+    caches built from different fetcher orderings would otherwise
+    produce different hashes and cause spurious cache-gen mismatches.
+    """
+    canonical = json.dumps(dict(sorted(models.items())), separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:_CACHE_GEN_LEN]
+
+
+def _read_cache(provider: str) -> tuple[Mapping[str, str], float, str] | None:
+    """
+    Return (models, refreshed_at, cache_gen) on a usable cache, None on:
+    - Missing file.
+    - JSON parse failure (a malformed cache must not escape as
+      JSONDecodeError to /models; treat as absent and let the caller
+      schedule a refresh).
+    - Schema version mismatch.
+    - Structural mismatch (missing or wrong-typed required fields).
+
+    All id and display values are coerced to str so a hand-edited
+    cache cannot leak non-string values to the keyboard renderer.
+    """
+    path = _cache_path(provider)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        log.warning("discovery: malformed cache for %s; treating as absent", provider)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("schema_version") != _SCHEMA_VERSION:
+        return None
+    models = payload.get("models")
+    refreshed_at = payload.get("refreshed_at")
+    if not isinstance(models, dict) or not isinstance(refreshed_at, (int, float)):
+        return None
+    cleaned = {str(k): str(v) for k, v in models.items()}
+    return cleaned, float(refreshed_at), _compute_cache_gen(cleaned)
+
+
+def _write_cache_atomic(provider: str, models: Mapping[str, str], refreshed_at: float) -> None:
+    """
+    Write the cache via tempfile + os.replace so a mid-write failure
+    leaves the prior cache file byte-for-byte unchanged.
+
+    The temp file lives in the cache directory so os.replace is a
+    same-filesystem rename (atomic on POSIX). A NamedTemporaryFile in
+    /tmp would risk EXDEV on hosts where /var/lib and /tmp live on
+    different filesystems.
+    """
+    path = _cache_path(provider)
+    payload = {
+        "schema_version": _SCHEMA_VERSION,
+        "provider": provider,
+        "refreshed_at": refreshed_at,
+        "models": dict(models),
+    }
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f"{provider}.",
+        suffix=".json.tmp",
+        dir=path.parent,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, sort_keys=True)
+        os.replace(tmp_name, path)
+        # mkstemp creates with mode 0o600; widen to 0o644 so admin
+        # debugging from a different OS user can read the file.
+        os.chmod(path, 0o644)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+# ── Refresh scheduling ───────────────────────────────────────────────
+
+
+def _is_discoverable(provider: str) -> bool:
+    """A provider is discoverable iff a fetcher is registered for it."""
+    return provider in _FETCHERS
+
+
+def _schedule_refresh(provider: str) -> None:
+    """
+    Schedule a background refresh for `provider` on the running loop.
+
+    No-ops in three cases:
+    - No event loop is running. Synchronous callers (admin CLI, tests)
+      cannot drive an async task, so silently skip rather than crash.
+    - A refresh for this provider is already in flight. Dedupes the
+      common `/models` spam pattern.
+    - The provider is not discoverable. The fetcher dispatch would
+      raise inside the task, so don't start it.
+    """
+    if not _is_discoverable(provider):
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    if provider in _refresh_tasks:
+        return
+    task = loop.create_task(refresh_provider_models(provider))
+    _refresh_tasks[provider] = task
+    task.add_done_callback(lambda t, p=provider: _evict_task(p, t))
+
+
+def _evict_task(provider: str, task: asyncio.Task[RefreshResult]) -> None:
+    """
+    Drop the finished task from the dedupe map and log any failure.
+
+    Pop unconditionally even if the task raised so a poisoned entry
+    cannot block the next refresh from being scheduled.
+    """
+    _refresh_tasks.pop(provider, None)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        log.warning("discovery: background refresh for %s failed: %s", provider, exc)
+
+
+# ── Read path ────────────────────────────────────────────────────────
+
+
+def get_provider_model_source(
+    provider: str,
+    *,
+    schedule_refresh: bool = True,
+) -> ProviderModelSource:
+    """
+    Synchronously resolve the current model surface for `provider`.
+
+    Reads the on-disk cache, decides fresh / stale / fallback, and on
+    an absent or stale cache for a discoverable provider schedules a
+    background refresh (when `schedule_refresh=True` AND an event loop
+    is running). The read path itself never blocks on HTTP: the worst
+    case is a single JSON parse of a small cache file and a cheap
+    sha256.
+
+    Phase 1 only knows `openrouter` as a discoverable provider; other
+    providers always return `kind="open_ended"` here. Callers that
+    need the curated dict (installer wizard, validation) keep going
+    through `models_for_backend` in `kai.config`.
+
+    Args:
+        provider: Provider name (e.g. "openrouter").
+        schedule_refresh: When True and a loop is running, an
+            absent/stale read may schedule a background refresh. Set
+            False from the admin CLI, which drives the refresh itself.
+
+    Returns:
+        ProviderModelSource describing the read.
+    """
+    cache = _read_cache(provider)
+    if cache is None:
+        if schedule_refresh:
+            _schedule_refresh(provider)
+        return ProviderModelSource(
+            kind="open_ended",
+            models={},
+            refreshed_at=None,
+            cache_gen=None,
+        )
+    models, refreshed_at, cache_gen = cache
+    if (time.time() - refreshed_at) < _DISCOVERY_TTL_SECONDS:
+        return ProviderModelSource(
+            kind="discovered",
+            models=models,
+            refreshed_at=refreshed_at,
+            cache_gen=cache_gen,
+        )
+    if schedule_refresh:
+        _schedule_refresh(provider)
+    return ProviderModelSource(
+        kind="discovered_stale",
+        models=models,
+        refreshed_at=refreshed_at,
+        cache_gen=cache_gen,
+    )
+
+
+# ── Fetchers ─────────────────────────────────────────────────────────
+
+
+async def _fetch_openrouter(timeout: float) -> dict[str, str]:
+    """
+    Fetch the OpenRouter model catalog.
+
+    `GET https://openrouter.ai/api/v1/models` returns
+    `{"data": [{"id": "...", "name": "...", ...}, ...]}`. The endpoint
+    does not require an API key. Phase 1 surfaces every catalog row
+    without modality filtering; a Phase 2 follow-up may layer a
+    chat-suitable-only filter on top.
+    """
+    url = "https://openrouter.ai/api/v1/models"
+    client_timeout = aiohttp.ClientTimeout(total=timeout)
+    async with (
+        aiohttp.ClientSession() as session,
+        session.get(url, timeout=client_timeout) as resp,
+    ):
+        resp.raise_for_status()
+        payload = await resp.json()
+    if not isinstance(payload, dict):
+        raise RefreshError(f"openrouter: unexpected response shape (root is {type(payload).__name__})")
+    data = payload.get("data")
+    if not isinstance(data, list):
+        raise RefreshError("openrouter: response missing or non-list 'data' field")
+    out: dict[str, str] = {}
+    for row in data:
+        if not isinstance(row, dict):
+            continue
+        model_id = row.get("id")
+        if not isinstance(model_id, str) or not model_id:
+            continue
+        name = row.get("name")
+        display = name if isinstance(name, str) and name else model_id
+        out[model_id] = display
+    return out
+
+
+_FETCHERS["openrouter"] = _fetch_openrouter
+
+
+# ── Refresh ──────────────────────────────────────────────────────────
+
+
+async def refresh_provider_models(
+    provider: str,
+    *,
+    timeout: float = _REFRESH_TIMEOUT_SECONDS,
+) -> RefreshResult:
+    """
+    Refresh one provider's cache and return the diff against the prior
+    contents.
+
+    On any failure path (no fetcher, network error, timeout, non-2xx,
+    parse error) raises `RefreshError` and leaves the on-disk cache
+    untouched. On success writes the cache atomically and returns
+    `RefreshResult` for the caller's diff output.
+
+    Args:
+        provider: Provider name. Must have a fetcher registered.
+        timeout: Per-request timeout in seconds.
+
+    Raises:
+        RefreshError: On any fetch or parse failure.
+    """
+    fetcher = _FETCHERS.get(provider)
+    if fetcher is None:
+        raise RefreshError(f"{provider}: no fetcher registered; not a discoverable provider")
+    try:
+        new_models = await fetcher(timeout)
+    except RefreshError:
+        raise
+    except Exception as exc:
+        raise RefreshError(f"{provider}: fetch failed ({type(exc).__name__}: {exc})") from exc
+
+    prior = _read_cache(provider)
+    prior_models = prior[0] if prior is not None else {}
+    added = sorted(set(new_models) - set(prior_models))
+    removed = sorted(set(prior_models) - set(new_models))
+
+    refreshed_at = time.time()
+    _write_cache_atomic(provider, new_models, refreshed_at)
+
+    return RefreshResult(
+        provider=provider,
+        models_added=added,
+        models_removed=removed,
+        total=len(new_models),
+        refreshed_at=refreshed_at,
+    )

--- a/src/kai/refresh_models.py
+++ b/src/kai/refresh_models.py
@@ -1,26 +1,34 @@
-"""Opt-in refresh helper for `PROVIDER_MODELS`.
+"""Admin audit and one-shot cache refresh for provider model lists.
 
-Operator runs `python -m kai.refresh_models` (or `make refresh-models`)
-to query each curated provider's `/v1/models` endpoint and print a
-unified diff against the in-tree `PROVIDER_MODELS[provider]` keys.
-The command never writes source files; operator review of the diff
-is the trust boundary. Pass `--write-snippet` to emit a paste-able
-Python fragment to stdout that the operator copies into
-`src/kai/config.py` by hand.
+`/models`'s background refresh is the runtime freshness mechanism;
+this command is the operator-facing audit and on-demand refresh tool.
+
+Curated providers (anthropic, openai, google): the command queries
+each provider's `/v1/models` endpoint and prints a unified diff
+against the in-tree `PROVIDER_MODELS[provider]` keys. The command
+never writes source files; operator review of the diff is the trust
+boundary. Pass `--write-snippet` to emit a paste-able Python fragment
+that the operator copies into `src/kai/config.py` by hand.
+
+Discovered providers (openrouter): the command calls the discovery
+layer's refresh directly and prints a diff against the prior on-disk
+cache. The discovery cache is written atomically on success;
+unchanged on failure.
 
 Exit codes:
-- 0: every queried provider responded; no diff against the in-tree
+- 0: every queried provider responded; no diff against the prior
      list (or every queried provider was skipped for missing auth).
 - 1: every queried provider responded; at least one provider has a
      diff (new and / or retired models).
 - 2: at least one provider failed to respond (network error, 5xx,
      unexpected response shape). Other providers' diffs still print.
 
-Per-provider auth comes from `PROVIDER_KEY_VARS`. A provider whose
-API key is unset in env skips with a `"skipped: no API key"` notice;
-this is not counted as a failure (exit 2 reserves for actual remote
-faults). OpenRouter and Ollama are absent from `PROVIDER_MODELS`
-today (open-ended providers) and skip with a one-line notice.
+Per-provider auth for curated providers comes from
+`PROVIDER_KEY_VARS`. A provider whose API key is unset in env skips
+with a `"skipped: no API key"` notice; this is not counted as a
+failure (exit 2 reserves for actual remote faults). Ollama is
+absent from both `PROVIDER_MODELS` and Phase 1's discovery layer and
+skips with a one-line notice; Phase 2a brings it into discovery.
 """
 
 from __future__ import annotations
@@ -158,6 +166,48 @@ def _render_snippet(provider: str, remote_models: list[str]) -> str:
     return "\n".join(lines)
 
 
+async def _refresh_openrouter() -> tuple[int, list[str]]:
+    """Refresh the OpenRouter discovery cache and print a diff.
+
+    Calls the discovery layer's `refresh_provider_models` directly so
+    the bot's runtime refresh scheduler does not race against this
+    one-shot path. On a RefreshError (network failure, parse error,
+    timeout), the prior cache stays on disk and the function returns
+    status 2 with the error appended to the output lines.
+    """
+    import time
+
+    from kai.discovery import RefreshError, get_provider_model_source, refresh_provider_models
+
+    lines: list[str] = []
+    prior = get_provider_model_source("openrouter", schedule_refresh=False)
+    if prior.kind == "open_ended" or prior.refreshed_at is None:
+        lines.append("openrouter: cache empty (first refresh)")
+    else:
+        age_hours = (time.time() - prior.refreshed_at) / 3600
+        lines.append(f"openrouter: cache age {age_hours:.1f}h, {len(prior.models)} models")
+
+    try:
+        result = await refresh_provider_models("openrouter")
+    except RefreshError as exc:
+        lines.append(f"openrouter: ERROR ({exc})")
+        return 2, lines
+
+    summary_bits = [f"{result.total} models"]
+    if result.models_added:
+        summary_bits.append(f"{len(result.models_added)} new")
+    if result.models_removed:
+        summary_bits.append(f"{len(result.models_removed)} retired")
+    lines.append("openrouter: " + ", ".join(summary_bits))
+    for m in result.models_added:
+        lines.append(f"  +  {m}")
+    for m in result.models_removed:
+        lines.append(f"  -  {m}")
+
+    status = 1 if (result.models_added or result.models_removed) else 0
+    return status, lines
+
+
 async def _refresh_one(provider: str, *, write_snippet: bool) -> tuple[int, list[str]]:
     """Refresh one provider's model list.
 
@@ -166,6 +216,8 @@ async def _refresh_one(provider: str, *, write_snippet: bool) -> tuple[int, list
         1 = diff present
         2 = fetch failed
     """
+    if provider == "openrouter":
+        return await _refresh_openrouter()
     if provider not in _provider_fetchers:
         return 0, [f"{provider}: skipped (open-ended provider; no curated list to diff)"]
     key_var = PROVIDER_KEY_VARS.get(provider, "")
@@ -194,9 +246,13 @@ async def _main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="python -m kai.refresh_models",
         description=(
-            "Query each curated provider's /v1/models endpoint and print a "
-            "diff against PROVIDER_MODELS in src/kai/config.py. Never writes "
-            "source files; operator hand-edits config.py after reviewing the diff."
+            "Admin audit and one-shot cache refresh for provider model "
+            "lists. Curated providers print a diff against the in-tree "
+            "PROVIDER_MODELS (never writes source files; the operator "
+            "hand-edits src/kai/config.py after reviewing the diff). "
+            "Discovered providers refresh the on-disk discovery cache "
+            "directly. The runtime freshness mechanism is /models's "
+            "background refresh; this command is operator-facing."
         ),
     )
     parser.add_argument(

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -31,9 +31,9 @@ from kai.bot import (
     _handle_workspace_deny,
     _is_authorized,
     _is_notify_chat_used,
-    _models_keyboard,
     _notify_if_queued,
     _prepend_queue_marker,
+    _render_models_keyboard,
     _reply_safe,
     _require_auth,
     _resolve_workspace_path,
@@ -56,7 +56,9 @@ from kai.bot import (
     handle_message,
     handle_model,
     handle_model_callback,
+    handle_model_pick_callback,
     handle_models,
+    handle_models_page_callback,
     handle_new,
     handle_photo,
     handle_review_command,
@@ -75,6 +77,7 @@ from kai.bot import (
     handle_workspaces,
 )
 from kai.config import PROVIDER_MODELS, Config, UserConfig
+from kai.discovery import ProviderModelSource
 from kai.review import CollectionWarning, PRReviewResult
 from kai.tts import DEFAULT_VOICE, VOICES
 from kai.workspace_utils import is_workspace_allowed
@@ -944,27 +947,34 @@ class TestEditMessageSafe:
         assert len(sent) <= 4096
 
 
-# ── _models_keyboard ─────────────────────────────────────────────────
+# ── _render_models_keyboard ──────────────────────────────────────────
 
 
 class TestModelsKeyboard:
-    # Use Anthropic's curated models for keyboard tests
-    _anthropic_models = PROVIDER_MODELS["anthropic"]
+    """Curated-source rendering (the historical UX). Discovered-source
+    rendering is covered by `TestDiscoveredKeyboard` below."""
+
+    _curated_source = ProviderModelSource(
+        kind="curated",
+        models=PROVIDER_MODELS["anthropic"],
+        refreshed_at=None,
+        cache_gen=None,
+    )
 
     def test_current_model_gets_green_dot(self):
-        kb = _models_keyboard("sonnet", self._anthropic_models)
+        kb = _render_models_keyboard("sonnet", self._curated_source)
         labels = _button_labels(kb)
         assert any("\U0001f7e2" in lbl and "Sonnet" in lbl for lbl in labels)
 
     def test_all_models_present(self):
-        kb = _models_keyboard("sonnet", self._anthropic_models)
+        kb = _render_models_keyboard("sonnet", self._curated_source)
         callbacks = _button_callbacks(kb)
         assert "model:opus" in callbacks
         assert "model:sonnet" in callbacks
         assert "model:haiku" in callbacks
 
     def test_callback_data_format(self):
-        kb = _models_keyboard("opus", self._anthropic_models)
+        kb = _render_models_keyboard("opus", self._curated_source)
         callbacks = _button_callbacks(kb)
         assert all(c.startswith("model:") for c in callbacks)
 
@@ -6511,3 +6521,327 @@ class TestHandleReviewCommand:
             await handle_review_command(update, ctx)
 
         assert mock_generate.call_args.kwargs["local_repo_path"] == "/home/workspace"
+
+
+# ── Model discovery: keyboard, callbacks, usage paths ────────────────
+
+
+def _seed_openrouter_cache(
+    monkeypatch,
+    tmp_path: Path,
+    models: dict[str, str],
+    *,
+    stale: bool = False,
+) -> str:
+    """Write a discovery cache to a tmp DATA_DIR and return the
+    cache_gen the layer would compute for it.
+
+    Tests use the returned `cache_gen` to build callback strings that
+    match what `_render_models_keyboard` would emit, so an "ok" path
+    and a "stale gen" path can both be exercised against the same
+    cache shape.
+    """
+    import json
+    import time as _time
+
+    from kai import discovery as _disc
+    from kai.discovery import (
+        _DISCOVERY_TTL_SECONDS,
+        _SCHEMA_VERSION,
+        _cache_path,
+        _compute_cache_gen,
+    )
+
+    monkeypatch.setattr(_disc, "DATA_DIR", tmp_path)
+    _disc._refresh_tasks.clear()
+    path = _cache_path("openrouter")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    refreshed_at = (_time.time() - _DISCOVERY_TTL_SECONDS - 60) if stale else _time.time()
+    payload = {
+        "schema_version": _SCHEMA_VERSION,
+        "provider": "openrouter",
+        "refreshed_at": refreshed_at,
+        "models": models,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return _compute_cache_gen(models)
+
+
+def _redirect_discovery_data_dir(monkeypatch, tmp_path: Path) -> None:
+    """Point discovery at a tmp directory without seeding a cache; the
+    absent-cache path is what tests exercise."""
+    from kai import discovery as _disc
+
+    monkeypatch.setattr(_disc, "DATA_DIR", tmp_path)
+    _disc._refresh_tasks.clear()
+
+
+def _discovered_source(models: dict[str, str], cache_gen: str = "abcd1234") -> ProviderModelSource:
+    return ProviderModelSource(kind="discovered", models=models, refreshed_at=1.0, cache_gen=cache_gen)
+
+
+class TestDiscoveredKeyboard:
+    """Discovered-source rendering: indirect callback data,
+    pagination, byte-length safety for oversized IDs."""
+
+    _SMALL = {f"prov{i}/m{i}": f"M{i}" for i in range(5)}
+    _AT_THRESHOLD = {f"prov/m{i:03d}": f"M{i}" for i in range(20)}
+    _OVER_THRESHOLD = {f"prov/m{i:03d}": f"M{i}" for i in range(25)}
+
+    def test_keyboard_uses_model_pick_prefix(self):
+        kb = _render_models_keyboard("", _discovered_source(self._SMALL))
+        callbacks = _button_callbacks(kb)
+        assert all(c.startswith("model_pick:") for c in callbacks)
+
+    def test_keyboard_does_not_paginate_at_threshold(self):
+        """20 models render flat with no nav row, matching the curated
+        UX cutoff so the operator does not see a navigation bar for a
+        small catalog."""
+        kb = _render_models_keyboard("", _discovered_source(self._AT_THRESHOLD))
+        callbacks = _button_callbacks(kb)
+        assert all(c.startswith("model_pick:") for c in callbacks)
+        assert len(callbacks) == 20
+
+    def test_keyboard_paginates_over_threshold(self):
+        """25 models on page 0 show 20 model rows plus a `next »`
+        button keyed against the same cache_gen."""
+        kb = _render_models_keyboard("", _discovered_source(self._OVER_THRESHOLD, cache_gen="cafef00d"))
+        callbacks = _button_callbacks(kb)
+        model_picks = [c for c in callbacks if c.startswith("model_pick:")]
+        page_buttons = [c for c in callbacks if c.startswith("models_page:")]
+        assert len(model_picks) == 20
+        assert page_buttons == ["models_page:cafef00d:1"]
+
+    def test_callback_data_within_64_bytes_for_oversized_openrouter_id(self):
+        """The live OpenRouter catalog has an ID that overflows the
+        64-byte callback_data limit when used with a direct
+        `model:<id>` prefix. The indirect `model_pick:<gen>:<index>`
+        scheme bounds every button at ~23 bytes regardless of the
+        underlying ID length."""
+        oversized = "cognitivecomputations/dolphin-mistral-24b-venice-edition:free"
+        models = {oversized: "Dolphin Mistral 24B Venice :free"}
+        kb = _render_models_keyboard("", _discovered_source(models, cache_gen="aaaaaaaa"))
+        for row in kb.inline_keyboard:
+            for button in row:
+                assert len(button.callback_data.encode("utf-8")) <= 64
+
+    def test_keyboard_marks_current_model_with_green_dot(self):
+        kb = _render_models_keyboard("prov/m003", _discovered_source(self._OVER_THRESHOLD))
+        labels = _button_labels(kb)
+        assert any("\U0001f7e2" in lbl for lbl in labels)
+
+
+class TestHandleModelsDiscovery:
+    @pytest.mark.asyncio
+    async def test_discovered_keyboard_uses_cached_models(self, tmp_path, monkeypatch):
+        _seed_openrouter_cache(
+            monkeypatch,
+            tmp_path,
+            {f"prov/m{i:03d}": f"M{i}" for i in range(5)},
+        )
+        pool = _make_mock_claude(model="prov/m000", provider="openrouter")
+        update = _make_update()
+        ctx = _make_context(claude=pool)
+        await handle_models(update, ctx)
+        call = update.message.reply_text.call_args
+        assert "Choose a model" in call[0][0]
+        assert "catalogue updating" not in call[0][0]
+        callbacks = _button_callbacks(call[1]["reply_markup"])
+        assert all(c.startswith("model_pick:") for c in callbacks)
+
+    @pytest.mark.asyncio
+    async def test_discovered_stale_titles_message(self, tmp_path, monkeypatch):
+        _seed_openrouter_cache(
+            monkeypatch,
+            tmp_path,
+            {f"prov/m{i:03d}": f"M{i}" for i in range(5)},
+            stale=True,
+        )
+        pool = _make_mock_claude(model="prov/m000", provider="openrouter")
+        update = _make_update()
+        ctx = _make_context(claude=pool)
+        await handle_models(update, ctx)
+        title = update.message.reply_text.call_args[0][0]
+        assert "catalogue updating in background" in title
+
+    @pytest.mark.asyncio
+    async def test_open_ended_when_cache_absent_for_openrouter(self, tmp_path, monkeypatch):
+        _redirect_discovery_data_dir(monkeypatch, tmp_path)
+        pool = _make_mock_claude(model="anthropic/claude-sonnet-4.5", provider="openrouter")
+        update = _make_update()
+        ctx = _make_context(claude=pool)
+        await handle_models(update, ctx)
+        call = update.message.reply_text.call_args
+        reply = call[0][0]
+        assert "Current model" in reply
+        assert "/model" in reply
+        assert call[1].get("reply_markup") is None or "reply_markup" not in call[1]
+
+
+class TestHandleModelPickCallback:
+    @pytest.mark.asyncio
+    async def test_selects_correct_model_for_oversized_id(self, tmp_path, monkeypatch):
+        """An ID too large for direct callback_data still routes
+        correctly because the click carries an index instead of the
+        id itself."""
+        oversized = "cognitivecomputations/dolphin-mistral-24b-venice-edition:free"
+        models = {oversized: "Dolphin", "z/last": "Z"}
+        cache_gen = _seed_openrouter_cache(monkeypatch, tmp_path, models)
+        ids = sorted(models.keys())
+        index = ids.index(oversized)
+        pool = _make_mock_claude(model="z/last", provider="openrouter")
+        update = _make_callback_update(data=f"model_pick:{cache_gen}:{index:03d}")
+        ctx = _make_context(claude=pool)
+        with (
+            patch("kai.bot.sessions.clear_session", new_callable=AsyncMock),
+            patch("kai.bot.sessions.set_user_setting", new_callable=AsyncMock),
+            patch("kai.bot.sessions.delete_workspace_config_setting", new_callable=AsyncMock),
+        ):
+            await handle_model_pick_callback(update, ctx)
+        pool.set_model.assert_called_once_with(ANY, oversized)
+
+    @pytest.mark.asyncio
+    async def test_stale_cache_gen_rejects_gracefully(self, tmp_path, monkeypatch):
+        """A click whose cache_gen no longer matches the on-disk
+        catalog edits the message with the catalogue-changed notice
+        and does NOT route the click."""
+        _seed_openrouter_cache(monkeypatch, tmp_path, {"a/one": "One", "b/two": "Two"})
+        pool = _make_mock_claude(model="a/one", provider="openrouter")
+        update = _make_callback_update(data="model_pick:deadbeef:000")
+        ctx = _make_context(claude=pool)
+        await handle_model_pick_callback(update, ctx)
+        edit_text = update.callback_query.edit_message_text.call_args[0][0]
+        assert "Catalogue changed" in edit_text
+        pool.set_model.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_cache_rejects_gracefully(self, tmp_path, monkeypatch):
+        """A click that arrives after the cache file is deleted gets
+        the catalogue-changed notice; the handler does not raise."""
+        _redirect_discovery_data_dir(monkeypatch, tmp_path)
+        pool = _make_mock_claude(model="a/one", provider="openrouter")
+        update = _make_callback_update(data="model_pick:deadbeef:000")
+        ctx = _make_context(claude=pool)
+        await handle_model_pick_callback(update, ctx)
+        edit_text = update.callback_query.edit_message_text.call_args[0][0]
+        assert "Catalogue changed" in edit_text
+
+    @pytest.mark.asyncio
+    async def test_malformed_cache_rejects_gracefully(self, tmp_path, monkeypatch):
+        """A corrupt cache file at click time gets the
+        catalogue-changed notice. JSONDecodeError does not propagate."""
+        from kai import discovery as _disc
+        from kai.discovery import _cache_path
+
+        monkeypatch.setattr(_disc, "DATA_DIR", tmp_path)
+        _disc._refresh_tasks.clear()
+        path = _cache_path("openrouter")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{this is not json", encoding="utf-8")
+        pool = _make_mock_claude(model="a/one", provider="openrouter")
+        update = _make_callback_update(data="model_pick:deadbeef:000")
+        ctx = _make_context(claude=pool)
+        await handle_model_pick_callback(update, ctx)
+        edit_text = update.callback_query.edit_message_text.call_args[0][0]
+        assert "Catalogue changed" in edit_text
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_index_rejects_gracefully(self, tmp_path, monkeypatch):
+        """A click whose index is beyond the cached list (e.g. a
+        truncated or tampered callback) gets the catalogue-changed
+        notice. No IndexError propagates."""
+        cache_gen = _seed_openrouter_cache(monkeypatch, tmp_path, {"a/one": "One"})
+        pool = _make_mock_claude(model="a/one", provider="openrouter")
+        update = _make_callback_update(data=f"model_pick:{cache_gen}:999")
+        ctx = _make_context(claude=pool)
+        await handle_model_pick_callback(update, ctx)
+        edit_text = update.callback_query.edit_message_text.call_args[0][0]
+        assert "Catalogue changed" in edit_text
+
+
+class TestHandleModelsPageCallback:
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_rejected(self, tmp_path, monkeypatch):
+        """The page callback shares the authorization gate that
+        model_pick uses; unauthorized users get the not-authorized
+        answer rather than a new keyboard."""
+        _seed_openrouter_cache(monkeypatch, tmp_path, {"a/one": "One"})
+        update = _make_callback_update(data="models_page:deadbeef:1", user_id=99)
+        ctx = _make_context(config=_make_config(allowed_user_ids={1}))
+        await handle_models_page_callback(update, ctx)
+        update.callback_query.answer.assert_called_once_with("Not authorized.")
+
+
+class TestUsageStringsForDiscoveredSource:
+    """The /model, /settings model, and /workspace config model
+    no-args usage paths collapse to a short generic sentence for any
+    discovered or large source. A 340-model OpenRouter catalog joined
+    with ` | ` is ~9 KB; the short form keeps every command's no-args
+    reply well under Telegram's 4096-char limit."""
+
+    _LARGE = {f"prov/m{i:03d}": f"M{i}" for i in range(25)}
+
+    @pytest.mark.asyncio
+    async def test_model_command_usage_short_for_discovered_source(self, tmp_path, monkeypatch):
+        _seed_openrouter_cache(monkeypatch, tmp_path, self._LARGE)
+        pool = _make_mock_claude(model="prov/m000", provider="openrouter")
+        update = _make_update()
+        ctx = _make_context(claude=pool, args=[])
+        await handle_model(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert reply == "Usage: /model <model_id>. Use /models to browse available models."
+        assert " | " not in reply
+
+    @pytest.mark.asyncio
+    async def test_settings_model_usage_short_for_discovered_source(self, tmp_path, monkeypatch):
+        from contextlib import ExitStack
+
+        _seed_openrouter_cache(monkeypatch, tmp_path, self._LARGE)
+        pool = _make_mock_claude(model="prov/m000", provider="openrouter")
+        update = _make_update(text="/settings model")
+        ctx = _make_context(claude=pool, args=["model"])
+        mock_sessions = AsyncMock()
+        mock_sessions.get_user_settings = AsyncMock(return_value={})
+        with ExitStack() as stack:
+            stack.enter_context(patch("kai.bot.sessions", mock_sessions))
+            await handle_settings(update, ctx)
+        reply = update.message.reply_text.call_args[0][0]
+        assert reply == "Usage: /settings model <model_id>. Use /models to browse available models."
+        assert " | " not in reply
+
+    @pytest.mark.asyncio
+    async def test_workspace_config_model_usage_short_for_discovered_source(self, tmp_path, monkeypatch):
+        from contextlib import ExitStack
+
+        _seed_openrouter_cache(monkeypatch, tmp_path, self._LARGE)
+        pool = _make_mock_claude(model="prov/m000", provider="openrouter")
+        update = _make_update(text="/workspace config model")
+        ctx = _make_context(claude=pool)
+        mock_sessions = AsyncMock()
+        mock_sessions.get_workspace_config_settings = AsyncMock(return_value={})
+        with ExitStack() as stack:
+            stack.enter_context(patch("kai.bot.sessions", mock_sessions))
+            await _handle_workspace_config(update, ctx, "config model")
+        reply = update.message.reply_text.call_args[0][0]
+        assert reply == ("Usage: /workspace config model <model_id>. Use /models to browse available models.")
+        assert " | " not in reply
+
+    @pytest.mark.asyncio
+    async def test_model_command_validates_independent_of_discovery_cache(self, tmp_path, monkeypatch):
+        """A `/model <id>` on openrouter still passes validation when
+        the discovery cache is empty; openrouter is open-ended in
+        `validate_model_for_backend`, so a model the cache has not
+        yet learned about is still selectable via text command.
+        Otherwise an operator who knows a freshly-released ID could
+        not use it until the next background refresh landed."""
+        _redirect_discovery_data_dir(monkeypatch, tmp_path)
+        pool = _make_mock_claude(model="anthropic/claude-sonnet-4.5", provider="openrouter")
+        update = _make_update()
+        ctx = _make_context(claude=pool, args=["anthropic/claude-sonnet-4.5"])
+        with (
+            patch("kai.bot.sessions.clear_session", new_callable=AsyncMock),
+            patch("kai.bot.sessions.set_user_setting", new_callable=AsyncMock),
+            patch("kai.bot.sessions.delete_workspace_config_setting", new_callable=AsyncMock),
+        ):
+            await handle_model(update, ctx)
+        pool.set_model.assert_called_once_with(ANY, "anthropic/claude-sonnet-4.5")

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -6771,6 +6771,41 @@ class TestHandleModelsPageCallback:
         await handle_models_page_callback(update, ctx)
         update.callback_query.answer.assert_called_once_with("Not authorized.")
 
+    @pytest.mark.asyncio
+    async def test_legitimate_next_page_returns_remaining_models(self, tmp_path, monkeypatch):
+        """The happy path: 25-model catalog, page 1 renders the
+        remaining 5 model_pick buttons (and only a `« prev` nav button,
+        because we are at the last page)."""
+        models = {f"prov/m{i:03d}": f"M{i}" for i in range(25)}
+        cache_gen = _seed_openrouter_cache(monkeypatch, tmp_path, models)
+        pool = _make_mock_claude(model="prov/m000", provider="openrouter")
+        update = _make_callback_update(data=f"models_page:{cache_gen}:1")
+        ctx = _make_context(claude=pool)
+        await handle_models_page_callback(update, ctx)
+        update.callback_query.edit_message_reply_markup.assert_called_once()
+        kb = update.callback_query.edit_message_reply_markup.call_args.kwargs["reply_markup"]
+        callbacks = _button_callbacks(kb)
+        model_picks = [c for c in callbacks if c.startswith("model_pick:")]
+        page_buttons = [c for c in callbacks if c.startswith("models_page:")]
+        assert len(model_picks) == 5
+        assert page_buttons == [f"models_page:{cache_gen}:0"]
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_page_rejects_gracefully(self, tmp_path, monkeypatch):
+        """A page index beyond the cache size (stale or tampered
+        callback) gets the catalogue-changed notice instead of an
+        empty keyboard. Mirrors the defensive shape the model_pick
+        path uses for out-of-range indices."""
+        models = {f"prov/m{i:03d}": f"M{i}" for i in range(25)}
+        cache_gen = _seed_openrouter_cache(monkeypatch, tmp_path, models)
+        pool = _make_mock_claude(model="prov/m000", provider="openrouter")
+        update = _make_callback_update(data=f"models_page:{cache_gen}:999")
+        ctx = _make_context(claude=pool)
+        await handle_models_page_callback(update, ctx)
+        edit_text = update.callback_query.edit_message_text.call_args[0][0]
+        assert "Catalogue changed" in edit_text
+        update.callback_query.edit_message_reply_markup.assert_not_called()
+
 
 class TestUsageStringsForDiscoveredSource:
     """The /model, /settings model, and /workspace config model

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,470 @@
+"""
+Tests for the provider model discovery layer.
+
+Covers the synchronous read path (cache hit / stale / absent /
+malformed / schema-mismatch), the background-refresh scheduler and
+its dedupe, the OpenRouter fetcher's parse rules, atomic writes, and
+the import-cycle smoke that pins the topology between
+`kai.config.model_source_for_backend` and `kai.discovery`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kai import discovery
+from kai.discovery import (
+    _DISCOVERY_TTL_SECONDS,
+    _SCHEMA_VERSION,
+    ProviderModelSource,
+    RefreshError,
+    RefreshResult,
+    _cache_path,
+    _compute_cache_gen,
+    _fetch_openrouter,
+    get_provider_model_source,
+    refresh_provider_models,
+)
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_discovery_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Isolate each test from the others.
+
+    - DATA_DIR is redirected to a per-test tmp directory so cache
+      reads and writes touch only that tree.
+    - The module-level dedupe map is cleared so a leftover task from
+      a prior test cannot poison the current schedule.
+    - Any in-flight tasks are cancelled at teardown.
+    """
+    monkeypatch.setattr(discovery, "DATA_DIR", tmp_path)
+    discovery._refresh_tasks.clear()
+    yield
+    for task in list(discovery._refresh_tasks.values()):
+        task.cancel()
+    discovery._refresh_tasks.clear()
+
+
+def _write_cache(provider: str, models: dict[str, str], refreshed_at: float) -> None:
+    """Helper: write a well-formed cache file directly without going
+    through the discovery layer's write path. Used to seed the cache
+    in tests for the read path."""
+    path = _cache_path(provider)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, Any] = {
+        "schema_version": _SCHEMA_VERSION,
+        "provider": provider,
+        "refreshed_at": refreshed_at,
+        "models": models,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _register_fetcher(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    returns: dict[str, str] | None = None,
+    raises: BaseException | None = None,
+    event: asyncio.Event | None = None,
+    block_until: asyncio.Event | None = None,
+    counter: list[int] | None = None,
+) -> None:
+    """Helper: swap the openrouter fetcher for a controllable async
+    function. Restored at test teardown by monkeypatch.
+
+    `returns`/`raises` decide the outcome. `event` (set just before
+    return) and `block_until` (awaited before return) give tests
+    deterministic control over the call ordering. `counter` (a single-
+    element list used as a mutable counter) lets the dedupe tests
+    count call entries without smuggling a closure variable.
+    """
+
+    async def fetcher(_timeout: float) -> dict[str, str]:
+        if counter is not None:
+            counter[0] += 1
+        if event is not None:
+            event.set()
+        if block_until is not None:
+            await block_until.wait()
+        if raises is not None:
+            raise raises
+        return dict(returns or {})
+
+    monkeypatch.setitem(discovery._FETCHERS, "openrouter", fetcher)
+
+
+# ── Read path: absent cache ──────────────────────────────────────────
+
+
+async def test_absent_cache_for_discoverable_provider_schedules_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First /models on a fresh install returns the open-ended
+    fallback AND kicks off a background refresh so the cache
+    bootstraps. Without this the first read goes dark and the cache
+    is never populated by the runtime path."""
+    fetched = asyncio.Event()
+    _register_fetcher(monkeypatch, returns={"a/b": "Ay Bee"}, event=fetched)
+
+    source = get_provider_model_source("openrouter")
+    assert source.kind == "open_ended"
+    assert source.models == {}
+    # Refresh task is registered in the dedupe map under the running
+    # loop's lifetime; await its completion to keep the fixture's
+    # teardown loop clean.
+    assert "openrouter" in discovery._refresh_tasks
+    await asyncio.wait_for(fetched.wait(), timeout=1.0)
+    await asyncio.gather(*discovery._refresh_tasks.values(), return_exceptions=True)
+
+
+def test_absent_cache_for_discoverable_provider_no_loop_does_not_crash() -> None:
+    """In synchronous test contexts there is no running loop. The
+    scheduler is a no-op rather than raising, so the discovery layer
+    stays callable from any context (admin CLI, sync tests)."""
+    source = get_provider_model_source("openrouter")
+    assert source.kind == "open_ended"
+    assert "openrouter" not in discovery._refresh_tasks
+
+
+def test_absent_cache_for_non_discoverable_provider_does_not_schedule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider without a fetcher cannot be refreshed; the scheduler
+    must not enqueue a task that would raise inside the fetcher
+    dispatch. Verified under a fresh dedupe map."""
+    source = get_provider_model_source("not-a-real-provider")
+    assert source.kind == "open_ended"
+    assert "not-a-real-provider" not in discovery._refresh_tasks
+
+
+# ── Read path: schema and parse failures ─────────────────────────────
+
+
+async def test_schema_version_mismatch_invalidates_cache_and_schedules_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cache file from a future schema cannot be read safely; treat
+    as absent and schedule a refresh that will overwrite it."""
+    path = _cache_path("openrouter")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"schema_version": 0, "provider": "openrouter", "refreshed_at": 0.0, "models": {}}),
+        encoding="utf-8",
+    )
+    fetched = asyncio.Event()
+    _register_fetcher(monkeypatch, returns={"new/model": "New"}, event=fetched)
+
+    source = get_provider_model_source("openrouter")
+    assert source.kind == "open_ended"
+    assert "openrouter" in discovery._refresh_tasks
+    await asyncio.wait_for(fetched.wait(), timeout=1.0)
+    await asyncio.gather(*discovery._refresh_tasks.values(), return_exceptions=True)
+
+
+async def test_malformed_cache_invalidates_and_schedules_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A corrupt cache file (invalid JSON) must not let
+    JSONDecodeError escape to /models. Treat as absent, schedule a
+    refresh, return the open-ended fallback synchronously."""
+    path = _cache_path("openrouter")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{this is not json", encoding="utf-8")
+    fetched = asyncio.Event()
+    _register_fetcher(monkeypatch, returns={"new/model": "New"}, event=fetched)
+
+    source = get_provider_model_source("openrouter")
+    assert source.kind == "open_ended"
+    assert "openrouter" in discovery._refresh_tasks
+    await asyncio.wait_for(fetched.wait(), timeout=1.0)
+    await asyncio.gather(*discovery._refresh_tasks.values(), return_exceptions=True)
+
+
+# ── Read path: fresh and stale cache ─────────────────────────────────
+
+
+def test_cache_fresh_returns_discovered_without_refresh() -> None:
+    """A cache within TTL returns kind=discovered and the scheduler
+    does NOT enqueue a refresh; the data is good."""
+    _write_cache("openrouter", {"a/b": "Ay Bee"}, time.time() - 60)
+    source = get_provider_model_source("openrouter")
+    assert source.kind == "discovered"
+    assert source.models == {"a/b": "Ay Bee"}
+    assert source.cache_gen is not None
+    assert "openrouter" not in discovery._refresh_tasks
+
+
+async def test_cache_stale_returns_discovered_stale_and_schedules_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cache past TTL is still served (kind=discovered_stale) so
+    the keyboard does not go dark, but a refresh is scheduled in the
+    background to bring the cache forward."""
+    _write_cache("openrouter", {"a/b": "Ay Bee"}, time.time() - _DISCOVERY_TTL_SECONDS - 60)
+    fetched = asyncio.Event()
+    _register_fetcher(monkeypatch, returns={"a/b": "Ay Bee"}, event=fetched)
+
+    source = get_provider_model_source("openrouter")
+    assert source.kind == "discovered_stale"
+    assert "openrouter" in discovery._refresh_tasks
+    await asyncio.wait_for(fetched.wait(), timeout=1.0)
+    await asyncio.gather(*discovery._refresh_tasks.values(), return_exceptions=True)
+
+
+# ── Refresh dedupe ───────────────────────────────────────────────────
+
+
+async def test_concurrent_stale_reads_dedupe_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A chat-spam of /models against a stale cache must collapse to a
+    single in-flight refresh per provider; otherwise OpenRouter sees
+    one request per click."""
+    _write_cache("openrouter", {"a/b": "Ay Bee"}, time.time() - _DISCOVERY_TTL_SECONDS - 60)
+    block = asyncio.Event()
+    counter = [0]
+    _register_fetcher(monkeypatch, returns={"a/b": "Ay Bee"}, block_until=block, counter=counter)
+
+    get_provider_model_source("openrouter")
+    get_provider_model_source("openrouter")
+    get_provider_model_source("openrouter")
+    # All three reads share one task.
+    assert len(discovery._refresh_tasks) == 1
+    block.set()
+    await asyncio.gather(*discovery._refresh_tasks.values(), return_exceptions=True)
+    assert counter[0] == 1
+
+
+async def test_concurrent_absent_reads_dedupe_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same dedupe property must hold for the absent-cache bootstrap
+    path: two simultaneous first /models calls do not stack two
+    network fetches against an upstream that just went live."""
+    block = asyncio.Event()
+    counter = [0]
+    _register_fetcher(monkeypatch, returns={"a/b": "Ay Bee"}, block_until=block, counter=counter)
+
+    get_provider_model_source("openrouter")
+    get_provider_model_source("openrouter")
+    assert len(discovery._refresh_tasks) == 1
+    block.set()
+    await asyncio.gather(*discovery._refresh_tasks.values(), return_exceptions=True)
+    assert counter[0] == 1
+
+
+# ── Refresh write path ───────────────────────────────────────────────
+
+
+async def test_refresh_writes_cache_atomically(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Successful refresh writes via tempfile + os.replace. The
+    atomicity property: a write that completes leaves the new cache
+    in place; no .tmp detritus survives."""
+    _register_fetcher(monkeypatch, returns={"a/b": "Ay Bee", "c/d": "See Dee"})
+    result = await refresh_provider_models("openrouter")
+    assert isinstance(result, RefreshResult)
+    assert result.total == 2
+
+    path = _cache_path("openrouter")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == _SCHEMA_VERSION
+    assert payload["models"] == {"a/b": "Ay Bee", "c/d": "See Dee"}
+    # No leftover temp files from the atomic-write dance.
+    assert not list(path.parent.glob("*.tmp"))
+
+
+async def test_refresh_failure_raises_RefreshError_and_preserves_prior_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A network failure mid-refresh must leave the cache byte-for-
+    byte unchanged so the next /models still works against the prior
+    snapshot. The exception type is RefreshError so the admin CLI
+    has a single class to catch."""
+    _write_cache("openrouter", {"a/b": "Ay Bee"}, time.time() - 60)
+    path = _cache_path("openrouter")
+    prior_bytes = path.read_bytes()
+
+    _register_fetcher(monkeypatch, raises=OSError("simulated network drop"))
+    with pytest.raises(RefreshError):
+        await refresh_provider_models("openrouter")
+    assert path.read_bytes() == prior_bytes
+
+    # Next read still sees the prior cache as a usable snapshot.
+    source = get_provider_model_source("openrouter", schedule_refresh=False)
+    assert source.kind == "discovered"
+    assert source.models == {"a/b": "Ay Bee"}
+
+
+# ── OpenRouter fetcher ───────────────────────────────────────────────
+
+
+class _MockResponse:
+    """Minimal context-manager response stand-in for aiohttp's
+    ClientSession.get(...). raise_for_status() is a no-op; json() is
+    awaitable. The session/request shape is mirrored by _MockSession
+    below."""
+
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    async def __aenter__(self) -> _MockResponse:
+        return self
+
+    async def __aexit__(self, *_a: Any) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def json(self) -> Any:
+        return self._payload
+
+
+class _MockSession:
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    async def __aenter__(self) -> _MockSession:
+        return self
+
+    async def __aexit__(self, *_a: Any) -> None:
+        return None
+
+    def get(self, *_args: Any, **_kwargs: Any) -> _MockResponse:
+        return _MockResponse(self._payload)
+
+
+def _patch_aiohttp(monkeypatch: pytest.MonkeyPatch, payload: Any) -> None:
+    """Replace aiohttp.ClientSession with a stub that returns `payload`
+    from session.get().json()."""
+    import aiohttp
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda: _MockSession(payload))
+
+
+async def test_openrouter_fetcher_parses_id_and_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Rows with a `name` use it as display; rows without `name` fall
+    back to `id` as both key and display."""
+    _patch_aiohttp(
+        monkeypatch,
+        {
+            "data": [
+                {"id": "a/one", "name": "First"},
+                {"id": "b/two", "name": "Second"},
+                {"id": "c/three"},
+            ]
+        },
+    )
+    result = await _fetch_openrouter(10.0)
+    assert result == {
+        "a/one": "First",
+        "b/two": "Second",
+        "c/three": "c/three",
+    }
+
+
+async def test_openrouter_fetcher_skips_rows_without_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rows lacking an `id` field are dropped silently. A future
+    OpenRouter schema change that adds non-model rows must not break
+    Kai's read."""
+    _patch_aiohttp(
+        monkeypatch,
+        {
+            "data": [
+                {"id": "a/one", "name": "First"},
+                {"name": "No id"},
+                {"id": "", "name": "Empty id"},
+                "not a dict",
+            ]
+        },
+    )
+    result = await _fetch_openrouter(10.0)
+    assert result == {"a/one": "First"}
+
+
+# ── Cache snapshot identity ──────────────────────────────────────────
+
+
+def test_cache_gen_changes_when_models_change() -> None:
+    """cache_gen binds a keyboard to a specific catalog snapshot. Two
+    caches with the same models must produce the same hash; adding a
+    model must change it. Otherwise the callback-rejection mechanism
+    on background refresh cannot distinguish snapshots."""
+    a = {"x/y": "Display"}
+    b = {"x/y": "Display"}
+    c = {"x/y": "Display", "p/q": "Other"}
+    assert _compute_cache_gen(a) == _compute_cache_gen(b)
+    assert _compute_cache_gen(a) != _compute_cache_gen(c)
+
+
+# ── schedule_refresh=False contract ──────────────────────────────────
+
+
+def test_schedule_refresh_false_never_schedules_on_absent_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Admin CLI calls with schedule_refresh=False because it drives
+    the refresh itself. The read must NOT also schedule a background
+    task on the bot's loop; otherwise concurrent refreshes race."""
+    _register_fetcher(monkeypatch, returns={"a/b": "Ay Bee"})
+    source = get_provider_model_source("openrouter", schedule_refresh=False)
+    assert source.kind == "open_ended"
+    assert "openrouter" not in discovery._refresh_tasks
+
+
+def test_schedule_refresh_false_never_schedules_on_stale_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same contract on the stale-cache branch."""
+    _write_cache("openrouter", {"a/b": "Ay Bee"}, time.time() - _DISCOVERY_TTL_SECONDS - 60)
+    _register_fetcher(monkeypatch, returns={"a/b": "Ay Bee"})
+    source = get_provider_model_source("openrouter", schedule_refresh=False)
+    assert source.kind == "discovered_stale"
+    assert "openrouter" not in discovery._refresh_tasks
+
+
+# ── Cache directory permissions ──────────────────────────────────────
+
+
+async def test_cache_dir_created_with_correct_mode(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """First write under a fresh DATA_DIR creates the discovery
+    directory at mode 0o755 so admin debugging from another OS user
+    can read the cache."""
+    _register_fetcher(monkeypatch, returns={"a/b": "Ay Bee"})
+    await refresh_provider_models("openrouter")
+    cache_dir = tmp_path / "discovery"
+    assert cache_dir.is_dir()
+    assert (cache_dir.stat().st_mode & 0o777) == 0o755
+
+
+# ── Import topology smoke ────────────────────────────────────────────
+
+
+def test_import_cycle_smoke() -> None:
+    """Pin the no-cycle property between kai.config and kai.discovery.
+
+    A future contributor who adds a top-level `from kai.discovery
+    import ProviderModelSource` to config.py would re-introduce the
+    cycle this PR carefully avoids. This smoke imports both modules
+    fresh (well, observes them already imported in the test process)
+    and calls the cross-module entry point: a successful return with
+    a usable kind proves the topology holds."""
+    import kai.config
+    import kai.discovery
+
+    assert kai.config is not None
+    assert kai.discovery is not None
+    source = kai.config.model_source_for_backend("goose", "openrouter", schedule_refresh=False)
+    assert isinstance(source, ProviderModelSource)
+    assert source.kind in ("discovered", "discovered_stale", "open_ended")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -282,6 +282,26 @@ async def test_refresh_writes_cache_atomically(monkeypatch: pytest.MonkeyPatch) 
     assert not list(path.parent.glob("*.tmp"))
 
 
+async def test_refresh_with_empty_result_and_nonempty_prior_raises_refresh_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An upstream incident that returns a shape-valid but semantically
+    empty catalog (e.g. `{"data": []}`) must NOT overwrite a working
+    prior cache with `{}`. Without this guard, the next /models read
+    would see `kind="discovered"` against an empty map and render a
+    keyboard with zero buttons, taking the operator from "stale but
+    usable" to "no usable surface" on a transient upstream fault.
+    """
+    _write_cache("openrouter", {"a/b": "Ay Bee", "c/d": "See Dee"}, time.time() - 60)
+    path = _cache_path("openrouter")
+    prior_bytes = path.read_bytes()
+
+    _register_fetcher(monkeypatch, returns={})
+    with pytest.raises(RefreshError):
+        await refresh_provider_models("openrouter")
+    assert path.read_bytes() == prior_bytes
+
+
 async def test_refresh_failure_raises_RefreshError_and_preserves_prior_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -302,6 +302,29 @@ async def test_refresh_with_empty_result_and_nonempty_prior_raises_refresh_error
     assert path.read_bytes() == prior_bytes
 
 
+async def test_refresh_with_empty_result_and_no_prior_raises_refresh_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a first-run install, an empty fetch must also raise rather
+    than write an empty cache. Otherwise the next read would lock in
+    `kind="discovered"` against an empty map for one TTL, rendering
+    an empty keyboard instead of the open-ended fallback that lets
+    the operator type a model id while OpenRouter recovers.
+    """
+    path = _cache_path("openrouter")
+    assert not path.exists()
+
+    _register_fetcher(monkeypatch, returns={})
+    with pytest.raises(RefreshError):
+        await refresh_provider_models("openrouter")
+    assert not path.exists()
+
+    # Next read still takes the open-ended fallback (which the bot
+    # surfaces as a text prompt), not an empty discovered keyboard.
+    source = get_provider_model_source("openrouter", schedule_refresh=False)
+    assert source.kind == "open_ended"
+
+
 async def test_refresh_failure_raises_RefreshError_and_preserves_prior_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_refresh_models.py
+++ b/tests/test_refresh_models.py
@@ -1,0 +1,179 @@
+"""
+Tests for the `python -m kai.refresh_models` admin command.
+
+Covers the OpenRouter branch (writes the discovery cache, prints the
+diff, maps fetcher failures to exit 2 with prior-cache preservation)
+and pins that the existing curated-provider fetchers still produce
+their PROVIDER_MODELS diff output.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kai import discovery, refresh_models
+from kai.discovery import _SCHEMA_VERSION, _cache_path
+
+
+@pytest.fixture(autouse=True)
+def _isolate_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect the discovery cache to a per-test tmp directory and
+    clear any leftover refresh tasks between tests."""
+    monkeypatch.setattr(discovery, "DATA_DIR", tmp_path)
+    discovery._refresh_tasks.clear()
+    yield
+    discovery._refresh_tasks.clear()
+
+
+def _register_openrouter_fetcher(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    returns: dict[str, str] | None = None,
+    raises: BaseException | None = None,
+) -> None:
+    """Swap the discovery layer's openrouter fetcher for a controllable
+    async function. The admin CLI calls discovery.refresh_provider_models
+    which dispatches through the same _FETCHERS map the runtime uses,
+    so monkeypatching there exercises the real CLI path."""
+
+    async def fetcher(_timeout: float) -> dict[str, str]:
+        if raises is not None:
+            raise raises
+        return dict(returns or {})
+
+    monkeypatch.setitem(discovery._FETCHERS, "openrouter", fetcher)
+
+
+def _isolate_curated_providers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear API keys for the curated providers so their branches skip
+    with 'no API key' instead of attempting a real network call.
+    Tests that care about the openrouter branch only do not want noise
+    from the anthropic/openai/google paths."""
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+async def test_refresh_models_openrouter_writes_discovery_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The admin CLI's openrouter branch writes the discovery cache
+    file as a side effect of the refresh. Pins that calling the CLI
+    is sufficient to bootstrap the cache (no separate setup step
+    needed)."""
+    _isolate_curated_providers(monkeypatch)
+    _register_openrouter_fetcher(monkeypatch, returns={"a/one": "First", "b/two": "Second"})
+
+    status = await refresh_models._main([])
+    cache_path = _cache_path("openrouter")
+    assert cache_path.exists()
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == _SCHEMA_VERSION
+    assert payload["models"] == {"a/one": "First", "b/two": "Second"}
+    # First fetch with no prior cache produces an "added" diff so the
+    # status code reflects "diff present" (1), not "no change" (0).
+    assert status == 1
+
+
+async def test_refresh_models_openrouter_prints_cache_diff(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When a prior cache exists, the diff section names every added
+    and retired model. Operators rely on this output to spot upstream
+    catalog churn during an audit."""
+    _isolate_curated_providers(monkeypatch)
+    # Seed a prior cache.
+    cache_path = _cache_path("openrouter")
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "schema_version": _SCHEMA_VERSION,
+                "provider": "openrouter",
+                "refreshed_at": 0.0,
+                "models": {"old/keeper": "Keeper", "old/removed": "To Be Removed"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    _register_openrouter_fetcher(
+        monkeypatch,
+        returns={"old/keeper": "Keeper", "new/added": "Freshly Added"},
+    )
+
+    status = await refresh_models._main([])
+    out = capsys.readouterr().out
+    assert "openrouter: 2 models, 1 new, 1 retired" in out
+    assert "  +  new/added" in out
+    assert "  -  old/removed" in out
+    assert status == 1
+
+
+async def test_refresh_models_openrouter_failure_maps_to_exit_2_and_preserves_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A fetcher exception during the openrouter branch must:
+    1. Map to exit code 2 (matching the failure semantics of the
+       curated providers' /v1/models error path).
+    2. Leave the prior on-disk cache byte-for-byte unchanged so the
+       runtime /models keeps working against the prior snapshot.
+    3. Print an `openrouter: ERROR (...)` line carrying the wrapped
+       exception's type so operators can spot what failed."""
+    _isolate_curated_providers(monkeypatch)
+    cache_path = _cache_path("openrouter")
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "schema_version": _SCHEMA_VERSION,
+                "provider": "openrouter",
+                "refreshed_at": 0.0,
+                "models": {"prior/intact": "Intact"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    prior_bytes = cache_path.read_bytes()
+
+    _register_openrouter_fetcher(monkeypatch, raises=OSError("simulated outage"))
+    status = await refresh_models._main([])
+    out = capsys.readouterr().out
+
+    assert status == 2
+    assert cache_path.read_bytes() == prior_bytes
+    assert "openrouter: ERROR" in out
+    assert "OSError" in out
+
+
+async def test_refresh_models_existing_provider_fetchers_unchanged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The curated provider audit (anthropic/openai/google) still
+    produces its PROVIDER_MODELS diff output. Pins that the
+    openrouter addition did NOT change the curated audit behaviour;
+    Phase 2b will absorb these into discovery as a separate change."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    # Avoid the openrouter network call; a successful no-op response
+    # keeps the test focused on the curated branch.
+    _register_openrouter_fetcher(monkeypatch, returns={})
+
+    async def fake_anthropic(_api_key: str) -> list[str]:
+        # Return one model the in-tree PROVIDER_MODELS["anthropic"]
+        # does NOT carry so the diff line names a "new" model and the
+        # status code rises to 1.
+        return ["claude-future-model"]
+
+    monkeypatch.setitem(refresh_models._provider_fetchers, "anthropic", fake_anthropic)
+
+    status = await refresh_models._main([])
+    out = capsys.readouterr().out
+    # Diff line for anthropic appears with the new-model name.
+    assert "anthropic:" in out
+    assert "claude-future-model" in out
+    # Diff in any provider means status >= 1.
+    assert status >= 1


### PR DESCRIPTION
## Summary

Phase 1 of the model-discovery work. Adds a per-provider discovery layer in `src/kai/discovery.py` that wraps the existing curated lists in `src/kai/config.py`. Provider registration stays explicit, defaults stay curated, validation stays canonical. The Telegram `/models` keyboard now consults the layer via a new `model_source_for_backend(...)` and renders an indirect-callback paginated keyboard for discovered sources; `/model <id>`, `/settings model`, and `/workspace config model` all migrate to the same surface and collapse to a short usage sentence for discovered or large catalogs.

OpenRouter is the seed discoverable provider; cache TTL 24h with on-demand background refresh, atomic writes, dedupe, and graceful fallback. Later phases (filed separately after this lands) bring Ollama, the direct API providers, and OpenCode into the same layer.

## What changed

- **`src/kai/discovery.py` (new):** `ProviderModelSource` and `RefreshResult` dataclasses plus a `RefreshError` exception. Synchronous `get_provider_model_source(provider)` reads the on-disk cache and (when a loop is running) schedules a background refresh on absent / stale / schema-mismatched / malformed reads. Async `refresh_provider_models(provider)` performs the actual fetch and atomically writes via `tempfile + os.replace`. Module-level dedupe dict keys background tasks by provider so chat-spam of `/models` collapses to a single in-flight refresh.
- **`src/kai/config.py`:** New `model_source_for_backend(...)` dispatches per (backend, provider) to discovery for `goose+openrouter` and to the existing curated dicts for everyone else. Import topology between `config.py` and `discovery.py` uses a `TYPE_CHECKING` block, a quoted return-type annotation, and a local runtime import inside the function body to avoid a cycle (`discovery.py` imports `DATA_DIR` from `config.py` at module load).
- **`src/kai/bot.py`:** `_render_models_keyboard(current, source, page=0)` replaces the old `_models_keyboard(...)`; curated keyboards keep direct `model:<id>` callbacks, discovered keyboards use `model_pick:<cache_gen>:<index>` so OpenRouter IDs that exceed Telegram's 64-byte callback_data cap stay selectable (one already exists in the live catalog). Pagination at 20 entries per page with `models_page:<cache_gen>:<page>`. New `handle_model_pick_callback` and `handle_models_page_callback` re-read the cache on click and answer `Catalogue changed; please re-open /models.` on any stale-gen / missing / malformed / out-of-range condition. The `/model`, `/settings model`, and `/workspace config model` no-args usage replies collapse to `Usage: <cmd> <model_id>. Use /models to browse available models.` whenever the source is discovered/discovered_stale or larger than the page size. Validation is unchanged: `/model <id>` against an open-ended provider still passes without the cache being warm.
- **`src/kai/refresh_models.py`:** New openrouter branch calls `discovery.refresh_provider_models("openrouter")` directly (admin CLI bypasses the runtime scheduler with `schedule_refresh=False`), prints a cache-age summary plus added/removed diff, maps `RefreshError` to exit code 2 with the prior cache preserved. Module docstring and argparse description reworded to "admin audit and one-shot cache refresh." Existing curated-provider fetchers (anthropic, openai, google) unchanged.
- **Tests:** 18 in `tests/test_discovery.py` (new), 4 in `tests/test_refresh_models.py` (new), 18 in `tests/test_bot.py` (new) plus 3 migrated existing tests. Plus an import-cycle smoke that pins the topology so a future contributor cannot regress to a top-level `from kai.discovery import ProviderModelSource` in `config.py`.
- **Docs:** README's "Model switching" section explains the three layers (registered / discovered / curated). Wiki page draft for `Model-Discovery.md` at `/var/lib/kai/home/2114582497/docs/wiki-model-discovery.md` to push after merge.

Closes #705

## Test plan

- [x] `make check` (ruff + format) clean
- [x] `make test` clean (4598 passed, 1 skipped; +40 over `main`)
- [x] Live OpenRouter catalog has an ID at 61 bytes; the test fixture uses it and asserts every rendered button's `callback_data` is ≤64 bytes
- [x] Import-cycle smoke (`test_import_cycle_smoke`) imports `kai.config` and `kai.discovery` and round-trips through `model_source_for_backend("goose", "openrouter")`
- [x] Acceptance grep from the v3 spec: discovery module, `model_source_for_backend`, no top-level `from kai.discovery import` in `config.py`, `TYPE_CHECKING` block present, installer free of runtime-surface imports, `discovered_stale` / `catalogue updating` / `model_pick:` / `models_page:` / `Catalogue changed` all wired in `bot.py`
- [ ] Manual: post-merge admin smoke — `sudo -u kai env KAI_DATA_DIR=/var/lib/kai KAI_INSTALL_DIR=/opt/kai /opt/kai/venv/bin/python -m kai.refresh_models` to warm the OpenRouter cache against the live endpoint, then a Telegram `/models` from an openrouter-effective user
