### PR TITLE
Add installed backend registry

### DIFF
--- a/src/kai/backend_registry.py
+++ b/src/kai/backend_registry.py
@@ -1,0 +1,178 @@
+"""
+Installed backend registry.
+
+This module is the machine-capability boundary for local agent
+backends. User-facing configuration names backend IDs ("codex",
+"claude", etc.); executable paths are resolved from an admin-owned
+registry when present, with the legacy admin-owned ``*_BIN``
+environment variables retained as a compatibility fallback.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_BACKENDS_YAML = Path("/etc/kai/backends.yaml")
+BACKENDS_YAML_ENV = "KAI_BACKENDS_YAML"
+
+_BACKEND_ENV_VARS: dict[str, str] = {
+    "claude": "CLAUDE_BIN",
+    "codex": "CODEX_BIN",
+    "opencode": "OPENCODE_BIN",
+    "goose": "GOOSE_BIN",
+}
+
+
+class BackendRegistryError(Exception):
+    """Raised when the installed backend registry is malformed or unusable."""
+
+
+@dataclass(frozen=True)
+class BackendRegistryEntry:
+    """One installed backend capability."""
+
+    id: str
+    driver: str
+    runtime: str
+    command: str
+    allowed_models: tuple[str, ...] = ()
+
+
+def backend_registry_path() -> Path:
+    """Return the configured backend registry path."""
+    override = os.environ.get(BACKENDS_YAML_ENV, "").strip()
+    if override:
+        return Path(override)
+    return DEFAULT_BACKENDS_YAML
+
+
+def backend_registry_exists(path: Path | None = None) -> bool:
+    """Return whether an installed backend registry is present."""
+    if path is not None:
+        return path.is_file()
+    if os.environ.get(BACKENDS_YAML_ENV, "").strip():
+        return backend_registry_path().is_file()
+    if not os.environ.get("KAI_INSTALL_DIR", "").strip():
+        return False
+    return backend_registry_path().is_file()
+
+
+def backend_registry_is_authoritative() -> bool:
+    """Return whether backend command resolution must use the registry."""
+    return bool(os.environ.get(BACKENDS_YAML_ENV, "").strip()) or backend_registry_exists()
+
+
+def load_backend_registry(path: Path | None = None) -> dict[str, BackendRegistryEntry]:
+    """
+    Load the admin-owned backend registry.
+
+    Returns an empty dict when no registry exists. A present but
+    malformed registry is a configuration error because runtime and
+    sudoers path decisions must not silently fall back to unrelated
+    binaries.
+    """
+    explicit_path = path is not None or bool(os.environ.get(BACKENDS_YAML_ENV, "").strip())
+    registry_path = path or backend_registry_path()
+    if not registry_path.is_file():
+        if explicit_path:
+            raise BackendRegistryError(f"backend registry {registry_path} does not exist")
+        return {}
+    try:
+        raw = yaml.safe_load(registry_path.read_text()) or {}
+    except OSError as e:
+        raise BackendRegistryError(f"could not read backend registry {registry_path}: {e}") from e
+    except yaml.YAMLError as e:
+        raise BackendRegistryError(f"backend registry {registry_path} is not valid YAML: {e}") from e
+    if not isinstance(raw, dict):
+        raise BackendRegistryError(f"backend registry {registry_path}: expected a YAML mapping")
+    backends = raw.get("backends", {})
+    if not isinstance(backends, dict):
+        raise BackendRegistryError(f"backend registry {registry_path}: 'backends' must be a mapping")
+
+    entries: dict[str, BackendRegistryEntry] = {}
+    for backend_id, value in backends.items():
+        backend = str(backend_id).strip().lower()
+        if not backend:
+            raise BackendRegistryError(f"backend registry {registry_path}: empty backend id")
+        if not isinstance(value, dict):
+            raise BackendRegistryError(f"backend registry {registry_path}: backend {backend!r} must be a mapping")
+        command = str(value.get("command") or "").strip()
+        if not command:
+            raise BackendRegistryError(f"backend registry {registry_path}: backend {backend!r} missing command")
+        models = value.get("allowed_models", [])
+        if models is None:
+            model_tuple: tuple[str, ...] = ()
+        elif isinstance(models, list):
+            model_tuple = tuple(str(item).strip() for item in models if str(item).strip())
+        else:
+            raise BackendRegistryError(
+                f"backend registry {registry_path}: backend {backend!r} allowed_models must be a list"
+            )
+        entries[backend] = BackendRegistryEntry(
+            id=backend,
+            driver=str(value.get("driver") or backend).strip() or backend,
+            runtime=str(value.get("runtime") or "local_process").strip() or "local_process",
+            command=command,
+            allowed_models=model_tuple,
+        )
+    return entries
+
+
+def _validate_absolute_executable(backend: str, command: str, source: str) -> str:
+    path = Path(command)
+    if not path.is_absolute():
+        raise BackendRegistryError(f"{source} for backend {backend!r} is not absolute: {command!r}")
+    if not path.is_file():
+        raise BackendRegistryError(f"{source} for backend {backend!r} is not a file: {command!r}")
+    if not os.access(str(path), os.X_OK):
+        raise BackendRegistryError(f"{source} for backend {backend!r} is not executable: {command!r}")
+    return str(path)
+
+
+def _legacy_env_or_path_command(backend: str, *, allow_bare_fallback: bool) -> str:
+    env_var = _BACKEND_ENV_VARS.get(backend)
+    if env_var is None:
+        raise ValueError(f"unknown backend for command resolution: {backend!r}")
+    override = os.environ.get(env_var)
+    if override:
+        if allow_bare_fallback:
+            return override
+        return _validate_absolute_executable(backend, override, env_var)
+    if allow_bare_fallback:
+        return backend
+    resolved = shutil.which(backend)
+    if resolved is not None:
+        return resolved
+    raise BackendRegistryError(f"{env_var} unset, `{backend}` not on PATH")
+
+
+def resolve_backend_command(backend: str, *, allow_bare_fallback: bool = False) -> str:
+    """
+    Resolve the command for an installed backend.
+
+    Precedence:
+      1. admin-owned backend registry, if present;
+      2. legacy admin-owned ``*_BIN`` environment variable;
+      3. PATH lookup;
+      4. optional bare command fallback for persistent/dev spawns.
+    """
+    backend = backend.strip().lower()
+    if backend_registry_is_authoritative():
+        registry = load_backend_registry()
+        entry = registry.get(backend)
+        if entry is None:
+            raise BackendRegistryError(f"backend registry has no entry for backend {backend!r}")
+        return _validate_absolute_executable(backend, entry.command, "backend registry command")
+    return _legacy_env_or_path_command(backend, allow_bare_fallback=allow_bare_fallback)
+
+
+def render_backend_registry(entries: dict[str, dict[str, Any]]) -> str:
+    """Render backend registry YAML with stable ordering."""
+    ordered = {"version": 1, "backends": {key: entries[key] for key in sorted(entries)}}
+    return yaml.safe_dump(ordered, sort_keys=False)

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -41,6 +41,7 @@ from kai.backend import (
     ensure_user_preferences,
     sanitize_agent_environment,
 )
+from kai.backend_registry import BackendRegistryError, backend_registry_is_authoritative, resolve_backend_command
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
 
 log = logging.getLogger(__name__)
@@ -207,15 +208,16 @@ class ClaudeCodeBackend(AgentBackend):
         if self.is_alive:
             return
 
-        # Resolve the claude binary path. The CLAUDE_BIN env var lets
-        # the install (or operator) pin an absolute path; the sudoers
-        # rule for cross-user spawns names the same file, and sudo's
-        # PATH resolution of a bare name must land on exactly that
-        # file for the rule to match. The fallback order mirrors
-        # install.py's sudoers generator: service-user native install,
-        # Homebrew install, then bare "claude" for single-user PATH
-        # installs. Mirrors the CODEX_BIN handling in codex.py.
-        claude_bin = os.environ.get("CLAUDE_BIN") or _resolve_default_claude_bin()
+        # Resolve from the installed backend registry when present.
+        # Without a registry, keep the legacy backend-specific fallback
+        # order so development and older installs behave unchanged.
+        if backend_registry_is_authoritative():
+            try:
+                claude_bin = resolve_backend_command("claude", allow_bare_fallback=True)
+            except BackendRegistryError as e:
+                raise RuntimeError(f"Claude startup failed: {e}") from e
+        else:
+            claude_bin = os.environ.get("CLAUDE_BIN") or _resolve_default_claude_bin()
 
         # Build the Claude command arguments.
         claude_cmd = [

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -66,6 +66,7 @@ from kai.backend import (
     ensure_user_preferences,
     sanitize_agent_environment,
 )
+from kai.backend_registry import BackendRegistryError, backend_registry_is_authoritative, resolve_backend_command
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
 
 log = logging.getLogger(__name__)
@@ -443,15 +444,16 @@ class CodexBackend(AgentBackend):
         if effective_codex_user:
             env["TMPDIR"] = str(DATA_DIR / "tmp" / effective_codex_user)
 
-        # Resolve the codex binary path. When `codex` is not on the
-        # service user's PATH (multi-user installs where codex lives
-        # in a per-os_user home, e.g. /Users/daniel/.npm-global/bin),
-        # sudo cannot find the bare name and the spawn dies with
-        # "a password is required". The CODEX_BIN env var lets the
-        # install (or operator) pin an absolute path that the sudoers
-        # rule also names exactly. Without CODEX_BIN, use the same
-        # common absolute fallback the installer writes to sudoers.
-        codex_bin = os.environ.get("CODEX_BIN") or _resolve_default_codex_bin()
+        # Resolve from the installed backend registry when present.
+        # Without a registry, keep the legacy common-path fallback so
+        # development and older installs behave unchanged.
+        if backend_registry_is_authoritative():
+            try:
+                codex_bin = resolve_backend_command("codex", allow_bare_fallback=True)
+            except BackendRegistryError as e:
+                raise RuntimeError(f"Codex startup failed: {e}") from e
+        else:
+            codex_bin = os.environ.get("CODEX_BIN") or _resolve_default_codex_bin()
         codex_argv = [codex_bin]
         # The reasoning-effort override rides BEFORE the subcommand
         # token: `-c key=value` is defined at the codex CLI root

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -3211,9 +3211,9 @@ def load_config() -> Config:
                 raise SystemExit(
                     f"Memory extraction requires the {_backend!r} binary to be reachable "
                     f"at startup (at least one extraction-eligible user routes to it), but "
-                    f"{e}. Set {_backend.upper()}_BIN to the binary's absolute path or "
-                    f"fix PATH; rerun the wizard if you no longer want memory extraction "
-                    f"enabled."
+                    f"{e}. Update the installed backend registry with `make install`, "
+                    f"set {_backend.upper()}_BIN as an admin-owned compatibility override, "
+                    f"or fix PATH; rerun the wizard if you no longer want memory extraction enabled."
                 ) from None
 
     # Renamed env vars: warn when the legacy name is present so the

--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -20,6 +20,7 @@ import logging
 import os
 
 from kai.acp import AcpBackend
+from kai.backend_registry import BackendRegistryError, backend_registry_is_authoritative, resolve_backend_command
 
 log = logging.getLogger(__name__)
 
@@ -109,7 +110,13 @@ class GooseBackend(AcpBackend):
         back to bare "goose" so installs with goose on PATH keep
         working without the override.
         """
-        goose_bin = os.environ.get("GOOSE_BIN") or "goose"
+        if backend_registry_is_authoritative():
+            try:
+                goose_bin = resolve_backend_command("goose", allow_bare_fallback=True)
+            except BackendRegistryError as e:
+                raise RuntimeError(f"Goose startup failed: {e}") from e
+        else:
+            goose_bin = os.environ.get("GOOSE_BIN") or "goose"
         return [goose_bin, "acp", "--with-builtin", "developer"]
 
     def build_env(self, base_env: dict[str, str]) -> dict[str, str]:

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -39,6 +39,7 @@ from pathlib import Path
 
 import yaml
 
+from kai.backend_registry import render_backend_registry
 from kai.config import (
     _VALID_ROLES,
     BACKEND_PROVIDERS,
@@ -74,6 +75,7 @@ INSTALL_CONF = PROJECT_ROOT / "install.conf"
 # test suite can patch one attribute and stay isolated from the host's
 # real runtime config.
 USERS_YAML = Path("/etc/kai/users.yaml")
+BACKENDS_YAML = Path("/etc/kai/backends.yaml")
 
 # Default installation paths
 _DEFAULT_INSTALL_DIR = "/opt/kai"
@@ -3195,6 +3197,7 @@ def _generate_sudoers(
         {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/users.yaml
         {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/workspaces.yaml
         {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/memory-projects.yaml
+        {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/backends.yaml
         {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/totp.secret
         {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/totp.attempts
         {service_user} ALL=(root) NOPASSWD: {tee_path} /etc/kai/totp.attempts
@@ -4685,7 +4688,10 @@ def _cmd_apply() -> None:
         env.pop("MEMORY_RECALL_SHADOW_ENABLED", None)
         _apply_secrets(env, dry_run, users_yaml_staging_path=users_yaml_staging_path)
 
-        # -- Step 6: Deploy Goose config (if any goose-backed user) --
+        # -- Step 6: Deploy installed backend registry --
+        _apply_backend_registry(service_user, env, dry_run)
+
+        # -- Step 7: Deploy Goose config (if any goose-backed user) --
         # The function gates itself: global DEFAULT_BACKEND=goose or a
         # per-user backend override in users.yaml both mean some
         # session spawns `goose acp`; otherwise it no-ops.
@@ -4699,7 +4705,7 @@ def _cmd_apply() -> None:
             agent_backend=agent_backend,
         )
 
-        # -- Step 7: Configure sudoers --
+        # -- Step 8: Configure sudoers --
         _apply_sudoers(
             service_user,
             dry_run,
@@ -4710,10 +4716,10 @@ def _cmd_apply() -> None:
             agent_backend=agent_backend,
         )
 
-        # -- Step 8: Migrate runtime data --
+        # -- Step 9: Migrate runtime data --
         _apply_migrate(data_path, install_path, svc_uid, svc_gid, dry_run)
 
-        # -- Step 9: Generate service definition --
+        # -- Step 10: Generate service definition --
         webhook_port = int(env.get("WEBHOOK_PORT", "8080"))
         _apply_service(install_dir, data_dir, service_user, platform, dry_run, webhook_port)
         # Apply path completed without exception. Flipping the flag
@@ -5812,6 +5818,48 @@ def _apply_secrets(
             print(f"  Copied {yaml_dst}")
 
 
+def _build_backend_registry(service_user: str, env: dict[str, str]) -> str:
+    """Build the installed backend registry from admin-owned install state."""
+    svc_home = _user_home(service_user)
+    entries = {
+        "claude": {
+            "driver": "claude",
+            "runtime": "local_process",
+            "command": env.get("CLAUDE_BIN") or _resolve_default_claude_bin(service_user),
+            "allowed_models": sorted(PROVIDER_MODELS["anthropic"].keys()),
+        },
+        "codex": {
+            "driver": "codex",
+            "runtime": "local_process",
+            "command": env.get("CODEX_BIN") or _resolve_default_codex_bin(),
+            "allowed_models": sorted(CODEX_MODELS.keys()),
+        },
+        "goose": {
+            "driver": "goose",
+            "runtime": "local_process",
+            "command": env.get("GOOSE_BIN") or "/opt/homebrew/bin/goose",
+        },
+        "opencode": {
+            "driver": "opencode",
+            "runtime": "local_process",
+            "command": env.get("OPENCODE_BIN") or f"{svc_home}/.local/bin/opencode",
+        },
+    }
+    return render_backend_registry(entries)
+
+
+def _apply_backend_registry(service_user: str, env: dict[str, str], dry_run: bool) -> None:
+    """Write the non-secret installed backend registry."""
+    content = _build_backend_registry(service_user, env)
+    if dry_run:
+        print(f"[DRY RUN] Would write: {BACKENDS_YAML} (mode 0644)")
+        return
+    BACKENDS_YAML.write_text(content)
+    os.chmod(BACKENDS_YAML, 0o644)
+    os.chown(BACKENDS_YAML, 0, 0)
+    print(f"  Wrote {BACKENDS_YAML}")
+
+
 def _apply_goose_config(
     service_user: str,
     install_path: Path,
@@ -6017,23 +6065,23 @@ def _apply_sudoers(
         expected_bins: dict[str, tuple[Path, str]] = {
             "claude": (
                 Path(claude_bin or _resolve_default_claude_bin(service_user)),
-                "Re-run 'make config' and point CLAUDE_BIN at the actual claude "
-                "install location to keep the rule and runtime in sync.",
+                "Run 'make install' after installing claude globally, or re-run "
+                "'make config' and point CLAUDE_BIN at the actual install location.",
             ),
             "codex": (
                 Path(codex_bin or _resolve_default_codex_bin()),
-                "Re-run 'make config' and point CODEX_BIN at the actual codex "
-                "install location to keep the rule and runtime in sync.",
+                "Run 'make install' after installing codex globally, or re-run "
+                "'make config' and point CODEX_BIN at the actual install location.",
             ),
             "opencode": (
                 Path(opencode_bin or f"{svc_home}/.local/bin/opencode"),
-                "Re-run 'make config' and point OPENCODE_BIN at the actual "
-                "opencode install location to keep the rule and runtime in sync.",
+                "Run 'make install' after installing opencode globally, or re-run "
+                "'make config' and point OPENCODE_BIN at the actual install location.",
             ),
             "goose": (
                 Path(goose_bin or "/opt/homebrew/bin/goose"),
-                "Re-run 'make config' and point GOOSE_BIN at the actual goose "
-                "install location to keep the rule and runtime in sync.",
+                "Run 'make install' after installing goose globally, or re-run "
+                "'make config' and point GOOSE_BIN at the actual install location.",
             ),
         }
         for backend in sorted(backends_in_use & expected_bins.keys()):

--- a/src/kai/oneshot_binary.py
+++ b/src/kai/oneshot_binary.py
@@ -32,6 +32,8 @@ import os
 import shutil
 from pathlib import Path
 
+from kai.backend_registry import BackendRegistryError, backend_registry_is_authoritative, resolve_backend_command
+
 
 class BinaryResolutionError(Exception):
     """
@@ -92,6 +94,12 @@ def resolve_oneshot_binary(backend: str) -> str:
     caller's config validation upstream of this function has a
     bug, not the operator's PATH.
     """
+    if backend_registry_is_authoritative():
+        try:
+            return resolve_backend_command(backend)
+        except BackendRegistryError as e:
+            raise BinaryResolutionError(f"could not resolve {backend} binary from backend registry: {e}") from e
+
     if backend == "claude":
         # Structural mirror of the codex / opencode / goose arms.
         # CLAUDE_BIN, when set, is validated as a configuration error

--- a/src/kai/opencode.py
+++ b/src/kai/opencode.py
@@ -43,6 +43,7 @@ import os
 from typing import Literal
 
 from kai.acp import AcpBackend
+from kai.backend_registry import BackendRegistryError, backend_registry_is_authoritative, resolve_backend_command
 
 log = logging.getLogger(__name__)
 
@@ -265,7 +266,13 @@ class OpenCodeBackend(AcpBackend):
         installs with opencode on PATH keep working without the
         override.
         """
-        opencode_bin = os.environ.get("OPENCODE_BIN") or "opencode"
+        if backend_registry_is_authoritative():
+            try:
+                opencode_bin = resolve_backend_command("opencode", allow_bare_fallback=True)
+            except BackendRegistryError as e:
+                raise RuntimeError(f"OpenCode startup failed: {e}") from e
+        else:
+            opencode_bin = os.environ.get("OPENCODE_BIN") or "opencode"
         return [opencode_bin, "acp"]
 
     def build_env(self, base_env: dict[str, str]) -> dict[str, str]:

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from kai.backend_registry import (
+    BackendRegistryError,
+    render_backend_registry,
+    resolve_backend_command,
+)
+
+
+def _exe(path):
+    path.write_text("#!/bin/sh\nexit 0\n")
+    path.chmod(0o755)
+    return path
+
+
+def test_registry_command_wins_over_legacy_env(tmp_path, monkeypatch):
+    codex = _exe(tmp_path / "codex")
+    registry = tmp_path / "backends.yaml"
+    registry.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "backends": {
+                    "codex": {
+                        "driver": "codex",
+                        "runtime": "local_process",
+                        "command": str(codex),
+                    }
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+    monkeypatch.setenv("CODEX_BIN", str(tmp_path / "stale-codex"))
+
+    assert resolve_backend_command("codex") == str(codex)
+
+
+def test_present_registry_rejects_unknown_backend(tmp_path, monkeypatch):
+    registry = tmp_path / "backends.yaml"
+    registry.write_text("version: 1\nbackends: {}\n")
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+    with pytest.raises(BackendRegistryError, match="no entry"):
+        resolve_backend_command("codex")
+
+
+def test_registry_command_must_be_absolute(tmp_path, monkeypatch):
+    registry = tmp_path / "backends.yaml"
+    registry.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "backends": {
+                    "claude": {
+                        "driver": "claude",
+                        "runtime": "local_process",
+                        "command": "claude",
+                    }
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+    with pytest.raises(BackendRegistryError, match="not absolute"):
+        resolve_backend_command("claude")
+
+
+def test_default_missing_registry_uses_legacy_path_resolution(monkeypatch):
+    monkeypatch.delenv("KAI_BACKENDS_YAML", raising=False)
+    monkeypatch.delenv("CLAUDE_BIN", raising=False)
+    monkeypatch.setattr("kai.backend_registry.DEFAULT_BACKENDS_YAML", Path("/does/not/exist"))
+    monkeypatch.setattr("kai.backend_registry.shutil.which", lambda name: f"/fake/{name}")
+
+    assert resolve_backend_command("claude") == "/fake/claude"
+
+
+def test_explicit_missing_registry_fails(monkeypatch):
+    monkeypatch.setenv("KAI_BACKENDS_YAML", "/does/not/exist")
+
+    with pytest.raises(BackendRegistryError, match="does not exist"):
+        resolve_backend_command("claude")
+
+
+def test_render_backend_registry_is_stable():
+    rendered = render_backend_registry(
+        {
+            "codex": {"driver": "codex", "runtime": "local_process", "command": "/usr/local/bin/codex"},
+            "claude": {"driver": "claude", "runtime": "local_process", "command": "/opt/homebrew/bin/claude"},
+        }
+    )
+    data = yaml.safe_load(rendered)
+
+    assert list(data["backends"]) == ["claude", "codex"]
+    assert data["version"] == 1

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -18,6 +18,7 @@ import kai.install
 from kai.install import (
     _LAUNCHD_LABEL,
     ServiceStartError,
+    _apply_backend_registry,
     _apply_directories,
     _apply_goose_config,
     _apply_migrate,
@@ -331,6 +332,7 @@ class TestGenerateSudoers:
         assert f"{cat_path} /etc/kai/users.yaml" in result
         assert f"{cat_path} /etc/kai/workspaces.yaml" in result
         assert f"{cat_path} /etc/kai/memory-projects.yaml" in result
+        assert f"{cat_path} /etc/kai/backends.yaml" in result
         assert f"{cat_path} /etc/kai/totp.secret" in result
         assert f"{cat_path} /etc/kai/totp.attempts" in result
 
@@ -2988,6 +2990,7 @@ class TestCmdApply:
             "_apply_venv": 2,
             "_apply_models": 1,
             "_apply_secrets": 1,
+            "_apply_backend_registry": 2,
             "_apply_goose_config": 4,
             "_apply_sudoers": 1,
             "_apply_migrate": 4,
@@ -3745,6 +3748,7 @@ class TestCmdApplyDefaultModelGate:
             "_apply_venv",
             "_apply_models",
             "_apply_secrets",
+            "_apply_backend_registry",
             "_apply_goose_config",
             "_apply_sudoers",
             "_apply_migrate",
@@ -7070,6 +7074,35 @@ class TestApplySecretsDryRun:
         assert "/etc/kai/users.yaml" in output
 
 
+class TestApplyBackendRegistry:
+    def test_build_registry_uses_env_paths(self, monkeypatch):
+        monkeypatch.setattr("kai.install._resolve_default_claude_bin", lambda service_user: "/fallback/claude")
+        monkeypatch.setattr("kai.install._resolve_default_codex_bin", lambda: "/fallback/codex")
+
+        rendered = kai.install._build_backend_registry(
+            "kai",
+            {
+                "CLAUDE_BIN": "/custom/claude",
+                "CODEX_BIN": "/custom/codex",
+                "OPENCODE_BIN": "/custom/opencode",
+                "GOOSE_BIN": "/custom/goose",
+            },
+        )
+        data = yaml.safe_load(rendered)
+
+        assert data["backends"]["claude"]["command"] == "/custom/claude"
+        assert data["backends"]["codex"]["command"] == "/custom/codex"
+        assert data["backends"]["opencode"]["command"] == "/custom/opencode"
+        assert data["backends"]["goose"]["command"] == "/custom/goose"
+        assert "gpt-5.6-sol" in data["backends"]["codex"]["allowed_models"]
+
+    def test_dry_run_prints_registry_write(self, capsys):
+        _apply_backend_registry("kai", {}, dry_run=True)
+        output = capsys.readouterr().out
+        assert "/etc/kai/backends.yaml" in output
+        assert "0644" in output
+
+
 # ── _apply_secrets staging copy precedence ───────────────────────────
 
 
@@ -7622,6 +7655,7 @@ class TestCmdApplyStagingHandoff:
         monkeypatch.setattr("kai.install._apply_venv", lambda *a, **kw: None)
         monkeypatch.setattr("kai.install._apply_models", lambda *a, **kw: None)
         monkeypatch.setattr("kai.install._apply_secrets", _fake_apply_secrets)
+        monkeypatch.setattr("kai.install._apply_backend_registry", lambda *a, **kw: None)
         monkeypatch.setattr("kai.install._apply_sudoers", lambda *a, **kw: None)
         monkeypatch.setattr("kai.install._apply_migrate", lambda *a, **kw: None)
         monkeypatch.setattr("kai.install._apply_service", lambda *a, **kw: None)
@@ -8043,6 +8077,7 @@ class TestCmdApplySingleUserRefuses:
         monkeypatch.setattr("kai.install._apply_venv", lambda *a, **kw: None)
         monkeypatch.setattr("kai.install._apply_models", lambda *a, **kw: None)
         monkeypatch.setattr("kai.install._apply_secrets", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.install._apply_backend_registry", lambda *a, **kw: None)
         monkeypatch.setattr("kai.install._apply_sudoers", lambda *a, **kw: None)
         monkeypatch.setattr("kai.install._apply_migrate", lambda *a, **kw: None)
         monkeypatch.setattr("kai.install._apply_service", lambda *a, **kw: None)


### PR DESCRIPTION
## Summary

Adds an installed backend registry as the machine-capability boundary for local agent backends.

This moves Kai toward the model discussed from `kai-workspace-design.md`: user configuration selects a backend/model policy, while installed machine capabilities decide which executable may actually be run.

## What changed

- Added `src/kai/backend_registry.py`.
  - Loads `/etc/kai/backends.yaml` by default.
  - Supports `KAI_BACKENDS_YAML` for tests/explicit override.
  - Resolves backend IDs (`codex`, `claude`, `goose`, `opencode`) to admin-owned executable paths.
  - Rejects malformed registries and non-absolute/non-executable registry commands.
  - Preserves legacy `*_BIN` / PATH behavior when no installed registry is present.

- Updated local backend launch paths.
  - Persistent backends (`claude`, `codex`, `goose`, `opencode`) use the registry when it is authoritative.
  - One-shot binary resolution also uses the registry first.
  - Legacy behavior remains available for dev/test environments without an installed registry.

- Updated install.
  - `make install` now writes `/etc/kai/backends.yaml` with mode `0644`.
  - Registry entries are emitted for the installed local-process backends, not just the currently selected backend.
  - `sudoers` allows Kai to read `/etc/kai/backends.yaml`.
  - Existing `*_BIN` values remain compatibility inputs for the installer-generated registry.

- Updated diagnostics.
  - Backend path remediation now points toward `make install` / installed backend registry updates rather than user-owned config path edits.

## Security impact

This is the first step in closing off user-provided executable paths:

- Runtime users choose backend IDs and models.
- Installed/admin-owned configuration chooses executable paths.
- A present registry is authoritative and prevents silent fallback to arbitrary PATH binaries.
- Legacy fallback remains only for environments without an installed registry, preserving tests and development workflows.

This does not yet remove all legacy compatibility paths. It establishes the boundary so the next PR can tighten configuration validation without breaking installed Kai.

## Verification

- `.venv/bin/python -m pytest tests/test_backend_registry.py`
- `.venv/bin/python -m pytest tests/test_backend_registry.py tests/test_config.py::TestMemoryReasonerBinaryValidation tests/test_config.py::TestCodexMemorySameUserSymmetry tests/test_claude.py tests/test_codex.py tests/test_goose.py tests/test_opencode.py`
- `.venv/bin/python -m pytest tests/test_install.py`
- `.venv/bin/python -m pytest tests/test_config.py tests/test_backend_registry.py`
- `.venv/bin/python -m pytest`

Full suite result:

```text
4722 passed, 1 skipped in 36.24s
```

## Install note

After merge, run:

```sh
make install
```

That will create/update `/etc/kai/backends.yaml` for the installed service.
