### PR TITLE
Bind internal APIs to authenticated principals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ build/
 .ruff_cache/
 
 # Runtime artifacts
+.kai-backup/
 kai.db
 logs/
 history/

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,10 @@ setup:
 config:
 	$(BIN)python -m kai install config
 
+# Any non-empty DRY_RUN becomes an explicit CLI flag inside the root
+# process. Do not rely on sudo environment propagation for this safety gate.
 install:
-	sudo DRY_RUN="$(DRY_RUN)" $(BIN)python -m kai install apply
+	sudo $(BIN)python -m kai install apply $(if $(strip $(DRY_RUN)),--dry-run,)
 
 install-status:
 	$(BIN)python -m kai install status

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Kai has real local authority, so the security model is part of the product rathe
 - **Path confinement:** File exchange is constrained to allowed workspace and file-storage paths.
 - **Service proxy:** Third-party API keys live in server-side config and are injected at request time, not placed in conversation context.
 - **Per-user isolation:** Users have separate history, files, workspaces, jobs, settings, and agent subprocesses.
+- **Principal-bound internal API:** Agent API credentials resolve to a fixed user and explicit scopes in the outer service; request data cannot select another principal.
+- **Separated webhook credentials:** GitHub, generic, and Telegram ingress use distinct secrets that are not exposed to persistent agent subprocesses.
 - **Optional OS isolation:** A user's backend subprocess can run under a dedicated OS account through generated sudoers rules.
 
 See [TOTP Authentication](https://github.com/dcellison/kai/wiki/TOTP-Authentication), [GitHub Notification Routing](https://github.com/dcellison/kai/wiki/GitHub-Notification-Routing), and [Exposing Kai to the Internet](https://github.com/dcellison/kai/wiki/Exposing-Kai-to-the-Internet) for the detailed operational docs.

--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -57,6 +57,7 @@ from kai.backend import (
     build_session_context,
     ensure_user_memory,
     ensure_user_preferences,
+    sanitize_agent_environment,
 )
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
 
@@ -755,10 +756,9 @@ class AcpBackend(AgentBackend):
 
         Goose adds GOOSE_MODEL (and conditionally GOOSE_PROVIDER).
         OpenCode may add OPENCODE_CONFIG_CONTENT or OPENCODE_CONFIG.
-        The shared layer applies workspace env_file / inline env and
-        the webhook secret AFTER this hook so workspace overrides can
-        still shadow backend-specific defaults; the webhook secret is
-        applied last so workspace env cannot override it.
+        The shared layer applies workspace env_file / inline env after this
+        hook, strips outer control-plane credentials, and applies the
+        principal-bound API credential last.
 
         Hook receives a mutable dict copy of the inherited environment;
         it may mutate in place or return a different dict.
@@ -931,7 +931,7 @@ class AcpBackend(AgentBackend):
         Start the ACP subprocess if not already running.
 
         Spawns the subprocess via build_argv() with the env produced by
-        build_env() (plus workspace overrides and the webhook secret),
+        build_env() (plus workspace overrides and the principal credential),
         then runs the two-step handshake:
         1. initialize - establishes protocol version and capabilities
         2. session/new - creates a session with backend-specific params
@@ -960,8 +960,9 @@ class AcpBackend(AgentBackend):
         # 2. Backend-specific keys (via self.build_env)
         # 3. Per-workspace env_file values
         # 4. Per-workspace inline env values (override env_file)
-        # 5. Webhook secret (workspace env can't override it)
-        # 6. Per-os-user TMPDIR anchor (cross-user mode only; LAST so
+        # 5. Remove outer control-plane credentials
+        # 6. Principal API credential (workspace env can't override it)
+        # 7. Per-os-user TMPDIR anchor (cross-user mode only; LAST so
         #    workspace env cannot point one user's temp writes at
         #    another's). The per-user dirs under <DATA_DIR>/tmp/ are
         #    created and chowned by install.py; TMPDIR survives
@@ -972,6 +973,7 @@ class AcpBackend(AgentBackend):
                 env.update(parse_env_file(self.workspace_config.env_file))
             if self.workspace_config.env:
                 env.update(self.workspace_config.env)
+        env = sanitize_agent_environment(env)
         if self._api_context.webhook_secret:
             env["KAI_WEBHOOK_SECRET"] = self._api_context.webhook_secret
         if effective_os_user:

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -29,6 +29,38 @@ from kai.history import get_recent_history
 log = logging.getLogger(__name__)
 
 
+# Outer-daemon control-plane credentials must never enter a persistent agent
+# environment. Provider API keys are intentionally not listed: some supported
+# backends use them for model authentication, whereas these values authorize
+# Telegram, external webhooks, or the service account's GitHub identity.
+_CONTROL_PLANE_ENV_VARS = frozenset(
+    {
+        "GH_TOKEN",
+        "GENERIC_WEBHOOK_SECRET",
+        "GITHUB_TOKEN",
+        "GITHUB_WEBHOOK_SECRET",
+        "KAI_WEBHOOK_SECRET",
+        "TELEGRAM_BOT_TOKEN",
+        "TELEGRAM_WEBHOOK_SECRET",
+        "WEBHOOK_SECRET",
+    }
+)
+
+
+def sanitize_agent_environment(environment: dict[str, str]) -> dict[str, str]:
+    """Return an agent environment without outer control-plane credentials.
+
+    Callers apply workspace environment configuration first, sanitize second,
+    and finally add the principal-bound ``KAI_WEBHOOK_SECRET`` credential. This
+    ordering prevents both inherited daemon state and a workspace env file from
+    restoring an external signing or bot credential.
+    """
+    sanitized = environment.copy()
+    for name in _CONTROL_PLANE_ENV_VARS:
+        sanitized.pop(name, None)
+    return sanitized
+
+
 def apply_workspace_model(
     workspace_config: WorkspaceConfig | None,
     backend: str,
@@ -121,7 +153,7 @@ class ApiContext:
 
     Attributes:
         webhook_port: Local port the webhook server listens on.
-        webhook_secret: Shared secret for authenticating API requests.
+        webhook_secret: Principal-bound credential for internal API requests.
         services_info: List of dicts describing available external services.
     """
 
@@ -389,8 +421,9 @@ def build_session_context(
         )
 
     # Inject scheduling API info (always, so cron works from any workspace).
-    # The secret is passed via $KAI_WEBHOOK_SECRET env var (not embedded
-    # in prompt text) to prevent leakage through session logs.
+    # The principal credential is passed via $KAI_WEBHOOK_SECRET (legacy
+    # variable name) rather than embedded in prompt text, preventing session-log
+    # leakage while preserving existing agent instructions.
     if api.webhook_secret:
         api_note = (
             f"[Scheduling API: To create jobs, use curl (NEVER WebFetch) to POST JSON to "
@@ -755,9 +788,8 @@ def _is_notification_only_chat_id(chat_id: int | None, config: Config) -> bool:
     True iff this chat_id has no interactive user entry in users.yaml.
 
     A chat_id is "notification-only" when it appears in the running
-    system (a github_notify_chat_id field on another user's config, or
-    an /api/send-message target, or any chat that received a
-    notification and is therefore in allowed_user_ids) but is NOT the
+    system (a github_notify_chat_id field on another user's config, an
+    /api/send-message target, or any other outbound destination) but is NOT the
     primary telegram_id key of any user entry. Examples: a GitHub
     notification group chat, a deploy-status broadcast channel, a
     review-summary destination room.
@@ -769,9 +801,8 @@ def _is_notification_only_chat_id(chat_id: int | None, config: Config) -> bool:
     Returns True (skip auto-provisioning) when the chat_id is not a
     key in user_configs. The contract on True: the caller must NOT
     create a per-user directory for this chat_id. The chat_id
-    remains valid for outbound notification sending (it lives in
-    allowed_user_ids); only the home-workspace provisioning is
-    suppressed.
+    remains valid for outbound notification sending; only the home-workspace
+    provisioning is suppressed.
     """
     if chat_id is None:
         return False
@@ -832,8 +863,7 @@ def resolve_home_workspace(
 
     # Notification-only chat_ids must not auto-provision a home
     # directory. The chat_id is real enough to receive outbound
-    # notifications (it was added to allowed_user_ids at config-load
-    # time), but it has no interactive user entry in users.yaml. The
+    # notifications, but it has no interactive user entry in users.yaml. The
     # previous unconditional ensure_user_home call mkdir'd an empty
     # `home/<chat_id>/` on first contact - either a stray inbound
     # message from the notification chat (a human in the GitHub

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -2772,6 +2772,8 @@ async def _github_api_ensure_webhook(
     """
     if config.telegram_webhook_url is None:
         raise github_api.GitHubAPIError(0, "No webhook URL configured (polling mode)")
+    if not config.github_webhook_secret:
+        raise github_api.GitHubAPIError(0, "GITHUB_WEBHOOK_SECRET is not configured")
     owner, name = repo.split("/", 1)
     webhook_url = _derive_webhook_url(config.telegram_webhook_url)
 
@@ -2790,7 +2792,7 @@ async def _github_api_ensure_webhook(
         name,
         token,
         webhook_url,
-        config.webhook_secret,
+        config.github_webhook_secret,
     )
     await sessions.set_setting(f"github_hook_id:{repo}", str(hook_id))
 
@@ -3208,7 +3210,7 @@ async def _handle_github_notify(
 
     if value == "reset":
         # Read the current notify chat_id before deleting it, so we can
-        # remove it from the live allowed_user_ids set.
+        # remove it from the live notification-destination registry.
         old_val = await sessions.get_setting(f"github_notify_chat:{chat_id}")
         await sessions.delete_setting(f"github_notify_chat:{chat_id}")
         if old_val:
@@ -3216,12 +3218,9 @@ async def _handle_github_notify(
                 old_chat_id = int(old_val)
             except ValueError:
                 old_chat_id = None
-            # Never remove the user's own chat_id from the allowed
-            # set. This is the primary guard for legacy mode (no
-            # users.yaml) where remove_allowed_chat_id's user_configs
-            # check cannot fire. Also correct in multi-user mode -
-            # a user's own ID was in allowed_user_ids before any
-            # notify additions and must stay.
+            # Never remove the user's own chat_id from the legacy registry.
+            # The registry is no longer an authorization source, but keeping
+            # this guard preserves its outbound-destination semantics.
             if old_chat_id is not None and old_chat_id != chat_id:
                 still_used = await _is_notify_chat_used(
                     old_chat_id,
@@ -3241,9 +3240,8 @@ async def _handle_github_notify(
         return
 
     # If there is an existing notify destination that differs from the
-    # new one, clean it up from allowed_user_ids before overwriting.
-    # Without this, the old chat_id would linger in the set until
-    # restart - a minor auth leak for abandoned group chats.
+    # new one, clean it up from the live registry before overwriting.
+    # Without this, the old chat_id would linger until restart.
     old_val = await sessions.get_setting(f"github_notify_chat:{chat_id}")
     if old_val:
         try:
@@ -3261,8 +3259,8 @@ async def _handle_github_notify(
 
     await sessions.set_setting(f"github_notify_chat:{chat_id}", str(notify_id))
 
-    # Update the live allowed_user_ids set so /api/send-message accepts
-    # this chat_id immediately, without requiring a restart.
+    # Keep the legacy live destination registry synchronized. Internal API
+    # access is credential-bound and does not consult this collection.
     webhook.add_allowed_chat_id(notify_id)
 
     await update.message.reply_text(f"GitHub notifications will go to chat {notify_id}.")
@@ -3344,34 +3342,34 @@ async def handle_webhooks(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     config: Config = context.bot_data["config"]
     running = webhook.is_running()
     status = "running" if running else "not running"
-    has_secret = bool(config.webhook_secret)
+    has_github_secret = bool(config.github_webhook_secret)
+    has_generic_secret = bool(config.generic_webhook_secret)
     lines = [
         f"Webhook server: {status}",
         f"Port: {config.webhook_port}",
         "",
         "Endpoints:",
         "  GET  /health          (health check)",
+        "  POST /api/schedule    (principal-bound scheduling API)",
+        "  POST /api/services/*  (principal-bound service proxy)",
     ]
-    if has_secret:
-        lines += [
-            "  POST /webhook/github  (GitHub events)",
-            "  POST /webhook         (generic)",
-            "  POST /api/schedule    (scheduling API)",
-            "  POST /api/services/*  (external service proxy)",
-        ]
-    else:
+    if has_github_secret:
+        lines.append("  POST /webhook/github  (GitHub events)")
+    if has_generic_secret:
+        lines.append("  POST /webhook         (generic)")
+    if not has_github_secret and not has_generic_secret:
         lines += [
             "",
-            "WEBHOOK_SECRET not set — only /health is active.",
-            "Set WEBHOOK_SECRET in .env to enable webhooks and scheduling.",
+            "No external webhook secrets are configured.",
+            "Internal APIs remain active with per-user process credentials.",
         ]
-    if running and has_secret:
+    if running and has_github_secret:
         lines += [
             "",
             "GitHub setup:",
             "1. Set Payload URL to https://your-host/webhook/github",
             "2. Content type: application/json",
-            "3. Set the secret to match WEBHOOK_SECRET",
+            "3. Set the secret to match GITHUB_WEBHOOK_SECRET",
             "4. Choose events: Pushes, Pull requests, Issues, Comments",
         ]
     await update.message.reply_text("\n".join(lines))

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -39,6 +39,7 @@ from kai.backend import (
     build_session_context,
     ensure_user_memory,
     ensure_user_preferences,
+    sanitize_agent_environment,
 )
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
 
@@ -273,14 +274,16 @@ class ClaudeCodeBackend(AgentBackend):
         # 1. Base environment (inherited from parent process)
         # 2. Per-workspace env_file values (shared .env file)
         # 3. Per-workspace inline env values (override env_file)
-        # 4. Webhook secret (LAST - workspace env can't override it)
+        # 4. Remove outer control-plane credentials
+        # 5. Principal API credential (LAST - workspace env can't override it)
         env = os.environ.copy()
         if self.workspace_config:
             if self.workspace_config.env_file:
                 env.update(parse_env_file(self.workspace_config.env_file))
             if self.workspace_config.env:
                 env.update(self.workspace_config.env)
-        # Webhook secret last - ensures workspace env can't override it.
+        env = sanitize_agent_environment(env)
+        # Principal credential last - ensures workspace env can't override it.
         if self._api_context.webhook_secret:
             env["KAI_WEBHOOK_SECRET"] = self._api_context.webhook_secret
 

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -62,6 +62,7 @@ from kai.backend import (
     build_session_context,
     ensure_user_memory,
     ensure_user_preferences,
+    sanitize_agent_environment,
 )
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
 
@@ -335,8 +336,9 @@ class CodexBackend(AgentBackend):
         # 3. CODEX_PROVIDER (forward-compat placeholder; "openai" today)
         # 4. Per-workspace env_file values
         # 5. Per-workspace inline env values (override env_file)
-        # 6. Webhook secret (workspace env can't override it)
-        # 7. Per-os-user TMPDIR anchor (cross-user mode only; set
+        # 6. Remove outer control-plane credentials
+        # 7. Principal API credential (workspace env can't override it)
+        # 8. Per-os-user TMPDIR anchor (cross-user mode only; set
         #    below once the effective user is resolved, LAST so
         #    workspace env cannot point one user's temp writes at
         #    another's)
@@ -350,6 +352,7 @@ class CodexBackend(AgentBackend):
                 env.update(parse_env_file(self.workspace_config.env_file))
             if self.workspace_config.env:
                 env.update(self.workspace_config.env)
+        env = sanitize_agent_environment(env)
         if self._api_context.webhook_secret:
             env["KAI_WEBHOOK_SECRET"] = self._api_context.webhook_secret
 

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -15,6 +15,7 @@ derived from this file's location in the source tree: src/kai/config.py -> proje
 import logging
 import os
 import pwd
+import secrets
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -208,8 +209,11 @@ PROVIDER_DEFAULTS: dict[str, str] = {
 # codex CLI exposes a different set than the OpenAI HTTP API surface
 # goose drives, and treating them as one list lets a goose-only
 # model (e.g. gpt-5.4-nano) leak onto a codex install where the CLI
-# rejects it. Refresh when the codex CLI bumps; no auto-discovery.
+# rejects it. GPT-5.6 uses the stable alias that OpenAI documents as
+# routing to GPT-5.6 Sol (verified 2026-08-07). Refresh when the codex
+# CLI bumps; no auto-discovery.
 CODEX_MODELS: dict[str, str] = {
+    "gpt-5.6": "\U0001f7e2 GPT-5.6",
     "gpt-5.5": "\U0001f7e2 GPT-5.5",
     "gpt-5.4": "\U0001f7e1 GPT-5.4",
     "gpt-5.4-mini": "\U0001f535 GPT-5.4 Mini",
@@ -1083,7 +1087,7 @@ class Config:
             When None, Kai falls back to long-polling (Kai pulls updates from Telegram).
         telegram_webhook_secret: Secret token for validating incoming Telegram updates.
             Sent by Telegram as X-Telegram-Bot-Api-Secret-Token header on each update.
-            Only required in webhook mode. Defaults to WEBHOOK_SECRET if not explicitly set.
+            Only used in webhook mode. Generated for the process when not explicitly set.
         allowed_user_ids: Set of Telegram user IDs permitted to interact with the bot (required)
         default_model: Default model name, provider-dependent (e.g. sonnet, gpt-5.5-pro, gemini-2.5-pro)
         default_timeout: Seconds before an agent response is considered timed
@@ -1094,7 +1098,11 @@ class Config:
             panics). 0 = no limit.
         session_db_path: Path to the SQLite database for sessions, jobs, and settings
         webhook_port: Port for the local aiohttp server (webhooks + scheduling API)
-        webhook_secret: HMAC secret for verifying incoming webhook payloads
+        github_webhook_secret: HMAC secret for verifying GitHub webhook payloads.
+        generic_webhook_secret: Header secret for the generic webhook endpoint.
+        webhook_secret: Deprecated WEBHOOK_SECRET compatibility credential. During
+            the migration window it is accepted only by the GitHub and generic
+            external webhook routes, never by Telegram or internal APIs.
         voice_enabled: Whether to transcribe Telegram voice notes via whisper-cpp
         whisper_model_path: Path to the whisper-cpp GGML model file
         tts_enabled: Whether to enable Piper text-to-speech for voice responses
@@ -1174,6 +1182,10 @@ class Config:
 
     # Webhook server
     webhook_port: int = 8080
+    github_webhook_secret: str = ""
+    generic_webhook_secret: str = ""
+    # Deprecated: temporary external-only fallback for existing GitHub and
+    # generic webhook callers. Never use this for Telegram or internal APIs.
     webhook_secret: str = ""
 
     # Voice input (speech-to-text via whisper-cpp)
@@ -2641,19 +2653,13 @@ def load_config() -> Config:
     if raw_webhook_url:
         telegram_webhook_url = raw_webhook_url
 
-        # Webhook secret: validates incoming updates from Telegram. Falls back to
-        # WEBHOOK_SECRET so existing installs work without a config change. Must be
-        # non-empty in webhook mode; an empty secret would let anyone POST fake
-        # updates to /webhook/telegram.
+        # Webhook secret: validates incoming updates from Telegram. A fresh
+        # process-lifetime value is safe here because start() registers that same
+        # value with Telegram before accepting traffic. Never reuse an external
+        # webhook signing secret across protocol boundaries.
         telegram_webhook_secret = os.environ.get("TELEGRAM_WEBHOOK_SECRET", "").strip()
         if not telegram_webhook_secret:
-            telegram_webhook_secret = os.environ.get("WEBHOOK_SECRET", "").strip()
-        if not telegram_webhook_secret:
-            raise SystemExit(
-                "TELEGRAM_WEBHOOK_SECRET (or WEBHOOK_SECRET as fallback) is required in .env "
-                "when TELEGRAM_WEBHOOK_URL is set. Without it, anyone could POST fake updates "
-                "to the Telegram webhook endpoint."
-            )
+            telegram_webhook_secret = secrets.token_urlsafe(32)
         log.info("Telegram transport: webhook (%s)", telegram_webhook_url)
     else:
         log.info("Telegram transport: polling (TELEGRAM_WEBHOOK_URL not set)")
@@ -3219,6 +3225,28 @@ def load_config() -> Config:
             f"'{global_provider}' (must be one of: {', '.join(valid)})"
         )
 
+    github_webhook_secret = os.environ.get("GITHUB_WEBHOOK_SECRET", "").strip()
+    generic_webhook_secret = os.environ.get("GENERIC_WEBHOOK_SECRET", "").strip()
+    legacy_webhook_secret = os.environ.get("WEBHOOK_SECRET", "").strip()
+    if legacy_webhook_secret:
+        log.warning(
+            "WEBHOOK_SECRET is deprecated; temporary compatibility authentication "
+            "is enabled for /webhook/github and /webhook only. It never "
+            "authenticates Telegram or /api/* routes."
+        )
+
+    configured_ingress_secrets = [
+        ("TELEGRAM_WEBHOOK_SECRET", telegram_webhook_secret),
+        ("GITHUB_WEBHOOK_SECRET", github_webhook_secret),
+        ("GENERIC_WEBHOOK_SECRET", generic_webhook_secret),
+    ]
+    for index, (left_name, left_value) in enumerate(configured_ingress_secrets):
+        if not left_value:
+            continue
+        for right_name, right_value in configured_ingress_secrets[index + 1 :]:
+            if right_value and left_value == right_value:
+                raise SystemExit(f"{left_name} and {right_name} must use different values")
+
     return Config(
         telegram_bot_token=token,
         telegram_webhook_url=telegram_webhook_url,
@@ -3234,7 +3262,9 @@ def load_config() -> Config:
         codex_auth_mode=codex_auth_mode,
         codex_effort_level=codex_effort_level,
         webhook_port=webhook_port,
-        webhook_secret=os.environ.get("WEBHOOK_SECRET", ""),
+        github_webhook_secret=github_webhook_secret,
+        generic_webhook_secret=generic_webhook_secret,
+        webhook_secret=legacy_webhook_secret,
         voice_enabled=os.environ.get("VOICE_ENABLED", "").lower() in ("1", "true", "yes"),
         tts_enabled=os.environ.get("TTS_ENABLED", "").lower() in ("1", "true", "yes"),
         workspace_base=workspace_base,

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -19,15 +19,12 @@ Two subcommands:
 
     python -m kai.eval.modeswitch check
         Runtime sanity check against the running service. Reports the
-        live effective mode plus the deployed prompt versions. Reads
-        WEBHOOK_SECRET from the process environment; source
-        /etc/kai/env first under sudo:
+        live effective mode plus the deployed prompt versions. The
+        localhost health response carries the non-sensitive mode bit,
+        so this diagnostic does not need an internal API credential.
 
-            sudo bash -c 'source /etc/kai/env && env | grep WEBHOOK_SECRET'
-
-        Exit codes: 0 on a clean read; 2 if WEBHOOK_SECRET is not in
-        the environment; 1 if /health is down or /api/memory/stats
-        returns an unexpected status.
+        Exit codes: 0 on a clean read; 1 if /health is down or its
+        response does not contain a valid mode.
 
 The verify subcommand is the merge gate. The check subcommand is
 informational and can be re-run as production state changes.
@@ -39,8 +36,7 @@ Operator round-trip (manual; sudo-gated; not automated by this script):
        macOS: sudo launchctl bootout system/com.syrinx.kai
               sudo launchctl bootstrap system /Library/LaunchDaemons/com.syrinx.kai.plist
        Linux: sudo systemctl stop kai && sudo systemctl start kai
-    3. source /etc/kai/env  # pull WEBHOOK_SECRET into the shell env
-       python -m kai.eval.modeswitch check    # confirms disabled
+    3. python -m kai.eval.modeswitch check    # confirms disabled
     4. python -m kai.eval.modeswitch verify   # logic invariants under both flags
     5. operator: sudo edit /etc/kai/env, set MEMORY_ENABLED=true
     6. operator restarts the service (same commands as step 2)
@@ -753,7 +749,7 @@ def _read_prompt_versions() -> tuple[str, str]:
     return "unknown", "unknown"
 
 
-def _http_get(url: str, secret: str | None = None, timeout: float = 5.0) -> tuple[int, bytes]:
+def _http_get(url: str, timeout: float = 5.0) -> tuple[int, bytes]:
     """Issue a GET against the local kai service and return
     (status_code, body_bytes). On network error or timeout, returns
     (0, b"") so the caller can branch on a non-200/non-503 status.
@@ -764,8 +760,6 @@ def _http_get(url: str, secret: str | None = None, timeout: float = 5.0) -> tupl
     responding.
     """
     req = urllib.request.Request(url)
-    if secret is not None:
-        req.add_header("X-Webhook-Secret", secret)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             return resp.status, resp.read()
@@ -782,36 +776,7 @@ def _http_get(url: str, secret: str | None = None, timeout: float = 5.0) -> tupl
 
 
 def _run_check() -> int:
-    """Probe the running service and print a five-line report.
-
-    Tri-state exit code:
-      0: clean read (health=ok and stats returned a definite mode)
-      1: health=down or stats returned an unexpected status
-      2: WEBHOOK_SECRET not in process environment
-    """
-    # Distinguish "not exported" (None) from "exported but empty"
-    # (the empty string). Both fail the same way for /api/memory/stats
-    # auth (the request would carry no usable secret), but the
-    # diagnostic differs: a missing-from-env case wants "source
-    # /etc/kai/env first"; an empty-but-set case wants the operator
-    # to fix the env-file value. `check` is the tool operators run
-    # when debugging a config issue; a misleading diagnostic at that
-    # moment is worse than verbose accuracy.
-    secret = os.environ.get("WEBHOOK_SECRET")
-
-    if secret is None:
-        print("secret_found: no")
-        print("  WEBHOOK_SECRET not set; source /etc/kai/env first")
-        print("  e.g. sudo bash -c 'source /etc/kai/env && env | grep WEBHOOK_SECRET'")
-        return 2
-    if secret == "":
-        print("secret_found: empty")
-        print("  WEBHOOK_SECRET is exported but empty; check /etc/kai/env for a typo")
-        print("  (a line like `WEBHOOK_SECRET=` with no value)")
-        return 2
-
-    print("secret_found: yes")
-
+    """Probe the running service and print its live memory mode."""
     # Resolve the webhook port from the environment so the harness
     # tracks a non-default deploy (dev instance on a different port,
     # port-conflict resolution). Mirrors the `WEBHOOK_PORT` env var
@@ -834,7 +799,7 @@ def _run_check() -> int:
 
     # Health probe first; if the service is down, the stats probe
     # cannot succeed and we report up-front.
-    health_status, _ = _http_get(f"{base_url}/health")
+    health_status, health_body = _http_get(f"{base_url}/health")
     if health_status != 200:
         print(f"health: down (status={health_status})")
         ext_v, ep_v = _read_prompt_versions()
@@ -845,31 +810,21 @@ def _run_check() -> int:
 
     print("health: ok")
 
-    # Stats probe: 200 = enabled, 503 = disabled, anything else =
-    # unexpected. Issue the request with NO `chat_id` query
-    # parameter so the server falls back to its app-default
-    # (`request.app[CHAT_ID_KEY]` at webhook.py's _resolve_chat_id).
-    # Earlier versions of this harness passed `chat_id=1` as a
-    # placeholder, which fails: _resolve_chat_id runs after secret
-    # auth but before the memory.is_enabled() branch, and rejects
-    # any explicit chat_id not in `allowed_user_ids` with a 403.
-    # The mode probe needs the enabled/disabled signal, not any
-    # particular user's stats, so omitting the parameter routes
-    # cleanly through the app-default and reports the system-wide
-    # memory state.
-    stats_url = f"{base_url}/api/memory/stats"
-    stats_status, _ = _http_get(stats_url, secret=secret)
-
     ext_v, ep_v = _read_prompt_versions()
 
-    if stats_status == 200:
+    try:
+        health_payload = json.loads(health_body)
+    except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
+        health_payload = {}
+    memory_enabled = health_payload.get("memory_enabled") if isinstance(health_payload, dict) else None
+    if memory_enabled is True:
         print("mode: enabled")
         rc = 0
-    elif stats_status == 503:
+    elif memory_enabled is False:
         print("mode: disabled")
         rc = 0
     else:
-        print(f"mode: unknown({stats_status})")
+        print("mode: unknown(health-payload)")
         rc = 1
 
     print(f"extraction_prompt_version: {ext_v}")

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -475,6 +475,21 @@ def _validate_codex_bin(value: str) -> bool:
     return p.is_absolute() and p.is_file() and os.access(p, os.X_OK)
 
 
+def _resolve_codex_bin_prompt_default(existing_env: dict[str, str]) -> str:
+    """Return a usable default for every Codex binary-path prompt.
+
+    Preserve a saved CODEX_BIN while it is executable. If an upgrade moved
+    the binary, discard the stale value and prefer the executable currently
+    discoverable on the operator's PATH. The Homebrew path remains only a
+    suggestion when Codex cannot be discovered; prompt validation still
+    prevents the wizard from accepting a missing executable.
+    """
+    saved = existing_env.get("CODEX_BIN", "")
+    if _validate_codex_bin(saved):
+        return saved
+    return shutil.which("codex") or "/opt/homebrew/bin/codex"
+
+
 def _validate_opencode_bin(value: str) -> bool:
     """Return True when the path is absolute, exists, and is executable.
 
@@ -749,8 +764,9 @@ def _cmd_config() -> None:
     Interactive Q&A that collects configuration values and writes install.conf.
 
     If install.conf already exists, its values are used as defaults so re-running
-    only asks about changes. Auto-detects platform and generates a webhook secret
-    if one isn't already set. Validates all inputs before writing.
+    only asks about changes. Auto-detects platform, generates distinct named
+    webhook secrets, and preserves an existing legacy secret for the temporary
+    compatibility window. Validates all inputs before writing.
 
     No sudo required - this runs as the current user.
     """
@@ -768,6 +784,7 @@ def _cmd_config() -> None:
             print(f"Warning: could not read existing {INSTALL_CONF}: {e}\n")
 
     existing_env: dict = existing.get("env", {})
+    legacy_webhook_secret = existing_env.get("WEBHOOK_SECRET", "")
 
     # Auto-detect platform
     if sys.platform == "darwin":
@@ -1138,13 +1155,14 @@ def _cmd_config() -> None:
         # Codex binary path: wizard-prompted and persisted in install.conf
         # so `make install` writes both /etc/kai/env's CODEX_BIN and the
         # sudoers SETENV rule from the same source of truth. Default
-        # suggestion uses `which codex` from the operator's PATH; falls
-        # back to Homebrew only when which finds nothing.
+        # suggestion keeps a valid saved path, otherwise uses `which codex`
+        # from the operator's PATH. This recovers automatically when an
+        # upgrade moves the binary. Falls back to Homebrew only when which
+        # finds nothing; validation still prevents accepting a missing path.
         while True:
-            which_codex = shutil.which("codex") or "/opt/homebrew/bin/codex"
             codex_bin = _prompt(
                 "Codex binary path",
-                existing_env.get("CODEX_BIN", which_codex),
+                _resolve_codex_bin_prompt_default(existing_env),
                 required=True,
             )
             if _validate_codex_bin(codex_bin):
@@ -1336,10 +1354,9 @@ def _cmd_config() -> None:
     if "codex" in peruser_backends and not codex_bin:
         print("  users.yaml has a codex entry; the daemon needs a resolvable codex binary.")
         while True:
-            which_codex = shutil.which("codex") or "/opt/homebrew/bin/codex"
             codex_bin = _prompt(
                 "Codex binary path",
-                existing_env.get("CODEX_BIN", which_codex),
+                _resolve_codex_bin_prompt_default(existing_env),
                 required=True,
             )
             if _validate_codex_bin(codex_bin):
@@ -1622,11 +1639,32 @@ def _cmd_config() -> None:
             break
         print("  Must be a valid port number (1-65535).")
 
-    # Auto-generate webhook secret if not already set
-    default_secret = existing_env.get("WEBHOOK_SECRET", "")
-    if not default_secret:
-        default_secret = secrets.token_hex(32)
-    webhook_secret = _prompt("Webhook secret", default_secret, required=True)
+    # Named credentials are the long-term configuration. Keep them distinct
+    # from an existing legacy credential so the runtime can identify and log
+    # callers that still depend on compatibility authentication.
+    default_github_secret = existing_env.get("GITHUB_WEBHOOK_SECRET", "")
+    reserved_webhook_secrets = {legacy_webhook_secret, tg_webhook_secret}
+    while not default_github_secret or default_github_secret in reserved_webhook_secrets:
+        default_github_secret = secrets.token_hex(32)
+    while True:
+        github_webhook_secret = _prompt(
+            "GitHub webhook secret",
+            default_github_secret,
+            required=True,
+        )
+        if github_webhook_secret not in reserved_webhook_secrets:
+            break
+        print("  GitHub, Telegram, and legacy webhook secrets must use different values.")
+        default_github_secret = secrets.token_hex(32)
+
+    if tg_webhook_secret and tg_webhook_secret == legacy_webhook_secret:
+        print("  Telegram and legacy webhook secrets must be different; Telegram will use a generated token.")
+        tg_webhook_secret = ""
+
+    generic_webhook_secret = existing_env.get("GENERIC_WEBHOOK_SECRET", "")
+    reserved_webhook_secrets = {github_webhook_secret, legacy_webhook_secret, tg_webhook_secret}
+    while not generic_webhook_secret or generic_webhook_secret in reserved_webhook_secrets:
+        generic_webhook_secret = secrets.token_hex(32)
     print()
 
     # -- Workspaces --
@@ -1782,10 +1820,9 @@ def _cmd_config() -> None:
                 # block already ran.
                 if agent_backend == "codex" and not codex_bin:
                     while True:
-                        which_codex = shutil.which("codex") or "/opt/homebrew/bin/codex"
                         codex_bin = _prompt(
                             "Codex binary path (required by codex memory reasoner)",
-                            existing_env.get("CODEX_BIN", which_codex),
+                            _resolve_codex_bin_prompt_default(existing_env),
                             required=True,
                         )
                         if _validate_codex_bin(codex_bin):
@@ -2005,10 +2042,13 @@ def _cmd_config() -> None:
     env: dict[str, str] = {
         "TELEGRAM_BOT_TOKEN": bot_token,
         "WEBHOOK_PORT": port,
-        "WEBHOOK_SECRET": webhook_secret,
+        "GITHUB_WEBHOOK_SECRET": github_webhook_secret,
+        "GENERIC_WEBHOOK_SECRET": generic_webhook_secret,
         "VOICE_ENABLED": str(voice_enabled).lower(),
         "TTS_ENABLED": str(tts_enabled).lower(),
     }
+    if legacy_webhook_secret:
+        env["WEBHOOK_SECRET"] = legacy_webhook_secret
 
     # DEFAULT_BACKEND is the global default backend; users.yaml entries
     # can override it per user. Only write non-default values to keep
@@ -2421,15 +2461,22 @@ def _set_ownership(path: Path, uid: int, gid: int, recursive: bool = False) -> N
                 os.chown(child, uid, gid)
 
 
-def _copy_tree(src: Path, dst: Path, excludes: set[str] | None = None) -> None:
+def _copy_tree(
+    src: Path,
+    dst: Path,
+    excludes: set[str] | None = None,
+    *,
+    replace: bool = False,
+) -> None:
     """
     Copy a directory tree, excluding patterns like __pycache__.
 
-    Uses a merge-based approach: walks the source tree and copies each file
-    individually, creating destination directories as needed. Files at the
-    destination that don't exist in the source are left untouched. This is
-    critical for workspace/.claude/ where runtime-created content (skills,
-    Claude Code state files) must survive installs.
+    By default, uses a merge-based approach: walks the source tree and copies
+    each file individually, creating destination directories as needed. Files
+    at the destination that don't exist in the source are left untouched.
+    Callers for generated trees such as the installed Python source can pass
+    ``replace=True`` so deleted source files do not survive an upgrade and get
+    packaged into the venv as obsolete modules.
 
     The previous implementation used shutil.rmtree(dst) before copytree(),
     which destroyed ALL destination contents including runtime data that the
@@ -2451,7 +2498,14 @@ def _copy_tree(src: Path, dst: Path, excludes: set[str] | None = None) -> None:
         src: Source directory.
         dst: Destination directory (created if it doesn't exist).
         excludes: Set of glob patterns to exclude (e.g., {"__pycache__", "*.pyc"}).
+        replace: Remove the destination tree before copying.
     """
+    if replace:
+        if dst.is_symlink():
+            dst.unlink()
+        elif dst.exists():
+            shutil.rmtree(dst)
+
     ignore_fn = shutil.ignore_patterns(*(excludes or set()))
 
     for src_dir, dirs, files in os.walk(src):
@@ -5239,7 +5293,10 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
         _retire_install_home_dir(install_path, dry_run=dry_run)
         return
 
-    _copy_tree(src_src, src_dst, _SOURCE_EXCLUDES)
+    # The install source is generated, root-owned state with no runtime data.
+    # Replace it exactly so removed modules cannot remain importable or be
+    # included by the subsequent non-editable pip install.
+    _copy_tree(src_src, src_dst, _SOURCE_EXCLUDES, replace=True)
     _set_ownership(src_dst, 0, 0, recursive=True)
     print(f"  Copied source to {src_dst}")
 
@@ -5270,6 +5327,33 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
     _retire_install_home_dir(install_path, dry_run=dry_run)
 
 
+def _resolve_venv_base_python() -> str:
+    """Resolve and validate the Python interpreter used to create/repair a venv."""
+    python = shutil.which("python3.13")
+    if python is None and sys.version_info >= (3, 13):
+        # `sudo` may reset PATH and hide Homebrew even though the installer is
+        # already running under a valid project-venv interpreter. Python's venv
+        # module resolves that interpreter's base executable when creating or
+        # upgrading the target environment.
+        python = sys.executable
+    python = python or shutil.which("python3") or "python3"
+    result = subprocess.run(
+        [python, "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        parts = result.stdout.strip().split(".")
+        major, minor = parts[0], parts[1]
+        if (int(major), int(minor)) < (3, 13):
+            raise SystemExit(
+                f"Python >= 3.13 required, but {python} is {result.stdout.strip()}. "
+                f"Install Python 3.13+ and ensure it is on PATH."
+            )
+    return python
+
+
 def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:
     """
     Create or update the virtual environment in the install location.
@@ -5288,10 +5372,19 @@ def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:
         dry_run: If True, print what would be done without doing it.
     """
     venv_path = install_path / "venv"
+    venv_python = venv_path / "bin" / "python"
     pyproject_dst = install_path / "pyproject.toml"
     src_dst = install_path / "src"
+    build_path = install_path / "build"
 
     if is_update and venv_path.exists():
+        # Homebrew removes the old Cellar path when Python is upgraded. A venv
+        # created with symlinks can therefore remain on disk while its Python
+        # interpreter becomes a dangling symlink. Detect that before the
+        # checksum fast-path or a no-source-change update would leave a service
+        # that cannot restart.
+        venv_needs_repair = not (venv_python.is_file() and os.access(venv_python, os.X_OK))
+
         # Check if pyproject.toml or source files changed. Both are needed
         # because the install is non-editable: pip copies code into the venv's
         # site-packages, so updating src/ at the install path alone does
@@ -5301,15 +5394,22 @@ def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:
         old_pyproject = ""
         if pyproject_checksum_file.exists():
             old_pyproject = pyproject_checksum_file.read_text().strip()
-        new_pyproject = _file_checksum(pyproject_dst)
+        # During a real apply, _apply_source has already copied the incoming
+        # files to the install tree. During a dry run that copy is deliberately
+        # skipped, so compare the repository inputs directly or the preview
+        # will incorrectly report an unchanged venv for every source-only
+        # update.
+        incoming_pyproject = PROJECT_ROOT / "pyproject.toml" if dry_run else pyproject_dst
+        new_pyproject = _file_checksum(incoming_pyproject)
 
         src_checksum_file = install_path / ".src.sha256"
         old_src = ""
         if src_checksum_file.exists():
             old_src = src_checksum_file.read_text().strip()
-        new_src = _src_checksum(src_dst)
+        incoming_src = PROJECT_ROOT / "src" if dry_run else src_dst
+        new_src = _src_checksum(incoming_src)
 
-        if old_pyproject == new_pyproject and old_src == new_src:
+        if old_pyproject == new_pyproject and old_src == new_src and not venv_needs_repair:
             print("  Venv unchanged (pyproject.toml and source checksums match)")
             return
 
@@ -5321,51 +5421,67 @@ def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:
             changed.append("source")
 
         if dry_run:
-            print(f"[DRY RUN] Would update venv ({' and '.join(changed)} changed)")
+            if venv_needs_repair:
+                print("[DRY RUN] Would repair venv (Python interpreter missing or unusable)")
+            if changed:
+                print(f"[DRY RUN] Would update venv ({' and '.join(changed)} changed)")
+            if build_path.exists():
+                print(f"[DRY RUN] Would remove stale package build artifacts: {build_path}")
             return
 
-        print(f"  Updating venv ({' and '.join(changed)} changed)...")
+        if venv_needs_repair:
+            python = _resolve_venv_base_python()
+            print(f"  Repairing venv with {python}...")
+            # `venv --upgrade` does not overwrite dangling interpreter
+            # symlinks. Remove only those generated links first; installed
+            # packages and every usable executable remain untouched.
+            removed_links = 0
+            for candidate in sorted((venv_path / "bin").glob("python*")):
+                if candidate.is_symlink() and not candidate.exists():
+                    candidate.unlink()
+                    removed_links += 1
+            if removed_links:
+                print(f"  Removed {removed_links} dangling venv interpreter symlink(s)")
+            subprocess.run(
+                [python, "-m", "venv", "--upgrade", str(venv_path)],
+                check=True,
+            )
+            if not (venv_python.is_file() and os.access(venv_python, os.X_OK)):
+                raise RuntimeError(f"Venv repair did not create a usable interpreter: {venv_python}")
+            print("  Repaired venv interpreter")
+
+        if changed:
+            print(f"  Updating venv ({' and '.join(changed)} changed)...")
     else:
         if dry_run:
             print(f"[DRY RUN] Would create venv: {venv_path}")
+            if build_path.exists():
+                print(f"[DRY RUN] Would remove stale package build artifacts: {build_path}")
             print("[DRY RUN] Would install package into venv")
             return
 
         print(f"  Creating venv at {venv_path}...")
-        # Find Python 3.13+
-        python = shutil.which("python3.13") or shutil.which("python3") or "python3"
-
-        # Verify the resolved Python meets the minimum version before creating
-        # the venv. Without this, a 3.12 venv gets built successfully but pip
-        # install fails later with a confusing requires-python error.
-        result = subprocess.run(
-            [python, "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode == 0:
-            parts = result.stdout.strip().split(".")
-            major, minor = parts[0], parts[1]
-            if (int(major), int(minor)) < (3, 13):
-                raise SystemExit(
-                    f"Python >= 3.13 required, but {python} is {result.stdout.strip()}. "
-                    f"Install Python 3.13+ and ensure it is on PATH."
-                )
+        python = _resolve_venv_base_python()
 
         subprocess.run(
             [python, "-m", "venv", str(venv_path)],
             check=True,
         )
 
+    # setuptools can reuse build/lib from an earlier wheel build and include
+    # Python modules that were subsequently deleted from src/. Always remove
+    # this generated tree before pip builds the non-editable package.
+    if build_path.exists():
+        shutil.rmtree(build_path)
+        print(f"  Removed stale package build artifacts: {build_path}")
+
     # Install the package with optional dependencies.
     # Uses a non-editable install (not -e) so the venv is self-contained
     # and doesn't depend on the source directory being writable.
-    pip = str(venv_path / "bin" / "pip")
     extras = "memory,totp,tts"
     install_spec = f"{install_path}[{extras}]"
     subprocess.run(
-        [pip, "install", install_spec],
+        [str(venv_python), "-m", "pip", "install", install_spec],
         check=True,
     )
     print("  Installed package into venv")

--- a/src/kai/internal_api_auth.py
+++ b/src/kai/internal_api_auth.py
@@ -1,0 +1,125 @@
+"""Process-local authentication and authorization for Kai's internal HTTP API.
+
+Persistent and one-shot agents need a narrow way to call the loopback API, but
+must never receive an external webhook signing secret or choose another user's
+identity. This module issues random, process-lifetime credentials that resolve
+to a server-owned principal and an explicit set of API scopes.
+"""
+
+from __future__ import annotations
+
+import hmac
+import secrets
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class InternalAPIScope(StrEnum):
+    """Operations an internal API credential may perform."""
+
+    JOBS_READ = "jobs:read"
+    JOBS_WRITE = "jobs:write"
+    SERVICES_CALL = "services:call"
+    MESSAGES_SEND = "messages:send"
+    FILES_SEND = "files:send"
+    MEMORY_READ = "memory:read"
+    MEMORY_WRITE = "memory:write"
+
+
+_AGENT_SCOPES = frozenset(InternalAPIScope)
+_NOTIFICATION_SCOPES = frozenset({InternalAPIScope.MESSAGES_SEND})
+
+
+@dataclass(frozen=True)
+class InternalAPIPrincipal:
+    """Identity and authority resolved from an internal API credential."""
+
+    chat_id: int
+    scopes: frozenset[InternalAPIScope]
+
+    def allows(self, scope: InternalAPIScope) -> bool:
+        """Return whether this principal has the requested API scope."""
+        return scope in self.scopes
+
+
+class InternalAPIAuth:
+    """Issue and resolve random credentials for internal API principals.
+
+    Credentials live only for the lifetime of the outer Kai process. Persistent
+    backends are lazy children of that same process, so they receive the current
+    credential whenever they start and do not require an at-rest token store.
+
+    Args:
+        agent_credentials: Optional fixed per-user credentials. Production code
+            leaves this unset and receives cryptographically random tokens; the
+            explicit form keeps direct handler tests deterministic.
+    """
+
+    def __init__(self, agent_credentials: Mapping[int, str] | None = None) -> None:
+        self._principals_by_credential: dict[str, InternalAPIPrincipal] = {}
+        self._credentials_by_principal: dict[InternalAPIPrincipal, str] = {}
+
+        for chat_id, credential in (agent_credentials or {}).items():
+            self._register(
+                credential,
+                InternalAPIPrincipal(chat_id=chat_id, scopes=_AGENT_SCOPES),
+            )
+
+    @classmethod
+    def for_users(cls, user_ids: Iterable[int]) -> InternalAPIAuth:
+        """Create an auth store with a full agent credential for each user."""
+        auth = cls()
+        for chat_id in sorted(set(user_ids)):
+            auth.agent_credential_for(chat_id)
+        return auth
+
+    def agent_credential_for(self, chat_id: int) -> str:
+        """Return the full internal API credential for a persistent user agent."""
+        return self._credential_for(InternalAPIPrincipal(chat_id=chat_id, scopes=_AGENT_SCOPES))
+
+    def notification_credential_for(self, chat_id: int) -> str:
+        """Return a send-message-only credential for a notification agent."""
+        return self._credential_for(InternalAPIPrincipal(chat_id=chat_id, scopes=_NOTIFICATION_SCOPES))
+
+    def authenticate(self, credential: str) -> InternalAPIPrincipal | None:
+        """Resolve a credential to its server-owned principal, if valid.
+
+        Every candidate is compared with ``hmac.compare_digest``. The store is
+        intentionally small (normally one or two credentials per configured
+        user), so avoiding a normal dictionary lookup keeps the comparison
+        behavior independent of secret prefix or string hash behavior.
+        """
+        if not credential:
+            return None
+
+        matched: InternalAPIPrincipal | None = None
+        for expected, principal in self._principals_by_credential.items():
+            if hmac.compare_digest(credential, expected):
+                matched = principal
+        return matched
+
+    def _credential_for(self, principal: InternalAPIPrincipal) -> str:
+        """Return an existing credential for a principal or issue a new one."""
+        existing = self._credentials_by_principal.get(principal)
+        if existing is not None:
+            return existing
+
+        while True:
+            credential = secrets.token_urlsafe(32)
+            if credential not in self._principals_by_credential:
+                break
+        self._register(credential, principal)
+        return credential
+
+    def _register(self, credential: str, principal: InternalAPIPrincipal) -> None:
+        """Register one non-empty, unique credential/principal pair."""
+        if not credential:
+            raise ValueError("Internal API credentials must not be empty")
+        if credential in self._principals_by_credential:
+            raise ValueError("Internal API credentials must be unique")
+        if principal in self._credentials_by_principal:
+            raise ValueError("Each internal API principal must have one credential")
+
+        self._principals_by_credential[credential] = principal
+        self._credentials_by_principal[principal] = credential

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -33,6 +33,7 @@ from kai.config import (
     validate_model_for_backend,
 )
 from kai.goose import GooseBackend
+from kai.internal_api_auth import InternalAPIAuth
 from kai.workspace_utils import is_workspace_allowed
 
 log = logging.getLogger(__name__)
@@ -69,6 +70,10 @@ class SubprocessPool:
     ):
         self._config = config
         self._services_info = services_info
+        # Tokens are random and process-local. The pool owns the store because
+        # it creates every persistent backend; webhook.start() receives this
+        # same object through bot_data so credential resolution cannot drift.
+        self._internal_api_auth = InternalAPIAuth.for_users(config.allowed_user_ids)
         self._pool: dict[int, AgentBackend] = {}
         self._last_activity: dict[int, float] = {}
         # Pending one-time setup for a freshly-created backend instance.
@@ -82,6 +87,11 @@ class SubprocessPool:
         self._pending_settings_restore: set[int] = set()
         self._in_flight: set[int] = set()  # chat_ids with active send()
         self._eviction_task: asyncio.Task | None = None
+
+    @property
+    def internal_api_auth(self) -> InternalAPIAuth:
+        """Return the credential store shared with the loopback HTTP server."""
+        return self._internal_api_auth
 
     # ── Instance management ─────────────────────────────────────────
 
@@ -235,13 +245,18 @@ class SubprocessPool:
         # OpenCode ACP, "codex" uses OpenAI Codex CLI's app-server
         # JSON-RPC protocol, anything else (including the default
         # "claude") uses Claude Code CLI.
+        # Internal API availability is independent of public webhook ingress.
+        # Agents receive only their random principal credential, never an
+        # external webhook signing secret.
+        internal_api_credential = self._internal_api_auth.agent_credential_for(chat_id)
+
         if backend == "goose":
             return GooseBackend(
                 model=model,
                 workspace=workspace,
                 home_workspace=home_ws,
                 webhook_port=self._config.webhook_port,
-                webhook_secret=self._config.webhook_secret,
+                webhook_secret=internal_api_credential,
                 timeout_seconds=timeout,
                 services_info=self._services_info,
                 workspace_config=ws_config,
@@ -262,7 +277,7 @@ class SubprocessPool:
                 workspace=workspace,
                 home_workspace=home_ws,
                 webhook_port=self._config.webhook_port,
-                webhook_secret=self._config.webhook_secret,
+                webhook_secret=internal_api_credential,
                 timeout_seconds=timeout,
                 services_info=self._services_info,
                 workspace_config=ws_config,
@@ -284,7 +299,7 @@ class SubprocessPool:
                 workspace=workspace,
                 home_workspace=home_ws,
                 webhook_port=self._config.webhook_port,
-                webhook_secret=self._config.webhook_secret,
+                webhook_secret=internal_api_credential,
                 timeout_seconds=timeout,
                 services_info=self._services_info,
                 workspace_config=ws_config,
@@ -300,7 +315,7 @@ class SubprocessPool:
             workspace=workspace,
             home_workspace=home_ws,
             webhook_port=self._config.webhook_port,
-            webhook_secret=self._config.webhook_secret,
+            webhook_secret=internal_api_credential,
             timeout_seconds=timeout,
             services_info=self._services_info,
             claude_user=os_user,

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -31,10 +31,12 @@ Routes are organized into these groups:
     - /api/memory/stats     - Memory statistics for a user (GET)
     - /api/memory/all       - Delete all memories for a user (DELETE, requires confirm token)
 
-The Telegram webhook route uses its own secret (TELEGRAM_WEBHOOK_SECRET) and is
-only registered in webhook mode. All other webhook/API endpoints require
-WEBHOOK_SECRET. When WEBHOOK_SECRET is unset, only /health is active (plus
-/webhook/telegram if in webhook mode).
+Every ingress domain has an independent credential. Telegram uses its configured
+or process-generated secret token, GitHub uses GITHUB_WEBHOOK_SECRET, and the
+generic endpoint uses GENERIC_WEBHOOK_SECRET. During migration only, the
+deprecated WEBHOOK_SECRET is an external-only fallback for the GitHub and generic
+routes; successful fallback use is logged. Internal API routes always use random,
+principal-bound process credentials and do not depend on external webhook secrets.
 
 GitHub events are formatted into human-readable Markdown messages and sent
 to the configured Telegram chat. The formatter pattern (dispatch dict mapping
@@ -59,6 +61,7 @@ from telegram.ext import Application
 
 from kai import cron, memory, review, services, sessions, triage
 from kai.config import DATA_DIR, IMAGE_EXTENSIONS, Config, ModelRole, UserConfig, resolve_user_model
+from kai.internal_api_auth import InternalAPIAuth, InternalAPIPrincipal, InternalAPIScope
 from kai.telegram_utils import chunk_text
 
 log = logging.getLogger(__name__)
@@ -84,6 +87,10 @@ ALLOWED_USER_IDS_KEY: web.AppKey[set[int]] = web.AppKey("allowed_user_ids", set)
 ALLOWED_WORKSPACES_KEY: web.AppKey[list[str]] = web.AppKey("allowed_workspaces", list)
 CHAT_ID_KEY: web.AppKey[int] = web.AppKey("chat_id", int)
 CONFIG_KEY: web.AppKey[Config] = web.AppKey("config", Config)
+GENERIC_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("generic_webhook_secret", str)
+GITHUB_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("github_webhook_secret", str)
+INTERNAL_API_AUTH_KEY: web.AppKey[InternalAPIAuth] = web.AppKey("internal_api_auth", InternalAPIAuth)
+LEGACY_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("legacy_webhook_secret", str)
 POOL_KEY: web.AppKey[object] = web.AppKey("pool", object)
 PR_REVIEW_COOLDOWN_KEY: web.AppKey[int] = web.AppKey("pr_review_cooldown", int)
 PR_REVIEW_TIMEOUT_S_KEY: web.AppKey[int] = web.AppKey("pr_review_timeout_s", int)
@@ -92,12 +99,11 @@ TELEGRAM_APP_KEY: web.AppKey[Application] = web.AppKey("telegram_app", Applicati
 TELEGRAM_BOT_KEY: web.AppKey[Bot] = web.AppKey("telegram_bot", Bot)
 TELEGRAM_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("telegram_webhook_secret", str)
 WEBHOOK_PORT_KEY: web.AppKey[int] = web.AppKey("webhook_port", int)
-WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("webhook_secret", str)
 WORKSPACE_BASE_KEY: web.AppKey[str | None] = web.AppKey("workspace_base")
 
 
 class UnauthorizedChatIdError(Exception):
-    """Raised when a request specifies a chat_id not in allowed_user_ids."""
+    """Raised when a request targets a chat_id other than its principal."""
 
 
 # Module-level server state, managed by start() and stop()
@@ -302,34 +308,65 @@ def _strip_markdown(text: str) -> str:
     return text
 
 
-def _require_secret(handler):
-    """Decorator that validates the X-Webhook-Secret header before
-    calling the route handler. Returns 401 on mismatch."""
+def _require_generic_webhook_secret(handler):
+    """Validate the generic credential, with observable legacy fallback."""
 
     @functools.wraps(handler)
     async def wrapper(request: web.Request) -> web.Response:
-        secret = request.app[WEBHOOK_SECRET_KEY]
+        secret = request.app[GENERIC_WEBHOOK_SECRET_KEY]
+        legacy_secret = request.app.get(LEGACY_WEBHOOK_SECRET_KEY, "")
         provided = request.headers.get("X-Webhook-Secret", "")
-        if not hmac.compare_digest(provided, secret):
+        if secret and hmac.compare_digest(provided, secret):
+            return await handler(request)
+        if legacy_secret and hmac.compare_digest(provided, legacy_secret):
+            log.warning(
+                "Legacy WEBHOOK_SECRET authenticated /webhook from %s; migrate this caller to GENERIC_WEBHOOK_SECRET",
+                request.remote,
+            )
+            return await handler(request)
+        else:
             log.warning("Auth failure on %s from %s", request.path, request.remote)
             return web.Response(status=401, text="Invalid secret")
-        return await handler(request)
 
     return wrapper
 
 
-def _resolve_chat_id(request: web.Request, payload: dict) -> int:
-    """
-    Extract chat_id from the request payload if present, otherwise
-    fall back to the app-level default.
+def _require_internal_api(scope: InternalAPIScope):
+    """Require a principal-bound internal API credential with one scope."""
 
-    This allows the inner Claude process to specify which user a
-    message/file/job belongs to, while remaining backward-compatible
-    with callers that don't pass chat_id.
+    def decorator(handler):
+        @functools.wraps(handler)
+        async def wrapper(request: web.Request) -> web.Response:
+            credential = request.headers.get("X-Webhook-Secret", "")
+            principal = request.app[INTERNAL_API_AUTH_KEY].authenticate(credential)
+            if principal is None:
+                log.warning("Internal API auth failure on %s from %s", request.path, request.remote)
+                return web.Response(status=401, text="Invalid credential")
+            if not principal.allows(scope):
+                log.warning(
+                    "Internal API scope denial on %s for principal %d",
+                    request.path,
+                    principal.chat_id,
+                )
+                return web.Response(status=403, text="Credential is not authorized for this operation")
+            return await handler(request, principal)
+
+        return wrapper
+
+    return decorator
+
+
+def _resolve_chat_id(principal: InternalAPIPrincipal, payload: dict) -> int:
+    """
+    Resolve identity from the authenticated principal, not request data.
+
+    A caller may include chat_id for clarity and compatibility, but it must
+    match the server-resolved credential owner. Omitting chat_id uses that
+    owner directly; there is no admin or application-default fallback.
 
     Raises:
         ValueError: If chat_id is present but not a valid integer.
-        UnauthorizedChatIdError: If chat_id is not in allowed_user_ids.
+        UnauthorizedChatIdError: If chat_id differs from the principal.
     """
     explicit = payload.get("chat_id")
     if explicit is not None:
@@ -342,14 +379,12 @@ def _resolve_chat_id(request: web.Request, payload: dict) -> int:
             resolved = int(explicit)
         except (TypeError, ValueError):
             raise ValueError(f"chat_id must be an integer, got {explicit!r}") from None
-        # Validate the resolved chat_id is an authorized user.
-        # Without this, a prompt injection attack could make inner Claude
-        # send messages to arbitrary Telegram users.
-        allowed = request.app.get(ALLOWED_USER_IDS_KEY)
-        if allowed is not None and resolved not in allowed:
-            raise UnauthorizedChatIdError(f"chat_id {resolved} is not an authorized user")
+        if resolved != principal.chat_id:
+            raise UnauthorizedChatIdError(
+                f"chat_id {resolved} does not match authenticated principal {principal.chat_id}"
+            )
         return resolved
-    return request.app[CHAT_ID_KEY]
+    return principal.chat_id
 
 
 # ── GitHub event formatters ───────────────────────────────────────────
@@ -464,7 +499,7 @@ def _verify_github_signature(secret: str, body: bytes, signature: str) -> bool:
     comparison to prevent timing attacks.
 
     Args:
-        secret: The shared webhook secret configured in GitHub and .env.
+        secret: The dedicated GITHUB_WEBHOOK_SECRET configured in GitHub and Kai.
         body: The raw request body bytes.
         signature: The X-Hub-Signature-256 header value (e.g., "sha256=abc123...").
 
@@ -481,8 +516,8 @@ def _verify_github_signature(secret: str, body: bytes, signature: str) -> bool:
 
 
 async def _handle_health(request: web.Request) -> web.Response:
-    """Health check endpoint. Returns {"status": "ok"} for uptime monitoring."""
-    return web.json_response({"status": "ok"})
+    """Return liveness plus the non-sensitive memory feature mode."""
+    return web.json_response({"status": "ok", "memory_enabled": memory.is_enabled()})
 
 
 async def _handle_telegram_update(request: web.Request) -> web.Response:
@@ -546,13 +581,22 @@ async def _handle_github(request: web.Request) -> web.Response:
     Supported events: push, pull_request, issues, issue_comment, pull_request_review.
     Unsupported events are silently acknowledged with {"msg": "ignored"}.
     """
-    secret = request.app[WEBHOOK_SECRET_KEY]
+    secret = request.app[GITHUB_WEBHOOK_SECRET_KEY]
+    legacy_secret = request.app.get(LEGACY_WEBHOOK_SECRET_KEY, "")
 
     body = await request.read()
 
     # Validate HMAC-SHA256 signature from GitHub
     signature = request.headers.get("X-Hub-Signature-256", "")
-    if not _verify_github_signature(secret, body, signature):
+    if secret and _verify_github_signature(secret, body, signature):
+        pass
+    elif legacy_secret and _verify_github_signature(legacy_secret, body, signature):
+        log.warning(
+            "Legacy WEBHOOK_SECRET authenticated /webhook/github from %s; "
+            "migrate the GitHub webhook to GITHUB_WEBHOOK_SECRET",
+            request.remote,
+        )
+    else:
         log.warning("GitHub webhook: invalid signature")
         return web.Response(status=401, text="Invalid signature")
 
@@ -800,7 +844,7 @@ async def _process_github_event_for_user(
                 review.review_pr(
                     payload,
                     webhook_port=request.app[WEBHOOK_PORT_KEY],
-                    webhook_secret=request.app[WEBHOOK_SECRET_KEY],
+                    webhook_secret=request.app[INTERNAL_API_AUTH_KEY].notification_credential_for(target_chat_id),
                     claude_user=claude_user,
                     local_repo_path=local_repo_path,
                     spec_dir=request.app.get(SPEC_DIR_KEY, "specs"),
@@ -850,7 +894,7 @@ async def _process_github_event_for_user(
                 triage.triage_issue(
                     payload,
                     webhook_port=request.app[WEBHOOK_PORT_KEY],
-                    webhook_secret=request.app[WEBHOOK_SECRET_KEY],
+                    webhook_secret=request.app[INTERNAL_API_AUTH_KEY].notification_credential_for(target_chat_id),
                     claude_user=claude_user,
                     notify_chat_id=target_chat_id,
                     agent_backend=agent_backend,
@@ -898,7 +942,7 @@ async def _process_github_event_for_user(
     )
 
 
-@_require_secret
+@_require_generic_webhook_secret
 async def _handle_generic(request: web.Request) -> web.Response:
     """
     Handle generic webhook notifications from any source.
@@ -1024,8 +1068,8 @@ def _validate_schedule_data(
     return json.dumps(parsed), None
 
 
-@_require_secret
-async def _handle_schedule(request: web.Request) -> web.Response:
+@_require_internal_api(InternalAPIScope.JOBS_WRITE)
+async def _handle_schedule(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
     Create a new scheduled job via the HTTP API.
 
@@ -1085,7 +1129,7 @@ async def _handle_schedule(request: web.Request) -> web.Response:
     auto_remove = payload.get("auto_remove", False)
     notify_on_check = payload.get("notify_on_check", False)
     try:
-        chat_id = _resolve_chat_id(request, payload)
+        chat_id = _resolve_chat_id(principal, payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
     except UnauthorizedChatIdError as e:
@@ -1126,8 +1170,8 @@ async def _handle_schedule(request: web.Request) -> web.Response:
 # ── Jobs API ─────────────────────────────────────────────────────────
 
 
-@_require_secret
-async def _handle_get_jobs(request: web.Request) -> web.Response:
+@_require_internal_api(InternalAPIScope.JOBS_READ)
+async def _handle_get_jobs(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
     List all active jobs for the configured chat.
 
@@ -1139,7 +1183,7 @@ async def _handle_get_jobs(request: web.Request) -> web.Response:
     # dict so _resolve_chat_id can extract and validate chat_id the same
     # way it does for POST endpoints with JSON bodies.
     try:
-        chat_id = _resolve_chat_id(request, dict(request.query))
+        chat_id = _resolve_chat_id(principal, dict(request.query))
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
     except UnauthorizedChatIdError as e:
@@ -1148,8 +1192,8 @@ async def _handle_get_jobs(request: web.Request) -> web.Response:
     return web.json_response(jobs)
 
 
-@_require_secret
-async def _handle_get_job(request: web.Request) -> web.Response:
+@_require_internal_api(InternalAPIScope.JOBS_READ)
+async def _handle_get_job(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
     Get a single job by its database ID.
 
@@ -1163,7 +1207,7 @@ async def _handle_get_job(request: web.Request) -> web.Response:
 
     # Resolve caller identity for ownership check
     try:
-        chat_id = _resolve_chat_id(request, dict(request.query))
+        chat_id = _resolve_chat_id(principal, dict(request.query))
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
     except UnauthorizedChatIdError as e:
@@ -1178,8 +1222,8 @@ async def _handle_get_job(request: web.Request) -> web.Response:
     return web.json_response(job)
 
 
-@_require_secret
-async def _handle_delete_job(request: web.Request) -> web.Response:
+@_require_internal_api(InternalAPIScope.JOBS_WRITE)
+async def _handle_delete_job(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
     Delete a scheduled job by ID via the HTTP API.
 
@@ -1193,12 +1237,10 @@ async def _handle_delete_job(request: web.Request) -> web.Response:
     except ValueError:
         return web.json_response({"error": "Invalid job ID"}, status=400)
 
-    # Resolve caller identity from query params (e.g., ?chat_id=456).
-    # Falls back to admin chat_id when omitted, preserving backward
-    # compatibility. _resolve_chat_id validates against allowed_user_ids
-    # to prevent cross-user job manipulation via prompt injection.
+    # Resolve caller identity from its server-owned principal. A query-string
+    # chat_id is accepted only when it repeats that identity.
     try:
-        chat_id = _resolve_chat_id(request, dict(request.query))
+        chat_id = _resolve_chat_id(principal, dict(request.query))
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
     except UnauthorizedChatIdError as e:
@@ -1222,8 +1264,8 @@ async def _handle_delete_job(request: web.Request) -> web.Response:
     return web.json_response({"deleted": job_id})
 
 
-@_require_secret
-async def _handle_update_job(request: web.Request) -> web.Response:
+@_require_internal_api(InternalAPIScope.JOBS_WRITE)
+async def _handle_update_job(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
     Update a scheduled job's mutable fields via the HTTP API.
 
@@ -1285,7 +1327,7 @@ async def _handle_update_job(request: web.Request) -> web.Response:
     # an updatable column - update_job only writes explicitly named fields
     # (name, prompt, schedule_type, etc.) to the SET clause.
     try:
-        chat_id = _resolve_chat_id(request, payload)
+        chat_id = _resolve_chat_id(principal, payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
     except UnauthorizedChatIdError as e:
@@ -1326,8 +1368,8 @@ async def _handle_update_job(request: web.Request) -> web.Response:
 # ── Service proxy ────────────────────────────────────────────────────
 
 
-@_require_secret
-async def _handle_service_call(request: web.Request) -> web.Response:
+@_require_internal_api(InternalAPIScope.SERVICES_CALL)
+async def _handle_service_call(request: web.Request, _principal: InternalAPIPrincipal) -> web.Response:
     """
     Proxy an authenticated request to an external service.
 
@@ -1387,8 +1429,8 @@ async def _handle_service_call(request: web.Request) -> web.Response:
 # ── Messaging ────────────────────────────────────────────────────────
 
 
-@_require_secret
-async def _handle_send_message(request: web.Request) -> web.Response:
+@_require_internal_api(InternalAPIScope.MESSAGES_SEND)
+async def _handle_send_message(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
     Send a text message to the Telegram chat.
 
@@ -1421,7 +1463,7 @@ async def _handle_send_message(request: web.Request) -> web.Response:
 
     bot = request.app[TELEGRAM_BOT_KEY]
     try:
-        chat_id = _resolve_chat_id(request, payload)
+        chat_id = _resolve_chat_id(principal, payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
     except UnauthorizedChatIdError as e:
@@ -1441,8 +1483,8 @@ async def _handle_send_message(request: web.Request) -> web.Response:
 # ── File exchange ────────────────────────────────────────────────────
 
 
-@_require_secret
-async def _handle_send_file(request: web.Request) -> web.Response:
+@_require_internal_api(InternalAPIScope.FILES_SEND)
+async def _handle_send_file(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
     Send a file from the filesystem to the Telegram chat.
 
@@ -1477,7 +1519,7 @@ async def _handle_send_file(request: web.Request) -> web.Response:
 
     # Resolve chat_id first - needed for per-user workspace confinement
     try:
-        chat_id = _resolve_chat_id(request, payload)
+        chat_id = _resolve_chat_id(principal, payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
     except UnauthorizedChatIdError as e:
@@ -1576,8 +1618,8 @@ def _memory_disabled_response() -> web.Response:
     return web.json_response({"error": "Memory system disabled"}, status=503)
 
 
-@_require_secret
-async def _handle_memory_add(request: web.Request) -> web.Response:
+@_require_internal_api(InternalAPIScope.MEMORY_WRITE)
+async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
     Store a structured memory via memory.add_structured().
 
@@ -1593,13 +1635,13 @@ async def _handle_memory_add(request: web.Request) -> web.Response:
         tags: list[str], optional
         metadata: dict, optional (keys "type" and "tags" are reserved by
             add_structured; user values for those will be overwritten)
-        chat_id: int, optional, defaults to the configured webhook chat_id
+        chat_id: int, optional, defaults to the authenticated principal
 
     Responses:
         200 {"id": "<mem0-uuid>"} on success
         400 on bad input (invalid JSON, missing/empty content, bad chat_id)
-        401 on bad/missing X-Webhook-Secret (handled by the decorator)
-        403 on unauthorized chat_id
+        401 on bad/missing internal API credential (handled by the decorator)
+        403 on a chat_id that differs from the authenticated principal
         503 when memory is disabled (precheck; do not retry, escalate)
         500 when add_structured() returns None despite memory being enabled
             (the underlying store call failed; may be transient)
@@ -1657,7 +1699,7 @@ async def _handle_memory_add(request: web.Request) -> web.Response:
         return web.json_response({"error": "metadata must be a JSON object"}, status=400)
 
     try:
-        chat_id = _resolve_chat_id(request, payload)
+        chat_id = _resolve_chat_id(principal, payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
     except UnauthorizedChatIdError as e:
@@ -1708,8 +1750,8 @@ async def _handle_memory_add(request: web.Request) -> web.Response:
     return web.json_response({"id": memory_id})
 
 
-@_require_secret
-async def _handle_memory_search(request: web.Request) -> web.Response:
+@_require_internal_api(InternalAPIScope.MEMORY_READ)
+async def _handle_memory_search(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
     Search memories via memory.search().
 
@@ -1721,7 +1763,7 @@ async def _handle_memory_search(request: web.Request) -> web.Response:
     Request body (JSON):
         query: str, required, non-empty after strip
         limit: int, optional (defaults to config.memory_search_limit)
-        chat_id: int, optional, defaults to the configured webhook chat_id
+        chat_id: int, optional, defaults to the authenticated principal
 
     Responses:
         200 {"results": [<MemoryResult-dict>, ...]} on success (empty list
@@ -1762,7 +1804,7 @@ async def _handle_memory_search(request: web.Request) -> web.Response:
         return web.json_response({"error": "limit must be a positive integer"}, status=400)
 
     try:
-        chat_id = _resolve_chat_id(request, payload)
+        chat_id = _resolve_chat_id(principal, payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
     except UnauthorizedChatIdError as e:
@@ -1799,15 +1841,15 @@ async def _handle_memory_search(request: web.Request) -> web.Response:
         return web.json_response({"error": "Memory search failed"}, status=500)
 
 
-@_require_secret
-async def _handle_memory_stats(request: web.Request) -> web.Response:
+@_require_internal_api(InternalAPIScope.MEMORY_READ)
+async def _handle_memory_stats(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
     Return memory statistics via memory.get_stats().
 
     GET endpoint reads chat_id from query params, mirroring _handle_get_jobs.
 
     Query params:
-        chat_id: int, optional (defaults to the configured webhook chat_id)
+        chat_id: int, optional (defaults to the authenticated principal)
 
     Response is the MemoryStats object at the top level, NOT wrapped in
     {"results": ...} - single-object reads return the object bare per
@@ -1829,7 +1871,7 @@ async def _handle_memory_stats(request: web.Request) -> web.Response:
     # GET handlers feed query params to _resolve_chat_id; established
     # pattern at _handle_get_jobs.
     try:
-        chat_id = _resolve_chat_id(request, dict(request.query))
+        chat_id = _resolve_chat_id(principal, dict(request.query))
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
     except UnauthorizedChatIdError as e:
@@ -1862,8 +1904,8 @@ async def _handle_memory_stats(request: web.Request) -> web.Response:
         return web.json_response({"error": "Memory stats failed"}, status=500)
 
 
-@_require_secret
-async def _handle_memory_delete_all(request: web.Request) -> web.Response:
+@_require_internal_api(InternalAPIScope.MEMORY_WRITE)
+async def _handle_memory_delete_all(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
     Delete all memories for a user via memory.delete_all().
 
@@ -1879,7 +1921,7 @@ async def _handle_memory_delete_all(request: web.Request) -> web.Response:
 
     Request body (JSON):
         confirm: str, required, must equal "delete-all-memories"
-        chat_id: int, optional, defaults to the configured webhook chat_id
+        chat_id: int, optional, defaults to the authenticated principal
 
     Responses:
         200 {"status": "deleted"} on success
@@ -1917,7 +1959,7 @@ async def _handle_memory_delete_all(request: web.Request) -> web.Response:
         )
 
     try:
-        chat_id = _resolve_chat_id(request, payload)
+        chat_id = _resolve_chat_id(principal, payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
     except UnauthorizedChatIdError as e:
@@ -2062,6 +2104,47 @@ async def _webhook_health_loop(bot, webhook_url: str, webhook_secret: str, chat_
 # ── Lifecycle ────────────────────────────────────────────────────────
 
 
+def _register_routes(app: web.Application, config: Config) -> None:
+    """Register independently gated external routes and always-on internal APIs."""
+    app.router.add_get("/health", _handle_health)
+
+    if config.webhook_secret:
+        app[LEGACY_WEBHOOK_SECRET_KEY] = config.webhook_secret
+
+    if config.telegram_webhook_url:
+        if not config.telegram_webhook_secret:
+            raise RuntimeError("Telegram webhook mode requires a non-empty secret")
+        app[TELEGRAM_WEBHOOK_SECRET_KEY] = config.telegram_webhook_secret
+        app.router.add_post("/webhook/telegram", _handle_telegram_update)
+
+    if config.github_webhook_secret or config.webhook_secret:
+        app[GITHUB_WEBHOOK_SECRET_KEY] = config.github_webhook_secret
+        app.router.add_post("/webhook/github", _handle_github)
+    else:
+        log.warning("GITHUB_WEBHOOK_SECRET not set - GitHub webhook endpoint disabled")
+
+    if config.generic_webhook_secret or config.webhook_secret:
+        app[GENERIC_WEBHOOK_SECRET_KEY] = config.generic_webhook_secret
+        app.router.add_post("/webhook", _handle_generic)
+    else:
+        log.info("GENERIC_WEBHOOK_SECRET not set - generic webhook endpoint disabled")
+
+    # These routes authenticate through INTERNAL_API_AUTH_KEY. Their
+    # availability must not be coupled to any public ingress configuration.
+    app.router.add_post("/api/schedule", _handle_schedule)
+    app.router.add_get("/api/jobs", _handle_get_jobs)
+    app.router.add_get("/api/jobs/{id}", _handle_get_job)
+    app.router.add_delete("/api/jobs/{id}", _handle_delete_job)
+    app.router.add_patch("/api/jobs/{id}", _handle_update_job)
+    app.router.add_post("/api/services/{name}", _handle_service_call)
+    app.router.add_post("/api/send-message", _handle_send_message)
+    app.router.add_post("/api/send-file", _handle_send_file)
+    app.router.add_post("/api/memory/add", _handle_memory_add)
+    app.router.add_post("/api/memory/search", _handle_memory_search)
+    app.router.add_get("/api/memory/stats", _handle_memory_stats)
+    app.router.add_delete("/api/memory/all", _handle_memory_delete_all)
+
+
 async def start(telegram_app, config) -> None:
     """
     Start the HTTP server and optionally register the Telegram webhook.
@@ -2083,12 +2166,16 @@ async def start(telegram_app, config) -> None:
     _app = web.Application()
     _app[TELEGRAM_APP_KEY] = telegram_app
     _app[TELEGRAM_BOT_KEY] = telegram_app.bot
-    _app[WEBHOOK_SECRET_KEY] = config.webhook_secret
 
-    # Set the default chat_id for API calls that don't specify a target.
-    # users.yaml is mandatory so the first admin is the default; when
-    # no admin is defined, fall back to the first user with a warning
-    # (the same warning at config load time covers the no-admin case).
+    pool = telegram_app.bot_data.get("pool")
+    internal_api_auth = getattr(pool, "internal_api_auth", None)
+    if not isinstance(internal_api_auth, InternalAPIAuth):
+        raise RuntimeError("Subprocess pool did not provide an internal API credential store")
+    _app[INTERNAL_API_AUTH_KEY] = internal_api_auth
+
+    # Set the fallback destination for unattributed external webhook events.
+    # Internal API calls never use this value for identity; their credential
+    # resolves a principal before the handler runs.
     admins = config.get_admins()
     if admins:
         _app[CHAT_ID_KEY] = admins[0].telegram_id
@@ -2103,16 +2190,18 @@ async def start(telegram_app, config) -> None:
         )
         _app[CHAT_ID_KEY] = fallback.telegram_id
 
-    # Store allowed user IDs for chat_id validation in _resolve_chat_id.
-    # Prevents prompt injection from routing messages to arbitrary users.
-    _app[ALLOWED_USER_IDS_KEY] = config.allowed_user_ids
+    # Keep notification destinations separate from Config.allowed_user_ids,
+    # which is the immutable-at-runtime source for Telegram inbound auth. The
+    # API no longer consults this set for identity; credentials resolve their
+    # principal server-side.
+    _app[ALLOWED_USER_IDS_KEY] = set(config.allowed_user_ids)
 
     # Store config for GitHub actor routing in _handle_github()
     _app[CONFIG_KEY] = config
 
     # Store the subprocess pool for per-user workspace lookup in send-file.
     # Set by main.py after pool creation; may be None during init.
-    _app[POOL_KEY] = telegram_app.bot_data.get("pool")
+    _app[POOL_KEY] = pool
 
     # Server-level config for review/triage background tasks. Per-user
     # feature flags (pr_review, issue_triage) are resolved at event time
@@ -2128,9 +2217,9 @@ async def start(telegram_app, config) -> None:
     _app[ALLOWED_WORKSPACES_KEY] = [str(p) for p in config.allowed_workspaces]
     _app[SPEC_DIR_KEY] = config.spec_dir
 
-    # Add per-user github_notify_chat_id values to allowed_user_ids
-    # so review/triage agents can POST to /api/send-message with
-    # these chat_ids. Loads from both users.yaml and DB.
+    # Maintain the legacy live notification-destination registry from both
+    # users.yaml and DB. This set is intentionally detached from Config's
+    # inbound Telegram principals and is not consulted by internal API auth.
     for uc in config.user_configs.values():
         if uc.github_notify_chat_id is not None:
             _app[ALLOWED_USER_IDS_KEY].add(uc.github_notify_chat_id)
@@ -2147,31 +2236,7 @@ async def start(telegram_app, config) -> None:
                     uid,
                     val,
                 )
-    _app.router.add_get("/health", _handle_health)
-
-    # Only register the Telegram webhook route in webhook mode. In polling mode,
-    # there's no need for the endpoint and no secret to validate against.
-    if config.telegram_webhook_url:
-        _app[TELEGRAM_WEBHOOK_SECRET_KEY] = config.telegram_webhook_secret
-        _app.router.add_post("/webhook/telegram", _handle_telegram_update)
-
-    if config.webhook_secret:
-        _app.router.add_post("/webhook/github", _handle_github)
-        _app.router.add_post("/webhook", _handle_generic)
-        _app.router.add_post("/api/schedule", _handle_schedule)
-        _app.router.add_get("/api/jobs", _handle_get_jobs)
-        _app.router.add_get("/api/jobs/{id}", _handle_get_job)
-        _app.router.add_delete("/api/jobs/{id}", _handle_delete_job)
-        _app.router.add_patch("/api/jobs/{id}", _handle_update_job)
-        _app.router.add_post("/api/services/{name}", _handle_service_call)
-        _app.router.add_post("/api/send-message", _handle_send_message)
-        _app.router.add_post("/api/send-file", _handle_send_file)
-        _app.router.add_post("/api/memory/add", _handle_memory_add)
-        _app.router.add_post("/api/memory/search", _handle_memory_search)
-        _app.router.add_get("/api/memory/stats", _handle_memory_stats)
-        _app.router.add_delete("/api/memory/all", _handle_memory_delete_all)
-    else:
-        log.warning("WEBHOOK_SECRET not set - webhook and scheduling endpoints disabled")
+    _register_routes(_app, config)
 
     _runner = web.AppRunner(_app, access_log=None)
     await _runner.setup()
@@ -2275,11 +2340,11 @@ def is_running() -> bool:
 
 def add_allowed_chat_id(chat_id: int) -> None:
     """
-    Add a chat_id to the live allowed_user_ids set.
+    Add a chat_id to the legacy live notification-destination registry.
 
     Called by bot.py when /github notify sets a new notification
-    destination. Without this, the new chat_id is rejected by
-    _resolve_chat_id() until the next restart.
+    destination. This registry no longer grants Telegram or internal API
+    authority; those identities come from users.yaml and API credentials.
     """
     if _app is not None:
         allowed = _app.get(ALLOWED_USER_IDS_KEY)
@@ -2289,18 +2354,15 @@ def add_allowed_chat_id(chat_id: int) -> None:
 
 def remove_allowed_chat_id(chat_id: int) -> None:
     """
-    Remove a chat_id from the live allowed_user_ids set, but only
+    Remove a chat_id from the live notification registry, but only
     if it does not belong to an actual authorized user.
 
     Called by bot.py when /github notify reset clears a notification
     destination. A user's own telegram_id must never be removed.
 
-    Important: config.allowed_user_ids and _app[ALLOWED_USER_IDS_KEY]
-    are the SAME set object (assigned by reference at start()). We
-    cannot use config.allowed_user_ids as the guard because any
-    chat_id we previously added via add_allowed_chat_id() would also
-    appear there. Instead, check config.user_configs (a dict keyed
-    by telegram_id, populated at load time, never mutated at runtime).
+    Config.allowed_user_ids is deliberately a different set object so
+    notification changes cannot mutate inbound Telegram authorization.
+    user_configs remains the immutable source for the preservation guard.
     """
     if _app is not None:
         allowed = _app.get(ALLOWED_USER_IDS_KEY)

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1474,9 +1474,18 @@ class TestEnvLayering:
 
     @pytest.mark.asyncio
     async def test_webhook_secret_applied_last(self, tmp_path):
-        """KAI_WEBHOOK_SECRET cannot be overridden by workspace env."""
+        """Only the principal credential survives workspace env layering."""
         env_file = tmp_path / "ws.env"
-        env_file.write_text("KAI_WEBHOOK_SECRET=workspace-secret\nFOO=bar\n")
+        env_file.write_text(
+            "KAI_WEBHOOK_SECRET=workspace-secret\n"
+            "WEBHOOK_SECRET=legacy-generic-secret\n"
+            "GENERIC_WEBHOOK_SECRET=generic-signing-secret\n"
+            "GITHUB_WEBHOOK_SECRET=github-signing-secret\n"
+            "TELEGRAM_WEBHOOK_SECRET=telegram-signing-secret\n"
+            "TELEGRAM_BOT_TOKEN=bot-token\n"
+            "GH_TOKEN=outer-github-token\n"
+            "FOO=bar\n"
+        )
         ws = WorkspaceConfig(path=Path("/tmp/ws"), env_file=env_file)
         b = _make_fake(workspace_config=ws, webhook_secret="real-secret")
 
@@ -1498,6 +1507,12 @@ class TestEnvLayering:
         assert env["FOO"] == "bar"
         # Webhook secret wins over workspace env_file's attempt to override.
         assert env["KAI_WEBHOOK_SECRET"] == "real-secret"
+        assert "WEBHOOK_SECRET" not in env
+        assert "GENERIC_WEBHOOK_SECRET" not in env
+        assert "GITHUB_WEBHOOK_SECRET" not in env
+        assert "TELEGRAM_WEBHOOK_SECRET" not in env
+        assert "TELEGRAM_BOT_TOKEN" not in env
+        assert "GH_TOKEN" not in env
 
     @pytest.mark.asyncio
     async def test_workspace_inline_env_overrides_file(self, tmp_path):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -598,6 +598,8 @@ def _make_config(**overrides) -> Config:
         "allowed_user_ids": {1},
         "workspace_base": None,
         "allowed_workspaces": [],
+        "github_webhook_secret": "github-test-secret",
+        "generic_webhook_secret": "generic-test-secret",
         "webhook_secret": "test-secret",
         "webhook_port": 8080,
         "tts_enabled": False,
@@ -962,6 +964,13 @@ class TestModelsKeyboard:
         assert "model:opus" in callbacks
         assert "model:sonnet" in callbacks
         assert "model:haiku" in callbacks
+
+    def test_codex_keyboard_offers_gpt56(self):
+        """The documented GPT-5.6 alias is selectable on the Codex surface."""
+        from kai.config import CODEX_MODELS
+
+        kb = _models_keyboard("gpt-5.5", CODEX_MODELS)
+        assert "model:gpt-5.6" in _button_callbacks(kb)
 
     def test_callback_data_format(self):
         kb = _models_keyboard("opus", self._anthropic_models)
@@ -1693,7 +1702,7 @@ class TestHandleWebhooks:
     @pytest.mark.asyncio
     async def test_running_with_secret(self):
         update = _make_update()
-        ctx = _make_context(config=_make_config(webhook_secret="s3cret"))
+        ctx = _make_context(config=_make_config(github_webhook_secret="s3cret"))
         with patch("kai.bot.webhook.is_running", return_value=True):
             await handle_webhooks(update, ctx)
         reply = update.message.reply_text.call_args[0][0]
@@ -1703,20 +1712,26 @@ class TestHandleWebhooks:
     @pytest.mark.asyncio
     async def test_not_running(self):
         update = _make_update()
-        ctx = _make_context(config=_make_config(webhook_secret="s3cret"))
+        ctx = _make_context(config=_make_config(github_webhook_secret="s3cret"))
         with patch("kai.bot.webhook.is_running", return_value=False):
             await handle_webhooks(update, ctx)
         reply = update.message.reply_text.call_args[0][0]
         assert "not running" in reply
 
     @pytest.mark.asyncio
-    async def test_no_secret(self):
+    async def test_no_external_secrets(self):
         update = _make_update()
-        ctx = _make_context(config=_make_config(webhook_secret=""))
+        ctx = _make_context(
+            config=_make_config(
+                github_webhook_secret="",
+                generic_webhook_secret="",
+            )
+        )
         with patch("kai.bot.webhook.is_running", return_value=True):
             await handle_webhooks(update, ctx)
         reply = update.message.reply_text.call_args[0][0]
-        assert "WEBHOOK_SECRET not set" in reply
+        assert "No external webhook secrets" in reply
+        assert "/api/schedule" in reply
 
 
 # ── handle_workspace ─────────────────────────────────────────────────

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -956,8 +956,14 @@ class TestEnsureStarted:
         mock_exec.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_passes_webhook_secret_in_env(self):
-        """Webhook secret is passed via KAI_WEBHOOK_SECRET env var."""
+    async def test_passes_only_principal_credential_in_env(self, monkeypatch):
+        """The agent gets its API credential but no outer control-plane secrets."""
+        monkeypatch.setenv("WEBHOOK_SECRET", "legacy-generic-secret")
+        monkeypatch.setenv("GENERIC_WEBHOOK_SECRET", "generic-signing-secret")
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "github-signing-secret")
+        monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "telegram-signing-secret")
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+        monkeypatch.setenv("GH_TOKEN", "outer-github-token")
         claude = _make_claude(webhook_secret="my-secret")
 
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
@@ -971,6 +977,12 @@ class TestEnsureStarted:
 
             call_kwargs = mock_exec.call_args[1]
             assert call_kwargs["env"]["KAI_WEBHOOK_SECRET"] == "my-secret"
+            assert "WEBHOOK_SECRET" not in call_kwargs["env"]
+            assert "GENERIC_WEBHOOK_SECRET" not in call_kwargs["env"]
+            assert "GITHUB_WEBHOOK_SECRET" not in call_kwargs["env"]
+            assert "TELEGRAM_WEBHOOK_SECRET" not in call_kwargs["env"]
+            assert "TELEGRAM_BOT_TOKEN" not in call_kwargs["env"]
+            assert "GH_TOKEN" not in call_kwargs["env"]
 
     @pytest.mark.asyncio
     async def test_subprocess_limit_is_at_least_16mb(self):

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1552,8 +1552,14 @@ class TestSubprocessConstruction:
         assert call_kwargs["stderr"] == asyncio.subprocess.PIPE
 
     @pytest.mark.asyncio
-    async def test_webhook_secret_injected(self):
-        """KAI_WEBHOOK_SECRET is set in the subprocess env when configured."""
+    async def test_only_principal_credential_is_injected(self, monkeypatch):
+        """Codex receives its API credential but no outer control-plane secrets."""
+        monkeypatch.setenv("WEBHOOK_SECRET", "legacy-generic-secret")
+        monkeypatch.setenv("GENERIC_WEBHOOK_SECRET", "generic-signing-secret")
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "github-signing-secret")
+        monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "telegram-signing-secret")
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+        monkeypatch.setenv("GITHUB_TOKEN", "outer-github-token")
         c = _make_codex(webhook_secret="s3cr3t")
         proc = _make_mock_proc(_handshake_lines())
 
@@ -1562,6 +1568,12 @@ class TestSubprocessConstruction:
 
         call_kwargs = mock_exec.call_args[1]
         assert call_kwargs["env"]["KAI_WEBHOOK_SECRET"] == "s3cr3t"
+        assert "WEBHOOK_SECRET" not in call_kwargs["env"]
+        assert "GENERIC_WEBHOOK_SECRET" not in call_kwargs["env"]
+        assert "GITHUB_WEBHOOK_SECRET" not in call_kwargs["env"]
+        assert "TELEGRAM_WEBHOOK_SECRET" not in call_kwargs["env"]
+        assert "TELEGRAM_BOT_TOKEN" not in call_kwargs["env"]
+        assert "GITHUB_TOKEN" not in call_kwargs["env"]
 
 
 # ── Per-user OAuth isolation (codex_user / sudo wrap) ─────────────

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,8 @@ _CONFIG_ENV_VARS = [
     "TELEGRAM_BOT_TOKEN",
     "TELEGRAM_WEBHOOK_URL",
     "TELEGRAM_WEBHOOK_SECRET",
+    "GITHUB_WEBHOOK_SECRET",
+    "GENERIC_WEBHOOK_SECRET",
     "ALLOWED_USER_IDS",
     "DEFAULT_MODEL",
     "CLAUDE_MODEL",
@@ -376,10 +378,56 @@ class TestLoadConfigOptional:
         config = load_config()
         assert config.workspace_base == tmp_path
 
-    def test_webhook_secret(self, monkeypatch):
+    def test_explicit_webhook_secrets_are_separate(self, monkeypatch):
         _set_required(monkeypatch)
-        monkeypatch.setenv("WEBHOOK_SECRET", "s3cret")
-        assert load_config().webhook_secret == "s3cret"
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "github-secret")
+        monkeypatch.setenv("GENERIC_WEBHOOK_SECRET", "generic-secret")
+        config = load_config()
+        assert config.github_webhook_secret == "github-secret"
+        assert config.generic_webhook_secret == "generic-secret"
+
+    def test_legacy_webhook_secret_stays_separate_for_external_fallback(self, monkeypatch, caplog):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("WEBHOOK_SECRET", "legacy-secret")
+
+        with caplog.at_level(logging.WARNING, logger="kai.config"):
+            config = load_config()
+
+        assert config.github_webhook_secret == ""
+        assert config.generic_webhook_secret == ""
+        assert config.webhook_secret == "legacy-secret"
+        assert "deprecated" in caplog.text
+        assert "/webhook/github and /webhook only" in caplog.text
+
+    def test_explicit_generic_secret_wins_over_legacy(self, monkeypatch, caplog):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("GENERIC_WEBHOOK_SECRET", "generic-secret")
+        monkeypatch.setenv("WEBHOOK_SECRET", "legacy-secret")
+
+        with caplog.at_level(logging.WARNING, logger="kai.config"):
+            config = load_config()
+
+        assert config.generic_webhook_secret == "generic-secret"
+        assert config.github_webhook_secret == ""
+        assert config.webhook_secret == "legacy-secret"
+        assert "temporary compatibility authentication" in caplog.text
+
+    @pytest.mark.parametrize(
+        ("left_name", "right_name"),
+        [
+            ("GITHUB_WEBHOOK_SECRET", "GENERIC_WEBHOOK_SECRET"),
+            ("TELEGRAM_WEBHOOK_SECRET", "GITHUB_WEBHOOK_SECRET"),
+            ("TELEGRAM_WEBHOOK_SECRET", "GENERIC_WEBHOOK_SECRET"),
+        ],
+    )
+    def test_ingress_secrets_must_be_distinct(self, monkeypatch, left_name, right_name):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.com/webhook/telegram")
+        monkeypatch.setenv(left_name, "reused-secret")
+        monkeypatch.setenv(right_name, "reused-secret")
+
+        with pytest.raises(SystemExit, match="must use different values"):
+            load_config()
 
     def test_allowed_workspaces_default_empty(self, monkeypatch):
         _set_required(monkeypatch)
@@ -452,35 +500,38 @@ class TestTelegramWebhookConfig:
         """With TELEGRAM_WEBHOOK_URL set, config selects webhook mode."""
         _set_required(monkeypatch)
         monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.com/webhook/telegram")
-        monkeypatch.setenv("WEBHOOK_SECRET", "shared-secret")
+        monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "telegram-secret")
         config = load_config()
         assert config.telegram_webhook_url == "https://example.com/webhook/telegram"
 
-    def test_secret_defaults_to_webhook_secret(self, monkeypatch):
-        """TELEGRAM_WEBHOOK_SECRET falls back to WEBHOOK_SECRET when unset."""
+    def test_secret_is_generated_when_unset(self, monkeypatch):
+        """Webhook mode gets a process credential without reusing another domain's secret."""
         _set_required(monkeypatch)
         monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.com/webhook/telegram")
-        monkeypatch.setenv("WEBHOOK_SECRET", "shared-secret")
-        # TELEGRAM_WEBHOOK_SECRET deliberately not set
-        config = load_config()
-        assert config.telegram_webhook_secret == "shared-secret"
+        monkeypatch.setenv("WEBHOOK_SECRET", "legacy-secret")
+        monkeypatch.setattr("kai.config.secrets.token_urlsafe", lambda _n: "generated-telegram-secret")
 
-    def test_explicit_secret_overrides_fallback(self, monkeypatch):
+        config = load_config()
+        assert config.telegram_webhook_secret == "generated-telegram-secret"
+
+    def test_explicit_secret_is_used(self, monkeypatch):
         """TELEGRAM_WEBHOOK_SECRET uses its own value when explicitly set."""
         _set_required(monkeypatch)
         monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.com/webhook/telegram")
-        monkeypatch.setenv("WEBHOOK_SECRET", "shared-secret")
+        monkeypatch.setenv("WEBHOOK_SECRET", "legacy-secret")
         monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "tg-only-secret")
         config = load_config()
         assert config.telegram_webhook_secret == "tg-only-secret"
 
-    def test_webhook_url_without_secret_raises(self, monkeypatch):
-        """Webhook mode with no secret is rejected to prevent open endpoint."""
+    def test_generated_secret_does_not_require_external_secret(self, monkeypatch):
+        """Webhook mode stays authenticated even when no external webhook is enabled."""
         _set_required(monkeypatch)
         monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.com/webhook/telegram")
-        # Neither TELEGRAM_WEBHOOK_SECRET nor WEBHOOK_SECRET set
-        with pytest.raises(SystemExit, match="TELEGRAM_WEBHOOK_SECRET"):
-            load_config()
+        monkeypatch.setattr("kai.config.secrets.token_urlsafe", lambda _n: "generated-telegram-secret")
+
+        config = load_config()
+
+        assert config.telegram_webhook_secret == "generated-telegram-secret"
 
     def test_polling_mode_ignores_missing_secret(self, monkeypatch):
         """In polling mode, missing secrets are fine (no webhook to protect)."""
@@ -964,7 +1015,7 @@ class TestGitHubReposWarning:
 _MINIMAL_GLOBAL_ENV = {
     "TELEGRAM_BOT_TOKEN": "fake-token",
     "WEBHOOK_PORT": "8080",
-    "WEBHOOK_SECRET": "test-secret",
+    "GENERIC_WEBHOOK_SECRET": "test-secret",
 }
 
 
@@ -2447,9 +2498,10 @@ class TestCodexModelsSurface:
     constants with no overlap requirement and no fallback path.
     """
 
-    def test_codex_models_includes_gpt55_and_codex_variants(self):
+    def test_codex_models_includes_current_alias_and_codex_variants(self):
         from kai.config import CODEX_MODELS
 
+        assert "gpt-5.6" in CODEX_MODELS
         assert "gpt-5.5" in CODEX_MODELS
         assert "gpt-5.3-codex" in CODEX_MODELS
         assert "gpt-5.3-codex-spark" in CODEX_MODELS
@@ -2485,6 +2537,7 @@ class TestValidateModelForBackend:
     def test_codex_accepts_codex_models(self):
         from kai.config import validate_model_for_backend
 
+        assert validate_model_for_backend("gpt-5.6", "codex", "openai") is True
         assert validate_model_for_backend("gpt-5.5", "codex", "openai") is True
         assert validate_model_for_backend("gpt-5.4-mini", "codex", "openai") is True
 
@@ -2859,7 +2912,7 @@ class TestDefaultTimeoutRename:
             "ALLOWED_USER_IDS": "12345",
             "DEFAULT_MODEL": "sonnet",
             "WEBHOOK_PORT": "8080",
-            "WEBHOOK_SECRET": "test-secret",
+            "GENERIC_WEBHOOK_SECRET": "test-secret",
         }
         base.update(overrides)
         for k, v in base.items():
@@ -2917,7 +2970,7 @@ class TestAgentSessionLifecycleRename:
             "ALLOWED_USER_IDS": "12345",
             "DEFAULT_MODEL": "sonnet",
             "WEBHOOK_PORT": "8080",
-            "WEBHOOK_SECRET": "test-secret",
+            "GENERIC_WEBHOOK_SECRET": "test-secret",
         }
         base.update(overrides)
         for k, v in base.items():
@@ -2977,7 +3030,7 @@ class TestLoadConfigBackendAwareModelValidation:
             "TELEGRAM_BOT_TOKEN": "test-token",
             "ALLOWED_USER_IDS": "12345",
             "WEBHOOK_PORT": "8080",
-            "WEBHOOK_SECRET": "test-secret",
+            "GENERIC_WEBHOOK_SECRET": "test-secret",
         }
         base.update(overrides)
         for k, v in base.items():
@@ -3381,7 +3434,7 @@ class TestLoadMemoryProjects:
             monkeypatch.delenv(v, raising=False)
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
         monkeypatch.setenv("ALLOWED_USER_IDS", "12345")
-        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+        monkeypatch.setenv("GENERIC_WEBHOOK_SECRET", "test-secret")
         _patch_protected_users_yaml(
             monkeypatch,
             "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n",

--- a/tests/test_eval_modeswitch.py
+++ b/tests/test_eval_modeswitch.py
@@ -520,71 +520,15 @@ class TestExtractionCallSiteGating:
 
 
 class TestCheckSubcommand:
-    """check subcommand's tri-state exit code contract: 0 on a clean
-    read, 2 on missing WEBHOOK_SECRET, 1 on health-down or unexpected
-    stats status. Tests monkeypatch the `_http_get` helper to drive
-    each branch without standing up an HTTP server."""
-
-    def test_check_missing_secret_exits_2(self, monkeypatch, capsys) -> None:
-        """WEBHOOK_SECRET not exported at all: print the
-        not-set hint and exit 2 BEFORE making any HTTP call."""
-        monkeypatch.delenv("WEBHOOK_SECRET", raising=False)
-
-        # _http_get must NOT be called on this path. If it is,
-        # the HTTP shim would try to reach localhost:8080, which
-        # might pick up the running production service and skew
-        # the test. Explicit raise on call surfaces the regression.
-        def _no_http(*args, **kwargs):
-            raise AssertionError("_http_get must not be called when secret is missing")
-
-        monkeypatch.setattr(modeswitch, "_http_get", _no_http)
-        rc = modeswitch._run_check()
-        assert rc == 2
-        out = capsys.readouterr().out
-        # Pin all three lines the production code emits on the
-        # missing-secret path. The example-command line is part of
-        # the diagnostic shape; dropping it would leave the operator
-        # without the actionable next step.
-        assert "secret_found: no" in out
-        assert "WEBHOOK_SECRET not set" in out
-        assert "sudo bash -c 'source /etc/kai/env" in out
-
-    def test_check_empty_secret_exits_2_with_distinct_diagnostic(self, monkeypatch, capsys) -> None:
-        """WEBHOOK_SECRET exported but set to the empty string:
-        report `secret_found: empty` (not `no`) and exit 2 with a
-        diagnostic that points the operator at the env-file typo,
-        not at sourcing the env file. The two cases are
-        operationally distinct: one is "you didn't source", the
-        other is "you sourced but the value is wrong"."""
-        monkeypatch.setenv("WEBHOOK_SECRET", "")
-
-        def _no_http(*args, **kwargs):
-            raise AssertionError("_http_get must not be called when secret is empty")
-
-        monkeypatch.setattr(modeswitch, "_http_get", _no_http)
-        rc = modeswitch._run_check()
-        assert rc == 2
-        out = capsys.readouterr().out
-        # Pin all three lines the production code emits on the
-        # empty-secret path. The "a line like" parenthetical is the
-        # actionable hint pointing at the env-file typo shape; the
-        # operator needs it to know what to look for.
-        assert "secret_found: empty" in out
-        assert "exported but empty" in out
-        assert "a line like" in out
-        # The distinct diagnostic must NOT collapse back to the
-        # not-set messaging that the operator already ruled out by
-        # sourcing the env file.
-        assert "WEBHOOK_SECRET not set" not in out
+    """The runtime check reads the non-sensitive mode from /health."""
 
     def test_check_health_down_exits_1(self, monkeypatch, capsys) -> None:
         """Health probe returns non-200: report `health: down`, skip
         the stats probe, and exit 1. Prompt-version probe still runs
         because operators want the deploy version visible even when
         the service is down."""
-        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
 
-        def _http_health_down(url, secret=None, timeout=5.0):
+        def _http_health_down(url, timeout=5.0):
             if "/health" in url:
                 return 500, b""
             raise AssertionError(f"unexpected url: {url}")
@@ -594,132 +538,53 @@ class TestCheckSubcommand:
         rc = modeswitch._run_check()
         assert rc == 1
         out = capsys.readouterr().out
-        # Pin every line the production code emits on the health-
-        # down path: secret_found, health, mode, and BOTH prompt
-        # versions. A regression that drops any of these lines
-        # silently (e.g., an early-return that skips the prompt-
-        # version probe) would go undetected without all four
-        # assertions; pinning the full output shape closes that
-        # gap.
-        assert "secret_found: yes" in out
         assert "health: down" in out
         assert "mode: unknown(service-down)" in out
         assert "extraction_prompt_version: 7" in out
         assert "episode_prompt_version: 1" in out
 
-    def test_check_stats_503_reports_disabled(self, monkeypatch, capsys) -> None:
-        """Stats probe returns 503 (memory disabled): report
-        `mode: disabled` and exit 0. The 503 is the documented
-        memory-disabled response from the @_require_secret-protected
-        endpoint."""
-        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
-
-        def _http_disabled(url, secret=None, timeout=5.0):
-            if "/health" in url:
-                return 200, b'{"status": "ok"}'
-            if "/api/memory/stats" in url:
-                # Auth header MUST be present. The test asserts the
-                # secret was threaded through; without this, a
-                # regression that dropped the X-Webhook-Secret header
-                # would let the test pass against a 401 (which the
-                # caller would then mis-classify).
-                assert secret == "test-secret", f"expected secret to be threaded; got {secret!r}"
-                # URL must NOT carry an explicit chat_id. The
-                # webhook handler resolves chat_id BEFORE the
-                # is_enabled() branch and rejects any explicit
-                # value not in allowed_user_ids with a 403; an
-                # earlier version of this harness passed chat_id=1
-                # and silently 403'd against production. Pinning
-                # the absence here closes the regression.
-                assert "chat_id" not in url, f"stats URL must not carry a chat_id parameter; got {url!r}"
-                return 503, b'{"error": "memory disabled"}'
-            raise AssertionError(f"unexpected url: {url}")
+    def test_check_health_reports_disabled(self, monkeypatch, capsys) -> None:
+        def _http_disabled(url, timeout=5.0):
+            assert url.endswith("/health")
+            return 200, b'{"status": "ok", "memory_enabled": false}'
 
         monkeypatch.setattr(modeswitch, "_http_get", _http_disabled)
         monkeypatch.setattr(modeswitch, "_read_prompt_versions", lambda: ("7", "1"))
         rc = modeswitch._run_check()
         assert rc == 0
         out = capsys.readouterr().out
-        # Pin every line the production code emits on the disabled
-        # mode path. Same shape as test_check_health_down_exits_1.
-        assert "secret_found: yes" in out
         assert "health: ok" in out
         assert "mode: disabled" in out
         assert "extraction_prompt_version: 7" in out
         assert "episode_prompt_version: 1" in out
 
-    def test_check_stats_200_reports_enabled(self, monkeypatch, capsys) -> None:
-        """Stats probe returns 200 with a stats payload (memory
-        enabled): report `mode: enabled` and exit 0."""
-        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
-
-        def _http_enabled(url, secret=None, timeout=5.0):
-            if "/health" in url:
-                return 200, b'{"status": "ok"}'
-            if "/api/memory/stats" in url:
-                # Same auth-header threading guard as the disabled
-                # test: a regression that drops `secret=secret` at
-                # the stats call site would let the test pass against
-                # an unauthed 200 (which the production code would
-                # never see in real life, but the test should not
-                # silently accept), masking the regression. Pinned
-                # symmetrically across all stats-touching mocks.
-                assert secret == "test-secret", f"expected secret to be threaded; got {secret!r}"
-                # URL must NOT carry an explicit chat_id (see the
-                # disabled-test comment for the 403-against-prod
-                # rationale).
-                assert "chat_id" not in url, f"stats URL must not carry a chat_id parameter; got {url!r}"
-                return 200, b'{"total_count": 42}'
-            raise AssertionError(f"unexpected url: {url}")
+    def test_check_health_reports_enabled(self, monkeypatch, capsys) -> None:
+        def _http_enabled(url, timeout=5.0):
+            assert url.endswith("/health")
+            return 200, b'{"status": "ok", "memory_enabled": true}'
 
         monkeypatch.setattr(modeswitch, "_http_get", _http_enabled)
         monkeypatch.setattr(modeswitch, "_read_prompt_versions", lambda: ("7", "1"))
         rc = modeswitch._run_check()
         assert rc == 0
         out = capsys.readouterr().out
-        # Pin every line the production code emits on the enabled
-        # mode path. Same shape as the disabled, health-down, and
-        # unexpected-status test cases.
-        assert "secret_found: yes" in out
         assert "health: ok" in out
         assert "mode: enabled" in out
         assert "extraction_prompt_version: 7" in out
         assert "episode_prompt_version: 1" in out
 
-    def test_check_stats_unexpected_status_exits_1(self, monkeypatch, capsys) -> None:
-        """Stats probe returns a status that's neither 200 nor 503
-        (e.g. 401 from a wrong secret, or a 500 server error): report
-        the status and exit 1. This is the shape that the spec's
-        anti-false-negative argument hinges on; a silent fall-through
-        to 'disabled' here would defeat the entire harness."""
-        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
-
-        def _http_unexpected(url, secret=None, timeout=5.0):
-            if "/health" in url:
-                return 200, b'{"status": "ok"}'
-            if "/api/memory/stats" in url:
-                # Same auth-header threading guard as the disabled
-                # and enabled tests; pinned symmetrically across
-                # all stats-touching mocks.
-                assert secret == "test-secret", f"expected secret to be threaded; got {secret!r}"
-                # URL must NOT carry an explicit chat_id (see the
-                # disabled-test comment for the 403-against-prod
-                # rationale).
-                assert "chat_id" not in url, f"stats URL must not carry a chat_id parameter; got {url!r}"
-                return 401, b'{"error": "unauthorized"}'
-            raise AssertionError(f"unexpected url: {url}")
+    def test_check_invalid_health_payload_exits_1(self, monkeypatch, capsys) -> None:
+        def _http_unexpected(url, timeout=5.0):
+            assert url.endswith("/health")
+            return 200, b'{"status": "ok"}'
 
         monkeypatch.setattr(modeswitch, "_http_get", _http_unexpected)
         monkeypatch.setattr(modeswitch, "_read_prompt_versions", lambda: ("7", "1"))
         rc = modeswitch._run_check()
         assert rc == 1
         out = capsys.readouterr().out
-        # Pin every line the production code emits on the
-        # unexpected-status path. Same shape as the disabled and
-        # health-down test cases.
-        assert "secret_found: yes" in out
         assert "health: ok" in out
-        assert "mode: unknown(401)" in out
+        assert "mode: unknown(health-payload)" in out
         assert "extraction_prompt_version: 7" in out
         assert "episode_prompt_version: 1" in out
 
@@ -729,26 +594,14 @@ class TestCheckSubcommand:
         is what unblocks the rest of the report; without it, the
         harness would crash with ValueError on a config typo.
 
-        Mock follows the same auth-secret + chat_id-absence pattern as
-        the three other stats-touching mocks; full output shape pinned
-        per the same pattern as the four mode-reporting tests."""
-        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+        The health probe remains the only request."""
         monkeypatch.setenv("WEBHOOK_PORT", "not-an-integer")
 
         captured_urls: list[str] = []
 
-        def _http_with_capture(url, secret=None, timeout=5.0):
+        def _http_with_capture(url, timeout=5.0):
             captured_urls.append(url)
-            if "/health" in url:
-                return 200, b'{"status": "ok"}'
-            if "/api/memory/stats" in url:
-                # Auth-secret + chat_id-absence guards parallel to
-                # _http_disabled / _http_enabled / _http_unexpected;
-                # see the disabled-test comment for the rationale.
-                assert secret == "test-secret", f"expected secret to be threaded; got {secret!r}"
-                assert "chat_id" not in url, f"stats URL must not carry a chat_id parameter; got {url!r}"
-                return 200, b'{"total_count": 0}'
-            raise AssertionError(f"unexpected url: {url}")
+            return 200, b'{"status": "ok", "memory_enabled": true}'
 
         monkeypatch.setattr(modeswitch, "_http_get", _http_with_capture)
         monkeypatch.setattr(modeswitch, "_read_prompt_versions", lambda: ("7", "1"))
@@ -760,9 +613,6 @@ class TestCheckSubcommand:
         # Every captured URL must point at port 8080, the documented
         # fallback. Pinning the URL is what proves the fallback ran.
         assert all("localhost:8080" in u for u in captured_urls), captured_urls
-        # Pin the full five-line report shape, parallel to the
-        # other mode-reporting tests in this class.
-        assert "secret_found: yes" in out
         assert "health: ok" in out
         assert "mode: enabled" in out
         assert "extraction_prompt_version: 7" in out
@@ -776,23 +626,14 @@ class TestCheckSubcommand:
         accept and report `health: down (status=0)`, which is the
         confusing diagnostic the range guard exists to prevent.
 
-        Mock follows the same auth-secret + chat_id-absence pattern as
-        the three other stats-touching mocks; full output shape pinned
-        per the same pattern as the four mode-reporting tests."""
-        monkeypatch.setenv("WEBHOOK_SECRET", "test-secret")
+        The health probe remains the only request."""
         monkeypatch.setenv("WEBHOOK_PORT", "99999")
 
         captured_urls: list[str] = []
 
-        def _http_with_capture(url, secret=None, timeout=5.0):
+        def _http_with_capture(url, timeout=5.0):
             captured_urls.append(url)
-            if "/health" in url:
-                return 200, b'{"status": "ok"}'
-            if "/api/memory/stats" in url:
-                assert secret == "test-secret", f"expected secret to be threaded; got {secret!r}"
-                assert "chat_id" not in url, f"stats URL must not carry a chat_id parameter; got {url!r}"
-                return 200, b'{"total_count": 0}'
-            raise AssertionError(f"unexpected url: {url}")
+            return 200, b'{"status": "ok", "memory_enabled": true}'
 
         monkeypatch.setattr(modeswitch, "_http_get", _http_with_capture)
         monkeypatch.setattr(modeswitch, "_read_prompt_versions", lambda: ("7", "1"))
@@ -805,9 +646,6 @@ class TestCheckSubcommand:
         # reading the source.
         assert "out of range" in out
         assert all("localhost:8080" in u for u in captured_urls), captured_urls
-        # Pin the full five-line report shape, parallel to the
-        # other mode-reporting tests in this class.
-        assert "secret_found: yes" in out
         assert "health: ok" in out
         assert "mode: enabled" in out
         assert "extraction_prompt_version: 7" in out

--- a/tests/test_github_self_service.py
+++ b/tests/test_github_self_service.py
@@ -36,7 +36,7 @@ def _make_config(**overrides) -> Config:
         "telegram_bot_token": "test-token",
         "allowed_user_ids": {1},
         "telegram_webhook_url": "https://api.example.com/webhook/telegram",
-        "webhook_secret": "test-secret",
+        "github_webhook_secret": "test-secret",
         "webhook_port": 8080,
     }
     defaults.update(overrides)
@@ -593,6 +593,18 @@ class TestEnsureWebhook:
         """Raises GitHubAPIError(0) when telegram_webhook_url is None."""
         config = _make_config(telegram_webhook_url=None)
         with pytest.raises(GitHubAPIError, match="polling mode"):
+            await _github_api_ensure_webhook("alice/repo", "ghp_test", config)
+
+    @pytest.mark.asyncio
+    async def test_missing_github_secret_raises(self):
+        """GitHub registration cannot borrow a generic or legacy secret."""
+        config = _make_config(
+            github_webhook_secret="",
+            generic_webhook_secret="generic-secret",
+            webhook_secret="legacy-secret",
+        )
+
+        with pytest.raises(GitHubAPIError, match="GITHUB_WEBHOOK_SECRET"):
             await _github_api_ensure_webhook("alice/repo", "ghp_test", config)
 
     @pytest.mark.asyncio

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -48,6 +48,7 @@ from kai.install import (
     _prompt_choice,
     _prompt_optional_choice,
     _read_users_yaml_text,
+    _resolve_codex_bin_prompt_default,
     _retire_install_home_claude,
     _retire_install_home_dir,
     _set_ownership,
@@ -1342,6 +1343,9 @@ class TestCmdConfig:
         assert conf["version"] == 1
         assert conf["install_dir"] == "/opt/kai"
         assert conf["env"]["TELEGRAM_BOT_TOKEN"] == "fake-token"
+        assert conf["env"]["GITHUB_WEBHOOK_SECRET"] == "test-secret"
+        assert conf["env"]["GENERIC_WEBHOOK_SECRET"] != "test-secret"
+        assert "WEBHOOK_SECRET" not in conf["env"]
         # The context window setting was removed; the wizard never
         # emits the retired key.
         assert "CLAUDE_MAX_CONTEXT_WINDOW" not in conf["env"]
@@ -1828,6 +1832,13 @@ class TestCmdConfig:
         # Should preserve existing values when user accepts defaults
         assert conf["install_dir"] == "/custom/path"
         assert conf["env"]["TELEGRAM_BOT_TOKEN"] == "existing-token"
+        # The legacy value remains available to both external routes during
+        # observation. New named credentials are distinct so fallback use can
+        # be identified and logged endpoint by endpoint.
+        assert conf["env"]["GITHUB_WEBHOOK_SECRET"] != "existing-secret"
+        assert conf["env"]["GENERIC_WEBHOOK_SECRET"] != "existing-secret"
+        assert conf["env"]["GITHUB_WEBHOOK_SECRET"] != conf["env"]["GENERIC_WEBHOOK_SECRET"]
+        assert conf["env"]["WEBHOOK_SECRET"] == "existing-secret"
         # With a canonical users.yaml already present the wizard skips the
         # user-creation prompts entirely and never stages a new file, so
         # no admin prompt is shown and no top-level staging key is written.
@@ -2875,6 +2886,59 @@ class TestCmdApply:
         assert not (tmp_path / "opt" / "kai").exists()
         # Secrets reminder should NOT appear during dry run
         assert "contains secrets" not in output
+
+    def test_dry_run_flag_reaches_every_apply_helper(self, tmp_path, monkeypatch):
+        """The apply orchestrator passes True to every mutation boundary.
+
+        This protects the end-to-end contract independently of each helper's
+        own no-mutation tests. A future positional-argument regression at any
+        call site fails here before a privileged dry run can reach that helper
+        with dry_run=False.
+        """
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        monkeypatch.setenv("DRY_RUN", "1")
+        conf_path = tmp_path / "install.conf"
+        conf_path.write_text(
+            json.dumps(
+                {
+                    "install_dir": str(tmp_path / "opt" / "kai"),
+                    "data_dir": str(tmp_path / "var" / "lib" / "kai"),
+                    "service_user": "nobody",
+                    "platform": "darwin",
+                    "env": {"TELEGRAM_BOT_TOKEN": "tok"},
+                }
+            )
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+
+        dry_run_positions = {
+            "_stop_service": 1,
+            "_apply_directories": 4,
+            "_apply_source": 3,
+            "_apply_venv": 2,
+            "_apply_models": 1,
+            "_apply_secrets": 1,
+            "_apply_goose_config": 4,
+            "_apply_sudoers": 1,
+            "_apply_migrate": 4,
+            "_apply_service": 4,
+            "_start_service": 1,
+        }
+        observed: dict[str, bool] = {}
+
+        def recorder(name: str, position: int):
+            def record(*args, **kwargs):
+                value = kwargs.get("dry_run", args[position] if len(args) > position else None)
+                observed[name] = value
+
+            return record
+
+        for name, position in dry_run_positions.items():
+            monkeypatch.setattr(f"kai.install.{name}", recorder(name, position))
+
+        _cmd_apply()
+
+        assert observed == {name: True for name in dry_run_positions}
 
     def test_generates_env_file_content(self):
         """The generated env file contains all provided values."""
@@ -4015,6 +4079,20 @@ class TestCmdStatus:
 class TestApplyVenv:
     """Tests for _apply_venv(), which creates the virtual environment."""
 
+    def test_base_python_falls_back_to_running_interpreter(self, monkeypatch):
+        """A sudo-reset PATH still uses the installer's valid Python 3.13."""
+        monkeypatch.setattr(shutil, "which", lambda name: None)
+        commands = []
+
+        def fake_run(cmd, **kwargs):
+            commands.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="3.13\n", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert kai.install._resolve_venv_base_python() == kai.install.sys.executable
+        assert commands[0][0] == kai.install.sys.executable
+
     def test_rejects_old_python(self, tmp_path, monkeypatch):
         """Exits with a clear error if the resolved Python is below 3.13."""
         install = tmp_path / "opt" / "kai"
@@ -4043,7 +4121,8 @@ class TestApplyVenv:
         """Skips reinstall when both pyproject.toml and source checksums match."""
         install = tmp_path / "opt" / "kai"
         install.mkdir(parents=True)
-        (install / "venv").mkdir()
+        (install / "venv" / "bin").mkdir(parents=True)
+        (install / "venv" / "bin" / "python").touch(mode=0o755)
 
         # Write pyproject.toml and source files
         (install / "pyproject.toml").write_text("[project]\nname = 'kai'\n")
@@ -4067,6 +4146,10 @@ class TestApplyVenv:
         install = tmp_path / "opt" / "kai"
         install.mkdir(parents=True)
         (install / "venv" / "bin").mkdir(parents=True)
+        (install / "venv" / "bin" / "python").touch(mode=0o755)
+        stale_build = install / "build" / "lib" / "kai"
+        stale_build.mkdir(parents=True)
+        (stale_build / "obsolete.py").write_text("# removed source module")
 
         # Write pyproject.toml and initial source
         (install / "pyproject.toml").write_text("[project]\nname = 'kai'\n")
@@ -4094,35 +4177,52 @@ class TestApplyVenv:
 
         output = capsys.readouterr().out
         assert "source changed" in output
+        assert "Removed stale package build artifacts" in output
+        assert not (install / "build").exists()
         assert "Installed package into venv" in output
 
-    def test_reinstalls_on_source_change_dry_run(self, tmp_path, capsys):
-        """Dry run reports source change without actually reinstalling."""
+    def test_reinstalls_on_source_change_dry_run(self, tmp_path, monkeypatch, capsys):
+        """Dry run compares incoming source even though the copy is skipped."""
         install = tmp_path / "opt" / "kai"
         install.mkdir(parents=True)
-        (install / "venv").mkdir()
+        (install / "venv" / "bin").mkdir(parents=True)
+        (install / "venv" / "bin" / "python").touch(mode=0o755)
+        stale_build = install / "build" / "lib" / "kai"
+        stale_build.mkdir(parents=True)
+        (stale_build / "obsolete.py").write_text("# removed source module")
 
         (install / "pyproject.toml").write_text("[project]\nname = 'kai'\n")
         src = install / "src" / "kai"
         src.mkdir(parents=True)
         (src / "bot.py").write_text("# bot v1")
 
-        # Save checksums, then modify source
+        # Save checksums for the currently installed source.
         (install / ".pyproject.sha256").write_text(_file_checksum(install / "pyproject.toml") + "\n")
         (install / ".src.sha256").write_text(_src_checksum(install / "src") + "\n")
-        (src / "bot.py").write_text("# bot v2 - new feature")
+
+        # The incoming repository has changed, but dry-run must not copy it to
+        # the install tree merely to compute the preview.
+        project = tmp_path / "project"
+        (project / "src" / "kai").mkdir(parents=True)
+        (project / "pyproject.toml").write_text("[project]\nname = 'kai'\n")
+        (project / "src" / "kai" / "bot.py").write_text("# bot v2 - new feature")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", project)
 
         _apply_venv(install, is_update=True, dry_run=True)
 
         output = capsys.readouterr().out
         assert "DRY RUN" in output
         assert "source changed" in output
+        assert "Would remove stale package build artifacts" in output
+        assert (install / "build" / "lib" / "kai" / "obsolete.py").exists()
+        assert (install / "src" / "kai" / "bot.py").read_text() == "# bot v1"
 
     def test_saves_both_checksums_after_install(self, tmp_path, monkeypatch):
         """Both .pyproject.sha256 and .src.sha256 are written after a successful install."""
         install = tmp_path / "opt" / "kai"
         install.mkdir(parents=True)
         (install / "venv" / "bin").mkdir(parents=True)
+        (install / "venv" / "bin" / "python").touch(mode=0o755)
 
         (install / "pyproject.toml").write_text("[project]\nname = 'kai'\n")
         src = install / "src" / "kai"
@@ -4152,6 +4252,7 @@ class TestApplyVenv:
         install = tmp_path / "opt" / "kai"
         install.mkdir(parents=True)
         (install / "venv" / "bin").mkdir(parents=True)
+        (install / "venv" / "bin" / "python").touch(mode=0o755)
 
         (install / "pyproject.toml").write_text("[project]\nname = 'kai'\n")
         src = install / "src" / "kai"
@@ -4174,6 +4275,71 @@ class TestApplyVenv:
         # Should reinstall because .src.sha256 is missing (old_src == "" != new_src)
         assert "source changed" in output
         assert "Installed package into venv" in output
+
+    def test_repairs_dangling_venv_python_before_install(self, tmp_path, monkeypatch, capsys):
+        """A Homebrew upgrade leaving a dangling venv symlink is repaired in place."""
+        install = tmp_path / "opt" / "kai"
+        venv_bin = install / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        venv_python = venv_bin / "python"
+        venv_python.symlink_to("python3.13")
+        (venv_bin / "python3").symlink_to("python3.13")
+        (venv_bin / "python3.13").symlink_to("/removed/homebrew/python3.13")
+
+        (install / "pyproject.toml").write_text("[project]\nname = 'kai'\n")
+        src = install / "src" / "kai"
+        src.mkdir(parents=True)
+        (src / "__init__.py").write_text("# init")
+        (install / ".pyproject.sha256").write_text(_file_checksum(install / "pyproject.toml") + "\n")
+        (install / ".src.sha256").write_text(_src_checksum(install / "src") + "\n")
+
+        base_python = "/opt/homebrew/bin/python3.13"
+        monkeypatch.setattr(shutil, "which", lambda name: base_python)
+        commands = []
+
+        def fake_run(cmd, **kwargs):
+            commands.append(cmd)
+            if "-c" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, stdout="3.13\n", stderr="")
+            if cmd[:4] == [base_python, "-m", "venv", "--upgrade"]:
+                venv_python.touch(mode=0o755)
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr("kai.install._set_ownership", lambda *a, **kw: None)
+
+        _apply_venv(install, is_update=True, dry_run=False)
+
+        output = capsys.readouterr().out
+        assert "Repairing venv" in output
+        assert "Removed 3 dangling venv interpreter symlink" in output
+        assert "Repaired venv interpreter" in output
+        assert [base_python, "-m", "venv", "--upgrade", str(install / "venv")] in commands
+        assert [str(venv_python), "-m", "pip", "install", f"{install}[memory,totp,tts]"] in commands
+
+    def test_dry_run_reports_dangling_venv_python_without_repair(self, tmp_path, monkeypatch, capsys):
+        """Dry-run detects a broken venv but never invokes a repair command."""
+        install = tmp_path / "opt" / "kai"
+        venv_bin = install / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "python").symlink_to("/removed/homebrew/python3.13")
+
+        (install / "pyproject.toml").write_text("[project]\nname = 'kai'\n")
+        src = install / "src" / "kai"
+        src.mkdir(parents=True)
+        (src / "__init__.py").write_text("# init")
+        (install / ".pyproject.sha256").write_text(_file_checksum(install / "pyproject.toml") + "\n")
+        (install / ".src.sha256").write_text(_src_checksum(install / "src") + "\n")
+
+        def fail_run(*args, **kwargs):
+            raise AssertionError("dry-run must not invoke subprocess.run")
+
+        monkeypatch.setattr(subprocess, "run", fail_run)
+
+        _apply_venv(install, is_update=True, dry_run=True)
+
+        output = capsys.readouterr().out
+        assert "[DRY RUN] Would repair venv" in output
 
 
 class TestSrcChecksum:
@@ -5487,6 +5653,42 @@ class TestCli:
         assert captured_env.get("DRY_RUN") == "1"
 
 
+class TestMakeInstallDryRun:
+    """The Make layer must carry dry-run intent across sudo explicitly."""
+
+    @staticmethod
+    def _clean_env() -> dict[str, str]:
+        env = os.environ.copy()
+        env.pop("DRY_RUN", None)
+        return env
+
+    @pytest.mark.skipif(shutil.which("make") is None, reason="make is not installed")
+    def test_nonempty_dry_run_adds_explicit_cli_flag(self):
+        result = subprocess.run(
+            ["make", "-n", "DRY_RUN=1", "install"],
+            cwd=Path(__file__).resolve().parents[1],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=self._clean_env(),
+        )
+
+        assert "install apply --dry-run" in result.stdout
+
+    @pytest.mark.skipif(shutil.which("make") is None, reason="make is not installed")
+    def test_normal_install_does_not_add_dry_run_flag(self):
+        result = subprocess.run(
+            ["make", "-n", "install"],
+            cwd=Path(__file__).resolve().parents[1],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=self._clean_env(),
+        )
+
+        assert "install apply --dry-run" not in result.stdout
+
+
 # ── _set_ownership ───────────────────────────────────────────────────
 
 
@@ -5584,6 +5786,21 @@ class TestCopyTree:
 
         assert (dst / "new.py").read_text() == "new"
         assert (dst / "runtime_data.txt").read_text() == "must survive"
+
+    def test_replace_removes_destination_only_files(self, tmp_path: Path) -> None:
+        """Generated trees can opt into exact replacement to remove stale files."""
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "current.py").write_text("current")
+
+        dst = tmp_path / "dst"
+        dst.mkdir()
+        (dst / "obsolete.py").write_text("obsolete")
+
+        _copy_tree(src, dst, replace=True)
+
+        assert (dst / "current.py").read_text() == "current"
+        assert not (dst / "obsolete.py").exists()
 
     def test_overwrites_matching_files(self, tmp_path: Path) -> None:
         """Source files overwrite same-named destination files."""
@@ -5842,6 +6059,14 @@ class TestApplySource:
         config_dst = install / "config"
         config_calls = [c for c in mock_copy.call_args_list if c[0][0] == config_dir and c[0][1] == config_dst]
         assert len(config_calls) == 1
+
+        # Installed Python source is generated state and must be replaced
+        # exactly so repository deletions remove obsolete installed modules.
+        source_dir = src / "src"
+        source_dst = install / "src"
+        source_calls = [c for c in mock_copy.call_args_list if c[0][0] == source_dir and c[0][1] == source_dst]
+        assert len(source_calls) == 1
+        assert source_calls[0].kwargs["replace"] is True
 
         # <install>/config/ should be root-owned (static template, not runtime data)
         own_calls = [c for c in mock_own.call_args_list if c[0] == (config_dst, 0, 0) and c[1].get("recursive") is True]
@@ -8620,6 +8845,34 @@ class TestValidateCodexBin:
         f.write_text("#!/bin/sh\necho hi\n")
         f.chmod(0o755)
         assert _validate_codex_bin(str(f)) is True
+
+
+class TestResolveCodexBinPromptDefault:
+    """Upgrade-safe default selection for the Codex wizard prompt."""
+
+    def test_valid_saved_path_remains_authoritative(self, tmp_path, monkeypatch):
+        saved = tmp_path / "saved-codex"
+        saved.write_text("#!/bin/sh\n")
+        saved.chmod(0o755)
+        detected = tmp_path / "detected-codex"
+        detected.write_text("#!/bin/sh\n")
+        detected.chmod(0o755)
+        monkeypatch.setattr("kai.install.shutil.which", lambda command: str(detected))
+
+        result = _resolve_codex_bin_prompt_default({"CODEX_BIN": str(saved)})
+
+        assert result == str(saved)
+
+    def test_stale_saved_path_recovers_to_detected_executable(self, tmp_path, monkeypatch):
+        stale = tmp_path / "moved-codex"
+        detected = tmp_path / "detected-codex"
+        detected.write_text("#!/bin/sh\n")
+        detected.chmod(0o755)
+        monkeypatch.setattr("kai.install.shutil.which", lambda command: str(detected))
+
+        result = _resolve_codex_bin_prompt_default({"CODEX_BIN": str(stale)})
+
+        assert result == str(detected)
 
 
 class TestValidateOpenCodeBin:

--- a/tests/test_internal_api_auth.py
+++ b/tests/test_internal_api_auth.py
@@ -1,0 +1,44 @@
+"""Tests for principal-bound internal API credentials."""
+
+import pytest
+
+from kai.internal_api_auth import InternalAPIAuth, InternalAPIScope
+
+
+def test_agent_credentials_are_unique_and_resolve_server_side() -> None:
+    """Each user receives a distinct token that resolves to only that user."""
+    auth = InternalAPIAuth.for_users({123, 456})
+
+    token_123 = auth.agent_credential_for(123)
+    token_456 = auth.agent_credential_for(456)
+    principal_123 = auth.authenticate(token_123)
+    principal_456 = auth.authenticate(token_456)
+
+    assert token_123 != token_456
+    assert principal_123 is not None
+    assert principal_456 is not None
+    assert principal_123.chat_id == 123
+    assert principal_456.chat_id == 456
+    assert auth.authenticate("not-a-token") is None
+
+
+def test_notification_credential_has_only_message_scope() -> None:
+    """One-shot notification agents cannot access jobs, files, services, or memory."""
+    auth = InternalAPIAuth()
+    principal = auth.authenticate(auth.notification_credential_for(-100123))
+
+    assert principal is not None
+    assert principal.chat_id == -100123
+    assert principal.allows(InternalAPIScope.MESSAGES_SEND)
+    assert not principal.allows(InternalAPIScope.JOBS_READ)
+    assert not principal.allows(InternalAPIScope.JOBS_WRITE)
+    assert not principal.allows(InternalAPIScope.SERVICES_CALL)
+    assert not principal.allows(InternalAPIScope.FILES_SEND)
+    assert not principal.allows(InternalAPIScope.MEMORY_READ)
+    assert not principal.allows(InternalAPIScope.MEMORY_WRITE)
+
+
+def test_fixed_test_credentials_must_be_unique() -> None:
+    """Ambiguous credential-to-principal mappings are rejected."""
+    with pytest.raises(ValueError, match="unique"):
+        InternalAPIAuth({123: "same", 456: "same"})

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -70,6 +70,28 @@ class TestInstanceCreation:
         a = pool.get(111)
         b = pool.get(222)
         assert a is not b
+        assert a._api_context.webhook_secret != b._api_context.webhook_secret
+        assert a._api_context.webhook_secret != "secret"
+        assert b._api_context.webhook_secret != "secret"
+
+    def test_internal_api_credential_exists_without_external_webhooks(self):
+        """Disabling public ingress must not remove the agent's scoped API."""
+        pool = SubprocessPool(
+            config=_make_config(
+                webhook_secret="",
+                github_webhook_secret="",
+                generic_webhook_secret="",
+            ),
+            services_info=[],
+        )
+
+        instance = pool.get(111)
+
+        credential = instance._api_context.webhook_secret
+        assert credential
+        principal = pool.internal_api_auth.authenticate(credential)
+        assert principal is not None
+        assert principal.chat_id == 111
 
     def test_get_uses_user_config(self, tmp_path):
         """User with os_user and home_workspace gets correct instance."""

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -12,17 +12,19 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from kai.config import UserConfig
+from kai.internal_api_auth import InternalAPIAuth, InternalAPIScope
 from kai.webhook import (
     ALLOWED_USER_IDS_KEY,
     ALLOWED_WORKSPACES_KEY,
     CHAT_ID_KEY,
     CONFIG_KEY,
+    GITHUB_WEBHOOK_SECRET_KEY,
+    INTERNAL_API_AUTH_KEY,
     PR_REVIEW_COOLDOWN_KEY,
     PR_REVIEW_TIMEOUT_S_KEY,
     SPEC_DIR_KEY,
     TELEGRAM_BOT_KEY,
     WEBHOOK_PORT_KEY,
-    WEBHOOK_SECRET_KEY,
     WORKSPACE_BASE_KEY,
     _fmt_issue_comment,
     _fmt_issues,
@@ -415,7 +417,8 @@ def _build_test_app(
     Tests should mock sessions.resolve_github_settings to control these.
     """
     app = web.Application()
-    app[WEBHOOK_SECRET_KEY] = _TEST_SECRET
+    app[GITHUB_WEBHOOK_SECRET_KEY] = _TEST_SECRET
+    app[INTERNAL_API_AUTH_KEY] = InternalAPIAuth()
     app[PR_REVIEW_COOLDOWN_KEY] = cooldown
     # Review subprocess resource limits (defaults match config.py).
     app[PR_REVIEW_TIMEOUT_S_KEY] = 900
@@ -734,7 +737,13 @@ class TestPRReviewRouting:
             # Verify the payload and config were passed correctly
             assert call_kwargs[0][0] == payload
             assert call_kwargs[1]["webhook_port"] == 8080
-            assert call_kwargs[1]["webhook_secret"] == _TEST_SECRET
+            credential = call_kwargs[1]["webhook_secret"]
+            assert credential != _TEST_SECRET
+            principal = app[INTERNAL_API_AUTH_KEY].authenticate(credential)
+            assert principal is not None
+            assert principal.chat_id == 12345
+            assert principal.allows(InternalAPIScope.MESSAGES_SEND)
+            assert not principal.allows(InternalAPIScope.JOBS_WRITE)
             # model_override must be a real string, not a mock. The
             # dataclass-shaped defaults on the fixture config let
             # resolve_user_model return the registry default for the
@@ -2154,11 +2163,11 @@ class TestPerUserRouting:
 
 
 class TestAllowedChatIdMutations:
-    """Tests for the live allowed_user_ids set mutation functions.
+    """Tests for the legacy live notification-destination registry.
 
     These functions are called by bot.py when /github notify modifies
-    a notification destination, keeping the in-memory set in sync with
-    the database without requiring a restart.
+    a notification destination. The registry must remain detached from
+    Config.allowed_user_ids so outbound changes cannot authorize senders.
     """
 
     def test_add_allowed_chat_id(self):
@@ -2189,6 +2198,22 @@ class TestAllowedChatIdMutations:
             # Sets don't have duplicates; just verify it's present
             assert 999 in app[ALLOWED_USER_IDS_KEY]
             assert len(app[ALLOWED_USER_IDS_KEY]) == 2  # {100, 999}
+        finally:
+            wh._app = old_app
+
+    def test_add_does_not_mutate_inbound_principals(self):
+        """Adding an outbound destination cannot authorize a Telegram user."""
+        import kai.webhook as wh
+
+        inbound_principals = {100}
+        app = web.Application()
+        app[ALLOWED_USER_IDS_KEY] = set(inbound_principals)
+        old_app = wh._app
+        wh._app = app
+        try:
+            add_allowed_chat_id(999)
+            assert app[ALLOWED_USER_IDS_KEY] == {100, 999}
+            assert inbound_principals == {100}
         finally:
             wh._app = old_app
 

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -10,17 +10,22 @@ import pytest
 from aiohttp import web
 
 from kai import sessions
+from kai.internal_api_auth import InternalAPIAuth, InternalAPIPrincipal
 from kai.services import ServiceResponse
 from kai.webhook import (
     ALLOWED_USER_IDS_KEY,
     CHAT_ID_KEY,
     CONFIG_KEY,
+    GENERIC_WEBHOOK_SECRET_KEY,
+    GITHUB_WEBHOOK_SECRET_KEY,
+    INTERNAL_API_AUTH_KEY,
+    LEGACY_WEBHOOK_SECRET_KEY,
     POOL_KEY,
     PR_REVIEW_COOLDOWN_KEY,
     TELEGRAM_APP_KEY,
     TELEGRAM_BOT_KEY,
     TELEGRAM_WEBHOOK_SECRET_KEY,
-    WEBHOOK_SECRET_KEY,
+    UnauthorizedChatIdError,
     _handle_delete_job,
     _handle_generic,
     _handle_get_job,
@@ -40,6 +45,11 @@ from kai.webhook import (
 )
 
 
+def _make_internal_api_auth() -> InternalAPIAuth:
+    """Create deterministic credentials for the two API test principals."""
+    return InternalAPIAuth({123: "test-secret", 456: "other-secret"})
+
+
 @pytest.fixture
 async def db(tmp_path):
     """Initialize a fresh database for each test."""
@@ -53,7 +63,8 @@ def mock_request():
     """Create a minimal mock request with app dict and helpers."""
     request = MagicMock(spec=web.Request)
     request.app = {
-        WEBHOOK_SECRET_KEY: "test-secret",
+        INTERNAL_API_AUTH_KEY: _make_internal_api_auth(),
+        GENERIC_WEBHOOK_SECRET_KEY: "signing-secret",
         TELEGRAM_APP_KEY: MagicMock(),
         TELEGRAM_BOT_KEY: AsyncMock(),
         CHAT_ID_KEY: 123,
@@ -342,7 +353,8 @@ def send_file_request(tmp_path):
     mock_pool.get_effective_workspace = AsyncMock(return_value=tmp_path)
     request = MagicMock(spec=web.Request)
     request.app = {
-        WEBHOOK_SECRET_KEY: "test-secret",
+        INTERNAL_API_AUTH_KEY: _make_internal_api_auth(),
+        GENERIC_WEBHOOK_SECRET_KEY: "signing-secret",
         TELEGRAM_BOT_KEY: AsyncMock(),
         CHAT_ID_KEY: 123,
         POOL_KEY: mock_pool,
@@ -431,7 +443,8 @@ def send_message_request():
     """Create a mock request for the send-message endpoint."""
     request = MagicMock(spec=web.Request)
     request.app = {
-        WEBHOOK_SECRET_KEY: "test-secret",
+        INTERNAL_API_AUTH_KEY: _make_internal_api_auth(),
+        GENERIC_WEBHOOK_SECRET_KEY: "signing-secret",
         TELEGRAM_BOT_KEY: AsyncMock(),
         CHAT_ID_KEY: 123,
     }
@@ -536,6 +549,16 @@ class TestTelegramUpdate:
         assert resp.status == 401
         telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_not_called()
 
+    async def test_legacy_webhook_secret_is_not_accepted(self, telegram_request):
+        """The external transition credential never crosses into Telegram auth."""
+        telegram_request.app[LEGACY_WEBHOOK_SECRET_KEY] = "legacy-secret"
+        telegram_request.headers = {"X-Telegram-Bot-Api-Secret-Token": "legacy-secret"}
+
+        resp = await _handle_telegram_update(telegram_request)
+
+        assert resp.status == 401
+        telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_not_called()
+
     async def test_missing_secret_returns_401(self, telegram_request):
         """Missing secret header returns 401."""
         telegram_request.headers = {}
@@ -585,7 +608,8 @@ def github_request():
     mock_config.user_configs = {}
     request = MagicMock(spec=web.Request)
     request.app = {
-        WEBHOOK_SECRET_KEY: "test-secret",
+        INTERNAL_API_AUTH_KEY: _make_internal_api_auth(),
+        GITHUB_WEBHOOK_SECRET_KEY: "test-secret",
         TELEGRAM_BOT_KEY: AsyncMock(),
         CHAT_ID_KEY: 12345,
         CONFIG_KEY: mock_config,
@@ -703,6 +727,39 @@ class TestGitHubWebhook:
         assert resp.status == 401
         github_request.app[TELEGRAM_BOT_KEY].send_message.assert_not_called()
 
+    async def test_legacy_signature_is_accepted_and_logged(self, github_request, caplog):
+        """An existing GitHub registration stays live and produces migration telemetry."""
+        body = b'{"zen": "migration"}'
+        github_request.app[LEGACY_WEBHOOK_SECRET_KEY] = "legacy-secret"
+        github_request.read = AsyncMock(return_value=body)
+        github_request.headers = {
+            "X-Hub-Signature-256": _sign_body("legacy-secret", body),
+            "X-GitHub-Event": "ping",
+        }
+
+        with caplog.at_level("WARNING", logger="kai.webhook"):
+            resp = await _handle_github(github_request)
+
+        assert resp.status == 200
+        assert "Legacy WEBHOOK_SECRET authenticated /webhook/github" in caplog.text
+        assert "GITHUB_WEBHOOK_SECRET" in caplog.text
+
+    async def test_named_signature_does_not_log_legacy_use(self, github_request, caplog):
+        """The primary named credential wins even while compatibility is configured."""
+        body = b'{"zen": "named"}'
+        github_request.app[LEGACY_WEBHOOK_SECRET_KEY] = "legacy-secret"
+        github_request.read = AsyncMock(return_value=body)
+        github_request.headers = {
+            "X-Hub-Signature-256": _sign_body("test-secret", body),
+            "X-GitHub-Event": "ping",
+        }
+
+        with caplog.at_level("WARNING", logger="kai.webhook"):
+            resp = await _handle_github(github_request)
+
+        assert resp.status == 200
+        assert "Legacy WEBHOOK_SECRET authenticated" not in caplog.text
+
     async def test_ping_event_returns_pong(self, github_request):
         """GitHub ping events are acknowledged without sending to Telegram."""
         body = b'{"zen": "testing"}'
@@ -778,7 +835,8 @@ def generic_request():
     """Create a mock request for the generic webhook endpoint."""
     request = MagicMock(spec=web.Request)
     request.app = {
-        WEBHOOK_SECRET_KEY: "test-secret",
+        INTERNAL_API_AUTH_KEY: _make_internal_api_auth(),
+        GENERIC_WEBHOOK_SECRET_KEY: "test-secret",
         TELEGRAM_BOT_KEY: AsyncMock(),
         CHAT_ID_KEY: 12345,
     }
@@ -858,6 +916,30 @@ class TestGenericWebhook:
         resp = await _handle_generic(generic_request)
 
         assert resp.status == 401
+
+    async def test_legacy_secret_is_accepted_and_logged(self, generic_request, caplog):
+        """An unknown external caller gets a compatibility window with telemetry."""
+        generic_request.app[LEGACY_WEBHOOK_SECRET_KEY] = "legacy-secret"
+        generic_request.headers = {"X-Webhook-Secret": "legacy-secret"}
+        generic_request.json = AsyncMock(return_value={"message": "legacy caller"})
+
+        with caplog.at_level("WARNING", logger="kai.webhook"):
+            resp = await _handle_generic(generic_request)
+
+        assert resp.status == 200
+        assert "Legacy WEBHOOK_SECRET authenticated /webhook" in caplog.text
+        assert "GENERIC_WEBHOOK_SECRET" in caplog.text
+
+    async def test_named_secret_does_not_log_legacy_use(self, generic_request, caplog):
+        """The generic route checks its named credential before the fallback."""
+        generic_request.app[LEGACY_WEBHOOK_SECRET_KEY] = "legacy-secret"
+        generic_request.json = AsyncMock(return_value={"message": "named caller"})
+
+        with caplog.at_level("WARNING", logger="kai.webhook"):
+            resp = await _handle_generic(generic_request)
+
+        assert resp.status == 200
+        assert "Legacy WEBHOOK_SECRET authenticated" not in caplog.text
 
 
 # ── GET /api/jobs ──────────────────────────────────────────────────
@@ -1297,7 +1379,8 @@ def service_request():
     """Create a mock request for the service proxy endpoint."""
     request = MagicMock(spec=web.Request)
     request.app = {
-        WEBHOOK_SECRET_KEY: "test-secret",
+        INTERNAL_API_AUTH_KEY: _make_internal_api_auth(),
+        GENERIC_WEBHOOK_SECRET_KEY: "signing-secret",
     }
     request.headers = {"X-Webhook-Secret": "test-secret"}
     request.match_info = {"name": "perplexity"}
@@ -1385,56 +1468,59 @@ class TestServiceCall:
 
 
 class TestResolveChatId:
-    def _make_request(self, app_chat_id=12345):
-        """Create a minimal mock request with an app-level chat_id."""
-        request = MagicMock()
-        request.app = {CHAT_ID_KEY: app_chat_id}
-        return request
+    def _principal(self, chat_id: int = 123) -> InternalAPIPrincipal:
+        """Resolve a deterministic test principal from its credential."""
+        auth = _make_internal_api_auth()
+        credential = "test-secret" if chat_id == 123 else "other-secret"
+        principal = auth.authenticate(credential)
+        assert principal is not None
+        return principal
 
-    def test_explicit_chat_id(self):
-        """Uses chat_id from payload when present."""
-        request = self._make_request(app_chat_id=99999)
-        assert _resolve_chat_id(request, {"chat_id": 42}) == 42
+    def test_mismatched_explicit_chat_id_rejected(self):
+        """Rejects a request-supplied identity that differs from the principal."""
+        principal = self._principal()
+        with pytest.raises(UnauthorizedChatIdError, match="does not match authenticated principal"):
+            _resolve_chat_id(principal, {"chat_id": 42})
 
-    def test_fallback_to_app_default(self):
-        """Falls back to app-level chat_id when payload has no chat_id."""
-        request = self._make_request(app_chat_id=12345)
-        assert _resolve_chat_id(request, {}) == 12345
+    def test_omitted_chat_id_uses_principal(self):
+        """Omitted chat_id resolves to the authenticated principal."""
+        principal = self._principal()
+        assert _resolve_chat_id(principal, {}) == 123
 
     def test_invalid_non_numeric(self):
         """Raises ValueError for non-numeric chat_id."""
-        request = self._make_request()
+        principal = self._principal()
         with pytest.raises(ValueError, match="must be an integer"):
-            _resolve_chat_id(request, {"chat_id": "abc"})
+            _resolve_chat_id(principal, {"chat_id": "abc"})
 
     def test_invalid_float(self):
         """Raises ValueError for non-integer float chat_id."""
-        request = self._make_request()
+        principal = self._principal()
         with pytest.raises(ValueError, match="must be an integer"):
-            _resolve_chat_id(request, {"chat_id": 12345.6})
+            _resolve_chat_id(principal, {"chat_id": 12345.6})
 
     def test_invalid_bool(self):
         """Raises ValueError for boolean chat_id."""
-        request = self._make_request()
+        principal = self._principal()
         with pytest.raises(ValueError, match="must be an integer"):
-            _resolve_chat_id(request, {"chat_id": True})
+            _resolve_chat_id(principal, {"chat_id": True})
 
     def test_integer_like_float_accepted(self):
         """Integer-like float (e.g. 42.0) is accepted."""
-        request = self._make_request()
-        assert _resolve_chat_id(request, {"chat_id": 42.0}) == 42
+        principal = self._principal(chat_id=456)
+        assert _resolve_chat_id(principal, {"chat_id": 456.0}) == 456
 
     def test_string_integer_accepted(self):
         """String-encoded integer (e.g. from JSON) is accepted."""
-        request = self._make_request()
-        assert _resolve_chat_id(request, {"chat_id": "42"}) == 42
+        principal = self._principal(chat_id=456)
+        assert _resolve_chat_id(principal, {"chat_id": "456"}) == 456
 
 
 class TestGetJobsChatIdRouting:
     @pytest.mark.asyncio
     async def test_query_param_routes_to_user(self, db, mock_request):
         """GET /api/jobs?chat_id=456 returns jobs for that user."""
-        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         mock_request.app[CHAT_ID_KEY] = 123
         mock_request.query = {"chat_id": "456"}
 
@@ -1468,7 +1554,7 @@ class TestScheduleChatIdRouting:
     @pytest.mark.asyncio
     async def test_explicit_chat_id_in_body(self, db, mock_request):
         """POST /api/schedule with chat_id routes job to that user."""
-        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         mock_request.app[CHAT_ID_KEY] = 123
         mock_request.app[TELEGRAM_APP_KEY].job_queue = MagicMock()
         mock_request.app[TELEGRAM_APP_KEY].job_queue.jobs.return_value = []
@@ -1501,8 +1587,45 @@ class TestScheduleChatIdRouting:
 
 class TestChatIdAuthorization:
     @pytest.mark.asyncio
+    async def test_external_signing_secret_is_not_an_api_credential(self, mock_request):
+        """Possession of the GitHub/generic signing secret does not authorize API calls."""
+        mock_request.headers = {"X-Webhook-Secret": "signing-secret"}
+        mock_request.json = AsyncMock(return_value={"text": "hello"})
+
+        resp = await _handle_send_message(mock_request)
+
+        assert resp.status == 401
+        mock_request.app[TELEGRAM_BOT_KEY].send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_legacy_webhook_secret_is_not_an_api_credential(self, mock_request):
+        """The transition fallback remains external-only."""
+        mock_request.app[LEGACY_WEBHOOK_SECRET_KEY] = "legacy-secret"
+        mock_request.headers = {"X-Webhook-Secret": "legacy-secret"}
+        mock_request.json = AsyncMock(return_value={"text": "hello"})
+
+        resp = await _handle_send_message(mock_request)
+
+        assert resp.status == 401
+        mock_request.app[TELEGRAM_BOT_KEY].send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_notification_credential_cannot_manage_jobs(self, mock_request):
+        """A review/triage notification credential is limited to sending messages."""
+        auth = mock_request.app[INTERNAL_API_AUTH_KEY]
+        credential = auth.notification_credential_for(123)
+        mock_request.headers = {"X-Webhook-Secret": credential}
+
+        mock_request.json = AsyncMock(return_value={"text": "review complete"})
+        send_resp = await _handle_send_message(mock_request)
+        assert send_resp.status == 200
+
+        schedule_resp = await _handle_schedule(mock_request)
+        assert schedule_resp.status == 403
+
+    @pytest.mark.asyncio
     async def test_unauthorized_chat_id_returns_403(self, db, mock_request):
-        """POST /api/schedule with chat_id not in allowed_user_ids returns 403."""
+        """POST /api/schedule with chat_id differing from the principal returns 403."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.app[TELEGRAM_APP_KEY].job_queue = MagicMock()
         mock_request.app[TELEGRAM_APP_KEY].job_queue.jobs.return_value = []
@@ -1513,7 +1636,7 @@ class TestChatIdAuthorization:
                 "prompt": "test",
                 "schedule_type": "daily",
                 "schedule_data": {"times": ["09:00"]},
-                "chat_id": 999999,  # not in allowed_user_ids
+                "chat_id": 999999,  # differs from authenticated principal 123
             }
         )
 
@@ -1521,24 +1644,25 @@ class TestChatIdAuthorization:
         assert resp.status == 403
 
     @pytest.mark.asyncio
-    async def test_authorized_chat_id_accepted(self, db, mock_request):
-        """POST /api/schedule with chat_id in allowed_user_ids succeeds."""
+    async def test_other_authorized_chat_id_rejected(self, db, mock_request):
+        """A credential for user 123 cannot schedule work as user 456."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.app[TELEGRAM_APP_KEY].job_queue = MagicMock()
         mock_request.app[TELEGRAM_APP_KEY].job_queue.jobs.return_value = []
 
         mock_request.json = AsyncMock(
             return_value={
-                "name": "Good Job",
+                "name": "Cross-user Job",
                 "prompt": "test",
                 "schedule_type": "daily",
                 "schedule_data": {"times": ["09:00"]},
-                "chat_id": 456,  # in allowed_user_ids
+                "chat_id": 456,  # authorized user, but not this caller's principal
             }
         )
 
         resp = await _handle_schedule(mock_request)
-        assert resp.status == 200
+        assert resp.status == 403
+        assert await sessions.get_jobs(456) == []
 
     @pytest.mark.asyncio
     async def test_send_message_unauthorized_returns_403(self, db, mock_request):
@@ -1559,23 +1683,18 @@ class TestChatIdAuthorization:
         assert resp.status == 403
 
     def test_resolve_chat_id_unauthorized(self):
-        """_resolve_chat_id raises UnauthorizedChatIdError for unknown users."""
-        from kai.webhook import UnauthorizedChatIdError
-
-        request = MagicMock()
-        request.app = {CHAT_ID_KEY: 123, ALLOWED_USER_IDS_KEY: {123, 456}}
+        """_resolve_chat_id rejects any identity other than the principal."""
+        principal = _make_internal_api_auth().authenticate("test-secret")
+        assert principal is not None
 
         with pytest.raises(UnauthorizedChatIdError):
-            _resolve_chat_id(request, {"chat_id": 999999})
+            _resolve_chat_id(principal, {"chat_id": 999999})
 
-    def test_resolve_chat_id_no_allowed_list(self):
-        """_resolve_chat_id skips validation when allowed_user_ids is not set."""
-        request = MagicMock()
-        request.app = {CHAT_ID_KEY: 123}
-
-        # Should not raise even though 999 isn't in any allowed list
-        result = _resolve_chat_id(request, {"chat_id": 999})
-        assert result == 999
+    def test_resolve_chat_id_accepts_matching_principal(self):
+        """_resolve_chat_id accepts an explicit repetition of the principal."""
+        principal = _make_internal_api_auth().authenticate("test-secret")
+        assert principal is not None
+        assert _resolve_chat_id(principal, {"chat_id": 123}) == 123
 
 
 # ── Job ownership ──────────────────────────────────────────────────
@@ -1673,13 +1792,14 @@ class TestGetJobsAuth:
     """Authorization tests for GET /api/jobs."""
 
     @pytest.mark.asyncio
-    async def test_omitted_chat_id_defaults_to_admin(self, db, mock_request):
-        """GET /api/jobs without chat_id falls back to admin, preserving backward compat."""
+    async def test_omitted_chat_id_uses_authenticated_principal(self, db, mock_request):
+        """Omitted identity resolves to the credential owner, never the app default."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        # No query param set; should fall back to app[CHAT_ID_KEY] = 123
+        # A deliberately different app default proves it is not an auth fallback.
+        mock_request.app[CHAT_ID_KEY] = 456
         await sessions.create_job(
             chat_id=123,
-            name="Admin Job",
+            name="Principal Job",
             job_type="reminder",
             prompt="test",
             schedule_type="daily",
@@ -1690,7 +1810,7 @@ class TestGetJobsAuth:
         assert resp.status == 200
         body = json.loads(resp.body.decode())
         assert len(body) == 1
-        assert body[0]["name"] == "Admin Job"
+        assert body[0]["name"] == "Principal Job"
 
     @pytest.mark.asyncio
     async def test_unauthorized_chat_id_returns_403(self, db, mock_request):
@@ -1704,7 +1824,7 @@ class TestGetJobsAuth:
     @pytest.mark.asyncio
     async def test_authorized_chat_id_returns_only_their_jobs(self, db, mock_request):
         """GET /api/jobs?chat_id=456 returns only user 456's jobs."""
-        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         mock_request.query = {"chat_id": "456"}
 
         await sessions.create_job(
@@ -1734,10 +1854,10 @@ class TestGetJobAuth:
     """Authorization and ownership tests for GET /api/jobs/{id}."""
 
     @pytest.mark.asyncio
-    async def test_omitted_chat_id_defaults_to_admin(self, db, mock_request):
-        """GET /api/jobs/{id} without chat_id falls back to admin, preserving backward compat."""
+    async def test_omitted_chat_id_uses_principal(self, db, mock_request):
+        """GET /api/jobs/{id} without chat_id uses the credential owner."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        # No query param set; should fall back to app[CHAT_ID_KEY] = 123
+        mock_request.app[CHAT_ID_KEY] = 456
         job_id = await sessions.create_job(
             chat_id=123,
             name="Admin Job",
@@ -1756,7 +1876,7 @@ class TestGetJobAuth:
     @pytest.mark.asyncio
     async def test_wrong_owner_returns_404(self, db, mock_request):
         """GET /api/jobs/{id} returns 404 when job belongs to another user."""
-        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         # Caller is user 456, job belongs to user 123
         mock_request.query = {"chat_id": "456"}
         job_id = await sessions.create_job(
@@ -1775,7 +1895,7 @@ class TestGetJobAuth:
     @pytest.mark.asyncio
     async def test_owner_can_view_own_job(self, db, mock_request):
         """GET /api/jobs/{id}?chat_id=456 returns the job when owned by 456."""
-        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         mock_request.query = {"chat_id": "456"}
         job_id = await sessions.create_job(
             chat_id=456,
@@ -1807,10 +1927,10 @@ class TestDeleteJobAuth:
     """Authorization tests for DELETE /api/jobs/{id}."""
 
     @pytest.mark.asyncio
-    async def test_omitted_chat_id_defaults_to_admin(self, db, mock_request):
-        """DELETE without chat_id falls back to admin, preserving backward compat."""
+    async def test_omitted_chat_id_uses_principal(self, db, mock_request):
+        """DELETE without chat_id uses the credential owner."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        # No query param set; should fall back to app[CHAT_ID_KEY] = 123
+        mock_request.app[CHAT_ID_KEY] = 456
         job_id = await sessions.create_job(
             chat_id=123,
             name="Admin Job",
@@ -1828,7 +1948,7 @@ class TestDeleteJobAuth:
     @pytest.mark.asyncio
     async def test_user_can_delete_own_job(self, db, mock_request):
         """DELETE /api/jobs/{id}?chat_id=456 deletes user 456's job."""
-        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         mock_request.query = {"chat_id": "456"}
         job_id = await sessions.create_job(
             chat_id=456,
@@ -1847,7 +1967,7 @@ class TestDeleteJobAuth:
     @pytest.mark.asyncio
     async def test_cannot_delete_other_users_job(self, db, mock_request):
         """DELETE /api/jobs/{id}?chat_id=456 returns 404 for admin's job."""
-        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         mock_request.query = {"chat_id": "456"}
         job_id = await sessions.create_job(
             chat_id=123,
@@ -1879,9 +1999,10 @@ class TestUpdateJobAuth:
     """Authorization tests for PATCH /api/jobs/{id}."""
 
     @pytest.mark.asyncio
-    async def test_omitted_chat_id_defaults_to_admin(self, db, mock_request):
-        """PATCH without chat_id in body falls back to admin, preserving backward compat."""
+    async def test_omitted_chat_id_uses_principal(self, db, mock_request):
+        """PATCH without chat_id in the body uses the credential owner."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app[CHAT_ID_KEY] = 456
         job_id = await sessions.create_job(
             chat_id=123,
             name="Original",
@@ -1891,7 +2012,7 @@ class TestUpdateJobAuth:
             schedule_data='{"run_at": "2026-06-01T12:00:00+00:00"}',
         )
         mock_request.match_info = {"id": str(job_id)}
-        # No chat_id in body; falls back to app[CHAT_ID_KEY] = 123
+        # No chat_id in body; the token still resolves to user 123.
         mock_request.json = AsyncMock(return_value={"name": "Updated"})
 
         resp = await _handle_update_job(mock_request)
@@ -1903,7 +2024,7 @@ class TestUpdateJobAuth:
     @pytest.mark.asyncio
     async def test_user_can_update_own_job(self, db, mock_request):
         """PATCH with chat_id in body updates the user's own job."""
-        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         job_id = await sessions.create_job(
             chat_id=456,
             name="Original",
@@ -1924,7 +2045,7 @@ class TestUpdateJobAuth:
     @pytest.mark.asyncio
     async def test_cannot_update_other_users_job(self, db, mock_request):
         """PATCH with chat_id=456 returns 404 for admin's job."""
-        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         job_id = await sessions.create_job(
             chat_id=123,
             name="Admin Job",
@@ -2144,7 +2265,7 @@ class TestMemoryAdd:
         existing facts under the same chat_id (silently, since both writes
         succeed).
         """
-        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         mock_request.json = AsyncMock(return_value={"content": "x", "chat_id": 456})
 
         with (
@@ -2158,9 +2279,9 @@ class TestMemoryAdd:
         assert isinstance(kwargs["user_id"], str)
 
     async def test_returns_403_on_unauthorized_chat_id(self, mock_request):
-        """chat_id not in allowed_user_ids -> 403, primitive not called."""
+        """chat_id differing from the principal -> 403, primitive not called."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        # 999 is not in the fixture's allowed_user_ids = {123, 456}
+        # The credential resolves to principal 123, not the requested 999.
         mock_request.json = AsyncMock(return_value={"content": "x", "chat_id": 999})
 
         with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.add_structured") as mock_add:
@@ -2490,7 +2611,7 @@ class TestMemorySearch:
         assert body == {"error": "Memory search failed"}
 
     async def test_returns_403_on_unauthorized_chat_id(self, mock_request):
-        """chat_id not in allowed_user_ids -> 403, primitive not called."""
+        """chat_id differing from the principal -> 403, primitive not called."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.json = AsyncMock(return_value={"query": "x", "chat_id": 999})
 
@@ -2575,8 +2696,8 @@ class TestMemoryStats:
         """GET endpoint: chat_id comes from query params, mirroring _handle_get_jobs."""
         from kai.memory import MemoryStats
 
-        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
-        # 456 is in allowed_user_ids; query params come in as strings.
+        mock_request.headers = {"X-Webhook-Secret": "other-secret"}
+        # The user-456 credential matches the string query parameter.
         mock_request.query = {"chat_id": "456"}
 
         with (
@@ -2598,7 +2719,7 @@ class TestMemoryStats:
         assert resp.status == 401
 
     async def test_returns_403_on_unauthorized_chat_id(self, mock_request):
-        """Query-string chat_id outside allowed_user_ids -> 403."""
+        """Query-string chat_id differing from the principal -> 403."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.query = {"chat_id": "999"}
 
@@ -2710,7 +2831,7 @@ class TestMemoryDeleteAll:
 
     async def test_calls_delete_all_with_stringified_user_id(self, mock_request):
         """int -> str cast at the memory boundary, same as add."""
-        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         mock_request.json = AsyncMock(return_value={"confirm": self._CONFIRM, "chat_id": 456})
 
         with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.delete_all") as mock_del:
@@ -2749,7 +2870,7 @@ class TestMemoryDeleteAll:
         assert body == {"error": "Memory delete failed"}
 
     async def test_returns_403_on_unauthorized_chat_id(self, mock_request):
-        """chat_id not in allowed_user_ids -> 403, primitive not called.
+        """chat_id differing from the principal -> 403, primitive not called.
 
         Verifies the 403 path runs even when the confirm token is
         correct: an unauthorized caller with the right token should
@@ -2791,7 +2912,11 @@ class TestMemoryDeleteAll:
 # minimal - the goal is to reach the isinstance check, not to exercise
 # the rest of the handler.
 _NON_OBJECT_HANDLERS = [
-    pytest.param(_handle_generic, lambda r: None, id="generic"),
+    pytest.param(
+        _handle_generic,
+        lambda r: setattr(r, "headers", {"X-Webhook-Secret": "signing-secret"}),
+        id="generic",
+    ),
     pytest.param(_handle_schedule, lambda r: None, id="schedule"),
     pytest.param(
         _handle_update_job,

--- a/tests/test_webhook_routes.py
+++ b/tests/test_webhook_routes.py
@@ -1,0 +1,85 @@
+"""Route-registration tests for separated external and internal credentials."""
+
+import json
+
+from aiohttp import web
+
+from kai.config import Config
+from kai.webhook import _handle_health, _register_routes
+
+
+def _config(**overrides: object) -> Config:
+    values: dict[str, object] = {
+        "telegram_bot_token": "test-token",
+        "allowed_user_ids": {123},
+    }
+    values.update(overrides)
+    return Config(**values)
+
+
+def _routes(app: web.Application) -> set[tuple[str, str]]:
+    return {(route.method, route.resource.canonical) for route in app.router.routes()}
+
+
+def test_internal_api_routes_do_not_depend_on_external_secrets() -> None:
+    app = web.Application()
+
+    _register_routes(app, _config())
+
+    routes = _routes(app)
+    assert ("POST", "/api/schedule") in routes
+    assert ("GET", "/api/jobs") in routes
+    assert ("GET", "/api/memory/stats") in routes
+    assert ("POST", "/webhook/github") not in routes
+    assert ("POST", "/webhook") not in routes
+
+
+def test_external_webhook_routes_are_enabled_independently() -> None:
+    github_app = web.Application()
+    generic_app = web.Application()
+
+    _register_routes(github_app, _config(github_webhook_secret="github-secret"))
+    _register_routes(generic_app, _config(generic_webhook_secret="generic-secret"))
+
+    github_routes = _routes(github_app)
+    generic_routes = _routes(generic_app)
+    assert ("POST", "/webhook/github") in github_routes
+    assert ("POST", "/webhook") not in github_routes
+    assert ("POST", "/webhook") in generic_routes
+    assert ("POST", "/webhook/github") not in generic_routes
+
+
+def test_legacy_credential_temporarily_enables_both_external_routes() -> None:
+    app = web.Application()
+
+    _register_routes(app, _config(webhook_secret="legacy-secret"))
+
+    routes = _routes(app)
+    assert ("POST", "/webhook/github") in routes
+    assert ("POST", "/webhook") in routes
+    assert ("POST", "/api/schedule") in routes
+
+
+def test_telegram_route_is_independent_of_other_webhooks() -> None:
+    app = web.Application()
+
+    _register_routes(
+        app,
+        _config(
+            telegram_webhook_url="https://example.com/webhook/telegram",
+            telegram_webhook_secret="telegram-secret",
+        ),
+    )
+
+    routes = _routes(app)
+    assert ("POST", "/webhook/telegram") in routes
+    assert ("POST", "/webhook/github") not in routes
+    assert ("POST", "/webhook") not in routes
+
+
+async def test_health_reports_non_sensitive_memory_mode(monkeypatch) -> None:
+    monkeypatch.setattr("kai.webhook.memory.is_enabled", lambda: True)
+
+    response = await _handle_health(None)  # type: ignore[arg-type]
+
+    assert json.loads(response.body) == {"status": "ok", "memory_enabled": True}


### PR DESCRIPTION
Closes #740

## Why this change

A static security review found that Kai's logical per-`chat_id` namespacing was
not backed by a trustworthy caller identity at the loopback HTTP boundary.
Every persistent agent received the same installation-wide `WEBHOOK_SECRET`,
and an authenticated request could then select any configured `chat_id`. In a
multi-user install, one compromised or prompt-injected agent could therefore
act in another user's jobs, memory, message, or file namespace.

That bearer was also reused as the GitHub webhook signing secret and, by
default, as the Telegram webhook token. Giving it to an agent therefore exposed
credentials trusted at external ingress boundaries. Separately, the mutable set
of outbound GitHub notification destinations was the same set used for inbound
Telegram authorization.

This PR fixes those three related trust-boundary defects. It also hardens the
protected install path that must deliver the migration safely: the original
`DRY_RUN` signal did not reliably cross `sudo`, source-only changes could be
missed or packaged with deleted modules, and a Homebrew Python upgrade could
leave `/opt/kai/venv` present but unusable.

The final small user-facing change adds the supported `gpt-5.6` alias to Kai's
Codex model picker. The existing GPT-5.5 default is unchanged. See OpenAI's
[current model guidance](https://developers.openai.com/api/docs/guides/latest-model).

## New trust model

| Surface | Credential | Authority source |
|---|---|---|
| `/api/*` | Random process-local `KAI_WEBHOOK_SECRET` | Server-owned `InternalAPIPrincipal(chat_id, scopes)` |
| `/webhook/github` | `GITHUB_WEBHOOK_SECRET` HMAC | Verified GitHub event plus configured subscription routing |
| `/webhook` | `GENERIC_WEBHOOK_SECRET` header | Generic external webhook handler |
| `/webhook/telegram` | `TELEGRAM_WEBHOOK_SECRET` | Telegram update plus immutable configured user allowlist |
| `/health` | None | Non-sensitive liveness and memory-mode state only |

`WEBHOOK_SECRET` remains a temporary migration credential for the GitHub and
generic webhook routes only. A successful legacy fallback is logged with the
route and migration target. It cannot authenticate Telegram or any `/api/*`
route.

## What changed

### Principal-bound internal API

- Added `InternalAPIAuth`, `InternalAPIPrincipal`, and `InternalAPIScope`.
- The subprocess pool owns one credential store for the outer-process lifetime
  and issues a distinct full agent credential for each configured Telegram user.
- GitHub review/triage notification workers receive a separate
  `messages:send`-only credential for their destination.
- Every internal API handler declares its required scope.
- Omitted `chat_id` values resolve to the authenticated principal. An explicit
  `chat_id` is accepted only when it repeats that same identity.
- Job, memory, message, and file operations no longer fall back to the admin
  identity.
- Internal API routes are always registered and no longer depend on whether an
  external webhook has been configured.

The tokens are random, kept only in outer-process memory, and rotate on service
restart. No internal token is stored in `install.conf`, `/etc/kai/env`, or the
database.

### Secret-domain and principal separation

- Added dedicated GitHub and generic webhook configuration fields.
- Removed Telegram's fallback to `WEBHOOK_SECRET`; webhook mode uses an explicit
  token or a freshly generated process token.
- Rejects duplicate configured values across the Telegram, GitHub, and generic
  secret domains.
- GitHub self-service webhook creation now uses only
  `GITHUB_WEBHOOK_SECRET`.
- Persistent Claude, Codex, Goose, and OpenCode environments are sanitized after
  workspace env layering and before the principal credential is injected.
  External webhook secrets and an attempted workspace override of
  `KAI_WEBHOOK_SECRET` are removed.
- The outbound notification registry is now a copy, not an alias of
  `Config.allowed_user_ids`; adding a notification destination cannot create a
  Telegram principal.
- The memory-mode diagnostic now reads the non-sensitive flag from `/health`
  instead of sourcing an API secret and calling a user-scoped endpoint.

### Configuration and migration

- `make config` preserves an existing dedicated secret and generates distinct
  GitHub/generic values when needed.
- A pre-existing `WEBHOOK_SECRET` is retained only as the deprecated migration
  credential; it is not copied into a new secret domain.
- Protected apply writes the separated values to `/etc/kai/env` with the
  existing `0600` handling.
- Missing or moved Codex binaries are rediscovered instead of pinning a stale
  Homebrew path forever.
- README security documentation reflects the principal-bound API and separated
  webhook domains.

### Protected installer reliability

- `make DRY_RUN=1 install` now becomes an explicit `--dry-run` argument inside
  the root Python process instead of relying on sudo environment propagation.
- Tests assert that dry-run reaches every apply helper and performs no
  filesystem mutation.
- Dry-run source-change detection compares the incoming repository tree; it no
  longer compares the unchanged installed destination after intentionally
  skipping the copy.
- Generated `/opt/kai/src` is replaced exactly so deleted modules cannot survive
  an upgrade.
- The installer removes stale `build/` output before building the wheel.
- Venv updates invoke `venv/bin/python -m pip`, detect a missing/unusable
  interpreter, remove only dangling generated Python symlinks, and repair the
  environment with `python -m venv --upgrade`.
- The base interpreter resolver can fall back to the already-running Python
  3.13 when sudo's restricted `PATH` hides Homebrew.
- Source and `pyproject.toml` checksums are written only after a successful
  install, preserving retry behavior after a partial failure.
- `.kai-backup/` is ignored as a local runtime/rollback artifact.

### Codex model picker

- Added `gpt-5.6` to `CODEX_MODELS` and its Telegram keyboard validation.
- Kept `CODEX_DEFAULT_MODEL` at `gpt-5.5`.
- Did not add the alias to Goose/OpenAI API provider choices; Codex keeps its own
  curated CLI model surface.

## Compatibility and migration behavior

- Existing protected installations can apply this change without a database
  migration.
- An old config containing only `WEBHOOK_SECRET` keeps GitHub/generic ingress
  working through the logged compatibility path. Re-running `make config`
  creates the dedicated values.
- Custom callers that previously used `WEBHOOK_SECRET` against `/api/*` are
  intentionally rejected. Keeping that fallback would preserve the original
  cross-user vulnerability; internal APIs now require a credential issued for a
  server-owned principal.
- Restarting Kai rotates internal credentials and recreates backend subprocesses
  with the new values.
- Rollback to pre-change code is straightforward only while a legacy
  `WEBHOOK_SECRET` remains configured. An installation that has removed or never
  had that value must create one before rolling back, because older code expects
  the shared credential.

## Verification

Automated checks on the rebased commit:

```text
make check
  ruff check: passed
  ruff format --check: 126 files already formatted

.venv/bin/python -m pytest tests/ -q
  4632 passed, 1 skipped in 38.65s
```

Coverage added or updated for:

- credential uniqueness, principal resolution, constant-time comparison path,
  and notification scopes;
- cross-user rejection for jobs, memory, messages, and files;
- endpoint-specific GitHub, generic, Telegram, legacy, and internal credentials;
- route registration with each external integration independently disabled;
- backend environment sanitization and last-writer credential injection;
- notification destinations remaining outside Telegram inbound auth;
- config secret uniqueness, generation, preservation, and legacy migration;
- explicit sudo dry-run propagation and zero-mutation behavior;
- incoming-source checksum detection, exact source replacement, stale build
  cleanup, and dangling venv repair;
- GPT-5.6 model validation and Telegram picker callback.

The staged diff also passed `git diff --check` and a credential-pattern scan.

## Live protected-install validation

The change was exercised on an existing macOS protected installation rather
than only in mocked installer tests:

1. `make DRY_RUN=1 install` reported the source/venv update, source replacement,
   secret/sudoers writes, ownership operations, launcher replacement, and
   service restart as planned actions, then ended with `No changes were made`.
2. `make install` successfully stopped the daemon, replaced source, rebuilt the
   wheel, wrote protected config, and restarted launchd.
3. An existing broken Homebrew-backed venv was repaired in place on the
   preceding apply, and a subsequent apply completed normally.
4. Local and tunneled `/health` checks both returned HTTP 200.
5. The repository, `/opt/kai/src`, and all 54 installed `kai` Python modules had
   identical file sets and content hashes.
6. The post-deploy log segment contained no errors, critical entries, or
   tracebacks.
7. The live auth matrix confirmed that dedicated external secrets authenticate
   only their own routes, legacy auth is limited to GitHub/generic, Telegram
   rejects every other secret, and `/api/*` rejects all external credentials.
8. The installed registry accepted `gpt-5.6`, and selecting it through Kai was
   confirmed end-to-end.

## Review guide

Suggested order:

1. `src/kai/internal_api_auth.py` for the principal and scope model.
2. `src/kai/pool.py` and backend environment builders for credential issuance
   and propagation.
3. `src/kai/webhook.py` for endpoint-specific authentication, scope decorators,
   principal-derived routing, and route registration.
4. `src/kai/config.py`, `src/kai/install.py`, and `Makefile` for migration and
   protected-install guarantees.
5. `tests/test_internal_api_auth.py`, `tests/test_webhook_routes.py`,
   `tests/test_webhook_api.py`, and `tests/test_install.py` for the boundary and
   regression coverage.

## Explicitly out of scope

This PR does not claim to complete the entire static assessment. Separate work
is still required for:

- per-user GitHub deputy identity and repository authorization;
- enforcing distinct OS users for every deployment shape;
- TOTP fail-closed behavior, locking, and complete sensitive-command coverage;
- per-user filesystem modes, database/PAT protection, and Codex image storage;
- issue-triage mutation allowlists;
- structural service-proxy URL joining and redirect-origin validation;
- durable webhook acknowledgement, transactional scheduling, and crash status;
- strict type-checking and dependency/security scanning in CI.

Those are intentionally left for focused follow-up issues rather than being
silently mixed into this trust-boundary migration.
