### PR TITLE
Suppress the empty User setup wizard header when nothing to do

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -898,15 +898,25 @@ def _cmd_config() -> None:
     # `PROJECT_ROOT/users.yaml` from a previous install cycle is
     # ignored; a one-line deprecation warning tells the operator to
     # remove it or move it to the canonical location.
-    print("-- User setup --")
     stray_project_users_yaml = PROJECT_ROOT / "users.yaml"
     if deployment_mode == "protected":
         users_yaml_path = USERS_YAML
     else:
         users_yaml_path = _xdg_users_yaml_path()
-    if stray_project_users_yaml.exists():
-        print(f"  Note: {stray_project_users_yaml} is no longer used. Move it to {users_yaml_path} or remove it.")
     users_yaml_exists = users_yaml_path.exists()
+    stray_note = (
+        f"  Note: {stray_project_users_yaml} is no longer used. Move it to {users_yaml_path} or remove it."
+        if stray_project_users_yaml.exists()
+        else None
+    )
+    # The user-setup section emits output only when there is something to
+    # do: a first-time install (the admin prompts below run) or a stray
+    # leftover to warn about. When the canonical users.yaml already
+    # exists the wizard leaves it untouched, so it prints no bare header.
+    if not users_yaml_exists or stray_note:
+        print("-- User setup --")
+    if stray_note:
+        print(stray_note)
 
     # Admin os_user captured by the advanced-mode prompt block below.
     # Carried in scope here so the codex-memory branch can reuse it
@@ -932,9 +942,8 @@ def _cmd_config() -> None:
     # the canonical file from a no-longer-current staging artifact.
     users_yaml_staging_path: str | None = None
 
-    # When the canonical users.yaml already exists the wizard leaves it
-    # untouched (edit it directly or use the Telegram commands), so the
-    # admin-identity prompts below run only on a first-time install.
+    # First-time install only: collect the admin identity and stage a
+    # users.yaml. An existing canonical file is left untouched.
     if not users_yaml_exists:
         while True:
             admin_telegram_id = _prompt(

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1022,7 +1022,13 @@ def _cmd_config() -> None:
             users_yaml_path.write_text(users_yaml_content)
             os.chmod(users_yaml_path, 0o600)
         print(f"  Generated {users_yaml_path}")
-    print()
+    # Blank separator only when the user-setup section above actually
+    # printed something (first-time prompts or a stray-leftover note),
+    # gated on the same condition as its header. On a re-run with an
+    # existing users.yaml the section is silent, so this would otherwise
+    # be an orphaned blank line before the transport prompt.
+    if not users_yaml_exists or stray_note:
+        print()
 
     transport = _prompt_choice(
         "Telegram transport",

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1831,8 +1831,11 @@ class TestCmdConfig:
         # With a canonical users.yaml already present the wizard skips the
         # user-creation prompts entirely and never stages a new file, so
         # no admin prompt is shown and no top-level staging key is written.
+        # The user-setup section also stays silent (no bare header) because
+        # there is nothing to do and no stray leftover to warn about.
         output = capsys.readouterr().out
         assert "Admin Telegram ID" not in output
+        assert "-- User setup --" not in output
         assert "users_yaml_staging_path" not in conf
 
     def test_validates_required_fields(self):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1831,8 +1831,10 @@ class TestCmdConfig:
         # With a canonical users.yaml already present the wizard skips the
         # user-creation prompts entirely and never stages a new file, so
         # no admin prompt is shown and no top-level staging key is written.
-        # The user-setup section also stays silent (no bare header) because
-        # there is nothing to do and no stray leftover to warn about.
+        # The user-setup section also stays fully silent: no bare header
+        # and no trailing blank separator (both gated on the same
+        # "something to show" condition), so it adds nothing between the
+        # bot-token and transport prompts.
         output = capsys.readouterr().out
         assert "Admin Telegram ID" not in output
         assert "-- User setup --" not in output


### PR DESCRIPTION
## Summary

Follow-up to the wizard reminder cleanup (#721). Removing the `users.yaml already configured / edit it directly...` reminder left the user-setup section printing noise on a re-run when the canonical `users.yaml` already exists. This makes the whole section stay silent when there is nothing to do.

Two parts:

1. **Empty header**: the `-- User setup --` header was still printed unconditionally, so it showed with no content under it.
2. **Orphaned blank line**: the trailing `print()` separator after the section still fired, leaving a blank line between the `Telegram bot token` and `Telegram transport` prompts.

Both are now gated on the same "is there anything to show" condition. The section emits output only when:

- **First-time install** (no canonical `users.yaml` yet): header + admin prompts + trailing separator, as before.
- **A stray `PROJECT_ROOT/users.yaml` leftover**: header + the "no longer used, move/remove it" note.
- **Canonical file already present, no stray** (the common re-run case): completely silent. No header, no blank line.

The stray-leftover warning is preserved in both the first-time and existing-config paths.

## Tests

`make check` clean; full suite passes (4600 passed, 1 skipped). The existing-users wizard test asserts `-- User setup --` is absent when the canonical file exists; the header and the separator share one condition, so that assertion locks in both.
