### PR TITLE
Retry Telegram updates when enqueue fails

### DIFF
--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -579,9 +579,9 @@ async def _handle_telegram_update(request: web.Request) -> web.Response:
     receipt before Telegram's timeout. The per-chat lock in bot.py serializes
     concurrent messages, so ordering is preserved.
 
-    Always returns 200 on valid-secret requests, even on errors. Telegram retries
-    on non-200 responses, so surfacing internal errors as HTTP errors would cause
-    an infinite retry loop. Errors are logged instead.
+    Returns 200 after the update is queued. Payload errors still return 200 to
+    avoid permanent Telegram retries, but a local enqueue failure returns 500
+    because no work was accepted and a retry may succeed.
     """
     secret = request.app[TELEGRAM_WEBHOOK_SECRET_KEY]
     provided = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
@@ -600,15 +600,28 @@ async def _handle_telegram_update(request: web.Request) -> web.Response:
 
     try:
         update = Update.de_json(data, bot)
-        if update:
-            # Fire-and-forget: return 200 to Telegram immediately while
-            # processing continues in the background. Without this, Claude's
-            # response time would exceed Telegram's webhook timeout.
-            task = asyncio.create_task(telegram_app.process_update(update))
-            _background_tasks.add(task)
-            task.add_done_callback(_background_tasks.discard)
     except Exception:
-        log.exception("Error processing Telegram update")
+        log.exception("Error deserializing Telegram update")
+        return web.Response(status=200)
+    if not update:
+        return web.Response(status=200)
+
+    # Fire-and-forget: return 200 to Telegram immediately while processing
+    # continues in the background. Without this, Claude's response time would
+    # exceed Telegram's webhook timeout.
+    process_update = None
+    try:
+        process_update = telegram_app.process_update(update)
+        task = asyncio.create_task(process_update)
+    except Exception:
+        if process_update is not None:
+            close = getattr(process_update, "close", None)
+            if close is not None:
+                close()
+        log.exception("Failed to enqueue Telegram update")
+        return web.Response(status=500, text="Failed to enqueue update")
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
 
     return web.Response(status=200)
 

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -681,6 +681,20 @@ class TestTelegramUpdate:
         assert resp.status == 200
         telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_not_called()
 
+    async def test_enqueue_failure_returns_500(self, telegram_request, monkeypatch):
+        """If no background task is queued, do not acknowledge the update as accepted."""
+        fake_update = MagicMock()
+        monkeypatch.setattr("kai.webhook.Update.de_json", MagicMock(return_value=fake_update))
+        monkeypatch.setattr("kai.webhook.asyncio.create_task", MagicMock(side_effect=RuntimeError("loop closing")))
+        telegram_request.json = AsyncMock(return_value={"update_id": 123})
+        webhook_mod._background_tasks.clear()
+
+        resp = await _handle_telegram_update(telegram_request)
+
+        assert resp.status == 500
+        telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_called_once_with(fake_update)
+        assert webhook_mod._background_tasks == set()
+
 
 # ── webhook shutdown background task drain ─────────────────────────
 


### PR DESCRIPTION
## Summary
- return HTTP 500 when a Telegram webhook update cannot be queued as a background task
- keep malformed/undecodable payload handling at HTTP 200 to avoid permanent Telegram retries
- close an unqueued process_update coroutine on enqueue failure
- add regression coverage for the no-work-accepted path

## Security / reliability impact
This addresses a narrow part of assessment finding #10. Kai should no longer acknowledge a Telegram update as accepted when local task creation fails before any work has been queued, allowing Telegram to retry that update.

This is not a durable inbound queue; it only corrects the failed-enqueue edge case.

## Validation
- `.venv/bin/python -m pytest tests/test_webhook_api.py -q`
- `.venv/bin/python -m pytest tests -q`
- `.venv/bin/ruff check src tests`
- `.venv/bin/ruff format --check src tests`
