### PR TITLE
fix(security): retire legacy webhook fallback through make config

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ Kai has real local authority, so the security model is part of the product rathe
 - **Separated webhook credentials:** GitHub, generic, and Telegram ingress use distinct secrets that are not exposed to persistent agent subprocesses.
 - **Optional OS isolation:** A user's backend subprocess can run under a dedicated OS account through generated sudoers rules.
 
+Upgraded installations may temporarily retain the former shared
+`WEBHOOK_SECRET`. After all GitHub and generic webhook callers have been moved
+to their named secrets, run `make config` and answer `false` to **Retain
+deprecated WEBHOOK_SECRET fallback**. Pressing Enter keeps compatibility. The
+generated `install.conf` can then be reviewed with `make DRY_RUN=1 install`
+before `make install` deploys it.
+
 See [TOTP Authentication](https://github.com/dcellison/kai/wiki/TOTP-Authentication), [GitHub Notification Routing](https://github.com/dcellison/kai/wiki/GitHub-Notification-Routing), and [Exposing Kai to the Internet](https://github.com/dcellison/kai/wiki/Exposing-Kai-to-the-Internet) for the detailed operational docs.
 
 ## Common Workflows

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -766,8 +766,8 @@ def _cmd_config() -> None:
 
     If install.conf already exists, its values are used as defaults so re-running
     only asks about changes. Auto-detects platform, generates distinct named
-    webhook secrets, and preserves an existing legacy secret for the temporary
-    compatibility window. Validates all inputs before writing.
+    webhook secrets, and offers an explicit safe-default choice to preserve or
+    retire an existing legacy secret. Validates all inputs before writing.
 
     No sudo required - this runs as the current user.
     """
@@ -1669,6 +1669,23 @@ def _cmd_config() -> None:
     reserved_webhook_secrets = {github_webhook_secret, legacy_webhook_secret, tg_webhook_secret}
     while not generic_webhook_secret or generic_webhook_secret in reserved_webhook_secrets:
         generic_webhook_secret = secrets.token_hex(32)
+
+    # install.conf is generated output from this wizard. An upgraded install
+    # must therefore retire the legacy fallback here rather than by editing or
+    # post-processing that artifact. Preserve compatibility on Enter: callers
+    # have to be migrated and tested before the operator explicitly chooses
+    # false. Fresh installations never carry WEBHOOK_SECRET and skip the prompt.
+    if legacy_webhook_secret:
+        print()
+        print("A deprecated WEBHOOK_SECRET compatibility fallback is present.")
+        print("Retire it only after GitHub and generic webhook callers use their named secrets.")
+        retain_legacy_webhook_secret = _prompt_bool(
+            "Retain deprecated WEBHOOK_SECRET fallback",
+            True,
+        )
+        if not retain_legacy_webhook_secret:
+            legacy_webhook_secret = ""
+            print("  WEBHOOK_SECRET will be omitted from the generated configuration.")
     print()
 
     # -- Workspaces --

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1850,7 +1850,54 @@ class TestCmdConfig:
         output = capsys.readouterr().out
         assert "Admin Telegram ID" not in output
         assert "-- User setup --" not in output
+        assert "A deprecated WEBHOOK_SECRET compatibility fallback is present" in output
         assert "users_yaml_staging_path" not in conf
+
+    def test_regeneration_can_retire_legacy_webhook_fallback(self, tmp_path, monkeypatch, capsys):
+        """The operator retires compatibility through make config; the
+        generated artifact omits only the legacy key and keeps named secrets.
+        """
+        monkeypatch.chdir(tmp_path)
+        conf_path = tmp_path / "install.conf"
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._simulate_existing_etc_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 999\n    name: existing\n    role: admin\n",
+        )
+        existing = {
+            "version": 1,
+            "install_dir": "/opt/kai",
+            "data_dir": "/var/lib/kai",
+            "service_user": "kai",
+            "platform": "darwin",
+            "env": {
+                "TELEGRAM_BOT_TOKEN": "existing-token",
+                "WEBHOOK_SECRET": "legacy-secret",
+                "GITHUB_WEBHOOK_SECRET": "github-secret",
+                "GENERIC_WEBHOOK_SECRET": "generic-secret",
+            },
+        }
+        conf_path.write_text(json.dumps(existing))
+
+        def answer(prompt: str) -> str:
+            if "Claude binary path" in prompt:
+                return "/usr/bin/true"
+            if "Retain deprecated WEBHOOK_SECRET fallback" in prompt:
+                return "false"
+            return ""
+
+        monkeypatch.setattr("builtins.input", answer)
+
+        _cmd_config()
+
+        generated = json.loads(conf_path.read_text())
+        assert "WEBHOOK_SECRET" not in generated["env"]
+        assert generated["env"]["GITHUB_WEBHOOK_SECRET"] == "github-secret"
+        assert generated["env"]["GENERIC_WEBHOOK_SECRET"] == "generic-secret"
+        assert generated["env"]["TELEGRAM_BOT_TOKEN"] == "existing-token"
+        output = capsys.readouterr().out
+        assert "WEBHOOK_SECRET will be omitted from the generated configuration" in output
 
     def test_validates_required_fields(self):
         """Required-field validation rejects empty input."""


### PR DESCRIPTION
## Summary

- Add an explicit upgrade-only choice to make config for retaining or retiring the deprecated shared WEBHOOK_SECRET fallback.
- Keep compatibility by default: pressing Enter preserves the fallback.
- When the operator explicitly selects false, omit WEBHOOK_SECRET from the newly generated install.conf while preserving GITHUB_WEBHOOK_SECRET and GENERIC_WEBHOOK_SECRET.
- Skip the prompt entirely for fresh installations that have no legacy credential.
- Document the safe regeneration, dry-run, and deployment sequence.

## Why

install.conf is generated output from make config. Before this change, the wizard silently carried an existing WEBHOOK_SECRET forward forever, so a protected installation had no supported way to finish the credential-separation migration. Post-processing install.conf would put migration policy on the artifact instead of in the configuration process that owns it.

This change keeps retirement inside make config and makes the potentially breaking choice explicit.

## Security and compatibility

- No automatic or default retirement.
- No secret values are printed.
- Dedicated GitHub and generic secrets are generated and validated before the retirement choice.
- Choosing false removes only the legacy compatibility key from generated output.
- make config still makes no privileged or runtime changes.
- Deployment remains a separate make DRY_RUN=1 install and make install operation.

## Validation

- 4659 passed, 1 skipped
- Repository-wide Ruff lint passed
- Repository-wide Ruff format check passed
- git diff --check passed
- Focused tests cover safe-default preservation and explicit artifact regeneration without the legacy key

## Deployment after maintainer merge

1. Run make config.
2. At Retain deprecated WEBHOOK_SECRET fallback, select false only after named-secret callers have been migrated and tested.
3. Review with make DRY_RUN=1 install.
4. Deploy with make install.
5. Verify the health endpoint, webhook deliveries, and absence of the legacy compatibility warning.