### PR TITLE
Compensate failed schedule registration

### DIFF
--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -1176,7 +1176,16 @@ async def _handle_schedule(request: web.Request, principal: InternalAPIPrincipal
 
     # Register with APScheduler immediately so it starts firing
     telegram_app = request.app[TELEGRAM_APP_KEY]
-    await cron.register_job_by_id(telegram_app, job_id)
+    try:
+        registered = await cron.register_job_by_id(telegram_app, job_id)
+    except Exception:
+        log.exception("Failed to register job %d with scheduler", job_id)
+        await sessions.deactivate_job(job_id, chat_id=chat_id)
+        return web.json_response({"error": "Failed to register job"}, status=500)
+    if not registered:
+        log.error("Failed to register job %d with scheduler", job_id)
+        await sessions.deactivate_job(job_id, chat_id=chat_id)
+        return web.json_response({"error": "Failed to register job"}, status=500)
 
     log.info("Scheduled job %d '%s' via API (%s)", job_id, name, schedule_type)
     return web.json_response({"job_id": job_id, "name": name})

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -1307,6 +1307,50 @@ class TestScheduleValidation:
         body = json.loads(resp.body.decode())
         mock_register.assert_called_once_with(mock_request.app[TELEGRAM_APP_KEY], body["job_id"])
 
+    async def test_scheduler_false_deactivates_created_job(self, db, mock_request):
+        """A registration miss returns 500 and does not leave an active duplicateable job."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app[CHAT_ID_KEY] = 123
+        mock_request.json = AsyncMock(
+            return_value={
+                "name": "scheduler false",
+                "prompt": "test",
+                "schedule_type": "interval",
+                "schedule_data": {"seconds": 300},
+            }
+        )
+        with patch("kai.cron.register_job_by_id", new_callable=AsyncMock, return_value=False):
+            resp = await _handle_schedule(mock_request)
+
+        assert resp.status == 500
+        body = json.loads(resp.body.decode())
+        assert body["error"] == "Failed to register job"
+        assert await sessions.get_jobs(123) == []
+
+    async def test_scheduler_exception_deactivates_created_job(self, db, mock_request):
+        """A registration exception returns 500 and compensates the committed row."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app[CHAT_ID_KEY] = 123
+        mock_request.json = AsyncMock(
+            return_value={
+                "name": "scheduler raise",
+                "prompt": "test",
+                "schedule_type": "interval",
+                "schedule_data": {"seconds": 300},
+            }
+        )
+        with patch(
+            "kai.cron.register_job_by_id",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("scheduler unavailable"),
+        ):
+            resp = await _handle_schedule(mock_request)
+
+        assert resp.status == 500
+        body = json.loads(resp.body.decode())
+        assert body["error"] == "Failed to register job"
+        assert await sessions.get_jobs(123) == []
+
     async def test_invalid_json_returns_400(self, db, mock_request):
         """Malformed JSON body returns 400."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}


### PR DESCRIPTION
## Summary
- check the result of immediate scheduler registration after creating a job
- catch scheduler registration exceptions
- soft-deactivate the newly-created row if registration fails, so retries do not leave duplicate active jobs
- add regression coverage for both false registration results and registration exceptions

## Security / reliability impact
This addresses the schedule-create consistency portion of assessment finding #10. A failed in-memory scheduler registration should no longer leave an active DB job behind after returning an HTTP 500.

The row is soft-deactivated rather than deleted so operators retain diagnostic history.

## Validation
- `.venv/bin/python -m pytest tests/test_webhook_api.py -q`
- `.venv/bin/python -m pytest tests -q`
- `.venv/bin/ruff check src tests`
- `.venv/bin/ruff format --check src tests`
