### PR TITLE
Validate protected config metadata

### DIFF
--- a/src/kai/backend_registry.py
+++ b/src/kai/backend_registry.py
@@ -19,6 +19,8 @@ from typing import Any
 
 import yaml
 
+from kai.protected_config import ProtectedConfigError, validate_protected_file_metadata
+
 DEFAULT_BACKENDS_YAML = Path("/etc/kai/backends.yaml")
 BACKENDS_YAML_ENV = "KAI_BACKENDS_YAML"
 INSTALL_DIR_ENV = "KAI_INSTALL_DIR"
@@ -90,7 +92,14 @@ def load_backend_registry(path: Path | None = None) -> dict[str, BackendRegistry
         if explicit_path:
             raise BackendRegistryError(f"backend registry {registry_path} does not exist")
         return {}
-    _validate_registry_file_permissions(registry_path)
+    try:
+        validate_protected_file_metadata(
+            registry_path,
+            max_mode=0o644,
+            require_root_owner=bool(os.environ.get(INSTALL_DIR_ENV, "").strip()),
+        )
+    except ProtectedConfigError as e:
+        raise BackendRegistryError(str(e)) from e
     try:
         raw = yaml.safe_load(registry_path.read_text()) or {}
     except OSError as e:
@@ -130,18 +139,6 @@ def load_backend_registry(path: Path | None = None) -> dict[str, BackendRegistry
             allowed_models=model_tuple,
         )
     return entries
-
-
-def _validate_registry_file_permissions(path: Path) -> None:
-    """Reject registry files writable by group or other users."""
-    try:
-        mode = stat.S_IMODE(path.stat().st_mode)
-    except OSError as e:
-        raise BackendRegistryError(f"could not stat backend registry {path}: {e}") from e
-    if mode & 0o022:
-        raise BackendRegistryError(
-            f"backend registry {path} has unsafe permissions {mode:#04o}; remove group/other write access"
-        )
 
 
 def _validate_absolute_executable(backend: str, command: str, source: str) -> str:

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import yaml
 from dotenv import load_dotenv
 
+from kai.protected_config import ProtectedConfigError, validate_protected_file_metadata
 from kai.user_isolation import validate_protected_user_isolation
 
 log = logging.getLogger(__name__)
@@ -1501,6 +1502,11 @@ def _read_protected_file(path: str) -> str | None:
         File contents as a string, or None on any failure (missing file,
         no sudoers rule, timeout, etc.).
     """
+    try:
+        if not validate_protected_file_metadata(path, missing_ok=True):
+            return None
+    except ProtectedConfigError as e:
+        raise SystemExit(str(e)) from e
     try:
         result = subprocess.run(
             ["sudo", "-n", "cat", path],

--- a/src/kai/protected_config.py
+++ b/src/kai/protected_config.py
@@ -1,0 +1,61 @@
+"""Metadata validation for protected Kai configuration files."""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+
+class ProtectedConfigError(RuntimeError):
+    """Raised when a protected config file cannot be trusted."""
+
+
+_DEFAULT_MAX_MODE = 0o600
+_MAX_MODES_BY_PATH = {
+    "/etc/kai/backends.yaml": 0o644,
+}
+
+
+def max_mode_for_protected_file(path: str | Path) -> int:
+    """Return the most permissive allowed mode for a protected config file."""
+    return _MAX_MODES_BY_PATH.get(str(path), _DEFAULT_MAX_MODE)
+
+
+def validate_protected_file_metadata(
+    path: str | Path,
+    *,
+    max_mode: int | None = None,
+    require_root_owner: bool = True,
+    missing_ok: bool = False,
+) -> bool:
+    """
+    Validate ownership and mode for a protected config file.
+
+    Returns True when the file exists and passes validation. Returns False
+    only when ``missing_ok`` is true and the file is absent.
+    """
+    protected_path = Path(path)
+    try:
+        stat_result = protected_path.stat()
+    except FileNotFoundError:
+        if missing_ok:
+            return False
+        raise
+    except OSError as e:
+        raise ProtectedConfigError(f"could not stat protected config {protected_path}: {e}") from e
+
+    if not stat.S_ISREG(stat_result.st_mode):
+        raise ProtectedConfigError(f"protected config {protected_path} is not a regular file")
+
+    mode = stat.S_IMODE(stat_result.st_mode)
+    allowed_mode = max_mode_for_protected_file(protected_path) if max_mode is None else max_mode
+    if mode & ~allowed_mode:
+        raise ProtectedConfigError(
+            f"protected config {protected_path} has unsafe permissions {mode:#04o}; "
+            f"expected no more than {allowed_mode:#04o}"
+        )
+    if require_root_owner and stat_result.st_uid != 0:
+        raise ProtectedConfigError(
+            f"protected config {protected_path} is owned by uid {stat_result.st_uid}; expected root ownership"
+        )
+    return True

--- a/src/kai/totp.py
+++ b/src/kai/totp.py
@@ -24,6 +24,8 @@ import time
 
 import pyotp
 
+from kai.protected_config import ProtectedConfigError, validate_protected_file_metadata
+
 # Root-owned files, mode 0600. Only accessible via sudo.
 # The sudoers rule in /etc/sudoers.d/kai authorizes the bot process
 # to run exactly these two commands on exactly these paths, NOPASSWD.
@@ -128,10 +130,11 @@ def _totp_files_present() -> tuple[bool, bool]:
 
     def _present(path: str) -> bool:
         try:
-            os.stat(path)
-            return True
+            return validate_protected_file_metadata(path, missing_ok=True)
         except FileNotFoundError:
             return False
+        except ProtectedConfigError as exc:
+            raise TotpStateError(str(exc)) from exc
         except OSError as exc:
             raise TotpStateError(f"Could not determine TOTP state for {path}: {exc}") from exc
 
@@ -146,6 +149,10 @@ def _read_secret() -> str:
     disabled by strictly checking that *both* protected files are absent
     before reaching this helper.
     """
+    try:
+        validate_protected_file_metadata(TOTP_SECRET_PATH)
+    except (OSError, ProtectedConfigError) as exc:
+        raise TotpStateError(str(exc)) from exc
     try:
         result = subprocess.run(
             ["sudo", "-n", "cat", TOTP_SECRET_PATH],
@@ -180,6 +187,10 @@ def _read_attempts() -> dict:
     fail open.
     """
     try:
+        validate_protected_file_metadata(TOTP_ATTEMPTS_PATH)
+    except (OSError, ProtectedConfigError) as exc:
+        raise TotpStateError(str(exc)) from exc
+    try:
         result = subprocess.run(
             ["sudo", "-n", "cat", TOTP_ATTEMPTS_PATH],
             capture_output=True,
@@ -205,6 +216,10 @@ def _write_attempts(state: dict) -> None:
     Raises TotpStateError unless sudo tee confirms success.  Authentication is
     not granted when resetting the failure counter cannot be persisted.
     """
+    try:
+        validate_protected_file_metadata(TOTP_ATTEMPTS_PATH)
+    except (OSError, ProtectedConfigError) as exc:
+        raise TotpStateError(str(exc)) from exc
     try:
         result = subprocess.run(
             ["sudo", "-n", "tee", TOTP_ATTEMPTS_PATH],

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import yaml
@@ -8,6 +9,7 @@ import yaml
 from kai.backend_registry import (
     BackendRegistryError,
     backend_registry_is_authoritative,
+    load_backend_registry,
     render_backend_registry,
     resolve_backend_command,
 )
@@ -101,6 +103,37 @@ def test_registry_file_must_not_be_group_or_world_writable(tmp_path, monkeypatch
 
     with pytest.raises(BackendRegistryError, match="unsafe permissions"):
         resolve_backend_command("claude")
+
+
+def test_installed_registry_file_must_be_root_owned(tmp_path, monkeypatch):
+    """Installed mode treats the registry as an admin-owned capability map."""
+    registry = tmp_path / "backends.yaml"
+    registry.write_text("version: 1\nbackends: {}\n")
+    monkeypatch.setenv("KAI_INSTALL_DIR", "/opt/kai")
+    monkeypatch.setattr("kai.backend_registry.DEFAULT_BACKENDS_YAML", registry)
+    real_stat = Path.stat
+
+    def fake_stat(self, *args, **kwargs):
+        result = real_stat(self, *args, **kwargs)
+        if self == registry:
+            return SimpleNamespace(st_mode=result.st_mode, st_uid=12345)
+        return result
+
+    monkeypatch.setattr("kai.backend_registry.Path.stat", fake_stat)
+
+    with pytest.raises(BackendRegistryError, match="root ownership"):
+        load_backend_registry()
+
+
+def test_explicit_dev_registry_does_not_require_root_owner(tmp_path, monkeypatch):
+    """A test/dev registry can be user-owned when installed mode is not active."""
+    registry = tmp_path / "backends.yaml"
+    registry.write_text("version: 1\nbackends: {}\n")
+    registry.chmod(0o644)
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+    monkeypatch.delenv("KAI_INSTALL_DIR", raising=False)
+
+    assert load_backend_registry() == {}
 
 
 @pytest.mark.parametrize("mode", [0o775, 0o757])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -638,7 +638,10 @@ class TestReadProtectedFile:
             stdout="KEY=value\n",
             stderr="",
         )
-        with patch("kai.config.subprocess.run", return_value=mock_result):
+        with (
+            patch("kai.config.validate_protected_file_metadata", return_value=True),
+            patch("kai.config.subprocess.run", return_value=mock_result),
+        ):
             result = _read_protected_file("/etc/kai/env")
         assert result == "KEY=value\n"
 
@@ -650,27 +653,61 @@ class TestReadProtectedFile:
             stdout="",
             stderr="sudo: a password is required\n",
         )
-        with patch("kai.config.subprocess.run", return_value=mock_result):
+        with (
+            patch("kai.config.validate_protected_file_metadata", return_value=True),
+            patch("kai.config.subprocess.run", return_value=mock_result),
+        ):
             result = _read_protected_file("/etc/kai/env")
         assert result is None
 
     def test_timeout_returns_none(self):
         """Returns None when subprocess times out."""
-        with patch(
-            "kai.config.subprocess.run",
-            side_effect=subprocess.TimeoutExpired(cmd="sudo", timeout=5),
+        with (
+            patch("kai.config.validate_protected_file_metadata", return_value=True),
+            patch(
+                "kai.config.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="sudo", timeout=5),
+            ),
         ):
             result = _read_protected_file("/etc/kai/env")
         assert result is None
 
     def test_oserror_returns_none(self):
         """Returns None when subprocess raises OSError (e.g., sudo not found)."""
-        with patch(
-            "kai.config.subprocess.run",
-            side_effect=OSError("No such file or directory"),
+        with (
+            patch("kai.config.validate_protected_file_metadata", return_value=True),
+            patch(
+                "kai.config.subprocess.run",
+                side_effect=OSError("No such file or directory"),
+            ),
         ):
             result = _read_protected_file("/etc/kai/env")
         assert result is None
+
+    def test_missing_metadata_returns_none_without_sudo(self):
+        """Absent protected file remains an optional-missing result."""
+        with (
+            patch("kai.config.validate_protected_file_metadata", return_value=False),
+            patch("kai.config.subprocess.run") as run,
+        ):
+            result = _read_protected_file("/etc/kai/env")
+        assert result is None
+        run.assert_not_called()
+
+    def test_unsafe_metadata_raises_system_exit(self):
+        """Unsafe protected config metadata fails closed, not as missing config."""
+        from kai.protected_config import ProtectedConfigError
+
+        with (
+            patch(
+                "kai.config.validate_protected_file_metadata",
+                side_effect=ProtectedConfigError("unsafe protected config"),
+            ),
+            patch("kai.config.subprocess.run") as run,
+            pytest.raises(SystemExit, match="unsafe protected config"),
+        ):
+            _read_protected_file("/etc/kai/env")
+        run.assert_not_called()
 
 
 # ── Dual-mode config loading ─────────────────────────────────────

--- a/tests/test_protected_config.py
+++ b/tests/test_protected_config.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kai.protected_config import (
+    ProtectedConfigError,
+    max_mode_for_protected_file,
+    validate_protected_file_metadata,
+)
+
+
+def test_missing_ok_returns_false(tmp_path):
+    assert validate_protected_file_metadata(tmp_path / "missing", missing_ok=True) is False
+
+
+def test_default_max_mode_is_0600():
+    assert max_mode_for_protected_file("/etc/kai/env") == 0o600
+
+
+def test_backends_yaml_max_mode_is_0644():
+    assert max_mode_for_protected_file("/etc/kai/backends.yaml") == 0o644
+
+
+def test_rejects_permissions_more_permissive_than_max(tmp_path):
+    path = tmp_path / "env"
+    path.write_text("KEY=value\n")
+    path.chmod(0o644)
+
+    with pytest.raises(ProtectedConfigError, match="unsafe permissions"):
+        validate_protected_file_metadata(path, max_mode=0o600, require_root_owner=False)
+
+
+def test_rejects_non_regular_file(tmp_path):
+    path = tmp_path / "env"
+    path.mkdir()
+    path.chmod(0o600)
+
+    with pytest.raises(ProtectedConfigError, match="regular file"):
+        validate_protected_file_metadata(path, max_mode=0o600, require_root_owner=False)
+
+
+def test_accepts_subset_of_max_permissions(tmp_path):
+    path = tmp_path / "env"
+    path.write_text("KEY=value\n")
+    path.chmod(0o400)
+
+    assert validate_protected_file_metadata(path, max_mode=0o600, require_root_owner=False) is True
+
+
+def test_rejects_non_root_owner_when_required(tmp_path, monkeypatch):
+    path = tmp_path / "env"
+    path.write_text("KEY=value\n")
+    path.chmod(0o600)
+    real_stat = Path.stat
+
+    def fake_stat(self, *args, **kwargs):
+        result = real_stat(self, *args, **kwargs)
+        if self == path:
+            return SimpleNamespace(st_mode=result.st_mode, st_uid=12345)
+        return result
+
+    monkeypatch.setattr("kai.protected_config.Path.stat", fake_stat)
+
+    with pytest.raises(ProtectedConfigError, match="root ownership"):
+        validate_protected_file_metadata(path, require_root_owner=True)

--- a/tests/test_totp.py
+++ b/tests/test_totp.py
@@ -38,6 +38,12 @@ def _reset_totp_cache():
     kai.totp._totp_is_configured = False
 
 
+@pytest.fixture(autouse=True)
+def _protected_metadata_ok(monkeypatch):
+    """Protected metadata checks are mocked unless a test overrides them."""
+    monkeypatch.setattr("kai.totp.validate_protected_file_metadata", lambda *args, **kwargs: True)
+
+
 # A stable base32 secret used across tests.
 _TEST_SECRET = "JBSWY3DPEHPK3PXP"
 
@@ -245,6 +251,18 @@ def test_is_totp_configured_fails_closed_on_secret_read_error():
         pytest.raises(TotpStateError, match="secret read failed"),
     ):
         is_totp_configured()
+
+
+def test_totp_files_present_fails_closed_on_unsafe_metadata(monkeypatch):
+    """Unsafe protected file metadata is unavailable, not disabled TOTP."""
+
+    def _unsafe_metadata(*args, **kwargs):
+        raise kai.totp.ProtectedConfigError("unsafe protected config")
+
+    monkeypatch.setattr("kai.totp.validate_protected_file_metadata", _unsafe_metadata)
+
+    with pytest.raises(TotpStateError, match="unsafe protected config"):
+        kai.totp._totp_files_present()
 
 
 # ── get_lockout_remaining ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add shared protected-config metadata validation for root ownership, regular files, and restrictive modes
- apply the contract to protected /etc/kai reads, TOTP state files, and the backend registry
- keep backends.yaml readable at 0644 because it is non-secret policy, while secret-bearing files default to 0600

## Validation
- .venv/bin/python -m pytest tests/test_protected_config.py tests/test_backend_registry.py tests/test_config.py tests/test_workspace_config.py tests/test_totp.py tests/test_totp_cli.py tests/test_main.py tests/test_install.py -q
- .venv/bin/python -m ruff format --check src/kai/protected_config.py src/kai/backend_registry.py src/kai/config.py src/kai/totp.py tests/test_backend_registry.py tests/test_config.py tests/test_protected_config.py tests/test_totp.py
- .venv/bin/python -m ruff check src/kai/protected_config.py src/kai/backend_registry.py src/kai/config.py src/kai/totp.py tests/test_backend_registry.py tests/test_config.py tests/test_protected_config.py tests/test_totp.py