### PR TITLE
Enforce backend registry model allowlists

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -20,15 +20,18 @@ import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
+from fnmatch import fnmatchcase
 from pathlib import Path
 
 import yaml
 from dotenv import load_dotenv
 
+from kai.backend_registry import BackendRegistryError, backend_registry_is_authoritative, load_backend_registry
 from kai.protected_config import ProtectedConfigError, validate_protected_file_metadata
 from kai.user_isolation import validate_protected_user_isolation
 
 log = logging.getLogger(__name__)
+_legacy_registry_model_warning_emitted: set[tuple[str, str]] = set()
 
 
 # ── Module-level paths and constants ─────────────────────────────────
@@ -697,6 +700,59 @@ def is_opencode_model_shape(model: str) -> bool:
     return all(parts)
 
 
+def _backend_registry_allowed_models(backend: str) -> tuple[str, ...] | None:
+    """Return the authoritative registry allowlist for a backend, if any.
+
+    Empty/missing `allowed_models` means "no registry-level model
+    ceiling"; the backend's built-in validator remains authoritative.
+    A malformed or missing required registry fails closed by returning
+    an empty tuple, which makes every model invalid for that backend.
+    """
+    if not backend_registry_is_authoritative():
+        return None
+    try:
+        entry = load_backend_registry().get(backend)
+    except BackendRegistryError as exc:
+        log.error("Could not load backend registry while validating model for %s: %s", backend, exc)
+        return ()
+    if entry is None:
+        log.error("Backend registry has no entry for backend %s while validating models", backend)
+        return ()
+    return entry.allowed_models or None
+
+
+def _model_allowed_by_registry(model: str, backend: str, allowed_models: tuple[str, ...]) -> bool:
+    """Return whether a backend-registry allowlist permits a model.
+
+    `allowed_models` entries support exact strings and shell-style
+    wildcards. The generated Claude registry uses this to preserve the
+    existing `claude-*` full-model-ID behavior while still making the
+    protected registry an enforceable ceiling.
+    """
+    if any(fnmatchcase(model, pattern) for pattern in allowed_models):
+        return True
+
+    # Compatibility for upgraded installs whose existing generated
+    # registry predates the `claude-*` wildcard. The old generator
+    # wrote exactly the short Anthropic aliases. Preserve the runtime's
+    # intentional full-ID behavior until the next `make install`
+    # rewrites /etc/kai/backends.yaml with the explicit wildcard.
+    if backend == "claude" and model.startswith("claude-"):
+        old_generated_claude_aliases = frozenset(PROVIDER_MODELS["anthropic"].keys())
+        if frozenset(allowed_models) == old_generated_claude_aliases:
+            warned = (backend, model)
+            if warned not in _legacy_registry_model_warning_emitted:
+                _legacy_registry_model_warning_emitted.add(warned)
+                log.warning(
+                    "Backend registry allowed_models for claude uses the legacy alias-only form; "
+                    "allowing full Claude model id %r for compatibility. Re-run make install to "
+                    "write the explicit claude-* allowlist.",
+                    model,
+                )
+            return True
+    return False
+
+
 def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> bool:
     """Check if a model is valid for the active backend.
 
@@ -729,14 +785,21 @@ def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> b
     share no fallback path.
     """
     if backend == "codex":
-        return model in CODEX_MODELS
-    if backend == "opencode":
-        return is_opencode_model_shape(model)
-    if backend == "claude" and model.startswith("claude-"):
+        base_allowed = model in CODEX_MODELS
+    elif backend == "opencode":
+        base_allowed = is_opencode_model_shape(model)
+    elif (backend == "claude" or (backend == "goose" and eff_provider == "anthropic")) and model.startswith("claude-"):
+        base_allowed = True
+    else:
+        base_allowed = validate_model_for_provider(model, eff_provider)
+
+    if not base_allowed:
+        return False
+
+    registry_allowed = _backend_registry_allowed_models(backend)
+    if registry_allowed is None:
         return True
-    if backend == "goose" and eff_provider == "anthropic" and model.startswith("claude-"):
-        return True
-    return validate_model_for_provider(model, eff_provider)
+    return _model_allowed_by_registry(model, backend, registry_allowed)
 
 
 # (context, matched legacy key) pairs that have already emitted a

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -5945,7 +5945,7 @@ def _build_backend_registry(service_user: str, env: dict[str, str]) -> str:
             "driver": "claude",
             "runtime": "local_process",
             "command": env.get("CLAUDE_BIN") or _resolve_default_claude_bin(service_user),
-            "allowed_models": sorted(PROVIDER_MODELS["anthropic"].keys()),
+            "allowed_models": sorted((*PROVIDER_MODELS["anthropic"].keys(), "claude-*")),
         },
         "codex": {
             "driver": "codex",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2683,6 +2683,13 @@ class TestCodexModelsSurface:
 class TestValidateModelForBackend:
     """Backend-aware validator."""
 
+    @staticmethod
+    def _write_backend_registry(tmp_path, monkeypatch, body: str) -> None:
+        registry = tmp_path / "backends.yaml"
+        registry.write_text(textwrap.dedent(body).lstrip())
+        registry.chmod(0o644)
+        monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
     def test_codex_accepts_codex_models(self):
         from kai.config import validate_model_for_backend
 
@@ -2711,6 +2718,47 @@ class TestValidateModelForBackend:
 
     def test_codex_rejects_claude_models(self):
         from kai.config import validate_model_for_backend
+
+        assert validate_model_for_backend("opus", "codex", "openai") is False
+
+    def test_registry_allowed_models_narrows_codex_surface(self, tmp_path, monkeypatch):
+        from kai.config import validate_model_for_backend
+
+        self._write_backend_registry(
+            tmp_path,
+            monkeypatch,
+            """
+            version: 1
+            backends:
+              codex:
+                driver: codex
+                runtime: local_process
+                command: /usr/local/bin/codex
+                allowed_models:
+                  - gpt-5.5
+            """,
+        )
+
+        assert validate_model_for_backend("gpt-5.5", "codex", "openai") is True
+        assert validate_model_for_backend("gpt-5.6-sol", "codex", "openai") is False
+
+    def test_registry_allowed_models_cannot_widen_codex_surface(self, tmp_path, monkeypatch):
+        from kai.config import validate_model_for_backend
+
+        self._write_backend_registry(
+            tmp_path,
+            monkeypatch,
+            """
+            version: 1
+            backends:
+              codex:
+                driver: codex
+                runtime: local_process
+                command: /usr/local/bin/codex
+                allowed_models:
+                  - opus
+            """,
+        )
 
         assert validate_model_for_backend("opus", "codex", "openai") is False
 
@@ -2757,6 +2805,55 @@ class TestValidateModelForBackend:
         assert validate_model_for_backend("claude-haiku-4-5-20251001", "claude", "anthropic") is True
         # The curated alias trio keeps working alongside the passthrough.
         assert validate_model_for_backend("sonnet", "claude", "anthropic") is True
+
+    def test_registry_allowed_models_supports_claude_wildcard(self, tmp_path, monkeypatch):
+        from kai.config import validate_model_for_backend
+
+        self._write_backend_registry(
+            tmp_path,
+            monkeypatch,
+            """
+            version: 1
+            backends:
+              claude:
+                driver: claude
+                runtime: local_process
+                command: /opt/homebrew/bin/claude
+                allowed_models:
+                  - haiku
+                  - opus
+                  - sonnet
+                  - claude-*
+            """,
+        )
+
+        assert validate_model_for_backend("sonnet", "claude", "anthropic") is True
+        assert validate_model_for_backend("claude-opus-4-8", "claude", "anthropic") is True
+        assert validate_model_for_backend("gpt-5.5", "claude", "anthropic") is False
+
+    def test_legacy_alias_only_claude_registry_preserves_full_ids(self, tmp_path, monkeypatch, caplog):
+        from kai.config import validate_model_for_backend
+
+        self._write_backend_registry(
+            tmp_path,
+            monkeypatch,
+            """
+            version: 1
+            backends:
+              claude:
+                driver: claude
+                runtime: local_process
+                command: /opt/homebrew/bin/claude
+                allowed_models:
+                  - haiku
+                  - opus
+                  - sonnet
+            """,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            assert validate_model_for_backend("claude-opus-4-8", "claude", "anthropic") is True
+        assert "legacy alias-only form" in caplog.text
 
     def test_claude_rejects_non_claude_garbage(self):
         """The structural passthrough is claude-* scoped; other strings

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7356,6 +7356,7 @@ class TestApplyBackendRegistry:
         assert data["backends"]["opencode"]["command"] == "/custom/opencode"
         assert data["backends"]["goose"]["command"] == "/custom/goose"
         assert "gpt-5.6-sol" in data["backends"]["codex"]["allowed_models"]
+        assert "claude-*" in data["backends"]["claude"]["allowed_models"]
 
     def test_registry_and_sudoers_use_same_explicit_backend_paths(self):
         env = {


### PR DESCRIPTION
## Summary
- enforce backend registry allowed_models as a model ceiling when the protected registry is authoritative
- keep built-in backend validation first, so a registry cannot widen a backend surface
- support exact and wildcard allowed_models entries
- generate Claude registry allowed_models with claude-* plus the short aliases
- preserve upgraded alias-only Claude registries for full claude-* IDs until make install rewrites /etc/kai/backends.yaml

## Security rationale
The backend registry is the admin-owned backend capability map. Its allowed_models field should be enforceable; otherwise the registry appears to restrict models but runtime selection can bypass it. This PR makes allowed_models authoritative without breaking Claude full-model-ID behavior.

## Compatibility
Existing generated Claude registries only list haiku, opus, and sonnet. Runtime intentionally accepts full claude-* IDs, so this PR keeps that old exact alias-only registry shape compatible and emits a warning asking the operator to re-run make install. New installs write claude-* explicitly.

## Verification
- .venv/bin/python -m pytest tests/test_config.py::TestValidateModelForBackend tests/test_backend_registry.py tests/test_install.py::TestApplyBackendRegistry -q
- .venv/bin/python -m pytest tests/test_config.py tests/test_install.py tests/test_backend_registry.py -q
- .venv/bin/ruff format src/kai/config.py src/kai/install.py tests/test_config.py tests/test_install.py
- .venv/bin/ruff check src/kai/config.py src/kai/install.py tests/test_config.py tests/test_install.py
- .venv/bin/python -m pytest -q