### PR TITLE
Compensate failed schedule update registration

### DIFF
--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -1436,6 +1436,8 @@ async def _handle_update_job(request: web.Request, principal: InternalAPIPrincip
     if not isinstance(payload, dict):
         return web.json_response({"error": "Request body must be a JSON object"}, status=400)
 
+    existing_job: dict | None = None
+
     # Validate schedule_type if provided
     new_schedule_type = payload.get("schedule_type")
     if new_schedule_type and new_schedule_type not in _VALID_SCHEDULE_TYPES:
@@ -1473,6 +1475,18 @@ async def _handle_update_job(request: web.Request, principal: InternalAPIPrincip
         return web.json_response({"error": str(e)}, status=400)
     except UnauthorizedChatIdError as e:
         return web.json_response({"error": str(e)}, status=403)
+
+    # If the schedule changes, keep the previous row so a failed scheduler
+    # re-registration can be compensated. Without this, PATCH can leave the DB
+    # saying a job is active on the new schedule while APScheduler has no
+    # corresponding in-memory job.
+    schedule_changed = new_schedule_type is not None or schedule_data is not None
+    if schedule_changed:
+        if existing_job is None:
+            existing_job = await sessions.get_job_by_id(job_id)
+        if existing_job is None or existing_job["chat_id"] != chat_id:
+            return web.json_response({"error": "Job not found or inactive"}, status=404)
+
     updated = await sessions.update_job(
         job_id,
         chat_id=chat_id,
@@ -1487,11 +1501,8 @@ async def _handle_update_job(request: web.Request, principal: InternalAPIPrincip
     if not updated:
         return web.json_response({"error": "Job not found or inactive"}, status=404)
 
-    # If schedule changed, re-register with APScheduler. Remove old entries
-    # and re-register with the new schedule from the database.
-    schedule_changed = new_schedule_type is not None or schedule_data is not None
     if schedule_changed:
-        # Remove old APScheduler entries
+        assert existing_job is not None
         telegram_app = request.app[TELEGRAM_APP_KEY]
         jq = telegram_app.job_queue
         assert jq is not None
@@ -1499,11 +1510,48 @@ async def _handle_update_job(request: web.Request, principal: InternalAPIPrincip
         for j in jq.jobs():
             if j.name == prefix or (j.name and j.name.startswith(f"{prefix}_")):
                 j.schedule_removal()
-        # Re-register with new schedule
-        await cron.register_job_by_id(telegram_app, job_id)
+        try:
+            registered = await cron.register_job_by_id(telegram_app, job_id)
+        except Exception:
+            log.exception("Failed to re-register updated job %d with scheduler", job_id)
+            await _restore_job_after_failed_reschedule(telegram_app, job_id, chat_id, existing_job)
+            return web.json_response({"error": "Failed to register job"}, status=500)
+        if not registered:
+            log.error("Failed to re-register updated job %d with scheduler", job_id)
+            await _restore_job_after_failed_reschedule(telegram_app, job_id, chat_id, existing_job)
+            return web.json_response({"error": "Failed to register job"}, status=500)
 
     log.info("Updated job %d via API", job_id)
     return web.json_response({"updated": job_id})
+
+
+async def _restore_job_after_failed_reschedule(
+    telegram_app: Application,
+    job_id: int,
+    chat_id: int,
+    previous_job: dict,
+) -> None:
+    """Best-effort rollback after PATCH committed but scheduler registration failed."""
+    restored = await sessions.update_job(
+        job_id,
+        chat_id=chat_id,
+        name=previous_job["name"],
+        prompt=previous_job["prompt"],
+        schedule_type=previous_job["schedule_type"],
+        schedule_data=previous_job["schedule_data"],
+        auto_remove=previous_job["auto_remove"],
+        notify_on_check=previous_job["notify_on_check"],
+    )
+    if not restored:
+        log.error("Failed to restore job %d after scheduler registration failure", job_id)
+        return
+    try:
+        restored_registered = await cron.register_job_by_id(telegram_app, job_id)
+    except Exception:
+        log.exception("Failed to restore scheduler entry for job %d after rollback", job_id)
+        return
+    if not restored_registered:
+        log.error("Failed to restore scheduler entry for job %d after rollback", job_id)
 
 
 # ── Service proxy ────────────────────────────────────────────────────

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -4,7 +4,7 @@ import asyncio
 import hashlib
 import hmac as hmac_mod
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from aiohttp import web
@@ -351,6 +351,88 @@ class TestUpdateJob:
         body = json.loads(resp.body.decode())
         assert "error" in body
         assert "json" in body["error"].lower()
+
+    async def test_update_schedule_registration_false_rolls_back_job(self, db, mock_request):
+        """PATCH rolls back DB changes if scheduler registration returns False."""
+        job_id = await sessions.create_job(
+            chat_id=123,
+            name="old name",
+            job_type="reminder",
+            prompt="old prompt",
+            schedule_type="interval",
+            schedule_data='{"seconds": 300}',
+            auto_remove=False,
+            notify_on_check=True,
+        )
+        queued_job = MagicMock()
+        queued_job.name = f"cron_{job_id}"
+        mock_request.app[TELEGRAM_APP_KEY].job_queue.jobs.return_value = [queued_job]
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.match_info = {"id": str(job_id)}
+        mock_request.json = AsyncMock(
+            return_value={
+                "name": "new name",
+                "prompt": "new prompt",
+                "schedule_data": {"seconds": 600},
+                "auto_remove": True,
+                "notify_on_check": False,
+            }
+        )
+
+        with patch(
+            "kai.cron.register_job_by_id",
+            new_callable=AsyncMock,
+            side_effect=[False, True],
+        ) as mock_register:
+            resp = await _handle_update_job(mock_request)
+
+        assert resp.status == 500
+        body = json.loads(resp.body.decode())
+        assert body["error"] == "Failed to register job"
+        queued_job.schedule_removal.assert_called_once()
+        mock_register.assert_has_awaits(
+            [
+                call(mock_request.app[TELEGRAM_APP_KEY], job_id),
+                call(mock_request.app[TELEGRAM_APP_KEY], job_id),
+            ]
+        )
+        job = await sessions.get_job_by_id(job_id)
+        assert job is not None
+        assert job["name"] == "old name"
+        assert job["prompt"] == "old prompt"
+        assert job["schedule_type"] == "interval"
+        assert job["schedule_data"] == '{"seconds": 300}'
+        assert job["auto_remove"] is False
+        assert job["notify_on_check"] is True
+
+    async def test_update_schedule_registration_exception_rolls_back_job(self, db, mock_request):
+        """PATCH rolls back DB changes if scheduler registration raises."""
+        job_id = await sessions.create_job(
+            chat_id=123,
+            name="old name",
+            job_type="reminder",
+            prompt="old prompt",
+            schedule_type="daily",
+            schedule_data='{"times": ["09:00"]}',
+        )
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.match_info = {"id": str(job_id)}
+        mock_request.json = AsyncMock(return_value={"schedule_data": {"times": ["10:00"]}})
+
+        with patch(
+            "kai.cron.register_job_by_id",
+            new_callable=AsyncMock,
+            side_effect=[RuntimeError("scheduler unavailable"), True],
+        ):
+            resp = await _handle_update_job(mock_request)
+
+        assert resp.status == 500
+        body = json.loads(resp.body.decode())
+        assert body["error"] == "Failed to register job"
+        job = await sessions.get_job_by_id(job_id)
+        assert job is not None
+        assert job["schedule_type"] == "daily"
+        assert job["schedule_data"] == '{"times": ["09:00"]}'
 
 
 # ── POST /api/send-file ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the remaining schedule-update consistency gap from security finding #10.

`POST /api/schedule` already compensated failed scheduler registration by deactivating the newly-created row. `PATCH /api/jobs/{id}` still had the same class of failure: it could commit a schedule change to the database, remove the old APScheduler entry, and then ignore a failed or crashing re-registration attempt. That left an active DB row whose in-memory scheduler state did not match reality.

This PR makes schedule update re-registration fail closed:

- capture the existing job row before applying a schedule-changing PATCH
- return 404 before mutation if the job is missing or belongs to another chat
- after DB update, remove the old APScheduler entries and attempt to register the new schedule
- if registration returns false or raises, rollback the DB row to its prior mutable fields
- best-effort restore the prior scheduler entry
- return HTTP 500 instead of reporting a successful update

## Security impact

This reduces accepted-work inconsistency for scheduled jobs:

- no silent success when the scheduler did not accept the new schedule
- no active DB row left representing a schedule that was not registered
- mixed metadata + schedule PATCHes rollback as a unit when scheduler registration fails

This is still best-effort around the in-memory scheduler, because APScheduler has no transaction boundary shared with SQLite. The durable invariant is that API success now means the scheduler accepted the new row; API failure restores the DB representation and attempts to restore the old scheduler entry.

## Tests

- `.venv/bin/python -m pytest tests/test_webhook_api.py -q`
  - `246 passed`
- `.venv/bin/python -m pytest tests/test_cron.py tests/test_sessions.py tests/test_main.py -q`
  - `200 passed`
- `.venv/bin/python -m pytest -q`
  - `4753 passed, 1 skipped`
