### PR TITLE
Exit nonzero on unexpected Kai crash

### DIFF
--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -214,9 +214,10 @@ def _start() -> None:
 
     Loads configuration, then delegates to an async initialization
     function that manages the full application lifecycle. Catches
-    KeyboardInterrupt for clean Ctrl+C shutdown and logs any
-    unexpected crashes. SystemExit propagates to `main`'s choke
-    point, which mirrors gate messages into the main log.
+    KeyboardInterrupt for clean Ctrl+C shutdown and converts unexpected
+    crashes into a non-zero process exit after logging them. SystemExit
+    propagates to `main`'s choke point, which mirrors gate messages
+    into the main log.
     """
     config = load_config()
     logging.info("Kai starting (model=%s, users=%s)", config.default_model, config.allowed_user_ids)
@@ -440,8 +441,9 @@ def _start() -> None:
         asyncio.run(_init_and_run())
     except KeyboardInterrupt:
         logging.info("Kai stopped.")
-    except Exception:
+    except Exception as exc:
         logging.exception("Kai crashed")
+        raise SystemExit(1) from exc
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,7 @@ import logging
 from datetime import UTC, datetime
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -380,3 +381,34 @@ class TestMainStartupErrorLogging:
             main()
 
         assert not [r for r in caplog.records if r.levelno == logging.CRITICAL]
+
+
+class TestStartCrashExit:
+    """Unexpected runtime crashes must not look like clean process exits."""
+
+    def test_unexpected_asyncio_crash_exits_nonzero(self, caplog, monkeypatch):
+        from kai.main import _start
+
+        monkeypatch.setattr(
+            "kai.main.load_config",
+            lambda: SimpleNamespace(
+                default_model="gpt-test",
+                allowed_user_ids={123},
+                telegram_webhook_url=None,
+                session_db_path=":memory:",
+            ),
+        )
+        monkeypatch.setattr("kai.main._read_protected_file", lambda _path: "")
+        monkeypatch.setattr("kai.main.services.load_services", lambda _path: {})
+
+        def fail_run(coro):
+            coro.close()
+            raise RuntimeError("event loop died")
+
+        monkeypatch.setattr("kai.main.asyncio.run", fail_run)
+
+        with caplog.at_level(logging.ERROR), pytest.raises(SystemExit) as excinfo:
+            _start()
+
+        assert excinfo.value.code == 1
+        assert any(r.levelno == logging.ERROR and "Kai crashed" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- convert unexpected top-level runtime crashes into `SystemExit(1)` after logging
- preserve clean `KeyboardInterrupt` behavior
- add focused coverage so a failed `asyncio.run()` no longer looks like a successful process exit

## Security / reliability impact
This addresses the top-level crash portion of assessment finding #10. Kai should no longer report a successful process exit after an unexpected runtime crash, which makes supervisor behavior and operator monitoring accurate.

## Validation
- `.venv/bin/python -m pytest tests/test_main.py -q`
- `.venv/bin/python -m pytest tests -q`
- `.venv/bin/ruff check src tests`
- `.venv/bin/ruff format --check src tests`
