### PR TITLE
fix(security): restrict persistent agent memory scopes

### DIFF
--- a/src/kai/internal_api_auth.py
+++ b/src/kai/internal_api_auth.py
@@ -24,10 +24,23 @@ class InternalAPIScope(StrEnum):
     MESSAGES_SEND = "messages:send"
     FILES_SEND = "files:send"
     MEMORY_READ = "memory:read"
-    MEMORY_WRITE = "memory:write"
+    MEMORY_ADD = "memory:add"
+    MEMORY_DELETE_ALL = "memory:delete-all"
 
 
-_AGENT_SCOPES = frozenset(InternalAPIScope)
+# Keep the persistent-agent profile explicit. Constructing it from the enum
+# would silently grant every future capability to every long-lived agent.
+_PERSISTENT_AGENT_SCOPES = frozenset(
+    {
+        InternalAPIScope.JOBS_READ,
+        InternalAPIScope.JOBS_WRITE,
+        InternalAPIScope.SERVICES_CALL,
+        InternalAPIScope.MESSAGES_SEND,
+        InternalAPIScope.FILES_SEND,
+        InternalAPIScope.MEMORY_READ,
+        InternalAPIScope.MEMORY_ADD,
+    }
+)
 _NOTIFICATION_SCOPES = frozenset({InternalAPIScope.MESSAGES_SEND})
 
 
@@ -63,20 +76,20 @@ class InternalAPIAuth:
         for chat_id, credential in (agent_credentials or {}).items():
             self._register(
                 credential,
-                InternalAPIPrincipal(chat_id=chat_id, scopes=_AGENT_SCOPES),
+                InternalAPIPrincipal(chat_id=chat_id, scopes=_PERSISTENT_AGENT_SCOPES),
             )
 
     @classmethod
     def for_users(cls, user_ids: Iterable[int]) -> InternalAPIAuth:
-        """Create an auth store with a full agent credential for each user."""
+        """Create an auth store with a persistent-agent credential for each user."""
         auth = cls()
         for chat_id in sorted(set(user_ids)):
             auth.agent_credential_for(chat_id)
         return auth
 
     def agent_credential_for(self, chat_id: int) -> str:
-        """Return the full internal API credential for a persistent user agent."""
-        return self._credential_for(InternalAPIPrincipal(chat_id=chat_id, scopes=_AGENT_SCOPES))
+        """Return the scoped internal API credential for a persistent user agent."""
+        return self._credential_for(InternalAPIPrincipal(chat_id=chat_id, scopes=_PERSISTENT_AGENT_SCOPES))
 
     def notification_credential_for(self, chat_id: int) -> str:
         """Return a send-message-only credential for a notification agent."""

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -1618,7 +1618,7 @@ def _memory_disabled_response() -> web.Response:
     return web.json_response({"error": "Memory system disabled"}, status=503)
 
 
-@_require_internal_api(InternalAPIScope.MEMORY_WRITE)
+@_require_internal_api(InternalAPIScope.MEMORY_ADD)
 async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
     Store a structured memory via memory.add_structured().
@@ -1904,7 +1904,7 @@ async def _handle_memory_stats(request: web.Request, principal: InternalAPIPrinc
         return web.json_response({"error": "Memory stats failed"}, status=500)
 
 
-@_require_internal_api(InternalAPIScope.MEMORY_WRITE)
+@_require_internal_api(InternalAPIScope.MEMORY_DELETE_ALL)
 async def _handle_memory_delete_all(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
     Delete all memories for a user via memory.delete_all().

--- a/tests/test_internal_api_auth.py
+++ b/tests/test_internal_api_auth.py
@@ -22,6 +22,26 @@ def test_agent_credentials_are_unique_and_resolve_server_side() -> None:
     assert auth.authenticate("not-a-token") is None
 
 
+def test_persistent_agent_profile_is_explicit_and_excludes_delete_all() -> None:
+    """Persistent agents retain normal APIs but cannot wipe all memory."""
+    auth = InternalAPIAuth.for_users({123})
+    principal = auth.authenticate(auth.agent_credential_for(123))
+
+    assert principal is not None
+    assert principal.scopes == frozenset(
+        {
+            InternalAPIScope.JOBS_READ,
+            InternalAPIScope.JOBS_WRITE,
+            InternalAPIScope.SERVICES_CALL,
+            InternalAPIScope.MESSAGES_SEND,
+            InternalAPIScope.FILES_SEND,
+            InternalAPIScope.MEMORY_READ,
+            InternalAPIScope.MEMORY_ADD,
+        }
+    )
+    assert not principal.allows(InternalAPIScope.MEMORY_DELETE_ALL)
+
+
 def test_notification_credential_has_only_message_scope() -> None:
     """One-shot notification agents cannot access jobs, files, services, or memory."""
     auth = InternalAPIAuth()
@@ -35,7 +55,8 @@ def test_notification_credential_has_only_message_scope() -> None:
     assert not principal.allows(InternalAPIScope.SERVICES_CALL)
     assert not principal.allows(InternalAPIScope.FILES_SEND)
     assert not principal.allows(InternalAPIScope.MEMORY_READ)
-    assert not principal.allows(InternalAPIScope.MEMORY_WRITE)
+    assert not principal.allows(InternalAPIScope.MEMORY_ADD)
+    assert not principal.allows(InternalAPIScope.MEMORY_DELETE_ALL)
 
 
 def test_fixed_test_credentials_must_be_unique() -> None:

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -10,7 +10,7 @@ import pytest
 from aiohttp import web
 
 from kai import sessions
-from kai.internal_api_auth import InternalAPIAuth, InternalAPIPrincipal
+from kai.internal_api_auth import InternalAPIAuth, InternalAPIPrincipal, InternalAPIScope
 from kai.services import ServiceResponse
 from kai.webhook import (
     ALLOWED_USER_IDS_KEY,
@@ -48,6 +48,15 @@ from kai.webhook import (
 def _make_internal_api_auth() -> InternalAPIAuth:
     """Create deterministic credentials for the two API test principals."""
     return InternalAPIAuth({123: "test-secret", 456: "other-secret"})
+
+
+async def _call_memory_delete_all_as_authorized(request, *, chat_id: int = 123):
+    """Exercise delete-all handler behavior with an explicitly privileged principal."""
+    principal = InternalAPIPrincipal(
+        chat_id=chat_id,
+        scopes=frozenset({InternalAPIScope.MEMORY_DELETE_ALL}),
+    )
+    return await _handle_memory_delete_all.__wrapped__(request, principal)
 
 
 @pytest.fixture
@@ -2783,7 +2792,7 @@ class TestMemoryDeleteAll:
         mock_request.json = AsyncMock(return_value={"confirm": self._CONFIRM})
 
         with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.delete_all"):
-            resp = await _handle_memory_delete_all(mock_request)
+            resp = await _call_memory_delete_all_as_authorized(mock_request)
 
         assert resp.status == 200
         body = json.loads(resp.body.decode())
@@ -2795,7 +2804,7 @@ class TestMemoryDeleteAll:
         mock_request.json = AsyncMock(return_value={})
 
         with patch("kai.memory.delete_all") as mock_del:
-            resp = await _handle_memory_delete_all(mock_request)
+            resp = await _call_memory_delete_all_as_authorized(mock_request)
 
         assert resp.status == 400
         body = json.loads(resp.body.decode())
@@ -2810,7 +2819,7 @@ class TestMemoryDeleteAll:
         mock_request.json = AsyncMock(return_value={"confirm": "yes-please"})
 
         with patch("kai.memory.delete_all") as mock_del:
-            resp = await _handle_memory_delete_all(mock_request)
+            resp = await _call_memory_delete_all_as_authorized(mock_request)
 
         assert resp.status == 400
         mock_del.assert_not_called()
@@ -2821,7 +2830,7 @@ class TestMemoryDeleteAll:
         mock_request.json = AsyncMock(return_value={"confirm": self._CONFIRM})
 
         with patch("kai.memory.is_enabled", return_value=False), patch("kai.memory.delete_all") as mock_del:
-            resp = await _handle_memory_delete_all(mock_request)
+            resp = await _call_memory_delete_all_as_authorized(mock_request)
 
         assert resp.status == 503
         # The user explicitly asked for a delete; if memory is off, we
@@ -2835,7 +2844,7 @@ class TestMemoryDeleteAll:
         mock_request.json = AsyncMock(return_value={"confirm": self._CONFIRM, "chat_id": 456})
 
         with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.delete_all") as mock_del:
-            await _handle_memory_delete_all(mock_request)
+            await _call_memory_delete_all_as_authorized(mock_request, chat_id=456)
 
         assert mock_del.call_args.kwargs["user_id"] == "456"
         assert isinstance(mock_del.call_args.kwargs["user_id"], str)
@@ -2863,7 +2872,7 @@ class TestMemoryDeleteAll:
             patch("kai.memory.is_enabled", return_value=True),
             patch("kai.memory.delete_all", side_effect=RuntimeError("boom")),
         ):
-            resp = await _handle_memory_delete_all(mock_request)
+            resp = await _call_memory_delete_all_as_authorized(mock_request)
 
         assert resp.status == 500
         body = json.loads(resp.body.decode())
@@ -2883,9 +2892,21 @@ class TestMemoryDeleteAll:
             patch("kai.memory.is_enabled", return_value=True),
             patch("kai.memory.delete_all") as mock_del,
         ):
+            resp = await _call_memory_delete_all_as_authorized(mock_request)
+
+        assert resp.status == 403
+        mock_del.assert_not_called()
+
+    async def test_persistent_agent_scope_cannot_delete_all(self, mock_request):
+        """A normal persistent-agent credential is denied before deletion."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"confirm": self._CONFIRM})
+
+        with patch("kai.memory.delete_all") as mock_del:
             resp = await _handle_memory_delete_all(mock_request)
 
         assert resp.status == 403
+        assert resp.text == "Credential is not authorized for this operation"
         mock_del.assert_not_called()
 
 
@@ -2932,7 +2953,7 @@ _NON_OBJECT_HANDLERS = [
     pytest.param(_handle_send_file, lambda r: None, id="send_file"),
     pytest.param(_handle_memory_add, lambda r: None, id="memory_add"),
     pytest.param(_handle_memory_search, lambda r: None, id="memory_search"),
-    pytest.param(_handle_memory_delete_all, lambda r: None, id="memory_delete_all"),
+    pytest.param(_call_memory_delete_all_as_authorized, lambda r: None, id="memory_delete_all"),
 ]
 
 # Non-object JSON shapes the handlers must reject. `True` is included


### PR DESCRIPTION
## Summary

Restrict persistent-agent internal API authority by replacing the implicit all-scopes profile with an explicit capability set and separating ordinary memory writes from destructive full-memory deletion.

This is the first small least-privilege follow-up to the authenticated-principal work. It deliberately leaves job, service, messaging, and file behavior unchanged.

## Security rationale

The principal-bound internal API now prevents one agent from selecting another user's `chat_id`, and notification credentials are already send-message-only. Persistent agents, however, still received `frozenset(InternalAPIScope)`. That had two problems:

1. every persistent agent automatically received every current internal API capability; and
2. adding a future enum member would silently grant that capability to every long-lived agent.

The broad `memory:write` scope also covered both normal fact creation and `DELETE /api/memory/all`. The endpoint's static confirmation string is useful for typo resistance, but it is not an authorization boundary against a prompt-injected persistent agent.

## Changes

- Replace the enum-derived persistent-agent scope set with an explicit `_PERSISTENT_AGENT_SCOPES` profile.
- Replace `memory:write` with two capabilities:
  - `memory:add`
  - `memory:delete-all`
- Grant persistent agents `memory:add` but not `memory:delete-all`.
- Keep notification credentials restricted to `messages:send` only.
- Require `memory:add` on `POST /api/memory/add`.
- Require `memory:delete-all` on `DELETE /api/memory/all`.
- Add regression coverage proving:
  - the persistent profile is exactly the intended explicit set;
  - persistent agents retain memory-add authority;
  - persistent agents receive `403` on delete-all before the memory primitive is called;
  - notification credentials receive neither memory capability; and
  - delete-all handler validation remains covered beneath a synthetic explicitly privileged principal.

## Compatibility

No configuration, database, installer, or deployment migration is required.

Normal persistent-agent behavior is preserved: job management, configured service calls, proactive messaging, file delivery, memory reads, and memory addition retain their existing scopes. The only removed standing capability is the unadvertised ability for a persistent conversational agent to wipe all of its user's semantic memory through the internal API.

The delete-all handler and scope remain available for a future explicitly trusted issuance path, but neither persistent-agent nor notification credentials receive that scope today.

## Verification

- `python -m pytest -q`: **4,642 passed, 1 skipped**
- Focused authorization/webhook suite: **234 passed**
- Ruff on all four changed files: passed
- `git diff --check`: passed
- Confirmed no stale `MEMORY_WRITE`, `memory:write`, or enum-derived all-scope profile remains under `src/` or `tests/`

## Follow-up work not included

- Per-user/per-service authorization for the external-service proxy
- Separate create/update/delete job capabilities and user-confirmed destructive job actions
- Confining file delivery to `DATA_DIR/files/<principal>`
- Making injected internal-API documentation capability-aware

Those changes have different compatibility and configuration consequences and should remain independently reviewable.
