### PR TITLE
Fix Codex binary fallback sync

### DIFF
--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -91,6 +91,22 @@ log = logging.getLogger(__name__)
 _TURN_IMAGE_DIR = DATA_DIR / "files" / "codex_turn_images"
 
 
+def _resolve_default_codex_bin() -> str:
+    """Resolve Codex to a stable absolute path when CODEX_BIN is unset.
+
+    Cross-user launches go through sudoers, whose command matching is
+    path-exact. Prefer common absolute install paths so runtime and the
+    installer's sudoers fallback stay aligned after a users.yaml-only
+    switch to the codex backend.
+    """
+    for candidate in ("/usr/local/bin/codex", "/opt/homebrew/bin/codex"):
+        path = Path(candidate)
+        if path.is_file() and os.access(path, os.X_OK):
+            return candidate
+    discovered = shutil.which("codex")
+    return discovered or "codex"
+
+
 def _grant_turn_image_read_access(path: Path, reader_user: str) -> None:
     """Grant exactly one cross-OS-user reader access to a private image.
 
@@ -433,9 +449,9 @@ class CodexBackend(AgentBackend):
         # sudo cannot find the bare name and the spawn dies with
         # "a password is required". The CODEX_BIN env var lets the
         # install (or operator) pin an absolute path that the sudoers
-        # rule also names exactly. Falls back to bare "codex" so
-        # single-user installs with codex on PATH still work.
-        codex_bin = os.environ.get("CODEX_BIN") or "codex"
+        # rule also names exactly. Without CODEX_BIN, use the same
+        # common absolute fallback the installer writes to sudoers.
+        codex_bin = os.environ.get("CODEX_BIN") or _resolve_default_codex_bin()
         codex_argv = [codex_bin]
         # The reasoning-effort override rides BEFORE the subcommand
         # token: `-c key=value` is defined at the codex CLI root

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -501,15 +501,30 @@ def _resolve_codex_bin_prompt_default(existing_env: dict[str, str]) -> str:
     """Return a usable default for every Codex binary-path prompt.
 
     Preserve a saved CODEX_BIN while it is executable. If an upgrade moved
-    the binary, discard the stale value and prefer the executable currently
-    discoverable on the operator's PATH. The Homebrew path remains only a
-    suggestion when Codex cannot be discovered; prompt validation still
-    prevents the wizard from accepting a missing executable.
+    the binary, discard the stale value and use the same common-path
+    resolver that sudoers generation uses.
     """
     saved = existing_env.get("CODEX_BIN", "")
     if _validate_codex_bin(saved):
         return saved
-    return shutil.which("codex") or "/opt/homebrew/bin/codex"
+    return _resolve_default_codex_bin()
+
+
+def _resolve_default_codex_bin() -> str:
+    """Return the default Codex binary path used by sudoers.
+
+    Prefer stable absolute install locations over the installer caller's
+    PATH. The runtime uses the same precedence when CODEX_BIN is unset,
+    so a users.yaml-only backend switch can be made effective with
+    `make install` rather than an interactive `make config` pass.
+    """
+    for candidate in ("/usr/local/bin/codex", "/opt/homebrew/bin/codex"):
+        if _validate_codex_bin(candidate):
+            return candidate
+    discovered = shutil.which("codex")
+    if discovered and _validate_codex_bin(discovered):
+        return discovered
+    return "/usr/local/bin/codex"
 
 
 def _validate_opencode_bin(value: str) -> bool:
@@ -3150,8 +3165,9 @@ def _generate_sudoers(
     service user's `~/.local/bin/claude` (the native installer
     location); operators with a custom install location (e.g. the
     Homebrew cask) override via CLAUDE_BIN. The codex binary path
-    defaults to /opt/homebrew/bin/codex; Linux installs override with
-    the CODEX_BIN env var at install time. The opencode rule uses the
+    defaults to the first executable common install location; unusual
+    installs override with the CODEX_BIN env var at install time. The
+    opencode rule uses the
     service user's `~/.local/bin/opencode` path (where the upstream
     installer drops the binary by default); operators with a custom
     install location can override via OPENCODE_BIN. The goose rule
@@ -3222,14 +3238,12 @@ def _generate_sudoers(
         claude_bin_resolved = claude_bin or _resolve_default_claude_bin(service_user)
         # Codex binary path is now threaded as an argument. The wizard
         # prompts for and persists the value in install.conf; _cmd_apply
-        # passes it to _apply_sudoers which passes it here. We
-        # deliberately do NOT call shutil.which or os.environ inside
-        # this function: resolving against root's install-time PATH
-        # would silently pick the wrong binary on multi-user installs
-        # (the same failure mode PR #455 removed for claude_bin). The
-        # Homebrew fallback only fires on a first-time install where
-        # the wizard has not run yet.
-        codex_bin_resolved = codex_bin or "/opt/homebrew/bin/codex"
+        # passes it to _apply_sudoers which passes it here. When a user
+        # later switches users.yaml to codex without re-running the
+        # wizard, resolve a common absolute Codex install path that the
+        # runtime uses too. That keeps sudoers and runtime in sync while
+        # still letting CODEX_BIN override unusual installs explicitly.
+        codex_bin_resolved = codex_bin or _resolve_default_codex_bin()
         # OpenCode binary path. Upstream's install script drops the
         # binary under the SERVICE user's ~/.local/bin/opencode by
         # default, so the same `svc_home` anchoring applies as the
@@ -5945,7 +5959,8 @@ def _apply_sudoers(
     SETENV rules pin the same absolute paths the running bot will
     invoke. `claude_bin` falls back to the service user's
     `~/.local/bin/claude` (the native installer location);
-    `codex_bin` falls back to /opt/homebrew/bin/codex; `opencode_bin`
+    `codex_bin` falls back to a common absolute codex install path;
+    `opencode_bin`
     falls back to the service user's `~/.local/bin/opencode`;
     `goose_bin` falls back to /opt/homebrew/bin/goose. The fallbacks
     fire only on installs where the wizard has not collected a value.
@@ -6006,7 +6021,7 @@ def _apply_sudoers(
                 "install location to keep the rule and runtime in sync.",
             ),
             "codex": (
-                Path(codex_bin or "/opt/homebrew/bin/codex"),
+                Path(codex_bin or _resolve_default_codex_bin()),
                 "Re-run 'make config' and point CODEX_BIN at the actual codex "
                 "install location to keep the rule and runtime in sync.",
             ),

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -397,6 +397,8 @@ class TestHandshake:
 
         with (
             patch.dict(os.environ, {}, clear=False),
+            patch.object(Path, "is_file", lambda _p: False),
+            patch("kai.codex.shutil.which", lambda _name: None),
             patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec,
         ):
             os.environ.pop("CODEX_BIN", None)
@@ -404,6 +406,32 @@ class TestHandshake:
 
         argv = mock_exec.call_args[0]
         assert argv[0] == "codex"
+        assert argv[1] == "app-server"
+
+    @pytest.mark.asyncio
+    async def test_argv_uses_common_absolute_codex_fallback(self):
+        """
+        When CODEX_BIN is unset but Codex exists at a common absolute
+        install path, runtime uses that path so sudoers command matching
+        can succeed after a users.yaml-only switch to the codex backend.
+        """
+        c = _make_codex()
+        proc = _make_mock_proc(_handshake_lines())
+
+        def fake_is_file(path: Path) -> bool:
+            return str(path) == "/usr/local/bin/codex"
+
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch.object(Path, "is_file", fake_is_file),
+            patch("os.access", lambda p, mode: str(p) == "/usr/local/bin/codex"),
+            patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec,
+        ):
+            os.environ.pop("CODEX_BIN", None)
+            await c._ensure_started()
+
+        argv = mock_exec.call_args[0]
+        assert argv[0] == "/usr/local/bin/codex"
         assert argv[1] == "app-server"
 
     @pytest.mark.asyncio
@@ -1741,14 +1769,14 @@ class TestCodexUserSudoWrap:
 
     @pytest.mark.asyncio
     async def test_no_sudo_when_codex_user_unset(self):
-        """Default (codex_user=None): argv starts with "codex", no sudo."""
+        """Default (codex_user=None): argv is not sudo-wrapped."""
         c = _make_codex()
         proc = _make_mock_proc(_handshake_lines())
         with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
             await c._ensure_started()
         argv = mock_exec.call_args[0]
-        assert argv[0] == "codex"
         assert "sudo" not in argv
+        assert argv[1] == "app-server"
 
     @pytest.mark.asyncio
     async def test_sudo_wraps_argv_when_codex_user_set(self):
@@ -1774,8 +1802,9 @@ class TestCodexUserSudoWrap:
         # chat leg as on extraction / review / triage.
         assert "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR,CODEX_HOME,OPENAI_API_KEY,OPENAI_BASE_URL" in argv
         # Codex binary follows the sudo prologue.
-        codex_i = argv.index("codex")
-        assert argv[codex_i + 1] == "app-server"
+        separator_i = argv.index("--")
+        assert argv[separator_i + 1].endswith("/codex") or argv[separator_i + 1] == "codex"
+        assert argv[separator_i + 2] == "app-server"
 
     @pytest.mark.asyncio
     async def test_tmpdir_anchored_per_os_user_in_cross_user_mode(self):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -9122,6 +9122,7 @@ class TestResolveCodexBinPromptDefault:
         detected = tmp_path / "detected-codex"
         detected.write_text("#!/bin/sh\n")
         detected.chmod(0o755)
+        monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: p == str(detected))
         monkeypatch.setattr("kai.install.shutil.which", lambda command: str(detected))
 
         result = _resolve_codex_bin_prompt_default({"CODEX_BIN": str(stale)})
@@ -9662,15 +9663,17 @@ class TestGenerateSudoersCodexBinArg:
         assert "kai ALL=(daniel) SETENV: NOPASSWD: /Users/daniel/.npm-global/bin/codex" in out
         assert "/opt/homebrew/bin/codex" not in out
 
-    def test_codex_bin_arg_none_falls_back_to_homebrew(self):
+    def test_codex_bin_arg_none_prefers_common_absolute_path(self, monkeypatch):
         from kai.install import _generate_sudoers
 
+        monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: p == "/usr/local/bin/codex")
         out = _generate_sudoers(
             service_user="kai",
             os_users=["daniel"],
             codex_bin=None,
         )
-        assert "/opt/homebrew/bin/codex" in out
+        assert "kai ALL=(daniel) SETENV: NOPASSWD: /usr/local/bin/codex" in out
+        assert "/opt/homebrew/bin/codex" not in out
 
     def test_codex_bin_does_not_read_os_environ(self, monkeypatch):
         """Setting CODEX_BIN in os.environ should have NO effect; only


### PR DESCRIPTION
## Summary

Fixes the Codex startup failure seen after switching a user in users.yaml to backend: codex without re-running make config.

The root cause is that Kai's runtime could invoke /usr/local/bin/codex while the installer-generated sudoers fallback still pinned /opt/homebrew/bin/codex when CODEX_BIN was absent. In cross-user mode sudoers command matching is exact, so the kai service user got a password prompt instead of a passwordless launch, and Kai only surfaced the generic app-server handshake failure.

Changes:
- Add a shared-precedence Codex fallback policy in runtime: /usr/local/bin/codex, then /opt/homebrew/bin/codex, then PATH discovery.
- Use the same fallback policy for installer sudoers generation when CODEX_BIN is not explicitly configured.
- Make the make config prompt default use the same fallback resolver.
- Update tests to lock the no-wizard users.yaml backend-switch case.

## Verification

- .venv/bin/python -m pytest tests/test_codex.py tests/test_install.py

## Operational note

After this lands, changing an existing installed user's users.yaml backend to codex should only require make install/restart to regenerate sudoers from the installed users.yaml. It should not require an interactive make config pass unless Codex is installed at an unusual path that Kai cannot discover.