### PR TITLE
Isolate malformed startup job registration

### DIFF
--- a/src/kai/cron.py
+++ b/src/kai/cron.py
@@ -117,20 +117,24 @@ async def _register_new_jobs(app: Application) -> int:
     now = datetime.now(UTC)
     count = 0
     for job in jobs:
-        job_name = f"cron_{job['id']}"
-        # Daily jobs with multiple times get suffixed names (cron_13_0, cron_13_1)
-        if any(name == job_name or name.startswith(f"{job_name}_") for name in registered):
-            continue
-        schedule = json.loads(job["schedule_data"])
-        # Skip expired one-shot jobs rather than registering them
-        if job["schedule_type"] == "once":
-            run_at = _ensure_utc(datetime.fromisoformat(schedule["run_at"]))
-            if run_at <= now:
-                await sessions.deactivate_job(job["id"])
-                log.info("Skipped expired one-shot job %d: %s", job["id"], job["name"])
+        try:
+            job_name = f"cron_{job['id']}"
+            # Daily jobs with multiple times get suffixed names (cron_13_0, cron_13_1)
+            if any(name == job_name or name.startswith(f"{job_name}_") for name in registered):
                 continue
-        _register_job(app, job)
-        count += 1
+            schedule = json.loads(job["schedule_data"])
+            # Skip expired one-shot jobs rather than registering them
+            if job["schedule_type"] == "once":
+                run_at = _ensure_utc(datetime.fromisoformat(schedule["run_at"]))
+                if run_at <= now:
+                    await sessions.deactivate_job(job["id"])
+                    log.info("Skipped expired one-shot job %d: %s", job["id"], job["name"])
+                    continue
+            _register_job(app, job)
+            count += 1
+        except Exception:
+            job_id = job.get("id", "<unknown>") if isinstance(job, dict) else "<unknown>"
+            log.exception("Failed to register active job %s during startup; skipping", job_id)
     return count
 
 

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -323,6 +323,21 @@ class TestRegisterNewJobs:
             count = await _register_new_jobs(mock_app)
         assert count == 2
 
+    @pytest.mark.asyncio()
+    async def test_malformed_job_does_not_abort_startup_registration(self, mock_app, caplog):
+        """One malformed active DB row is logged and skipped; later jobs still register."""
+        caplog.set_level("ERROR", logger="kai.cron")
+        jobs = [
+            _make_job(job_id=1, schedule_data="{not-json"),
+            _make_job(job_id=2, schedule_type="interval", schedule_data=json.dumps({"seconds": 60})),
+        ]
+        with patch("kai.cron.sessions.get_all_active_jobs", new_callable=AsyncMock, return_value=jobs):
+            count = await _register_new_jobs(mock_app)
+
+        assert count == 1
+        mock_app.job_queue.run_repeating.assert_called_once()
+        assert "Failed to register active job 1 during startup" in caplog.text
+
 
 # ── init_jobs ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- isolate failures while registering active scheduled jobs during startup
- log and skip a malformed/problematic row instead of aborting registration for all later rows
- add regression coverage that a malformed job does not prevent a later valid job from registering

## Security / reliability impact
This addresses the startup registration fragility portion of assessment finding #10. A single malformed active job row should no longer prevent Kai from restoring the rest of the active schedule after restart.

This deliberately does not deactivate malformed rows; that is a separate data-retention/operator-policy decision.

## Validation
- `.venv/bin/python -m pytest tests/test_cron.py -q`
- `.venv/bin/python -m pytest tests -q`
- `.venv/bin/ruff check src tests`
- `.venv/bin/ruff format --check src tests`
