### PR TITLE
Require TOTP for all sensitive Telegram handlers

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -306,6 +306,32 @@ def _require_auth(func):
     return wrapper
 
 
+def _require_sensitive_authentication(func):
+    """Wrap a registered handler with authorization and TOTP middleware.
+
+    The wrapper lives at the Telegram registration boundary so it can protect
+    handlers defined in other modules (notably memory_command) without a
+    circular import.  Authorization runs first to avoid disclosing the bot or
+    issuing TOTP challenges to unknown Telegram users.
+    """
+
+    @functools.wraps(func)
+    async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        config: Config = context.bot_data["config"]
+        if not _is_authorized(config, _user_id(update)):
+            if update.callback_query is not None:
+                await update.callback_query.answer("Not authorized.")
+            return
+        if not await _check_totp(update, context):
+            return
+        return await func(update, context)
+
+    # Tests and registration audits use this explicit marker instead of
+    # inferring security from wrapper names or decorator order.
+    wrapper._kai_totp_sensitive = True  # type: ignore[attr-defined]
+    return wrapper
+
+
 # ── Telegram message utilities ───────────────────────────────────────
 
 
@@ -3469,8 +3495,8 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
                                          sole configured repo.
         /review <owner/repo> <pr-number> explicit repository.
 
-    Auth + TOTP gate mirrors content-invoking commands. The review
-    runs inside the update handler (per the spec: not a detached
+    Runtime registration places this handler behind the common authorization
+    and TOTP middleware. The review runs inside the update handler (not a detached
     background task). On success the review text lands at
     ``/tmp/pr-<N>-review.md`` as the canonical artifact, a
     timestamped copy is staged under the chat's file area via
@@ -3480,13 +3506,6 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
     untouched.
     """
     assert update.message is not None
-
-    # TOTP gate: same precedent as content-invoking commands that run
-    # a user-scoped backend subprocess (handle_photo, handle_document,
-    # handle_voice). The review backend consumes the user's
-    # OAuth-authed subprocess, so the gate applies here too.
-    if not await _check_totp(update, context):
-        return
 
     # `actor_id` drives every user-scoped lookup (config, effective
     # repos, backend, provider, model override); `chat_id` drives
@@ -4141,6 +4160,8 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 async def _deny_totp_state_error(update: Update, exc: TotpStateError) -> None:
     """Deny an update when protected TOTP state cannot be trusted."""
     log.error("TOTP state unavailable; denying Telegram update: %s", exc)
+    if update.callback_query is not None:
+        await update.callback_query.answer("Authentication unavailable.", show_alert=True)
     message = update.message or update.effective_message
     if message is not None:
         await message.reply_text("Authentication service unavailable. Access denied; contact the Kai administrator.")
@@ -4151,13 +4172,10 @@ async def _check_totp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> boo
     Check TOTP authentication if configured. Returns True if the request
     should proceed, False if a challenge was sent or access denied.
 
-    Must be called at the top of any handler that sends user content to
-    Claude. For non-text handlers (photo, document, voice), this sends
-    the challenge prompt and returns False - the user must then type
-    their code as a text message, which handle_message processes.
-
-    Informational commands (/stats, /help, /job, etc.) do NOT need
-    this gate since they don't invoke Claude with user content.
+    Used directly by content handlers and by the common sensitive-handler
+    middleware. For non-text updates, this sends the challenge prompt and
+    returns False; the user then types their code as a text message, which
+    handle_message processes.
     """
     try:
         if not await asyncio.to_thread(is_totp_configured):
@@ -4168,7 +4186,10 @@ async def _check_totp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> boo
 
     assert context.user_data is not None
     assert update.effective_chat is not None
-    assert update.message is not None
+    message = update.message or update.effective_message
+    if message is None:
+        log.error("TOTP challenge denied: Telegram update has no effective message")
+        return False
 
     totp_cfg: Config = context.bot_data["config"]
     session_min = totp_cfg.totp_session_minutes
@@ -4189,7 +4210,9 @@ async def _check_totp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> boo
         context.user_data["totp_pending"] = {
             "expires_at": time.time() + challenge_sec,
         }
-        await update.message.reply_text("Session expired. Enter code from authenticator.")
+        await message.reply_text("Session expired. Enter code from authenticator.")
+    if update.callback_query is not None:
+        await update.callback_query.answer("Authentication required.")
     return False
 
 
@@ -4665,33 +4688,51 @@ def create_bot(config: Config, *, use_webhook: bool = True) -> Application:
         services_info=services.get_available_services(),
     )
 
-    # Command handlers (alphabetical registration, but order doesn't matter for commands)
-    app.add_handler(CommandHandler("start", handle_start))
-    app.add_handler(CommandHandler("new", handle_new))
-    app.add_handler(CommandHandler("models", handle_models))
-    app.add_handler(CommandHandler("model", handle_model))
-    app.add_handler(CommandHandler("stats", handle_stats))
-    app.add_handler(CommandHandler("help", handle_help))
-    app.add_handler(CommandHandler("job", handle_job))
-    app.add_handler(CommandHandler("jobs", handle_jobs))
-    app.add_handler(CommandHandler("settings", handle_settings))
-    app.add_handler(CommandHandler("project", handle_project))
-    app.add_handler(CommandHandler("workspace", handle_workspace))
-    app.add_handler(CommandHandler("ws", handle_workspace))
-    app.add_handler(CommandHandler("workspaces", handle_workspaces))
-    app.add_handler(CommandHandler("voice", handle_voice_command))
-    app.add_handler(CommandHandler("voices", handle_voices))
-    app.add_handler(CommandHandler("webhooks", handle_webhooks))
-    app.add_handler(CommandHandler("github", handle_github))
-    app.add_handler(CommandHandler("review", handle_review_command))
-    app.add_handler(CommandHandler("memory", memory_command.handle_memory_command))
-    app.add_handler(CommandHandler("stop", handle_stop))
+    # Default every recognized command to sensitive. `/start` and `/help`
+    # disclose no user state and remain available so an authorized operator can
+    # get recovery guidance before authenticating. Adding a future command to
+    # this table automatically puts it behind TOTP unless it is deliberately
+    # added to the narrow exemption set.
+    command_handlers = [
+        ("start", handle_start),
+        ("new", handle_new),
+        ("models", handle_models),
+        ("model", handle_model),
+        ("stats", handle_stats),
+        ("help", handle_help),
+        ("job", handle_job),
+        ("jobs", handle_jobs),
+        ("settings", handle_settings),
+        ("project", handle_project),
+        ("workspace", handle_workspace),
+        ("ws", handle_workspace),
+        ("workspaces", handle_workspaces),
+        ("voice", handle_voice_command),
+        ("voices", handle_voices),
+        ("webhooks", handle_webhooks),
+        ("github", handle_github),
+        ("review", handle_review_command),
+        ("memory", memory_command.handle_memory_command),
+        ("stop", handle_stop),
+    ]
+    totp_exempt_commands = {"start", "help"}
+    for command, callback in command_handlers:
+        registered_callback = (
+            callback if command in totp_exempt_commands else _require_sensitive_authentication(callback)
+        )
+        app.add_handler(CommandHandler(command, registered_callback))
 
-    # Callback query handlers for inline keyboards (pattern-matched)
-    app.add_handler(CallbackQueryHandler(handle_model_callback, pattern=r"^model:"))
-    app.add_handler(CallbackQueryHandler(handle_voice_callback, pattern=r"^voice:"))
-    app.add_handler(CallbackQueryHandler(handle_workspace_callback, pattern=r"^ws:"))
-    app.add_handler(CallbackQueryHandler(memory_command.handle_memory_callback, pattern=r"^mem:"))
+    # Every callback either discloses user state or mutates it, so all callback
+    # families share the same authorization/TOTP middleware.
+    app.add_handler(CallbackQueryHandler(_require_sensitive_authentication(handle_model_callback), pattern=r"^model:"))
+    app.add_handler(CallbackQueryHandler(_require_sensitive_authentication(handle_voice_callback), pattern=r"^voice:"))
+    app.add_handler(CallbackQueryHandler(_require_sensitive_authentication(handle_workspace_callback), pattern=r"^ws:"))
+    app.add_handler(
+        CallbackQueryHandler(
+            _require_sensitive_authentication(memory_command.handle_memory_callback),
+            pattern=r"^mem:",
+        )
+    )
 
     # Media handlers (must be before the catch-all text handler)
     app.add_handler(MessageHandler(filters.PHOTO, handle_photo))

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5364,6 +5364,40 @@ class TestCommandMenu:
         missing = EXPECTED_MENU_COMMANDS - registered
         assert not missing, f"Menu commands without handlers: {missing}"
 
+    def test_all_stateful_commands_use_common_totp_middleware(self):
+        """Every command except the narrow recovery set defaults to TOTP."""
+        from telegram.ext import CommandHandler as CH
+
+        app = create_bot(_make_config())
+        callbacks: dict[str, object] = {}
+        for group_handlers in app.handlers.values():
+            for handler in group_handlers:
+                if isinstance(handler, CH):
+                    for command in handler.commands:
+                        callbacks[command] = handler.callback
+
+        assert {
+            name for name, callback in callbacks.items() if not getattr(callback, "_kai_totp_sensitive", False)
+        } == {
+            "start",
+            "help",
+        }
+
+    def test_all_inline_callbacks_use_common_totp_middleware(self):
+        """Model, voice, workspace, and memory buttons cannot bypass TOTP."""
+        from telegram.ext import CallbackQueryHandler as CQH
+
+        app = create_bot(_make_config())
+        callbacks = [
+            handler.callback
+            for group_handlers in app.handlers.values()
+            for handler in group_handlers
+            if isinstance(handler, CQH)
+        ]
+
+        assert len(callbacks) == 4
+        assert all(getattr(callback, "_kai_totp_sensitive", False) for callback in callbacks)
+
     def test_menu_matches_expected_set(self):
         """The set_my_commands list in main.py matches EXPECTED_MENU_COMMANDS.
 

--- a/tests/test_bot_totp.py
+++ b/tests/test_bot_totp.py
@@ -18,7 +18,13 @@ import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from kai.bot import handle_document, handle_message, handle_photo, handle_voice
+from kai.bot import (
+    _require_sensitive_authentication,
+    handle_document,
+    handle_message,
+    handle_photo,
+    handle_voice,
+)
 from kai.totp import TotpStateError
 
 # ── Test helpers ──────────────────────────────────────────────────────────
@@ -38,6 +44,7 @@ def _make_update(text: str = "hello") -> MagicMock:
     update.effective_chat.id = 12345
     update.effective_chat.send_message = AsyncMock()
     update.effective_user.id = 67890
+    update.callback_query = None
     return update
 
 
@@ -82,6 +89,65 @@ def _downstream_patches() -> dict:
         "_clear_responding": MagicMock(),
         "get_lock": MagicMock(return_value=_fake_lock()),
     }
+
+
+# ── Common sensitive-handler middleware ─────────────────────────────
+
+
+async def test_sensitive_middleware_requires_authorization_before_totp():
+    """Unknown users are silently dropped without receiving a TOTP challenge."""
+    update = _make_update("/job info 1")
+    ctx = _make_context()
+    handler = AsyncMock()
+    wrapped = _require_sensitive_authentication(handler)
+
+    with (
+        patch("kai.bot._is_authorized", return_value=False),
+        patch("kai.bot._check_totp", new_callable=AsyncMock) as check_totp,
+    ):
+        await wrapped(update, ctx)
+
+    check_totp.assert_not_awaited()
+    handler.assert_not_awaited()
+
+
+async def test_sensitive_middleware_dispatches_only_after_totp():
+    """An authorized, authenticated update reaches its sensitive handler."""
+    update = _make_update("/job info 1")
+    ctx = _make_context()
+    handler = AsyncMock()
+    wrapped = _require_sensitive_authentication(handler)
+
+    with (
+        patch("kai.bot._is_authorized", return_value=True),
+        patch("kai.bot._check_totp", new_callable=AsyncMock, return_value=True) as check_totp,
+    ):
+        await wrapped(update, ctx)
+
+    check_totp.assert_awaited_once_with(update, ctx)
+    handler.assert_awaited_once_with(update, ctx)
+
+
+async def test_sensitive_callback_challenges_without_dispatching():
+    """Expired inline callbacks prompt for a text code and never mutate state."""
+    update = _make_update()
+    update.message = None
+    update.effective_message.reply_text = AsyncMock()
+    update.callback_query = MagicMock()
+    update.callback_query.answer = AsyncMock()
+    ctx = _make_context()
+    handler = AsyncMock()
+    wrapped = _require_sensitive_authentication(handler)
+
+    with (
+        patch("kai.bot._is_authorized", return_value=True),
+        patch("kai.bot.is_totp_configured", return_value=True),
+    ):
+        await wrapped(update, ctx)
+
+    update.effective_message.reply_text.assert_awaited_once_with("Session expired. Enter code from authenticator.")
+    update.callback_query.answer.assert_awaited_once_with("Authentication required.")
+    handler.assert_not_awaited()
 
 
 # ── Gate-blocking tests ───────────────────────────────────────────────────
@@ -273,6 +339,7 @@ async def test_invalid_code_shows_remaining_attempts():
 def _make_photo_update() -> MagicMock:
     """Create a mock Update with a photo attachment."""
     update = MagicMock()
+    update.callback_query = None
     update.message.photo = [MagicMock()]  # non-empty = has photo
     update.message.caption = "What is this?"
     update.message.reply_text = AsyncMock()
@@ -285,6 +352,7 @@ def _make_photo_update() -> MagicMock:
 def _make_document_update() -> MagicMock:
     """Create a mock Update with a document attachment."""
     update = MagicMock()
+    update.callback_query = None
     update.message.document = MagicMock()
     update.message.document.file_name = "test.txt"
     update.message.document.file_size = 100
@@ -299,6 +367,7 @@ def _make_document_update() -> MagicMock:
 def _make_voice_update() -> MagicMock:
     """Create a mock Update with a voice message."""
     update = MagicMock()
+    update.callback_query = None
     update.message.voice = MagicMock()
     update.message.reply_text = AsyncMock()
     update.message.delete = AsyncMock()


### PR DESCRIPTION
## Summary

- add common authorization and TOTP middleware at the Telegram handler-registration boundary
- protect every recognized command by default, with only /start and /help explicitly exempt for recovery guidance
- protect all model, voice, workspace, and memory inline-button callbacks
- support TOTP challenges and fail-closed state errors for callback queries
- move /review onto the same centralized enforcement path instead of keeping a one-off gate

## Security impact

Previously, TOTP covered agent-content handlers but did not consistently cover sensitive state reads and mutations. Commands such as /job info, /job cancel, /memory, /github token, settings, model, and workspace operations could therefore bypass the second factor.

The new registration policy checks Telegram authorization before attempting TOTP, so unknown users do not receive authentication prompts. For authorized users, every registered stateful command and every inline callback must pass the common TOTP check when TOTP is configured. New commands added to the command table inherit protection unless deliberately added to the narrow exemption set.

## User experience

- installations without TOTP configured behave as before
- /start and /help remain available before TOTP authentication
- an expired command or button action prompts for the authenticator code
- after entering a valid code, the user retries the original command or button action
- callback users receive immediate Telegram feedback when authentication is required or unavailable

## Verification

- make check
- 571 focused bot, TOTP, and memory-command tests passed
- full suite: 4696 passed, 1 skipped
- registration audits assert that only /start and /help lack the sensitive-handler marker and that all four callback families are protected

## Deployment

No configuration, secret, database, or installer changes are required. This is the second and final TOTP coverage slice following the fail-closed state hardening in #748.