### PR TITLE
Validate backend registry schema

### DIFF
--- a/src/kai/backend_registry.py
+++ b/src/kai/backend_registry.py
@@ -31,6 +31,7 @@ _BACKEND_ENV_VARS: dict[str, str] = {
     "opencode": "OPENCODE_BIN",
     "goose": "GOOSE_BIN",
 }
+_SUPPORTED_RUNTIME = "local_process"
 
 
 class BackendRegistryError(Exception):
@@ -117,24 +118,48 @@ def load_backend_registry(path: Path | None = None) -> dict[str, BackendRegistry
         backend = str(backend_id).strip().lower()
         if not backend:
             raise BackendRegistryError(f"backend registry {registry_path}: empty backend id")
+        if backend not in _BACKEND_ENV_VARS:
+            valid = ", ".join(sorted(_BACKEND_ENV_VARS))
+            raise BackendRegistryError(
+                f"backend registry {registry_path}: unsupported backend {backend!r}; valid backends: {valid}"
+            )
         if not isinstance(value, dict):
             raise BackendRegistryError(f"backend registry {registry_path}: backend {backend!r} must be a mapping")
         command = str(value.get("command") or "").strip()
         if not command:
             raise BackendRegistryError(f"backend registry {registry_path}: backend {backend!r} missing command")
+        driver = str(value.get("driver") or backend).strip().lower() or backend
+        if driver != backend:
+            raise BackendRegistryError(
+                f"backend registry {registry_path}: backend {backend!r} driver {driver!r} must match backend id"
+            )
+        runtime = str(value.get("runtime") or _SUPPORTED_RUNTIME).strip().lower() or _SUPPORTED_RUNTIME
+        if runtime != _SUPPORTED_RUNTIME:
+            raise BackendRegistryError(
+                f"backend registry {registry_path}: backend {backend!r} runtime {runtime!r} is not supported"
+            )
         models = value.get("allowed_models", [])
         if models is None:
             model_tuple: tuple[str, ...] = ()
         elif isinstance(models, list):
-            model_tuple = tuple(str(item).strip() for item in models if str(item).strip())
+            checked_models: list[str] = []
+            for item in models:
+                if not isinstance(item, str):
+                    raise BackendRegistryError(
+                        f"backend registry {registry_path}: backend {backend!r} allowed_models entries must be strings"
+                    )
+                model = item.strip()
+                if model:
+                    checked_models.append(model)
+            model_tuple = tuple(checked_models)
         else:
             raise BackendRegistryError(
                 f"backend registry {registry_path}: backend {backend!r} allowed_models must be a list"
             )
         entries[backend] = BackendRegistryEntry(
             id=backend,
-            driver=str(value.get("driver") or backend).strip() or backend,
-            runtime=str(value.get("runtime") or "local_process").strip() or "local_process",
+            driver=driver,
+            runtime=runtime,
             command=command,
             allowed_models=model_tuple,
         )

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -53,6 +53,29 @@ def test_present_registry_rejects_unknown_backend(tmp_path, monkeypatch):
         resolve_backend_command("codex")
 
 
+def test_registry_rejects_unsupported_backend_id(tmp_path, monkeypatch):
+    custom = _exe(tmp_path / "custom")
+    registry = tmp_path / "backends.yaml"
+    registry.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "backends": {
+                    "custom": {
+                        "driver": "custom",
+                        "runtime": "local_process",
+                        "command": str(custom),
+                    }
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+    with pytest.raises(BackendRegistryError, match="unsupported backend 'custom'"):
+        load_backend_registry()
+
+
 def test_registry_command_must_be_absolute(tmp_path, monkeypatch):
     registry = tmp_path / "backends.yaml"
     registry.write_text(
@@ -73,6 +96,98 @@ def test_registry_command_must_be_absolute(tmp_path, monkeypatch):
 
     with pytest.raises(BackendRegistryError, match="not absolute"):
         resolve_backend_command("claude")
+
+
+def test_registry_driver_must_match_backend_id(tmp_path, monkeypatch):
+    codex = _exe(tmp_path / "codex")
+    registry = tmp_path / "backends.yaml"
+    registry.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "backends": {
+                    "codex": {
+                        "driver": "claude",
+                        "runtime": "local_process",
+                        "command": str(codex),
+                    }
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+    with pytest.raises(BackendRegistryError, match="driver 'claude' must match backend id"):
+        load_backend_registry()
+
+
+def test_registry_runtime_must_be_local_process(tmp_path, monkeypatch):
+    codex = _exe(tmp_path / "codex")
+    registry = tmp_path / "backends.yaml"
+    registry.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "backends": {
+                    "codex": {
+                        "driver": "codex",
+                        "runtime": "container",
+                        "command": str(codex),
+                    }
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+    with pytest.raises(BackendRegistryError, match="runtime 'container' is not supported"):
+        load_backend_registry()
+
+
+def test_registry_defaults_driver_and_runtime_to_backend_local_process(tmp_path, monkeypatch):
+    codex = _exe(tmp_path / "codex")
+    registry = tmp_path / "backends.yaml"
+    registry.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "backends": {
+                    "codex": {
+                        "command": str(codex),
+                    }
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+    entry = load_backend_registry()["codex"]
+    assert entry.driver == "codex"
+    assert entry.runtime == "local_process"
+
+
+def test_registry_allowed_models_entries_must_be_strings(tmp_path, monkeypatch):
+    codex = _exe(tmp_path / "codex")
+    registry = tmp_path / "backends.yaml"
+    registry.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "backends": {
+                    "codex": {
+                        "driver": "codex",
+                        "runtime": "local_process",
+                        "command": str(codex),
+                        "allowed_models": ["gpt-5.6-sol", 56],
+                    }
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+    with pytest.raises(BackendRegistryError, match="allowed_models entries must be strings"):
+        load_backend_registry()
 
 
 @pytest.mark.parametrize("mode", [0o664, 0o646])


### PR DESCRIPTION
## Summary
- reject unsupported backend ids in backends.yaml
- require registry driver values to match their backend id
- require runtime to be the supported local_process runtime
- reject non-string allowed_models entries instead of silently stringifying them

## Security rationale
The backend registry is a protected machine-capability map used by runtime command resolution and sudoers alignment. Its schema should fail closed when entries drift from the supported local backend contract.

This intentionally does not enforce strict parent-directory ownership for backend executables. On this host, valid Homebrew/Codex installs use symlinks and Homebrew paths that are not root-owned, so that stricter rule would break the working installation.

## Verification
- .venv/bin/python -m pytest tests/test_backend_registry.py -q
- .venv/bin/python -m pytest tests/test_backend_registry.py tests/test_config.py tests/test_install.py -q
- .venv/bin/ruff format --check src/kai/backend_registry.py tests/test_backend_registry.py
- .venv/bin/ruff check src/kai/backend_registry.py tests/test_backend_registry.py
- .venv/bin/python -m pytest -q