### PR TITLE
fix(codex): use supported GPT-5.6 model IDs

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -23,7 +23,14 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from kai.config import DATA_DIR, PROJECT_ROOT, Config, WorkspaceConfig, validate_model_for_backend
+from kai.config import (
+    DATA_DIR,
+    PROJECT_ROOT,
+    Config,
+    WorkspaceConfig,
+    canonicalize_model_for_backend,
+    validate_model_for_backend,
+)
 from kai.history import get_recent_history
 
 log = logging.getLogger(__name__)
@@ -78,16 +85,17 @@ def apply_workspace_model(
     workspaces.yaml entry with `model: gpt-5.4-nano` applied to a
     CodexBackend instance, where codex CLI rejects nano).
 
-    Returns workspace_config.model when valid for the active backend;
-    otherwise returns current_model unchanged and logs a WARNING so
-    the operator sees the override was skipped. Shared helper so the
-    rejection contract stays uniform across CodexBackend,
+    Returns the backend-canonical workspace model when valid for the
+    active backend; otherwise returns current_model unchanged and logs
+    a WARNING so the operator sees the override was skipped. Shared
+    helper so the rejection contract stays uniform across CodexBackend,
     ClaudeCodeBackend, and GooseBackend.
     """
     if workspace_config is None or not workspace_config.model:
         return current_model
-    if validate_model_for_backend(workspace_config.model, backend, provider):
-        return workspace_config.model
+    candidate = canonicalize_model_for_backend(workspace_config.model, backend)
+    if validate_model_for_backend(candidate, backend, provider):
+        return candidate
     log.warning(
         "Ignoring workspace model override '%s' for %s/%s (invalid for the active backend); keeping model='%s'",
         workspace_config.model,

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -209,11 +209,15 @@ PROVIDER_DEFAULTS: dict[str, str] = {
 # codex CLI exposes a different set than the OpenAI HTTP API surface
 # goose drives, and treating them as one list lets a goose-only
 # model (e.g. gpt-5.4-nano) leak onto a codex install where the CLI
-# rejects it. GPT-5.6 uses the stable alias that OpenAI documents as
-# routing to GPT-5.6 Sol (verified 2026-08-07). Refresh when the codex
-# CLI bumps; no auto-discovery.
+# rejects it. GPT-5.6 has three subscription-Codex model IDs; the
+# family shorthand is not accepted by the ChatGPT-account service
+# even though some Codex documentation and CLI examples use it.
+# Verified against Codex app-server model/list on 2026-08-07. Refresh
+# when the codex CLI bumps; no auto-discovery.
 CODEX_MODELS: dict[str, str] = {
-    "gpt-5.6": "\U0001f7e2 GPT-5.6",
+    "gpt-5.6-sol": "\U0001f7e2 GPT-5.6 Sol",
+    "gpt-5.6-terra": "\U0001f7e1 GPT-5.6 Terra",
+    "gpt-5.6-luna": "\U0001f535 GPT-5.6 Luna",
     "gpt-5.5": "\U0001f7e2 GPT-5.5",
     "gpt-5.4": "\U0001f7e1 GPT-5.4",
     "gpt-5.4-mini": "\U0001f535 GPT-5.4 Mini",
@@ -221,6 +225,22 @@ CODEX_MODELS: dict[str, str] = {
     "gpt-5.3-codex-spark": "⚡ GPT-5.3 Codex Spark",
     "gpt-5.2": "\U0001f7e4 GPT-5.2",
 }
+
+# One-release compatibility for the invalid GPT-5.6 family shorthand
+# Kai briefly offered. Keep aliases out of CODEX_MODELS so new model
+# pickers and validators expose only IDs accepted by Codex. Callers
+# that ingest persisted operator state canonicalize before validating.
+_LEGACY_CODEX_MODEL_ALIASES: dict[str, str] = {
+    "gpt-5.6": "gpt-5.6-sol",
+}
+
+
+def canonicalize_model_for_backend(model: str, backend: str) -> str:
+    """Map a retired model spelling to the exact ID its backend accepts."""
+    if backend == "codex":
+        return _LEGACY_CODEX_MODEL_ALIASES.get(model, model)
+    return model
+
 
 # Codex's default model when DEFAULT_MODEL is unset on a codex install.
 # Independent of PROVIDER_DEFAULTS["openai"] (goose-on-openai still
@@ -236,9 +256,12 @@ OPEN_ENDED_PROVIDERS: frozenset[str] = frozenset({"openrouter", "ollama"})
 # (workspaces can be used by users on different backends/providers).
 # Includes CODEX_MODELS so codex-only IDs like gpt-5.5 are accepted
 # in workspaces.yaml; each backend's change_workspace decides whether
-# to actually USE the override for its surface.
+# to actually USE the override for its surface. Legacy Codex aliases
+# remain loadable for one release and are canonicalized at apply time.
 _ALL_CURATED_MODELS: frozenset[str] = frozenset(
-    list(model for models in PROVIDER_MODELS.values() for model in models) + list(CODEX_MODELS.keys())
+    list(model for models in PROVIDER_MODELS.values() for model in models)
+    + list(CODEX_MODELS.keys())
+    + list(_LEGACY_CODEX_MODEL_ALIASES.keys())
 )
 
 
@@ -2346,6 +2369,7 @@ def _load_user_configs(
         model = entry.get("model")
         if model is not None:
             model = str(model).strip().lower()
+            model = canonicalize_model_for_backend(model, eff_backend)
         if model is None and eff_provider in OPEN_ENDED_PROVIDERS:
             log.warning(
                 "users.yaml: user '%s' is on open-ended provider '%s' with no "
@@ -2553,6 +2577,7 @@ def _load_user_configs(
                         f"users.yaml: user '{name}' has models.{role_key} with an empty value; "
                         f"remove the key or set a non-empty model string."
                     )
+                value_str = canonicalize_model_for_backend(value_str, eff_backend)
                 if not validate_model_for_backend(value_str, eff_backend, eff_provider):
                     raise SystemExit(
                         f"users.yaml: user '{name}' has models.{role_key}={value_str!r} which is "
@@ -3172,7 +3197,10 @@ def load_config() -> Config:
                 ", ".join(features),
             )
 
-    default_model = os.environ.get("DEFAULT_MODEL", "sonnet")
+    default_model = canonicalize_model_for_backend(
+        os.environ.get("DEFAULT_MODEL", "sonnet"),
+        default_backend,
+    )
 
     # Parse DEFAULT_MODELS_JSON: global per-role defaults captured by
     # the wizard's per-role customization step. Empty / unset / invalid
@@ -3205,6 +3233,7 @@ def load_config() -> Config:
             value_str = str(raw_value).strip()
             if not value_str:
                 raise SystemExit(f"DEFAULT_MODELS_JSON: empty value for role '{role_key}'.")
+            value_str = canonicalize_model_for_backend(value_str, default_backend)
             default_models[role_key] = value_str
 
     # Validate DEFAULT_MODEL against the effective global backend.

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -56,6 +56,7 @@ from kai.config import (
     ModelRole,
     _read_protected_file,
     _resolve_renamed_key,
+    canonicalize_model_for_backend,
     models_for_backend,
     validate_model_for_backend,
 )
@@ -1437,6 +1438,7 @@ def _cmd_config() -> None:
     # choices list. Prefilling the bad value would let the operator
     # accept the just-rejected value with Enter.
     raw_existing_model = existing_env.get("DEFAULT_MODEL", existing_env.get("CLAUDE_MODEL", ""))
+    raw_existing_model = canonicalize_model_for_backend(raw_existing_model, agent_backend)
     if raw_existing_model and validate_model_for_backend(raw_existing_model, agent_backend, eff_provider):
         default_model_prefill_value = raw_existing_model
     else:
@@ -1466,7 +1468,9 @@ def _cmd_config() -> None:
         try:
             parsed_existing = json.loads(existing_default_models_raw)
             if isinstance(parsed_existing, dict):
-                existing_default_models = {str(k): str(v) for k, v in parsed_existing.items()}
+                existing_default_models = {
+                    str(k): canonicalize_model_for_backend(str(v), agent_backend) for k, v in parsed_existing.items()
+                }
         except ValueError:
             # Invalid JSON in env: ignore; the wizard re-captures.
             pass
@@ -4305,7 +4309,9 @@ def _cmd_apply() -> None:
     # already migrated to it at the top of apply.
     provider_raw = env.get("DEFAULT_PROVIDER", "").strip().lower()
     eff_provider_for_check = "anthropic" if agent_backend_raw == "claude" else provider_raw
-    resolved_model = default_model_raw or "sonnet"
+    resolved_model = canonicalize_model_for_backend(default_model_raw or "sonnet", agent_backend_raw)
+    if default_model_raw and resolved_model != default_model_raw:
+        env["DEFAULT_MODEL"] = resolved_model
     # Backend-aware validation: codex installs validate against
     # CODEX_MODELS only - no fallback to PROVIDER_MODELS["openai"].
     # That closes the regression where install.conf with

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -28,6 +28,7 @@ from kai.config import (
     PROVIDER_DEFAULTS,
     Config,
     WorkspaceConfig,
+    canonicalize_model_for_backend,
     get_effective_provider,
     get_user_backend_and_provider,
     validate_model_for_backend,
@@ -210,6 +211,13 @@ class SubprocessPool:
                     self._config.default_model,
                 )
                 model = self._config.default_model
+
+        # Canonicalize retired backend-specific spellings after the
+        # complete precedence cascade and before constructing a backend.
+        # This keeps direct Config objects and persisted users.yaml values
+        # from reaching the Codex app-server with the rejected gpt-5.6
+        # family shorthand.
+        model = canonicalize_model_for_backend(model, backend)
 
         timeout = user.timeout if user and user.timeout is not None else self._config.default_timeout
         # home_ws is what the backend treats as "home" for the foreign-
@@ -468,14 +476,23 @@ class SubprocessPool:
         # precedence guard matches what was actually applied to
         # instance.model.
         ws_model_raw = instance.workspace_config.model if instance.workspace_config else None
-        ws_model_applied = bool(
-            ws_model_raw and validate_model_for_backend(ws_model_raw, instance_backend, instance.provider)
-        )
-        if not ws_model_applied and "model" in db_settings and db_settings["model"] != instance.model:
-            stored_model = db_settings["model"]
+        ws_model = canonicalize_model_for_backend(ws_model_raw, instance_backend) if ws_model_raw is not None else None
+        ws_model_applied = bool(ws_model and validate_model_for_backend(ws_model, instance_backend, instance.provider))
+        if not ws_model_applied and "model" in db_settings:
+            stored_model_raw = db_settings["model"]
+            stored_model = canonicalize_model_for_backend(stored_model_raw, instance_backend)
             if validate_model_for_backend(stored_model, instance_backend, instance.provider):
-                instance.model = stored_model
-                needs_restart = True
+                if stored_model != stored_model_raw:
+                    await sessions.set_user_setting(chat_id, "model", stored_model)
+                    log.info(
+                        "Migrated stored model for user %d from '%s' to '%s'",
+                        chat_id,
+                        stored_model_raw,
+                        stored_model,
+                    )
+                if stored_model != instance.model:
+                    instance.model = stored_model
+                    needs_restart = True
             else:
                 log.warning(
                     "Ignoring stored model '%s' for user %d (invalid for backend '%s'/provider '%s')",
@@ -599,7 +616,7 @@ class SubprocessPool:
     def set_model(self, chat_id: int, model: str) -> None:
         """Set the model for a user's subprocess."""
         instance = self.get(chat_id)
-        instance.model = model
+        instance.model = canonicalize_model_for_backend(model, instance.backend_name)
 
     async def get_effective_workspace(self, chat_id: int) -> Path:
         """

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -722,6 +722,14 @@ async def resolve_user_defaults(
     db_settings = await get_user_settings(chat_id)
     user_config = config.get_user_config(chat_id)
 
+    # Model aliases are backend-specific. Resolve the user's backend
+    # before returning a persisted preference so command handlers that
+    # inspect settings prior to subprocess creation display the same
+    # canonical ID the backend will receive.
+    from kai.config import canonicalize_model_for_backend, get_user_backend_and_provider
+
+    backend, _provider = get_user_backend_and_provider(user_config, config)
+
     # Model: DB > users.yaml > env > "sonnet".
     # Strip whitespace so "" and " " don't pass through as valid model
     # names. The UI validates before storing, but direct DB manipulation
@@ -733,6 +741,7 @@ async def resolve_user_defaults(
     raw_yaml_model = user_config.model if user_config else None
     yaml_model = raw_yaml_model.strip() if raw_yaml_model is not None else None
     model = db_model if db_model else yaml_model if yaml_model else config.default_model
+    model = canonicalize_model_for_backend(model, backend)
 
     # Timeout: DB > users.yaml > env > 120
     yaml_timeout = user_config.timeout if user_config and user_config.timeout is not None else None

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1452,6 +1452,12 @@ class TestApplyWorkspaceModel:
         wc = WorkspaceConfig(path=Path("/tmp/ws"), model="gpt-5.5", timeout=None)
         assert apply_workspace_model(wc, "codex", "openai", "gpt-5.4") == "gpt-5.5"
 
+    def test_codex_canonicalizes_legacy_gpt56_workspace_override(self):
+        from kai.backend import apply_workspace_model
+
+        wc = WorkspaceConfig(path=Path("/tmp/ws"), model="gpt-5.6", timeout=None)
+        assert apply_workspace_model(wc, "codex", "openai", "gpt-5.5") == "gpt-5.6-sol"
+
     def test_codex_rejects_goose_only_override(self, caplog):
         from kai.backend import apply_workspace_model
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -965,12 +965,16 @@ class TestModelsKeyboard:
         assert "model:sonnet" in callbacks
         assert "model:haiku" in callbacks
 
-    def test_codex_keyboard_offers_gpt56(self):
-        """The documented GPT-5.6 alias is selectable on the Codex surface."""
+    def test_codex_keyboard_offers_exact_gpt56_models(self):
+        """The ChatGPT-account GPT-5.6 IDs are selectable, not the rejected shorthand."""
         from kai.config import CODEX_MODELS
 
         kb = _models_keyboard("gpt-5.5", CODEX_MODELS)
-        assert "model:gpt-5.6" in _button_callbacks(kb)
+        callbacks = _button_callbacks(kb)
+        assert "model:gpt-5.6-sol" in callbacks
+        assert "model:gpt-5.6-terra" in callbacks
+        assert "model:gpt-5.6-luna" in callbacks
+        assert "model:gpt-5.6" not in callbacks
 
     def test_callback_data_format(self):
         kb = _models_keyboard("opus", self._anthropic_models)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2498,10 +2498,13 @@ class TestCodexModelsSurface:
     constants with no overlap requirement and no fallback path.
     """
 
-    def test_codex_models_includes_current_alias_and_codex_variants(self):
+    def test_codex_models_includes_gpt56_family_and_codex_variants(self):
         from kai.config import CODEX_MODELS
 
-        assert "gpt-5.6" in CODEX_MODELS
+        assert "gpt-5.6-sol" in CODEX_MODELS
+        assert "gpt-5.6-terra" in CODEX_MODELS
+        assert "gpt-5.6-luna" in CODEX_MODELS
+        assert "gpt-5.6" not in CODEX_MODELS
         assert "gpt-5.5" in CODEX_MODELS
         assert "gpt-5.3-codex" in CODEX_MODELS
         assert "gpt-5.3-codex-spark" in CODEX_MODELS
@@ -2537,9 +2540,22 @@ class TestValidateModelForBackend:
     def test_codex_accepts_codex_models(self):
         from kai.config import validate_model_for_backend
 
-        assert validate_model_for_backend("gpt-5.6", "codex", "openai") is True
+        assert validate_model_for_backend("gpt-5.6-sol", "codex", "openai") is True
+        assert validate_model_for_backend("gpt-5.6-terra", "codex", "openai") is True
+        assert validate_model_for_backend("gpt-5.6-luna", "codex", "openai") is True
         assert validate_model_for_backend("gpt-5.5", "codex", "openai") is True
         assert validate_model_for_backend("gpt-5.4-mini", "codex", "openai") is True
+
+    def test_codex_rejects_gpt56_family_shorthand(self):
+        from kai.config import validate_model_for_backend
+
+        assert validate_model_for_backend("gpt-5.6", "codex", "openai") is False
+
+    def test_codex_canonicalizes_retired_gpt56_shorthand(self):
+        from kai.config import canonicalize_model_for_backend
+
+        assert canonicalize_model_for_backend("gpt-5.6", "codex") == "gpt-5.6-sol"
+        assert canonicalize_model_for_backend("gpt-5.6", "goose") == "gpt-5.6"
 
     def test_codex_rejects_nano_even_though_in_openai_provider_list(self):
         from kai.config import PROVIDER_MODELS, validate_model_for_backend
@@ -2732,6 +2748,16 @@ class TestDefaultBackendEnvResolution:
         config_module._renamed_key_deprecation_warned.clear()
         cfg = load_config()
         assert cfg.default_backend == "codex"
+
+    def test_codex_legacy_gpt56_default_is_canonicalized(self, monkeypatch):
+        """An installed shorthand survives upgrade as the exact Sol model ID."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv("DEFAULT_BACKEND", "codex")
+        monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.6")
+
+        cfg = load_config()
+
+        assert cfg.default_model == "gpt-5.6-sol"
 
     def test_legacy_AGENT_BACKEND_env_still_resolved_with_warning(self, monkeypatch, caplog):
         """Only the deprecated key set: it still resolves, and a WARNING

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3764,6 +3764,26 @@ class TestCmdApplyDefaultModelGate:
         assert written_env.get("DEFAULT_BACKEND") == "codex"
         assert "AGENT_BACKEND" not in written_env
 
+    def test_apply_canonicalizes_legacy_codex_gpt56_model(self, tmp_path, monkeypatch):
+        """Apply rewrites the rejected family shorthand before writing /etc/kai/env."""
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {"DEFAULT_MODEL": "gpt-5.6", "DEFAULT_BACKEND": "codex"},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        self._patch_side_effects(monkeypatch)
+        secrets_mock = MagicMock()
+        monkeypatch.setattr("kai.install._apply_secrets", secrets_mock)
+        monkeypatch.setenv("DRY_RUN", "1")
+
+        _cmd_apply()
+
+        written_env = secrets_mock.call_args.args[0]
+        assert written_env["DEFAULT_MODEL"] == "gpt-5.6-sol"
+
     def test_apply_resolves_new_DEFAULT_BACKEND(self, tmp_path, monkeypatch):
         """A new-name install.conf passes through cleanly: goose-path
         setup is reached (the gate accepts a goose-valid model and apply

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kai.config import Config, UserConfig
+from kai.config import Config, UserConfig, WorkspaceConfig
 from kai.goose import GooseBackend
 from kai.pool import SubprocessPool
 
@@ -644,6 +644,67 @@ class TestWorkspaceRestoration:
             # Model is a CLI flag, so changing it triggers restart
             assert instance.model == "opus"
             mock_restart.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_restore_migrates_legacy_codex_gpt56_setting(self, tmp_path):
+        """The briefly offered family shorthand is persisted as the exact Sol ID."""
+        config = _make_config(
+            default_backend="codex",
+            default_provider="openai",
+            default_model="gpt-5.5",
+        )
+        pool = SubprocessPool(config=config, services_info=[])
+        instance = pool.get(111)
+
+        with (
+            patch(
+                "kai.pool.sessions.get_user_settings",
+                new_callable=AsyncMock,
+                return_value={"model": "gpt-5.6"},
+            ),
+            patch("kai.pool.sessions.set_user_setting", new_callable=AsyncMock) as mock_store,
+            patch.object(instance, "restart", new_callable=AsyncMock) as mock_restart,
+        ):
+            await pool._apply_user_db_settings(111, instance)
+
+        assert instance.model == "gpt-5.6-sol"
+        mock_store.assert_awaited_once_with(111, "model", "gpt-5.6-sol")
+        mock_restart.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_legacy_codex_workspace_alias_keeps_precedence_over_db_model(self, tmp_path):
+        """Canonicalization must not make an applied workspace override look invalid."""
+        ws = (tmp_path / "ws").resolve()
+        ws.mkdir()
+        user = UserConfig(
+            telegram_id=111,
+            name="alice",
+            backend="codex",
+            home_workspace=ws,
+        )
+        config = _make_config(
+            default_backend="codex",
+            default_provider="openai",
+            default_model="gpt-5.5",
+            user_configs={111: user},
+        )
+        config.workspace_configs[ws] = WorkspaceConfig(path=ws, model="gpt-5.6")
+        pool = SubprocessPool(config=config, services_info=[])
+        instance = pool.get(111)
+        assert instance.model == "gpt-5.6-sol"
+
+        with (
+            patch(
+                "kai.pool.sessions.get_user_settings",
+                new_callable=AsyncMock,
+                return_value={"model": "gpt-5.5"},
+            ),
+            patch.object(instance, "restart", new_callable=AsyncMock) as mock_restart,
+        ):
+            await pool._apply_user_db_settings(111, instance)
+
+        assert instance.model == "gpt-5.6-sol"
+        mock_restart.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_restore_no_db_settings_no_restart(self, tmp_path):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -644,6 +644,19 @@ class TestResolveUserDefaults:
         # Unset fields still come from globals
         assert result["timeout"] == 120
 
+    async def test_codex_legacy_gpt56_setting_resolves_to_sol(self, db):
+        """Settings displays use the same exact Codex ID as runtime dispatch."""
+        config = self._make_config(
+            default_backend="codex",
+            default_provider="openai",
+            default_model="gpt-5.5",
+        )
+        await sessions.set_user_setting(111, "model", "gpt-5.6")
+
+        result = await sessions.resolve_user_defaults(111, config)
+
+        assert result["model"] == "gpt-5.6-sol"
+
     async def test_yaml_overrides_globals(self, db):
         """users.yaml settings override global defaults."""
         from kai.config import UserConfig


### PR DESCRIPTION
## Summary

Correct Kai's Codex GPT-5.6 model choices for ChatGPT subscription authentication.

Kai briefly offered the family shorthand `gpt-5.6`. Codex accepted the selection locally but the ChatGPT-account service rejected the first request with HTTP 400:

> The 'gpt-5.6' model is not supported when using Codex with a ChatGPT account.

The account-aware Codex app-server catalog reports three selectable GPT-5.6 IDs:

- `gpt-5.6-sol` — default flagship model
- `gpt-5.6-terra` — balanced model
- `gpt-5.6-luna` — faster/lighter model

These exact model names also match the [official Codex model documentation](https://learn.chatgpt.com/docs/models).

## Root cause

The Codex registry used the `gpt-5.6` family shorthand shown in some documentation and CLI examples. That shorthand is not an account-selectable model ID for this ChatGPT subscription. Kai's validation therefore admitted a value that the downstream Codex service rejected.

## Changes

### Exact model surface

- Remove `gpt-5.6` from `CODEX_MODELS`.
- Add `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
- Update the Telegram model keyboard to expose only the exact supported IDs.
- Keep Kai's existing global Codex default at `gpt-5.5`; this change adds valid GPT-5.6 choices without silently changing every user's selected model.

### One-release compatibility migration

Add a Codex-only compatibility mapping from `gpt-5.6` to `gpt-5.6-sol`. The mapping is intentionally separate from the public model registry: new selections must use an exact supported ID, while existing installations continue working after upgrade.

The compatibility path covers:

- `DEFAULT_MODEL` during runtime configuration loading
- `DEFAULT_MODELS_JSON` role overrides
- existing `install.conf` values during `make config` and install apply
- per-user `model` and `models.*` entries in `users.yaml`
- YAML and database-backed workspace model overrides
- per-user model preferences stored in SQLite
- settings display before a subprocess has been created
- direct pool/backend construction paths used by runtime and tests

When a per-user SQLite preference contains `gpt-5.6`, Kai persists the corrected `gpt-5.6-sol` value when settings are restored. Canonicalization does not disturb workspace-over-user precedence and is not applied to non-Codex backends.

### Installer behavior

Install apply rewrites a legacy Codex `DEFAULT_MODEL=gpt-5.6` value to `gpt-5.6-sol` before writing `/etc/kai/env`. This prevents an existing `install.conf` from reintroducing the rejected model during an otherwise successful update.

## Verification

- Full test suite: **4,640 passed, 1 skipped**
- Focused model/migration regression suite: **67 passed**
- Ruff lint: passed
- Ruff formatting check: passed
- `git diff --check`: passed

Regression coverage includes:

- exact GPT-5.6 registry membership and validation
- Telegram picker callback values
- runtime `DEFAULT_MODEL` migration
- install apply environment migration
- per-user database migration and subprocess restart
- pre-subprocess settings resolution
- legacy workspace override canonicalization
- workspace precedence over user database settings after canonicalization
- non-Codex isolation of the compatibility mapping

## Deployment notes

After review, the normal deployment sequence remains:

1. `make DRY_RUN=1 install`
2. Inspect the dry-run plan.
3. `make install`
4. Select GPT-5.6 Sol, Terra, or Luna from Kai's model picker.

Existing users who selected the rejected shorthand are migrated to GPT-5.6 Sol automatically. No manual database edit is required.
