### PR TITLE
Use backend registry for config command choices

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -5675,13 +5675,14 @@ def _configured_install_backends(env: dict[str, str], users_yaml_path: str | Pat
     return configured & VALID_BACKENDS
 
 
-def _backend_registry_entries(service_user: str, env: dict[str, str], users_yaml_path: str | Path | None = None) -> dict[str, dict[str, object]]:
+def _backend_registry_entries(
+    service_user: str, env: dict[str, str], users_yaml_path: str | Path | None = None
+) -> dict[str, dict[str, object]]:
     """Build backend registry entries from discovered global installs."""
     discovered = _discover_backend_commands(service_user)
     if not discovered:
         raise SystemExit(
-            "No supported backend command was found. Install at least one of: "
-            "claude, codex, goose, opencode."
+            "No supported backend command was found. Install at least one of: claude, codex, goose, opencode."
         )
 
     missing = sorted(_configured_install_backends(env, users_yaml_path) - discovered.keys())

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -460,10 +460,10 @@ def _validate_chat_id(value: str) -> bool:
 def _validate_claude_bin(value: str) -> bool:
     """Return True when the path is absolute, exists, and is executable.
 
-    Required by the claude wizard prompt; the path is baked into both
-    the runtime CLAUDE_BIN env var and the sudoers rule that allows
-    cross-os_user claude spawns, so a non-existent path here would
-    surface as a confusing 'a password is required' at first message.
+    Used by installer discovery/fallback paths before a command is
+    written into the admin-owned backend registry or sudoers rules, so
+    a non-existent path here would surface as a confusing 'a password
+    is required' at first message.
     The path must also be absolute: a relative path resolves against
     the wizard's working directory at validation time but against the
     daemon's working directory at spawn time, and sudoers command
@@ -479,10 +479,10 @@ def _validate_claude_bin(value: str) -> bool:
 def _validate_codex_bin(value: str) -> bool:
     """Return True when the path is absolute, exists, and is executable.
 
-    Required by the codex wizard prompt; the path is baked into both
-    the runtime CODEX_BIN env var and the sudoers rule that allows
-    cross-os_user codex spawns, so a non-existent path here would
-    surface as a confusing 'a password is required' at first message.
+    Used by installer discovery/fallback paths before a command is
+    written into the admin-owned backend registry or sudoers rules, so
+    a non-existent path here would surface as a confusing 'a password
+    is required' at first message.
     The absoluteness requirement mirrors `_validate_claude_bin` above:
     relative paths resolve differently for the wizard and the daemon,
     and sudoers command matching expects absolute paths.
@@ -513,7 +513,7 @@ def _resolve_default_claude_bin(service_user: str) -> str:
 
 
 def _resolve_codex_bin_prompt_default(existing_env: dict[str, str]) -> str:
-    """Return a usable default for every Codex binary-path prompt.
+    """Return a usable default for legacy Codex binary-path callers.
 
     Preserve a saved CODEX_BIN while it is executable. If an upgrade moved
     the binary, discard the stale value and use the same common-path
@@ -545,11 +545,10 @@ def _resolve_default_codex_bin() -> str:
 def _validate_opencode_bin(value: str) -> bool:
     """Return True when the path is absolute, exists, and is executable.
 
-    Required by the opencode wizard prompt; the path is baked into
-    both the runtime OPENCODE_BIN env var and the sudoers rule that
-    allows cross-os_user opencode spawns, so a non-existent path
-    here would surface as a confusing 'a password is required' or
-    'command not found' at the first one-shot call. Paired with
+    Used by installer discovery/fallback paths before a command is
+    written into the admin-owned backend registry or sudoers rules, so
+    a non-existent path here would surface as a confusing 'a password
+    is required' or 'command not found' at the first one-shot call. Paired with
     `_validate_codex_bin` above so the two binary validators stay
     together; the body shape matches codex byte-for-byte (absolute
     plus is-file plus executable) because the underlying requirement
@@ -564,16 +563,94 @@ def _validate_opencode_bin(value: str) -> bool:
 def _validate_goose_bin(value: str) -> bool:
     """Return True when the path is absolute, exists, and is executable.
 
-    Required by the goose wizard prompt; same dual consumer as the
-    codex and opencode validators above (runtime GOOSE_BIN env var
-    plus the per-user sudoers rule), and the same absolute plus
-    is-file plus executable body because the underlying requirement
-    is the same.
+    Used by installer discovery/fallback paths before a command is
+    written into the admin-owned backend registry or sudoers rules.
+    Same absolute plus is-file plus executable body as the other
+    backend validators because the underlying requirement is the same.
     """
     if not value:
         return False
     p = Path(value)
     return p.is_absolute() and p.is_file() and os.access(p, os.X_OK)
+
+
+def _first_executable_path(candidates: Iterable[str]) -> str:
+    """Return the first absolute executable file in candidates, else empty."""
+    for candidate in candidates:
+        if not candidate:
+            continue
+        path = Path(candidate)
+        if path.is_absolute() and path.is_file() and os.access(str(path), os.X_OK):
+            return str(path)
+    return ""
+
+
+def _discover_backend_commands(service_user: str) -> dict[str, str]:
+    """
+    Discover globally installed backend commands without reading user-
+    supplied path config.
+
+    The result feeds /etc/kai/backends.yaml. Operators choose backend
+    IDs; command paths are install facts discovered by the installer
+    and written as admin-owned state.
+    """
+    svc_home = _user_home(service_user)
+    candidates: dict[str, tuple[str, ...]] = {
+        "claude": (
+            str(Path(svc_home) / ".local" / "bin" / "claude"),
+            "/opt/homebrew/bin/claude",
+            shutil.which("claude") or "",
+        ),
+        "codex": (
+            "/usr/local/bin/codex",
+            "/opt/homebrew/bin/codex",
+            shutil.which("codex") or "",
+        ),
+        "goose": (
+            "/opt/homebrew/bin/goose",
+            shutil.which("goose") or "",
+        ),
+        "opencode": (
+            str(Path(svc_home) / ".local" / "bin" / "opencode"),
+            shutil.which("opencode") or "",
+        ),
+    }
+    discovered: dict[str, str] = {}
+    for backend, backend_candidates in candidates.items():
+        command = _first_executable_path(backend_candidates)
+        if command:
+            discovered[backend] = command
+    return discovered
+
+
+def _backend_choices_from_existing_registry() -> list[str]:
+    """Return backend IDs from the installed registry, if it is readable."""
+    content = ""
+    if BACKENDS_YAML.is_file():
+        try:
+            content = BACKENDS_YAML.read_text()
+        except OSError:
+            content = ""
+    if not content:
+        content = _read_protected_file(str(BACKENDS_YAML)) or ""
+    if not content:
+        return []
+    try:
+        raw = yaml.safe_load(content) or {}
+    except yaml.YAMLError:
+        return []
+    if not isinstance(raw, dict) or not isinstance(raw.get("backends"), dict):
+        return []
+    choices = [str(backend).strip().lower() for backend in raw["backends"]]
+    return sorted(backend for backend in choices if backend in VALID_BACKENDS)
+
+
+def _backend_choices_for_config(service_user: str) -> list[str]:
+    """Return backend choices for the wizard from registry/discovery."""
+    registry_choices = _backend_choices_from_existing_registry()
+    if registry_choices:
+        return registry_choices
+    return sorted(_discover_backend_commands(service_user))
 
 
 def _install_staging_path(filename: str) -> Path:
@@ -879,16 +956,12 @@ def _users_yaml_goose_providers(users_yaml_path: Path, global_provider: str) -> 
 
 def _users_yaml_agent_backends(users_yaml_path: Path) -> set[str]:
     """
-    Collect the distinct per-user `backend` values for
-    wizard-side binary collection.
+    Collect the distinct per-user `backend` values for installer checks.
 
-    A users.yaml entry on a non-global backend makes that backend's
-    binary load-bearing at runtime (the chat spawn and the per-user
-    memory-extraction dispatch both route by each user's effective
-    backend, and the fail-closed startup gate refuses to boot when
-    an extraction-eligible user routes to an unresolvable binary),
-    so the wizard must know which backends are in play beyond the
-    global one. Parsing and degrade behavior live in
+    A users.yaml entry on a non-global backend makes that backend
+    load-bearing at runtime, so installer validation must account for
+    backends in play beyond the global one. Parsing and degrade
+    behavior live in
     `_users_yaml_entries` (empty result on any malformed input).
     """
     backends: set[str] = set()
@@ -1243,12 +1316,18 @@ def _cmd_config() -> None:
 
     # -- Default backend --
     print("-- Default backend --")
+    backend_choices = _backend_choices_for_config(service_user)
+    if not backend_choices:
+        raise SystemExit(
+            "No installed Kai backends were found. Install at least one supported backend "
+            "(claude, codex, goose, or opencode) globally, then re-run make config."
+        )
     # Prefill reads DEFAULT_BACKEND, falling back to the deprecated
     # AGENT_BACKEND key so a re-run against a legacy install.conf keeps
     # the operator's prior choice; the wizard writes DEFAULT_BACKEND only.
     agent_backend = _prompt_choice(
         "Default backend",
-        sorted(VALID_BACKENDS),
+        backend_choices,
         _resolve_renamed_key(
             existing_env.get,
             new_key="DEFAULT_BACKEND",
@@ -1269,51 +1348,10 @@ def _cmd_config() -> None:
     # Gate on the global backend selection only. Per-user
     # `backend: codex` overrides in users.yaml do NOT trigger
     # the auth-mode setup here; codex AUTH for those users stays
-    # out-of-band (per-OS-user `codex login`). Their BINARY path is
-    # collected by the per-user backend scan after the provider
-    # block, which feeds this same codex_bin variable.
+    # out-of-band (per-OS-user `codex login`). The command path comes
+    # from admin-owned backends.yaml.
     codex_auth_mode = ""
     codex_api_key = ""
-    codex_bin = ""
-    # OpenCode binary path collected by the global-opencode block
-    # below (and re-prompted by the memory-extraction defense-in-depth
-    # gate if a future refactor exposes a path where the global block
-    # did not run). Empty when opencode is not in play so the
-    # persistence gate at the tail of this function skips emitting
-    # OPENCODE_BIN to install.conf.
-    opencode_bin = ""
-    # Goose binary path: same collection and persistence shape as
-    # opencode above (global-goose block, extraction defense-in-depth
-    # re-prompt, empty-skip persistence gate for GOOSE_BIN).
-    goose_bin = ""
-    # Claude binary path: same collection and persistence shape as
-    # opencode (global-claude block, extraction defense-in-depth
-    # re-prompt, empty-skip persistence gate for CLAUDE_BIN).
-    claude_bin = ""
-    if agent_backend == "claude":
-        # Claude binary path: wizard-prompted and persisted in
-        # install.conf so `make install` writes both /etc/kai/env's
-        # CLAUDE_BIN and the sudoers SETENV rule from the same source
-        # of truth. Default suggestion uses `which claude` from the
-        # operator's PATH; falls back to the empty string when which
-        # finds nothing (claude has two canonical install locations,
-        # the native installer's ~/.local/bin/claude and the Homebrew
-        # cask's /opt/homebrew/bin/claude, so an empty default forces
-        # the operator to type the path explicitly rather than accept
-        # a wrong guess between the two). The _cmd_apply env
-        # passthrough (`sudo CLAUDE_BIN=... make install`) still works
-        # as the ad-hoc deploy escape hatch; the wizard path is the
-        # canonical source of truth.
-        while True:
-            which_claude = shutil.which("claude") or ""
-            claude_bin = _prompt(
-                "Claude binary path",
-                existing_env.get("CLAUDE_BIN", which_claude),
-                required=True,
-            )
-            if _validate_claude_bin(claude_bin):
-                break
-            print(f"  Path '{claude_bin}' is not an absolute path to an existing executable.")
     if agent_backend == "codex":
         codex_auth_mode = _prompt_choice(
             "Codex auth mode",
@@ -1326,22 +1364,6 @@ def _cmd_config() -> None:
                 existing_env.get("OPENAI_API_KEY", ""),
                 required=True,
             )
-        # Codex binary path: wizard-prompted and persisted in install.conf
-        # so `make install` writes both /etc/kai/env's CODEX_BIN and the
-        # sudoers SETENV rule from the same source of truth. Default
-        # suggestion keeps a valid saved path, otherwise uses `which codex`
-        # from the operator's PATH. This recovers automatically when an
-        # upgrade moves the binary. Falls back to Homebrew only when which
-        # finds nothing; validation still prevents accepting a missing path.
-        while True:
-            codex_bin = _prompt(
-                "Codex binary path",
-                _resolve_codex_bin_prompt_default(existing_env),
-                required=True,
-            )
-            if _validate_codex_bin(codex_bin):
-                break
-            print(f"  Path '{codex_bin}' is not an absolute path to an existing executable.")
         if codex_auth_mode == "subscription":
             print("  After install, log in to codex as the target os_user:")
             print("    <os_user> ~$ codex login")
@@ -1349,8 +1371,8 @@ def _cmd_config() -> None:
             print("  If users.yaml has per-user `backend: codex` entries with")
             print("  different os_users, log in as each of those too.")
 
-    # OpenCode setup: binary-path wizard prompt + post-install auth
-    # reminder. OpenCode joins BACKENDS_NEEDING_PROVIDER_PROMPT so the
+    # OpenCode setup: post-install auth reminder. OpenCode joins
+    # BACKENDS_NEEDING_PROVIDER_PROMPT so the
     # operator names the provider used by the (backend, provider, role)
     # registry; the API-key sub-prompt skips for opencode because
     # opencode auth lives in `~/.local/share/opencode/auth.json` and
@@ -1362,60 +1384,13 @@ def _cmd_config() -> None:
     # Gate on the global backend selection only. Per-user
     # `backend: opencode` overrides in users.yaml do NOT
     # trigger the setup here; opencode AUTH for those users stays
-    # out-of-band (`opencode auth login` per OS user). Their BINARY
-    # path is collected by the per-user backend scan after the
-    # provider block, which feeds this same opencode_bin variable.
+    # out-of-band (`opencode auth login` per OS user). The command path
+    # comes from admin-owned backends.yaml.
     if agent_backend == "opencode":
-        # OpenCode binary path: wizard-prompted and persisted in
-        # install.conf so `make install` writes both /etc/kai/env's
-        # OPENCODE_BIN and the sudoers SETENV rule from the same
-        # source of truth. Default suggestion uses `which opencode`
-        # from the operator's PATH; falls back to the empty string
-        # when which finds nothing (opencode has no single canonical
-        # install location across operator platforms, so an empty
-        # default forces the operator to type the path explicitly
-        # rather than accept a wrong default). The _cmd_apply env
-        # passthrough (`sudo OPENCODE_BIN=... make install`) still
-        # works as the ad-hoc deploy escape hatch; the wizard path is
-        # the canonical source of truth.
-        while True:
-            which_opencode = shutil.which("opencode") or ""
-            opencode_bin = _prompt(
-                "OpenCode binary path",
-                existing_env.get("OPENCODE_BIN", which_opencode),
-                required=True,
-            )
-            if _validate_opencode_bin(opencode_bin):
-                break
-            print(f"  Path '{opencode_bin}' is not an absolute path to an existing executable.")
         print("  After install, authenticate OpenCode for at least one provider:")
         print("    <service_user> ~$ opencode auth login")
         print("  Kai writes the active model into OPENCODE_CONFIG_CONTENT at process spawn;")
         print("  OpenCode resolves it against the credentials in ~/.local/share/opencode/auth.json.")
-
-    # Goose setup: binary-path wizard prompt. Mirrors the opencode
-    # block above: the wizard-persisted path drives /etc/kai/env's
-    # GOOSE_BIN and the per-user sudoers SETENV rule from one source
-    # of truth, and resolve_oneshot_binary("goose") prefers it over
-    # PATH discovery at run time. Default suggestion uses `which
-    # goose` from the operator's PATH (Homebrew installs land there);
-    # falls back to the empty string when which finds nothing so the
-    # operator types the path explicitly rather than accepting a
-    # wrong default. Provider auth needs no extra reminder here: the
-    # provider prompt below collects the API key for key-based
-    # providers, and keychain auth via `goose configure` is per-user
-    # and out of band.
-    if agent_backend == "goose":
-        while True:
-            which_goose = shutil.which("goose") or ""
-            goose_bin = _prompt(
-                "Goose binary path",
-                existing_env.get("GOOSE_BIN", which_goose),
-                required=True,
-            )
-            if _validate_goose_bin(goose_bin):
-                break
-            print(f"  Path '{goose_bin}' is not an absolute path to an existing executable.")
 
     # Multi-provider backends (opencode, goose): operator picks the
     # provider that drives the (backend, provider, role) registry
@@ -1499,67 +1474,9 @@ def _cmd_config() -> None:
     if extra_provider_keys:
         print()
 
-    # Per-user entries on a non-global backend make that backend's
-    # binary load-bearing: the chat spawn and the per-user memory-
-    # extraction dispatch both route by each user's effective
-    # backend, and the fail-closed startup gate refuses to boot when
-    # an extraction-eligible user routes to an unresolvable binary.
-    # The blocks above collect a binary only for the global backend,
-    # so collect here for every other backend per-user entries put
-    # in play; the values flow into the same codex_bin / opencode_bin
-    # / goose_bin variables, so the existing persistence (env var,
-    # install.conf, sudoers SETENV rule) needs no new emission sites.
-    # Prompt loops mirror the global blocks, including each backend's
-    # default posture (codex falls back to Homebrew; claude, goose,
-    # and opencode force an explicit path when `which` finds nothing).
-    peruser_backends = _users_yaml_agent_backends(users_yaml_path)
-    if "claude" in peruser_backends and not claude_bin:
-        print("  users.yaml has a claude entry; the daemon needs a resolvable claude binary.")
-        while True:
-            which_claude = shutil.which("claude") or ""
-            claude_bin = _prompt(
-                "Claude binary path",
-                existing_env.get("CLAUDE_BIN", which_claude),
-                required=True,
-            )
-            if _validate_claude_bin(claude_bin):
-                break
-            print(f"  Path '{claude_bin}' is not an absolute path to an existing executable.")
-    if "codex" in peruser_backends and not codex_bin:
-        print("  users.yaml has a codex entry; the daemon needs a resolvable codex binary.")
-        while True:
-            codex_bin = _prompt(
-                "Codex binary path",
-                _resolve_codex_bin_prompt_default(existing_env),
-                required=True,
-            )
-            if _validate_codex_bin(codex_bin):
-                break
-            print(f"  Path '{codex_bin}' is not an absolute path to an existing executable.")
-    if "opencode" in peruser_backends and not opencode_bin:
-        print("  users.yaml has an opencode entry; the daemon needs a resolvable opencode binary.")
-        while True:
-            which_opencode = shutil.which("opencode") or ""
-            opencode_bin = _prompt(
-                "OpenCode binary path",
-                existing_env.get("OPENCODE_BIN", which_opencode),
-                required=True,
-            )
-            if _validate_opencode_bin(opencode_bin):
-                break
-            print(f"  Path '{opencode_bin}' is not an absolute path to an existing executable.")
-    if "goose" in peruser_backends and not goose_bin:
-        print("  users.yaml has a goose entry; the daemon needs a resolvable goose binary.")
-        while True:
-            which_goose = shutil.which("goose") or ""
-            goose_bin = _prompt(
-                "Goose binary path",
-                existing_env.get("GOOSE_BIN", which_goose),
-                required=True,
-            )
-            if _validate_goose_bin(goose_bin):
-                break
-            print(f"  Path '{goose_bin}' is not an absolute path to an existing executable.")
+    # Per-user backend entries do not collect command paths here.
+    # The installed backend registry is the command-path authority for
+    # every backend, whether selected globally or per-user.
 
     # -- Agent --
     # Determine the effective provider for model choices. Claude
@@ -1958,87 +1875,8 @@ def _cmd_config() -> None:
                 # config; the wizard prompts that used to ask for both
                 # were retired with the env vars they emitted.
                 #
-                # No codex-memory-specific os_user gate fires here.
-                # Codex now follows claude's `resolve_claude_user`
-                # symmetry: missing `os_user` spawns codex in-process
-                # as the bot user, the same self-sudo-skip path
-                # claude uses. The earlier global-codex block already
-                # collected CODEX_BIN; nothing else specific to codex
-                # memory needs setup at this point. CODEX_BIN must be
-                # collected on every global-codex install; this second
-                # prompt is a defense-in-depth no-op when the earlier
-                # block already ran.
-                if agent_backend == "codex" and not codex_bin:
-                    while True:
-                        codex_bin = _prompt(
-                            "Codex binary path (required by codex memory reasoner)",
-                            _resolve_codex_bin_prompt_default(existing_env),
-                            required=True,
-                        )
-                        if _validate_codex_bin(codex_bin):
-                            break
-                        print(f"  Path '{codex_bin}' is not an absolute path to an existing executable.")
-                # Symmetric defense-in-depth for the opencode global
-                # backend. The global-opencode block above already
-                # collected opencode_bin on the normal flow; the gate
-                # here exists for the same future-refactor reason
-                # codex documents above: a refactor that moved the
-                # memory-extraction prompt before the global-backend
-                # block could reach this point with opencode_bin
-                # still empty. Default-suggestion value differs from
-                # codex (empty fallback instead of Homebrew) because
-                # opencode has no canonical install location across
-                # platforms; an empty default forces the operator to
-                # type the path explicitly rather than accept a wrong
-                # default.
-                if agent_backend == "opencode" and not opencode_bin:
-                    while True:
-                        which_opencode = shutil.which("opencode") or ""
-                        opencode_bin = _prompt(
-                            "OpenCode binary path (required by opencode memory reasoner)",
-                            existing_env.get("OPENCODE_BIN", which_opencode),
-                            required=True,
-                        )
-                        if _validate_opencode_bin(opencode_bin):
-                            break
-                        print(f"  Path '{opencode_bin}' is not an absolute path to an existing executable.")
-                # Same defense-in-depth shape for the goose global
-                # backend: the global-goose block above collects
-                # goose_bin on the normal flow; this gate covers a
-                # future refactor that reaches the extraction prompts
-                # with goose_bin still empty. Defaults mirror the
-                # global block (`which goose`, else empty so the
-                # operator types the path explicitly).
-                if agent_backend == "goose" and not goose_bin:
-                    while True:
-                        which_goose = shutil.which("goose") or ""
-                        goose_bin = _prompt(
-                            "Goose binary path (required by goose memory reasoner)",
-                            existing_env.get("GOOSE_BIN", which_goose),
-                            required=True,
-                        )
-                        if _validate_goose_bin(goose_bin):
-                            break
-                        print(f"  Path '{goose_bin}' is not an absolute path to an existing executable.")
-                # Same defense-in-depth shape for the claude global
-                # backend, completing the four-backend set: the
-                # global-claude block above collects claude_bin on
-                # the normal flow; this gate covers a future refactor
-                # that reaches the extraction prompts with claude_bin
-                # still empty. Defaults mirror the global block
-                # (`which claude`, else empty so the operator types
-                # the path explicitly).
-                if agent_backend == "claude" and not claude_bin:
-                    while True:
-                        which_claude = shutil.which("claude") or ""
-                        claude_bin = _prompt(
-                            "Claude binary path (required by claude memory reasoner)",
-                            existing_env.get("CLAUDE_BIN", which_claude),
-                            required=True,
-                        )
-                        if _validate_claude_bin(claude_bin):
-                            break
-                        print(f"  Path '{claude_bin}' is not an absolute path to an existing executable.")
+                # Command-path validation is owned by install apply and
+                # the admin-owned backend registry, not by make config.
                 # Extraction timeout is the LLM-call hard cap inside
                 # memory_extraction.py:541. Default 10s is too aggressive
                 # for production - real extractions routinely take 20-30s
@@ -2251,42 +2089,6 @@ def _cmd_config() -> None:
         existing_key_value = existing_env.get(provider_key_var, "")
         if existing_key_value:
             env[provider_key_var] = existing_key_value
-
-    # Persist the wizard-collected codex binary path whenever any
-    # codex surface (agent backend or memory reasoner) is in play.
-    # Gating on `codex_bin` rather than `agent_backend == "codex"`
-    # covers the supported claude+codex / goose+codex memory cases
-    # where the codex binary is required solely because the memory
-    # reasoner is codex; the second collection block at the memory
-    # gate above guarantees `codex_bin` is set on those paths. The
-    # same value drives /etc/kai/env's CODEX_BIN and the sudoers
-    # SETENV rule so the two can never drift. _cmd_apply's env-var
-    # override block keeps working for ad-hoc deploys (sudo
-    # CODEX_BIN=... kai install apply) but the wizard path remains
-    # the canonical source of truth.
-    if codex_bin:
-        env["CODEX_BIN"] = codex_bin
-    # Same gating shape as codex above: the value persists only when
-    # the wizard collected one (truthy opencode_bin), so a claude or
-    # goose install does not pollute install.conf with an empty
-    # OPENCODE_BIN= line. The single env emission drives both
-    # /etc/kai/env's OPENCODE_BIN and the sudoers SETENV rule so the
-    # two cannot drift.
-    if opencode_bin:
-        env["OPENCODE_BIN"] = opencode_bin
-    # Same gating shape again for goose: persist only when the wizard
-    # collected a value, so non-goose installs do not carry an empty
-    # GOOSE_BIN= line. The single emission drives both /etc/kai/env's
-    # GOOSE_BIN and the sudoers SETENV rule so the two cannot drift.
-    if goose_bin:
-        env["GOOSE_BIN"] = goose_bin
-    # Same gating shape again for claude: persist only when the wizard
-    # collected a value, so installs that never collected one carry no
-    # CLAUDE_BIN= line and keep resolving claude via the service PATH.
-    # The single emission drives both /etc/kai/env's CLAUDE_BIN and
-    # the sudoers SETENV rule so the two cannot drift.
-    if claude_bin:
-        env["CLAUDE_BIN"] = claude_bin
 
     # Remove stale renamed keys if present - leaving both the old and
     # new key causes silent confusion (the deprecation warning is
@@ -3192,19 +2994,11 @@ def _generate_sudoers(
     opencode, and goose binaries (plus a `NOPASSWD: /bin/kill` rule for the
     cross-user kill escalation) are emitted for every distinct `os_user`
     value in users.yaml. Users matching `service_user` are skipped (the
-    runtime detects self-sudo via resolve_claude_user() and spawns the
-    agent directly without sudo). The claude rule defaults to the
-    service user's `~/.local/bin/claude` (the native installer
-    location); operators with a custom install location (e.g. the
-    Homebrew cask) override via CLAUDE_BIN. The codex binary path
-    defaults to the first executable common install location; unusual
-    installs override with the CODEX_BIN env var at install time. The
-    opencode rule uses the
-    service user's `~/.local/bin/opencode` path (where the upstream
-    installer drops the binary by default); operators with a custom
-    install location can override via OPENCODE_BIN. The goose rule
-    defaults to /opt/homebrew/bin/goose (the Homebrew cask location)
-    with the same GOOSE_BIN override shape.
+    runtime detects self-sudo and spawns the agent directly without
+    sudo). In normal protected installs, callers pass command paths
+    from the admin-owned backend registry generated by `_cmd_apply`.
+    The local fallbacks remain only for direct/dev callers that invoke
+    this formatter without registry-derived paths.
 
     Args:
         service_user: The OS username that runs the Kai service.
@@ -3255,40 +3049,14 @@ def _generate_sudoers(
         target_users.append(candidate)
 
     if target_users:
-        # Anchor the rule path to the wizard-collected CLAUDE_BIN when
-        # present, else the default resolver's service-user native
-        # install / Homebrew fallback.
-        # The runtime spawn uses the same precedence (claude.py reads
-        # CLAUDE_BIN, else tries the same native/Homebrew fallbacks
-        # before spawning bare `claude`), so the rule references the
-        # same binary the bot invokes. We deliberately do NOT call
-        # shutil.which here: resolving against whatever
-        # PATH root has when `sudo make install` runs can pick up any
-        # user's `~/.local/bin/claude` that happens to be on PATH at
-        # install time, baking the wrong path into the rule and
-        # breaking the bot's sudo dispatch.
+        # In protected installs, these arguments come from
+        # /etc/kai/backends.yaml generation. Direct/dev callers that
+        # omit them still get deterministic local fallbacks for the
+        # legacy formatter contract.
         svc_home = _user_home(service_user)
         claude_bin_resolved = claude_bin or _resolve_default_claude_bin(service_user)
-        # Codex binary path is now threaded as an argument. The wizard
-        # prompts for and persists the value in install.conf; _cmd_apply
-        # passes it to _apply_sudoers which passes it here. When a user
-        # later switches users.yaml to codex without re-running the
-        # wizard, resolve a common absolute Codex install path that the
-        # runtime uses too. That keeps sudoers and runtime in sync while
-        # still letting CODEX_BIN override unusual installs explicitly.
         codex_bin_resolved = codex_bin or _resolve_default_codex_bin()
-        # OpenCode binary path. Upstream's install script drops the
-        # binary under the SERVICE user's ~/.local/bin/opencode by
-        # default, so the same `svc_home` anchoring applies as the
-        # claude rule above. Operators with a custom install location
-        # override via OPENCODE_BIN (the wizard prompts for and
-        # persists the value the same way CODEX_BIN is handled).
         opencode_bin_resolved = opencode_bin or f"{svc_home}/.local/bin/opencode"
-        # Goose binary path. Homebrew's block-goose-cli cask drops the
-        # binary under /opt/homebrew/bin/goose on macOS; the wizard
-        # prompts for and persists GOOSE_BIN the same way CODEX_BIN
-        # and OPENCODE_BIN are handled, so the fallback fires only on
-        # a first-time install where the wizard has not run yet.
         goose_bin_resolved = goose_bin or "/opt/homebrew/bin/goose"
         # kill(1) for the cross-user kill escalation (#456). The bot
         # runs `sudo -n -u <target> /bin/kill -<sig> <pid>` against
@@ -4684,45 +4452,12 @@ def _cmd_apply() -> None:
         _apply_models(install_path, dry_run)
 
         # -- Step 5: Write secrets --
-        # Inject CODEX_BIN from the apply-time env so the operator's
-        # explicit `sudo CODEX_BIN=... kai install apply` is honored
-        # without round-tripping through the wizard. Apply-time env
-        # wins over any value already in install.conf.
-        #
-        # Gate the apply-time shell env pass-through on the global
-        # DEFAULT_BACKEND only: it is an ad-hoc escape hatch for global
-        # backend installs (`sudo CODEX_BIN=... kai install apply`).
-        # Per-user backend entries do NOT need it; their binary paths
-        # are collected by the `make config` per-user backend scan
-        # and arrive here through install.conf, which `_apply_sudoers`
-        # consumes below. Codex AUTH for per-user entries stays
-        # out-of-band (per-OS-user `codex login`).
-        env_codex_bin = os.environ.get("CODEX_BIN")
-        if env_codex_bin and env.get("DEFAULT_BACKEND") == "codex":
-            env["CODEX_BIN"] = env_codex_bin
-        # Mirror the same env pass-through for OPENCODE_BIN so an
-        # `sudo OPENCODE_BIN=... kai install apply` invocation pins
-        # the same path the running bot will resolve via
-        # resolve_oneshot_binary("opencode"). Same scoping as
-        # CODEX_BIN above: global installs only; per-user opencode
-        # entries get their path from the wizard scan via
-        # install.conf, with auth out-of-band (`opencode auth login`).
-        env_opencode_bin = os.environ.get("OPENCODE_BIN")
-        if env_opencode_bin and env.get("DEFAULT_BACKEND") == "opencode":
-            env["OPENCODE_BIN"] = env_opencode_bin
-        # And for GOOSE_BIN, completing the per-backend trio. Same
-        # split as the two above: shell env override for global goose
-        # installs, install.conf from the wizard scan for per-user
-        # entries.
-        env_goose_bin = os.environ.get("GOOSE_BIN")
-        if env_goose_bin and env.get("DEFAULT_BACKEND") == "goose":
-            env["GOOSE_BIN"] = env_goose_bin
-        # And for CLAUDE_BIN, completing the per-backend set. The
-        # DEFAULT_BACKEND gate compares against the runtime default
-        # because the wizard omits the key on claude installs.
-        env_claude_bin = os.environ.get("CLAUDE_BIN")
-        if env_claude_bin and env.get("DEFAULT_BACKEND", "claude") == "claude":
-            env["CLAUDE_BIN"] = env_claude_bin
+        # Backend executable paths are no longer accepted from
+        # install.conf or apply-time environment variables. They are
+        # discovered by the installer and written to admin-owned
+        # /etc/kai/backends.yaml below.
+        for backend_bin_key in ("CLAUDE_BIN", "CODEX_BIN", "OPENCODE_BIN", "GOOSE_BIN"):
+            env.pop(backend_bin_key, None)
         # DEFAULT_TIMEOUT migration. Operators upgrading without
         # re-running the wizard carry the legacy AGENT_TIMEOUT_SECONDS
         # key in install.conf; rewrite to the canonical name at apply
@@ -4779,10 +4514,6 @@ def _cmd_apply() -> None:
         _apply_sudoers(
             service_user,
             dry_run,
-            claude_bin=env.get("CLAUDE_BIN"),
-            codex_bin=env.get("CODEX_BIN"),
-            opencode_bin=env.get("OPENCODE_BIN"),
-            goose_bin=env.get("GOOSE_BIN"),
             agent_backend=agent_backend,
         )
 
@@ -5937,34 +5668,63 @@ def _apply_secrets(
         print(f"  Copied {yaml_dst}")
 
 
-def _build_backend_registry(service_user: str, env: dict[str, str]) -> str:
-    """Build the installed backend registry from admin-owned install state."""
-    svc_home = _user_home(service_user)
-    entries = {
-        "claude": {
-            "driver": "claude",
-            "runtime": "local_process",
-            "command": env.get("CLAUDE_BIN") or _resolve_default_claude_bin(service_user),
-            "allowed_models": sorted((*PROVIDER_MODELS["anthropic"].keys(), "claude-*")),
-        },
-        "codex": {
-            "driver": "codex",
-            "runtime": "local_process",
-            "command": env.get("CODEX_BIN") or _resolve_default_codex_bin(),
-            "allowed_models": sorted(CODEX_MODELS.keys()),
-        },
-        "goose": {
-            "driver": "goose",
-            "runtime": "local_process",
-            "command": env.get("GOOSE_BIN") or "/opt/homebrew/bin/goose",
-        },
-        "opencode": {
-            "driver": "opencode",
-            "runtime": "local_process",
-            "command": env.get("OPENCODE_BIN") or f"{svc_home}/.local/bin/opencode",
-        },
-    }
-    return render_backend_registry(entries)
+def _configured_install_backends(env: dict[str, str], users_yaml_path: str | Path | None = None) -> set[str]:
+    """Return backend IDs used by global config or users.yaml overrides."""
+    configured = {env.get("DEFAULT_BACKEND", "claude").strip().lower() or "claude"}
+    configured |= _collect_backends_from_yaml(users_yaml_path or USERS_YAML)
+    return configured & VALID_BACKENDS
+
+
+def _backend_registry_entries(service_user: str, env: dict[str, str], users_yaml_path: str | Path | None = None) -> dict[str, dict[str, object]]:
+    """Build backend registry entries from discovered global installs."""
+    discovered = _discover_backend_commands(service_user)
+    if not discovered:
+        raise SystemExit(
+            "No supported backend command was found. Install at least one of: "
+            "claude, codex, goose, opencode."
+        )
+
+    missing = sorted(_configured_install_backends(env, users_yaml_path) - discovered.keys())
+    if missing:
+        raise SystemExit(
+            "Configured backend(s) are not installed globally: "
+            f"{', '.join(missing)}. Install them, or change DEFAULT_BACKEND/users.yaml to an installed backend."
+        )
+
+    entries: dict[str, dict[str, object]] = {}
+    for backend, command in sorted(discovered.items()):
+        if backend == "claude":
+            entries[backend] = {
+                "driver": "claude",
+                "runtime": "local_process",
+                "command": command,
+                "allowed_models": sorted((*PROVIDER_MODELS["anthropic"].keys(), "claude-*")),
+            }
+        elif backend == "codex":
+            entries[backend] = {
+                "driver": "codex",
+                "runtime": "local_process",
+                "command": command,
+                "allowed_models": sorted(CODEX_MODELS.keys()),
+            }
+        elif backend == "goose":
+            entries[backend] = {
+                "driver": "goose",
+                "runtime": "local_process",
+                "command": command,
+            }
+        elif backend == "opencode":
+            entries[backend] = {
+                "driver": "opencode",
+                "runtime": "local_process",
+                "command": command,
+            }
+    return entries
+
+
+def _build_backend_registry(service_user: str, env: dict[str, str], users_yaml_path: str | Path | None = None) -> str:
+    """Build the installed backend registry from discovered global commands."""
+    return render_backend_registry(_backend_registry_entries(service_user, env, users_yaml_path))
 
 
 def _apply_backend_registry(service_user: str, env: dict[str, str], dry_run: bool) -> None:
@@ -6120,17 +5880,12 @@ def _apply_sudoers(
     SETENV: NOPASSWD: rule. Without this, hand-added per-user rules
     were silently wiped on every `sudo make install`.
 
-    `claude_bin`, `codex_bin`, `opencode_bin`, and `goose_bin` are
-    threaded from `_cmd_apply`'s env dict (which sources them from
-    install.conf, after the apply-time env-var override block) so the
-    SETENV rules pin the same absolute paths the running bot will
-    invoke. `claude_bin` falls back to the service user's
-    `~/.local/bin/claude` (the native installer location);
-    `codex_bin` falls back to a common absolute codex install path;
-    `opencode_bin`
-    falls back to the service user's `~/.local/bin/opencode`;
-    `goose_bin` falls back to /opt/homebrew/bin/goose. The fallbacks
-    fire only on installs where the wizard has not collected a value.
+    Backend command paths are resolved from installer discovery and
+    rendered into /etc/kai/backends.yaml. This function reuses the
+    same registry entry builder so sudoers and the runtime registry
+    have one command source. The optional `*_bin` parameters are kept
+    for direct/dev formatter compatibility; `_cmd_apply` does not feed
+    them from install.conf or process environment.
 
     `agent_backend` is the install's global backend (the env dict's
     DEFAULT_BACKEND, defaulting to claude when the key is absent, which
@@ -6151,13 +5906,19 @@ def _apply_sudoers(
     # dry run, since the operator's next step is `sudo make install` which
     # would hit the same error with worse blast radius (partial install).
     os_users = _collect_os_users_from_yaml(users_yaml_path)
+    registry_entries = _backend_registry_entries(service_user, {"DEFAULT_BACKEND": agent_backend}, users_yaml_path)
+    registry_commands = {
+        backend: str(entry["command"])
+        for backend, entry in registry_entries.items()
+        if isinstance(entry, dict) and isinstance(entry.get("command"), str)
+    }
     sudoers_content = _generate_sudoers(
         service_user,
         os_users,
-        claude_bin=claude_bin,
-        codex_bin=codex_bin,
-        opencode_bin=opencode_bin,
-        goose_bin=goose_bin,
+        claude_bin=registry_commands.get("claude"),
+        codex_bin=registry_commands.get("codex"),
+        opencode_bin=registry_commands.get("opencode"),
+        goose_bin=registry_commands.get("goose"),
     )
 
     # Backstop check: each per-user rule pins a backend binary to a
@@ -6177,30 +5938,25 @@ def _apply_sudoers(
     # backend switch cannot strand a user without a rule.
     if os_users:
         backends_in_use = {agent_backend} | _collect_backends_from_yaml(users_yaml_path)
-        svc_home = _user_home(service_user)
         # Each entry's path must resolve to exactly what _generate_sudoers
         # pins for that backend's rule (including the fallbacks); a new
         # backend with a sudoers rule needs an entry in both places.
         expected_bins: dict[str, tuple[Path, str]] = {
             "claude": (
-                Path(claude_bin or _resolve_default_claude_bin(service_user)),
-                "Run 'make install' after installing claude globally, or re-run "
-                "'make config' and point CLAUDE_BIN at the actual install location.",
+                Path(registry_commands.get("claude", "")),
+                "Install claude globally and rerun make install so /etc/kai/backends.yaml is regenerated.",
             ),
             "codex": (
-                Path(codex_bin or _resolve_default_codex_bin()),
-                "Run 'make install' after installing codex globally, or re-run "
-                "'make config' and point CODEX_BIN at the actual install location.",
+                Path(registry_commands.get("codex", "")),
+                "Install codex globally and rerun make install so /etc/kai/backends.yaml is regenerated.",
             ),
             "opencode": (
-                Path(opencode_bin or f"{svc_home}/.local/bin/opencode"),
-                "Run 'make install' after installing opencode globally, or re-run "
-                "'make config' and point OPENCODE_BIN at the actual install location.",
+                Path(registry_commands.get("opencode", "")),
+                "Install opencode globally and rerun make install so /etc/kai/backends.yaml is regenerated.",
             ),
             "goose": (
-                Path(goose_bin or "/opt/homebrew/bin/goose"),
-                "Run 'make install' after installing goose globally, or re-run "
-                "'make config' and point GOOSE_BIN at the actual install location.",
+                Path(registry_commands.get("goose", "")),
+                "Install goose globally and rerun make install so /etc/kai/backends.yaml is regenerated.",
             ),
         }
         for backend in sorted(backends_in_use & expected_bins.keys()):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -72,6 +72,29 @@ from kai.install import (
     cli,
 )
 
+
+@pytest.fixture(autouse=True)
+def _isolate_installed_backend_discovery(monkeypatch, tmp_path):
+    """Keep install tests independent of host-installed backend CLIs.
+
+    CI runners have none of claude/codex/goose/opencode installed,
+    while developer machines may have a real /etc/kai/backends.yaml.
+    Most install tests are not about command discovery, so give them a
+    deterministic registry-shaped discovery result. Tests that exercise
+    missing/discovered backend behavior override this fixture locally.
+    """
+    monkeypatch.setattr("kai.install.BACKENDS_YAML", tmp_path / "absent-backends.yaml")
+    monkeypatch.setattr(
+        "kai.install._discover_backend_commands",
+        lambda service_user: {
+            "claude": "/test/bin/claude",
+            "codex": "/test/bin/codex",
+            "goose": "/test/bin/goose",
+            "opencode": "/test/bin/opencode",
+        },
+    )
+
+
 # ── Validation helpers ───────────────────────────────────────────────
 
 
@@ -7420,7 +7443,7 @@ class TestApplyBackendRegistry:
         )
         _apply_backend_registry("kai", {}, dry_run=True)
         output = capsys.readouterr().out
-        assert "/etc/kai/backends.yaml" in output
+        assert "backends.yaml" in output
         assert "0644" in output
 
     def test_configured_backend_must_be_discovered(self, monkeypatch):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -394,7 +394,7 @@ class TestGenerateSudoers:
     def test_claude_bin_homebrew_fallback_when_service_native_missing(self, monkeypatch):
         """On macOS, a missing service-user native Claude install falls
         back to the Homebrew cask path so runtime backend switches can
-        use Claude without a hand-authored CLAUDE_BIN."""
+        use Claude when the direct formatter fallback is exercised."""
         monkeypatch.setattr("kai.install._user_home", lambda u: "/Users/kai")
         monkeypatch.setattr(
             "kai.install._validate_claude_bin",
@@ -407,9 +407,9 @@ class TestGenerateSudoers:
         assert "/Users/kai/.local/bin/claude" not in result
 
     def test_claude_bin_arg_overrides_default(self, monkeypatch):
-        """An explicit claude_bin (the wizard-collected CLAUDE_BIN)
-        replaces the service-home fallback in the per-user rule, so
-        the rule names the same binary the runtime spawn pins."""
+        """An explicit claude_bin replaces the service-home fallback
+        in the per-user rule. Protected install callers pass this from
+        the backend registry."""
         monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
         result = _generate_sudoers("kai", os_users=["alice"], claude_bin="/opt/homebrew/bin/claude")
         assert "kai ALL=(alice) SETENV: NOPASSWD: /opt/homebrew/bin/claude" in result
@@ -1282,6 +1282,10 @@ class TestCmdConfig:
             "kai.install._install_staging_path",
             lambda filename: tmp_path / filename,
         )
+        monkeypatch.setattr(
+            "kai.install._backend_choices_for_config",
+            lambda service_user: ["claude", "codex", "goose", "opencode"],
+        )
 
     @staticmethod
     def _simulate_existing_etc_users_yaml(monkeypatch, content):
@@ -1315,6 +1319,56 @@ class TestCmdConfig:
             content = yaml.safe_dump(parsed, sort_keys=False)
         monkeypatch.setattr("kai.install._read_users_yaml_text", lambda path: content)
 
+    def test_backend_choices_read_existing_registry(self, tmp_path, monkeypatch):
+        registry = tmp_path / "backends.yaml"
+        registry.write_text(
+            "version: 1\n"
+            "backends:\n"
+            "  codex:\n"
+            "    command: /usr/local/bin/codex\n"
+            "  goose:\n"
+            "    command: /opt/homebrew/bin/goose\n"
+            "  unknown:\n"
+            "    command: /tmp/unknown\n"
+        )
+        monkeypatch.setattr("kai.install.BACKENDS_YAML", registry)
+
+        assert kai.install._backend_choices_from_existing_registry() == ["codex", "goose"]
+
+    def test_backend_choices_fallback_to_global_discovery(self, monkeypatch):
+        monkeypatch.setattr("kai.install._backend_choices_from_existing_registry", lambda: [])
+        monkeypatch.setattr(
+            "kai.install._discover_backend_commands",
+            lambda service_user: {"opencode": "/usr/local/bin/opencode", "codex": "/usr/local/bin/codex"},
+        )
+
+        assert kai.install._backend_choices_for_config("kai") == ["codex", "opencode"]
+
+    def test_config_fails_when_no_backend_is_installed(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr("kai.install._install_staging_path", lambda filename: tmp_path / filename)
+        monkeypatch.setattr("kai.install._backend_choices_for_config", lambda service_user: [])
+        inputs = iter(
+            [
+                "protected",
+                "/opt/kai",
+                "/var/lib/kai",
+                "kai",
+                "darwin",
+                "fake-token",
+                "12345",
+                "admin",
+                "testuser",
+                "polling",
+            ]
+        )
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        with pytest.raises(SystemExit, match="No installed Kai backends were found"):
+            _cmd_config()
+
     def test_writes_install_conf(self, tmp_path, monkeypatch):
         """Config subcommand writes valid JSON to install.conf."""
         monkeypatch.chdir(tmp_path)
@@ -1336,7 +1390,6 @@ class TestCmdConfig:
                 "testuser",  # required protected os_user
                 "polling",  # transport
                 "claude",  # agent backend
-                "/usr/bin/true",  # claude binary path
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
@@ -1388,12 +1441,9 @@ class TestCmdConfig:
         assert data["users"][0]["telegram_id"] == 12345
         assert data["users"][0]["role"] == "admin"
 
-    def test_claude_install_emits_claude_bin(self, tmp_path, monkeypatch):
-        """The wizard-collected claude binary path lands in
-        install.conf's env as CLAUDE_BIN, so `make install` writes
-        /etc/kai/env's CLAUDE_BIN and the sudoers SETENV rule from the
-        same source of truth (the same contract CODEX_BIN /
-        OPENCODE_BIN / GOOSE_BIN follow)."""
+    def test_config_does_not_emit_backend_binary_paths(self, tmp_path, monkeypatch):
+        """Backend command paths are install registry facts, not
+        install.conf values collected from the operator."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
@@ -1405,7 +1455,8 @@ class TestCmdConfig:
         _cmd_config()
 
         conf = json.loads((tmp_path / "install.conf").read_text())
-        assert conf["env"]["CLAUDE_BIN"] == "/usr/bin/true"
+        for key in ("CLAUDE_BIN", "CODEX_BIN", "GOOSE_BIN", "OPENCODE_BIN"):
+            assert key not in conf["env"]
 
     def test_advanced_user_options(self, tmp_path, monkeypatch):
         """
@@ -1436,7 +1487,6 @@ class TestCmdConfig:
                 # no home_workspace prompt post-#353
                 "polling",  # transport
                 "claude",  # agent backend
-                "/usr/bin/true",  # claude binary path
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
@@ -1518,7 +1568,6 @@ class TestCmdConfig:
                 "testuser",  # required protected os_user
                 "polling",  # transport
                 "claude",  # agent backend
-                "/usr/bin/true",  # claude binary path
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
@@ -1587,7 +1636,6 @@ class TestCmdConfig:
                 "testuser",  # os_user (no home_workspace prompt should follow)
                 "polling",
                 "claude",
-                "/usr/bin/true",  # claude binary path
                 "sonnet",
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",
@@ -1649,7 +1697,6 @@ class TestCmdConfig:
                 "testuser",  # required protected os_user
                 "polling",  # transport
                 "goose",  # agent backend (prompt shown because existing config has goose)
-                "/opt/homebrew/bin/goose",  # goose binary path (validator stubbed)
                 "anthropic",  # goose provider
                 "sk-ant-test-key",  # ANTHROPIC_API_KEY
                 "sonnet",  # model
@@ -1680,7 +1727,6 @@ class TestCmdConfig:
         assert conf["env"]["DEFAULT_BACKEND"] == "goose"
         assert conf["env"]["DEFAULT_PROVIDER"] == "anthropic"
         assert conf["env"]["ANTHROPIC_API_KEY"] == "sk-ant-test-key"
-        assert conf["env"]["GOOSE_BIN"] == "/opt/homebrew/bin/goose"
         # Memory was declined, so the retrieval-only note must not
         # print; it belongs only to the memory-enabled flow.
         out = capsys.readouterr().out
@@ -1785,7 +1831,6 @@ class TestCmdConfig:
                 "testuser",  # required protected os_user
                 "polling",  # transport
                 "goose",  # agent backend
-                "/opt/homebrew/bin/goose",  # goose binary path (validator stubbed)
                 "ollama",  # goose provider (no key needed)
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
@@ -1843,13 +1888,7 @@ class TestCmdConfig:
         existing_users_yaml = "users:\n  - telegram_id: 999\n    name: existing\n    role: admin\n"
         self._simulate_existing_etc_users_yaml(monkeypatch, existing_users_yaml)
 
-        # Press Enter for everything except the claude binary prompt,
-        # whose default depends on the runner's PATH (`which claude`);
-        # an explicit answer keeps the test host-independent.
-        monkeypatch.setattr(
-            "builtins.input",
-            lambda prompt: "/usr/bin/true" if "Claude binary path" in prompt else "",
-        )
+        monkeypatch.setattr("builtins.input", lambda prompt: "")
 
         _cmd_config()
 
@@ -1905,8 +1944,6 @@ class TestCmdConfig:
         conf_path.write_text(json.dumps(existing))
 
         def answer(prompt: str) -> str:
-            if "Claude binary path" in prompt:
-                return "/usr/bin/true"
             if "Retain deprecated WEBHOOK_SECRET fallback" in prompt:
                 return "false"
             return ""
@@ -1985,21 +2022,10 @@ class TestCmdConfig:
             )
         # Wizard prompts for provider + API key only for non-claude
         # backends. The API key prompt itself is skipped when provider
-        # is "ollama" (local model, no auth). The goose backend block
-        # additionally prompts for the binary path before the provider
-        # prompt; goose callers stub `_validate_goose_bin` (the codex
-        # wizard-test precedent), so the literal path here never
-        # touches the host filesystem.
+        # is "ollama" (local model, no auth). Backend command paths
+        # now come from the installed backend registry/discovery, not
+        # from config wizard answers.
         backend_block: list[str] = []
-        if agent_backend == "claude":
-            # The global-claude block prompts for the binary path
-            # right after backend selection. /usr/bin/true exists and
-            # is executable on macOS and Linux CI runners alike, so
-            # the real _validate_claude_bin passes without a claude
-            # install on the host and without a validator stub.
-            backend_block.append("/usr/bin/true")
-        if agent_backend == "goose":
-            backend_block.append("/opt/homebrew/bin/goose")
         if agent_backend != "claude":
             backend_block.append(llm_provider)
             if llm_provider != "ollama":
@@ -2372,13 +2398,8 @@ class TestCmdConfig:
         conf_path.write_text(json.dumps(existing))
         # users.yaml is simulated above via _simulate_existing_etc_users_yaml,
         # which keeps the wizard on the existing-config branch and skips
-        # the per-user prompts that lack defaults. The claude binary
-        # prompt gets an explicit answer because its default depends
-        # on the runner's PATH (`which claude`).
-        monkeypatch.setattr(
-            "builtins.input",
-            lambda prompt: "/usr/bin/true" if "Claude binary path" in prompt else "",
-        )
+        # the per-user prompts that lack defaults.
+        monkeypatch.setattr("builtins.input", lambda prompt: "")
 
         _cmd_config()
 
@@ -2468,7 +2489,6 @@ class TestCmdConfig:
                 "testuser",  # required protected os_user
                 "polling",  # transport
                 "goose",  # agent backend (was claude)
-                "/opt/homebrew/bin/goose",  # goose binary path (validator stubbed)
                 "anthropic",  # goose provider
                 "sk-ant-test-key",  # API key
                 "sonnet",  # model
@@ -2809,7 +2829,6 @@ class TestCmdConfig:
                 "polling",  # transport
                 "codex",  # agent backend
                 "subscription",  # codex auth mode
-                "/usr/local/bin/codex",  # codex binary path
                 # model: handled by _prompt_default_model mock
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # agent timeout
@@ -3333,7 +3352,6 @@ class TestCmdConfigDefaultModelDispatch:
             "fake-token",  # bot token
             "polling",  # transport
             "claude",  # agent backend
-            "/usr/bin/true",  # claude binary path
             # no DEFAULT_MODEL prompt; agent default comes from MODEL_REGISTRY
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout (global default)
@@ -3374,7 +3392,6 @@ class TestCmdConfigDefaultModelDispatch:
             "codex",  # agent backend
             "subscription",  # codex auth mode
             # No OPENAI_API_KEY prompt in subscription mode
-            "/usr/local/bin/codex",  # codex binary path
             # No provider prompt (codex is single-provider; absent from BACKENDS_NEEDING_PROVIDER_PROMPT)
             # no DEFAULT_MODEL prompt; agent default comes from MODEL_REGISTRY
             "false",  # customize per-role models (decline; use registry defaults)
@@ -3407,7 +3424,6 @@ class TestCmdConfigDefaultModelDispatch:
             "fake-token",  # bot token
             "polling",  # transport
             "goose",  # agent backend
-            "/opt/homebrew/bin/goose",  # goose binary path (validator stubbed)
             "openai",  # llm provider
             "openai-key",  # OPENAI_API_KEY
             # no DEFAULT_MODEL prompt; agent default comes from MODEL_REGISTRY
@@ -7336,10 +7352,16 @@ class TestApplySecretsDryRun:
 
 
 class TestApplyBackendRegistry:
-    def test_build_registry_uses_env_paths(self, monkeypatch):
-        monkeypatch.setattr("kai.install._resolve_default_claude_bin", lambda service_user: "/fallback/claude")
-        monkeypatch.setattr("kai.install._resolve_default_codex_bin", lambda: "/fallback/codex")
-
+    def test_build_registry_uses_discovered_global_commands(self, monkeypatch):
+        monkeypatch.setattr(
+            "kai.install._discover_backend_commands",
+            lambda service_user: {
+                "claude": "/global/claude",
+                "codex": "/global/codex",
+                "opencode": "/global/opencode",
+                "goose": "/global/goose",
+            },
+        )
         rendered = kai.install._build_backend_registry(
             "kai",
             {
@@ -7351,42 +7373,61 @@ class TestApplyBackendRegistry:
         )
         data = yaml.safe_load(rendered)
 
-        assert data["backends"]["claude"]["command"] == "/custom/claude"
-        assert data["backends"]["codex"]["command"] == "/custom/codex"
-        assert data["backends"]["opencode"]["command"] == "/custom/opencode"
-        assert data["backends"]["goose"]["command"] == "/custom/goose"
+        assert data["backends"]["claude"]["command"] == "/global/claude"
+        assert data["backends"]["codex"]["command"] == "/global/codex"
+        assert data["backends"]["opencode"]["command"] == "/global/opencode"
+        assert data["backends"]["goose"]["command"] == "/global/goose"
         assert "gpt-5.6-sol" in data["backends"]["codex"]["allowed_models"]
         assert "fable" in data["backends"]["claude"]["allowed_models"]
         assert "claude-*" in data["backends"]["claude"]["allowed_models"]
 
-    def test_registry_and_sudoers_use_same_explicit_backend_paths(self):
+    def test_registry_and_sudoers_use_same_discovered_backend_paths(self, monkeypatch):
+        monkeypatch.setattr(
+            "kai.install._discover_backend_commands",
+            lambda service_user: {
+                "claude": "/registry/claude",
+                "codex": "/registry/codex",
+                "opencode": "/registry/opencode",
+                "goose": "/registry/goose",
+            },
+        )
         env = {
-            "CLAUDE_BIN": "/registry/claude",
-            "CODEX_BIN": "/registry/codex",
-            "OPENCODE_BIN": "/registry/opencode",
-            "GOOSE_BIN": "/registry/goose",
+            "CLAUDE_BIN": "/ignored/claude",
+            "CODEX_BIN": "/ignored/codex",
+            "OPENCODE_BIN": "/ignored/opencode",
+            "GOOSE_BIN": "/ignored/goose",
         }
 
         registry = yaml.safe_load(kai.install._build_backend_registry("kai", env))
+        commands = {backend: entry["command"] for backend, entry in registry["backends"].items()}
         sudoers = _generate_sudoers(
             "kai",
             os_users=["alice"],
-            claude_bin=env["CLAUDE_BIN"],
-            codex_bin=env["CODEX_BIN"],
-            opencode_bin=env["OPENCODE_BIN"],
-            goose_bin=env["GOOSE_BIN"],
+            claude_bin=commands["claude"],
+            codex_bin=commands["codex"],
+            opencode_bin=commands["opencode"],
+            goose_bin=commands["goose"],
         )
 
         for backend in ("claude", "codex", "opencode", "goose"):
             command = registry["backends"][backend]["command"]
-            assert command == env[f"{backend.upper()}_BIN"]
             assert f"kai ALL=(alice) SETENV: NOPASSWD: {command}" in sudoers
 
-    def test_dry_run_prints_registry_write(self, capsys):
+    def test_dry_run_prints_registry_write(self, capsys, monkeypatch):
+        monkeypatch.setattr(
+            "kai.install._discover_backend_commands",
+            lambda service_user: {"claude": "/global/claude"},
+        )
         _apply_backend_registry("kai", {}, dry_run=True)
         output = capsys.readouterr().out
         assert "/etc/kai/backends.yaml" in output
         assert "0644" in output
+
+    def test_configured_backend_must_be_discovered(self, monkeypatch):
+        monkeypatch.setattr("kai.install._discover_backend_commands", lambda service_user: {"codex": "/global/codex"})
+
+        with pytest.raises(SystemExit, match="Configured backend\\(s\\) are not installed globally: claude"):
+            kai.install._build_backend_registry("kai", {"DEFAULT_BACKEND": "claude"})
 
 
 # ── _apply_secrets staging copy precedence ───────────────────────────
@@ -7806,7 +7847,6 @@ class TestCmdConfigCanonicalUsersYaml:
             "testuser",  # required protected os_user
             "polling",
             "claude",
-            "/usr/bin/true",  # claude binary path
             "sonnet",
             "false",  # customize per-role models (decline)
             "120",
@@ -8270,7 +8310,6 @@ class TestCmdConfigSingleUserMode:
             "false",  # advanced
             "polling",  # transport
             "claude",  # backend
-            "/usr/bin/true",  # claude binary path
             "sonnet",  # model
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # timeout
@@ -8538,6 +8577,10 @@ class TestApplySudoersDryRun:
         svc_home.mkdir(parents=True)
         # Intentionally do NOT create svc_home/.local/bin/claude.
         monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        monkeypatch.setattr(
+            "kai.install._discover_backend_commands",
+            lambda service_user: {"claude": str(svc_home / ".local" / "bin" / "claude")},
+        )
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
 
@@ -8552,6 +8595,10 @@ class TestApplySudoersDryRun:
         svc_home = tmp_path / "home" / "kai"
         svc_home.mkdir(parents=True)
         monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        monkeypatch.setattr(
+            "kai.install._discover_backend_commands",
+            lambda service_user: {"claude": str(svc_home / ".local" / "bin" / "claude")},
+        )
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text("users: []\n")
 
@@ -8567,6 +8614,10 @@ class TestApplySudoersDryRun:
         bin_dir.mkdir(parents=True)
         (bin_dir / "claude").write_text("#!/bin/sh\n")
         monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        monkeypatch.setattr(
+            "kai.install._discover_backend_commands",
+            lambda service_user: {"claude": str(bin_dir / "claude")},
+        )
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
 
@@ -8582,6 +8633,10 @@ class TestApplySudoersDryRun:
         svc_home.mkdir(parents=True)
         # Neither the claude binary nor the opencode binary exists.
         monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        monkeypatch.setattr(
+            "kai.install._discover_backend_commands",
+            lambda service_user: {"opencode": str(tmp_path / "nope" / "opencode")},
+        )
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
 
@@ -8589,14 +8644,13 @@ class TestApplySudoersDryRun:
             "kai",
             dry_run=True,
             users_yaml_path=users_yaml,
-            opencode_bin=str(tmp_path / "nope" / "opencode"),
             agent_backend="opencode",
         )
 
         captured = capsys.readouterr()
         assert "claude" not in captured.err
         assert "opencode sudoers" in captured.err
-        assert "OPENCODE_BIN" in captured.err
+        assert "/etc/kai/backends.yaml" in captured.err
 
     def test_opencode_only_install_silent_when_binary_exists(self, tmp_path, capsys, monkeypatch):
         """An opencode-only install with its binary in place warns about
@@ -8606,6 +8660,10 @@ class TestApplySudoersDryRun:
         opencode = tmp_path / "opencode"
         opencode.write_text("#!/bin/sh\n")
         monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        monkeypatch.setattr(
+            "kai.install._discover_backend_commands",
+            lambda service_user: {"opencode": str(opencode)},
+        )
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
 
@@ -8613,19 +8671,22 @@ class TestApplySudoersDryRun:
             "kai",
             dry_run=True,
             users_yaml_path=users_yaml,
-            opencode_bin=str(opencode),
             agent_backend="opencode",
         )
 
         captured = capsys.readouterr()
         assert "Warning" not in captured.err
 
-    def test_codex_backend_missing_binary_names_codex_bin(self, tmp_path, capsys, monkeypatch):
+    def test_codex_backend_missing_binary_names_registry(self, tmp_path, capsys, monkeypatch):
         """A codex install with a missing binary gets the codex warning
-        pointing at the CODEX_BIN wizard setting."""
+        pointing at backend registry regeneration."""
         svc_home = tmp_path / "home" / "kai"
         svc_home.mkdir(parents=True)
         monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        monkeypatch.setattr(
+            "kai.install._discover_backend_commands",
+            lambda service_user: {"codex": str(tmp_path / "nope" / "codex")},
+        )
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
 
@@ -8633,13 +8694,12 @@ class TestApplySudoersDryRun:
             "kai",
             dry_run=True,
             users_yaml_path=users_yaml,
-            codex_bin=str(tmp_path / "nope" / "codex"),
             agent_backend="codex",
         )
 
         captured = capsys.readouterr()
         assert "codex sudoers" in captured.err
-        assert "CODEX_BIN" in captured.err
+        assert "/etc/kai/backends.yaml" in captured.err
         assert "claude" not in captured.err
 
     def test_per_user_backend_override_widens_the_check(self, tmp_path, capsys, monkeypatch):
@@ -8652,6 +8712,13 @@ class TestApplySudoersDryRun:
         opencode = tmp_path / "opencode"
         opencode.write_text("#!/bin/sh\n")
         monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        monkeypatch.setattr(
+            "kai.install._discover_backend_commands",
+            lambda service_user: {
+                "claude": str(svc_home / ".local" / "bin" / "claude"),
+                "opencode": str(opencode),
+            },
+        )
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text(
             "users:\n"
@@ -8666,7 +8733,6 @@ class TestApplySudoersDryRun:
             "kai",
             dry_run=True,
             users_yaml_path=users_yaml,
-            opencode_bin=str(opencode),
             agent_backend="opencode",
         )
 
@@ -8677,9 +8743,9 @@ class TestApplySudoersDryRun:
         assert "the claude sudoers rule" in captured.err
         assert "the opencode sudoers rule" not in captured.err
 
-    def test_goose_only_install_missing_binary_names_goose_bin(self, tmp_path, capsys, monkeypatch):
+    def test_goose_only_install_missing_binary_names_registry(self, tmp_path, capsys, monkeypatch):
         """A goose-only install with os_users warns when the goose
-        binary path does not exist, and the remedy names GOOSE_BIN:
+        binary path does not exist, and the remedy names the registry:
         goose now has a per-user sudoers rule with a pinned path, so
         the backstop covers it the same way it covers the other
         backends. The path is passed explicitly (never the host
@@ -8688,6 +8754,10 @@ class TestApplySudoersDryRun:
         svc_home = tmp_path / "home" / "kai"
         svc_home.mkdir(parents=True)
         monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        monkeypatch.setattr(
+            "kai.install._discover_backend_commands",
+            lambda service_user: {"goose": str(tmp_path / "nope" / "goose")},
+        )
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
 
@@ -8695,13 +8765,12 @@ class TestApplySudoersDryRun:
             "kai",
             dry_run=True,
             users_yaml_path=users_yaml,
-            goose_bin=str(tmp_path / "nope" / "goose"),
             agent_backend="goose",
         )
 
         captured = capsys.readouterr()
         assert "the goose sudoers rule" in captured.err
-        assert "GOOSE_BIN" in captured.err
+        assert "/etc/kai/backends.yaml" in captured.err
         # Scoping: a goose-only install must not be told about the
         # other backends' binaries.
         assert "the claude sudoers rule" not in captured.err
@@ -8715,6 +8784,10 @@ class TestApplySudoersDryRun:
         svc_home = tmp_path / "home" / "kai"
         svc_home.mkdir(parents=True)
         monkeypatch.setattr("kai.install._user_home", lambda u: str(svc_home))
+        monkeypatch.setattr(
+            "kai.install._discover_backend_commands",
+            lambda service_user: {"goose": str(goose)},
+        )
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
         goose = tmp_path / "goose"
@@ -8725,7 +8798,6 @@ class TestApplySudoersDryRun:
             "kai",
             dry_run=True,
             users_yaml_path=users_yaml,
-            goose_bin=str(goose),
             agent_backend="goose",
         )
 
@@ -9701,20 +9773,8 @@ class TestValidateGooseBin:
         assert _validate_goose_bin(str(f)) is True
 
 
-class TestOpenCodeBinWizardPrompt:
-    """Wizard collects OPENCODE_BIN when the operator picks opencode
-    as the global backend. Mirrors the codex wizard's collection
-    pattern: prompt with `shutil.which("opencode")` as the default
-    suggestion, validate the chosen path, persist to install.conf
-    so `make install` reads from the same source of truth as the
-    sudoers SETENV rule emitter (PR #577). The escape hatch
-    `sudo OPENCODE_BIN=... make install` is preserved by the
-    `_cmd_apply` env passthrough also added in PR #577.
-
-    These tests focus on the wizard surface; the sudoers-rule
-    threading is already covered under TestGenerateSudoersCodexBinArg
-    and the matching opencode regression tests in test_install.py.
-    """
+class TestOpenCodeConfigWizard:
+    """OpenCode config writes backend/provider settings, not binary paths."""
 
     def _redirect_staging(self, monkeypatch, tmp_path):
         """Redirect the staging-path helper so the wizard writes under tmp_path."""
@@ -9723,15 +9783,12 @@ class TestOpenCodeBinWizardPrompt:
             lambda filename: tmp_path / filename,
         )
 
-    def _opencode_inputs(self, opencode_bin_path: str) -> list[str]:
+    def _opencode_inputs(self) -> list[str]:
         """Build the input sequence for an opencode-backend wizard run.
 
-        Mirrors the codex-install test's input sequence at line ~2440
-        of test_install.py except for the agent backend and the
-        binary-path prompt: codex has `codex_auth_mode` plus the
-        codex binary path; opencode has only the opencode binary
-        path (no auth mode prompt because opencode auth lives outside
-        the wizard surface, in `~/.local/share/opencode/auth.json`).
+        OpenCode auth and command installation live outside
+        `make config`; the installed backend registry records command
+        paths during `make install`.
         """
         return [
             "protected",  # deployment mode
@@ -9745,7 +9802,6 @@ class TestOpenCodeBinWizardPrompt:
             "testuser",  # required protected os_user
             "polling",  # transport
             "opencode",  # agent backend
-            opencode_bin_path,  # OPENCODE_BIN
             "anthropic",  # provider (opencode joined BACKENDS_NEEDING_PROVIDER_PROMPT)
             # API key prompt skipped for opencode (auth managed by `opencode auth login`).
             # model: handled by _prompt_default_model mock
@@ -9773,19 +9829,15 @@ class TestOpenCodeBinWizardPrompt:
             "",  # perplexity key
         ]
 
-    def test_wizard_persists_opencode_bin_to_install_conf(self, tmp_path, monkeypatch):
-        """The wizard's opencode block collects OPENCODE_BIN and
-        persists it under `env` in install.conf. The persisted value
-        is then threaded into /etc/kai/env and the sudoers rule by
-        `_cmd_apply` and `_generate_sudoers` (covered separately)."""
-        opencode_path = tmp_path / "fake_opencode"
-        opencode_path.write_text("#!/bin/sh\necho hi\n")
-        opencode_path.chmod(0o755)
-
+    def test_wizard_persists_opencode_backend_without_bin(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._redirect_staging(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "kai.install._backend_choices_for_config",
+            lambda service_user: ["opencode"],
+        )
         # Mock the model prompt so the test doesn't drive the
         # provider/model free-text branch directly.
         monkeypatch.setattr(
@@ -9793,261 +9845,14 @@ class TestOpenCodeBinWizardPrompt:
             MagicMock(return_value="anthropic/claude-sonnet-4-5"),
         )
 
-        inputs = iter(self._opencode_inputs(str(opencode_path)))
+        inputs = iter(self._opencode_inputs())
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
 
         _cmd_config()
 
         env = json.loads((tmp_path / "install.conf").read_text())["env"]
-        assert env["OPENCODE_BIN"] == str(opencode_path)
         assert env["DEFAULT_BACKEND"] == "opencode"
-
-    def test_wizard_loops_on_invalid_opencode_bin(self, tmp_path, monkeypatch):
-        """An invalid path (does not exist, or not executable) must
-        re-prompt until the operator types a valid one. Symmetric
-        with the codex validator loop at install.py:810-819."""
-        valid_path = tmp_path / "fake_opencode"
-        valid_path.write_text("#!/bin/sh\necho hi\n")
-        valid_path.chmod(0o755)
-        invalid_path = tmp_path / "does_not_exist"
-
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
-        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
-        self._redirect_staging(monkeypatch, tmp_path)
-        monkeypatch.setattr(
-            "kai.install._prompt_default_model",
-            MagicMock(return_value="anthropic/claude-sonnet-4-5"),
-        )
-
-        # Build inputs: first opencode_bin is invalid; loop pulls the
-        # next input from the iterator, which is the valid path. The
-        # rest of the wizard inputs follow.
-        inputs_list = self._opencode_inputs(str(valid_path))
-        # Find the position of opencode_bin in the input list and
-        # inject the invalid path before it.
-        opencode_idx = inputs_list.index(str(valid_path))
-        inputs_list.insert(opencode_idx, str(invalid_path))
-        inputs = iter(inputs_list)
-        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
-
-        _cmd_config()
-
-        env = json.loads((tmp_path / "install.conf").read_text())["env"]
-        # The persisted value is the valid path, NOT the invalid one
-        # the operator typed first. Confirms the validator loop did
-        # not accept the bad input.
-        assert env["OPENCODE_BIN"] == str(valid_path)
-
-    def test_wizard_uses_shutil_which_as_default_suggestion(self, tmp_path, monkeypatch):
-        """When no existing OPENCODE_BIN is in install.conf, the
-        wizard's prompt uses `shutil.which("opencode")` as the
-        default suggestion. Pinned via a capture-and-assert on the
-        `_prompt` call's `default` argument."""
-        opencode_path = tmp_path / "fake_opencode"
-        opencode_path.write_text("#!/bin/sh\necho hi\n")
-        opencode_path.chmod(0o755)
-        # Sentinel which `shutil.which` returns; the wizard should
-        # pass this value as the prompt default.
-        sentinel_which_value = "/sentinel/which/opencode"
-        # Make `shutil.which("opencode")` return the sentinel; leave
-        # other lookups untouched so the wizard's other PATH-based
-        # checks still work.
-        original_which = shutil.which
-
-        def _which(name):
-            if name == "opencode":
-                return sentinel_which_value
-            return original_which(name)
-
-        monkeypatch.setattr("kai.install.shutil.which", _which)
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
-        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
-        self._redirect_staging(monkeypatch, tmp_path)
-        monkeypatch.setattr(
-            "kai.install._prompt_default_model",
-            MagicMock(return_value="anthropic/claude-sonnet-4-5"),
-        )
-
-        # Capture every `_prompt` call so the test can verify the
-        # OpenCode binary prompt was offered the sentinel value as
-        # the default. The captured tuples are (label, default, ...).
-        captured: list[tuple] = []
-        from kai.install import _prompt as _real_prompt
-
-        def _capturing_prompt(label, default="", required=False, **kwargs):
-            captured.append((label, default, required))
-            # Return the typed value via the input iterator path so
-            # the rest of the wizard flow proceeds normally. Re-route
-            # by calling the real prompt, which uses input().
-            return _real_prompt(label, default=default, required=required, **kwargs)
-
-        monkeypatch.setattr("kai.install._prompt", _capturing_prompt)
-
-        inputs = iter(self._opencode_inputs(str(opencode_path)))
-        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
-
-        _cmd_config()
-
-        # Find the OpenCode binary path prompt in the captured list
-        # and assert its default value was the sentinel from
-        # `shutil.which("opencode")`. The exact label text matches
-        # what the spec specifies.
-        opencode_prompts = [c for c in captured if c[0] == "OpenCode binary path"]
-        assert opencode_prompts, "wizard did not prompt for OpenCode binary path"
-        _label, default, required = opencode_prompts[0]
-        assert default == sentinel_which_value
-        assert required is True
-
-    def test_memory_extraction_defense_in_depth_block_collects_opencode_bin(self, tmp_path, monkeypatch):
-        """Defense-in-depth: when `agent_backend == "opencode"` and the
-        memory-extraction block is reached without `opencode_bin`
-        having been collected (e.g., a future refactor moved the
-        memory-extraction prompt before the global-backend block),
-        the wizard re-prompts with a memory-reasoner-flavored label
-        rather than silently leaving install.conf without
-        `OPENCODE_BIN`.
-
-        The current wizard ordering makes this combination
-        unreachable in practice; the test simulates it by forcing
-        the global-opencode block's validator to accept an empty
-        string (which the operator types when the first prompt
-        appears), so the wizard exits that block with
-        `opencode_bin == ""`. The memory-extraction block's
-        `if agent_backend == "opencode" and not opencode_bin:` gate
-        fires, re-prompts, and the second value is what persists.
-        Pinned so a future refactor that exposes this code path is
-        covered by an existing test rather than discovered at
-        runtime.
-        """
-        valid_path = tmp_path / "fake_opencode"
-        valid_path.write_text("#!/bin/sh\necho hi\n")
-        valid_path.chmod(0o755)
-
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
-        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
-        self._redirect_staging(monkeypatch, tmp_path)
-        monkeypatch.setattr(
-            "kai.install._prompt_default_model",
-            MagicMock(return_value="anthropic/claude-sonnet-4-5"),
-        )
-
-        # Force the validator to accept the empty string the
-        # global-opencode block sees so the loop exits with
-        # opencode_bin == "" and the memory-extraction defense-in-
-        # depth gate fires. The real validator still rejects empty
-        # in production; this monkeypatch is what simulates the
-        # future-refactor failure mode the defense-in-depth block
-        # guards against.
-        monkeypatch.setattr("kai.install._validate_opencode_bin", lambda p: True)
-
-        # Stub `_prompt` so the global-opencode label returns empty
-        # (bypassing `_prompt`'s required-field re-prompt loop) and
-        # the defense-in-depth label returns the valid path. Every
-        # other prompt label passes through to the real `_prompt`
-        # so the rest of the wizard flow consumes the input
-        # iterator normally. This is the precision the test needs:
-        # forcing opencode_bin to "" after the global block without
-        # changing the wizard's other prompts.
-        captured: list[tuple] = []
-        from kai.install import _prompt as _real_prompt
-
-        def _stub_prompt(label, default="", required=False, **kwargs):
-            captured.append((label, default, required))
-            if label == "OpenCode binary path":
-                return ""
-            if label == "OpenCode binary path (required by opencode memory reasoner)":
-                return str(valid_path)
-            return _real_prompt(label, default=default, required=required, **kwargs)
-
-        monkeypatch.setattr("kai.install._prompt", _stub_prompt)
-
-        # The stubbed _prompt for "OpenCode binary path" does not
-        # call input(), so the slot in _opencode_inputs for that
-        # prompt is unused. Drop it so the subsequent timeout
-        # prompt does not consume the placeholder path as its
-        # integer input.
-        inputs_list = self._opencode_inputs(str(valid_path))
-        inputs_list.remove(str(valid_path))
-        inputs = iter(inputs_list)
-        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
-
-        _cmd_config()
-
-        # Both labels appear in the captured prompts: the global-
-        # opencode one (no memory-reasoner suffix) and the defense-
-        # in-depth one (with the suffix).
-        labels = [c[0] for c in captured]
-        assert "OpenCode binary path" in labels
-        assert "OpenCode binary path (required by opencode memory reasoner)" in labels
-
-        # install.conf carries the value from the second prompt
-        # (the defense-in-depth block's collection), which is the
-        # valid path. The empty value from the first prompt is
-        # overwritten when the defense-in-depth block re-assigns
-        # opencode_bin.
-        env = json.loads((tmp_path / "install.conf").read_text())["env"]
-        assert env["OPENCODE_BIN"] == str(valid_path)
-
-    def test_wizard_re_run_preserves_existing_opencode_bin(self, tmp_path, monkeypatch):
-        """A re-run of `make config` with an existing OPENCODE_BIN
-        in install.conf uses the existing value as the default
-        suggestion, NOT the PATH-derived value. Mirrors the codex
-        re-run preservation pattern: `existing_env.get("OPENCODE_BIN",
-        which_opencode)` reads from the already-persisted value
-        first."""
-        opencode_path = tmp_path / "fake_opencode"
-        opencode_path.write_text("#!/bin/sh\necho hi\n")
-        opencode_path.chmod(0o755)
-        prior_path = tmp_path / "prior_opencode"
-        prior_path.write_text("#!/bin/sh\necho prior\n")
-        prior_path.chmod(0o755)
-
-        # Pre-populate install.conf with an existing OPENCODE_BIN
-        # value so the wizard's re-run branch fires.
-        prior_conf = {
-            "install_dir": "/opt/kai",
-            "data_dir": "/var/lib/kai",
-            "service_user": "kai",
-            "platform": "darwin",
-            "env": {
-                "OPENCODE_BIN": str(prior_path),
-                "TELEGRAM_BOT_TOKEN": "fake-token",
-            },
-        }
-        (tmp_path / "install.conf").write_text(json.dumps(prior_conf))
-
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
-        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
-        self._redirect_staging(monkeypatch, tmp_path)
-        monkeypatch.setattr(
-            "kai.install._prompt_default_model",
-            MagicMock(return_value="anthropic/claude-sonnet-4-5"),
-        )
-
-        captured: list[tuple] = []
-        from kai.install import _prompt as _real_prompt
-
-        def _capturing_prompt(label, default="", required=False, **kwargs):
-            captured.append((label, default, required))
-            return _real_prompt(label, default=default, required=required, **kwargs)
-
-        monkeypatch.setattr("kai.install._prompt", _capturing_prompt)
-
-        inputs = iter(self._opencode_inputs(str(opencode_path)))
-        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
-
-        _cmd_config()
-
-        # The OpenCode binary prompt's default came from the
-        # pre-populated env, not from shutil.which.
-        opencode_prompts = [c for c in captured if c[0] == "OpenCode binary path"]
-        assert opencode_prompts, "wizard did not prompt for OpenCode binary path"
-        _, default, _ = opencode_prompts[0]
-        assert default == str(prior_path)
+        assert "OPENCODE_BIN" not in env
 
     def test_memory_extraction_enabled_persists_for_opencode_install(self, tmp_path, monkeypatch):
         """An opencode operator who answers `true` to the memory
@@ -10072,14 +9877,14 @@ class TestOpenCodeBinWizardPrompt:
         into install.conf, giving the cleanup gate's matching `.pop`
         sites real keys to (not) strip.
         """
-        opencode_path = tmp_path / "fake_opencode"
-        opencode_path.write_text("#!/bin/sh\necho hi\n")
-        opencode_path.chmod(0o755)
-
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._redirect_staging(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "kai.install._backend_choices_for_config",
+            lambda service_user: ["opencode"],
+        )
         monkeypatch.setattr(
             "kai.install._prompt_default_model",
             MagicMock(return_value="anthropic/claude-sonnet-4-5"),
@@ -10091,7 +9896,7 @@ class TestOpenCodeBinWizardPrompt:
         # cleanup gate has matching keys to (not) strip. The "120"
         # value appears twice (agent timeout, then episode timeout);
         # take the second occurrence for the episode-timeout slot.
-        inputs_list = self._opencode_inputs(str(opencode_path))
+        inputs_list = self._opencode_inputs()
         inputs_list[inputs_list.index("10")] = "20"  # MEMORY_EXTRACTION_TIMEOUT_S
         first_120 = inputs_list.index("120")
         inputs_list[inputs_list.index("120", first_120 + 1)] = "180"  # MEMORY_EPISODE_TIMEOUT_S
@@ -10114,6 +9919,7 @@ class TestOpenCodeBinWizardPrompt:
         # operator chose values different from the dataclass defaults.
         assert env["MEMORY_EXTRACTION_TIMEOUT_S"] == "20"
         assert env["MEMORY_EPISODE_TIMEOUT_S"] == "180"
+        assert "OPENCODE_BIN" not in env
 
 
 class TestGenerateSudoersCodexBinArg:
@@ -10549,6 +10355,10 @@ class TestWizardPerUserGooseProviderKeys:
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(
+            "kai.install._backend_choices_for_config",
+            lambda service_user: ["claude", "codex", "goose", "opencode"],
+        )
         TestCmdConfig._simulate_existing_etc_users_yaml(monkeypatch, users_yaml)
         monkeypatch.setattr(
             "kai.install._prompt_default_model",
@@ -10574,19 +10384,16 @@ class TestWizardPerUserGooseProviderKeys:
 
     def test_peruser_goose_entry_prompts_for_key(self, tmp_path, monkeypatch, capsys):
         """Global claude install with a per-user goose+deepseek entry:
-        the wizard prompts for DEEPSEEK_API_KEY and then the goose
-        binary path (both inserted right after the global claude-
-        binary slot in the input chain) and emits both to env."""
+        the wizard prompts for DEEPSEEK_API_KEY but does not collect a
+        goose binary path; backend commands come from the registry."""
         self._setup(monkeypatch, tmp_path, self.GOOSE_DEEPSEEK_USERS_YAML)
-        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
         inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
-        i = inputs.index("/usr/bin/true")
-        inputs = inputs[: i + 1] + ["sk-ds-peruser", "/opt/homebrew/bin/goose"] + inputs[i + 1 :]
+        inputs.insert(inputs.index("claude") + 1, "sk-ds-peruser")
 
         env = self._run(monkeypatch, tmp_path, inputs)
 
         assert env["DEEPSEEK_API_KEY"] == "sk-ds-peruser"
-        assert env["GOOSE_BIN"] == "/opt/homebrew/bin/goose"
+        assert "GOOSE_BIN" not in env
         out = capsys.readouterr().out
         assert "goose entry on deepseek" in out
         assert "DEEPSEEK_API_KEY" in out
@@ -10715,12 +10522,8 @@ class TestUsersYamlAgentBackends:
         assert _users_yaml_agent_backends(p) == set()
 
 
-class TestWizardPerUserBackendBinaries:
-    """Wizard collection of agent binary paths when per-user entries
-    use a backend other than the global one. Mirrors the provider-key
-    collection: scan users.yaml, prompt only for binaries the global
-    blocks did not already collect, flow into the existing
-    persistence variables."""
+class TestWizardPerUserBackendsUseRegistry:
+    """Per-user backend entries do not authorize config-time binary paths."""
 
     CODEX_USERS_YAML = (
         "users:\n"
@@ -10731,15 +10534,6 @@ class TestWizardPerUserBackendBinaries:
         "    name: bob\n"
         "    backend: codex\n"
     )
-    CLAUDE_USERS_YAML = (
-        "users:\n"
-        "  - telegram_id: 1\n"
-        "    name: alice\n"
-        "    role: admin\n"
-        "  - telegram_id: 2\n"
-        "    name: bob\n"
-        "    backend: claude\n"
-    )
     PLAIN_USERS_YAML = "users:\n  - telegram_id: 1\n    name: alice\n    role: admin\n"
 
     @staticmethod
@@ -10747,6 +10541,10 @@ class TestWizardPerUserBackendBinaries:
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(
+            "kai.install._backend_choices_for_config",
+            lambda service_user: ["claude", "codex", "goose", "opencode"],
+        )
         TestCmdConfig._simulate_existing_etc_users_yaml(monkeypatch, users_yaml)
         monkeypatch.setattr(
             "kai.install._prompt_default_model",
@@ -10762,52 +10560,21 @@ class TestWizardPerUserBackendBinaries:
         _cmd_config()
         return json.loads((tmp_path / "install.conf").read_text())["env"]
 
-    def test_peruser_codex_entry_prompts_for_binary(self, tmp_path, monkeypatch, capsys):
-        """Global claude install with a per-user codex entry: the
-        wizard prompts for the codex binary path and CODEX_BIN lands
-        in env, so the fail-closed extraction gate can resolve codex
-        at startup. This is the incident shape: per-user codex on a
-        non-codex global install previously had no collection path
-        and the daemon exited at boot."""
+    def test_peruser_codex_entry_does_not_prompt_for_binary(self, tmp_path, monkeypatch):
         self._setup(monkeypatch, tmp_path, self.CODEX_USERS_YAML)
-        monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
         inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
-        i = inputs.index("/usr/bin/true")
-        inputs = inputs[: i + 1] + ["/per-user/npm/bin/codex"] + inputs[i + 1 :]
 
         env = self._run(monkeypatch, tmp_path, inputs)
 
-        assert env["CODEX_BIN"] == "/per-user/npm/bin/codex"
-        assert "codex entry" in capsys.readouterr().out
-
-    def test_peruser_claude_entry_prompts_for_binary(self, tmp_path, monkeypatch, capsys):
-        """Global goose install with a per-user claude entry: the
-        wizard prompts for the claude binary path and CLAUDE_BIN
-        lands in env, the same collection contract the other three
-        backends follow. The answer is a real executable so the
-        unstubbed _validate_claude_bin passes on any runner."""
-        self._setup(monkeypatch, tmp_path, self.CLAUDE_USERS_YAML)
-        monkeypatch.setattr("kai.install._validate_goose_bin", lambda p: bool(p))
-        inputs = list(TestCmdConfigDefaultModelDispatch._inputs_for_goose_openai())
-        i = inputs.index("openai-key")
-        inputs = inputs[: i + 1] + ["/usr/bin/true"] + inputs[i + 1 :]
-
-        env = self._run(monkeypatch, tmp_path, inputs)
-
-        assert env["CLAUDE_BIN"] == "/usr/bin/true"
-        assert "claude entry" in capsys.readouterr().out
+        assert "CODEX_BIN" not in env
 
     def test_global_codex_does_not_reprompt(self, tmp_path, monkeypatch):
-        """Global codex install with a per-user codex entry: the
-        global block already collected codex_bin, so the per-user
-        block must not prompt again (the unmodified codex chain is
-        consumed exactly)."""
         self._setup(monkeypatch, tmp_path, self.CODEX_USERS_YAML)
-        monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
 
         env = self._run(monkeypatch, tmp_path, TestCmdConfigDefaultModelDispatch._inputs_for_codex_subscription())
 
-        assert env["CODEX_BIN"] == "/usr/local/bin/codex"
+        assert env["DEFAULT_BACKEND"] == "codex"
+        assert "CODEX_BIN" not in env
 
     def test_plain_users_yaml_no_binary_prompt(self, tmp_path, monkeypatch):
         """No per-user backend entries: the unmodified claude chain is
@@ -10821,26 +10588,20 @@ class TestWizardPerUserBackendBinaries:
         assert "OPENCODE_BIN" not in env
 
     def test_stored_binary_offered_as_default(self, tmp_path, monkeypatch):
-        """Re-run with a stored CODEX_BIN: the prompt fires again for
-        the still-present codex entry and pressing Enter keeps the
-        stored path."""
+        """Re-run with a stored CODEX_BIN strips it on resave."""
         self._setup(
             monkeypatch,
             tmp_path,
             self.CODEX_USERS_YAML,
             existing_env={"TELEGRAM_BOT_TOKEN": "fake-token", "CODEX_BIN": "/stored/bin/codex"},
         )
-        monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
         inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
-        i = inputs.index("/usr/bin/true")
-        # Empty answer accepts the prompt default (the stored path).
-        inputs = inputs[: i + 1] + [""] + inputs[i + 1 :]
 
         env = self._run(monkeypatch, tmp_path, inputs)
 
-        assert env["CODEX_BIN"] == "/stored/bin/codex"
+        assert "CODEX_BIN" not in env
 
-    def test_mixed_case_codex_entry_still_prompts(self, tmp_path, monkeypatch):
+    def test_mixed_case_codex_entry_still_does_not_prompt(self, tmp_path, monkeypatch):
         """`backend: Codex` is valid at runtime (the loader
         lowercases before validation) and routes the user, so the
         scan must normalize the same way; a casing difference must
@@ -10856,20 +10617,13 @@ class TestWizardPerUserBackendBinaries:
             "    backend: Codex\n"
         )
         self._setup(monkeypatch, tmp_path, mixed_yaml)
-        monkeypatch.setattr("kai.install._validate_codex_bin", lambda p: bool(p))
         inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
-        i = inputs.index("/usr/bin/true")
-        inputs = inputs[: i + 1] + ["/per-user/npm/bin/codex"] + inputs[i + 1 :]
 
         env = self._run(monkeypatch, tmp_path, inputs)
 
-        assert env["CODEX_BIN"] == "/per-user/npm/bin/codex"
+        assert "CODEX_BIN" not in env
 
-    def test_peruser_opencode_entry_prompts_for_binary(self, tmp_path, monkeypatch, capsys):
-        """Global claude install with a per-user opencode entry: the
-        wizard prompts for the opencode binary path and OPENCODE_BIN
-        lands in env, completing the acceptance triple (codex, goose,
-        opencode) on the per-user scan."""
+    def test_peruser_opencode_entry_does_not_prompt_for_binary(self, tmp_path, monkeypatch):
         opencode_yaml = (
             "users:\n"
             "  - telegram_id: 1\n"
@@ -10880,12 +10634,8 @@ class TestWizardPerUserBackendBinaries:
             "    backend: opencode\n"
         )
         self._setup(monkeypatch, tmp_path, opencode_yaml)
-        monkeypatch.setattr("kai.install._validate_opencode_bin", lambda p: bool(p))
         inputs = TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend()
-        i = inputs.index("/usr/bin/true")
-        inputs = inputs[: i + 1] + ["/custom/bin/opencode"] + inputs[i + 1 :]
 
         env = self._run(monkeypatch, tmp_path, inputs)
 
-        assert env["OPENCODE_BIN"] == "/custom/bin/opencode"
-        assert "opencode entry" in capsys.readouterr().out
+        assert "OPENCODE_BIN" not in env


### PR DESCRIPTION
## Summary
- stop collecting backend binary paths in make config; install.conf no longer emits CLAUDE_BIN/CODEX_BIN/GOOSE_BIN/OPENCODE_BIN
- derive make config backend choices from the installed backend registry, falling back to installer discovery only when no registry exists yet
- generate /etc/kai/backends.yaml and sudoers command paths from the same discovered global backend commands, ignoring legacy install.conf/process-env path overrides during apply
- fail install when configured global/per-user backends are not installed globally

## Validation
- .venv/bin/python -m pytest tests/test_install.py -q -x
- .venv/bin/python -m pytest tests/test_backend_registry.py tests/test_config.py tests/test_protected_config.py tests/test_claude.py tests/test_codex.py tests/test_goose.py tests/test_opencode.py -q
- .venv/bin/python -m pytest -q