### PR TITLE
Process Telegram webhooks through durable queue

### DIFF
--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -459,6 +459,23 @@ async def retry_telegram_update(row_id: int, error: str) -> bool:
     return cursor.rowcount > 0
 
 
+async def discard_telegram_update(row_id: int, error: str) -> bool:
+    """Mark a claimed Telegram update done after a permanent processing failure."""
+    cursor = await _get_db().execute(
+        """
+        UPDATE telegram_update_queue
+        SET status = 'done',
+            last_error = ?,
+            processed_at = CURRENT_TIMESTAMP,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = ? AND status = 'processing'
+        """,
+        (error, row_id),
+    )
+    await _get_db().commit()
+    return cursor.rowcount > 0
+
+
 async def requeue_processing_telegram_updates() -> int:
     """
     Requeue updates left in processing by a previous process crash.

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -119,6 +119,8 @@ _webhook_registered: bool = False
 # Each task removes itself from the set via a done callback.
 _background_tasks: set[asyncio.Task] = set()
 _BACKGROUND_TASK_DRAIN_TIMEOUT = 30.0
+_telegram_queue_worker_task: asyncio.Task | None = None
+_TELEGRAM_UPDATE_MAX_ATTEMPTS = 5
 
 # Webhook health monitor task, started in start() and cancelled in stop().
 # Periodically checks Telegram's getWebhookInfo for delivery errors and
@@ -169,6 +171,74 @@ async def _drain_background_tasks(timeout: float = _BACKGROUND_TASK_DRAIN_TIMEOU
     await asyncio.gather(*still_pending, return_exceptions=True)
     for task in still_pending:
         _background_tasks.discard(task)
+
+
+async def _process_queued_telegram_update(
+    row: sessions.TelegramUpdateQueueRow,
+    telegram_app: Application,
+    bot: Bot,
+) -> None:
+    row_id = row["id"]
+    try:
+        data = json.loads(row["payload"])
+        update = Update.de_json(data, bot)
+    except Exception as exc:
+        error = f"{type(exc).__name__}: {exc}"
+        log.exception("Discarding malformed queued Telegram update %s", row_id)
+        await sessions.discard_telegram_update(row_id, error)
+        return
+
+    if update is None:
+        await sessions.complete_telegram_update(row_id)
+        return
+
+    try:
+        await telegram_app.process_update(update)
+    except Exception as exc:
+        error = f"{type(exc).__name__}: {exc}"
+        if row["attempt_count"] >= _TELEGRAM_UPDATE_MAX_ATTEMPTS:
+            log.exception(
+                "Discarding Telegram update queue row %s after %d failed attempt(s)",
+                row_id,
+                row["attempt_count"],
+            )
+            await sessions.discard_telegram_update(row_id, error)
+            return
+        log.exception("Telegram update queue row %s failed; retrying later", row_id)
+        await sessions.retry_telegram_update(row_id, error)
+        return
+
+    await sessions.complete_telegram_update(row_id)
+
+
+async def _telegram_update_queue_worker(telegram_app: Application, bot: Bot) -> None:
+    try:
+        while True:
+            row = await sessions.claim_next_telegram_update()
+            if row is None:
+                return
+            await _process_queued_telegram_update(row, telegram_app, bot)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        log.exception("Telegram update queue worker crashed")
+
+
+def _telegram_worker_done(task: asyncio.Task) -> None:
+    global _telegram_queue_worker_task
+    if _telegram_queue_worker_task is task:
+        _telegram_queue_worker_task = None
+    _background_tasks.discard(task)
+
+
+def _ensure_telegram_update_queue_worker(telegram_app: Application, bot: Bot) -> None:
+    global _telegram_queue_worker_task
+    if _telegram_queue_worker_task is not None and not _telegram_queue_worker_task.done():
+        return
+    task = asyncio.create_task(_telegram_update_queue_worker(telegram_app, bot))
+    _telegram_queue_worker_task = task
+    _background_tasks.add(task)
+    task.add_done_callback(_telegram_worker_done)
 
 
 # If Telegram reports an error within this window, re-register the webhook.
@@ -568,20 +638,21 @@ async def _handle_telegram_update(request: web.Request) -> web.Response:
     Receive a Telegram update pushed via webhook.
 
     Validates the X-Telegram-Bot-Api-Secret-Token header against the configured
-    secret, deserializes the JSON body into a python-telegram-bot Update object,
-    and dispatches it to the existing handler system via process_update().
+    secret, persists the raw update to the durable inbound queue, and starts a
+    background worker that dispatches queued updates to process_update().
 
-    IMPORTANT: process_update() is launched as a background task, not awaited.
+    IMPORTANT: queued updates are processed by a background task, not awaited.
     Claude responses can take 30+ seconds, and Telegram's webhook client times
     out after ~30-35s. If we awaited process_update(), Telegram would assume
     delivery failed and retry the same message, causing duplicate responses.
-    By returning 200 immediately and processing in the background, we acknowledge
-    receipt before Telegram's timeout. The per-chat lock in bot.py serializes
-    concurrent messages, so ordering is preserved.
+    By returning 200 after durable enqueue and processing in the background, we
+    acknowledge receipt before Telegram's timeout while allowing restart replay.
+    The per-chat lock in bot.py serializes concurrent messages, so ordering is
+    preserved per chat.
 
-    Returns 200 after the update is queued. Payload errors still return 200 to
-    avoid permanent Telegram retries, but a local enqueue failure returns 500
-    because no work was accepted and a retry may succeed.
+    Returns 200 after the update is durably queued. Payloads without a usable
+    update_id still return 200 to avoid permanent Telegram retries, but a local
+    persistence failure returns 500 because no work was accepted.
     """
     secret = request.app[TELEGRAM_WEBHOOK_SECRET_KEY]
     provided = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
@@ -597,31 +668,21 @@ async def _handle_telegram_update(request: web.Request) -> web.Response:
 
     telegram_app = request.app[TELEGRAM_APP_KEY]
     bot = request.app[TELEGRAM_BOT_KEY]
-
-    try:
-        update = Update.de_json(data, bot)
-    except Exception:
-        log.exception("Error deserializing Telegram update")
-        return web.Response(status=200)
-    if not update:
+    update_id = data.get("update_id") if isinstance(data, dict) else None
+    if isinstance(update_id, bool) or not isinstance(update_id, int):
+        log.warning("Telegram update: missing or invalid update_id")
         return web.Response(status=200)
 
-    # Fire-and-forget: return 200 to Telegram immediately while processing
-    # continues in the background. Without this, Claude's response time would
-    # exceed Telegram's webhook timeout.
-    process_update = None
     try:
-        process_update = telegram_app.process_update(update)
-        task = asyncio.create_task(process_update)
+        await sessions.enqueue_telegram_update(update_id, json.dumps(data))
     except Exception:
-        if process_update is not None:
-            close = getattr(process_update, "close", None)
-            if close is not None:
-                close()
-        log.exception("Failed to enqueue Telegram update")
+        log.exception("Failed to persist Telegram update %s", update_id)
         return web.Response(status=500, text="Failed to enqueue update")
-    _background_tasks.add(task)
-    task.add_done_callback(_background_tasks.discard)
+
+    try:
+        _ensure_telegram_update_queue_worker(telegram_app, bot)
+    except Exception:
+        log.exception("Failed to start Telegram update queue worker")
 
     return web.Response(status=200)
 
@@ -2346,6 +2407,11 @@ async def start(telegram_app, config) -> None:
     # Without retries, a single timeout kills the whole startup and launchd
     # eventually gives up restarting.
     if config.telegram_webhook_url:
+        requeued = await sessions.requeue_processing_telegram_updates()
+        if requeued:
+            log.info("Requeued %d unfinished Telegram update(s) from previous run", requeued)
+        _ensure_telegram_update_queue_worker(telegram_app, telegram_app.bot)
+
         max_attempts = 5
         for attempt in range(1, max_attempts + 1):
             try:

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -97,6 +97,22 @@ class TestTelegramUpdateQueue:
         assert second_claim["attempt_count"] == 2
         assert second_claim["last_error"] == "temporary failure"
 
+    async def test_discard_marks_processing_update_done_with_error(self, db):
+        row_id, _ = await sessions.enqueue_telegram_update(1005, '{"update_id":1005}')
+        claimed = await sessions.claim_next_telegram_update()
+        assert claimed is not None
+
+        assert await sessions.discard_telegram_update(row_id, "poison update") is True
+
+        async with sessions._get_db().execute(
+            "SELECT status, last_error FROM telegram_update_queue WHERE id = ?",
+            (row_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row["status"] == "done"
+        assert row["last_error"] == "poison update"
+        assert await sessions.claim_next_telegram_update() is None
+
     async def test_requeue_processing_updates_for_startup_recovery(self, db):
         row_id, _ = await sessions.enqueue_telegram_update(1004, '{"update_id":1004}')
         first_claim = await sessions.claim_next_telegram_update()

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -620,7 +620,7 @@ def telegram_request():
 
 
 class TestTelegramUpdate:
-    async def test_valid_secret_dispatches_update(self, telegram_request, monkeypatch):
+    async def test_valid_secret_dispatches_update(self, db, telegram_request, monkeypatch):
         """Valid secret and JSON body dispatches to process_update."""
         fake_update = MagicMock()
         monkeypatch.setattr("kai.webhook.Update.de_json", MagicMock(return_value=fake_update))
@@ -629,10 +629,10 @@ class TestTelegramUpdate:
         resp = await _handle_telegram_update(telegram_request)
 
         assert resp.status == 200
-        # process_update runs as a background task (fire-and-forget to avoid
-        # Telegram's webhook timeout). Yield to the event loop so the task
-        # actually executes before we assert.
-        await asyncio.sleep(0)
+        # process_update runs from the durable queue worker. Wait for that
+        # worker before the DB fixture closes.
+        assert webhook_mod._telegram_queue_worker_task is not None
+        await webhook_mod._telegram_queue_worker_task
         telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_called_once_with(fake_update)
 
     async def test_wrong_secret_returns_401(self, telegram_request):
@@ -671,29 +671,79 @@ class TestTelegramUpdate:
         assert resp.status == 200
         telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_not_called()
 
-    async def test_null_update_skips_dispatch(self, telegram_request, monkeypatch):
-        """If Update.de_json returns None, process_update is not called."""
-        monkeypatch.setattr("kai.webhook.Update.de_json", MagicMock(return_value=None))
-        telegram_request.json = AsyncMock(return_value={"update_id": 999})
+    async def test_missing_update_id_skips_dispatch(self, telegram_request):
+        """Updates without a durable dedupe key are swallowed to avoid permanent retries."""
+        telegram_request.json = AsyncMock(return_value={"message": {"text": "missing id"}})
 
         resp = await _handle_telegram_update(telegram_request)
 
         assert resp.status == 200
         telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_not_called()
 
-    async def test_enqueue_failure_returns_500(self, telegram_request, monkeypatch):
-        """If no background task is queued, do not acknowledge the update as accepted."""
-        fake_update = MagicMock()
-        monkeypatch.setattr("kai.webhook.Update.de_json", MagicMock(return_value=fake_update))
-        monkeypatch.setattr("kai.webhook.asyncio.create_task", MagicMock(side_effect=RuntimeError("loop closing")))
+    async def test_persistence_failure_returns_500(self, telegram_request, monkeypatch):
+        """If the durable queue write fails, do not acknowledge the update as accepted."""
+        monkeypatch.setattr(
+            "kai.webhook.sessions.enqueue_telegram_update",
+            AsyncMock(side_effect=RuntimeError("database locked")),
+        )
         telegram_request.json = AsyncMock(return_value={"update_id": 123})
         webhook_mod._background_tasks.clear()
 
         resp = await _handle_telegram_update(telegram_request)
 
         assert resp.status == 500
-        telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_called_once_with(fake_update)
+        telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_not_called()
         assert webhook_mod._background_tasks == set()
+
+    async def test_worker_retries_then_completes_transient_failure(self, db, telegram_request, monkeypatch):
+        """A process_update exception requeues the durable row for another attempt."""
+        fake_update = MagicMock()
+        monkeypatch.setattr("kai.webhook.Update.de_json", MagicMock(return_value=fake_update))
+        telegram_request.app[TELEGRAM_APP_KEY].process_update = AsyncMock(side_effect=[RuntimeError("boom"), None])
+
+        row_id, _ = await sessions.enqueue_telegram_update(124, '{"update_id":124}')
+        webhook_mod._ensure_telegram_update_queue_worker(
+            telegram_request.app[TELEGRAM_APP_KEY],
+            telegram_request.app[TELEGRAM_BOT_KEY],
+        )
+        assert webhook_mod._telegram_queue_worker_task is not None
+        await webhook_mod._telegram_queue_worker_task
+
+        telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_awaited_with(fake_update)
+        assert telegram_request.app[TELEGRAM_APP_KEY].process_update.await_count == 2
+        async with sessions._get_db().execute(
+            "SELECT status, attempt_count, last_error FROM telegram_update_queue WHERE id = ?",
+            (row_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row["status"] == "done"
+        assert row["attempt_count"] == 2
+        assert "RuntimeError: boom" in row["last_error"]
+
+    async def test_worker_discards_poison_update_after_max_attempts(self, db, telegram_request, monkeypatch):
+        """A permanently failing queued update is discarded after bounded retries."""
+        fake_update = MagicMock()
+        monkeypatch.setattr("kai.webhook.Update.de_json", MagicMock(return_value=fake_update))
+        monkeypatch.setattr(webhook_mod, "_TELEGRAM_UPDATE_MAX_ATTEMPTS", 2)
+        telegram_request.app[TELEGRAM_APP_KEY].process_update = AsyncMock(side_effect=RuntimeError("always bad"))
+
+        row_id, _ = await sessions.enqueue_telegram_update(125, '{"update_id":125}')
+        webhook_mod._ensure_telegram_update_queue_worker(
+            telegram_request.app[TELEGRAM_APP_KEY],
+            telegram_request.app[TELEGRAM_BOT_KEY],
+        )
+        assert webhook_mod._telegram_queue_worker_task is not None
+        await webhook_mod._telegram_queue_worker_task
+
+        assert telegram_request.app[TELEGRAM_APP_KEY].process_update.await_count == 2
+        async with sessions._get_db().execute(
+            "SELECT status, attempt_count, last_error FROM telegram_update_queue WHERE id = ?",
+            (row_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row["status"] == "done"
+        assert row["attempt_count"] == 2
+        assert "RuntimeError: always bad" in row["last_error"]
 
 
 # ── webhook shutdown background task drain ─────────────────────────


### PR DESCRIPTION
## Summary
- persist Telegram webhook updates to the durable queue before returning HTTP 200
- process queued updates from a background worker
- requeue rows left in `processing` from a previous crash during webhook startup
- retry transient `process_update()` failures and discard poison updates after bounded attempts
- keep malformed JSON / unusable `update_id` behavior non-retrying to avoid permanent Telegram retry loops

## Security / reliability impact
This completes the main durable inbound Telegram queue wiring for assessment finding #10.

After this change, a Telegram webhook update is acknowledged only after it is stored in SQLite. If Kai crashes after acknowledgement but before processing finishes, startup requeues unfinished work and the worker processes it after restart.

Remaining caveat: if `process_update()` itself performs non-idempotent side effects and then crashes before the row is marked done, the durable queue can replay that update. That is the expected at-least-once tradeoff for durable delivery; bot handlers still need to be written with that in mind.

## Validation
- `.venv/bin/python -m pytest tests/test_webhook_api.py tests/test_sessions.py -q`
- `.venv/bin/python -m pytest tests -q`
- `.venv/bin/ruff check src tests`
- `.venv/bin/ruff format --check src tests`
