### PR TITLE
Isolate Codex turn images per principal

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ make run
 
 `make config` writes the runtime env file and mandatory `users.yaml` for the deployment mode you select. Pick `single_user` for a local repo checkout under your own account. Pick `protected` when you want source, data, and secrets split across protected system directories. Protected mode requires every Telegram user to have a unique `os_user` that differs from the Kai service account; this keeps persistent agents from inheriting the daemon's protected-config capabilities. Single-user mode continues to support running the agent as the operator account.
 
+Protected Linux installations that use Codex image input also require `setfacl` (normally provided by the distribution's `acl` package). Kai uses a read-only named ACL so an image can remain private to the service and its intended `os_user`; if ACL support is unavailable, that image is dropped with a user-visible notice instead of being made world-readable.
+
 For full installation details, see [Getting Started](https://github.com/dcellison/kai/wiki/Getting-Started), [Multi-User Setup](https://github.com/dcellison/kai/wiki/Multi-User-Setup), and [System Architecture](https://github.com/dcellison/kai/wiki/System-Architecture).
 
 ## Security Model

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -42,8 +42,10 @@ import base64
 import json
 import logging
 import os
+import shutil
 import signal
 import subprocess
+import sys
 import tempfile
 import time
 from collections.abc import AsyncIterator
@@ -79,19 +81,55 @@ log = logging.getLogger(__name__)
 # here and apply it before setting CODEX_MODEL on the subprocess env.
 
 
-# Where per-turn image files for codex live. The app-server's
-# LocalImageUserInput takes a file path, not an inline payload, so the
-# base64 image data the bot layer sends in content blocks must be
-# materialized on disk for the duration of the turn. The directory
-# sits under DATA_DIR/files because that tree is the established
-# agent-readable upload area (the bot already tells agents to read
-# saved uploads there by absolute path); the workspace would also be
-# readable but project workspaces can be git repositories, and a
-# transient binary appearing inside one invites accidental commits.
+# Where per-turn image files for codex live. Each authenticated principal gets
+# a non-listable child directory. The app-server's LocalImageUserInput takes a
+# file path, not an inline payload, so the base64 image data the bot layer sends
+# in content blocks must be materialized on disk for the duration of the turn.
+# The directory sits under DATA_DIR/files because that tree is the established
+# upload area; the workspace would also be readable but can be a git repository,
+# where a transient binary invites accidental commits.
 _TURN_IMAGE_DIR = DATA_DIR / "files" / "codex_turn_images"
 
 
-def write_turn_image_file(block: dict) -> Path | None:
+def _grant_turn_image_read_access(path: Path, reader_user: str) -> None:
+    """Grant exactly one cross-OS-user reader access to a private image.
+
+    Kai owns the freshly created file and keeps its POSIX mode at ``0600``.
+    A named ACL gives the isolated Codex OS user read-only access without
+    making the image readable to every local account or granting Kai a broader
+    sudo file-copy capability.
+
+    macOS ships ACL support in ``/bin/chmod``. Linux uses ``setfacl``; if it is
+    unavailable, the caller fails closed and drops the image with the existing
+    user-visible notice instead of weakening permissions.
+    """
+    if sys.platform == "darwin":
+        command = [
+            "/bin/chmod",
+            "+a",
+            f"user:{reader_user} allow read,readattr,readextattr,readsecurity",
+            str(path),
+        ]
+    elif sys.platform.startswith("linux"):
+        setfacl = shutil.which("setfacl")
+        if setfacl is None:
+            raise OSError("setfacl is required for isolated Codex image input on Linux")
+        command = [setfacl, "-m", f"u:{reader_user}:r--", str(path)]
+    else:
+        raise OSError(f"isolated Codex image input is unsupported on {sys.platform}")
+
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"exit status {result.returncode}"
+        raise OSError(f"could not grant Codex image access to {reader_user}: {detail}")
+
+
+def write_turn_image_file(
+    block: dict,
+    *,
+    chat_id: int | None,
+    reader_user: str | None,
+) -> Path | None:
     """
     Materialize an Anthropic-style base64 image block as a file for
     codex's `localImage` input item.
@@ -102,13 +140,14 @@ def write_turn_image_file(block: dict) -> Path | None:
     blocks verbatim. The codex app-server has no inline-payload image
     input; its `LocalImageUserInput` is `{"type": "localImage",
     "path": ...}`, so the payload is written to a temp file and the
-    path rides the turn. The caller owns the file's lifetime and
-    unlinks it when the turn ends.
+    path rides the turn. The caller owns the file's lifetime and unlinks it
+    when the turn ends.
 
-    The file is chmod 0o644 after writing (NamedTemporaryFile
-    defaults to 0o600, which the target-user subprocess cannot open
-    on the sudo-wrapped path) and the directory 0o755, the same
-    posture as the codex one-shot's `--output-schema` temp file.
+    Files remain mode ``0600``. In cross-user mode, ``reader_user`` receives a
+    read-only named ACL. The root and per-principal directories are mode
+    ``0711``: the isolated process can traverse a path it was explicitly given,
+    while other local users cannot list staged filenames. File permissions
+    remain the confidentiality boundary even if a random filename is learned.
 
     Returns None when the block is not the expected Anthropic base64
     shape, the payload is not valid base64, or the write fails; the
@@ -133,20 +172,32 @@ def write_turn_image_file(block: dict) -> Path | None:
     # the filename.
     subtype = media_type.split("/", 1)[-1]
     suffix = f".{subtype}" if subtype.isalnum() else ".img"
+    principal = "unscoped" if chat_id is None else str(chat_id)
+    principal_dir = _TURN_IMAGE_DIR / principal
+    path: Path | None = None
     try:
         _TURN_IMAGE_DIR.mkdir(parents=True, exist_ok=True)
-        _TURN_IMAGE_DIR.chmod(0o755)
+        _TURN_IMAGE_DIR.chmod(0o711)
+        principal_dir.mkdir(parents=True, exist_ok=True)
+        principal_dir.chmod(0o711)
         with tempfile.NamedTemporaryFile(
             mode="wb",
             suffix=suffix,
             prefix="turn-image-",
-            dir=str(_TURN_IMAGE_DIR),
+            dir=str(principal_dir),
             delete=False,
         ) as fh:
-            fh.write(raw)
             path = Path(fh.name)
-        path.chmod(0o644)
+            fh.write(raw)
+        path.chmod(0o600)
+        if reader_user is not None:
+            _grant_turn_image_read_access(path, reader_user)
     except OSError as e:
+        if path is not None:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
         log.warning("CodexBackend: could not write turn image file: %s", e)
         return None
     return path
@@ -779,7 +830,11 @@ class CodexBackend(AgentBackend):
                     input_blocks.append({"type": "text", "text": block["text"]})
                     continue
                 if block_type == "image":
-                    image_path = write_turn_image_file(block)
+                    image_path = write_turn_image_file(
+                        block,
+                        chat_id=chat_id,
+                        reader_user=self._effective_codex_user,
+                    )
                     if image_path is not None:
                         turn_image_paths.append(image_path)
                         input_blocks.append({"type": "localImage", "path": str(image_path)})

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -3645,6 +3645,50 @@ def _start_service(platform: str, dry_run: bool, **_kwargs: object) -> None:
     raise ServiceStartError(detail)
 
 
+def _secure_codex_turn_image_staging(data_path: Path, dry_run: bool) -> None:
+    """Retire world-readable Codex turn images from the legacy layout.
+
+    Older releases wrote ``turn-image-*`` files directly under the shared
+    ``codex_turn_images`` directory with mode ``0644``. The service is stopped
+    while install migration runs, so no legitimate turn can still be using
+    those transient files. Remove only the exact legacy filename class, leave
+    unrelated entries and new per-principal subdirectories untouched, and make
+    the staging root traversable but non-listable for isolated OS users.
+    """
+    staging_root = data_path / "files" / "codex_turn_images"
+    if staging_root.is_symlink():
+        raise RuntimeError(f"Refusing unsafe Codex image staging path: {staging_root}")
+    if not staging_root.exists():
+        return
+    if not staging_root.is_dir():
+        raise RuntimeError(f"Refusing unsafe Codex image staging path: {staging_root}")
+
+    legacy_files = sorted(
+        (
+            entry
+            for entry in staging_root.iterdir()
+            if entry.name.startswith("turn-image-") and (entry.is_file() or entry.is_symlink())
+        ),
+        key=lambda entry: entry.name,
+    )
+    current_mode = staging_root.stat().st_mode & 0o777
+
+    if dry_run:
+        if legacy_files:
+            print(f"[DRY RUN] Would remove {len(legacy_files)} legacy Codex turn image file(s) from {staging_root}")
+        if current_mode != 0o711:
+            print(f"[DRY RUN] Would set mode 0711 on Codex image staging root: {staging_root}")
+        return
+
+    for path in legacy_files:
+        path.unlink(missing_ok=True)
+    os.chmod(staging_root, 0o711)
+    if legacy_files:
+        print(f"  Removed {len(legacy_files)} legacy Codex turn image file(s) from {staging_root}")
+    if current_mode != 0o711:
+        print(f"  Secured Codex image staging root {staging_root} (mode 0711)")
+
+
 def _apply_migrate(
     data_path: Path,
     install_path: Path,
@@ -3677,6 +3721,11 @@ def _apply_migrate(
     # uses to keep the host's real config out of test outcomes.
     if users_yaml_path is None:
         users_yaml_path = USERS_YAML
+
+    # Retire the old shared/listable Codex image layout before migrating or
+    # reconciling other runtime data. The protected service is stopped for the
+    # whole apply transaction, so every root-level turn image is stale.
+    _secure_codex_turn_image_staging(data_path, dry_run)
 
     # -- Database migration --
     db_src = PROJECT_ROOT / "kai.db"

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -215,10 +215,14 @@ def _anthropic_image_block(media_type: str = "image/jpeg") -> dict:
     }
 
 
-async def _collect_events(c: CodexBackend, prompt: str | list = "test") -> list[StreamEvent]:
+async def _collect_events(
+    c: CodexBackend,
+    prompt: str | list = "test",
+    chat_id: int | None = None,
+) -> list[StreamEvent]:
     """Send a prompt and collect all yielded StreamEvents."""
     events = []
-    async for event in c._send_locked(prompt):
+    async for event in c._send_locked(prompt, chat_id=chat_id):
         events.append(event)
     return events
 
@@ -1174,47 +1178,141 @@ class TestPromptCoercion:
 
 class TestWriteTurnImageFile:
     """`write_turn_image_file` materializes the Anthropic base64 image
-    shape as a world-readable file for codex's localImage input, and
-    returns None on any other shape so the caller drops the block."""
+    shape as a private, principal-scoped file for codex's localImage
+    input, and returns None on any other shape so the caller drops the
+    block."""
 
     def test_writes_decoded_bytes_with_subtype_suffix(self):
-        path = write_turn_image_file(_anthropic_image_block())
+        path = write_turn_image_file(
+            _anthropic_image_block(),
+            chat_id=12345,
+            reader_user=None,
+        )
         assert path is not None
         try:
             assert path.read_bytes() == _IMAGE_BYTES
             assert path.name.startswith("turn-image-")
             assert path.suffix == ".jpeg"
-            assert path.parent.name == "codex_turn_images"
-            # World-readable so a sudo-routed codex user can open it.
-            assert path.stat().st_mode & 0o777 == 0o644
+            assert path.parent.name == "12345"
+            assert path.parent.parent.name == "codex_turn_images"
+            assert path.parent.stat().st_mode & 0o777 == 0o711
+            assert path.parent.parent.stat().st_mode & 0o777 == 0o711
+            assert path.stat().st_mode & 0o777 == 0o600
         finally:
             path.unlink()
 
     def test_non_alnum_subtype_falls_back_to_neutral_suffix(self):
-        path = write_turn_image_file(_anthropic_image_block(media_type="image/svg+xml"))
+        path = write_turn_image_file(
+            _anthropic_image_block(media_type="image/svg+xml"),
+            chat_id=12345,
+            reader_user=None,
+        )
         assert path is not None
         try:
             assert path.suffix == ".img"
         finally:
             path.unlink()
 
+    def test_distinct_principals_use_distinct_non_listable_directories(self):
+        first = write_turn_image_file(_anthropic_image_block(), chat_id=111, reader_user=None)
+        second = write_turn_image_file(_anthropic_image_block(), chat_id=222, reader_user=None)
+        assert first is not None and second is not None
+        try:
+            assert first.parent.name == "111"
+            assert second.parent.name == "222"
+            assert first.parent != second.parent
+            assert first.stat().st_mode & 0o777 == 0o600
+            assert second.stat().st_mode & 0o777 == 0o600
+        finally:
+            first.unlink()
+            second.unlink()
+
+    def test_macos_cross_user_file_gets_named_read_acl(self):
+        completed = MagicMock(returncode=0, stderr="")
+        with (
+            patch("kai.codex.sys.platform", "darwin"),
+            patch("kai.codex.subprocess.run", return_value=completed) as run,
+        ):
+            path = write_turn_image_file(
+                _anthropic_image_block(),
+                chat_id=12345,
+                reader_user="alice",
+            )
+
+        assert path is not None
+        try:
+            assert path.stat().st_mode & 0o777 == 0o600
+            command = run.call_args.args[0]
+            assert command[:2] == ["/bin/chmod", "+a"]
+            assert command[2] == "user:alice allow read,readattr,readextattr,readsecurity"
+            assert command[3] == str(path)
+        finally:
+            path.unlink()
+
+    def test_linux_without_setfacl_fails_closed_and_removes_file(self):
+        with (
+            patch("kai.codex.sys.platform", "linux"),
+            patch("kai.codex.shutil.which", return_value=None),
+        ):
+            path = write_turn_image_file(
+                _anthropic_image_block(),
+                chat_id=98765,
+                reader_user="alice",
+            )
+
+        assert path is None
+        principal_dir = DATA_DIR / "files" / "codex_turn_images" / "98765"
+        assert not list(principal_dir.glob("turn-image-*"))
+
+    def test_linux_cross_user_file_gets_named_read_acl(self):
+        completed = MagicMock(returncode=0, stderr="")
+        with (
+            patch("kai.codex.sys.platform", "linux"),
+            patch("kai.codex.shutil.which", return_value="/usr/bin/setfacl"),
+            patch("kai.codex.subprocess.run", return_value=completed) as run,
+        ):
+            path = write_turn_image_file(
+                _anthropic_image_block(),
+                chat_id=12345,
+                reader_user="alice",
+            )
+
+        assert path is not None
+        try:
+            assert path.stat().st_mode & 0o777 == 0o600
+            assert run.call_args.args[0] == [
+                "/usr/bin/setfacl",
+                "-m",
+                "u:alice:r--",
+                str(path),
+            ]
+        finally:
+            path.unlink()
+
     def test_non_dict_source_returns_none(self):
-        assert write_turn_image_file({"type": "image", "source": "fake"}) is None
+        assert (
+            write_turn_image_file(
+                {"type": "image", "source": "fake"},
+                chat_id=12345,
+                reader_user=None,
+            )
+            is None
+        )
 
     def test_non_base64_source_type_returns_none(self):
         block = {"type": "image", "source": {"type": "url", "url": "https://x.test/i.png"}}
-        assert write_turn_image_file(block) is None
+        assert write_turn_image_file(block, chat_id=12345, reader_user=None) is None
 
     def test_missing_fields_return_none(self):
         block = {"type": "image", "source": {"type": "base64", "media_type": "image/png"}}
-        assert write_turn_image_file(block) is None
+        assert write_turn_image_file(block, chat_id=12345, reader_user=None) is None
 
     def test_invalid_base64_returns_none(self):
         block = {
             "type": "image",
             "source": {"type": "base64", "media_type": "image/png", "data": "not!valid!b64"},
         }
-        assert write_turn_image_file(block) is None
+        assert write_turn_image_file(block, chat_id=12345, reader_user=None) is None
 
 
 class TestImageForwarding:
@@ -1247,6 +1345,24 @@ class TestImageForwarding:
         final = events[-1].response
         assert final is not None and final.success
         assert "[Note:" not in final.text
+
+    @pytest.mark.asyncio
+    async def test_image_writer_receives_principal_and_effective_os_user(self):
+        c = _make_codex()
+        c._proc = _make_mock_proc([_agent_message_delta("ok"), _turn_completed("completed")])
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+        c._effective_codex_user = "alice"
+
+        with patch("kai.codex.write_turn_image_file", return_value=None) as writer:
+            await _collect_events(c, prompt=[_anthropic_image_block()], chat_id=24680)
+
+        writer.assert_called_once_with(
+            _anthropic_image_block(),
+            chat_id=24680,
+            reader_user="alice",
+        )
 
     @pytest.mark.asyncio
     async def test_dropped_image_seeds_user_notice(self):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -51,6 +51,7 @@ from kai.install import (
     _resolve_codex_bin_prompt_default,
     _retire_install_home_claude,
     _retire_install_home_dir,
+    _secure_codex_turn_image_staging,
     _set_ownership,
     _src_checksum,
     _start_service,
@@ -4612,6 +4613,56 @@ class TestSrcChecksum:
 
 
 # ── Migration ────────────────────────────────────────────────────────
+
+
+class TestSecureCodexTurnImageStaging:
+    def test_removes_only_legacy_files_and_makes_root_non_listable(self, tmp_path, capsys):
+        staging_root = tmp_path / "data" / "files" / "codex_turn_images"
+        staging_root.mkdir(parents=True, mode=0o755)
+        staging_root.chmod(0o755)
+        legacy = staging_root / "turn-image-old.jpeg"
+        legacy.write_bytes(b"private image")
+        legacy.chmod(0o644)
+        unrelated = staging_root / "operator-note.txt"
+        unrelated.write_text("keep")
+        principal_dir = staging_root / "12345"
+        principal_dir.mkdir()
+
+        _secure_codex_turn_image_staging(tmp_path / "data", dry_run=False)
+
+        assert not legacy.exists()
+        assert unrelated.read_text() == "keep"
+        assert principal_dir.is_dir()
+        assert staging_root.stat().st_mode & 0o777 == 0o711
+        output = capsys.readouterr().out
+        assert "Removed 1 legacy Codex turn image file" in output
+        assert "mode 0711" in output
+
+    def test_dry_run_reports_without_mutating(self, tmp_path, capsys):
+        staging_root = tmp_path / "data" / "files" / "codex_turn_images"
+        staging_root.mkdir(parents=True, mode=0o755)
+        staging_root.chmod(0o755)
+        legacy = staging_root / "turn-image-crash.png"
+        legacy.write_bytes(b"private image")
+
+        _secure_codex_turn_image_staging(tmp_path / "data", dry_run=True)
+
+        assert legacy.exists()
+        assert staging_root.stat().st_mode & 0o777 == 0o755
+        output = capsys.readouterr().out
+        assert "[DRY RUN] Would remove 1 legacy Codex turn image file" in output
+        assert "[DRY RUN] Would set mode 0711" in output
+
+    def test_refuses_symlink_staging_root(self, tmp_path):
+        data_path = tmp_path / "data"
+        files_dir = data_path / "files"
+        files_dir.mkdir(parents=True)
+        target = tmp_path / "attacker-controlled"
+        target.mkdir()
+        (files_dir / "codex_turn_images").symlink_to(target, target_is_directory=True)
+
+        with pytest.raises(RuntimeError, match="Refusing unsafe Codex image staging path"):
+            _secure_codex_turn_image_staging(data_path, dry_run=False)
 
 
 class TestApplyMigrate:


### PR DESCRIPTION
## Summary

- replace the shared, listable Codex image directory with per-principal staging directories
- keep every staged image at POSIX mode 0600
- grant read-only access only to the effective isolated Codex OS user through a named ACL
- make staging directories traversable but non-listable at mode 0711
- retire legacy root-level turn-image files during protected installation
- document the Linux setfacl requirement for protected Codex image input

## Security impact

Codex app-server accepts image input only by local file path. Previously Kai wrote every users image into one mode-0755 directory and changed each temporary file to mode 0644 so a sudo-routed Codex process could read it. Any local account could therefore list and read an in-flight image or a cleanup failure left behind after a crash.

The new path is codex_turn_images/<principal>/turn-image-<random>.<suffix>. The image remains owned by Kai with mode 0600. In cross-user mode, only the effective os_user receives a named read ACL. Other local users cannot list either the staging root or principal directory, and cannot read the file even if its random filename is learned.

This preserves same-user development mode without an ACL. On protected Linux installations, missing setfacl fails closed: Kai deletes the newly staged file and uses the existing user-visible image-drop notice instead of reverting to world-readable permissions.

## Migration and dry-run behavior

Protected install migration runs while the service is stopped. It:

- removes only root-level turn-image-* files from the legacy layout, because no active turn can still own them
- preserves unrelated files and all new per-principal subdirectories
- changes the staging root from mode 0755 to 0711
- refuses a symlink or non-directory staging root
- reports every action without mutation under DRY_RUN=1

No configuration, database, secret, or users.yaml change is required.

## Verification

- make check
- focused Codex and installer suite: 597 passed
- complete suite: 4704 passed, 1 skipped
- disposable macOS host probe confirmed the exact chmod +a ACL form while retaining POSIX mode 0600
- tests cover principal separation, directory and file modes, macOS ACL construction, Linux setfacl construction, missing-setfacl fail-closed cleanup, legacy cleanup, dry-run behavior, and unsafe staging-root refusal

## Scope

This is the first filesystem-isolation slice from security finding 7. Principal-scoped send-file access, SQLite/PAT permissions, and deletion of Telegram token messages remain separate follow-up work.