### PR TITLE
Report webhook secret migration status

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -6348,12 +6348,16 @@ def _cmd_status() -> None:
     platform = "darwin" if sys.platform == "darwin" else "linux"
     install_dir = _DEFAULT_INSTALL_DIR
     data_dir = _DEFAULT_DATA_DIR
+    conf_env: dict[str, str] = {}
     if INSTALL_CONF.exists():
         try:
             conf = json.loads(INSTALL_CONF.read_text())
             platform = conf.get("platform", platform)
             install_dir = conf.get("install_dir", install_dir)
             data_dir = conf.get("data_dir", data_dir)
+            raw_env = conf.get("env", {})
+            if isinstance(raw_env, dict):
+                conf_env = {str(key): str(value) for key, value in raw_env.items()}
         except (json.JSONDecodeError, OSError):
             pass
 
@@ -6365,6 +6369,7 @@ def _cmd_status() -> None:
     print(_check_path(Path("/etc/kai/services.yaml"), "Services"))
     print(_check_path(Path("/etc/sudoers.d/kai"), "Sudoers"))
     print(_check_service_status(platform))
+    print(_webhook_secret_migration_status(conf_env))
 
     # Check workspace path traversal if install.conf has a service user
     if INSTALL_CONF.exists():
@@ -6393,6 +6398,18 @@ def _cmd_status() -> None:
                 version = line.split("=")[1].strip().strip('"').strip("'")
                 print(f"Version: {version}")
                 break
+
+
+def _webhook_secret_migration_status(env: dict[str, str]) -> str:
+    """Return a non-secret diagnostic for external webhook migration state."""
+    if env.get("WEBHOOK_SECRET", "").strip():
+        return (
+            "Webhook secret migration: legacy WEBHOOK_SECRET fallback configured "
+            "(GitHub/generic callers may still depend on it)"
+        )
+    if env.get("GITHUB_WEBHOOK_SECRET", "").strip() and env.get("GENERIC_WEBHOOK_SECRET", "").strip():
+        return "Webhook secret migration: named GitHub/generic secrets configured; no legacy fallback in install.conf"
+    return "Webhook secret migration: no legacy fallback in install.conf"
 
 
 # ── CLI dispatch ─────────────────────────────────────────────────────

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -68,6 +68,7 @@ from kai.install import (
     _validate_positive_int,
     _validate_telegram_id,
     _validate_user_ids,
+    _webhook_secret_migration_status,
     cli,
 )
 
@@ -4278,6 +4279,75 @@ class TestCmdStatus:
         _cmd_status()
         output = capsys.readouterr().out
         assert "Installation Status" in output
+
+    def test_reports_legacy_webhook_secret_fallback(self, tmp_path, monkeypatch, capsys):
+        conf_path = tmp_path / "install.conf"
+        conf_path.write_text(
+            json.dumps(
+                {
+                    "platform": "darwin",
+                    "install_dir": str(tmp_path / "opt-kai"),
+                    "data_dir": str(tmp_path / "var-lib-kai"),
+                    "env": {
+                        "WEBHOOK_SECRET": "legacy-secret",
+                        "GITHUB_WEBHOOK_SECRET": "github-secret",
+                        "GENERIC_WEBHOOK_SECRET": "generic-secret",
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr(
+            "kai.install.subprocess.run",
+            lambda *a, **kw: subprocess.CompletedProcess(args=[], returncode=1, stdout=""),
+        )
+
+        _cmd_status()
+
+        output = capsys.readouterr().out
+        assert "legacy WEBHOOK_SECRET fallback configured" in output
+        assert "legacy-secret" not in output
+        assert "github-secret" not in output
+        assert "generic-secret" not in output
+
+    def test_reports_named_webhook_secrets_without_legacy_fallback(self, tmp_path, monkeypatch, capsys):
+        conf_path = tmp_path / "install.conf"
+        conf_path.write_text(
+            json.dumps(
+                {
+                    "platform": "darwin",
+                    "install_dir": str(tmp_path / "opt-kai"),
+                    "data_dir": str(tmp_path / "var-lib-kai"),
+                    "env": {
+                        "GITHUB_WEBHOOK_SECRET": "github-secret",
+                        "GENERIC_WEBHOOK_SECRET": "generic-secret",
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr(
+            "kai.install.subprocess.run",
+            lambda *a, **kw: subprocess.CompletedProcess(args=[], returncode=1, stdout=""),
+        )
+
+        _cmd_status()
+
+        output = capsys.readouterr().out
+        assert "named GitHub/generic secrets configured" in output
+        assert "no legacy fallback" in output
+        assert "github-secret" not in output
+        assert "generic-secret" not in output
+
+    def test_webhook_secret_migration_status_is_non_secret(self):
+        assert "legacy WEBHOOK_SECRET fallback configured" in _webhook_secret_migration_status(
+            {
+                "WEBHOOK_SECRET": "legacy-secret",
+                "GITHUB_WEBHOOK_SECRET": "github-secret",
+                "GENERIC_WEBHOOK_SECRET": "generic-secret",
+            }
+        )
+        assert "legacy-secret" not in _webhook_secret_migration_status({"WEBHOOK_SECRET": "legacy-secret"})
 
 
 # ── Venv creation ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add a non-secret install-status diagnostic for legacy WEBHOOK_SECRET fallback state
- report when named GitHub/generic webhook secrets are configured without the legacy fallback
- cover the diagnostic with tests that verify no secret values are printed

## Validation
- .venv/bin/python -m pytest tests/test_install.py::TestCmdStatus -q
- make check

## Compatibility
No runtime behavior changes. The legacy fallback remains configured/accepted exactly as before; this only exposes migration state to the operator.