### PR TITLE
Add reviewed install dependency constraints

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -24,7 +24,7 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install -e '.[dev,memory,totp,tts]'
+        run: pip install --constraint requirements/constraints.txt -e '.[dev,memory,totp,tts]'
 
       - name: Run dependency audit
         run: |

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # where tools are installed globally (no .venv).
 BIN = .venv/bin/
 
-.PHONY: run lint format check typecheck audit-deps test setup config install install-status tts-model refresh-models
+.PHONY: run lint format check typecheck audit-deps check-install-constraints test setup config install install-status tts-model refresh-models
 
 run:
 	$(BIN)python -m kai
@@ -21,6 +21,9 @@ typecheck:
 
 audit-deps:
 	$(BIN)pip-audit --local --skip-editable
+
+check-install-constraints:
+	$(BIN)python -m pip install --dry-run --constraint requirements/constraints.txt -e '.[memory,totp,tts]'
 
 test:
 	$(BIN)python -m pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ make format     # Format with ruff
 make check      # Lint and format check
 make typecheck  # Run Pyright on the maintained typed baseline
 make audit-deps # Report known vulnerabilities in installed dependencies
+make check-install-constraints # Dry-run install dependency resolution with constraints
 make test       # Run pytest
 make run        # Start Kai locally
 ```

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,0 +1,22 @@
+# Reviewed install constraints for Kai's protected install.
+#
+# The protected installer copies this file into /opt/kai and passes it to
+# `pip install --constraint` when installing `.[memory,totp,tts]`.
+#
+# Scope: direct runtime and optional-install dependencies only. Do not add
+# incidental transitive packages here unless a vulnerability, compatibility
+# issue, or reproducibility incident requires it.
+
+python-telegram-bot==22.6
+aiosqlite==0.22.1
+python-dotenv==1.2.2
+aiohttp==3.14.3
+pyyaml==6.0.3
+
+mem0ai==2.0.0
+sentence-transformers==5.4.1
+
+piper-tts==1.4.1
+
+pyotp==2.9.0
+qrcode==8.2


### PR DESCRIPTION
## Summary

- add a reviewed `requirements/constraints.txt` for direct protected-install dependencies
- add `make check-install-constraints` to dry-run the installer dependency set against the constraints file
- make the dependency-audit workflow install with the same constraints

## Rationale

PR #773 made the installer constraints-aware but left behavior unchanged because no constraints file existed. This PR turns that path on with a deliberately narrow constraints file: direct runtime and optional-install dependencies only.

This is not a full transitive lock. It constrains the packages Kai asks for directly, reduces silent install drift, and keeps transitive dependency policy reviewable in later smaller changes.

Notable security choice: `aiohttp` is constrained to `3.14.3` because `pip-audit` still reported advisories against `3.13.4`.

## Validation

- `make check`
- `make typecheck`
- parsed `requirements/constraints.txt` with `packaging.requirements.Requirement`
- parsed `.github/workflows/dependency-audit.yml` with PyYAML
- `make check-install-constraints`
- `.venv/bin/python -m pip install --dry-run --constraint requirements/constraints.txt -e '.[dev,memory,totp,tts]'`
- `.venv/bin/pip-audit --requirement requirements/constraints.txt`
