### PR TITLE
fix(security): make TOTP state fail closed

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -35,6 +35,7 @@ import functools
 import json
 import logging
 import math
+import os
 import re
 import shutil
 import time
@@ -78,25 +79,41 @@ from kai.transcribe import TranscriptionError, transcribe_voice
 from kai.tts import DEFAULT_VOICE, VOICES, TTSError, synthesize_speech
 from kai.workspace_utils import is_workspace_allowed
 
-# TOTP is optional (requires pip install -e '.[totp]'). When the extra is not
-# installed, is_totp_configured() returns False and the gate is fully disabled.
-# All four stubs are defined in the except block so Pyright doesn't flag them
-# as possibly-unbound at their call sites inside the gate.
+# TOTP is optional for single-user development (requires pip install
+# -e '.[totp]'). A missing extra may disable the gate only when neither
+# protected TOTP file exists. If protected state exists, fail closed.
 try:
-    from kai.totp import get_failure_count, get_lockout_remaining, is_totp_configured, verify_code
-except ImportError:
+    from kai.totp import TotpStateError, get_failure_count, get_lockout_remaining, is_totp_configured, verify_code
+except ImportError as exc:
+    _TOTP_IMPORT_FAILURE = exc
+
+    class TotpStateError(RuntimeError):  # type: ignore[no-redef]
+        """TOTP protected state exists but the optional implementation is unavailable."""
 
     def is_totp_configured() -> bool:  # type: ignore[misc]
+        try:
+            state_exists = any(os.path.exists(path) for path in ("/etc/kai/totp.secret", "/etc/kai/totp.attempts"))
+        except OSError as exc:
+            raise TotpStateError("Could not determine whether protected TOTP state exists") from exc
+        if state_exists:
+            raise TotpStateError("Protected TOTP state exists but TOTP support could not be imported") from (
+                _TOTP_IMPORT_FAILURE
+            )
         return False
 
-    def get_lockout_remaining() -> int:  # type: ignore[misc]
-        return 0
+    def get_lockout_remaining(principal_id: int) -> int:  # type: ignore[misc]
+        raise TotpStateError("TOTP support is unavailable")
 
-    def verify_code(code: str, lockout_attempts: int = 3, lockout_minutes: int = 15) -> bool:  # type: ignore[misc]
-        return False
+    def verify_code(  # type: ignore[misc]
+        code: str,
+        principal_id: int,
+        lockout_attempts: int = 3,
+        lockout_minutes: int = 15,
+    ) -> bool:
+        raise TotpStateError("TOTP support is unavailable")
 
-    def get_failure_count() -> int:  # type: ignore[misc]
-        return 0
+    def get_failure_count(principal_id: int) -> int:  # type: ignore[misc]
+        raise TotpStateError("TOTP support is unavailable")
 
 
 log = logging.getLogger(__name__)
@@ -4121,6 +4138,14 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 # ── Main message handler ─────────────────────────────────────────────
 
 
+async def _deny_totp_state_error(update: Update, exc: TotpStateError) -> None:
+    """Deny an update when protected TOTP state cannot be trusted."""
+    log.error("TOTP state unavailable; denying Telegram update: %s", exc)
+    message = update.message or update.effective_message
+    if message is not None:
+        await message.reply_text("Authentication service unavailable. Access denied; contact the Kai administrator.")
+
+
 async def _check_totp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
     """
     Check TOTP authentication if configured. Returns True if the request
@@ -4134,8 +4159,12 @@ async def _check_totp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> boo
     Informational commands (/stats, /help, /job, etc.) do NOT need
     this gate since they don't invoke Claude with user content.
     """
-    if not await asyncio.to_thread(is_totp_configured):
-        return True
+    try:
+        if not await asyncio.to_thread(is_totp_configured):
+            return True
+    except TotpStateError as exc:
+        await _deny_totp_state_error(update, exc)
+        return False
 
     assert context.user_data is not None
     assert update.effective_chat is not None
@@ -4164,6 +4193,83 @@ async def _check_totp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> boo
     return False
 
 
+async def _check_totp_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
+    """Run the complete text-message TOTP challenge and verification flow."""
+    try:
+        if not await asyncio.to_thread(is_totp_configured):
+            return True
+
+        assert context.user_data is not None
+        assert update.effective_chat is not None
+        assert update.message is not None
+
+        principal_id = _user_id(update)
+        totp_cfg: Config = context.bot_data["config"]
+        auth_time = context.user_data.get("totp_authenticated_at", 0)
+        totp_expired = time.time() - auth_time > totp_cfg.totp_session_minutes * 60
+
+        if not totp_expired:
+            # Auth is still valid - refresh the timestamp so the session
+            # timeout measures inactivity, not time since login.
+            context.user_data["totp_authenticated_at"] = time.time()
+            return True
+
+        pending = context.user_data.get("totp_pending")
+        if not pending:
+            # First message after expiry - send challenge via the shared helper.
+            await _check_totp(update, context)
+            return False
+
+        if time.time() > pending["expires_at"]:
+            del context.user_data["totp_pending"]
+            await update.message.reply_text("TOTP challenge expired. Send another message to try again.")
+            return False
+
+        code = update.message.text.strip() if update.message.text else ""
+
+        # Only treat 6-digit ASCII strings as code attempts. Other messages
+        # are kept out of the verifier and are not deleted from Telegram.
+        if not (code.isascii() and code.isdigit() and len(code) == 6):
+            await update.effective_chat.send_message("Authentication required. Enter your 6-digit code.")
+            return False
+
+        try:
+            await update.message.delete()
+        except Exception:
+            pass
+
+        lockout_remaining = await asyncio.to_thread(get_lockout_remaining, principal_id)
+        if lockout_remaining > 0:
+            minutes = math.ceil(lockout_remaining / 60)
+            await update.effective_chat.send_message(
+                f"Too many failed attempts. Locked out for {minutes} more minute{'s' if minutes != 1 else ''}."
+            )
+            return False
+
+        lockout_attempts = totp_cfg.totp_lockout_attempts
+        lockout_minutes = totp_cfg.totp_lockout_minutes
+        if await asyncio.to_thread(verify_code, code, principal_id, lockout_attempts, lockout_minutes):
+            del context.user_data["totp_pending"]
+            context.user_data["totp_authenticated_at"] = time.time()
+            await update.effective_chat.send_message("Authenticated.")
+            return False
+
+        lockout_remaining = await asyncio.to_thread(get_lockout_remaining, principal_id)
+        if lockout_remaining > 0:
+            del context.user_data["totp_pending"]
+            await update.effective_chat.send_message(
+                f"Too many failed attempts. Locked out for {lockout_minutes} minutes."
+            )
+        else:
+            failures = await asyncio.to_thread(get_failure_count, principal_id)
+            remaining = max(0, lockout_attempts - failures)
+            await update.effective_chat.send_message(f"Invalid code. {remaining} attempt(s) remaining.")
+        return False
+    except TotpStateError as exc:
+        await _deny_totp_state_error(update, exc)
+        return False
+
+
 @_require_auth
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -4176,87 +4282,8 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     if not update.message or not update.message.text:
         return
 
-    # ── TOTP gate ────────────────────────────────────────────────────────
-    # handle_message needs the full TOTP flow: check session, send
-    # challenge, AND verify codes. Media handlers use _check_totp()
-    # which only handles the first two steps. We keep the expiry check
-    # inline here because _check_totp sets totp_pending as a side effect,
-    # and we need to read the pending state before that happens.
-    if await asyncio.to_thread(is_totp_configured):
-        assert context.user_data is not None
-        assert update.effective_chat is not None
-
-        totp_cfg: Config = context.bot_data["config"]
-        auth_time = context.user_data.get("totp_authenticated_at", 0)
-        totp_expired = time.time() - auth_time > totp_cfg.totp_session_minutes * 60
-
-        if totp_expired:
-            pending = context.user_data.get("totp_pending")
-
-            if not pending:
-                # First message after expiry - send challenge via helper
-                await _check_totp(update, context)
-                return
-
-            # A challenge is in flight. This text is the TOTP code.
-            if time.time() > pending["expires_at"]:
-                del context.user_data["totp_pending"]
-                await update.message.reply_text("TOTP challenge expired. Send another message to try again.")
-                return
-
-            code = update.message.text.strip() if update.message.text else ""
-
-            # Only treat 6-digit ASCII strings as code attempts. Other
-            # messages (e.g., normal chat that arrived concurrently with the
-            # challenge) are dropped with a brief reminder instead of being
-            # fed to verify_code(). This prevents message deletion, spurious
-            # "Invalid code" responses, and unnecessary sudo calls.
-            # Note: isascii() guard is needed because isdigit() accepts
-            # non-ASCII digit characters (superscripts, Arabic-Indic, etc.).
-            if not (code.isascii() and code.isdigit() and len(code) == 6):
-                await update.effective_chat.send_message("Authentication required. Enter your 6-digit code.")
-                return
-
-            # Delete the code message so it doesn't linger in chat
-            try:
-                await update.message.delete()
-            except Exception:
-                pass
-
-            # Check global lockout before calling verify_code()
-            lockout_remaining = await asyncio.to_thread(get_lockout_remaining)
-            if lockout_remaining > 0:
-                minutes = math.ceil(lockout_remaining / 60)
-                await update.effective_chat.send_message(
-                    f"Too many failed attempts. Locked out for {minutes} more minute{'s' if minutes != 1 else ''}."
-                )
-                return
-
-            lockout_attempts = totp_cfg.totp_lockout_attempts
-            lockout_minutes = totp_cfg.totp_lockout_minutes
-
-            if await asyncio.to_thread(verify_code, code, lockout_attempts, lockout_minutes):
-                del context.user_data["totp_pending"]
-                context.user_data["totp_authenticated_at"] = time.time()
-                await update.effective_chat.send_message("Authenticated.")
-                return
-
-            # Verification failed
-            lockout_remaining = await asyncio.to_thread(get_lockout_remaining)
-            if lockout_remaining > 0:
-                del context.user_data["totp_pending"]
-                await update.effective_chat.send_message(
-                    f"Too many failed attempts. Locked out for {lockout_minutes} minutes."
-                )
-            else:
-                remaining = lockout_attempts - await asyncio.to_thread(get_failure_count)
-                await update.effective_chat.send_message(f"Invalid code. {remaining} attempt(s) remaining.")
-            return
-
-        # Auth is still valid - refresh the timestamp so the session
-        # timeout measures inactivity, not time since login.
-        context.user_data["totp_authenticated_at"] = time.time()
-    # ── End TOTP gate ─────────────────────────────────────────────────────
+    if not await _check_totp_text(update, context):
+        return
 
     chat_id = _chat_id(update)
     prompt = update.message.text

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -2884,18 +2884,26 @@ def load_config() -> Config:
 
     try:
         totp_session_minutes = int(os.environ.get("TOTP_SESSION_MINUTES", "30"))
+        if totp_session_minutes <= 0:
+            raise SystemExit("TOTP_SESSION_MINUTES must be a positive integer")
     except ValueError:
         raise SystemExit("TOTP_SESSION_MINUTES must be an integer") from None
     try:
         totp_challenge_seconds = int(os.environ.get("TOTP_CHALLENGE_SECONDS", "120"))
+        if totp_challenge_seconds <= 0:
+            raise SystemExit("TOTP_CHALLENGE_SECONDS must be a positive integer")
     except ValueError:
         raise SystemExit("TOTP_CHALLENGE_SECONDS must be an integer") from None
     try:
         totp_lockout_attempts = int(os.environ.get("TOTP_LOCKOUT_ATTEMPTS", "3"))
+        if totp_lockout_attempts <= 0:
+            raise SystemExit("TOTP_LOCKOUT_ATTEMPTS must be a positive integer")
     except ValueError:
         raise SystemExit("TOTP_LOCKOUT_ATTEMPTS must be an integer") from None
     try:
         totp_lockout_minutes = int(os.environ.get("TOTP_LOCKOUT_MINUTES", "15"))
+        if totp_lockout_minutes <= 0:
+            raise SystemExit("TOTP_LOCKOUT_MINUTES must be a positive integer")
     except ValueError:
         raise SystemExit("TOTP_LOCKOUT_MINUTES must be an integer") from None
 

--- a/src/kai/totp.py
+++ b/src/kai/totp.py
@@ -19,6 +19,7 @@ import os
 import shutil
 import subprocess
 import sys
+import threading
 import time
 
 import pyotp
@@ -37,13 +38,113 @@ TOTP_ATTEMPTS_PATH = "/etc/kai/totp.attempts"
 # picked up on the next message without a restart. False results are never cached.
 _totp_is_configured: bool = False
 
+# ``python-telegram-bot`` is configured with concurrent updates, so two code
+# attempts for the same principal can reach worker threads at the same time.
+# Hold this lock across the complete read/verify/write transaction.  An RLock
+# also lets is_totp_configured() validate the same files through the private
+# read helpers without creating a second locking protocol.
+_totp_state_lock = threading.RLock()
 
-def _read_secret() -> str | None:
+_ATTEMPTS_VERSION = 2
+_LEGACY_PRINCIPAL = "*"
+
+
+class TotpStateError(RuntimeError):
+    """TOTP is enabled but its protected state cannot be trusted."""
+
+
+def _empty_attempts() -> dict:
+    """Return a fresh versioned, per-principal attempt-state document."""
+    return {"version": _ATTEMPTS_VERSION, "principals": {}}
+
+
+def _validate_attempt_record(value: object) -> dict:
+    """Validate and normalize one principal's persisted lockout record."""
+    if not isinstance(value, dict):
+        raise TotpStateError("TOTP attempt state contains a non-object principal record")
+    failures = value.get("failures")
+    lockout_until = value.get("lockout_until")
+    if isinstance(failures, bool) or not isinstance(failures, int) or failures < 0:
+        raise TotpStateError("TOTP attempt state contains an invalid failure count")
+    if isinstance(lockout_until, bool) or not isinstance(lockout_until, (int, float)) or lockout_until < 0:
+        raise TotpStateError("TOTP attempt state contains an invalid lockout timestamp")
+    return {"failures": failures, "lockout_until": float(lockout_until)}
+
+
+def _normalize_attempts(data: object) -> dict:
+    """Normalize current and legacy attempt-state documents.
+
+    The legacy document stored one global ``failures``/``lockout_until`` pair.
+    Preserve it under the wildcard principal during migration so deploying the
+    new schema cannot silently clear an active lockout.  A principal gets its
+    own record on its next verification attempt.
+    """
+    if not isinstance(data, dict):
+        raise TotpStateError("TOTP attempt state must be a JSON object")
+
+    if "version" not in data and ("failures" in data or "lockout_until" in data):
+        return {
+            "version": _ATTEMPTS_VERSION,
+            "principals": {_LEGACY_PRINCIPAL: _validate_attempt_record(data)},
+        }
+
+    if data.get("version") != _ATTEMPTS_VERSION:
+        raise TotpStateError("TOTP attempt state has an unsupported schema version")
+    principals = data.get("principals")
+    if not isinstance(principals, dict):
+        raise TotpStateError("TOTP attempt state is missing its principals mapping")
+
+    normalized: dict[str, dict] = {}
+    for principal, record in principals.items():
+        if not isinstance(principal, str) or not principal:
+            raise TotpStateError("TOTP attempt state contains an invalid principal key")
+        normalized[principal] = _validate_attempt_record(record)
+    return {"version": _ATTEMPTS_VERSION, "principals": normalized}
+
+
+def _principal_key(principal_id: int) -> str:
+    """Return the stable persisted key for a Telegram principal."""
+    if isinstance(principal_id, bool) or not isinstance(principal_id, int) or principal_id <= 0:
+        raise ValueError("principal_id must be a positive Telegram user ID")
+    return str(principal_id)
+
+
+def _principal_attempts(state: dict, principal: str) -> dict:
+    """Read a principal record, inheriting a legacy global record once."""
+    principals = state["principals"]
+    record = principals.get(principal, principals.get(_LEGACY_PRINCIPAL))
+    if record is None:
+        return {"failures": 0, "lockout_until": 0.0}
+    return dict(record)
+
+
+def _totp_files_present() -> tuple[bool, bool]:
+    """Return strict presence flags for the secret and attempt-state files.
+
+    Stat does not read either root-owned file.  A permission or I/O error is
+    distinct from a clean FileNotFoundError and must not disable a configured
+    authentication boundary.
+    """
+
+    def _present(path: str) -> bool:
+        try:
+            os.stat(path)
+            return True
+        except FileNotFoundError:
+            return False
+        except OSError as exc:
+            raise TotpStateError(f"Could not determine TOTP state for {path}: {exc}") from exc
+
+    return _present(TOTP_SECRET_PATH), _present(TOTP_ATTEMPTS_PATH)
+
+
+def _read_secret() -> str:
     """
     Read the TOTP base32 secret from the root-owned secret file via sudo.
 
-    Returns the secret string, or None if the file doesn't exist, the sudo
-    rule isn't configured, or any subprocess error occurs.
+    Every failure raises TotpStateError.  Callers decide whether TOTP is
+    disabled by strictly checking that *both* protected files are absent
+    before reaching this helper.
     """
     try:
         result = subprocess.run(
@@ -52,22 +153,31 @@ def _read_secret() -> str | None:
             text=True,
             timeout=5,
         )
-        if result.returncode == 0:
-            return result.stdout.strip() or None
-        return None
-    except (subprocess.TimeoutExpired, OSError):
-        return None
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        raise TotpStateError("Could not read the protected TOTP secret") from exc
+    if result.returncode != 0:
+        raise TotpStateError(f"Protected TOTP secret read failed with exit status {result.returncode}")
+    secret = result.stdout.strip()
+    if not secret:
+        raise TotpStateError("Protected TOTP secret is empty")
+    try:
+        # Construction alone does not decode base32; generating a value does.
+        pyotp.TOTP(secret).at(0)
+    except Exception as exc:
+        raise TotpStateError("Protected TOTP secret is invalid") from exc
+    return secret
 
 
 def _read_attempts() -> dict:
     """
     Read the rate-limiting state from the root-owned attempts file via sudo.
 
-    Returns a dict with keys:
-      - "failures": int, number of consecutive failed attempts
-      - "lockout_until": float, Unix timestamp when lockout expires (0 = no lockout)
+    Returns a versioned document whose ``principals`` mapping contains each
+    Telegram user's consecutive failure count and lockout expiry.
 
-    Returns a clean default state if the file is missing, unreadable, or corrupt.
+    Raises TotpStateError if the file is missing, unreadable, corrupt, or has
+    an invalid schema.  Resetting failures on a read error would make lockout
+    fail open.
     """
     try:
         result = subprocess.run(
@@ -76,86 +186,99 @@ def _read_attempts() -> dict:
             text=True,
             timeout=5,
         )
-        if result.returncode == 0 and result.stdout.strip():
-            data = json.loads(result.stdout.strip())
-            # Validate expected types to avoid TypeError on arithmetic later.
-            # Both fields are used in numeric operations: failures gets + 1,
-            # lockout_until gets compared to time.time(). A corrupted or
-            # hand-edited file with string values would crash without this.
-            if (
-                isinstance(data, dict)
-                and isinstance(data.get("failures"), (int, float))
-                and isinstance(data.get("lockout_until"), (int, float))
-            ):
-                return data
-    except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
-        pass
-    return {"failures": 0, "lockout_until": 0}
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        raise TotpStateError("Could not read protected TOTP attempt state") from exc
+    if result.returncode != 0:
+        raise TotpStateError(f"Protected TOTP attempt-state read failed with exit status {result.returncode}")
+    if not result.stdout.strip():
+        raise TotpStateError("Protected TOTP attempt state is empty")
+    try:
+        return _normalize_attempts(json.loads(result.stdout))
+    except json.JSONDecodeError as exc:
+        raise TotpStateError("Protected TOTP attempt state is not valid JSON") from exc
 
 
 def _write_attempts(state: dict) -> None:
     """
     Write the rate-limiting state to the root-owned attempts file via sudo tee.
 
-    Silently swallows errors - if the write fails, the lockout won't persist
-    across restarts, which degrades gracefully (the in-memory state still applies
-    for the current session).
+    Raises TotpStateError unless sudo tee confirms success.  Authentication is
+    not granted when resetting the failure counter cannot be persisted.
     """
     try:
-        subprocess.run(
+        result = subprocess.run(
             ["sudo", "-n", "tee", TOTP_ATTEMPTS_PATH],
             input=json.dumps(state),
             capture_output=True,
             text=True,
             timeout=5,
         )
-    except (subprocess.TimeoutExpired, OSError):
-        pass
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        raise TotpStateError("Could not write protected TOTP attempt state") from exc
+    if result.returncode != 0:
+        raise TotpStateError(f"Protected TOTP attempt-state write failed with exit status {result.returncode}")
 
 
 def is_totp_configured() -> bool:
     """
     Return True if the TOTP secret file exists and is readable via sudo.
 
-    Used by the bot to decide whether to prompt for a code at session start.
-    If this returns False, TOTP is disabled and the bot runs without it.
+    False is returned only when both the secret and attempt-state files are
+    cleanly absent.  If either file exists, both must be readable and valid;
+    any partial or inaccessible state raises TotpStateError so the bot denies
+    access instead of silently disabling TOTP.
 
     The True result is cached for the lifetime of the process to avoid spawning
     a subprocess on every incoming message. False is never cached so that
     enabling TOTP while the bot is running takes effect on the next message.
     """
     global _totp_is_configured
-    if _totp_is_configured:
-        return True
-    result = _read_secret() is not None
-    if result:
+    with _totp_state_lock:
+        if _totp_is_configured:
+            return True
+        secret_present, attempts_present = _totp_files_present()
+        if not secret_present and not attempts_present:
+            return False
+        if not secret_present or not attempts_present:
+            raise TotpStateError("TOTP is enabled but its protected files are incomplete")
+        _read_secret()
+        _read_attempts()
         _totp_is_configured = True
-    return result
+        return True
 
 
-def get_lockout_remaining() -> int:
+def get_lockout_remaining(principal_id: int) -> int:
     """
     Return the number of seconds remaining in the current lockout, or 0 if not locked out.
 
     Used to give the user a meaningful "try again in X minutes" message rather
     than a silent rejection.
     """
-    state = _read_attempts()
-    remaining = state.get("lockout_until", 0) - time.time()
-    return max(0, int(remaining))
+    principal = _principal_key(principal_id)
+    with _totp_state_lock:
+        state = _principal_attempts(_read_attempts(), principal)
+        remaining = state["lockout_until"] - time.time()
+        return max(0, int(remaining))
 
 
-def get_failure_count() -> int:
+def get_failure_count(principal_id: int) -> int:
     """
     Return the number of consecutive failed verification attempts since the last success.
 
     Public wrapper around the private _read_attempts() so bot.py doesn't need to
     import or call a private function across module boundaries.
     """
-    return _read_attempts().get("failures", 0)
+    principal = _principal_key(principal_id)
+    with _totp_state_lock:
+        return _principal_attempts(_read_attempts(), principal)["failures"]
 
 
-def verify_code(code: str, lockout_attempts: int = 3, lockout_minutes: int = 15) -> bool:
+def verify_code(
+    code: str,
+    principal_id: int,
+    lockout_attempts: int = 3,
+    lockout_minutes: int = 15,
+) -> bool:
     """
     Verify a 6-digit TOTP code against the stored secret.
 
@@ -164,41 +287,37 @@ def verify_code(code: str, lockout_attempts: int = 3, lockout_minutes: int = 15)
       for `lockout_minutes` minutes, even with a valid code.
     - A successful verification resets the failure counter.
 
-    Returns True only if the code is valid and the account is not locked out.
-    Returns False if: locked out, secret unavailable, or code invalid.
+    Returns True only if the code is valid, the principal is not locked out,
+    and the reset state was durably written. Returns False for a lockout or an
+    invalid code. Protected-state failures raise TotpStateError.
     """
     # Reject obviously malformed codes immediately, before any subprocess calls.
     if not code.isdigit() or len(code) != 6:
         return False
 
-    # Check lockout before doing anything else - don't even read the secret
-    # if we're in a lockout period, to avoid unnecessary sudo calls.
-    state = _read_attempts()
-    if state.get("lockout_until", 0) > time.time():
+    principal = _principal_key(principal_id)
+    with _totp_state_lock:
+        # The lock covers the entire read/verify/write transaction. Without
+        # it, concurrent failures can both read N and persist N+1.
+        document = _read_attempts()
+        state = _principal_attempts(document, principal)
+        if state["lockout_until"] > time.time():
+            return False
+
+        secret = _read_secret()
+        if pyotp.TOTP(secret).verify(code):
+            document["principals"][principal] = {"failures": 0, "lockout_until": 0.0}
+            _write_attempts(document)
+            return True
+
+        failures = state["failures"] + 1
+        lockout_until = time.time() + lockout_minutes * 60 if failures >= lockout_attempts else 0.0
+        document["principals"][principal] = {
+            "failures": failures,
+            "lockout_until": lockout_until,
+        }
+        _write_attempts(document)
         return False
-
-    secret = _read_secret()
-    if not secret:
-        return False
-
-    totp = pyotp.TOTP(secret)
-    if totp.verify(code):
-        # Success - reset the failure counter so a future failure starts fresh.
-        _write_attempts({"failures": 0, "lockout_until": 0})
-        return True
-
-    # Failed attempt - increment counter and trigger lockout if threshold is reached.
-    failures = state.get("failures", 0) + 1
-    if failures >= lockout_attempts:
-        _write_attempts(
-            {
-                "failures": failures,
-                "lockout_until": time.time() + lockout_minutes * 60,
-            }
-        )
-    else:
-        _write_attempts({"failures": failures, "lockout_until": 0})
-    return False
 
 
 # ── CLI entry point (python -m kai totp <subcommand>) ────────────────
@@ -239,7 +358,7 @@ def _cmd_setup() -> None:
     # Create a clean attempts file: root:root 0600.
     fd = os.open(TOTP_ATTEMPTS_PATH, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
     with os.fdopen(fd, "w") as f:
-        f.write(json.dumps({"failures": 0, "lockout_until": 0}))
+        f.write(json.dumps(_empty_attempts()))
     os.chown(TOTP_ATTEMPTS_PATH, 0, 0)
 
     # Generate and print the QR code to the terminal.
@@ -260,7 +379,7 @@ def _cmd_setup() -> None:
     # The bot process (running as the 'kai' user) needs these rules to verify
     # codes at runtime. Showing them first ensures the user adds them before
     # treating setup as complete - without sudoers, the bot can't read the
-    # secret file and will silently behave as if TOTP is not configured.
+    # secret file and will deny authentication because TOTP state is unavailable.
     print("\nAdd the following lines to /etc/sudoers.d/kai (via visudo -f /etc/sudoers.d/kai):")
     print("(Complete this step before restarting the bot.)\n")
     print(f"  kai ALL=(root) NOPASSWD: {_CAT} {TOTP_SECRET_PATH}")
@@ -271,7 +390,7 @@ def _cmd_setup() -> None:
     # This runs as root (sudo python -m kai totp setup) so it doesn't depend
     # on the sudoers rules above - root can always sudo.
     code = input("\nEnter a 6-digit code to confirm setup: ").strip()
-    if verify_code(code):
+    if pyotp.TOTP(secret).verify(code):
         print("TOTP setup complete.")
     else:
         print(
@@ -287,10 +406,14 @@ def _cmd_status() -> None:
 
     Does not require root - reads via the sudoers-authorized sudo call.
     """
-    if is_totp_configured():
-        print("TOTP is configured.")
-    else:
-        print("TOTP is not configured.")
+    try:
+        if is_totp_configured():
+            print("TOTP is configured.")
+        else:
+            print("TOTP is not configured.")
+    except TotpStateError as exc:
+        print(f"TOTP is configured but unavailable: {exc}")
+        sys.exit(1)
 
 
 def _cmd_reset() -> None:

--- a/tests/test_bot_totp.py
+++ b/tests/test_bot_totp.py
@@ -19,6 +19,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from kai.bot import handle_document, handle_message, handle_photo, handle_voice
+from kai.totp import TotpStateError
 
 # ── Test helpers ──────────────────────────────────────────────────────────
 
@@ -36,6 +37,7 @@ def _make_update(text: str = "hello") -> MagicMock:
     update.message.delete = AsyncMock()
     update.effective_chat.id = 12345
     update.effective_chat.send_message = AsyncMock()
+    update.effective_user.id = 67890
     return update
 
 
@@ -125,6 +127,24 @@ async def test_gate_skipped_when_totp_not_configured():
     update.message.reply_text.assert_not_called()
 
 
+async def test_gate_fails_closed_when_totp_state_is_unavailable():
+    """A protected-state read error denies the message instead of disabling TOTP."""
+    update = _make_update("hello")
+    ctx = _make_context()
+
+    with (
+        patch("kai.bot._is_authorized", return_value=True),
+        patch("kai.bot.is_totp_configured", side_effect=TotpStateError("sudo failed")),
+        patch("kai.bot._handle_response", new_callable=AsyncMock) as handle_response,
+    ):
+        await handle_message(update, ctx)
+
+    update.message.reply_text.assert_called_once_with(
+        "Authentication service unavailable. Access denied; contact the Kai administrator."
+    )
+    handle_response.assert_not_awaited()
+
+
 async def test_code_message_deleted_after_verification():
     """The code message is deleted from chat regardless of whether verification succeeds or fails."""
     pending = {"expires_at": time.time() + 120}
@@ -172,7 +192,7 @@ async def test_successful_auth_sets_timestamp():
         patch("kai.bot._is_authorized", return_value=True),
         patch("kai.bot.is_totp_configured", return_value=True),
         patch("kai.bot.get_lockout_remaining", return_value=0),
-        patch("kai.bot.verify_code", return_value=True),
+        patch("kai.bot.verify_code", return_value=True) as verify,
     ):
         await handle_message(update, ctx)
     after = time.time()
@@ -181,6 +201,27 @@ async def test_successful_auth_sets_timestamp():
     assert before <= ctx.user_data["totp_authenticated_at"] <= after
     # Pending state must be cleared after successful auth.
     assert "totp_pending" not in ctx.user_data
+    verify.assert_called_once_with("123456", 67890, 3, 15)
+
+
+async def test_gate_denies_when_attempt_state_write_fails():
+    """A valid code is not accepted unless its counter reset persists."""
+    pending = {"expires_at": time.time() + 120}
+    update = _make_update("123456")
+    ctx = _make_context({"totp_pending": pending})
+
+    with (
+        patch("kai.bot._is_authorized", return_value=True),
+        patch("kai.bot.is_totp_configured", return_value=True),
+        patch("kai.bot.get_lockout_remaining", return_value=0),
+        patch("kai.bot.verify_code", side_effect=TotpStateError("tee failed")),
+    ):
+        await handle_message(update, ctx)
+
+    assert "totp_authenticated_at" not in ctx.user_data
+    update.message.reply_text.assert_called_once_with(
+        "Authentication service unavailable. Access denied; contact the Kai administrator."
+    )
 
 
 async def test_lockout_message_shown_when_rate_limited():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -817,6 +817,24 @@ class TestProtectedUserIsolation:
 # ── PR review config ─────────────────────────────────────────────
 
 
+class TestTotpConfig:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "TOTP_SESSION_MINUTES",
+            "TOTP_CHALLENGE_SECONDS",
+            "TOTP_LOCKOUT_ATTEMPTS",
+            "TOTP_LOCKOUT_MINUTES",
+        ],
+    )
+    def test_security_timing_values_must_be_positive(self, monkeypatch, name):
+        """Zero cannot disable a TOTP session or lockout control."""
+        _set_required(monkeypatch)
+        monkeypatch.setenv(name, "0")
+        with pytest.raises(SystemExit, match=f"{name} must be a positive integer"):
+            load_config()
+
+
 class TestPRReviewConfig:
     def test_defaults(self, monkeypatch):
         """PR review resource controls take dataclass defaults when env is empty."""

--- a/tests/test_totp.py
+++ b/tests/test_totp.py
@@ -8,6 +8,8 @@ within the totp module for each test.
 
 import json
 import time
+from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import pyotp
@@ -15,6 +17,7 @@ import pytest
 
 import kai.totp
 from kai.totp import (
+    TotpStateError,
     get_failure_count,
     get_lockout_remaining,
     is_totp_configured,
@@ -47,11 +50,21 @@ def _secret_proc(secret: str = _TEST_SECRET) -> MagicMock:
     return m
 
 
-def _attempts_proc(failures: int = 0, lockout_until: float = 0) -> MagicMock:
+def _attempts_proc(failures: int = 0, lockout_until: float = 0, principal_id: int = 12345) -> MagicMock:
     """Return a mock subprocess result that looks like a successful sudo cat of the attempts file."""
     m = MagicMock()
     m.returncode = 0
-    m.stdout = json.dumps({"failures": failures, "lockout_until": lockout_until})
+    m.stdout = json.dumps(
+        {
+            "version": 2,
+            "principals": {
+                str(principal_id): {
+                    "failures": failures,
+                    "lockout_until": lockout_until,
+                }
+            },
+        }
+    )
     return m
 
 
@@ -77,10 +90,10 @@ def _tee_proc() -> MagicMock:
 def test_verify_code_rejects_malformed_input():
     """verify_code returns False immediately for non-6-digit input, with no subprocess calls."""
     with patch("kai.totp.subprocess.run") as mock_run:
-        assert verify_code("12345") is False  # too short
-        assert verify_code("1234567") is False  # too long
-        assert verify_code("12345a") is False  # non-digit
-        assert verify_code("") is False  # empty
+        assert verify_code("12345", 12345) is False  # too short
+        assert verify_code("1234567", 12345) is False  # too long
+        assert verify_code("12345a", 12345) is False  # non-digit
+        assert verify_code("", 12345) is False  # empty
         mock_run.assert_not_called()
 
 
@@ -95,7 +108,7 @@ def test_verify_code_valid():
             _secret_proc(),  # _read_secret
             _tee_proc(),  # _write_attempts (reset counter on success)
         ]
-        result = verify_code(valid_code)
+        result = verify_code(valid_code, 12345)
 
     assert result is True
 
@@ -108,7 +121,7 @@ def test_verify_code_invalid():
             _secret_proc(),  # _read_secret
             _tee_proc(),  # _write_attempts (increment failures)
         ]
-        result = verify_code("000000")
+        result = verify_code("000000", 12345)
 
     assert result is False
 
@@ -124,14 +137,14 @@ def test_failure_counter_increments():
             _secret_proc(),  # _read_secret
             _tee_proc(),  # _write_attempts
         ]
-        verify_code("000000")
+        verify_code("000000", 12345)
 
         # Inspect what was written - it's the third call, with input= containing the state.
         write_call = mock_run.call_args_list[2]
         written = json.loads(write_call.kwargs["input"])
 
-    assert written["failures"] == 1
-    assert written["lockout_until"] == 0
+    assert written["principals"]["12345"]["failures"] == 1
+    assert written["principals"]["12345"]["lockout_until"] == 0
 
 
 def test_lockout_triggers_after_n_failures():
@@ -143,15 +156,16 @@ def test_lockout_triggers_after_n_failures():
             _secret_proc(),  # _read_secret
             _tee_proc(),  # _write_attempts - should trigger lockout
         ]
-        verify_code("000000")
+        verify_code("000000", 12345)
 
         write_call = mock_run.call_args_list[2]
         written = json.loads(write_call.kwargs["input"])
 
-    assert written["failures"] == 3
+    record = written["principals"]["12345"]
+    assert record["failures"] == 3
     # lockout_until should be roughly now + 15 minutes
-    assert written["lockout_until"] > time.time()
-    assert written["lockout_until"] < time.time() + 15 * 60 + 5  # +5s tolerance
+    assert record["lockout_until"] > time.time()
+    assert record["lockout_until"] < time.time() + 15 * 60 + 5  # +5s tolerance
 
 
 def test_verify_returns_false_during_lockout_even_with_valid_code():
@@ -163,7 +177,7 @@ def test_verify_returns_false_during_lockout_even_with_valid_code():
         mock_run.side_effect = [
             _attempts_proc(failures=3, lockout_until=future_lockout),  # _read_attempts
         ]
-        result = verify_code(valid_code)
+        result = verify_code(valid_code, 12345)
 
     assert result is False
     # Only one subprocess call should have been made (reading attempts).
@@ -181,29 +195,56 @@ def test_successful_code_resets_failure_counter():
             _secret_proc(),  # _read_secret
             _tee_proc(),  # _write_attempts
         ]
-        result = verify_code(valid_code)
+        result = verify_code(valid_code, 12345)
 
         write_call = mock_run.call_args_list[2]
         written = json.loads(write_call.kwargs["input"])
 
     assert result is True
-    assert written["failures"] == 0
-    assert written["lockout_until"] == 0
+    assert written["principals"]["12345"]["failures"] == 0
+    assert written["principals"]["12345"]["lockout_until"] == 0
 
 
 # ── is_totp_configured ───────────────────────────────────────────────
 
 
 def test_is_totp_configured_true_when_readable():
-    """is_totp_configured returns True when the secret file is readable."""
-    with patch("kai.totp.subprocess.run", return_value=_secret_proc()):
+    """Configured means both protected files exist, are readable, and validate."""
+    with (
+        patch("kai.totp._totp_files_present", return_value=(True, True)),
+        patch("kai.totp.subprocess.run", side_effect=[_secret_proc(), _attempts_proc()]),
+    ):
         assert is_totp_configured() is True
 
 
-def test_is_totp_configured_false_when_file_missing():
-    """is_totp_configured returns False when sudo cat exits non-zero (file missing, no sudoers rule, etc.)."""
-    with patch("kai.totp.subprocess.run", return_value=_failed_proc()):
+def test_is_totp_configured_false_only_when_both_files_absent():
+    """A cleanly absent secret and attempts file is the sole disabled state."""
+    with (
+        patch("kai.totp._totp_files_present", return_value=(False, False)),
+        patch("kai.totp.subprocess.run") as mock_run,
+    ):
         assert is_totp_configured() is False
+    mock_run.assert_not_called()
+
+
+@pytest.mark.parametrize("presence", [(True, False), (False, True)])
+def test_is_totp_configured_fails_closed_on_partial_state(presence):
+    """Losing either protected file cannot silently disable configured TOTP."""
+    with (
+        patch("kai.totp._totp_files_present", return_value=presence),
+        pytest.raises(TotpStateError, match="incomplete"),
+    ):
+        is_totp_configured()
+
+
+def test_is_totp_configured_fails_closed_on_secret_read_error():
+    """A sudo/permission failure is unavailable, not 'not configured'."""
+    with (
+        patch("kai.totp._totp_files_present", return_value=(True, True)),
+        patch("kai.totp.subprocess.run", return_value=_failed_proc()),
+        pytest.raises(TotpStateError, match="secret read failed"),
+    ):
+        is_totp_configured()
 
 
 # ── get_lockout_remaining ────────────────────────────────────────────
@@ -212,14 +253,14 @@ def test_is_totp_configured_false_when_file_missing():
 def test_get_lockout_remaining_zero_when_not_locked():
     """get_lockout_remaining returns 0 when lockout_until is 0 (no active lockout)."""
     with patch("kai.totp.subprocess.run", return_value=_attempts_proc(lockout_until=0)):
-        assert get_lockout_remaining() == 0
+        assert get_lockout_remaining(12345) == 0
 
 
 def test_get_lockout_remaining_positive_when_locked():
     """get_lockout_remaining returns a positive number of seconds when locked out."""
     future = time.time() + 300  # 5 minutes from now
     with patch("kai.totp.subprocess.run", return_value=_attempts_proc(lockout_until=future)):
-        remaining = get_lockout_remaining()
+        remaining = get_lockout_remaining(12345)
 
     # Should be close to 300, allow a few seconds of test execution slack.
     assert 295 <= remaining <= 300
@@ -231,7 +272,7 @@ def test_get_lockout_remaining_positive_when_locked():
 def test_get_failure_count_returns_failures_from_disk():
     """get_failure_count returns the current consecutive failure count from the attempts file."""
     with patch("kai.totp.subprocess.run", return_value=_attempts_proc(failures=2)):
-        count = get_failure_count()
+        count = get_failure_count(12345)
 
     assert count == 2
 
@@ -239,7 +280,7 @@ def test_get_failure_count_returns_failures_from_disk():
 def test_get_failure_count_returns_zero_on_clean_state():
     """get_failure_count returns 0 when there are no recorded failures."""
     with patch("kai.totp.subprocess.run", return_value=_attempts_proc(failures=0)):
-        count = get_failure_count()
+        count = get_failure_count(12345)
 
     assert count == 0
 
@@ -247,8 +288,8 @@ def test_get_failure_count_returns_zero_on_clean_state():
 # ── _read_attempts validation ────────────────────────────────────────
 
 
-def test_corrupt_lockout_until_falls_back_to_defaults():
-    """A non-numeric lockout_until in the attempts file triggers the fallback.
+def test_corrupt_lockout_until_fails_closed():
+    """A non-numeric lockout timestamp is rejected rather than reset.
 
     Fixes #36: the validation checked failures but not lockout_until,
     so a corrupted value like "abc" would pass validation and later
@@ -257,19 +298,102 @@ def test_corrupt_lockout_until_falls_back_to_defaults():
     corrupt = MagicMock()
     corrupt.returncode = 0
     corrupt.stdout = json.dumps({"failures": 0, "lockout_until": "abc"})
-    with patch("kai.totp.subprocess.run", return_value=corrupt):
-        remaining = get_lockout_remaining()
+    with (
+        patch("kai.totp.subprocess.run", return_value=corrupt),
+        pytest.raises(TotpStateError, match="lockout timestamp"),
+    ):
+        get_lockout_remaining(12345)
 
-    # Default state has lockout_until=0, so remaining should be 0
-    assert remaining == 0
 
-
-def test_corrupt_failures_falls_back_to_defaults():
-    """A non-numeric failures field triggers the fallback to defaults."""
+def test_corrupt_failures_fails_closed():
+    """A non-numeric failure count is rejected rather than reset."""
     corrupt = MagicMock()
     corrupt.returncode = 0
     corrupt.stdout = json.dumps({"failures": "xyz", "lockout_until": 0})
-    with patch("kai.totp.subprocess.run", return_value=corrupt):
-        count = get_failure_count()
+    with (
+        patch("kai.totp.subprocess.run", return_value=corrupt),
+        pytest.raises(TotpStateError, match="failure count"),
+    ):
+        get_failure_count(12345)
 
-    assert count == 0
+
+def test_legacy_global_state_is_preserved_during_migration():
+    """The old global counter becomes a wildcard fallback, not a reset."""
+    legacy = MagicMock(returncode=0, stdout=json.dumps({"failures": 2, "lockout_until": 0}))
+    with patch("kai.totp.subprocess.run", return_value=legacy):
+        assert get_failure_count(67890) == 2
+
+
+def test_attempt_state_is_isolated_per_principal():
+    """One Telegram user's failures do not consume another user's attempts."""
+    document = {
+        "version": 2,
+        "principals": {
+            "111": {"failures": 2, "lockout_until": 0},
+            "222": {"failures": 0, "lockout_until": 0},
+        },
+    }
+    proc = MagicMock(returncode=0, stdout=json.dumps(document))
+    with patch("kai.totp.subprocess.run", return_value=proc):
+        assert get_failure_count(111) == 2
+        assert get_failure_count(222) == 0
+
+
+def test_verification_updates_only_requesting_principal():
+    """Writing one failure preserves every other principal's record."""
+    document = {
+        "version": 2,
+        "principals": {
+            "111": {"failures": 1, "lockout_until": 0},
+            "222": {"failures": 2, "lockout_until": 0},
+        },
+    }
+    attempts = MagicMock(returncode=0, stdout=json.dumps(document))
+    with (
+        patch("kai.totp.subprocess.run", side_effect=[attempts, _secret_proc(), _tee_proc()]) as run,
+        patch("kai.totp.pyotp.TOTP.verify", return_value=False),
+    ):
+        assert verify_code("000000", 111) is False
+
+    written = json.loads(run.call_args_list[2].kwargs["input"])
+    assert written["principals"]["111"]["failures"] == 2
+    assert written["principals"]["222"]["failures"] == 2
+
+
+def test_failed_attempt_write_is_not_silently_ignored():
+    """A tee failure raises, so a valid code cannot bypass durable state."""
+    valid_code = pyotp.TOTP(_TEST_SECRET).now()
+    with (
+        patch(
+            "kai.totp.subprocess.run",
+            side_effect=[_attempts_proc(), _secret_proc(), _failed_proc()],
+        ),
+        pytest.raises(TotpStateError, match="write failed"),
+    ):
+        verify_code(valid_code, 12345)
+
+
+def test_concurrent_failures_are_serialized():
+    """Concurrent read-modify-write transactions cannot lose an increment."""
+    stored = {"version": 2, "principals": {}}
+
+    def read_attempts():
+        return deepcopy(stored)
+
+    def write_attempts(value):
+        nonlocal stored
+        # Widen the race window. The module lock must still preserve both writes.
+        time.sleep(0.01)
+        stored = deepcopy(value)
+
+    with (
+        patch("kai.totp._read_attempts", side_effect=read_attempts),
+        patch("kai.totp._read_secret", return_value=_TEST_SECRET),
+        patch("kai.totp._write_attempts", side_effect=write_attempts),
+        patch("kai.totp.pyotp.TOTP.verify", return_value=False),
+        ThreadPoolExecutor(max_workers=2) as executor,
+    ):
+        results = list(executor.map(lambda _: verify_code("000000", 12345), range(2)))
+
+    assert results == [False, False]
+    assert stored["principals"]["12345"]["failures"] == 2


### PR DESCRIPTION
## Summary

- distinguish a cleanly disabled TOTP installation from configured-but-unavailable protected state
- fail closed on missing, partial, unreadable, empty, corrupt, or unsupported TOTP state
- require successful persistence of attempt-state updates before authentication can succeed
- replace the global lockout counter with versioned per-Telegram-principal records
- serialize the complete read/verify/write transaction under concurrent Telegram updates
- reject non-positive TOTP session, challenge, and lockout controls

## Security rationale

Previously, every secret-read failure was treated as “TOTP not configured.” A sudo failure, timeout, missing half of the protected state, or I/O error could therefore disable the gate before the process had successfully read the secret. Attempt-state read failures reset the effective counter to zero, and `sudo tee` failures were ignored. Concurrent updates could also read the same failure count and overwrite one another’s increments.

This change gives protected TOTP state three explicit outcomes:

1. both files cleanly absent: TOTP is intentionally disabled
2. both files present, readable, and valid: TOTP is enabled
3. any partial or untrustworthy state: access is denied and the administrator is notified

The bot never authenticates a code unless the corresponding counter reset is successfully persisted.

## Per-principal lockout state

The attempts file now uses a versioned schema:

```json
{
  "version": 2,
  "principals": {
    "2114582497": {"failures": 0, "lockout_until": 0.0}
  }
}
```

Lockouts are keyed by the authenticated Telegram user ID, not by destination chat ID. This avoids one user consuming another user’s attempts, including when authorized users operate inside group chats.

The old global `{failures, lockout_until}` shape is accepted and conservatively preserved as a wildcard fallback. It is not reset during rollout; each principal receives an explicit record on their next verification attempt.

## Concurrency and failure behavior

- one process-wide reentrant lock covers the full attempt-state read, code verification, and write
- a concurrent pair of failures therefore persists `N + 2`, not two copies of `N + 1`
- non-zero `cat` and `tee` exit statuses, timeouts, I/O errors, invalid JSON, invalid field types, and invalid secret material raise a dedicated state error
- Telegram handlers catch that error, deny the update, log the condition, and never invoke the agent
- an installation missing the optional TOTP dependency still fails closed if protected TOTP files exist

## Compatibility

- installations that have never configured TOTP remain unchanged
- existing configured installations retain their secret and global lockout history
- no live files are migrated during package installation; schema migration occurs on the first subsequent verification write
- no live installation or protected TOTP file was read or modified while developing this PR

## Verification

- focused TOTP/config suite: `356 passed`
- broader bot suite: `331 passed`
- `make check`
- full suite: `4691 passed, 1 skipped`
- explicit tests cover partial state, sudo read failure, sudo write failure, corrupt state, legacy migration, per-principal isolation, and a forced concurrent-update race

## Scope boundary

This is the first half of assessment finding 6: protected TOTP state and lockout reliability. Centralizing TOTP enforcement across sensitive command and callback handlers remains the next separate, reviewable security slice.
