### PR TITLE
Bound direct dependency major versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,10 @@ CI includes a scheduled, non-blocking dependency audit workflow. Run
 The audit is advisory until the existing dependency-vulnerability backlog
 is cleared or an explicit ignore policy is documented.
 
+Direct dependencies should use both a lower bound and a conservative upper
+bound, normally the next major version. This keeps routine installs from
+silently crossing major-version compatibility boundaries.
+
 ### Tests
 
 - Tests live in `tests/` and use **pytest** with **pytest-asyncio**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68.0"]
+requires = ["setuptools>=68.0,<84"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -9,11 +9,11 @@ description = "Telegram gateway to Claude Code CLI"
 license = "Apache-2.0"
 requires-python = ">=3.13"
 dependencies = [
-    "python-telegram-bot[ext]>=20.0",
-    "aiosqlite>=0.19.0",
-    "python-dotenv>=1.0.0",
-    "aiohttp>=3.9.0",
-    "pyyaml>=6.0",
+    "python-telegram-bot[ext]>=20.0,<23",
+    "aiosqlite>=0.19.0,<1",
+    "python-dotenv>=1.0.0,<2",
+    "aiohttp>=3.9.0,<4",
+    "pyyaml>=6.0,<7",
 ]
 
 [project.scripts]
@@ -21,22 +21,22 @@ kai = "kai.main:main"
 
 [project.optional-dependencies]
 dev = [
-    "ruff>=0.9.0",
-    "pyright>=1.1.390",
-    "pip-audit>=2.10.0",
-    "pytest>=8.0",
-    "pytest-asyncio>=0.24.0",
+    "ruff>=0.9.0,<1",
+    "pyright>=1.1.390,<2",
+    "pip-audit>=2.10.0,<3",
+    "pytest>=8.0,<10",
+    "pytest-asyncio>=0.24.0,<2",
 ]
 memory = [
-    "mem0ai>=2.0.0",
-    "sentence-transformers>=3.0.0",
+    "mem0ai>=2.0.0,<3",
+    "sentence-transformers>=3.0.0,<6",
 ]
 tts = [
-    "piper-tts>=1.4.0",
+    "piper-tts>=1.4.0,<2",
 ]
 totp = [
-    "pyotp>=2.9",
-    "qrcode>=7.4",
+    "pyotp>=2.9,<3",
+    "qrcode>=7.4,<9",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary

- add conservative upper bounds to direct runtime, optional, dev, and build dependencies
- document the dependency-bound policy for future changes

## Rationale

Kai previously used lower-only direct dependency specifiers. That allows routine installs and CI runs to cross major-version compatibility boundaries without review. This PR keeps the currently working dependency families but prevents silent major-version jumps.

This is intentionally smaller than introducing a full lock file. It reduces dependency drift immediately without changing the installer flow or forcing a new lock-management process in the same change.

## Validation

- parsed every build/runtime/optional dependency with `packaging.requirements.Requirement`
- `make check`
- `make typecheck`
- `.venv/bin/python -m pip install --dry-run -e '.[dev,totp]'`
- `.venv/bin/python -m pip install --dry-run -e '.[memory,totp,tts]'`
