### PR TITLE
Reject writable backend registries

### DIFF
--- a/src/kai/backend_registry.py
+++ b/src/kai/backend_registry.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import stat
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -89,6 +90,7 @@ def load_backend_registry(path: Path | None = None) -> dict[str, BackendRegistry
         if explicit_path:
             raise BackendRegistryError(f"backend registry {registry_path} does not exist")
         return {}
+    _validate_registry_file_permissions(registry_path)
     try:
         raw = yaml.safe_load(registry_path.read_text()) or {}
     except OSError as e:
@@ -128,6 +130,18 @@ def load_backend_registry(path: Path | None = None) -> dict[str, BackendRegistry
             allowed_models=model_tuple,
         )
     return entries
+
+
+def _validate_registry_file_permissions(path: Path) -> None:
+    """Reject registry files writable by group or other users."""
+    try:
+        mode = stat.S_IMODE(path.stat().st_mode)
+    except OSError as e:
+        raise BackendRegistryError(f"could not stat backend registry {path}: {e}") from e
+    if mode & 0o022:
+        raise BackendRegistryError(
+            f"backend registry {path} has unsafe permissions {mode:#04o}; remove group/other write access"
+        )
 
 
 def _validate_absolute_executable(backend: str, command: str, source: str) -> str:

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -73,6 +73,36 @@ def test_registry_command_must_be_absolute(tmp_path, monkeypatch):
         resolve_backend_command("claude")
 
 
+@pytest.mark.parametrize("mode", [0o664, 0o646])
+def test_registry_file_must_not_be_group_or_world_writable(tmp_path, monkeypatch, mode):
+    """The installed backend registry is a machine-capability boundary.
+
+    If the file is writable by group/other users, a non-admin account
+    could swap backend commands and bypass the curated registry.
+    """
+    claude = _exe(tmp_path / "claude")
+    registry = tmp_path / "backends.yaml"
+    registry.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "backends": {
+                    "claude": {
+                        "driver": "claude",
+                        "runtime": "local_process",
+                        "command": str(claude),
+                    }
+                },
+            }
+        )
+    )
+    registry.chmod(mode)
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+    with pytest.raises(BackendRegistryError, match="unsafe permissions"):
+        resolve_backend_command("claude")
+
+
 def test_default_missing_registry_uses_legacy_path_resolution(monkeypatch):
     monkeypatch.delenv("KAI_BACKENDS_YAML", raising=False)
     monkeypatch.delenv("KAI_INSTALL_DIR", raising=False)


### PR DESCRIPTION
## Summary
- reject backend registry files that are writable by group or other users
- keep existing installed registry mode compatible: 0644 remains accepted
- add regression coverage for group-writable and world-writable registries

## Tests
- .venv/bin/python -m pytest tests/test_backend_registry.py -q
- .venv/bin/python -m pytest tests/test_install.py -q

Note: pytest emitted unrelated temporary-directory cleanup warnings after successful runs.