### PR TITLE
Normalize runtime backend identifiers

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -868,7 +868,7 @@ def _backend_name_for_instance(instance: object) -> str:
     """Map a backend instance to its config-key backend name.
 
     Reads the `backend_name` class attribute every concrete backend sets
-    (claude_code / goose / codex / opencode). A falsy value indicates a
+    (claude / goose / codex / opencode). A falsy value indicates a
     test double or legacy stub that never overrode the ABC default of
     `""`; for those, log a warning and fall back to "claude" so the
     historical default for unknown shapes is preserved.

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -92,7 +92,7 @@ class ClaudeCodeBackend(AgentBackend):
     # Stable identifier consumed by pool/bot dispatch and tagged into
     # the `memory.recall` line so log analysts can attribute recall
     # behavior to the caller backend.
-    backend_name = "claude_code"
+    backend_name = "claude"
 
     def __init__(
         self,

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -439,7 +439,7 @@ class SubprocessPool:
         needs_restart = False
 
         # Read the backend identifier off the instance. Every concrete
-        # backend sets `backend_name` as a class attribute (claude_code
+        # backend sets `backend_name` as a class attribute (claude
         # / goose / codex / opencode). The ABC default is the empty
         # string, so a test double or legacy stub that never overrides
         # falls through to "claude" with a warning; this preserves the

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -2242,7 +2242,7 @@ class TestSignalTargetUserPidFreeFunctions:
                 pid=4242,
                 sig=signal.SIGTERM,
                 purpose="chat",
-                backend="claude_code",
+                backend="claude",
             )
 
         assert list(captured["argv"]) == [
@@ -2275,7 +2275,7 @@ class TestSignalTargetUserPidFreeFunctions:
                 pid=4242,
                 sig=int(signal.SIGKILL),
                 purpose="chat",
-                backend="claude_code",
+                backend="claude",
             )
 
         warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1776,7 +1776,7 @@ class TestAssembleTurnContext:
             session_context="",
             workspace_reminder="",
             workspace=ws,
-            backend_name="claude_code",
+            backend_name="claude",
             job_type="interactive",
             session_id="sess-1",
         )
@@ -1786,7 +1786,7 @@ class TestAssembleTurnContext:
         kwargs = scoped_mock.call_args.kwargs
         assert kwargs["user_id"] == "42"
         assert kwargs["workspace"] == ws
-        assert kwargs["backend_name"] == "claude_code"
+        assert kwargs["backend_name"] == "claude"
         assert kwargs["job_type"] == "interactive"
         assert kwargs["session_id"] == "sess-1"
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -88,19 +88,19 @@ class TestBackendNameForInstance:
     off the instance rather than inspecting the concrete class name.
 
     Real backends each set the attribute to their canonical identifier
-    (claude.py: "claude_code"; goose.py: "goose"; codex.py: "codex").
+    (claude.py: "claude"; goose.py: "goose"; codex.py: "codex").
     A test double or legacy stub that never overrode the ABC default
     falls back to "claude" with a warning so model validation still
     routes through the provider-only path.
     """
 
     def test_claude_backend_returns_class_attribute(self):
-        """ClaudeCodeBackend.backend_name is "claude_code" (the shadow-log tag)."""
+        """ClaudeCodeBackend.backend_name is "claude"."""
         from kai.claude import ClaudeCodeBackend
 
         instance = MagicMock(spec=ClaudeCodeBackend)
         instance.backend_name = ClaudeCodeBackend.backend_name
-        assert _backend_name_for_instance(instance) == "claude_code"
+        assert _backend_name_for_instance(instance) == "claude"
 
     def test_goose_backend_returns_goose(self):
         """GooseBackend.backend_name is "goose"."""

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -5609,7 +5609,7 @@ class TestFormatScopedContextWithRecallPayload:
             "what is kai?",
             user_id="123",
             workspace=project_root,
-            backend_name="claude_code",
+            backend_name="claude",
             job_type="interactive",
             session_id="sess-1",
         )


### PR DESCRIPTION
## Summary

Normalizes the Claude runtime backend identifier to match the config/backend-registry key.

Before this change, `ClaudeCodeBackend.backend_name` was `claude_code` while every operator-facing/backend-registry surface used `claude`. Goose, Codex, and OpenCode already matched their config keys.

## Changes

- Changes `ClaudeCodeBackend.backend_name` from `claude_code` to `claude`.
- Updates bot/pool comments to document the canonical runtime identifiers as:
  - `claude`
  - `goose`
  - `codex`
  - `opencode`
- Updates tests and test metadata examples that still used `claude_code`.

## Why

Runtime backend identifiers are consumed by model validation, workspace model overrides, memory recall metadata, and signal/log context. Keeping the identifier equal to the config/backend-registry key prevents the Claude path from falling into an unknown-backend/provider-only validation shape while every other backend uses the canonical key.

## Validation

- `.venv/bin/python -m pytest tests/test_bot.py tests/test_pool.py tests/test_backend.py tests/test_acp.py tests/test_memory.py -q`
- `.venv/bin/python -m pytest`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
