### PR TITLE
Move agent default model into registry

### DIFF
--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -72,12 +72,12 @@ from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude
 log = logging.getLogger(__name__)
 
 
-# Codex is openai-only in v1. Pool.py resolves self.model via
-# PROVIDER_DEFAULTS["openai"] (currently "gpt-5.4") for codex-backed
-# users, so the value is already in OpenAI's native form ("gpt-5.4",
-# "gpt-5.4-mini", "gpt-5.4-nano"). No logical-name remapping is
-# needed at this layer, unlike goose.py which translates "sonnet" /
-# "opus" / "haiku" to claude-sonnet-4-6 etc for the Anthropic case.
+# Codex is openai-only in v1. Pool.py resolves self.model through the
+# backend/provider model registry for codex-backed users, so the value
+# is already in Codex's native model form ("gpt-5.6-sol", "gpt-5.5",
+# "gpt-5.4-mini", etc.). No logical-name remapping is needed at this
+# layer, unlike goose.py which translates "sonnet" / "opus" / "haiku"
+# to claude-sonnet-4-6 etc for the Anthropic case.
 # If a future codex version accepts a Kai-internal alias, add a map
 # here and apply it before setting CODEX_MODEL on the subprocess env.
 

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -187,14 +187,11 @@ PROVIDER_MODELS: dict[str, dict[str, str]] = {
     },
 }
 
-# Default model for each provider, used as the wizard prompt
-# suggestion for the conversational role (DEFAULT_MODEL / per-user
-# `models.agent`). The conversational role does the most work and
-# the heaviest work in the Kai system; defaulting to a balanced or
-# speed-tier model on this surface underspends on the highest-value
-# path. Each entry below is the strongest curated model the provider
-# offers. Open-ended providers (openrouter, ollama) have no entry;
-# users on those providers MUST set a model explicitly.
+# Strongest curated model for provider-only callers such as the model
+# reset UI. Install-wide conversational defaults are backend-aware and
+# live in MODEL_REGISTRY[ModelRole.AGENT]; do not use this table as an
+# install/runtime fallback for an arbitrary backend/provider pair. Each
+# entry below is the strongest curated model the provider offers.
 #
 # Non-agent roles (PR review, issue triage, memory extraction,
 # memory episode, behavioral judge, behavioral gen) use the tier
@@ -269,18 +266,11 @@ _ALL_CURATED_MODELS: frozenset[str] = frozenset(
 
 # ── Per-role model registry ──────────────────────────────────────────
 #
-# Maps (backend, role) -> the model identifier each backend's CLI
-# accepts as --model for that role. Centralizes per-function defaults
-# so codex and any future backend can declare its mapping in one place
-# instead of scattered _TRIAGE_MODEL / _REVIEW_MODEL / _DEFAULT_*
+# Maps (backend, provider, role) -> the model identifier each backend's
+# CLI accepts as --model for that role. Centralizes defaults so codex
+# and any future backend can declare their model surface in one place
+# instead of scattered _TRIAGE_MODEL / _REVIEW_MODEL / DEFAULT_MODEL
 # constants across modules.
-#
-# Scope: only the four one-shot agent roles whose model strings move
-# between backends in the codex epic. CONVERSATION is excluded
-# deliberately: conversational model selection is owned by pool.py +
-# DEFAULT_MODEL + PROVIDER_DEFAULTS, and routing it through the
-# registry would collide with the per-user override layer that
-# users.yaml / /settings already provide.
 
 
 class ModelRole(StrEnum):
@@ -294,6 +284,7 @@ class ModelRole(StrEnum):
     that backend's CLI as --model.
     """
 
+    AGENT = "agent"
     PR_REVIEW = "pr_review"
     ISSUE_TRIAGE = "issue_triage"
     BEHAVIORAL_JUDGE = "behavioral_judge"
@@ -317,6 +308,7 @@ class ModelRole(StrEnum):
 # reasoning) means one line here plus a per-(backend, provider)
 # tier-map entry in lockstep.
 _TIER_BY_ROLE: dict[ModelRole, str] = {
+    ModelRole.AGENT: "agent",
     ModelRole.PR_REVIEW: "balanced",
     ModelRole.ISSUE_TRIAGE: "balanced",
     ModelRole.MEMORY_EXTRACTION: "cheap",
@@ -347,19 +339,23 @@ _BACKEND_PROVIDER_TIER_MODELS: dict[tuple[str, str], dict[str, str]] = {
     # cheap-tier roles where a fully-pinned model version is
     # preferable so an automated stage-2 episode generation stays
     # reproducible across CLI version bumps.
-    ("claude", "anthropic"): {"balanced": "sonnet", "cheap": "claude-haiku-4-5-20251001"},
+    ("claude", "anthropic"): {"agent": "sonnet", "balanced": "sonnet", "cheap": "claude-haiku-4-5-20251001"},
     # Codex CLI accepts the OpenAI model surface. gpt-5.5 is the
     # current frontier reasoning model; gpt-5.4-mini stays as the
     # cheap tier for high-volume roles (memory extraction, episode
     # generation, behavioral judge).
-    ("codex", "openai"): {"balanced": "gpt-5.5", "cheap": "gpt-5.4-mini"},
+    ("codex", "openai"): {"agent": CODEX_DEFAULT_MODEL, "balanced": "gpt-5.5", "cheap": "gpt-5.4-mini"},
     # OpenCode/Anthropic surface uses the `anthropic/<model>`
     # provider-prefixed shape; the model halves match the current
     # Claude SKUs (Sonnet 4.6 and Haiku 4.5 as of 2026-06-09).
-    ("opencode", "anthropic"): {"balanced": "anthropic/claude-sonnet-4-6", "cheap": "anthropic/claude-haiku-4-5"},
+    ("opencode", "anthropic"): {
+        "agent": "anthropic/claude-sonnet-4-6",
+        "balanced": "anthropic/claude-sonnet-4-6",
+        "cheap": "anthropic/claude-haiku-4-5",
+    },
     # OpenCode/OpenAI: same tier split as codex/openai but in the
     # opencode provider-prefixed shape.
-    ("opencode", "openai"): {"balanced": "openai/gpt-5.5", "cheap": "openai/gpt-5.4-mini"},
+    ("opencode", "openai"): {"agent": "openai/gpt-5.5", "balanced": "openai/gpt-5.5", "cheap": "openai/gpt-5.4-mini"},
     # DeepSeek V4 first-class OpenCode surface (V4 Pro and V4 Flash).
     # The legacy `deepseek-chat` / `deepseek-reasoner` aliases (mode
     # flags on V4 Flash) retire 2026-07-24, so do not use them in
@@ -368,33 +364,55 @@ _BACKEND_PROVIDER_TIER_MODELS: dict[tuple[str, str], dict[str, str]] = {
     # for high-volume / latency-sensitive roles (the cheap tier
     # covers memory extraction / memory episode / behavioral_judge).
     # Same 1M context on both; the split is capability-vs-cost.
-    ("opencode", "deepseek"): {"balanced": "deepseek/deepseek-v4-pro", "cheap": "deepseek/deepseek-v4-flash"},
+    ("opencode", "deepseek"): {
+        "agent": "deepseek/deepseek-v4-pro",
+        "balanced": "deepseek/deepseek-v4-pro",
+        "cheap": "deepseek/deepseek-v4-flash",
+    },
     # Google's most advanced for complex tasks per the Gemini API
     # docs (2026-06-09) is gemini-2.5-pro; gemini-2.5-flash is the
     # speed/cost tier. The 3.x family is mostly Preview / specialized.
-    ("opencode", "google"): {"balanced": "google/gemini-2.5-pro", "cheap": "google/gemini-2.5-flash"},
+    ("opencode", "google"): {
+        "agent": "google/gemini-2.5-pro",
+        "balanced": "google/gemini-2.5-pro",
+        "cheap": "google/gemini-2.5-flash",
+    },
     # OpenRouter's "provider/model" shape nests under opencode's own
     # "provider/model" prefix; the structural check accepts this
     # because the outer slash is what matters to opencode.
     ("opencode", "openrouter"): {
+        "agent": "openrouter/anthropic/claude-sonnet-4-6",
         "balanced": "openrouter/anthropic/claude-sonnet-4-6",
         "cheap": "openrouter/anthropic/claude-haiku-4-5",
     },
-    ("opencode", "ollama"): {"balanced": "ollama/llama4:70b", "cheap": "ollama/llama4:8b"},
-    ("goose", "anthropic"): {"balanced": "claude-sonnet-4-6", "cheap": "claude-haiku-4-5"},
-    ("goose", "openai"): {"balanced": "gpt-5.5", "cheap": "gpt-5.4-mini"},
+    ("opencode", "ollama"): {
+        "agent": "ollama/llama4:70b",
+        "balanced": "ollama/llama4:70b",
+        "cheap": "ollama/llama4:8b",
+    },
+    ("goose", "anthropic"): {
+        "agent": "claude-sonnet-4-6",
+        "balanced": "claude-sonnet-4-6",
+        "cheap": "claude-haiku-4-5",
+    },
+    ("goose", "openai"): {"agent": "gpt-5.5-pro", "balanced": "gpt-5.5", "cheap": "gpt-5.4-mini"},
     # goose-on-deepseek: bare model names; goose passes them through
     # to the provider API directly (no opencode-style "provider/"
     # prefix). Same Pro / Flash split as opencode-on-deepseek above;
     # same 2026-07-24 deprecation reason for skipping the legacy
     # `deepseek-chat` alias.
-    ("goose", "deepseek"): {"balanced": "deepseek-v4-pro", "cheap": "deepseek-v4-flash"},
-    ("goose", "google"): {"balanced": "gemini-2.5-pro", "cheap": "gemini-2.5-flash"},
+    ("goose", "deepseek"): {
+        "agent": "deepseek-v4-pro",
+        "balanced": "deepseek-v4-pro",
+        "cheap": "deepseek-v4-flash",
+    },
+    ("goose", "google"): {"agent": "gemini-2.5-pro", "balanced": "gemini-2.5-pro", "cheap": "gemini-2.5-flash"},
     ("goose", "openrouter"): {
+        "agent": "openrouter/anthropic/claude-sonnet-4-6",
         "balanced": "openrouter/anthropic/claude-sonnet-4-6",
         "cheap": "openrouter/anthropic/claude-haiku-4-5",
     },
-    ("goose", "ollama"): {"balanced": "llama4:70b", "cheap": "llama4:8b"},
+    ("goose", "ollama"): {"agent": "llama4:70b", "balanced": "llama4:70b", "cheap": "llama4:8b"},
 }
 
 
@@ -472,6 +490,11 @@ def get_model_for(role: ModelRole, backend: str, provider: str, override: str = 
         raise LookupError(
             f"No registry entry for (backend={backend}, provider={effective_provider}, role={role.value})"
         ) from None
+
+
+def get_default_model_for_backend(backend: str, provider: str) -> str:
+    """Resolve the registry default for the conversational agent role."""
+    return get_model_for(ModelRole.AGENT, backend, provider)
 
 
 def _check_model_registry_complete() -> None:
@@ -1172,7 +1195,10 @@ class Config:
     telegram_webhook_secret: str | None = None
 
     # Claude Code process configuration
-    default_model: str = "sonnet"
+    # Real runtime config is populated by load_config() from
+    # MODEL_REGISTRY[ModelRole.AGENT]. Empty here prevents direct
+    # Config() construction from silently assuming a Claude model.
+    default_model: str = ""
     # Global per-role model defaults. Parsed from DEFAULT_MODELS_JSON
     # env var at load time as a JSON object: keys are role identifiers
     # ("agent" plus every ModelRole.value), values are model strings.
@@ -2388,9 +2414,10 @@ def _load_user_configs(
             )
 
         # Warn if user is on an open-ended provider with no model set.
-        # PROVIDER_DEFAULTS has no entry for openrouter/ollama, so the
-        # pool would fall back to the global default_model (e.g., "sonnet")
-        # which is almost certainly wrong for that provider.
+        # The registry has an agent default for each shipped
+        # backend/provider pair, but openrouter/ollama installations are
+        # operator-specific enough that a per-user explicit model is
+        # still preferable.
         model = entry.get("model")
         if model is not None:
             model = str(model).strip().lower()
@@ -3282,8 +3309,10 @@ def load_config() -> Config:
                 ", ".join(features),
             )
 
+    global_provider = get_effective_provider(default_backend, default_provider)
+    configured_default_model = os.environ.get("DEFAULT_MODEL", "").strip()
     default_model = canonicalize_model_for_backend(
-        os.environ.get("DEFAULT_MODEL", "sonnet"),
+        configured_default_model or get_default_model_for_backend(default_backend, global_provider),
         default_backend,
     )
 
@@ -3321,21 +3350,22 @@ def load_config() -> Config:
             value_str = canonicalize_model_for_backend(value_str, default_backend)
             default_models[role_key] = value_str
 
-    # Validate DEFAULT_MODEL against the effective global backend.
+    # Validate DEFAULT_MODEL / registry agent default against the
+    # effective global backend.
     # Codex installs validate against CODEX_MODELS only - no fallback
     # to PROVIDER_MODELS["openai"]. Other backends still use the
     # provider-only validator. Catches typos at startup instead of
     # letting them propagate to a confusing runtime failure.
-    global_provider = get_effective_provider(default_backend, default_provider)
     if not validate_model_for_backend(default_model, default_backend, global_provider):
+        source_label = "DEFAULT_MODEL" if configured_default_model else "MODEL_REGISTRY agent default"
         if default_backend == "codex":
             valid = sorted(CODEX_MODELS.keys())
             raise SystemExit(
-                f"DEFAULT_MODEL '{default_model}' is not valid for codex (must be one of: {', '.join(valid)})"
+                f"{source_label} '{default_model}' is not valid for codex (must be one of: {', '.join(valid)})"
             )
         valid = sorted(PROVIDER_MODELS.get(global_provider, {}).keys())
         raise SystemExit(
-            f"DEFAULT_MODEL '{default_model}' is not valid for provider "
+            f"{source_label} '{default_model}' is not valid for provider "
             f"'{global_provider}' (must be one of: {', '.join(valid)})"
         )
 

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -44,14 +44,12 @@ from kai.config import (
     _VALID_ROLES,
     BACKEND_PROVIDERS,
     BACKENDS_NEEDING_PROVIDER_PROMPT,
-    CODEX_DEFAULT_MODEL,
     CODEX_EFFORT_LEVELS,
     CODEX_MODELS,
     EFFORT_LEVELS,
     MODEL_REGISTRY,
     ONESHOT_REASONER_BACKENDS,
     PROJECT_ROOT,
-    PROVIDER_DEFAULTS,
     PROVIDER_KEY_VARS,
     PROVIDER_MODELS,
     VALID_BACKENDS,
@@ -59,6 +57,7 @@ from kai.config import (
     _read_protected_file,
     _resolve_renamed_key,
     canonicalize_model_for_backend,
+    get_default_model_for_backend,
     models_for_backend,
     validate_model_for_backend,
 )
@@ -306,7 +305,13 @@ def _prompt_bool(label: str, default: bool = False) -> bool:
 
 def _prompt_default_model(agent_backend: str, eff_provider: str, default_val: str) -> str:
     """
-    Prompt for DEFAULT_MODEL, dispatching on the active backend.
+    Deprecated compatibility helper for the retired DEFAULT_MODEL prompt.
+
+    The install wizard no longer calls this. The conversational default
+    is MODEL_REGISTRY's ModelRole.AGENT row for the active
+    backend/provider. Keep this helper temporarily so older tests and
+    out-of-tree tooling that monkeypatch it fail softly rather than
+    raising AttributeError.
 
     Three shapes of model surface need different prompts:
     - Codex backend ships its own curated CLI model list (CODEX_MODELS)
@@ -321,11 +326,9 @@ def _prompt_default_model(agent_backend: str, eff_provider: str, default_val: st
       without a PROVIDER_MODELS entry) accept arbitrary model
       identifiers; the operator types one via _prompt(required=True).
 
-    The required=True on the open-ended branch forces the operator to
-    commit to a concrete model string. load_config falls back to "sonnet"
-    when DEFAULT_MODEL is empty or missing, and "sonnet" is anthropic-only;
-    letting the operator leave the field blank on an open-ended provider
-    would set them up for a startup-time validation failure.
+    The required=True on the open-ended branch forced the operator to
+    commit to a concrete model string. Current installs should use the
+    agent row in MODEL_REGISTRY instead.
 
     Args:
         agent_backend: The active backend ("claude", "codex", "goose").
@@ -1514,70 +1517,24 @@ def _cmd_config() -> None:
             print(f"  Path '{goose_bin}' is not an absolute path to an existing executable.")
 
     # -- Agent --
-    # DEFAULT_MODEL and DEFAULT_TIMEOUT are
-    # inheritable installation defaults:
-    # users.yaml entries that omit a per-user override fall back to
-    # these values at runtime. The prompts therefore fire on every
-    # wizard run regardless of users.yaml presence. The previous
-    # users_yaml_exists gate skipped them entirely on the
-    # re-run-with-users.yaml path, which let a stale global model
-    # survive a backend switch (the operator-visible bug: switching
-    # DEFAULT_BACKEND from one model surface to another left the prior
-    # value unchanged because the re-validation path never ran).
-    #
     # Determine the effective provider for model choices. Claude
-    # backend always uses Anthropic; Goose uses the selected provider.
+    # backend always uses Anthropic; Codex always uses OpenAI; multi-
+    # provider backends use the selected provider. The conversational
+    # default model is no longer prompted here; it is the
+    # MODEL_REGISTRY[ModelRole.AGENT] row for this backend/provider.
+    # Existing DEFAULT_MODEL / CLAUDE_MODEL keys are intentionally not
+    # re-emitted so re-running the wizard migrates installs back to the
+    # registry default. Per-user `models.agent` remains the override
+    # surface for individual users.
     eff_provider = "anthropic" if agent_backend == "claude" else llm_provider
 
-    def _default_model_prefill() -> str:
-        """Backend-aware prefill for the re-prompt-after-reject path.
-
-        Codex installs use CODEX_DEFAULT_MODEL (independent from
-        PROVIDER_DEFAULTS["openai"] which goose-on-openai still
-        consults). Other backends use PROVIDER_DEFAULTS[eff_provider].
-        """
-        if agent_backend == "codex":
-            return CODEX_DEFAULT_MODEL
-        return PROVIDER_DEFAULTS.get(eff_provider, "")
-
     print("-- Agent --")
-    # DEFAULT_MODEL is an inheritable installation default; the prompt
-    # fires on every wizard run with the existing env value prefilled
-    # when it validates for the (possibly newly chosen) backend.
-    # Always routing through _prompt_default_model is load-bearing for
-    # the operator who wants to change the global model without
-    # changing backends: the previous "keep silently on valid match"
-    # shortcut left them with no path to update it via the wizard.
-    #
-    # Re-validation is backend-aware, not provider-only: codex rejects
-    # gpt-5.4-nano even though it's valid for goose-on-openai, so a
-    # backend switch with a model that lives only on the prior surface
-    # falls through to the curated default. Empty raw_existing_model
-    # also fails validation; the _prompt(required=True) branch in
-    # _prompt_default_model handles the open-ended case.
-    #
-    # When the existing value fails validation, the rejection reason
-    # is printed and the prefill becomes the backend-aware default
-    # rather than the rejected value, because _prompt_default_model
-    # returns its default parameter without re-validating against the
-    # choices list. Prefilling the bad value would let the operator
-    # accept the just-rejected value with Enter.
-    raw_existing_model = existing_env.get("DEFAULT_MODEL", existing_env.get("CLAUDE_MODEL", ""))
-    raw_existing_model = canonicalize_model_for_backend(raw_existing_model, agent_backend)
-    if raw_existing_model and validate_model_for_backend(raw_existing_model, agent_backend, eff_provider):
-        default_model_prefill_value = raw_existing_model
-    else:
-        if raw_existing_model:
-            surface = "codex" if agent_backend == "codex" else f"provider '{eff_provider}'"
-            print(f"  DEFAULT_MODEL '{raw_existing_model}' is not valid for {surface}. Please choose a new default.")
-        default_model_prefill_value = _default_model_prefill()
-    model = _prompt_default_model(agent_backend, eff_provider, default_model_prefill_value)
 
     # Per-role model customization. The conversational role (`agent`)
-    # was just captured via `_prompt_default_model` above; this block
-    # offers the six non-conversational roles (PR review, issue triage,
-    # memory extraction, memory episode, behavioral judge, behavioral
-    # gen) as an optional follow-up. Default-accept is one keystroke
+    # is not prompted; its default is marked in MODEL_REGISTRY. This
+    # block offers the non-conversational roles (PR review, issue
+    # triage, memory extraction, memory episode, behavioral judge,
+    # behavioral gen) as an optional follow-up. Default-accept is one keystroke
     # ("no, use registry defaults"); operators who want per-role
     # control answer yes and walk the role list.
     #
@@ -1619,6 +1576,8 @@ def _cmd_config() -> None:
         # Walk every ModelRole regardless so the wizard surfaces the
         # full set; operators accept defaults to skip individual roles.
         for role in ModelRole:
+            if role is ModelRole.AGENT:
+                continue
             role_key = role.value
             try:
                 role_default = MODEL_REGISTRY[(agent_backend, eff_provider, role)]
@@ -2305,16 +2264,12 @@ def _cmd_config() -> None:
     env.pop("MEMORY_EPISODE_BUDGET_USD", None)
     env.pop("MEMORY_SCOPED_RECALL_ENABLED", None)
     env.pop("MEMORY_RECALL_SHADOW_ENABLED", None)
-
-    # DEFAULT_MODEL is always emitted. The model is global (per-user
-    # values in users.yaml are overrides on top of it, not replacements),
-    # and load_config validates DEFAULT_MODEL against the effective
-    # provider at startup. The load_config fallback ("sonnet") is
-    # anthropic-only, so omitting the key on non-anthropic backends
-    # produces a startup-time SystemExit; emitting it unconditionally
-    # makes the env file self-describing and forces the wizard layer
-    # to own the validation responsibility.
-    env["DEFAULT_MODEL"] = model
+    # DEFAULT_MODEL / CLAUDE_MODEL are retired from the wizard output.
+    # The conversational default now comes from MODEL_REGISTRY's
+    # ModelRole.AGENT row for the active backend/provider. Existing
+    # hand-edited DEFAULT_MODEL remains loadable, but re-running
+    # `make config` migrates back to the registry default.
+    env.pop("DEFAULT_MODEL", None)
 
     # DEFAULT_MODELS_JSON carries the per-role customization overrides
     # captured above (delta-from-defaults: only roles the operator
@@ -4490,11 +4445,10 @@ def _cmd_apply() -> None:
         ) from exc
 
     # Defensive validation: refuse to apply an install.conf whose
-    # (DEFAULT_MODEL, effective_provider) pair would fail load_config's
-    # startup check. Without this gate, apply would stop the service,
-    # rewrite /etc/kai/env, then the next service start would crash with
-    # an inscrutable message; the operator would see a partial-state
-    # installation and a dead bot.
+    # explicit DEFAULT_MODEL would fail load_config's startup check.
+    # DEFAULT_MODEL itself is no longer required; when absent,
+    # load_config uses MODEL_REGISTRY's ModelRole.AGENT row for the
+    # active backend/provider.
     #
     # Normalize the same way load_config does (config.py reads both env
     # vars through .strip().lower() before validating). A hand-edited
@@ -4503,10 +4457,6 @@ def _cmd_apply() -> None:
     # the apply gate, and then fail at startup. The legacy AGENT_BACKEND
     # key was already migrated to DEFAULT_BACKEND at the top of apply.
     #
-    # Resolve the same fallback load_config uses ("" -> "sonnet"). An
-    # empty or missing DEFAULT_MODEL is silently promoted at runtime;
-    # if we do not mirror that promotion here, the apply gate misses
-    # the missing-key case that is precisely what this gate exists for.
     default_model_raw = env.get("DEFAULT_MODEL", "")
     agent_backend_raw = env.get("DEFAULT_BACKEND", "claude").strip().lower()
     # Write the normalized value back so the downstream goose-config and
@@ -4522,7 +4472,15 @@ def _cmd_apply() -> None:
     # already migrated to it at the top of apply.
     provider_raw = env.get("DEFAULT_PROVIDER", "").strip().lower()
     eff_provider_for_check = "anthropic" if agent_backend_raw == "claude" else provider_raw
-    resolved_model = canonicalize_model_for_backend(default_model_raw or "sonnet", agent_backend_raw)
+    try:
+        registry_default_model = get_default_model_for_backend(agent_backend_raw, eff_provider_for_check)
+    except LookupError as exc:
+        raise SystemExit(
+            f"MODEL_REGISTRY has no agent default for backend '{agent_backend_raw}' "
+            f"and provider '{eff_provider_for_check}'. No usable default model is installed; "
+            "fix src/kai/config.py or set an explicit compatible DEFAULT_MODEL before applying."
+        ) from exc
+    resolved_model = canonicalize_model_for_backend(default_model_raw or registry_default_model, agent_backend_raw)
     if default_model_raw and resolved_model != default_model_raw:
         env["DEFAULT_MODEL"] = resolved_model
     # Backend-aware validation: codex installs validate against
@@ -4542,15 +4500,15 @@ def _cmd_apply() -> None:
             surface_label = f"provider '{eff_provider_for_check}'"
         if default_model_raw:
             msg = f"install.conf has DEFAULT_MODEL='{default_model_raw}' which is not valid for {surface_label}."
+            remedy = "Remove DEFAULT_MODEL to use the registry default, or set a compatible model."
         else:
             msg = (
-                f"install.conf has no DEFAULT_MODEL; the load_config fallback "
-                f"'sonnet' is not valid for {surface_label}."
+                f"MODEL_REGISTRY agent default '{registry_default_model}' is not valid for {surface_label}; "
+                "no usable default model is installed."
             )
+            remedy = "Fix MODEL_REGISTRY's agent row or set an explicit compatible DEFAULT_MODEL."
         valid_list = ", ".join(valid_models) or "(no curated list)"
-        raise SystemExit(
-            f"{msg} Re-run 'python -m kai install config' to pick a compatible model. Valid models: {valid_list}"
-        )
+        raise SystemExit(f"{msg} {remedy} Valid models: {valid_list}")
 
     dry_run = os.environ.get("DRY_RUN", "").strip() in ("1", "true", "yes")
     if dry_run:

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -23,12 +23,11 @@ from kai import sessions
 from kai.backend import AgentBackend, StreamEvent, resolve_home_workspace
 from kai.claude import ClaudeCodeBackend
 from kai.config import (
-    CODEX_DEFAULT_MODEL,
     OPEN_ENDED_PROVIDERS,
-    PROVIDER_DEFAULTS,
     Config,
     WorkspaceConfig,
     canonicalize_model_for_backend,
+    get_default_model_for_backend,
     get_effective_provider,
     get_user_backend_and_provider,
     validate_model_for_backend,
@@ -192,7 +191,8 @@ class SubprocessPool:
         elif backend == self._config.default_backend and effective_provider == global_provider:
             model = self._config.default_model
             # Catch the case where the global backend itself is an open-ended
-            # provider and DEFAULT_MODEL is something generic like "sonnet".
+            # provider and DEFAULT_MODEL is a backend-specific value
+            # that may be invalid for the open-ended provider.
             # Startup validation passes because open-ended providers accept
             # any model string, but the provider API will reject it.
             if effective_provider in OPEN_ENDED_PROVIDERS:
@@ -203,41 +203,8 @@ class SubprocessPool:
                     chat_id,
                     model,
                 )
-        elif backend == "codex":
-            # Per-user codex override on a non-codex global install.
-            # Use codex's own default (gpt-5.5) - not PROVIDER_DEFAULTS["openai"]
-            # which goose-on-openai still consults and which would
-            # bypass the codex/goose surface separation.
-            model = CODEX_DEFAULT_MODEL
-        elif backend == "opencode":
-            # Per-user opencode override on a non-opencode global install
-            # with no user.model. There is no safe per-provider default
-            # we can guess (opencode model strings are full provider/model
-            # IDs and we do not know which providers the operator has
-            # authenticated). Pass empty so OpenCodeBackend.build_env
-            # skips OPENCODE_CONFIG_CONTENT and OpenCode falls back to
-            # its own config files. Warn so the operator notices.
-            log.warning(
-                "No model configured for opencode user %d; OpenCode will use "
-                "its own config defaults (set DEFAULT_MODEL globally or per-user "
-                "in users.yaml to override)",
-                chat_id,
-            )
-            model = ""
         else:
-            model = PROVIDER_DEFAULTS.get(effective_provider, "")
-            if not model:
-                # Open-ended provider (openrouter, ollama) with no model configured.
-                # Use the global default as a last resort but warn - it's almost
-                # certainly wrong (e.g., "sonnet" sent to ollama).
-                log.warning(
-                    "No model configured for provider '%s' (chat %d); "
-                    "falling back to global default '%s' which may not be valid",
-                    effective_provider,
-                    chat_id,
-                    self._config.default_model,
-                )
-                model = self._config.default_model
+            model = get_default_model_for_backend(backend, effective_provider)
 
         # Canonicalize retired backend-specific spellings after the
         # complete precedence cascade and before constructing a backend.

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -730,7 +730,7 @@ async def resolve_user_defaults(
 
     backend, _provider = get_user_backend_and_provider(user_config, config)
 
-    # Model: DB > users.yaml > env > "sonnet".
+    # Model: DB > users.yaml > registry/env default.
     # Strip whitespace so "" and " " don't pass through as valid model
     # names. The UI validates before storing, but direct DB manipulation
     # could insert empty strings that cause confusing runtime errors.

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -74,7 +74,7 @@ from kai.bot import (
     handle_workspace_callback,
     handle_workspaces,
 )
-from kai.config import PROVIDER_MODELS, Config, UserConfig
+from kai.config import PROVIDER_MODELS, Config, UserConfig, get_default_model_for_backend
 from kai.review import CollectionWarning, PRReviewResult
 from kai.tts import DEFAULT_VOICE, VOICES
 from kai.workspace_utils import is_workspace_allowed
@@ -604,6 +604,7 @@ def _make_config(**overrides) -> Config:
         "webhook_port": 8080,
         "tts_enabled": False,
         "voice_enabled": False,
+        "default_model": get_default_model_for_backend("claude", "anthropic"),
     }
     defaults.update(overrides)
     return Config(**defaults)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3257,20 +3257,12 @@ class TestProtectedUserIsolationPreflight:
 
 class TestCmdConfigDefaultModelDispatch:
     """
-    Wizard dispatch for DEFAULT_MODEL when users.yaml exists.
+    Wizard handling for retired DEFAULT_MODEL prompting.
 
-    Dispatch shape:
-    - _prompt_default_model fires on every wizard run, regardless of
-      whether the existing value validates;
-    - the prefill is the existing value when it validates against the
-      effective backend, otherwise the backend-aware curated default
-      (never the just-rejected value).
-
-    Always routing through the prompt is load-bearing: it lets an
-    operator with users.yaml present change the inherited global
-    model via `make config` instead of needing to hand-edit
-    /etc/kai/env. The previous "keep silently on valid match"
-    shortcut closed that path.
+    The conversational default now comes from MODEL_REGISTRY's
+    ModelRole.AGENT row for the effective backend/provider. Re-running
+    the wizard does not call _prompt_default_model and does not emit
+    DEFAULT_MODEL, even when an older install.conf still carries one.
 
     The wizard has many prompts that fire before and after the model
     dispatch. The helper below mocks _prompt_default_model to capture
@@ -3332,7 +3324,7 @@ class TestCmdConfigDefaultModelDispatch:
             "polling",  # transport
             "claude",  # agent backend
             "/usr/bin/true",  # claude binary path
-            # model prompt is handled by the _prompt_default_model mock
+            # no DEFAULT_MODEL prompt; agent default comes from MODEL_REGISTRY
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout (global default)
             "0",  # max session age hours (0 = no limit)
@@ -3374,7 +3366,7 @@ class TestCmdConfigDefaultModelDispatch:
             # No OPENAI_API_KEY prompt in subscription mode
             "/usr/local/bin/codex",  # codex binary path
             # No provider prompt (codex is single-provider; absent from BACKENDS_NEEDING_PROVIDER_PROMPT)
-            # Model prompt handled by the _prompt_default_model mock
+            # no DEFAULT_MODEL prompt; agent default comes from MODEL_REGISTRY
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout (global default)
             "0",  # max session age hours (0 = no limit)
@@ -3408,7 +3400,7 @@ class TestCmdConfigDefaultModelDispatch:
             "/opt/homebrew/bin/goose",  # goose binary path (validator stubbed)
             "openai",  # llm provider
             "openai-key",  # OPENAI_API_KEY
-            # model prompt is handled by the _prompt_default_model mock
+            # no DEFAULT_MODEL prompt; agent default comes from MODEL_REGISTRY
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout (global default)
             "0",  # max session age hours (0 = no limit)
@@ -3432,9 +3424,9 @@ class TestCmdConfigDefaultModelDispatch:
         """
         Run _cmd_config with _prompt_default_model mocked.
 
-        Returns (mock_object, written_env) where mock_object exposes
-        call_args / called for assertion, and written_env is the env
-        dict that the wizard wrote to install.conf.
+        Returns (mock_object, written_env). The mock should remain
+        uncalled; it is installed to catch accidental reintroduction of
+        the retired DEFAULT_MODEL prompt.
         """
         from unittest.mock import MagicMock
 
@@ -3538,11 +3530,12 @@ class TestCmdConfigDefaultModelDispatch:
             assert level in prompt, f"codex effort prompt missing level {level!r}; prompt={prompt!r}"
         assert "empty = codex default" in prompt
 
-    def test_reprompts_on_provider_flip_with_users_yaml(self, tmp_path, monkeypatch):
+    def test_provider_flip_drops_existing_default_model(self, tmp_path, monkeypatch):
         """
         With users.yaml present and DEFAULT_MODEL=sonnet, flipping to
-        goose+openai prompts for a new model and the chosen value lands
-        in install.conf.
+        goose+openai does not prompt for a replacement. The regenerated
+        install.conf drops DEFAULT_MODEL so runtime uses the registry
+        agent default for goose/openai.
         """
         self._setup(monkeypatch, tmp_path, existing_env={"DEFAULT_MODEL": "sonnet"})
         monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
@@ -3552,20 +3545,16 @@ class TestCmdConfigDefaultModelDispatch:
             self._inputs_for_goose_openai(),
             helper_return="gpt-5.4-mini",
         )
-        helper.assert_called_once()
-        # New signature: (agent_backend, eff_provider, default_val)
-        assert helper.call_args.args[0] == "goose"
-        assert helper.call_args.args[1] == "openai"
-        assert env["DEFAULT_MODEL"] == "gpt-5.4-mini"
+        helper.assert_not_called()
+        assert env["DEFAULT_BACKEND"] == "goose"
+        assert env["DEFAULT_PROVIDER"] == "openai"
+        assert "DEFAULT_MODEL" not in env
 
-    def test_prompt_fires_with_valid_existing_as_prefill(self, tmp_path, monkeypatch):
+    def test_valid_existing_default_model_is_not_reemitted(self, tmp_path, monkeypatch):
         """
         With users.yaml present, DEFAULT_MODEL=sonnet, and the wizard
-        kept on claude, the model prompt STILL fires and the existing
-        value is passed as the prefill. The operator's choice (from
-        the helper return) lands in install.conf. Pins the contract
-        that the operator can always edit the global model via
-        `make config`, not just when it is invalid for the backend.
+        kept on claude, the model prompt does not fire and the
+        regenerated install.conf omits DEFAULT_MODEL.
         """
         self._setup(monkeypatch, tmp_path, existing_env={"DEFAULT_MODEL": "sonnet"})
         helper, env = self._run(
@@ -3574,19 +3563,14 @@ class TestCmdConfigDefaultModelDispatch:
             self._inputs_for_claude_backend(),
             helper_return="haiku",
         )
-        helper.assert_called_once()
-        # Prefill is the existing value because it validates for claude.
-        assert helper.call_args.args[0] == "claude"
-        assert helper.call_args.args[1] == "anthropic"
-        assert helper.call_args.args[2] == "sonnet"
-        assert env["DEFAULT_MODEL"] == "haiku"
+        helper.assert_not_called()
+        assert "DEFAULT_MODEL" not in env
 
-    def test_reprompts_on_empty_existing_model_claude(self, tmp_path, monkeypatch):
+    def test_empty_existing_model_uses_registry_default_claude(self, tmp_path, monkeypatch):
         """
-        users.yaml present, no DEFAULT_MODEL in existing env, backend stays
-        claude. Empty existing model fails validate_model_for_provider
-        (empty is not in PROVIDER_MODELS["anthropic"]), so the dispatch
-        re-prompts.
+        users.yaml present, no DEFAULT_MODEL in existing env, backend
+        stays claude. The wizard does not prompt; runtime falls through
+        to MODEL_REGISTRY's claude/anthropic agent default.
         """
         self._setup(monkeypatch, tmp_path, existing_env={})
         helper, env = self._run(
@@ -3595,17 +3579,15 @@ class TestCmdConfigDefaultModelDispatch:
             self._inputs_for_claude_backend(),
             helper_return="sonnet",
         )
-        helper.assert_called_once()
-        # New signature: (agent_backend, eff_provider, default_val)
-        assert helper.call_args.args[0] == "claude"
-        assert helper.call_args.args[1] == "anthropic"
-        assert env["DEFAULT_MODEL"] == "sonnet"
+        helper.assert_not_called()
+        assert "DEFAULT_MODEL" not in env
 
-    def test_reprompts_on_empty_existing_model_openai(self, tmp_path, monkeypatch):
+    def test_empty_existing_model_uses_registry_default_openai(self, tmp_path, monkeypatch):
         """
         Empty-existing-model path on a non-anthropic provider: flip to
-        goose+openai with no DEFAULT_MODEL in existing env, dispatch
-        re-prompts, helper fires with eff_provider equal to "openai".
+        goose+openai with no DEFAULT_MODEL in existing env. The wizard
+        does not prompt; runtime falls through to MODEL_REGISTRY's
+        goose/openai agent default.
         """
         self._setup(monkeypatch, tmp_path, existing_env={})
         monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
@@ -3615,21 +3597,17 @@ class TestCmdConfigDefaultModelDispatch:
             self._inputs_for_goose_openai(),
             helper_return="gpt-5.4",
         )
-        helper.assert_called_once()
-        # New signature: (agent_backend, eff_provider, default_val)
-        assert helper.call_args.args[0] == "goose"
-        assert helper.call_args.args[1] == "openai"
-        assert env["DEFAULT_MODEL"] == "gpt-5.4"
+        helper.assert_not_called()
+        assert env["DEFAULT_BACKEND"] == "goose"
+        assert env["DEFAULT_PROVIDER"] == "openai"
+        assert "DEFAULT_MODEL" not in env
 
-    def test_reprompt_prefill_is_provider_default_not_invalid_existing(self, tmp_path, monkeypatch):
+    def test_invalid_existing_default_model_is_dropped(self, tmp_path, monkeypatch):
         """
-        When re-prompting because the existing model is invalid for the
-        new provider, the prefill is PROVIDER_DEFAULTS for the new
-        provider, NOT the just-rejected value. Guards against
-        _prompt_choice's default-passthrough behavior (it returns its
-        `default` parameter on empty input without validating it against
-        the `choices` list); if the dispatch passed the invalid model as
-        the prefill, the operator pressing Enter would re-accept it.
+        When an older install.conf carries a DEFAULT_MODEL that is
+        invalid for the newly selected backend/provider, the wizard
+        drops it instead of prompting for a replacement. Runtime then
+        uses MODEL_REGISTRY's agent default.
         """
         self._setup(monkeypatch, tmp_path, existing_env={"DEFAULT_MODEL": "opus"})
         monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
@@ -3639,14 +3617,10 @@ class TestCmdConfigDefaultModelDispatch:
             self._inputs_for_goose_openai(),
             helper_return="gpt-5.4-mini",
         )
-        helper.assert_called_once()
-        # New signature: (agent_backend, eff_provider, default_val).
-        # Third positional arg is the prefill. Must be
-        # PROVIDER_DEFAULTS["openai"] = "gpt-5.5-pro" (the strongest
-        # OpenAI text model), NOT the rejected "opus".
-        assert helper.call_args.args[2] == "gpt-5.5-pro"
-        assert helper.call_args.args[2] != "opus"
-        assert env["DEFAULT_MODEL"] == "gpt-5.4-mini"
+        helper.assert_not_called()
+        assert env["DEFAULT_BACKEND"] == "goose"
+        assert env["DEFAULT_PROVIDER"] == "openai"
+        assert "DEFAULT_MODEL" not in env
 
     def test_codex_install_enables_memory_with_codex_reasoner(self, tmp_path, monkeypatch):
         """
@@ -3777,14 +3751,14 @@ class TestCmdApplyDefaultModelGate:
         msg = str(excinfo.value)
         assert "sonnet" in msg
         assert "openai" in msg
-        assert "install config" in msg
+        assert "registry default" in msg
         stop_service.assert_not_called()
 
-    def test_rejects_missing_default_model_on_non_anthropic(self, tmp_path, monkeypatch):
+    def test_accepts_missing_default_model_on_non_anthropic(self, tmp_path, monkeypatch):
         """
-        Missing DEFAULT_MODEL on a non-anthropic provider raises
-        SystemExit naming the load_config 'sonnet' fallback so the
-        operator understands why an unset key is a problem.
+        Missing DEFAULT_MODEL on a non-anthropic provider is valid now:
+        load_config uses MODEL_REGISTRY's agent default for the active
+        backend/provider.
         """
         monkeypatch.setattr("os.geteuid", lambda: 0)
         conf_path = self._write_install_conf(
@@ -3794,19 +3768,37 @@ class TestCmdApplyDefaultModelGate:
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         stop_service = self._patch_side_effects(monkeypatch)
 
+        _cmd_apply()
+        stop_service.assert_called_once()
+
+    def test_rejects_invalid_registry_agent_default(self, tmp_path, monkeypatch):
+        """
+        Missing DEFAULT_MODEL does not mean "install anything": apply
+        validates MODEL_REGISTRY's agent default for the selected
+        backend/provider before any service side effects.
+        """
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {"DEFAULT_BACKEND": "goose", "DEFAULT_PROVIDER": "openai"},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install.get_default_model_for_backend", lambda *_args: "sonnet")
+        stop_service = self._patch_side_effects(monkeypatch)
+
         with pytest.raises(SystemExit) as excinfo:
             _cmd_apply()
         msg = str(excinfo.value)
-        assert "no DEFAULT_MODEL" in msg
-        assert "sonnet" in msg
+        assert "MODEL_REGISTRY agent default" in msg
+        assert "no usable default model is installed" in msg
         assert "openai" in msg
         stop_service.assert_not_called()
 
     def test_accepts_missing_default_model_on_anthropic(self, tmp_path, monkeypatch):
         """
-        Missing DEFAULT_MODEL on anthropic: resolves to 'sonnet' via the
-        load_config fallback; sonnet is valid for anthropic so the gate
-        passes and apply proceeds past _stop_service.
+        Missing DEFAULT_MODEL on anthropic resolves through
+        MODEL_REGISTRY's agent default, so the gate passes and apply
+        proceeds past _stop_service.
         """
         monkeypatch.setattr("os.geteuid", lambda: 0)
         conf_path = self._write_install_conf(

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -336,12 +336,11 @@ class TestPerUserBackendRouting:
         assert isinstance(instance, OpenCodeBackend)
         assert instance.model == "anthropic/claude-sonnet-4-6"
 
-    def test_opencode_user_without_model_falls_back_to_empty(self, caplog):
+    def test_opencode_user_without_model_uses_registry_agent_default(self, caplog):
         """
         Per-user `backend: opencode` with no model and global
-        backend != opencode: OpenCodeBackend gets model="" so OPENCODE_
-        CONFIG_CONTENT is omitted and OpenCode uses its own config
-        files. A warning is logged so the operator notices the gap.
+        backend != opencode: OpenCodeBackend gets the registry's
+        opencode/anthropic agent default.
         """
         import logging
 
@@ -363,8 +362,8 @@ class TestPerUserBackendRouting:
         with caplog.at_level(logging.WARNING, logger="kai.pool"):
             instance = pool.get(111)
         assert isinstance(instance, OpenCodeBackend)
-        assert instance.model == ""
-        assert any("No model configured for opencode" in rec.message for rec in caplog.records)
+        assert instance.model == "anthropic/claude-sonnet-4-6"
+        assert not any("No model configured for opencode" in rec.message for rec in caplog.records)
 
     def test_codex_user_on_claude_global_install_gets_codex_default(self):
         """


### PR DESCRIPTION
## Summary

Moves the install-wide conversational agent default out of `make config` and into the model registry.

This removes the operator prompt for `DEFAULT_MODEL` during configuration. A regenerated `install.conf` now omits stale `DEFAULT_MODEL` / `CLAUDE_MODEL` values, and runtime resolves the default from `MODEL_REGISTRY[ModelRole.AGENT]` for the active backend/provider.

## Why

`DEFAULT_MODEL=sonnet` is only safe when Claude/Anthropic is actually available. After the backend registry work, a global default model should be tied to the installed backend/provider surface, not hand-carried through `install.conf`.

The install path now fails before service side effects if neither of these is true:

- an explicit `DEFAULT_MODEL` is compatible with the selected backend/provider, or
- the model registry has a valid `agent` default for the selected backend/provider.

That prevents a bad or missing default model from producing a successful-looking install followed by a dead Kai service.

## Changes

- Adds `ModelRole.AGENT` and marks agent defaults in the backend/provider model registry.
- Changes `load_config()` so missing `DEFAULT_MODEL` resolves from the registry instead of a hard-coded Claude `sonnet` fallback.
- Removes the `DEFAULT_MODEL` prompt from `make config`.
- Drops stale `DEFAULT_MODEL` / `CLAUDE_MODEL` when regenerating `install.conf`.
- Keeps explicit hand-edited `DEFAULT_MODEL` loadable, but validates it against the active backend/provider.
- Validates the registry agent default during `install apply` before stopping/restarting the service.
- Updates per-user backend fallback in the subprocess pool to use the registry agent default.
- Updates comments and tests that assumed the wizard owned the conversational default.

## Validation

- `.venv/bin/python -m pytest tests/test_config.py tests/test_install.py tests/test_pool.py tests/test_bot.py -q`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`

Earlier full-suite validation on this patch series also passed:

- `.venv/bin/python -m pytest`
