### PR TITLE
Use per-user GitHub tokens for reviews

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -3596,6 +3596,7 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
     claude_user = user_config.os_user if user_config and user_config.os_user else None
     agent_backend, provider = get_user_backend_and_provider(user_config, config)
     model_override = resolve_user_model(ModelRole.PR_REVIEW, user_config, config)
+    github_token = await sessions.get_setting(f"github_token:{actor_id}")
 
     # Only pass the workspace as `local_repo_path` when its `origin`
     # remote actually matches the target repo. Otherwise the bundle
@@ -3624,6 +3625,7 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
             provider=provider,
             timeout_s=config.pr_review_timeout_s,
             model_override=model_override,
+            github_token=github_token,
         )
     except Exception as exc:
         log.exception("Manual review failed for %s#%d", repo, pr_number)

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -33,6 +33,7 @@ import binascii
 import glob as glob_mod
 import json
 import logging
+import os
 import re
 import urllib.parse
 from dataclasses import dataclass, field
@@ -73,6 +74,20 @@ _REVIEW_TIMEOUT = 900
 # Header prepended to every review comment on GitHub. Distinguishes
 # automated reviews from human comments. Per design decision #11.
 _REVIEW_HEADER = "## Review by Kai\n\n"
+
+
+def _github_cli_env(github_token: str | None) -> dict[str, str] | None:
+    """Return a gh subprocess environment pinned to a user token, if present."""
+    token = github_token.strip() if github_token else ""
+    if not token:
+        return None
+    env = dict(os.environ)
+    # gh recognizes GH_TOKEN first; GITHUB_TOKEN is also supported for
+    # GitHub.com. Set both so a daemon-level token cannot leak through.
+    env["GH_TOKEN"] = token
+    env["GITHUB_TOKEN"] = token
+    return env
+
 
 # Maximum total characters of prior review comments to include in the
 # prompt. Oldest reviews are truncated first if the cap is exceeded,
@@ -680,7 +695,7 @@ async def load_conventions(
 # ── Prior comment awareness ────────────────────────────────────────
 
 
-async def fetch_prior_comments(repo: str, pr_number: int) -> str | None:
+async def fetch_prior_comments(repo: str, pr_number: int, github_token: str | None = None) -> str | None:
     """
     Fetch prior review comments from the PR's comment thread.
 
@@ -714,6 +729,7 @@ async def fetch_prior_comments(repo: str, pr_number: int) -> str | None:
             ".[]",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=_github_cli_env(github_token),
         )
         stdout, stderr = await proc.communicate()
 
@@ -950,7 +966,7 @@ def build_review_prompt(
     return "\n".join(parts)
 
 
-async def fetch_pr_diff(repo: str, pr_number: int) -> str:
+async def fetch_pr_diff(repo: str, pr_number: int, github_token: str | None = None) -> str:
     """
     Fetch the diff for a PR using the GitHub CLI.
 
@@ -976,6 +992,7 @@ async def fetch_pr_diff(repo: str, pr_number: int) -> str:
         repo,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        env=_github_cli_env(github_token),
     )
     stdout, stderr = await proc.communicate()
 
@@ -1000,7 +1017,11 @@ _PR_VIEW_FIELDS = (
 )
 
 
-async def fetch_extended_pr_metadata(repo: str, pr_number: int) -> ExtendedPRMetadata:
+async def fetch_extended_pr_metadata(
+    repo: str,
+    pr_number: int,
+    github_token: str | None = None,
+) -> ExtendedPRMetadata:
     """
     Fetch the bundle's view of PR metadata via `gh pr view --json`.
 
@@ -1037,6 +1058,7 @@ async def fetch_extended_pr_metadata(repo: str, pr_number: int) -> ExtendedPRMet
         _PR_VIEW_FIELDS,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        env=_github_cli_env(github_token),
     )
     stdout, stderr = await proc.communicate()
     if proc.returncode != 0:
@@ -1087,7 +1109,7 @@ async def fetch_extended_pr_metadata(repo: str, pr_number: int) -> ExtendedPRMet
 _ISSUE_VIEW_FIELDS = "number,title,body,state,url,labels,comments"
 
 
-async def fetch_linked_issue(repo: str, issue_number: int) -> LinkedIssue:
+async def fetch_linked_issue(repo: str, issue_number: int, github_token: str | None = None) -> LinkedIssue:
     """
     Fetch a single linked issue via `gh issue view --json`.
 
@@ -1117,6 +1139,7 @@ async def fetch_linked_issue(repo: str, issue_number: int) -> LinkedIssue:
         _ISSUE_VIEW_FIELDS,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        env=_github_cli_env(github_token),
     )
     stdout, stderr = await proc.communicate()
     if proc.returncode != 0:
@@ -1152,6 +1175,7 @@ async def fetch_linked_issue(repo: str, issue_number: int) -> LinkedIssue:
 async def fetch_linked_issues(
     repo: str,
     issue_numbers: tuple[int, ...],
+    github_token: str | None = None,
 ) -> tuple[tuple[LinkedIssue, ...], tuple[CollectionWarning, ...]]:
     """
     Fetch every linked issue in parallel; per-issue failures are warnings.
@@ -1178,7 +1202,7 @@ async def fetch_linked_issues(
     # network call. return_exceptions=True keeps a single failure from
     # poisoning the gather; we classify per-task below.
     results = await asyncio.gather(
-        *(fetch_linked_issue(repo, n) for n in issue_numbers),
+        *(fetch_linked_issue(repo, n, github_token=github_token) for n in issue_numbers),
         return_exceptions=True,
     )
     issues: list[LinkedIssue] = []
@@ -1253,6 +1277,7 @@ async def _fetch_file_at_head(
     repo: str,
     head_oid: str,
     path: str,
+    github_token: str | None = None,
 ) -> tuple[str | None, str | None]:
     """
     Fetch a single file's contents at `head_oid` via the GitHub contents API.
@@ -1282,6 +1307,7 @@ async def _fetch_file_at_head(
         f"repos/{repo}/contents/{encoded_path}?ref={head_oid}",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        env=_github_cli_env(github_token),
     )
     stdout, stderr = await proc.communicate()
     if proc.returncode != 0:
@@ -1336,6 +1362,7 @@ async def _fetch_file_at_head(
 
 async def fetch_changed_files_at_head(
     metadata: ExtendedPRMetadata,
+    github_token: str | None = None,
 ) -> tuple[tuple[ChangedFile, ...], tuple[CollectionWarning, ...]]:
     """
     Fetch full file contents at the PR head for every changed file.
@@ -1398,7 +1425,10 @@ async def fetch_changed_files_at_head(
 
     if fetchable:
         results = await asyncio.gather(
-            *(_fetch_file_at_head(metadata.repo, metadata.head_oid, p) for _, p, _ in fetchable),
+            *(
+                _fetch_file_at_head(metadata.repo, metadata.head_oid, p, github_token=github_token)
+                for _, p, _ in fetchable
+            ),
             return_exceptions=True,
         )
         for (idx, path, status), result in zip(fetchable, results, strict=True):
@@ -2575,6 +2605,7 @@ async def build_pr_review_context(
     local_repo_path: str | None = None,
     spec_dir: str = "specs",
     include_prior_comments: bool = True,
+    github_token: str | None = None,
 ) -> PRReviewContext:
     """
     Collect the full review-context bundle for a PR.
@@ -2612,14 +2643,14 @@ async def build_pr_review_context(
     """
     warnings: list[CollectionWarning] = []
 
-    metadata = await fetch_extended_pr_metadata(repo, pr_number)
-    patch = await fetch_pr_diff(repo, pr_number)
+    metadata = await fetch_extended_pr_metadata(repo, pr_number, github_token=github_token)
+    patch = await fetch_pr_diff(repo, pr_number, github_token=github_token)
 
     # Collection of independent fetchers in parallel. Each returns
     # (data, warnings) so a single failing fetcher cannot poison the
     # whole bundle.
-    linked_task = fetch_linked_issues(repo, metadata.closing_issue_numbers)
-    files_task = fetch_changed_files_at_head(metadata)
+    linked_task = fetch_linked_issues(repo, metadata.closing_issue_numbers, github_token=github_token)
+    files_task = fetch_changed_files_at_head(metadata, github_token=github_token)
 
     (linked_issues, linked_warnings), (changed_files, files_warnings) = await asyncio.gather(linked_task, files_task)
     warnings.extend(linked_warnings)
@@ -2630,7 +2661,7 @@ async def build_pr_review_context(
     # and bodies in the `commits` payload. Re-pull that payload here
     # so the bundle carries the bodies even though
     # `ExtendedPRMetadata` only holds OIDs.
-    commits = await _fetch_pr_commits(repo, pr_number)
+    commits = await _fetch_pr_commits(repo, pr_number, github_token=github_token)
 
     # Symbol extraction is pure; surrounding-code search is async
     # because rg invocations run concurrently.
@@ -2659,7 +2690,7 @@ async def build_pr_review_context(
     prior_comments = None
     if include_prior_comments:
         try:
-            prior_comments = await fetch_prior_comments(repo, pr_number)
+            prior_comments = await fetch_prior_comments(repo, pr_number, github_token=github_token)
         except Exception:
             log.warning("Failed to fetch prior comments for %s#%d", repo, pr_number, exc_info=True)
             warnings.append(
@@ -2686,7 +2717,7 @@ async def build_pr_review_context(
     return budget_review_context(raw)
 
 
-async def _fetch_pr_commits(repo: str, pr_number: int) -> tuple[Commit, ...]:
+async def _fetch_pr_commits(repo: str, pr_number: int, github_token: str | None = None) -> tuple[Commit, ...]:
     """
     Fetch per-commit headline + body via `gh pr view --json commits`.
 
@@ -2709,6 +2740,7 @@ async def _fetch_pr_commits(repo: str, pr_number: int) -> tuple[Commit, ...]:
         "commits",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        env=_github_cli_env(github_token),
     )
     stdout, _ = await proc.communicate()
     if proc.returncode != 0:
@@ -3121,7 +3153,7 @@ async def run_review(
         return result.text
 
 
-async def post_review_comment(repo: str, pr_number: int, review: str) -> bool:
+async def post_review_comment(repo: str, pr_number: int, review: str, github_token: str | None = None) -> bool:
     """
     Post the review as a single GitHub PR comment via the gh CLI.
 
@@ -3154,6 +3186,7 @@ async def post_review_comment(repo: str, pr_number: int, review: str) -> bool:
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        env=_github_cli_env(github_token),
     )
     _, stderr = await proc.communicate(input=comment_body.encode())
 
@@ -3226,6 +3259,7 @@ async def generate_pr_review(
     provider: str = "",
     timeout_s: int = _REVIEW_TIMEOUT,
     model_override: str = "",
+    github_token: str | None = None,
 ) -> PRReviewResult:
     """
     Build the review bundle, render the prompt, and run the review backend.
@@ -3267,6 +3301,7 @@ async def generate_pr_review(
         local_repo_path=local_repo_path,
         spec_dir=spec_dir,
         include_prior_comments=include_prior_comments,
+        github_token=github_token,
     )
     prompt = build_review_prompt_from_context(context)
     review_text = await run_review(
@@ -3299,6 +3334,7 @@ async def review_pr(
     provider: str = "",
     timeout_s: int = _REVIEW_TIMEOUT,
     model_override: str = "",
+    github_token: str | None = None,
 ) -> None:
     """
     Full review pipeline: build the bundle, run the review, post results.
@@ -3334,7 +3370,7 @@ async def review_pr(
         # that produced no reviewable change. Skipping early avoids
         # pulling the rest of the bundle (linked issues, file
         # contents, related search) for a no-op review.
-        early_patch = await fetch_pr_diff(metadata.repo, metadata.number)
+        early_patch = await fetch_pr_diff(metadata.repo, metadata.number, github_token=github_token)
         if not early_patch.strip():
             log.info("Empty diff for %s#%d, skipping review", metadata.repo, metadata.number)
             return
@@ -3350,6 +3386,7 @@ async def review_pr(
             provider=provider,
             timeout_s=timeout_s,
             model_override=model_override,
+            github_token=github_token,
         )
 
         if not result.review_text.strip():
@@ -3357,7 +3394,9 @@ async def review_pr(
             await send_review_summary(metadata, False, webhook_port, webhook_secret, notify_chat_id)
             return
 
-        posted = await post_review_comment(metadata.repo, metadata.number, result.review_text)
+        posted = await post_review_comment(
+            metadata.repo, metadata.number, result.review_text, github_token=github_token
+        )
         await send_review_summary(metadata, posted, webhook_port, webhook_secret, notify_chat_id)
 
     except Exception:

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -891,6 +891,7 @@ async def _process_github_event_for_user(
     # Resolve this user's effective GitHub settings
     settings = await sessions.resolve_github_settings(chat_id, config)
     target_chat_id = settings["notify_chat_id"]
+    github_token = await sessions.get_setting(f"github_token:{chat_id}")
 
     # Resolve per-user os_user for subprocess isolation. None falls
     # back to "run as the bot's own OS user" inside the agent backend.
@@ -973,6 +974,7 @@ async def _process_github_event_for_user(
                     provider=provider,
                     timeout_s=request.app[PR_REVIEW_TIMEOUT_S_KEY],
                     model_override=pr_review_model_override,
+                    github_token=github_token,
                 )
             )
             _background_tasks.add(task)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5919,6 +5919,12 @@ class TestHandleReviewCommand:
     warning surfacing).
     """
 
+    @pytest.fixture(autouse=True)
+    def _mock_github_token_setting(self):
+        """Default manual review tests run without a stored per-user GitHub token."""
+        with patch("kai.bot.sessions.get_setting", new_callable=AsyncMock, return_value=None):
+            yield
+
     @pytest.mark.asyncio
     async def test_short_form_uses_workspace_git_remote_match(self, tmp_path, monkeypatch):
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
@@ -5946,6 +5952,7 @@ class TestHandleReviewCommand:
                 "kai.sessions.get_effective_repos",
                 new=AsyncMock(return_value=["dcellison/kai", "dcellison/other"]),
             ),
+            patch("kai.bot.sessions.get_setting", new=AsyncMock(return_value="ghp_user")),
             patch(
                 "kai.bot.review.generate_pr_review",
                 new=AsyncMock(return_value=_review_result()),
@@ -5954,6 +5961,7 @@ class TestHandleReviewCommand:
             await handle_review_command(update, ctx)
 
         assert mock_generate.call_args.args == ("dcellison/kai", 681)
+        assert mock_generate.call_args.kwargs["github_token"] == "ghp_user"
 
     @pytest.mark.asyncio
     async def test_short_form_falls_back_to_sole_configured_repo(self, tmp_path, monkeypatch):

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -508,6 +508,18 @@ class TestFetchPRDiff:
         assert "+added" in result
 
     @pytest.mark.asyncio
+    async def test_user_token_sets_gh_environment(self):
+        """A supplied user PAT overrides inherited gh authentication."""
+        mock_proc = _mock_process(stdout=b"diff --git a/foo.py b/foo.py\n+added\n")
+
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await fetch_pr_diff("owner/repo", 42, github_token="ghp_user")
+
+        env = mock_exec.call_args.kwargs["env"]
+        assert env["GH_TOKEN"] == "ghp_user"
+        assert env["GITHUB_TOKEN"] == "ghp_user"
+
+    @pytest.mark.asyncio
     async def test_failure_raises(self):
         """Non-zero exit from gh pr diff raises RuntimeError with the error message."""
         mock_proc = _mock_process(stderr=b"not found", returncode=1)
@@ -1005,6 +1017,19 @@ class TestPostReviewComment:
         assert "Looks good." in stdin_text
 
     @pytest.mark.asyncio
+    async def test_user_token_sets_gh_environment(self):
+        """Comment posting uses the supplied user's GitHub token."""
+        mock_proc = _mock_process(returncode=0)
+
+        with patch("kai.review.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            result = await post_review_comment("owner/repo", 42, "Looks good.", github_token="ghp_user")
+
+        assert result is True
+        env = mock_exec.call_args.kwargs["env"]
+        assert env["GH_TOKEN"] == "ghp_user"
+        assert env["GITHUB_TOKEN"] == "ghp_user"
+
+    @pytest.mark.asyncio
     async def test_failure_returns_false(self):
         """Failed gh pr comment returns False."""
         mock_proc = _mock_process(stderr=b"not found", returncode=1)
@@ -1158,11 +1183,11 @@ class TestReviewPR:
         ):
             await review_pr(payload, 8080, "secret", claude_user="kai")
 
-        mock_diff.assert_called_once_with("owner/repo", 42)
+        mock_diff.assert_called_once_with("owner/repo", 42, github_token=None)
         mock_generate.assert_called_once()
         assert mock_generate.call_args.args == ("owner/repo", 42)
         assert mock_generate.call_args.kwargs["claude_user"] == "kai"
-        mock_post.assert_called_once_with("owner/repo", 42, "review output")
+        mock_post.assert_called_once_with("owner/repo", 42, "review output", github_token=None)
 
         expected_meta = PRMetadata(
             repo="owner/repo",
@@ -1293,6 +1318,26 @@ class TestReviewPR:
         assert kwargs["provider"] == "openai"
         assert kwargs["timeout_s"] == 42
         assert kwargs["model_override"] == "gpt-foo"
+
+    @pytest.mark.asyncio
+    async def test_forwards_github_token_to_fetch_generate_and_post(self):
+        """Webhook reviews use one per-user token for every gh subprocess stage."""
+        payload = _webhook_payload()
+
+        with (
+            patch("kai.review.fetch_pr_diff", return_value="diff content") as mock_diff,
+            patch(
+                "kai.review.generate_pr_review",
+                return_value=_result(),
+            ) as mock_generate,
+            patch("kai.review.post_review_comment", return_value=True) as mock_post,
+            patch("kai.review.send_review_summary"),
+        ):
+            await review_pr(payload, 8080, "secret", github_token="ghp_user")
+
+        mock_diff.assert_called_once_with("owner/repo", 42, github_token="ghp_user")
+        assert mock_generate.call_args.kwargs["github_token"] == "ghp_user"
+        mock_post.assert_called_once_with("owner/repo", 42, "review output", github_token="ghp_user")
 
 
 # ── resolve_spec_from_body ─────────────────────────────────────────

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -402,6 +402,13 @@ def _make_pr_payload(action: str, pr_number: int = 42, merged: bool = False) -> 
     }
 
 
+@pytest.fixture(autouse=True)
+def _default_github_token_lookup():
+    """Webhook tests default to no stored per-user GitHub token."""
+    with patch("kai.webhook.sessions.get_setting", new_callable=AsyncMock, return_value=None):
+        yield
+
+
 def _build_test_app(
     cooldown: int = 300,
     config: object | None = None,
@@ -551,6 +558,12 @@ class TestPRReviewRouting:
     def _stub_review_and_triage(self, _mock_review_and_triage):
         """Default routing tests do not need real review_pr / triage_issue."""
         yield
+
+    @pytest.fixture(autouse=True)
+    def _mock_github_token_setting(self):
+        """Default routing tests run without a stored per-user GitHub token."""
+        with patch("kai.webhook.sessions.get_setting", new_callable=AsyncMock, return_value=None):
+            yield
 
     @pytest.mark.asyncio
     async def test_routes_opened_when_enabled(self, _clear_cooldowns, _mock_resolve_repo):
@@ -726,6 +739,7 @@ class TestPRReviewRouting:
 
         with (
             _mock_settings(pr_review=True),
+            patch("kai.webhook.sessions.get_setting", new_callable=AsyncMock, return_value="ghp_user"),
             patch("kai.webhook.review.review_pr", new_callable=AsyncMock) as mock_review,
         ):
             async with TestClient(TestServer(app)) as client:
@@ -761,6 +775,7 @@ class TestPRReviewRouting:
             # silently pass a MagicMock instance here, vacuously
             # satisfying mocked review_pr but failing under real code.
             assert isinstance(call_kwargs[1]["model_override"], str)
+            assert call_kwargs[1]["github_token"] == "ghp_user"
             # _resolve_local_repo is mocked to return None here;
             # dedicated tests for resolution logic are in TestResolveLocalRepo.
             assert call_kwargs[1]["local_repo_path"] is None

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -72,6 +72,13 @@ async def db(tmp_path):
     await sessions.close_db()
 
 
+@pytest.fixture(autouse=True)
+def _default_github_token_lookup():
+    """Webhook API tests default to no stored per-user GitHub token."""
+    with patch("kai.webhook.sessions.get_setting", new_callable=AsyncMock, return_value=None):
+        yield
+
+
 @pytest.fixture
 def mock_request():
     """Create a minimal mock request with app dict and helpers."""


### PR DESCRIPTION
## Summary
- thread an optional per-user GitHub token through review gh subprocess helpers
- set GH_TOKEN and GITHUB_TOKEN for gh reads and comment posting when a stored /github token exists
- pass the requesting user's token from automated webhook reviews and manual /review
- add regressions for token env propagation and caller handoff

## Security rationale
This addresses the remaining shared-GitHub-deputy portion of assessment finding #3. Repository allowlisting already prevents arbitrary review targets; this change also makes stored per-user GitHub credentials effective for review fetch/comment operations instead of silently relying on the daemon's gh identity.

Compatibility note: users without a stored /github token continue to fall back to the existing gh CLI identity. A stricter fail-closed token requirement can be added separately if desired.

## Validation
- .venv/bin/python -m pytest tests/test_review.py::TestFetchPriorComments tests/test_review.py::TestFetchPRDiff tests/test_review.py::TestPostReviewComment tests/test_review.py::TestFetchExtendedPRMetadata tests/test_review.py::TestFetchLinkedIssue tests/test_review.py::TestFetchLinkedIssues tests/test_review.py::TestFetchChangedFilesAtHead tests/test_review.py::TestReviewPR tests/test_webhook.py::TestPRReviewRouting tests/test_bot.py::TestHandleReviewCommand -q
- .venv/bin/python -m pytest tests/test_review.py tests/test_webhook.py tests/test_webhook_api.py tests/test_bot.py -q
- make check
- make typecheck