### PR TITLE
Fail closed on unsupported behavioral eval backends

### DIFF
--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -98,9 +98,13 @@ from typing import Any
 # aligned with whatever else consumes the same shape (currently the
 # collision-probe generator). If the drift bucketing changes, every
 # consumer follows automatically.
+from kai.backend_registry import (
+    BackendRegistryError,
+    resolve_backend_command,
+    resolve_default_backend,
+)
 from kai.codex_exec import extract_codex_text
 from kai.config import (
-    ONESHOT_REASONER_BACKENDS,
     ModelRole,
     _resolve_eval_provider,
     _resolve_renamed_key,
@@ -113,6 +117,8 @@ from kai.eval._probes import (
     probe_set_hash,
 )
 from kai.prompt_utils import make_boundary
+
+_SUPPORTED_BEHAVIORAL_BACKENDS = frozenset({"claude", "codex"})
 
 log = logging.getLogger(__name__)
 
@@ -289,6 +295,10 @@ class BehavioralConfig:
     gen_timeout_s: int
     seed: str
     max_concurrency: int
+    # The evaluator currently has protocol-specific implementations for
+    # exactly these two backends. Callers must select one explicitly;
+    # unsupported identities are rejected before any subprocess starts.
+    backend: str
     # Eval-only synthetic-pollution count. Defaults to 0 so existing
     # tests and existing CLI invocations stay byte-for-byte identical
     # to today's behavior; a non-zero value opts the run into the
@@ -309,14 +319,6 @@ class BehavioralConfig:
     # test fixtures that build a config without invoking the CLI still
     # get a sensible path.
     data_dir: Path = Path(".")
-    # Active agent backend for this run ("claude" or "codex"). Resolved
-    # once at _run_cli from DEFAULT_BACKEND and threaded through every
-    # subprocess builder + stdout parser + version capture so the
-    # codex and claude verticals can stay byte-isolated. Default
-    # "claude" matches the pre-codex behavior so test fixtures that
-    # build a config without setting this field still produce the
-    # historical command shape.
-    backend: str = "claude"
 
 
 @dataclass
@@ -422,10 +424,7 @@ def _build_judge_cmd(config: BehavioralConfig) -> list[str]:
     probe as judge_error with no diagnostic. Re-run the verification
     if upgrading the CLI past 2.x.
     """
-    # CLAUDE_BIN env override is honored same as triage/review and the
-    # one-shot resolver, so the eval spawns the same binary the rest
-    # of the system pins.
-    claude_bin = os.environ.get("CLAUDE_BIN") or "claude"
+    claude_bin = resolve_backend_command("claude", allow_bare_fallback=True)
     return [
         claude_bin,
         "--print",
@@ -466,8 +465,7 @@ def _build_gen_cmd(config: BehavioralConfig) -> list[str]:
       `claude_cli_version` field in the output JSON lets cross-run
       comparisons detect drift in that residual.
     """
-    # Same CLAUDE_BIN precedence as the judge builder above.
-    claude_bin = os.environ.get("CLAUDE_BIN") or "claude"
+    claude_bin = resolve_backend_command("claude", allow_bare_fallback=True)
     return [
         claude_bin,
         "--print",
@@ -498,12 +496,11 @@ def _build_judge_cmd_codex(config: BehavioralConfig) -> list[str]:
     (see `_validate_judge_envelope`) and injects the system prompt as
     a boundary-delimited prefix to stdin (see `_render_codex_stdin`).
 
-    `CODEX_BIN` env override is honored same as triage/review and the
-    persistent backend: installs where codex lives in a per-os_user
-    home and not on the service user's PATH still resolve the absolute
-    binary. Falls back to bare "codex" when unset.
+    The binary is resolved through the same protected backend registry
+    used by the persistent runtime. Development installs retain the
+    legacy environment/PATH resolution behavior.
     """
-    codex_bin = os.environ.get("CODEX_BIN") or "codex"
+    codex_bin = resolve_backend_command("codex", allow_bare_fallback=True)
     return [
         codex_bin,
         "exec",
@@ -533,7 +530,7 @@ def _build_gen_cmd_codex(config: BehavioralConfig) -> list[str]:
     joins all completed items with a blank-line separator so multi-item
     turns are not truncated (the PR #490 / PR #491 lesson).
     """
-    codex_bin = os.environ.get("CODEX_BIN") or "codex"
+    codex_bin = resolve_backend_command("codex", allow_bare_fallback=True)
     return [
         codex_bin,
         "exec",
@@ -1194,9 +1191,11 @@ async def _run_one_arm(
     if config.backend == "codex":
         cmd = _build_gen_cmd_codex(config)
         stdin_payload = _render_codex_stdin("", arm_prompt)
-    else:
+    elif config.backend == "claude":
         cmd = _build_gen_cmd(config)
         stdin_payload = arm_prompt
+    else:
+        raise ValueError(f"unsupported behavioral-eval backend: {config.backend!r}")
     rc, stdout, _stderr, elapsed_ms = await _run_subprocess(
         cmd=cmd,
         stdin_payload=stdin_payload,
@@ -1208,8 +1207,10 @@ async def _run_one_arm(
         return None, elapsed_ms
     if config.backend == "codex":
         text = _parse_codex_gen_stdout(stdout).strip()
-    else:
+    elif config.backend == "claude":
         text = stdout.decode("utf-8", errors="replace").strip()
+    else:  # pragma: no cover - guarded before subprocess dispatch above
+        raise ValueError(f"unsupported behavioral-eval backend: {config.backend!r}")
     if not text:
         # Successful exit with no output is still a broken response -
         # the judge cannot score nothing against the gold fact. Bucket
@@ -1248,9 +1249,11 @@ async def _run_one_judge(
         # no boundary block, but the judge always uses a non-empty
         # system prompt, so the SYSTEM section is present.
         stdin_payload = _render_codex_stdin(_JUDGE_SYSTEM_PROMPT, payload)
-    else:
+    elif config.backend == "claude":
         cmd = _build_judge_cmd(config)
         stdin_payload = payload
+    else:
+        raise ValueError(f"unsupported behavioral-eval backend: {config.backend!r}")
     rc, stdout, _stderr, elapsed_ms = await _run_subprocess(
         cmd=cmd,
         stdin_payload=stdin_payload,
@@ -1266,7 +1269,9 @@ async def _run_one_judge(
         # against _JUDGE_SCHEMA via _validate_judge_envelope.
         parsed = _parse_codex_judge_stdout(stdout)
         return parsed, elapsed_ms
-    return _parse_judge_stdout(stdout), elapsed_ms
+    if config.backend == "claude":
+        return _parse_judge_stdout(stdout), elapsed_ms
+    raise ValueError(f"unsupported behavioral-eval backend: {config.backend!r}")  # pragma: no cover
 
 
 async def _run_one_probe(
@@ -1728,8 +1733,8 @@ def _capture_agent_cli_version(backend: str) -> tuple[str, str]:
     JSON key the caller should write under: `"claude_cli_version"` on
     a claude run, `"codex_cli_version"` on a codex run. The harness
     writes exactly one of those keys and leaves the other absent.
-    Unknown backends fall back to the claude tuple so non-registry
-    paths (e.g. goose) preserve the pre-codex behavior.
+    Unsupported backends are rejected rather than being routed through
+    a different backend's CLI protocol.
 
     Used to detect cross-run drift in the residual default context the
     CLI injects. A CLI upgrade between runs that changes that default
@@ -1751,14 +1756,14 @@ def _capture_agent_cli_version(backend: str) -> tuple[str, str]:
     """
     if backend == "codex":
         field_name = "codex_cli_version"
-        codex_bin = os.environ.get("CODEX_BIN") or "codex"
+        codex_bin = resolve_backend_command("codex", allow_bare_fallback=True)
         argv = [codex_bin, "--version"]
-    else:
-        # claude (and any unknown backend, by design) - same binary
-        # precedence as the judge / generator builders.
+    elif backend == "claude":
         field_name = "claude_cli_version"
-        claude_bin = os.environ.get("CLAUDE_BIN") or "claude"
+        claude_bin = resolve_backend_command("claude", allow_bare_fallback=True)
         argv = [claude_bin, "--version"]
+    else:
+        raise ValueError(f"unsupported behavioral-eval backend: {backend!r}")
     try:
         result = subprocess.run(
             argv,
@@ -2201,6 +2206,31 @@ async def _run_cli(args: argparse.Namespace) -> int:
     if data_dir is None:
         return 1
 
+    # Resolve the explicit installation choice through the same
+    # protected registry contract used by the service. The evaluator
+    # implements backend-specific wire protocols, so it must reject an
+    # installed backend whose evaluator vertical has not been written.
+    configured_backend = _resolve_renamed_key(
+        os.environ.get,
+        new_key="DEFAULT_BACKEND",
+        legacy_keys=["AGENT_BACKEND"],
+        context="behavioral eval env",
+        default="",
+    )
+    try:
+        eval_backend = resolve_default_backend(configured_backend or "")
+    except BackendRegistryError as exc:
+        print(f"eval: {exc}", file=sys.stderr)
+        return 1
+    if eval_backend not in _SUPPORTED_BEHAVIORAL_BACKENDS:
+        supported = ", ".join(sorted(_SUPPORTED_BEHAVIORAL_BACKENDS))
+        print(
+            f"eval: backend {eval_backend!r} is installed but behavioral evaluation "
+            f"does not implement its CLI protocol; supported backends: {supported}",
+            file=sys.stderr,
+        )
+        return 1
+
     # Drift detection + tag mapping: reuses the shared helper so every
     # eval consumer agrees on which probes are scorable on a given
     # snapshot.
@@ -2224,53 +2254,23 @@ async def _run_cli(args: argparse.Namespace) -> int:
     # _build_parser) means an unset flag yields override="" so the
     # branch below picks the right backend-appropriate default.
     #
-    # MODEL_REGISTRY covers every backend in ONESHOT_REASONER_BACKENDS,
-    # which is every real backend today. The else arm below survives as
-    # the defensive path for a DEFAULT_BACKEND env value the registry
-    # does not know (a typo, or a future backend mid-introduction):
-    # explicit --judge-model / --gen-model wins, otherwise the legacy
-    # _DEFAULT_JUDGE_MODEL / _DEFAULT_GEN_MODEL constants are used
-    # rather than crashing with a LookupError on an unset flag.
-    # Reads DEFAULT_BACKEND with the one-release AGENT_BACKEND fallback;
-    # global default is "claude" (this is the installation-wide setting,
-    # not a per-user override).
-    eval_backend = (
-        (
-            _resolve_renamed_key(
-                os.environ.get,
-                new_key="DEFAULT_BACKEND",
-                legacy_keys=["AGENT_BACKEND"],
-                context="behavioral eval env",
-                default="claude",
-            )
-            or "claude"
-        )
-        .strip()
-        .lower()
-    )
     # Provider is read from the eval-time env (DEFAULT_PROVIDER, with a
     # one-release fallback to the deprecated LLM_PROVIDER name) via the
     # shared resolver. Single-provider backends (claude, codex) ignore
     # this value because their provider is implicit at runtime.
     eval_provider = _resolve_eval_provider("behavioral eval env")
-    if eval_backend in ONESHOT_REASONER_BACKENDS:
-        resolved_judge_model = get_model_for(
-            ModelRole.BEHAVIORAL_JUDGE,
-            eval_backend,
-            eval_provider,
-            override=args.judge_model or "",
-        )
-        resolved_gen_model = get_model_for(
-            ModelRole.BEHAVIORAL_GEN,
-            eval_backend,
-            eval_provider,
-            override=args.gen_model or "",
-        )
-    else:
-        # Unrecognized DEFAULT_BACKEND env value: explicit flag wins,
-        # otherwise the legacy _DEFAULT_* constant is used.
-        resolved_judge_model = args.judge_model or _DEFAULT_JUDGE_MODEL
-        resolved_gen_model = args.gen_model or _DEFAULT_GEN_MODEL
+    resolved_judge_model = get_model_for(
+        ModelRole.BEHAVIORAL_JUDGE,
+        eval_backend,
+        eval_provider,
+        override=args.judge_model or "",
+    )
+    resolved_gen_model = get_model_for(
+        ModelRole.BEHAVIORAL_GEN,
+        eval_backend,
+        eval_provider,
+        override=args.gen_model or "",
+    )
     config = BehavioralConfig(
         judge_model=resolved_judge_model,
         judge_timeout_s=args.judge_timeout_s,

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -104,6 +104,7 @@ def _make_config(**overrides) -> BehavioralConfig:
         "gen_timeout_s": 120,
         "seed": "0123456789abcdef",
         "max_concurrency": 4,
+        "backend": "claude",
     }
     base.update(overrides)
     return BehavioralConfig(**base)
@@ -895,15 +896,8 @@ class TestBackendAwareModelResolution:
     """
     Verify the backend-aware dispatch in _run_cli for judge/gen models.
 
-    The resolution shape:
-    - On claude / codex, get_model_for(role, backend, override=args.x or "")
-      handles the lookup. Unset flag yields the registry default;
-      explicit flag wins via override.
-    - On goose (and any future non-registry backend), the legacy
-      _DEFAULT_JUDGE_MODEL / _DEFAULT_GEN_MODEL constants are used
-      when the flag is unset, mirroring pre-Phase-1 behavior. Without
-      this fallback, get_model_for would raise LookupError on the
-      missing (goose, BEHAVIORAL_*) row and crash the eval CLI.
+    Only backends with behavioral-evaluator protocol implementations
+    may reach model resolution or subprocess dispatch.
     """
 
     @staticmethod
@@ -957,44 +951,37 @@ class TestBackendAwareModelResolution:
             asyncio.run(behavioral._run_cli(args))
         return captured["config"]
 
-    def test_goose_unset_flag_uses_registry(self, tmp_path, monkeypatch):
-        """
-        Goose is a registry-resolved backend: an unset flag resolves
-        through the (goose, provider, role) rows the same way claude
-        does. DEFAULT_PROVIDER is required env on goose installs, so the
-        eval reads it the same way the runtime does.
-        """
-        from kai.config import ModelRole, get_model_for
+    @staticmethod
+    def _run_for_exit_code(args):
+        with (
+            patch.object(behavioral, "_initialize_memory", return_value=Path("/tmp")),
+            patch.object(behavioral, "_run_all_probes", new=AsyncMock()) as run_probes,
+        ):
+            exit_code = asyncio.run(behavioral._run_cli(args))
+        return exit_code, run_probes
 
-        monkeypatch.setenv("DEFAULT_BACKEND", "goose")
-        monkeypatch.setenv("DEFAULT_PROVIDER", "anthropic")
-        args = self._make_args(tmp_path)  # judge_model=None, gen_model=None
-        config = self._run_with_captured_config(args)
-        assert config.judge_model == get_model_for(ModelRole.BEHAVIORAL_JUDGE, "goose", "anthropic")
-        assert config.gen_model == get_model_for(ModelRole.BEHAVIORAL_GEN, "goose", "anthropic")
+    @pytest.mark.parametrize("backend", ["goose", "opencode"])
+    def test_backend_without_behavioral_protocol_fails_closed(self, backend, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("DEFAULT_BACKEND", backend)
+        args = self._make_args(tmp_path, judge_model="explicit-judge", gen_model="explicit-gen")
 
-    def test_unrecognized_backend_falls_back_to_legacy_constant(self, tmp_path, monkeypatch):
-        """
-        A DEFAULT_BACKEND env value the registry does not know must NOT
-        trigger get_model_for (no registry row, would raise
-        LookupError). The fallback path uses _DEFAULT_JUDGE_MODEL.
-        """
+        exit_code, run_probes = self._run_for_exit_code(args)
+
+        assert exit_code == 1
+        run_probes.assert_not_awaited()
+        assert (
+            f"backend {backend!r} is installed but behavioral evaluation does not implement" in capsys.readouterr().err
+        )
+
+    def test_unrecognized_backend_fails_closed(self, tmp_path, monkeypatch, capsys):
         monkeypatch.setenv("DEFAULT_BACKEND", "nonexistent")
-        args = self._make_args(tmp_path)  # judge_model=None, gen_model=None
-        config = self._run_with_captured_config(args)
-        assert config.judge_model == behavioral._DEFAULT_JUDGE_MODEL
-        assert config.gen_model == behavioral._DEFAULT_GEN_MODEL
+        args = self._make_args(tmp_path)
 
-    def test_goose_explicit_flag_wins(self, tmp_path, monkeypatch):
-        """
-        Explicit --judge-model still wins on goose. The fallback only
-        kicks in for an unset (None) flag value.
-        """
-        monkeypatch.setenv("DEFAULT_BACKEND", "goose")
-        args = self._make_args(tmp_path, judge_model="opus", gen_model="haiku")
-        config = self._run_with_captured_config(args)
-        assert config.judge_model == "opus"
-        assert config.gen_model == "haiku"
+        exit_code, run_probes = self._run_for_exit_code(args)
+
+        assert exit_code == 1
+        run_probes.assert_not_awaited()
+        assert "configured default backend 'nonexistent' is not valid" in capsys.readouterr().err
 
     def test_claude_unset_flag_uses_registry(self, tmp_path, monkeypatch):
         """
@@ -1020,28 +1007,22 @@ class TestBackendAwareModelResolution:
 
     def test_behavioral_eval_resolves_new_DEFAULT_BACKEND(self, tmp_path, monkeypatch):
         """The eval reads DEFAULT_BACKEND. With only the new key set
-        (no AGENT_BACKEND), it stamps the resolved backend and resolves
-        the goose registry rows."""
-        from kai.config import ModelRole, get_model_for
+        (no AGENT_BACKEND), it stamps the resolved backend."""
 
         monkeypatch.delenv("AGENT_BACKEND", raising=False)
-        monkeypatch.setenv("DEFAULT_BACKEND", "goose")
-        monkeypatch.setenv("DEFAULT_PROVIDER", "anthropic")
+        monkeypatch.setenv("DEFAULT_BACKEND", "codex")
         args = self._make_args(tmp_path)
         config = self._run_with_captured_config(args)
-        assert config.judge_model == get_model_for(ModelRole.BEHAVIORAL_JUDGE, "goose", "anthropic")
+        assert config.backend == "codex"
 
     def test_behavioral_eval_resolves_legacy_AGENT_BACKEND(self, tmp_path, monkeypatch):
         """One-release back-compat: a legacy AGENT_BACKEND env value
         (no DEFAULT_BACKEND) still resolves the eval backend."""
-        from kai.config import ModelRole, get_model_for
-
         monkeypatch.delenv("DEFAULT_BACKEND", raising=False)
-        monkeypatch.setenv("AGENT_BACKEND", "goose")
-        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        monkeypatch.setenv("AGENT_BACKEND", "codex")
         args = self._make_args(tmp_path)
         config = self._run_with_captured_config(args)
-        assert config.judge_model == get_model_for(ModelRole.BEHAVIORAL_JUDGE, "goose", "anthropic")
+        assert config.backend == "codex"
 
 
 class TestProbeIdMatchesSourcePosition:
@@ -1750,16 +1731,9 @@ class TestCaptureAgentCliVersionCodex:
         assert field == "codex_cli_version"
         assert mock_run.call_args[0][0] == ["/tmp/fake-codex", "--version"]
 
-    def test_unknown_backend_falls_back_to_claude(self, monkeypatch):
-        monkeypatch.delenv("CODEX_BIN", raising=False)
-        monkeypatch.delenv("CLAUDE_BIN", raising=False)
-        fake_result = MagicMock()
-        fake_result.returncode = 0
-        fake_result.stdout = "claude 2.1.118\n"
-        with patch("kai.eval.behavioral.subprocess.run", return_value=fake_result) as mock_run:
-            field, _value = _capture_agent_cli_version("goose")
-        assert field == "claude_cli_version"
-        assert mock_run.call_args[0][0] == ["claude", "--version"]
+    def test_unknown_backend_fails_closed(self):
+        with pytest.raises(ValueError, match="unsupported behavioral-eval backend: 'goose'"):
+            _capture_agent_cli_version("goose")
 
     def test_subprocess_failure_returns_unknown(self):
         fake_result = MagicMock()


### PR DESCRIPTION
## Summary

- resolve the behavioral evaluator's backend through the same explicit default/backend-registry contract as the service
- reject backend identities whose behavioral CLI protocol is not implemented before reading memory or spawning a process
- replace final-else backend routing with explicit Claude/Codex branches
- resolve evaluator executables through the protected backend registry in installed mode while retaining development env/PATH compatibility
- require `BehavioralConfig` callers to name the backend explicitly

## Security impact

Previously, `goose`, `opencode`, an unknown value, or a missing selection could reach fallback paths that constructed and parsed another backend's CLI protocol. That could execute an unintended installed binary and mislabel the evaluation result. The evaluator now fails closed with an operator-facing error and does no probe/memory/subprocess work for unsupported identities.

This is scoped to `python -m kai.eval.behavioral`; normal Telegram chat routing is unchanged.

## Verification

- `python -m pytest tests/test_eval_behavioral.py tests/test_backend_registry.py -q` — 158 passed
- `python -m pytest tests/` — 4,834 passed, 1 skipped
- `make check`
- `make typecheck`