### PR TITLE
Add module size reporting target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,10 @@ into `/opt/kai` and passes it to `pip install --constraint`. Treat changes to
 that file as install-affecting supply-chain changes and review them with the
 same care as `pyproject.toml`.
 
+Use `make module-sizes` when planning trust-boundary refactors. The report is
+advisory; it exists to make oversized modules visible before incremental
+decomposition work.
+
 ### Tests
 
 - Tests live in `tests/` and use **pytest** with **pytest-asyncio**.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # where tools are installed globally (no .venv).
 BIN = .venv/bin/
 
-.PHONY: run lint format check typecheck audit-deps check-install-constraints test setup config install install-status tts-model refresh-models
+.PHONY: run lint format check typecheck audit-deps check-install-constraints module-sizes test setup config install install-status tts-model refresh-models
 
 run:
 	$(BIN)python -m kai
@@ -24,6 +24,9 @@ audit-deps:
 
 check-install-constraints:
 	$(BIN)python -m pip install --dry-run --constraint requirements/constraints.txt -e '.[memory,totp,tts]'
+
+module-sizes:
+	$(BIN)python scripts/module-sizes.py
 
 test:
 	$(BIN)python -m pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ make check      # Lint and format check
 make typecheck  # Run Pyright on the maintained typed baseline
 make audit-deps # Report known vulnerabilities in installed dependencies
 make check-install-constraints # Dry-run install dependency resolution with constraints
+make module-sizes # Report large Python modules for decomposition planning
 make test       # Run pytest
 make run        # Start Kai locally
 ```

--- a/scripts/module-sizes.py
+++ b/scripts/module-sizes.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Report large Python modules by physical line count.
+
+This is a lightweight maintainability guardrail for trust-boundary review.
+It intentionally reports by default instead of failing: Kai currently has
+known oversized modules, and the immediate goal is a stable decomposition
+baseline rather than blocking unrelated security fixes.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_ROOT = Path("src/kai")
+DEFAULT_LIMIT = 2000
+
+
+@dataclass(frozen=True, order=True)
+class ModuleSize:
+    """Line-count measurement for one Python source file."""
+
+    lines: int
+    path: Path
+
+
+def iter_python_files(root: Path) -> Iterable[Path]:
+    """Yield Python source files below `root`, excluding generated/cache trees."""
+    for path in sorted(root.rglob("*.py")):
+        parts = set(path.parts)
+        if "__pycache__" in parts or ".venv" in parts or ".git" in parts:
+            continue
+        yield path
+
+
+def count_lines(path: Path) -> int:
+    """Return the number of physical lines in `path`."""
+    with path.open("rb") as handle:
+        return sum(1 for _ in handle)
+
+
+def measure_modules(root: Path) -> list[ModuleSize]:
+    """Return module sizes below `root`, largest first."""
+    sizes = [ModuleSize(lines=count_lines(path), path=path) for path in iter_python_files(root)]
+    return sorted(sizes, reverse=True)
+
+
+def render_report(sizes: Iterable[ModuleSize], *, limit: int, top: int) -> str:
+    """Render a compact line-count report."""
+    rows = list(sizes)
+    oversized = [row for row in rows if row.lines >= limit]
+    visible = rows[:top]
+
+    lines = [
+        f"Python module size report (threshold: {limit} lines)",
+        f"Modules at or above threshold: {len(oversized)}",
+        "",
+        "lines  path",
+        "-----  ----",
+    ]
+    lines.extend(f"{row.lines:5d}  {row.path}" for row in visible)
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root", type=Path, default=DEFAULT_ROOT, help=f"source root to scan (default: {DEFAULT_ROOT})"
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help=f"line-count threshold for oversized modules (default: {DEFAULT_LIMIT})",
+    )
+    parser.add_argument("--top", type=int, default=20, help="number of largest modules to print (default: 20)")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    print(render_report(measure_modules(args.root), limit=args.limit, top=args.top))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_module_sizes_script.py
+++ b/tests/test_module_sizes_script.py
@@ -1,0 +1,59 @@
+"""Tests for scripts/module-sizes.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "module-sizes.py"
+
+
+def _load_module_sizes():
+    spec = importlib.util.spec_from_file_location("kai_module_sizes_script", SCRIPT_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_iter_python_files_excludes_cache_trees(tmp_path):
+    module_sizes = _load_module_sizes()
+    root = tmp_path / "src" / "kai"
+    root.mkdir(parents=True)
+    kept = root / "bot.py"
+    kept.write_text("print('ok')\n")
+    cache_dir = root / "__pycache__"
+    cache_dir.mkdir()
+    (cache_dir / "bot.py").write_text("not real source\n")
+
+    assert list(module_sizes.iter_python_files(root)) == [kept]
+
+
+def test_measure_modules_sorts_largest_first(tmp_path):
+    module_sizes = _load_module_sizes()
+    root = tmp_path / "src" / "kai"
+    root.mkdir(parents=True)
+    small = root / "small.py"
+    large = root / "large.py"
+    small.write_text("one\n")
+    large.write_text("one\ntwo\nthree\n")
+
+    result = module_sizes.measure_modules(root)
+
+    assert [(row.lines, row.path) for row in result] == [(3, large), (1, small)]
+
+
+def test_render_report_counts_modules_at_threshold(tmp_path):
+    module_sizes = _load_module_sizes()
+    first = module_sizes.ModuleSize(lines=10, path=tmp_path / "first.py")
+    second = module_sizes.ModuleSize(lines=5, path=tmp_path / "second.py")
+
+    report = module_sizes.render_report([first, second], limit=5, top=1)
+
+    assert "threshold: 5 lines" in report
+    assert "Modules at or above threshold: 2" in report
+    assert "first.py" in report
+    assert "second.py" not in report


### PR DESCRIPTION
## Summary

- add `scripts/module-sizes.py` for dependency-free Python module line-count reporting
- add `make module-sizes`
- document the advisory workflow for trust-boundary decomposition planning
- add focused tests for the reporting helper

## Rationale

The remaining part of the CI/maintainability finding is that several trust-boundary modules are too large to review comfortably. This PR adds measurement first. It does not fail CI or refactor runtime code; it creates a stable baseline for choosing small extraction PRs.

Current report shows 12 modules at or above the default 2,000-line threshold, led by:

- `src/kai/install.py`
- `src/kai/bot.py`
- `src/kai/config.py`
- `src/kai/memory_extraction.py`
- `src/kai/review.py`
- `src/kai/memory.py`
- `src/kai/webhook.py`

## Validation

- `tests/test_module_sizes_script.py`
- `make module-sizes`
- `make check`
- `make typecheck`
