### PR TITLE
Require backend registry in installed mode

### DIFF
--- a/src/kai/backend_registry.py
+++ b/src/kai/backend_registry.py
@@ -3,9 +3,9 @@ Installed backend registry.
 
 This module is the machine-capability boundary for local agent
 backends. User-facing configuration names backend IDs ("codex",
-"claude", etc.); executable paths are resolved from an admin-owned
-registry when present, with the legacy admin-owned ``*_BIN``
-environment variables retained as a compatibility fallback.
+"claude", etc.); protected installs resolve executable paths from
+an admin-owned registry. Single-user/dev runs keep the legacy
+``*_BIN`` / PATH fallback unless an explicit registry override is set.
 """
 
 from __future__ import annotations
@@ -20,6 +20,7 @@ import yaml
 
 DEFAULT_BACKENDS_YAML = Path("/etc/kai/backends.yaml")
 BACKENDS_YAML_ENV = "KAI_BACKENDS_YAML"
+INSTALL_DIR_ENV = "KAI_INSTALL_DIR"
 
 _BACKEND_ENV_VARS: dict[str, str] = {
     "claude": "CLAUDE_BIN",
@@ -58,26 +59,31 @@ def backend_registry_exists(path: Path | None = None) -> bool:
         return path.is_file()
     if os.environ.get(BACKENDS_YAML_ENV, "").strip():
         return backend_registry_path().is_file()
-    if not os.environ.get("KAI_INSTALL_DIR", "").strip():
+    if not os.environ.get(INSTALL_DIR_ENV, "").strip():
         return False
     return backend_registry_path().is_file()
 
 
+def backend_registry_required() -> bool:
+    """Return whether this process must use the backend registry."""
+    return bool(os.environ.get(BACKENDS_YAML_ENV, "").strip() or os.environ.get(INSTALL_DIR_ENV, "").strip())
+
+
 def backend_registry_is_authoritative() -> bool:
     """Return whether backend command resolution must use the registry."""
-    return bool(os.environ.get(BACKENDS_YAML_ENV, "").strip()) or backend_registry_exists()
+    return backend_registry_required() or backend_registry_exists()
 
 
 def load_backend_registry(path: Path | None = None) -> dict[str, BackendRegistryEntry]:
     """
     Load the admin-owned backend registry.
 
-    Returns an empty dict when no registry exists. A present but
-    malformed registry is a configuration error because runtime and
-    sudoers path decisions must not silently fall back to unrelated
-    binaries.
+    Returns an empty dict only for single-user/dev mode when no registry
+    exists. A missing required registry, or a present but malformed
+    registry, is a configuration error because runtime and sudoers path
+    decisions must not silently fall back to unrelated binaries.
     """
-    explicit_path = path is not None or bool(os.environ.get(BACKENDS_YAML_ENV, "").strip())
+    explicit_path = path is not None or backend_registry_required()
     registry_path = path or backend_registry_path()
     if not registry_path.is_file():
         if explicit_path:
@@ -157,9 +163,10 @@ def resolve_backend_command(backend: str, *, allow_bare_fallback: bool = False) 
     Resolve the command for an installed backend.
 
     Precedence:
-      1. admin-owned backend registry, if present;
-      2. legacy admin-owned ``*_BIN`` environment variable;
-      3. PATH lookup;
+      1. admin-owned backend registry for protected installs or explicit
+         registry overrides;
+      2. legacy ``*_BIN`` environment variable for single-user/dev mode;
+      3. PATH lookup for single-user/dev mode;
       4. optional bare command fallback for persistent/dev spawns.
     """
     backend = backend.strip().lower()

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -7,6 +7,7 @@ import yaml
 
 from kai.backend_registry import (
     BackendRegistryError,
+    backend_registry_is_authoritative,
     render_backend_registry,
     resolve_backend_command,
 )
@@ -74,11 +75,23 @@ def test_registry_command_must_be_absolute(tmp_path, monkeypatch):
 
 def test_default_missing_registry_uses_legacy_path_resolution(monkeypatch):
     monkeypatch.delenv("KAI_BACKENDS_YAML", raising=False)
+    monkeypatch.delenv("KAI_INSTALL_DIR", raising=False)
     monkeypatch.delenv("CLAUDE_BIN", raising=False)
     monkeypatch.setattr("kai.backend_registry.DEFAULT_BACKENDS_YAML", Path("/does/not/exist"))
     monkeypatch.setattr("kai.backend_registry.shutil.which", lambda name: f"/fake/{name}")
 
     assert resolve_backend_command("claude") == "/fake/claude"
+
+
+def test_installed_mode_missing_registry_fails(monkeypatch):
+    monkeypatch.delenv("KAI_BACKENDS_YAML", raising=False)
+    monkeypatch.setenv("KAI_INSTALL_DIR", "/opt/kai")
+    monkeypatch.setenv("CLAUDE_BIN", "/tmp/legacy-claude")
+    monkeypatch.setattr("kai.backend_registry.DEFAULT_BACKENDS_YAML", Path("/does/not/exist"))
+
+    assert backend_registry_is_authoritative()
+    with pytest.raises(BackendRegistryError, match="does not exist"):
+        resolve_backend_command("claude")
 
 
 def test_explicit_missing_registry_fails(monkeypatch):


### PR DESCRIPTION
## Summary

Requires the installed backend registry whenever Kai is running in protected/installed mode.

After #754, `/etc/kai/backends.yaml` exists and defines the installed backend commands. This PR closes the remaining protected-mode fallback where a missing registry could silently fall back to legacy `*_BIN` or PATH resolution.

## What changed

- Added an explicit installed-mode registry requirement.
  - `KAI_INSTALL_DIR` set => backend registry is authoritative.
  - `KAI_BACKENDS_YAML` set => backend registry is authoritative.
  - Missing required registry now fails closed.

- Preserved single-user/dev behavior.
  - If neither `KAI_INSTALL_DIR` nor `KAI_BACKENDS_YAML` is set, missing `/etc/kai/backends.yaml` still falls back to the legacy local resolution path.
  - This keeps simple `make config` / `make run` workflows working.

- Added a regression test proving installed mode does not fall back to `CLAUDE_BIN` when the registry is missing.

## Security impact

Protected installs now use `/etc/kai/backends.yaml` as the mandatory machine-capability boundary. If the registry is absent or malformed, Kai fails instead of resolving backend commands from environment variables or PATH.

This does not remove single-user local resolution. That should be handled separately with a per-user/local backend registry design.

## Verification

- `.venv/bin/python -m pytest tests/test_backend_registry.py tests/test_oneshot_binary.py tests/test_claude.py tests/test_codex.py tests/test_goose.py tests/test_opencode.py`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/python -m pytest`

Full suite result:

```text
4723 passed, 1 skipped in 35.91s
```
