### PR TITLE
Treat empty protected services config as authoritative

### DIFF
--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -225,7 +225,7 @@ def _start() -> None:
     # Load external service definitions. In a protected installation, services.yaml
     # lives in /etc/kai/ (root-owned). Falls back to PROJECT_ROOT for development.
     protected_yaml = _read_protected_file("/etc/kai/services.yaml")
-    if protected_yaml:
+    if protected_yaml is not None:
         loaded = services.load_services_from_string(protected_yaml)
     else:
         loaded = services.load_services(PROJECT_ROOT / "services.yaml")

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -4,14 +4,16 @@
 # external API that inner Claude can call via the local proxy endpoint.
 #
 # Setup:
-#   1. Copy this file to the repo root: cp templates/services.yaml services.yaml
-#   2. Uncomment the services you want to use
+#   1. Copy this file to services.yaml for single-user installs, or to
+#      /etc/kai/services.yaml for protected installs.
+#   2. Uncomment the services you want to use.
 #   3. Add each service name to the intended users' `allowed_services`
-#      lists in users.yaml
-#   4. Set the corresponding API key(s) in .env
-#   5. Restart Kai
+#      lists in users.yaml.
+#   4. Set the corresponding API key(s) in .env for single-user installs,
+#      or /etc/kai/env for protected installs.
+#   5. Restart Kai.
 #
-# Kai injects authentication from .env at call time — API keys never
+# Kai injects authentication from the server-side env at call time — API keys never
 # enter Claude's context. See <DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md for usage docs.
 #
 # Auth types:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -386,9 +386,8 @@ class TestMainStartupErrorLogging:
 class TestStartCrashExit:
     """Unexpected runtime crashes must not look like clean process exits."""
 
-    def test_unexpected_asyncio_crash_exits_nonzero(self, caplog, monkeypatch):
-        from kai.main import _start
-
+    @staticmethod
+    def _patch_minimal_config(monkeypatch):
         monkeypatch.setattr(
             "kai.main.load_config",
             lambda: SimpleNamespace(
@@ -398,17 +397,75 @@ class TestStartCrashExit:
                 session_db_path=":memory:",
             ),
         )
-        monkeypatch.setattr("kai.main._read_protected_file", lambda _path: "")
-        monkeypatch.setattr("kai.main.services.load_services", lambda _path: {})
 
+    @staticmethod
+    def _patch_asyncio_crash(monkeypatch):
         def fail_run(coro):
             coro.close()
             raise RuntimeError("event loop died")
 
         monkeypatch.setattr("kai.main.asyncio.run", fail_run)
 
+    def test_unexpected_asyncio_crash_exits_nonzero(self, caplog, monkeypatch):
+        from kai.main import _start
+
+        self._patch_minimal_config(monkeypatch)
+        monkeypatch.setattr("kai.main._read_protected_file", lambda _path: "")
+        monkeypatch.setattr("kai.main.services.load_services", lambda _path: {})
+        self._patch_asyncio_crash(monkeypatch)
+
         with caplog.at_level(logging.ERROR), pytest.raises(SystemExit) as excinfo:
             _start()
 
         assert excinfo.value.code == 1
         assert any(r.levelno == logging.ERROR and "Kai crashed" in r.getMessage() for r in caplog.records)
+
+    def test_empty_protected_services_yaml_disables_services_without_local_fallback(self, monkeypatch):
+        """An empty readable /etc/kai/services.yaml is authoritative.
+
+        Protected installs must not fall back to PROJECT_ROOT/services.yaml
+        merely because the protected file is empty.
+        """
+        from kai.main import _start
+
+        calls: list[tuple[str, str]] = []
+        self._patch_minimal_config(monkeypatch)
+        monkeypatch.setattr("kai.main._read_protected_file", lambda _path: "")
+        monkeypatch.setattr(
+            "kai.main.services.load_services_from_string",
+            lambda text: calls.append(("protected", text)) or {},
+        )
+        monkeypatch.setattr(
+            "kai.main.services.load_services",
+            lambda path: calls.append(("local", str(path))) or {},
+        )
+        self._patch_asyncio_crash(monkeypatch)
+
+        with pytest.raises(SystemExit):
+            _start()
+
+        assert calls == [("protected", "")]
+
+    def test_unreadable_protected_services_yaml_uses_local_fallback(self, monkeypatch):
+        """None from the protected reader means absent/unreadable, so dev
+        fallback to PROJECT_ROOT/services.yaml is still preserved.
+        """
+        from kai.main import _start
+
+        calls: list[tuple[str, str]] = []
+        self._patch_minimal_config(monkeypatch)
+        monkeypatch.setattr("kai.main._read_protected_file", lambda _path: None)
+        monkeypatch.setattr(
+            "kai.main.services.load_services_from_string",
+            lambda text: calls.append(("protected", text)) or {},
+        )
+        monkeypatch.setattr(
+            "kai.main.services.load_services",
+            lambda path: calls.append(("local", str(path))) or {},
+        )
+        self._patch_asyncio_crash(monkeypatch)
+
+        with pytest.raises(SystemExit):
+            _start()
+
+        assert calls == [("local", str(Path(__file__).resolve().parents[1] / "services.yaml"))]


### PR DESCRIPTION
## Summary
- treat readable but empty /etc/kai/services.yaml as authoritative instead of falling back to repo-root services.yaml
- preserve local fallback only when the protected services config is absent or unreadable
- update services.yaml template guidance for protected installs

## Tests
- .venv/bin/python -m pytest tests/test_main.py -q
- .venv/bin/python -m pytest tests/test_services.py -q
- .venv/bin/python -m pytest tests/test_install.py -q

Note: pytest emitted unrelated temporary-directory cleanup warnings after successful runs.