### PR TITLE
Defer user file reads in protected installs

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -666,6 +666,11 @@ class AcpBackend(AgentBackend):
         # unbounded memory growth in a long-lived agent subprocess.
         # The pool passes Config.agent_max_session_hours.
         max_session_hours: float = 0,
+        # Protected installs keep per-user files unreadable to other
+        # users. When true, first-turn context injects paths instead
+        # of daemon-read file contents; the user-isolated subprocess
+        # can read its own files directly.
+        defer_user_file_reads: bool = False,
     ):
         # ABC-required attributes (pool.py reads/writes these)
         self.model = model
@@ -676,6 +681,7 @@ class AcpBackend(AgentBackend):
         self.provider = provider
         self.memory_enabled = memory_enabled
         self.os_user = os_user
+        self.defer_user_file_reads = defer_user_file_reads
         # Session-age recycling limit (ABC surface; checked by the
         # inherited _should_recycle at the top of _send_locked).
         self.max_session_hours = max_session_hours
@@ -1222,6 +1228,7 @@ class AcpBackend(AgentBackend):
                 chat_id=chat_id,
                 data_dir=DATA_DIR,
                 memory_enabled=self.memory_enabled,
+                defer_user_file_reads=self.defer_user_file_reads,
             )
 
         reminder = build_foreign_workspace_reminder(self.workspace, self.home_workspace) or ""

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -294,6 +294,7 @@ def build_session_context(
     chat_id: int | None,
     data_dir: Path,
     memory_enabled: bool = False,
+    defer_user_file_reads: bool = False,
 ) -> str:
     """
     Build the context prefix for the first message of a new session.
@@ -318,6 +319,11 @@ def build_session_context(
             as a bool rather than the full Config to match the existing
             convention of backends taking individual config fields at
             construction.
+        defer_user_file_reads: When True, do not read per-user files
+            from the daemon process. Instead inject the paths the
+            user-isolated backend subprocess should read. This is the
+            protected-install path that allows per-user directories to
+            be tightened without granting daemon-readable contents.
     """
     parts: list[str] = []
 
@@ -327,12 +333,18 @@ def build_session_context(
     # in get_workspace_system_prompt().
     if workspace != home_workspace:
         identity_path = home_workspace / ".claude" / "CLAUDE.md"
-        try:
-            identity = identity_path.read_text().strip()
-            if identity:
-                parts.append(f"[Your core identity and instructions:]\n{identity}")
-        except OSError:
-            pass
+        if defer_user_file_reads:
+            parts.append(
+                "[Your core identity and instructions are stored at "
+                f"{identity_path}. Read this file before applying identity-specific instructions.]"
+            )
+        else:
+            try:
+                identity = identity_path.read_text().strip()
+                if identity:
+                    parts.append(f"[Your core identity and instructions:]\n{identity}")
+            except OSError:
+                pass
 
     # Memory subsystem state marker. Tells the inner agent where to
     # route new fact saves: enabled = POST /api/memory/add (Qdrant),
@@ -358,18 +370,24 @@ def build_session_context(
     # is no global-fallback PREFERENCES.md.
     if chat_id is not None:
         pref_path = data_dir / "preferences" / str(chat_id) / "PREFERENCES.md"
-        try:
-            pref_text = pref_path.read_text().strip()
-            if pref_text:
-                parts.append(f"[Your personal preferences (file: {pref_path}):]\n{pref_text}")
-            else:
-                parts.append(f"[Your personal preferences (file: {pref_path}):]\n(currently empty)")
-        except OSError:
-            # OSError fires only on missing or unreadable files; the
-            # empty case is handled by the else branch above with a
-            # distinct "(currently empty)" placeholder. Match the
-            # MEMORY.md branch's wording for symmetry.
-            parts.append(f"[Your personal preferences (file: {pref_path}):]\n(not yet created)")
+        if defer_user_file_reads:
+            parts.append(
+                f"[Your personal preferences are stored at {pref_path}. "
+                "Read this file before applying personal preference instructions.]"
+            )
+        else:
+            try:
+                pref_text = pref_path.read_text().strip()
+                if pref_text:
+                    parts.append(f"[Your personal preferences (file: {pref_path}):]\n{pref_text}")
+                else:
+                    parts.append(f"[Your personal preferences (file: {pref_path}):]\n(currently empty)")
+            except OSError:
+                # OSError fires only on missing or unreadable files; the
+                # empty case is handled by the else branch above with a
+                # distinct "(currently empty)" placeholder. Match the
+                # MEMORY.md branch's wording for symmetry.
+                parts.append(f"[Your personal preferences (file: {pref_path}):]\n(not yet created)")
 
     # Inject Kai's personal memory from DATA_DIR ONLY in disabled mode.
     # In enabled mode, Qdrant is the active fact surface (retrieved via
@@ -397,14 +415,20 @@ def build_session_context(
             memory_path = data_dir / "memory" / str(chat_id) / "MEMORY.md"
         else:
             memory_path = data_dir / "memory" / "MEMORY.md"
-        try:
-            memory = memory_path.read_text().strip()
-            if memory:
-                parts.append(f"[Your persistent memory (file: {memory_path}):]\n{memory}")
-            else:
-                parts.append(f"[Your persistent memory (file: {memory_path}):]\n(currently empty)")
-        except OSError:
-            parts.append(f"[Your persistent memory (file: {memory_path}):]\n(not yet created)")
+        if defer_user_file_reads and chat_id is not None:
+            parts.append(
+                f"[Your persistent memory is stored at {memory_path}. "
+                "Read this file when persistent memory is relevant; update it for durable memory writes.]"
+            )
+        else:
+            try:
+                memory = memory_path.read_text().strip()
+                if memory:
+                    parts.append(f"[Your persistent memory (file: {memory_path}):]\n{memory}")
+                else:
+                    parts.append(f"[Your persistent memory (file: {memory_path}):]\n(currently empty)")
+            except OSError:
+                parts.append(f"[Your persistent memory (file: {memory_path}):]\n(not yet created)")
 
     # Per-workspace system prompt from workspaces.yaml. Injected
     # between the identity/memory block and conversation history,

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -121,6 +121,11 @@ class ClaudeCodeBackend(AgentBackend):
         # the kwarg; production callers (pool.py) always pass an
         # explicit value.
         memory_enabled: bool = False,
+        # Protected installs keep per-user files unreadable to other
+        # users. When true, first-turn context injects paths instead
+        # of daemon-read file contents; the user-isolated subprocess
+        # can read its own files directly.
+        defer_user_file_reads: bool = False,
     ):
         # ABC-required attributes (pool.py reads/writes these)
         self.model = model
@@ -141,6 +146,7 @@ class ClaudeCodeBackend(AgentBackend):
         # Session-age recycling limit (ABC surface; checked by the
         # inherited _should_recycle at the top of _send_locked).
         self.max_session_hours = max_session_hours
+        self.defer_user_file_reads = defer_user_file_reads
 
         # Claude-Code-specific attributes (not on the ABC)
         self.claude_user = claude_user
@@ -764,6 +770,7 @@ class ClaudeCodeBackend(AgentBackend):
                 chat_id=chat_id,
                 data_dir=DATA_DIR,
                 memory_enabled=self.memory_enabled,
+                defer_user_file_reads=self.defer_user_file_reads,
             )
 
         # Foreign-workspace reminder is built fresh per turn (its

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -298,6 +298,11 @@ class CodexBackend(AgentBackend):
         # load, so any non-empty value reaching this point is one of
         # the CLI's accepted tiers.
         codex_effort_level: str = "",
+        # Protected installs keep per-user files unreadable to other
+        # users. When true, first-turn context injects paths instead
+        # of daemon-read file contents; the user-isolated subprocess
+        # can read its own files directly.
+        defer_user_file_reads: bool = False,
     ):
         # ABC-required attributes (pool.py reads/writes these)
         self.model = model
@@ -309,6 +314,7 @@ class CodexBackend(AgentBackend):
         self.codex_user = codex_user
         self.memory_enabled = memory_enabled
         self.codex_effort_level = codex_effort_level
+        self.defer_user_file_reads = defer_user_file_reads
         # Session-age recycling limit (ABC surface; checked by the
         # inherited _should_recycle at the top of _send_locked).
         self.max_session_hours = max_session_hours
@@ -813,6 +819,7 @@ class CodexBackend(AgentBackend):
                 chat_id=chat_id,
                 data_dir=DATA_DIR,
                 memory_enabled=self.memory_enabled,
+                defer_user_file_reads=self.defer_user_file_reads,
             )
 
         # Foreign-workspace reminder is built fresh per turn (its

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -267,6 +267,7 @@ class SubprocessPool:
                 memory_enabled=self._config.memory_enabled,
                 os_user=os_user,
                 max_session_hours=self._config.agent_max_session_hours,
+                defer_user_file_reads=getattr(self._config, "protected_install", False) is True,
             )
 
         if backend == "opencode":
@@ -288,6 +289,7 @@ class SubprocessPool:
                 memory_enabled=self._config.memory_enabled,
                 os_user=os_user,
                 max_session_hours=self._config.agent_max_session_hours,
+                defer_user_file_reads=getattr(self._config, "protected_install", False) is True,
             )
 
         if backend == "codex":
@@ -311,6 +313,7 @@ class SubprocessPool:
                 memory_enabled=self._config.memory_enabled,
                 max_session_hours=self._config.agent_max_session_hours,
                 codex_effort_level=self._config.codex_effort_level,
+                defer_user_file_reads=getattr(self._config, "protected_install", False) is True,
             )
 
         return ClaudeCodeBackend(
@@ -327,6 +330,7 @@ class SubprocessPool:
             autocompact_pct=self._config.claude_autocompact_pct,
             claude_effort_level=self._config.claude_effort_level,
             memory_enabled=self._config.memory_enabled,
+            defer_user_file_reads=getattr(self._config, "protected_install", False) is True,
         )
 
     # ── Prompt routing ──────────────────────────────────────────────

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -89,6 +89,41 @@ class TestBuildSessionContext:
         assert "[Your core identity and instructions:]" in result
         assert "Be helpful." in result
 
+    def test_defer_user_file_reads_injects_paths_not_contents(self, tmp_path):
+        """Protected mode avoids daemon-side reads of user-owned files."""
+        home = tmp_path / "home" / "12345"
+        home.mkdir(parents=True)
+        (home / ".claude").mkdir()
+        (home / ".claude" / "CLAUDE.md").write_text("PRIVATE IDENTITY")
+
+        foreign = tmp_path / "foreign"
+        foreign.mkdir()
+        data_dir = tmp_path / "data"
+        pref_dir = data_dir / "preferences" / "12345"
+        pref_dir.mkdir(parents=True)
+        (pref_dir / "PREFERENCES.md").write_text("PRIVATE PREFS")
+        memory_dir = data_dir / "memory" / "12345"
+        memory_dir.mkdir(parents=True)
+        (memory_dir / "MEMORY.md").write_text("PRIVATE MEMORY")
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=foreign,
+                home_workspace=home,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=12345,
+                data_dir=data_dir,
+                defer_user_file_reads=True,
+            )
+
+        assert "PRIVATE IDENTITY" not in result
+        assert "PRIVATE PREFS" not in result
+        assert "PRIVATE MEMORY" not in result
+        assert str(home / ".claude" / "CLAUDE.md") in result
+        assert str(pref_dir / "PREFERENCES.md") in result
+        assert str(memory_dir / "MEMORY.md") in result
+
     def test_memory_exists(self, tmp_path):
         """Memory content included when file exists and is non-empty."""
         workspace = tmp_path / "ws"

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -442,6 +442,30 @@ class TestPerUserBackendRouting:
             assert isinstance(instance, expected_type)
             assert instance.max_session_hours == 6.5
 
+    def test_protected_install_defers_user_file_reads_for_all_backends(self):
+        """Protected installs stop backend context from reading user files in the daemon."""
+        from kai.claude import ClaudeCodeBackend
+        from kai.codex import CodexBackend
+        from kai.opencode import OpenCodeBackend
+
+        users = {
+            111: UserConfig(telegram_id=111, name="a", backend="claude", provider="anthropic", model="sonnet"),
+            222: UserConfig(telegram_id=222, name="b", backend="codex"),
+            333: UserConfig(telegram_id=333, name="c", backend="goose", provider="anthropic", model="sonnet"),
+            444: UserConfig(telegram_id=444, name="d", backend="opencode", model="anthropic/claude-sonnet-4-6"),
+        }
+        config = _make_config(protected_install=True, user_configs=users)
+        pool = SubprocessPool(config=config, services_info=[])
+        for chat_id, expected_type in [
+            (111, ClaudeCodeBackend),
+            (222, CodexBackend),
+            (333, GooseBackend),
+            (444, OpenCodeBackend),
+        ]:
+            instance = pool.get(chat_id)
+            assert isinstance(instance, expected_type)
+            assert instance.defer_user_file_reads is True
+
     def test_opencode_user_receives_os_user(self):
         """An opencode user's os_user reaches OpenCodeBackend, which
         wires the per-user sudo isolation in the shared ACP layer


### PR DESCRIPTION
## Summary
- add a protected-mode backend/context flag that stops the daemon from reading per-user home, preferences, and MEMORY.md contents
- inject user-owned file paths instead so the isolated backend process can read its own files
- thread the flag from Config.protected_install through Claude, Codex, Goose, and OpenCode backend construction

## Security rationale
This is the prerequisite for tightening /var/lib/kai/home, /var/lib/kai/preferences, and /var/lib/kai/memory per-user directory modes. The daemon previously had to read those files directly, which forced broad read/traverse permissions. This change removes that daemon-read dependency in protected installs without changing local/single-user behavior.

## Behavior
- protected installs: first-turn context references user-owned file paths instead of embedding file contents read by the daemon
- non-protected installs: existing inline identity/preferences/MEMORY.md injection is unchanged
- no installer permission changes in this PR

## Validation
- .venv/bin/python -m pytest tests/test_backend.py tests/test_pool.py tests/test_claude.py tests/test_codex.py tests/test_acp.py tests/test_opencode.py tests/test_bot.py tests/test_config.py -q
- make check
- make typecheck