### PR TITLE
Make default backend resolution registry-driven

### DIFF
--- a/src/kai/backend_registry.py
+++ b/src/kai/backend_registry.py
@@ -205,7 +205,9 @@ def resolve_default_backend(configured_backend: str = "") -> str:
     if configured:
         if configured not in _BACKEND_ENV_VARS:
             valid = ", ".join(sorted(_BACKEND_ENV_VARS))
-            raise BackendRegistryError(f"configured default backend {configured!r} is not valid; valid backends: {valid}")
+            raise BackendRegistryError(
+                f"configured default backend {configured!r} is not valid; valid backends: {valid}"
+            )
         if registry is not None and configured not in registry:
             installed = ", ".join(sorted(registry)) or "<none>"
             raise BackendRegistryError(

--- a/src/kai/backend_registry.py
+++ b/src/kai/backend_registry.py
@@ -166,6 +166,68 @@ def load_backend_registry(path: Path | None = None) -> dict[str, BackendRegistry
     return entries
 
 
+def load_backend_registry_default_backend(path: Path | None = None) -> str:
+    """Return the registry's configured default backend, if present."""
+    entries = load_backend_registry(path)
+    registry_path = path or backend_registry_path()
+    try:
+        raw = yaml.safe_load(registry_path.read_text()) or {}
+    except OSError as e:
+        raise BackendRegistryError(f"could not read backend registry {registry_path}: {e}") from e
+    except yaml.YAMLError as e:
+        raise BackendRegistryError(f"backend registry {registry_path} is not valid YAML: {e}") from e
+    if not isinstance(raw, dict):
+        raise BackendRegistryError(f"backend registry {registry_path}: expected a YAML mapping")
+    default_backend = str(raw.get("default_backend") or "").strip().lower()
+    if not default_backend:
+        return ""
+    if default_backend not in entries:
+        raise BackendRegistryError(
+            f"backend registry {registry_path}: default_backend {default_backend!r} has no backend entry"
+        )
+    return default_backend
+
+
+def resolve_default_backend(configured_backend: str = "") -> str:
+    """
+    Resolve the effective default backend without provider-specific fallback.
+
+    A configured backend wins, but installed/explicit-registry mode also
+    requires it to exist in the backend registry. If no backend is
+    configured, an authoritative registry may select one via
+    `default_backend`, or by containing exactly one backend entry.
+    """
+    configured = configured_backend.strip().lower()
+    registry: dict[str, BackendRegistryEntry] | None = None
+    if backend_registry_is_authoritative():
+        registry = load_backend_registry()
+
+    if configured:
+        if configured not in _BACKEND_ENV_VARS:
+            valid = ", ".join(sorted(_BACKEND_ENV_VARS))
+            raise BackendRegistryError(f"configured default backend {configured!r} is not valid; valid backends: {valid}")
+        if registry is not None and configured not in registry:
+            installed = ", ".join(sorted(registry)) or "<none>"
+            raise BackendRegistryError(
+                f"configured default backend {configured!r} is not installed; installed backends: {installed}"
+            )
+        return configured
+
+    if registry is not None:
+        registry_default = load_backend_registry_default_backend()
+        if registry_default:
+            return registry_default
+        if len(registry) == 1:
+            return next(iter(registry))
+        installed = ", ".join(sorted(registry)) or "<none>"
+        raise BackendRegistryError(
+            "DEFAULT_BACKEND is not set and backend registry does not define default_backend; "
+            f"installed backends: {installed}"
+        )
+
+    raise BackendRegistryError("DEFAULT_BACKEND is not set and no backend registry is available")
+
+
 def _validate_absolute_executable(backend: str, command: str, source: str) -> str:
     path = Path(command)
     if not path.is_absolute():
@@ -223,7 +285,16 @@ def resolve_backend_command(backend: str, *, allow_bare_fallback: bool = False) 
     return _legacy_env_or_path_command(backend, allow_bare_fallback=allow_bare_fallback)
 
 
-def render_backend_registry(entries: dict[str, dict[str, Any]]) -> str:
+def render_backend_registry(entries: dict[str, dict[str, Any]], *, default_backend: str = "") -> str:
     """Render backend registry YAML with stable ordering."""
-    ordered = {"version": 1, "backends": {key: entries[key] for key in sorted(entries)}}
+    ordered: dict[str, Any] = {"version": 1}
+    normalized_default = default_backend.strip().lower()
+    if normalized_default:
+        if normalized_default not in entries:
+            raise BackendRegistryError(
+                f"default_backend {normalized_default!r} has no backend entry; "
+                f"available backends: {', '.join(sorted(entries))}"
+            )
+        ordered["default_backend"] = normalized_default
+    ordered["backends"] = {key: entries[key] for key in sorted(entries)}
     return yaml.safe_dump(ordered, sort_keys=False)

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -26,7 +26,12 @@ from pathlib import Path
 import yaml
 from dotenv import load_dotenv
 
-from kai.backend_registry import BackendRegistryError, backend_registry_is_authoritative, load_backend_registry
+from kai.backend_registry import (
+    BackendRegistryError,
+    backend_registry_is_authoritative,
+    load_backend_registry,
+    resolve_default_backend,
+)
 from kai.protected_config import ProtectedConfigError, validate_protected_file_metadata
 from kai.user_isolation import validate_protected_user_isolation
 
@@ -832,12 +837,13 @@ def _resolve_renamed_key(
     them still resolves.
 
     Absence semantics differ by caller and are made explicit through
-    `default`: global readers pass `default="claude"` (the
-    installation default); the per-user yaml reader passes
-    `default=None` so a backend-less user still inherits the global
-    backend via the caller's `user_backend or global_backend` cascade.
-    Returning "claude" for an absent per-user key would wrongly pin
-    that user to claude on a non-claude install.
+    `default`: global backend readers pass an empty default and then
+    resolve through the installed backend registry; the per-user yaml
+    reader passes `default=None` so a backend-less user still inherits
+    the global backend via the caller's `user_backend or global_backend`
+    cascade. Returning a concrete backend for an absent per-user key
+    would wrongly pin that user to a backend instead of preserving
+    inheritance.
 
     Args:
         get: Lookup callable taking a key and returning value-or-None
@@ -1430,9 +1436,10 @@ class Config:
     totp_lockout_attempts: int = 3
     totp_lockout_minutes: int = 15
 
-    # Default backend selection: "claude" (default) uses Claude Code CLI,
-    # "goose" uses Goose ACP (Agent Client Protocol) as the agent harness.
-    default_backend: str = "claude"
+    # Default backend selection. Production config is resolved by
+    # load_config(); direct test/helper construction should set this
+    # explicitly when backend-specific behavior is under test.
+    default_backend: str = ""
 
     # LLM provider for non-Claude backends (e.g. Goose). Determines
     # which API key env var the backend expects and whether Kai's
@@ -3070,23 +3077,19 @@ def load_config() -> Config:
     except ValueError:
         raise SystemExit("TOTP_LOCKOUT_MINUTES must be an integer") from None
 
-    # Default backend selection - "claude" (default) or "goose".
-    # DEFAULT_BACKEND with a one-release fallback to the deprecated
-    # AGENT_BACKEND name; absence means the installation default "claude".
-    default_backend = (
-        (
-            _resolve_renamed_key(
-                os.environ.get,
-                new_key="DEFAULT_BACKEND",
-                legacy_keys=["AGENT_BACKEND"],
-                context="/etc/kai/env",
-                default="claude",
-            )
-            or "claude"
-        )
-        .strip()
-        .lower()
+    # Default backend selection. The value must be explicitly
+    # configured or derived from the installed backend registry.
+    default_backend_raw = _resolve_renamed_key(
+        os.environ.get,
+        new_key="DEFAULT_BACKEND",
+        legacy_keys=["AGENT_BACKEND"],
+        context="/etc/kai/env",
+        default="",
     )
+    try:
+        default_backend = resolve_default_backend(default_backend_raw or "")
+    except BackendRegistryError as exc:
+        raise SystemExit(str(exc)) from None
     if default_backend not in VALID_BACKENDS:
         raise SystemExit(
             f"DEFAULT_BACKEND '{default_backend}' is not valid (must be one of: {', '.join(sorted(VALID_BACKENDS))})"

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2827,15 +2827,19 @@ def _build_codex_login_reminder(
     are no longer read.
     """
     default_backend = (
-        _resolve_renamed_key(
-            env.get,
-            new_key="DEFAULT_BACKEND",
-            legacy_keys=["AGENT_BACKEND"],
-            context="install.conf",
-            default="",
+        (
+            _resolve_renamed_key(
+                env.get,
+                new_key="DEFAULT_BACKEND",
+                legacy_keys=["AGENT_BACKEND"],
+                context="install.conf",
+                default="",
+            )
+            or ""
         )
-        or ""
-    ).strip().lower()
+        .strip()
+        .lower()
+    )
     if default_backend != "codex":
         return None
     if env.get("CODEX_AUTH_MODE", "subscription") != "subscription":
@@ -5689,15 +5693,19 @@ def _configured_install_backends(
 def _resolve_install_default_backend(env: dict[str, str], discovered: dict[str, str] | None = None) -> str:
     """Resolve install-time default backend without provider-specific fallback."""
     configured = (
-        _resolve_renamed_key(
-            env.get,
-            new_key="DEFAULT_BACKEND",
-            legacy_keys=["AGENT_BACKEND"],
-            context="install.conf",
-            default="",
+        (
+            _resolve_renamed_key(
+                env.get,
+                new_key="DEFAULT_BACKEND",
+                legacy_keys=["AGENT_BACKEND"],
+                context="install.conf",
+                default="",
+            )
+            or ""
         )
-        or ""
-    ).strip().lower()
+        .strip()
+        .lower()
+    )
     if configured:
         if configured not in VALID_BACKENDS:
             raise SystemExit(
@@ -5710,8 +5718,7 @@ def _resolve_install_default_backend(env: dict[str, str], discovered: dict[str, 
         return next(iter(installed))
     installed_label = ", ".join(sorted(installed)) or "<none>"
     raise SystemExit(
-        "DEFAULT_BACKEND is not set. Re-run `make config` and choose one of the installed backends: "
-        f"{installed_label}."
+        f"DEFAULT_BACKEND is not set. Re-run `make config` and choose one of the installed backends: {installed_label}."
     )
 
 
@@ -5726,7 +5733,9 @@ def _backend_registry_entries(
         )
 
     default_backend = _resolve_install_default_backend(env, discovered)
-    missing = sorted(_configured_install_backends(env, users_yaml_path, default_backend=default_backend) - discovered.keys())
+    missing = sorted(
+        _configured_install_backends(env, users_yaml_path, default_backend=default_backend) - discovered.keys()
+    )
     if missing:
         raise SystemExit(
             "Configured backend(s) are not installed globally: "

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -39,7 +39,7 @@ from pathlib import Path
 
 import yaml
 
-from kai.backend_registry import render_backend_registry
+from kai.backend_registry import BackendRegistryError, render_backend_registry
 from kai.config import (
     _VALID_ROLES,
     BACKEND_PROVIDERS,
@@ -1324,19 +1324,30 @@ def _cmd_config() -> None:
         )
     # Prefill reads DEFAULT_BACKEND, falling back to the deprecated
     # AGENT_BACKEND key so a re-run against a legacy install.conf keeps
-    # the operator's prior choice; the wizard writes DEFAULT_BACKEND only.
-    agent_backend = _prompt_choice(
-        "Default backend",
-        backend_choices,
+    # the operator's prior choice. Without an existing value, a
+    # single-backend install can accept Enter; multi-backend installs
+    # must choose explicitly.
+    existing_backend = (
         _resolve_renamed_key(
             existing_env.get,
             new_key="DEFAULT_BACKEND",
             legacy_keys=["AGENT_BACKEND"],
             context="install.conf",
-            default="claude",
+            default="",
         )
-        or "claude",
+        or ""
     )
+    backend_prefill = existing_backend or (backend_choices[0] if len(backend_choices) == 1 else "")
+    while True:
+        agent_backend = _prompt_optional_choice(
+            "Default backend",
+            backend_choices,
+            backend_prefill,
+            empty_hint="choose one",
+        )
+        if agent_backend:
+            break
+        print("  Default backend is required.")
 
     # Codex auth handling runs BEFORE the legacy provider/key block so
     # subscription mode is not gated on an OPENAI_API_KEY the operator
@@ -2039,12 +2050,9 @@ def _cmd_config() -> None:
         env["WEBHOOK_SECRET"] = legacy_webhook_secret
 
     # DEFAULT_BACKEND is the global default backend; users.yaml entries
-    # can override it per user. Only write non-default values to keep
-    # the env file clean (the runtime defaults to claude when the key
-    # is absent). The wizard writes the new name only; the runtime keeps
-    # a one-release read fallback for a legacy AGENT_BACKEND key.
-    if agent_backend != "claude":
-        env["DEFAULT_BACKEND"] = agent_backend
+    # can override it per user. The wizard writes the selected backend
+    # explicitly; absence is not a backend-selection signal.
+    env["DEFAULT_BACKEND"] = agent_backend
 
     # LLM provider and API key. Written alongside the backend choice
     # so they survive into /etc/kai/env and are not wiped on reinstall.
@@ -2820,10 +2828,14 @@ def _build_codex_login_reminder(
     """
     default_backend = (
         _resolve_renamed_key(
-            env.get, new_key="DEFAULT_BACKEND", legacy_keys=["AGENT_BACKEND"], context="install.conf", default="claude"
+            env.get,
+            new_key="DEFAULT_BACKEND",
+            legacy_keys=["AGENT_BACKEND"],
+            context="install.conf",
+            default="",
         )
-        or "claude"
-    )
+        or ""
+    ).strip().lower()
     if default_backend != "codex":
         return None
     if env.get("CODEX_AUTH_MODE", "subscription") != "subscription":
@@ -4333,16 +4345,10 @@ def _cmd_apply() -> None:
     # key was already migrated to DEFAULT_BACKEND at the top of apply.
     #
     default_model_raw = env.get("DEFAULT_MODEL", "")
-    agent_backend_raw = env.get("DEFAULT_BACKEND", "claude").strip().lower()
-    # Write the normalized value back so the downstream goose-config and
-    # sudoers gates (which read env.get("DEFAULT_BACKEND") raw) and the
-    # written /etc/kai/env all see the canonical lowercase form. Only
-    # when the key is present, to preserve the "claude omits the key"
-    # contract. Without this, a hand-edited install.conf with
-    # DEFAULT_BACKEND="Goose" passes validation here but skips goose
-    # config deployment below.
-    if "DEFAULT_BACKEND" in env:
-        env["DEFAULT_BACKEND"] = agent_backend_raw
+    agent_backend_raw = _resolve_install_default_backend(env, _discover_backend_commands(service_user))
+    # Write the normalized value back so downstream gates and the
+    # written /etc/kai/env all see the canonical lowercase form.
+    env["DEFAULT_BACKEND"] = agent_backend_raw
     # Reads the canonical DEFAULT_PROVIDER; a legacy LLM_PROVIDER key was
     # already migrated to it at the top of apply.
     provider_raw = env.get("DEFAULT_PROVIDER", "").strip().lower()
@@ -4500,7 +4506,7 @@ def _cmd_apply() -> None:
         # The function gates itself: global DEFAULT_BACKEND=goose or a
         # per-user backend override in users.yaml both mean some
         # session spawns `goose acp`; otherwise it no-ops.
-        agent_backend = env.get("DEFAULT_BACKEND", "claude")
+        agent_backend = _resolve_install_default_backend(env)
         _apply_goose_config(
             service_user,
             install_path,
@@ -5668,11 +5674,45 @@ def _apply_secrets(
         print(f"  Copied {yaml_dst}")
 
 
-def _configured_install_backends(env: dict[str, str], users_yaml_path: str | Path | None = None) -> set[str]:
+def _configured_install_backends(
+    env: dict[str, str],
+    users_yaml_path: str | Path | None = None,
+    *,
+    default_backend: str | None = None,
+) -> set[str]:
     """Return backend IDs used by global config or users.yaml overrides."""
-    configured = {env.get("DEFAULT_BACKEND", "claude").strip().lower() or "claude"}
+    configured = {default_backend or _resolve_install_default_backend(env)}
     configured |= _collect_backends_from_yaml(users_yaml_path or USERS_YAML)
     return configured & VALID_BACKENDS
+
+
+def _resolve_install_default_backend(env: dict[str, str], discovered: dict[str, str] | None = None) -> str:
+    """Resolve install-time default backend without provider-specific fallback."""
+    configured = (
+        _resolve_renamed_key(
+            env.get,
+            new_key="DEFAULT_BACKEND",
+            legacy_keys=["AGENT_BACKEND"],
+            context="install.conf",
+            default="",
+        )
+        or ""
+    ).strip().lower()
+    if configured:
+        if configured not in VALID_BACKENDS:
+            raise SystemExit(
+                f"DEFAULT_BACKEND '{configured}' is not valid (must be one of: {', '.join(sorted(VALID_BACKENDS))})"
+            )
+        return configured
+
+    installed = discovered if discovered is not None else _discover_backend_commands("kai")
+    if len(installed) == 1:
+        return next(iter(installed))
+    installed_label = ", ".join(sorted(installed)) or "<none>"
+    raise SystemExit(
+        "DEFAULT_BACKEND is not set. Re-run `make config` and choose one of the installed backends: "
+        f"{installed_label}."
+    )
 
 
 def _backend_registry_entries(
@@ -5685,7 +5725,8 @@ def _backend_registry_entries(
             "No supported backend command was found. Install at least one of: claude, codex, goose, opencode."
         )
 
-    missing = sorted(_configured_install_backends(env, users_yaml_path) - discovered.keys())
+    default_backend = _resolve_install_default_backend(env, discovered)
+    missing = sorted(_configured_install_backends(env, users_yaml_path, default_backend=default_backend) - discovered.keys())
     if missing:
         raise SystemExit(
             "Configured backend(s) are not installed globally: "
@@ -5725,7 +5766,12 @@ def _backend_registry_entries(
 
 def _build_backend_registry(service_user: str, env: dict[str, str], users_yaml_path: str | Path | None = None) -> str:
     """Build the installed backend registry from discovered global commands."""
-    return render_backend_registry(_backend_registry_entries(service_user, env, users_yaml_path))
+    entries = _backend_registry_entries(service_user, env, users_yaml_path)
+    default_backend = _resolve_install_default_backend(env, {backend: "" for backend in entries})
+    try:
+        return render_backend_registry(entries, default_backend=default_backend)
+    except BackendRegistryError as exc:
+        raise SystemExit(str(exc)) from None
 
 
 def _apply_backend_registry(service_user: str, env: dict[str, str], dry_run: bool) -> None:
@@ -5747,7 +5793,7 @@ def _apply_goose_config(
     svc_gid: int,
     dry_run: bool,
     users_yaml_path: str | Path | None = None,
-    agent_backend: str = "claude",
+    agent_backend: str = "",
 ) -> None:
     """
     Deploy the Goose extension config to every home goose runs from.
@@ -5767,7 +5813,8 @@ def _apply_goose_config(
     `_apply_sudoers`). No-ops when nothing in the install is
     goose-backed - neither the global backend nor any users.yaml
     override - so the apply pipeline can call it unconditionally and
-    a claude-only install is never blocked on the goose template.
+    an install without Goose users is never blocked on the goose
+    template.
     """
     # None resolves to the module-level USERS_YAML at call time rather
     # than in the signature: a def-time default would bake the
@@ -5870,7 +5917,7 @@ def _apply_sudoers(
     codex_bin: str | None = None,
     opencode_bin: str | None = None,
     goose_bin: str | None = None,
-    agent_backend: str = "claude",
+    agent_backend: str = "",
 ) -> None:
     """
     Write sudoers rules for the service user to read protected config.
@@ -5888,11 +5935,9 @@ def _apply_sudoers(
     for direct/dev formatter compatibility; `_cmd_apply` does not feed
     them from install.conf or process environment.
 
-    `agent_backend` is the install's global backend (the env dict's
-    DEFAULT_BACKEND, defaulting to claude when the key is absent, which
-    matches the runtime default). Together with the per-user
-    backend overrides in users.yaml it scopes the missing-binary
-    backstop below to backends the install actually uses.
+    `agent_backend` is the install's resolved global backend. Together
+    with the per-user backend overrides in users.yaml it scopes the
+    missing-binary backstop below to backends the install actually uses.
     """
     # None resolves to the module-level USERS_YAML at call time rather
     # than in the signature: a def-time default would bake the

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -10,7 +10,9 @@ from kai.backend_registry import (
     BackendRegistryError,
     backend_registry_is_authoritative,
     load_backend_registry,
+    load_backend_registry_default_backend,
     render_backend_registry,
+    resolve_default_backend,
     resolve_backend_command,
 )
 
@@ -318,3 +320,89 @@ def test_render_backend_registry_is_stable():
 
     assert list(data["backends"]) == ["claude", "codex"]
     assert data["version"] == 1
+
+
+def test_render_backend_registry_includes_valid_default_backend():
+    rendered = render_backend_registry(
+        {
+            "codex": {"driver": "codex", "runtime": "local_process", "command": "/usr/local/bin/codex"},
+            "goose": {"driver": "goose", "runtime": "local_process", "command": "/opt/homebrew/bin/goose"},
+        },
+        default_backend="codex",
+    )
+    data = yaml.safe_load(rendered)
+
+    assert data["default_backend"] == "codex"
+    assert list(data["backends"]) == ["codex", "goose"]
+
+
+def test_render_backend_registry_rejects_unknown_default_backend():
+    with pytest.raises(BackendRegistryError, match="default_backend 'opencode' has no backend entry"):
+        render_backend_registry(
+            {"codex": {"driver": "codex", "runtime": "local_process", "command": "/usr/local/bin/codex"}},
+            default_backend="opencode",
+        )
+
+
+def test_resolve_default_backend_uses_registry_default(tmp_path, monkeypatch):
+    codex = _exe(tmp_path / "codex")
+    goose = _exe(tmp_path / "goose")
+    registry = tmp_path / "backends.yaml"
+    registry.write_text(
+        render_backend_registry(
+            {
+                "codex": {"driver": "codex", "runtime": "local_process", "command": str(codex)},
+                "goose": {"driver": "goose", "runtime": "local_process", "command": str(goose)},
+            },
+            default_backend="goose",
+        )
+    )
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+    assert load_backend_registry_default_backend() == "goose"
+    assert resolve_default_backend("") == "goose"
+
+
+def test_resolve_default_backend_uses_sole_registry_backend(tmp_path, monkeypatch):
+    codex = _exe(tmp_path / "codex")
+    registry = tmp_path / "backends.yaml"
+    registry.write_text(
+        render_backend_registry(
+            {"codex": {"driver": "codex", "runtime": "local_process", "command": str(codex)}}
+        )
+    )
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+    assert resolve_default_backend("") == "codex"
+
+
+def test_resolve_default_backend_requires_selection_for_ambiguous_registry(tmp_path, monkeypatch):
+    codex = _exe(tmp_path / "codex")
+    goose = _exe(tmp_path / "goose")
+    registry = tmp_path / "backends.yaml"
+    registry.write_text(
+        render_backend_registry(
+            {
+                "codex": {"driver": "codex", "runtime": "local_process", "command": str(codex)},
+                "goose": {"driver": "goose", "runtime": "local_process", "command": str(goose)},
+            }
+        )
+    )
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+    with pytest.raises(BackendRegistryError, match="does not define default_backend"):
+        resolve_default_backend("")
+
+
+def test_resolve_default_backend_rejects_configured_backend_missing_from_registry(tmp_path, monkeypatch):
+    codex = _exe(tmp_path / "codex")
+    registry = tmp_path / "backends.yaml"
+    registry.write_text(
+        render_backend_registry(
+            {"codex": {"driver": "codex", "runtime": "local_process", "command": str(codex)}}
+        )
+    )
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+    with pytest.raises(BackendRegistryError, match="not installed"):
+        resolve_default_backend("goose")

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -12,8 +12,8 @@ from kai.backend_registry import (
     load_backend_registry,
     load_backend_registry_default_backend,
     render_backend_registry,
-    resolve_default_backend,
     resolve_backend_command,
+    resolve_default_backend,
 )
 
 
@@ -367,9 +367,7 @@ def test_resolve_default_backend_uses_sole_registry_backend(tmp_path, monkeypatc
     codex = _exe(tmp_path / "codex")
     registry = tmp_path / "backends.yaml"
     registry.write_text(
-        render_backend_registry(
-            {"codex": {"driver": "codex", "runtime": "local_process", "command": str(codex)}}
-        )
+        render_backend_registry({"codex": {"driver": "codex", "runtime": "local_process", "command": str(codex)}})
     )
     monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
 
@@ -398,9 +396,7 @@ def test_resolve_default_backend_rejects_configured_backend_missing_from_registr
     codex = _exe(tmp_path / "codex")
     registry = tmp_path / "backends.yaml"
     registry.write_text(
-        render_backend_registry(
-            {"codex": {"driver": "codex", "runtime": "local_process", "command": str(codex)}}
-        )
+        render_backend_registry({"codex": {"driver": "codex", "runtime": "local_process", "command": str(codex)}})
     )
     monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -644,6 +644,7 @@ def _make_config(**overrides) -> Config:
         "webhook_port": 8080,
         "tts_enabled": False,
         "voice_enabled": False,
+        "default_backend": "claude",
         "default_model": get_default_model_for_backend("claude", "anthropic"),
     }
     defaults.update(overrides)
@@ -3491,8 +3492,8 @@ class TestHandleResponse:
         # contract under test is the outer gate plus the inner config
         # branch, neither of which depends on prior_pairs being
         # non-empty. memory_extraction_enabled=True so the inner gate
-        # passes; default_backend defaults to "claude" so the backend
-        # check passes too.
+        # passes; _make_config explicitly selects the Claude backend
+        # used by this test's mocked pool.
         config = _make_config(
             memory_extraction_enabled=True,
             episode_classifier_context_turns=0,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -88,6 +88,7 @@ _CONFIG_ENV_VARS = [
     "MEMORY_DUPLICATE_THRESHOLD",
     "KAI_DATA_DIR",
     "KAI_INSTALL_DIR",
+    "KAI_BACKENDS_YAML",
 ]
 
 
@@ -107,6 +108,7 @@ def _clean_env(monkeypatch):
     )
     for var in _CONFIG_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("DEFAULT_BACKEND", "claude")
 
 
 @pytest.fixture(autouse=True)
@@ -145,6 +147,7 @@ def _set_required(monkeypatch, token="fake-token", user_ids="123"):
     """
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", token)
     monkeypatch.setenv("ALLOWED_USER_IDS", user_ids)
+    monkeypatch.setenv("DEFAULT_BACKEND", "claude")
     # Build a minimal valid users.yaml from `user_ids` so the
     # mandatory-users contract is met. Names are auto-generated;
     # role=admin so the no-admin-warning does not fire.
@@ -228,7 +231,7 @@ class TestLoadConfigDefaults:
         assert config.workspace_base is None
         # Autocompact tuning defaults to 0 (use Claude Code default)
         assert config.claude_autocompact_pct == 0
-        # Agent backend default
+        # Agent backend from explicit test config
         assert config.default_backend == "claude"
 
     def test_autocompact_from_env(self, monkeypatch):
@@ -323,7 +326,7 @@ class TestLoadConfigErrors:
         """DEFAULT_BACKEND with an unrecognized value raises SystemExit."""
         _set_required(monkeypatch)
         monkeypatch.setenv("DEFAULT_BACKEND", "invalid")
-        with pytest.raises(SystemExit, match="DEFAULT_BACKEND"):
+        with pytest.raises(SystemExit, match="default backend"):
             load_config()
 
     def test_invalid_provider(self, monkeypatch):
@@ -3036,8 +3039,55 @@ class TestDefaultBackendEnvResolution:
 
     The global env reader prefers DEFAULT_BACKEND and falls back to the
     deprecated AGENT_BACKEND for one release with a one-shot warning.
-    Absence means the installation default "claude".
+    Absence is resolved from the installed backend registry.
     """
+
+    def test_default_backend_can_come_from_sole_registry_backend(self, monkeypatch, tmp_path):
+        """An installed registry with one backend is sufficient when
+        DEFAULT_BACKEND is unset."""
+        from kai.backend_registry import render_backend_registry
+
+        _set_required(monkeypatch)
+        monkeypatch.delenv("DEFAULT_BACKEND", raising=False)
+        codex = tmp_path / "codex"
+        codex.write_text("#!/bin/sh\nexit 0\n")
+        codex.chmod(0o755)
+        registry = tmp_path / "backends.yaml"
+        registry.write_text(
+            render_backend_registry(
+                {"codex": {"driver": "codex", "runtime": "local_process", "command": str(codex)}}
+            )
+        )
+        monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+        cfg = load_config()
+
+        assert cfg.default_backend == "codex"
+
+    def test_default_backend_requires_selection_with_multiple_registry_backends(self, monkeypatch, tmp_path):
+        """Multiple installed backends require an explicit default."""
+        from kai.backend_registry import render_backend_registry
+
+        _set_required(monkeypatch)
+        monkeypatch.delenv("DEFAULT_BACKEND", raising=False)
+        codex = tmp_path / "codex"
+        goose = tmp_path / "goose"
+        for exe in (codex, goose):
+            exe.write_text("#!/bin/sh\nexit 0\n")
+            exe.chmod(0o755)
+        registry = tmp_path / "backends.yaml"
+        registry.write_text(
+            render_backend_registry(
+                {
+                    "codex": {"driver": "codex", "runtime": "local_process", "command": str(codex)},
+                    "goose": {"driver": "goose", "runtime": "local_process", "command": str(goose)},
+                }
+            )
+        )
+        monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+        with pytest.raises(SystemExit, match="does not define default_backend"):
+            load_config()
 
     def test_default_backend_env_resolved(self, monkeypatch):
         """The new key sets the global backend with no deprecation noise."""
@@ -3241,6 +3291,7 @@ class TestDefaultTimeoutRename:
         base = {
             "TELEGRAM_BOT_TOKEN": "test-token",
             "ALLOWED_USER_IDS": "12345",
+            "DEFAULT_BACKEND": "claude",
             "DEFAULT_MODEL": "sonnet",
             "WEBHOOK_PORT": "8080",
             "GENERIC_WEBHOOK_SECRET": "test-secret",
@@ -3299,6 +3350,7 @@ class TestAgentSessionLifecycleRename:
         base = {
             "TELEGRAM_BOT_TOKEN": "test-token",
             "ALLOWED_USER_IDS": "12345",
+            "DEFAULT_BACKEND": "claude",
             "DEFAULT_MODEL": "sonnet",
             "WEBHOOK_PORT": "8080",
             "GENERIC_WEBHOOK_SECRET": "test-secret",
@@ -3765,6 +3817,7 @@ class TestLoadMemoryProjects:
             monkeypatch.delenv(v, raising=False)
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
         monkeypatch.setenv("ALLOWED_USER_IDS", "12345")
+        monkeypatch.setenv("DEFAULT_BACKEND", "claude")
         monkeypatch.setenv("GENERIC_WEBHOOK_SECRET", "test-secret")
         _patch_protected_users_yaml(
             monkeypatch,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3054,9 +3054,7 @@ class TestDefaultBackendEnvResolution:
         codex.chmod(0o755)
         registry = tmp_path / "backends.yaml"
         registry.write_text(
-            render_backend_registry(
-                {"codex": {"driver": "codex", "runtime": "local_process", "command": str(codex)}}
-            )
+            render_backend_registry({"codex": {"driver": "codex", "runtime": "local_process", "command": str(codex)}})
         )
         monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1455,8 +1455,8 @@ class TestCmdConfig:
         assert conf["env"]["CLAUDE_AUTOCOMPACT_PCT"] == "80"
         # ALLOWED_USER_IDS should not be in the env dict
         assert "ALLOWED_USER_IDS" not in conf["env"]
-        # Default backend should not appear in env (only non-default values)
-        assert "DEFAULT_BACKEND" not in conf["env"]
+        # Default backend is emitted explicitly.
+        assert conf["env"]["DEFAULT_BACKEND"] == "claude"
         # users.yaml should have been generated
         yaml_path = tmp_path / "users.yaml"
         assert yaml_path.exists()
@@ -1902,6 +1902,7 @@ class TestCmdConfig:
             "env": {
                 "TELEGRAM_BOT_TOKEN": "existing-token",
                 "WEBHOOK_SECRET": "existing-secret",
+                "DEFAULT_BACKEND": "claude",
             },
         }
         conf_path.write_text(json.dumps(existing))
@@ -1962,6 +1963,7 @@ class TestCmdConfig:
                 "WEBHOOK_SECRET": "legacy-secret",
                 "GITHUB_WEBHOOK_SECRET": "github-secret",
                 "GENERIC_WEBHOOK_SECRET": "generic-secret",
+                "DEFAULT_BACKEND": "claude",
             },
         }
         conf_path.write_text(json.dumps(existing))
@@ -2189,7 +2191,7 @@ class TestCmdConfig:
         assert "CLAUDE_EFFORT_LEVEL" not in env
         assert "CLAUDE_USER" not in env
 
-        # Sanity: DEFAULT_BACKEND was emitted (it always is for non-claude).
+        # Sanity: DEFAULT_BACKEND is emitted explicitly.
         assert env.get("DEFAULT_BACKEND") == "goose"
 
     def test_goose_backend_prunes_existing_claude_only_keys(self, tmp_path, monkeypatch):
@@ -2399,7 +2401,8 @@ class TestCmdConfig:
             "users:\n  - telegram_id: 999\n    name: existing\n    role: admin\n",
         )
 
-        # DEFAULT_BACKEND seeded explicitly so the extraction-keys cleanup (non-claude pops them) doesn't depend on the wizard's implicit default.
+        # DEFAULT_BACKEND seeded explicitly so the extraction-keys cleanup
+        # has a concrete backend selection.
         existing = {
             "version": 1,
             "install_dir": "/opt/kai",
@@ -2993,7 +2996,7 @@ class TestCmdApply:
                     "data_dir": str(tmp_path / "var" / "lib" / "kai"),
                     "service_user": "nobody",
                     "platform": "darwin",
-                    "env": {"TELEGRAM_BOT_TOKEN": "tok"},
+                    "env": {"TELEGRAM_BOT_TOKEN": "tok", "DEFAULT_BACKEND": "claude"},
                 }
             )
         )
@@ -3029,7 +3032,7 @@ class TestCmdApply:
                     "data_dir": str(tmp_path / "var" / "lib" / "kai"),
                     "service_user": "nobody",
                     "platform": "darwin",
-                    "env": {"TELEGRAM_BOT_TOKEN": "tok"},
+                    "env": {"TELEGRAM_BOT_TOKEN": "tok", "DEFAULT_BACKEND": "claude"},
                 }
             )
         )
@@ -3105,7 +3108,7 @@ class TestCmdApply:
                     "data_dir": str(tmp_path / "var" / "lib" / "kai"),
                     "service_user": "nobody",
                     "platform": "darwin",
-                    "env": {"TELEGRAM_BOT_TOKEN": "tok"},
+                    "env": {"TELEGRAM_BOT_TOKEN": "tok", "DEFAULT_BACKEND": "claude"},
                 }
             )
         )
@@ -3223,7 +3226,7 @@ class TestProtectedUserIsolationPreflight:
             "data_dir": str(tmp_path / "data"),
             "service_user": "kai-service",
             "platform": "darwin",
-            "env": {"TELEGRAM_BOT_TOKEN": "tok", "DEFAULT_MODEL": "sonnet"},
+            "env": {"TELEGRAM_BOT_TOKEN": "tok", "DEFAULT_BACKEND": "claude", "DEFAULT_MODEL": "sonnet"},
         }
         if staging is not None:
             conf["users_yaml_staging_path"] = str(staging)
@@ -3735,6 +3738,8 @@ class TestCmdApplyDefaultModelGate:
     @staticmethod
     def _write_install_conf(tmp_path, env: dict[str, str]) -> Path:
         """Write a minimal install.conf with the given env dict."""
+        if "DEFAULT_BACKEND" not in env and "AGENT_BACKEND" not in env:
+            env = {"DEFAULT_BACKEND": "claude", **env}
         kai.install.USERS_YAML.write_text(
             "users:\n  - telegram_id: 1\n    name: test\n    role: admin\n    os_user: root\n"
         )
@@ -7388,6 +7393,7 @@ class TestApplyBackendRegistry:
         rendered = kai.install._build_backend_registry(
             "kai",
             {
+                "DEFAULT_BACKEND": "codex",
                 "CLAUDE_BIN": "/custom/claude",
                 "CODEX_BIN": "/custom/codex",
                 "OPENCODE_BIN": "/custom/opencode",
@@ -7400,6 +7406,7 @@ class TestApplyBackendRegistry:
         assert data["backends"]["codex"]["command"] == "/global/codex"
         assert data["backends"]["opencode"]["command"] == "/global/opencode"
         assert data["backends"]["goose"]["command"] == "/global/goose"
+        assert data["default_backend"] == "codex"
         assert "gpt-5.6-sol" in data["backends"]["codex"]["allowed_models"]
         assert "fable" in data["backends"]["claude"]["allowed_models"]
         assert "claude-*" in data["backends"]["claude"]["allowed_models"]
@@ -7415,6 +7422,7 @@ class TestApplyBackendRegistry:
             },
         )
         env = {
+            "DEFAULT_BACKEND": "codex",
             "CLAUDE_BIN": "/ignored/claude",
             "CODEX_BIN": "/ignored/codex",
             "OPENCODE_BIN": "/ignored/opencode",
@@ -7611,7 +7619,7 @@ class TestStripInstallConfKeys:
             "version": 1,
             "install_dir": "/opt/kai",
             "users_yaml_staging_path": "/tmp/staged",
-            "env": {"TELEGRAM_BOT_TOKEN": "tok"},
+            "env": {"TELEGRAM_BOT_TOKEN": "tok", "DEFAULT_BACKEND": "claude"},
         }
         conf_path.write_text(json.dumps(original, indent=2) + "\n")
         os.chmod(conf_path, 0o600)
@@ -7623,7 +7631,7 @@ class TestStripInstallConfKeys:
         assert "users_yaml_staging_path" not in rewritten
         assert rewritten["version"] == 1
         assert rewritten["install_dir"] == "/opt/kai"
-        assert rewritten["env"] == {"TELEGRAM_BOT_TOKEN": "tok"}
+        assert rewritten["env"] == original["env"]
         assert stat.S_IMODE(conf_path.stat().st_mode) == 0o600
 
     def test_idempotent_when_key_absent(self, tmp_path, monkeypatch):
@@ -8508,7 +8516,7 @@ class TestCmdApplySingleUserRefuses:
             "data_dir": str(tmp_path),
             "service_user": "kai",
             "platform": "darwin",
-            "env": {"TELEGRAM_BOT_TOKEN": "tok"},
+            "env": {"TELEGRAM_BOT_TOKEN": "tok", "DEFAULT_BACKEND": "claude"},
         }
         path = tmp_path / "install.conf"
         path.write_text(json.dumps(conf, indent=2) + "\n")
@@ -8589,7 +8597,7 @@ class TestCmdApplySingleUserRefuses:
 class TestApplySudoersDryRun:
     def test_dry_run(self, capsys):
         """Dry run: prints expected messages."""
-        _apply_sudoers("kai", dry_run=True)
+        _apply_sudoers("kai", dry_run=True, agent_backend="claude")
         output = capsys.readouterr().out
         assert "DRY RUN" in output
         assert "sudoers" in output.lower() or "visudo" in output.lower()
@@ -8607,7 +8615,7 @@ class TestApplySudoersDryRun:
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
 
-        _apply_sudoers("kai", dry_run=True, users_yaml_path=users_yaml)
+        _apply_sudoers("kai", dry_run=True, users_yaml_path=users_yaml, agent_backend="claude")
 
         captured = capsys.readouterr()
         assert "Warning" in captured.err
@@ -8625,7 +8633,7 @@ class TestApplySudoersDryRun:
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text("users: []\n")
 
-        _apply_sudoers("kai", dry_run=True, users_yaml_path=users_yaml)
+        _apply_sudoers("kai", dry_run=True, users_yaml_path=users_yaml, agent_backend="claude")
 
         captured = capsys.readouterr()
         assert "Warning" not in captured.err
@@ -8644,7 +8652,7 @@ class TestApplySudoersDryRun:
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text("users:\n  - telegram_id: 1\n    os_user: alice\n")
 
-        _apply_sudoers("kai", dry_run=True, users_yaml_path=users_yaml)
+        _apply_sudoers("kai", dry_run=True, users_yaml_path=users_yaml, agent_backend="claude")
 
         captured = capsys.readouterr()
         assert "Warning" not in captured.err
@@ -10266,7 +10274,7 @@ class TestBuildCodexLoginReminder:
         assert _build_codex_login_reminder(env, "kai", users_yaml_path=users_yaml) is None
 
     def test_missing_agent_backend_returns_none(self, tmp_path):
-        """No DEFAULT_BACKEND key in env defaults to claude; reminder skipped."""
+        """No explicit codex default, no reminder."""
         from kai.install import _build_codex_login_reminder
 
         users_yaml = self._write_users_yaml(tmp_path, [])

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -51,6 +51,7 @@ _BASE_CONFIG = Config(
     telegram_bot_token="test-token",
     allowed_user_ids={12345},
     webhook_secret="test-secret",
+    default_backend="claude",
 )
 
 

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -82,6 +82,7 @@ _BASE_CONFIG = Config(
     telegram_bot_token="test-token",
     allowed_user_ids={12345},
     webhook_secret="test-secret",
+    default_backend="claude",
 )
 
 


### PR DESCRIPTION
## Summary
- add registry support for an explicit default_backend and neutral default-backend resolution
- make load_config resolve the default backend from explicit config, registry default, or a sole installed registry backend
- make make config/apply write and validate DEFAULT_BACKEND explicitly instead of treating an omitted key as a backend choice
- render default_backend into /etc/kai/backends.yaml and update installer tests around the explicit contract

## Tests
- .venv/bin/python -m pytest tests/test_backend_registry.py tests/test_config.py tests/test_install.py

## Notes
This PR intentionally does not touch review/triage/pool backend fallbacks yet. Those are the next smaller slices after the global/default selection contract is in place.