### PR TITLE
Install memory project registry config

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -5809,12 +5809,12 @@ def _apply_secrets(
         print(f"[DRY RUN] Would write: {env_path} (mode 0600)")
         if users_yaml_src is not None:
             print(f"[DRY RUN] Would copy: {users_yaml_src} -> {etc_kai / 'users.yaml'} (mode 0600)")
-        # TODO: services.yaml and workspaces.yaml still copy from
+        # TODO: services.yaml, workspaces.yaml, and memory-projects.yaml still copy from
         # PROJECT_ROOT pending follow-up issues that mirror the
         # users.yaml staging flow for those files. The asymmetry is
         # intentional and tracked; users.yaml moves first because it
         # is auth-bearing.
-        for yaml_name in ("services.yaml", "workspaces.yaml"):
+        for yaml_name in ("services.yaml", "workspaces.yaml", "memory-projects.yaml"):
             if (PROJECT_ROOT / yaml_name).exists():
                 print(f"[DRY RUN] Would copy: {etc_kai / yaml_name} (mode 0600)")
         return
@@ -5841,11 +5841,11 @@ def _apply_secrets(
     # Copy optional YAML config files to /etc/kai/ if they exist in the
     # source directory. All get root-only permissions (mode 0600) since
     # they may contain sensitive configuration (API keys in services.yaml).
-    # TODO: services.yaml and workspaces.yaml still read from
+    # TODO: services.yaml, workspaces.yaml, and memory-projects.yaml still read from
     # PROJECT_ROOT pending follow-up issues that mirror the users.yaml
     # staging flow. The asymmetry is documented in-code so it is
     # visible to anyone touching this function.
-    for yaml_name in ("services.yaml", "workspaces.yaml"):
+    for yaml_name in ("services.yaml", "workspaces.yaml", "memory-projects.yaml"):
         yaml_src = PROJECT_ROOT / yaml_name
         yaml_dst = etc_kai / yaml_name
         if yaml_src.exists():

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7300,6 +7300,19 @@ class TestApplySecretsDryRun:
         assert str(staging) in output
         assert "/etc/kai/users.yaml" in output
 
+    def test_dry_run_previews_optional_protected_yaml_configs(self, tmp_path, monkeypatch, capsys):
+        """Dry run previews every optional YAML file runtime can load from /etc/kai."""
+        for name in ("services.yaml", "workspaces.yaml", "memory-projects.yaml"):
+            (tmp_path / name).write_text("{}\n")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+
+        _apply_secrets({"TELEGRAM_BOT_TOKEN": "test"}, dry_run=True)
+
+        output = capsys.readouterr().out
+        assert "/etc/kai/services.yaml" in output
+        assert "/etc/kai/workspaces.yaml" in output
+        assert "/etc/kai/memory-projects.yaml" in output
+
 
 class TestApplyBackendRegistry:
     def test_build_registry_uses_env_paths(self, monkeypatch):
@@ -7366,10 +7379,10 @@ class TestApplySecretsUsersYamlStaging:
 
     @staticmethod
     def _no_other_yamls(monkeypatch, tmp_path):
-        """Make `PROJECT_ROOT/services.yaml` and `workspaces.yaml` absent.
+        """Make optional protected YAML configs absent from PROJECT_ROOT.
 
         Keeps the test focused on the users.yaml staging path; the
-        legacy project-tree copy for the other two files is out of
+        legacy project-tree copy for the other config files is out of
         scope here.
         """
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
@@ -7417,6 +7430,21 @@ class TestApplySecretsUsersYamlStaging:
         assert 0o600 in users_modes
         users_owners = [(uid, gid) for p, uid, gid in chowned if p == "/etc/kai/users.yaml"]
         assert (0, 0) in users_owners
+
+    def test_copies_optional_protected_yaml_configs(self, tmp_path, monkeypatch):
+        """services/workspaces/memory-projects are installed as root-owned 0600 config."""
+        for name in ("services.yaml", "workspaces.yaml", "memory-projects.yaml"):
+            (tmp_path / name).write_text("{}\n")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        copied, chmodded, chowned = self._intercept_filesystem(monkeypatch)
+
+        _apply_secrets({"TELEGRAM_BOT_TOKEN": "test"}, dry_run=False, users_yaml_staging_path=None)
+
+        for name in ("services.yaml", "workspaces.yaml", "memory-projects.yaml"):
+            dst = f"/etc/kai/{name}"
+            assert (str(tmp_path / name), dst) in copied
+            assert (dst, 0o600) in chmodded
+            assert (dst, 0, 0) in chowned
 
     def test_skips_when_path_is_none(self, tmp_path, monkeypatch):
         """No staging path -> no users.yaml copy."""


### PR DESCRIPTION
## Summary
- copy optional memory-projects.yaml into /etc/kai during install, matching runtime protected-config lookup
- include memory-projects.yaml in install dry-run previews
- add tests pinning install/dry-run handling for services.yaml, workspaces.yaml, and memory-projects.yaml

## Verification
- .venv/bin/python -m pytest tests/test_install.py tests/test_config.py tests/test_workspace_config.py -q
- .venv/bin/ruff format --check src/kai/install.py tests/test_install.py
- .venv/bin/ruff check src/kai/install.py tests/test_install.py

## Notes
- This is a consistency hardening fix. No behavior changes if memory-projects.yaml is absent.
- The file is installed root-owned 0600, same as the other protected optional YAML config files.