### PR TITLE
Support install dependency constraints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,11 @@ Direct dependencies should use both a lower bound and a conservative upper
 bound, normally the next major version. This keeps routine installs from
 silently crossing major-version compatibility boundaries.
 
+If `requirements/constraints.txt` exists, the protected installer copies it
+into `/opt/kai` and passes it to `pip install --constraint`. Treat changes to
+that file as install-affecting supply-chain changes and review them with the
+same care as `pyproject.toml`.
+
 ### Tests
 
 - Tests live in `tests/` and use **pytest** with **pytest-asyncio**.

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -125,6 +125,7 @@ class ServiceStartError(Exception):
 # Files and directories to copy from source to the install location.
 # Excludes __pycache__, .pyc, and other build artifacts.
 _SOURCE_EXCLUDES = {"__pycache__", "*.pyc", "*.egg-info", ".git", ".venv", ".env"}
+_INSTALL_CONSTRAINTS_REL = Path("requirements") / "constraints.txt"
 
 # ── Input helpers ────────────────────────────────────────────────────
 
@@ -5430,11 +5431,13 @@ def _retire_install_home_dir(install_path: Path, dry_run: bool) -> None:
 
 
 def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool) -> None:
-    """Copy source tree and home config from PROJECT_ROOT to the install location."""
+    """Copy source tree, package metadata, optional constraints, and home config into the install tree."""
     src_src = PROJECT_ROOT / "src"
     src_dst = install_path / "src"
     pyproject_src = PROJECT_ROOT / "pyproject.toml"
     pyproject_dst = install_path / "pyproject.toml"
+    constraints_src = PROJECT_ROOT / _INSTALL_CONSTRAINTS_REL
+    constraints_dst = install_path / _INSTALL_CONSTRAINTS_REL
     # Config templates (e.g. goose-config.yaml) referenced by later
     # install steps like _apply_goose_config(). Root-owned since
     # these are static templates, not runtime data. Per-user runtime
@@ -5470,6 +5473,10 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
     if dry_run:
         print(f"[DRY RUN] Would copy: {src_src} -> {src_dst}")
         print(f"[DRY RUN] Would copy: {pyproject_src} -> {pyproject_dst}")
+        if constraints_src.is_file():
+            print(f"[DRY RUN] Would copy: {constraints_src} -> {constraints_dst}")
+        elif constraints_dst.exists():
+            print(f"[DRY RUN] Would remove stale install constraints: {constraints_dst}")
         if config_src.is_dir():
             print(f"[DRY RUN] Would copy: {config_src} -> {config_dst}")
         # Dry-run preview for the empty-home cleanup. Matches the
@@ -5489,6 +5496,15 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
     shutil.copy2(pyproject_src, pyproject_dst)
     os.chown(pyproject_dst, 0, 0)
     print(f"  Copied {pyproject_dst}")
+
+    if constraints_src.is_file():
+        constraints_dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(constraints_src, constraints_dst)
+        os.chown(constraints_dst, 0, 0)
+        print(f"  Copied {constraints_dst}")
+    elif constraints_dst.exists():
+        constraints_dst.unlink()
+        print(f"  Removed stale install constraints {constraints_dst}")
 
     # Copy templates/config/ -> install/config/ (config templates like
     # goose-config.yaml). These are static templates referenced by
@@ -5540,6 +5556,11 @@ def _resolve_venv_base_python() -> str:
     return python
 
 
+def _optional_file_checksum(path: Path) -> str:
+    """Return a file checksum, or an empty string when the optional file is absent."""
+    return _file_checksum(path) if path.is_file() else ""
+
+
 def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:
     """
     Create or update the virtual environment in the install location.
@@ -5560,6 +5581,7 @@ def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:
     venv_path = install_path / "venv"
     venv_python = venv_path / "bin" / "python"
     pyproject_dst = install_path / "pyproject.toml"
+    constraints_dst = install_path / _INSTALL_CONSTRAINTS_REL
     src_dst = install_path / "src"
     build_path = install_path / "build"
 
@@ -5588,6 +5610,13 @@ def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:
         incoming_pyproject = PROJECT_ROOT / "pyproject.toml" if dry_run else pyproject_dst
         new_pyproject = _file_checksum(incoming_pyproject)
 
+        constraints_checksum_file = install_path / ".constraints.sha256"
+        old_constraints = ""
+        if constraints_checksum_file.exists():
+            old_constraints = constraints_checksum_file.read_text().strip()
+        incoming_constraints = PROJECT_ROOT / _INSTALL_CONSTRAINTS_REL if dry_run else constraints_dst
+        new_constraints = _optional_file_checksum(incoming_constraints)
+
         src_checksum_file = install_path / ".src.sha256"
         old_src = ""
         if src_checksum_file.exists():
@@ -5595,14 +5624,21 @@ def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:
         incoming_src = PROJECT_ROOT / "src" if dry_run else src_dst
         new_src = _src_checksum(incoming_src)
 
-        if old_pyproject == new_pyproject and old_src == new_src and not venv_needs_repair:
-            print("  Venv unchanged (pyproject.toml and source checksums match)")
+        if (
+            old_pyproject == new_pyproject
+            and old_constraints == new_constraints
+            and old_src == new_src
+            and not venv_needs_repair
+        ):
+            print("  Venv unchanged (pyproject.toml, constraints, and source checksums match)")
             return
 
         # Report what changed for operator visibility
         changed: list[str] = []
         if old_pyproject != new_pyproject:
             changed.append("pyproject.toml")
+        if old_constraints != new_constraints:
+            changed.append("constraints")
         if old_src != new_src:
             changed.append("source")
 
@@ -5666,16 +5702,18 @@ def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:
     # and doesn't depend on the source directory being writable.
     extras = "memory,totp,tts"
     install_spec = f"{install_path}[{extras}]"
-    subprocess.run(
-        [str(venv_python), "-m", "pip", "install", install_spec],
-        check=True,
-    )
+    pip_install_cmd = [str(venv_python), "-m", "pip", "install"]
+    if constraints_dst.is_file():
+        pip_install_cmd.extend(["--constraint", str(constraints_dst)])
+    pip_install_cmd.append(install_spec)
+    subprocess.run(pip_install_cmd, check=True)
     print("  Installed package into venv")
 
     # Save checksums for future update detection. Both are written after a
     # successful install so that a partial failure (e.g., pip crash mid-install)
     # leaves stale checksums and triggers a retry on the next run.
     (install_path / ".pyproject.sha256").write_text(_file_checksum(pyproject_dst) + "\n")
+    (install_path / ".constraints.sha256").write_text(_optional_file_checksum(constraints_dst) + "\n")
     (install_path / ".src.sha256").write_text(_src_checksum(src_dst) + "\n")
 
     # Set venv ownership to root (read-only for service user)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -46,6 +46,7 @@ from kai.install import (
     _generate_systemd_unit,
     _generate_users_yaml,
     _migrate_identity_to_claude_md,
+    _optional_file_checksum,
     _prompt_choice,
     _prompt_optional_choice,
     _read_users_yaml_text,
@@ -4431,11 +4432,89 @@ class TestApplyVenv:
 
         # Both checksum files should exist now
         assert (install / ".pyproject.sha256").exists()
+        assert (install / ".constraints.sha256").exists()
         assert (install / ".src.sha256").exists()
 
         # And they should contain the correct checksums
         assert (install / ".pyproject.sha256").read_text().strip() == _file_checksum(install / "pyproject.toml")
+        assert (install / ".constraints.sha256").read_text().strip() == ""
         assert (install / ".src.sha256").read_text().strip() == _src_checksum(install / "src")
+
+    def test_reinstalls_on_constraints_change(self, tmp_path, monkeypatch, capsys):
+        """Constraint file changes trigger a venv reinstall even when source is unchanged."""
+        install = tmp_path / "opt" / "kai"
+        install.mkdir(parents=True)
+        (install / "venv" / "bin").mkdir(parents=True)
+        (install / "venv" / "bin" / "python").touch(mode=0o755)
+
+        (install / "pyproject.toml").write_text("[project]\nname = 'kai'\n")
+        constraints = install / "requirements" / "constraints.txt"
+        constraints.parent.mkdir(parents=True)
+        constraints.write_text("aiohttp==3.13.4\n")
+        src = install / "src" / "kai"
+        src.mkdir(parents=True)
+        (src / "__init__.py").write_text("# init")
+
+        (install / ".pyproject.sha256").write_text(_file_checksum(install / "pyproject.toml") + "\n")
+        (install / ".constraints.sha256").write_text(_file_checksum(constraints) + "\n")
+        (install / ".src.sha256").write_text(_src_checksum(install / "src") + "\n")
+
+        constraints.write_text("aiohttp==3.14.0\n")
+
+        commands = []
+
+        def fake_run(cmd, **kwargs):
+            commands.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr("kai.install._set_ownership", lambda *a, **kw: None)
+
+        _apply_venv(install, is_update=True, dry_run=False)
+
+        output = capsys.readouterr().out
+        assert "constraints changed" in output
+        assert [
+            str(install / "venv" / "bin" / "python"),
+            "-m",
+            "pip",
+            "install",
+            "--constraint",
+            str(constraints),
+            f"{install}[memory,totp,tts]",
+        ] in commands
+        assert (install / ".constraints.sha256").read_text().strip() == _file_checksum(constraints)
+
+    def test_dry_run_reports_constraints_change(self, tmp_path, monkeypatch, capsys):
+        """Dry-run compares incoming constraints without copying them."""
+        install = tmp_path / "opt" / "kai"
+        install.mkdir(parents=True)
+        (install / "venv" / "bin").mkdir(parents=True)
+        (install / "venv" / "bin" / "python").touch(mode=0o755)
+
+        (install / "pyproject.toml").write_text("[project]\nname = 'kai'\n")
+        src = install / "src" / "kai"
+        src.mkdir(parents=True)
+        (src / "__init__.py").write_text("# init")
+
+        (install / ".pyproject.sha256").write_text(_file_checksum(install / "pyproject.toml") + "\n")
+        (install / ".src.sha256").write_text(_src_checksum(install / "src") + "\n")
+
+        project = tmp_path / "project"
+        (project / "src" / "kai").mkdir(parents=True)
+        (project / "pyproject.toml").write_text("[project]\nname = 'kai'\n")
+        (project / "src" / "kai" / "__init__.py").write_text("# init")
+        incoming_constraints = project / "requirements" / "constraints.txt"
+        incoming_constraints.parent.mkdir(parents=True)
+        incoming_constraints.write_text("aiohttp==3.13.4\n")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", project)
+
+        _apply_venv(install, is_update=True, dry_run=True)
+
+        output = capsys.readouterr().out
+        assert "DRY RUN" in output
+        assert "constraints changed" in output
+        assert not (install / "requirements" / "constraints.txt").exists()
 
     def test_first_update_without_src_checksum(self, tmp_path, monkeypatch, capsys):
         """First update after this fix triggers reinstall (no .src.sha256 from old install)."""
@@ -6215,17 +6294,17 @@ class TestGenerateLauncherScript:
 
 class TestApplySource:
     """
-    _apply_source copies src/, pyproject.toml, and templates/config/
-    into the install tree, and retires the dead <install>/home/.claude/
-    subtree (and any legacy IDENTITY.md) via _retire_install_home_claude.
-    Post-#447 the install tree carries no CLAUDE.md; the per-user
-    runtime <DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md is seeded by
+    _apply_source copies src/, pyproject.toml, optional install
+    constraints, and templates/config/ into the install tree, and
+    retires the dead <install>/home/.claude/ subtree (and any legacy
+    IDENTITY.md) via _retire_install_home_claude. Post-#447 the install
+    tree carries no CLAUDE.md; the per-user runtime
+    <DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md is seeded by
     _apply_migrate (eager, install-time) and backend.ensure_user_home
     (lazy, first-message fallback). The retirement helper has its own
-    pinned contracts in TestRetireInstallHomeClaude below; the
-    migration helper that ran before #447 is no longer called from
-    _apply_source but is unit-tested directly in
-    TestMigrateIdentityToClaudeMd.
+    pinned contracts in TestRetireInstallHomeClaude below; the migration
+    helper that ran before #447 is no longer called from _apply_source
+    but is unit-tested directly in TestMigrateIdentityToClaudeMd.
     """
 
     def test_dry_run_does_not_mention_retired_template_paths(self, tmp_path, capsys):
@@ -6331,6 +6410,59 @@ class TestApplySource:
         # Should not create the destination during dry run.
         assert not (tmp_path / "install" / "config").exists()
         assert not (tmp_path / "install" / "home" / "config").exists()
+
+    def test_copies_install_constraints(self, tmp_path):
+        """requirements/constraints.txt is copied to the install tree when present."""
+        src = tmp_path / "source"
+        (src / "src").mkdir(parents=True)
+        (src / "src" / "module.py").write_text("code")
+        (src / "pyproject.toml").write_text("[project]")
+        constraints_src = src / "requirements" / "constraints.txt"
+        constraints_src.parent.mkdir(parents=True)
+        constraints_src.write_text("aiohttp==3.13.4\n")
+        install = tmp_path / "install"
+        install.mkdir()
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install._set_ownership"),
+            patch("os.chown"),
+        ):
+            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
+
+        constraints_dst = install / "requirements" / "constraints.txt"
+        assert constraints_dst.read_text() == "aiohttp==3.13.4\n"
+
+    def test_removes_stale_install_constraints(self, tmp_path):
+        """A removed source constraints file removes the stale install copy."""
+        src = tmp_path / "source"
+        (src / "src").mkdir(parents=True)
+        (src / "src" / "module.py").write_text("code")
+        (src / "pyproject.toml").write_text("[project]")
+        install = tmp_path / "install"
+        install.mkdir()
+        constraints_dst = install / "requirements" / "constraints.txt"
+        constraints_dst.parent.mkdir(parents=True)
+        constraints_dst.write_text("aiohttp==3.13.4\n")
+
+        with (
+            patch("kai.install.PROJECT_ROOT", src),
+            patch("kai.install._set_ownership"),
+            patch("os.chown"),
+        ):
+            _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
+
+        assert not constraints_dst.exists()
+
+
+class TestOptionalFileChecksum:
+    def test_missing_file_returns_empty_string(self, tmp_path):
+        assert _optional_file_checksum(tmp_path / "missing.txt") == ""
+
+    def test_existing_file_returns_file_checksum(self, tmp_path):
+        path = tmp_path / "constraints.txt"
+        path.write_text("aiohttp==3.13.4\n")
+        assert _optional_file_checksum(path) == _file_checksum(path)
 
 
 # ── _retire_install_home_claude ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- teach the protected installer to copy `requirements/constraints.txt` when present
- pass the copied constraints file to `pip install --constraint`
- include constraints changes in venv update detection and dry-run reporting
- remove stale installed constraints when the source constraints file is removed

## Rationale

This prepares Kai for reviewed dependency constraints without changing current install behavior when no constraints file exists. It is the next supply-chain control after advisory auditing and direct dependency upper bounds: once a constraints file is introduced, `make install` will use the same reviewed dependency boundary instead of relying on operator shell behavior.

## Validation

- `tests/test_install.py::TestApplyVenv`
- `tests/test_install.py::TestApplySource`
- `tests/test_install.py::TestOptionalFileChecksum`
- `tests/test_install.py`
- `make check`
- `make typecheck`
