### PR TITLE
Rename AGENT_BACKEND to DEFAULT_BACKEND

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ Workspaces can also define a system prompt via `workspaces.yaml` for workspace-s
 
 #### Memory backend selection
 
-Semantic memory extraction (the subprocess that proactively writes facts and episode summaries) routes per-user: each user's effective `agent_backend` selects the reasoner, and the model comes from the project's `MODEL_REGISTRY` for that `(role, backend)` pair. Claude-effective users get the claude reasoner with the claude-registry model; codex-effective users get the codex reasoner with the codex-registry model; opencode-effective users get the opencode reasoner with the opencode-registry model (a `provider/model` string resolved at runtime by `opencode` against the operator's `opencode auth login` state). There is no per-deployment override for the memory reasoner or model; an operator who wants a different model edits the registry in `config.py`.
+Semantic memory extraction (the subprocess that proactively writes facts and episode summaries) routes per-user: each user's effective `default_backend` selects the reasoner, and the model comes from the project's `MODEL_REGISTRY` for that `(role, backend)` pair. Claude-effective users get the claude reasoner with the claude-registry model; codex-effective users get the codex reasoner with the codex-registry model; opencode-effective users get the opencode reasoner with the opencode-registry model (a `provider/model` string resolved at runtime by `opencode` against the operator's `opencode auth login` state). There is no per-deployment override for the memory reasoner or model; an operator who wants a different model edits the registry in `config.py`.
 
 OpenCode users get the same one-shot parity as claude and codex users: PR review, issue triage, memory extraction, episode generation, and behavioral eval all dispatch through `OpenCodeOneShotReasoner`, which spawns a fresh `opencode acp` JSON-RPC subprocess per call and denies any tool-permission request mid-stream. No fall-through to `claude --print` or `codex exec` for opencode users on any one-shot site.
 
 Each backend that runs extraction on this install must have its binary reachable at startup; the bot exits at config-load otherwise with a message naming the offending backend and resolution sequence. Retrieval-only memory (`MEMORY_ENABLED=true` with extraction disabled) requires no extraction binary.
 
-To verify a memory configuration end-to-end without writing to the store, run `python -m kai.smoke.memory` from the install directory. Pass `--user-id <chat_id>` to drive the smoke under that user's effective backend (otherwise the global `AGENT_BACKEND` is used). Pass `--os-user <name>` when the effective backend resolves to codex or opencode and the target user is not the bot process user; both reasoners refuse to spawn under sudo without one. The smoke prints the resolved binary, the argv that ran, and any extracted facts.
+To verify a memory configuration end-to-end without writing to the store, run `python -m kai.smoke.memory` from the install directory. Pass `--user-id <chat_id>` to drive the smoke under that user's effective backend (otherwise the global `DEFAULT_BACKEND` is used). Pass `--os-user <name>` when the effective backend resolves to codex or opencode and the target user is not the bot process user; both reasoners refuse to spawn under sudo without one. The smoke prints the resolved binary, the argv that ran, and any extracted facts.
 
 ### Scheduled jobs
 
@@ -215,7 +215,7 @@ Authorization, per-user model selection, per-user OS isolation, per-user GitHub 
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `TELEGRAM_BOT_TOKEN` | Yes | | Bot token from BotFather |
-| `AGENT_BACKEND` | No | `claude` | Global agent backend: `claude`, `goose`, `codex`, or `opencode`. Per-user override goes in `users.yaml`. |
+| `DEFAULT_BACKEND` | No | `claude` | Global default backend: `claude`, `goose`, `codex`, or `opencode`. Per-user override goes in `users.yaml`. (The former `AGENT_BACKEND` name is still read for one release with a deprecation warning.) |
 | `LLM_PROVIDER` | Non-claude | | Global provider for non-claude backends. Per-user override in `users.yaml`. |
 | `DEFAULT_MODEL` | No | `sonnet` | Installation-wide default model. Per-user override in `users.yaml` `model`, or `/settings model`. |
 | `AGENT_TIMEOUT_SECONDS` | No | `120` | Installation-wide default per-message timeout. Per-user override in `users.yaml` `timeout`, or `/settings timeout`. |

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -1188,7 +1188,7 @@ def _revert_instance_field(pool: SubprocessPool, chat_id: int, field: str, confi
             # If the user's provider differs from the global provider, the
             # global default_model may be invalid for their provider.
             provider = instance.provider
-            effective_global = get_effective_provider(config.agent_backend, config.llm_provider)
+            effective_global = get_effective_provider(config.default_backend, config.llm_provider)
             if provider == effective_global:
                 instance.model = config.default_model
             else:
@@ -4499,7 +4499,9 @@ async def _handle_response(
                 # is mandatory here.
                 user_config = config.get_user_config(chat_id)
                 effective_backend = (
-                    user_config.agent_backend if user_config and user_config.agent_backend else config.agent_backend
+                    user_config.default_backend
+                    if user_config and user_config.default_backend
+                    else config.default_backend
                 )
                 if config.memory_extraction_enabled and effective_backend in ONESHOT_REASONER_BACKENDS:
                     # Windowed PRIOR CONTEXT for the episode classifier

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -16,6 +16,7 @@ import logging
 import os
 import pwd
 import subprocess
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
@@ -78,7 +79,7 @@ ONESHOT_REASONER_BACKENDS: frozenset[str] = frozenset({"claude", "codex", "goose
 # that needs to know "what providers can this backend talk to" reads
 # from this map. Claude and codex are 1:1 with one provider each;
 # opencode and goose are 1:N. load_config validates that every user's
-# (agent_backend, llm_provider) pair is a member. Adding a new
+# (default_backend, llm_provider) pair is a member. Adding a new
 # backend is one row here; adding a new provider to an existing
 # backend is one tuple element. Tuple values (not frozensets) so the
 # wizard offers providers in a stable, documented order; sorted
@@ -685,6 +686,69 @@ def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> b
     return validate_model_for_provider(model, eff_provider)
 
 
+# Contexts that have already emitted the AGENT_BACKEND deprecation
+# warning. Keyed by the `context` string each reader passes so a given
+# source (the env file, a specific user's yaml entry, install.conf)
+# warns at most once per process instead of once per lookup.
+_default_backend_deprecation_warned: set[str] = set()
+
+
+def _resolve_default_backend(
+    get: Callable[[str], str | None],
+    new_key: str,
+    old_key: str,
+    *,
+    context: str,
+    default: str | None,
+) -> str | None:
+    """Read the default-backend setting, preferring the new key name.
+
+    Centralizes the one-release back-compat window for the
+    `AGENT_BACKEND` -> `DEFAULT_BACKEND` rename. Every reader (env,
+    install.conf dict, per-user yaml entry) passes its own lookup
+    callable plus the key casing for its source so a single
+    implementation serves all of them.
+
+    Absence semantics differ by caller and are made explicit through
+    `default`: global readers pass `default="claude"` (the
+    installation default); the per-user yaml reader passes
+    `default=None` so a backend-less user still inherits the global
+    backend via the caller's `user_backend or global_backend` cascade.
+    Returning "claude" for an absent per-user key would wrongly pin
+    that user to claude on a non-claude install.
+
+    Args:
+        get: Lookup callable taking a key and returning value-or-None
+            (os.environ.get, env_dict.get, entry.get).
+        new_key: The current key name (DEFAULT_BACKEND / default_backend).
+        old_key: The deprecated key name (AGENT_BACKEND / agent_backend).
+        context: Human-readable source name for the one-shot
+            deprecation log line (e.g. "/etc/kai/env", "install.conf",
+            "users.yaml entry for <user>").
+        default: Value to return when neither key is set.
+
+    Returns:
+        The resolved backend string, or `default` when neither key is
+        present. Does not validate against VALID_BACKENDS; callers keep
+        their existing validation.
+    """
+    new_value = get(new_key)
+    if new_value is not None:
+        return new_value
+    old_value = get(old_key)
+    if old_value is not None:
+        if context not in _default_backend_deprecation_warned:
+            _default_backend_deprecation_warned.add(context)
+            log.warning(
+                "%s is deprecated; rename to %s (found in %s)",
+                old_key,
+                new_key,
+                context,
+            )
+        return old_value
+    return default
+
+
 def models_for_backend(agent_backend: str, eff_provider: str) -> dict[str, str] | None:
     """Curated model list for the given (backend, provider) pair.
 
@@ -712,8 +776,8 @@ def models_for_backend(agent_backend: str, eff_provider: str) -> dict[str, str] 
 def get_user_backend_and_provider(user_config: "UserConfig | None", config: "Config") -> tuple[str, str]:
     """Resolve (backend, provider) for a chat_id with the per-user cascade.
 
-    Pool.py and bot.py already implement this cascade (user.agent_backend
-    > config.agent_backend, similar for llm_provider); this function
+    Pool.py and bot.py already implement this cascade (user.default_backend
+    > config.default_backend, similar for llm_provider); this function
     consolidates it in one place so every runtime model-validation site
     sees the same effective backend for a given user. Backend determines
     provider 1:1 for codex (openai) and claude (anthropic); goose and
@@ -721,7 +785,7 @@ def get_user_backend_and_provider(user_config: "UserConfig | None", config: "Con
     value is informational - the real provider/model resolution lives
     inside OpenCode's full `provider/model` string at runtime).
     """
-    backend = user_config.agent_backend if user_config and user_config.agent_backend else config.agent_backend
+    backend = user_config.default_backend if user_config and user_config.default_backend else config.default_backend
     if backend == "claude":
         provider = "anthropic"
     elif backend == "codex":
@@ -938,7 +1002,7 @@ class UserConfig:
     allowed_workspaces: list[Path] = field(default_factory=list)
     # Per-user backend/provider override. Admin-controlled via users.yaml,
     # not user-configurable via /settings. None = use global config.
-    agent_backend: str | None = None
+    default_backend: str | None = None
     llm_provider: str | None = None
     # GitHub notification routing fields. github_repos controls which
     # repos route webhook events to this user. pr_review and issue_triage
@@ -1050,7 +1114,7 @@ class Config:
     # Codex backend auth mode. "subscription" (default): the codex CLI
     # uses ~/.codex/auth.json populated by an interactive `codex login`.
     # "api_key": codex reads OPENAI_API_KEY from the environment, the
-    # same way goose+openai does. Only consulted when AGENT_BACKEND=codex;
+    # same way goose+openai does. Only consulted when DEFAULT_BACKEND=codex;
     # ignored on every other backend.
     codex_auth_mode: str = "subscription"
 
@@ -1148,14 +1212,14 @@ class Config:
     totp_lockout_attempts: int = 3
     totp_lockout_minutes: int = 15
 
-    # Agent backend selection: "claude" (default) uses Claude Code CLI,
+    # Default backend selection: "claude" (default) uses Claude Code CLI,
     # "goose" uses Goose ACP (Agent Client Protocol) as the agent harness.
-    agent_backend: str = "claude"
+    default_backend: str = "claude"
 
     # LLM provider for non-Claude backends (e.g. Goose). Determines
     # which API key env var the backend expects and whether Kai's
     # logical model names ("sonnet", "opus") are translated to Anthropic IDs.
-    # Ignored when agent_backend="claude".
+    # Ignored when default_backend="claude".
     llm_provider: str = ""
 
     # Semantic memory system (Mem0 + Qdrant + local embeddings).
@@ -1880,7 +1944,7 @@ def _compute_extraction_eligible_backends(
         return set()
     eligible: set[str] = set()
     for uc in user_configs.values():
-        effective = uc.agent_backend or agent_backend
+        effective = uc.default_backend or agent_backend
         if effective in ONESHOT_REASONER_BACKENDS:
             eligible.add(effective)
     return eligible
@@ -1895,7 +1959,7 @@ def _apply_legacy_model_env_overrides(
     Reads PR_REVIEW_MODEL_<EFFECTIVE_BACKEND> and
     ISSUE_TRIAGE_MODEL_<EFFECTIVE_BACKEND> from the process env for
     each user. EFFECTIVE_BACKEND is the user's per-user override
-    (`uc.agent_backend`) or `default_backend` when the user has no
+    (`uc.default_backend`) or `default_backend` when the user has no
     override. The resolution is inlined as a single fallback
     expression rather than calling `get_user_backend_and_provider`,
     because the full Config object is not yet built at this point in
@@ -1919,7 +1983,7 @@ def _apply_legacy_model_env_overrides(
     warned = False
     out: dict[int, UserConfig] = {}
     for uid, uc in user_configs.items():
-        backend = uc.agent_backend or default_backend
+        backend = uc.default_backend or default_backend
         existing_models = dict(uc.models or {})
         for role_str, env_prefix in [
             ("pr_review", "PR_REVIEW_MODEL"),
@@ -1966,7 +2030,7 @@ def _compute_extraction_eligible_backend_provider_pairs(
         return set()
     eligible: set[tuple[str, str]] = set()
     for uc in user_configs.values():
-        eff_backend = uc.agent_backend or agent_backend
+        eff_backend = uc.default_backend or agent_backend
         if eff_backend not in ONESHOT_REASONER_BACKENDS:
             continue
         eff_provider = uc.llm_provider or agent_provider
@@ -2013,7 +2077,7 @@ def _load_user_configs(
     when every entry was rejected.
 
     Args:
-        global_backend: The global agent_backend from env config.
+        global_backend: The global default_backend from env config.
         global_llm_provider: The global llm_provider from env config.
             Both are needed to cascade per-user model validation:
             a user's effective provider determines which models are valid.
@@ -2151,14 +2215,25 @@ def _load_user_configs(
         if entry.get("max_budget") is not None:
             log.warning("users.yaml: 'max_budget' for %s is no longer supported; ignoring", name)
 
-        # Validate optional agent_backend (must be valid if set)
+        # Validate optional per-user default_backend (must be valid if
+        # set). Reads default_backend, falling back to the deprecated
+        # agent_backend key for one release. default=None so a user
+        # with neither key inherits the global backend below via
+        # `user_backend or global_backend`, rather than being pinned to
+        # claude.
         user_backend: str | None = None
-        raw_backend = entry.get("agent_backend")
+        raw_backend = _resolve_default_backend(
+            entry.get,
+            "default_backend",
+            "agent_backend",
+            context=f"users.yaml entry for {name}",
+            default=None,
+        )
         if raw_backend is not None:
             backend_str = str(raw_backend).strip().lower()
             if backend_str not in VALID_BACKENDS:
                 raise SystemExit(
-                    f"users.yaml: user '{name}' has invalid agent_backend '{backend_str}' "
+                    f"users.yaml: user '{name}' has invalid default_backend '{backend_str}' "
                     f"(must be one of: {', '.join(sorted(VALID_BACKENDS))})"
                 )
             user_backend = backend_str
@@ -2200,7 +2275,7 @@ def _load_user_configs(
         # resolved (neither user-level nor global), that's a fatal config error.
         if eff_backend in BACKENDS_NEEDING_PROVIDER_PROMPT and not eff_provider_str:
             raise SystemExit(
-                f"users.yaml: user '{name}' has agent_backend='{eff_backend}' but no "
+                f"users.yaml: user '{name}' has default_backend='{eff_backend}' but no "
                 f"llm_provider is configured (set it in users.yaml or as "
                 f"LLM_PROVIDER env var)"
             )
@@ -2446,7 +2521,7 @@ def _load_user_configs(
             timeout=user_timeout,
             workspace_base=user_workspace_base,
             allowed_workspaces=user_allowed_workspaces,
-            agent_backend=user_backend,
+            default_backend=user_backend,
             llm_provider=user_provider,
             github_repos=github_repos,
             github_notify_chat_id=github_notify_chat_id,
@@ -2689,11 +2764,26 @@ def load_config() -> Config:
     except ValueError:
         raise SystemExit("TOTP_LOCKOUT_MINUTES must be an integer") from None
 
-    # Agent backend selection - "claude" (default) or "goose"
-    agent_backend = os.environ.get("AGENT_BACKEND", "claude").strip().lower()
-    if agent_backend not in VALID_BACKENDS:
+    # Default backend selection - "claude" (default) or "goose".
+    # DEFAULT_BACKEND with a one-release fallback to the deprecated
+    # AGENT_BACKEND name; absence means the installation default "claude".
+    default_backend = (
+        (
+            _resolve_default_backend(
+                os.environ.get,
+                "DEFAULT_BACKEND",
+                "AGENT_BACKEND",
+                context="/etc/kai/env",
+                default="claude",
+            )
+            or "claude"
+        )
+        .strip()
+        .lower()
+    )
+    if default_backend not in VALID_BACKENDS:
         raise SystemExit(
-            f"AGENT_BACKEND '{agent_backend}' is not valid (must be one of: {', '.join(sorted(VALID_BACKENDS))})"
+            f"DEFAULT_BACKEND '{default_backend}' is not valid (must be one of: {', '.join(sorted(VALID_BACKENDS))})"
         )
 
     # Verify the per-role model registry has rows for every role the
@@ -2710,14 +2800,14 @@ def load_config() -> Config:
     # lookup can find a row.
     llm_provider = ""
     valid_providers: tuple[str, ...] | None = (
-        BACKEND_PROVIDERS.get(agent_backend) if agent_backend in BACKENDS_NEEDING_PROVIDER_PROMPT else None
+        BACKEND_PROVIDERS.get(default_backend) if default_backend in BACKENDS_NEEDING_PROVIDER_PROMPT else None
     )
     if valid_providers is not None:
         llm_provider = os.environ.get("LLM_PROVIDER", "").strip().lower()
         if llm_provider not in valid_providers:
             raise SystemExit(
                 f"LLM_PROVIDER '{llm_provider}' is not valid for backend "
-                f"'{agent_backend}' (must be one of: "
+                f"'{default_backend}' (must be one of: "
                 f"{', '.join(sorted(valid_providers))})"
             )
 
@@ -2763,7 +2853,7 @@ def load_config() -> Config:
     # from install.conf with the wizard's emission blocks removed, so
     # the keys do not survive the next reinstall.
     _deprecated_memory_env = (
-        ("MEMORY_REASONER_BACKEND", "memory reasoner is now derived per-user from agent_backend"),
+        ("MEMORY_REASONER_BACKEND", "memory reasoner is now derived per-user from default_backend"),
         ("MEMORY_EXTRACTION_MODEL", "memory extraction model is now resolved per-user from the MODEL_REGISTRY"),
         ("MEMORY_EPISODE_MODEL", "memory episode model is now resolved per-user from the MODEL_REGISTRY"),
         (
@@ -2895,7 +2985,7 @@ def load_config() -> Config:
     # explicit override for tests and ad-hoc development; the operator
     # path is always one of the two resolved defaults.
     users_yaml_path = _resolve_users_yaml_path(bool(protected_env))
-    user_configs = _load_user_configs(agent_backend, llm_provider, users_yaml_path)
+    user_configs = _load_user_configs(default_backend, llm_provider, users_yaml_path)
     # Seed UserConfig.models from the deprecated per-role env vars
     # (PR_REVIEW_MODEL_<BACKEND> / ISSUE_TRIAGE_MODEL_<BACKEND>). The
     # values reach dispatch through UserConfig.models rather than via
@@ -2903,7 +2993,7 @@ def load_config() -> Config:
     # so the per-user `models:` map remains the single source of
     # truth for per-role selection. One-shot deprecation warning
     # fires inside the helper when any seed value applies.
-    user_configs = _apply_legacy_model_env_overrides(user_configs, agent_backend)
+    user_configs = _apply_legacy_model_env_overrides(user_configs, default_backend)
     allowed_ids = set(user_configs.keys())
     if os.environ.get("ALLOWED_USER_IDS", "").strip():
         log.warning(
@@ -2921,7 +3011,7 @@ def load_config() -> Config:
     # `_ingest_memory`'s extraction gate in bot.py (membership in
     # ONESHOT_REASONER_BACKENDS).
     extraction_eligible_backends = _compute_extraction_eligible_backends(
-        agent_backend, user_configs, memory_extraction_enabled
+        default_backend, user_configs, memory_extraction_enabled
     )
 
     # Per-eligible-backend binary resolution. The earlier
@@ -3055,9 +3145,9 @@ def load_config() -> Config:
     # to PROVIDER_MODELS["openai"]. Other backends still use the
     # provider-only validator. Catches typos at startup instead of
     # letting them propagate to a confusing runtime failure.
-    global_provider = get_effective_provider(agent_backend, llm_provider)
-    if not validate_model_for_backend(default_model, agent_backend, global_provider):
-        if agent_backend == "codex":
+    global_provider = get_effective_provider(default_backend, llm_provider)
+    if not validate_model_for_backend(default_model, default_backend, global_provider):
+        if default_backend == "codex":
             valid = sorted(CODEX_MODELS.keys())
             raise SystemExit(
                 f"DEFAULT_MODEL '{default_model}' is not valid for codex (must be one of: {', '.join(valid)})"
@@ -3100,7 +3190,7 @@ def load_config() -> Config:
         totp_challenge_seconds=totp_challenge_seconds,
         totp_lockout_attempts=totp_lockout_attempts,
         totp_lockout_minutes=totp_lockout_minutes,
-        agent_backend=agent_backend,
+        default_backend=default_backend,
         llm_provider=llm_provider,
         memory_enabled=memory_enabled,
         memory_search_limit=memory_search_limit,

--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -99,7 +99,12 @@ from typing import Any
 # collision-probe generator). If the drift bucketing changes, every
 # consumer follows automatically.
 from kai.codex_exec import extract_codex_text
-from kai.config import ONESHOT_REASONER_BACKENDS, ModelRole, get_model_for
+from kai.config import (
+    ONESHOT_REASONER_BACKENDS,
+    ModelRole,
+    _resolve_default_backend,
+    get_model_for,
+)
 from kai.eval._probes import (
     Probe,
     detect_drift,
@@ -304,7 +309,7 @@ class BehavioralConfig:
     # get a sensible path.
     data_dir: Path = Path(".")
     # Active agent backend for this run ("claude" or "codex"). Resolved
-    # once at _run_cli from AGENT_BACKEND and threaded through every
+    # once at _run_cli from DEFAULT_BACKEND and threaded through every
     # subprocess builder + stdout parser + version capture so the
     # codex and claude verticals can stay byte-isolated. Default
     # "claude" matches the pre-codex behavior so test fixtures that
@@ -2220,12 +2225,28 @@ async def _run_cli(args: argparse.Namespace) -> int:
     #
     # MODEL_REGISTRY covers every backend in ONESHOT_REASONER_BACKENDS,
     # which is every real backend today. The else arm below survives as
-    # the defensive path for an AGENT_BACKEND env value the registry
+    # the defensive path for a DEFAULT_BACKEND env value the registry
     # does not know (a typo, or a future backend mid-introduction):
     # explicit --judge-model / --gen-model wins, otherwise the legacy
     # _DEFAULT_JUDGE_MODEL / _DEFAULT_GEN_MODEL constants are used
     # rather than crashing with a LookupError on an unset flag.
-    eval_backend = os.environ.get("AGENT_BACKEND", "claude").strip().lower()
+    # Reads DEFAULT_BACKEND with the one-release AGENT_BACKEND fallback;
+    # global default is "claude" (this is the installation-wide setting,
+    # not a per-user override).
+    eval_backend = (
+        (
+            _resolve_default_backend(
+                os.environ.get,
+                "DEFAULT_BACKEND",
+                "AGENT_BACKEND",
+                context="behavioral eval env",
+                default="claude",
+            )
+            or "claude"
+        )
+        .strip()
+        .lower()
+    )
     # Provider is read from the eval-time LLM_PROVIDER env (the eval
     # gate runs as a developer tool against the operator's configured
     # backend / provider, not against a sandboxed user). Single-provider
@@ -2246,7 +2267,7 @@ async def _run_cli(args: argparse.Namespace) -> int:
             override=args.gen_model or "",
         )
     else:
-        # Unrecognized AGENT_BACKEND env value: explicit flag wins,
+        # Unrecognized DEFAULT_BACKEND env value: explicit flag wins,
         # otherwise the legacy _DEFAULT_* constant is used.
         resolved_judge_model = args.judge_model or _DEFAULT_JUDGE_MODEL
         resolved_gen_model = args.gen_model or _DEFAULT_GEN_MODEL

--- a/src/kai/eval/extraction.py
+++ b/src/kai/eval/extraction.py
@@ -630,10 +630,10 @@ async def _run_one_probe(
         # Per-user dispatch (issue #515): `_run_extractor` now requires
         # an explicit `effective_backend`. The eval harness runs in
         # single-backend mode (one prompt-pair comparison per run, no
-        # mixed-backend cascade), so the global `agent_backend` is the
+        # mixed-backend cascade), so the global `default_backend` is the
         # correct backend for both arms; threading it explicitly avoids
         # relying on a default we no longer have.
-        effective_backend = config.agent_backend
+        effective_backend = config.default_backend
         pre_v5 = sum(memory_extraction._RULE_6_REJECTIONS.snapshot().values())
         v5_result = await memory_extraction._run_extractor(
             payload,

--- a/src/kai/eval/memory_backend_gate.py
+++ b/src/kai/eval/memory_backend_gate.py
@@ -621,7 +621,7 @@ def make_backend_config(base_config: Config, backend: str) -> Config:
     Forces memory_enabled=True and memory_extraction_enabled=True so
     the harness can run against an install whose env file disables
     memory in production. Drives the per-user dispatch (issue #515)
-    by setting `agent_backend` to the backend under test; with no
+    by setting `default_backend` to the backend under test; with no
     `user_configs` override, `_resolve_effective_backend` in
     `memory_extraction.py` returns the global value for every
     extraction call, so the harness deterministically exercises one
@@ -634,7 +634,7 @@ def make_backend_config(base_config: Config, backend: str) -> Config:
         base_config,
         memory_enabled=True,
         memory_extraction_enabled=True,
-        agent_backend=backend,
+        default_backend=backend,
     )
 
 

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -55,6 +55,7 @@ from kai.config import (
     VALID_BACKENDS,
     ModelRole,
     _read_protected_file,
+    _resolve_default_backend,
     models_for_backend,
     validate_model_for_backend,
 )
@@ -644,13 +645,31 @@ def _users_yaml_entries(users_yaml_path: Path) -> list[dict]:
     return [entry for entry in users if isinstance(entry, dict)]
 
 
+def _entry_backend(entry: dict) -> object:
+    """
+    Read a users.yaml entry's backend, preferring the new
+    `default_backend` key and falling back to the deprecated
+    `agent_backend` key for one release.
+
+    Returns the raw value (or None) so callers apply their own
+    normalization/validation, matching how they read the key today.
+    No deprecation warning here: the daemon-side `_load_user_configs`
+    emits the per-user warning; these installer scanners only need
+    set membership.
+    """
+    value = entry.get("default_backend")
+    if value is not None:
+        return value
+    return entry.get("agent_backend")
+
+
 def _users_yaml_goose_providers(users_yaml_path: Path, global_provider: str) -> list[str]:
     """
     Collect the distinct providers per-user goose entries need API
     keys for.
 
     Returns the sorted set of `llm_provider` values across entries
-    whose `agent_backend` is "goose", falling back to
+    whose `default_backend` is "goose", falling back to
     `global_provider` for entries that omit the field - the same
     cascade the runtime applies. Goose is the only backend whose
     per-user auth rides the daemon environment: claude, codex, and
@@ -665,7 +684,7 @@ def _users_yaml_goose_providers(users_yaml_path: Path, global_provider: str) -> 
         # (str.strip().lower()): mixed-case `Goose` / `DeepSeek`
         # values are valid at runtime, so the scan must not let a
         # casing difference skip a key the daemon will demand.
-        backend = entry.get("agent_backend")
+        backend = _entry_backend(entry)
         if not isinstance(backend, str) or backend.strip().lower() != "goose":
             continue
         provider = entry.get("llm_provider") or global_provider
@@ -676,7 +695,7 @@ def _users_yaml_goose_providers(users_yaml_path: Path, global_provider: str) -> 
 
 def _users_yaml_agent_backends(users_yaml_path: Path) -> set[str]:
     """
-    Collect the distinct per-user `agent_backend` values for
+    Collect the distinct per-user `default_backend` values for
     wizard-side binary collection.
 
     A users.yaml entry on a non-global backend makes that backend's
@@ -690,7 +709,7 @@ def _users_yaml_agent_backends(users_yaml_path: Path) -> set[str]:
     """
     backends: set[str] = set()
     for entry in _users_yaml_entries(users_yaml_path):
-        backend = entry.get("agent_backend")
+        backend = _entry_backend(entry)
         # Normalize the same way the runtime loader does
         # (str.strip().lower()): mixed-case values like `Codex` are
         # valid at runtime and route the user, so the scan must
@@ -1015,12 +1034,22 @@ def _cmd_config() -> None:
         )
     print()
 
-    # -- Agent backend --
-    print("-- Agent backend --")
+    # -- Default backend --
+    print("-- Default backend --")
+    # Prefill reads DEFAULT_BACKEND, falling back to the deprecated
+    # AGENT_BACKEND key so a re-run against a legacy install.conf keeps
+    # the operator's prior choice; the wizard writes DEFAULT_BACKEND only.
     agent_backend = _prompt_choice(
-        "Agent backend",
+        "Default backend",
         sorted(VALID_BACKENDS),
-        existing_env.get("AGENT_BACKEND", "claude"),
+        _resolve_default_backend(
+            existing_env.get,
+            "DEFAULT_BACKEND",
+            "AGENT_BACKEND",
+            context="install.conf",
+            default="claude",
+        )
+        or "claude",
     )
 
     # Codex auth handling runs BEFORE the legacy provider/key block so
@@ -1030,8 +1059,8 @@ def _cmd_config() -> None:
     # block below skips codex entirely; codex follows the same path
     # claude does for the provider prompt.
     #
-    # Gate on the global `agent_backend` selection only. Per-user
-    # `agent_backend: codex` overrides in users.yaml do NOT trigger
+    # Gate on the global backend selection only. Per-user
+    # `default_backend: codex` overrides in users.yaml do NOT trigger
     # the auth-mode setup here; codex AUTH for those users stays
     # out-of-band (per-OS-user `codex login`). Their BINARY path is
     # collected by the per-user backend scan after the provider
@@ -1109,7 +1138,7 @@ def _cmd_config() -> None:
             print("  After install, log in to codex as the target os_user:")
             print("    <os_user> ~$ codex login")
             print("  Run as the os_user themselves, not via sudo from another account.")
-            print("  If users.yaml has per-user `agent_backend: codex` entries with")
+            print("  If users.yaml has per-user `default_backend: codex` entries with")
             print("  different os_users, log in as each of those too.")
 
     # OpenCode setup: binary-path wizard prompt + post-install auth
@@ -1122,8 +1151,8 @@ def _cmd_config() -> None:
     # models_for_backend("opencode", _) returns None, the operator gets
     # a free-text prompt for a full `provider/model` ID.
     #
-    # Gate on the global `agent_backend` selection only. Per-user
-    # `agent_backend: opencode` overrides in users.yaml do NOT
+    # Gate on the global backend selection only. Per-user
+    # `default_backend: opencode` overrides in users.yaml do NOT
     # trigger the setup here; opencode AUTH for those users stays
     # out-of-band (`opencode auth login` per OS user). Their BINARY
     # path is collected by the per-user backend scan after the
@@ -1321,7 +1350,7 @@ def _cmd_config() -> None:
     # users_yaml_exists gate skipped them entirely on the
     # re-run-with-users.yaml path, which let a stale global model
     # survive a backend switch (the operator-visible bug: switching
-    # AGENT_BACKEND from one model surface to another left the prior
+    # DEFAULT_BACKEND from one model surface to another left the prior
     # value unchanged because the re-validation path never ran).
     #
     # Determine the effective provider for model choices. Claude
@@ -1954,12 +1983,13 @@ def _cmd_config() -> None:
         "TTS_ENABLED": str(tts_enabled).lower(),
     }
 
-    # AGENT_BACKEND is the global default backend; users.yaml entries
+    # DEFAULT_BACKEND is the global default backend; users.yaml entries
     # can override it per user. Only write non-default values to keep
     # the env file clean (the runtime defaults to claude when the key
-    # is absent).
+    # is absent). The wizard writes the new name only; the runtime keeps
+    # a one-release read fallback for a legacy AGENT_BACKEND key.
     if agent_backend != "claude":
-        env["AGENT_BACKEND"] = agent_backend
+        env["DEFAULT_BACKEND"] = agent_backend
 
     # LLM provider and API key. Written alongside the backend choice
     # so they survive into /etc/kai/env and are not wiped on reinstall.
@@ -2582,7 +2612,7 @@ def _collect_os_users_from_yaml(users_yaml_path: str | Path) -> list[str]:
 
 def _collect_backends_from_yaml(users_yaml_path: str | Path) -> set[str]:
     """
-    Read users.yaml and return the distinct per-user agent_backend values.
+    Read users.yaml and return the distinct per-user default_backend values.
 
     Sibling of `_collect_os_users_from_yaml` with the same lightweight
     posture: the installer only needs the backend names to scope the
@@ -2614,7 +2644,7 @@ def _collect_backends_from_yaml(users_yaml_path: str | Path) -> set[str]:
     for entry in users:
         if not isinstance(entry, dict):
             continue
-        backend = entry.get("agent_backend")
+        backend = _entry_backend(entry)
         # PyYAML may parse unquoted scalars as non-strings; only string
         # values can name a backend.
         if not isinstance(backend, str):
@@ -2633,7 +2663,7 @@ def _collect_goose_os_users_from_yaml(
     Read users.yaml and return distinct, validated os_user values of
     goose-backed users.
 
-    A user is goose-backed when their entry's `agent_backend` is
+    A user is goose-backed when their entry's `default_backend` is
     "goose", or when the entry carries no per-user backend and the
     install's global backend (`agent_backend`) is goose - the same
     inheritance contract the runtime applies. `_apply_goose_config`
@@ -2668,7 +2698,7 @@ def _collect_goose_os_users_from_yaml(
     for entry in users:
         if not isinstance(entry, dict):
             continue
-        backend = entry.get("agent_backend")
+        backend = _entry_backend(entry)
         # Non-string / empty per-user values mean "inherit the global
         # backend" (PyYAML may parse unquoted scalars as non-strings;
         # the runtime loader rejects those separately).
@@ -2716,7 +2746,11 @@ def _build_codex_login_reminder(
     for backwards compatibility with the existing caller / tests, but
     are no longer read.
     """
-    if env.get("AGENT_BACKEND", "claude") != "codex":
+    default_backend = (
+        _resolve_default_backend(env.get, "DEFAULT_BACKEND", "AGENT_BACKEND", context="install.conf", default="claude")
+        or "claude"
+    )
+    if default_backend != "codex":
         return None
     if env.get("CODEX_AUTH_MODE", "subscription") != "subscription":
         return None
@@ -2725,7 +2759,7 @@ def _build_codex_login_reminder(
         "  Log in to codex as the target os_user before the first message:\n"
         "    <os_user> ~$ codex login\n"
         "  Run as the os_user themselves, not via sudo from another account.\n"
-        "  If users.yaml has per-user `agent_backend: codex` entries with\n"
+        "  If users.yaml has per-user `default_backend: codex` entries with\n"
         "  different os_users, log in as each of those too."
     )
 
@@ -4093,6 +4127,21 @@ def _cmd_apply() -> None:
     service_user = conf.get("service_user")
     platform = conf.get("platform")
     env = conf.get("env", {})
+    # Migrate a legacy AGENT_BACKEND key in the install.conf env dict to
+    # DEFAULT_BACKEND once, here, before any gate reads it or
+    # _apply_secrets writes /etc/kai/env. Apply consumes the env dict
+    # directly (it never goes through load_config), so without this an
+    # apply driven by a legacy install.conf would either skip
+    # backend-specific setup or, for codex/goose, validate the default
+    # model against the wrong (claude/anthropic) surface and fail. After
+    # this block every downstream `env.get("DEFAULT_BACKEND")` sees the
+    # resolved value and /etc/kai/env is written with the new name only.
+    if "AGENT_BACKEND" in env and "DEFAULT_BACKEND" not in env:
+        env["DEFAULT_BACKEND"] = env.pop("AGENT_BACKEND")
+    elif "AGENT_BACKEND" in env:
+        # Both present: the new key wins; drop the legacy one so it does
+        # not linger in the written env file.
+        del env["AGENT_BACKEND"]
     # Top-level installer metadata: present only when the wizard
     # staged a first-time users.yaml that has not yet been applied.
     # The empty-string -> None coercion treats a hand-edited conf
@@ -4129,23 +4178,24 @@ def _cmd_apply() -> None:
     #
     # Normalize the same way load_config does (config.py reads both env
     # vars through .strip().lower() before validating). A hand-edited
-    # install.conf with "AGENT_BACKEND": "Claude" or trailing whitespace
+    # install.conf with "DEFAULT_BACKEND": "Claude" or trailing whitespace
     # would otherwise compute the wrong effective provider here, pass
-    # the apply gate, and then fail at startup.
+    # the apply gate, and then fail at startup. The legacy AGENT_BACKEND
+    # key was already migrated to DEFAULT_BACKEND at the top of apply.
     #
     # Resolve the same fallback load_config uses ("" -> "sonnet"). An
     # empty or missing DEFAULT_MODEL is silently promoted at runtime;
     # if we do not mirror that promotion here, the apply gate misses
     # the missing-key case that is precisely what this gate exists for.
     default_model_raw = env.get("DEFAULT_MODEL", "")
-    agent_backend_raw = env.get("AGENT_BACKEND", "claude").strip().lower()
+    agent_backend_raw = env.get("DEFAULT_BACKEND", "claude").strip().lower()
     llm_provider_raw = env.get("LLM_PROVIDER", "").strip().lower()
     eff_provider_for_check = "anthropic" if agent_backend_raw == "claude" else llm_provider_raw
     resolved_model = default_model_raw or "sonnet"
     # Backend-aware validation: codex installs validate against
     # CODEX_MODELS only - no fallback to PROVIDER_MODELS["openai"].
     # That closes the regression where install.conf with
-    # AGENT_BACKEND=codex and DEFAULT_MODEL=opus survived apply
+    # DEFAULT_BACKEND=codex and DEFAULT_MODEL=opus survived apply
     # because validate_model_for_provider accepted unknown effective-
     # provider "" unchecked, or where DEFAULT_MODEL=gpt-5.4-nano
     # (goose-valid) survived because the wizard mapped codex onto
@@ -4242,7 +4292,7 @@ def _cmd_apply() -> None:
         # wins over any value already in install.conf.
         #
         # Gate the apply-time shell env pass-through on the global
-        # AGENT_BACKEND only: it is an ad-hoc escape hatch for global
+        # DEFAULT_BACKEND only: it is an ad-hoc escape hatch for global
         # backend installs (`sudo CODEX_BIN=... kai install apply`).
         # Per-user backend entries do NOT need it; their binary paths
         # are collected by the `make config` per-user backend scan
@@ -4250,7 +4300,7 @@ def _cmd_apply() -> None:
         # consumes below. Codex AUTH for per-user entries stays
         # out-of-band (per-OS-user `codex login`).
         env_codex_bin = os.environ.get("CODEX_BIN")
-        if env_codex_bin and env.get("AGENT_BACKEND") == "codex":
+        if env_codex_bin and env.get("DEFAULT_BACKEND") == "codex":
             env["CODEX_BIN"] = env_codex_bin
         # Mirror the same env pass-through for OPENCODE_BIN so an
         # `sudo OPENCODE_BIN=... kai install apply` invocation pins
@@ -4260,20 +4310,20 @@ def _cmd_apply() -> None:
         # entries get their path from the wizard scan via
         # install.conf, with auth out-of-band (`opencode auth login`).
         env_opencode_bin = os.environ.get("OPENCODE_BIN")
-        if env_opencode_bin and env.get("AGENT_BACKEND") == "opencode":
+        if env_opencode_bin and env.get("DEFAULT_BACKEND") == "opencode":
             env["OPENCODE_BIN"] = env_opencode_bin
         # And for GOOSE_BIN, completing the per-backend trio. Same
         # split as the two above: shell env override for global goose
         # installs, install.conf from the wizard scan for per-user
         # entries.
         env_goose_bin = os.environ.get("GOOSE_BIN")
-        if env_goose_bin and env.get("AGENT_BACKEND") == "goose":
+        if env_goose_bin and env.get("DEFAULT_BACKEND") == "goose":
             env["GOOSE_BIN"] = env_goose_bin
         # And for CLAUDE_BIN, completing the per-backend set. The
-        # AGENT_BACKEND gate compares against the runtime default
+        # DEFAULT_BACKEND gate compares against the runtime default
         # because the wizard omits the key on claude installs.
         env_claude_bin = os.environ.get("CLAUDE_BIN")
-        if env_claude_bin and env.get("AGENT_BACKEND", "claude") == "claude":
+        if env_claude_bin and env.get("DEFAULT_BACKEND", "claude") == "claude":
             env["CLAUDE_BIN"] = env_claude_bin
         # AGENT_TIMEOUT_SECONDS migration. Operators upgrading without
         # re-running the wizard carry the legacy CLAUDE_TIMEOUT_SECONDS
@@ -4306,10 +4356,10 @@ def _cmd_apply() -> None:
         _apply_secrets(env, dry_run, users_yaml_staging_path=users_yaml_staging_path)
 
         # -- Step 6: Deploy Goose config (if any goose-backed user) --
-        # The function gates itself: global AGENT_BACKEND=goose or a
-        # per-user agent_backend override in users.yaml both mean some
+        # The function gates itself: global DEFAULT_BACKEND=goose or a
+        # per-user default_backend override in users.yaml both mean some
         # session spawns `goose acp`; otherwise it no-ops.
-        agent_backend = env.get("AGENT_BACKEND", "claude")
+        agent_backend = env.get("DEFAULT_BACKEND", "claude")
         _apply_goose_config(
             service_user,
             install_path,
@@ -5523,9 +5573,9 @@ def _apply_sudoers(
     fire only on installs where the wizard has not collected a value.
 
     `agent_backend` is the install's global backend (the env dict's
-    AGENT_BACKEND, defaulting to claude when the key is absent, which
+    DEFAULT_BACKEND, defaulting to claude when the key is absent, which
     matches the runtime default). Together with the per-user
-    agent_backend overrides in users.yaml it scopes the missing-binary
+    default_backend overrides in users.yaml it scopes the missing-binary
     backstop below to backends the install actually uses.
     """
     # None resolves to the module-level USERS_YAML at call time rather
@@ -5558,7 +5608,7 @@ def _apply_sudoers(
     # reinstall, or wizard re-run that makes the paths agree.
     #
     # The check is scoped to backends the install actually uses (the
-    # global agent_backend plus any per-user agent_backend overrides
+    # global backend plus any per-user default_backend overrides
     # in users.yaml): telling an opencode-only operator to install
     # claude would manufacture a requirement that does not exist and
     # train operators to ignore the warning. The rules themselves are

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2649,7 +2649,13 @@ def _collect_backends_from_yaml(users_yaml_path: str | Path) -> set[str]:
         # values can name a backend.
         if not isinstance(backend, str):
             continue
-        normalized = backend.strip()
+        # Normalize with .strip().lower() to match the runtime loader
+        # (`_load_user_configs` lowercases before validating). A mixed-
+        # case `default_backend: Goose` routes the user to goose at
+        # runtime; without lowering here, `_apply_goose_config`'s
+        # `"goose" in <set>` membership check would miss it and skip
+        # the per-user goose config deployment.
+        normalized = backend.strip().lower()
         if normalized:
             backends.add(normalized)
     return backends
@@ -2701,8 +2707,15 @@ def _collect_goose_os_users_from_yaml(
         backend = _entry_backend(entry)
         # Non-string / empty per-user values mean "inherit the global
         # backend" (PyYAML may parse unquoted scalars as non-strings;
-        # the runtime loader rejects those separately).
-        effective = backend.strip() if isinstance(backend, str) and backend.strip() else agent_backend
+        # the runtime loader rejects those separately). Lowercase the
+        # per-user value to match the runtime loader so a mixed-case
+        # `default_backend: Goose` entry's os_user still receives the
+        # goose config deploy. The global `agent_backend` arg is
+        # already normalized by the caller (_cmd_apply).
+        if isinstance(backend, str) and backend.strip():
+            effective = backend.strip().lower()
+        else:
+            effective = agent_backend
         if effective != "goose":
             continue
         os_user = entry.get("os_user")
@@ -4189,6 +4202,15 @@ def _cmd_apply() -> None:
     # the missing-key case that is precisely what this gate exists for.
     default_model_raw = env.get("DEFAULT_MODEL", "")
     agent_backend_raw = env.get("DEFAULT_BACKEND", "claude").strip().lower()
+    # Write the normalized value back so the downstream goose-config and
+    # sudoers gates (which read env.get("DEFAULT_BACKEND") raw) and the
+    # written /etc/kai/env all see the canonical lowercase form. Only
+    # when the key is present, to preserve the "claude omits the key"
+    # contract. Without this, a hand-edited install.conf with
+    # DEFAULT_BACKEND="Goose" passes validation here but skips goose
+    # config deployment below.
+    if "DEFAULT_BACKEND" in env:
+        env["DEFAULT_BACKEND"] = agent_backend_raw
     llm_provider_raw = env.get("LLM_PROVIDER", "").strip().lower()
     eff_provider_for_check = "anthropic" if agent_backend_raw == "claude" else llm_provider_raw
     resolved_model = default_model_raw or "sonnet"

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -1321,7 +1321,7 @@ def init_memory(config: Config) -> None:
     )
 
     eligible_pairs: set[tuple[str, str]] = _compute_extraction_eligible_backend_provider_pairs(
-        config.agent_backend,
+        config.default_backend,
         config.llm_provider,
         config.user_configs,
         config.memory_extraction_enabled,

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -1902,7 +1902,9 @@ async def _send_dashboard(
     # gate's backend resolution in bot.py.
     config: Config = context.bot_data["config"]
     user_config = config.get_user_config(chat_id)
-    effective_backend = user_config.agent_backend if user_config and user_config.agent_backend else config.agent_backend
+    effective_backend = (
+        user_config.default_backend if user_config and user_config.default_backend else config.default_backend
+    )
     if effective_backend not in ONESHOT_REASONER_BACKENDS:
         text += (
             f"\n\nNote: memory extraction is not available on the {effective_backend} "

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1939,10 +1939,10 @@ def _resolve_os_user(user_id: str, config: Config) -> str | None:
 
 def _resolve_effective_backend(user_id: str, config: Config) -> str:
     """
-    Resolve the user being extracted to its effective `agent_backend`.
+    Resolve the user being extracted to its effective `default_backend`.
 
-    Cascade: per-user `agent_backend` from users.yaml wins; otherwise
-    the global `config.agent_backend` applies. The same shape
+    Cascade: per-user `default_backend` from users.yaml wins; otherwise
+    the global `config.default_backend` applies. The same shape
     `_ingest_memory` in bot.py uses to gate extraction eligibility,
     kept in lockstep so the per-user dispatch site here cannot drift
     from the eligibility check there.
@@ -1962,11 +1962,11 @@ def _resolve_effective_backend(user_id: str, config: Config) -> str:
     try:
         tid = int(user_id)
     except ValueError:
-        return config.agent_backend
+        return config.default_backend
     user_cfg = config.user_configs.get(tid)
     if user_cfg is None:
-        return config.agent_backend
-    return user_cfg.agent_backend or config.agent_backend
+        return config.default_backend
+    return user_cfg.default_backend or config.default_backend
 
 
 def _resolve_user_config(user_id: str, config: Config):

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -109,13 +109,13 @@ class SubprocessPool:
         """
         Create an AgentBackend for a specific user.
 
-        Backend selection: per-user agent_backend (from users.yaml)
-        overrides the global config.agent_backend. Both share the same
+        Backend selection: per-user default_backend (from users.yaml)
+        overrides the global config.default_backend. Both share the same
         ABC interface; pool.py is backend-agnostic after this point.
 
         Resolution order for each setting:
         1. UserConfig from users.yaml (os_user, home_workspace, model,
-           timeout, agent_backend, llm_provider)
+           timeout, default_backend, llm_provider)
         2. Global config defaults (from .env)
 
         Per-user DB overrides (set via /settings or /model) are applied
@@ -136,7 +136,7 @@ class SubprocessPool:
         # resolver so codex always reports provider="openai" even when
         # llm_provider is unset, matching the same cascade bot.py and
         # the install-time validator use. Without this, a user with
-        # `agent_backend: codex` on a globally-claude install ended up
+        # `default_backend: codex` on a globally-claude install ended up
         # with effective_provider="" and the fallback below dispatched
         # the global default_model ("sonnet"), which codex CLI rejects.
         backend, effective_provider = get_user_backend_and_provider(user, self._config)
@@ -144,14 +144,14 @@ class SubprocessPool:
         # claude (anthropic) and codex (openai) so global_provider lines
         # up with effective_provider whenever the user has not overridden
         # the backend; no codex-specific patch needed here.
-        global_provider = get_effective_provider(self._config.agent_backend, self._config.llm_provider)
+        global_provider = get_effective_provider(self._config.default_backend, self._config.llm_provider)
 
         # Per-user model. When the user's effective backend differs
         # from the global one, the global default_model may not be
         # valid; fall back to the per-backend default instead.
         if user and user.model:
             model = user.model
-        elif backend == self._config.agent_backend and effective_provider == global_provider:
+        elif backend == self._config.default_backend and effective_provider == global_provider:
             model = self._config.default_model
             # Catch the case where the global backend itself is an open-ended
             # provider and DEFAULT_MODEL is something generic like "sonnet".

--- a/src/kai/smoke/memory.py
+++ b/src/kai/smoke/memory.py
@@ -13,9 +13,9 @@ install's memory state.
 
 Invocation: `python -m kai.smoke.memory [--user-id <chat_id>] [--os-user <name>]`.
 
-The `--user-id` flag selects which user's effective `agent_backend`
+The `--user-id` flag selects which user's effective `default_backend`
 the smoke runs under (the same per-user dispatch production uses).
-When omitted, the smoke falls back to the global `config.agent_backend`.
+When omitted, the smoke falls back to the global `config.default_backend`.
 The `--os-user` flag is required when the resolved effective backend
 is codex; the codex reasoner refuses to spawn without an os_user (it
 exists to prevent the bot user from running codex). Pass the per-user
@@ -101,9 +101,9 @@ async def _run(user_id: str | None, os_user: str | None) -> int:
 
     # Resolve the effective backend the smoke runs under. With per-user
     # dispatch (issue #515), production extraction uses each user's
-    # effective `agent_backend`; the smoke mirrors that by accepting a
+    # effective `default_backend`; the smoke mirrors that by accepting a
     # `--user-id` that the helper looks up in users.yaml. Without
-    # `--user-id`, fall back to the global `agent_backend` (the legacy
+    # `--user-id`, fall back to the global `default_backend` (the legacy
     # single-backend smoke path). The string the helper takes is the
     # raw user_id (production threads it through `extract_and_store`
     # the same way), so reuse it directly.
@@ -115,7 +115,7 @@ async def _run(user_id: str | None, os_user: str | None) -> int:
         sys.stderr.write(
             f"smoke: effective backend {effective_backend!r} has no memory reasoner. "
             f"Pass --user-id matching an entry in users.yaml whose effective backend "
-            f"is one of: {eligible}, or run with a matching global AGENT_BACKEND.\n"
+            f"is one of: {eligible}, or run with a matching global DEFAULT_BACKEND.\n"
         )
         return 1
 
@@ -125,7 +125,7 @@ async def _run(user_id: str | None, os_user: str | None) -> int:
     print(f"provider: {effective_provider}")
     print(f"extraction model: {extraction_model}")
     print(f"episode model: {episode_model}")
-    print(f"user_id: {user_id or '(none; using global agent_backend)'}")
+    print(f"user_id: {user_id or '(none; using global default_backend)'}")
     print(f"os_user: {os_user or '(none; direct spawn)'}")
 
     reasoner = _build_memory_reasoner(effective_backend, os_user=os_user)
@@ -213,8 +213,8 @@ def main() -> int:
         dest="user_id",
         default=None,
         help=(
-            "Telegram chat_id whose effective agent_backend selects the reasoner. "
-            "Defaults to the global agent_backend when omitted."
+            "Telegram chat_id whose effective default_backend selects the reasoner. "
+            "Defaults to the global default_backend when omitted."
         ),
     )
     parser.add_argument(

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -738,10 +738,10 @@ async def _process_github_event_for_user(
     # Resolve per-user backend/provider for the review/triage agents.
     # Same resolution logic as pool.py _create_instance: per-user
     # config overrides global config.
-    if user_config and user_config.agent_backend:
-        agent_backend = user_config.agent_backend
+    if user_config and user_config.default_backend:
+        agent_backend = user_config.default_backend
     else:
-        agent_backend = config.agent_backend
+        agent_backend = config.default_backend
 
     if user_config and user_config.llm_provider:
         provider = user_config.llm_provider

--- a/templates/.env
+++ b/templates/.env
@@ -15,9 +15,9 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 # Agent backend: "claude" (default), "goose", "codex", or "opencode".
 # "claude" uses Claude Code CLI; "goose"/"opencode" use ACP;
 # "codex" uses the OpenAI Codex CLI's app-server JSON-RPC protocol.
-#AGENT_BACKEND=claude
+#DEFAULT_BACKEND=claude
 
-# LLM provider. Required when AGENT_BACKEND is a non-Claude backend.
+# LLM provider. Required when DEFAULT_BACKEND is a non-Claude backend.
 # Valid values depend on the backend:
 #   goose: anthropic, deepseek, google, ollama, openai, openrouter
 #LLM_PROVIDER=anthropic
@@ -168,8 +168,8 @@ MEMORY_ENABLED=false
 # Memory reasoner and model: NO env var.
 #
 # Memory extraction routes the reasoner subprocess per-user, based
-# on each user's effective agent_backend (per-user override in
-# users.yaml > global AGENT_BACKEND). Claude users get the claude
+# on each user's effective backend (per-user override in
+# users.yaml > global DEFAULT_BACKEND). Claude users get the claude
 # reasoner with the claude-registry model; codex users get the
 # codex reasoner with the codex-registry model. There is no
 # deployment-level override surface: model selection happens

--- a/templates/config/goose-config.yaml
+++ b/templates/config/goose-config.yaml
@@ -1,7 +1,7 @@
 # Goose extension configuration for Kai.
 #
 # Deployed to ~/.config/goose/config.yaml by `make install` when
-# AGENT_BACKEND=goose. Controls which Goose extensions are loaded
+# DEFAULT_BACKEND=goose. Controls which Goose extensions are loaded
 # in ACP mode (`goose acp`).
 #
 # GOOSE_MODEL and GOOSE_PROVIDER are intentionally omitted here;

--- a/templates/users.yaml
+++ b/templates/users.yaml
@@ -34,12 +34,12 @@ users:
     # model: opus             # haiku/sonnet/opus for claude; provider/model for opencode
     # timeout: 300            # response timeout in seconds (max 600)
 
-    # Agent backend. Overrides the global AGENT_BACKEND from .env for
+    # Default backend. Overrides the global DEFAULT_BACKEND from .env for
     # this user only. Default is "claude" (Claude Code CLI). Other
     # options: "goose" (Goose ACP, requires llm_provider + API key),
     # "codex" (OpenAI Codex CLI), "opencode" (OpenCode ACP; model is
     # a full "provider/model" ID, auth managed by `opencode auth login`).
-    # agent_backend: goose
+    # default_backend: goose
     # llm_provider: openai    # required for goose; ignored for opencode
     # model: anthropic/claude-sonnet-4-6   # opencode example (full provider/model ID)
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -173,7 +173,7 @@ class TestGetUserModelsWarningSuppression:
         # prompts for an llm_provider). The pre-fix code path warns
         # because "" is not in OPEN_ENDED_PROVIDERS.
         config = MagicMock()
-        config.agent_backend = "opencode"
+        config.default_backend = "opencode"
         config.llm_provider = ""
         config.get_user_config = MagicMock(return_value=None)
         pool = MagicMock(spec=SubprocessPool)
@@ -194,7 +194,7 @@ class TestGetUserModelsWarningSuppression:
         from kai.pool import SubprocessPool
 
         config = MagicMock()
-        config.agent_backend = "codex"
+        config.default_backend = "codex"
         config.llm_provider = ""
         config.get_user_config = MagicMock(return_value=None)
         pool = MagicMock(spec=SubprocessPool)
@@ -3431,7 +3431,7 @@ class TestHandleResponse:
         # contract under test is the outer gate plus the inner config
         # branch, neither of which depends on prior_pairs being
         # non-empty. memory_extraction_enabled=True so the inner gate
-        # passes; agent_backend defaults to "claude" so the backend
+        # passes; default_backend defaults to "claude" so the backend
         # check passes too.
         config = _make_config(
             memory_extraction_enabled=True,
@@ -3497,7 +3497,7 @@ class TestHandleResponse:
                 12345: UserConfig(
                     telegram_id=12345,
                     name="opencode-user",
-                    agent_backend="opencode",
+                    default_backend="opencode",
                 ),
             },
         )
@@ -3539,7 +3539,7 @@ class TestHandleResponse:
                 12345: UserConfig(
                     telegram_id=12345,
                     name="goose-user",
-                    agent_backend="goose",
+                    default_backend="goose",
                     llm_provider="openai",
                 ),
             },
@@ -4711,7 +4711,7 @@ class TestHandleSettings:
         """
         update = _make_update(text="/settings reset model")
         config = _make_config(
-            agent_backend="codex",
+            default_backend="codex",
             llm_provider="",
             default_model="gpt-5.5",
         )
@@ -6205,7 +6205,7 @@ class TestHandleReviewCommand:
                     telegram_id=12345,
                     name="op",
                     github_repos=["dcellison/kai"],
-                    agent_backend="codex",
+                    default_backend="codex",
                     llm_provider="openai",
                     os_user="daniel",
                 ),

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -2222,7 +2222,7 @@ class TestCodexGrandchildEscalation:
 
 class TestStartupFailureSurface:
     """
-    Spec #556 acceptance criterion: a per-user `agent_backend: codex`
+    Spec #556 acceptance criterion: a per-user `default_backend: codex`
     entry on a non-codex install must produce a chat-visible
     startup-failure StreamEvent (not silent failure, not fall-through
     to claude) when codex tooling is missing.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,7 +63,7 @@ _CONFIG_ENV_VARS = [
     "TOTP_CHALLENGE_SECONDS",
     "TOTP_LOCKOUT_ATTEMPTS",
     "TOTP_LOCKOUT_MINUTES",
-    "AGENT_BACKEND",
+    "DEFAULT_BACKEND",
     "LLM_PROVIDER",
     "MEMORY_ENABLED",
     "MEMORY_SEARCH_LIMIT",
@@ -198,7 +198,7 @@ class TestLoadConfigDefaults:
         # Autocompact tuning defaults to 0 (use Claude Code default)
         assert config.claude_autocompact_pct == 0
         # Agent backend default
-        assert config.agent_backend == "claude"
+        assert config.default_backend == "claude"
 
     def test_autocompact_from_env(self, monkeypatch):
         _set_required(monkeypatch)
@@ -289,16 +289,16 @@ class TestLoadConfigErrors:
             load_config()
 
     def test_invalid_agent_backend(self, monkeypatch):
-        """AGENT_BACKEND with an unrecognized value raises SystemExit."""
+        """DEFAULT_BACKEND with an unrecognized value raises SystemExit."""
         _set_required(monkeypatch)
-        monkeypatch.setenv("AGENT_BACKEND", "invalid")
-        with pytest.raises(SystemExit, match="AGENT_BACKEND"):
+        monkeypatch.setenv("DEFAULT_BACKEND", "invalid")
+        with pytest.raises(SystemExit, match="DEFAULT_BACKEND"):
             load_config()
 
     def test_invalid_llm_provider(self, monkeypatch):
         """LLM_PROVIDER with an unrecognized value raises SystemExit."""
         _set_required(monkeypatch)
-        monkeypatch.setenv("AGENT_BACKEND", "goose")
+        monkeypatch.setenv("DEFAULT_BACKEND", "goose")
         monkeypatch.setenv("LLM_PROVIDER", "invalid")
         with pytest.raises(SystemExit, match="LLM_PROVIDER"):
             load_config()
@@ -306,7 +306,7 @@ class TestLoadConfigErrors:
     def test_missing_llm_provider(self, monkeypatch):
         """LLM_PROVIDER missing when backend=goose raises SystemExit."""
         _set_required(monkeypatch)
-        monkeypatch.setenv("AGENT_BACKEND", "goose")
+        monkeypatch.setenv("DEFAULT_BACKEND", "goose")
         with pytest.raises(SystemExit, match="LLM_PROVIDER"):
             load_config()
 
@@ -326,7 +326,7 @@ class TestLoadConfigErrors:
     def test_valid_llm_provider(self, monkeypatch):
         """Valid LLM_PROVIDER is accepted and stored."""
         _set_required(monkeypatch)
-        monkeypatch.setenv("AGENT_BACKEND", "goose")
+        monkeypatch.setenv("DEFAULT_BACKEND", "goose")
         monkeypatch.setenv("LLM_PROVIDER", "openai")
         # DEFAULT_MODEL must be valid for the openai provider
         monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4")
@@ -334,9 +334,9 @@ class TestLoadConfigErrors:
         assert cfg.llm_provider == "openai"
 
     def test_goose_without_provider_exits(self, monkeypatch):
-        """AGENT_BACKEND=goose without LLM_PROVIDER fails at startup."""
+        """DEFAULT_BACKEND=goose without LLM_PROVIDER fails at startup."""
         _set_required(monkeypatch)
-        monkeypatch.setenv("AGENT_BACKEND", "goose")
+        monkeypatch.setenv("DEFAULT_BACKEND", "goose")
         # LLM_PROVIDER not set - empty string is not in VALID_PROVIDERS["goose"]
         with pytest.raises(SystemExit, match=r"LLM_PROVIDER.*not valid"):
             load_config()
@@ -1546,7 +1546,7 @@ class TestMemoryReasonerBinaryValidation:
         _set_required(monkeypatch)
         _patch_protected_users_yaml(
             monkeypatch,
-            "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    agent_backend: codex\n    os_user: alice_os\n",
+            "users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    default_backend: codex\n    os_user: alice_os\n",
         )
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
@@ -1613,24 +1613,24 @@ class TestCodexMemorySameUserSymmetry:
     """Codex memory follows claude's `resolve_claude_user` symmetry
     (issue #522): `os_user` is optional and same-user spawn is a
     supported deployment shape. config-load does NOT refuse any of:
-    AGENT_BACKEND=codex without users.yaml, codex-effective user
+    DEFAULT_BACKEND=codex without users.yaml, codex-effective user
     without os_user, or codex-effective user with os_user matching
     the bot user. Pinning these as starts-cleanly cases guards
     against a future change that re-introduces the pre-#522
     deployment-shape assumption."""
 
     def test_codex_no_users_yaml_starts_cleanly(self, monkeypatch):
-        """AGENT_BACKEND=codex with extraction enabled and no
+        """DEFAULT_BACKEND=codex with extraction enabled and no
         users.yaml loads successfully. Per-user dispatch falls back
         to the global agent_backend; the spawn target is the bot
         user via the self-sudo-skip path."""
         _set_required(monkeypatch)
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        monkeypatch.setenv("DEFAULT_BACKEND", "codex")
         monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
         config = load_config()
-        assert config.agent_backend == "codex"
+        assert config.default_backend == "codex"
         assert config.memory_extraction_enabled is True
 
     def test_codex_users_yaml_missing_os_user_starts_cleanly(self, monkeypatch):
@@ -1645,7 +1645,7 @@ class TestCodexMemorySameUserSymmetry:
         )
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        monkeypatch.setenv("DEFAULT_BACKEND", "codex")
         monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
         config = load_config()
         assert config.user_configs is not None
@@ -1665,7 +1665,7 @@ class TestCodexMemorySameUserSymmetry:
         )
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        monkeypatch.setenv("DEFAULT_BACKEND", "codex")
         monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
         config = load_config()
         assert config.user_configs[12345].os_user == bot_user
@@ -1682,7 +1682,7 @@ class TestCodexMemorySameUserSymmetry:
         )
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        monkeypatch.setenv("DEFAULT_BACKEND", "codex")
         monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
         config = load_config()
         assert config.user_configs[12345].os_user == "alice_os"
@@ -1712,7 +1712,7 @@ class TestMemoryReasonerModelResolution:
     def test_codex_default_resolves_to_codex_model(self, monkeypatch):
         """Codex install: registry resolves to a codex-CLI-valid SKU.
         Test path is the per-user dispatch surface that production
-        will follow: AGENT_BACKEND=codex + users.yaml with os_user."""
+        will follow: DEFAULT_BACKEND=codex + users.yaml with os_user."""
         _set_required(monkeypatch)
         _patch_protected_users_yaml(
             monkeypatch,
@@ -1720,7 +1720,7 @@ class TestMemoryReasonerModelResolution:
         )
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
-        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        monkeypatch.setenv("DEFAULT_BACKEND", "codex")
         monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4-mini")
         load_config()
         assert get_model_for(ModelRole.MEMORY_EXTRACTION, "codex", "openai") == "gpt-5.4-mini"
@@ -1776,13 +1776,13 @@ class TestExtractionEligibleBackendsHelper:
 
         configs = {
             1: UserConfig(telegram_id=1, name="alice", os_user="a"),
-            2: UserConfig(telegram_id=2, name="bob", os_user="b", agent_backend="codex"),
+            2: UserConfig(telegram_id=2, name="bob", os_user="b", default_backend="codex"),
         }
         eligible = _compute_extraction_eligible_backends("claude", configs, True)
         assert eligible == {"claude", "codex"}
 
     def test_goose_users_contribute_to_eligible_set(self):
-        """A users.yaml entry with `agent_backend: goose` contributes
+        """A users.yaml entry with `default_backend: goose` contributes
         to the eligible set now that goose ships a OneShotReasoner;
         the config-load precondition / binary checks must fire for a
         goose user the same way they do for the other backends."""
@@ -1790,7 +1790,7 @@ class TestExtractionEligibleBackendsHelper:
 
         configs = {
             1: UserConfig(telegram_id=1, name="alice", os_user="a"),
-            2: UserConfig(telegram_id=2, name="bob", os_user="b", agent_backend="goose", llm_provider="openai"),
+            2: UserConfig(telegram_id=2, name="bob", os_user="b", default_backend="goose", llm_provider="openai"),
         }
         eligible = _compute_extraction_eligible_backends("claude", configs, True)
         assert eligible == {"claude", "goose"}
@@ -1806,7 +1806,7 @@ class TestExtractionEligibleBackendsHelper:
         monkeypatch.setattr(config_module, "ONESHOT_REASONER_BACKENDS", frozenset({"claude", "codex"}))
         configs = {
             1: UserConfig(telegram_id=1, name="alice", os_user="a"),
-            2: UserConfig(telegram_id=2, name="bob", os_user="b", agent_backend="goose", llm_provider="openai"),
+            2: UserConfig(telegram_id=2, name="bob", os_user="b", default_backend="goose", llm_provider="openai"),
         }
         eligible = _compute_extraction_eligible_backends("claude", configs, True)
         assert eligible == {"claude"}
@@ -1822,13 +1822,13 @@ class TestExtractionEligibleBackendsHelper:
 
         configs = {
             1: UserConfig(telegram_id=1, name="alice", os_user="a"),
-            2: UserConfig(telegram_id=2, name="bob", os_user="b", agent_backend="opencode"),
+            2: UserConfig(telegram_id=2, name="bob", os_user="b", default_backend="opencode"),
         }
         eligible = _compute_extraction_eligible_backends("claude", configs, True)
         assert eligible == {"claude", "opencode"}
 
     def test_global_opencode_with_no_users_yields_opencode_only(self):
-        """Single-user opencode install (global AGENT_BACKEND=opencode,
+        """Single-user opencode install (global DEFAULT_BACKEND=opencode,
         empty users dict) still produces an empty eligible set because
         the cascade only counts users present in the dict. This is the
         same shape the claude / codex paths produce for an empty
@@ -1865,8 +1865,8 @@ class TestRegistryValidationPerEligibleBackend:
     runtime without its codex memory-role rows being validated."""
 
     def test_missing_codex_memory_extraction_row_systemexits(self, monkeypatch):
-        """Mixed install: AGENT_BACKEND=claude with one users.yaml
-        entry pinned to `agent_backend: codex`. Patch the registry
+        """Mixed install: DEFAULT_BACKEND=claude with one users.yaml
+        entry pinned to `default_backend: codex`. Patch the registry
         so the codex MEMORY_EXTRACTION row is missing; load_config
         SystemExits at startup."""
         import kai.config as config_mod
@@ -1877,7 +1877,7 @@ class TestRegistryValidationPerEligibleBackend:
             monkeypatch,
             "users:\n"
             "  - telegram_id: 1\n    name: alice\n    role: admin\n"
-            "    agent_backend: codex\n    os_user: alice_os\n",
+            "    default_backend: codex\n    os_user: alice_os\n",
         )
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
@@ -2653,25 +2653,85 @@ class TestValidBackends:
         assert "codex" not in BACKENDS_NEEDING_PROVIDER_PROMPT
 
 
+class TestDefaultBackendEnvResolution:
+    """Back-compat for the AGENT_BACKEND -> DEFAULT_BACKEND env rename.
+
+    The global env reader prefers DEFAULT_BACKEND and falls back to the
+    deprecated AGENT_BACKEND for one release with a one-shot warning.
+    Absence means the installation default "claude".
+    """
+
+    def test_default_backend_env_resolved(self, monkeypatch):
+        """The new key sets the global backend with no deprecation noise."""
+        import kai.config as config_module
+
+        _set_required(monkeypatch)
+        monkeypatch.delenv("AGENT_BACKEND", raising=False)
+        monkeypatch.setenv("DEFAULT_BACKEND", "codex")
+        # codex validates DEFAULT_MODEL against CODEX_MODELS at load.
+        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.5")
+        # Clear the one-shot warned-context set so the assertion below
+        # observes this process's actual warn behavior.
+        config_module._default_backend_deprecation_warned.clear()
+        cfg = load_config()
+        assert cfg.default_backend == "codex"
+
+    def test_legacy_AGENT_BACKEND_env_still_resolved_with_warning(self, monkeypatch, caplog):
+        """Only the deprecated key set: it still resolves, and a WARNING
+        names the rename so the operator can migrate /etc/kai/env."""
+        import logging
+
+        import kai.config as config_module
+
+        _set_required(monkeypatch)
+        monkeypatch.delenv("DEFAULT_BACKEND", raising=False)
+        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.5")
+        config_module._default_backend_deprecation_warned.clear()
+        with caplog.at_level(logging.WARNING):
+            cfg = load_config()
+        assert cfg.default_backend == "codex"
+        assert any("AGENT_BACKEND" in r.message and "DEFAULT_BACKEND" in r.message for r in caplog.records)
+
+    def test_default_backend_env_wins_when_both_set(self, monkeypatch, caplog):
+        """The new key wins over the deprecated one, and no deprecation
+        warning fires because the legacy key is never consulted."""
+        import logging
+
+        import kai.config as config_module
+
+        _set_required(monkeypatch)
+        monkeypatch.setenv("DEFAULT_BACKEND", "goose")
+        monkeypatch.setenv("LLM_PROVIDER", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.5")
+        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        config_module._default_backend_deprecation_warned.clear()
+        with caplog.at_level(logging.WARNING):
+            cfg = load_config()
+        assert cfg.default_backend == "goose"
+        assert not any("AGENT_BACKEND is deprecated" in r.message for r in caplog.records)
+
+
 class TestGetUserBackendAndProvider:
     """Per-user cascade resolver."""
 
-    def _config(self, agent_backend="claude", llm_provider=""):
+    def _config(self, default_backend="claude", llm_provider=""):
         cfg = MagicMock()
-        cfg.agent_backend = agent_backend
+        cfg.default_backend = default_backend
         cfg.llm_provider = llm_provider
         return cfg
 
-    def _user_config(self, agent_backend=None, llm_provider=None):
+    def _user_config(self, default_backend=None, llm_provider=None):
         uc = MagicMock()
-        uc.agent_backend = agent_backend
+        uc.default_backend = default_backend
         uc.llm_provider = llm_provider
         return uc
 
     def test_no_user_config_returns_global(self):
         from kai.config import get_user_backend_and_provider
 
-        cfg = self._config(agent_backend="claude")
+        cfg = self._config(default_backend="claude")
         backend, provider = get_user_backend_and_provider(None, cfg)
         assert backend == "claude"
         assert provider == "anthropic"
@@ -2679,8 +2739,8 @@ class TestGetUserBackendAndProvider:
     def test_user_backend_overrides_global(self):
         from kai.config import get_user_backend_and_provider
 
-        cfg = self._config(agent_backend="claude")
-        uc = self._user_config(agent_backend="codex")
+        cfg = self._config(default_backend="claude")
+        uc = self._user_config(default_backend="codex")
         backend, provider = get_user_backend_and_provider(uc, cfg)
         assert backend == "codex"
         assert provider == "openai"
@@ -2688,8 +2748,8 @@ class TestGetUserBackendAndProvider:
     def test_global_codex_user_goose_returns_goose(self):
         from kai.config import get_user_backend_and_provider
 
-        cfg = self._config(agent_backend="codex")
-        uc = self._user_config(agent_backend="goose", llm_provider="openai")
+        cfg = self._config(default_backend="codex")
+        uc = self._user_config(default_backend="goose", llm_provider="openai")
         backend, provider = get_user_backend_and_provider(uc, cfg)
         assert backend == "goose"
         assert provider == "openai"
@@ -2697,8 +2757,8 @@ class TestGetUserBackendAndProvider:
     def test_codex_provider_is_openai_regardless_of_llm_provider(self):
         from kai.config import get_user_backend_and_provider
 
-        cfg = self._config(agent_backend="codex")
-        uc = self._user_config(agent_backend="codex", llm_provider="anthropic")
+        cfg = self._config(default_backend="codex")
+        uc = self._user_config(default_backend="codex", llm_provider="anthropic")
         backend, provider = get_user_backend_and_provider(uc, cfg)
         assert backend == "codex"
         assert provider == "openai"
@@ -2836,17 +2896,17 @@ class TestLoadConfigBackendAwareModelValidation:
         )
 
     def test_codex_rejects_goose_only_model(self, monkeypatch):
-        self._env(monkeypatch, AGENT_BACKEND="codex", DEFAULT_MODEL="gpt-5.4-nano")
+        self._env(monkeypatch, DEFAULT_BACKEND="codex", DEFAULT_MODEL="gpt-5.4-nano")
         with pytest.raises(SystemExit, match="not valid for codex"):
             load_config()
 
     def test_codex_rejects_claude_model(self, monkeypatch):
-        self._env(monkeypatch, AGENT_BACKEND="codex", DEFAULT_MODEL="opus")
+        self._env(monkeypatch, DEFAULT_BACKEND="codex", DEFAULT_MODEL="opus")
         with pytest.raises(SystemExit, match="not valid for codex"):
             load_config()
 
     def test_codex_accepts_gpt55(self, monkeypatch):
-        self._env(monkeypatch, AGENT_BACKEND="codex", DEFAULT_MODEL="gpt-5.5")
+        self._env(monkeypatch, DEFAULT_BACKEND="codex", DEFAULT_MODEL="gpt-5.5")
         cfg = load_config()
         assert cfg.default_model == "gpt-5.5"
 
@@ -3589,7 +3649,7 @@ class TestResolveUserModel:
 
     def _config(self, default_models=None):
         cfg = MagicMock()
-        cfg.agent_backend = "claude"
+        cfg.default_backend = "claude"
         cfg.llm_provider = ""
         cfg.default_models = default_models or {}
         return cfg
@@ -3652,7 +3712,7 @@ class TestLegacyEnvOverrideSeeding:
         from kai.config import UserConfig, _apply_legacy_model_env_overrides
 
         monkeypatch.setenv("PR_REVIEW_MODEL_CLAUDE", "opus")
-        uc = UserConfig(telegram_id=1, name="test", agent_backend="codex")
+        uc = UserConfig(telegram_id=1, name="test", default_backend="codex")
         out = _apply_legacy_model_env_overrides({1: uc}, "claude")
         assert out[1].models is None
 

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -933,7 +933,7 @@ class TestBackendAwareModelResolution:
         Invoke _run_cli with heavyweight machinery mocked, capturing
         the BehavioralConfig that gets handed to _run_all_probes.
 
-        Callers apply monkeypatch.setenv("AGENT_BACKEND", ...) before
+        Callers apply monkeypatch.setenv("DEFAULT_BACKEND", ...) before
         calling this helper; the env is already set by the time
         _run_cli reads it.
         """
@@ -966,7 +966,7 @@ class TestBackendAwareModelResolution:
         """
         from kai.config import ModelRole, get_model_for
 
-        monkeypatch.setenv("AGENT_BACKEND", "goose")
+        monkeypatch.setenv("DEFAULT_BACKEND", "goose")
         monkeypatch.setenv("LLM_PROVIDER", "anthropic")
         args = self._make_args(tmp_path)  # judge_model=None, gen_model=None
         config = self._run_with_captured_config(args)
@@ -975,11 +975,11 @@ class TestBackendAwareModelResolution:
 
     def test_unrecognized_backend_falls_back_to_legacy_constant(self, tmp_path, monkeypatch):
         """
-        An AGENT_BACKEND env value the registry does not know must NOT
+        A DEFAULT_BACKEND env value the registry does not know must NOT
         trigger get_model_for (no registry row, would raise
         LookupError). The fallback path uses _DEFAULT_JUDGE_MODEL.
         """
-        monkeypatch.setenv("AGENT_BACKEND", "nonexistent")
+        monkeypatch.setenv("DEFAULT_BACKEND", "nonexistent")
         args = self._make_args(tmp_path)  # judge_model=None, gen_model=None
         config = self._run_with_captured_config(args)
         assert config.judge_model == behavioral._DEFAULT_JUDGE_MODEL
@@ -990,7 +990,7 @@ class TestBackendAwareModelResolution:
         Explicit --judge-model still wins on goose. The fallback only
         kicks in for an unset (None) flag value.
         """
-        monkeypatch.setenv("AGENT_BACKEND", "goose")
+        monkeypatch.setenv("DEFAULT_BACKEND", "goose")
         args = self._make_args(tmp_path, judge_model="opus", gen_model="haiku")
         config = self._run_with_captured_config(args)
         assert config.judge_model == "opus"
@@ -1004,7 +1004,7 @@ class TestBackendAwareModelResolution:
         Phase 1's no-behavior-change invariant, so the resolved values
         must equal the pre-Phase-1 defaults.
         """
-        monkeypatch.setenv("AGENT_BACKEND", "claude")
+        monkeypatch.setenv("DEFAULT_BACKEND", "claude")
         args = self._make_args(tmp_path)
         config = self._run_with_captured_config(args)
         assert config.judge_model == behavioral._DEFAULT_JUDGE_MODEL
@@ -1012,11 +1012,36 @@ class TestBackendAwareModelResolution:
 
     def test_claude_explicit_flag_wins(self, tmp_path, monkeypatch):
         """Explicit flag wins on claude too, exercising the override path."""
-        monkeypatch.setenv("AGENT_BACKEND", "claude")
+        monkeypatch.setenv("DEFAULT_BACKEND", "claude")
         args = self._make_args(tmp_path, judge_model="opus", gen_model="sonnet")
         config = self._run_with_captured_config(args)
         assert config.judge_model == "opus"
         assert config.gen_model == "sonnet"
+
+    def test_behavioral_eval_resolves_new_DEFAULT_BACKEND(self, tmp_path, monkeypatch):
+        """The eval reads DEFAULT_BACKEND. With only the new key set
+        (no AGENT_BACKEND), it stamps the resolved backend and resolves
+        the goose registry rows."""
+        from kai.config import ModelRole, get_model_for
+
+        monkeypatch.delenv("AGENT_BACKEND", raising=False)
+        monkeypatch.setenv("DEFAULT_BACKEND", "goose")
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        args = self._make_args(tmp_path)
+        config = self._run_with_captured_config(args)
+        assert config.judge_model == get_model_for(ModelRole.BEHAVIORAL_JUDGE, "goose", "anthropic")
+
+    def test_behavioral_eval_resolves_legacy_AGENT_BACKEND(self, tmp_path, monkeypatch):
+        """One-release back-compat: a legacy AGENT_BACKEND env value
+        (no DEFAULT_BACKEND) still resolves the eval backend."""
+        from kai.config import ModelRole, get_model_for
+
+        monkeypatch.delenv("DEFAULT_BACKEND", raising=False)
+        monkeypatch.setenv("AGENT_BACKEND", "goose")
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        args = self._make_args(tmp_path)
+        config = self._run_with_captured_config(args)
+        assert config.judge_model == get_model_for(ModelRole.BEHAVIORAL_JUDGE, "goose", "anthropic")
 
 
 class TestProbeIdMatchesSourcePosition:

--- a/tests/test_eval_memory_backend_gate.py
+++ b/tests/test_eval_memory_backend_gate.py
@@ -248,15 +248,15 @@ class TestValidateUserPrefix:
 class TestMakeBackendConfig:
     def test_claude_resolves_claude_models(self):
         """Issue #515 retired the memory reasoner + model env vars;
-        `make_backend_config` now stamps `agent_backend` and the eval
+        `make_backend_config` now stamps `default_backend` and the eval
         harness reads models inline via `get_model_for(role, backend)`
-        at each call site. Pin both the agent_backend selection and
+        at each call site. Pin both the default_backend selection and
         the registry-resolved model strings so a future registry
         change surfaces here."""
         from kai.config import ModelRole, get_model_for
 
         config = g.make_backend_config(_BASE_CONFIG, "claude")
-        assert config.agent_backend == "claude"
+        assert config.default_backend == "claude"
         assert config.memory_enabled is True
         assert config.memory_extraction_enabled is True
         # Registry resolution still produces the expected literals.
@@ -267,7 +267,7 @@ class TestMakeBackendConfig:
         from kai.config import ModelRole, get_model_for
 
         config = g.make_backend_config(_BASE_CONFIG, "codex")
-        assert config.agent_backend == "codex"
+        assert config.default_backend == "codex"
         assert get_model_for(ModelRole.MEMORY_EXTRACTION, "codex", "openai") == "gpt-5.4-mini"
         assert get_model_for(ModelRole.MEMORY_EPISODE, "codex", "openai") == "gpt-5.4-mini"
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1347,7 +1347,7 @@ class TestCmdConfig:
         # ALLOWED_USER_IDS should not be in the env dict
         assert "ALLOWED_USER_IDS" not in conf["env"]
         # Default backend should not appear in env (only non-default values)
-        assert "AGENT_BACKEND" not in conf["env"]
+        assert "DEFAULT_BACKEND" not in conf["env"]
         # users.yaml should have been generated
         yaml_path = tmp_path / "users.yaml"
         assert yaml_path.exists()
@@ -1592,7 +1592,7 @@ class TestCmdConfig:
         )
 
     def test_goose_backend_writes_env(self, tmp_path, monkeypatch, capsys):
-        """Selecting goose backend writes AGENT_BACKEND to env."""
+        """Selecting goose backend writes DEFAULT_BACKEND to env."""
         monkeypatch.chdir(tmp_path)
         conf_path = tmp_path / "install.conf"
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
@@ -1601,7 +1601,7 @@ class TestCmdConfig:
 
         # Pre-seed existing config with goose backend so the prompt
         # appears (it is gated behind an existing non-claude value).
-        existing = {"version": 1, "env": {"AGENT_BACKEND": "goose"}}
+        existing = {"version": 1, "env": {"DEFAULT_BACKEND": "goose"}}
         conf_path.write_text(json.dumps(existing))
 
         monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
@@ -1646,7 +1646,7 @@ class TestCmdConfig:
         _cmd_config()
 
         conf = json.loads((tmp_path / "install.conf").read_text())
-        assert conf["env"]["AGENT_BACKEND"] == "goose"
+        assert conf["env"]["DEFAULT_BACKEND"] == "goose"
         assert conf["env"]["LLM_PROVIDER"] == "anthropic"
         assert conf["env"]["ANTHROPIC_API_KEY"] == "sk-ant-test-key"
         assert conf["env"]["GOOSE_BIN"] == "/opt/homebrew/bin/goose"
@@ -1666,7 +1666,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._redirect_staging(monkeypatch, tmp_path)
 
-        existing = {"version": 1, "env": {"AGENT_BACKEND": "goose"}}
+        existing = {"version": 1, "env": {"DEFAULT_BACKEND": "goose"}}
         conf_path.write_text(json.dumps(existing))
 
         memory_block = [
@@ -1708,7 +1708,7 @@ class TestCmdConfig:
         monkeypatch.setattr(install_module, "ONESHOT_REASONER_BACKENDS", frozenset({"claude", "codex"}))
         self._redirect_staging(monkeypatch, tmp_path)
 
-        existing = {"version": 1, "env": {"AGENT_BACKEND": "goose"}}
+        existing = {"version": 1, "env": {"DEFAULT_BACKEND": "goose"}}
         conf_path.write_text(json.dumps(existing))
 
         memory_block = [
@@ -1736,7 +1736,7 @@ class TestCmdConfig:
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._redirect_staging(monkeypatch, tmp_path)
 
-        existing = {"version": 1, "env": {"AGENT_BACKEND": "goose"}}
+        existing = {"version": 1, "env": {"DEFAULT_BACKEND": "goose"}}
         conf_path.write_text(json.dumps(existing))
 
         # No API key input after "ollama" - the prompt is skipped.
@@ -2049,8 +2049,8 @@ class TestCmdConfig:
         assert "CLAUDE_EFFORT_LEVEL" not in env
         assert "CLAUDE_USER" not in env
 
-        # Sanity: AGENT_BACKEND was emitted (it always is for non-claude).
-        assert env.get("AGENT_BACKEND") == "goose"
+        # Sanity: DEFAULT_BACKEND was emitted (it always is for non-claude).
+        assert env.get("DEFAULT_BACKEND") == "goose"
 
     def test_goose_backend_prunes_existing_claude_only_keys(self, tmp_path, monkeypatch):
         """When the operator switches an existing claude install to
@@ -2075,7 +2075,7 @@ class TestCmdConfig:
         pre_existing = {
             "version": 1,
             "env": {
-                "AGENT_BACKEND": "claude",
+                "DEFAULT_BACKEND": "claude",
                 "CLAUDE_AUTOCOMPACT_PCT": "50",
                 "CLAUDE_EFFORT_LEVEL": "xhigh",
                 "CLAUDE_USER": "kai",
@@ -2093,11 +2093,11 @@ class TestCmdConfig:
         conf = json.loads(conf_path.read_text())
         env = conf["env"]
         # All three previously-set Claude-only keys must be absent.
-        # AGENT_BACKEND must reflect the new selection.
+        # DEFAULT_BACKEND must reflect the new selection.
         assert "CLAUDE_AUTOCOMPACT_PCT" not in env
         assert "CLAUDE_EFFORT_LEVEL" not in env
         assert "CLAUDE_USER" not in env
-        assert env.get("AGENT_BACKEND") == "goose"
+        assert env.get("DEFAULT_BACKEND") == "goose"
 
     def test_memory_enabled_writes_tunables(self, tmp_path, monkeypatch):
         """MEMORY_ENABLED=true with extraction writes the chosen tunables."""
@@ -2259,7 +2259,7 @@ class TestCmdConfig:
             "users:\n  - telegram_id: 999\n    name: existing\n    role: admin\n",
         )
 
-        # AGENT_BACKEND seeded explicitly so the extraction-keys cleanup (non-claude pops them) doesn't depend on the wizard's implicit default.
+        # DEFAULT_BACKEND seeded explicitly so the extraction-keys cleanup (non-claude pops them) doesn't depend on the wizard's implicit default.
         existing = {
             "version": 1,
             "install_dir": "/opt/kai",
@@ -2269,7 +2269,7 @@ class TestCmdConfig:
             "env": {
                 "TELEGRAM_BOT_TOKEN": "existing-token",
                 "WEBHOOK_SECRET": "existing-secret",
-                "AGENT_BACKEND": "claude",
+                "DEFAULT_BACKEND": "claude",
                 "MEMORY_ENABLED": "true",
                 "MEMORY_EXTRACTION_ENABLED": "true",
                 "MEMORY_EXTRACTION_BUDGET_USD": "0.08",
@@ -2354,7 +2354,7 @@ class TestCmdConfig:
         existing = {
             "version": 1,
             "env": {
-                "AGENT_BACKEND": "goose",
+                "DEFAULT_BACKEND": "goose",
                 "MEMORY_ENABLED": "true",
                 "MEMORY_EXTRACTION_ENABLED": "true",
                 "MEMORY_EXTRACTION_BUDGET_USD": "0.05",
@@ -2640,7 +2640,7 @@ class TestCmdConfig:
         # else falls back to dataclass defaults via load_config.
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
         monkeypatch.setenv("ALLOWED_USER_IDS", "1")
-        monkeypatch.setenv("AGENT_BACKEND", "codex")
+        monkeypatch.setenv("DEFAULT_BACKEND", "codex")
         # DEFAULT_MODEL validates against the agent backend's model
         # set; codex requires a CODEX_MODELS entry. The wizard would
         # have prompted for this; here we set it explicitly to focus
@@ -2649,7 +2649,7 @@ class TestCmdConfig:
         monkeypatch.setenv("MEMORY_ENABLED", "true")
         monkeypatch.setenv("MEMORY_EXTRACTION_ENABLED", "true")
         # MEMORY_REASONER_BACKEND retired (issue #515); memory reasoner
-        # derives from AGENT_BACKEND per-user. The wizard no longer
+        # derives from DEFAULT_BACKEND per-user. The wizard no longer
         # emits the key.
         # MEMORY_EPISODE_MODEL is intentionally NOT set; the codex
         # branch defaults the wizard prompt to blank, which means
@@ -2660,7 +2660,7 @@ class TestCmdConfig:
         config = load_config()
         assert config.memory_enabled is True
         assert config.memory_extraction_enabled is True
-        assert config.agent_backend == "codex"
+        assert config.default_backend == "codex"
         # Per-user dispatch (issue #515) resolves the memory model
         # from the registry at extraction time; verify both stage roles
         # have a codex-valid row.
@@ -2795,7 +2795,7 @@ class TestCmdConfig:
         config = load_config()
         assert config.memory_enabled is True
         assert config.memory_extraction_enabled is True
-        assert config.agent_backend == "codex"
+        assert config.default_backend == "codex"
         assert config.user_configs is not None
         assert 12345 in config.user_configs
         # No os_user → in-process spawn at runtime via the
@@ -3234,6 +3234,22 @@ class TestCmdConfigDefaultModelDispatch:
         _, env = self._run(monkeypatch, tmp_path, base, helper_return="gpt-5.5")
         assert env.get("CODEX_EFFORT_LEVEL") == "high"
 
+    def test_install_conf_legacy_AGENT_BACKEND_migrates_on_resave(self, tmp_path, monkeypatch):
+        """Re-running the wizard against a prior install.conf that
+        carries the deprecated AGENT_BACKEND key writes DEFAULT_BACKEND
+        only: the wizard never re-emits the legacy key, so the resaved
+        install.conf is clean. The legacy value is still honored as the
+        prefill (read through the resolver)."""
+        self._setup(monkeypatch, tmp_path, existing_env={"AGENT_BACKEND": "codex"})
+        _, env = self._run(
+            monkeypatch,
+            tmp_path,
+            self._inputs_for_codex_subscription(),
+            helper_return="gpt-5.5",
+        )
+        assert env.get("DEFAULT_BACKEND") == "codex"
+        assert "AGENT_BACKEND" not in env
+
     def test_codex_effort_prompt_displays_choices(self, tmp_path, monkeypatch):
         """
         The Codex effort prompt advertises the allowed values and the
@@ -3429,10 +3445,10 @@ class TestCmdConfigDefaultModelDispatch:
         inputs = base_inputs[: idx + 1] + memory_inputs[1:] + base_inputs[idx + 1 :]
         _, env = self._run(monkeypatch, tmp_path, inputs, helper_return="gpt-5.4")
         # Codex install persists memory extraction config; the global
-        # AGENT_BACKEND=codex is what makes codex extraction-eligible.
+        # DEFAULT_BACKEND=codex is what makes codex extraction-eligible.
         assert env.get("MEMORY_ENABLED") == "true"
         assert env.get("MEMORY_EXTRACTION_ENABLED") == "true"
-        assert env.get("AGENT_BACKEND") == "codex"
+        assert env.get("DEFAULT_BACKEND") == "codex"
         # MEMORY_REASONER_BACKEND retired; the wizard must not emit it.
         assert "MEMORY_REASONER_BACKEND" not in env
 
@@ -3501,7 +3517,7 @@ class TestCmdApplyDefaultModelGate:
         monkeypatch.setattr("os.geteuid", lambda: 0)
         conf_path = self._write_install_conf(
             tmp_path,
-            {"DEFAULT_MODEL": "sonnet", "AGENT_BACKEND": "goose", "LLM_PROVIDER": "openai"},
+            {"DEFAULT_MODEL": "sonnet", "DEFAULT_BACKEND": "goose", "LLM_PROVIDER": "openai"},
         )
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         stop_service = self._patch_side_effects(monkeypatch)
@@ -3523,7 +3539,7 @@ class TestCmdApplyDefaultModelGate:
         monkeypatch.setattr("os.geteuid", lambda: 0)
         conf_path = self._write_install_conf(
             tmp_path,
-            {"AGENT_BACKEND": "goose", "LLM_PROVIDER": "openai"},
+            {"DEFAULT_BACKEND": "goose", "LLM_PROVIDER": "openai"},
         )
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         stop_service = self._patch_side_effects(monkeypatch)
@@ -3545,7 +3561,7 @@ class TestCmdApplyDefaultModelGate:
         monkeypatch.setattr("os.geteuid", lambda: 0)
         conf_path = self._write_install_conf(
             tmp_path,
-            {"AGENT_BACKEND": "claude"},
+            {"DEFAULT_BACKEND": "claude"},
         )
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         stop_service = self._patch_side_effects(monkeypatch)
@@ -3568,7 +3584,7 @@ class TestCmdApplyDefaultModelGate:
             tmp_path,
             {
                 "DEFAULT_MODEL": "anthropic/claude-sonnet-4-6",
-                "AGENT_BACKEND": "goose",
+                "DEFAULT_BACKEND": "goose",
                 "LLM_PROVIDER": "openrouter",
             },
         )
@@ -3589,7 +3605,7 @@ class TestCmdApplyDefaultModelGate:
         monkeypatch.setenv("DRY_RUN", "1")
         conf_path = self._write_install_conf(
             tmp_path,
-            {"DEFAULT_MODEL": "sonnet", "AGENT_BACKEND": "goose", "LLM_PROVIDER": "openai"},
+            {"DEFAULT_MODEL": "sonnet", "DEFAULT_BACKEND": "goose", "LLM_PROVIDER": "openai"},
         )
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         stop_service = self._patch_side_effects(monkeypatch)
@@ -3604,12 +3620,12 @@ class TestCmdApplyDefaultModelGate:
     def test_normalizes_llm_provider_case_and_whitespace(self, tmp_path, monkeypatch):
         """
         Mirrors load_config's .strip().lower() normalization on
-        AGENT_BACKEND and LLM_PROVIDER. The test relies on a code path
+        DEFAULT_BACKEND and LLM_PROVIDER. The test relies on a code path
         where normalized and un-normalized lookups produce DIFFERENT
         gate outcomes, so that the test fails if either transformation
         is dropped from the gate.
 
-        Setup: AGENT_BACKEND="goose", LLM_PROVIDER=" OpenAI ", DEFAULT_MODEL="sonnet".
+        Setup: DEFAULT_BACKEND="goose", LLM_PROVIDER=" OpenAI ", DEFAULT_MODEL="sonnet".
         - With .strip().lower() applied: eff_provider="openai",
           validate("sonnet", "openai") returns False (sonnet is not in
           PROVIDER_MODELS["openai"]) -> SystemExit.
@@ -3628,7 +3644,7 @@ class TestCmdApplyDefaultModelGate:
             tmp_path,
             {
                 "DEFAULT_MODEL": "sonnet",
-                "AGENT_BACKEND": "goose",
+                "DEFAULT_BACKEND": "goose",
                 "LLM_PROVIDER": " OpenAI ",
             },
         )
@@ -3642,6 +3658,55 @@ class TestCmdApplyDefaultModelGate:
         # load_config error wording.
         assert "openai" in str(excinfo.value).lower()
         stop_service.assert_not_called()
+
+    def test_apply_resolves_legacy_AGENT_BACKEND(self, tmp_path, monkeypatch):
+        """A legacy install.conf carrying AGENT_BACKEND=codex must
+        validate the default model against the CODEX surface (not
+        anthropic) and migrate the env dict so /etc/kai/env is written
+        with DEFAULT_BACKEND and no AGENT_BACKEND.
+
+        Apply consumes the install.conf env dict directly, never through
+        load_config, so the migration has to happen inside _cmd_apply.
+        gpt-5.5 is codex-valid but NOT anthropic-valid: if the apply
+        path defaulted the backend to claude, this would SystemExit.
+        """
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {"DEFAULT_MODEL": "gpt-5.5", "AGENT_BACKEND": "codex"},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        self._patch_side_effects(monkeypatch)
+        # Capture the env dict handed to _apply_secrets to confirm the
+        # in-memory migration ran before the write.
+        secrets_mock = MagicMock()
+        monkeypatch.setattr("kai.install._apply_secrets", secrets_mock)
+        monkeypatch.setenv("DRY_RUN", "1")
+
+        _cmd_apply()
+
+        secrets_mock.assert_called_once()
+        written_env = secrets_mock.call_args.args[0]
+        assert written_env.get("DEFAULT_BACKEND") == "codex"
+        assert "AGENT_BACKEND" not in written_env
+
+    def test_apply_resolves_new_DEFAULT_BACKEND(self, tmp_path, monkeypatch):
+        """A new-name install.conf passes through cleanly: goose-path
+        setup is reached (the gate accepts a goose-valid model and apply
+        proceeds past _stop_service)."""
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {"DEFAULT_MODEL": "gpt-5.5", "DEFAULT_BACKEND": "goose", "LLM_PROVIDER": "openai"},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        stop_service = self._patch_side_effects(monkeypatch)
+        monkeypatch.setenv("DRY_RUN", "1")
+
+        _cmd_apply()
+        stop_service.assert_called_once()
 
 
 # ── Directory creation ───────────────────────────────────────────────
@@ -6941,7 +7006,7 @@ class TestCmdApplyStagingHandoff:
                 "TELEGRAM_BOT_TOKEN": "tok",
                 "WEBHOOK_SECRET": "secret",
                 "DEFAULT_MODEL": "sonnet",
-                "AGENT_BACKEND": "claude",
+                "DEFAULT_BACKEND": "claude",
             },
         }
         if staging_path is not None:
@@ -7368,7 +7433,7 @@ class TestCmdApplySingleUserRefuses:
                 "TELEGRAM_BOT_TOKEN": "tok",
                 "WEBHOOK_SECRET": "secret",
                 "DEFAULT_MODEL": "sonnet",
-                "AGENT_BACKEND": "claude",
+                "DEFAULT_BACKEND": "claude",
             },
         }
         conf_path = tmp_path / "install.conf"
@@ -7542,7 +7607,7 @@ class TestApplySudoersDryRun:
             "    os_user: alice\n"
             "  - telegram_id: 2\n"
             "    os_user: bob\n"
-            "    agent_backend: claude\n"
+            "    default_backend: claude\n"
         )
 
         _apply_sudoers(
@@ -7617,7 +7682,7 @@ class TestApplySudoersDryRun:
 
 
 class TestCollectBackendsFromYaml:
-    """The lightweight per-user agent_backend reader that scopes the
+    """The lightweight per-user default_backend reader that scopes the
     sudoers missing-binary backstop."""
 
     def test_missing_file_returns_empty_set(self, tmp_path):
@@ -7628,11 +7693,11 @@ class TestCollectBackendsFromYaml:
         path.write_text(
             "users:\n"
             "  - telegram_id: 1\n"
-            "    agent_backend: codex\n"
+            "    default_backend: codex\n"
             "  - telegram_id: 2\n"
-            "    agent_backend: opencode\n"
+            "    default_backend: opencode\n"
             "  - telegram_id: 3\n"
-            "    agent_backend: codex\n"
+            "    default_backend: codex\n"
             "  - telegram_id: 4\n"
         )
         assert _collect_backends_from_yaml(path) == {"codex", "opencode"}
@@ -7640,9 +7705,44 @@ class TestCollectBackendsFromYaml:
     def test_non_string_and_blank_values_skipped(self, tmp_path):
         path = tmp_path / "users.yaml"
         path.write_text(
-            "users:\n  - telegram_id: 1\n    agent_backend: 42\n  - telegram_id: 2\n    agent_backend: '  '\n"
+            "users:\n  - telegram_id: 1\n    default_backend: 42\n  - telegram_id: 2\n    default_backend: '  '\n"
         )
         assert _collect_backends_from_yaml(path) == set()
+
+
+class TestEntryBackendLegacyKey:
+    """Every installer-side users.yaml scanner reads a per-user entry's
+    backend through `_entry_backend`, which prefers `default_backend`
+    and falls back to the deprecated `agent_backend` key for one
+    release. Without this, a per-user `default_backend: goose` entry
+    would be invisible to wizard/apply setup (provider keys, binary
+    collection, goose config deployment, sudoers scoping)."""
+
+    @pytest.mark.parametrize("key", ["default_backend", "agent_backend"])
+    def test_collect_backends_reads_both_keys(self, tmp_path, key):
+        path = tmp_path / "users.yaml"
+        path.write_text(f"users:\n  - telegram_id: 1\n    {key}: goose\n")
+        assert _collect_backends_from_yaml(path) == {"goose"}
+
+    @pytest.mark.parametrize("key", ["default_backend", "agent_backend"])
+    def test_users_yaml_agent_backends_reads_both_keys(self, tmp_path, key):
+        path = tmp_path / "users.yaml"
+        path.write_text(f"users:\n  - telegram_id: 1\n    {key}: codex\n")
+        assert _users_yaml_agent_backends(path) == {"codex"}
+
+    @pytest.mark.parametrize("key", ["default_backend", "agent_backend"])
+    def test_goose_providers_reads_both_keys(self, tmp_path, key):
+        path = tmp_path / "users.yaml"
+        path.write_text(f"users:\n  - telegram_id: 1\n    {key}: goose\n    llm_provider: openai\n")
+        assert _users_yaml_goose_providers(path, "anthropic") == ["openai"]
+
+    @pytest.mark.parametrize("key", ["default_backend", "agent_backend"])
+    def test_goose_os_users_reads_both_keys(self, tmp_path, key):
+        from kai.install import _collect_goose_os_users_from_yaml
+
+        path = tmp_path / "users.yaml"
+        path.write_text(f"users:\n  - telegram_id: 1\n    {key}: goose\n    os_user: alice\n")
+        assert _collect_goose_os_users_from_yaml(path, "claude") == ["alice"]
 
 
 # ── _apply_service dry run ───────────────────────────────────────────
@@ -7776,17 +7876,17 @@ class TestApplyGooseConfig:
             "users:\n"
             "  - telegram_id: 1\n"
             "    name: alice\n"
-            "    agent_backend: goose\n"
+            "    default_backend: goose\n"
             "    os_user: alice\n"
             # Duplicate os_user entry: the deploy must dedupe.
             "  - telegram_id: 2\n"
             "    name: alice2\n"
-            "    agent_backend: goose\n"
+            "    default_backend: goose\n"
             "    os_user: alice\n"
             # Non-goose user with an os_user: not a deploy target.
             "  - telegram_id: 3\n"
             "    name: bob\n"
-            "    agent_backend: codex\n"
+            "    default_backend: codex\n"
             "    os_user: bob\n"
         )
 
@@ -7831,7 +7931,7 @@ class TestApplyGooseConfig:
 
     def test_global_goose_install_deploys_to_os_users_without_override(self, tmp_path, monkeypatch):
         """On a global goose install, users.yaml entries with no
-        per-user agent_backend inherit goose and their os_user homes
+        per-user default_backend inherit goose and their os_user homes
         are deploy targets."""
         import types
 
@@ -7882,7 +7982,7 @@ class TestApplyGooseConfig:
 
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text(
-            "users:\n  - telegram_id: 1\n    name: alice\n    agent_backend: goose\n    os_user: alice\n"
+            "users:\n  - telegram_id: 1\n    name: alice\n    default_backend: goose\n    os_user: alice\n"
         )
         monkeypatch.setattr(
             "kai.install.pwd",
@@ -7916,7 +8016,7 @@ class TestApplyGooseConfig:
         # return before the template existence check.
         install_path = tmp_path / "opt" / "kai"
         users_yaml = tmp_path / "users.yaml"
-        users_yaml.write_text("users:\n  - {telegram_id: 1, name: a, agent_backend: codex, os_user: bob}\n")
+        users_yaml.write_text("users:\n  - {telegram_id: 1, name: a, default_backend: codex, os_user: bob}\n")
 
         _apply_goose_config(
             "kai",
@@ -7943,7 +8043,7 @@ class TestApplyGooseConfig:
 
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text(
-            "users:\n  - telegram_id: 1\n    name: ghost\n    agent_backend: goose\n    os_user: ghost\n"
+            "users:\n  - telegram_id: 1\n    name: ghost\n    default_backend: goose\n    os_user: ghost\n"
         )
 
         def _raise_keyerror(name):
@@ -7982,8 +8082,8 @@ class TestCollectGooseOsUsersFromYaml:
         path = tmp_path / "users.yaml"
         path.write_text(
             "users:\n"
-            "  - {telegram_id: 1, name: a, agent_backend: goose, os_user: alice}\n"
-            "  - {telegram_id: 2, name: b, agent_backend: codex, os_user: bob}\n"
+            "  - {telegram_id: 1, name: a, default_backend: goose, os_user: alice}\n"
+            "  - {telegram_id: 2, name: b, default_backend: codex, os_user: bob}\n"
             "  - {telegram_id: 3, name: c, os_user: carol}\n"
         )
         assert _collect_goose_os_users_from_yaml(path, "claude") == ["alice"]
@@ -7995,7 +8095,7 @@ class TestCollectGooseOsUsersFromYaml:
         path.write_text(
             "users:\n"
             "  - {telegram_id: 1, name: a, os_user: alice}\n"
-            "  - {telegram_id: 2, name: b, agent_backend: claude, os_user: bob}\n"
+            "  - {telegram_id: 2, name: b, default_backend: claude, os_user: bob}\n"
         )
         assert _collect_goose_os_users_from_yaml(path, "goose") == ["alice"]
 
@@ -8003,7 +8103,7 @@ class TestCollectGooseOsUsersFromYaml:
         from kai.install import _collect_goose_os_users_from_yaml
 
         path = tmp_path / "users.yaml"
-        path.write_text("users:\n  - {telegram_id: 1, name: a, agent_backend: goose}\n")
+        path.write_text("users:\n  - {telegram_id: 1, name: a, default_backend: goose}\n")
         assert _collect_goose_os_users_from_yaml(path, "claude") == []
 
     def test_duplicates_deduped_preserving_order(self, tmp_path):
@@ -8012,9 +8112,9 @@ class TestCollectGooseOsUsersFromYaml:
         path = tmp_path / "users.yaml"
         path.write_text(
             "users:\n"
-            "  - {telegram_id: 1, name: a, agent_backend: goose, os_user: alice}\n"
-            "  - {telegram_id: 2, name: b, agent_backend: goose, os_user: dana}\n"
-            "  - {telegram_id: 3, name: c, agent_backend: goose, os_user: alice}\n"
+            "  - {telegram_id: 1, name: a, default_backend: goose, os_user: alice}\n"
+            "  - {telegram_id: 2, name: b, default_backend: goose, os_user: dana}\n"
+            "  - {telegram_id: 3, name: c, default_backend: goose, os_user: alice}\n"
         )
         assert _collect_goose_os_users_from_yaml(path, "claude") == ["alice", "dana"]
 
@@ -8022,7 +8122,7 @@ class TestCollectGooseOsUsersFromYaml:
         from kai.install import _collect_goose_os_users_from_yaml
 
         path = tmp_path / "users.yaml"
-        path.write_text('users:\n  - {telegram_id: 1, name: a, agent_backend: goose, os_user: "bad)user"}\n')
+        path.write_text('users:\n  - {telegram_id: 1, name: a, default_backend: goose, os_user: "bad)user"}\n')
         with pytest.raises(ValueError, match="Invalid os_user"):
             _collect_goose_os_users_from_yaml(path, "claude")
 
@@ -8597,7 +8697,7 @@ class TestOpenCodeBinWizardPrompt:
 
         env = json.loads((tmp_path / "install.conf").read_text())["env"]
         assert env["OPENCODE_BIN"] == str(opencode_path)
-        assert env["AGENT_BACKEND"] == "opencode"
+        assert env["DEFAULT_BACKEND"] == "opencode"
 
     def test_wizard_loops_on_invalid_opencode_bin(self, tmp_path, monkeypatch):
         """An invalid path (does not exist, or not executable) must
@@ -8898,9 +8998,9 @@ class TestOpenCodeBinWizardPrompt:
         _cmd_config()
 
         env = json.loads((tmp_path / "install.conf").read_text())["env"]
-        # AGENT_BACKEND pins which gate branch fired; opencode here
+        # DEFAULT_BACKEND pins which gate branch fired; opencode here
         # exercises the previously-broken cleanup path.
-        assert env["AGENT_BACKEND"] == "opencode"
+        assert env["DEFAULT_BACKEND"] == "opencode"
         # MEMORY_EXTRACTION_ENABLED was always emitted by the wizard,
         # then silently stripped by the cleanup gate before the gate
         # read from ONESHOT_REASONER_BACKENDS. Load-bearing assertion
@@ -8958,7 +9058,7 @@ class TestApplyBackendAwareModelValidation:
     def _conf(self, tmp_path, **env_overrides):
         env = {
             "TELEGRAM_BOT_TOKEN": "tok",
-            "AGENT_BACKEND": "codex",
+            "DEFAULT_BACKEND": "codex",
             "DEFAULT_MODEL": "gpt-5.5",
         }
         env.update(env_overrides)
@@ -9101,8 +9201,8 @@ class TestApplyAgentTimeoutMigration:
 class TestBuildCodexLoginReminder:
     """Post-install codex subscription-auth reminder policy.
 
-    The reminder is global-only: it fires when AGENT_BACKEND=codex AND
-    auth mode is subscription. Per-user `agent_backend: codex` entries
+    The reminder is global-only: it fires when DEFAULT_BACKEND=codex AND
+    auth mode is subscription. Per-user `default_backend: codex` entries
     in users.yaml DO NOT trigger the reminder; mixed-backend installs
     are operator-managed and the reminder would be wizard noise for
     operators who chose a non-codex global backend.
@@ -9126,7 +9226,7 @@ class TestBuildCodexLoginReminder:
             tmp_path,
             [{"telegram_id": 1, "name": "alice", "role": "admin", "os_user": "alice"}],
         )
-        env = {"AGENT_BACKEND": "codex", "CODEX_AUTH_MODE": "subscription"}
+        env = {"DEFAULT_BACKEND": "codex", "CODEX_AUTH_MODE": "subscription"}
         text = _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml)
         assert text is not None
         assert "Codex subscription auth required:" in text
@@ -9137,7 +9237,7 @@ class TestBuildCodexLoginReminder:
         from kai.install import _build_codex_login_reminder
 
         users_yaml = self._write_users_yaml(tmp_path, [])
-        env = {"AGENT_BACKEND": "codex"}
+        env = {"DEFAULT_BACKEND": "codex"}
         text = _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml)
         assert text is not None
 
@@ -9158,7 +9258,7 @@ class TestBuildCodexLoginReminder:
                 {"telegram_id": 2, "name": "bob", "role": "user", "os_user": "bob"},
             ],
         )
-        env = {"AGENT_BACKEND": "codex"}
+        env = {"DEFAULT_BACKEND": "codex"}
         text = _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml)
         assert text is not None
         # No per-user enumeration. Specific os_user lines must NOT appear.
@@ -9184,12 +9284,12 @@ class TestBuildCodexLoginReminder:
                     "telegram_id": 1,
                     "name": "alice",
                     "role": "admin",
-                    "agent_backend": "codex",
+                    "default_backend": "codex",
                     "os_user": "alice",
                 }
             ],
         )
-        env = {"AGENT_BACKEND": "claude"}
+        env = {"DEFAULT_BACKEND": "claude"}
         assert _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml) is None
 
     def test_pure_claude_returns_none(self, tmp_path):
@@ -9200,7 +9300,7 @@ class TestBuildCodexLoginReminder:
             tmp_path,
             [{"telegram_id": 1, "name": "alice", "role": "admin", "os_user": "alice"}],
         )
-        env = {"AGENT_BACKEND": "claude"}
+        env = {"DEFAULT_BACKEND": "claude"}
         assert _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml) is None
 
     def test_codex_api_key_mode_returns_none(self, tmp_path):
@@ -9211,11 +9311,11 @@ class TestBuildCodexLoginReminder:
             tmp_path,
             [{"telegram_id": 1, "name": "alice", "role": "admin", "os_user": "alice"}],
         )
-        env = {"AGENT_BACKEND": "codex", "CODEX_AUTH_MODE": "api_key"}
+        env = {"DEFAULT_BACKEND": "codex", "CODEX_AUTH_MODE": "api_key"}
         assert _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml) is None
 
     def test_missing_agent_backend_returns_none(self, tmp_path):
-        """No AGENT_BACKEND key in env defaults to claude; reminder skipped."""
+        """No DEFAULT_BACKEND key in env defaults to claude; reminder skipped."""
         from kai.install import _build_codex_login_reminder
 
         users_yaml = self._write_users_yaml(tmp_path, [])
@@ -9242,7 +9342,7 @@ class TestUsersYamlGooseProviders:
     def test_goose_entry_with_explicit_provider(self, tmp_path):
         p = self._write(
             tmp_path,
-            "users:\n  - telegram_id: 1\n    name: a\n    agent_backend: goose\n    llm_provider: deepseek\n",
+            "users:\n  - telegram_id: 1\n    name: a\n    default_backend: goose\n    llm_provider: deepseek\n",
         )
         assert _users_yaml_goose_providers(p, "") == ["deepseek"]
 
@@ -9253,29 +9353,29 @@ class TestUsersYamlGooseProviders:
         canonical provider form PROVIDER_KEY_VARS is keyed on."""
         p = self._write(
             tmp_path,
-            "users:\n  - telegram_id: 1\n    name: a\n    agent_backend: Goose\n    llm_provider: DeepSeek\n",
+            "users:\n  - telegram_id: 1\n    name: a\n    default_backend: Goose\n    llm_provider: DeepSeek\n",
         )
         assert _users_yaml_goose_providers(p, "") == ["deepseek"]
 
     def test_falls_back_to_global_provider(self, tmp_path):
         """An entry that omits llm_provider inherits the global
         provider, mirroring the runtime cascade."""
-        p = self._write(tmp_path, "users:\n  - telegram_id: 1\n    name: a\n    agent_backend: goose\n")
+        p = self._write(tmp_path, "users:\n  - telegram_id: 1\n    name: a\n    default_backend: goose\n")
         assert _users_yaml_goose_providers(p, "deepseek") == ["deepseek"]
 
     def test_no_global_fallback_yields_nothing(self, tmp_path):
         """No llm_provider anywhere: the scan returns nothing and the
         runtime's users.yaml validation owns the error."""
-        p = self._write(tmp_path, "users:\n  - telegram_id: 1\n    name: a\n    agent_backend: goose\n")
+        p = self._write(tmp_path, "users:\n  - telegram_id: 1\n    name: a\n    default_backend: goose\n")
         assert _users_yaml_goose_providers(p, "") == []
 
     def test_distinct_providers_deduplicated_and_sorted(self, tmp_path):
         p = self._write(
             tmp_path,
             "users:\n"
-            "  - telegram_id: 1\n    name: a\n    agent_backend: goose\n    llm_provider: openai\n"
-            "  - telegram_id: 2\n    name: b\n    agent_backend: goose\n    llm_provider: deepseek\n"
-            "  - telegram_id: 3\n    name: c\n    agent_backend: goose\n    llm_provider: deepseek\n",
+            "  - telegram_id: 1\n    name: a\n    default_backend: goose\n    llm_provider: openai\n"
+            "  - telegram_id: 2\n    name: b\n    default_backend: goose\n    llm_provider: deepseek\n"
+            "  - telegram_id: 3\n    name: c\n    default_backend: goose\n    llm_provider: deepseek\n",
         )
         assert _users_yaml_goose_providers(p, "") == ["deepseek", "openai"]
 
@@ -9285,8 +9385,8 @@ class TestUsersYamlGooseProviders:
         p = self._write(
             tmp_path,
             "users:\n"
-            "  - telegram_id: 1\n    name: a\n    agent_backend: opencode\n    llm_provider: deepseek\n"
-            "  - telegram_id: 2\n    name: b\n    agent_backend: codex\n"
+            "  - telegram_id: 1\n    name: a\n    default_backend: opencode\n    llm_provider: deepseek\n"
+            "  - telegram_id: 2\n    name: b\n    default_backend: codex\n"
             "  - telegram_id: 3\n    name: c\n",
         )
         assert _users_yaml_goose_providers(p, "deepseek") == []
@@ -9316,7 +9416,7 @@ class TestWizardPerUserGooseProviderKeys:
         "    role: admin\n"
         "  - telegram_id: 2\n"
         "    name: bob\n"
-        "    agent_backend: goose\n"
+        "    default_backend: goose\n"
         "    llm_provider: deepseek\n"
     )
 
@@ -9460,9 +9560,9 @@ class TestUsersYamlAgentBackends:
         p = self._write(
             tmp_path,
             "users:\n"
-            "  - telegram_id: 1\n    name: a\n    agent_backend: goose\n"
-            "  - telegram_id: 2\n    name: b\n    agent_backend: codex\n"
-            "  - telegram_id: 3\n    name: c\n    agent_backend: codex\n"
+            "  - telegram_id: 1\n    name: a\n    default_backend: goose\n"
+            "  - telegram_id: 2\n    name: b\n    default_backend: codex\n"
+            "  - telegram_id: 3\n    name: c\n    default_backend: codex\n"
             "  - telegram_id: 4\n    name: d\n",
         )
         assert _users_yaml_agent_backends(p) == {"goose", "codex"}
@@ -9470,18 +9570,18 @@ class TestUsersYamlAgentBackends:
     def test_strips_whitespace_skips_non_strings(self, tmp_path):
         p = self._write(
             tmp_path,
-            "users:\n  - telegram_id: 1\n    name: a\n    agent_backend: ' codex '\n  - telegram_id: 2\n    name: b\n    agent_backend: 7\n",
+            "users:\n  - telegram_id: 1\n    name: a\n    default_backend: ' codex '\n  - telegram_id: 2\n    name: b\n    default_backend: 7\n",
         )
         assert _users_yaml_agent_backends(p) == {"codex"}
 
     def test_mixed_case_normalized_like_runtime(self, tmp_path):
-        """The runtime loader accepts `agent_backend` case-insensitively
+        """The runtime loader accepts `default_backend` case-insensitively
         (str.strip().lower() before validation), so mixed-case entries
         route users at runtime; the scan must produce the canonical
         lower-case form or the prompt gates silently miss them."""
         p = self._write(
             tmp_path,
-            "users:\n  - telegram_id: 1\n    name: a\n    agent_backend: Codex\n  - telegram_id: 2\n    name: b\n    agent_backend: ' GOOSE '\n",
+            "users:\n  - telegram_id: 1\n    name: a\n    default_backend: Codex\n  - telegram_id: 2\n    name: b\n    default_backend: ' GOOSE '\n",
         )
         assert _users_yaml_agent_backends(p) == {"codex", "goose"}
 
@@ -9507,7 +9607,7 @@ class TestWizardPerUserBackendBinaries:
         "    role: admin\n"
         "  - telegram_id: 2\n"
         "    name: bob\n"
-        "    agent_backend: codex\n"
+        "    default_backend: codex\n"
     )
     CLAUDE_USERS_YAML = (
         "users:\n"
@@ -9516,7 +9616,7 @@ class TestWizardPerUserBackendBinaries:
         "    role: admin\n"
         "  - telegram_id: 2\n"
         "    name: bob\n"
-        "    agent_backend: claude\n"
+        "    default_backend: claude\n"
     )
     PLAIN_USERS_YAML = "users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n"
 
@@ -9619,7 +9719,7 @@ class TestWizardPerUserBackendBinaries:
         assert env["CODEX_BIN"] == "/stored/bin/codex"
 
     def test_mixed_case_codex_entry_still_prompts(self, tmp_path, monkeypatch):
-        """`agent_backend: Codex` is valid at runtime (the loader
+        """`default_backend: Codex` is valid at runtime (the loader
         lowercases before validation) and routes the user, so the
         scan must normalize the same way; a casing difference must
         not skip the binary prompt and reintroduce the startup-gate
@@ -9631,7 +9731,7 @@ class TestWizardPerUserBackendBinaries:
             "    role: admin\n"
             "  - telegram_id: 2\n"
             "    name: bob\n"
-            "    agent_backend: Codex\n"
+            "    default_backend: Codex\n"
         )
         self._setup(monkeypatch, tmp_path, mixed_yaml)
         monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
@@ -9655,7 +9755,7 @@ class TestWizardPerUserBackendBinaries:
             "    role: admin\n"
             "  - telegram_id: 2\n"
             "    name: bob\n"
-            "    agent_backend: opencode\n"
+            "    default_backend: opencode\n"
         )
         self._setup(monkeypatch, tmp_path, opencode_yaml)
         monkeypatch.setattr("kai.install._validate_opencode_bin", lambda p: bool(p))

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3708,6 +3708,35 @@ class TestCmdApplyDefaultModelGate:
         _cmd_apply()
         stop_service.assert_called_once()
 
+    def test_apply_normalizes_mixed_case_global_backend(self, tmp_path, monkeypatch):
+        """A hand-edited install.conf with `DEFAULT_BACKEND: "Goose"`
+        normalizes to lowercase in the written env so the downstream
+        goose-config / sudoers gates (which read the raw value) and
+        /etc/kai/env all see the canonical form. Without the write-back,
+        validation lowercases for the gate but `_apply_goose_config`
+        would see "Goose" and skip the deploy."""
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {"DEFAULT_MODEL": "gpt-5.5", "DEFAULT_BACKEND": "Goose", "LLM_PROVIDER": "openai"},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        self._patch_side_effects(monkeypatch)
+        secrets_mock = MagicMock()
+        monkeypatch.setattr("kai.install._apply_secrets", secrets_mock)
+        goose_mock = MagicMock()
+        monkeypatch.setattr("kai.install._apply_goose_config", goose_mock)
+        monkeypatch.setenv("DRY_RUN", "1")
+
+        _cmd_apply()
+
+        written_env = secrets_mock.call_args.args[0]
+        assert written_env.get("DEFAULT_BACKEND") == "goose"
+        # The goose-config deploy gate receives the normalized value.
+        assert goose_mock.call_args.kwargs.get("agent_backend") == "goose"
+
 
 # ── Directory creation ───────────────────────────────────────────────
 
@@ -7742,6 +7771,23 @@ class TestEntryBackendLegacyKey:
 
         path = tmp_path / "users.yaml"
         path.write_text(f"users:\n  - telegram_id: 1\n    {key}: goose\n    os_user: alice\n")
+        assert _collect_goose_os_users_from_yaml(path, "claude") == ["alice"]
+
+    def test_collect_backends_normalizes_mixed_case(self, tmp_path):
+        """A mixed-case per-user value is valid at runtime (the loader
+        lowercases); the scanner must normalize too so the goose-config
+        membership check `"goose" in <set>` matches."""
+        path = tmp_path / "users.yaml"
+        path.write_text("users:\n  - telegram_id: 1\n    default_backend: Goose\n")
+        assert _collect_backends_from_yaml(path) == {"goose"}
+
+    def test_goose_os_users_normalizes_mixed_case(self, tmp_path):
+        """A mixed-case `default_backend: Goose` user's os_user must
+        still be collected for the per-user goose config deploy."""
+        from kai.install import _collect_goose_os_users_from_yaml
+
+        path = tmp_path / "users.yaml"
+        path.write_text("users:\n  - telegram_id: 1\n    default_backend: Goose\n    os_user: alice\n")
         assert _collect_goose_os_users_from_yaml(path, "claude") == ["alice"]
 
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -297,7 +297,7 @@ class TestInitMemory:
             lambda backend: f"/fake/{backend}-binary",
         )
         # Per-user dispatch: the eligible set is computed from
-        # `agent_backend` (legacy ALLOWED_USER_IDS auth has no
+        # `default_backend` (legacy ALLOWED_USER_IDS auth has no
         # users.yaml, so every user inherits the global). A
         # single-backend install logs the uniform-mode flat keys plus
         # the per-backend maps. users.yaml is mandatory post-#565
@@ -305,7 +305,7 @@ class TestInitMemory:
         # backend matches the global.
         config = _make_config(
             memory_extraction_enabled=True,
-            agent_backend="codex",
+            default_backend="codex",
             user_configs={1: UserConfig(telegram_id=1, name="alice", os_user="a")},
         )
         with (
@@ -345,10 +345,10 @@ class TestInitMemory:
         )
         config = _make_config(
             memory_extraction_enabled=True,
-            agent_backend="claude",
+            default_backend="claude",
             user_configs={
                 1: UserConfig(telegram_id=1, name="alice", os_user="a"),
-                2: UserConfig(telegram_id=2, name="bob", os_user="b", agent_backend="codex"),
+                2: UserConfig(telegram_id=2, name="bob", os_user="b", default_backend="codex"),
             },
         )
         with (

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -2108,7 +2108,7 @@ def auth_config():
     cfg = MagicMock()
     cfg.allowed_user_ids = {999}
     cfg.memory_search_floor = 0.3
-    cfg.agent_backend = "claude"
+    cfg.default_backend = "claude"
     cfg.get_user_config.return_value = None
     return cfg
 
@@ -2355,7 +2355,7 @@ class TestDashboardBackendNote:
     async def test_note_appended_for_non_reasoner_backend(
         self, monkeypatch, update_factory, context_factory, auth_config
     ):
-        auth_config.agent_backend = "goose"
+        auth_config.default_backend = "goose"
         monkeypatch.setattr(memory_command, "ONESHOT_REASONER_BACKENDS", frozenset({"claude", "codex"}))
         monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
         monkeypatch.setattr(
@@ -2375,7 +2375,7 @@ class TestDashboardBackendNote:
         """The empty state is where "why is this empty?" is sharpest;
         the note must appear there too, not only on populated
         dashboards."""
-        auth_config.agent_backend = "goose"
+        auth_config.default_backend = "goose"
         monkeypatch.setattr(memory_command, "ONESHOT_REASONER_BACKENDS", frozenset({"claude", "codex"}))
         monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
         monkeypatch.setattr(
@@ -2412,7 +2412,7 @@ class TestDashboardBackendNote:
         the note; the fall-through matches the extraction gate's
         backend resolution."""
         user_cfg = MagicMock()
-        user_cfg.agent_backend = "goose"
+        user_cfg.default_backend = "goose"
         auth_config.get_user_config.return_value = user_cfg
         monkeypatch.setattr(memory_command, "ONESHOT_REASONER_BACKENDS", frozenset({"claude", "codex"}))
         monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -3722,7 +3722,7 @@ class TestRunExtractorWithCodexEnvelope:
                     duration_ms=42,
                 )
 
-        config = _cfg(agent_backend="codex")
+        config = _cfg(default_backend="codex")
         with patch("kai.memory_extraction._build_memory_reasoner", return_value=_FakeCodexReasoner()):
             result = await memory_extraction._run_extractor(
                 payload_text="payload",
@@ -3752,7 +3752,7 @@ class TestRunExtractorWithCodexEnvelope:
             async def run(self, **kwargs):
                 raise OneShotOutputError("codex final JSON missing required fields: ['facts', 'has_episode']")
 
-        config = _cfg(agent_backend="codex")
+        config = _cfg(default_backend="codex")
         with patch("kai.memory_extraction._build_memory_reasoner", return_value=_OutputErrorReasoner()):
             result = await memory_extraction._run_extractor(
                 payload_text="payload",
@@ -3963,14 +3963,14 @@ class TestExtractAndStorePerUserDispatch:
 
         config = replace(
             _cfg(),
-            agent_backend="claude",
+            default_backend="claude",
             user_configs={
                 1: UserConfig(telegram_id=1, name="alice", os_user="alice_os"),
                 2: UserConfig(
                     telegram_id=2,
                     name="bob",
                     os_user="bob_os",
-                    agent_backend="codex",
+                    default_backend="codex",
                 ),
             },
         )
@@ -4014,14 +4014,14 @@ class TestExtractAndStorePerUserDispatch:
 
         config = replace(
             _cfg(),
-            agent_backend="claude",
+            default_backend="claude",
             user_configs={
                 1: UserConfig(telegram_id=1, name="alice", os_user="alice_os"),
                 2: UserConfig(
                     telegram_id=2,
                     name="bob",
                     os_user="bob_os",
-                    agent_backend="codex",
+                    default_backend="codex",
                 ),
             },
         )
@@ -4035,8 +4035,8 @@ class TestExtractAndStorePerUserDispatch:
 
     @pytest.mark.asyncio
     async def test_per_user_override_wins_over_global(self, monkeypatch):
-        """Global `AGENT_BACKEND=claude` with a per-user
-        `agent_backend: codex` override resolves to codex for the
+        """Global `DEFAULT_BACKEND=claude` with a per-user
+        `default_backend: codex` override resolves to codex for the
         override user. Pin the cascade direction (per-user beats
         global) at the dispatch site."""
         from kai import memory as memory_module
@@ -4068,13 +4068,13 @@ class TestExtractAndStorePerUserDispatch:
 
         config = replace(
             _cfg(),
-            agent_backend="claude",
+            default_backend="claude",
             user_configs={
                 1: UserConfig(
                     telegram_id=1,
                     name="alice",
                     os_user="alice_os",
-                    agent_backend="codex",
+                    default_backend="codex",
                 )
             },
         )
@@ -4083,8 +4083,8 @@ class TestExtractAndStorePerUserDispatch:
 
     @pytest.mark.asyncio
     async def test_inherits_global_when_no_per_user_override(self, monkeypatch):
-        """Global `AGENT_BACKEND=codex` with a users.yaml entry that
-        does not pin `agent_backend` resolves to codex for that
+        """Global `DEFAULT_BACKEND=codex` with a users.yaml entry that
+        does not pin `default_backend` resolves to codex for that
         user. Pins the cascade fallback when no override exists."""
         from kai import memory as memory_module
         from kai.config import UserConfig
@@ -4115,7 +4115,7 @@ class TestExtractAndStorePerUserDispatch:
 
         config = replace(
             _cfg(),
-            agent_backend="codex",
+            default_backend="codex",
             user_configs={
                 1: UserConfig(telegram_id=1, name="alice", os_user="alice_os"),
             },
@@ -4148,13 +4148,13 @@ class TestExtractAndStorePerUserDispatch:
 
         config = replace(
             _cfg(),
-            agent_backend="claude",
+            default_backend="claude",
             user_configs={
                 1: UserConfig(
                     telegram_id=1,
                     name="alice",
                     os_user="alice_os",
-                    agent_backend="codex",
+                    default_backend="codex",
                 )
             },
         )

--- a/tests/test_memory_reclassify.py
+++ b/tests/test_memory_reclassify.py
@@ -99,7 +99,7 @@ def _config(tmp_path: Path) -> MagicMock:
     cfg = MagicMock()
     cfg.memory_projects = {}
     cfg.user_configs = {}
-    cfg.agent_backend = "claude"
+    cfg.default_backend = "claude"
     cfg.llm_provider = ""
     cfg.memory_extraction_timeout_s = 60
     cfg.session_db_path = tmp_path / "kai.db"
@@ -468,7 +468,7 @@ class TestResolveClassificationSettings:
     def test_user_overrides_win_over_global(self, tmp_path):
         cfg = _config(tmp_path)
         user = MagicMock()
-        user.agent_backend = "codex"
+        user.default_backend = "codex"
         user.llm_provider = "deepseek"
         user.os_user = "alice"
         cfg.user_configs = {100: user}
@@ -479,7 +479,7 @@ class TestResolveClassificationSettings:
 
     def test_unsupported_effective_backend_errors(self, tmp_path):
         cfg = _config(tmp_path)
-        cfg.agent_backend = "not-a-reasoner-backend"
+        cfg.default_backend = "not-a-reasoner-backend"
         settings = memory_reclassify.resolve_classification_settings(
             cfg, "100", backend=None, os_user=None, provider=None
         )
@@ -489,7 +489,7 @@ class TestResolveClassificationSettings:
     def test_explicit_flags_override_resolution(self, tmp_path):
         cfg = _config(tmp_path)
         user = MagicMock()
-        user.agent_backend = "codex"
+        user.default_backend = "codex"
         user.llm_provider = "deepseek"
         user.os_user = "alice"
         cfg.user_configs = {100: user}
@@ -564,7 +564,7 @@ class TestDryRun:
     @pytest.mark.asyncio
     async def test_unsupported_backend_exits_2(self, dry_run_env):
         env = dry_run_env
-        env["config"].agent_backend = "not-a-reasoner-backend"
+        env["config"].default_backend = "not-a-reasoner-backend"
         code = await env["run"](backend=None)
         assert code == 2
 

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -548,7 +548,7 @@ class TestConstructor:
 
 class TestStartupFailureSurface:
     """
-    Spec #556 acceptance criterion: a per-user `agent_backend: opencode`
+    Spec #556 acceptance criterion: a per-user `default_backend: opencode`
     entry on a non-opencode install must produce a chat-visible
     startup-failure StreamEvent (not silent failure, not fall-through
     to claude) when `opencode` is missing from PATH.

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -144,11 +144,11 @@ class TestInstanceCreation:
 
 class TestPerUserBackendRouting:
     def test_user_gets_goose_when_global_is_claude(self):
-        """User with agent_backend=goose gets GooseBackend even when global is claude."""
+        """User with default_backend=goose gets GooseBackend even when global is claude."""
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            agent_backend="goose",
+            default_backend="goose",
             llm_provider="openai",
             model="gpt-5.4",
         )
@@ -160,7 +160,7 @@ class TestPerUserBackendRouting:
         assert instance.model == "gpt-5.4"
 
     def test_user_without_backend_gets_global(self):
-        """User with no agent_backend gets the global backend (claude)."""
+        """User with no default_backend gets the global backend (claude)."""
         user = UserConfig(telegram_id=111, name="alice")
         config = _make_config(user_configs={111: user})
         pool = SubprocessPool(config=config, services_info=[])
@@ -174,12 +174,12 @@ class TestPerUserBackendRouting:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            agent_backend="goose",
+            default_backend="goose",
             llm_provider="google",
             model="gemini-3-flash",
         )
         config = _make_config(
-            agent_backend="goose",
+            default_backend="goose",
             llm_provider="openai",
             default_model="gpt-5.4",
             user_configs={111: user},
@@ -196,7 +196,7 @@ class TestPerUserBackendRouting:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            agent_backend="goose",
+            default_backend="goose",
             llm_provider="openai",
             # No model set - should get openai default, not global "sonnet"
         )
@@ -213,7 +213,7 @@ class TestPerUserBackendRouting:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            agent_backend="goose",
+            default_backend="goose",
             llm_provider="openai",
             model="gpt-5.4",
         )
@@ -235,7 +235,7 @@ class TestPerUserBackendRouting:
 
     def test_opencode_user_on_claude_global_install(self):
         """
-        Per-user `agent_backend: opencode` on a globally-claude install
+        Per-user `default_backend: opencode` on a globally-claude install
         with a free-text model gets an OpenCodeBackend with the supplied
         model intact. OpenCode model strings are full provider/model
         IDs; no per-provider default substitution applies.
@@ -245,11 +245,11 @@ class TestPerUserBackendRouting:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            agent_backend="opencode",
+            default_backend="opencode",
             model="anthropic/claude-sonnet-4-6",
         )
         config = _make_config(
-            agent_backend="claude",
+            default_backend="claude",
             llm_provider="anthropic",
             default_model="sonnet",
             user_configs={111: user},
@@ -261,7 +261,7 @@ class TestPerUserBackendRouting:
 
     def test_opencode_user_without_model_falls_back_to_empty(self, caplog):
         """
-        Per-user `agent_backend: opencode` with no model and global
+        Per-user `default_backend: opencode` with no model and global
         backend != opencode: OpenCodeBackend gets model="" so OPENCODE_
         CONFIG_CONTENT is omitted and OpenCode uses its own config
         files. A warning is logged so the operator notices the gap.
@@ -273,11 +273,11 @@ class TestPerUserBackendRouting:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            agent_backend="opencode",
+            default_backend="opencode",
             # NO model: tests the bare opencode-override case.
         )
         config = _make_config(
-            agent_backend="claude",
+            default_backend="claude",
             llm_provider="anthropic",
             default_model="sonnet",
             user_configs={111: user},
@@ -291,7 +291,7 @@ class TestPerUserBackendRouting:
 
     def test_codex_user_on_claude_global_install_gets_codex_default(self):
         """
-        Per-user `agent_backend: codex` on a globally-claude install
+        Per-user `default_backend: codex` on a globally-claude install
         must NOT fall through to the global default_model ("sonnet"),
         which codex CLI rejects. Without the
         get_user_backend_and_provider routing in _create_instance,
@@ -304,12 +304,12 @@ class TestPerUserBackendRouting:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            agent_backend="codex",
+            default_backend="codex",
             # NO llm_provider, NO model - tests the bare codex-override case.
         )
         # Globally-claude install (the failure surface from PR #489 review).
         config = _make_config(
-            agent_backend="claude",
+            default_backend="claude",
             llm_provider="anthropic",
             default_model="sonnet",
             user_configs={111: user},
@@ -329,7 +329,7 @@ class TestPerUserBackendRouting:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            agent_backend="goose",
+            default_backend="goose",
             llm_provider="anthropic",
             model="sonnet",
             os_user="alice-os",
@@ -350,11 +350,13 @@ class TestPerUserBackendRouting:
 
         users = {
             111: UserConfig(
-                telegram_id=111, name="a", agent_backend="claude", llm_provider="anthropic", model="sonnet"
+                telegram_id=111, name="a", default_backend="claude", llm_provider="anthropic", model="sonnet"
             ),
-            222: UserConfig(telegram_id=222, name="b", agent_backend="codex"),
-            333: UserConfig(telegram_id=333, name="c", agent_backend="goose", llm_provider="anthropic", model="sonnet"),
-            444: UserConfig(telegram_id=444, name="d", agent_backend="opencode", model="anthropic/claude-sonnet-4-6"),
+            222: UserConfig(telegram_id=222, name="b", default_backend="codex"),
+            333: UserConfig(
+                telegram_id=333, name="c", default_backend="goose", llm_provider="anthropic", model="sonnet"
+            ),
+            444: UserConfig(telegram_id=444, name="d", default_backend="opencode", model="anthropic/claude-sonnet-4-6"),
         }
         config = _make_config(agent_max_session_hours=6.5, user_configs=users)
         pool = SubprocessPool(config=config, services_info=[])
@@ -380,7 +382,7 @@ class TestPerUserBackendRouting:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            agent_backend="opencode",
+            default_backend="opencode",
             model="anthropic/claude-sonnet-4-6",
             os_user="alice-os",
         )
@@ -726,11 +728,11 @@ class TestWorkspaceRestoration:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            agent_backend="codex",
+            default_backend="codex",
             home_workspace=ws,
         )
         config = _make_config(
-            agent_backend="codex",
+            default_backend="codex",
             llm_provider="openai",
             default_model="gpt-5.5",
             user_configs={111: user},

--- a/tests/test_smoke_memory.py
+++ b/tests/test_smoke_memory.py
@@ -37,7 +37,7 @@ def _config(**overrides) -> Config:
     defaults = {
         "memory_enabled": True,
         "memory_extraction_enabled": True,
-        "agent_backend": "claude",
+        "default_backend": "claude",
         "memory_extraction_timeout_s": 30,
     }
     defaults.update(overrides)
@@ -193,12 +193,12 @@ class TestSmokeMemoryRoutingPrecondition:
     @pytest.mark.asyncio
     async def test_codex_without_os_user_proceeds(self, monkeypatch, capsys):
         """Issue #522: codex same-user spawn is supported. Smoke
-        without --os-user against AGENT_BACKEND=codex no longer
+        without --os-user against DEFAULT_BACKEND=codex no longer
         exits 1 on the precondition; it proceeds to the reasoner
         call. Pins the symmetry with claude same-user."""
         from kai.smoke import memory as smoke_module
 
-        monkeypatch.setattr(smoke_module, "load_config", lambda: _config(agent_backend="codex"))
+        monkeypatch.setattr(smoke_module, "load_config", lambda: _config(default_backend="codex"))
         fake_run = AsyncMock(
             return_value=OneShotResult(
                 text=_success_envelope(),
@@ -250,7 +250,7 @@ class TestSmokeMemoryUserIdDispatch:
     """The `--user-id` flag drives the smoke's effective backend
     resolution (issue #515). With per-user dispatch, the smoke must
     reach the same reasoner production would for that user; without
-    `--user-id`, it falls back to the global `agent_backend`."""
+    `--user-id`, it falls back to the global `default_backend`."""
 
     @pytest.mark.asyncio
     async def test_user_id_resolves_codex_user(self, monkeypatch, capsys):
@@ -267,7 +267,7 @@ class TestSmokeMemoryUserIdDispatch:
                     telegram_id=1,
                     name="codex_user",
                     os_user="codex_os",
-                    agent_backend="codex",
+                    default_backend="codex",
                 )
             }
         )
@@ -303,18 +303,18 @@ class TestSmokeMemoryUserIdDispatch:
     @pytest.mark.asyncio
     async def test_user_id_resolves_claude_user(self, monkeypatch, capsys):
         """A `--user-id` matching a claude-effective users.yaml entry
-        resolves to claude even when global AGENT_BACKEND=codex."""
+        resolves to claude even when global DEFAULT_BACKEND=codex."""
         from kai.config import UserConfig
         from kai.smoke import memory as smoke_module
 
         config = _config(
-            agent_backend="codex",
+            default_backend="codex",
             user_configs={
                 1: UserConfig(
                     telegram_id=1,
                     name="claude_user",
                     os_user="claude_os",
-                    agent_backend="claude",
+                    default_backend="claude",
                 )
             },
         )
@@ -350,12 +350,12 @@ class TestSmokeMemoryUserIdDispatch:
     @pytest.mark.asyncio
     async def test_no_user_id_uses_global_agent_backend(self, monkeypatch, capsys):
         """Smoke without `--user-id` falls back to the global
-        `agent_backend`. Pins the legacy single-backend smoke path
+        `default_backend`. Pins the legacy single-backend smoke path
         so the per-user dispatch change does not silently break
         operator habits ('run smoke without flags' still works)."""
         from kai.smoke import memory as smoke_module
 
-        config = _config(agent_backend="claude")
+        config = _config(default_backend="claude")
         monkeypatch.setattr(smoke_module, "load_config", lambda: config)
         captured_backend: list[str] = []
 

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -45,7 +45,7 @@ class TestUserConfig:
         assert uc.github_notify_chat_id is None
         assert uc.pr_review is None
         assert uc.issue_triage is None
-        assert uc.agent_backend is None
+        assert uc.default_backend is None
         assert uc.llm_provider is None
 
     def test_all_fields(self):
@@ -64,7 +64,7 @@ class TestUserConfig:
             github_notify_chat_id=-100123456789,
             pr_review=True,
             issue_triage=False,
-            agent_backend="goose",
+            default_backend="goose",
             llm_provider="openai",
         )
         assert uc.role == "admin"
@@ -77,7 +77,7 @@ class TestUserConfig:
         assert uc.github_notify_chat_id == -100123456789
         assert uc.pr_review is True
         assert uc.issue_triage is False
-        assert uc.agent_backend == "goose"
+        assert uc.default_backend == "goose"
         assert uc.llm_provider == "openai"
 
     def test_frozen(self):
@@ -827,13 +827,13 @@ class TestLoadUserConfigs:
     # ── Per-user backend/provider ─────────────────────────────────
 
     def test_valid_agent_backend(self, tmp_path):
-        """Valid agent_backend is parsed and stored."""
+        """Valid default_backend is parsed and stored."""
         data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
                 name: alice
-                agent_backend: goose
+                default_backend: goose
                 llm_provider: openai
                 model: gpt-5.4
             """,
@@ -843,23 +843,23 @@ class TestLoadUserConfigs:
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
-        assert configs[111].agent_backend == "goose"
+        assert configs[111].default_backend == "goose"
         assert configs[111].llm_provider == "openai"
         assert configs[111].model == "gpt-5.4"
 
     def test_invalid_agent_backend_exits(self, tmp_path):
-        """Invalid agent_backend causes SystemExit."""
+        """Invalid default_backend causes SystemExit."""
         data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
                 name: alice
-                agent_backend: invalid
+                default_backend: invalid
             """,
         )
         with (
             patch("kai.config._read_protected_yaml", return_value=data),
-            pytest.raises(SystemExit, match="invalid agent_backend"),
+            pytest.raises(SystemExit, match="invalid default_backend"),
         ):
             _load_user_configs("claude", "")
 
@@ -870,7 +870,7 @@ class TestLoadUserConfigs:
             users:
               - telegram_id: 111
                 name: alice
-                agent_backend: goose
+                default_backend: goose
                 llm_provider: badprovider
             """,
         )
@@ -887,7 +887,7 @@ class TestLoadUserConfigs:
             users:
               - telegram_id: 111
                 name: alice
-                agent_backend: goose
+                default_backend: goose
             """,
         )
         with (
@@ -897,6 +897,63 @@ class TestLoadUserConfigs:
         ):
             _load_user_configs("claude", "")
 
+    def test_legacy_agent_backend_in_users_yaml_still_resolved_with_warning(self, tmp_path, caplog):
+        """A users.yaml entry using the deprecated `agent_backend:` key
+        still resolves to default_backend for one release, with a
+        one-shot deprecation warning naming the user."""
+        import logging
+
+        import kai.config as config_module
+
+        data = self._yaml_dict(
+            """\
+            users:
+              - telegram_id: 111
+                name: alice
+                agent_backend: codex
+            """,
+        )
+        config_module._default_backend_deprecation_warned.clear()
+        with (
+            patch("kai.config._read_protected_yaml", return_value=data),
+            caplog.at_level(logging.WARNING),
+        ):
+            configs = _load_user_configs("claude", "")
+        assert configs[111].default_backend == "codex"
+        assert any("agent_backend" in r.message and "default_backend" in r.message for r in caplog.records)
+
+    def test_user_without_backend_inherits_nonclaude_global(self, tmp_path):
+        """A users.yaml entry that omits the backend key must NOT be
+        pinned to claude: its stored override stays None so the
+        runtime cascade (user override OR global) inherits the global
+        backend. Regression guard for the resolver-default split: the
+        per-user reader passes default=None, not default="claude".
+        """
+        data = self._yaml_dict(
+            """\
+            users:
+              - telegram_id: 111
+                name: alice
+            """,
+        )
+        with patch("kai.config._read_protected_yaml", return_value=data):
+            # Global backend is goose; the user has no per-user backend.
+            configs = _load_user_configs("goose", "openai")
+        # None on the stored override is what makes the runtime cascade
+        # inherit the global backend rather than forcing claude.
+        assert configs[111].default_backend is None
+        # And the canonical cascade resolves the user to the global goose.
+        from kai.config import Config, get_user_backend_and_provider
+
+        global_cfg = Config(
+            telegram_bot_token="test",
+            allowed_user_ids={1},
+            default_backend="goose",
+            llm_provider="openai",
+        )
+        backend, _provider = get_user_backend_and_provider(configs[111], global_cfg)
+        assert backend == "goose"
+
     def test_goose_backend_inherits_global_provider(self, tmp_path):
         """User with goose backend inherits global llm_provider."""
         data = self._yaml_dict(
@@ -904,7 +961,7 @@ class TestLoadUserConfigs:
             users:
               - telegram_id: 111
                 name: alice
-                agent_backend: goose
+                default_backend: goose
                 model: gpt-5.4
             """,
         )
@@ -915,7 +972,7 @@ class TestLoadUserConfigs:
             configs = _load_user_configs("goose", "openai")
         assert configs is not None
         # User inherits global provider, no per-user override stored
-        assert configs[111].agent_backend == "goose"
+        assert configs[111].default_backend == "goose"
         assert configs[111].llm_provider is None
 
     def test_model_validated_against_user_provider(self, tmp_path):
@@ -925,7 +982,7 @@ class TestLoadUserConfigs:
             users:
               - telegram_id: 111
                 name: alice
-                agent_backend: goose
+                default_backend: goose
                 llm_provider: openai
                 model: opus
             """,
@@ -945,7 +1002,7 @@ class TestLoadUserConfigs:
             users:
               - telegram_id: 111
                 name: alice
-                agent_backend: goose
+                default_backend: goose
                 llm_provider: ollama
             """,
         )

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -450,7 +450,7 @@ def _build_test_app(
         mock_config = MagicMock()
         mock_config.user_configs = {}
         mock_config.default_models = {}
-        mock_config.agent_backend = "claude"
+        mock_config.default_backend = "claude"
         mock_config.llm_provider = ""
         # get_user_config is synchronous in real Config; must not
         # return a coroutine. With no users configured, always None.
@@ -1306,7 +1306,7 @@ class TestGetSubscribedUsers:
         config = MagicMock()
         config.user_configs = user_configs if user_configs is not None else {}
         config.default_models = {}
-        config.agent_backend = "claude"
+        config.default_backend = "claude"
         config.llm_provider = ""
         return config
 
@@ -1517,7 +1517,7 @@ class TestPerUserRouting:
         config = MagicMock()
         config.user_configs = {u.telegram_id: u for u in users}
         config.default_models = {}
-        config.agent_backend = "claude"
+        config.default_backend = "claude"
         config.llm_provider = ""
         # get_user_config returns the UserConfig for a given ID
         config.get_user_config = lambda uid: config.user_configs.get(uid)
@@ -2049,13 +2049,13 @@ class TestPerUserRouting:
 
     @pytest.mark.asyncio
     async def test_review_receives_user_backend(self, _clear_cooldowns, _mock_resolve_repo):
-        """Per-user agent_backend/llm_provider are passed to review_pr."""
+        """Per-user default_backend/llm_provider are passed to review_pr."""
         base = self._make_user_config(111, repos=["owner/repo"])
         # Frozen dataclass - use replace to set per-user backend override
-        user = dataclasses.replace(base, agent_backend="goose", llm_provider="openai")
+        user = dataclasses.replace(base, default_backend="goose", llm_provider="openai")
         config = self._make_config_with_users([user])
         # Global defaults (should be overridden by per-user values)
-        config.agent_backend = "claude"
+        config.default_backend = "claude"
         config.llm_provider = ""
         app = _build_test_app(config=config)
         payload = _make_pr_payload("opened")
@@ -2084,11 +2084,11 @@ class TestPerUserRouting:
 
     @pytest.mark.asyncio
     async def test_triage_receives_user_backend(self, _clear_cooldowns):
-        """Per-user agent_backend/llm_provider are passed to triage_issue."""
+        """Per-user default_backend/llm_provider are passed to triage_issue."""
         base = self._make_user_config(111, repos=["owner/repo"])
-        user = dataclasses.replace(base, agent_backend="goose", llm_provider="anthropic")
+        user = dataclasses.replace(base, default_backend="goose", llm_provider="anthropic")
         config = self._make_config_with_users([user])
-        config.agent_backend = "claude"
+        config.default_backend = "claude"
         config.llm_provider = ""
         app = _build_test_app(config=config)
         payload = _make_issue_payload("opened")
@@ -2119,9 +2119,9 @@ class TestPerUserRouting:
     async def test_review_uses_global_backend_when_no_user_override(self, _clear_cooldowns, _mock_resolve_repo):
         """Without per-user override, review_pr gets the global backend."""
         user = self._make_user_config(111, repos=["owner/repo"])
-        # No agent_backend/llm_provider set on user - defaults are None
+        # No default_backend/llm_provider set on user - defaults are None
         config = self._make_config_with_users([user])
-        config.agent_backend = "goose"
+        config.default_backend = "goose"
         config.llm_provider = "google"
         app = _build_test_app(config=config)
         payload = _make_pr_payload("opened")


### PR DESCRIPTION
## Summary

Renames the installation-wide and per-user "which backend by default" knob from `AGENT_BACKEND` to `DEFAULT_BACKEND`, paralleling `DEFAULT_MODEL` and dropping the redundant "agent_" prefix (backends *are* the agents in this codebase). The old name is still read for one release with a one-shot deprecation warning at every reader; all writers emit the new name only.

This is groundwork ahead of adding the Pi backend (#696), so that work only learns the new vocabulary.

## What changed

- **`Config.agent_backend` → `Config.default_backend`** and **`UserConfig.agent_backend` → `UserConfig.default_backend`**. Every constructor call and attribute access swept.
- **Env var / config key**: `AGENT_BACKEND` → `DEFAULT_BACKEND` (env), `agent_backend:` → `default_backend:` (users.yaml per-user key), `AGENT_BACKEND` → `DEFAULT_BACKEND` (install.conf env dict).
- **Shared resolver** `_resolve_default_backend(get, new_key, old_key, *, context, default)` in `config.py`: reads the new key, falls back to the old with a one-shot per-context deprecation log. Takes a required `default` so the two absence semantics stay distinct — global readers pass `default="claude"` (installation default); the per-user users.yaml reader passes `default=None` so a backend-less user still inherits the global backend via the existing `user_backend or global_backend` cascade (rather than being pinned to claude on a non-claude install).
- **Five readers routed through the resolver**: `load_config` (env), `_cmd_apply` (install.conf dict), `behavioral._run_cli` (env), `_load_user_configs` (per-user yaml), plus the wizard prefill.
- **Installer (`_cmd_apply`)** consumes the install.conf env dict directly (never through `load_config`), so it migrates a legacy `AGENT_BACKEND` key to `DEFAULT_BACKEND` once at the top of apply, before any backend gate reads it or `/etc/kai/env` is written. Without this, a legacy install.conf would validate a codex/goose default model against the wrong (claude/anthropic) surface and fail, or silently skip backend-specific setup.
- **Four installer-side users.yaml scanners** (`_users_yaml_goose_providers`, `_users_yaml_agent_backends`, `_collect_backends_from_yaml`, `_collect_goose_os_users_from_yaml`) read each entry's backend through a new `_entry_backend(entry)` helper (prefer `default_backend`, fall back `agent_backend`).
- **Wizard**: prompt label "Agent backend" → "Default backend"; prefill reads either key; writes `DEFAULT_BACKEND` only (so a re-run silently migrates `install.conf`).
- **Templates** (`templates/.env`, `templates/users.yaml`, `templates/config/goose-config.yaml`) and **docs** (README; wiki pages pushed after merge).

Internal function parameters named `agent_backend` that hold the *effective* (post-cascade) backend at a call site (e.g. `models_for_backend`, `review_pr`, `run_triage`, `_apply_goose_config`) are intentionally left unchanged — they name a runtime value, not a default.

## Test plan

- [x] `make check` (ruff + format) clean
- [x] `make test` clean (4576 passed, 1 skipped; +18 over `main`)
- [x] New back-compat tests: legacy `AGENT_BACKEND` env still resolves with a warning; new key wins when both set; legacy `agent_backend:` users.yaml key still resolves with a warning
- [x] New inheritance regression guard: a users.yaml user omitting the backend key inherits a non-claude global backend (resolver `default=None`), not claude
- [x] New apply-path tests: a legacy `AGENT_BACKEND=codex` install.conf validates against the codex surface and writes `/etc/kai/env` with `DEFAULT_BACKEND` and no `AGENT_BACKEND`; a new-name install.conf passes through cleanly
- [x] New scanner coverage: all four installer users.yaml scanners read both key names
- [x] New behavioral-eval coverage: resolves both `DEFAULT_BACKEND` and legacy `AGENT_BACKEND`
- [x] New wizard resave-migration test: re-running against a legacy install.conf writes `DEFAULT_BACKEND`, drops `AGENT_BACKEND`
- [ ] Manual post-merge: `make config` shows the "Default backend" prompt; a legacy `/etc/kai/env` with `AGENT_BACKEND` logs the deprecation warning at startup and still resolves
