### PR TITLE
Protect SQLite state and GitHub token input

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -2883,9 +2883,10 @@ async def _handle_github_token(
     """
     Handle /github token <ghp_...> and /github token clear.
 
-    Stores or clears the user's GitHub PAT. The token is stored as
-    plaintext in SQLite - acceptable for a local deployment where
-    DB file access implies host access. Never logged, never echoed.
+    Stores or clears the user's GitHub PAT. The token is stored in
+    owner-only SQLite state, never logged, never echoed, and the
+    source Telegram command is deleted after a successful store when
+    Telegram permits deletion.
     """
     assert update.message is not None
 
@@ -2898,9 +2899,15 @@ async def _handle_github_token(
         await update.message.reply_text("GitHub token removed.")
         return
 
-    # Store the token. Plaintext in SQLite is acceptable for local
-    # deployment where DB file access implies host access.
+    # Store the token in owner-only SQLite state, then delete the
+    # token-bearing Telegram command where Telegram permits it.
     await sessions.set_setting(f"github_token:{chat_id}", args[0])
+    try:
+        await update.message.delete()
+    except BadRequest as exc:
+        log.warning("Could not delete GitHub token command message: %s", exc)
+    except Exception:
+        log.exception("Could not delete GitHub token command message")
     await update.message.reply_text("GitHub token stored.")
 
 

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -3744,9 +3744,15 @@ def _apply_migrate(
             else:
                 print("  Database integrity check passed")
 
+            os.chmod(db_dst, 0o600)
             os.chown(db_dst, svc_uid, svc_gid)
     elif db_dst.exists():
         print("  Database already exists at destination, skipping migration")
+        if dry_run:
+            print(f"[DRY RUN] Would secure database: {db_dst} (mode 0600, {svc_uid}:{svc_gid})")
+        else:
+            os.chmod(db_dst, 0o600)
+            os.chown(db_dst, svc_uid, svc_gid)
     elif not db_src.exists():
         print("  No source database found, skipping migration")
 

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
@@ -53,6 +54,26 @@ def _get_db() -> aiosqlite.Connection:
     return _db
 
 
+def _restrict_sqlite_file(path: Path) -> None:
+    """Create/chmod a SQLite file so persisted secrets are owner-only."""
+    flags = os.O_CREAT | os.O_RDWR
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    fd = os.open(path, flags, 0o600)
+    try:
+        os.fchmod(fd, 0o600)
+    finally:
+        os.close(fd)
+    path.chmod(0o600)
+
+
+def _restrict_sqlite_files(db_path: Path) -> None:
+    """Restrict the main DB and any SQLite WAL/SHM companion files."""
+    for path in (db_path, Path(f"{db_path}-wal"), Path(f"{db_path}-shm")):
+        if path.exists():
+            path.chmod(0o600)
+
+
 # ── Initialization ───────────────────────────────────────────────────
 
 
@@ -72,6 +93,7 @@ async def init_db(db_path: Path) -> None:
         db_path: Path to the SQLite database file (created if missing).
     """
     global _db
+    _restrict_sqlite_file(db_path)
     _db = await aiosqlite.connect(str(db_path))
     _get_db().row_factory = aiosqlite.Row
     # PRAGMAs are database configuration, not schema. They must execute
@@ -85,6 +107,7 @@ async def init_db(db_path: Path) -> None:
         if row and row[0] != "wal":
             log.warning("Failed to enable WAL mode; journal_mode is %s", row[0])
     await _get_db().execute("PRAGMA busy_timeout=5000")
+    _restrict_sqlite_files(db_path)
 
     try:
         # BEGIN IMMEDIATE acquires the write lock up front rather than on
@@ -198,6 +221,7 @@ async def init_db(db_path: Path) -> None:
             await _get_db().execute("ALTER TABLE workspace_history_new RENAME TO workspace_history")
 
         await _get_db().commit()
+        _restrict_sqlite_files(db_path)
     except Exception:
         # Roll back the entire init sequence. The database is left in its
         # pre-init state (no partial tables, no half-migrated schema).

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -4875,6 +4875,41 @@ class TestHandleGitHub:
     # ── 3. /github notify <chat_id> ───────────────────────────────
 
     @pytest.mark.asyncio
+    async def test_token_store_deletes_source_message(self):
+        """/github token stores the PAT and deletes the Telegram command."""
+        update = _make_update(text="/github token ghp_secret")
+        config = _make_config()
+        ctx = _make_context(config=config, args=["token", "ghp_secret"])
+        mock_sessions = AsyncMock()
+        mock_sessions.set_setting = AsyncMock()
+
+        with patch("kai.bot.sessions", mock_sessions):
+            await handle_github(update, ctx)
+
+        mock_sessions.set_setting.assert_called_once_with("github_token:12345", "ghp_secret")
+        update.message.delete.assert_awaited_once()
+        reply = update.message.reply_text.call_args[0][0]
+        assert "stored" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_token_store_continues_if_source_delete_fails(self):
+        """A Telegram delete failure is logged but does not drop the PAT update."""
+        update = _make_update(text="/github token ghp_secret")
+        update.message.delete.side_effect = BadRequest("message can't be deleted")
+        config = _make_config()
+        ctx = _make_context(config=config, args=["token", "ghp_secret"])
+        mock_sessions = AsyncMock()
+        mock_sessions.set_setting = AsyncMock()
+
+        with patch("kai.bot.sessions", mock_sessions):
+            await handle_github(update, ctx)
+
+        mock_sessions.set_setting.assert_called_once_with("github_token:12345", "ghp_secret")
+        update.message.delete.assert_awaited_once()
+        reply = update.message.reply_text.call_args[0][0]
+        assert "stored" in reply.lower()
+
+    @pytest.mark.asyncio
     async def test_notify_set(self):
         """/github notify 123456 sets notification chat and updates live set."""
         update = _make_update(text="/github notify 123456")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -4699,6 +4699,7 @@ class TestApplyMigrate:
 
         assert (data_path / "kai.db").exists()
         assert (data_path / "kai.db").read_text() == "fake-db-content"
+        assert stat.S_IMODE((data_path / "kai.db").stat().st_mode) == 0o600
 
     def test_verifies_integrity(self, tmp_path, monkeypatch):
         """Runs PRAGMA integrity_check on the copied database."""
@@ -4738,11 +4739,16 @@ class TestApplyMigrate:
         data_path.mkdir()
         (data_path / "logs").mkdir()
         (data_path / "kai.db").write_text("existing-content")
+        (data_path / "kai.db").chmod(0o644)
+        chowned: list[tuple[str, int, int]] = []
+        monkeypatch.setattr("kai.install.os.chown", lambda path, uid, gid: chowned.append((str(path), uid, gid)))
 
         _apply_migrate(data_path, tmp_path / "install", svc_uid=501, svc_gid=20, dry_run=False)
 
         # Destination should be unchanged
         assert (data_path / "kai.db").read_text() == "existing-content"
+        assert stat.S_IMODE((data_path / "kai.db").stat().st_mode) == 0o600
+        assert (str(data_path / "kai.db"), 501, 20) in chowned
         assert "already exists" in capsys.readouterr().out
 
     def test_copies_logs(self, tmp_path, monkeypatch):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,6 +1,7 @@
 """Tests for sessions.py async database CRUD."""
 
 import sqlite3
+import stat
 from pathlib import Path
 
 import aiosqlite
@@ -1454,6 +1455,32 @@ class TestWorkspaceHistoryMigration:
 
 class TestInitDbTransaction:
     """Verify init_db wraps all DDL in a single atomic transaction."""
+
+    @pytest.mark.asyncio
+    async def test_fresh_db_file_is_owner_only(self, tmp_path):
+        """SQLite files can hold GitHub PATs, so the DB must be 0600."""
+        db_path = tmp_path / "fresh.db"
+        await sessions.init_db(db_path)
+        try:
+            assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+            for companion in (Path(f"{db_path}-wal"), Path(f"{db_path}-shm")):
+                if companion.exists():
+                    assert stat.S_IMODE(companion.stat().st_mode) == 0o600
+        finally:
+            await sessions.close_db()
+
+    @pytest.mark.asyncio
+    async def test_existing_db_file_mode_is_repaired(self, tmp_path):
+        """Startup repairs an older permissive kai.db mode."""
+        db_path = tmp_path / "existing.db"
+        db_path.write_bytes(b"")
+        db_path.chmod(0o644)
+
+        await sessions.init_db(db_path)
+        try:
+            assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+        finally:
+            await sessions.close_db()
 
     @pytest.mark.asyncio
     async def test_fresh_db_creates_all_tables(self, tmp_path):


### PR DESCRIPTION
## Summary

Addresses the remaining secret-at-rest pieces from the filesystem isolation finding:

- SQLite state files are explicitly restricted to `0600`.
- `/github token <PAT>` deletes the token-bearing Telegram command after storing the token.
- Install migration repairs existing deployed `kai.db` ownership/mode.

## Changes

- Pre-create/chmod the SQLite DB file before opening it.
- Chmod the main DB plus `-wal` / `-shm` companion files during startup.
- After schema initialization commits, re-apply the DB/WAL/SHM mode check so companion files created during DDL are also covered.
- During install migration:
  - copied `kai.db` is chmodded `0600`;
  - existing destination `kai.db` is repaired to `0600` and service ownership.
- After `/github token <PAT>` succeeds:
  - delete the source Telegram command where Telegram permits deletion;
  - log and continue if Telegram rejects deletion.

## Why

The database stores sensitive values, including GitHub PATs. Relying on ambient umask or historical file mode is not sufficient for a protected multi-user install.

Telegram command history is also a secret-at-rest surface for PATs. The token still lives in SQLite, but the user’s original `/github token ...` message should not remain in chat history when Kai can remove it.

## Validation

- `.venv/bin/python -m pytest tests/test_sessions.py tests/test_install.py tests/test_bot.py -q`
- `.venv/bin/python -m pytest`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
