### PR TITLE
Reject writable backend commands

### DIFF
--- a/src/kai/backend_registry.py
+++ b/src/kai/backend_registry.py
@@ -152,6 +152,14 @@ def _validate_absolute_executable(backend: str, command: str, source: str) -> st
         raise BackendRegistryError(f"{source} for backend {backend!r} is not a file: {command!r}")
     if not os.access(str(path), os.X_OK):
         raise BackendRegistryError(f"{source} for backend {backend!r} is not executable: {command!r}")
+    try:
+        mode = stat.S_IMODE(path.stat().st_mode)
+    except OSError as e:
+        raise BackendRegistryError(f"could not stat {source} for backend {backend!r}: {e}") from e
+    if mode & 0o022:
+        raise BackendRegistryError(
+            f"{source} for backend {backend!r} has unsafe permissions {mode:#04o}; remove group/other write access"
+        )
     return str(path)
 
 

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -103,6 +103,34 @@ def test_registry_file_must_not_be_group_or_world_writable(tmp_path, monkeypatch
         resolve_backend_command("claude")
 
 
+@pytest.mark.parametrize("mode", [0o775, 0o757])
+def test_registry_command_must_not_be_group_or_world_writable(tmp_path, monkeypatch, mode):
+    """The registry file is not sufficient if the registered executable
+    can be replaced in place by a non-admin account.
+    """
+    codex = _exe(tmp_path / "codex")
+    codex.chmod(mode)
+    registry = tmp_path / "backends.yaml"
+    registry.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "backends": {
+                    "codex": {
+                        "driver": "codex",
+                        "runtime": "local_process",
+                        "command": str(codex),
+                    }
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+    with pytest.raises(BackendRegistryError, match="unsafe permissions"):
+        resolve_backend_command("codex")
+
+
 def test_default_missing_registry_uses_legacy_path_resolution(monkeypatch):
     monkeypatch.delenv("KAI_BACKENDS_YAML", raising=False)
     monkeypatch.delenv("KAI_INSTALL_DIR", raising=False)


### PR DESCRIPTION
## Summary
- reject resolved backend command files that are writable by group or other users
- keep normal 0755 Homebrew-style executable targets compatible
- add regression coverage for group-writable and world-writable backend commands

## Compatibility
- Existing Claude, Codex, and Goose command targets on the current host have safe target modes.
- Missing registry entries are still only detected when that backend is selected/resolved; this PR does not validate every registry entry at startup.

## Tests
- .venv/bin/python -m pytest tests/test_backend_registry.py -q
- .venv/bin/python -m ruff check src/kai/backend_registry.py tests/test_backend_registry.py
- .venv/bin/python -m ruff format --check src/kai/backend_registry.py tests/test_backend_registry.py

Note: pytest emitted unrelated temporary-directory cleanup warnings after successful runs.