### PR TITLE
Constrain send-file to authenticated principal

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -466,7 +466,8 @@ def build_session_context(
             f"[File API: To send a file to the user, use curl (NEVER WebFetch) to POST JSON to "
             f"http://localhost:{api.webhook_port}/api/send-file "
             f"with header 'X-Webhook-Secret: $KAI_WEBHOOK_SECRET' (environment variable). "
-            f'Required: "path" (absolute file path within the current workspace {workspace}). '
+            f'Required: "path" (absolute file path within the current workspace {workspace} '
+            f"or your principal-scoped incoming-file directory {files_path}). "
             f'Optional: "caption". Images are sent as photos, '
             f"everything else as documents.\n"
             f"Incoming files from the user are auto-saved to "

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -1514,8 +1514,10 @@ async def _handle_send_file(request: web.Request, principal: InternalAPIPrincipa
     an optional "caption". Images are sent as photos (rendered inline),
     everything else as document attachments.
 
-    Path confinement: the resolved path must be inside the current workspace
-    directory. This prevents path traversal attacks via symlinks or "../".
+    Path confinement: the resolved path must be inside the authenticated
+    principal's current workspace or its scoped upload directory. This
+    prevents path traversal attacks via symlinks or "../" and prevents one
+    principal from sending files from another principal's upload directory.
 
     Returns:
         JSON {"status": "sent", "file": "<filename>"} on success, or an
@@ -1557,18 +1559,19 @@ async def _handle_send_file(request: web.Request, principal: InternalAPIPrincipa
     if pool is None:
         return web.json_response({"error": "No workspace configured"}, status=403)
     workspace = str(await pool.get_effective_workspace(chat_id))
-    # Allow files from either the workspace or DATA_DIR/files/.
-    # DATA_DIR/files/ is where uploaded files now live (PR #145).
-    # Confinement to DATA_DIR/"files" (not all of DATA_DIR) is deliberate;
-    # inner Claude should not be able to send the database, logs, or
-    # history files via this endpoint.
+    # Allow files from either the workspace or this authenticated principal's
+    # upload directory. Telegram uploads are stored under
+    # DATA_DIR/files/<chat_id>/; the legacy shared DATA_DIR/files/ root and
+    # sibling principals' directories are deliberately excluded. The scope is
+    # derived from the authenticated principal, never from a caller-selected
+    # request field.
     workspace_resolved = Path(workspace).resolve()
-    files_resolved = (DATA_DIR / "files").resolve()
+    principal_files_resolved = (DATA_DIR / "files" / str(principal.chat_id)).resolve()
     try:
         path.relative_to(workspace_resolved)
     except ValueError:
         try:
-            path.relative_to(files_resolved)
+            path.relative_to(principal_files_resolved)
         except ValueError:
             return web.json_response({"error": "Path outside allowed directories"}, status=403)
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -352,6 +352,26 @@ class TestBuildSessionContext:
         assert "Messaging API" in result
         assert "File API" in result
 
+    def test_file_api_docs_name_principal_upload_directory(self, tmp_path):
+        """File API guidance exposes only the current principal's upload path."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        (data_dir / "memory").mkdir(parents=True)
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=123,
+                data_dir=data_dir,
+            )
+
+        assert result is not None
+        assert f"principal-scoped incoming-file directory {data_dir}/files/123/" in result
+
     def test_services_included(self, tmp_path):
         """External services block is injected when services are configured."""
         workspace = tmp_path / "ws"

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -375,6 +375,17 @@ def send_file_request(tmp_path):
     return request
 
 
+@pytest.fixture
+def isolated_send_file_roots(tmp_path, send_file_request, monkeypatch):
+    """Give send-file distinct workspace and per-principal upload roots."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr("kai.webhook.DATA_DIR", data_dir)
+    send_file_request.app[POOL_KEY].get_effective_workspace.return_value = workspace
+    return send_file_request, workspace, data_dir
+
+
 class TestSendFile:
     async def test_send_image_as_photo(self, tmp_path, send_file_request):
         """Image files are sent via send_photo (rendered inline in Telegram)."""
@@ -432,6 +443,76 @@ class TestSendFile:
         send_file_request.json = AsyncMock(return_value={"path": "/etc/passwd"})
         resp = await _handle_send_file(send_file_request)
         assert resp.status == 403
+
+    async def test_authenticated_principal_can_send_own_uploaded_file(self, isolated_send_file_roots):
+        """The principal's DATA_DIR/files/<chat_id> directory is allowed."""
+        request, _workspace, data_dir = isolated_send_file_roots
+        uploaded = data_dir / "files" / "123" / "report.txt"
+        uploaded.parent.mkdir(parents=True)
+        uploaded.write_text("principal-owned")
+        request.json = AsyncMock(return_value={"path": str(uploaded)})
+
+        resp = await _handle_send_file(request)
+
+        assert resp.status == 200
+        request.app[TELEGRAM_BOT_KEY].send_document.assert_awaited_once()
+
+    async def test_file_scope_follows_authenticated_credential(self, isolated_send_file_roots):
+        """A second credential receives its own scope, independent of app defaults."""
+        request, _workspace, data_dir = isolated_send_file_roots
+        uploaded = data_dir / "files" / "456" / "report.txt"
+        uploaded.parent.mkdir(parents=True)
+        uploaded.write_text("second principal")
+        request.headers = {"X-Webhook-Secret": "other-secret"}
+        request.json = AsyncMock(return_value={"path": str(uploaded)})
+
+        resp = await _handle_send_file(request)
+
+        assert resp.status == 200
+        request.app[TELEGRAM_BOT_KEY].send_document.assert_awaited_once()
+        assert request.app[TELEGRAM_BOT_KEY].send_document.await_args.args[0] == 456
+
+    async def test_authenticated_principal_cannot_send_sibling_uploaded_file(self, isolated_send_file_roots):
+        """A FILES_SEND credential cannot select another principal's upload."""
+        request, _workspace, data_dir = isolated_send_file_roots
+        sibling_file = data_dir / "files" / "456" / "secret.txt"
+        sibling_file.parent.mkdir(parents=True)
+        sibling_file.write_text("other principal")
+        request.json = AsyncMock(return_value={"path": str(sibling_file)})
+
+        resp = await _handle_send_file(request)
+
+        assert resp.status == 403
+        request.app[TELEGRAM_BOT_KEY].send_document.assert_not_awaited()
+
+    async def test_authenticated_principal_cannot_send_legacy_shared_file(self, isolated_send_file_roots):
+        """Ambiguous files in the legacy shared root are not exposed by the API."""
+        request, _workspace, data_dir = isolated_send_file_roots
+        shared_file = data_dir / "files" / "legacy.txt"
+        shared_file.parent.mkdir(parents=True)
+        shared_file.write_text("unattributed")
+        request.json = AsyncMock(return_value={"path": str(shared_file)})
+
+        resp = await _handle_send_file(request)
+
+        assert resp.status == 403
+        request.app[TELEGRAM_BOT_KEY].send_document.assert_not_awaited()
+
+    async def test_symlink_cannot_escape_principal_upload_directory(self, isolated_send_file_roots):
+        """Resolving a symlink into a sibling principal's directory is denied."""
+        request, _workspace, data_dir = isolated_send_file_roots
+        sibling_file = data_dir / "files" / "456" / "secret.txt"
+        sibling_file.parent.mkdir(parents=True)
+        sibling_file.write_text("other principal")
+        link = data_dir / "files" / "123" / "link.txt"
+        link.parent.mkdir(parents=True)
+        link.symlink_to(sibling_file)
+        request.json = AsyncMock(return_value={"path": str(link)})
+
+        resp = await _handle_send_file(request)
+
+        assert resp.status == 403
+        request.app[TELEGRAM_BOT_KEY].send_document.assert_not_awaited()
 
     async def test_invalid_json_returns_400(self, send_file_request):
         """Returns 400 for malformed JSON body."""


### PR DESCRIPTION
## Summary

Constrain `/api/send-file` to the authenticated internal-API principal's file namespace.

The endpoint continues to support the two paths a Kai agent legitimately needs:

- the principal's effective workspace; and
- `DATA_DIR/files/<authenticated chat_id>/`, where Kai stores that user's Telegram uploads and generated review artifacts.

It no longer treats the installation-wide `DATA_DIR/files/` tree as one shared allowlist.

## Security issue

The internal API already authenticated callers as an `InternalAPIPrincipal`, and `/api/send-file` already used that principal to select the Telegram destination. Its filesystem authorization was broader, however: any credential with `FILES_SEND` could select any resolved file below `DATA_DIR/files/`.

In a multi-user installation, a persistent agent for chat `123` could therefore ask Kai to send a file from `DATA_DIR/files/456/` to chat `123`. This crossed the authenticated-principal boundary even though the outbound Telegram destination itself was correctly confined.

## Changes

- Derive the upload allowlist from `principal.chat_id`, not a request field or process-wide app default.
- Allow `DATA_DIR/files/<principal.chat_id>/` alongside the existing effective-workspace allowance.
- Reject sibling principals' upload directories.
- Reject unattributed files in the legacy shared `DATA_DIR/files/` root.
- Preserve resolved-path confinement, including denial of a symlink from one principal's directory into another's.
- Update the injected File API guidance so agents are told about their principal-scoped incoming-file directory rather than only the workspace.

The existing generic 403 response is retained so rejected paths do not disclose filesystem details.

## Compatibility and deployment

All production upload call sites already pass the authenticated Telegram chat ID to `_save_upload`, including photo uploads, document uploads, and staged PR-review artifacts. Those files therefore already live under `DATA_DIR/files/<chat_id>/` and remain sendable.

Files produced in the agent's current workspace also remain sendable exactly as before.

No files are moved or deleted. A legacy, unattributed file directly under `DATA_DIR/files/` is intentionally no longer exposed through this API; if ownership is known, it can be moved into the correct user's directory or workspace.

This change has no configuration-schema, secret, database, TOTP, sudoers, or installer migration changes. After merge, the normal dry-run and install flow will deploy the updated source and restart Kai.

## Tests

New regression coverage verifies:

- a principal can send a file from its own upload directory;
- a second credential is scoped by its own authenticated identity even when the app default refers to another chat;
- a principal cannot send a sibling user's uploaded file;
- the legacy shared root is denied;
- a symlink into a sibling user's directory is denied; and
- generated agent guidance names the principal-scoped path.

Verification:

- `make check`
- `make test` — 4,710 passed, 1 skipped

