### PR TITLE
Remove redundant reminders from the config wizard

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -932,29 +932,10 @@ def _cmd_config() -> None:
     # the canonical file from a no-longer-current staging artifact.
     users_yaml_staging_path: str | None = None
 
-    if users_yaml_exists:
-        # Summarize the existing config without modifying it. Reads
-        # go through `_read_users_yaml_text` so the protected
-        # `/etc/kai/users.yaml` path works via sudo cat. Empty
-        # summary on unreadable / malformed - the summary is
-        # cosmetic, the downstream codex predicate is what matters.
-        summary = ""
-        raw_yaml = _read_users_yaml_text(users_yaml_path)
-        if raw_yaml is not None:
-            try:
-                data = yaml.safe_load(raw_yaml)
-            except yaml.YAMLError:
-                data = None
-            if isinstance(data, dict) and isinstance(data.get("users"), list):
-                entries = data["users"]
-                n_users = len(entries)
-                n_admins = sum(1 for e in entries if isinstance(e, dict) and str(e.get("role", "")).lower() == "admin")
-                summary = (
-                    f" ({n_users} user{'s' if n_users != 1 else ''}, {n_admins} admin{'s' if n_admins != 1 else ''})"
-                )
-        print(f"  users.yaml already configured{summary}.")
-        print("  To modify users, edit users.yaml directly or use Telegram commands.")
-    else:
+    # When the canonical users.yaml already exists the wizard leaves it
+    # untouched (edit it directly or use the Telegram commands), so the
+    # admin-identity prompts below run only on a first-time install.
+    if not users_yaml_exists:
         while True:
             admin_telegram_id = _prompt(
                 "Admin Telegram ID",
@@ -1662,8 +1643,6 @@ def _cmd_config() -> None:
     # timeout. Both fire on every wizard run. The per-user
     # `pr_review` toggle lives in users.yaml (or /github reviews).
     print("-- PR review agent --")
-    print("  Per-user PR review toggle lives in users.yaml ('pr_review')")
-    print("  or via /github reviews on|off.")
 
     # Global cooldown always prompts: any opted-in user can drive
     # reviews, so the cooldown must be configurable for any install

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1808,7 +1808,7 @@ class TestCmdConfig:
         conf_path.write_text(json.dumps(existing))
 
         # Pretend /etc/kai/users.yaml is already in place; the wizard
-        # then summarizes it and skips the user-creation prompts.
+        # then skips the user-creation prompts and leaves it untouched.
         existing_users_yaml = "users:\n  - telegram_id: 999\n    name: existing\n    role: admin\n"
         self._simulate_existing_etc_users_yaml(monkeypatch, existing_users_yaml)
 
@@ -1826,10 +1826,11 @@ class TestCmdConfig:
         # Should preserve existing values when user accepts defaults
         assert conf["install_dir"] == "/custom/path"
         assert conf["env"]["TELEGRAM_BOT_TOKEN"] == "existing-token"
-        # Summary path printed; the wizard never staged a new users.yaml
-        # so no top-level staging key was written.
+        # With a canonical users.yaml already present the wizard skips the
+        # user-creation prompts entirely and never stages a new file, so
+        # no admin prompt is shown and no top-level staging key is written.
         output = capsys.readouterr().out
-        assert "already configured" in output
+        assert "Admin Telegram ID" not in output
         assert "users_yaml_staging_path" not in conf
 
     def test_validates_required_fields(self):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1265,15 +1265,17 @@ class TestCmdConfig:
     def _simulate_existing_etc_users_yaml(monkeypatch, content):
         """Simulate the canonical users.yaml already existing with the given content.
 
-        Used by tests that want to exercise the wizard's "skip user
-        prompts; summarize existing config" branch without touching the
-        real `/etc/kai/`. Patches the path's existence check AND the
-        sudo-cat reader that the wizard goes through (`Path.exists` for
-        the existence gate; `_read_users_yaml_text` for the body the
-        wizard prints a summary of). The existence patch compares
-        against the live `kai.install.USERS_YAML` attribute rather than
-        a hardcoded path, so it stacks on top of the autouse
-        `_isolate_users_yaml` redirect from conftest.
+        Used by tests that want the wizard to take the existing-canonical
+        path (skip the user-creation prompts, leave the file untouched)
+        without touching the real `/etc/kai/`. Patches the path's
+        existence check AND the sudo-cat reader the wizard goes through
+        (`Path.exists` for the existence gate; `_read_users_yaml_text`
+        for the body the wizard's later per-user scans parse, e.g.
+        `_users_yaml_goose_providers` / `_users_yaml_agent_backends`).
+        The existence patch compares against the live
+        `kai.install.USERS_YAML` attribute rather than a hardcoded path,
+        so it stacks on top of the autouse `_isolate_users_yaml` redirect
+        from conftest.
         """
         _real_exists = Path.exists
 


### PR DESCRIPTION
## Summary

Removes two `make config` notes that restate information the operator already has, so the wizard output is less noisy.

- **User setup**: on the existing-config path the wizard printed `users.yaml already configured (N users, M admins)` and `To modify users, edit users.yaml directly or use Telegram commands`. Dropped. That branch only computed a cosmetic summary string for the deleted message, so it collapses into a single `if not users_yaml_exists:` guard around the first-time admin prompts.
- **PR review agent**: dropped the `Per-user PR review toggle lives in users.yaml ('pr_review') or via /github reviews on|off` line under the section header.

The `-- User setup --` and `-- PR review agent --` section headers stay (they are structural markers, consistent with every other wizard section).

## Tests

`make check` clean; full suite passes (4600 passed, 1 skipped). The existing-users.yaml wizard test no longer asserts the removed `already configured` text; it now verifies the stronger behavior directly (no admin prompt is shown and no users.yaml is staged when the canonical file already exists).
