### PR TITLE
Fail closed on protected YAML read failures

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1534,9 +1534,18 @@ def _read_protected_yaml(filename: str) -> dict | object | None:
         be read, or the _YAML_MALFORMED sentinel if the file exists but
         is invalid. Callers must check ``is _YAML_MALFORMED`` before use.
     """
-    content = _read_protected_file(f"/etc/kai/{filename}")
-    if content is None:
+    path = f"/etc/kai/{filename}"
+    try:
+        present = validate_protected_file_metadata(path, missing_ok=True)
+    except ProtectedConfigError as e:
+        raise SystemExit(str(e)) from e
+    if not present:
         return None
+
+    content = _read_protected_file(path)
+    if content is None:
+        log.error("Protected config /etc/kai/%s exists but could not be read; refusing local fallback", filename)
+        return _YAML_MALFORMED
     try:
         result = yaml.safe_load(content)
         if isinstance(result, dict):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -97,6 +97,7 @@ def _clean_env(monkeypatch):
     monkeypatch.setattr("kai.config.load_dotenv", lambda *a, **kw: None)
     # Prevent real sudo calls during tests - default to None (dev mode fallback)
     monkeypatch.setattr("kai.config._read_protected_file", lambda path: None)
+    monkeypatch.setattr("kai.config.validate_protected_file_metadata", lambda path, **kw: False)
     # Protected-isolation tests use synthetic OS account names. Give each
     # name a stable, non-service UID by default; focused passwd/alias tests
     # override this lookup explicitly.
@@ -168,6 +169,9 @@ def _patch_protected_users_yaml(monkeypatch, content: str) -> None:
       - `/etc/kai/users.yaml` returns `content`, which the protected-
         path branch of `_read_users_yaml` consumes via the existing
         `_read_protected_yaml` sudo-cat shim.
+      - protected-file metadata validation sees `/etc/kai/users.yaml`
+        as present and every other protected YAML file as absent, so
+        tests do not stat the host's real `/etc/kai`.
 
     Any other protected-file lookup returns None (the default shape
     on dev hosts). Tests that specifically need the XDG / single-user
@@ -185,6 +189,10 @@ def _patch_protected_users_yaml(monkeypatch, content: str) -> None:
         return None
 
     monkeypatch.setattr("kai.config._read_protected_file", _fake_read)
+    monkeypatch.setattr(
+        "kai.config.validate_protected_file_metadata",
+        lambda path, **kw: path == "/etc/kai/users.yaml",
+    )
 
 
 def _patch_single_user_users_yaml(monkeypatch, tmp_path: Path, content: str) -> None:
@@ -715,6 +723,10 @@ class TestReadProtectedFile:
 
 class TestDualModeLoading:
     @staticmethod
+    def _protected_metadata(path: str, **_kwargs) -> bool:
+        return path in {"/etc/kai/env", "/etc/kai/users.yaml"}
+
+    @staticmethod
     def _protected_reader(env_content: str):
         """Lambda that responds to both /etc/kai/env and /etc/kai/users.yaml.
 
@@ -736,6 +748,7 @@ class TestDualModeLoading:
 
     def test_loads_from_protected_env(self, monkeypatch):
         """When /etc/kai/env is readable, values are used as config."""
+        monkeypatch.setattr("kai.config.validate_protected_file_metadata", self._protected_metadata)
         monkeypatch.setattr(
             "kai.config._read_protected_file",
             self._protected_reader("TELEGRAM_BOT_TOKEN=protected-token\nALLOWED_USER_IDS=999\n"),
@@ -747,6 +760,7 @@ class TestDualModeLoading:
 
     def test_protected_env_strips_quotes(self, monkeypatch):
         """Quote marks around values in /etc/kai/env are stripped."""
+        monkeypatch.setattr("kai.config.validate_protected_file_metadata", self._protected_metadata)
         monkeypatch.setattr(
             "kai.config._read_protected_file",
             self._protected_reader("TELEGRAM_BOT_TOKEN=\"quoted-token\"\nALLOWED_USER_IDS='999'\n"),
@@ -757,6 +771,7 @@ class TestDualModeLoading:
 
     def test_protected_env_skips_comments_and_blanks(self, monkeypatch):
         """Comments and blank lines in /etc/kai/env are ignored."""
+        monkeypatch.setattr("kai.config.validate_protected_file_metadata", self._protected_metadata)
         monkeypatch.setattr(
             "kai.config._read_protected_file",
             self._protected_reader("# comment\n\nTELEGRAM_BOT_TOKEN=tok\n\nALLOWED_USER_IDS=999\n"),
@@ -789,6 +804,7 @@ class TestDualModeLoading:
 
     def test_env_vars_take_precedence_over_protected(self, monkeypatch):
         """Explicitly set env vars override values from /etc/kai/env."""
+        monkeypatch.setattr("kai.config.validate_protected_file_metadata", self._protected_metadata)
         monkeypatch.setattr(
             "kai.config._read_protected_file",
             self._protected_reader("TELEGRAM_BOT_TOKEN=from-file\nALLOWED_USER_IDS=999\n"),

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2728,6 +2728,10 @@ class TestCmdConfig:
 
         monkeypatch.setattr("kai.config._read_protected_file", _fake_read)
         monkeypatch.setattr(
+            "kai.config.validate_protected_file_metadata",
+            lambda path, **kw: path == "/etc/kai/users.yaml",
+        )
+        monkeypatch.setattr(
             "kai.config.pwd.getpwnam",
             lambda name: MagicMock(pw_uid=os.geteuid() + 100_000),
         )
@@ -2870,6 +2874,10 @@ class TestCmdConfig:
             return None
 
         monkeypatch.setattr("kai.config._read_protected_file", _fake_read)
+        monkeypatch.setattr(
+            "kai.config.validate_protected_file_metadata",
+            lambda path, **kw: path == "/etc/kai/users.yaml",
+        )
         monkeypatch.setattr(
             "kai.config.pwd.getpwnam",
             lambda name: MagicMock(pw_uid=os.geteuid() + 100_000),

--- a/tests/test_workspace_config.py
+++ b/tests/test_workspace_config.py
@@ -183,21 +183,44 @@ class TestStripQuotes:
 class TestReadProtectedYaml:
     def test_returns_parsed_yaml(self):
         """Returns parsed dict when sudo cat succeeds."""
-        with patch("kai.config._read_protected_file", return_value="workspaces:\n  - path: /tmp\n"):
+        with (
+            patch("kai.config.validate_protected_file_metadata", return_value=True),
+            patch("kai.config._read_protected_file", return_value="workspaces:\n  - path: /tmp\n"),
+        ):
             result = _read_protected_yaml("workspaces.yaml")
         assert result == {"workspaces": [{"path": "/tmp"}]}
 
-    def test_returns_none_on_missing_file(self):
+    def test_returns_none_on_missing_metadata_without_sudo(self):
         """Returns None when the protected file doesn't exist."""
-        with patch("kai.config._read_protected_file", return_value=None):
+        with (
+            patch("kai.config.validate_protected_file_metadata", return_value=False),
+            patch("kai.config._read_protected_file") as read_file,
+        ):
             result = _read_protected_yaml("workspaces.yaml")
         assert result is None
+        read_file.assert_not_called()
+
+    def test_returns_malformed_on_present_but_unreadable(self, caplog):
+        """A protected read failure must not fall back to local config."""
+        from kai.config import _YAML_MALFORMED
+
+        with (
+            patch("kai.config.validate_protected_file_metadata", return_value=True),
+            patch("kai.config._read_protected_file", return_value=None),
+        ):
+            result = _read_protected_yaml("workspaces.yaml")
+
+        assert result is _YAML_MALFORMED
+        assert "refusing local fallback" in caplog.text
 
     def test_returns_malformed_on_non_dict(self):
         """Returns _YAML_MALFORMED when YAML parses to a non-dict."""
         from kai.config import _YAML_MALFORMED
 
-        with patch("kai.config._read_protected_file", return_value="- item1\n- item2\n"):
+        with (
+            patch("kai.config.validate_protected_file_metadata", return_value=True),
+            patch("kai.config._read_protected_file", return_value="- item1\n- item2\n"),
+        ):
             result = _read_protected_yaml("workspaces.yaml")
         assert result is _YAML_MALFORMED
 
@@ -205,7 +228,10 @@ class TestReadProtectedYaml:
         """Returns _YAML_MALFORMED (not None) when YAML is invalid."""
         from kai.config import _YAML_MALFORMED
 
-        with patch("kai.config._read_protected_file", return_value="{{bad["):
+        with (
+            patch("kai.config.validate_protected_file_metadata", return_value=True),
+            patch("kai.config._read_protected_file", return_value="{{bad["),
+        ):
             result = _read_protected_yaml("workspaces.yaml")
         assert result is _YAML_MALFORMED
 


### PR DESCRIPTION
## Summary
- distinguish absent protected YAML from present-but-unreadable protected YAML
- prevent protected workspaces.yaml, memory-projects.yaml, and users.yaml read failures from falling through to repo-local fallback files
- update config/install tests so protected-file metadata is mocked with the protected read seam

## Validation
- .venv/bin/python -m pytest -q
- .venv/bin/python -m ruff format --check .
- .venv/bin/python -m ruff check .