### PR TITLE
fix(security): authorize GitHub operations by repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Kai has real local authority, so the security model is part of the product rathe
 - **Local execution:** Kai runs on your machine. Conversations do not pass through a Kai-hosted relay.
 - **Path confinement:** File exchange is constrained to allowed workspace and file-storage paths.
 - **Service proxy:** Third-party API keys live in server-side config and are injected only for services explicitly allowed to that user in `users.yaml`; keys are never placed in conversation context.
+- **GitHub operation boundary:** Shared-identity PR review and issue triage run only for repositories explicitly authorized to that user in admin-controlled `users.yaml`; notification subscriptions cannot grant operation access.
 - **Per-user isolation:** Users have separate history, files, workspaces, jobs, settings, and agent subprocesses.
 - **Principal-bound internal API:** Agent API credentials resolve to a fixed user and explicit scopes in the outer service; request data cannot select another principal.
 - **Separated webhook credentials:** GitHub, generic, and Telegram ingress use distinct secrets that are not exposed to persistent agent subprocesses.

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -3395,9 +3395,9 @@ async def _resolve_review_repo(
     Walks the conservative ladder per the spec:
 
     1. If the active workspace is a git checkout whose `origin` remote
-       normalizes to exactly one repo in the user's effective GitHub
-       repo list, return that repo.
-    2. Otherwise, if the user's effective GitHub repo list contains
+       normalizes to exactly one repo in the user's admin-configured
+       GitHub repo list, return that repo.
+    2. Otherwise, if the user's configured GitHub repo list contains
        exactly one repo, return that repo.
     3. Otherwise, return the empty string so the caller can prompt
        for the explicit `owner/repo` form.
@@ -3423,18 +3423,16 @@ async def _resolve_review_repo(
             without re-fetching.
     """
     user_config = config.get_user_config(actor_id)
-    yaml_repos = user_config.github_repos if user_config else []
-    effective_repos = await sessions.get_effective_repos(actor_id, yaml_repos)
-    effective_lower = {r.lower() for r in effective_repos}
+    authorized_repos = sorted({repo.strip().lower() for repo in (user_config.github_repos if user_config else [])})
 
     workspace_remote_raw = await review._resolve_workspace_remote_repo(workspace)
     workspace_remote = workspace_remote_raw.lower() if workspace_remote_raw else ""
 
-    if workspace_remote and workspace_remote in effective_lower:
+    if workspace_remote and workspace_remote in authorized_repos:
         return workspace_remote, workspace_remote
 
-    if len(effective_repos) == 1:
-        return effective_repos[0].lower(), workspace_remote
+    if len(authorized_repos) == 1:
+        return authorized_repos[0].lower(), workspace_remote
 
     return "", workspace_remote
 
@@ -3449,9 +3447,9 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
         /review <pr-number>              repository is inferred from
                                          the active workspace's git
                                          remote (when it matches one
-                                         of the user's effective
+                                         of the user's configured
                                          GitHub repos) or from the
-                                         sole effective repo.
+                                         sole configured repo.
         /review <owner/repo> <pr-number> explicit repository.
 
     Auth + TOTP gate mirrors content-invoking commands. The review
@@ -3508,7 +3506,7 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
             await update.message.reply_text(
                 f"{usage}\n"
                 "Could not infer the repository from your active workspace or your "
-                "effective GitHub repo list."
+                "admin-configured GitHub repo list."
             )
             return
     elif len(args) == 2:
@@ -3528,13 +3526,30 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
         await update.message.reply_text(usage)
         return
 
+    # Review collection shells out to `gh` in the outer Kai process. The
+    # target must therefore come from the user's admin-controlled users.yaml
+    # grant, never merely from a self-service notification subscription. This
+    # check covers both the inferred and explicit command forms and defaults
+    # to no authority for missing users and admins with an empty list.
+    user_config = config.get_user_config(actor_id)
+    if user_config is None or not user_config.authorizes_github_repo(repo):
+        log.warning(
+            "Denied manual GitHub review for user %d: repository %s is not admin-authorized",
+            actor_id,
+            repo,
+        )
+        await update.message.reply_text(
+            f"Repository `{repo}` is not authorized for GitHub review. "
+            "Ask the Kai administrator to add its exact name to your github_repos entry in users.yaml."
+        )
+        return
+
     # Per-user backend / provider / claude-user / model-override
     # resolution. Use the shared `get_user_backend_and_provider`
     # helper so a manual /review picks up exactly the same effective
     # backend the rest of the bot uses for this user; hand-rolling
     # the fallback would drift if config.py's resolution rules ever
     # change.
-    user_config = config.get_user_config(actor_id)
     claude_user = user_config.os_user if user_config and user_config.os_user else None
     agent_backend, provider = get_user_backend_and_provider(user_config, config)
     model_override = resolve_user_model(ModelRole.PR_REVIEW, user_config, config)

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1044,6 +1044,9 @@ class UserConfig:
         timeout: Default timeout in seconds for Claude responses.
         workspace_base: Base directory for /workspace new and name resolution.
             Falls back to global WORKSPACE_BASE env var if not set.
+        github_repos: Admin-controlled repositories this user may access
+            through Kai's shared GitHub review and triage authority. The
+            mutable notification subscription list cannot expand this set.
         allowed_services: External proxy service names this user's persistent
             agent may call. Empty by default, including for admins.
     """
@@ -1072,8 +1075,11 @@ class UserConfig:
     backend: str | None = None
     provider: str | None = None
     # GitHub notification routing fields. github_repos controls which
-    # repos route webhook events to this user. pr_review and issue_triage
-    # are tri-state: None = use global default, True/False = admin override.
+    # repos initially route webhook events to this user and is also the
+    # admin-controlled authorization boundary for review/triage operations.
+    # Self-service notification subscriptions never expand that authority.
+    # pr_review and issue_triage are tri-state: None = use global default,
+    # True/False = admin override.
     github_repos: list[str] = field(default_factory=list)
     github_notify_chat_id: int | None = None
     pr_review: bool | None = None
@@ -1095,6 +1101,17 @@ class UserConfig:
     # gets `models["agent"] = model_value` synthesized at load time
     # so existing users.yaml files keep working unchanged.
     models: dict[str, str] | None = None
+
+    def authorizes_github_repo(self, repo: str) -> bool:
+        """Return whether shared-identity GitHub operations may target ``repo``.
+
+        Only the loaded, admin-controlled ``users.yaml`` baseline grants
+        this authority. Database additions made through ``/github add`` are
+        notification subscriptions and are deliberately not consulted here.
+        GitHub owner/repository names are case-insensitive.
+        """
+        normalized = repo.strip().lower()
+        return bool(normalized) and any(configured.strip().lower() == normalized for configured in self.github_repos)
 
 
 # ── Config dataclass ─────────────────────────────────────────────────

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -778,6 +778,8 @@ async def _process_github_event_for_user(
     # back to "run as the bot's own OS user" inside the agent backend.
     user_config = config.get_user_config(chat_id)
     claude_user = user_config.os_user if user_config and user_config.os_user else None
+    repo_full_name = payload.get("repository", {}).get("full_name", "")
+    github_operations_authorized = bool(user_config and user_config.authorizes_github_repo(repo_full_name))
 
     # Resolve per-user backend/provider for the review/triage agents.
     # Same resolution logic as pool.py _create_instance: per-user
@@ -811,10 +813,10 @@ async def _process_github_event_for_user(
     # (closed, merged) still get the standard Telegram notification.
     if settings["pr_review"] and event_type == "pull_request":
         action = payload.get("action", "")
-        if action in ("opened", "reopened", "synchronize"):
+        if action in ("opened", "reopened", "synchronize") and github_operations_authorized:
             pr = payload.get("pull_request", {})
             pr_number = pr.get("number", 0)
-            repo = payload.get("repository", {}).get("full_name", "")
+            repo = repo_full_name
             cooldown = request.app.get(PR_REVIEW_COOLDOWN_KEY, 300)
 
             # Cooldown is server-level, shared across all users.
@@ -866,6 +868,12 @@ async def _process_github_event_for_user(
                 chat_id,
             )
             return
+        if action in ("opened", "reopened", "synchronize"):
+            log.warning(
+                "Denied automated GitHub review for user %d: repository %s is not admin-authorized",
+                chat_id,
+                repo_full_name,
+            )
 
     # ── Issue triage routing ────────────────────────────────────
     # When issue triage is enabled for this user, opened issues are
@@ -875,10 +883,10 @@ async def _process_github_event_for_user(
     # the standard formatter.
     if settings["issue_triage"] and event_type == "issues":
         action = payload.get("action", "")
-        if action == "opened":
+        if action == "opened" and github_operations_authorized:
             issue = payload.get("issue", {})
             issue_number = issue.get("number", 0)
-            repo = payload.get("repository", {}).get("full_name", "")
+            repo = repo_full_name
 
             if _should_skip_triage(repo, issue_number):
                 log.info(
@@ -912,6 +920,12 @@ async def _process_github_event_for_user(
                 chat_id,
             )
             return
+        if action == "opened":
+            log.warning(
+                "Denied automated GitHub issue triage for user %d: repository %s is not admin-authorized",
+                chat_id,
+                repo_full_name,
+            )
 
     # ── Standard notification path ───────────────────────────────
     # Look up the formatter for this event type

--- a/templates/users.yaml
+++ b/templates/users.yaml
@@ -49,11 +49,13 @@ users:
     # provider: openai    # required for goose and opencode (selects the model registry)
     # model: anthropic/claude-sonnet-4-6   # opencode example (full provider/model ID)
 
-    # GitHub notification settings. github_repos controls which repos
-    # route events to this user. pr_review and issue_triage toggle
-    # automated processing. github_notify_chat_id sends notifications
+    # GitHub settings. github_repos is the admin-controlled authorization
+    # boundary for GitHub review and triage operations, as well as the
+    # initial notification list. Omission grants no review/triage authority,
+    # even to admins. `/github add` can add notification subscriptions but
+    # never expands this operations allowlist. pr_review and issue_triage
+    # toggle automated processing. github_notify_chat_id sends notifications
     # to a separate chat (e.g., a Telegram group) instead of the DM.
-    # All are optional and overridable via /github commands.
     # github_repos:
     #   - alice/my-project
     #   - alice/other-repo

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5825,6 +5825,21 @@ def _review_result(text: str = "review output", warnings=()) -> PRReviewResult:
     )
 
 
+def _review_command_config(*repos: str, user_id: int = 1) -> Config:
+    """Build a production-shaped config for an authorized review actor."""
+    configured = list(repos or ("dcellison/kai",))
+    return _make_config(
+        allowed_user_ids={user_id},
+        user_configs={
+            user_id: UserConfig(
+                telegram_id=user_id,
+                name="reviewer",
+                github_repos=configured,
+            )
+        },
+    )
+
+
 class TestHandleReviewCommand:
     """
     Manual /review command. The handler shares the bundle path with
@@ -5841,8 +5856,8 @@ class TestHandleReviewCommand:
         update = _make_update()
         config = _make_config(
             user_configs={
-                12345: UserConfig(
-                    telegram_id=12345,
+                1: UserConfig(
+                    telegram_id=1,
                     name="op",
                     github_repos=["dcellison/kai", "dcellison/other"],
                 ),
@@ -5871,16 +5886,16 @@ class TestHandleReviewCommand:
         assert mock_generate.call_args.args == ("dcellison/kai", 681)
 
     @pytest.mark.asyncio
-    async def test_short_form_falls_back_to_sole_effective_repo(self, tmp_path, monkeypatch):
+    async def test_short_form_falls_back_to_sole_configured_repo(self, tmp_path, monkeypatch):
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update()
-        # Workspace remote doesn't match the single effective repo;
-        # the sole-effective fallback kicks in.
+        # Workspace remote doesn't match the single configured repo;
+        # the sole-configured fallback kicks in.
         config = _make_config(
             user_configs={
-                12345: UserConfig(
-                    telegram_id=12345,
+                1: UserConfig(
+                    telegram_id=1,
                     name="op",
                     github_repos=["dcellison/kai"],
                 ),
@@ -5906,6 +5921,28 @@ class TestHandleReviewCommand:
         assert mock_generate.call_args.args == ("dcellison/kai", 681)
 
     @pytest.mark.asyncio
+    async def test_short_form_deduplicates_case_varied_configured_repo(self, tmp_path, monkeypatch):
+        """Duplicate config spellings remain one usable authorization."""
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        config = _review_command_config("DCellison/Kai", "dcellison/kai")
+        ctx = _make_context(config=config, args=["681"])
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch("kai.review._resolve_workspace_remote_repo", new=AsyncMock(return_value="")),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        assert mock_generate.call_args.args == ("dcellison/kai", 681)
+
+    @pytest.mark.asyncio
     async def test_short_form_usage_error_when_unresolved(self, tmp_path, monkeypatch):
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
@@ -5913,8 +5950,8 @@ class TestHandleReviewCommand:
         # Multi-repo + no workspace match → usage error.
         config = _make_config(
             user_configs={
-                12345: UserConfig(
-                    telegram_id=12345,
+                1: UserConfig(
+                    telegram_id=1,
                     name="op",
                     github_repos=["dcellison/kai", "dcellison/other"],
                 ),
@@ -5946,7 +5983,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update()
-        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx = _make_context(config=_review_command_config(), args=["dcellison/kai", "681"])
         ctx.bot.send_document = AsyncMock()
 
         with (
@@ -5959,6 +5996,51 @@ class TestHandleReviewCommand:
             await handle_review_command(update, ctx)
 
         assert mock_generate.call_args.args == ("dcellison/kai", 681)
+
+    @pytest.mark.asyncio
+    async def test_explicit_repo_denied_when_only_another_user_is_authorized(self, tmp_path, monkeypatch):
+        """One user cannot spend Kai's GitHub authority granted to another."""
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update(user_id=1)
+        config = _make_config(
+            allowed_user_ids={1, 2},
+            user_configs={
+                1: UserConfig(telegram_id=1, name="alice", github_repos=["alice/repo"]),
+                2: UserConfig(telegram_id=2, name="bob", github_repos=["private/target"]),
+            },
+        )
+        ctx = _make_context(config=config, args=["private/target", "681"])
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch("kai.bot.review.generate_pr_review", new=AsyncMock()) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        mock_generate.assert_not_awaited()
+        replies = [call.args[0] for call in update.message.reply_text.call_args_list]
+        assert any("not authorized for GitHub review" in reply for reply in replies)
+
+    @pytest.mark.asyncio
+    async def test_db_added_subscription_does_not_authorize_explicit_review(self, tmp_path, monkeypatch):
+        """Mutable notification subscriptions never grant shared-gh access."""
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update(user_id=1)
+        config = _review_command_config("configured/repo")
+        ctx = _make_context(config=config, args=["db-added/repo", "681"])
+        mock_effective = AsyncMock(return_value=["configured/repo", "db-added/repo"])
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch("kai.bot.sessions.get_effective_repos", new=mock_effective),
+            patch("kai.bot.review.generate_pr_review", new=AsyncMock()) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        mock_effective.assert_not_awaited()
+        mock_generate.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_invalid_repo_format_returns_error(self, tmp_path, monkeypatch):
@@ -6007,7 +6089,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update()
-        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx = _make_context(config=_review_command_config(), args=["dcellison/kai", "681"])
         ctx.bot.send_document = AsyncMock()
 
         ack_at_call: list[int] = []
@@ -6030,7 +6112,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update()
-        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx = _make_context(config=_review_command_config(), args=["dcellison/kai", "681"])
         ctx.bot.send_document = AsyncMock()
 
         with (
@@ -6053,7 +6135,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update(chat_id=12345)
-        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx = _make_context(config=_review_command_config(), args=["dcellison/kai", "681"])
         ctx.bot.send_document = AsyncMock()
 
         with (
@@ -6075,7 +6157,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update(chat_id=12345)
-        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx = _make_context(config=_review_command_config(), args=["dcellison/kai", "681"])
         ctx.bot.send_document = AsyncMock()
 
         with (
@@ -6101,7 +6183,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update()
-        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx = _make_context(config=_review_command_config(), args=["dcellison/kai", "681"])
         ctx.bot.send_document = AsyncMock()
 
         with (
@@ -6125,7 +6207,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update()
-        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx = _make_context(config=_review_command_config(), args=["dcellison/kai", "681"])
         ctx.bot.send_document = AsyncMock()
 
         from kai.webhook import _review_cooldowns
@@ -6147,7 +6229,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update()
-        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx = _make_context(config=_review_command_config(), args=["dcellison/kai", "681"])
         ctx.bot.send_document = AsyncMock()
 
         warnings = (CollectionWarning(source="related_search", message="search unavailable for repo"),)
@@ -6169,7 +6251,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update()
-        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx = _make_context(config=_review_command_config(), args=["dcellison/kai", "681"])
         ctx.bot.send_document = AsyncMock()
 
         with (
@@ -6209,7 +6291,7 @@ class TestHandleReviewCommand:
     async def test_group_chat_uses_user_id_for_user_scoped_lookups(self, tmp_path, monkeypatch):
         # In a notification group the message arrives on a group
         # chat_id but the actor is the operator. User-scoped lookups
-        # (user_config, effective repos) must key on user_id, NOT
+        # (user_config, configured repos) must key on user_id, NOT
         # chat_id, so the review picks up the operator's settings.
         # Without this split, get_user_config(group_chat_id) returns
         # None, github_repos is [], and the resolution silently
@@ -6234,12 +6316,9 @@ class TestHandleReviewCommand:
         ctx = _make_context(config=config, args=["681"])
         ctx.bot.send_document = AsyncMock()
 
-        mock_effective = AsyncMock(return_value=["dcellison/kai"])
-
         with (
             patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
             patch("kai.review._resolve_workspace_remote_repo", new=AsyncMock(return_value="")),
-            patch("kai.sessions.get_effective_repos", new=mock_effective),
             patch(
                 "kai.bot.review.generate_pr_review",
                 new=AsyncMock(return_value=_review_result()),
@@ -6247,9 +6326,6 @@ class TestHandleReviewCommand:
         ):
             await handle_review_command(update, ctx)
 
-        # effective-repos lookup uses the actor (user) id, not the
-        # group chat id - this is the load-bearing assertion.
-        assert mock_effective.await_args.args[0] == 12345
         # The review actually runs with the operator's resolved
         # settings (codex / openai / daniel), not the global
         # defaults that would apply if the lookup had used the
@@ -6258,7 +6334,7 @@ class TestHandleReviewCommand:
         assert kwargs["agent_backend"] == "codex"
         assert kwargs["provider"] == "openai"
         assert kwargs["claude_user"] == "daniel"
-        # And the inferred repo is the operator's (sole) effective
+        # And the inferred repo is the operator's sole configured
         # repo, not empty.
         assert mock_generate.call_args.args == ("dcellison/kai", 681)
 
@@ -6270,7 +6346,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update(chat_id=12345)
-        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx = _make_context(config=_review_command_config(), args=["dcellison/kai", "681"])
         ctx.bot.send_document = AsyncMock(side_effect=RuntimeError("file too large"))
 
         with (
@@ -6300,7 +6376,7 @@ class TestHandleReviewCommand:
         # write_text call raises OSError without touching real /tmp.
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path / "does-not-exist")
         update = _make_update()
-        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx = _make_context(config=_review_command_config(), args=["dcellison/kai", "681"])
         ctx.bot.send_document = AsyncMock()
 
         with (
@@ -6324,7 +6400,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update()
-        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx = _make_context(config=_review_command_config(), args=["dcellison/kai", "681"])
         ctx.bot.send_document = AsyncMock()
 
         with (
@@ -6356,7 +6432,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update()
-        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx = _make_context(config=_review_command_config(), args=["dcellison/kai", "681"])
         ctx.bot.send_document = AsyncMock()
 
         # Build warnings whose combined size exceeds 4096 chars.
@@ -6406,7 +6482,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update()
-        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx = _make_context(config=_review_command_config(), args=["dcellison/kai", "681"])
         ctx.bot.send_document = AsyncMock()
 
         with (
@@ -6433,7 +6509,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update()
-        ctx = _make_context(args=["dcellison/kai", "681"])
+        ctx = _make_context(config=_review_command_config(), args=["dcellison/kai", "681"])
         ctx.bot.send_document = AsyncMock()
 
         with (
@@ -6452,8 +6528,8 @@ class TestHandleReviewCommand:
         assert mock_generate.call_args.kwargs["local_repo_path"] == "/home/workspace"
 
     @pytest.mark.asyncio
-    async def test_short_form_sole_effective_with_mismatched_workspace_passes_none(self, tmp_path, monkeypatch):
-        # Short form falls back to the sole effective repo because
+    async def test_short_form_sole_configured_with_mismatched_workspace_passes_none(self, tmp_path, monkeypatch):
+        # Short form falls back to the sole configured repo because
         # the workspace remote does not match it (or is empty).
         # local_repo_path must be None in that case for the same
         # reason as the explicit form: the workspace and the
@@ -6463,8 +6539,8 @@ class TestHandleReviewCommand:
         update = _make_update()
         config = _make_config(
             user_configs={
-                12345: UserConfig(
-                    telegram_id=12345,
+                1: UserConfig(
+                    telegram_id=1,
                     name="op",
                     github_repos=["dcellison/kai"],
                 ),
@@ -6476,13 +6552,9 @@ class TestHandleReviewCommand:
         with (
             patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
             # No GitHub remote at all (e.g. a plain non-git
-            # workspace) - the sole-effective fallback fires but
+            # workspace) - the sole-configured fallback fires but
             # the workspace must not propagate.
             patch("kai.review._resolve_workspace_remote_repo", new=AsyncMock(return_value="")),
-            patch(
-                "kai.sessions.get_effective_repos",
-                new=AsyncMock(return_value=["dcellison/kai"]),
-            ),
             patch(
                 "kai.bot.review.generate_pr_review",
                 new=AsyncMock(return_value=_review_result()),
@@ -6502,8 +6574,8 @@ class TestHandleReviewCommand:
         update = _make_update()
         config = _make_config(
             user_configs={
-                12345: UserConfig(
-                    telegram_id=12345,
+                1: UserConfig(
+                    telegram_id=1,
                     name="op",
                     github_repos=["dcellison/kai", "dcellison/other"],
                 ),
@@ -6517,10 +6589,6 @@ class TestHandleReviewCommand:
             patch(
                 "kai.review._resolve_workspace_remote_repo",
                 new=AsyncMock(return_value="dcellison/kai"),
-            ),
-            patch(
-                "kai.sessions.get_effective_repos",
-                new=AsyncMock(return_value=["dcellison/kai", "dcellison/other"]),
             ),
             patch(
                 "kai.bot.review.generate_pr_review",

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -734,6 +734,26 @@ class TestLoadUserConfigs:
         assert configs is not None
         assert configs[111].github_repos == []
 
+    def test_github_operations_require_exact_admin_configured_repo(self):
+        """Repository authority is exact, case-insensitive, and fail-closed."""
+        user = UserConfig(
+            telegram_id=111,
+            name="alice",
+            role="admin",
+            github_repos=["Owner/Allowed"],
+        )
+
+        assert user.authorizes_github_repo("owner/allowed")
+        assert user.authorizes_github_repo("OWNER/ALLOWED")
+        assert not user.authorizes_github_repo("owner/other")
+        assert not user.authorizes_github_repo("")
+
+    def test_admin_without_github_repos_has_no_operation_authority(self):
+        """Admin role never implies wildcard GitHub review/triage access."""
+        admin = UserConfig(telegram_id=111, name="alice", role="admin")
+
+        assert not admin.authorizes_github_repo("owner/repo")
+
     # ── github_notify_chat_id field ──
 
     def test_github_notify_chat_id_parsed(self, tmp_path):

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -407,10 +407,11 @@ def _build_test_app(
 ) -> web.Application:
     """Build a minimal aiohttp app with _handle_github wired up.
 
-    The config parameter controls per-user routing. When None, a mock
-    Config with user_configs={} is used, which causes _get_subscribed_users
-    to return empty and the fallback path (admin chat_id) to fire. To test
-    per-user routing, pass a mock with user_configs populated.
+    The config parameter controls per-user routing. When None, the legacy
+    fallback-admin fixture is retained, but its synchronous user lookup
+    returns an explicit ``owner/repo`` authorization so review/triage tests
+    exercise the permitted path. To test other routing, pass a mock with
+    custom user_configs.
 
     Feature flags (pr_review, issue_triage, notify_chat_id) are now resolved
     per-user via resolve_github_settings() instead of app dict globals.
@@ -435,8 +436,10 @@ def _build_test_app(
     mock_bot = AsyncMock()
     app[TELEGRAM_BOT_KEY] = mock_bot
     app[CHAT_ID_KEY] = 12345
-    # Config for per-user routing. Default mock has no user_configs,
-    # so all events fall through to admin chat_id.
+    # Config for per-user routing. The default deliberately keeps an empty
+    # routing map so these older tests exercise the fallback path without a DB,
+    # while get_user_config returns the fallback admin's explicit operations
+    # authorization.
     if config is None:
         # Config is a sync dataclass. Using AsyncMock here would make
         # every chained attribute call (e.g. config.default_models.get(...))
@@ -451,13 +454,19 @@ def _build_test_app(
         # which the mocked downstream callers accept but real code
         # would not.
         mock_config = MagicMock()
+        default_user = UserConfig(
+            telegram_id=12345,
+            name="test-admin",
+            role="admin",
+            github_repos=["owner/repo"],
+        )
         mock_config.user_configs = {}
         mock_config.default_models = {}
         mock_config.default_backend = "claude"
         mock_config.default_provider = ""
-        # get_user_config is synchronous in real Config; must not
-        # return a coroutine. With no users configured, always None.
-        mock_config.get_user_config = lambda uid: None
+        # get_user_config is synchronous in real Config; it must not return a
+        # coroutine or authorization could be tested against a mock object.
+        mock_config.get_user_config = lambda uid: default_user if uid == 12345 else None
         app[CONFIG_KEY] = mock_config
     else:
         app[CONFIG_KEY] = config
@@ -1996,8 +2005,8 @@ class TestPerUserRouting:
         assert call_args[0][0] == 111
 
     @pytest.mark.asyncio
-    async def test_admin_wildcard_triggers_pr_review(self, _clear_cooldowns, _mock_resolve_repo):
-        """Admin wildcard with pr_review=True triggers the review agent."""
+    async def test_admin_wildcard_cannot_trigger_pr_review(self, _clear_cooldowns, _mock_resolve_repo, caplog):
+        """Subscription wildcard never grants shared-identity review authority."""
         admin = self._make_user_config(111, role="admin")
         config = self._make_config_with_users([admin])
         app = _build_test_app(config=config)
@@ -2022,7 +2031,82 @@ class TestPerUserRouting:
 
             # Allow background task to complete
             await asyncio.sleep(0.01)
-            mock_review.assert_called_once()
+            mock_review.assert_not_called()
+            app[TELEGRAM_BOT_KEY].send_message.assert_called_once()
+            assert "not admin-authorized" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_db_added_subscription_cannot_trigger_pr_review(
+        self,
+        _clear_cooldowns,
+        _mock_resolve_repo,
+        caplog,
+    ):
+        """An effective notification subscription does not grant review."""
+        user = self._make_user_config(111, repos=[])
+        config = self._make_config_with_users([user])
+        app = _build_test_app(config=config)
+        payload = _make_pr_payload("opened")
+        body = json.dumps(payload).encode()
+        sig = _sign_payload(payload)
+
+        with (
+            patch(
+                "kai.webhook.sessions.get_effective_repos",
+                new=AsyncMock(return_value=["owner/repo"]),
+            ),
+            _mock_settings(pr_review=True, notify_chat_id=111),
+            patch("kai.webhook.review.review_pr", new_callable=AsyncMock) as mock_review,
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/webhook/github",
+                    data=body,
+                    headers={
+                        "X-GitHub-Event": "pull_request",
+                        "X-Hub-Signature-256": sig,
+                    },
+                )
+                assert resp.status == 200
+
+            await asyncio.sleep(0.01)
+            mock_review.assert_not_called()
+            app[TELEGRAM_BOT_KEY].send_message.assert_called_once()
+            assert "not admin-authorized" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_db_added_subscription_cannot_trigger_issue_triage(self, _clear_cooldowns, caplog):
+        """Mutable notification state cannot grant GitHub mutations."""
+        user = self._make_user_config(111, repos=[])
+        config = self._make_config_with_users([user])
+        app = _build_test_app(config=config)
+        payload = _make_issue_payload("opened")
+        body = json.dumps(payload).encode()
+        sig = _sign_payload(payload)
+
+        with (
+            patch(
+                "kai.webhook.sessions.get_effective_repos",
+                new=AsyncMock(return_value=["owner/repo"]),
+            ),
+            _mock_settings(issue_triage=True, notify_chat_id=111),
+            patch("kai.webhook.triage.triage_issue", new_callable=AsyncMock) as mock_triage,
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/webhook/github",
+                    data=body,
+                    headers={
+                        "X-GitHub-Event": "issues",
+                        "X-Hub-Signature-256": sig,
+                    },
+                )
+                assert resp.status == 200
+
+            await asyncio.sleep(0.01)
+            mock_triage.assert_not_called()
+            app[TELEGRAM_BOT_KEY].send_message.assert_called_once()
+            assert "not admin-authorized" in caplog.text
 
     @pytest.mark.asyncio
     async def test_regular_user_no_repos_receives_nothing(self, _clear_cooldowns):


### PR DESCRIPTION
## Summary

- make admin-controlled `users.yaml` `github_repos` the exact authorization boundary for shared-identity GitHub review and triage operations
- require that authorization for both forms of manual `/review`
- require it before automatic PR review or issue triage is dispatched
- keep mutable `/github add` entries as notification subscriptions only

## Security behavior

Kai's review and triage collectors currently execute `gh` using the outer service's GitHub identity. Before this change:

- `/review owner/repo N` shape-validated the repository but did not authorize it
- the effective repo list included DB entries created through `/github add`, even when no PAT proved access
- admins with empty subscription lists could receive wildcard events and invoke automation

The new `UserConfig.authorizes_github_repo()` predicate consults only the loaded, admin-controlled `github_repos` baseline. Repository matching is exact and case-insensitive. Missing users, empty lists, and admin role alone grant no review or triage authority.

DB-added subscriptions still receive ordinary GitHub notifications. When review or triage is enabled for such a subscription, Kai logs the denial and falls back to the normal Telegram notification instead of invoking the shared GitHub deputy.

## Compatibility and configuration

Existing users with repositories already listed under `github_repos` retain manual review and automated review/triage for those repositories. No new configuration field or database migration is required.

```yaml
users:
  - telegram_id: 123456789
    name: alice
    github_repos:
      - owner/repository
```

Short-form `/review N` still resolves from a matching workspace remote or a sole configured repository. Duplicate/case-varied configured entries are deduplicated for this inference.

`/github add` remains available for self-service notification subscriptions and PAT-based webhook management, but it does not expand review/triage authority. An administrator must add a repository to `users.yaml` for those operations.

## Scope boundary and follow-up

This closes the cross-repository authorization half of the shared-GitHub-deputy finding. `gh` execution still uses the outer service identity. A subsequent bounded change should bind GitHub execution to the requesting user's PAT or OS identity.

## Verification

- repository-wide `ruff format --check .`
- repository-wide `ruff check .`
- `git diff --check`
- focused GitHub/config/session regression suite: `665 passed`
- full repository suite: `4658 passed, 1 skipped`

No live installation or protected system configuration was changed by this branch.
