### PR TITLE
Add advisory dependency audit workflow

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,45 @@
+# Report known Python dependency vulnerabilities.
+#
+# This workflow is intentionally non-blocking while Kai still has an
+# existing vulnerability backlog. It runs on a schedule and on manual
+# dispatch so maintainers can see the current dependency risk without
+# breaking unrelated PRs. Convert it to blocking once the backlog is
+# cleared or an explicit ignore policy is in place.
+name: Dependency audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 11 * * 1"
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -e '.[dev,memory,totp,tts]'
+
+      - name: Run dependency audit
+        run: |
+          set +e
+          make BIN= audit-deps > pip-audit.txt
+          status=$?
+          pip-audit --local --skip-editable --format json --output pip-audit.json
+          echo "pip-audit exited with status ${status}" >> pip-audit.txt
+          cat pip-audit.txt
+          exit 0
+
+      - name: Upload audit report
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-audit-report
+          path: |
+            pip-audit.txt
+            pip-audit.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,11 @@ networking, file I/O, or process execution follow these rules:
 - **No new attack surface without discussion.** New endpoints, file
   operations, or shell commands get discussed in an issue first.
 
+CI includes a scheduled, non-blocking dependency audit workflow. Run
+`make audit-deps` locally to inspect the current installed environment.
+The audit is advisory until the existing dependency-vulnerability backlog
+is cleared or an explicit ignore policy is documented.
+
 ### Tests
 
 - Tests live in `tests/` and use **pytest** with **pytest-asyncio**.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # where tools are installed globally (no .venv).
 BIN = .venv/bin/
 
-.PHONY: run lint format check typecheck test setup config install install-status tts-model refresh-models
+.PHONY: run lint format check typecheck audit-deps test setup config install install-status tts-model refresh-models
 
 run:
 	$(BIN)python -m kai
@@ -18,6 +18,9 @@ check: lint
 
 typecheck:
 	$(BIN)pyright --pythonpath "$$($(BIN)python -c 'import sys; print(sys.executable)')"
+
+audit-deps:
+	$(BIN)pip-audit --local --skip-editable
 
 test:
 	$(BIN)python -m pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ make lint       # Run ruff
 make format     # Format with ruff
 make check      # Lint and format check
 make typecheck  # Run Pyright on the maintained typed baseline
+make audit-deps # Report known vulnerabilities in installed dependencies
 make test       # Run pytest
 make run        # Start Kai locally
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ kai = "kai.main:main"
 dev = [
     "ruff>=0.9.0",
     "pyright>=1.1.390",
+    "pip-audit>=2.10.0",
     "pytest>=8.0",
     "pytest-asyncio>=0.24.0",
 ]


### PR DESCRIPTION
## Summary

- add `make audit-deps` for local Python dependency vulnerability reporting
- add a scheduled/manual GitHub Actions dependency audit workflow
- keep the audit advisory for now, uploading text and JSON reports without blocking unrelated PRs

## Rationale

Kai currently has a dependency vulnerability backlog, so making `pip-audit` fail every PR would block normal security cleanup work. This PR adds visibility first. Once the backlog is either cleared or explicitly ignored with documented rationale, the workflow can be converted to blocking.

## Validation

- `make typecheck`
- `make check`
- `.venv/bin/python -c 'import yaml; yaml.safe_load(open(".github/workflows/dependency-audit.yml")); print("workflow yaml ok")'`
- `make audit-deps` reports the current known vulnerability backlog as expected

## Notes

- The workflow runs on a weekly schedule and via `workflow_dispatch`.
- The workflow intentionally exits 0 after producing `pip-audit.txt` and `pip-audit.json`.
