### PR TITLE
Tighten per-user data directory modes

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -35,6 +35,43 @@ from kai.history import get_recent_history
 
 log = logging.getLogger(__name__)
 
+_PRIVATE_USER_ROOT_MODE = 0o711
+_PRIVATE_USER_DIR_MODE = 0o700
+_PRIVATE_USER_FILE_MODE = 0o600
+
+
+def _chmod_private_user_root(path: Path) -> None:
+    """Best-effort chmod for shared per-user data roots."""
+    if path.is_symlink():
+        return
+    try:
+        os.chmod(path, _PRIVATE_USER_ROOT_MODE)
+    except PermissionError:
+        pass
+
+
+def _chmod_private_user_dir(path: Path) -> None:
+    """Best-effort chmod for lazily-created user-owned directories."""
+    if path.is_symlink():
+        return
+    try:
+        os.chmod(path, _PRIVATE_USER_DIR_MODE)
+    except PermissionError:
+        # In protected installs, install.py may have already chowned this path
+        # to the target os_user. The service user can traverse/read only via
+        # configured handoff paths and must not crash if chmod returns EPERM.
+        pass
+
+
+def _chmod_private_user_file(path: Path) -> None:
+    """Best-effort chmod for lazily-created user-owned files."""
+    if path.is_symlink():
+        return
+    try:
+        os.chmod(path, _PRIVATE_USER_FILE_MODE)
+    except PermissionError:
+        pass
+
 
 # Outer-daemon control-plane credentials must never enter a persistent agent
 # environment. Provider API keys are intentionally not listed: some supported
@@ -593,19 +630,22 @@ def ensure_user_memory(chat_id: int | None, data_dir: Path) -> None:
     # still has a writable memory_root for the inner agent to update.
     # Without this branch a write attempt from the subprocess would
     # FileNotFoundError on the missing parent directory.
+    memory_root = data_dir / "memory"
     if chat_id is None:
-        user_memory_dir = data_dir / "memory"
+        user_memory_dir = memory_root
         user_memory_file = user_memory_dir / "MEMORY.md"
     else:
-        user_memory_dir = data_dir / "memory" / str(chat_id)
+        user_memory_dir = memory_root / str(chat_id)
         user_memory_file = user_memory_dir / "MEMORY.md"
 
     try:
-        user_memory_dir.mkdir(parents=True, exist_ok=True)
+        memory_root.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_ROOT_MODE)
+        _chmod_private_user_root(memory_root)
+        user_memory_dir.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
+        if chat_id is not None:
+            _chmod_private_user_dir(user_memory_dir)
         if not user_memory_file.exists():
             # Seed from the template if one ships with the source tree.
-            # Copy2 preserves mode bits so a deliberately permissive
-            # template stays that way.
             template = PROJECT_ROOT / "templates" / ".claude" / "MEMORY.md"
             if template.is_file():
                 shutil.copy2(template, user_memory_file)
@@ -614,6 +654,7 @@ def ensure_user_memory(chat_id: int | None, data_dir: Path) -> None:
                 # install tree is incomplete). Create a minimal placeholder
                 # so the subprocess has a writable file to edit.
                 user_memory_file.write_text("# Memory\n")
+        _chmod_private_user_file(user_memory_file)
     except OSError:
         log.warning(
             "ensure_user_memory: could not bootstrap %s",
@@ -651,16 +692,17 @@ def ensure_user_preferences(chat_id: int | None, data_dir: Path) -> None:
     if chat_id is None:
         return
 
-    user_pref_dir = data_dir / "preferences" / str(chat_id)
+    preferences_root = data_dir / "preferences"
+    user_pref_dir = preferences_root / str(chat_id)
     user_pref_file = user_pref_dir / "PREFERENCES.md"
 
     try:
-        user_pref_dir.mkdir(parents=True, exist_ok=True)
+        preferences_root.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_ROOT_MODE)
+        _chmod_private_user_root(preferences_root)
+        user_pref_dir.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
+        _chmod_private_user_dir(user_pref_dir)
         if not user_pref_file.exists():
             # Seed from the template if one ships with the source tree.
-            # Copy2 preserves mode bits so a deliberately permissive
-            # template stays that way. Mirrors ensure_user_memory's seed
-            # step.
             template = PROJECT_ROOT / "templates" / ".claude" / "PREFERENCES.md"
             if template.is_file():
                 shutil.copy2(template, user_pref_file)
@@ -671,6 +713,7 @@ def ensure_user_preferences(chat_id: int | None, data_dir: Path) -> None:
                 # to edit. Matches ensure_user_memory's `# Memory\n`
                 # precedent for symmetry.
                 user_pref_file.write_text("# Preferences\n")
+        _chmod_private_user_file(user_pref_file)
     except OSError:
         log.warning(
             "ensure_user_preferences: could not bootstrap %s",
@@ -716,10 +759,11 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
     real user; it is not shared between actual Telegram users because
     any real message carries a chat_id.
 
-    Mode 0755 with per-user chown at install time is what isolates
-    users from each other. Matches memory/ exactly (install.py
-    `_apply_migrate` uses the same ownership rules). Isolation comes
-    from ownership, not mode bits.
+    Managed per-user home directories are private (0700) with per-user
+    chown at install time. The lazy fallback uses the same private mode
+    under the caller's ownership for dev / single-user paths. Distinct
+    os_user entries added after install still require a reinstall so
+    install.py can apply the correct ownership.
 
     Like ensure_user_memory and ensure_user_preferences, this seeds
     `<home>/.claude/CLAUDE.md` from `templates/.claude/CLAUDE.md` when
@@ -738,21 +782,23 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
     # fixed "anon" subdir so the resolver always returns a concrete
     # path rather than None; avoids defensive None-checks at every call
     # site.
+    home_root = data_dir / "home"
     if chat_id is None:
-        path = data_dir / "home" / "anon"
+        path = home_root / "anon"
     else:
-        path = data_dir / "home" / str(chat_id)
+        path = home_root / str(chat_id)
 
     # mkdir parents=True is load-bearing: on a brand-new install the
     # data_dir/home/ root may not exist yet (the installer creates it,
     # but dev paths and the tests go straight through lazy bootstrap).
     # exist_ok=True means this is safe to call on every session init.
-    path.mkdir(parents=True, exist_ok=True, mode=0o755)
+    home_root.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_ROOT_MODE)
+    _chmod_private_user_root(home_root)
+    path.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
     # mkdir's mode= argument is masked by the process umask, so on a
-    # service configured with umask 0o027 the directory can end up 0o750
-    # instead of 0o755. That blocks group traversal and can break the
-    # inner subprocess when sudo -u targets a different identity. Force
-    # the intended bits explicitly - this is the same pattern install.py
+    # service configured with a restrictive umask the directory can end
+    # up narrower than 0o700. Force the intended bits explicitly - this
+    # is the same pattern install.py
     # `_apply_migrate` uses after its mkdir calls.
     #
     # Swallow PermissionError because in a multi-user install the
@@ -765,7 +811,7 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
     # Narrow to PermissionError rather than bare OSError so unrelated
     # failure modes (ENOENT, ENOTDIR, EIO) still propagate.
     try:
-        os.chmod(path, 0o755)
+        os.chmod(path, _PRIVATE_USER_DIR_MODE)
     except PermissionError:
         pass
 
@@ -781,22 +827,8 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
         claude_dir = path / ".claude"
         claude_dst = claude_dir / "CLAUDE.md"
         if not claude_dst.exists():
-            claude_dir.mkdir(parents=True, exist_ok=True)
-            # mkdir's mode= is masked by umask; force the bits to 0o755
-            # explicitly the same way the parent `path` does above.
-            # Without this, a service running under umask 0o027 lands
-            # the .claude/ subdir at 0o750, which blocks group-traverse
-            # for distinct-os_user subprocesses (sudo -H -u <os_user>)
-            # and silently breaks identity reads. ensure_user_memory
-            # and ensure_user_preferences create their per-user parent
-            # dirs without an explicit chmod and so have the same
-            # pre-existing umask gap on `data_dir/memory/<chat_id>/`
-            # and `data_dir/preferences/<chat_id>/`. ensure_user_home
-            # already chmods its own per-user parent at line 617; the
-            # call here closes the matching gap on the .claude/ subdir
-            # it creates. Closing the sibling-function gaps is out of
-            # scope for this PR but worth a follow-up.
-            os.chmod(claude_dir, 0o755)
+            claude_dir.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
+            _chmod_private_user_dir(claude_dir)
             template = PROJECT_ROOT / "templates" / ".claude" / "CLAUDE.md"
             if template.is_file():
                 shutil.copy2(template, claude_dst)
@@ -806,6 +838,8 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
                 # ensure_user_preferences' `# Preferences\n` last-resort
                 # placeholder so the inner agent has a writable file.
                 claude_dst.write_text("# Identity\n")
+        _chmod_private_user_dir(claude_dir)
+        _chmod_private_user_file(claude_dst)
     except OSError:
         log.warning(
             "ensure_user_home: could not seed CLAUDE.md at %s",

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -102,6 +102,10 @@ _SERVICE_START_MAX_ATTEMPTS = 3
 _SERVICE_START_SETTLE_SECONDS = 1
 _SERVICE_START_RETRY_SECONDS = 2
 
+_PRIVATE_USER_ROOT_MODE = 0o711
+_PRIVATE_USER_DIR_MODE = 0o700
+_PRIVATE_USER_FILE_MODE = 0o600
+
 
 class ServiceStartError(Exception):
     """Raised by `_start_service` when the post-condition verify
@@ -2555,12 +2559,40 @@ def _set_ownership(path: Path, uid: int, gid: int, recursive: bool = False) -> N
         os.lchown(path, uid, gid)
     else:
         os.chown(path, uid, gid)
-    if recursive and path.is_dir():
+    if recursive and path.is_dir() and not path.is_symlink():
         for child in path.rglob("*"):
             if child.is_symlink():
                 os.lchown(child, uid, gid)
             else:
                 os.chown(child, uid, gid)
+
+
+def _set_private_user_tree_modes(path: Path) -> None:
+    """
+    Make a user-owned Kai data subtree private without following symlinks.
+
+    Directories become 0700; regular files become 0600. Symlinks are skipped:
+    chmod(2) would affect the target on most platforms, which is not safe for
+    a tree that may contain stale or operator-created entries.
+    """
+    if path.is_symlink():
+        return
+    if path.is_dir():
+        os.chmod(path, _PRIVATE_USER_DIR_MODE)
+        for root, dirs, files in os.walk(path, followlinks=False):
+            root_path = Path(root)
+            if not root_path.is_symlink():
+                os.chmod(root_path, _PRIVATE_USER_DIR_MODE)
+            for dirname in dirs:
+                child = root_path / dirname
+                if not child.is_symlink():
+                    os.chmod(child, _PRIVATE_USER_DIR_MODE)
+            for filename in files:
+                child = root_path / filename
+                if not child.is_symlink():
+                    os.chmod(child, _PRIVATE_USER_FILE_MODE)
+    elif path.exists():
+        os.chmod(path, _PRIVATE_USER_FILE_MODE)
 
 
 def _copy_tree(
@@ -3823,6 +3855,7 @@ def _apply_migrate(
                 f"users.yaml entry, then re-run sudo make install."
             ) from exc
         per_user_ids[str(chat_id)] = (pwd_entry.pw_uid, pwd_entry.pw_gid)
+    known_user_dir_names = {str(chat_id) for chat_id, _os_user in memory_owners if chat_id is not None}
 
     # Resolve the primary operator's chat_id (first yaml entry). When
     # users.yaml is absent or empty (first-ever install, single-user
@@ -3955,17 +3988,19 @@ def _apply_migrate(
         # ValueError; we cannot reach this block in that state.
 
         if dry_run:
-            print(f"[DRY RUN] Would set ownership on {memory_tree} (service + per-user)")
+            print(f"[DRY RUN] Would set ownership/modes on {memory_tree} (service + per-user)")
             for name, (uid, gid) in per_user_ids.items():
-                print(f"[DRY RUN]   {memory_tree / name} -> ({uid}:{gid})")
+                print(f"[DRY RUN]   {memory_tree / name} -> ({uid}:{gid}, mode 0700)")
         else:
             # Top-level directory: service-owned so the service user
             # can create new per-user subdirs on add-user flows.
             _set_ownership(memory_tree, svc_uid, svc_gid, recursive=False)
+            os.chmod(memory_tree, _PRIVATE_USER_ROOT_MODE)
             for entry in memory_tree.iterdir():
-                if entry.is_dir() and entry.name in per_user_ids:
-                    uid, gid = per_user_ids[entry.name]
+                if entry.is_dir() and entry.name in known_user_dir_names:
+                    uid, gid = per_user_ids.get(entry.name, (svc_uid, svc_gid))
                     _set_ownership(entry, uid, gid, recursive=True)
+                    _set_private_user_tree_modes(entry)
                 else:
                     # qdrant/, mem0_history.db, extractor_cwd/, and any
                     # memory/<chat_id>/ whose user has no os_user set.
@@ -4025,15 +4060,17 @@ def _apply_migrate(
     # ownership on first-run only and stale files would persist.
     if preferences_tree.is_dir():
         if dry_run:
-            print(f"[DRY RUN] Would set ownership on {preferences_tree} (service + per-user)")
+            print(f"[DRY RUN] Would set ownership/modes on {preferences_tree} (service + per-user)")
             for name, (uid, gid) in per_user_ids.items():
-                print(f"[DRY RUN]   {preferences_tree / name} -> ({uid}:{gid})")
+                print(f"[DRY RUN]   {preferences_tree / name} -> ({uid}:{gid}, mode 0700)")
         else:
             _set_ownership(preferences_tree, svc_uid, svc_gid, recursive=False)
+            os.chmod(preferences_tree, _PRIVATE_USER_ROOT_MODE)
             for entry in preferences_tree.iterdir():
-                if entry.is_dir() and entry.name in per_user_ids:
-                    uid, gid = per_user_ids[entry.name]
+                if entry.is_dir() and entry.name in known_user_dir_names:
+                    uid, gid = per_user_ids.get(entry.name, (svc_uid, svc_gid))
                     _set_ownership(entry, uid, gid, recursive=True)
+                    _set_private_user_tree_modes(entry)
                 else:
                     # Subdirs whose chat_id has no os_user, or any
                     # stray top-level entry, fall through to service
@@ -4071,15 +4108,13 @@ def _apply_migrate(
     # ownership is already correct, and if it did not run a defensive
     # chown here would mask the real bug rather than fix it.
     if not dry_run:
-        home_root.mkdir(parents=True, exist_ok=True, mode=0o755)
+        home_root.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_ROOT_MODE)
         # mkdir's mode= is masked by umask. Under the production
-        # service umask of 0o027 the directory ends up 0o750, which
-        # blocks group traversal: a distinct-os_user subprocess that
-        # is not in the service group cannot enter home_root to reach
-        # its own per-user slot, even though that slot has correct
-        # 0o755 mode. Force the bits explicitly - same pattern as
-        # ensure_user_home and the user_dir.chmod two lines below.
-        os.chmod(home_root, 0o755)
+        # service umask of 0o027 the directory would otherwise end up
+        # 0o710. Force traversal-only public bits so distinct os_user
+        # subprocesses can reach their own private slots without
+        # listing sibling chat IDs.
+        os.chmod(home_root, _PRIVATE_USER_ROOT_MODE)
     # Resolve data_path once for the symlink-safe containment check
     # below. _collect_user_home_overrides canonicalizes each override
     # via Path.resolve(); comparing against an unresolved data_path
@@ -4100,26 +4135,28 @@ def _apply_migrate(
         # resolve_home_workspace returns it verbatim at runtime. Case
         # 1: no override - provision the per-user default slot.
         user_dir = override if override is not None else home_root / str(chat_id)
-        if user_dir.exists():
-            continue  # idempotent across reinstalls
+        user_dir_exists = user_dir.exists()
         if dry_run:
             if str(chat_id) in per_user_ids:
                 uid, gid = per_user_ids[str(chat_id)]
-                print(f"[DRY RUN] Would create {user_dir} ({uid}:{gid})")
+                action = "set private mode on" if user_dir_exists else "create"
+                print(f"[DRY RUN] Would {action} {user_dir} ({uid}:{gid}, mode 0700)")
             else:
-                print(f"[DRY RUN] Would create {user_dir} ({svc_uid}:{svc_gid})")
+                action = "set private mode on" if user_dir_exists else "create"
+                print(f"[DRY RUN] Would {action} {user_dir} ({svc_uid}:{svc_gid}, mode 0700)")
             continue
-        user_dir.mkdir(parents=True, exist_ok=True, mode=0o755)
+        user_dir.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
         # mkdir does not always honor mode (it is masked by umask).
         # Force the intended bits explicitly so the per-user dir
-        # ends up 0755 regardless of the install-time umask.
-        os.chmod(user_dir, 0o755)
+        # ends up private regardless of the install-time umask.
+        os.chmod(user_dir, _PRIVATE_USER_DIR_MODE)
         if str(chat_id) in per_user_ids:
             uid, gid = per_user_ids[str(chat_id)]
             _set_ownership(user_dir, uid, gid, recursive=False)
         else:
             _set_ownership(user_dir, svc_uid, svc_gid, recursive=False)
-        print(f"  Created {user_dir}")
+        if not user_dir_exists:
+            print(f"  Created {user_dir}")
 
     # -- CLAUDE.md per-user pre-creation --
     # Mirror the MEMORY.md / PREFERENCES.md per-user pattern above. For
@@ -4207,13 +4244,10 @@ def _apply_migrate(
         # `not exists()` is the same guard ensure_user_memory and
         # ensure_user_preferences use; matches the seed-step contract.
         claude_dir.mkdir(parents=True, exist_ok=True)
-        # mkdir's mode= is masked by umask; force 0o755 explicitly so a
-        # service running under umask 0o027 does not land the subdir at
-        # 0o750 (which would block group-traverse for distinct-os_user
-        # subprocesses). Mirrors the chmod in
-        # `backend.ensure_user_home`'s lazy seed branch and the
-        # parent-dir chmod in the home-creation loop above.
-        os.chmod(claude_dir, 0o755)
+        # mkdir's mode= is masked by umask; force the private mode
+        # explicitly. The user-owned home slot is now 0700, so no
+        # sibling user needs traversal through this subdir.
+        os.chmod(claude_dir, _PRIVATE_USER_DIR_MODE)
         if not claude_dst.exists():
             # Wrap the actual file write in try/except so an OSError
             # (broken symlink at claude_dst, mounted FS, permissions)
@@ -4276,6 +4310,7 @@ def _apply_migrate(
             _set_ownership(claude_dir, uid, gid, recursive=True)
         else:
             _set_ownership(claude_dir, svc_uid, svc_gid, recursive=True)
+        _set_private_user_tree_modes(claude_dir)
 
     # -- Per-os-user temp directories (#454) --
     # The inner Claude binary writes a content-hashed settings cache
@@ -4824,18 +4859,18 @@ def _apply_directories(
         (data_path / "logs", svc_uid, svc_gid, 0o755),
         (data_path / "files", svc_uid, svc_gid, 0o755),
         (data_path / "history", svc_uid, svc_gid, 0o755),
-        (data_path / "memory", svc_uid, svc_gid, 0o755),
+        (data_path / "memory", svc_uid, svc_gid, _PRIVATE_USER_ROOT_MODE),
         # Per-user preferences root (#400). Top-level dir is service-
         # owned so the bot can lazily create new preferences/<chat_id>/
         # subdirs at first message; per-user subdirs are pre-created
         # and chowned in _apply_migrate when the user has a distinct
         # os_user.
-        (data_path / "preferences", svc_uid, svc_gid, 0o755),
+        (data_path / "preferences", svc_uid, svc_gid, _PRIVATE_USER_ROOT_MODE),
         # Per-user home root (#353). Top-level dir is service-owned so
         # the bot can lazily create new home/<chat_id>/ subdirs at first
         # message; per-user subdirs are pre-created and chowned in
         # _apply_migrate when the user has a distinct os_user.
-        (data_path / "home", svc_uid, svc_gid, 0o755),
+        (data_path / "home", svc_uid, svc_gid, _PRIVATE_USER_ROOT_MODE),
         (Path("/etc/kai"), 0, 0, 0o755),
     ]
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -9,6 +9,7 @@ and the ApiContext/AgentResponse/StreamEvent data types. These functions are pur
 
 import logging
 import os
+import stat
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -769,33 +770,30 @@ class TestEnsureUserHome:
         assert result == tmp_path / "home" / "anon"
         assert result.is_dir()
 
-    def test_directory_mode_is_exactly_0755(self, tmp_path):
+    def test_directory_mode_is_exactly_0700(self, tmp_path):
         """
-        Mode must be EXACTLY 0o755 after ensure_user_home, regardless
-        of the process umask. The umask on a hardened service is
-        commonly 0o027, which would mask mkdir(mode=0o755) down to
-        0o750 - blocking group traversal and breaking the inner
-        subprocess when sudo -u targets a different identity. The
-        helper must chmod explicitly after mkdir to force the intended
-        bits; this test fails loudly if that chmod is ever removed.
+        Mode must be EXACTLY 0o700 after ensure_user_home. Per-user
+        home workspaces contain identity files and agent state, so they
+        should not be listable/readable by sibling OS users.
 
-        A weaker assertion (mode & 0o022 == 0) would accept 0o750 and
-        silently mask a regression of exactly this kind.
+        A weaker assertion (mode & 0o077 == 0) would accept 0o600 and
+        silently mask a regression that makes the directory unusable.
         """
-        # Set a hostile umask to simulate the production service config
-        # (umask 0o027 on the launchd plist). Without the explicit chmod
-        # in ensure_user_home, mkdir(mode=0o755) would return 0o750 here.
+        # Set a hostile umask. Without the explicit chmod in
+        # ensure_user_home, mkdir(mode=0o700) can be masked down.
         import os as _os
         import stat
 
-        prev_umask = _os.umask(0o027)
+        (tmp_path / "home").mkdir()
+        prev_umask = _os.umask(0o777)
         try:
             result = ensure_user_home(99, tmp_path)
         finally:
             _os.umask(prev_umask)
 
         mode = stat.S_IMODE(result.stat().st_mode)
-        assert mode == 0o755, f"expected 0o755, got {oct(mode)}"
+        assert mode == 0o700, f"expected 0o700, got {oct(mode)}"
+        assert stat.S_IMODE((tmp_path / "home").stat().st_mode) == 0o711
 
     def test_seeds_claude_md_from_template(self, tmp_path):
         """
@@ -823,6 +821,8 @@ class TestEnsureUserHome:
         claude_dst = home / ".claude" / "CLAUDE.md"
         assert claude_dst.is_file(), f"Expected lazy seed at {claude_dst}"
         assert claude_dst.read_text() == "# Kai template\n"
+        assert stat.S_IMODE((home / ".claude").stat().st_mode) == 0o700
+        assert stat.S_IMODE(claude_dst.stat().st_mode) == 0o600
 
     def test_seed_is_idempotent(self, tmp_path):
         """An existing per-user CLAUDE.md is never overwritten on later calls."""
@@ -1237,6 +1237,9 @@ class TestEnsureUserMemory:
         target = data_dir / "memory" / "42" / "MEMORY.md"
         assert target.is_file()
         assert "About the User" in target.read_text()
+        assert stat.S_IMODE((data_dir / "memory").stat().st_mode) == 0o711
+        assert stat.S_IMODE(target.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
 
     def test_no_template_creates_placeholder(self, tmp_path, monkeypatch):
         """Falls back to minimal '# Memory\\n' when no example template exists."""
@@ -1295,6 +1298,8 @@ class TestEnsureUserMemory:
         legacy = data_dir / "memory" / "MEMORY.md"
         assert legacy.is_file()
         assert "Dev" in legacy.read_text()
+        assert stat.S_IMODE((data_dir / "memory").stat().st_mode) == 0o711
+        assert stat.S_IMODE(legacy.stat().st_mode) == 0o600
         # No per-user subdir was created (chat_id=None must not
         # leak into a numeric subdirectory name).
         assert list((data_dir / "memory").iterdir()) == [legacy]
@@ -1356,6 +1361,9 @@ class TestEnsureUserPreferences:
         target = data_dir / "preferences" / "42" / "PREFERENCES.md"
         assert target.is_file()
         assert "Style" in target.read_text()
+        assert stat.S_IMODE((data_dir / "preferences").stat().st_mode) == 0o711
+        assert stat.S_IMODE(target.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
 
     def test_no_template_creates_placeholder(self, tmp_path, monkeypatch):
         """Falls back to '# Preferences\\n' placeholder when no example template exists."""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -4137,6 +4137,21 @@ class TestApplyDirectories:
 
         assert ws_base.exists()
 
+    def test_user_data_roots_are_traversal_only(self, tmp_path, monkeypatch):
+        """Per-user data roots are not listable by sibling OS users."""
+        chmods: list[tuple[str, int]] = []
+        monkeypatch.setattr("os.chmod", lambda path, mode: chmods.append((str(path), mode)))
+
+        install = tmp_path / "opt" / "kai"
+        data = tmp_path / "var" / "lib" / "kai"
+
+        _apply_directories(install, data, 503, 20, dry_run=False, workspace_base=None)
+
+        mode_by_path = dict(chmods)
+        assert mode_by_path[str(data / "memory")] == 0o711
+        assert mode_by_path[str(data / "preferences")] == 0o711
+        assert mode_by_path[str(data / "home")] == 0o711
+
 
 # ── Status subcommand ────────────────────────────────────────────────
 
@@ -5050,6 +5065,8 @@ class TestApplyMigratePerUserMemory:
         primary_dst = memory_dir / "8888" / "MEMORY.md"
         assert primary_dst.exists()
         assert primary_dst.read_text() == "operator notes from before #347"
+        assert stat.S_IMODE((memory_dir / "8888").stat().st_mode) == 0o700
+        assert stat.S_IMODE(primary_dst.stat().st_mode) == 0o600
         # Critical: legacy global MUST be gone (move, not copy) so a
         # later read at memory/MEMORY.md cannot leak this content.
         assert not legacy_global.exists()
@@ -5365,13 +5382,12 @@ class TestApplyMigratePerUserHome:
         Pre-fix: the block was guarded by `if home_root.is_dir():`
         which silently skipped everything when the parent was absent.
 
-        Round 2 review fix: home_root must end up at exactly 0o755,
-        not whatever the umask leaves behind. mkdir(mode=0o755) is
+        Current security contract: home_root must end up at exactly
+        0o711, not whatever the umask leaves behind. mkdir(mode=0o711) is
         masked by the process umask; under the production service
-        umask of 0o027 this would leave home_root at 0o750, blocking
-        group traversal for distinct-os_user subprocesses. We set a
-        hostile umask inside the test to prove the explicit chmod
-        survives it.
+        umask of 0o027 this would leave home_root at 0o710. We set a
+        hostile umask inside the test to prove the explicit chmod both
+        preserves traversal and prevents directory listing by siblings.
         """
         import os as _os
         import stat
@@ -5389,7 +5405,7 @@ class TestApplyMigratePerUserHome:
 
         # Hostile umask matches the production service launchd config.
         # Without the explicit os.chmod after mkdir, home_root would
-        # come out as 0o750 here.
+        # come out as 0o710 here.
         prev_umask = _os.umask(0o027)
         try:
             _apply_migrate(
@@ -5407,12 +5423,12 @@ class TestApplyMigratePerUserHome:
         home_root = data_path / "home"
         assert home_root.is_dir()
         assert (home_root / "8888").is_dir()
-        # Both at exactly 0o755 (group/other read+traverse, no write).
-        assert stat.S_IMODE(home_root.stat().st_mode) == 0o755, (
+        # Root is traversal-only for siblings; the per-user slot is private.
+        assert stat.S_IMODE(home_root.stat().st_mode) == 0o711, (
             f"home_root mode {oct(stat.S_IMODE(home_root.stat().st_mode))} - "
             "umask masked the mkdir mode and explicit chmod did not run"
         )
-        assert stat.S_IMODE((home_root / "8888").stat().st_mode) == 0o755
+        assert stat.S_IMODE((home_root / "8888").stat().st_mode) == 0o700
 
     def test_override_resolves_through_data_path_symlink(self, tmp_path, monkeypatch):
         """
@@ -5524,6 +5540,8 @@ class TestApplyMigratePerUserPreferences:
         target = data_path / "preferences" / "7777" / "PREFERENCES.md"
         assert target.is_file()
         assert "Style" in target.read_text()
+        assert target.stat().st_mode & 0o777 == 0o600
+        assert (data_path / "preferences" / "7777").stat().st_mode & 0o777 == 0o700
 
     def test_seeds_each_user_in_multi_user_yaml(self, tmp_path, monkeypatch):
         """Every users.yaml entry gets its own PREFERENCES.md seeded from the template."""


### PR DESCRIPTION
## Summary
- make shared per-user data roots traversal-only (0711) for memory, preferences, and home
- make configured and lazily-created user subtrees private: directories 0700, managed files 0600
- skip chmod recursion through symlinks and avoid recursing through a symlink root during ownership reconciliation
- reconcile existing per-user home/memory/preferences modes on install instead of only on first creation

## Validation
- .venv/bin/python -m pytest tests/test_backend.py tests/test_install.py -q
- make check
- make typecheck