### PR TITLE
fix(security): require protected OS user isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ make config
 make run
 ```
 
-`make config` writes the runtime env file and mandatory `users.yaml` for the deployment mode you select. Pick `single_user` for a local repo checkout under your own account. Pick `protected` when you want source, data, and secrets split across protected system directories.
+`make config` writes the runtime env file and mandatory `users.yaml` for the deployment mode you select. Pick `single_user` for a local repo checkout under your own account. Pick `protected` when you want source, data, and secrets split across protected system directories. Protected mode requires every Telegram user to have a unique `os_user` that differs from the Kai service account; this keeps persistent agents from inheriting the daemon's protected-config capabilities. Single-user mode continues to support running the agent as the operator account.
 
 For full installation details, see [Getting Started](https://github.com/dcellison/kai/wiki/Getting-Started), [Multi-User Setup](https://github.com/dcellison/kai/wiki/Multi-User-Setup), and [System Architecture](https://github.com/dcellison/kai/wiki/System-Architecture).
 

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -25,6 +25,8 @@ from pathlib import Path
 import yaml
 from dotenv import load_dotenv
 
+from kai.user_isolation import validate_protected_user_isolation
+
 log = logging.getLogger(__name__)
 
 
@@ -3133,6 +3135,27 @@ def load_config() -> Config:
     # path is always one of the two resolved defaults.
     users_yaml_path = _resolve_users_yaml_path(bool(protected_env))
     user_configs = _load_user_configs(default_backend, default_provider, users_yaml_path)
+    if protected_env:
+        # A protected install gives the outer service account narrowly
+        # scoped sudo access to root-owned Kai configuration.  A persistent
+        # conversational agent running as that same account would inherit
+        # those capabilities even though its environment is sanitized.
+        # Fail at startup if a hand-edited users.yaml weakens the boundary.
+        try:
+            service_user = pwd.getpwuid(os.geteuid()).pw_name
+        except KeyError:
+            raise SystemExit(
+                f"Protected installation could not resolve the Kai service account for effective uid {os.geteuid()}."
+            ) from None
+        try:
+            validate_protected_user_isolation(
+                ((uc.telegram_id, uc.name, uc.os_user) for uc in user_configs.values()),
+                service_user,
+                account_uid=lambda name: pwd.getpwnam(name).pw_uid,
+                service_uid=os.geteuid(),
+            )
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc
     # Seed UserConfig.models from the deprecated per-role env vars
     # (PR_REVIEW_MODEL_<BACKEND> / ISSUE_TRIAGE_MODEL_<BACKEND>). The
     # values reach dispatch through UserConfig.models rather than via

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -40,6 +40,7 @@ from pathlib import Path
 import yaml
 
 from kai.config import (
+    _VALID_ROLES,
     BACKEND_PROVIDERS,
     BACKENDS_NEEDING_PROVIDER_PROMPT,
     CODEX_DEFAULT_MODEL,
@@ -60,6 +61,7 @@ from kai.config import (
     models_for_backend,
     validate_model_for_backend,
 )
+from kai.user_isolation import validate_protected_user_isolation
 
 # Config file written by `config`, read by `apply`.
 # Anchored to PROJECT_ROOT so it resolves correctly regardless of CWD.
@@ -661,6 +663,75 @@ def _users_yaml_entries(users_yaml_path: Path) -> list[dict]:
     return [entry for entry in users if isinstance(entry, dict)]
 
 
+def _protected_user_assignments(users_yaml_path: Path) -> list[tuple[int, str, str | None]]:
+    """Load the interactive principals relevant to protected OS isolation.
+
+    This is an installer-side projection of config._load_user_configs: invalid
+    entries are ignored, duplicate Telegram IDs use the first valid entry, and
+    all valid entries retain only the identity fields needed by the isolation
+    validator.  Unlike the wizard's informational scanners, this reader fails
+    loudly on an unreadable or malformed file because apply must validate the
+    effective users.yaml before stopping a working service.
+    """
+    raw = _read_users_yaml_text(users_yaml_path)
+    if raw is None:
+        raise ValueError(f"Protected users.yaml is missing or unreadable: {users_yaml_path}")
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Protected users.yaml is malformed: {users_yaml_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"Protected users.yaml must contain a YAML mapping: {users_yaml_path}")
+    entries = data.get("users")
+    if not isinstance(entries, list):
+        raise ValueError(f"Protected users.yaml must contain a 'users' list: {users_yaml_path}")
+
+    assignments: list[tuple[int, str, str | None]] = []
+    seen_ids: set[int] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        raw_id = entry.get("telegram_id")
+        try:
+            if isinstance(raw_id, bool):
+                raise ValueError
+            telegram_id = int(raw_id)
+            if telegram_id <= 0:
+                raise ValueError
+        except (TypeError, ValueError):
+            continue
+        name = str(entry.get("name") or "").strip()
+        role = str(entry.get("role", "user")).strip().lower()
+        if not name or role not in _VALID_ROLES or telegram_id in seen_ids:
+            continue
+        seen_ids.add(telegram_id)
+
+        raw_os_user = entry.get("os_user")
+        os_user = str(raw_os_user).strip() if raw_os_user is not None else ""
+        os_user = os_user or None
+        if os_user is not None and not _validate_os_user(os_user):
+            raise ValueError(f"Invalid os_user {os_user!r} in {users_yaml_path}: must match {_OS_USER_RE.pattern}")
+        assignments.append((telegram_id, name, os_user))
+    return assignments
+
+
+def _validate_protected_users_yaml(
+    users_yaml_path: Path,
+    service_user: str,
+    *,
+    require_existing_accounts: bool,
+    service_uid: int | None = None,
+) -> tuple[str, ...]:
+    """Validate protected user isolation, optionally including passwd lookup."""
+    assignments = _protected_user_assignments(users_yaml_path)
+    return validate_protected_user_isolation(
+        assignments,
+        service_user,
+        account_uid=(lambda name: pwd.getpwnam(name).pw_uid) if require_existing_accounts else None,
+        service_uid=service_uid,
+    )
+
+
 def _entry_backend(entry: dict) -> object:
     """
     Read a users.yaml entry's backend, preferring the new `backend`
@@ -980,34 +1051,42 @@ def _cmd_config() -> None:
                 break
             print("  Name may only contain letters, numbers, spaces, hyphens, and underscores.")
 
-        # Advanced options: os_user and home_workspace.
-        advanced = _prompt_bool("Configure advanced user options", False)
-
-        if advanced:
-            # `os_user` is optional on both backends and follows the
-            # same semantics: an empty value (or a value matching the
-            # bot process user) spawns the agent in-process via the
-            # self-sudo-skip path detected by `resolve_claude_user`;
-            # a different OS account wraps the agent argv in `sudo -H
-            # -u <user>` for cross-user isolation. Operators who run
-            # kai under their own account leave this empty; operators
-            # with a dedicated kai service user and separate per-user
-            # OS accounts set it to those accounts.
-            default_os_user = os.environ.get("USER", "")
+        if deployment_mode == "protected":
+            # The service account can sudo-cat exact protected Kai files.
+            # A persistent agent running as that identity would inherit
+            # those capabilities, so protected mode has no same-user path.
+            print("  Protected mode requires a distinct OS account for each interactive user.")
             while True:
-                admin_os_user = _prompt("OS user for subprocess isolation", default_os_user).strip() or None
-                if admin_os_user is None or _validate_os_user(admin_os_user):
-                    break
-                print("  Username may only contain letters, numbers, dots, hyphens, and underscores.")
+                admin_os_user = _prompt(
+                    "OS user for subprocess isolation",
+                    "",
+                    required=True,
+                ).strip()
+                if not _validate_os_user(admin_os_user):
+                    print("  Username may only contain letters, numbers, dots, hyphens, and underscores.")
+                    continue
+                if admin_os_user == service_user:
+                    print(f"  Must differ from the Kai service account {service_user!r}.")
+                    continue
+                break
+        else:
+            # Single-user mode intentionally keeps the historic optional
+            # same-user spawn shape. There is no protected service account
+            # or cross-principal boundary in this deployment mode.
+            advanced = _prompt_bool("Configure advanced user options", False)
+            if advanced:
+                default_os_user = os.environ.get("USER", "")
+                while True:
+                    admin_os_user = _prompt("OS user for subprocess isolation", default_os_user).strip() or None
+                    if admin_os_user is None or _validate_os_user(admin_os_user):
+                        break
+                    print("  Username may only contain letters, numbers, dots, hyphens, and underscores.")
 
+        if admin_os_user is not None:
             # No wizard prompt for home_workspace post-#353. The admin lands
             # in DATA_DIR/home/<chat_id>/ like any other user; the per-user
             # default is private to them. An admin who wants a path outside
-            # DATA_DIR (a clone of the dev tree, a synced volume, etc.) can
-            # add `home_workspace: /absolute/path` to their users.yaml entry
-            # by hand after install. Removing the prompt prevents the wizard
-            # from defaulting back to the shared PROJECT_ROOT directory the
-            # spec exists to eliminate.
+            # DATA_DIR can add `home_workspace` to users.yaml by hand.
             admin_home_workspace = None
 
         # First-time write target depends on deployment mode:
@@ -1040,6 +1119,16 @@ def _cmd_config() -> None:
             users_yaml_path.write_text(users_yaml_content)
             os.chmod(users_yaml_path, 0o600)
         print(f"  Generated {users_yaml_path}")
+
+    if deployment_mode == "protected":
+        try:
+            _validate_protected_users_yaml(
+                users_yaml_path,
+                service_user,
+                require_existing_accounts=False,
+            )
+        except ValueError as exc:
+            raise SystemExit(f"Protected user isolation validation failed before writing install.conf:\n{exc}") from exc
     # Blank separator only when the user-setup section above actually
     # printed something (first-time prompts or a stray-leftover note),
     # gated on the same condition as its header. On a re-run with an
@@ -4293,6 +4382,26 @@ def _cmd_apply() -> None:
         svc_gid = user_info.pw_gid
     except KeyError:
         raise SystemExit(f"Service user '{service_user}' does not exist on this system.") from None
+
+    # Resolve and validate the users.yaml that this apply would leave active
+    # before stopping the running service or touching disk. A readable staging
+    # file wins on first install; otherwise the canonical protected copy stays
+    # authoritative, matching _apply_secrets' copy/skip behavior.
+    staged_users_yaml = Path(users_yaml_staging_path) if users_yaml_staging_path else None
+    effective_users_yaml = (
+        staged_users_yaml if staged_users_yaml is not None and staged_users_yaml.is_file() else USERS_YAML
+    )
+    try:
+        _validate_protected_users_yaml(
+            effective_users_yaml,
+            service_user,
+            require_existing_accounts=True,
+            service_uid=svc_uid,
+        )
+    except ValueError as exc:
+        raise SystemExit(
+            f"Protected user isolation preflight failed; no installation changes were made:\n{exc}"
+        ) from exc
 
     # Defensive validation: refuse to apply an install.conf whose
     # (DEFAULT_MODEL, effective_provider) pair would fail load_config's

--- a/src/kai/user_isolation.py
+++ b/src/kai/user_isolation.py
@@ -1,0 +1,93 @@
+"""Protected-install OS-user isolation validation.
+
+The protected deployment runs the outer Kai daemon as a dedicated service
+account and persistent conversational agents as per-user OS accounts.  Keeping
+those identities distinct is a security boundary: the service account has
+exact sudo permissions for protected Kai configuration that an agent must not
+inherit.
+
+Single-user repo deployments intentionally do not use this validator.  In that
+mode the operator and agent are the same trust domain and no protected service
+account exists.
+"""
+
+from collections.abc import Callable, Iterable
+
+UserAssignment = tuple[int, str, str | None]
+
+
+def validate_protected_user_isolation(
+    assignments: Iterable[UserAssignment],
+    service_user: str,
+    *,
+    account_uid: Callable[[str], int] | None = None,
+    service_uid: int | None = None,
+) -> tuple[str, ...]:
+    """Validate the OS-user boundary for a protected installation.
+
+    Every interactive Telegram principal must name an OS account, that account
+    must differ from the outer service account, and two principals must not
+    share an account.  Sharing would also share agent credentials, home files,
+    and any data readable by that Unix identity.
+
+    Returns the normalized target usernames in input order.  Raises
+    ``ValueError`` with one actionable message containing every violation so an
+    operator can repair ``users.yaml`` in one pass.  When ``account_uid`` is
+    supplied, the validator also requires every target account to exist and
+    compares resolved UIDs so passwd aliases cannot bypass the name checks.
+    """
+    service_user = service_user.strip()
+    rows = list(assignments)
+    errors: list[str] = []
+    targets: list[str] = []
+    principals_by_target: dict[str, list[str]] = {}
+    principals_by_uid: dict[int, list[tuple[str, str]]] = {}
+
+    if not rows:
+        errors.append("users.yaml contains no valid interactive users")
+
+    for telegram_id, name, raw_os_user in rows:
+        principal = f"{name!r} (telegram_id={telegram_id})"
+        os_user = raw_os_user.strip() if raw_os_user else ""
+        if not os_user:
+            errors.append(f"user {principal} is missing required os_user")
+            continue
+        if os_user == service_user:
+            errors.append(f"user {principal} maps to service account {service_user!r}")
+            continue
+        targets.append(os_user)
+        principals_by_target.setdefault(os_user, []).append(principal)
+        if account_uid is not None:
+            try:
+                uid = account_uid(os_user)
+            except KeyError:
+                errors.append(f"user {principal} maps to nonexistent OS account {os_user!r}")
+                continue
+            if service_uid is not None and uid == service_uid:
+                errors.append(
+                    f"user {principal} maps to OS account {os_user!r}, which resolves to service uid {service_uid}"
+                )
+                continue
+            principals_by_uid.setdefault(uid, []).append((os_user, principal))
+
+    for os_user, principals in principals_by_target.items():
+        if len(principals) > 1:
+            errors.append(f"OS account {os_user!r} is shared by multiple Telegram principals: " + ", ".join(principals))
+
+    for uid, resolved in principals_by_uid.items():
+        names = {os_user for os_user, _principal in resolved}
+        if len(names) > 1:
+            principals = ", ".join(f"{principal} via {os_user!r}" for os_user, principal in resolved)
+            errors.append(f"OS uid {uid} is shared by multiple account names and Telegram principals: {principals}")
+
+    if errors:
+        detail = "\n  - ".join(errors)
+        raise ValueError(
+            "Protected installation requires one unique, non-service os_user "
+            "for every interactive user:\n"
+            f"  - {detail}\n"
+            "Assign each users.yaml entry its own existing OS account, distinct "
+            f"from service account {service_user!r}."
+        )
+
+    return tuple(targets)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -97,6 +97,13 @@ def _clean_env(monkeypatch):
     monkeypatch.setattr("kai.config.load_dotenv", lambda *a, **kw: None)
     # Prevent real sudo calls during tests - default to None (dev mode fallback)
     monkeypatch.setattr("kai.config._read_protected_file", lambda path: None)
+    # Protected-isolation tests use synthetic OS account names. Give each
+    # name a stable, non-service UID by default; focused passwd/alias tests
+    # override this lookup explicitly.
+    monkeypatch.setattr(
+        "kai.config.pwd.getpwnam",
+        lambda name: MagicMock(pw_uid=10000 + sum(ord(char) for char in name)),
+    )
     for var in _CONFIG_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
 
@@ -141,7 +148,10 @@ def _set_required(monkeypatch, token="fake-token", user_ids="123"):
     # mandatory-users contract is met. Names are auto-generated;
     # role=admin so the no-admin-warning does not fire.
     user_entries = "\n".join(
-        f"  - telegram_id: {uid.strip()}\n    name: test-user-{uid.strip()}\n    role: admin"
+        f"  - telegram_id: {uid.strip()}\n"
+        f"    name: test-user-{uid.strip()}\n"
+        f"    role: admin\n"
+        f"    os_user: test-os-user-{uid.strip()}"
         for uid in user_ids.split(",")
         if uid.strip()
     )
@@ -175,6 +185,14 @@ def _patch_protected_users_yaml(monkeypatch, content: str) -> None:
         return None
 
     monkeypatch.setattr("kai.config._read_protected_file", _fake_read)
+
+
+def _patch_single_user_users_yaml(monkeypatch, tmp_path: Path, content: str) -> None:
+    """Simulate a single-user deployment with an explicit users.yaml."""
+    users_yaml = tmp_path / "users.yaml"
+    users_yaml.write_text(content)
+    monkeypatch.setenv("KAI_USERS_YAML", str(users_yaml))
+    monkeypatch.setattr("kai.config._read_protected_file", lambda path: None)
 
 
 # ── Happy path ───────────────────────────────────────────────────────
@@ -668,7 +686,7 @@ class TestDualModeLoading:
         the auth contract; otherwise load_config raises before
         reaching the env-file assertions these tests exist for.
         """
-        users_yaml = "users:\n  - telegram_id: 999\n    name: test\n    role: admin\n"
+        users_yaml = "users:\n  - telegram_id: 999\n    name: test\n    role: admin\n    os_user: protected-test-user\n"
 
         def _read(path):
             if path == "/etc/kai/env":
@@ -740,6 +758,60 @@ class TestDualModeLoading:
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "from-env")
         config = load_config()
         assert config.telegram_bot_token == "from-env"
+
+
+class TestProtectedUserIsolation:
+    def test_protected_install_requires_os_user(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n",
+        )
+        with pytest.raises(SystemExit, match="missing required os_user"):
+            load_config()
+
+    def test_protected_install_rejects_service_account(self, monkeypatch):
+        service_user = pwd.getpwuid(os.geteuid()).pw_name
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+        _patch_protected_users_yaml(
+            monkeypatch,
+            f"users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n    os_user: {service_user}\n",
+        )
+        with pytest.raises(SystemExit, match="maps to service account"):
+            load_config()
+
+    def test_protected_install_rejects_shared_os_account(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n"
+            "  - telegram_id: 1\n    name: alice\n    role: admin\n    os_user: shared\n"
+            "  - telegram_id: 2\n    name: bob\n    role: user\n    os_user: shared\n",
+        )
+        with pytest.raises(SystemExit, match="shared by multiple Telegram principals"):
+            load_config()
+
+    def test_protected_install_rejects_service_uid_alias(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+        monkeypatch.setattr(
+            "kai.config.pwd.getpwnam",
+            lambda name: MagicMock(pw_uid=os.geteuid()),
+        )
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n    os_user: kai-alias\n",
+        )
+        with pytest.raises(SystemExit, match="resolves to service uid"):
+            load_config()
+
+    def test_single_user_install_still_allows_missing_os_user(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+        _patch_single_user_users_yaml(
+            monkeypatch,
+            tmp_path,
+            "users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n",
+        )
+        assert load_config().user_configs[1].os_user is None
 
 
 # ── PR review config ─────────────────────────────────────────────
@@ -1665,14 +1737,13 @@ class TestMemoryReasonerBinaryValidation:
 
 
 class TestCodexMemorySameUserSymmetry:
-    """Codex memory follows claude's `resolve_claude_user` symmetry
-    (issue #522): `os_user` is optional and same-user spawn is a
-    supported deployment shape. config-load does NOT refuse any of:
-    DEFAULT_BACKEND=codex without users.yaml, codex-effective user
-    without os_user, or codex-effective user with os_user matching
-    the bot user. Pinning these as starts-cleanly cases guards
-    against a future change that re-introduces the pre-#522
-    deployment-shape assumption."""
+    """Same-user Codex remains supported for single-user deployments.
+
+    Protected installs now enforce a different trust boundary: every
+    conversational principal must run as a distinct non-service OS account.
+    These issue-#522 compatibility cases therefore use the XDG/single-user
+    config path rather than simulating root-owned protected configuration.
+    """
 
     def test_codex_no_users_yaml_starts_cleanly(self, monkeypatch):
         """DEFAULT_BACKEND=codex with extraction enabled and no
@@ -1688,14 +1759,15 @@ class TestCodexMemorySameUserSymmetry:
         assert config.default_backend == "codex"
         assert config.memory_extraction_enabled is True
 
-    def test_codex_users_yaml_missing_os_user_starts_cleanly(self, monkeypatch):
+    def test_codex_users_yaml_missing_os_user_starts_cleanly(self, monkeypatch, tmp_path):
         """A codex-effective users.yaml entry without `os_user`
         loads successfully. The runtime treats missing os_user as
         in-process spawn (claude's existing pattern), so config-load
         does not refuse the shape."""
         _set_required(monkeypatch)
-        _patch_protected_users_yaml(
+        _patch_single_user_users_yaml(
             monkeypatch,
+            tmp_path,
             "users:\n  - telegram_id: 67890\n    name: bob\n    role: user\n",
         )
         monkeypatch.setenv("MEMORY_ENABLED", "true")
@@ -1706,7 +1778,7 @@ class TestCodexMemorySameUserSymmetry:
         assert config.user_configs is not None
         assert config.user_configs[67890].os_user is None
 
-    def test_codex_users_yaml_same_user_as_bot_starts_cleanly(self, monkeypatch):
+    def test_codex_users_yaml_same_user_as_bot_starts_cleanly(self, monkeypatch, tmp_path):
         """A codex-effective users.yaml entry with `os_user`
         matching the bot user loads successfully. The runtime
         detects same-user via `resolve_claude_user` and spawns
@@ -1714,8 +1786,9 @@ class TestCodexMemorySameUserSymmetry:
         for same-user."""
         bot_user = pwd.getpwuid(os.getuid()).pw_name
         _set_required(monkeypatch)
-        _patch_protected_users_yaml(
+        _patch_single_user_users_yaml(
             monkeypatch,
+            tmp_path,
             f"users:\n  - telegram_id: 12345\n    name: alice\n    role: admin\n    os_user: {bot_user}\n",
         )
         monkeypatch.setenv("MEMORY_ENABLED", "true")
@@ -2947,7 +3020,7 @@ class TestDefaultTimeoutRename:
         # admin entry so load_config completes for these env-driven tests.
         _patch_protected_users_yaml(
             monkeypatch,
-            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n",
+            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n    os_user: test-os-user\n",
         )
 
     def test_DEFAULT_TIMEOUT_env_wins_when_both_set(self, monkeypatch, caplog):
@@ -3003,7 +3076,7 @@ class TestAgentSessionLifecycleRename:
             monkeypatch.setenv(k, v)
         _patch_protected_users_yaml(
             monkeypatch,
-            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n",
+            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n    os_user: test-os-user\n",
         )
 
     def test_agent_keys_preferred_over_legacy(self, monkeypatch):
@@ -3065,7 +3138,7 @@ class TestLoadConfigBackendAwareModelValidation:
         # admin entry so the validation tests reach the model check.
         _patch_protected_users_yaml(
             monkeypatch,
-            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n",
+            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n    os_user: test-os-user\n",
         )
 
     def test_codex_rejects_goose_only_model(self, monkeypatch):
@@ -3463,7 +3536,7 @@ class TestLoadMemoryProjects:
         monkeypatch.setenv("GENERIC_WEBHOOK_SECRET", "test-secret")
         _patch_protected_users_yaml(
             monkeypatch,
-            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n",
+            "users:\n  - telegram_id: 12345\n    name: test\n    role: admin\n    os_user: test-os-user\n",
         )
 
         registry_root = tmp_path / "registry_root"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1287,6 +1287,12 @@ class TestCmdConfig:
             return _real_exists(self)
 
         monkeypatch.setattr(Path, "exists", _exists_with_canonical)
+        parsed = yaml.safe_load(content)
+        if isinstance(parsed, dict) and isinstance(parsed.get("users"), list):
+            for index, entry in enumerate(parsed["users"]):
+                if isinstance(entry, dict) and not entry.get("os_user"):
+                    entry["os_user"] = f"test-os-user-{index}"
+            content = yaml.safe_dump(parsed, sort_keys=False)
         monkeypatch.setattr("kai.install._read_users_yaml_text", lambda path: content)
 
     def test_writes_install_conf(self, tmp_path, monkeypatch):
@@ -1307,7 +1313,7 @@ class TestCmdConfig:
                 "fake-token",  # bot token
                 "12345",  # admin telegram ID
                 "admin",  # admin display name
-                "false",  # advanced user options
+                "testuser",  # required protected os_user
                 "polling",  # transport
                 "claude",  # agent backend
                 "/usr/bin/true",  # claude binary path
@@ -1406,7 +1412,6 @@ class TestCmdConfig:
                 "fake-token",  # bot token
                 "12345",  # admin telegram ID
                 "admin",  # admin display name
-                "true",  # advanced user options
                 "testuser",  # os_user
                 # no home_workspace prompt post-#353
                 "polling",  # transport
@@ -1490,7 +1495,7 @@ class TestCmdConfig:
                 "fake-token",  # bot token
                 "12345",  # admin telegram ID
                 "admin",  # admin display name
-                "false",  # advanced user options -> no os_user, no home prompt
+                "testuser",  # required protected os_user
                 "polling",  # transport
                 "claude",  # agent backend
                 "/usr/bin/true",  # claude binary path
@@ -1559,7 +1564,6 @@ class TestCmdConfig:
                 "fake-token",
                 "12345",
                 "admin",
-                "true",  # advanced -> os_user prompt
                 "testuser",  # os_user (no home_workspace prompt should follow)
                 "polling",
                 "claude",
@@ -1622,7 +1626,7 @@ class TestCmdConfig:
                 "fake-token",  # bot token
                 "12345",  # admin telegram ID
                 "admin",  # admin display name
-                "false",  # advanced user options
+                "testuser",  # required protected os_user
                 "polling",  # transport
                 "goose",  # agent backend (prompt shown because existing config has goose)
                 "/opt/homebrew/bin/goose",  # goose binary path (validator stubbed)
@@ -1758,7 +1762,7 @@ class TestCmdConfig:
                 "fake-token",  # bot token
                 "12345",  # admin telegram ID
                 "admin",  # admin display name
-                "false",  # advanced user options
+                "testuser",  # required protected os_user
                 "polling",  # transport
                 "goose",  # agent backend
                 "/opt/homebrew/bin/goose",  # goose binary path (validator stubbed)
@@ -2000,7 +2004,7 @@ class TestCmdConfig:
             "fake-token",  # bot token
             "12345",  # admin telegram ID
             "admin",  # admin display name
-            "false",  # advanced user options
+            "testuser",  # required protected os_user
             "polling",  # transport
             agent_backend,  # agent backend
             *backend_block,  # llm_provider + api_key (non-claude only)
@@ -2441,7 +2445,7 @@ class TestCmdConfig:
                 "fake-token",  # bot token
                 "12345",  # admin telegram ID
                 "admin",  # admin display name
-                "false",  # advanced user options
+                "testuser",  # required protected os_user
                 "polling",  # transport
                 "goose",  # agent backend (was claude)
                 "/opt/homebrew/bin/goose",  # goose binary path (validator stubbed)
@@ -2703,6 +2707,10 @@ class TestCmdConfig:
             return None
 
         monkeypatch.setattr("kai.config._read_protected_file", _fake_read)
+        monkeypatch.setattr(
+            "kai.config.pwd.getpwnam",
+            lambda name: MagicMock(pw_uid=os.geteuid() + 100_000),
+        )
         # Seed only the env keys the wizard would emit. Everything
         # else falls back to dataclass defaults via load_config.
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
@@ -2737,20 +2745,12 @@ class TestCmdConfig:
         assert get_model_for(ModelRole.MEMORY_EPISODE, "codex", "openai") in CODEX_MODELS
 
     def test_codex_fresh_install_with_memory_extraction_yields_valid_users_yaml(self, tmp_path, monkeypatch):
-        """Fresh-install integration contract for codex memory.
+        """Fresh protected Codex+memory config carries OS isolation.
 
-        When the wizard drives the path 'no users.yaml -> codex backend
-        -> enable memory -> enable extraction' AND the operator accepts
-        the default 'Configure advanced user options = false', the
-        wizard writes users.yaml with NO `os_user`. Issue #522 makes
-        that valid: codex memory follows claude's `resolve_claude_user`
-        symmetry and spawns in-process when os_user is unset. The
-        produced env + users.yaml must pass load_config() without any
-        codex-memory-specific precondition firing.
-
-        Pre-#522 this same input shape required a separate reprompt
-        for a non-bot os_user; that reprompt is now gone along with
-        the load_config precondition that motivated it.
+        Issue #522's same-user Codex symmetry remains supported in
+        single-user mode. Protected mode now requires an explicit target
+        account, and the generated env + users.yaml must still pass the
+        complete load_config integration path.
         """
         from unittest.mock import MagicMock
 
@@ -2781,7 +2781,7 @@ class TestCmdConfig:
                 "fake-token",  # bot token
                 "12345",  # admin telegram ID
                 "admin",  # admin display name
-                "false",  # advanced user options (no os_user)
+                "testuser",  # required protected os_user
                 "polling",  # transport
                 "codex",  # agent backend
                 "subscription",  # codex auth mode
@@ -2818,15 +2818,13 @@ class TestCmdConfig:
 
         _cmd_config()
 
-        # users.yaml is written without os_user; same-user spawn is
-        # the supported deployment shape for an operator who accepts
-        # the default "Configure advanced user options = false".
+        # Protected users.yaml carries the explicit non-service target.
         users_yaml_path = tmp_path / "users.yaml"
         assert users_yaml_path.exists()
         data = yaml.safe_load(users_yaml_path.read_text())
         entry = data["users"][0]
         assert entry["telegram_id"] == 12345
-        assert entry.get("os_user") is None
+        assert entry.get("os_user") == "testuser"
 
         # Integration pin: feed the produced env + users.yaml into
         # load_config and assert it accepts the shape. The wizard
@@ -2853,6 +2851,10 @@ class TestCmdConfig:
 
         monkeypatch.setattr("kai.config._read_protected_file", _fake_read)
         monkeypatch.setattr(
+            "kai.config.pwd.getpwnam",
+            lambda name: MagicMock(pw_uid=os.geteuid() + 100_000),
+        )
+        monkeypatch.setattr(
             "kai.oneshot_binary.resolve_oneshot_binary",
             lambda backend: f"/fake/{backend}",
         )
@@ -2865,9 +2867,7 @@ class TestCmdConfig:
         assert config.default_backend == "codex"
         assert config.user_configs is not None
         assert 12345 in config.user_configs
-        # No os_user → in-process spawn at runtime via the
-        # self-sudo-skip path.
-        assert config.user_configs[12345].os_user is None
+        assert config.user_configs[12345].os_user == "testuser"
 
 
 # ── Apply subcommand ─────────────────────────────────────────────────
@@ -2911,6 +2911,9 @@ class TestCmdApply:
         """DRY_RUN=1 prints actions without executing them."""
         monkeypatch.setattr("os.geteuid", lambda: 0)
         monkeypatch.setenv("DRY_RUN", "1")
+        kai.install.USERS_YAML.write_text(
+            "users:\n  - telegram_id: 1\n    name: test\n    role: admin\n    os_user: root\n"
+        )
 
         conf_path = tmp_path / "install.conf"
         conf_path.write_text(
@@ -2945,6 +2948,9 @@ class TestCmdApply:
         """
         monkeypatch.setattr("os.geteuid", lambda: 0)
         monkeypatch.setenv("DRY_RUN", "1")
+        kai.install.USERS_YAML.write_text(
+            "users:\n  - telegram_id: 1\n    name: test\n    role: admin\n    os_user: root\n"
+        )
         conf_path = tmp_path / "install.conf"
         conf_path.write_text(
             json.dumps(
@@ -3017,6 +3023,9 @@ class TestCmdApply:
         reach its try/finally block; the rest of the apply path is
         either short-circuited by dry-run or monkey-patched per test.
         Returns the conf path."""
+        kai.install.USERS_YAML.write_text(
+            "users:\n  - telegram_id: 1\n    name: test\n    role: admin\n    os_user: root\n"
+        )
         conf_path = tmp_path / "install.conf"
         conf_path.write_text(
             json.dumps(
@@ -3133,6 +3142,100 @@ class TestCmdApply:
         assert "Manual recovery" in out
 
 
+class TestProtectedUserIsolationPreflight:
+    @staticmethod
+    def _write_conf(tmp_path: Path, *, staging: Path | None = None) -> Path:
+        conf = {
+            "version": 1,
+            "deployment_mode": "protected",
+            "install_dir": str(tmp_path / "opt-kai"),
+            "data_dir": str(tmp_path / "data"),
+            "service_user": "kai-service",
+            "platform": "darwin",
+            "env": {"TELEGRAM_BOT_TOKEN": "tok", "DEFAULT_MODEL": "sonnet"},
+        }
+        if staging is not None:
+            conf["users_yaml_staging_path"] = str(staging)
+        path = tmp_path / "install.conf"
+        path.write_text(json.dumps(conf))
+        return path
+
+    @staticmethod
+    def _fake_accounts(monkeypatch, *, missing: str | None = None) -> None:
+        class _FakePwd:
+            pw_gid = 4242
+
+            def __init__(self, uid):
+                self.pw_uid = uid
+
+        def _lookup(name):
+            if name == missing:
+                raise KeyError(name)
+            return _FakePwd(4242 if name == "kai-service" else 5252)
+
+        monkeypatch.setattr("kai.install.pwd.getpwnam", _lookup)
+
+    def test_missing_os_user_aborts_before_service_stop(self, tmp_path, monkeypatch):
+        kai.install.USERS_YAML.write_text("users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n")
+        monkeypatch.setattr("kai.install.INSTALL_CONF", self._write_conf(tmp_path))
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        self._fake_accounts(monkeypatch)
+        stop = MagicMock()
+        monkeypatch.setattr("kai.install._stop_service", stop)
+
+        with pytest.raises(SystemExit, match="missing required os_user"):
+            _cmd_apply()
+        stop.assert_not_called()
+        assert not (tmp_path / "opt-kai").exists()
+
+    def test_service_account_mapping_aborts_before_service_stop(self, tmp_path, monkeypatch):
+        kai.install.USERS_YAML.write_text(
+            "users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n    os_user: kai-service\n"
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", self._write_conf(tmp_path))
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        self._fake_accounts(monkeypatch)
+        stop = MagicMock()
+        monkeypatch.setattr("kai.install._stop_service", stop)
+
+        with pytest.raises(SystemExit, match="maps to service account"):
+            _cmd_apply()
+        stop.assert_not_called()
+
+    def test_nonexistent_target_aborts_before_service_stop(self, tmp_path, monkeypatch):
+        kai.install.USERS_YAML.write_text(
+            "users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n    os_user: absent-user\n"
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", self._write_conf(tmp_path))
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        self._fake_accounts(monkeypatch, missing="absent-user")
+        stop = MagicMock()
+        monkeypatch.setattr("kai.install._stop_service", stop)
+
+        with pytest.raises(SystemExit, match="nonexistent OS account"):
+            _cmd_apply()
+        stop.assert_not_called()
+
+    def test_staged_users_yaml_is_the_preflight_authority(self, tmp_path, monkeypatch):
+        kai.install.USERS_YAML.write_text(
+            "users:\n  - telegram_id: 1\n    name: safe\n    role: admin\n    os_user: safe-user\n"
+        )
+        staging = tmp_path / "staged-users.yaml"
+        staging.write_text("users:\n  - telegram_id: 2\n    name: unsafe\n    role: admin\n")
+        monkeypatch.setattr(
+            "kai.install.INSTALL_CONF",
+            self._write_conf(tmp_path, staging=staging),
+        )
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        self._fake_accounts(monkeypatch)
+        stop = MagicMock()
+        monkeypatch.setattr("kai.install._stop_service", stop)
+
+        with pytest.raises(SystemExit, match="missing required os_user"):
+            _cmd_apply()
+        stop.assert_not_called()
+
+
 class TestCmdConfigDefaultModelDispatch:
     """
     Wizard dispatch for DEFAULT_MODEL when users.yaml exists.
@@ -3169,9 +3272,10 @@ class TestCmdConfigDefaultModelDispatch:
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
-        # Pretend the canonical users.yaml exists with empty user list;
-        # only the presence flag matters for this dispatch test, not the
-        # content. Compares against the live USERS_YAML attribute so it
+        # Pretend the canonical users.yaml exists with one isolated user;
+        # only the presence flag matters for this dispatch test. Protected
+        # mode now validates the OS-user boundary before later prompts.
+        # Compares against the live USERS_YAML attribute so it
         # stacks on the autouse `_isolate_users_yaml` redirect.
         _real_exists = Path.exists
 
@@ -3181,7 +3285,10 @@ class TestCmdConfigDefaultModelDispatch:
             return _real_exists(self)
 
         monkeypatch.setattr(Path, "exists", _exists_with_canonical)
-        monkeypatch.setattr("kai.install._read_users_yaml_text", lambda path: "users: []\n")
+        monkeypatch.setattr(
+            "kai.install._read_users_yaml_text",
+            lambda path: "users:\n  - telegram_id: 1\n    name: test\n    role: admin\n    os_user: test-os-user\n",
+        )
 
         if existing_env is not None:
             (tmp_path / "install.conf").write_text(json.dumps({"env": existing_env, "version": 1}))
@@ -3586,6 +3693,9 @@ class TestCmdApplyDefaultModelGate:
     @staticmethod
     def _write_install_conf(tmp_path, env: dict[str, str]) -> Path:
         """Write a minimal install.conf with the given env dict."""
+        kai.install.USERS_YAML.write_text(
+            "users:\n  - telegram_id: 1\n    name: test\n    role: admin\n    os_user: root\n"
+        )
         conf_path = tmp_path / "install.conf"
         conf_path.write_text(
             json.dumps(
@@ -7270,7 +7380,7 @@ class TestCmdConfigCanonicalUsersYaml:
             "fake-token",
             "12345",  # admin telegram id
             "admin",  # admin name
-            "false",  # advanced
+            "testuser",  # required protected os_user
             "polling",
             "claude",
             "/usr/bin/true",  # claude binary path
@@ -7427,10 +7537,15 @@ class TestCmdApplyStagingHandoff:
         monkeypatch.setattr("os.geteuid", lambda: 0)
 
         class _FakePwd:
-            pw_uid = 4242
             pw_gid = 4242
 
-        monkeypatch.setattr("pwd.getpwnam", lambda name: _FakePwd)
+            def __init__(self, uid):
+                self.pw_uid = uid
+
+        monkeypatch.setattr("pwd.getpwnam", lambda name: _FakePwd(4242 if name == "kai" else 5252))
+        kai.install.USERS_YAML.write_text(
+            "users:\n  - telegram_id: 1\n    name: test\n    role: admin\n    os_user: testuser\n"
+        )
 
         def _fake_apply_secrets(env, dry_run, users_yaml_staging_path=None):
             captured["users_yaml_staging_path"] = users_yaml_staging_path
@@ -7452,7 +7567,7 @@ class TestCmdApplyStagingHandoff:
         top-level conf key, preserving env and other top-level keys.
         """
         staging = tmp_path / "users.yaml"
-        staging.write_text("users: []\n")
+        staging.write_text("users:\n  - telegram_id: 1\n    name: test\n    role: admin\n    os_user: testuser\n")
         conf_path = self._minimal_conf(tmp_path, str(staging))
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         monkeypatch.delenv("DRY_RUN", raising=False)
@@ -7478,7 +7593,7 @@ class TestCmdApplyStagingHandoff:
         handoff exactly as if the dry run had never happened.
         """
         staging = tmp_path / "users.yaml"
-        staging.write_text("users: []\n")
+        staging.write_text("users:\n  - telegram_id: 1\n    name: test\n    role: admin\n    os_user: testuser\n")
         conf_path = self._minimal_conf(tmp_path, str(staging))
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         monkeypatch.setenv("DRY_RUN", "1")
@@ -7521,7 +7636,7 @@ class TestCmdApplyStagingHandoff:
         operator_cache = tmp_path / "operator-cache"
         operator_cache.mkdir()
         staging = operator_cache / "users.yaml"
-        staging.write_text("users: []\n")
+        staging.write_text("users:\n  - telegram_id: 1\n    name: test\n    role: admin\n    os_user: testuser\n")
         conf_path = self._minimal_conf(tmp_path, str(staging))
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         monkeypatch.delenv("DRY_RUN", raising=False)
@@ -7847,10 +7962,15 @@ class TestCmdApplySingleUserRefuses:
         # fire when deployment_mode is missing from the conf.
 
         class _FakePwd:
-            pw_uid = 4242
             pw_gid = 4242
 
-        monkeypatch.setattr("pwd.getpwnam", lambda name: _FakePwd)
+            def __init__(self, uid):
+                self.pw_uid = uid
+
+        monkeypatch.setattr("pwd.getpwnam", lambda name: _FakePwd(4242 if name == "kai" else 5252))
+        kai.install.USERS_YAML.write_text(
+            "users:\n  - telegram_id: 1\n    name: test\n    role: admin\n    os_user: testuser\n"
+        )
         monkeypatch.setattr("kai.install._stop_service", lambda *a, **kw: None)
         monkeypatch.setattr("kai.install._apply_directories", lambda *a, **kw: None)
         monkeypatch.setattr("kai.install._apply_source", lambda *a, **kw: None)
@@ -9088,7 +9208,7 @@ class TestOpenCodeBinWizardPrompt:
             "fake-token",  # bot token
             "12345",  # admin telegram ID
             "admin",  # admin display name
-            "false",  # advanced user options (no per-user os_user)
+            "testuser",  # required protected os_user
             "polling",  # transport
             "opencode",  # agent backend
             opencode_bin_path,  # OPENCODE_BIN
@@ -9505,6 +9625,9 @@ class TestApplyBackendAwareModelValidation:
     """_cmd_apply rejects codex installs with goose-only or claude models."""
 
     def _conf(self, tmp_path, **env_overrides):
+        kai.install.USERS_YAML.write_text(
+            "users:\n  - telegram_id: 1\n    name: test\n    role: admin\n    os_user: root\n"
+        )
         env = {
             "TELEGRAM_BOT_TOKEN": "tok",
             "DEFAULT_BACKEND": "codex",

--- a/tests/test_user_isolation.py
+++ b/tests/test_user_isolation.py
@@ -1,0 +1,85 @@
+"""Tests for the protected-install OS-user trust boundary."""
+
+import pytest
+
+from kai.user_isolation import validate_protected_user_isolation
+
+
+def test_accepts_unique_non_service_accounts():
+    targets = validate_protected_user_isolation(
+        [(1, "alice", "alice"), (2, "bob", "bob")],
+        "kai",
+    )
+    assert targets == ("alice", "bob")
+
+
+def test_rejects_missing_os_user():
+    with pytest.raises(ValueError, match="missing required os_user"):
+        validate_protected_user_isolation([(1, "alice", None)], "kai")
+
+
+def test_rejects_service_account():
+    with pytest.raises(ValueError, match="maps to service account 'kai'"):
+        validate_protected_user_isolation([(1, "alice", "kai")], "kai")
+
+
+def test_rejects_shared_os_account():
+    with pytest.raises(ValueError, match="shared by multiple Telegram principals"):
+        validate_protected_user_isolation(
+            [(1, "alice", "shared"), (2, "bob", "shared")],
+            "kai",
+        )
+
+
+def test_reports_all_violations_together():
+    with pytest.raises(ValueError) as excinfo:
+        validate_protected_user_isolation(
+            [
+                (1, "missing", None),
+                (2, "service", "kai"),
+                (3, "shared-a", "shared"),
+                (4, "shared-b", "shared"),
+            ],
+            "kai",
+        )
+    message = str(excinfo.value)
+    assert "missing required os_user" in message
+    assert "maps to service account 'kai'" in message
+    assert "shared by multiple Telegram principals" in message
+
+
+def test_rejects_empty_assignment_set():
+    with pytest.raises(ValueError, match="no valid interactive users"):
+        validate_protected_user_isolation([], "kai")
+
+
+def test_rejects_account_alias_for_service_uid():
+    uids = {"kai-alias": 503}
+    with pytest.raises(ValueError, match="resolves to service uid 503"):
+        validate_protected_user_isolation(
+            [(1, "alice", "kai-alias")],
+            "kai",
+            account_uid=uids.__getitem__,
+            service_uid=503,
+        )
+
+
+def test_rejects_two_account_names_for_same_uid():
+    uids = {"alice": 501, "alice-alias": 501}
+    with pytest.raises(ValueError, match="OS uid 501 is shared"):
+        validate_protected_user_isolation(
+            [(1, "alice", "alice"), (2, "bob", "alice-alias")],
+            "kai",
+            account_uid=uids.__getitem__,
+            service_uid=503,
+        )
+
+
+def test_rejects_nonexistent_target_account():
+    with pytest.raises(ValueError, match="nonexistent OS account 'missing'"):
+        validate_protected_user_isolation(
+            [(1, "alice", "missing")],
+            "kai",
+            account_uid={}.__getitem__,
+            service_uid=503,
+        )


### PR DESCRIPTION
## Summary

- require every interactive user in a protected deployment to map to a distinct OS account
- reject the Kai service account, shared usernames, shared resolved UIDs, and nonexistent accounts
- enforce the boundary in the configuration wizard, before apply mutates an installation, and again at runtime
- preserve the existing same-user behavior for `single_user` deployments

## Security rationale

The protected daemon account has narrowly scoped sudo access to root-owned Kai configuration and TOTP material. A persistent conversational agent running under that account would inherit those capabilities even if its subprocess environment were sanitized. Username-only checks would also be insufficient because multiple passwd names can resolve to the same UID.

This change makes the intended trust boundary explicit: the outer daemon remains the privileged broker, while each Telegram principal's persistent agent runs under its own non-service Unix UID.

## Behavior and rollout

### `make config`

Protected mode now requires an `os_user` for a newly generated user and rejects the service-account name. Existing protected `users.yaml` is validated before `install.conf` is written. `install.conf` remains an artifact generated by `make config`; this change does not treat it as the canonical user configuration.

### `make install`

Apply validates the effective `users.yaml` before stopping the service or writing anything. It resolves system accounts and rejects:

- a missing `os_user`
- the service username or any alias resolving to the service UID
- the same username assigned to multiple Telegram principals
- different usernames resolving to the same UID
- a nonexistent target account

On failure, apply exits with an actionable message and explicitly reports that no installation changes were made. Dry-run follows the same preflight.

### Runtime

Protected startup repeats the UID-aware validation and fails closed if `users.yaml` is later edited into an unsafe state. Single-user/XDG deployments do not cross this boundary and retain their optional same-user configuration.

## Compatibility

The current production mappings were checked read-only and pass the new preflight:

- `daniel` maps to `daniel`
- `scott` maps to `sellison`

No live installation files were changed while developing this PR.

## Verification

- `make check`
- focused installer/config/isolation suite: `798 passed`
- full test suite: `4677 passed, 1 skipped`
- read-only real-config preflight: passed for `('daniel', 'sellison')`

## Follow-up

This closes the protected service-UID/persistent-agent isolation gap. TOTP authorization hardening remains the next separate security slice.
