### PR TITLE
Add Pyright baseline to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,8 @@ jobs:
       - name: Lint and format check
         run: make BIN= check
 
+      - name: Type check
+        run: make BIN= typecheck
+
       - name: Run tests
         run: make BIN= test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,13 +134,16 @@ async def save_session(chat_id: int, session_id: str, model: str, cost_usd: floa
 
 ### Type Safety
 
-The codebase passes Pyright in strict mode. All code changes are
-expected to maintain this:
+CI runs Pyright on a maintained baseline of typed trust-boundary modules.
+All code changes in that baseline are expected to keep it clean:
 
 - Type annotations on all function signatures.
 - `assert` for narrowing `Optional` types from external libraries.
 - Extract `@property` returns to local variables before narrowing
   (Pyright limitation).
+
+The full codebase is not yet Pyright-clean. Expand the baseline
+incrementally as modules are cleaned up.
 
 ### Security
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # where tools are installed globally (no .venv).
 BIN = .venv/bin/
 
-.PHONY: run lint format check test setup config install install-status tts-model refresh-models
+.PHONY: run lint format check typecheck test setup config install install-status tts-model refresh-models
 
 run:
 	$(BIN)python -m kai
@@ -15,6 +15,9 @@ format:
 
 check: lint
 	$(BIN)ruff format --check .
+
+typecheck:
+	$(BIN)pyright --pythonpath "$$($(BIN)python -c 'import sys; print(sys.executable)')"
 
 test:
 	$(BIN)python -m pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ make setup      # Install in editable mode with dev tools
 make lint       # Run ruff
 make format     # Format with ruff
 make check      # Lint and format check
+make typecheck  # Run Pyright on the maintained typed baseline
 make test       # Run pytest
 make run        # Start Kai locally
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ kai = "kai.main:main"
 [project.optional-dependencies]
 dev = [
     "ruff>=0.9.0",
+    "pyright>=1.1.390",
     "pytest>=8.0",
     "pytest-asyncio>=0.24.0",
 ]
@@ -80,3 +81,18 @@ markers = [
 # the specific class or test that triggers them; that keeps the
 # suppression scoped to the known third-party code path and the
 # blast radius bounded.
+
+[tool.pyright]
+pythonVersion = "3.13"
+pythonPlatform = "All"
+include = [
+    "src/kai/backend_registry.py",
+    "src/kai/github_api.py",
+    "src/kai/internal_api_auth.py",
+    "src/kai/locks.py",
+    "src/kai/prompt_utils.py",
+    "src/kai/services.py",
+    "src/kai/sessions.py",
+    "src/kai/user_isolation.py",
+    "src/kai/workspace_utils.py",
+]


### PR DESCRIPTION
## Summary

Starts addressing security finding #11 by adding an enforceable Pyright baseline to CI.

The assessment noted that `CONTRIBUTING.md` claimed strict Pyright coverage, but Pyright was neither installed as a dev dependency nor run in CI. A raw full-repo Pyright run is not currently viable: after setting Python 3.13 and using the project venv, the full source tree still reports 76 existing errors. Enforcing that all at once would turn this into a broad cleanup project.

This PR instead adds a small, passing baseline focused on typed trust-boundary/support modules:

- `src/kai/backend_registry.py`
- `src/kai/github_api.py`
- `src/kai/internal_api_auth.py`
- `src/kai/locks.py`
- `src/kai/prompt_utils.py`
- `src/kai/services.py`
- `src/kai/sessions.py`
- `src/kai/user_isolation.py`
- `src/kai/workspace_utils.py`

Changes:

- add `pyright` to the `dev` extra
- add `[tool.pyright]` config with Python 3.13 and the maintained baseline
- add `make typecheck`
- run `make BIN= typecheck` in CI
- update README/CONTRIBUTING so docs match the actually enforced state

## Notes

`make typecheck` passes `--pythonpath $(BIN)python` so Pyright resolves the same environment used by local dev and CI. Without this, local runs missed installed packages such as `aiosqlite`.

The intent is to expand this baseline incrementally as modules are cleaned up, rather than pretending the whole repository is already strict-clean.

## Verification

- `make typecheck`
  - `0 errors, 0 warnings, 0 informations`
- `make check`
  - Ruff check passed
  - Ruff format check passed
- `make test`
  - sandboxed run failed due environment restrictions on local socket binding / memory tests
  - rerun outside sandbox passed:
    - `4753 passed, 1 skipped`
