### PR TITLE
Validate install constraints in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,10 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install -e '.[dev,totp]'
+        run: pip install --constraint requirements/constraints.txt -e '.[dev,totp]'
+
+      - name: Validate install constraints
+        run: make BIN= check-install-constraints
 
       - name: Lint and format check
         run: make BIN= check


### PR DESCRIPTION
## Summary

- make normal CI install dependencies through `requirements/constraints.txt`
- add a CI step that dry-runs the protected-install dependency set against the constraints file

## Rationale

PR #774 added reviewed install constraints. This PR makes CI enforce that those constraints stay usable. Normal PR CI now catches both:

- conflicts between constrained direct runtime dependencies and the test/dev environment
- conflicts in the full protected-install extras set via `make check-install-constraints`

## Validation

- parsed `.github/workflows/ci.yml` with PyYAML
- `.venv/bin/python -m pip install --dry-run --constraint requirements/constraints.txt -e '.[dev,totp]'`
- `make check-install-constraints`
- `make check`
- `make typecheck`
