### PR TITLE
Finish the default_/bare-noun config naming scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Workspaces can also define a system prompt via `workspaces.yaml` for workspace-s
 
 #### Memory backend selection
 
-Semantic memory extraction (the subprocess that proactively writes facts and episode summaries) routes per-user: each user's effective `default_backend` selects the reasoner, and the model comes from the project's `MODEL_REGISTRY` for that `(role, backend)` pair. Claude-effective users get the claude reasoner with the claude-registry model; codex-effective users get the codex reasoner with the codex-registry model; opencode-effective users get the opencode reasoner with the opencode-registry model (a `provider/model` string resolved at runtime by `opencode` against the operator's `opencode auth login` state). There is no per-deployment override for the memory reasoner or model; an operator who wants a different model edits the registry in `config.py`.
+Semantic memory extraction (the subprocess that proactively writes facts and episode summaries) routes per-user: each user's effective backend selects the reasoner, and the model comes from the project's `MODEL_REGISTRY` for that `(role, backend)` pair. Claude-effective users get the claude reasoner with the claude-registry model; codex-effective users get the codex reasoner with the codex-registry model; opencode-effective users get the opencode reasoner with the opencode-registry model (a `provider/model` string resolved at runtime by `opencode` against the operator's `opencode auth login` state). There is no per-deployment override for the memory reasoner or model; an operator who wants a different model edits the registry in `config.py`.
 
 OpenCode users get the same one-shot parity as claude and codex users: PR review, issue triage, memory extraction, episode generation, and behavioral eval all dispatch through `OpenCodeOneShotReasoner`, which spawns a fresh `opencode acp` JSON-RPC subprocess per call and denies any tool-permission request mid-stream. No fall-through to `claude --print` or `codex exec` for opencode users on any one-shot site.
 
@@ -216,9 +216,9 @@ Authorization, per-user model selection, per-user OS isolation, per-user GitHub 
 |---|---|---|---|
 | `TELEGRAM_BOT_TOKEN` | Yes | | Bot token from BotFather |
 | `DEFAULT_BACKEND` | No | `claude` | Global default backend: `claude`, `goose`, `codex`, or `opencode`. Per-user override goes in `users.yaml`. (The former `AGENT_BACKEND` name is still read for one release with a deprecation warning.) |
-| `LLM_PROVIDER` | Non-claude | | Global provider for non-claude backends. Per-user override in `users.yaml`. |
+| `DEFAULT_PROVIDER` | Non-claude | | Global provider for non-claude backends. Per-user override in `users.yaml`. (The former `LLM_PROVIDER` name is still read for one release with a deprecation warning.) |
 | `DEFAULT_MODEL` | No | `sonnet` | Installation-wide default model. Per-user override in `users.yaml` `model`, or `/settings model`. |
-| `AGENT_TIMEOUT_SECONDS` | No | `120` | Installation-wide default per-message timeout. Per-user override in `users.yaml` `timeout`, or `/settings timeout`. |
+| `DEFAULT_TIMEOUT` | No | `120` | Installation-wide default per-message timeout. Per-user override in `users.yaml` `timeout`, or `/settings timeout`. (The former `AGENT_TIMEOUT_SECONDS` name is still read for one release with a deprecation warning.) |
 | `CLAUDE_AUTOCOMPACT_PCT` | No | `80` | Context compression threshold %, Claude Code only. When usage hits this, Claude compresses history. Can only lower the default (~83%), not raise it. |
 | `AGENT_MAX_SESSION_HOURS` | No | `0` | Maximum session age in hours before recycling the subprocess (0 = no limit). Applies to every backend. Recommended: 4-8 on memory-constrained machines. |
 | `WORKSPACE_BASE` | No | | Installation-wide default workspace base directory. Per-user override in `users.yaml` `workspace_base`. |
@@ -240,7 +240,7 @@ Authorization, per-user model selection, per-user OS isolation, per-user GitHub 
 | `TOTP_LOCKOUT_MINUTES` | No | `15` | TOTP lockout duration in minutes |
 | `FILE_RETENTION_DAYS` | No | `0` | Days to keep uploaded files before cleanup (0 to disable) |
 
-There is no spending cap: every supported backend runs on subscription auth where per-token cost numbers are not real billing. Runaway prevention comes from the per-message timeout (`AGENT_TIMEOUT_SECONDS`) and session lifecycle limits (`AGENT_MAX_SESSION_HOURS`, `AGENT_IDLE_TIMEOUT`).
+There is no spending cap: every supported backend runs on subscription auth where per-token cost numbers are not real billing. Runaway prevention comes from the per-message timeout (`DEFAULT_TIMEOUT`) and session lifecycle limits (`AGENT_MAX_SESSION_HOURS`, `AGENT_IDLE_TIMEOUT`).
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Authorization, per-user model selection, per-user OS isolation, per-user GitHub 
 |---|---|---|---|
 | `TELEGRAM_BOT_TOKEN` | Yes | | Bot token from BotFather |
 | `DEFAULT_BACKEND` | No | `claude` | Global default backend: `claude`, `goose`, `codex`, or `opencode`. Per-user override goes in `users.yaml`. (The former `AGENT_BACKEND` name is still read for one release with a deprecation warning.) |
-| `DEFAULT_PROVIDER` | Non-claude | | Global provider for non-claude backends. Per-user override in `users.yaml`. (The former `LLM_PROVIDER` name is still read for one release with a deprecation warning.) |
+| `DEFAULT_PROVIDER` | goose/opencode | | Global provider for the multi-provider backends (`goose`, `opencode`); `claude` and `codex` are single-provider and ignore it. Per-user override in `users.yaml`. (The former `LLM_PROVIDER` name is still read for one release with a deprecation warning.) |
 | `DEFAULT_MODEL` | No | `sonnet` | Installation-wide default model. Per-user override in `users.yaml` `model`, or `/settings model`. |
 | `DEFAULT_TIMEOUT` | No | `120` | Installation-wide default per-message timeout. Per-user override in `users.yaml` `timeout`, or `/settings timeout`. (The former `AGENT_TIMEOUT_SECONDS` name is still read for one release with a deprecation warning.) |
 | `CLAUDE_AUTOCOMPACT_PCT` | No | `80` | Context compression threshold %, Claude Code only. When usage hits this, Claude compresses history. Can only lower the default (~83%), not raise it. |

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -884,7 +884,7 @@ def _get_user_models(pool: SubprocessPool, chat_id: int, config: Config) -> dict
         # programming oversight, not user error. OpenCode is excluded
         # alongside codex because its None return is intentional (full
         # provider/model IDs are open-ended, not a missing registry
-        # entry), and the global llm_provider for opencode is usually
+        # entry), and the global provider for opencode is usually
         # empty so the OPEN_ENDED_PROVIDERS check above would not catch
         # it.
         log.warning(
@@ -1152,7 +1152,7 @@ async def _show_settings(update: Update, context: ContextTypes.DEFAULT_TYPE, cha
 
     # Timeout
     yaml_timeout = user_config.timeout if user_config else None
-    timeout, timeout_src = _resolve("timeout", yaml_timeout, config.agent_timeout_seconds, lambda v: f"{int(v)}s")
+    timeout, timeout_src = _resolve("timeout", yaml_timeout, config.default_timeout, lambda v: f"{int(v)}s")
 
     # Provider info - always show so users know their configuration.
     # Uses the shared helper that checks the running instance first,
@@ -1188,7 +1188,7 @@ def _revert_instance_field(pool: SubprocessPool, chat_id: int, field: str, confi
             # If the user's provider differs from the global provider, the
             # global default_model may be invalid for their provider.
             provider = instance.provider
-            effective_global = get_effective_provider(config.default_backend, config.llm_provider)
+            effective_global = get_effective_provider(config.default_backend, config.default_provider)
             if provider == effective_global:
                 instance.model = config.default_model
             else:
@@ -1204,7 +1204,7 @@ def _revert_instance_field(pool: SubprocessPool, chat_id: int, field: str, confi
                     fallback = config.default_model
                 instance.model = fallback
     elif field == "timeout":
-        instance.timeout_seconds = user.timeout if user and user.timeout is not None else config.agent_timeout_seconds
+        instance.timeout_seconds = user.timeout if user and user.timeout is not None else config.default_timeout
 
 
 async def _handle_settings_reset(
@@ -1891,7 +1891,7 @@ async def _show_workspace_config(
         elif user_config and user_config.timeout is not None:
             timeout, timeout_src = user_config.timeout, "users.yaml"
         else:
-            timeout, timeout_src = config.agent_timeout_seconds, "global default"
+            timeout, timeout_src = config.default_timeout, "global default"
         lines.append(f"  Timeout: {timeout}s ({timeout_src})")
     except (ValueError, TypeError):
         lines.append("  Timeout: (corrupted - reset with /workspace config reset timeout)")
@@ -4499,9 +4499,7 @@ async def _handle_response(
                 # is mandatory here.
                 user_config = config.get_user_config(chat_id)
                 effective_backend = (
-                    user_config.default_backend
-                    if user_config and user_config.default_backend
-                    else config.default_backend
+                    user_config.backend if user_config and user_config.backend else config.default_backend
                 )
                 if config.memory_extraction_enabled and effective_backend in ONESHOT_REASONER_BACKENDS:
                     # Windowed PRIOR CONTEXT for the episode classifier

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -79,7 +79,7 @@ ONESHOT_REASONER_BACKENDS: frozenset[str] = frozenset({"claude", "codex", "goose
 # that needs to know "what providers can this backend talk to" reads
 # from this map. Claude and codex are 1:1 with one provider each;
 # opencode and goose are 1:N. load_config validates that every user's
-# (default_backend, llm_provider) pair is a member. Adding a new
+# (backend, provider) pair is a member. Adding a new
 # backend is one row here; adding a new provider to an existing
 # backend is one tuple element. Tuple values (not frozensets) so the
 # wizard offers providers in a stable, documented order; sorted
@@ -104,8 +104,8 @@ BACKEND_PROVIDERS: dict[str, tuple[str, ...]] = {
 #
 # Kept distinct from BACKEND_PROVIDERS so claude / codex stay out of
 # the "requires provider" gates that drive the wizard provider-prompt,
-# the per-user `llm_provider` validation in _load_user_configs, and
-# the global LLM_PROVIDER env-var validation in load_config. Membership
+# the per-user `provider` validation in _load_user_configs, and
+# the global DEFAULT_PROVIDER env-var validation in load_config. Membership
 # in BACKEND_PROVIDERS describes what is allowed; membership here
 # describes what is required.
 BACKENDS_NEEDING_PROVIDER_PROMPT: frozenset[str] = frozenset(b for b, ps in BACKEND_PROVIDERS.items() if len(ps) > 1)
@@ -686,28 +686,35 @@ def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> b
     return validate_model_for_provider(model, eff_provider)
 
 
-# Contexts that have already emitted the AGENT_BACKEND deprecation
-# warning. Keyed by the `context` string each reader passes so a given
+# (context, matched legacy key) pairs that have already emitted a
+# renamed-key deprecation warning. Keyed by both halves so a given
 # source (the env file, a specific user's yaml entry, install.conf)
-# warns at most once per process instead of once per lookup.
-_default_backend_deprecation_warned: set[str] = set()
+# warns at most once per legacy key per process instead of once per
+# lookup, and a multi-key fallback chain warns distinctly for each
+# legacy name it encounters.
+_renamed_key_deprecation_warned: set[tuple[str, str]] = set()
 
 
-def _resolve_default_backend(
+def _resolve_renamed_key(
     get: Callable[[str], str | None],
-    new_key: str,
-    old_key: str,
     *,
+    new_key: str,
+    legacy_keys: list[str],
     context: str,
     default: str | None,
 ) -> str | None:
-    """Read the default-backend setting, preferring the new key name.
+    """Read a config value, preferring the new key over legacy names.
 
-    Centralizes the one-release back-compat window for the
-    `AGENT_BACKEND` -> `DEFAULT_BACKEND` rename. Every reader (env,
-    install.conf dict, per-user yaml entry) passes its own lookup
-    callable plus the key casing for its source so a single
-    implementation serves all of them.
+    Centralizes the one-release back-compat window for a key rename.
+    Every reader (env, install.conf dict, per-user yaml entry) passes
+    its own lookup callable plus the key casing for its source so a
+    single implementation serves all of them.
+
+    `legacy_keys` is ordered most-recent-first: the first legacy key
+    that is present wins. A key that has had more than one rename (the
+    per-user backend went `agent_backend` -> `default_backend` ->
+    `backend`) lists every prior name so an install carrying any of
+    them still resolves.
 
     Absence semantics differ by caller and are made explicit through
     `default`: global readers pass `default="claude"` (the
@@ -720,33 +727,64 @@ def _resolve_default_backend(
     Args:
         get: Lookup callable taking a key and returning value-or-None
             (os.environ.get, env_dict.get, entry.get).
-        new_key: The current key name (DEFAULT_BACKEND / default_backend).
-        old_key: The deprecated key name (AGENT_BACKEND / agent_backend).
+        new_key: The current key name (DEFAULT_BACKEND / backend).
+        legacy_keys: Deprecated key names, most-recent first
+            (e.g. ["default_backend", "agent_backend"]).
         context: Human-readable source name for the one-shot
             deprecation log line (e.g. "/etc/kai/env", "install.conf",
             "users.yaml entry for <user>").
-        default: Value to return when neither key is set.
+        default: Value to return when no key is set.
 
     Returns:
-        The resolved backend string, or `default` when neither key is
-        present. Does not validate against VALID_BACKENDS; callers keep
-        their existing validation.
+        The resolved string, or `default` when no key is present. Does
+        not validate the value; callers keep their existing validation.
     """
     new_value = get(new_key)
     if new_value is not None:
         return new_value
-    old_value = get(old_key)
-    if old_value is not None:
-        if context not in _default_backend_deprecation_warned:
-            _default_backend_deprecation_warned.add(context)
-            log.warning(
-                "%s is deprecated; rename to %s (found in %s)",
-                old_key,
-                new_key,
-                context,
-            )
-        return old_value
+    for old_key in legacy_keys:
+        old_value = get(old_key)
+        if old_value is not None:
+            warned = (context, old_key)
+            if warned not in _renamed_key_deprecation_warned:
+                _renamed_key_deprecation_warned.add(warned)
+                log.warning(
+                    "%s is deprecated; rename to %s (found in %s)",
+                    old_key,
+                    new_key,
+                    context,
+                )
+            return old_value
     return default
+
+
+def _resolve_eval_provider(context: str) -> str:
+    """Eval-time provider, read from the process env.
+
+    The developer eval tools (behavioral eval, memory backend gate) run
+    against the operator's configured provider rather than a sandboxed
+    user, so they read the same global env `load_config` does: the
+    canonical DEFAULT_PROVIDER with a one-release fallback to the
+    deprecated LLM_PROVIDER name. Single-provider backends (claude,
+    codex) ignore the result because their provider is implicit. Shared
+    so both eval entry points resolve the provider identically and
+    neither bypasses the rename window. `context` names the caller for
+    the one-shot deprecation log line.
+    """
+    return (
+        (
+            _resolve_renamed_key(
+                os.environ.get,
+                new_key="DEFAULT_PROVIDER",
+                legacy_keys=["LLM_PROVIDER"],
+                context=context,
+                default="",
+            )
+            or ""
+        )
+        .strip()
+        .lower()
+    )
 
 
 def models_for_backend(agent_backend: str, eff_provider: str) -> dict[str, str] | None:
@@ -776,22 +814,22 @@ def models_for_backend(agent_backend: str, eff_provider: str) -> dict[str, str] 
 def get_user_backend_and_provider(user_config: "UserConfig | None", config: "Config") -> tuple[str, str]:
     """Resolve (backend, provider) for a chat_id with the per-user cascade.
 
-    Pool.py and bot.py already implement this cascade (user.default_backend
-    > config.default_backend, similar for llm_provider); this function
+    Pool.py and bot.py already implement this cascade (user.backend
+    > config.default_backend, similar for provider); this function
     consolidates it in one place so every runtime model-validation site
     sees the same effective backend for a given user. Backend determines
     provider 1:1 for codex (openai) and claude (anthropic); goose and
-    opencode both consult the raw llm_provider cascade (opencode's
+    opencode both consult the raw provider cascade (opencode's
     value is informational - the real provider/model resolution lives
     inside OpenCode's full `provider/model` string at runtime).
     """
-    backend = user_config.default_backend if user_config and user_config.default_backend else config.default_backend
+    backend = user_config.backend if user_config and user_config.backend else config.default_backend
     if backend == "claude":
         provider = "anthropic"
     elif backend == "codex":
         provider = "openai"
     else:
-        provider = user_config.llm_provider if user_config and user_config.llm_provider else config.llm_provider
+        provider = user_config.provider if user_config and user_config.provider else config.default_provider
     return backend, provider
 
 
@@ -1002,8 +1040,8 @@ class UserConfig:
     allowed_workspaces: list[Path] = field(default_factory=list)
     # Per-user backend/provider override. Admin-controlled via users.yaml,
     # not user-configurable via /settings. None = use global config.
-    default_backend: str | None = None
-    llm_provider: str | None = None
+    backend: str | None = None
+    provider: str | None = None
     # GitHub notification routing fields. github_repos controls which
     # repos route webhook events to this user. pr_review and issue_triage
     # are tri-state: None = use global default, True/False = admin override.
@@ -1048,7 +1086,7 @@ class Config:
             Only required in webhook mode. Defaults to WEBHOOK_SECRET if not explicitly set.
         allowed_user_ids: Set of Telegram user IDs permitted to interact with the bot (required)
         default_model: Default model name, provider-dependent (e.g. sonnet, gpt-5.5-pro, gemini-2.5-pro)
-        agent_timeout_seconds: Seconds before an agent response is considered timed
+        default_timeout: Seconds before an agent response is considered timed
             out, on every backend
         agent_max_session_hours: Hours before an agent subprocess is recycled, on every
             backend. Prevents unbounded memory growth in long-lived agent processes (the
@@ -1086,7 +1124,7 @@ class Config:
     # MODEL_REGISTRY[(backend, provider, role)] (lowest) in the
     # resolution chain that `resolve_user_model` implements.
     default_models: dict[str, str] = field(default_factory=dict)
-    agent_timeout_seconds: int = 120
+    default_timeout: int = 120
     # Backend-generic pool lifecycle tunables, matching the AGENT_-
     # prefixed env vars they load from: every backend's subprocess is
     # recycled by age and evicted when idle.
@@ -1220,7 +1258,7 @@ class Config:
     # which API key env var the backend expects and whether Kai's
     # logical model names ("sonnet", "opus") are translated to Anthropic IDs.
     # Ignored when default_backend="claude".
-    llm_provider: str = ""
+    default_provider: str = ""
 
     # Semantic memory system (Mem0 + Qdrant + local embeddings).
     # When enabled, every conversation is embedded and searchable.
@@ -1944,7 +1982,7 @@ def _compute_extraction_eligible_backends(
         return set()
     eligible: set[str] = set()
     for uc in user_configs.values():
-        effective = uc.default_backend or agent_backend
+        effective = uc.backend or agent_backend
         if effective in ONESHOT_REASONER_BACKENDS:
             eligible.add(effective)
     return eligible
@@ -1959,7 +1997,7 @@ def _apply_legacy_model_env_overrides(
     Reads PR_REVIEW_MODEL_<EFFECTIVE_BACKEND> and
     ISSUE_TRIAGE_MODEL_<EFFECTIVE_BACKEND> from the process env for
     each user. EFFECTIVE_BACKEND is the user's per-user override
-    (`uc.default_backend`) or `default_backend` when the user has no
+    (`uc.backend`) or `default_backend` when the user has no
     override. The resolution is inlined as a single fallback
     expression rather than calling `get_user_backend_and_provider`,
     because the full Config object is not yet built at this point in
@@ -1983,7 +2021,7 @@ def _apply_legacy_model_env_overrides(
     warned = False
     out: dict[int, UserConfig] = {}
     for uid, uc in user_configs.items():
-        backend = uc.default_backend or default_backend
+        backend = uc.backend or default_backend
         existing_models = dict(uc.models or {})
         for role_str, env_prefix in [
             ("pr_review", "PR_REVIEW_MODEL"),
@@ -2030,10 +2068,10 @@ def _compute_extraction_eligible_backend_provider_pairs(
         return set()
     eligible: set[tuple[str, str]] = set()
     for uc in user_configs.values():
-        eff_backend = uc.default_backend or agent_backend
+        eff_backend = uc.backend or agent_backend
         if eff_backend not in ONESHOT_REASONER_BACKENDS:
             continue
-        eff_provider = uc.llm_provider or agent_provider
+        eff_provider = uc.provider or agent_provider
         if eff_backend == "claude":
             eff_provider = "anthropic"
         elif eff_backend == "codex":
@@ -2078,7 +2116,7 @@ def _load_user_configs(
 
     Args:
         global_backend: The global default_backend from env config.
-        global_llm_provider: The global llm_provider from env config.
+        global_llm_provider: The global default_provider from env config.
             Both are needed to cascade per-user model validation:
             a user's effective provider determines which models are valid.
         users_yaml_path: Resolved users.yaml path for this deployment.
@@ -2215,17 +2253,18 @@ def _load_user_configs(
         if entry.get("max_budget") is not None:
             log.warning("users.yaml: 'max_budget' for %s is no longer supported; ignoring", name)
 
-        # Validate optional per-user default_backend (must be valid if
-        # set). Reads default_backend, falling back to the deprecated
-        # agent_backend key for one release. default=None so a user
-        # with neither key inherits the global backend below via
-        # `user_backend or global_backend`, rather than being pinned to
-        # claude.
+        # Validate optional per-user backend (must be valid if set).
+        # Reads `backend`, falling back to the deprecated `default_backend`
+        # and then `agent_backend` keys for one release (the per-user key
+        # was renamed twice: agent_backend -> default_backend -> backend).
+        # default=None so a user with neither key inherits the global
+        # backend below via `user_backend or global_backend`, rather than
+        # being pinned to claude.
         user_backend: str | None = None
-        raw_backend = _resolve_default_backend(
+        raw_backend = _resolve_renamed_key(
             entry.get,
-            "default_backend",
-            "agent_backend",
+            new_key="backend",
+            legacy_keys=["default_backend", "agent_backend"],
             context=f"users.yaml entry for {name}",
             default=None,
         )
@@ -2233,14 +2272,22 @@ def _load_user_configs(
             backend_str = str(raw_backend).strip().lower()
             if backend_str not in VALID_BACKENDS:
                 raise SystemExit(
-                    f"users.yaml: user '{name}' has invalid default_backend '{backend_str}' "
+                    f"users.yaml: user '{name}' has invalid backend '{backend_str}' "
                     f"(must be one of: {', '.join(sorted(VALID_BACKENDS))})"
                 )
             user_backend = backend_str
 
-        # Validate optional llm_provider (must be valid for the user's backend)
+        # Validate optional per-user provider (must be valid for the
+        # user's backend). Reads `provider`, falling back to the
+        # deprecated `llm_provider` key for one release.
         user_provider: str | None = None
-        raw_provider = entry.get("llm_provider")
+        raw_provider = _resolve_renamed_key(
+            entry.get,
+            new_key="provider",
+            legacy_keys=["llm_provider"],
+            context=f"users.yaml entry for {name}",
+            default=None,
+        )
         if raw_provider is not None:
             provider_str = str(raw_provider).strip().lower()
             # Validate against the user's effective backend. If the user
@@ -2249,7 +2296,7 @@ def _load_user_configs(
             # Validate against BACKEND_PROVIDERS only when the backend
             # requires a provider prompt. Single-provider backends
             # (claude, codex) are absent from BACKENDS_NEEDING_PROVIDER_PROMPT,
-            # so a per-user llm_provider override on those backends is
+            # so a per-user provider override on those backends is
             # accepted without a curated-list check (the provider is
             # implicit at runtime regardless of what users.yaml says).
             valid: tuple[str, ...] | None = (
@@ -2259,7 +2306,7 @@ def _load_user_configs(
             )
             if valid is not None and provider_str not in valid:
                 raise SystemExit(
-                    f"users.yaml: user '{name}' has invalid llm_provider "
+                    f"users.yaml: user '{name}' has invalid provider "
                     f"'{provider_str}' for backend '{eff_backend_for_val}' "
                     f"(must be one of: {', '.join(sorted(valid))})"
                 )
@@ -2275,9 +2322,9 @@ def _load_user_configs(
         # resolved (neither user-level nor global), that's a fatal config error.
         if eff_backend in BACKENDS_NEEDING_PROVIDER_PROMPT and not eff_provider_str:
             raise SystemExit(
-                f"users.yaml: user '{name}' has default_backend='{eff_backend}' but no "
-                f"llm_provider is configured (set it in users.yaml or as "
-                f"LLM_PROVIDER env var)"
+                f"users.yaml: user '{name}' has backend='{eff_backend}' but no "
+                f"provider is configured (set it in users.yaml or as "
+                f"DEFAULT_PROVIDER env var)"
             )
 
         # Warn if user is on an open-ended provider with no model set.
@@ -2521,8 +2568,8 @@ def _load_user_configs(
             timeout=user_timeout,
             workspace_base=user_workspace_base,
             allowed_workspaces=user_allowed_workspaces,
-            default_backend=user_backend,
-            llm_provider=user_provider,
+            backend=user_backend,
+            provider=user_provider,
             github_repos=github_repos,
             github_notify_chat_id=github_notify_chat_id,
             pr_review=pr_review,
@@ -2639,26 +2686,27 @@ def load_config() -> Config:
 
     # Validate numeric config - fail fast with clear messages rather than
     # cryptic ValueError tracebacks from int()/float() on bad input.
-    # AGENT_TIMEOUT_SECONDS is the canonical key; CLAUDE_TIMEOUT_SECONDS
-    # is a legacy alias kept for installs upgrading without re-running
-    # the wizard. Apply-time migration in install.py rewrites
-    # /etc/kai/env to the new key, so the legacy fallback only fires
-    # on the first start after the upgrade.
-    raw_timeout = os.environ.get("AGENT_TIMEOUT_SECONDS", "").strip()
-    if not raw_timeout:
-        legacy_timeout = os.environ.get("CLAUDE_TIMEOUT_SECONDS", "").strip()
-        if legacy_timeout:
-            log.warning(
-                "CLAUDE_TIMEOUT_SECONDS is deprecated; use AGENT_TIMEOUT_SECONDS. "
-                "Re-run 'make install' to migrate /etc/kai/env automatically."
-            )
-            raw_timeout = legacy_timeout
-        else:
-            raw_timeout = "120"
+    # DEFAULT_TIMEOUT is the canonical key; AGENT_TIMEOUT_SECONDS is a
+    # legacy alias kept for installs upgrading without re-running the
+    # wizard. Apply-time migration in install.py rewrites /etc/kai/env
+    # to the new key, so the legacy fallback only fires on the first
+    # start after the upgrade. The lookup treats an empty value as
+    # absent so an unset/blank new key still falls through to the
+    # legacy name and then the 120 default.
+    raw_timeout = (
+        _resolve_renamed_key(
+            lambda k: (os.environ.get(k) or "").strip() or None,
+            new_key="DEFAULT_TIMEOUT",
+            legacy_keys=["AGENT_TIMEOUT_SECONDS"],
+            context="/etc/kai/env",
+            default=None,
+        )
+        or "120"
+    )
     try:
-        agent_timeout_seconds = int(raw_timeout)
+        default_timeout = int(raw_timeout)
     except ValueError:
-        raise SystemExit("AGENT_TIMEOUT_SECONDS must be an integer") from None
+        raise SystemExit("DEFAULT_TIMEOUT must be an integer") from None
     # AGENT_MAX_SESSION_HOURS / AGENT_IDLE_TIMEOUT are the canonical
     # keys; the CLAUDE_-prefixed forms are legacy aliases kept for
     # installs upgrading without re-running the wizard. Apply-time
@@ -2769,10 +2817,10 @@ def load_config() -> Config:
     # AGENT_BACKEND name; absence means the installation default "claude".
     default_backend = (
         (
-            _resolve_default_backend(
+            _resolve_renamed_key(
                 os.environ.get,
-                "DEFAULT_BACKEND",
-                "AGENT_BACKEND",
+                new_key="DEFAULT_BACKEND",
+                legacy_keys=["AGENT_BACKEND"],
                 context="/etc/kai/env",
                 default="claude",
             )
@@ -2797,16 +2845,30 @@ def load_config() -> Config:
     # Single-provider backends (claude, codex) skip the prompt because
     # their provider is implicit; multi-provider backends (opencode,
     # goose) must name one so the (backend, provider, role) registry
-    # lookup can find a row.
-    llm_provider = ""
+    # lookup can find a row. DEFAULT_PROVIDER with a one-release
+    # fallback to the deprecated LLM_PROVIDER name.
+    default_provider = ""
     valid_providers: tuple[str, ...] | None = (
         BACKEND_PROVIDERS.get(default_backend) if default_backend in BACKENDS_NEEDING_PROVIDER_PROMPT else None
     )
     if valid_providers is not None:
-        llm_provider = os.environ.get("LLM_PROVIDER", "").strip().lower()
-        if llm_provider not in valid_providers:
+        default_provider = (
+            (
+                _resolve_renamed_key(
+                    os.environ.get,
+                    new_key="DEFAULT_PROVIDER",
+                    legacy_keys=["LLM_PROVIDER"],
+                    context="/etc/kai/env",
+                    default="",
+                )
+                or ""
+            )
+            .strip()
+            .lower()
+        )
+        if default_provider not in valid_providers:
             raise SystemExit(
-                f"LLM_PROVIDER '{llm_provider}' is not valid for backend "
+                f"DEFAULT_PROVIDER '{default_provider}' is not valid for backend "
                 f"'{default_backend}' (must be one of: "
                 f"{', '.join(sorted(valid_providers))})"
             )
@@ -2985,7 +3047,7 @@ def load_config() -> Config:
     # explicit override for tests and ad-hoc development; the operator
     # path is always one of the two resolved defaults.
     users_yaml_path = _resolve_users_yaml_path(bool(protected_env))
-    user_configs = _load_user_configs(default_backend, llm_provider, users_yaml_path)
+    user_configs = _load_user_configs(default_backend, default_provider, users_yaml_path)
     # Seed UserConfig.models from the deprecated per-role env vars
     # (PR_REVIEW_MODEL_<BACKEND> / ISSUE_TRIAGE_MODEL_<BACKEND>). The
     # values reach dispatch through UserConfig.models rather than via
@@ -3044,7 +3106,6 @@ def load_config() -> Config:
     # not legacy renames; the runtime no longer reads them at all and
     # the corresponding wizard prompts have been retired.
     _renamed_env_vars = {
-        "CLAUDE_TIMEOUT_SECONDS": "AGENT_TIMEOUT_SECONDS.",
         "CLAUDE_MAX_SESSION_HOURS": "AGENT_MAX_SESSION_HOURS.",
         "CLAUDE_IDLE_TIMEOUT": "AGENT_IDLE_TIMEOUT.",
     }
@@ -3145,7 +3206,7 @@ def load_config() -> Config:
     # to PROVIDER_MODELS["openai"]. Other backends still use the
     # provider-only validator. Catches typos at startup instead of
     # letting them propagate to a confusing runtime failure.
-    global_provider = get_effective_provider(default_backend, llm_provider)
+    global_provider = get_effective_provider(default_backend, default_provider)
     if not validate_model_for_backend(default_model, default_backend, global_provider):
         if default_backend == "codex":
             valid = sorted(CODEX_MODELS.keys())
@@ -3165,7 +3226,7 @@ def load_config() -> Config:
         allowed_user_ids=allowed_ids,
         default_model=default_model,
         default_models=default_models,
-        agent_timeout_seconds=agent_timeout_seconds,
+        default_timeout=default_timeout,
         agent_max_session_hours=agent_max_session_hours,
         agent_idle_timeout=agent_idle_timeout,
         claude_autocompact_pct=claude_autocompact_pct,
@@ -3191,7 +3252,7 @@ def load_config() -> Config:
         totp_lockout_attempts=totp_lockout_attempts,
         totp_lockout_minutes=totp_lockout_minutes,
         default_backend=default_backend,
-        llm_provider=llm_provider,
+        default_provider=default_provider,
         memory_enabled=memory_enabled,
         memory_search_limit=memory_search_limit,
         memory_token_budget=memory_token_budget,

--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -102,7 +102,8 @@ from kai.codex_exec import extract_codex_text
 from kai.config import (
     ONESHOT_REASONER_BACKENDS,
     ModelRole,
-    _resolve_default_backend,
+    _resolve_eval_provider,
+    _resolve_renamed_key,
     get_model_for,
 )
 from kai.eval._probes import (
@@ -2235,10 +2236,10 @@ async def _run_cli(args: argparse.Namespace) -> int:
     # not a per-user override).
     eval_backend = (
         (
-            _resolve_default_backend(
+            _resolve_renamed_key(
                 os.environ.get,
-                "DEFAULT_BACKEND",
-                "AGENT_BACKEND",
+                new_key="DEFAULT_BACKEND",
+                legacy_keys=["AGENT_BACKEND"],
                 context="behavioral eval env",
                 default="claude",
             )
@@ -2247,12 +2248,11 @@ async def _run_cli(args: argparse.Namespace) -> int:
         .strip()
         .lower()
     )
-    # Provider is read from the eval-time LLM_PROVIDER env (the eval
-    # gate runs as a developer tool against the operator's configured
-    # backend / provider, not against a sandboxed user). Single-provider
-    # backends (claude, codex) ignore this value because their provider
-    # is implicit at runtime.
-    eval_provider = os.environ.get("LLM_PROVIDER", "").strip().lower()
+    # Provider is read from the eval-time env (DEFAULT_PROVIDER, with a
+    # one-release fallback to the deprecated LLM_PROVIDER name) via the
+    # shared resolver. Single-provider backends (claude, codex) ignore
+    # this value because their provider is implicit at runtime.
+    eval_provider = _resolve_eval_provider("behavioral eval env")
     if eval_backend in ONESHOT_REASONER_BACKENDS:
         resolved_judge_model = get_model_for(
             ModelRole.BEHAVIORAL_JUDGE,

--- a/src/kai/eval/gen_collision_probes.py
+++ b/src/kai/eval/gen_collision_probes.py
@@ -43,11 +43,11 @@ Architecture notes:
   and so the structured-log `purpose` tag (`"collision_probe_drafting"`)
   distinguishes drafting calls from PR reviews.
 - Provider normalization: `resolve_classification_settings` returns
-  the raw `llm_provider` cascade. For single-provider backends
+  the raw `provider` cascade. For single-provider backends
   (claude->anthropic, codex->openai), we normalize via
   `get_effective_provider` before passing into `resolve_user_model`.
   Without that step, a codex user with inherited
-  `config.llm_provider="anthropic"` would look up a non-existent
+  `config.default_provider="anthropic"` would look up a non-existent
   `(codex, anthropic, pr_review)` registry entry.
 - Embedding source: `kai.memory.embed_texts` is the public boundary.
   Every Mem0 internal-attribute hop lives in
@@ -701,11 +701,11 @@ def _resolve_run_config(
 
     Provider normalization is the key step `resolve_classification_settings`
     does NOT do (its `_resolve_effective_provider` returns the raw
-    `llm_provider` cascade). For single-provider backends, the raw
+    `provider` cascade). For single-provider backends, the raw
     value can be the wrong provider for the registry lookup. The
     explicit `get_effective_provider(backend, raw)` call here is the
     correct fix; without it, a codex user with inherited
-    `config.llm_provider="anthropic"` fails to resolve any model.
+    `config.default_provider="anthropic"` fails to resolve any model.
     """
     from kai.memory_reclassify import (
         _resolve_user_config,
@@ -725,9 +725,9 @@ def _resolve_run_config(
 
     # Normalize for single-provider backends before passing into
     # resolve_user_model. The raw cascade value can be the wrong
-    # provider when the user inherits a global llm_provider set for
+    # provider when the user inherits a global provider set for
     # a different backend (e.g. a codex user inheriting
-    # llm_provider="anthropic" would otherwise miss the
+    # provider="anthropic" would otherwise miss the
     # (codex, openai, pr_review) registry entry).
     effective_provider = get_effective_provider(effective_backend, raw_provider)
 

--- a/src/kai/eval/memory_backend_gate.py
+++ b/src/kai/eval/memory_backend_gate.py
@@ -36,7 +36,6 @@ import dataclasses
 import hashlib
 import json
 import logging
-import os
 import re
 import sys
 from dataclasses import dataclass, field
@@ -46,7 +45,7 @@ from pathlib import Path
 from typing import Any
 
 from kai import memory, memory_extraction
-from kai.config import ONESHOT_REASONER_BACKENDS, Config, ModelRole, get_model_for, load_config
+from kai.config import ONESHOT_REASONER_BACKENDS, Config, ModelRole, _resolve_eval_provider, get_model_for, load_config
 from kai.eval.extraction import _window_to_extractor_args
 from kai.eval.replay import _SANDBOX_USER_ID_PREFIX
 
@@ -734,10 +733,11 @@ async def run_backend(
     # registry, matching what `get_model_for(role, backend, provider)`
     # produces in production per-extraction. Pinned here so the
     # BackendRun summary reports the same SKUs the reasoner actually
-    # spawned. Eval-time provider comes from the LLM_PROVIDER env var
-    # (the gate runs as a developer tool against the operator's
-    # configured backend / provider, not against a sandboxed user).
-    eval_provider = os.environ.get("LLM_PROVIDER", "").strip().lower()
+    # spawned. Eval-time provider comes from the shared resolver
+    # (DEFAULT_PROVIDER, with a one-release fallback to the deprecated
+    # LLM_PROVIDER name); the gate runs as a developer tool against the
+    # operator's configured backend / provider, not a sandboxed user.
+    eval_provider = _resolve_eval_provider("memory backend gate env")
     run = BackendRun(
         backend=backend,
         sandbox_user_id=sandbox_user_id,

--- a/src/kai/eval/memory_backend_gate.py
+++ b/src/kai/eval/memory_backend_gate.py
@@ -614,7 +614,7 @@ def validate_user_prefix(prefix: str) -> None:
         )
 
 
-def make_backend_config(base_config: Config, backend: str) -> Config:
+def make_backend_config(base_config: Config, backend: str, provider: str = "") -> Config:
     """Build a per-backend copy of the production Config.
 
     Forces memory_enabled=True and memory_extraction_enabled=True so
@@ -628,12 +628,21 @@ def make_backend_config(base_config: Config, backend: str) -> Config:
     via `get_model_for(role, effective_backend)`; no Config fields
     carry per-backend models any more. Uses `dataclasses.replace`
     because `Config` is frozen.
+
+    `provider` is the eval-time provider stamped into `default_provider`
+    so the extraction path resolves the same (backend, provider) pair
+    the run summary reports. Without it, an install whose global backend
+    is single-provider (claude/codex) leaves `default_provider=""`, so a
+    goose/opencode arm would extract with an empty provider while the
+    report shows the resolved one. Single-provider arms ignore the value
+    (their provider is implicit).
     """
     return dataclasses.replace(
         base_config,
         memory_enabled=True,
         memory_extraction_enabled=True,
         default_backend=backend,
+        default_provider=provider,
     )
 
 
@@ -723,7 +732,14 @@ async def run_backend(
     FileHandler is removed in the finally so a crash mid-run does
     not leak a handler into the next arm.
     """
-    config = make_backend_config(base_config, backend)
+    # Eval-time provider comes from the shared resolver (DEFAULT_PROVIDER,
+    # with a one-release fallback to the deprecated LLM_PROVIDER name);
+    # the gate runs as a developer tool against the operator's configured
+    # backend / provider, not a sandboxed user. Stamped into the config
+    # below so the extraction path resolves the same (backend, provider)
+    # pair the run summary reports.
+    eval_provider = _resolve_eval_provider("memory backend gate env")
+    config = make_backend_config(base_config, backend, eval_provider)
     if reset:
         memory.delete_all(user_id=sandbox_user_id)
     elif memory.get_all(user_id=sandbox_user_id, limit=1):
@@ -733,11 +749,7 @@ async def run_backend(
     # registry, matching what `get_model_for(role, backend, provider)`
     # produces in production per-extraction. Pinned here so the
     # BackendRun summary reports the same SKUs the reasoner actually
-    # spawned. Eval-time provider comes from the shared resolver
-    # (DEFAULT_PROVIDER, with a one-release fallback to the deprecated
-    # LLM_PROVIDER name); the gate runs as a developer tool against the
-    # operator's configured backend / provider, not a sandboxed user.
-    eval_provider = _resolve_eval_provider("memory backend gate env")
+    # spawned.
     run = BackendRun(
         backend=backend,
         sandbox_user_id=sandbox_user_id,

--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -125,7 +125,7 @@ class GooseBackend(AcpBackend):
         talk to (openai, anthropic, google, etc.). Without it,
         session/new fails with "Internal error" against a binary that
         has no default provider configured. Kai's wizard writes
-        LLM_PROVIDER to /etc/kai/env for its own bookkeeping, but the
+        DEFAULT_PROVIDER to /etc/kai/env for its own bookkeeping, but the
         goose binary reads the GOOSE_-prefixed name; the translation
         happens here so the two layers stay decoupled. The value runs
         through `goose_provider_id` because goose's wire-level provider

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -55,7 +55,7 @@ from kai.config import (
     VALID_BACKENDS,
     ModelRole,
     _read_protected_file,
-    _resolve_default_backend,
+    _resolve_renamed_key,
     models_for_backend,
     validate_model_for_backend,
 )
@@ -327,7 +327,7 @@ def _prompt_default_model(agent_backend: str, eff_provider: str, default_val: st
             Codex routes to CODEX_MODELS; everything else delegates to
             the provider-based selection below.
         eff_provider: The effective provider for non-codex backends
-            (anthropic for claude; the configured llm_provider for
+            (anthropic for claude; the configured provider for
             goose; ignored when agent_backend == "codex").
         default_val: Prefill for the prompt. Callers should pass a value
             that is valid for the backend's surface (CODEX_DEFAULT_MODEL
@@ -647,9 +647,10 @@ def _users_yaml_entries(users_yaml_path: Path) -> list[dict]:
 
 def _entry_backend(entry: dict) -> object:
     """
-    Read a users.yaml entry's backend, preferring the new
-    `default_backend` key and falling back to the deprecated
-    `agent_backend` key for one release.
+    Read a users.yaml entry's backend, preferring the new `backend`
+    key and falling back to the deprecated `default_backend` and then
+    `agent_backend` keys for one release (the per-user key was renamed
+    twice: agent_backend -> default_backend -> backend).
 
     Returns the raw value (or None) so callers apply their own
     normalization/validation, matching how they read the key today.
@@ -657,10 +658,29 @@ def _entry_backend(entry: dict) -> object:
     emits the per-user warning; these installer scanners only need
     set membership.
     """
-    value = entry.get("default_backend")
-    if value is not None:
-        return value
-    return entry.get("agent_backend")
+    for key in ("backend", "default_backend", "agent_backend"):
+        value = entry.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def _entry_provider(entry: dict) -> object:
+    """
+    Read a users.yaml entry's provider, preferring the new `provider`
+    key and falling back to the deprecated `llm_provider` key for one
+    release. Mirrors `_entry_backend`.
+
+    Returns the raw value (or None) so callers apply their own
+    normalization, matching how they read the key today. No deprecation
+    warning here: the daemon-side `_load_user_configs` emits the
+    per-user warning; these installer scanners only need set membership.
+    """
+    for key in ("provider", "llm_provider"):
+        value = entry.get(key)
+        if value is not None:
+            return value
+    return None
 
 
 def _users_yaml_goose_providers(users_yaml_path: Path, global_provider: str) -> list[str]:
@@ -668,10 +688,10 @@ def _users_yaml_goose_providers(users_yaml_path: Path, global_provider: str) -> 
     Collect the distinct providers per-user goose entries need API
     keys for.
 
-    Returns the sorted set of `llm_provider` values across entries
-    whose `default_backend` is "goose", falling back to
-    `global_provider` for entries that omit the field - the same
-    cascade the runtime applies. Goose is the only backend whose
+    Returns the sorted set of `provider` values across entries
+    whose `backend` is "goose", falling back to `global_provider`
+    for entries that omit the field - the same cascade the runtime
+    applies. Goose is the only backend whose
     per-user auth rides the daemon environment: claude, codex, and
     opencode authenticate via per-OS-user on-disk state managed
     outside the wizard, so entries on those backends contribute
@@ -687,7 +707,7 @@ def _users_yaml_goose_providers(users_yaml_path: Path, global_provider: str) -> 
         backend = _entry_backend(entry)
         if not isinstance(backend, str) or backend.strip().lower() != "goose":
             continue
-        provider = entry.get("llm_provider") or global_provider
+        provider = _entry_provider(entry) or global_provider
         if isinstance(provider, str) and provider.strip():
             providers.add(provider.strip().lower())
     return sorted(providers)
@@ -695,7 +715,7 @@ def _users_yaml_goose_providers(users_yaml_path: Path, global_provider: str) -> 
 
 def _users_yaml_agent_backends(users_yaml_path: Path) -> set[str]:
     """
-    Collect the distinct per-user `default_backend` values for
+    Collect the distinct per-user `backend` values for
     wizard-side binary collection.
 
     A users.yaml entry on a non-global backend makes that backend's
@@ -1042,10 +1062,10 @@ def _cmd_config() -> None:
     agent_backend = _prompt_choice(
         "Default backend",
         sorted(VALID_BACKENDS),
-        _resolve_default_backend(
+        _resolve_renamed_key(
             existing_env.get,
-            "DEFAULT_BACKEND",
-            "AGENT_BACKEND",
+            new_key="DEFAULT_BACKEND",
+            legacy_keys=["AGENT_BACKEND"],
             context="install.conf",
             default="claude",
         )
@@ -1060,7 +1080,7 @@ def _cmd_config() -> None:
     # claude does for the provider prompt.
     #
     # Gate on the global backend selection only. Per-user
-    # `default_backend: codex` overrides in users.yaml do NOT trigger
+    # `backend: codex` overrides in users.yaml do NOT trigger
     # the auth-mode setup here; codex AUTH for those users stays
     # out-of-band (per-OS-user `codex login`). Their BINARY path is
     # collected by the per-user backend scan after the provider
@@ -1138,7 +1158,7 @@ def _cmd_config() -> None:
             print("  After install, log in to codex as the target os_user:")
             print("    <os_user> ~$ codex login")
             print("  Run as the os_user themselves, not via sudo from another account.")
-            print("  If users.yaml has per-user `default_backend: codex` entries with")
+            print("  If users.yaml has per-user `backend: codex` entries with")
             print("  different os_users, log in as each of those too.")
 
     # OpenCode setup: binary-path wizard prompt + post-install auth
@@ -1152,7 +1172,7 @@ def _cmd_config() -> None:
     # a free-text prompt for a full `provider/model` ID.
     #
     # Gate on the global backend selection only. Per-user
-    # `default_backend: opencode` overrides in users.yaml do NOT
+    # `backend: opencode` overrides in users.yaml do NOT
     # trigger the setup here; opencode AUTH for those users stays
     # out-of-band (`opencode auth login` per OS user). Their BINARY
     # path is collected by the per-user backend scan after the
@@ -1222,6 +1242,19 @@ def _cmd_config() -> None:
     llm_provider = ""
     llm_api_key_var = ""
     llm_api_key = ""
+    # Prefill the provider prompt from the existing env, preferring the
+    # canonical DEFAULT_PROVIDER key with a one-release fallback to the
+    # deprecated LLM_PROVIDER name.
+    provider_prefill = (
+        _resolve_renamed_key(
+            existing_env.get,
+            new_key="DEFAULT_PROVIDER",
+            legacy_keys=["LLM_PROVIDER"],
+            context="install.conf",
+            default="",
+        )
+        or ""
+    )
     valid_providers: tuple[str, ...] | None = (
         BACKEND_PROVIDERS.get(agent_backend) if agent_backend in BACKENDS_NEEDING_PROVIDER_PROMPT else None
     )
@@ -1229,7 +1262,7 @@ def _cmd_config() -> None:
         llm_provider = _prompt_choice(
             "LLM provider",
             sorted(valid_providers),
-            existing_env.get("LLM_PROVIDER", ""),
+            provider_prefill,
         )
         if agent_backend != "opencode":
             llm_api_key_var = PROVIDER_KEY_VARS.get(llm_provider, "")
@@ -1260,7 +1293,7 @@ def _cmd_config() -> None:
     extra_provider_keys: dict[str, str] = {}
     for peruser_provider in _users_yaml_goose_providers(
         users_yaml_path,
-        llm_provider or existing_env.get("LLM_PROVIDER", ""),
+        llm_provider or provider_prefill,
     ):
         peruser_key_var = PROVIDER_KEY_VARS.get(peruser_provider, "")
         if not peruser_key_var:
@@ -1342,7 +1375,7 @@ def _cmd_config() -> None:
             print(f"  Path '{goose_bin}' is not an absolute path to an existing executable.")
 
     # -- Agent --
-    # DEFAULT_MODEL and AGENT_TIMEOUT_SECONDS are
+    # DEFAULT_MODEL and DEFAULT_TIMEOUT are
     # inheritable installation defaults:
     # users.yaml entries that omit a per-user override fall back to
     # these values at runtime. The prompts therefore fire on every
@@ -1476,9 +1509,9 @@ def _cmd_config() -> None:
                 default_models_override[role_key] = value
 
     while True:
-        # AGENT_TIMEOUT_SECONDS is canonical; legacy
-        # CLAUDE_TIMEOUT_SECONDS is the fallback for upgrades.
-        timeout_default = existing_env.get("AGENT_TIMEOUT_SECONDS", existing_env.get("CLAUDE_TIMEOUT_SECONDS", "120"))
+        # DEFAULT_TIMEOUT is canonical; legacy AGENT_TIMEOUT_SECONDS is
+        # the one-release fallback for upgrades.
+        timeout_default = existing_env.get("DEFAULT_TIMEOUT", existing_env.get("AGENT_TIMEOUT_SECONDS", "120"))
         timeout = _prompt(
             "Agent timeout (seconds)",
             timeout_default,
@@ -1993,8 +2026,10 @@ def _cmd_config() -> None:
 
     # LLM provider and API key. Written alongside the backend choice
     # so they survive into /etc/kai/env and are not wiped on reinstall.
+    # The wizard writes the new DEFAULT_PROVIDER name only; the runtime
+    # keeps a one-release read fallback for a legacy LLM_PROVIDER key.
     if llm_provider:
-        env["LLM_PROVIDER"] = llm_provider
+        env["DEFAULT_PROVIDER"] = llm_provider
     if llm_api_key_var and llm_api_key:
         env[llm_api_key_var] = llm_api_key
 
@@ -2071,13 +2106,11 @@ def _cmd_config() -> None:
 
     # Remove stale renamed keys if present - leaving both the old and
     # new key causes silent confusion (the deprecation warning is
-    # suppressed when the new key exists). CLAUDE_TIMEOUT_SECONDS,
-    # CLAUDE_MAX_SESSION_HOURS, and CLAUDE_IDLE_TIMEOUT are renamed
-    # to their AGENT_-prefixed forms; pop the legacy keys on every
-    # regenerate so the next /etc/kai/env carries only the canonical
-    # forms.
+    # suppressed when the new key exists). CLAUDE_MAX_SESSION_HOURS and
+    # CLAUDE_IDLE_TIMEOUT are renamed to their AGENT_-prefixed forms;
+    # pop the legacy keys on every regenerate so the next /etc/kai/env
+    # carries only the canonical forms.
     env.pop("CLAUDE_MODEL", None)
-    env.pop("CLAUDE_TIMEOUT_SECONDS", None)
     env.pop("CLAUDE_MAX_SESSION_HOURS", None)
     env.pop("CLAUDE_IDLE_TIMEOUT", None)
     # Retired keys (no canonical replacement); drop lingering values
@@ -2113,12 +2146,11 @@ def _cmd_config() -> None:
     if default_models_override:
         env["DEFAULT_MODELS_JSON"] = json.dumps(default_models_override, sort_keys=True)
 
-    # AGENT_TIMEOUT_SECONDS is an inheritable installation default;
-    # per-user timeouts in users.yaml override at runtime. Always
-    # emitted because the prompt always fires. (Renamed from
-    # CLAUDE_TIMEOUT_SECONDS; the legacy key is migrated to the new
-    # name at apply time.)
-    env["AGENT_TIMEOUT_SECONDS"] = timeout
+    # DEFAULT_TIMEOUT is an inheritable installation default; per-user
+    # timeouts in users.yaml override at runtime. Always emitted because
+    # the prompt always fires. (The legacy AGENT_TIMEOUT_SECONDS key is
+    # migrated to the new name at apply time.)
+    env["DEFAULT_TIMEOUT"] = timeout
 
     # Session lifecycle keys are written delta-from-default (matching
     # the autocompact / effort treatment below) so a default-accepting
@@ -2612,7 +2644,7 @@ def _collect_os_users_from_yaml(users_yaml_path: str | Path) -> list[str]:
 
 def _collect_backends_from_yaml(users_yaml_path: str | Path) -> set[str]:
     """
-    Read users.yaml and return the distinct per-user default_backend values.
+    Read users.yaml and return the distinct per-user backend values.
 
     Sibling of `_collect_os_users_from_yaml` with the same lightweight
     posture: the installer only needs the backend names to scope the
@@ -2651,7 +2683,7 @@ def _collect_backends_from_yaml(users_yaml_path: str | Path) -> set[str]:
             continue
         # Normalize with .strip().lower() to match the runtime loader
         # (`_load_user_configs` lowercases before validating). A mixed-
-        # case `default_backend: Goose` routes the user to goose at
+        # case `backend: Goose` routes the user to goose at
         # runtime; without lowering here, `_apply_goose_config`'s
         # `"goose" in <set>` membership check would miss it and skip
         # the per-user goose config deployment.
@@ -2669,7 +2701,7 @@ def _collect_goose_os_users_from_yaml(
     Read users.yaml and return distinct, validated os_user values of
     goose-backed users.
 
-    A user is goose-backed when their entry's `default_backend` is
+    A user is goose-backed when their entry's `backend` is
     "goose", or when the entry carries no per-user backend and the
     install's global backend (`agent_backend`) is goose - the same
     inheritance contract the runtime applies. `_apply_goose_config`
@@ -2709,7 +2741,7 @@ def _collect_goose_os_users_from_yaml(
         # backend" (PyYAML may parse unquoted scalars as non-strings;
         # the runtime loader rejects those separately). Lowercase the
         # per-user value to match the runtime loader so a mixed-case
-        # `default_backend: Goose` entry's os_user still receives the
+        # `backend: Goose` entry's os_user still receives the
         # goose config deploy. The global `agent_backend` arg is
         # already normalized by the caller (_cmd_apply).
         if isinstance(backend, str) and backend.strip():
@@ -2760,7 +2792,9 @@ def _build_codex_login_reminder(
     are no longer read.
     """
     default_backend = (
-        _resolve_default_backend(env.get, "DEFAULT_BACKEND", "AGENT_BACKEND", context="install.conf", default="claude")
+        _resolve_renamed_key(
+            env.get, new_key="DEFAULT_BACKEND", legacy_keys=["AGENT_BACKEND"], context="install.conf", default="claude"
+        )
         or "claude"
     )
     if default_backend != "codex":
@@ -2772,7 +2806,7 @@ def _build_codex_login_reminder(
         "  Log in to codex as the target os_user before the first message:\n"
         "    <os_user> ~$ codex login\n"
         "  Run as the os_user themselves, not via sudo from another account.\n"
-        "  If users.yaml has per-user `default_backend: codex` entries with\n"
+        "  If users.yaml has per-user `backend: codex` entries with\n"
         "  different os_users, log in as each of those too."
     )
 
@@ -4155,6 +4189,14 @@ def _cmd_apply() -> None:
         # Both present: the new key wins; drop the legacy one so it does
         # not linger in the written env file.
         del env["AGENT_BACKEND"]
+    # Same migration for the provider key, renamed LLM_PROVIDER ->
+    # DEFAULT_PROVIDER. Apply reads the provider when validating the
+    # default model against a multi-provider backend's surface, so the
+    # legacy name must be resolved here too, before any gate reads it.
+    if "LLM_PROVIDER" in env and "DEFAULT_PROVIDER" not in env:
+        env["DEFAULT_PROVIDER"] = env.pop("LLM_PROVIDER")
+    elif "LLM_PROVIDER" in env:
+        del env["LLM_PROVIDER"]
     # Top-level installer metadata: present only when the wizard
     # staged a first-time users.yaml that has not yet been applied.
     # The empty-string -> None coercion treats a hand-edited conf
@@ -4211,8 +4253,10 @@ def _cmd_apply() -> None:
     # config deployment below.
     if "DEFAULT_BACKEND" in env:
         env["DEFAULT_BACKEND"] = agent_backend_raw
-    llm_provider_raw = env.get("LLM_PROVIDER", "").strip().lower()
-    eff_provider_for_check = "anthropic" if agent_backend_raw == "claude" else llm_provider_raw
+    # Reads the canonical DEFAULT_PROVIDER; a legacy LLM_PROVIDER key was
+    # already migrated to it at the top of apply.
+    provider_raw = env.get("DEFAULT_PROVIDER", "").strip().lower()
+    eff_provider_for_check = "anthropic" if agent_backend_raw == "claude" else provider_raw
     resolved_model = default_model_raw or "sonnet"
     # Backend-aware validation: codex installs validate against
     # CODEX_MODELS only - no fallback to PROVIDER_MODELS["openai"].
@@ -4347,14 +4391,14 @@ def _cmd_apply() -> None:
         env_claude_bin = os.environ.get("CLAUDE_BIN")
         if env_claude_bin and env.get("DEFAULT_BACKEND", "claude") == "claude":
             env["CLAUDE_BIN"] = env_claude_bin
-        # AGENT_TIMEOUT_SECONDS migration. Operators upgrading without
-        # re-running the wizard carry the legacy CLAUDE_TIMEOUT_SECONDS
+        # DEFAULT_TIMEOUT migration. Operators upgrading without
+        # re-running the wizard carry the legacy AGENT_TIMEOUT_SECONDS
         # key in install.conf; rewrite to the canonical name at apply
         # time so /etc/kai/env ends up clean and load_config does not
         # need the legacy fallback after the next start.
-        if "AGENT_TIMEOUT_SECONDS" not in env and "CLAUDE_TIMEOUT_SECONDS" in env:
-            env["AGENT_TIMEOUT_SECONDS"] = env["CLAUDE_TIMEOUT_SECONDS"]
-        env.pop("CLAUDE_TIMEOUT_SECONDS", None)
+        if "DEFAULT_TIMEOUT" not in env and "AGENT_TIMEOUT_SECONDS" in env:
+            env["DEFAULT_TIMEOUT"] = env["AGENT_TIMEOUT_SECONDS"]
+        env.pop("AGENT_TIMEOUT_SECONDS", None)
         # Same migration for the session lifecycle keys (renamed from
         # the CLAUDE_-prefixed forms; they govern every backend's pool).
         if "AGENT_MAX_SESSION_HOURS" not in env and "CLAUDE_MAX_SESSION_HOURS" in env:
@@ -4379,7 +4423,7 @@ def _cmd_apply() -> None:
 
         # -- Step 6: Deploy Goose config (if any goose-backed user) --
         # The function gates itself: global DEFAULT_BACKEND=goose or a
-        # per-user default_backend override in users.yaml both mean some
+        # per-user backend override in users.yaml both mean some
         # session spawns `goose acp`; otherwise it no-ops.
         agent_backend = env.get("DEFAULT_BACKEND", "claude")
         _apply_goose_config(
@@ -5597,7 +5641,7 @@ def _apply_sudoers(
     `agent_backend` is the install's global backend (the env dict's
     DEFAULT_BACKEND, defaulting to claude when the key is absent, which
     matches the runtime default). Together with the per-user
-    default_backend overrides in users.yaml it scopes the missing-binary
+    backend overrides in users.yaml it scopes the missing-binary
     backstop below to backends the install actually uses.
     """
     # None resolves to the module-level USERS_YAML at call time rather
@@ -5630,7 +5674,7 @@ def _apply_sudoers(
     # reinstall, or wizard re-run that makes the paths agree.
     #
     # The check is scoped to backends the install actually uses (the
-    # global backend plus any per-user default_backend overrides
+    # global backend plus any per-user backend overrides
     # in users.yaml): telling an opencode-only operator to install
     # claude would manufacture a requirement that does not exist and
     # train operators to ignore the warning. The rules themselves are

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -1322,7 +1322,7 @@ def init_memory(config: Config) -> None:
 
     eligible_pairs: set[tuple[str, str]] = _compute_extraction_eligible_backend_provider_pairs(
         config.default_backend,
-        config.llm_provider,
+        config.default_provider,
         config.user_configs,
         config.memory_extraction_enabled,
     )

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -1902,9 +1902,7 @@ async def _send_dashboard(
     # gate's backend resolution in bot.py.
     config: Config = context.bot_data["config"]
     user_config = config.get_user_config(chat_id)
-    effective_backend = (
-        user_config.default_backend if user_config and user_config.default_backend else config.default_backend
-    )
+    effective_backend = user_config.backend if user_config and user_config.backend else config.default_backend
     if effective_backend not in ONESHOT_REASONER_BACKENDS:
         text += (
             f"\n\nNote: memory extraction is not available on the {effective_backend} "

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1939,9 +1939,9 @@ def _resolve_os_user(user_id: str, config: Config) -> str | None:
 
 def _resolve_effective_backend(user_id: str, config: Config) -> str:
     """
-    Resolve the user being extracted to its effective `default_backend`.
+    Resolve the user being extracted to its effective backend.
 
-    Cascade: per-user `default_backend` from users.yaml wins; otherwise
+    Cascade: per-user `backend` from users.yaml wins; otherwise
     the global `config.default_backend` applies. The same shape
     `_ingest_memory` in bot.py uses to gate extraction eligibility,
     kept in lockstep so the per-user dispatch site here cannot drift
@@ -1966,7 +1966,7 @@ def _resolve_effective_backend(user_id: str, config: Config) -> str:
     user_cfg = config.user_configs.get(tid)
     if user_cfg is None:
         return config.default_backend
-    return user_cfg.default_backend or config.default_backend
+    return user_cfg.backend or config.default_backend
 
 
 def _resolve_user_config(user_id: str, config: Config):
@@ -1986,7 +1986,7 @@ def _resolve_user_config(user_id: str, config: Config):
 
 def _resolve_effective_provider(user_id: str, config: Config) -> str:
     """
-    Resolve the user being extracted to its effective `llm_provider`.
+    Resolve the user being extracted to its effective provider.
 
     Mirrors `_resolve_effective_backend`'s cascade for the provider
     axis. Required by the (backend, provider, role) MODEL_REGISTRY
@@ -2002,11 +2002,11 @@ def _resolve_effective_provider(user_id: str, config: Config) -> str:
     try:
         tid = int(user_id)
     except ValueError:
-        return config.llm_provider
+        return config.default_provider
     user_cfg = config.user_configs.get(tid)
     if user_cfg is None:
-        return config.llm_provider
-    return user_cfg.llm_provider or config.llm_provider
+        return config.default_provider
+    return user_cfg.provider or config.default_provider
 
 
 def _build_memory_reasoner(

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -109,13 +109,13 @@ class SubprocessPool:
         """
         Create an AgentBackend for a specific user.
 
-        Backend selection: per-user default_backend (from users.yaml)
+        Backend selection: per-user backend (from users.yaml)
         overrides the global config.default_backend. Both share the same
         ABC interface; pool.py is backend-agnostic after this point.
 
         Resolution order for each setting:
         1. UserConfig from users.yaml (os_user, home_workspace, model,
-           timeout, default_backend, llm_provider)
+           timeout, backend, provider)
         2. Global config defaults (from .env)
 
         Per-user DB overrides (set via /settings or /model) are applied
@@ -134,9 +134,9 @@ class SubprocessPool:
         # Per-user backend and provider, falling back to global config.
         # Routed through the canonical get_user_backend_and_provider
         # resolver so codex always reports provider="openai" even when
-        # llm_provider is unset, matching the same cascade bot.py and
+        # the provider is unset, matching the same cascade bot.py and
         # the install-time validator use. Without this, a user with
-        # `default_backend: codex` on a globally-claude install ended up
+        # `backend: codex` on a globally-claude install ended up
         # with effective_provider="" and the fallback below dispatched
         # the global default_model ("sonnet"), which codex CLI rejects.
         backend, effective_provider = get_user_backend_and_provider(user, self._config)
@@ -144,7 +144,7 @@ class SubprocessPool:
         # claude (anthropic) and codex (openai) so global_provider lines
         # up with effective_provider whenever the user has not overridden
         # the backend; no codex-specific patch needed here.
-        global_provider = get_effective_provider(self._config.default_backend, self._config.llm_provider)
+        global_provider = get_effective_provider(self._config.default_backend, self._config.default_provider)
 
         # Per-user model. When the user's effective backend differs
         # from the global one, the global default_model may not be
@@ -201,7 +201,7 @@ class SubprocessPool:
                 )
                 model = self._config.default_model
 
-        timeout = user.timeout if user and user.timeout is not None else self._config.agent_timeout_seconds
+        timeout = user.timeout if user and user.timeout is not None else self._config.default_timeout
         # home_ws is what the backend treats as "home" for the foreign-
         # workspace reminder. Same resolution as the workspace above so
         # the two cannot drift; pre-#353 this took a different path that

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -3055,7 +3055,7 @@ async def run_review(
     if agent_backend == "goose":
         if not provider:
             raise ValueError(
-                "agent_backend is 'goose' but provider is empty. Set LLM_PROVIDER in .env or per-user config."
+                "agent_backend is 'goose' but provider is empty. Set DEFAULT_PROVIDER in .env or per-user config."
             )
         # Dispatch to the goose one-shot reasoner, which owns the
         # `goose run -i - ... --max-turns 1` argv, GOOSE_BIN

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -741,7 +741,7 @@ async def resolve_user_defaults(
     except (ValueError, TypeError):
         timeout = None
     if timeout is None:
-        timeout = yaml_timeout if yaml_timeout is not None else config.agent_timeout_seconds
+        timeout = yaml_timeout if yaml_timeout is not None else config.default_timeout
 
     return {
         "model": model,

--- a/src/kai/smoke/memory.py
+++ b/src/kai/smoke/memory.py
@@ -13,7 +13,7 @@ install's memory state.
 
 Invocation: `python -m kai.smoke.memory [--user-id <chat_id>] [--os-user <name>]`.
 
-The `--user-id` flag selects which user's effective `default_backend`
+The `--user-id` flag selects which user's effective backend
 the smoke runs under (the same per-user dispatch production uses).
 When omitted, the smoke falls back to the global `config.default_backend`.
 The `--os-user` flag is required when the resolved effective backend
@@ -101,7 +101,7 @@ async def _run(user_id: str | None, os_user: str | None) -> int:
 
     # Resolve the effective backend the smoke runs under. With per-user
     # dispatch (issue #515), production extraction uses each user's
-    # effective `default_backend`; the smoke mirrors that by accepting a
+    # effective backend; the smoke mirrors that by accepting a
     # `--user-id` that the helper looks up in users.yaml. Without
     # `--user-id`, fall back to the global `default_backend` (the legacy
     # single-backend smoke path). The string the helper takes is the
@@ -213,7 +213,7 @@ def main() -> int:
         dest="user_id",
         default=None,
         help=(
-            "Telegram chat_id whose effective default_backend selects the reasoner. "
+            "Telegram chat_id whose effective backend selects the reasoner. "
             "Defaults to the global default_backend when omitted."
         ),
     )

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -501,7 +501,7 @@ async def run_triage(
     if agent_backend == "goose":
         if not provider:
             raise ValueError(
-                "agent_backend is 'goose' but provider is empty. Set LLM_PROVIDER in .env or per-user config."
+                "agent_backend is 'goose' but provider is empty. Set DEFAULT_PROVIDER in .env or per-user config."
             )
         # Dispatch to the goose one-shot reasoner, which owns the
         # `goose run -i - ... --max-turns 1` argv, GOOSE_BIN

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -738,15 +738,15 @@ async def _process_github_event_for_user(
     # Resolve per-user backend/provider for the review/triage agents.
     # Same resolution logic as pool.py _create_instance: per-user
     # config overrides global config.
-    if user_config and user_config.default_backend:
-        agent_backend = user_config.default_backend
+    if user_config and user_config.backend:
+        agent_backend = user_config.backend
     else:
         agent_backend = config.default_backend
 
-    if user_config and user_config.llm_provider:
-        provider = user_config.llm_provider
+    if user_config and user_config.provider:
+        provider = user_config.provider
     else:
-        provider = config.llm_provider
+        provider = config.default_provider
 
     # Per-role model overrides for review and triage. `resolve_user_model`
     # implements the full precedence chain: per-user `models:` from

--- a/templates/.env
+++ b/templates/.env
@@ -17,9 +17,10 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 # "codex" uses the OpenAI Codex CLI's app-server JSON-RPC protocol.
 #DEFAULT_BACKEND=claude
 
-# LLM provider. Required when DEFAULT_BACKEND is a non-Claude backend.
-# Valid values depend on the backend:
-#   goose: anthropic, deepseek, google, ollama, openai, openrouter
+# LLM provider. Required for the multi-provider backends (goose,
+# opencode); claude and codex are single-provider and ignore it.
+# Valid values:
+#   goose, opencode: anthropic, deepseek, google, ollama, openai, openrouter
 #DEFAULT_PROVIDER=anthropic
 
 # Provider API key. Set the one matching your DEFAULT_PROVIDER.

--- a/templates/.env
+++ b/templates/.env
@@ -20,9 +20,9 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 # LLM provider. Required when DEFAULT_BACKEND is a non-Claude backend.
 # Valid values depend on the backend:
 #   goose: anthropic, deepseek, google, ollama, openai, openrouter
-#LLM_PROVIDER=anthropic
+#DEFAULT_PROVIDER=anthropic
 
-# Provider API key. Set the one matching your LLM_PROVIDER.
+# Provider API key. Set the one matching your DEFAULT_PROVIDER.
 # Ollama does not require an API key (local inference).
 # These are backend env vars, not Kai config fields - Kai
 # passes them through to the subprocess environment. The wizard
@@ -52,7 +52,7 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 
 # Installation-wide default subprocess timeout (seconds). Per-user
 # overrides go in users.yaml 'timeout', or via /settings timeout.
-#AGENT_TIMEOUT_SECONDS=120
+#DEFAULT_TIMEOUT=120
 
 # Effort level for inner Claude reasoning (low|medium|high|xhigh|max).
 # Higher = more thinking tokens per turn = better answers + higher

--- a/templates/config/goose-config.yaml
+++ b/templates/config/goose-config.yaml
@@ -6,7 +6,7 @@
 #
 # GOOSE_MODEL and GOOSE_PROVIDER are intentionally omitted here;
 # both are set at runtime by GooseBackend when launching `goose acp`,
-# translated from the effective per-user model and llm_provider.
+# translated from the effective per-user model and provider.
 # Workspace config (workspaces.yaml env / env_file) can override
 # either one for per-workspace provider or model pinning.
 

--- a/templates/users.yaml
+++ b/templates/users.yaml
@@ -30,17 +30,17 @@ users:
 
     # Optional per-user defaults. Users can override these at runtime
     # via /settings. Omitted fields inherit installation defaults
-    # (DEFAULT_MODEL, AGENT_TIMEOUT_SECONDS).
+    # (DEFAULT_MODEL, DEFAULT_TIMEOUT).
     # model: opus             # haiku/sonnet/opus for claude; provider/model for opencode
     # timeout: 300            # response timeout in seconds (max 600)
 
     # Default backend. Overrides the global DEFAULT_BACKEND from .env for
     # this user only. Default is "claude" (Claude Code CLI). Other
-    # options: "goose" (Goose ACP, requires llm_provider + API key),
+    # options: "goose" (Goose ACP, requires provider + API key),
     # "codex" (OpenAI Codex CLI), "opencode" (OpenCode ACP; model is
     # a full "provider/model" ID, auth managed by `opencode auth login`).
-    # default_backend: goose
-    # llm_provider: openai    # required for goose; ignored for opencode
+    # backend: goose
+    # provider: openai    # required for goose; ignored for opencode
     # model: anthropic/claude-sonnet-4-6   # opencode example (full provider/model ID)
 
     # GitHub notification settings. github_repos controls which repos

--- a/templates/users.yaml
+++ b/templates/users.yaml
@@ -40,7 +40,7 @@ users:
     # "codex" (OpenAI Codex CLI), "opencode" (OpenCode ACP; model is
     # a full "provider/model" ID, auth managed by `opencode auth login`).
     # backend: goose
-    # provider: openai    # required for goose; ignored for opencode
+    # provider: openai    # required for goose and opencode (selects the model registry)
     # model: anthropic/claude-sonnet-4-6   # opencode example (full provider/model ID)
 
     # GitHub notification settings. github_repos controls which repos

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -162,19 +162,19 @@ class TestGetUserModelsWarningSuppression:
     """
 
     def test_opencode_does_not_log_missing_registry_warning(self, caplog):
-        """Global opencode install with empty llm_provider should NOT log the warning."""
+        """Global opencode install with empty provider should NOT log the warning."""
         import logging
 
         from kai.bot import _get_user_models
         from kai.pool import SubprocessPool
 
-        # Empty llm_provider is the realistic global-opencode case
+        # Empty provider is the realistic global-opencode case
         # (VALID_PROVIDERS["opencode"] does not exist; the wizard never
-        # prompts for an llm_provider). The pre-fix code path warns
+        # prompts for a provider). The pre-fix code path warns
         # because "" is not in OPEN_ENDED_PROVIDERS.
         config = MagicMock()
         config.default_backend = "opencode"
-        config.llm_provider = ""
+        config.default_provider = ""
         config.get_user_config = MagicMock(return_value=None)
         pool = MagicMock(spec=SubprocessPool)
         pool.get_if_exists = MagicMock(return_value=None)
@@ -195,7 +195,7 @@ class TestGetUserModelsWarningSuppression:
 
         config = MagicMock()
         config.default_backend = "codex"
-        config.llm_provider = ""
+        config.default_provider = ""
         config.get_user_config = MagicMock(return_value=None)
         pool = MagicMock(spec=SubprocessPool)
         pool.get_if_exists = MagicMock(return_value=None)
@@ -3497,7 +3497,7 @@ class TestHandleResponse:
                 12345: UserConfig(
                     telegram_id=12345,
                     name="opencode-user",
-                    default_backend="opencode",
+                    backend="opencode",
                 ),
             },
         )
@@ -3539,8 +3539,8 @@ class TestHandleResponse:
                 12345: UserConfig(
                     telegram_id=12345,
                     name="goose-user",
-                    default_backend="goose",
-                    llm_provider="openai",
+                    backend="goose",
+                    provider="openai",
                 ),
             },
         )
@@ -4702,7 +4702,7 @@ class TestHandleSettings:
     async def test_reset_reverts_codex_install_to_default(self):
         """
         /settings reset model on a wizard-generated codex install with
-        LLM_PROVIDER unset must revert to the wizard's DEFAULT_MODEL
+        DEFAULT_PROVIDER unset must revert to the wizard's DEFAULT_MODEL
         (e.g. gpt-5.5), not PROVIDER_DEFAULTS["openai"] (gpt-5.4).
         Regression for PR #489 re-review: get_effective_provider had
         to be taught the codex->openai rule so _revert_instance_field
@@ -4712,7 +4712,7 @@ class TestHandleSettings:
         update = _make_update(text="/settings reset model")
         config = _make_config(
             default_backend="codex",
-            llm_provider="",
+            default_provider="",
             default_model="gpt-5.5",
         )
         pool = _make_mock_claude(provider="openai")
@@ -4750,7 +4750,7 @@ class TestHandleSettings:
             await handle_settings(update, ctx)
 
         assert instance.model == config.default_model
-        assert instance.timeout_seconds == config.agent_timeout_seconds
+        assert instance.timeout_seconds == config.default_timeout
 
 
 # ── /github command ─────────────────────────────────────────────────
@@ -6205,8 +6205,8 @@ class TestHandleReviewCommand:
                     telegram_id=12345,
                     name="op",
                     github_repos=["dcellison/kai"],
-                    default_backend="codex",
-                    llm_provider="openai",
+                    backend="codex",
+                    provider="openai",
                     os_user="daniel",
                 ),
             },

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -2222,7 +2222,7 @@ class TestCodexGrandchildEscalation:
 
 class TestStartupFailureSurface:
     """
-    Spec #556 acceptance criterion: a per-user `default_backend: codex`
+    Spec #556 acceptance criterion: a per-user `backend: codex`
     entry on a non-codex install must produce a chat-visible
     startup-failure StreamEvent (not silent failure, not fall-through
     to claude) when codex tooling is missing.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,7 +32,7 @@ _CONFIG_ENV_VARS = [
     "ALLOWED_USER_IDS",
     "DEFAULT_MODEL",
     "CLAUDE_MODEL",
-    "CLAUDE_TIMEOUT_SECONDS",
+    "CLAUDE_TIMEOUT_SECONDS",  # removed; cleared so a host value cannot leak into tests
     "BUDGET_CEILING",  # retired (budgets are no longer tracked)
     "CLAUDE_MAX_BUDGET_USD",  # retired (budgets are no longer tracked)
     "AGENT_MAX_SESSION_HOURS",
@@ -64,7 +64,10 @@ _CONFIG_ENV_VARS = [
     "TOTP_LOCKOUT_ATTEMPTS",
     "TOTP_LOCKOUT_MINUTES",
     "DEFAULT_BACKEND",
-    "LLM_PROVIDER",
+    "DEFAULT_PROVIDER",
+    "LLM_PROVIDER",  # backward compat (renamed to DEFAULT_PROVIDER)
+    "DEFAULT_TIMEOUT",
+    "AGENT_TIMEOUT_SECONDS",  # backward compat (renamed to DEFAULT_TIMEOUT)
     "MEMORY_ENABLED",
     "MEMORY_SEARCH_LIMIT",
     "MEMORY_TOKEN_BUDGET",
@@ -186,7 +189,7 @@ class TestLoadConfigDefaults:
         _set_required(monkeypatch)
         config = load_config()
         assert config.default_model == "sonnet"
-        assert config.agent_timeout_seconds == 120
+        assert config.default_timeout == 120
         assert config.agent_max_session_hours == 0
         assert config.webhook_port == 8080
         # Without TELEGRAM_WEBHOOK_URL, defaults to polling mode
@@ -295,50 +298,50 @@ class TestLoadConfigErrors:
         with pytest.raises(SystemExit, match="DEFAULT_BACKEND"):
             load_config()
 
-    def test_invalid_llm_provider(self, monkeypatch):
-        """LLM_PROVIDER with an unrecognized value raises SystemExit."""
+    def test_invalid_provider(self, monkeypatch):
+        """DEFAULT_PROVIDER with an unrecognized value raises SystemExit."""
         _set_required(monkeypatch)
         monkeypatch.setenv("DEFAULT_BACKEND", "goose")
-        monkeypatch.setenv("LLM_PROVIDER", "invalid")
-        with pytest.raises(SystemExit, match="LLM_PROVIDER"):
+        monkeypatch.setenv("DEFAULT_PROVIDER", "invalid")
+        with pytest.raises(SystemExit, match="DEFAULT_PROVIDER"):
             load_config()
 
-    def test_missing_llm_provider(self, monkeypatch):
-        """LLM_PROVIDER missing when backend=goose raises SystemExit."""
+    def test_missing_provider(self, monkeypatch):
+        """DEFAULT_PROVIDER missing when backend=goose raises SystemExit."""
         _set_required(monkeypatch)
         monkeypatch.setenv("DEFAULT_BACKEND", "goose")
-        with pytest.raises(SystemExit, match="LLM_PROVIDER"):
+        with pytest.raises(SystemExit, match="DEFAULT_PROVIDER"):
             load_config()
 
-    def test_llm_provider_ignored_for_claude(self, monkeypatch):
-        """LLM_PROVIDER is not validated when backend=claude."""
+    def test_provider_ignored_for_claude(self, monkeypatch):
+        """DEFAULT_PROVIDER is not validated when backend=claude."""
         _set_required(monkeypatch)
         cfg = load_config()
-        assert cfg.llm_provider == ""
+        assert cfg.default_provider == ""
 
-    def test_invalid_llm_provider_ignored_for_claude(self, monkeypatch):
-        """Even an invalid LLM_PROVIDER is ignored when backend=claude."""
+    def test_invalid_provider_ignored_for_claude(self, monkeypatch):
+        """Even an invalid DEFAULT_PROVIDER is ignored when backend=claude."""
         _set_required(monkeypatch)
-        monkeypatch.setenv("LLM_PROVIDER", "completelywrong")
+        monkeypatch.setenv("DEFAULT_PROVIDER", "completelywrong")
         cfg = load_config()
-        assert cfg.llm_provider == ""
+        assert cfg.default_provider == ""
 
-    def test_valid_llm_provider(self, monkeypatch):
-        """Valid LLM_PROVIDER is accepted and stored."""
+    def test_valid_provider(self, monkeypatch):
+        """Valid DEFAULT_PROVIDER is accepted and stored."""
         _set_required(monkeypatch)
         monkeypatch.setenv("DEFAULT_BACKEND", "goose")
-        monkeypatch.setenv("LLM_PROVIDER", "openai")
+        monkeypatch.setenv("DEFAULT_PROVIDER", "openai")
         # DEFAULT_MODEL must be valid for the openai provider
         monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.4")
         cfg = load_config()
-        assert cfg.llm_provider == "openai"
+        assert cfg.default_provider == "openai"
 
     def test_goose_without_provider_exits(self, monkeypatch):
-        """DEFAULT_BACKEND=goose without LLM_PROVIDER fails at startup."""
+        """DEFAULT_BACKEND=goose without a provider fails at startup."""
         _set_required(monkeypatch)
         monkeypatch.setenv("DEFAULT_BACKEND", "goose")
-        # LLM_PROVIDER not set - empty string is not in VALID_PROVIDERS["goose"]
-        with pytest.raises(SystemExit, match=r"LLM_PROVIDER.*not valid"):
+        # DEFAULT_PROVIDER not set - empty string is not in VALID_PROVIDERS["goose"]
+        with pytest.raises(SystemExit, match=r"DEFAULT_PROVIDER.*not valid"):
             load_config()
 
 
@@ -807,7 +810,8 @@ def _mock_user_configs(monkeypatch):
 # GITHUB_NOTIFY_CHAT_ID) are no longer read at runtime and have no
 # deprecation handling here — the loader silently ignores them.
 _RENAMED_VARS_WITH_VALUES = {
-    "CLAUDE_TIMEOUT_SECONDS": "120",
+    "CLAUDE_MAX_SESSION_HOURS": "4",
+    "CLAUDE_IDLE_TIMEOUT": "900",
 }
 
 
@@ -826,11 +830,11 @@ class TestRenamedEnvWarnings:
     def test_empty_var_does_not_warn(self, monkeypatch, caplog):
         """Empty string env vars are not treated as 'set'."""
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake")
-        monkeypatch.setenv("CLAUDE_TIMEOUT_SECONDS", "")
+        monkeypatch.setenv("CLAUDE_IDLE_TIMEOUT", "")
         _mock_user_configs(monkeypatch)
         with caplog.at_level(logging.WARNING, logger="kai.config"):
             load_config()
-        assert "CLAUDE_TIMEOUT_SECONDS in env is deprecated" not in caplog.text
+        assert "CLAUDE_IDLE_TIMEOUT in env is deprecated" not in caplog.text
 
 
 # Retired env vars: the setting no longer exists, so the loader warns
@@ -979,7 +983,7 @@ class TestMinimalEnvWithUsersYaml:
         config = load_config()
         # Uses dataclass defaults when no env var is set
         assert config.default_model == "sonnet"
-        assert config.agent_timeout_seconds == 120
+        assert config.default_timeout == 120
         assert config.workspace_base is None
         assert config.allowed_workspaces == []
         # users.yaml IDs are the authorization surface
@@ -1776,13 +1780,13 @@ class TestExtractionEligibleBackendsHelper:
 
         configs = {
             1: UserConfig(telegram_id=1, name="alice", os_user="a"),
-            2: UserConfig(telegram_id=2, name="bob", os_user="b", default_backend="codex"),
+            2: UserConfig(telegram_id=2, name="bob", os_user="b", backend="codex"),
         }
         eligible = _compute_extraction_eligible_backends("claude", configs, True)
         assert eligible == {"claude", "codex"}
 
     def test_goose_users_contribute_to_eligible_set(self):
-        """A users.yaml entry with `default_backend: goose` contributes
+        """A users.yaml entry with `backend: goose` contributes
         to the eligible set now that goose ships a OneShotReasoner;
         the config-load precondition / binary checks must fire for a
         goose user the same way they do for the other backends."""
@@ -1790,7 +1794,7 @@ class TestExtractionEligibleBackendsHelper:
 
         configs = {
             1: UserConfig(telegram_id=1, name="alice", os_user="a"),
-            2: UserConfig(telegram_id=2, name="bob", os_user="b", default_backend="goose", llm_provider="openai"),
+            2: UserConfig(telegram_id=2, name="bob", os_user="b", backend="goose", provider="openai"),
         }
         eligible = _compute_extraction_eligible_backends("claude", configs, True)
         assert eligible == {"claude", "goose"}
@@ -1806,7 +1810,7 @@ class TestExtractionEligibleBackendsHelper:
         monkeypatch.setattr(config_module, "ONESHOT_REASONER_BACKENDS", frozenset({"claude", "codex"}))
         configs = {
             1: UserConfig(telegram_id=1, name="alice", os_user="a"),
-            2: UserConfig(telegram_id=2, name="bob", os_user="b", default_backend="goose", llm_provider="openai"),
+            2: UserConfig(telegram_id=2, name="bob", os_user="b", backend="goose", provider="openai"),
         }
         eligible = _compute_extraction_eligible_backends("claude", configs, True)
         assert eligible == {"claude"}
@@ -1822,7 +1826,7 @@ class TestExtractionEligibleBackendsHelper:
 
         configs = {
             1: UserConfig(telegram_id=1, name="alice", os_user="a"),
-            2: UserConfig(telegram_id=2, name="bob", os_user="b", default_backend="opencode"),
+            2: UserConfig(telegram_id=2, name="bob", os_user="b", backend="opencode"),
         }
         eligible = _compute_extraction_eligible_backends("claude", configs, True)
         assert eligible == {"claude", "opencode"}
@@ -2672,7 +2676,7 @@ class TestDefaultBackendEnvResolution:
         monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.5")
         # Clear the one-shot warned-context set so the assertion below
         # observes this process's actual warn behavior.
-        config_module._default_backend_deprecation_warned.clear()
+        config_module._renamed_key_deprecation_warned.clear()
         cfg = load_config()
         assert cfg.default_backend == "codex"
 
@@ -2687,7 +2691,7 @@ class TestDefaultBackendEnvResolution:
         monkeypatch.delenv("DEFAULT_BACKEND", raising=False)
         monkeypatch.setenv("AGENT_BACKEND", "codex")
         monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.5")
-        config_module._default_backend_deprecation_warned.clear()
+        config_module._renamed_key_deprecation_warned.clear()
         with caplog.at_level(logging.WARNING):
             cfg = load_config()
         assert cfg.default_backend == "codex"
@@ -2706,26 +2710,100 @@ class TestDefaultBackendEnvResolution:
         monkeypatch.setenv("OPENAI_API_KEY", "k")
         monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.5")
         monkeypatch.setenv("AGENT_BACKEND", "codex")
-        config_module._default_backend_deprecation_warned.clear()
+        config_module._renamed_key_deprecation_warned.clear()
         with caplog.at_level(logging.WARNING):
             cfg = load_config()
         assert cfg.default_backend == "goose"
         assert not any("AGENT_BACKEND is deprecated" in r.message for r in caplog.records)
 
 
+class TestDefaultProviderEnvResolution:
+    """Back-compat for the LLM_PROVIDER -> DEFAULT_PROVIDER env rename.
+
+    The provider is read only for multi-provider backends (goose,
+    opencode), so these tests drive goose so load_config consults the
+    key. The reader prefers DEFAULT_PROVIDER and falls back to the
+    deprecated LLM_PROVIDER for one release with a one-shot warning.
+    """
+
+    def test_legacy_LLM_PROVIDER_env_resolved_with_warning(self, monkeypatch, caplog):
+        import kai.config as config_module
+
+        _set_required(monkeypatch)
+        monkeypatch.setenv("DEFAULT_BACKEND", "goose")
+        monkeypatch.delenv("DEFAULT_PROVIDER", raising=False)
+        monkeypatch.setenv("LLM_PROVIDER", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.5")
+        config_module._renamed_key_deprecation_warned.clear()
+        with caplog.at_level(logging.WARNING):
+            cfg = load_config()
+        assert cfg.default_provider == "openai"
+        assert any("LLM_PROVIDER" in r.message and "DEFAULT_PROVIDER" in r.message for r in caplog.records)
+
+    def test_DEFAULT_PROVIDER_env_wins_when_both_set(self, monkeypatch, caplog):
+        import kai.config as config_module
+
+        _set_required(monkeypatch)
+        monkeypatch.setenv("DEFAULT_BACKEND", "goose")
+        monkeypatch.setenv("DEFAULT_PROVIDER", "openai")
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.5")
+        config_module._renamed_key_deprecation_warned.clear()
+        with caplog.at_level(logging.WARNING):
+            cfg = load_config()
+        assert cfg.default_provider == "openai"
+        assert not any("LLM_PROVIDER is deprecated" in r.message for r in caplog.records)
+
+
+class TestResolveEvalProvider:
+    """The shared eval-time provider resolver used by the behavioral
+    eval and the memory backend gate. Reads DEFAULT_PROVIDER with a
+    one-release fallback to the deprecated LLM_PROVIDER name."""
+
+    def test_reads_DEFAULT_PROVIDER(self, monkeypatch, caplog):
+        import kai.config as config_module
+
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)
+        monkeypatch.setenv("DEFAULT_PROVIDER", "OpenAI")
+        config_module._renamed_key_deprecation_warned.clear()
+        with caplog.at_level(logging.WARNING, logger="kai.config"):
+            # Normalizes via strip().lower().
+            assert config_module._resolve_eval_provider("eval ctx") == "openai"
+        assert not any("deprecated" in r.message for r in caplog.records)
+
+    def test_legacy_LLM_PROVIDER_resolved_with_warning(self, monkeypatch, caplog):
+        import kai.config as config_module
+
+        monkeypatch.delenv("DEFAULT_PROVIDER", raising=False)
+        monkeypatch.setenv("LLM_PROVIDER", "openai")
+        config_module._renamed_key_deprecation_warned.clear()
+        with caplog.at_level(logging.WARNING, logger="kai.config"):
+            assert config_module._resolve_eval_provider("eval ctx") == "openai"
+        assert any("LLM_PROVIDER" in r.message and "DEFAULT_PROVIDER" in r.message for r in caplog.records)
+
+    def test_neither_set_returns_empty(self, monkeypatch):
+        import kai.config as config_module
+
+        monkeypatch.delenv("DEFAULT_PROVIDER", raising=False)
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)
+        assert config_module._resolve_eval_provider("eval ctx") == ""
+
+
 class TestGetUserBackendAndProvider:
     """Per-user cascade resolver."""
 
-    def _config(self, default_backend="claude", llm_provider=""):
+    def _config(self, default_backend="claude", default_provider=""):
         cfg = MagicMock()
         cfg.default_backend = default_backend
-        cfg.llm_provider = llm_provider
+        cfg.default_provider = default_provider
         return cfg
 
-    def _user_config(self, default_backend=None, llm_provider=None):
+    def _user_config(self, backend=None, provider=None):
         uc = MagicMock()
-        uc.default_backend = default_backend
-        uc.llm_provider = llm_provider
+        uc.backend = backend
+        uc.provider = provider
         return uc
 
     def test_no_user_config_returns_global(self):
@@ -2740,7 +2818,7 @@ class TestGetUserBackendAndProvider:
         from kai.config import get_user_backend_and_provider
 
         cfg = self._config(default_backend="claude")
-        uc = self._user_config(default_backend="codex")
+        uc = self._user_config(backend="codex")
         backend, provider = get_user_backend_and_provider(uc, cfg)
         assert backend == "codex"
         assert provider == "openai"
@@ -2749,7 +2827,7 @@ class TestGetUserBackendAndProvider:
         from kai.config import get_user_backend_and_provider
 
         cfg = self._config(default_backend="codex")
-        uc = self._user_config(default_backend="goose", llm_provider="openai")
+        uc = self._user_config(backend="goose", provider="openai")
         backend, provider = get_user_backend_and_provider(uc, cfg)
         assert backend == "goose"
         assert provider == "openai"
@@ -2758,18 +2836,24 @@ class TestGetUserBackendAndProvider:
         from kai.config import get_user_backend_and_provider
 
         cfg = self._config(default_backend="codex")
-        uc = self._user_config(default_backend="codex", llm_provider="anthropic")
+        uc = self._user_config(backend="codex", provider="anthropic")
         backend, provider = get_user_backend_and_provider(uc, cfg)
         assert backend == "codex"
         assert provider == "openai"
 
 
-class TestAgentTimeoutSecondsRename:
-    """CLAUDE_TIMEOUT_SECONDS -> AGENT_TIMEOUT_SECONDS rename with legacy alias."""
+class TestDefaultTimeoutRename:
+    """AGENT_TIMEOUT_SECONDS -> DEFAULT_TIMEOUT rename with a one-release
+    legacy alias. The older CLAUDE_TIMEOUT_SECONDS step is gone entirely."""
 
     def _required_env(self, monkeypatch, **overrides):
         for var in _CONFIG_ENV_VARS:
             monkeypatch.delenv(var, raising=False)
+        # Clear the one-shot warned set so per-test warn assertions
+        # observe this process's actual warn behavior.
+        import kai.config as config_module
+
+        config_module._renamed_key_deprecation_warned.clear()
         base = {
             "TELEGRAM_BOT_TOKEN": "test-token",
             "ALLOWED_USER_IDS": "12345",
@@ -2787,26 +2871,36 @@ class TestAgentTimeoutSecondsRename:
             "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n",
         )
 
-    def test_agent_timeout_seconds_preferred(self, monkeypatch):
+    def test_DEFAULT_TIMEOUT_env_wins_when_both_set(self, monkeypatch, caplog):
         self._required_env(
             monkeypatch,
-            AGENT_TIMEOUT_SECONDS="180",
-            CLAUDE_TIMEOUT_SECONDS="60",
+            DEFAULT_TIMEOUT="180",
+            AGENT_TIMEOUT_SECONDS="60",
         )
-        cfg = load_config()
-        assert cfg.agent_timeout_seconds == 180
-
-    def test_legacy_only_falls_back_with_warning(self, monkeypatch, caplog):
-        self._required_env(monkeypatch, CLAUDE_TIMEOUT_SECONDS="240")
         with caplog.at_level(logging.WARNING, logger="kai.config"):
             cfg = load_config()
-        assert cfg.agent_timeout_seconds == 240
-        assert any("CLAUDE_TIMEOUT_SECONDS is deprecated" in r.message for r in caplog.records)
+        assert cfg.default_timeout == 180
+        # The legacy key is never consulted, so no deprecation warning.
+        assert not any("AGENT_TIMEOUT_SECONDS is deprecated" in r.message for r in caplog.records)
+
+    def test_legacy_AGENT_TIMEOUT_SECONDS_env_resolved_with_warning(self, monkeypatch, caplog):
+        self._required_env(monkeypatch, AGENT_TIMEOUT_SECONDS="240")
+        with caplog.at_level(logging.WARNING, logger="kai.config"):
+            cfg = load_config()
+        assert cfg.default_timeout == 240
+        assert any("AGENT_TIMEOUT_SECONDS" in r.message and "DEFAULT_TIMEOUT" in r.message for r in caplog.records)
+
+    def test_CLAUDE_TIMEOUT_SECONDS_no_longer_honored(self, monkeypatch):
+        """The older CLAUDE_TIMEOUT_SECONDS back-compat step was removed;
+        setting only it leaves the timeout at the 120 default."""
+        self._required_env(monkeypatch, CLAUDE_TIMEOUT_SECONDS="240")
+        cfg = load_config()
+        assert cfg.default_timeout == 120
 
     def test_neither_set_defaults_to_120(self, monkeypatch):
         self._required_env(monkeypatch)
         cfg = load_config()
-        assert cfg.agent_timeout_seconds == 120
+        assert cfg.default_timeout == 120
 
 
 class TestAgentSessionLifecycleRename:
@@ -3650,7 +3744,7 @@ class TestResolveUserModel:
     def _config(self, default_models=None):
         cfg = MagicMock()
         cfg.default_backend = "claude"
-        cfg.llm_provider = ""
+        cfg.default_provider = ""
         cfg.default_models = default_models or {}
         return cfg
 
@@ -3712,7 +3806,7 @@ class TestLegacyEnvOverrideSeeding:
         from kai.config import UserConfig, _apply_legacy_model_env_overrides
 
         monkeypatch.setenv("PR_REVIEW_MODEL_CLAUDE", "opus")
-        uc = UserConfig(telegram_id=1, name="test", default_backend="codex")
+        uc = UserConfig(telegram_id=1, name="test", backend="codex")
         out = _apply_legacy_model_env_overrides({1: uc}, "claude")
         assert out[1].models is None
 

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -961,13 +961,13 @@ class TestBackendAwareModelResolution:
         """
         Goose is a registry-resolved backend: an unset flag resolves
         through the (goose, provider, role) rows the same way claude
-        does. LLM_PROVIDER is required env on goose installs, so the
+        does. DEFAULT_PROVIDER is required env on goose installs, so the
         eval reads it the same way the runtime does.
         """
         from kai.config import ModelRole, get_model_for
 
         monkeypatch.setenv("DEFAULT_BACKEND", "goose")
-        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        monkeypatch.setenv("DEFAULT_PROVIDER", "anthropic")
         args = self._make_args(tmp_path)  # judge_model=None, gen_model=None
         config = self._run_with_captured_config(args)
         assert config.judge_model == get_model_for(ModelRole.BEHAVIORAL_JUDGE, "goose", "anthropic")
@@ -1026,7 +1026,7 @@ class TestBackendAwareModelResolution:
 
         monkeypatch.delenv("AGENT_BACKEND", raising=False)
         monkeypatch.setenv("DEFAULT_BACKEND", "goose")
-        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        monkeypatch.setenv("DEFAULT_PROVIDER", "anthropic")
         args = self._make_args(tmp_path)
         config = self._run_with_captured_config(args)
         assert config.judge_model == get_model_for(ModelRole.BEHAVIORAL_JUDGE, "goose", "anthropic")

--- a/tests/test_eval_memory_backend_gate.py
+++ b/tests/test_eval_memory_backend_gate.py
@@ -62,6 +62,33 @@ def _write_jsonl(path: Path, rows: list[dict]) -> None:
     path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
 
 
+class TestEvalProviderResolution:
+    """The gate resolves its eval-time provider through the shared
+    `_resolve_eval_provider` helper (DEFAULT_PROVIDER with a one-release
+    fallback to the deprecated LLM_PROVIDER name), so it does not bypass
+    the rename window. `run_backend` calls exactly `g._resolve_eval_provider`."""
+
+    def test_memory_backend_gate_reads_DEFAULT_PROVIDER(self, monkeypatch):
+        import kai.config as config_module
+
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)
+        monkeypatch.setenv("DEFAULT_PROVIDER", "openai")
+        config_module._renamed_key_deprecation_warned.clear()
+        assert g._resolve_eval_provider("memory backend gate env") == "openai"
+
+    def test_memory_backend_gate_legacy_LLM_PROVIDER_resolved_with_warning(self, monkeypatch, caplog):
+        import logging
+
+        import kai.config as config_module
+
+        monkeypatch.delenv("DEFAULT_PROVIDER", raising=False)
+        monkeypatch.setenv("LLM_PROVIDER", "openai")
+        config_module._renamed_key_deprecation_warned.clear()
+        with caplog.at_level(logging.WARNING, logger="kai.config"):
+            assert g._resolve_eval_provider("memory backend gate env") == "openai"
+        assert any("LLM_PROVIDER" in r.message and "DEFAULT_PROVIDER" in r.message for r in caplog.records)
+
+
 class TestLoadProbes:
     def test_accepts_all_categories(self, tmp_path):
         """A synthetic fixture exercising each allowed category must

--- a/tests/test_eval_memory_backend_gate.py
+++ b/tests/test_eval_memory_backend_gate.py
@@ -298,6 +298,23 @@ class TestMakeBackendConfig:
         assert get_model_for(ModelRole.MEMORY_EXTRACTION, "codex", "openai") == "gpt-5.4-mini"
         assert get_model_for(ModelRole.MEMORY_EPISODE, "codex", "openai") == "gpt-5.4-mini"
 
+    def test_stamps_eval_provider_for_extraction(self):
+        """The eval provider is stamped into `default_provider` so the
+        extraction path (which resolves provider from the config, not the
+        run summary) sees the same value the report does. Without this a
+        goose arm run from a claude/codex install would extract with an
+        empty provider."""
+        config = g.make_backend_config(_BASE_CONFIG, "goose", "openai")
+        assert config.default_backend == "goose"
+        assert config.default_provider == "openai"
+
+    def test_default_provider_empty_when_omitted(self):
+        """Single-provider arms (claude/codex) pass no provider; the
+        implicit provider is used regardless, so default_provider stays
+        empty."""
+        config = g.make_backend_config(_BASE_CONFIG, "claude")
+        assert config.default_provider == ""
+
 
 # ── Anchor matching ─────────────────────────────────────────────────
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1647,7 +1647,7 @@ class TestCmdConfig:
 
         conf = json.loads((tmp_path / "install.conf").read_text())
         assert conf["env"]["DEFAULT_BACKEND"] == "goose"
-        assert conf["env"]["LLM_PROVIDER"] == "anthropic"
+        assert conf["env"]["DEFAULT_PROVIDER"] == "anthropic"
         assert conf["env"]["ANTHROPIC_API_KEY"] == "sk-ant-test-key"
         assert conf["env"]["GOOSE_BIN"] == "/opt/homebrew/bin/goose"
         # Memory was declined, so the retrieval-only note must not
@@ -1781,7 +1781,7 @@ class TestCmdConfig:
         _cmd_config()
 
         conf = json.loads((tmp_path / "install.conf").read_text())
-        assert conf["env"]["LLM_PROVIDER"] == "ollama"
+        assert conf["env"]["DEFAULT_PROVIDER"] == "ollama"
         # Ollama is local inference - no API key should be present
         for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "OPENROUTER_API_KEY"):
             assert key not in conf["env"]
@@ -3111,7 +3111,7 @@ class TestCmdConfigDefaultModelDispatch:
         Input chain for the users_yaml_exists=True + codex+subscription path.
 
         Codex bypasses the legacy provider/key block (VALID_PROVIDERS["codex"]
-        is intentionally absent), so no llm_provider or API key prompts fire.
+        is intentionally absent), so no provider or API key prompts fire.
         autocompact_pct and effort_level are claude-only and suppressed.
         The codex auth-mode prompt is the new line vs the goose chain.
         """
@@ -3127,7 +3127,7 @@ class TestCmdConfigDefaultModelDispatch:
             "subscription",  # codex auth mode
             # No OPENAI_API_KEY prompt in subscription mode
             "/usr/local/bin/codex",  # codex binary path
-            # No llm_provider prompt (codex is single-provider; absent from BACKENDS_NEEDING_PROVIDER_PROMPT)
+            # No provider prompt (codex is single-provider; absent from BACKENDS_NEEDING_PROVIDER_PROMPT)
             # Model prompt handled by the _prompt_default_model mock
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout (global default)
@@ -3517,7 +3517,7 @@ class TestCmdApplyDefaultModelGate:
         monkeypatch.setattr("os.geteuid", lambda: 0)
         conf_path = self._write_install_conf(
             tmp_path,
-            {"DEFAULT_MODEL": "sonnet", "DEFAULT_BACKEND": "goose", "LLM_PROVIDER": "openai"},
+            {"DEFAULT_MODEL": "sonnet", "DEFAULT_BACKEND": "goose", "DEFAULT_PROVIDER": "openai"},
         )
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         stop_service = self._patch_side_effects(monkeypatch)
@@ -3539,7 +3539,7 @@ class TestCmdApplyDefaultModelGate:
         monkeypatch.setattr("os.geteuid", lambda: 0)
         conf_path = self._write_install_conf(
             tmp_path,
-            {"DEFAULT_BACKEND": "goose", "LLM_PROVIDER": "openai"},
+            {"DEFAULT_BACKEND": "goose", "DEFAULT_PROVIDER": "openai"},
         )
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         stop_service = self._patch_side_effects(monkeypatch)
@@ -3585,7 +3585,7 @@ class TestCmdApplyDefaultModelGate:
             {
                 "DEFAULT_MODEL": "anthropic/claude-sonnet-4-6",
                 "DEFAULT_BACKEND": "goose",
-                "LLM_PROVIDER": "openrouter",
+                "DEFAULT_PROVIDER": "openrouter",
             },
         )
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
@@ -3605,7 +3605,7 @@ class TestCmdApplyDefaultModelGate:
         monkeypatch.setenv("DRY_RUN", "1")
         conf_path = self._write_install_conf(
             tmp_path,
-            {"DEFAULT_MODEL": "sonnet", "DEFAULT_BACKEND": "goose", "LLM_PROVIDER": "openai"},
+            {"DEFAULT_MODEL": "sonnet", "DEFAULT_BACKEND": "goose", "DEFAULT_PROVIDER": "openai"},
         )
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         stop_service = self._patch_side_effects(monkeypatch)
@@ -3620,12 +3620,12 @@ class TestCmdApplyDefaultModelGate:
     def test_normalizes_llm_provider_case_and_whitespace(self, tmp_path, monkeypatch):
         """
         Mirrors load_config's .strip().lower() normalization on
-        DEFAULT_BACKEND and LLM_PROVIDER. The test relies on a code path
+        DEFAULT_BACKEND and DEFAULT_PROVIDER. The test relies on a code path
         where normalized and un-normalized lookups produce DIFFERENT
         gate outcomes, so that the test fails if either transformation
         is dropped from the gate.
 
-        Setup: DEFAULT_BACKEND="goose", LLM_PROVIDER=" OpenAI ", DEFAULT_MODEL="sonnet".
+        Setup: DEFAULT_BACKEND="goose", DEFAULT_PROVIDER=" OpenAI ", DEFAULT_MODEL="sonnet".
         - With .strip().lower() applied: eff_provider="openai",
           validate("sonnet", "openai") returns False (sonnet is not in
           PROVIDER_MODELS["openai"]) -> SystemExit.
@@ -3645,7 +3645,7 @@ class TestCmdApplyDefaultModelGate:
             {
                 "DEFAULT_MODEL": "sonnet",
                 "DEFAULT_BACKEND": "goose",
-                "LLM_PROVIDER": " OpenAI ",
+                "DEFAULT_PROVIDER": " OpenAI ",
             },
         )
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
@@ -3699,7 +3699,7 @@ class TestCmdApplyDefaultModelGate:
         monkeypatch.setattr("os.geteuid", lambda: 0)
         conf_path = self._write_install_conf(
             tmp_path,
-            {"DEFAULT_MODEL": "gpt-5.5", "DEFAULT_BACKEND": "goose", "LLM_PROVIDER": "openai"},
+            {"DEFAULT_MODEL": "gpt-5.5", "DEFAULT_BACKEND": "goose", "DEFAULT_PROVIDER": "openai"},
         )
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         stop_service = self._patch_side_effects(monkeypatch)
@@ -3720,7 +3720,7 @@ class TestCmdApplyDefaultModelGate:
         monkeypatch.setattr("os.geteuid", lambda: 0)
         conf_path = self._write_install_conf(
             tmp_path,
-            {"DEFAULT_MODEL": "gpt-5.5", "DEFAULT_BACKEND": "Goose", "LLM_PROVIDER": "openai"},
+            {"DEFAULT_MODEL": "gpt-5.5", "DEFAULT_BACKEND": "Goose", "DEFAULT_PROVIDER": "openai"},
         )
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         self._patch_side_effects(monkeypatch)
@@ -3736,6 +3736,75 @@ class TestCmdApplyDefaultModelGate:
         assert written_env.get("DEFAULT_BACKEND") == "goose"
         # The goose-config deploy gate receives the normalized value.
         assert goose_mock.call_args.kwargs.get("agent_backend") == "goose"
+
+    def test_apply_migrates_legacy_LLM_PROVIDER(self, tmp_path, monkeypatch):
+        """A legacy install.conf carrying LLM_PROVIDER migrates to
+        DEFAULT_PROVIDER in the env dict so /etc/kai/env is written with
+        the new name and no LLM_PROVIDER. Mirrors the AGENT_BACKEND
+        migration."""
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {"DEFAULT_MODEL": "gpt-5.5", "DEFAULT_BACKEND": "goose", "LLM_PROVIDER": "openai"},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        self._patch_side_effects(monkeypatch)
+        secrets_mock = MagicMock()
+        monkeypatch.setattr("kai.install._apply_secrets", secrets_mock)
+        monkeypatch.setenv("DRY_RUN", "1")
+
+        _cmd_apply()
+
+        written_env = secrets_mock.call_args.args[0]
+        assert written_env.get("DEFAULT_PROVIDER") == "openai"
+        assert "LLM_PROVIDER" not in written_env
+
+    def test_apply_migrates_legacy_AGENT_TIMEOUT_SECONDS(self, tmp_path, monkeypatch):
+        """A legacy install.conf carrying AGENT_TIMEOUT_SECONDS migrates
+        to DEFAULT_TIMEOUT in the env dict; /etc/kai/env is written with
+        the new name and no AGENT_TIMEOUT_SECONDS."""
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {"DEFAULT_MODEL": "sonnet", "AGENT_TIMEOUT_SECONDS": "180"},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        self._patch_side_effects(monkeypatch)
+        secrets_mock = MagicMock()
+        monkeypatch.setattr("kai.install._apply_secrets", secrets_mock)
+        monkeypatch.setenv("DRY_RUN", "1")
+
+        _cmd_apply()
+
+        written_env = secrets_mock.call_args.args[0]
+        assert written_env.get("DEFAULT_TIMEOUT") == "180"
+        assert "AGENT_TIMEOUT_SECONDS" not in written_env
+
+    def test_apply_DEFAULT_TIMEOUT_wins_over_legacy(self, tmp_path, monkeypatch):
+        """Both DEFAULT_TIMEOUT and the legacy AGENT_TIMEOUT_SECONDS
+        present: the new key wins and the legacy key is dropped."""
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {"DEFAULT_MODEL": "sonnet", "DEFAULT_TIMEOUT": "300", "AGENT_TIMEOUT_SECONDS": "180"},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        self._patch_side_effects(monkeypatch)
+        secrets_mock = MagicMock()
+        monkeypatch.setattr("kai.install._apply_secrets", secrets_mock)
+        monkeypatch.setenv("DRY_RUN", "1")
+
+        _cmd_apply()
+
+        written_env = secrets_mock.call_args.args[0]
+        assert written_env.get("DEFAULT_TIMEOUT") == "300"
+        assert "AGENT_TIMEOUT_SECONDS" not in written_env
 
 
 # ── Directory creation ───────────────────────────────────────────────
@@ -6689,7 +6758,7 @@ class TestStripInstallConfKeys:
 
 class TestCmdConfigGlobalDefaultsRegardlessOfUsersYaml:
     """Pins the contract that installation-wide defaults (DEFAULT_MODEL,
-    AGENT_TIMEOUT_SECONDS, WORKSPACE_BASE, PR_REVIEW_COOLDOWN) prompt
+    DEFAULT_TIMEOUT, WORKSPACE_BASE, PR_REVIEW_COOLDOWN) prompt
     on every wizard run and land in install.conf's env regardless of
     users.yaml presence.
 
@@ -6709,7 +6778,7 @@ class TestCmdConfigGlobalDefaultsRegardlessOfUsersYaml:
         )
 
     def test_agent_timeout_lands_with_users_yaml(self, tmp_path, monkeypatch):
-        """AGENT_TIMEOUT_SECONDS reaches env when users.yaml is present."""
+        """DEFAULT_TIMEOUT reaches env when users.yaml is present."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
@@ -6724,7 +6793,7 @@ class TestCmdConfigGlobalDefaultsRegardlessOfUsersYaml:
         _cmd_config()
 
         env = json.loads((tmp_path / "install.conf").read_text())["env"]
-        assert env["AGENT_TIMEOUT_SECONDS"] == "120"
+        assert env["DEFAULT_TIMEOUT"] == "120"
 
     def test_retired_context_window_key_dropped_on_regenerate(self, tmp_path, monkeypatch):
         """A regenerate over an install.conf carrying the retired
@@ -7636,7 +7705,7 @@ class TestApplySudoersDryRun:
             "    os_user: alice\n"
             "  - telegram_id: 2\n"
             "    os_user: bob\n"
-            "    default_backend: claude\n"
+            "    backend: claude\n"
         )
 
         _apply_sudoers(
@@ -7711,7 +7780,7 @@ class TestApplySudoersDryRun:
 
 
 class TestCollectBackendsFromYaml:
-    """The lightweight per-user default_backend reader that scopes the
+    """The lightweight per-user backend reader that scopes the
     sudoers missing-binary backstop."""
 
     def test_missing_file_returns_empty_set(self, tmp_path):
@@ -7722,51 +7791,60 @@ class TestCollectBackendsFromYaml:
         path.write_text(
             "users:\n"
             "  - telegram_id: 1\n"
-            "    default_backend: codex\n"
+            "    backend: codex\n"
             "  - telegram_id: 2\n"
-            "    default_backend: opencode\n"
+            "    backend: opencode\n"
             "  - telegram_id: 3\n"
-            "    default_backend: codex\n"
+            "    backend: codex\n"
             "  - telegram_id: 4\n"
         )
         assert _collect_backends_from_yaml(path) == {"codex", "opencode"}
 
     def test_non_string_and_blank_values_skipped(self, tmp_path):
         path = tmp_path / "users.yaml"
-        path.write_text(
-            "users:\n  - telegram_id: 1\n    default_backend: 42\n  - telegram_id: 2\n    default_backend: '  '\n"
-        )
+        path.write_text("users:\n  - telegram_id: 1\n    backend: 42\n  - telegram_id: 2\n    backend: '  '\n")
         assert _collect_backends_from_yaml(path) == set()
 
 
 class TestEntryBackendLegacyKey:
     """Every installer-side users.yaml scanner reads a per-user entry's
-    backend through `_entry_backend`, which prefers `default_backend`
-    and falls back to the deprecated `agent_backend` key for one
-    release. Without this, a per-user `default_backend: goose` entry
-    would be invisible to wizard/apply setup (provider keys, binary
-    collection, goose config deployment, sudoers scoping)."""
+    backend through `_entry_backend`, which prefers the new `backend`
+    key and falls back to the deprecated `default_backend` then
+    `agent_backend` keys for one release (renamed twice: agent_backend
+    -> default_backend -> backend). Without this, a per-user
+    `backend: goose` entry would be invisible to wizard/apply setup
+    (provider keys, binary collection, goose config deployment,
+    sudoers scoping)."""
 
-    @pytest.mark.parametrize("key", ["default_backend", "agent_backend"])
-    def test_collect_backends_reads_both_keys(self, tmp_path, key):
+    @pytest.mark.parametrize("key", ["backend", "default_backend", "agent_backend"])
+    def test_collect_backends_reads_all_keys(self, tmp_path, key):
         path = tmp_path / "users.yaml"
         path.write_text(f"users:\n  - telegram_id: 1\n    {key}: goose\n")
         assert _collect_backends_from_yaml(path) == {"goose"}
 
-    @pytest.mark.parametrize("key", ["default_backend", "agent_backend"])
-    def test_users_yaml_agent_backends_reads_both_keys(self, tmp_path, key):
+    @pytest.mark.parametrize("key", ["backend", "default_backend", "agent_backend"])
+    def test_users_yaml_agent_backends_reads_all_keys(self, tmp_path, key):
         path = tmp_path / "users.yaml"
         path.write_text(f"users:\n  - telegram_id: 1\n    {key}: codex\n")
         assert _users_yaml_agent_backends(path) == {"codex"}
 
-    @pytest.mark.parametrize("key", ["default_backend", "agent_backend"])
-    def test_goose_providers_reads_both_keys(self, tmp_path, key):
+    @pytest.mark.parametrize("key", ["backend", "default_backend", "agent_backend"])
+    def test_goose_providers_reads_all_backend_keys(self, tmp_path, key):
         path = tmp_path / "users.yaml"
-        path.write_text(f"users:\n  - telegram_id: 1\n    {key}: goose\n    llm_provider: openai\n")
+        path.write_text(f"users:\n  - telegram_id: 1\n    {key}: goose\n    provider: openai\n")
         assert _users_yaml_goose_providers(path, "anthropic") == ["openai"]
 
-    @pytest.mark.parametrize("key", ["default_backend", "agent_backend"])
-    def test_goose_os_users_reads_both_keys(self, tmp_path, key):
+    @pytest.mark.parametrize("provider_key", ["provider", "llm_provider"])
+    def test_goose_providers_reads_new_provider_key(self, tmp_path, provider_key):
+        """The goose-provider scanner reads the new `provider` key and the
+        deprecated `llm_provider` key through `_entry_provider`, so a user
+        on the new key still gets their provider API key collected."""
+        path = tmp_path / "users.yaml"
+        path.write_text(f"users:\n  - telegram_id: 1\n    backend: goose\n    {provider_key}: deepseek\n")
+        assert _users_yaml_goose_providers(path, "anthropic") == ["deepseek"]
+
+    @pytest.mark.parametrize("key", ["backend", "default_backend", "agent_backend"])
+    def test_goose_os_users_reads_all_keys(self, tmp_path, key):
         from kai.install import _collect_goose_os_users_from_yaml
 
         path = tmp_path / "users.yaml"
@@ -7778,16 +7856,16 @@ class TestEntryBackendLegacyKey:
         lowercases); the scanner must normalize too so the goose-config
         membership check `"goose" in <set>` matches."""
         path = tmp_path / "users.yaml"
-        path.write_text("users:\n  - telegram_id: 1\n    default_backend: Goose\n")
+        path.write_text("users:\n  - telegram_id: 1\n    backend: Goose\n")
         assert _collect_backends_from_yaml(path) == {"goose"}
 
     def test_goose_os_users_normalizes_mixed_case(self, tmp_path):
-        """A mixed-case `default_backend: Goose` user's os_user must
+        """A mixed-case `backend: Goose` user's os_user must
         still be collected for the per-user goose config deploy."""
         from kai.install import _collect_goose_os_users_from_yaml
 
         path = tmp_path / "users.yaml"
-        path.write_text("users:\n  - telegram_id: 1\n    default_backend: Goose\n    os_user: alice\n")
+        path.write_text("users:\n  - telegram_id: 1\n    backend: Goose\n    os_user: alice\n")
         assert _collect_goose_os_users_from_yaml(path, "claude") == ["alice"]
 
 
@@ -7922,17 +8000,17 @@ class TestApplyGooseConfig:
             "users:\n"
             "  - telegram_id: 1\n"
             "    name: alice\n"
-            "    default_backend: goose\n"
+            "    backend: goose\n"
             "    os_user: alice\n"
             # Duplicate os_user entry: the deploy must dedupe.
             "  - telegram_id: 2\n"
             "    name: alice2\n"
-            "    default_backend: goose\n"
+            "    backend: goose\n"
             "    os_user: alice\n"
             # Non-goose user with an os_user: not a deploy target.
             "  - telegram_id: 3\n"
             "    name: bob\n"
-            "    default_backend: codex\n"
+            "    backend: codex\n"
             "    os_user: bob\n"
         )
 
@@ -7977,7 +8055,7 @@ class TestApplyGooseConfig:
 
     def test_global_goose_install_deploys_to_os_users_without_override(self, tmp_path, monkeypatch):
         """On a global goose install, users.yaml entries with no
-        per-user default_backend inherit goose and their os_user homes
+        per-user backend inherit goose and their os_user homes
         are deploy targets."""
         import types
 
@@ -8027,9 +8105,7 @@ class TestApplyGooseConfig:
         monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
 
         users_yaml = tmp_path / "users.yaml"
-        users_yaml.write_text(
-            "users:\n  - telegram_id: 1\n    name: alice\n    default_backend: goose\n    os_user: alice\n"
-        )
+        users_yaml.write_text("users:\n  - telegram_id: 1\n    name: alice\n    backend: goose\n    os_user: alice\n")
         monkeypatch.setattr(
             "kai.install.pwd",
             types.SimpleNamespace(
@@ -8062,7 +8138,7 @@ class TestApplyGooseConfig:
         # return before the template existence check.
         install_path = tmp_path / "opt" / "kai"
         users_yaml = tmp_path / "users.yaml"
-        users_yaml.write_text("users:\n  - {telegram_id: 1, name: a, default_backend: codex, os_user: bob}\n")
+        users_yaml.write_text("users:\n  - {telegram_id: 1, name: a, backend: codex, os_user: bob}\n")
 
         _apply_goose_config(
             "kai",
@@ -8088,9 +8164,7 @@ class TestApplyGooseConfig:
         monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
 
         users_yaml = tmp_path / "users.yaml"
-        users_yaml.write_text(
-            "users:\n  - telegram_id: 1\n    name: ghost\n    default_backend: goose\n    os_user: ghost\n"
-        )
+        users_yaml.write_text("users:\n  - telegram_id: 1\n    name: ghost\n    backend: goose\n    os_user: ghost\n")
 
         def _raise_keyerror(name):
             raise KeyError(name)
@@ -8128,8 +8202,8 @@ class TestCollectGooseOsUsersFromYaml:
         path = tmp_path / "users.yaml"
         path.write_text(
             "users:\n"
-            "  - {telegram_id: 1, name: a, default_backend: goose, os_user: alice}\n"
-            "  - {telegram_id: 2, name: b, default_backend: codex, os_user: bob}\n"
+            "  - {telegram_id: 1, name: a, backend: goose, os_user: alice}\n"
+            "  - {telegram_id: 2, name: b, backend: codex, os_user: bob}\n"
             "  - {telegram_id: 3, name: c, os_user: carol}\n"
         )
         assert _collect_goose_os_users_from_yaml(path, "claude") == ["alice"]
@@ -8141,7 +8215,7 @@ class TestCollectGooseOsUsersFromYaml:
         path.write_text(
             "users:\n"
             "  - {telegram_id: 1, name: a, os_user: alice}\n"
-            "  - {telegram_id: 2, name: b, default_backend: claude, os_user: bob}\n"
+            "  - {telegram_id: 2, name: b, backend: claude, os_user: bob}\n"
         )
         assert _collect_goose_os_users_from_yaml(path, "goose") == ["alice"]
 
@@ -8149,7 +8223,7 @@ class TestCollectGooseOsUsersFromYaml:
         from kai.install import _collect_goose_os_users_from_yaml
 
         path = tmp_path / "users.yaml"
-        path.write_text("users:\n  - {telegram_id: 1, name: a, default_backend: goose}\n")
+        path.write_text("users:\n  - {telegram_id: 1, name: a, backend: goose}\n")
         assert _collect_goose_os_users_from_yaml(path, "claude") == []
 
     def test_duplicates_deduped_preserving_order(self, tmp_path):
@@ -8158,9 +8232,9 @@ class TestCollectGooseOsUsersFromYaml:
         path = tmp_path / "users.yaml"
         path.write_text(
             "users:\n"
-            "  - {telegram_id: 1, name: a, default_backend: goose, os_user: alice}\n"
-            "  - {telegram_id: 2, name: b, default_backend: goose, os_user: dana}\n"
-            "  - {telegram_id: 3, name: c, default_backend: goose, os_user: alice}\n"
+            "  - {telegram_id: 1, name: a, backend: goose, os_user: alice}\n"
+            "  - {telegram_id: 2, name: b, backend: goose, os_user: dana}\n"
+            "  - {telegram_id: 3, name: c, backend: goose, os_user: alice}\n"
         )
         assert _collect_goose_os_users_from_yaml(path, "claude") == ["alice", "dana"]
 
@@ -8168,7 +8242,7 @@ class TestCollectGooseOsUsersFromYaml:
         from kai.install import _collect_goose_os_users_from_yaml
 
         path = tmp_path / "users.yaml"
-        path.write_text('users:\n  - {telegram_id: 1, name: a, default_backend: goose, os_user: "bad)user"}\n')
+        path.write_text('users:\n  - {telegram_id: 1, name: a, backend: goose, os_user: "bad)user"}\n')
         with pytest.raises(ValueError, match="Invalid os_user"):
             _collect_goose_os_users_from_yaml(path, "claude")
 
@@ -8689,7 +8763,7 @@ class TestOpenCodeBinWizardPrompt:
             "polling",  # transport
             "opencode",  # agent backend
             opencode_bin_path,  # OPENCODE_BIN
-            "anthropic",  # llm_provider (opencode joined BACKENDS_NEEDING_PROVIDER_PROMPT)
+            "anthropic",  # provider (opencode joined BACKENDS_NEEDING_PROVIDER_PROMPT)
             # API key prompt skipped for opencode (auth managed by `opencode auth login`).
             # model: handled by _prompt_default_model mock
             "false",  # customize per-role models (decline; use registry defaults)
@@ -9215,40 +9289,11 @@ class TestCmdConfigSessionLifecycleKeys:
         assert "CLAUDE_IDLE_TIMEOUT" not in env
 
 
-class TestApplyAgentTimeoutMigration:
-    """Apply-time CLAUDE_TIMEOUT_SECONDS -> AGENT_TIMEOUT_SECONDS migration."""
-
-    def test_migration_logic_rewrites_legacy_key(self):
-        """The migration block (factored out so it's directly testable)
-        carries the value forward and pops the legacy key."""
-        env = {
-            "TELEGRAM_BOT_TOKEN": "tok",
-            "DEFAULT_MODEL": "sonnet",
-            "CLAUDE_TIMEOUT_SECONDS": "180",
-        }
-        if "AGENT_TIMEOUT_SECONDS" not in env and "CLAUDE_TIMEOUT_SECONDS" in env:
-            env["AGENT_TIMEOUT_SECONDS"] = env["CLAUDE_TIMEOUT_SECONDS"]
-        env.pop("CLAUDE_TIMEOUT_SECONDS", None)
-        assert env["AGENT_TIMEOUT_SECONDS"] == "180"
-        assert "CLAUDE_TIMEOUT_SECONDS" not in env
-
-    def test_new_key_wins_when_both_present(self):
-        env = {
-            "AGENT_TIMEOUT_SECONDS": "300",
-            "CLAUDE_TIMEOUT_SECONDS": "180",
-        }
-        if "AGENT_TIMEOUT_SECONDS" not in env and "CLAUDE_TIMEOUT_SECONDS" in env:
-            env["AGENT_TIMEOUT_SECONDS"] = env["CLAUDE_TIMEOUT_SECONDS"]
-        env.pop("CLAUDE_TIMEOUT_SECONDS", None)
-        assert env["AGENT_TIMEOUT_SECONDS"] == "300"
-        assert "CLAUDE_TIMEOUT_SECONDS" not in env
-
-
 class TestBuildCodexLoginReminder:
     """Post-install codex subscription-auth reminder policy.
 
     The reminder is global-only: it fires when DEFAULT_BACKEND=codex AND
-    auth mode is subscription. Per-user `default_backend: codex` entries
+    auth mode is subscription. Per-user `backend: codex` entries
     in users.yaml DO NOT trigger the reminder; mixed-backend installs
     are operator-managed and the reminder would be wizard noise for
     operators who chose a non-codex global backend.
@@ -9330,7 +9375,7 @@ class TestBuildCodexLoginReminder:
                     "telegram_id": 1,
                     "name": "alice",
                     "role": "admin",
-                    "default_backend": "codex",
+                    "backend": "codex",
                     "os_user": "alice",
                 }
             ],
@@ -9388,7 +9433,7 @@ class TestUsersYamlGooseProviders:
     def test_goose_entry_with_explicit_provider(self, tmp_path):
         p = self._write(
             tmp_path,
-            "users:\n  - telegram_id: 1\n    name: a\n    default_backend: goose\n    llm_provider: deepseek\n",
+            "users:\n  - telegram_id: 1\n    name: a\n    backend: goose\n    provider: deepseek\n",
         )
         assert _users_yaml_goose_providers(p, "") == ["deepseek"]
 
@@ -9399,29 +9444,29 @@ class TestUsersYamlGooseProviders:
         canonical provider form PROVIDER_KEY_VARS is keyed on."""
         p = self._write(
             tmp_path,
-            "users:\n  - telegram_id: 1\n    name: a\n    default_backend: Goose\n    llm_provider: DeepSeek\n",
+            "users:\n  - telegram_id: 1\n    name: a\n    backend: Goose\n    provider: DeepSeek\n",
         )
         assert _users_yaml_goose_providers(p, "") == ["deepseek"]
 
     def test_falls_back_to_global_provider(self, tmp_path):
-        """An entry that omits llm_provider inherits the global
+        """An entry that omits provider inherits the global
         provider, mirroring the runtime cascade."""
-        p = self._write(tmp_path, "users:\n  - telegram_id: 1\n    name: a\n    default_backend: goose\n")
+        p = self._write(tmp_path, "users:\n  - telegram_id: 1\n    name: a\n    backend: goose\n")
         assert _users_yaml_goose_providers(p, "deepseek") == ["deepseek"]
 
     def test_no_global_fallback_yields_nothing(self, tmp_path):
-        """No llm_provider anywhere: the scan returns nothing and the
+        """No provider anywhere: the scan returns nothing and the
         runtime's users.yaml validation owns the error."""
-        p = self._write(tmp_path, "users:\n  - telegram_id: 1\n    name: a\n    default_backend: goose\n")
+        p = self._write(tmp_path, "users:\n  - telegram_id: 1\n    name: a\n    backend: goose\n")
         assert _users_yaml_goose_providers(p, "") == []
 
     def test_distinct_providers_deduplicated_and_sorted(self, tmp_path):
         p = self._write(
             tmp_path,
             "users:\n"
-            "  - telegram_id: 1\n    name: a\n    default_backend: goose\n    llm_provider: openai\n"
-            "  - telegram_id: 2\n    name: b\n    default_backend: goose\n    llm_provider: deepseek\n"
-            "  - telegram_id: 3\n    name: c\n    default_backend: goose\n    llm_provider: deepseek\n",
+            "  - telegram_id: 1\n    name: a\n    backend: goose\n    provider: openai\n"
+            "  - telegram_id: 2\n    name: b\n    backend: goose\n    provider: deepseek\n"
+            "  - telegram_id: 3\n    name: c\n    backend: goose\n    provider: deepseek\n",
         )
         assert _users_yaml_goose_providers(p, "") == ["deepseek", "openai"]
 
@@ -9431,8 +9476,8 @@ class TestUsersYamlGooseProviders:
         p = self._write(
             tmp_path,
             "users:\n"
-            "  - telegram_id: 1\n    name: a\n    default_backend: opencode\n    llm_provider: deepseek\n"
-            "  - telegram_id: 2\n    name: b\n    default_backend: codex\n"
+            "  - telegram_id: 1\n    name: a\n    backend: opencode\n    provider: deepseek\n"
+            "  - telegram_id: 2\n    name: b\n    backend: codex\n"
             "  - telegram_id: 3\n    name: c\n",
         )
         assert _users_yaml_goose_providers(p, "deepseek") == []
@@ -9462,8 +9507,8 @@ class TestWizardPerUserGooseProviderKeys:
         "    role: admin\n"
         "  - telegram_id: 2\n"
         "    name: bob\n"
-        "    default_backend: goose\n"
-        "    llm_provider: deepseek\n"
+        "    backend: goose\n"
+        "    provider: deepseek\n"
     )
 
     @staticmethod
@@ -9537,7 +9582,7 @@ class TestWizardPerUserGooseProviderKeys:
 
         env = self._run(monkeypatch, tmp_path, inputs)
 
-        assert env["LLM_PROVIDER"] == "deepseek"
+        assert env["DEFAULT_PROVIDER"] == "deepseek"
         assert env["DEEPSEEK_API_KEY"] == "sk-ds-global"
         assert "does not require an API key" not in capsys.readouterr().out
 
@@ -9606,9 +9651,9 @@ class TestUsersYamlAgentBackends:
         p = self._write(
             tmp_path,
             "users:\n"
-            "  - telegram_id: 1\n    name: a\n    default_backend: goose\n"
-            "  - telegram_id: 2\n    name: b\n    default_backend: codex\n"
-            "  - telegram_id: 3\n    name: c\n    default_backend: codex\n"
+            "  - telegram_id: 1\n    name: a\n    backend: goose\n"
+            "  - telegram_id: 2\n    name: b\n    backend: codex\n"
+            "  - telegram_id: 3\n    name: c\n    backend: codex\n"
             "  - telegram_id: 4\n    name: d\n",
         )
         assert _users_yaml_agent_backends(p) == {"goose", "codex"}
@@ -9616,18 +9661,18 @@ class TestUsersYamlAgentBackends:
     def test_strips_whitespace_skips_non_strings(self, tmp_path):
         p = self._write(
             tmp_path,
-            "users:\n  - telegram_id: 1\n    name: a\n    default_backend: ' codex '\n  - telegram_id: 2\n    name: b\n    default_backend: 7\n",
+            "users:\n  - telegram_id: 1\n    name: a\n    backend: ' codex '\n  - telegram_id: 2\n    name: b\n    backend: 7\n",
         )
         assert _users_yaml_agent_backends(p) == {"codex"}
 
     def test_mixed_case_normalized_like_runtime(self, tmp_path):
-        """The runtime loader accepts `default_backend` case-insensitively
+        """The runtime loader accepts `backend` case-insensitively
         (str.strip().lower() before validation), so mixed-case entries
         route users at runtime; the scan must produce the canonical
         lower-case form or the prompt gates silently miss them."""
         p = self._write(
             tmp_path,
-            "users:\n  - telegram_id: 1\n    name: a\n    default_backend: Codex\n  - telegram_id: 2\n    name: b\n    default_backend: ' GOOSE '\n",
+            "users:\n  - telegram_id: 1\n    name: a\n    backend: Codex\n  - telegram_id: 2\n    name: b\n    backend: ' GOOSE '\n",
         )
         assert _users_yaml_agent_backends(p) == {"codex", "goose"}
 
@@ -9653,7 +9698,7 @@ class TestWizardPerUserBackendBinaries:
         "    role: admin\n"
         "  - telegram_id: 2\n"
         "    name: bob\n"
-        "    default_backend: codex\n"
+        "    backend: codex\n"
     )
     CLAUDE_USERS_YAML = (
         "users:\n"
@@ -9662,7 +9707,7 @@ class TestWizardPerUserBackendBinaries:
         "    role: admin\n"
         "  - telegram_id: 2\n"
         "    name: bob\n"
-        "    default_backend: claude\n"
+        "    backend: claude\n"
     )
     PLAIN_USERS_YAML = "users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n"
 
@@ -9765,7 +9810,7 @@ class TestWizardPerUserBackendBinaries:
         assert env["CODEX_BIN"] == "/stored/bin/codex"
 
     def test_mixed_case_codex_entry_still_prompts(self, tmp_path, monkeypatch):
-        """`default_backend: Codex` is valid at runtime (the loader
+        """`backend: Codex` is valid at runtime (the loader
         lowercases before validation) and routes the user, so the
         scan must normalize the same way; a casing difference must
         not skip the binary prompt and reintroduce the startup-gate
@@ -9777,7 +9822,7 @@ class TestWizardPerUserBackendBinaries:
             "    role: admin\n"
             "  - telegram_id: 2\n"
             "    name: bob\n"
-            "    default_backend: Codex\n"
+            "    backend: Codex\n"
         )
         self._setup(monkeypatch, tmp_path, mixed_yaml)
         monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
@@ -9801,7 +9846,7 @@ class TestWizardPerUserBackendBinaries:
             "    role: admin\n"
             "  - telegram_id: 2\n"
             "    name: bob\n"
-            "    default_backend: opencode\n"
+            "    backend: opencode\n"
         )
         self._setup(monkeypatch, tmp_path, opencode_yaml)
         monkeypatch.setattr("kai.install._validate_opencode_bin", lambda p: bool(p))

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -348,7 +348,7 @@ class TestInitMemory:
             default_backend="claude",
             user_configs={
                 1: UserConfig(telegram_id=1, name="alice", os_user="a"),
-                2: UserConfig(telegram_id=2, name="bob", os_user="b", default_backend="codex"),
+                2: UserConfig(telegram_id=2, name="bob", os_user="b", backend="codex"),
             },
         )
         with (

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -2412,7 +2412,7 @@ class TestDashboardBackendNote:
         the note; the fall-through matches the extraction gate's
         backend resolution."""
         user_cfg = MagicMock()
-        user_cfg.default_backend = "goose"
+        user_cfg.backend = "goose"
         auth_config.get_user_config.return_value = user_cfg
         monkeypatch.setattr(memory_command, "ONESHOT_REASONER_BACKENDS", frozenset({"claude", "codex"}))
         monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -3970,7 +3970,7 @@ class TestExtractAndStorePerUserDispatch:
                     telegram_id=2,
                     name="bob",
                     os_user="bob_os",
-                    default_backend="codex",
+                    backend="codex",
                 ),
             },
         )
@@ -4021,7 +4021,7 @@ class TestExtractAndStorePerUserDispatch:
                     telegram_id=2,
                     name="bob",
                     os_user="bob_os",
-                    default_backend="codex",
+                    backend="codex",
                 ),
             },
         )
@@ -4036,7 +4036,7 @@ class TestExtractAndStorePerUserDispatch:
     @pytest.mark.asyncio
     async def test_per_user_override_wins_over_global(self, monkeypatch):
         """Global `DEFAULT_BACKEND=claude` with a per-user
-        `default_backend: codex` override resolves to codex for the
+        `backend: codex` override resolves to codex for the
         override user. Pin the cascade direction (per-user beats
         global) at the dispatch site."""
         from kai import memory as memory_module
@@ -4074,7 +4074,7 @@ class TestExtractAndStorePerUserDispatch:
                     telegram_id=1,
                     name="alice",
                     os_user="alice_os",
-                    default_backend="codex",
+                    backend="codex",
                 )
             },
         )
@@ -4084,7 +4084,7 @@ class TestExtractAndStorePerUserDispatch:
     @pytest.mark.asyncio
     async def test_inherits_global_when_no_per_user_override(self, monkeypatch):
         """Global `DEFAULT_BACKEND=codex` with a users.yaml entry that
-        does not pin `default_backend` resolves to codex for that
+        does not pin `backend` resolves to codex for that
         user. Pins the cascade fallback when no override exists."""
         from kai import memory as memory_module
         from kai.config import UserConfig
@@ -4154,7 +4154,7 @@ class TestExtractAndStorePerUserDispatch:
                     telegram_id=1,
                     name="alice",
                     os_user="alice_os",
-                    default_backend="codex",
+                    backend="codex",
                 )
             },
         )

--- a/tests/test_memory_reclassify.py
+++ b/tests/test_memory_reclassify.py
@@ -100,7 +100,7 @@ def _config(tmp_path: Path) -> MagicMock:
     cfg.memory_projects = {}
     cfg.user_configs = {}
     cfg.default_backend = "claude"
-    cfg.llm_provider = ""
+    cfg.default_provider = ""
     cfg.memory_extraction_timeout_s = 60
     cfg.session_db_path = tmp_path / "kai.db"
     return cfg
@@ -468,8 +468,8 @@ class TestResolveClassificationSettings:
     def test_user_overrides_win_over_global(self, tmp_path):
         cfg = _config(tmp_path)
         user = MagicMock()
-        user.default_backend = "codex"
-        user.llm_provider = "deepseek"
+        user.backend = "codex"
+        user.provider = "deepseek"
         user.os_user = "alice"
         cfg.user_configs = {100: user}
         settings = memory_reclassify.resolve_classification_settings(
@@ -489,8 +489,8 @@ class TestResolveClassificationSettings:
     def test_explicit_flags_override_resolution(self, tmp_path):
         cfg = _config(tmp_path)
         user = MagicMock()
-        user.default_backend = "codex"
-        user.llm_provider = "deepseek"
+        user.backend = "codex"
+        user.provider = "deepseek"
         user.os_user = "alice"
         cfg.user_configs = {100: user}
         settings = memory_reclassify.resolve_classification_settings(

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -548,7 +548,7 @@ class TestConstructor:
 
 class TestStartupFailureSurface:
     """
-    Spec #556 acceptance criterion: a per-user `default_backend: opencode`
+    Spec #556 acceptance criterion: a per-user `backend: opencode`
     entry on a non-opencode install must produce a chat-visible
     startup-failure StreamEvent (not silent failure, not fall-through
     to claude) when `opencode` is missing from PATH.

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -43,7 +43,7 @@ def _make_config(**overrides) -> Config:
         "telegram_bot_token": "test",
         "allowed_user_ids": {111, 222},
         "default_model": "sonnet",
-        "agent_timeout_seconds": 30,
+        "default_timeout": 30,
         "agent_max_session_hours": 0,
         "agent_idle_timeout": 1800,
         "webhook_port": 8080,
@@ -131,7 +131,7 @@ class TestInstanceCreation:
         config = _make_config(
             user_configs={111: user},
             default_model="haiku",
-            agent_timeout_seconds=60,
+            default_timeout=60,
         )
         pool = SubprocessPool(config=config, services_info=[])
         instance = pool.get(111)
@@ -144,12 +144,12 @@ class TestInstanceCreation:
 
 class TestPerUserBackendRouting:
     def test_user_gets_goose_when_global_is_claude(self):
-        """User with default_backend=goose gets GooseBackend even when global is claude."""
+        """User with backend=goose gets GooseBackend even when global is claude."""
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            default_backend="goose",
-            llm_provider="openai",
+            backend="goose",
+            provider="openai",
             model="gpt-5.4",
         )
         config = _make_config(user_configs={111: user})
@@ -160,7 +160,7 @@ class TestPerUserBackendRouting:
         assert instance.model == "gpt-5.4"
 
     def test_user_without_backend_gets_global(self):
-        """User with no default_backend gets the global backend (claude)."""
+        """User with no backend gets the global backend (claude)."""
         user = UserConfig(telegram_id=111, name="alice")
         config = _make_config(user_configs={111: user})
         pool = SubprocessPool(config=config, services_info=[])
@@ -170,17 +170,17 @@ class TestPerUserBackendRouting:
         assert instance.provider == "anthropic"
 
     def test_user_provider_overrides_global(self):
-        """User with llm_provider gets GooseBackend with that provider."""
+        """User with provider gets GooseBackend with that provider."""
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            default_backend="goose",
-            llm_provider="google",
+            backend="goose",
+            provider="google",
             model="gemini-3-flash",
         )
         config = _make_config(
             default_backend="goose",
-            llm_provider="openai",
+            default_provider="openai",
             default_model="gpt-5.4",
             user_configs={111: user},
         )
@@ -196,8 +196,8 @@ class TestPerUserBackendRouting:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            default_backend="goose",
-            llm_provider="openai",
+            backend="goose",
+            provider="openai",
             # No model set - should get openai default, not global "sonnet"
         )
         config = _make_config(user_configs={111: user})
@@ -213,8 +213,8 @@ class TestPerUserBackendRouting:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            default_backend="goose",
-            llm_provider="openai",
+            backend="goose",
+            provider="openai",
             model="gpt-5.4",
         )
         config = _make_config(user_configs={111: user})
@@ -235,7 +235,7 @@ class TestPerUserBackendRouting:
 
     def test_opencode_user_on_claude_global_install(self):
         """
-        Per-user `default_backend: opencode` on a globally-claude install
+        Per-user `backend: opencode` on a globally-claude install
         with a free-text model gets an OpenCodeBackend with the supplied
         model intact. OpenCode model strings are full provider/model
         IDs; no per-provider default substitution applies.
@@ -245,12 +245,12 @@ class TestPerUserBackendRouting:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            default_backend="opencode",
+            backend="opencode",
             model="anthropic/claude-sonnet-4-6",
         )
         config = _make_config(
             default_backend="claude",
-            llm_provider="anthropic",
+            default_provider="anthropic",
             default_model="sonnet",
             user_configs={111: user},
         )
@@ -261,7 +261,7 @@ class TestPerUserBackendRouting:
 
     def test_opencode_user_without_model_falls_back_to_empty(self, caplog):
         """
-        Per-user `default_backend: opencode` with no model and global
+        Per-user `backend: opencode` with no model and global
         backend != opencode: OpenCodeBackend gets model="" so OPENCODE_
         CONFIG_CONTENT is omitted and OpenCode uses its own config
         files. A warning is logged so the operator notices the gap.
@@ -273,12 +273,12 @@ class TestPerUserBackendRouting:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            default_backend="opencode",
+            backend="opencode",
             # NO model: tests the bare opencode-override case.
         )
         config = _make_config(
             default_backend="claude",
-            llm_provider="anthropic",
+            default_provider="anthropic",
             default_model="sonnet",
             user_configs={111: user},
         )
@@ -291,7 +291,7 @@ class TestPerUserBackendRouting:
 
     def test_codex_user_on_claude_global_install_gets_codex_default(self):
         """
-        Per-user `default_backend: codex` on a globally-claude install
+        Per-user `backend: codex` on a globally-claude install
         must NOT fall through to the global default_model ("sonnet"),
         which codex CLI rejects. Without the
         get_user_backend_and_provider routing in _create_instance,
@@ -304,13 +304,13 @@ class TestPerUserBackendRouting:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            default_backend="codex",
-            # NO llm_provider, NO model - tests the bare codex-override case.
+            backend="codex",
+            # NO provider, NO model - tests the bare codex-override case.
         )
         # Globally-claude install (the failure surface from PR #489 review).
         config = _make_config(
             default_backend="claude",
-            llm_provider="anthropic",
+            default_provider="anthropic",
             default_model="sonnet",
             user_configs={111: user},
         )
@@ -329,8 +329,8 @@ class TestPerUserBackendRouting:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            default_backend="goose",
-            llm_provider="anthropic",
+            backend="goose",
+            provider="anthropic",
             model="sonnet",
             os_user="alice-os",
         )
@@ -349,14 +349,10 @@ class TestPerUserBackendRouting:
         from kai.opencode import OpenCodeBackend
 
         users = {
-            111: UserConfig(
-                telegram_id=111, name="a", default_backend="claude", llm_provider="anthropic", model="sonnet"
-            ),
-            222: UserConfig(telegram_id=222, name="b", default_backend="codex"),
-            333: UserConfig(
-                telegram_id=333, name="c", default_backend="goose", llm_provider="anthropic", model="sonnet"
-            ),
-            444: UserConfig(telegram_id=444, name="d", default_backend="opencode", model="anthropic/claude-sonnet-4-6"),
+            111: UserConfig(telegram_id=111, name="a", backend="claude", provider="anthropic", model="sonnet"),
+            222: UserConfig(telegram_id=222, name="b", backend="codex"),
+            333: UserConfig(telegram_id=333, name="c", backend="goose", provider="anthropic", model="sonnet"),
+            444: UserConfig(telegram_id=444, name="d", backend="opencode", model="anthropic/claude-sonnet-4-6"),
         }
         config = _make_config(agent_max_session_hours=6.5, user_configs=users)
         pool = SubprocessPool(config=config, services_info=[])
@@ -382,7 +378,7 @@ class TestPerUserBackendRouting:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            default_backend="opencode",
+            backend="opencode",
             model="anthropic/claude-sonnet-4-6",
             os_user="alice-os",
         )
@@ -728,12 +724,12 @@ class TestWorkspaceRestoration:
         user = UserConfig(
             telegram_id=111,
             name="alice",
-            default_backend="codex",
+            backend="codex",
             home_workspace=ws,
         )
         config = _make_config(
             default_backend="codex",
-            llm_provider="openai",
+            default_provider="openai",
             default_model="gpt-5.5",
             user_configs={111: user},
         )

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -621,7 +621,7 @@ class TestResolveUserDefaults:
             "telegram_bot_token": "test",
             "allowed_user_ids": {111},
             "default_model": "sonnet",
-            "agent_timeout_seconds": 120,
+            "default_timeout": 120,
         }
         defaults.update(kwargs)
         if user_configs is not None:

--- a/tests/test_smoke_memory.py
+++ b/tests/test_smoke_memory.py
@@ -267,7 +267,7 @@ class TestSmokeMemoryUserIdDispatch:
                     telegram_id=1,
                     name="codex_user",
                     os_user="codex_os",
-                    default_backend="codex",
+                    backend="codex",
                 )
             }
         )
@@ -314,7 +314,7 @@ class TestSmokeMemoryUserIdDispatch:
                     telegram_id=1,
                     name="claude_user",
                     os_user="claude_os",
-                    default_backend="claude",
+                    backend="claude",
                 )
             },
         )

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -45,8 +45,8 @@ class TestUserConfig:
         assert uc.github_notify_chat_id is None
         assert uc.pr_review is None
         assert uc.issue_triage is None
-        assert uc.default_backend is None
-        assert uc.llm_provider is None
+        assert uc.backend is None
+        assert uc.provider is None
 
     def test_all_fields(self):
         """Full config with every field populated."""
@@ -64,8 +64,8 @@ class TestUserConfig:
             github_notify_chat_id=-100123456789,
             pr_review=True,
             issue_triage=False,
-            default_backend="goose",
-            llm_provider="openai",
+            backend="goose",
+            provider="openai",
         )
         assert uc.role == "admin"
         assert uc.github == "alice-dev"
@@ -77,8 +77,8 @@ class TestUserConfig:
         assert uc.github_notify_chat_id == -100123456789
         assert uc.pr_review is True
         assert uc.issue_triage is False
-        assert uc.default_backend == "goose"
-        assert uc.llm_provider == "openai"
+        assert uc.backend == "goose"
+        assert uc.provider == "openai"
 
     def test_frozen(self):
         """UserConfig is immutable."""
@@ -827,14 +827,14 @@ class TestLoadUserConfigs:
     # ── Per-user backend/provider ─────────────────────────────────
 
     def test_valid_agent_backend(self, tmp_path):
-        """Valid default_backend is parsed and stored."""
+        """Valid backend is parsed and stored."""
         data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
                 name: alice
-                default_backend: goose
-                llm_provider: openai
+                backend: goose
+                provider: openai
                 model: gpt-5.4
             """,
         )
@@ -843,40 +843,40 @@ class TestLoadUserConfigs:
         ):
             configs = _load_user_configs("claude", "")
         assert configs is not None
-        assert configs[111].default_backend == "goose"
-        assert configs[111].llm_provider == "openai"
+        assert configs[111].backend == "goose"
+        assert configs[111].provider == "openai"
         assert configs[111].model == "gpt-5.4"
 
     def test_invalid_agent_backend_exits(self, tmp_path):
-        """Invalid default_backend causes SystemExit."""
+        """Invalid backend causes SystemExit."""
         data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
                 name: alice
-                default_backend: invalid
+                backend: invalid
             """,
         )
         with (
             patch("kai.config._read_protected_yaml", return_value=data),
-            pytest.raises(SystemExit, match="invalid default_backend"),
+            pytest.raises(SystemExit, match="invalid backend"),
         ):
             _load_user_configs("claude", "")
 
     def test_invalid_llm_provider_exits(self, tmp_path):
-        """Invalid llm_provider for the user's backend causes SystemExit."""
+        """Invalid provider for the user's backend causes SystemExit."""
         data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
                 name: alice
-                default_backend: goose
-                llm_provider: badprovider
+                backend: goose
+                provider: badprovider
             """,
         )
         with (
             patch("kai.config._read_protected_yaml", return_value=data),
-            pytest.raises(SystemExit, match="invalid llm_provider"),
+            pytest.raises(SystemExit, match="invalid provider"),
         ):
             _load_user_configs("claude", "")
 
@@ -887,20 +887,21 @@ class TestLoadUserConfigs:
             users:
               - telegram_id: 111
                 name: alice
-                default_backend: goose
+                backend: goose
             """,
         )
         with (
             patch("kai.config._read_protected_yaml", return_value=data),
             # Global provider is "" (empty), user has none set
-            pytest.raises(SystemExit, match="no llm_provider"),
+            pytest.raises(SystemExit, match="no provider is configured"),
         ):
             _load_user_configs("claude", "")
 
     def test_legacy_agent_backend_in_users_yaml_still_resolved_with_warning(self, tmp_path, caplog):
-        """A users.yaml entry using the deprecated `agent_backend:` key
-        still resolves to default_backend for one release, with a
-        one-shot deprecation warning naming the user."""
+        """A users.yaml entry using the oldest deprecated `agent_backend:`
+        key still resolves to the backend field for one release, with a
+        one-shot deprecation warning naming the user (the per-user key was
+        renamed twice: agent_backend -> default_backend -> backend)."""
         import logging
 
         import kai.config as config_module
@@ -913,14 +914,71 @@ class TestLoadUserConfigs:
                 agent_backend: codex
             """,
         )
-        config_module._default_backend_deprecation_warned.clear()
+        config_module._renamed_key_deprecation_warned.clear()
         with (
             patch("kai.config._read_protected_yaml", return_value=data),
             caplog.at_level(logging.WARNING),
         ):
             configs = _load_user_configs("claude", "")
-        assert configs[111].default_backend == "codex"
-        assert any("agent_backend" in r.message and "default_backend" in r.message for r in caplog.records)
+        assert configs[111].backend == "codex"
+        assert any(
+            "agent_backend is deprecated" in r.message and "rename to backend" in r.message for r in caplog.records
+        )
+
+    def test_legacy_default_backend_in_users_yaml_resolved_with_warning(self, tmp_path, caplog):
+        """A users.yaml entry using the intermediate deprecated
+        `default_backend:` key (the one #719 introduced as the per-user
+        key) still resolves to the backend field, with a warning."""
+        import logging
+
+        import kai.config as config_module
+
+        data = self._yaml_dict(
+            """\
+            users:
+              - telegram_id: 111
+                name: alice
+                default_backend: codex
+            """,
+        )
+        config_module._renamed_key_deprecation_warned.clear()
+        with (
+            patch("kai.config._read_protected_yaml", return_value=data),
+            caplog.at_level(logging.WARNING),
+        ):
+            configs = _load_user_configs("claude", "")
+        assert configs[111].backend == "codex"
+        assert any(
+            "default_backend is deprecated" in r.message and "rename to backend" in r.message for r in caplog.records
+        )
+
+    def test_legacy_llm_provider_in_users_yaml_resolved_with_warning(self, tmp_path, caplog):
+        """A users.yaml entry using the deprecated `llm_provider:` key
+        still resolves to the provider field for one release, with a
+        one-shot deprecation warning naming the user."""
+        import logging
+
+        import kai.config as config_module
+
+        data = self._yaml_dict(
+            """\
+            users:
+              - telegram_id: 111
+                name: alice
+                backend: goose
+                llm_provider: openai
+            """,
+        )
+        config_module._renamed_key_deprecation_warned.clear()
+        with (
+            patch("kai.config._read_protected_yaml", return_value=data),
+            caplog.at_level(logging.WARNING),
+        ):
+            configs = _load_user_configs("claude", "")
+        assert configs[111].provider == "openai"
+        assert any(
+            "llm_provider is deprecated" in r.message and "rename to provider" in r.message for r in caplog.records
+        )
 
     def test_user_without_backend_inherits_nonclaude_global(self, tmp_path):
         """A users.yaml entry that omits the backend key must NOT be
@@ -941,7 +999,7 @@ class TestLoadUserConfigs:
             configs = _load_user_configs("goose", "openai")
         # None on the stored override is what makes the runtime cascade
         # inherit the global backend rather than forcing claude.
-        assert configs[111].default_backend is None
+        assert configs[111].backend is None
         # And the canonical cascade resolves the user to the global goose.
         from kai.config import Config, get_user_backend_and_provider
 
@@ -949,19 +1007,19 @@ class TestLoadUserConfigs:
             telegram_bot_token="test",
             allowed_user_ids={1},
             default_backend="goose",
-            llm_provider="openai",
+            default_provider="openai",
         )
         backend, _provider = get_user_backend_and_provider(configs[111], global_cfg)
         assert backend == "goose"
 
     def test_goose_backend_inherits_global_provider(self, tmp_path):
-        """User with goose backend inherits global llm_provider."""
+        """User with goose backend inherits global provider."""
         data = self._yaml_dict(
             """\
             users:
               - telegram_id: 111
                 name: alice
-                default_backend: goose
+                backend: goose
                 model: gpt-5.4
             """,
         )
@@ -972,8 +1030,37 @@ class TestLoadUserConfigs:
             configs = _load_user_configs("goose", "openai")
         assert configs is not None
         # User inherits global provider, no per-user override stored
-        assert configs[111].default_backend == "goose"
-        assert configs[111].llm_provider is None
+        assert configs[111].backend == "goose"
+        assert configs[111].provider is None
+
+    def test_user_without_provider_inherits_global(self, tmp_path):
+        """A goose user that omits the provider key inherits the global
+        provider through the cascade rather than resolving to "". Guards
+        the per-user provider reader's default=None contract (mirrors the
+        backend inheritance guard)."""
+        data = self._yaml_dict(
+            """\
+            users:
+              - telegram_id: 111
+                name: alice
+                backend: goose
+                model: gpt-5.4
+            """,
+        )
+        with patch("kai.config._read_protected_yaml", return_value=data):
+            configs = _load_user_configs("goose", "openai")
+        # None stored is what lets the runtime cascade inherit the global.
+        assert configs[111].provider is None
+        from kai.config import Config, get_user_backend_and_provider
+
+        global_cfg = Config(
+            telegram_bot_token="test",
+            allowed_user_ids={1},
+            default_backend="goose",
+            default_provider="openai",
+        )
+        _backend, provider = get_user_backend_and_provider(configs[111], global_cfg)
+        assert provider == "openai"
 
     def test_model_validated_against_user_provider(self, tmp_path):
         """Model invalid for user's effective provider is rejected."""
@@ -982,8 +1069,8 @@ class TestLoadUserConfigs:
             users:
               - telegram_id: 111
                 name: alice
-                default_backend: goose
-                llm_provider: openai
+                backend: goose
+                provider: openai
                 model: opus
             """,
         )
@@ -1002,8 +1089,8 @@ class TestLoadUserConfigs:
             users:
               - telegram_id: 111
                 name: alice
-                default_backend: goose
-                llm_provider: ollama
+                backend: goose
+                provider: ollama
             """,
         )
         import logging

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -451,7 +451,7 @@ def _build_test_app(
         mock_config.user_configs = {}
         mock_config.default_models = {}
         mock_config.default_backend = "claude"
-        mock_config.llm_provider = ""
+        mock_config.default_provider = ""
         # get_user_config is synchronous in real Config; must not
         # return a coroutine. With no users configured, always None.
         mock_config.get_user_config = lambda uid: None
@@ -1307,7 +1307,7 @@ class TestGetSubscribedUsers:
         config.user_configs = user_configs if user_configs is not None else {}
         config.default_models = {}
         config.default_backend = "claude"
-        config.llm_provider = ""
+        config.default_provider = ""
         return config
 
     def _make_user(
@@ -1518,7 +1518,7 @@ class TestPerUserRouting:
         config.user_configs = {u.telegram_id: u for u in users}
         config.default_models = {}
         config.default_backend = "claude"
-        config.llm_provider = ""
+        config.default_provider = ""
         # get_user_config returns the UserConfig for a given ID
         config.get_user_config = lambda uid: config.user_configs.get(uid)
         return config
@@ -2049,14 +2049,14 @@ class TestPerUserRouting:
 
     @pytest.mark.asyncio
     async def test_review_receives_user_backend(self, _clear_cooldowns, _mock_resolve_repo):
-        """Per-user default_backend/llm_provider are passed to review_pr."""
+        """Per-user backend/provider are passed to review_pr."""
         base = self._make_user_config(111, repos=["owner/repo"])
         # Frozen dataclass - use replace to set per-user backend override
-        user = dataclasses.replace(base, default_backend="goose", llm_provider="openai")
+        user = dataclasses.replace(base, backend="goose", provider="openai")
         config = self._make_config_with_users([user])
         # Global defaults (should be overridden by per-user values)
         config.default_backend = "claude"
-        config.llm_provider = ""
+        config.default_provider = ""
         app = _build_test_app(config=config)
         payload = _make_pr_payload("opened")
         body = json.dumps(payload).encode()
@@ -2084,12 +2084,12 @@ class TestPerUserRouting:
 
     @pytest.mark.asyncio
     async def test_triage_receives_user_backend(self, _clear_cooldowns):
-        """Per-user default_backend/llm_provider are passed to triage_issue."""
+        """Per-user backend/provider are passed to triage_issue."""
         base = self._make_user_config(111, repos=["owner/repo"])
-        user = dataclasses.replace(base, default_backend="goose", llm_provider="anthropic")
+        user = dataclasses.replace(base, backend="goose", provider="anthropic")
         config = self._make_config_with_users([user])
         config.default_backend = "claude"
-        config.llm_provider = ""
+        config.default_provider = ""
         app = _build_test_app(config=config)
         payload = _make_issue_payload("opened")
         body = json.dumps(payload).encode()
@@ -2119,10 +2119,10 @@ class TestPerUserRouting:
     async def test_review_uses_global_backend_when_no_user_override(self, _clear_cooldowns, _mock_resolve_repo):
         """Without per-user override, review_pr gets the global backend."""
         user = self._make_user_config(111, repos=["owner/repo"])
-        # No default_backend/llm_provider set on user - defaults are None
+        # No backend/provider set on user - defaults are None
         config = self._make_config_with_users([user])
         config.default_backend = "goose"
-        config.llm_provider = "google"
+        config.default_provider = "google"
         app = _build_test_app(config=config)
         payload = _make_pr_payload("opened")
         body = json.dumps(payload).encode()


### PR DESCRIPTION
## Summary

Finishes the config naming scheme so it is uniform: a `default_` prefix marks an installation default (global), a bare noun marks the per-user override. Follow-up to the `AGENT_BACKEND` -> `DEFAULT_BACKEND` rename in #719.

| Concept | Global env | Config field | users.yaml key | UserConfig field |
| --- | --- | --- | --- | --- |
| backend | `DEFAULT_BACKEND` (unchanged) | `default_backend` (unchanged) | `backend` | `backend` |
| provider | `DEFAULT_PROVIDER` | `default_provider` | `provider` | `provider` |
| model | `DEFAULT_MODEL` (unchanged) | `default_model` (unchanged) | `model` (unchanged) | `model` (unchanged) |
| timeout | `DEFAULT_TIMEOUT` | `default_timeout` | `timeout` (unchanged) | `timeout` (unchanged) |

## Changes

Four key groups move, each with a one-release back-compat read window and a one-shot deprecation warning:

- **Per-user backend**: `UserConfig.default_backend` -> `backend`; users.yaml `default_backend` -> `backend`. Read chain `backend` -> `default_backend` -> `agent_backend` (the per-user key was renamed twice, so the oldest name still resolves this release).
- **Per-user provider**: `UserConfig.llm_provider` -> `provider`; users.yaml `llm_provider` -> `provider`.
- **Global provider**: `Config.llm_provider` -> `default_provider`; env `LLM_PROVIDER` -> `DEFAULT_PROVIDER`; install.conf key migrated at apply time.
- **Global timeout**: `Config.agent_timeout_seconds` -> `default_timeout`; env `AGENT_TIMEOUT_SECONDS` -> `DEFAULT_TIMEOUT`; install.conf key migrated at apply time. The older `CLAUDE_TIMEOUT_SECONDS` step is removed entirely (read fallback, wizard prefill, apply migration, and deprecated-env map entry).

## Mechanism

- `_resolve_default_backend` is generalized into `_resolve_renamed_key(get, *, new_key, legacy_keys, context, default)`, taking an ordered legacy-key list. It is the single back-compat implementation for every reader (process env, install.conf dict, users.yaml entry) and warns once per (context, matched legacy key).
- A new `_entry_provider` mirrors `_entry_backend` so both per-user provider read sites resolve through the same chain: the runtime loader and the installer goose-provider scanner (the scanner previously read `llm_provider` directly, which would have left a migrated install's goose API-key collection blind to the new key).
- The behavioral eval and the memory backend gate share a new `_resolve_eval_provider` helper so neither eval-time reader bypasses the rename window.

Effective-param names that hold a post-cascade runtime value are left unchanged; only config fields, env vars, and users.yaml keys move.

## Tests

`make check` and `make test` pass (4598 passed, 1 skipped). New back-compat coverage: legacy env/yaml resolution with warnings for each group, the apply-time `LLM_PROVIDER` and `AGENT_TIMEOUT_SECONDS` migrations, `CLAUDE_TIMEOUT_SECONDS` no longer honored, the installer scanners reading all backend keys and the new provider key, and the per-user provider inheritance cascade.

## Docs

Templates (`.env`, `users.yaml`, goose-config comment) and `README` updated to the new names with one-release deprecation notes on the global env table. The wiki update is staged separately and will be pushed after this merges.
