### PR TITLE
Require explicit backends for review and triage

### DIFF
--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -2962,8 +2962,9 @@ def build_review_prompt_from_context(context: PRReviewContext) -> str:
 
 async def run_review(
     prompt: str,
+    *,
+    agent_backend: str,
     claude_user: str | None = None,
-    agent_backend: str = "claude",
     provider: str = "",
     timeout_s: int = _REVIEW_TIMEOUT,
     # Per-role model override. Caller in webhook.py resolves
@@ -3118,9 +3119,9 @@ async def run_review(
         except OneShotError as exc:
             raise RuntimeError(f"Goose review failed: {exc}") from exc
         return result.text
-    else:
-        # Claude (the default backend). Dispatch to the claude
-        # one-shot reasoner in free-form mode (json_schema=None):
+    if agent_backend == "claude":
+        # Dispatch to the Claude one-shot reasoner in free-form mode
+        # (json_schema=None):
         # plain `claude --print` text output with no tools, no
         # session persistence, a neutral cwd, the allow-listed
         # subprocess env, and binary resolution shared with config
@@ -3152,6 +3153,8 @@ async def run_review(
             raise RuntimeError(f"Claude review failed: {exc}") from exc
         return result.text
 
+    raise ValueError(f"Unsupported review backend: {agent_backend!r}")
+
 
 async def post_review_comment(repo: str, pr_number: int, review: str, github_token: str | None = None) -> bool:
     """
@@ -3164,7 +3167,7 @@ async def post_review_comment(repo: str, pr_number: int, review: str, github_tok
     Args:
         repo: Full repository name (e.g., "dcellison/kai").
         pr_number: The PR number.
-        review: The review text from Claude.
+        review: The review text returned by the selected backend.
 
     Returns:
         True if the comment was posted successfully, False otherwise.
@@ -3251,11 +3254,11 @@ async def generate_pr_review(
     repo: str,
     pr_number: int,
     *,
+    agent_backend: str,
     local_repo_path: str | None = None,
     spec_dir: str = "specs",
     include_prior_comments: bool = True,
     claude_user: str | None = None,
-    agent_backend: str = "claude",
     provider: str = "",
     timeout_s: int = _REVIEW_TIMEOUT,
     model_override: str = "",
@@ -3326,11 +3329,12 @@ async def review_pr(
     payload: dict,
     webhook_port: int,
     webhook_secret: str,
+    *,
+    agent_backend: str,
     claude_user: str | None = None,
     local_repo_path: str | None = None,
     spec_dir: str = "specs",
     notify_chat_id: int | None = None,
-    agent_backend: str = "claude",
     provider: str = "",
     timeout_s: int = _REVIEW_TIMEOUT,
     model_override: str = "",
@@ -3358,6 +3362,7 @@ async def review_pr(
         payload: The full GitHub webhook payload dict.
         webhook_port: Local webhook server port.
         webhook_secret: Webhook secret for API auth.
+        agent_backend: Explicit backend selected for this review.
         claude_user: Optional OS user for the review subprocess.
         local_repo_path: Optional path to local repo checkout for
             spec resolution, conventions, and related-context search.

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -7,7 +7,7 @@ Provides functionality to:
 3. List available GitHub Projects for board assignment
 4. Construct boundary-delimited triage prompts (prompt injection prevention)
 5. Spawn a one-shot LLM subprocess for analysis
-6. Parse structured JSON responses from Claude (with markdown fence stripping)
+6. Parse structured JSON responses from the selected model (with markdown fence stripping)
 7. Apply triage results: labels, project assignment, comments, notifications
 8. Orchestrate the full pipeline from webhook event to posted triage
 
@@ -440,8 +440,9 @@ def build_triage_prompt(
 
 async def run_triage(
     prompt: str,
+    *,
+    agent_backend: str,
     claude_user: str | None = None,
-    agent_backend: str = "claude",
     provider: str = "",
     # Per-role model override. Caller in webhook.py resolves
     # `user_config.models.get("issue_triage", "")` and passes it;
@@ -581,9 +582,9 @@ async def run_triage(
         except OneShotError as exc:
             raise RuntimeError(f"Goose triage failed: {exc}") from exc
         return result.text
-    else:
-        # Claude (the default backend). Dispatch to the claude
-        # one-shot reasoner in free-form mode (json_schema=None):
+    if agent_backend == "claude":
+        # Dispatch to the Claude one-shot reasoner in free-form mode
+        # (json_schema=None):
         # plain `claude --print` text output with no tools, no
         # session persistence, a neutral cwd, the allow-listed
         # subprocess env, and binary resolution shared with config
@@ -615,6 +616,8 @@ async def run_triage(
         except OneShotError as exc:
             raise RuntimeError(f"Claude triage failed: {exc}") from exc
         return result.text
+
+    raise ValueError(f"Unsupported triage backend: {agent_backend!r}")
 
 
 def _parse_triage_json(raw: str) -> dict:
@@ -1150,9 +1153,10 @@ async def triage_issue(
     payload: dict,
     webhook_port: int,
     webhook_secret: str,
+    *,
+    agent_backend: str,
     claude_user: str | None = None,
     notify_chat_id: int | None = None,
-    agent_backend: str = "claude",
     provider: str = "",
     model_override: str = "",
     allowed_triage_projects: list[str] | None = None,
@@ -1173,7 +1177,8 @@ async def triage_issue(
         payload: The full GitHub webhook payload dict.
         webhook_port: Local webhook server port.
         webhook_secret: Webhook secret for API auth.
-        claude_user: Optional OS user for the Claude subprocess.
+        agent_backend: Explicit backend selected for this triage run.
+        claude_user: Optional OS user for the backend subprocess.
     """
     # Metadata extraction is inside try/except so a malformed payload
     # doesn't produce an unhandled exception in the background task.

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -536,7 +536,7 @@ class TestFetchPRDiff:
 
 class TestRunReviewClaudeDispatch:
     """
-    `run_review` with the default claude backend dispatches to
+    `run_review` with the explicitly selected Claude backend dispatches to
     `ClaudeOneShotReasoner` (NOT an inline `claude --print` spawn).
     The reasoner owns binary resolution, the free-form plain-text
     argv, per-user os_user routing, and the allow-listed subprocess
@@ -565,7 +565,7 @@ class TestRunReviewClaudeDispatch:
             patch("kai.review.ClaudeOneShotReasoner", return_value=fake) as ctor,
             patch("kai.review.asyncio.create_subprocess_exec") as mock_exec,
         ):
-            result = await run_review("review prompt", claude_user="someone")
+            result = await run_review("review prompt", agent_backend="claude", claude_user="someone")
 
         assert result == "review body from claude"
         ctor.assert_called_once()
@@ -593,7 +593,7 @@ class TestRunReviewClaudeDispatch:
         fake = self._fake_reasoner()
 
         with patch("kai.review.ClaudeOneShotReasoner", return_value=fake):
-            await run_review("prompt", model_override="opus")
+            await run_review("prompt", agent_backend="claude", model_override="opus")
 
         assert fake.run.call_args.kwargs["model"] == "opus"
 
@@ -605,7 +605,7 @@ class TestRunReviewClaudeDispatch:
         fake = self._fake_reasoner()
 
         with patch("kai.review.ClaudeOneShotReasoner", return_value=fake):
-            await run_review("prompt", timeout_s=777)
+            await run_review("prompt", agent_backend="claude", timeout_s=777)
 
         assert fake.run.call_args.kwargs["timeout"] == 777
 
@@ -620,7 +620,7 @@ class TestRunReviewClaudeDispatch:
             patch("kai.review.ClaudeOneShotReasoner", return_value=fake),
             pytest.raises(RuntimeError, match=r"Review subprocess timed out"),
         ):
-            await run_review("prompt")
+            await run_review("prompt", agent_backend="claude")
 
     @pytest.mark.asyncio
     async def test_run_review_collapses_oneshot_error_to_runtime_error(self):
@@ -635,7 +635,7 @@ class TestRunReviewClaudeDispatch:
             # detail; this is what reaches the Telegram failure notice.
             pytest.raises(RuntimeError, match=r"Claude review failed: exit 1: model not found"),
         ):
-            await run_review("prompt")
+            await run_review("prompt", agent_backend="claude")
 
 
 # ── run_review (Codex backend) ─────────────────────────────────────
@@ -875,19 +875,16 @@ class TestRunReviewGooseDispatch:
             await run_review("prompt", agent_backend="goose", provider="anthropic")
 
     @pytest.mark.asyncio
-    async def test_default_backend_is_claude(self):
-        """Calling run_review with no backend args still uses Claude
-        (dispatching to ClaudeOneShotReasoner, not goose)."""
-        from kai.oneshot import OneShotResult
+    async def test_backend_is_required(self):
+        """Review dispatch cannot select a backend implicitly."""
+        with pytest.raises(TypeError, match="agent_backend"):
+            await run_review("prompt")  # type: ignore[call-arg]
 
-        fake = MagicMock()
-        fake.run = AsyncMock(return_value=OneShotResult(text="ok", backend="claude", model="sonnet"))
-
-        with patch("kai.review.ClaudeOneShotReasoner", return_value=fake) as ctor:
-            await run_review("prompt")
-
-        ctor.assert_called_once()
-        fake.run.assert_awaited_once()
+    @pytest.mark.asyncio
+    async def test_unknown_backend_is_rejected(self):
+        """An unknown backend cannot fall through to another driver."""
+        with pytest.raises(ValueError, match="Unsupported review backend"):
+            await run_review("prompt", agent_backend="unknown")
 
     @pytest.mark.asyncio
     async def test_empty_provider_raises(self):
@@ -1181,7 +1178,7 @@ class TestReviewPR:
             patch("kai.review.post_review_comment", return_value=True) as mock_post,
             patch("kai.review.send_review_summary") as mock_summary,
         ):
-            await review_pr(payload, 8080, "secret", claude_user="kai")
+            await review_pr(payload, 8080, "secret", agent_backend="claude", claude_user="kai")
 
         mock_diff.assert_called_once_with("owner/repo", 42, github_token=None)
         mock_generate.assert_called_once()
@@ -1209,7 +1206,7 @@ class TestReviewPR:
             patch("kai.review.generate_pr_review") as mock_generate,
             patch("kai.review.send_review_summary") as mock_summary,
         ):
-            await review_pr(payload, 8080, "secret")
+            await review_pr(payload, 8080, "secret", agent_backend="claude")
 
         mock_generate.assert_not_called()
         mock_summary.assert_not_called()
@@ -1223,7 +1220,7 @@ class TestReviewPR:
             patch("kai.review.fetch_pr_diff", side_effect=RuntimeError("gh failed")),
             patch("kai.review.send_review_summary") as mock_summary,
         ):
-            await review_pr(payload, 8080, "secret")
+            await review_pr(payload, 8080, "secret", agent_backend="claude")
 
         mock_summary.assert_called_once()
         assert mock_summary.call_args[0][1] is False
@@ -1241,7 +1238,7 @@ class TestReviewPR:
             ),
             patch("kai.review.send_review_summary") as mock_summary,
         ):
-            await review_pr(payload, 8080, "secret")
+            await review_pr(payload, 8080, "secret", agent_backend="claude")
 
         mock_summary.assert_called_once()
         assert mock_summary.call_args[0][1] is False
@@ -1257,7 +1254,7 @@ class TestReviewPR:
             patch("kai.review.post_review_comment") as mock_post,
             patch("kai.review.send_review_summary") as mock_summary,
         ):
-            await review_pr(payload, 8080, "secret")
+            await review_pr(payload, 8080, "secret", agent_backend="claude")
 
         mock_post.assert_not_called()
         mock_summary.assert_called_once()
@@ -1281,6 +1278,7 @@ class TestReviewPR:
                 payload,
                 8080,
                 "secret",
+                agent_backend="claude",
                 local_repo_path="/repo",
                 spec_dir="my/specs",
             )
@@ -1333,7 +1331,7 @@ class TestReviewPR:
             patch("kai.review.post_review_comment", return_value=True) as mock_post,
             patch("kai.review.send_review_summary"),
         ):
-            await review_pr(payload, 8080, "secret", github_token="ghp_user")
+            await review_pr(payload, 8080, "secret", agent_backend="claude", github_token="ghp_user")
 
         mock_diff.assert_called_once_with("owner/repo", 42, github_token="ghp_user")
         assert mock_generate.call_args.kwargs["github_token"] == "ghp_user"

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -336,7 +336,7 @@ class TestListProjects:
 
 class TestRunTriageClaudeDispatch:
     """
-    `run_triage` with the default claude backend dispatches to
+    `run_triage` with the explicitly selected Claude backend dispatches to
     `ClaudeOneShotReasoner` (NOT an inline `claude --print` spawn).
     The reasoner owns binary resolution, the free-form plain-text
     argv, per-user os_user routing, and the allow-listed subprocess
@@ -364,7 +364,7 @@ class TestRunTriageClaudeDispatch:
             patch("kai.triage.ClaudeOneShotReasoner", return_value=fake) as ctor,
             patch("kai.triage.asyncio.create_subprocess_exec") as mock_exec,
         ):
-            result = await run_triage("triage prompt", claude_user="someone")
+            result = await run_triage("triage prompt", agent_backend="claude", claude_user="someone")
 
         assert result == '{"labels": ["bug"], "summary": "A bug."}'
         ctor.assert_called_once()
@@ -392,7 +392,7 @@ class TestRunTriageClaudeDispatch:
         fake = self._fake_reasoner()
 
         with patch("kai.triage.ClaudeOneShotReasoner", return_value=fake):
-            await run_triage("prompt", model_override="opus")
+            await run_triage("prompt", agent_backend="claude", model_override="opus")
 
         assert fake.run.call_args.kwargs["model"] == "opus"
 
@@ -407,7 +407,7 @@ class TestRunTriageClaudeDispatch:
             patch("kai.triage.ClaudeOneShotReasoner", return_value=fake),
             pytest.raises(RuntimeError, match=r"Triage subprocess timed out"),
         ):
-            await run_triage("prompt")
+            await run_triage("prompt", agent_backend="claude")
 
     @pytest.mark.asyncio
     async def test_run_triage_collapses_oneshot_error_to_runtime_error(self):
@@ -420,7 +420,7 @@ class TestRunTriageClaudeDispatch:
             patch("kai.triage.ClaudeOneShotReasoner", return_value=fake),
             pytest.raises(RuntimeError, match=r"Claude triage failed"),
         ):
-            await run_triage("prompt")
+            await run_triage("prompt", agent_backend="claude")
 
 
 # ── run_triage (Goose backend) ─────────────────────────────────────
@@ -532,19 +532,16 @@ class TestRunTriageGooseDispatch:
             await run_triage("prompt", agent_backend="goose", provider="anthropic")
 
     @pytest.mark.asyncio
-    async def test_default_backend_is_claude(self):
-        """Calling run_triage with no backend args still uses Claude
-        (dispatching to ClaudeOneShotReasoner, not goose)."""
-        from kai.oneshot import OneShotResult
+    async def test_backend_is_required(self):
+        """Triage dispatch cannot select a backend implicitly."""
+        with pytest.raises(TypeError, match="agent_backend"):
+            await run_triage("prompt")  # type: ignore[call-arg]
 
-        fake = MagicMock()
-        fake.run = AsyncMock(return_value=OneShotResult(text='{"labels": []}', backend="claude", model="sonnet"))
-
-        with patch("kai.triage.ClaudeOneShotReasoner", return_value=fake) as ctor:
-            await run_triage("prompt")
-
-        ctor.assert_called_once()
-        fake.run.assert_awaited_once()
+    @pytest.mark.asyncio
+    async def test_unknown_backend_is_rejected(self):
+        """An unknown backend cannot fall through to another driver."""
+        with pytest.raises(ValueError, match="Unsupported triage backend"):
+            await run_triage("prompt", agent_backend="unknown")
 
     @pytest.mark.asyncio
     async def test_empty_provider_raises(self):
@@ -1609,7 +1606,7 @@ class TestTriageIssue:
         ):
             mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
-            await triage_issue(payload, 8080, "secret")
+            await triage_issue(payload, 8080, "secret", agent_backend="claude")
 
         assert mock_session.post.called
         # Pipeline ran (multiple subprocess calls)
@@ -1652,7 +1649,13 @@ class TestTriageIssue:
             patch("kai.triage.run_triage", side_effect=mock_run_triage),
             patch("kai.triage.apply_triage", new_callable=AsyncMock) as mock_apply,
         ):
-            await triage_issue(payload, 8080, "secret", allowed_triage_projects=["Sprint 1"])
+            await triage_issue(
+                payload,
+                8080,
+                "secret",
+                agent_backend="claude",
+                allowed_triage_projects=["Sprint 1"],
+            )
 
         assert "Sprint 1" in captured_prompt["prompt"]
         assert "Secret Board" not in captured_prompt["prompt"]
@@ -1697,7 +1700,7 @@ class TestTriageIssue:
         ):
             mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
-            await triage_issue(payload, 8080, "secret", github_token="ghp_user")
+            await triage_issue(payload, 8080, "secret", agent_backend="claude", github_token="ghp_user")
 
         assert gh_envs
         assert all(env is not None for env in gh_envs)
@@ -1721,7 +1724,7 @@ class TestTriageIssue:
             mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
             # Should not raise
-            await triage_issue(payload, 8080, "secret")
+            await triage_issue(payload, 8080, "secret", agent_backend="claude")
 
         # Error notification was sent
         mock_session.post.assert_called_once()
@@ -1744,7 +1747,7 @@ class TestTriageIssue:
         ):
             mock_session, _ = _mock_aiohttp_session_post(status=200)
             _attach_session_to_class(mock_session, mock_session_cls)
-            await triage_issue(payload, 8080, "secret")
+            await triage_issue(payload, 8080, "secret", agent_backend="claude")
 
         # Error notification was sent
         mock_session.post.assert_called_once()
@@ -1958,6 +1961,7 @@ class TestTriageErrorContent:
                 {"issue": {}, "repository": {}},
                 webhook_port=8080,
                 webhook_secret="secret",
+                agent_backend="claude",
             )
 
         # The error_detail argument should be just the type name


### PR DESCRIPTION
## Summary

- require every review and triage entry point to receive an explicit backend
- make backend selection keyword-only across one-shot and orchestration APIs
- replace catch-all dispatch branches with an explicit Claude branch
- reject unknown backend identifiers instead of allowing them to reach another driver
- update backend-specific tests so their selected backend is declared

## Security and compatibility

Webhook and Telegram callers already resolve the effective per-user/global backend and pass it explicitly, so normal runtime behavior is preserved. Calls that omit the backend now fail immediately, and malformed or unknown backend names fail closed.

## Verification

- `make typecheck`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/python -m pytest tests/`

Result: 4,831 passed, 1 skipped.