### PR TITLE
Stage protected YAML configs during config

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -105,6 +105,11 @@ _SERVICE_START_RETRY_SECONDS = 2
 _PRIVATE_USER_ROOT_MODE = 0o711
 _PRIVATE_USER_DIR_MODE = 0o700
 _PRIVATE_USER_FILE_MODE = 0o600
+_OPTIONAL_PROTECTED_YAML_CONFIGS: tuple[str, ...] = (
+    "services.yaml",
+    "workspaces.yaml",
+    "memory-projects.yaml",
+)
 
 
 class ServiceStartError(Exception):
@@ -593,14 +598,42 @@ def _install_staging_path(filename: str) -> Path:
     return cache_dir / filename
 
 
+def _stage_optional_protected_yaml_configs(deployment_mode: str) -> dict[str, str]:
+    """Stage optional protected YAML configs for a later privileged apply.
+
+    Protected installs copy these files into `/etc/kai/`, but the
+    wizard runs as the unprivileged operator while apply runs as root.
+    Staging mirrors the users.yaml handoff: the project tree is read
+    while the operator is explicitly running `make config`, then apply
+    consumes a concrete operator-private path from install.conf.
+
+    Existing installs remain compatible because apply still falls back
+    to PROJECT_ROOT when no staging metadata is present.
+    """
+    if deployment_mode != "protected":
+        return {}
+
+    staged: dict[str, str] = {}
+    for yaml_name in _OPTIONAL_PROTECTED_YAML_CONFIGS:
+        src = PROJECT_ROOT / yaml_name
+        if not src.is_file():
+            continue
+        dst = _install_staging_path(yaml_name)
+        shutil.copy2(src, dst)
+        os.chmod(dst, 0o600)
+        staged[yaml_name] = str(dst)
+    return staged
+
+
 def _strip_install_conf_keys(*keys: str) -> None:
     """Remove the named top-level keys from `install.conf` and rewrite.
 
     Used by `_cmd_apply` after `apply_succeeded = True` to drop one-
-    shot installer-metadata keys (currently just `users_yaml_staging_
-    path`) so a subsequent re-run does not redo a handoff that already
-    completed. Top-level only: keys inside the `env` dict belong to
-    `/etc/kai/env` and are not touched by this helper.
+    shot installer-metadata keys (for example `users_yaml_staging_path`
+    and `protected_yaml_staging_paths`) so a subsequent re-run does not
+    redo a handoff that already completed. Top-level only: keys inside
+    the `env` dict belong to `/etc/kai/env` and are not touched by this
+    helper.
 
     Preserves the 0600 mode because `install.conf` still carries
     secrets (bot token, webhook secret) until the operator explicitly
@@ -1074,6 +1107,7 @@ def _cmd_config() -> None:
     # value from `existing`: a stale key would cause apply to overwrite
     # the canonical file from a no-longer-current staging artifact.
     users_yaml_staging_path: str | None = None
+    protected_yaml_staging_paths: dict[str, str] = {}
 
     # First-time install only: collect the admin identity and stage a
     # users.yaml. An existing canonical file is left untouched.
@@ -1179,6 +1213,12 @@ def _cmd_config() -> None:
     # existing users.yaml the section is silent, so this would otherwise
     # be an orphaned blank line before the transport prompt.
     if not users_yaml_exists or stray_note:
+        print()
+
+    protected_yaml_staging_paths = _stage_optional_protected_yaml_configs(deployment_mode)
+    if protected_yaml_staging_paths:
+        staged_names = ", ".join(sorted(protected_yaml_staging_paths))
+        print(f"Staged protected YAML config for install: {staged_names}")
         print()
 
     transport = _prompt_choice(
@@ -2479,6 +2519,8 @@ def _cmd_config() -> None:
     # before honoring any recorded staging path.
     if users_yaml_staging_path:
         conf["users_yaml_staging_path"] = users_yaml_staging_path
+    if protected_yaml_staging_paths:
+        conf["protected_yaml_staging_paths"] = protected_yaml_staging_paths
 
     INSTALL_CONF.write_text(json.dumps(conf, indent=2) + "\n")
     # Restrict permissions since the file contains secrets (bot token, webhook secret)
@@ -4454,6 +4496,29 @@ def _cmd_apply() -> None:
     # touching; the protected-mode gate ensures we never reach here
     # with that combination.
     users_yaml_staging_path = conf.get("users_yaml_staging_path", "") or None
+    raw_protected_yaml_staging_paths = conf.get("protected_yaml_staging_paths", {})
+    if raw_protected_yaml_staging_paths is None:
+        protected_yaml_staging_paths: dict[str, str] = {}
+    elif not isinstance(raw_protected_yaml_staging_paths, dict):
+        raise SystemExit("install.conf protected_yaml_staging_paths must be a mapping of filename -> path.")
+    else:
+        protected_yaml_staging_paths = {}
+        for raw_name, raw_path in raw_protected_yaml_staging_paths.items():
+            name = str(raw_name).strip()
+            if name not in _OPTIONAL_PROTECTED_YAML_CONFIGS:
+                raise SystemExit(
+                    f"install.conf protected_yaml_staging_paths has unsupported file {name!r}; "
+                    f"valid files: {', '.join(_OPTIONAL_PROTECTED_YAML_CONFIGS)}."
+                )
+            if not isinstance(raw_path, str):
+                raise SystemExit(
+                    f"install.conf protected_yaml_staging_paths[{name!r}] must be an absolute path string."
+                )
+            path = raw_path.strip()
+            if path:
+                if not Path(path).is_absolute():
+                    raise SystemExit(f"install.conf protected_yaml_staging_paths[{name!r}] must be an absolute path.")
+                protected_yaml_staging_paths[name] = path
 
     if not all([install_dir, data_dir, service_user, platform]):
         raise SystemExit("install.conf is missing required fields.")
@@ -4686,7 +4751,12 @@ def _cmd_apply() -> None:
         env.pop("MEMORY_EPISODE_BUDGET_USD", None)
         env.pop("MEMORY_SCOPED_RECALL_ENABLED", None)
         env.pop("MEMORY_RECALL_SHADOW_ENABLED", None)
-        _apply_secrets(env, dry_run, users_yaml_staging_path=users_yaml_staging_path)
+        _apply_secrets(
+            env,
+            dry_run,
+            users_yaml_staging_path=users_yaml_staging_path,
+            protected_yaml_staging_paths=protected_yaml_staging_paths,
+        )
 
         # -- Step 6: Deploy installed backend registry --
         _apply_backend_registry(service_user, env, dry_run)
@@ -4747,6 +4817,15 @@ def _cmd_apply() -> None:
             else:
                 Path(users_yaml_staging_path).unlink(missing_ok=True)
                 _strip_install_conf_keys("users_yaml_staging_path")
+        if protected_yaml_staging_paths:
+            if dry_run:
+                for path in protected_yaml_staging_paths.values():
+                    print(f"[DRY RUN] Would unlink staging file: {path}")
+                print("[DRY RUN] Would strip protected_yaml_staging_paths from install.conf")
+            else:
+                for path in protected_yaml_staging_paths.values():
+                    Path(path).unlink(missing_ok=True)
+                _strip_install_conf_keys("protected_yaml_staging_paths")
     except Exception:
         print("\nInstallation failed. See error above.")
         print("The installation may be in a partial state.")
@@ -5776,6 +5855,7 @@ def _apply_secrets(
     env: dict[str, str],
     dry_run: bool,
     users_yaml_staging_path: str | None = None,
+    protected_yaml_staging_paths: dict[str, str] | None = None,
 ) -> None:
     """Write the /etc/kai/env file from install.conf environment values.
 
@@ -5805,18 +5885,24 @@ def _apply_secrets(
         if candidate.is_file():
             users_yaml_src = candidate
 
+    optional_yaml_sources: dict[str, Path] = {}
+    for yaml_name in _OPTIONAL_PROTECTED_YAML_CONFIGS:
+        staged = (protected_yaml_staging_paths or {}).get(yaml_name)
+        if staged:
+            staged_path = Path(staged)
+            if staged_path.is_file():
+                optional_yaml_sources[yaml_name] = staged_path
+                continue
+        project_path = PROJECT_ROOT / yaml_name
+        if project_path.is_file():
+            optional_yaml_sources[yaml_name] = project_path
+
     if dry_run:
         print(f"[DRY RUN] Would write: {env_path} (mode 0600)")
         if users_yaml_src is not None:
             print(f"[DRY RUN] Would copy: {users_yaml_src} -> {etc_kai / 'users.yaml'} (mode 0600)")
-        # TODO: services.yaml, workspaces.yaml, and memory-projects.yaml still copy from
-        # PROJECT_ROOT pending follow-up issues that mirror the
-        # users.yaml staging flow for those files. The asymmetry is
-        # intentional and tracked; users.yaml moves first because it
-        # is auth-bearing.
-        for yaml_name in ("services.yaml", "workspaces.yaml", "memory-projects.yaml"):
-            if (PROJECT_ROOT / yaml_name).exists():
-                print(f"[DRY RUN] Would copy: {etc_kai / yaml_name} (mode 0600)")
+        for yaml_name, yaml_src in optional_yaml_sources.items():
+            print(f"[DRY RUN] Would copy: {yaml_src} -> {etc_kai / yaml_name} (mode 0600)")
         return
 
     env_path.write_text(env_content)
@@ -5838,21 +5924,17 @@ def _apply_secrets(
         os.chown(users_yaml_dst, 0, 0)
         print(f"  Copied {users_yaml_dst}")
 
-    # Copy optional YAML config files to /etc/kai/ if they exist in the
-    # source directory. All get root-only permissions (mode 0600) since
-    # they may contain sensitive configuration (API keys in services.yaml).
-    # TODO: services.yaml, workspaces.yaml, and memory-projects.yaml still read from
-    # PROJECT_ROOT pending follow-up issues that mirror the users.yaml
-    # staging flow. The asymmetry is documented in-code so it is
-    # visible to anyone touching this function.
-    for yaml_name in ("services.yaml", "workspaces.yaml", "memory-projects.yaml"):
-        yaml_src = PROJECT_ROOT / yaml_name
+    # Copy optional YAML config files to /etc/kai/. Staged files
+    # recorded by `make config` win; the project-tree fallback remains
+    # for upgraded install.conf files that predate the staging map.
+    # All get root-only permissions (mode 0600) since they may contain
+    # sensitive configuration (API keys in services.yaml).
+    for yaml_name, yaml_src in optional_yaml_sources.items():
         yaml_dst = etc_kai / yaml_name
-        if yaml_src.exists():
-            shutil.copy2(yaml_src, yaml_dst)
-            os.chmod(yaml_dst, 0o600)
-            os.chown(yaml_dst, 0, 0)
-            print(f"  Copied {yaml_dst}")
+        shutil.copy2(yaml_src, yaml_dst)
+        os.chmod(yaml_dst, 0o600)
+        os.chown(yaml_dst, 0, 0)
+        print(f"  Copied {yaml_dst}")
 
 
 def _build_backend_registry(service_user: str, env: dict[str, str]) -> str:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3117,7 +3117,7 @@ class TestCmdApply:
         monkeypatch.setattr("os.geteuid", lambda: 0)
         monkeypatch.setenv("DRY_RUN", "1")
 
-        def fake_apply_secrets(env, dry_run, users_yaml_staging_path=None):
+        def fake_apply_secrets(env, dry_run, users_yaml_staging_path=None, protected_yaml_staging_paths=None):
             raise SystemExit("simulated apply SystemExit (e.g. venv version gate)")
 
         def fake_start(platform, dry_run, **kw):
@@ -3149,7 +3149,7 @@ class TestCmdApply:
         class ApplyBlewUp(RuntimeError):
             pass
 
-        def fake_apply_secrets(env, dry_run, users_yaml_staging_path=None):
+        def fake_apply_secrets(env, dry_run, users_yaml_staging_path=None, protected_yaml_staging_paths=None):
             raise ApplyBlewUp("simulated apply step failure")
 
         def fake_start(platform, dry_run, **kw):
@@ -7313,6 +7313,27 @@ class TestApplySecretsDryRun:
         assert "/etc/kai/workspaces.yaml" in output
         assert "/etc/kai/memory-projects.yaml" in output
 
+    def test_dry_run_prefers_staged_optional_protected_yaml_configs(self, tmp_path, monkeypatch, capsys):
+        """Dry run shows staged optional YAML sources when install.conf recorded them."""
+        project = tmp_path / "project"
+        stage = tmp_path / "stage"
+        project.mkdir()
+        stage.mkdir()
+        (project / "services.yaml").write_text("project: true\n")
+        staged_services = stage / "services.yaml"
+        staged_services.write_text("staged: true\n")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", project)
+
+        _apply_secrets(
+            {"TELEGRAM_BOT_TOKEN": "test"},
+            dry_run=True,
+            protected_yaml_staging_paths={"services.yaml": str(staged_services)},
+        )
+
+        output = capsys.readouterr().out
+        assert f"{staged_services} -> /etc/kai/services.yaml" in output
+        assert f"{project / 'services.yaml'} -> /etc/kai/services.yaml" not in output
+
 
 class TestApplyBackendRegistry:
     def test_build_registry_uses_env_paths(self, monkeypatch):
@@ -7445,6 +7466,29 @@ class TestApplySecretsUsersYamlStaging:
             assert (str(tmp_path / name), dst) in copied
             assert (dst, 0o600) in chmodded
             assert (dst, 0, 0) in chowned
+
+    def test_staged_optional_protected_yaml_configs_win_over_project_tree(self, tmp_path, monkeypatch):
+        """Recorded staging paths are the privileged-apply source of truth."""
+        project = tmp_path / "project"
+        stage = tmp_path / "stage"
+        project.mkdir()
+        stage.mkdir()
+        (project / "services.yaml").write_text("project: true\n")
+        staged_services = stage / "services.yaml"
+        staged_services.write_text("staged: true\n")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", project)
+        copied, chmodded, chowned = self._intercept_filesystem(monkeypatch)
+
+        _apply_secrets(
+            {"TELEGRAM_BOT_TOKEN": "test"},
+            dry_run=False,
+            protected_yaml_staging_paths={"services.yaml": str(staged_services)},
+        )
+
+        assert (str(staged_services), "/etc/kai/services.yaml") in copied
+        assert (str(project / "services.yaml"), "/etc/kai/services.yaml") not in copied
+        assert ("/etc/kai/services.yaml", 0o600) in chmodded
+        assert ("/etc/kai/services.yaml", 0, 0) in chowned
 
     def test_skips_when_path_is_none(self, tmp_path, monkeypatch):
         """No staging path -> no users.yaml copy."""
@@ -7844,6 +7888,35 @@ class TestCmdConfigCanonicalUsersYaml:
         assert "users_yaml_staging_path" not in conf["env"]
         assert "USERS_YAML_STAGING_PATH" not in conf["env"]
 
+    def test_protected_install_records_optional_yaml_staging_paths(self, tmp_path, monkeypatch):
+        """Project-root optional YAML configs are staged as installer metadata."""
+        monkeypatch.chdir(tmp_path)
+        conf_path = tmp_path / "install.conf"
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        staging_dir = tmp_path / "stage"
+        staging_dir.mkdir()
+        monkeypatch.setattr(
+            "kai.install._install_staging_path",
+            lambda filename: staging_dir / filename,
+        )
+        (tmp_path / "services.yaml").write_text("services: {}\n")
+        (tmp_path / "workspaces.yaml").write_text("workspaces: []\n")
+
+        inputs = iter(self._base_inputs())
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        _cmd_config()
+
+        conf = json.loads(conf_path.read_text())
+        staged = conf["protected_yaml_staging_paths"]
+        assert staged == {
+            "services.yaml": str(staging_dir / "services.yaml"),
+            "workspaces.yaml": str(staging_dir / "workspaces.yaml"),
+        }
+        assert "protected_yaml_staging_paths" not in conf["env"]
+        assert (staging_dir / "services.yaml").read_text() == "services: {}\n"
+        assert stat.S_IMODE((staging_dir / "services.yaml").stat().st_mode) == 0o600
+
     def test_env_file_does_not_carry_staging_path(self, tmp_path, monkeypatch):
         """Regression guard: `_generate_env_file(env)` never emits a
         `USERS_YAML_STAGING_PATH` line. Pins the schema discipline that
@@ -7875,7 +7948,11 @@ class TestCmdApplyStagingHandoff:
     """
 
     @staticmethod
-    def _minimal_conf(tmp_path, staging_path: str | None) -> Path:
+    def _minimal_conf(
+        tmp_path,
+        staging_path: str | None,
+        protected_yaml_staging_paths: dict[str, object] | None = None,
+    ) -> Path:
         """Write a minimal install.conf the apply path can validate.
 
         Mirrors what `_cmd_config` would have produced for a claude
@@ -7897,6 +7974,8 @@ class TestCmdApplyStagingHandoff:
         }
         if staging_path is not None:
             conf["users_yaml_staging_path"] = staging_path
+        if protected_yaml_staging_paths is not None:
+            conf["protected_yaml_staging_paths"] = protected_yaml_staging_paths
         path = tmp_path / "install.conf"
         path.write_text(json.dumps(conf, indent=2) + "\n")
         os.chmod(path, 0o600)
@@ -7924,8 +8003,9 @@ class TestCmdApplyStagingHandoff:
             "users:\n  - telegram_id: 1\n    name: test\n    role: admin\n    os_user: testuser\n"
         )
 
-        def _fake_apply_secrets(env, dry_run, users_yaml_staging_path=None):
+        def _fake_apply_secrets(env, dry_run, users_yaml_staging_path=None, protected_yaml_staging_paths=None):
             captured["users_yaml_staging_path"] = users_yaml_staging_path
+            captured["protected_yaml_staging_paths"] = protected_yaml_staging_paths
 
         monkeypatch.setattr("kai.install._stop_service", lambda *a, **kw: None)
         monkeypatch.setattr("kai.install._apply_directories", lambda *a, **kw: None)
@@ -7960,6 +8040,7 @@ class TestCmdApplyStagingHandoff:
         assert not staging.exists()
         rewritten = json.loads(conf_path.read_text())
         assert "users_yaml_staging_path" not in rewritten
+        assert "protected_yaml_staging_paths" not in rewritten
         assert rewritten["env"]["TELEGRAM_BOT_TOKEN"] == "tok"
         assert rewritten["install_dir"] == str(tmp_path / "opt-kai")
         # Mode preservation: install.conf still carries secrets.
@@ -8003,6 +8084,77 @@ class TestCmdApplyStagingHandoff:
         assert captured["users_yaml_staging_path"] is None
         rewritten = json.loads(conf_path.read_text())
         assert "users_yaml_staging_path" not in rewritten
+
+    def test_real_apply_unlinks_and_strips_optional_yaml_staging(self, tmp_path, monkeypatch):
+        """Successful real apply cleans optional protected-YAML staging metadata."""
+        staging = tmp_path / "services.yaml"
+        staging.write_text("services: {}\n")
+        conf_path = self._minimal_conf(
+            tmp_path,
+            staging_path=None,
+            protected_yaml_staging_paths={"services.yaml": str(staging)},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.delenv("DRY_RUN", raising=False)
+        captured: dict = {}
+        self._stub_apply_internals(monkeypatch, captured)
+
+        _cmd_apply()
+
+        assert captured["protected_yaml_staging_paths"] == {"services.yaml": str(staging)}
+        assert not staging.exists()
+        rewritten = json.loads(conf_path.read_text())
+        assert "protected_yaml_staging_paths" not in rewritten
+
+    def test_dry_run_preserves_optional_yaml_staging(self, tmp_path, monkeypatch, capsys):
+        """Dry run does not consume optional protected-YAML staging files."""
+        staging = tmp_path / "services.yaml"
+        staging.write_text("services: {}\n")
+        conf_path = self._minimal_conf(
+            tmp_path,
+            staging_path=None,
+            protected_yaml_staging_paths={"services.yaml": str(staging)},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setenv("DRY_RUN", "1")
+        captured: dict = {}
+        self._stub_apply_internals(monkeypatch, captured)
+
+        _cmd_apply()
+
+        assert staging.exists()
+        rewritten = json.loads(conf_path.read_text())
+        assert rewritten.get("protected_yaml_staging_paths") == {"services.yaml": str(staging)}
+        out = capsys.readouterr().out
+        assert "[DRY RUN] Would unlink staging file" in out
+        assert "[DRY RUN] Would strip protected_yaml_staging_paths" in out
+
+    def test_optional_yaml_staging_path_must_be_string(self, tmp_path, monkeypatch):
+        """Hand-edited staging maps fail closed before install mutations."""
+        hand_edited_map = {"services.yaml": 123}
+        conf_path = self._minimal_conf(
+            tmp_path,
+            staging_path=None,
+            protected_yaml_staging_paths=hand_edited_map,
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+
+        with pytest.raises(SystemExit, match="must be an absolute path string"):
+            _cmd_apply()
+
+    def test_optional_yaml_staging_path_must_be_absolute(self, tmp_path, monkeypatch):
+        """Relative staging paths are refused before root copies config."""
+        conf_path = self._minimal_conf(
+            tmp_path,
+            staging_path=None,
+            protected_yaml_staging_paths={"services.yaml": "relative/services.yaml"},
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+
+        with pytest.raises(SystemExit, match="must be an absolute path"):
+            _cmd_apply()
 
     def test_home_mismatch_resolved_via_conf_key(self, tmp_path, monkeypatch):
         """Apply locates the staging file from install.conf even when


### PR DESCRIPTION
## Summary
- stage optional protected YAML configs from the project tree during make config
- record staged paths as top-level install.conf metadata, not runtime env
- make apply prefer staged protected YAML files while retaining project-tree fallback for older install.conf files
- clean staged files and strip metadata after successful real apply; dry run preserves both
- fail closed on malformed protected_yaml_staging_paths metadata

## Security rationale
services.yaml, workspaces.yaml, and memory-projects.yaml are protected runtime config under /etc/kai. Copying them directly from PROJECT_ROOT during privileged apply keeps a repo-tree read in the root install path. Staging snapshots those files during the explicit operator config step, mirroring the users.yaml handoff and preserving compatibility for existing installs.

## Verification
- .venv/bin/python -m pytest tests/test_install.py::TestApplySecretsDryRun tests/test_install.py::TestApplySecretsUsersYamlStaging tests/test_install.py::TestCmdConfigCanonicalUsersYaml tests/test_install.py::TestCmdApplyStagingHandoff -q
- .venv/bin/python -m pytest tests/test_install.py tests/test_config.py -q
- .venv/bin/ruff format src/kai/install.py tests/test_install.py
- .venv/bin/ruff check src/kai/install.py tests/test_install.py
- .venv/bin/python -m pytest -q