### PR TITLE
Drain webhook background tasks on shutdown

### DIFF
--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -118,6 +118,7 @@ _webhook_registered: bool = False
 # tasks, so an unreferenced task can be silently collected mid-execution).
 # Each task removes itself from the set via a done callback.
 _background_tasks: set[asyncio.Task] = set()
+_BACKGROUND_TASK_DRAIN_TIMEOUT = 30.0
 
 # Webhook health monitor task, started in start() and cancelled in stop().
 # Periodically checks Telegram's getWebhookInfo for delivery errors and
@@ -127,6 +128,48 @@ _health_monitor_task: asyncio.Task | None = None
 # How often to check webhook health (seconds). Frequent enough to catch
 # problems quickly, infrequent enough to avoid API rate limits.
 _HEALTH_CHECK_INTERVAL = 300  # 5 minutes
+
+
+async def _drain_background_tasks(timeout: float = _BACKGROUND_TASK_DRAIN_TIMEOUT) -> None:
+    """
+    Wait briefly for fire-and-forget webhook work during shutdown.
+
+    Telegram update processing, PR review, and issue triage are launched as
+    background tasks so inbound webhooks can be acknowledged promptly. During a
+    controlled shutdown, let those tasks finish before tearing down the server.
+    If they overrun the bounded timeout, cancel them rather than hanging
+    shutdown indefinitely.
+    """
+    pending = {task for task in _background_tasks if not task.done()}
+    if not pending:
+        return
+
+    log.info("Waiting for %d webhook background task(s) to finish", len(pending))
+    done, still_pending = await asyncio.wait(pending, timeout=timeout)
+    for task in done:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            log.exception("Webhook background task failed during shutdown")
+        finally:
+            _background_tasks.discard(task)
+
+    if not still_pending:
+        return
+
+    log.warning(
+        "Cancelling %d webhook background task(s) after %.1fs shutdown timeout",
+        len(still_pending),
+        timeout,
+    )
+    for task in still_pending:
+        task.cancel()
+    await asyncio.gather(*still_pending, return_exceptions=True)
+    for task in still_pending:
+        _background_tasks.discard(task)
+
 
 # If Telegram reports an error within this window, re-register the webhook.
 # Slightly longer than the check interval so a single transient error
@@ -2360,6 +2403,7 @@ async def stop() -> None:
             except Exception:
                 log.warning("Failed to deregister Telegram webhook (will re-register on next start)")
         _webhook_registered = False
+    await _drain_background_tasks(_BACKGROUND_TASK_DRAIN_TIMEOUT)
     if _runner:
         await _runner.cleanup()
         log.info("Webhook server stopped")

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from aiohttp import web
 
+import kai.webhook as webhook_mod
 from kai import sessions
 from kai.internal_api_auth import InternalAPIAuth, InternalAPIPrincipal, InternalAPIScope
 from kai.services import ServiceResponse
@@ -42,6 +43,7 @@ from kai.webhook import (
     _handle_telegram_update,
     _handle_update_job,
     _resolve_chat_id,
+    stop,
 )
 
 
@@ -678,6 +680,65 @@ class TestTelegramUpdate:
 
         assert resp.status == 200
         telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_not_called()
+
+
+# ── webhook shutdown background task drain ─────────────────────────
+
+
+class TestWebhookStopBackgroundTasks:
+    async def test_stop_waits_for_background_tasks_before_runner_cleanup(self, monkeypatch):
+        """Clean shutdown drains in-flight webhook work before tearing down aiohttp."""
+        events: list[str] = []
+
+        async def background_work():
+            await asyncio.sleep(0)
+            events.append("task")
+
+        async def cleanup():
+            events.append("cleanup")
+
+        task = asyncio.create_task(background_work())
+        webhook_mod._background_tasks.add(task)
+        task.add_done_callback(webhook_mod._background_tasks.discard)
+
+        runner = MagicMock()
+        runner.cleanup = AsyncMock(side_effect=cleanup)
+        monkeypatch.setattr(webhook_mod, "_runner", runner)
+        monkeypatch.setattr(webhook_mod, "_app", None)
+        monkeypatch.setattr(webhook_mod, "_webhook_registered", False)
+        monkeypatch.setattr(webhook_mod, "_health_monitor_task", None)
+
+        await stop()
+
+        assert events == ["task", "cleanup"]
+        assert webhook_mod._background_tasks == set()
+
+    async def test_stop_cancels_background_tasks_after_timeout(self, monkeypatch):
+        """Shutdown remains bounded if webhook background work does not finish."""
+        started = asyncio.Event()
+
+        async def background_work():
+            started.set()
+            await asyncio.Event().wait()
+
+        task = asyncio.create_task(background_work())
+        await started.wait()
+        webhook_mod._background_tasks.add(task)
+        task.add_done_callback(webhook_mod._background_tasks.discard)
+
+        runner = MagicMock()
+        runner.cleanup = AsyncMock()
+        monkeypatch.setattr(webhook_mod, "_runner", runner)
+        monkeypatch.setattr(webhook_mod, "_app", None)
+        monkeypatch.setattr(webhook_mod, "_webhook_registered", False)
+        monkeypatch.setattr(webhook_mod, "_health_monitor_task", None)
+        monkeypatch.setattr(webhook_mod, "_BACKGROUND_TASK_DRAIN_TIMEOUT", 0.001)
+
+        await stop()
+
+        assert task.cancelled()
+        assert webhook_mod._background_tasks == set()
+        runner.cleanup.assert_awaited_once()
 
 
 # ── GitHub webhook helpers ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add bounded shutdown draining for webhook background tasks
- wait for in-flight Telegram update, PR review, and issue triage tasks before aiohttp cleanup
- cancel tasks that exceed the shutdown drain timeout instead of hanging indefinitely
- add coverage for both successful drain and timeout cancellation

## Security / reliability impact
This addresses the clean-shutdown background-task portion of assessment finding #10. Kai should no longer drop already-started webhook background work during controlled shutdown without first giving it a bounded chance to complete.

This does not make Telegram webhook acknowledgement durable; durable inbound work remains a separate, larger design change.

## Validation
- `.venv/bin/python -m pytest tests/test_webhook_api.py -q`
- `.venv/bin/python -m pytest tests -q`
- `.venv/bin/ruff check src tests`
- `.venv/bin/ruff format --check src tests`
