### PR TITLE
Fix Claude fallback for Homebrew installs

### DIFF
--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -46,6 +46,27 @@ from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude
 log = logging.getLogger(__name__)
 
 
+def _resolve_default_claude_bin() -> str:
+    """Return the default Claude binary path for persistent chat."""
+    native = Path.home() / ".local" / "bin" / "claude"
+    if native.is_file() and os.access(native, os.X_OK):
+        return str(native)
+    homebrew = Path("/opt/homebrew/bin/claude")
+    if str(Path.home()).startswith("/Users/") and homebrew.is_file() and os.access(homebrew, os.X_OK):
+        return str(homebrew)
+    return "claude"
+
+
+_CLAUDE_STDERR_WARNING_MARKERS = (
+    "a password is required",
+    "permission denied",
+    "not found",
+    "no such file or directory",
+    "authentication",
+    "auth failed",
+)
+
+
 # ── Claude Code backend ─────────────────────────────────────────────
 
 
@@ -190,11 +211,11 @@ class ClaudeCodeBackend(AgentBackend):
         # the install (or operator) pin an absolute path; the sudoers
         # rule for cross-user spawns names the same file, and sudo's
         # PATH resolution of a bare name must land on exactly that
-        # file for the rule to match. Falls back to bare "claude" so
-        # installs with claude on the service user's PATH and no
-        # override keep working. Mirrors the CODEX_BIN handling in
-        # codex.py.
-        claude_bin = os.environ.get("CLAUDE_BIN") or "claude"
+        # file for the rule to match. The fallback order mirrors
+        # install.py's sudoers generator: service-user native install,
+        # Homebrew install, then bare "claude" for single-user PATH
+        # installs. Mirrors the CODEX_BIN handling in codex.py.
+        claude_bin = os.environ.get("CLAUDE_BIN") or _resolve_default_claude_bin()
 
         # Build the Claude command arguments.
         claude_cmd = [
@@ -383,7 +404,11 @@ class ClaudeCodeBackend(AgentBackend):
                     break
                 text = line.decode().strip()
                 if text:
-                    log.debug("Claude stderr: %s", text[:200])
+                    snippet = text[:200]
+                    if any(marker in text.lower() for marker in _CLAUDE_STDERR_WARNING_MARKERS):
+                        log.warning("Claude stderr: %s", snippet)
+                    else:
+                        log.debug("Claude stderr: %s", snippet)
             except Exception:
                 log.warning("Unexpected error in stderr drain", exc_info=True)
                 break

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -478,6 +478,25 @@ def _validate_codex_bin(value: str) -> bool:
     return p.is_absolute() and p.is_file() and os.access(p, os.X_OK)
 
 
+def _resolve_default_claude_bin(service_user: str) -> str:
+    """Return the default Claude binary path used by sudoers.
+
+    Native Claude installs land under the service user's home. The
+    Homebrew cask installs under /opt/homebrew/bin/claude. Prefer the
+    native service-user path when it exists, but recover the common
+    macOS Homebrew install instead of pinning sudoers to a missing
+    ~/.local/bin/claude.
+    """
+    svc_home = _user_home(service_user)
+    native = Path(svc_home) / ".local" / "bin" / "claude"
+    if _validate_claude_bin(str(native)):
+        return str(native)
+    homebrew = Path("/opt/homebrew/bin/claude")
+    if svc_home.startswith("/Users/") and _validate_claude_bin(str(homebrew)):
+        return str(homebrew)
+    return str(native)
+
+
 def _resolve_codex_bin_prompt_default(existing_env: dict[str, str]) -> str:
     """Return a usable default for every Codex binary-path prompt.
 
@@ -3188,18 +3207,19 @@ def _generate_sudoers(
 
     if target_users:
         # Anchor the rule path to the wizard-collected CLAUDE_BIN when
-        # present, else the SERVICE user's native-installer location.
+        # present, else the default resolver's service-user native
+        # install / Homebrew fallback.
         # The runtime spawn uses the same precedence (claude.py reads
-        # CLAUDE_BIN, else spawns bare `claude` which sudo resolves
-        # against the caller's PATH, the service user's), so the rule
-        # references the same binary the bot invokes. We deliberately
-        # do NOT call shutil.which here: resolving against whatever
+        # CLAUDE_BIN, else tries the same native/Homebrew fallbacks
+        # before spawning bare `claude`), so the rule references the
+        # same binary the bot invokes. We deliberately do NOT call
+        # shutil.which here: resolving against whatever
         # PATH root has when `sudo make install` runs can pick up any
         # user's `~/.local/bin/claude` that happens to be on PATH at
         # install time, baking the wrong path into the rule and
         # breaking the bot's sudo dispatch.
         svc_home = _user_home(service_user)
-        claude_bin_resolved = claude_bin or f"{svc_home}/.local/bin/claude"
+        claude_bin_resolved = claude_bin or _resolve_default_claude_bin(service_user)
         # Codex binary path is now threaded as an argument. The wizard
         # prompts for and persists the value in install.conf; _cmd_apply
         # passes it to _apply_sudoers which passes it here. We
@@ -5981,7 +6001,7 @@ def _apply_sudoers(
         # backend with a sudoers rule needs an entry in both places.
         expected_bins: dict[str, tuple[Path, str]] = {
             "claude": (
-                Path(claude_bin or f"{svc_home}/.local/bin/claude"),
+                Path(claude_bin or _resolve_default_claude_bin(service_user)),
                 "Re-run 'make config' and point CLAUDE_BIN at the actual claude "
                 "install location to keep the rule and runtime in sync.",
             ),

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -115,6 +115,12 @@ def _result_event(
 class TestCommandConstruction:
     """Verify _ensure_started() builds the right command depending on claude_user."""
 
+    @pytest.fixture(autouse=True)
+    def _legacy_default_claude_bin(self, monkeypatch):
+        """Most command-construction tests assert sudo wrapping, not
+        host-specific binary discovery."""
+        monkeypatch.setattr("kai.claude._resolve_default_claude_bin", lambda: "claude")
+
     @pytest.mark.asyncio
     async def test_cmd_without_claude_user(self):
         """Without claude_user, command starts with 'claude' directly."""
@@ -382,6 +388,27 @@ class TestCommandConstruction:
         (mirrors codex's CODEX_BIN and opencode's OPENCODE_BIN
         contract)."""
         monkeypatch.setenv("CLAUDE_BIN", "/opt/homebrew/bin/claude")
+        claude = _make_claude()
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+            cmd = mock_exec.call_args[0]
+            assert cmd[0] == "/opt/homebrew/bin/claude"
+
+    @pytest.mark.asyncio
+    async def test_default_claude_bin_uses_resolver(self, monkeypatch):
+        """When CLAUDE_BIN is unset, the argv head comes from the
+        native/Homebrew resolver rather than always being bare
+        `claude`."""
+        monkeypatch.delenv("CLAUDE_BIN", raising=False)
+        monkeypatch.setattr("kai.claude._resolve_default_claude_bin", lambda: "/opt/homebrew/bin/claude")
         claude = _make_claude()
 
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
@@ -1080,6 +1107,20 @@ class TestDrainStderr:
         await claude._drain_stderr()
 
         assert "some warning" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_permission_stderr_logs_warning(self, caplog):
+        """Startup-shaped stderr is visible at INFO-level deployments."""
+        caplog.set_level("WARNING", logger="kai.claude")
+        claude = _make_claude()
+        mock_proc = MagicMock()
+        mock_proc.stderr = MagicMock()
+        mock_proc.stderr.readline = AsyncMock(side_effect=[b"sudo: a password is required\n", b""])
+        claude._proc = mock_proc
+
+        await claude._drain_stderr()
+
+        assert "sudo: a password is required" in caplog.text
 
     @pytest.mark.asyncio
     async def test_truncates_long_lines(self, caplog):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -387,6 +387,21 @@ class TestGenerateSudoers:
         assert "/home/kai/.local/bin/claude" in result
         assert "/some/other/users/local/bin/claude" not in result
 
+    def test_claude_bin_homebrew_fallback_when_service_native_missing(self, monkeypatch):
+        """On macOS, a missing service-user native Claude install falls
+        back to the Homebrew cask path so runtime backend switches can
+        use Claude without a hand-authored CLAUDE_BIN."""
+        monkeypatch.setattr("kai.install._user_home", lambda u: "/Users/kai")
+        monkeypatch.setattr(
+            "kai.install._validate_claude_bin",
+            lambda p: p == "/opt/homebrew/bin/claude",
+        )
+
+        result = _generate_sudoers("kai", os_users=["alice"])
+
+        assert "kai ALL=(alice) SETENV: NOPASSWD: /opt/homebrew/bin/claude" in result
+        assert "/Users/kai/.local/bin/claude" not in result
+
     def test_claude_bin_arg_overrides_default(self, monkeypatch):
         """An explicit claude_bin (the wizard-collected CLAUDE_BIN)
         replaces the service-home fallback in the per-user rule, so


### PR DESCRIPTION
## Summary

- Resolve Claude's default binary path consistently between runtime and sudoers.
- Prefer `CLAUDE_BIN` when configured, then the service user's native `~/.local/bin/claude`, then Homebrew's `/opt/homebrew/bin/claude`, then the old bare `claude` fallback.
- Promote startup-shaped Claude stderr such as sudo password/path/auth failures to warning logs so "Claude process died" has an actionable cause in normal logs.

## Why

Kai could dynamically switch a user from Codex to Claude even when `make config` had never emitted `CLAUDE_BIN`. On this host, `claude` is installed at `/opt/homebrew/bin/claude`, while sudoers fell back to `/Users/kai/.local/bin/claude`. That fallback path did not exist, so the persistent Claude process died immediately under sudo and Kai only reported:

`Claude process died, restarting on next message`

The install now recovers the common macOS Homebrew install without requiring a hand-edited `install.conf`, and runtime uses the same fallback order as sudoers.

## Validation

- `.venv/bin/python -m pytest tests/test_claude.py tests/test_install.py`
- `660 passed`
- Host sanity check: `kai.install._resolve_default_claude_bin("kai")` resolves to `/opt/homebrew/bin/claude`

## Deployment Note

After merge, `make install` should rewrite `/etc/sudoers.d/kai` so the Claude per-user rule points at `/opt/homebrew/bin/claude` on this Mac. No manual `install.conf` edit should be needed.
