### PR TITLE
Require per-user GitHub tokens in protected installs

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -3597,6 +3597,12 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
     agent_backend, provider = get_user_backend_and_provider(user_config, config)
     model_override = resolve_user_model(ModelRole.PR_REVIEW, user_config, config)
     github_token = await sessions.get_setting(f"github_token:{actor_id}")
+    if getattr(config, "protected_install", False) is True and not github_token:
+        await update.message.reply_text(
+            "PR review requires a stored per-user GitHub token in protected installs. "
+            "Send `/github token <token>` first."
+        )
+        return
 
     # Only pass the workspace as `local_repo_path` when its `origin`
     # remote actually matches the target repo. Otherwise the bundle

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1268,6 +1268,11 @@ class Config:
     # Deprecated: temporary external-only fallback for existing GitHub and
     # generic webhook callers. Never use this for Telegram or internal APIs.
     webhook_secret: str = ""
+    # True when load_config() populated secrets from the protected
+    # installation env file (/etc/kai/env). Runtime code uses this to
+    # tighten boundaries that would break local single-user installs if
+    # enforced unconditionally.
+    protected_install: bool = False
 
     # Voice input (speech-to-text via whisper-cpp)
     voice_enabled: bool = False
@@ -3444,6 +3449,7 @@ def load_config() -> Config:
         github_webhook_secret=github_webhook_secret,
         generic_webhook_secret=generic_webhook_secret,
         webhook_secret=legacy_webhook_secret,
+        protected_install=bool(protected_env),
         voice_enabled=os.environ.get("VOICE_ENABLED", "").lower() in ("1", "true", "yes"),
         tts_enabled=os.environ.get("TTS_ENABLED", "").lower() in ("1", "true", "yes"),
         workspace_base=workspace_base,

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -28,6 +28,7 @@ of the model's response before acting on it.
 import asyncio
 import json
 import logging
+import os
 import re
 import tempfile
 from dataclasses import dataclass
@@ -55,6 +56,23 @@ _TRIAGE_TIMEOUT = 300
 # Header prepended to every triage comment on GitHub. Distinguishes
 # automated triage from human comments.
 _TRIAGE_HEADER = "## Triage by Kai\n\n"
+
+
+def _github_cli_env(github_token: str | None = None) -> dict[str, str] | None:
+    """
+    Return an environment for gh subprocesses using a per-user token.
+
+    None preserves gh's default authentication behavior, which is still
+    useful for local/single-user installs. Protected installs enforce
+    token presence before entering this module.
+    """
+    token = github_token.strip() if github_token else ""
+    if not token:
+        return None
+    env = os.environ.copy()
+    env["GH_TOKEN"] = token
+    env["GITHUB_TOKEN"] = token
+    return env
 
 
 @dataclass(frozen=True)
@@ -131,7 +149,13 @@ def _sanitize_search_query(title: str) -> str:
     return cleaned[:128]
 
 
-async def search_related_issues(repo: str, title: str, body: str, issue_number: int = 0) -> str:
+async def search_related_issues(
+    repo: str,
+    title: str,
+    body: str,
+    issue_number: int = 0,
+    github_token: str | None = None,
+) -> str:
     """
     Search for related issues in the repo using the GitHub CLI.
 
@@ -171,6 +195,7 @@ async def search_related_issues(repo: str, title: str, body: str, issue_number: 
             "number,title,state,labels",
             "--limit",
             "10",
+            env=_github_cli_env(github_token),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -200,7 +225,7 @@ async def search_related_issues(repo: str, title: str, body: str, issue_number: 
         return "[]"
 
 
-async def list_projects(owner: str) -> str:
+async def list_projects(owner: str, github_token: str | None = None) -> str:
     """
     List GitHub Projects for a user/org via the GitHub CLI.
 
@@ -222,6 +247,7 @@ async def list_projects(owner: str) -> str:
             owner,
             "--format",
             "json",
+            env=_github_cli_env(github_token),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -653,7 +679,7 @@ def _parse_triage_json(raw: str) -> dict:
     return result
 
 
-async def _label_exists(repo: str, label: str) -> bool:
+async def _label_exists(repo: str, label: str, github_token: str | None = None) -> bool:
     """
     Return True only when a label already exists in the repo.
 
@@ -676,6 +702,7 @@ async def _label_exists(repo: str, label: str) -> bool:
         label,
         "--json",
         "name",
+        env=_github_cli_env(github_token),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
@@ -714,6 +741,7 @@ async def apply_triage(
     projects_json: str = "[]",
     notify_chat_id: int | None = None,
     allowed_triage_projects: list[str] | None = None,
+    github_token: str | None = None,
 ) -> None:
     """
     Apply triage results: labels, project assignment, comment, and notification.
@@ -885,7 +913,7 @@ async def apply_triage(
     skipped_labels: list[str] = []
 
     for label in requested_labels:
-        if not await _label_exists(metadata.repo, label):
+        if not await _label_exists(metadata.repo, label, github_token=github_token):
             skipped_labels.append(label)
             log.warning(
                 "Skipping triage label '%s' for %s#%d because it does not exist in the repository",
@@ -904,6 +932,7 @@ async def apply_triage(
             metadata.repo,
             "--add-label",
             label,
+            env=_github_cli_env(github_token),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -963,6 +992,7 @@ async def apply_triage(
                 owner,
                 "--url",
                 metadata.url,
+                env=_github_cli_env(github_token),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -1044,6 +1074,7 @@ async def apply_triage(
             metadata.repo,
             "--body-file",
             str(body_path),
+            env=_github_cli_env(github_token),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -1125,6 +1156,7 @@ async def triage_issue(
     provider: str = "",
     model_override: str = "",
     allowed_triage_projects: list[str] | None = None,
+    github_token: str | None = None,
 ) -> None:
     """
     Full triage pipeline: analyze issue, apply labels, post results.
@@ -1151,11 +1183,17 @@ async def triage_issue(
         metadata = extract_issue_metadata(payload)
 
         # Step 1: Search for related/duplicate issues
-        related_issues = await search_related_issues(metadata.repo, metadata.title, metadata.body, metadata.number)
+        related_issues = await search_related_issues(
+            metadata.repo,
+            metadata.title,
+            metadata.body,
+            metadata.number,
+            github_token=github_token,
+        )
 
         # Step 2: List available project boards
         owner = metadata.repo.split("/")[0]
-        projects = await list_projects(owner)
+        projects = await list_projects(owner, github_token=github_token)
 
         allowed_projects = _filter_projects_json(projects, allowed_triage_projects)
 
@@ -1191,6 +1229,7 @@ async def triage_issue(
             projects_json=allowed_projects,
             notify_chat_id=notify_chat_id,
             allowed_triage_projects=allowed_triage_projects,
+            github_token=github_token,
         )
 
     except Exception as exc:

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -892,6 +892,7 @@ async def _process_github_event_for_user(
     settings = await sessions.resolve_github_settings(chat_id, config)
     target_chat_id = settings["notify_chat_id"]
     github_token = await sessions.get_setting(f"github_token:{chat_id}")
+    protected_install = getattr(config, "protected_install", False) is True
 
     # Resolve per-user os_user for subprocess isolation. None falls
     # back to "run as the bot's own OS user" inside the agent backend.
@@ -933,6 +934,19 @@ async def _process_github_event_for_user(
     if settings["pr_review"] and event_type == "pull_request":
         action = payload.get("action", "")
         if action in ("opened", "reopened", "synchronize") and github_operations_authorized:
+            if protected_install and not github_token:
+                log.warning(
+                    "Skipping automated GitHub review for user %d: protected install requires a per-user token",
+                    chat_id,
+                )
+                await bot.send_message(
+                    chat_id=target_chat_id,
+                    text=(
+                        f"PR review skipped for {repo_full_name}: protected installs require a stored "
+                        "per-user GitHub token. Send `/github token <token>` first."
+                    ),
+                )
+                return
             pr = payload.get("pull_request", {})
             pr_number = pr.get("number", 0)
             repo = repo_full_name
@@ -1004,6 +1018,19 @@ async def _process_github_event_for_user(
     if settings["issue_triage"] and event_type == "issues":
         action = payload.get("action", "")
         if action == "opened" and github_operations_authorized:
+            if protected_install and not github_token:
+                log.warning(
+                    "Skipping issue triage for user %d: protected install requires a per-user token",
+                    chat_id,
+                )
+                await bot.send_message(
+                    chat_id=target_chat_id,
+                    text=(
+                        f"Issue triage skipped for {repo_full_name}: protected installs require a stored "
+                        "per-user GitHub token. Send `/github token <token>` first."
+                    ),
+                )
+                return
             issue = payload.get("issue", {})
             issue_number = issue.get("number", 0)
             repo = repo_full_name
@@ -1029,6 +1056,7 @@ async def _process_github_event_for_user(
                     provider=provider,
                     model_override=issue_triage_model_override,
                     allowed_triage_projects=user_config.allowed_triage_projects if user_config else [],
+                    github_token=github_token,
                 )
             )
             _background_tasks.add(task)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5964,6 +5964,39 @@ class TestHandleReviewCommand:
         assert mock_generate.call_args.kwargs["github_token"] == "ghp_user"
 
     @pytest.mark.asyncio
+    async def test_protected_install_requires_github_token(self, tmp_path, monkeypatch):
+        """Manual /review does not use the daemon gh identity in protected installs."""
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update()
+        config = _make_config(
+            protected_install=True,
+            user_configs={
+                1: UserConfig(
+                    telegram_id=1,
+                    name="op",
+                    github_repos=["dcellison/kai"],
+                ),
+            },
+        )
+        ctx = _make_context(config=config, args=["dcellison/kai", "681"])
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch(
+                "kai.review._resolve_workspace_remote_repo",
+                new=AsyncMock(return_value="dcellison/kai"),
+            ),
+            patch("kai.bot.sessions.get_setting", new=AsyncMock(return_value=None)),
+            patch("kai.bot.review.generate_pr_review", new_callable=AsyncMock) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        mock_generate.assert_not_called()
+        reply = update.message.reply_text.call_args.args[0]
+        assert "per-user GitHub token" in reply
+
+    @pytest.mark.asyncio
     async def test_short_form_falls_back_to_sole_configured_repo(self, tmp_path, monkeypatch):
         monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -706,6 +706,7 @@ class TestDualModeLoading:
         config = load_config()
         assert config.telegram_bot_token == "protected-token"
         assert config.allowed_user_ids == {999}
+        assert config.protected_install is True
 
     def test_protected_env_strips_quotes(self, monkeypatch):
         """Quote marks around values in /etc/kai/env are stripped."""
@@ -725,6 +726,7 @@ class TestDualModeLoading:
         )
         config = load_config()
         assert config.telegram_bot_token == "tok"
+        assert config.protected_install is True
 
     def test_falls_back_to_dotenv(self, monkeypatch, tmp_path):
         """When /etc/kai/env is not readable, load_dotenv is called.

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1664,6 +1664,47 @@ class TestTriageIssue:
         assert "Secret Board" not in apply_kwargs["projects_json"]
 
     @pytest.mark.asyncio
+    async def test_github_token_flows_to_all_gh_subprocesses(self):
+        """A per-user token is used for every triage gh subprocess stage."""
+        payload = _issue_payload(title="Login broken")
+        triage_json = json.dumps(
+            {
+                "labels": ["bug"],
+                "duplicate_of": None,
+                "related": [],
+                "project": None,
+                "summary": "Login is broken.",
+                "priority": "high",
+            }
+        )
+        gh_envs: list[dict | None] = []
+
+        async def mock_exec(*args, **kwargs):
+            if args and args[0] == "gh":
+                gh_envs.append(kwargs.get("env"))
+                if "issue" in args and "list" in args:
+                    return _mock_subprocess(stdout="[]")
+                if "project" in args and "list" in args:
+                    return _mock_subprocess(stdout="[]")
+                if "label" in args and "list" in args:
+                    return _mock_subprocess(stdout=json.dumps([{"name": "bug"}]))
+                return _mock_subprocess(stdout="[]")
+            return _mock_subprocess(stdout=triage_json)
+
+        with (
+            patch("kai.triage.asyncio.create_subprocess_exec", side_effect=mock_exec),
+            patch("kai.triage.aiohttp.ClientSession") as mock_session_cls,
+        ):
+            mock_session, _ = _mock_aiohttp_session_post(status=200)
+            _attach_session_to_class(mock_session, mock_session_cls)
+            await triage_issue(payload, 8080, "secret", github_token="ghp_user")
+
+        assert gh_envs
+        assert all(env is not None for env in gh_envs)
+        assert all(env["GH_TOKEN"] == "ghp_user" for env in gh_envs)
+        assert all(env["GITHUB_TOKEN"] == "ghp_user" for env in gh_envs)
+
+    @pytest.mark.asyncio
     async def test_handles_error(self):
         """Claude subprocess failure logs error and sends Telegram notification."""
         payload = _issue_payload()

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -472,6 +472,7 @@ def _build_test_app(
         mock_config.default_models = {}
         mock_config.default_backend = "claude"
         mock_config.default_provider = ""
+        mock_config.protected_install = False
         # get_user_config is synchronous in real Config; it must not return a
         # coroutine or authorization could be tested against a mock object.
         mock_config.get_user_config = lambda uid: default_user if uid == 12345 else None
@@ -1342,6 +1343,7 @@ class TestGetSubscribedUsers:
         config.default_models = {}
         config.default_backend = "claude"
         config.default_provider = ""
+        config.protected_install = False
         return config
 
     def _make_user(
@@ -1553,6 +1555,7 @@ class TestPerUserRouting:
         config.default_models = {}
         config.default_backend = "claude"
         config.default_provider = ""
+        config.protected_install = False
         # get_user_config returns the UserConfig for a given ID
         config.get_user_config = lambda uid: config.user_configs.get(uid)
         return config
@@ -2192,6 +2195,40 @@ class TestPerUserRouting:
             assert mock_review.call_args[1]["provider"] == "openai"
 
     @pytest.mark.asyncio
+    async def test_protected_review_requires_user_github_token(self, _clear_cooldowns, _mock_resolve_repo):
+        """Protected installs do not fall back to the daemon gh identity for PR review."""
+        user = self._make_user_config(111, repos=["owner/repo"])
+        config = self._make_config_with_users([user])
+        config.protected_install = True
+        app = _build_test_app(config=config)
+        payload = _make_pr_payload("opened")
+        body = json.dumps(payload).encode()
+        sig = _sign_payload(payload)
+
+        with (
+            _mock_settings(pr_review=True, notify_chat_id=-100111),
+            patch("kai.webhook.sessions.get_setting", new_callable=AsyncMock, return_value=None),
+            patch("kai.webhook.review.review_pr", new_callable=AsyncMock) as mock_review,
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/webhook/github",
+                    data=body,
+                    headers={
+                        "X-GitHub-Event": "pull_request",
+                        "X-Hub-Signature-256": sig,
+                    },
+                )
+                assert resp.status == 200
+
+            await asyncio.sleep(0.01)
+            mock_review.assert_not_called()
+            app[TELEGRAM_BOT_KEY].send_message.assert_called_once()
+            call = app[TELEGRAM_BOT_KEY].send_message.call_args.kwargs
+            assert call["chat_id"] == -100111
+            assert "per-user GitHub token" in call["text"]
+
+    @pytest.mark.asyncio
     async def test_triage_receives_user_backend(self, _clear_cooldowns):
         """Per-user backend/provider are passed to triage_issue."""
         base = self._make_user_config(111, repos=["owner/repo"])
@@ -2229,6 +2266,40 @@ class TestPerUserRouting:
             assert mock_triage.call_args[1]["agent_backend"] == "goose"
             assert mock_triage.call_args[1]["provider"] == "anthropic"
             assert mock_triage.call_args[1]["allowed_triage_projects"] == ["Sprint 1"]
+
+    @pytest.mark.asyncio
+    async def test_protected_triage_requires_user_github_token(self, _clear_cooldowns):
+        """Protected installs do not fall back to the daemon gh identity for issue triage."""
+        user = self._make_user_config(111, repos=["owner/repo"])
+        config = self._make_config_with_users([user])
+        config.protected_install = True
+        app = _build_test_app(config=config)
+        payload = _make_issue_payload("opened")
+        body = json.dumps(payload).encode()
+        sig = _sign_payload(payload)
+
+        with (
+            _mock_settings(issue_triage=True, notify_chat_id=-100111),
+            patch("kai.webhook.sessions.get_setting", new_callable=AsyncMock, return_value=None),
+            patch("kai.webhook.triage.triage_issue", new_callable=AsyncMock) as mock_triage,
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/webhook/github",
+                    data=body,
+                    headers={
+                        "X-GitHub-Event": "issues",
+                        "X-Hub-Signature-256": sig,
+                    },
+                )
+                assert resp.status == 200
+
+            await asyncio.sleep(0.01)
+            mock_triage.assert_not_called()
+            app[TELEGRAM_BOT_KEY].send_message.assert_called_once()
+            call = app[TELEGRAM_BOT_KEY].send_message.call_args.kwargs
+            assert call["chat_id"] == -100111
+            assert "per-user GitHub token" in call["text"]
 
     @pytest.mark.asyncio
     async def test_review_uses_global_backend_when_no_user_override(self, _clear_cooldowns, _mock_resolve_repo):


### PR DESCRIPTION
## Summary
- expose protected-install state from config loading
- block protected-mode PR review and issue triage when the user has no stored GitHub token instead of falling back to the daemon gh identity
- thread per-user GitHub tokens through every triage gh subprocess

## Behavior
- protected installs: /review, PR review webhooks, and issue triage webhooks require /github token before GitHub read/mutation work runs
- single-user/local installs: existing gh CLI fallback remains available
- GitHub notifications still send to the configured Telegram chat/group without requiring a per-user token

## Validation
- .venv/bin/python -m pytest tests/test_bot.py tests/test_webhook.py tests/test_triage.py tests/test_review.py tests/test_config.py -q
- make check
- make typecheck