### PR TITLE
fix(security): authorize service proxy per user

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Kai has real local authority, so the security model is part of the product rathe
 - **Optional TOTP gate:** Time-based one-time passwords can protect the chat surface after idle timeout.
 - **Local execution:** Kai runs on your machine. Conversations do not pass through a Kai-hosted relay.
 - **Path confinement:** File exchange is constrained to allowed workspace and file-storage paths.
-- **Service proxy:** Third-party API keys live in server-side config and are injected at request time, not placed in conversation context.
+- **Service proxy:** Third-party API keys live in server-side config and are injected only for services explicitly allowed to that user in `users.yaml`; keys are never placed in conversation context.
 - **Per-user isolation:** Users have separate history, files, workspaces, jobs, settings, and agent subprocesses.
 - **Principal-bound internal API:** Agent API credentials resolve to a fixed user and explicit scopes in the outer service; request data cannot select another principal.
 - **Separated webhook credentials:** GitHub, generic, and Telegram ingress use distinct secrets that are not exposed to persistent agent subprocesses.

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1044,6 +1044,8 @@ class UserConfig:
         timeout: Default timeout in seconds for Claude responses.
         workspace_base: Base directory for /workspace new and name resolution.
             Falls back to global WORKSPACE_BASE env var if not set.
+        allowed_services: External proxy service names this user's persistent
+            agent may call. Empty by default, including for admins.
     """
 
     telegram_id: int
@@ -1076,6 +1078,10 @@ class UserConfig:
     github_notify_chat_id: int | None = None
     pr_review: bool | None = None
     issue_triage: bool | None = None
+    # External services the persistent agent may call through Kai's
+    # credential-injecting proxy. Admin-controlled via users.yaml and
+    # fail-closed: omission means no services, including for admins.
+    allowed_services: list[str] = field(default_factory=list)
     # Per-role per-user model overrides loaded from users.yaml `models:`.
     # Keys are role identifiers: "agent" for the conversational role
     # plus every ModelRole.value ("pr_review", "issue_triage",
@@ -2507,6 +2513,36 @@ def _load_user_configs(
                 name,
             )
 
+        # Parse the explicit per-user external-service allowlist. Service
+        # existence is checked later by SubprocessPool, after services.yaml
+        # has been loaded and missing-key services have been filtered out.
+        raw_allowed_services = entry.get("allowed_services", [])
+        allowed_services: list[str] = []
+        if isinstance(raw_allowed_services, list):
+            for raw_service in raw_allowed_services:
+                if not isinstance(raw_service, str):
+                    log.warning(
+                        "users.yaml: invalid allowed_services entry for %s: %r (expected a service name)",
+                        name,
+                        raw_service,
+                    )
+                    continue
+                service_name = raw_service.strip()
+                if not service_name or service_name == "*" or "/" in service_name:
+                    log.warning(
+                        "users.yaml: invalid allowed_services entry for %s: %r (wildcards and paths are not allowed)",
+                        name,
+                        raw_service,
+                    )
+                    continue
+                if service_name not in allowed_services:
+                    allowed_services.append(service_name)
+        else:
+            log.warning(
+                "users.yaml: allowed_services for %s must be a list (ignoring)",
+                name,
+            )
+
         # Parse optional github_notify_chat_id (integer, can be negative
         # for group chats). Follows the same pattern as telegram_id validation.
         github_notify_chat_id: int | None = None
@@ -2611,6 +2647,7 @@ def _load_user_configs(
             github_notify_chat_id=github_notify_chat_id,
             pr_review=pr_review,
             issue_triage=issue_triage,
+            allowed_services=allowed_services,
             models=user_models,
         )
 

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2600,6 +2600,7 @@ def _generate_users_yaml(
         # round-trip as non-string types through yaml.safe_load.
         f"    name: {_yaml_scalar(name)}",
         "    role: admin",
+        "    allowed_services: []",
     ]
     if os_user:
         lines.append(f"    os_user: {_yaml_scalar(os_user)}")

--- a/src/kai/internal_api_auth.py
+++ b/src/kai/internal_api_auth.py
@@ -28,13 +28,14 @@ class InternalAPIScope(StrEnum):
     MEMORY_DELETE_ALL = "memory:delete-all"
 
 
-# Keep the persistent-agent profile explicit. Constructing it from the enum
-# would silently grant every future capability to every long-lived agent.
-_PERSISTENT_AGENT_SCOPES = frozenset(
+# Keep the persistent-agent base profile explicit. Constructing it from the
+# enum would silently grant every future capability to every long-lived agent.
+# SERVICES_CALL is added only when that principal has at least one explicitly
+# allowed service name.
+_PERSISTENT_AGENT_BASE_SCOPES = frozenset(
     {
         InternalAPIScope.JOBS_READ,
         InternalAPIScope.JOBS_WRITE,
-        InternalAPIScope.SERVICES_CALL,
         InternalAPIScope.MESSAGES_SEND,
         InternalAPIScope.FILES_SEND,
         InternalAPIScope.MEMORY_READ,
@@ -50,10 +51,15 @@ class InternalAPIPrincipal:
 
     chat_id: int
     scopes: frozenset[InternalAPIScope]
+    allowed_services: frozenset[str] = frozenset()
 
     def allows(self, scope: InternalAPIScope) -> bool:
         """Return whether this principal has the requested API scope."""
         return scope in self.scopes
+
+    def allows_service(self, service_name: str) -> bool:
+        """Return whether this principal may call one named service."""
+        return self.allows(InternalAPIScope.SERVICES_CALL) and service_name in self.allowed_services
 
 
 class InternalAPIAuth:
@@ -67,29 +73,45 @@ class InternalAPIAuth:
         agent_credentials: Optional fixed per-user credentials. Production code
             leaves this unset and receives cryptographically random tokens; the
             explicit form keeps direct handler tests deterministic.
+        allowed_services_by_user: Explicit service names each persistent user
+            agent may call. Omitted users receive no service-call scope.
     """
 
-    def __init__(self, agent_credentials: Mapping[int, str] | None = None) -> None:
+    def __init__(
+        self,
+        agent_credentials: Mapping[int, str] | None = None,
+        *,
+        allowed_services_by_user: Mapping[int, Iterable[str]] | None = None,
+    ) -> None:
         self._principals_by_credential: dict[str, InternalAPIPrincipal] = {}
         self._credentials_by_principal: dict[InternalAPIPrincipal, str] = {}
+        self._allowed_services_by_user = {
+            chat_id: frozenset(name for name in names if name)
+            for chat_id, names in (allowed_services_by_user or {}).items()
+        }
 
         for chat_id, credential in (agent_credentials or {}).items():
             self._register(
                 credential,
-                InternalAPIPrincipal(chat_id=chat_id, scopes=_PERSISTENT_AGENT_SCOPES),
+                self._agent_principal(chat_id),
             )
 
     @classmethod
-    def for_users(cls, user_ids: Iterable[int]) -> InternalAPIAuth:
+    def for_users(
+        cls,
+        user_ids: Iterable[int],
+        *,
+        allowed_services_by_user: Mapping[int, Iterable[str]] | None = None,
+    ) -> InternalAPIAuth:
         """Create an auth store with a persistent-agent credential for each user."""
-        auth = cls()
+        auth = cls(allowed_services_by_user=allowed_services_by_user)
         for chat_id in sorted(set(user_ids)):
             auth.agent_credential_for(chat_id)
         return auth
 
     def agent_credential_for(self, chat_id: int) -> str:
         """Return the scoped internal API credential for a persistent user agent."""
-        return self._credential_for(InternalAPIPrincipal(chat_id=chat_id, scopes=_PERSISTENT_AGENT_SCOPES))
+        return self._credential_for(self._agent_principal(chat_id))
 
     def notification_credential_for(self, chat_id: int) -> str:
         """Return a send-message-only credential for a notification agent."""
@@ -111,6 +133,18 @@ class InternalAPIAuth:
             if hmac.compare_digest(credential, expected):
                 matched = principal
         return matched
+
+    def _agent_principal(self, chat_id: int) -> InternalAPIPrincipal:
+        """Build the configured persistent-agent principal for one user."""
+        allowed_services = self._allowed_services_by_user.get(chat_id, frozenset())
+        scopes = set(_PERSISTENT_AGENT_BASE_SCOPES)
+        if allowed_services:
+            scopes.add(InternalAPIScope.SERVICES_CALL)
+        return InternalAPIPrincipal(
+            chat_id=chat_id,
+            scopes=frozenset(scopes),
+            allowed_services=allowed_services,
+        )
 
     def _credential_for(self, principal: InternalAPIPrincipal) -> str:
         """Return an existing credential for a principal or issue a new one."""

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -70,11 +70,40 @@ class SubprocessPool:
         services_info: list[dict],
     ):
         self._config = config
-        self._services_info = services_info
+        available_service_names = {
+            service["name"]
+            for service in services_info
+            if isinstance(service.get("name"), str) and service["name"]
+        }
+        allowed_services_by_user: dict[int, frozenset[str]] = {}
+        self._services_info_by_user: dict[int, list[dict]] = {}
+        for chat_id in config.allowed_user_ids:
+            user = config.get_user_config(chat_id)
+            requested = frozenset(user.allowed_services if user else [])
+            unavailable = requested - available_service_names
+            if unavailable:
+                log.warning(
+                    "users.yaml: user %d has unavailable allowed_services: %s; denying them",
+                    chat_id,
+                    ", ".join(sorted(unavailable)),
+                )
+            allowed = requested & available_service_names
+            allowed_services_by_user[chat_id] = allowed
+            self._services_info_by_user[chat_id] = [
+                service for service in services_info if service.get("name") in allowed
+            ]
+        if available_service_names and not any(allowed_services_by_user.values()):
+            log.warning(
+                "External services are loaded but no user has an allowed_services grant; "
+                "the agent service proxy is disabled for every user"
+            )
         # Tokens are random and process-local. The pool owns the store because
         # it creates every persistent backend; webhook.start() receives this
         # same object through bot_data so credential resolution cannot drift.
-        self._internal_api_auth = InternalAPIAuth.for_users(config.allowed_user_ids)
+        self._internal_api_auth = InternalAPIAuth.for_users(
+            config.allowed_user_ids,
+            allowed_services_by_user=allowed_services_by_user,
+        )
         self._pool: dict[int, AgentBackend] = {}
         self._last_activity: dict[int, float] = {}
         # Pending one-time setup for a freshly-created backend instance.
@@ -257,6 +286,7 @@ class SubprocessPool:
         # Agents receive only their random principal credential, never an
         # external webhook signing secret.
         internal_api_credential = self._internal_api_auth.agent_credential_for(chat_id)
+        services_info = self._services_info_by_user.get(chat_id, [])
 
         if backend == "goose":
             return GooseBackend(
@@ -266,7 +296,7 @@ class SubprocessPool:
                 webhook_port=self._config.webhook_port,
                 webhook_secret=internal_api_credential,
                 timeout_seconds=timeout,
-                services_info=self._services_info,
+                services_info=services_info,
                 workspace_config=ws_config,
                 provider=effective_provider,
                 memory_enabled=self._config.memory_enabled,
@@ -287,7 +317,7 @@ class SubprocessPool:
                 webhook_port=self._config.webhook_port,
                 webhook_secret=internal_api_credential,
                 timeout_seconds=timeout,
-                services_info=self._services_info,
+                services_info=services_info,
                 workspace_config=ws_config,
                 provider=effective_provider,
                 memory_enabled=self._config.memory_enabled,
@@ -309,7 +339,7 @@ class SubprocessPool:
                 webhook_port=self._config.webhook_port,
                 webhook_secret=internal_api_credential,
                 timeout_seconds=timeout,
-                services_info=self._services_info,
+                services_info=services_info,
                 workspace_config=ws_config,
                 provider="openai",
                 codex_user=os_user,
@@ -325,7 +355,7 @@ class SubprocessPool:
             webhook_port=self._config.webhook_port,
             webhook_secret=internal_api_credential,
             timeout_seconds=timeout,
-            services_info=self._services_info,
+            services_info=services_info,
             claude_user=os_user,
             max_session_hours=self._config.agent_max_session_hours,
             workspace_config=ws_config,

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -71,9 +71,7 @@ class SubprocessPool:
     ):
         self._config = config
         available_service_names = {
-            service["name"]
-            for service in services_info
-            if isinstance(service.get("name"), str) and service["name"]
+            service["name"] for service in services_info if isinstance(service.get("name"), str) and service["name"]
         }
         allowed_services_by_user: dict[int, frozenset[str]] = {}
         self._services_info_by_user: dict[int, list[dict]] = {}

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -1369,7 +1369,7 @@ async def _handle_update_job(request: web.Request, principal: InternalAPIPrincip
 
 
 @_require_internal_api(InternalAPIScope.SERVICES_CALL)
-async def _handle_service_call(request: web.Request, _principal: InternalAPIPrincipal) -> web.Response:
+async def _handle_service_call(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
     Proxy an authenticated request to an external service.
 
@@ -1391,6 +1391,13 @@ async def _handle_service_call(request: web.Request, _principal: InternalAPIPrin
 
     # Extract service name from URL path
     service_name = request.match_info["name"]
+    if not principal.allows_service(service_name):
+        log.warning(
+            "Internal API service denial for principal %d: %s",
+            principal.chat_id,
+            service_name,
+        )
+        return web.json_response({"error": "Service is not authorized for this principal"}, status=403)
 
     # Parse optional JSON body with request parameters. The body is
     # genuinely optional here (services with no JSON-body config still

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -6,8 +6,10 @@
 # Setup:
 #   1. Copy this file to the repo root: cp templates/services.yaml services.yaml
 #   2. Uncomment the services you want to use
-#   3. Set the corresponding API key(s) in .env
-#   4. Restart Kai
+#   3. Add each service name to the intended users' `allowed_services`
+#      lists in users.yaml
+#   4. Set the corresponding API key(s) in .env
+#   5. Restart Kai
 #
 # Kai injects authentication from .env at call time — API keys never
 # enter Claude's context. See <DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md for usage docs.

--- a/templates/users.yaml
+++ b/templates/users.yaml
@@ -23,6 +23,12 @@ users:
     # os_user: alice          # OS user for subprocess isolation
     # home_workspace: ~/projects/main  # per-user home workspace
 
+    # External services this user's persistent agent may call through
+    # Kai's credential-injecting proxy. Omission means no services, even
+    # for admins. Names must match enabled entries in services.yaml.
+    allowed_services:
+      - perplexity
+
     # workspace_base: directory for /workspace new and name resolution.
     # /workspace <name> looks for subdirectories under this path.
     # Inherits the global WORKSPACE_BASE installation default if unset.

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -254,6 +254,7 @@ class TestGenerateUsersYaml:
         assert entry["telegram_id"] == 123456789  # int, not string
         assert entry["name"] == "alice"
         assert entry["role"] == "admin"
+        assert entry["allowed_services"] == []
         assert "os_user" not in entry
         assert "home_workspace" not in entry
 

--- a/tests/test_internal_api_auth.py
+++ b/tests/test_internal_api_auth.py
@@ -32,14 +32,35 @@ def test_persistent_agent_profile_is_explicit_and_excludes_delete_all() -> None:
         {
             InternalAPIScope.JOBS_READ,
             InternalAPIScope.JOBS_WRITE,
-            InternalAPIScope.SERVICES_CALL,
             InternalAPIScope.MESSAGES_SEND,
             InternalAPIScope.FILES_SEND,
             InternalAPIScope.MEMORY_READ,
             InternalAPIScope.MEMORY_ADD,
         }
     )
+    assert principal.allowed_services == frozenset()
+    assert not principal.allows(InternalAPIScope.SERVICES_CALL)
     assert not principal.allows(InternalAPIScope.MEMORY_DELETE_ALL)
+
+
+def test_persistent_agent_service_scope_requires_explicit_names() -> None:
+    """Service scope and resources are issued only from the per-user allowlist."""
+    auth = InternalAPIAuth.for_users(
+        {123, 456},
+        allowed_services_by_user={123: {"perplexity", "weather"}},
+    )
+
+    principal_123 = auth.authenticate(auth.agent_credential_for(123))
+    principal_456 = auth.authenticate(auth.agent_credential_for(456))
+
+    assert principal_123 is not None
+    assert principal_123.allows(InternalAPIScope.SERVICES_CALL)
+    assert principal_123.allows_service("perplexity")
+    assert principal_123.allows_service("weather")
+    assert not principal_123.allows_service("billing")
+    assert principal_456 is not None
+    assert not principal_456.allows(InternalAPIScope.SERVICES_CALL)
+    assert not principal_456.allows_service("perplexity")
 
 
 def test_notification_credential_has_only_message_scope() -> None:
@@ -49,6 +70,7 @@ def test_notification_credential_has_only_message_scope() -> None:
 
     assert principal is not None
     assert principal.chat_id == -100123
+    assert principal.allowed_services == frozenset()
     assert principal.allows(InternalAPIScope.MESSAGES_SEND)
     assert not principal.allows(InternalAPIScope.JOBS_READ)
     assert not principal.allows(InternalAPIScope.JOBS_WRITE)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -20,6 +20,7 @@ import pytest
 
 from kai.config import Config, UserConfig, WorkspaceConfig
 from kai.goose import GooseBackend
+from kai.internal_api_auth import InternalAPIScope
 from kai.pool import SubprocessPool
 
 
@@ -92,6 +93,60 @@ class TestInstanceCreation:
         principal = pool.internal_api_auth.authenticate(credential)
         assert principal is not None
         assert principal.chat_id == 111
+
+    def test_services_are_filtered_per_user_and_bound_to_principal(self):
+        """Only explicitly allowed, available services reach each agent."""
+        services_info = [
+            {"name": "perplexity", "method": "POST", "description": "search"},
+            {"name": "weather", "method": "GET", "description": "weather"},
+        ]
+        config = _make_config(
+            user_configs={
+                111: UserConfig(telegram_id=111, name="alice", allowed_services=["perplexity"]),
+                222: UserConfig(telegram_id=222, name="bob"),
+            }
+        )
+        pool = SubprocessPool(config=config, services_info=services_info)
+
+        alice = pool.get(111)
+        bob = pool.get(222)
+        alice_principal = pool.internal_api_auth.authenticate(alice._api_context.webhook_secret)
+        bob_principal = pool.internal_api_auth.authenticate(bob._api_context.webhook_secret)
+
+        assert alice._api_context.services_info == [services_info[0]]
+        assert bob._api_context.services_info == []
+        assert alice_principal is not None
+        assert alice_principal.allows(InternalAPIScope.SERVICES_CALL)
+        assert alice_principal.allows_service("perplexity")
+        assert not alice_principal.allows_service("weather")
+        assert bob_principal is not None
+        assert not bob_principal.allows(InternalAPIScope.SERVICES_CALL)
+
+    def test_unavailable_allowed_service_is_denied_with_warning(self, caplog):
+        """Typos and unloaded services never become credential authority."""
+        config = _make_config(
+            user_configs={
+                111: UserConfig(telegram_id=111, name="alice", allowed_services=["missing"]),
+                222: UserConfig(telegram_id=222, name="bob"),
+            }
+        )
+
+        pool = SubprocessPool(config=config, services_info=[])
+        instance = pool.get(111)
+        principal = pool.internal_api_auth.authenticate(instance._api_context.webhook_secret)
+
+        assert principal is not None
+        assert principal.allowed_services == frozenset()
+        assert instance._api_context.services_info == []
+        assert "unavailable allowed_services: missing; denying them" in caplog.text
+
+    def test_loaded_services_without_any_grants_warn(self, caplog):
+        """Secure upgrade default is visible rather than silently surprising."""
+        services_info = [{"name": "perplexity", "method": "POST", "description": "search"}]
+
+        SubprocessPool(config=_make_config(), services_info=services_info)
+
+        assert "service proxy is disabled for every user" in caplog.text
 
     def test_get_uses_user_config(self, tmp_path):
         """User with os_user and home_workspace gets correct instance."""

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -45,6 +45,7 @@ class TestUserConfig:
         assert uc.github_notify_chat_id is None
         assert uc.pr_review is None
         assert uc.issue_triage is None
+        assert uc.allowed_services == []
         assert uc.backend is None
         assert uc.provider is None
 
@@ -64,6 +65,7 @@ class TestUserConfig:
             github_notify_chat_id=-100123456789,
             pr_review=True,
             issue_triage=False,
+            allowed_services=["perplexity"],
             backend="goose",
             provider="openai",
         )
@@ -77,6 +79,7 @@ class TestUserConfig:
         assert uc.github_notify_chat_id == -100123456789
         assert uc.pr_review is True
         assert uc.issue_triage is False
+        assert uc.allowed_services == ["perplexity"]
         assert uc.backend == "goose"
         assert uc.provider == "openai"
 
@@ -539,6 +542,7 @@ class TestLoadUserConfigs:
         assert configs[111].github_notify_chat_id is None
         assert configs[111].pr_review is None
         assert configs[111].issue_triage is None
+        assert configs[111].allowed_services == []
 
     # ── workspace_base field ──
 
@@ -596,6 +600,59 @@ class TestLoadUserConfigs:
             configs = _load_user_configs("claude", "")
         assert configs is not None
         assert configs[111].workspace_base is None
+
+    # ── allowed_services field ──
+
+    def test_allowed_services_parsed_deduplicated_and_ordered(self, tmp_path):
+        data = self._yaml_dict(
+            """\
+            users:
+              - telegram_id: 111
+                name: alice
+                allowed_services:
+                  - perplexity
+                  - weather
+                  - perplexity
+            """,
+        )
+        with patch("kai.config._read_protected_yaml", return_value=data):
+            configs = _load_user_configs("claude", "")
+
+        assert configs[111].allowed_services == ["perplexity", "weather"]
+
+    def test_allowed_services_invalid_entries_fail_closed(self, tmp_path, caplog):
+        data = self._yaml_dict(
+            """\
+            users:
+              - telegram_id: 111
+                name: alice
+                allowed_services:
+                  - perplexity
+                  - '*'
+                  - nested/service
+                  - 42
+            """,
+        )
+        with patch("kai.config._read_protected_yaml", return_value=data):
+            configs = _load_user_configs("claude", "")
+
+        assert configs[111].allowed_services == ["perplexity"]
+        assert "invalid allowed_services entry" in caplog.text
+
+    def test_allowed_services_not_list_is_ignored(self, tmp_path, caplog):
+        data = self._yaml_dict(
+            """\
+            users:
+              - telegram_id: 111
+                name: alice
+                allowed_services: perplexity
+            """,
+        )
+        with patch("kai.config._read_protected_yaml", return_value=data):
+            configs = _load_user_configs("claude", "")
+
+        assert configs[111].allowed_services == []
+        assert "allowed_services for alice must be a list" in caplog.text
 
     # ── github_repos field ──
 

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -47,7 +47,10 @@ from kai.webhook import (
 
 def _make_internal_api_auth() -> InternalAPIAuth:
     """Create deterministic credentials for the two API test principals."""
-    return InternalAPIAuth({123: "test-secret", 456: "other-secret"})
+    return InternalAPIAuth(
+        {123: "test-secret", 456: "other-secret"},
+        allowed_services_by_user={123: {"perplexity"}},
+    )
 
 
 async def _call_memory_delete_all_as_authorized(request, *, chat_id: int = 123):
@@ -1471,6 +1474,30 @@ class TestServiceCall:
         resp = await _handle_service_call(service_request)
 
         assert resp.status == 401
+
+    async def test_unlisted_service_returns_403_before_proxy_call(self, service_request):
+        """A service-scoped principal cannot select a different service name."""
+        service_request.match_info = {"name": "billing"}
+        service_request.json = AsyncMock(return_value={"body": {}})
+
+        with patch("kai.services.call_service", new_callable=AsyncMock) as mock_call:
+            resp = await _handle_service_call(service_request)
+
+        assert resp.status == 403
+        assert json.loads(resp.body.decode()) == {"error": "Service is not authorized for this principal"}
+        mock_call.assert_not_called()
+
+    async def test_user_without_service_grants_lacks_scope(self, service_request):
+        """An empty allowlist omits the broad service-call scope entirely."""
+        service_request.headers = {"X-Webhook-Secret": "other-secret"}
+        service_request.json = AsyncMock(return_value={"body": {}})
+
+        with patch("kai.services.call_service", new_callable=AsyncMock) as mock_call:
+            resp = await _handle_service_call(service_request)
+
+        assert resp.status == 403
+        assert resp.text == "Credential is not authorized for this operation"
+        mock_call.assert_not_called()
 
 
 # ── _resolve_chat_id ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- add an admin-controlled `allowed_services` list to each `users.yaml` entry
- bind each persistent agent credential to its authenticated user and exact service names
- expose only authorized services in that user's agent prompt
- reject an unlisted service name before parsing or making any outer service call

## Security behavior

Service-proxy authority is now fail-closed and resource-specific:

- omission or an empty `allowed_services` list grants no service access, including to admins
- wildcard (`*`), path-like, empty, and non-string entries are rejected
- configured names that are unavailable after `services.yaml` and API-key loading are warned about and denied
- `services:call` is added to a persistent principal only when at least one explicitly allowed service is actually available
- notification credentials remain send-message-only and receive no service resources

This preserves credential injection in the outer Kai process while preventing an agent that can call one service from selecting every configured service by URL name.

## Configuration and upgrade behavior

Existing installations continue to start if `allowed_services` is absent. Their service proxy is disabled by default, and Kai emits a warning when services are loaded but no user has a grant.

To retain access to a service after deploying this change, add its exact enabled name to the intended entry in the admin-controlled `users.yaml`, for example:

```yaml
users:
  - telegram_id: 123456789
    name: alice
    role: admin
    allowed_services:
      - perplexity
```

First-time generated configuration explicitly writes `allowed_services: []`. No database migration is required.

## Verification

- `git diff --check`
- Ruff on all changed Python files
- focused authorization/config/install/backend suite: `944 passed`
- full repository suite: `4651 passed, 1 skipped`

No live installation or protected system configuration was changed as part of this branch.
