### PR TITLE
Fail closed on invalid backend identity

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from kai.config import (
     DATA_DIR,
     PROJECT_ROOT,
+    VALID_BACKENDS,
     Config,
     WorkspaceConfig,
     canonicalize_model_for_backend,
@@ -103,6 +104,24 @@ def sanitize_agent_environment(environment: dict[str, str]) -> dict[str, str]:
     for name in _CONTROL_PLANE_ENV_VARS:
         sanitized.pop(name, None)
     return sanitized
+
+
+def require_backend_name(instance: object) -> str:
+    """Return an instance's canonical backend identity or fail closed.
+
+    Every concrete backend must declare ``backend_name`` as one of the
+    configured backend identifiers. Missing, empty, non-string, and unknown
+    values indicate a programming or integration error; callers must never
+    substitute another backend because that would apply the wrong model,
+    provider, and execution policy.
+    """
+    name = getattr(instance, "backend_name", None)
+    if not isinstance(name, str) or name not in VALID_BACKENDS:
+        expected = ", ".join(sorted(VALID_BACKENDS))
+        raise RuntimeError(
+            f"Backend instance {type(instance).__name__} has invalid backend_name {name!r}; expected one of: {expected}"
+        )
+    return name
 
 
 def apply_workspace_model(
@@ -258,9 +277,8 @@ class AgentBackend(ABC):
     # Stable identifier for pool/bot dispatch and `memory.recall`
     # attribution; any future backend-aware code path can read it off
     # the instance too. Concrete backends override the class-level
-    # default with their canonical name. Default `""` keeps the ABC
-    # importable for tests that construct a stub backend without
-    # thinking about logging.
+    # sentinel with their canonical name. Consumers validate it through
+    # require_backend_name() before making backend-specific decisions.
     backend_name: str = ""
 
     @abstractmethod

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -58,7 +58,7 @@ from telegram.ext import (
 )
 
 from kai import github_api, memory_command, review, services, sessions, webhook
-from kai.backend import resolve_home_workspace
+from kai.backend import require_backend_name, resolve_home_workspace
 from kai.config import (
     DATA_DIR,
     ONESHOT_REASONER_BACKENDS,
@@ -870,23 +870,8 @@ async def handle_new(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
 
 
 def _backend_name_for_instance(instance: object) -> str:
-    """Map a backend instance to its config-key backend name.
-
-    Reads the `backend_name` class attribute every concrete backend sets
-    (claude / goose / codex / opencode). A falsy value indicates a
-    test double or legacy stub that never overrode the ABC default of
-    `""`; for those, log a warning and fall back to "claude" so the
-    historical default for unknown shapes is preserved.
-    """
-    name = getattr(instance, "backend_name", "")
-    if not name:
-        log.warning(
-            "Instance %s has empty backend_name; falling back to 'claude'. "
-            "Concrete backends must set the backend_name class attribute.",
-            type(instance).__name__,
-        )
-        return "claude"
-    return name
+    """Return a live instance's validated config-key backend name."""
+    return require_backend_name(instance)
 
 
 def _get_user_backend_provider(pool: SubprocessPool, chat_id: int, config: Config) -> tuple[str, str]:

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -20,10 +20,11 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from kai import sessions
-from kai.backend import AgentBackend, StreamEvent, resolve_home_workspace
+from kai.backend import AgentBackend, StreamEvent, require_backend_name, resolve_home_workspace
 from kai.claude import ClaudeCodeBackend
 from kai.config import (
     OPEN_ENDED_PROVIDERS,
+    VALID_BACKENDS,
     Config,
     WorkspaceConfig,
     canonicalize_model_for_backend,
@@ -132,6 +133,7 @@ class SubprocessPool:
         """
         if chat_id not in self._pool:
             instance = self._create_instance(chat_id)
+            require_backend_name(instance)
             self._pool[chat_id] = instance
             # Mark both one-time setup steps as pending. The split
             # matters at command-path callers that finish the workspace
@@ -170,13 +172,14 @@ class SubprocessPool:
 
         # Per-user backend and provider, falling back to global config.
         # Routed through the canonical get_user_backend_and_provider
-        # resolver so codex always reports provider="openai" even when
-        # the provider is unset, matching the same cascade bot.py and
-        # the install-time validator use. Without this, a user with
-        # `backend: codex` on a globally-claude install ended up
-        # with effective_provider="" and the fallback below dispatched
-        # the global default_model ("sonnet"), which codex CLI rejects.
+        # resolver so single-provider backends report their canonical
+        # provider even when the provider is unset, matching the same
+        # cascade bot.py and the install-time validator use. Without
+        # this, a per-user backend differing from the global backend can
+        # inherit an incompatible global model.
         backend, effective_provider = get_user_backend_and_provider(user, self._config)
+        if backend not in VALID_BACKENDS:
+            raise RuntimeError(f"Cannot create backend instance for unsupported backend {backend!r}")
         # get_effective_provider hardcodes the backend->provider rule for
         # claude (anthropic) and codex (openai) so global_provider lines
         # up with effective_provider whenever the user has not overridden
@@ -243,10 +246,8 @@ class SubprocessPool:
         # points the subprocess at the right home.
         os_user = user.os_user if user else None
 
-        # Backend selection: "goose" uses Goose ACP, "opencode" uses
-        # OpenCode ACP, "codex" uses OpenAI Codex CLI's app-server
-        # JSON-RPC protocol, anything else (including the default
-        # "claude") uses Claude Code CLI.
+        # Backend selection is explicit. No branch may substitute a
+        # different backend for a missing or unknown identifier.
         # Internal API availability is independent of public webhook ingress.
         # Agents receive only their random principal credential, never an
         # external webhook signing secret.
@@ -316,22 +317,25 @@ class SubprocessPool:
                 defer_user_file_reads=getattr(self._config, "protected_install", False) is True,
             )
 
-        return ClaudeCodeBackend(
-            model=model,
-            workspace=workspace,
-            home_workspace=home_ws,
-            webhook_port=self._config.webhook_port,
-            webhook_secret=internal_api_credential,
-            timeout_seconds=timeout,
-            services_info=services_info,
-            claude_user=os_user,
-            max_session_hours=self._config.agent_max_session_hours,
-            workspace_config=ws_config,
-            autocompact_pct=self._config.claude_autocompact_pct,
-            claude_effort_level=self._config.claude_effort_level,
-            memory_enabled=self._config.memory_enabled,
-            defer_user_file_reads=getattr(self._config, "protected_install", False) is True,
-        )
+        if backend == "claude":
+            return ClaudeCodeBackend(
+                model=model,
+                workspace=workspace,
+                home_workspace=home_ws,
+                webhook_port=self._config.webhook_port,
+                webhook_secret=internal_api_credential,
+                timeout_seconds=timeout,
+                services_info=services_info,
+                claude_user=os_user,
+                max_session_hours=self._config.agent_max_session_hours,
+                workspace_config=ws_config,
+                autocompact_pct=self._config.claude_autocompact_pct,
+                claude_effort_level=self._config.claude_effort_level,
+                memory_enabled=self._config.memory_enabled,
+                defer_user_file_reads=getattr(self._config, "protected_install", False) is True,
+            )
+
+        raise RuntimeError(f"Cannot create backend instance for unsupported backend {backend!r}")
 
     # ── Prompt routing ──────────────────────────────────────────────
 
@@ -442,24 +446,10 @@ class SubprocessPool:
         # because the value is baked into the CLI command at startup)
         needs_restart = False
 
-        # Read the backend identifier off the instance. Every concrete
-        # backend sets `backend_name` as a class attribute (claude
-        # / goose / codex / opencode). The ABC default is the empty
-        # string, so a test double or legacy stub that never overrides
-        # falls through to "claude" with a warning; this preserves the
-        # historical default for unknown shapes while keeping real
-        # backends out of the class-name if-chain that previously had
-        # to be extended for every new backend. Hoisted out of the
-        # DB-model branch because the ws_model guard below also needs
-        # it.
-        instance_backend = instance.backend_name
-        if not instance_backend:
-            log.warning(
-                "Instance %s has empty backend_name; falling back to 'claude'. "
-                "Concrete backends must set the backend_name class attribute.",
-                type(instance).__name__,
-            )
-            instance_backend = "claude"
+        # Validate the instance identity before applying backend-specific
+        # model policy. Missing or unknown identities are invariant
+        # violations and must not inherit another backend's rules.
+        instance_backend = require_backend_name(instance)
 
         # Model: only apply if workspace config has a VALID model for
         # this backend. A workspaces.yaml entry like
@@ -615,7 +605,7 @@ class SubprocessPool:
     def set_model(self, chat_id: int, model: str) -> None:
         """Set the model for a user's subprocess."""
         instance = self.get(chat_id)
-        instance.model = canonicalize_model_for_backend(model, instance.backend_name)
+        instance.model = canonicalize_model_for_backend(model, require_backend_name(instance))
 
     async def get_effective_workspace(self, chat_id: int) -> Path:
         """

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -90,9 +90,8 @@ class TestBackendNameForInstance:
 
     Real backends each set the attribute to their canonical identifier
     (claude.py: "claude"; goose.py: "goose"; codex.py: "codex").
-    A test double or legacy stub that never overrode the ABC default
-    falls back to "claude" with a warning so model validation still
-    routes through the provider-only path.
+    Missing or invalid identities are rejected so model validation
+    cannot silently use another backend's policy.
     """
 
     def test_claude_backend_returns_class_attribute(self):
@@ -119,33 +118,38 @@ class TestBackendNameForInstance:
         instance.backend_name = CodexBackend.backend_name
         assert _backend_name_for_instance(instance) == "codex"
 
-    def test_falsy_backend_name_falls_back_to_claude_with_warning(self, caplog):
-        """A stub with empty backend_name returns "claude" and logs a warning."""
-        import logging
+    def test_opencode_backend_returns_opencode(self):
+        """OpenCodeBackend.backend_name is "opencode"."""
+        from kai.opencode import OpenCodeBackend
 
-        # Plain object with empty backend_name to simulate a test double or
-        # legacy stub that never overrode the ABC default of "".
+        instance = MagicMock(spec=OpenCodeBackend)
+        instance.backend_name = OpenCodeBackend.backend_name
+        assert _backend_name_for_instance(instance) == "opencode"
+
+    def test_falsy_backend_name_is_rejected(self):
+        """A stub with an empty backend identity fails closed."""
         stub = MagicMock()
         stub.backend_name = ""
 
-        with caplog.at_level(logging.WARNING, logger="kai.bot"):
-            result = _backend_name_for_instance(stub)
-        assert result == "claude"
-        assert any("empty backend_name" in rec.message for rec in caplog.records)
+        with pytest.raises(RuntimeError, match="invalid backend_name"):
+            _backend_name_for_instance(stub)
 
-    def test_missing_backend_name_attribute_falls_back_to_claude(self, caplog):
-        """A stub without the attribute at all routes through the same fallback."""
-        import logging
+    def test_missing_backend_name_attribute_is_rejected(self):
+        """A stub without a backend identity fails closed."""
 
-        # Use a bare object so MagicMock's auto-attributes don't synthesize
-        # a non-empty backend_name on access. getattr returns the default.
         class _Stub:
             pass
 
-        with caplog.at_level(logging.WARNING, logger="kai.bot"):
-            result = _backend_name_for_instance(_Stub())
-        assert result == "claude"
-        assert any("empty backend_name" in rec.message for rec in caplog.records)
+        with pytest.raises(RuntimeError, match="invalid backend_name"):
+            _backend_name_for_instance(_Stub())
+
+    def test_unknown_backend_name_is_rejected(self):
+        """A non-canonical backend identity cannot reach model routing."""
+        stub = MagicMock()
+        stub.backend_name = "unknown"
+
+        with pytest.raises(RuntimeError, match="invalid backend_name"):
+            _backend_name_for_instance(stub)
 
 
 # ── _get_user_models warning suppression ─────────────────────────────
@@ -780,6 +784,7 @@ def _make_mock_claude(model="sonnet", workspace=None, is_alive=True, provider="a
     # Mock instance returned by pool.get() and pool.get_if_exists()
     # with the provider attribute for provider-aware model selection.
     instance = MagicMock()
+    instance.backend_name = "claude"
     instance.model = model
     instance.provider = provider
     instance.workspace = ws

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -43,6 +43,7 @@ def _make_config(**overrides) -> Config:
     defaults: dict = {
         "telegram_bot_token": "test",
         "allowed_user_ids": {111, 222},
+        "default_backend": "claude",
         "default_model": "sonnet",
         "default_timeout": 30,
         "agent_max_session_hours": 0,
@@ -242,9 +243,17 @@ class TestPerUserBackendRouting:
         config = _make_config(user_configs={111: user})
         pool = SubprocessPool(config=config, services_info=[])
         instance = pool.get(111)
-        # Default global backend is claude -> ClaudeCodeBackend
+        # This fixture explicitly selects Claude globally.
         assert not isinstance(instance, GooseBackend)
         assert instance.provider == "anthropic"
+
+    def test_unknown_global_backend_is_rejected(self):
+        """An unknown backend cannot fall through to a concrete driver."""
+        config = _make_config(default_backend="unknown")
+        pool = SubprocessPool(config=config, services_info=[])
+
+        with pytest.raises(RuntimeError, match="unsupported backend 'unknown'"):
+            pool.get(111)
 
     def test_user_provider_overrides_global(self):
         """User with provider gets GooseBackend with that provider."""
@@ -951,9 +960,9 @@ class TestRestoreBackendNameDispatch:
     """
     _apply_user_db_settings reads the backend identifier off
     `instance.backend_name` instead of inspecting the concrete class
-    name. Pin each real backend's value plus the falsy fallback so an
-    OpenCode (or any future) backend cannot regress the dispatch by
-    setting backend_name incorrectly.
+    name. Pin the declared identity and fail-closed behavior so a
+    current or future backend cannot regress dispatch by omitting or
+    misdeclaring backend_name.
     """
 
     @pytest.mark.asyncio
@@ -984,30 +993,18 @@ class TestRestoreBackendNameDispatch:
             mock_validate.assert_called_once_with("gpt-5.4-mini", "goose", "openai")
 
     @pytest.mark.asyncio
-    async def test_empty_backend_name_falls_back_to_claude_with_warning(self, tmp_path, caplog):
-        """A test double or legacy stub with empty backend_name routes to "claude" with a warning."""
-        import logging
-
+    async def test_empty_backend_name_is_rejected(self, tmp_path):
+        """An empty backend identity cannot inherit another backend's policy."""
         pool = SubprocessPool(config=_make_config(), services_info=[])
         instance = pool.get(111)
-        # Simulate a stub backend that never overrode the ABC default.
         instance.backend_name = ""
         instance.provider = "anthropic"
-        # Instance default model is "sonnet"; DB model must differ to
-        # actually reach the validate_model_for_backend call in the
-        # restore path (the guard short-circuits when they match).
         db_settings = {"model": "opus"}
         with (
-            caplog.at_level(logging.WARNING, logger="kai.pool"),
             patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value=db_settings),
-            patch("kai.pool.validate_model_for_backend", return_value=True) as mock_validate,
-            patch.object(instance, "restart", new_callable=AsyncMock),
+            pytest.raises(RuntimeError, match="invalid backend_name"),
         ):
             await pool._apply_user_db_settings(111, instance)
-            # Fallback string is "claude".
-            mock_validate.assert_called_once_with("opus", "claude", "anthropic")
-        # Warning was logged about the empty backend_name.
-        assert any("empty backend_name" in rec.message for rec in caplog.records)
 
 
 # ── get_if_exists ───────────────────────────────────────────────────
@@ -1364,6 +1361,7 @@ class TestGetEffectiveWorkspace:
             patch.object(SubprocessPool, "_create_instance") as mock_create,
         ):
             stub = MagicMock()
+            stub.backend_name = "claude"
             stub.change_workspace = AsyncMock()
             mock_create.return_value = stub
             result = await pool.get_effective_workspace(999)
@@ -1642,6 +1640,7 @@ class TestSendAppliesSettingsAfterResolverCall:
         pool = SubprocessPool(config=_make_config(), services_info=[])
         with patch("kai.pool.SubprocessPool._create_instance") as mock_create:
             stub = MagicMock()
+            stub.backend_name = "claude"
             stub.change_workspace = AsyncMock()
             mock_create.return_value = stub
             await pool.change_workspace(111, ws)


### PR DESCRIPTION
## Summary

- centralize validation of live backend instance identities
- require every instance to declare one supported canonical `backend_name`
- reject missing, empty, non-string, and unknown instance identities
- make pool instance creation dispatch explicitly across all four supported backends
- reject unsupported configured backend values instead of routing them to another driver
- apply validated identity to DB model restoration, model changes, and bot model/provider routing

## Behavior

Valid Claude, Codex, Goose, and OpenCode instances are unchanged. An invalid instance or unsupported configured backend now raises a clear invariant error before it is stored or used for backend-specific model and provider decisions.

## Verification

- `make typecheck`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/python -m pytest tests/` — 4,834 passed, 1 skipped
- focused backend/pool/bot suite — 502 passed