### PR TITLE
Separate notification destinations from auth principals

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -3278,7 +3278,7 @@ async def _handle_github_notify(
                     config=config,
                 )
                 if not still_used:
-                    webhook.remove_allowed_chat_id(old_chat_id)
+                    webhook.remove_notification_chat_id(old_chat_id)
         await update.message.reply_text("Notification destination reset to this chat.")
         return
 
@@ -3305,13 +3305,13 @@ async def _handle_github_notify(
                 config=config,
             )
             if not still_used:
-                webhook.remove_allowed_chat_id(old_notify)
+                webhook.remove_notification_chat_id(old_notify)
 
     await sessions.set_setting(f"github_notify_chat:{chat_id}", str(notify_id))
 
-    # Keep the legacy live destination registry synchronized. Internal API
-    # access is credential-bound and does not consult this collection.
-    webhook.add_allowed_chat_id(notify_id)
+    # Keep the live outbound-destination registry synchronized. This does not
+    # expand Telegram inbound authorization.
+    webhook.add_notification_chat_id(notify_id)
 
     await update.message.reply_text(f"GitHub notifications will go to chat {notify_id}.")
 

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -91,6 +91,7 @@ GENERIC_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("generic_webhook_secret
 GITHUB_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("github_webhook_secret", str)
 INTERNAL_API_AUTH_KEY: web.AppKey[InternalAPIAuth] = web.AppKey("internal_api_auth", InternalAPIAuth)
 LEGACY_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("legacy_webhook_secret", str)
+NOTIFICATION_CHAT_IDS_KEY: web.AppKey[set[int]] = web.AppKey("notification_chat_ids", set)
 POOL_KEY: web.AppKey[object] = web.AppKey("pool", object)
 PR_REVIEW_COOLDOWN_KEY: web.AppKey[int] = web.AppKey("pr_review_cooldown", int)
 PR_REVIEW_TIMEOUT_S_KEY: web.AppKey[int] = web.AppKey("pr_review_timeout_s", int)
@@ -2394,6 +2395,7 @@ async def start(telegram_app, config) -> None:
     # API no longer consults this set for identity; credentials resolve their
     # principal server-side.
     _app[ALLOWED_USER_IDS_KEY] = set(config.allowed_user_ids)
+    _app[NOTIFICATION_CHAT_IDS_KEY] = set()
 
     # Store config for GitHub actor routing in _handle_github()
     _app[CONFIG_KEY] = config
@@ -2421,14 +2423,14 @@ async def start(telegram_app, config) -> None:
     # inbound Telegram principals and is not consulted by internal API auth.
     for uc in config.user_configs.values():
         if uc.github_notify_chat_id is not None:
-            _app[ALLOWED_USER_IDS_KEY].add(uc.github_notify_chat_id)
+            _app[NOTIFICATION_CHAT_IDS_KEY].add(uc.github_notify_chat_id)
     # Also add any DB-stored notify chat IDs (set via /github notify).
     # webhook.start() is already async so the await is fine.
     for uid in config.user_configs:
         val = await sessions.get_setting(f"github_notify_chat:{uid}")
         if val:
             try:
-                _app[ALLOWED_USER_IDS_KEY].add(int(val))
+                _app[NOTIFICATION_CHAT_IDS_KEY].add(int(val))
             except ValueError:
                 log.warning(
                     "Invalid github_notify_chat for user %s in DB: %s (ignoring)",
@@ -2543,21 +2545,21 @@ def is_running() -> bool:
     return _runner is not None
 
 
-def add_allowed_chat_id(chat_id: int) -> None:
+def add_notification_chat_id(chat_id: int) -> None:
     """
-    Add a chat_id to the legacy live notification-destination registry.
+    Add a chat_id to the live notification-destination registry.
 
     Called by bot.py when /github notify sets a new notification
-    destination. This registry no longer grants Telegram or internal API
+    destination. This registry never grants Telegram or internal API
     authority; those identities come from users.yaml and API credentials.
     """
     if _app is not None:
-        allowed = _app.get(ALLOWED_USER_IDS_KEY)
-        if allowed is not None:
-            allowed.add(chat_id)
+        notification_chat_ids = _app.get(NOTIFICATION_CHAT_IDS_KEY)
+        if notification_chat_ids is not None:
+            notification_chat_ids.add(chat_id)
 
 
-def remove_allowed_chat_id(chat_id: int) -> None:
+def remove_notification_chat_id(chat_id: int) -> None:
     """
     Remove a chat_id from the live notification registry, but only
     if it does not belong to an actual authorized user.
@@ -2570,12 +2572,12 @@ def remove_allowed_chat_id(chat_id: int) -> None:
     user_configs remains the immutable source for the preservation guard.
     """
     if _app is not None:
-        allowed = _app.get(ALLOWED_USER_IDS_KEY)
-        if allowed is None:
+        notification_chat_ids = _app.get(NOTIFICATION_CHAT_IDS_KEY)
+        if notification_chat_ids is None:
             return
         # Never remove a chat_id that belongs to an actual user.
         # user_configs keys are telegram_ids of real users.
         config = _app.get(CONFIG_KEY)
         if config and chat_id in config.user_configs:
             return
-        allowed.discard(chat_id)
+        notification_chat_ids.discard(chat_id)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -4925,7 +4925,7 @@ class TestHandleGitHub:
 
         with (
             patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.add_allowed_chat_id") as mock_add,
+            patch("kai.bot.webhook.add_notification_chat_id") as mock_add,
         ):
             await handle_github(update, ctx)
 
@@ -5059,11 +5059,11 @@ class TestHandleGitHub:
         reply = update.message.reply_text.call_args[0][0]
         assert "unknown subcommand" in reply.lower()
 
-    # ── 11. /github notify - live allowed_user_ids updates ────────
+    # ── 11. /github notify - live notification destination updates ────────
 
     @pytest.mark.asyncio
-    async def test_notify_set_updates_allowed_ids(self):
-        """/github notify -100999 adds the group to allowed_user_ids immediately."""
+    async def test_notify_set_updates_notification_destinations(self):
+        """/github notify -100999 adds the group to notification destinations immediately."""
         update = _make_update(text="/github notify -100999")
         config = _make_config()
         ctx = _make_context(config=config, args=["notify", "-100999"])
@@ -5074,7 +5074,7 @@ class TestHandleGitHub:
 
         with (
             patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.add_allowed_chat_id") as mock_add,
+            patch("kai.bot.webhook.add_notification_chat_id") as mock_add,
         ):
             await handle_github(update, ctx)
 
@@ -5085,10 +5085,10 @@ class TestHandleGitHub:
 
     @pytest.mark.asyncio
     async def test_notify_set_overwrite_cleans_up_old(self):
-        """Overwriting a notify destination removes the old chat_id from allowed set.
+        """Overwriting a notify destination removes the old outbound destination.
 
-        Without this cleanup, the old chat_id would linger in allowed_user_ids
-        until restart - an auth leak for abandoned group chats.
+        Without this cleanup, the old chat_id would linger in the live
+        outbound notification registry until restart.
         """
         update = _make_update(text="/github notify -100888")
         config = _make_config()
@@ -5100,8 +5100,8 @@ class TestHandleGitHub:
 
         with (
             patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.add_allowed_chat_id") as mock_add,
-            patch("kai.bot.webhook.remove_allowed_chat_id") as mock_remove,
+            patch("kai.bot.webhook.add_notification_chat_id") as mock_add,
+            patch("kai.bot.webhook.remove_notification_chat_id") as mock_remove,
             patch("kai.bot._is_notify_chat_used", new_callable=AsyncMock, return_value=False),
         ):
             await handle_github(update, ctx)
@@ -5122,8 +5122,8 @@ class TestHandleGitHub:
 
         with (
             patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.add_allowed_chat_id") as mock_add,
-            patch("kai.bot.webhook.remove_allowed_chat_id") as mock_remove,
+            patch("kai.bot.webhook.add_notification_chat_id") as mock_add,
+            patch("kai.bot.webhook.remove_notification_chat_id") as mock_remove,
             # Another user still uses the old chat_id
             patch("kai.bot._is_notify_chat_used", new_callable=AsyncMock, return_value=True),
         ):
@@ -5146,8 +5146,8 @@ class TestHandleGitHub:
 
         with (
             patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.add_allowed_chat_id") as mock_add,
-            patch("kai.bot.webhook.remove_allowed_chat_id") as mock_remove,
+            patch("kai.bot.webhook.add_notification_chat_id") as mock_add,
+            patch("kai.bot.webhook.remove_notification_chat_id") as mock_remove,
         ):
             await handle_github(update, ctx)
 
@@ -5156,8 +5156,8 @@ class TestHandleGitHub:
         mock_add.assert_called_once_with(-100999)
 
     @pytest.mark.asyncio
-    async def test_notify_reset_removes_from_allowed_ids(self):
-        """/github notify reset removes the old chat_id from allowed_user_ids."""
+    async def test_notify_reset_removes_from_notification_destinations(self):
+        """/github notify reset removes the old outbound notification destination."""
         update = _make_update(text="/github notify reset")
         config = _make_config()
         ctx = _make_context(config=config, args=["notify", "reset"])
@@ -5168,7 +5168,7 @@ class TestHandleGitHub:
 
         with (
             patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.remove_allowed_chat_id") as mock_remove,
+            patch("kai.bot.webhook.remove_notification_chat_id") as mock_remove,
             patch("kai.bot._is_notify_chat_used", new_callable=AsyncMock, return_value=False),
         ):
             await handle_github(update, ctx)
@@ -5188,7 +5188,7 @@ class TestHandleGitHub:
 
         with (
             patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.remove_allowed_chat_id") as mock_remove,
+            patch("kai.bot.webhook.remove_notification_chat_id") as mock_remove,
             # Another user still uses this chat_id
             patch("kai.bot._is_notify_chat_used", new_callable=AsyncMock, return_value=True),
         ):
@@ -5201,8 +5201,8 @@ class TestHandleGitHub:
     async def test_notify_reset_self_id_skips_removal(self):
         """/github notify reset does NOT remove the user's own chat_id.
 
-        This is the primary guard for legacy mode (no users.yaml) where
-        remove_allowed_chat_id's user_configs check cannot fire.
+        This guard keeps the user's own authorized chat out of outbound
+        notification cleanup.
         """
         update = _make_update(text="/github notify reset")
         config = _make_config()
@@ -5214,7 +5214,7 @@ class TestHandleGitHub:
 
         with (
             patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.remove_allowed_chat_id") as mock_remove,
+            patch("kai.bot.webhook.remove_notification_chat_id") as mock_remove,
         ):
             await handle_github(update, ctx)
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -20,6 +20,7 @@ from kai.webhook import (
     CONFIG_KEY,
     GITHUB_WEBHOOK_SECRET_KEY,
     INTERNAL_API_AUTH_KEY,
+    NOTIFICATION_CHAT_IDS_KEY,
     PR_REVIEW_COOLDOWN_KEY,
     PR_REVIEW_TIMEOUT_S_KEY,
     SPEC_DIR_KEY,
@@ -42,8 +43,8 @@ from kai.webhook import (
     _triage_cooldowns,
     _verify_github_signature,
     _webhook_health_loop,
-    add_allowed_chat_id,
-    remove_allowed_chat_id,
+    add_notification_chat_id,
+    remove_notification_chat_id,
 )
 
 # ── _verify_github_signature ─────────────────────────────────────────
@@ -2249,45 +2250,100 @@ class TestPerUserRouting:
             assert mock_review.call_args[1]["provider"] == "google"
 
 
-# ── add_allowed_chat_id / remove_allowed_chat_id ────────────────────
+# ── add_notification_chat_id / remove_notification_chat_id ───────────
 
 
-class TestAllowedChatIdMutations:
-    """Tests for the legacy live notification-destination registry.
+class TestNotificationChatIdMutations:
+    """Tests for the live notification-destination registry.
 
     These functions are called by bot.py when /github notify modifies
     a notification destination. The registry must remain detached from
     Config.allowed_user_ids so outbound changes cannot authorize senders.
     """
 
-    def test_add_allowed_chat_id(self):
-        """add_allowed_chat_id adds a chat_id to the live set."""
+    @pytest.mark.asyncio
+    async def test_start_keeps_notification_destinations_out_of_inbound_principals(self):
+        """Configured and DB notification destinations do not become authorized users."""
+        import kai.webhook as wh
+
+        admin = UserConfig(
+            telegram_id=111,
+            name="alice",
+            role="admin",
+            github_notify_chat_id=-100111,
+        )
+        config = MagicMock()
+        config.user_configs = {111: admin}
+        config.allowed_user_ids = {111}
+        config.get_admins.return_value = [admin]
+        config.webhook_secret = None
+        config.telegram_webhook_url = None
+        config.telegram_webhook_secret = None
+        config.github_webhook_secret = None
+        config.generic_webhook_secret = None
+        config.pr_review_cooldown = 0
+        config.pr_review_timeout_s = 0
+        config.webhook_port = 0
+        config.workspace_base = None
+        config.allowed_workspaces = []
+        config.spec_dir = "specs"
+
+        telegram_app = MagicMock()
+        telegram_app.bot = AsyncMock()
+        telegram_app.bot_data = {"pool": MagicMock(internal_api_auth=InternalAPIAuth({111: "secret"}))}
+
+        fake_runner = MagicMock()
+        fake_runner.setup = AsyncMock()
+        fake_site = MagicMock()
+        fake_site.start = AsyncMock()
+
+        old_app = wh._app
+        old_runner = wh._runner
+        try:
+            with (
+                patch("kai.webhook.sessions.get_setting", new_callable=AsyncMock, return_value="-100222"),
+                patch("kai.webhook.web.AppRunner", return_value=fake_runner),
+                patch("kai.webhook.web.TCPSite", return_value=fake_site),
+            ):
+                await wh.start(telegram_app, config)
+
+            assert wh._app[ALLOWED_USER_IDS_KEY] == {111}
+            assert wh._app[NOTIFICATION_CHAT_IDS_KEY] == {-100111, -100222}
+        finally:
+            wh._app = old_app
+            wh._runner = old_runner
+
+    def test_add_notification_chat_id(self):
+        """add_notification_chat_id adds a chat_id to the outbound registry."""
         import kai.webhook as wh
 
         app = web.Application()
         app[ALLOWED_USER_IDS_KEY] = {100}
+        app[NOTIFICATION_CHAT_IDS_KEY] = set()
         old_app = wh._app
         wh._app = app
         try:
-            add_allowed_chat_id(999)
-            assert 999 in app[ALLOWED_USER_IDS_KEY]
+            add_notification_chat_id(999)
+            assert app[NOTIFICATION_CHAT_IDS_KEY] == {999}
+            assert app[ALLOWED_USER_IDS_KEY] == {100}
         finally:
             wh._app = old_app
 
-    def test_add_allowed_chat_id_idempotent(self):
+    def test_add_notification_chat_id_idempotent(self):
         """Adding the same chat_id twice does not duplicate it."""
         import kai.webhook as wh
 
         app = web.Application()
         app[ALLOWED_USER_IDS_KEY] = {100}
+        app[NOTIFICATION_CHAT_IDS_KEY] = set()
         old_app = wh._app
         wh._app = app
         try:
-            add_allowed_chat_id(999)
-            add_allowed_chat_id(999)
+            add_notification_chat_id(999)
+            add_notification_chat_id(999)
             # Sets don't have duplicates; just verify it's present
-            assert 999 in app[ALLOWED_USER_IDS_KEY]
-            assert len(app[ALLOWED_USER_IDS_KEY]) == 2  # {100, 999}
+            assert app[NOTIFICATION_CHAT_IDS_KEY] == {999}
+            assert app[ALLOWED_USER_IDS_KEY] == {100}
         finally:
             wh._app = old_app
 
@@ -2298,33 +2354,36 @@ class TestAllowedChatIdMutations:
         inbound_principals = {100}
         app = web.Application()
         app[ALLOWED_USER_IDS_KEY] = set(inbound_principals)
+        app[NOTIFICATION_CHAT_IDS_KEY] = set()
         old_app = wh._app
         wh._app = app
         try:
-            add_allowed_chat_id(999)
-            assert app[ALLOWED_USER_IDS_KEY] == {100, 999}
+            add_notification_chat_id(999)
+            assert app[ALLOWED_USER_IDS_KEY] == {100}
+            assert app[NOTIFICATION_CHAT_IDS_KEY] == {999}
             assert inbound_principals == {100}
         finally:
             wh._app = old_app
 
-    def test_add_allowed_chat_id_no_app(self):
-        """add_allowed_chat_id is a no-op when _app is None (polling mode)."""
+    def test_add_notification_chat_id_no_app(self):
+        """add_notification_chat_id is a no-op when _app is None (polling mode)."""
         import kai.webhook as wh
 
         old_app = wh._app
         wh._app = None
         try:
             # Should not raise
-            add_allowed_chat_id(999)
+            add_notification_chat_id(999)
         finally:
             wh._app = old_app
 
-    def test_remove_allowed_chat_id_group(self):
-        """remove_allowed_chat_id removes a group chat_id from the set."""
+    def test_remove_notification_chat_id_group(self):
+        """remove_notification_chat_id removes a group chat_id from the outbound registry."""
         import kai.webhook as wh
 
         app = web.Application()
-        app[ALLOWED_USER_IDS_KEY] = {100, -100123}
+        app[ALLOWED_USER_IDS_KEY] = {100}
+        app[NOTIFICATION_CHAT_IDS_KEY] = {-100123}
         # No config needed for this case - group IDs are never in user_configs
         mock_config = MagicMock()
         mock_config.user_configs = {}
@@ -2332,14 +2391,14 @@ class TestAllowedChatIdMutations:
         old_app = wh._app
         wh._app = app
         try:
-            remove_allowed_chat_id(-100123)
-            assert -100123 not in app[ALLOWED_USER_IDS_KEY]
-            assert 100 in app[ALLOWED_USER_IDS_KEY]
+            remove_notification_chat_id(-100123)
+            assert -100123 not in app[NOTIFICATION_CHAT_IDS_KEY]
+            assert app[ALLOWED_USER_IDS_KEY] == {100}
         finally:
             wh._app = old_app
 
-    def test_remove_allowed_chat_id_preserves_users(self):
-        """remove_allowed_chat_id does NOT remove a real user's telegram_id."""
+    def test_remove_notification_chat_id_preserves_users(self):
+        """remove_notification_chat_id does NOT remove a real user's telegram_id."""
         import kai.webhook as wh
 
         user = UserConfig(telegram_id=12345, name="alice")
@@ -2347,25 +2406,27 @@ class TestAllowedChatIdMutations:
         mock_config.user_configs = {12345: user}
 
         app = web.Application()
-        app[ALLOWED_USER_IDS_KEY] = {12345, -100999}
+        app[ALLOWED_USER_IDS_KEY] = {12345}
+        app[NOTIFICATION_CHAT_IDS_KEY] = {12345, -100999}
         app[CONFIG_KEY] = mock_config
         old_app = wh._app
         wh._app = app
         try:
-            remove_allowed_chat_id(12345)
+            remove_notification_chat_id(12345)
             # 12345 is a real user - must NOT be removed
             assert 12345 in app[ALLOWED_USER_IDS_KEY]
+            assert 12345 in app[NOTIFICATION_CHAT_IDS_KEY]
         finally:
             wh._app = old_app
 
-    def test_remove_allowed_chat_id_no_app(self):
-        """remove_allowed_chat_id is a no-op when _app is None (polling mode)."""
+    def test_remove_notification_chat_id_no_app(self):
+        """remove_notification_chat_id is a no-op when _app is None (polling mode)."""
         import kai.webhook as wh
 
         old_app = wh._app
         wh._app = None
         try:
             # Should not raise
-            remove_allowed_chat_id(-100123)
+            remove_notification_chat_id(-100123)
         finally:
             wh._app = old_app


### PR DESCRIPTION
## Summary
- add a dedicated webhook notification-destination registry separate from inbound Telegram principals
- stop startup and /github notify from adding notification chats to ALLOWED_USER_IDS_KEY
- rename live registry helpers to add/remove notification chat IDs
- add regressions proving configured and DB notification destinations do not become authorized users

## Security rationale
This closes assessment finding #5: outbound GitHub notification destinations must not become authenticated Telegram principals. A notification group can still receive GitHub messages, but it cannot talk to Kai merely because it is a notification target.

## Validation
- .venv/bin/python -m pytest tests/test_bot.py::TestHandleGitHub tests/test_webhook.py::TestNotificationChatIdMutations -q
- make check
- make typecheck
- .venv/bin/python -m pytest tests/test_bot.py tests/test_webhook.py -q
- .venv/bin/python -m pytest tests/test_webhook_api.py -q