### PR TITLE
Require allowlist for triage project assignment

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1072,6 +1072,9 @@ class UserConfig:
         github_repos: Admin-controlled repositories this user may access
             through Kai's shared GitHub review and triage authority. The
             mutable notification subscription list cannot expand this set.
+        allowed_triage_projects: Admin-controlled GitHub Project titles that
+            issue triage may add issues to. Empty means project assignment is
+            disabled for this user.
         allowed_services: External proxy service names this user's persistent
             agent may call. Empty by default, including for admins.
     """
@@ -1109,6 +1112,10 @@ class UserConfig:
     github_notify_chat_id: int | None = None
     pr_review: bool | None = None
     issue_triage: bool | None = None
+    # GitHub Project titles this user's automated issue triage may assign.
+    # Admin-controlled and fail-closed: omission means triage can still
+    # comment/label, but cannot mutate project boards.
+    allowed_triage_projects: list[str] = field(default_factory=list)
     # External services the persistent agent may call through Kai's
     # credential-injecting proxy. Admin-controlled via users.yaml and
     # fail-closed: omission means no services, including for admins.
@@ -2589,6 +2596,33 @@ def _load_user_configs(
                 name,
             )
 
+        raw_allowed_triage_projects = entry.get("allowed_triage_projects", [])
+        allowed_triage_projects: list[str] = []
+        if isinstance(raw_allowed_triage_projects, list):
+            for raw_project in raw_allowed_triage_projects:
+                if not isinstance(raw_project, str):
+                    log.warning(
+                        "users.yaml: invalid allowed_triage_projects entry for %s: %r (expected a project title)",
+                        name,
+                        raw_project,
+                    )
+                    continue
+                project_title = raw_project.strip()
+                if not project_title or project_title == "*":
+                    log.warning(
+                        "users.yaml: invalid allowed_triage_projects entry for %s: %r (blank titles and wildcards are not allowed)",
+                        name,
+                        raw_project,
+                    )
+                    continue
+                if project_title not in allowed_triage_projects:
+                    allowed_triage_projects.append(project_title)
+        else:
+            log.warning(
+                "users.yaml: allowed_triage_projects for %s must be a list (ignoring)",
+                name,
+            )
+
         # Parse optional github_notify_chat_id (integer, can be negative
         # for group chats). Follows the same pattern as telegram_id validation.
         github_notify_chat_id: int | None = None
@@ -2693,6 +2727,7 @@ def _load_user_configs(
             github_notify_chat_id=github_notify_chat_id,
             pr_review=pr_review,
             issue_triage=issue_triage,
+            allowed_triage_projects=allowed_triage_projects,
             allowed_services=allowed_services,
             models=user_models,
         )

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -238,6 +238,41 @@ async def list_projects(owner: str) -> str:
         return "[]"
 
 
+def _allowed_project_titles(allowed_projects: list[str] | None) -> set[str]:
+    """Normalize the admin-controlled triage project allowlist."""
+    if not allowed_projects:
+        return set()
+    return {project.strip().lower() for project in allowed_projects if project.strip()}
+
+
+def _project_list_from_json(projects_json: str) -> list[dict]:
+    """Extract the GitHub Projects list from gh project JSON output."""
+    try:
+        projects_data = json.loads(projects_json) if projects_json else []
+    except json.JSONDecodeError:
+        return []
+
+    project_list = projects_data.get("projects", []) if isinstance(projects_data, dict) else projects_data
+    if not isinstance(project_list, list):
+        return []
+
+    return [project for project in project_list if isinstance(project, dict)]
+
+
+def _filter_projects_json(projects_json: str, allowed_projects: list[str] | None) -> str:
+    """Return project JSON containing only explicitly allowed project titles."""
+    allowed_titles = _allowed_project_titles(allowed_projects)
+    if not allowed_titles:
+        return "[]"
+
+    filtered = [
+        project
+        for project in _project_list_from_json(projects_json)
+        if str(project.get("title", "")).strip().lower() in allowed_titles
+    ]
+    return json.dumps({"projects": filtered})
+
+
 def build_triage_prompt(
     metadata: IssueMetadata,
     related_issues: str,
@@ -678,6 +713,7 @@ async def apply_triage(
     webhook_secret: str,
     projects_json: str = "[]",
     notify_chat_id: int | None = None,
+    allowed_triage_projects: list[str] | None = None,
 ) -> None:
     """
     Apply triage results: labels, project assignment, comment, and notification.
@@ -693,6 +729,8 @@ async def apply_triage(
         webhook_secret: Secret for authenticating with the send-message API.
         projects_json: Raw JSON from list_projects(), reused to avoid a
             redundant gh project list call when looking up project numbers.
+        allowed_triage_projects: Admin-controlled project titles triage may
+            assign. Empty/None disables project assignment.
     """
     # Type-guard Claude's response fields. Claude may return wrong types
     # (e.g., "labels": "bug" instead of ["bug"], or ["bug", 42, null]).
@@ -883,56 +921,69 @@ async def apply_triage(
             applied_labels.append(label)
             log.info("Added label '%s' to %s#%d", label, metadata.repo, metadata.number)
 
-    # Step 2: Add to project board if assigned.
+    # Step 2: Add to project board if assigned and explicitly allowed.
     # Reuses projects_json from the earlier list_projects() call instead of
     # shelling out to gh project list again.
+    project_added: str | None = None
+    project_skipped: str | None = None
+    project_number: int | None = None
     if project:
+        allowed_titles = _allowed_project_titles(allowed_triage_projects)
+        if project.lower() not in allowed_titles:
+            project_skipped = project
+            log.warning(
+                "Skipping triage project '%s' for %s#%d because it is not in allowed_triage_projects",
+                project,
+                metadata.repo,
+                metadata.number,
+            )
+        else:
+            project_list = _project_list_from_json(projects_json)
+            for p in project_list:
+                if str(p.get("title", "")).strip().lower() == project.lower():
+                    raw_project_number = p.get("number")
+                    if isinstance(raw_project_number, int) and not isinstance(raw_project_number, bool):
+                        project_number = raw_project_number
+                    break
+
+            if project_number is None:
+                project_skipped = project
+                log.warning("Allowed project '%s' not found for %s", project, metadata.repo.split("/")[0])
+
+    if project and project_number is not None and project_skipped is None:
         owner = metadata.repo.split("/")[0]
 
         try:
-            projects_data = json.loads(projects_json) if projects_json else []
-            # gh project list --format json returns {"projects": [...]} as a dict
-            project_list = projects_data.get("projects", []) if isinstance(projects_data, dict) else projects_data
+            proc = await asyncio.create_subprocess_exec(
+                "gh",
+                "project",
+                "item-add",
+                str(project_number),
+                "--owner",
+                owner,
+                "--url",
+                metadata.url,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await proc.communicate()
 
-            project_number = None
-            if isinstance(project_list, list):
-                for p in project_list:
-                    if p.get("title", "").lower() == project.lower():
-                        project_number = p.get("number")
-                        break
-
-            if project_number:
-                proc = await asyncio.create_subprocess_exec(
-                    "gh",
-                    "project",
-                    "item-add",
-                    str(project_number),
-                    "--owner",
-                    owner,
-                    "--url",
-                    metadata.url,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
+            if proc.returncode == 0:
+                project_added = project
+                log.info(
+                    "Added %s#%d to project '%s'",
+                    metadata.repo,
+                    metadata.number,
+                    project,
                 )
-                _, stderr = await proc.communicate()
-
-                if proc.returncode == 0:
-                    log.info(
-                        "Added %s#%d to project '%s'",
-                        metadata.repo,
-                        metadata.number,
-                        project,
-                    )
-                else:
-                    log.warning(
-                        "Failed to add %s#%d to project '%s': %s",
-                        metadata.repo,
-                        metadata.number,
-                        project,
-                        stderr.decode().strip(),
-                    )
             else:
-                log.warning("Project '%s' not found for %s", project, owner)
+                log.warning(
+                    "Failed to add %s#%d to project '%s': %s",
+                    metadata.repo,
+                    metadata.number,
+                    project,
+                    stderr.decode().strip(),
+                )
         except Exception:
             log.exception("Failed to add %s#%d to project", metadata.repo, metadata.number)
 
@@ -966,8 +1017,10 @@ async def apply_triage(
     if related:
         related_str = ", ".join(f"#{n}" for n in related)
         comment_parts.append(f"**Related issues:** {related_str}")
-    if project:
-        comment_parts.append(f"**Added to project:** {project}")
+    if project_added:
+        comment_parts.append(f"**Added to project:** {project_added}")
+    if project_skipped:
+        comment_parts.append(f"**Project skipped:** {project_skipped}")
     comment_parts.append(f"**Next action:** {next_action}")
     if missing_info:
         comment_parts.append("**Missing information:**")
@@ -1031,8 +1084,10 @@ async def apply_triage(
     if related:
         related_str = ", ".join(f"#{n}" for n in related)
         telegram_parts.append(f"Related: {related_str}")
-    if project:
-        telegram_parts.append(f"Project: {project}")
+    if project_added:
+        telegram_parts.append(f"Project: {project_added}")
+    if project_skipped:
+        telegram_parts.append(f"Skipped project: {project_skipped}")
     if status == "blocked" and blocked_by is not None:
         blocked_by_display = f"#{blocked_by}" if isinstance(blocked_by, int) else blocked_by
         telegram_parts.append(f"Blocked by: {blocked_by_display}")
@@ -1069,6 +1124,7 @@ async def triage_issue(
     agent_backend: str = "claude",
     provider: str = "",
     model_override: str = "",
+    allowed_triage_projects: list[str] | None = None,
 ) -> None:
     """
     Full triage pipeline: analyze issue, apply labels, post results.
@@ -1101,8 +1157,10 @@ async def triage_issue(
         owner = metadata.repo.split("/")[0]
         projects = await list_projects(owner)
 
+        allowed_projects = _filter_projects_json(projects, allowed_triage_projects)
+
         # Step 3: Build the triage prompt
-        prompt = build_triage_prompt(metadata, related_issues, projects)
+        prompt = build_triage_prompt(metadata, related_issues, allowed_projects)
 
         # Step 4: Run the triage subprocess (matching the active backend)
         raw_response = await run_triage(
@@ -1126,7 +1184,13 @@ async def triage_issue(
         # Step 6: Apply triage (labels, project, comment, telegram).
         # Pass projects JSON to avoid a redundant gh project list call.
         await apply_triage(
-            metadata, triage_result, webhook_port, webhook_secret, projects_json=projects, notify_chat_id=notify_chat_id
+            metadata,
+            triage_result,
+            webhook_port,
+            webhook_secret,
+            projects_json=allowed_projects,
+            notify_chat_id=notify_chat_id,
+            allowed_triage_projects=allowed_triage_projects,
         )
 
     except Exception as exc:

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -908,6 +908,7 @@ async def _process_github_event_for_user(
                     agent_backend=agent_backend,
                     provider=provider,
                     model_override=issue_triage_model_override,
+                    allowed_triage_projects=user_config.allowed_triage_projects if user_config else [],
                 )
             )
             _background_tasks.add(task)

--- a/templates/users.yaml
+++ b/templates/users.yaml
@@ -62,6 +62,12 @@ users:
     # github_notify_chat_id: -100123456789
     # pr_review: true
     # issue_triage: true
+    # Issue triage can comment and apply existing repo labels when enabled.
+    # Project-board assignment is additionally fail-closed: list exact GitHub
+    # Project titles here if Kai may add this user's triaged issues to them.
+    # allowed_triage_projects:
+    #   - Sprint 1
+    #   - Bug triage
 
   # Example: regular user with minimal config
   # - telegram_id: 987654321

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -925,12 +925,52 @@ class TestApplyTriage:
         ):
             mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
-            await apply_triage(meta, result, 8080, "secret", projects_json=projects_json)
+            await apply_triage(
+                meta,
+                result,
+                8080,
+                "secret",
+                projects_json=projects_json,
+                allowed_triage_projects=["Sprint 1"],
+            )
 
         assert mock_session.post.called
         # Should have called gh project item-add
         item_add_calls = [cmd for cmd in commands_run if "project" in cmd and "item-add" in cmd]
         assert len(item_add_calls) > 0
+
+    @pytest.mark.asyncio
+    async def test_project_assignment_requires_allowlist(self):
+        """Model-selected projects are skipped unless explicitly allowlisted."""
+        meta = _make_metadata()
+        result = _triage_result(project="Sprint 1")
+        projects_json = json.dumps({"projects": [{"title": "Sprint 1", "number": 1}]})
+
+        commands_run = []
+        captured: dict[str, str | None] = {"comment": None}
+
+        async def mock_exec(*args, **kwargs):
+            commands_run.append(args)
+            if "issue" in args and "comment" in args and "--body-file" in args:
+                body_path = args[list(args).index("--body-file") + 1]
+                captured["comment"] = Path(body_path).read_text()
+            return _mock_subprocess(stdout="[]")
+
+        with (
+            patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
+            patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
+        ):
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_session_cls)
+            await apply_triage(meta, result, 8080, "secret", projects_json=projects_json)
+
+        assert mock_session.post.called
+        item_add_calls = [cmd for cmd in commands_run if "project" in cmd and "item-add" in cmd]
+        assert len(item_add_calls) == 0
+        assert "**Added to project:** Sprint 1" not in captured["comment"]
+        assert "**Project skipped:** Sprint 1" in captured["comment"]
+        body = mock_session.post.call_args[1]["json"]
+        assert "Skipped project: Sprint 1" in body["text"]
 
     @pytest.mark.asyncio
     async def test_no_project_skips_assignment(self):
@@ -1504,7 +1544,12 @@ class TestTriageActionability:
             blocked_by=None,
         )
         projects_json = json.dumps({"projects": [{"title": "Sprint 1", "number": 1}]})
-        comment, telegram = await _apply_triage_capture(meta, result, projects_json=projects_json)
+        comment, telegram = await _apply_triage_capture(
+            meta,
+            result,
+            projects_json=projects_json,
+            allowed_triage_projects=["Sprint 1"],
+        )
         # All existing fields render.
         assert "**Triage summary:** Login broken on Safari." in comment
         assert "**Priority:** high" in comment
@@ -1571,6 +1616,52 @@ class TestTriageIssue:
         assert call_count > 0
         # Telegram notification was sent
         mock_session.post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_project_prompt_and_apply_inputs_are_allowlist_filtered(self):
+        """Only allowlisted projects are shown to the model and passed to apply."""
+        payload = _issue_payload(title="Login broken")
+        projects_json = json.dumps(
+            {
+                "projects": [
+                    {"title": "Sprint 1", "number": 1},
+                    {"title": "Secret Board", "number": 2},
+                ]
+            }
+        )
+        triage_json = json.dumps(
+            {
+                "labels": [],
+                "duplicate_of": None,
+                "related": [],
+                "project": "Sprint 1",
+                "summary": "Login is broken.",
+                "priority": "high",
+            }
+        )
+
+        captured_prompt: dict[str, str] = {}
+
+        async def mock_run_triage(prompt: str, **kwargs):
+            captured_prompt["prompt"] = prompt
+            return triage_json
+
+        with (
+            patch("kai.triage.search_related_issues", new=AsyncMock(return_value="[]")),
+            patch("kai.triage.list_projects", new=AsyncMock(return_value=projects_json)),
+            patch("kai.triage.run_triage", side_effect=mock_run_triage),
+            patch("kai.triage.apply_triage", new_callable=AsyncMock) as mock_apply,
+        ):
+            await triage_issue(payload, 8080, "secret", allowed_triage_projects=["Sprint 1"])
+
+        assert "Sprint 1" in captured_prompt["prompt"]
+        assert "Secret Board" not in captured_prompt["prompt"]
+
+        mock_apply.assert_awaited_once()
+        apply_kwargs = mock_apply.call_args.kwargs
+        assert apply_kwargs["allowed_triage_projects"] == ["Sprint 1"]
+        assert "Sprint 1" in apply_kwargs["projects_json"]
+        assert "Secret Board" not in apply_kwargs["projects_json"]
 
     @pytest.mark.asyncio
     async def test_handles_error(self):

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -45,6 +45,7 @@ class TestUserConfig:
         assert uc.github_notify_chat_id is None
         assert uc.pr_review is None
         assert uc.issue_triage is None
+        assert uc.allowed_triage_projects == []
         assert uc.allowed_services == []
         assert uc.backend is None
         assert uc.provider is None
@@ -65,6 +66,7 @@ class TestUserConfig:
             github_notify_chat_id=-100123456789,
             pr_review=True,
             issue_triage=False,
+            allowed_triage_projects=["Sprint 1"],
             allowed_services=["perplexity"],
             backend="goose",
             provider="openai",
@@ -79,6 +81,7 @@ class TestUserConfig:
         assert uc.github_notify_chat_id == -100123456789
         assert uc.pr_review is True
         assert uc.issue_triage is False
+        assert uc.allowed_triage_projects == ["Sprint 1"]
         assert uc.allowed_services == ["perplexity"]
         assert uc.backend == "goose"
         assert uc.provider == "openai"
@@ -653,6 +656,59 @@ class TestLoadUserConfigs:
 
         assert configs[111].allowed_services == []
         assert "allowed_services for alice must be a list" in caplog.text
+
+    # ── allowed_triage_projects field ──
+
+    def test_allowed_triage_projects_parsed_deduplicated_and_ordered(self, tmp_path):
+        data = self._yaml_dict(
+            """\
+            users:
+              - telegram_id: 111
+                name: alice
+                allowed_triage_projects:
+                  - Sprint 1
+                  - Bug triage
+                  - Sprint 1
+            """,
+        )
+        with patch("kai.config._read_protected_yaml", return_value=data):
+            configs = _load_user_configs("claude", "")
+
+        assert configs[111].allowed_triage_projects == ["Sprint 1", "Bug triage"]
+
+    def test_allowed_triage_projects_invalid_entries_fail_closed(self, tmp_path, caplog):
+        data = self._yaml_dict(
+            """\
+            users:
+              - telegram_id: 111
+                name: alice
+                allowed_triage_projects:
+                  - Sprint 1
+                  - '*'
+                  - ''
+                  - 42
+            """,
+        )
+        with patch("kai.config._read_protected_yaml", return_value=data):
+            configs = _load_user_configs("claude", "")
+
+        assert configs[111].allowed_triage_projects == ["Sprint 1"]
+        assert "invalid allowed_triage_projects entry" in caplog.text
+
+    def test_allowed_triage_projects_not_list_is_ignored(self, tmp_path, caplog):
+        data = self._yaml_dict(
+            """\
+            users:
+              - telegram_id: 111
+                name: alice
+                allowed_triage_projects: Sprint 1
+            """,
+        )
+        with patch("kai.config._read_protected_yaml", return_value=data):
+            configs = _load_user_configs("claude", "")
+
+        assert configs[111].allowed_triage_projects == []
+        assert "allowed_triage_projects for alice must be a list" in caplog.text
 
     # ── github_repos field ──
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2179,7 +2179,12 @@ class TestPerUserRouting:
     async def test_triage_receives_user_backend(self, _clear_cooldowns):
         """Per-user backend/provider are passed to triage_issue."""
         base = self._make_user_config(111, repos=["owner/repo"])
-        user = dataclasses.replace(base, backend="goose", provider="anthropic")
+        user = dataclasses.replace(
+            base,
+            backend="goose",
+            provider="anthropic",
+            allowed_triage_projects=["Sprint 1"],
+        )
         config = self._make_config_with_users([user])
         config.default_backend = "claude"
         config.default_provider = ""
@@ -2207,6 +2212,7 @@ class TestPerUserRouting:
             mock_triage.assert_called_once()
             assert mock_triage.call_args[1]["agent_backend"] == "goose"
             assert mock_triage.call_args[1]["provider"] == "anthropic"
+            assert mock_triage.call_args[1]["allowed_triage_projects"] == ["Sprint 1"]
 
     @pytest.mark.asyncio
     async def test_review_uses_global_backend_when_no_user_override(self, _clear_cooldowns, _mock_resolve_repo):


### PR DESCRIPTION
## Summary

Adds an explicit operator allowlist for automated issue-triage project assignment.

Changes:

- add per-user `allowed_triage_projects` to `users.yaml` parsing
- default project assignment to fail-closed when the allowlist is absent or empty
- pass the per-user allowlist from GitHub webhook routing into `triage_issue`
- filter the projects shown to the triage model down to allowed project titles only
- reject any returned project that is not explicitly allowlisted
- surface skipped project assignments in the GitHub triage comment and Telegram summary
- update `templates/users.yaml` with the new setting
- add config, triage, and webhook tests

## Security rationale

Issue triage consumes model output derived from untrusted public issue content. Project-board assignment is a GitHub mutation, so randomized prompt boundaries are not an authorization boundary.

This keeps triage comments and existing-label application working, but project mutation now requires an admin-controlled per-user allowlist.

## Compatibility

Existing users with `issue_triage: true` will still get triage comments and existing-label application. They will no longer get automatic project assignment until the operator adds exact project titles under:

```yaml
allowed_triage_projects:
  - Sprint 1
```

That is intentional fail-closed behavior for this mutation path.

## Validation

- focused tests outside restricted sandbox: `272 passed`
- full suite outside restricted sandbox: `4733 passed, 1 skipped`
- `ruff check src tests`: passed
- `ruff format --check src tests`: passed

Note: webhook tests require local aiohttp socket binding, so they must run outside the restricted Codex sandbox.
