### PR TITLE
Make scheduled agent jobs backend-neutral

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -517,7 +517,7 @@ def build_session_context(
             f"http://localhost:{api.webhook_port}/api/schedule "
             f"with header 'X-Webhook-Secret: $KAI_WEBHOOK_SECRET' (environment variable). "
             f"Required fields: name, prompt, schedule_type, schedule_data. "
-            f"Optional: job_type (reminder|claude), auto_remove (bool). "
+            f"Optional: job_type (reminder|agent), auto_remove (bool). "
             f"To list jobs: GET /api/jobs. To update: PATCH /api/jobs/{{id}}. "
             f"To delete: DELETE /api/jobs/{{id}}.]"
         )

--- a/src/kai/cron.py
+++ b/src/kai/cron.py
@@ -4,14 +4,14 @@ Scheduled job execution engine using APScheduler.
 Provides functionality to:
 1. Load active jobs from the database and register them with APScheduler at startup
 2. Register new jobs on-the-fly when created via the scheduling API
-3. Execute jobs when their triggers fire (reminders and Claude-processed tasks)
+3. Execute jobs when their triggers fire (reminders and agent-processed tasks)
 4. Handle conditional auto-remove jobs with CONDITION_MET/CONDITION_NOT_MET markers
 
 Job types:
     - **reminder** — Sends the prompt text directly to Telegram as a message.
-    - **claude** — Sends the prompt through the persistent Claude process and
-      delivers Claude's response to Telegram. Supports auto-remove mode where
-      the job deactivates itself when Claude indicates a condition is met.
+    - **agent** — Sends the prompt through the user's selected backend and
+      delivers its response to Telegram. Supports auto-remove mode where the
+      job deactivates itself when the backend indicates a condition is met.
 
 Schedule types:
     - **once** — Fires at a specific ISO datetime, then deactivates.
@@ -33,13 +33,14 @@ from telegram.ext import Application, ContextTypes, ExtBot
 
 from kai import sessions
 from kai.history import log_message
+from kai.job_types import JOB_TYPE_AGENT, JOB_TYPE_REMINDER, normalize_job_type
 from kai.locks import get_lock
 from kai.telegram_utils import chunk_text
 
 log = logging.getLogger(__name__)
 
 # Protocol markers for conditional auto-remove jobs.
-# Claude is instructed to begin its response with one of these markers.
+# The selected agent backend is instructed to begin its response with one of these markers.
 # Matching is case-insensitive and checks the start of the first non-empty line.
 _CONDITION_MET_PREFIX = "CONDITION_MET:"
 _CONDITION_NOT_MET_PREFIX = (
@@ -175,13 +176,14 @@ def _register_job(app: Application, job: dict) -> None:
     jq = app.job_queue
     assert jq is not None
     schedule = json.loads(job["schedule_data"])
+    job_type = normalize_job_type(job["job_type"])
     job_name = f"cron_{job['id']}"
 
     # Data passed to the callback when the job fires
     callback_data = {
         "job_id": job["id"],
         "chat_id": job["chat_id"],
-        "job_type": job["job_type"],
+        "job_type": job_type,
         "prompt": job["prompt"],
         "auto_remove": job["auto_remove"],
         "notify_on_check": job.get("notify_on_check", False),
@@ -231,10 +233,10 @@ async def _job_callback(context: ContextTypes.DEFAULT_TYPE) -> None:
 
     Routes to the appropriate handler based on job_type:
     - "reminder" jobs send the prompt text directly to Telegram.
-    - "claude" jobs send the prompt through the persistent Claude process,
+    - "agent" jobs send the prompt through the user's selected backend,
       then handle the response (including conditional auto-remove logic).
 
-    For Claude jobs with auto_remove=True, the response is inspected for
+    For agent jobs with auto_remove=True, the response is inspected for
     protocol markers:
     - CONDITION_MET: <message> — delivers the message and deactivates the job.
     - CONDITION_NOT_MET: <message> — silently continues (default), or delivers
@@ -249,7 +251,11 @@ async def _job_callback(context: ContextTypes.DEFAULT_TYPE) -> None:
     assert isinstance(job.data, dict)
     data: dict = job.data
     chat_id = data["chat_id"]
-    job_type = data["job_type"]
+    try:
+        job_type = normalize_job_type(data["job_type"])
+    except ValueError:
+        log.error("Job %s has unsupported job_type %r; skipping", data.get("job_id", "<unknown>"), data.get("job_type"))
+        return
     prompt = data["prompt"]
     auto_remove = data["auto_remove"]
     job_id = data["job_id"]
@@ -257,7 +263,7 @@ async def _job_callback(context: ContextTypes.DEFAULT_TYPE) -> None:
     log.info("Job %d '%s' fired (type=%s)", job_id, data["name"], job_type)
 
     # ── Reminder jobs: send prompt text directly ──
-    if job_type == "reminder":
+    if job_type == JOB_TYPE_REMINDER:
         # Strip stray backslash escapes (e.g. \! from bash double-quoting in curl)
         prompt = prompt.replace("\\!", "!").replace("\\.", ".").replace("\\?", "?")
         try:
@@ -278,14 +284,18 @@ async def _job_callback(context: ContextTypes.DEFAULT_TYPE) -> None:
             await sessions.deactivate_job(job_id)
         return
 
-    # ── Claude jobs: send prompt through the subprocess pool ──
+    if job_type != JOB_TYPE_AGENT:  # pragma: no cover - normalize_job_type guards this
+        log.error("Job %d has unsupported normalized job_type %r; skipping", job_id, job_type)
+        return
+
+    # ── Agent jobs: send prompt through the subprocess pool ──
     pool = context.bot_data.get("pool")
     if not pool:
         log.error("No subprocess pool available for job %d", job_id)
         return
 
     async with get_lock(chat_id):
-        # Show typing indicator while Claude processes the prompt
+        # Show typing indicator while the selected backend processes the prompt
         try:
             await context.bot.send_chat_action(chat_id=chat_id, action=ChatAction.TYPING)
         except Exception:

--- a/src/kai/job_types.py
+++ b/src/kai/job_types.py
@@ -1,0 +1,20 @@
+"""Canonical scheduled-job type identifiers and compatibility handling."""
+
+JOB_TYPE_REMINDER = "reminder"
+JOB_TYPE_AGENT = "agent"
+
+# Accepted only as an input/storage compatibility alias. New writes use
+# JOB_TYPE_AGENT so the persisted identifier does not name an implementation.
+LEGACY_JOB_TYPE_AGENT = "claude"
+
+CANONICAL_JOB_TYPES = (JOB_TYPE_REMINDER, JOB_TYPE_AGENT)
+
+
+def normalize_job_type(job_type: object) -> str:
+    """Return a canonical job type or reject an unknown identity."""
+    if job_type == LEGACY_JOB_TYPE_AGENT:
+        return JOB_TYPE_AGENT
+    if job_type in CANONICAL_JOB_TYPES:
+        return str(job_type)
+    valid = ", ".join(CANONICAL_JOB_TYPES)
+    raise ValueError(f"job_type must be one of: {valid}")

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -7,7 +7,7 @@ into four tables:
 1. **sessions** - Agent session tracking (session ID, model).
    One row per chat_id, upserted on each response.
 
-2. **jobs** - Scheduled tasks (reminders, agent jobs with job_type "claude", conditional monitors).
+2. **jobs** - Scheduled tasks (reminders, agent jobs, conditional monitors).
    Created via the scheduling API (POST /api/schedule) or the inner agent's curl.
    Jobs have a schedule_type (once/daily/interval) and can be deactivated
    without deletion to preserve history.
@@ -40,6 +40,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
 import aiosqlite
+
+from kai.job_types import JOB_TYPE_AGENT, LEGACY_JOB_TYPE_AGENT, normalize_job_type
 
 if TYPE_CHECKING:
     from kai.config import Config, WorkspaceConfig
@@ -167,6 +169,15 @@ async def init_db(db_path: Path) -> None:
         if "notify_on_check" not in columns:
             log.debug("Adding notify_on_check column to jobs table")
             await _get_db().execute("ALTER TABLE jobs ADD COLUMN notify_on_check INTEGER DEFAULT 0")
+
+        # Durable compatibility migration: the old value named one
+        # implementation even though scheduled work always routes through the
+        # owning user's selected backend. Preserve every job while replacing
+        # only that identifier with the backend-neutral canonical value.
+        await _get_db().execute(
+            "UPDATE jobs SET job_type = ? WHERE job_type = ?",
+            (JOB_TYPE_AGENT, LEGACY_JOB_TYPE_AGENT),
+        )
 
         log.debug("Creating settings table")
         await _get_db().execute("""
@@ -514,7 +525,8 @@ async def create_job(
     Args:
         chat_id: Telegram chat ID that owns this job.
         name: Human-readable job name (shown in /jobs).
-        job_type: "reminder" (sends prompt as-is) or "claude" (processed by the agent backend).
+        job_type: "reminder" (sends prompt as-is) or "agent" (processed by the selected backend).
+            The legacy value "claude" is accepted and stored as "agent".
         prompt: Message text for reminders, or the agent prompt for agent-type jobs.
         schedule_type: "once", "daily", or "interval".
         schedule_data: JSON string with schedule details.
@@ -528,10 +540,20 @@ async def create_job(
     Returns:
         The auto-generated integer job ID.
     """
+    canonical_job_type = normalize_job_type(job_type)
     cursor = await _get_db().execute(
         """INSERT INTO jobs (chat_id, name, job_type, prompt, schedule_type, schedule_data, auto_remove, notify_on_check)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-        (chat_id, name, job_type, prompt, schedule_type, schedule_data, int(auto_remove), int(notify_on_check)),
+        (
+            chat_id,
+            name,
+            canonical_job_type,
+            prompt,
+            schedule_type,
+            schedule_data,
+            int(auto_remove),
+            int(notify_on_check),
+        ),
     )
     await _get_db().commit()
     # RuntimeError instead of assert so this guard survives python -O.
@@ -637,7 +659,7 @@ async def update_job(
     is inactive.
 
     Note: job_type and chat_id are intentionally not updatable. Changing
-    a job from reminder to claude (or vice versa) is a fundamentally
+    a job from reminder to agent processing (or vice versa) is a fundamentally
     different job — delete and recreate for that.
 
     Args:

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -20,7 +20,7 @@ Routes are organized into these groups:
     - /webhook/telegram     - Telegram updates (webhook mode only, secret_token auth)
     - /webhook/github       - GitHub events with HMAC-SHA256 signature validation
     - /webhook              - Generic webhooks with shared-secret auth
-    - /api/schedule         - Job creation API (used by inner Claude via curl)
+    - /api/schedule         - Job creation API (used by persistent agents via curl)
     - /api/jobs             - Job listing and detail API
     - /api/jobs/{id}        - Job detail (GET), deletion (DELETE), and update (PATCH)
     - /api/services/{name}  - External service proxy (injects auth from .env)
@@ -62,6 +62,7 @@ from telegram.ext import Application
 from kai import cron, memory, review, services, sessions, triage
 from kai.config import DATA_DIR, IMAGE_EXTENSIONS, Config, ModelRole, UserConfig, resolve_user_model
 from kai.internal_api_auth import InternalAPIAuth, InternalAPIPrincipal, InternalAPIScope
+from kai.job_types import CANONICAL_JOB_TYPES, normalize_job_type
 from kai.telegram_utils import chunk_text
 
 log = logging.getLogger(__name__)
@@ -1150,9 +1151,6 @@ async def _handle_generic(request: web.Request) -> web.Response:
 # Valid schedule types accepted by the scheduling API
 _VALID_SCHEDULE_TYPES = ("once", "daily", "interval")
 
-# Valid job types accepted by the scheduling API
-_VALID_JOB_TYPES = ("reminder", "claude")
-
 
 def _validate_schedule_data(
     schedule_data: dict | str,
@@ -1236,8 +1234,8 @@ async def _handle_schedule(request: web.Request, principal: InternalAPIPrincipal
     """
     Create a new scheduled job via the HTTP API.
 
-    This is the primary interface for the inner Claude Code process to create
-    scheduled tasks. Claude uses curl to POST here from within the workspace.
+    This is the primary interface for persistent agent backends to create
+    scheduled tasks from within the workspace.
 
     Required JSON fields: name, prompt, schedule_type, schedule_data.
     Optional fields: job_type (default "reminder"), auto_remove (default false),
@@ -1282,11 +1280,14 @@ async def _handle_schedule(request: web.Request, principal: InternalAPIPrincipal
             status=400,
         )
 
-    # Optional fields with defaults — validate job_type the same way as schedule_type
-    job_type = payload.get("job_type", "reminder")
-    if job_type not in _VALID_JOB_TYPES:
+    # Normalize the compatibility alias at ingress so all new rows use the
+    # backend-neutral identifier. sessions.create_job repeats this validation
+    # as the persistence boundary for non-HTTP callers.
+    try:
+        job_type = normalize_job_type(payload.get("job_type", "reminder"))
+    except ValueError:
         return web.json_response(
-            {"error": f"job_type must be one of: {', '.join(_VALID_JOB_TYPES)}"},
+            {"error": f"job_type must be one of: {', '.join(CANONICAL_JOB_TYPES)}"},
             status=400,
         )
     auto_remove = payload.get("auto_remove", False)
@@ -1347,7 +1348,7 @@ async def _handle_get_jobs(request: web.Request, principal: InternalAPIPrincipal
     """
     List all active jobs for the configured chat.
 
-    Used by the inner Claude to check what jobs are currently scheduled
+    Used by persistent agents to check what jobs are currently scheduled
     without needing to parse Telegram bot command output.
     """
 

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -7,7 +7,7 @@ Covers:
 3. register_job_by_id() - DB lookup + registration
 4. _register_new_jobs() - startup bulk registration
 5. init_jobs() - entry point delegation
-6. _job_callback() - reminder and Claude job execution branches
+6. _job_callback() - reminder and agent job execution branches
 """
 
 import json
@@ -31,7 +31,7 @@ from kai.cron import (
 
 @pytest.fixture(autouse=True)
 def mock_lock(monkeypatch):
-    """Stub out the async lock so Claude job tests don't need real asyncio locks."""
+    """Stub out the async lock so agent job tests don't need real asyncio locks."""
     lock = AsyncMock()
     lock.__aenter__ = AsyncMock()
     lock.__aexit__ = AsyncMock(return_value=False)
@@ -94,19 +94,19 @@ def mock_context():
         "schedule_type": "daily",
     }
     ctx.job.schedule_removal = MagicMock()
-    # Default: no Claude process (reminder tests don't need it)
+    # Default: no agent process (reminder tests don't need it)
     ctx.bot_data = {}
     return ctx
 
 
-def _make_claude_mock(text="The response", success=True, error=None):
+def _make_agent_mock(text="The response", success=True, error=None):
     """
-    Build a mock Claude process whose send() yields a single done event.
+    Build a mock agent pool whose send() yields a single done event.
 
     The async generator protocol matches what _job_callback expects:
     iterate events until event.done is True, then read event.response.
     """
-    mock_claude = MagicMock()
+    mock_agent = MagicMock()
 
     async def fake_send(prompt, chat_id=None):
         event = MagicMock()
@@ -117,8 +117,8 @@ def _make_claude_mock(text="The response", success=True, error=None):
         event.response.error = error
         yield event
 
-    mock_claude.send = fake_send
-    return mock_claude
+    mock_agent.send = fake_send
+    return mock_agent
 
 
 # ── _ensure_utc ──────────────────────────────────────────────────────
@@ -150,6 +150,19 @@ class TestEnsureUtc:
 
 
 class TestRegisterJob:
+    def test_legacy_agent_type_is_normalized_in_callback_data(self, mock_app):
+        job = _make_job(job_type="claude")
+        _register_job(mock_app, job)
+        assert mock_app.job_queue.run_daily.call_args.kwargs["data"]["job_type"] == "agent"
+
+    def test_unknown_job_type_is_rejected_before_registration(self, mock_app):
+        job = _make_job(job_type="unknown")
+        with pytest.raises(ValueError, match="job_type must be one of: reminder, agent"):
+            _register_job(mock_app, job)
+        mock_app.job_queue.run_once.assert_not_called()
+        mock_app.job_queue.run_daily.assert_not_called()
+        mock_app.job_queue.run_repeating.assert_not_called()
+
     def test_once_schedule(self, mock_app):
         """run_once is called with the parsed run_at datetime."""
         job = _make_job(
@@ -417,51 +430,74 @@ class TestJobCallbackReminder:
         mock_context.job.schedule_removal.assert_not_called()
 
 
-# ── _job_callback: Claude jobs (no auto-remove) ─────────────────────
+# ── _job_callback: agent jobs (no auto-remove) ──────────────────────
 
 
-class TestJobCallbackClaude:
+class TestJobCallbackAgent:
     @pytest.fixture(autouse=True)
-    def _setup_claude_context(self, mock_context):
-        """Configure mock_context for Claude job tests."""
-        mock_context.job.data["job_type"] = "claude"
+    def _setup_agent_context(self, mock_context):
+        """Configure mock_context for agent job tests."""
+        mock_context.job.data["job_type"] = "agent"
         self.ctx = mock_context
 
     @pytest.mark.asyncio()
-    async def test_sends_claude_response_to_telegram(self):
-        """Claude response is delivered with a [Job: name] prefix."""
-        self.ctx.bot_data = {"pool": _make_claude_mock("Hello world")}
+    async def test_sends_agent_response_to_telegram(self):
+        """The selected backend's response is delivered with a [Job: name] prefix."""
+        self.ctx.bot_data = {"pool": _make_agent_mock("Hello world")}
         with patch("kai.cron.log_message"):
             await _job_callback(self.ctx)
         self.ctx.bot.send_message.assert_called_once_with(chat_id=12345, text="[Job: Test Job]\nHello world")
 
     @pytest.mark.asyncio()
+    async def test_legacy_job_type_routes_through_selected_agent(self):
+        self.ctx.job.data["job_type"] = "claude"
+        self.ctx.bot_data = {"pool": _make_agent_mock("Legacy job preserved")}
+        with patch("kai.cron.log_message"):
+            await _job_callback(self.ctx)
+        self.ctx.bot.send_message.assert_called_once_with(
+            chat_id=12345,
+            text="[Job: Test Job]\nLegacy job preserved",
+        )
+
+    @pytest.mark.asyncio()
+    async def test_unknown_job_type_never_reaches_agent_pool(self, caplog):
+        self.ctx.job.data["job_type"] = "unknown"
+        pool = MagicMock()
+        self.ctx.bot_data = {"pool": pool}
+
+        await _job_callback(self.ctx)
+
+        assert "unsupported job_type 'unknown'; skipping" in caplog.text
+        pool.send.assert_not_called()
+        self.ctx.bot.send_message.assert_not_called()
+
+    @pytest.mark.asyncio()
     async def test_shows_typing_indicator(self):
-        """A typing indicator is sent before the Claude request."""
-        self.ctx.bot_data = {"pool": _make_claude_mock()}
+        """A typing indicator is sent before the agent request."""
+        self.ctx.bot_data = {"pool": _make_agent_mock()}
         with patch("kai.cron.log_message"):
             await _job_callback(self.ctx)
         self.ctx.bot.send_chat_action.assert_called_once()
 
     @pytest.mark.asyncio()
-    async def test_no_claude_process_returns_early(self, caplog):
-        """When claude isn't in bot_data, logs error and returns without crashing."""
+    async def test_no_agent_pool_returns_early(self, caplog):
+        """When the agent pool isn't in bot_data, log and return without crashing."""
         self.ctx.bot_data = {}
         await _job_callback(self.ctx)
         assert "No subprocess pool" in caplog.text
         self.ctx.bot.send_message.assert_not_called()
 
     @pytest.mark.asyncio()
-    async def test_claude_stream_exception_returns_early(self, caplog):
+    async def test_agent_stream_exception_returns_early(self, caplog):
         """Exceptions during agent interaction are caught and logged."""
-        mock_claude = MagicMock()
+        mock_agent = MagicMock()
 
         async def exploding_send(prompt):
             raise RuntimeError("process died")
             yield
 
-        mock_claude.send = exploding_send
-        self.ctx.bot_data = {"pool": mock_claude}
+        mock_agent.send = exploding_send
+        self.ctx.bot_data = {"pool": mock_agent}
         await _job_callback(self.ctx)
         assert "crashed" in caplog.text
         self.ctx.bot.send_message.assert_not_called()
@@ -469,7 +505,7 @@ class TestJobCallbackClaude:
     @pytest.mark.asyncio()
     async def test_no_done_event_returns_early(self, caplog):
         """When the stream ends without a done event, logs warning and returns."""
-        mock_claude = MagicMock()
+        mock_agent = MagicMock()
 
         async def empty_send(prompt, chat_id=None):
             # Yield a non-done event, then end
@@ -477,16 +513,16 @@ class TestJobCallbackClaude:
             event.done = False
             yield event
 
-        mock_claude.send = empty_send
-        self.ctx.bot_data = {"pool": mock_claude}
+        mock_agent.send = empty_send
+        self.ctx.bot_data = {"pool": mock_agent}
         await _job_callback(self.ctx)
         assert "without a done event" in caplog.text
         self.ctx.bot.send_message.assert_not_called()
 
     @pytest.mark.asyncio()
-    async def test_claude_error_response_returns_early(self, caplog):
-        """When Claude returns success=False, logs the error and returns."""
-        self.ctx.bot_data = {"pool": _make_claude_mock(success=False, error="rate limited")}
+    async def test_agent_error_response_returns_early(self, caplog):
+        """When the backend returns success=False, log the error and return."""
+        self.ctx.bot_data = {"pool": _make_agent_mock(success=False, error="rate limited")}
         await _job_callback(self.ctx)
         assert "rate limited" in caplog.text
         self.ctx.bot.send_message.assert_not_called()
@@ -494,7 +530,7 @@ class TestJobCallbackClaude:
     @pytest.mark.asyncio()
     async def test_forbidden_on_send_deactivates(self):
         """Forbidden when sending the result deactivates and removes the job."""
-        self.ctx.bot_data = {"pool": _make_claude_mock()}
+        self.ctx.bot_data = {"pool": _make_agent_mock()}
         self.ctx.bot.send_message.side_effect = Forbidden("blocked")
         with (
             patch("kai.cron.log_message"),
@@ -507,7 +543,7 @@ class TestJobCallbackClaude:
     @pytest.mark.asyncio()
     async def test_other_send_exception_does_not_deactivate(self):
         """Non-Forbidden send exceptions log the error but keep the job active."""
-        self.ctx.bot_data = {"pool": _make_claude_mock()}
+        self.ctx.bot_data = {"pool": _make_agent_mock()}
         self.ctx.bot.send_message.side_effect = RuntimeError("timeout")
         with (
             patch("kai.cron.log_message"),
@@ -517,10 +553,10 @@ class TestJobCallbackClaude:
         mock_deactivate.assert_not_called()
 
     @pytest.mark.asyncio()
-    async def test_one_shot_claude_deactivates_after_sending(self):
-        """One-shot Claude jobs (schedule_type=once) deactivate after delivery."""
+    async def test_one_shot_agent_deactivates_after_sending(self):
+        """One-shot agent jobs (schedule_type=once) deactivate after delivery."""
         self.ctx.job.data["schedule_type"] = "once"
-        self.ctx.bot_data = {"pool": _make_claude_mock("The answer is 42")}
+        self.ctx.bot_data = {"pool": _make_agent_mock("The answer is 42")}
         with (
             patch("kai.cron.log_message"),
             patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock) as mock_deactivate,
@@ -533,10 +569,10 @@ class TestJobCallbackClaude:
         self.ctx.job.schedule_removal.assert_not_called()
 
     @pytest.mark.asyncio()
-    async def test_recurring_claude_does_not_deactivate(self):
-        """Recurring Claude jobs (daily/interval) are not deactivated after delivery."""
+    async def test_recurring_agent_does_not_deactivate(self):
+        """Recurring agent jobs (daily/interval) are not deactivated after delivery."""
         self.ctx.job.data["schedule_type"] = "daily"
-        self.ctx.bot_data = {"pool": _make_claude_mock("Daily report")}
+        self.ctx.bot_data = {"pool": _make_agent_mock("Daily report")}
         with (
             patch("kai.cron.log_message"),
             patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock) as mock_deactivate,
@@ -551,15 +587,15 @@ class TestJobCallbackClaude:
 class TestJobCallbackConditionMet:
     @pytest.fixture(autouse=True)
     def _setup_auto_remove_context(self, mock_context):
-        """Configure mock_context for auto-remove Claude job tests."""
-        mock_context.job.data["job_type"] = "claude"
+        """Configure mock_context for auto-remove agent job tests."""
+        mock_context.job.data["job_type"] = "agent"
         mock_context.job.data["auto_remove"] = True
         self.ctx = mock_context
 
     @pytest.mark.asyncio()
     async def test_detects_condition_met_prefix(self):
         """Case-insensitive CONDITION_MET: prefix triggers the met branch."""
-        self.ctx.bot_data = {"pool": _make_claude_mock("condition_met: Package arrived!")}
+        self.ctx.bot_data = {"pool": _make_agent_mock("condition_met: Package arrived!")}
         with (
             patch("kai.cron.log_message"),
             patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock) as mock_deactivate,
@@ -572,7 +608,7 @@ class TestJobCallbackConditionMet:
     @pytest.mark.asyncio()
     async def test_extracts_message_after_marker(self):
         """The message text after CONDITION_MET: is delivered to the user."""
-        self.ctx.bot_data = {"pool": _make_claude_mock("CONDITION_MET: Package arrived!")}
+        self.ctx.bot_data = {"pool": _make_agent_mock("CONDITION_MET: Package arrived!")}
         with (
             patch("kai.cron.log_message"),
             patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock),
@@ -584,7 +620,7 @@ class TestJobCallbackConditionMet:
     @pytest.mark.asyncio()
     async def test_multi_line_response(self):
         """Text on lines after the marker line is included in the message."""
-        self.ctx.bot_data = {"pool": _make_claude_mock("CONDITION_MET: Done\nHere are details.")}
+        self.ctx.bot_data = {"pool": _make_agent_mock("CONDITION_MET: Done\nHere are details.")}
         with (
             patch("kai.cron.log_message"),
             patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock),
@@ -597,7 +633,7 @@ class TestJobCallbackConditionMet:
     @pytest.mark.asyncio()
     async def test_no_message_after_marker(self):
         """When nothing follows CONDITION_MET:, a default message is sent."""
-        self.ctx.bot_data = {"pool": _make_claude_mock("CONDITION_MET:")}
+        self.ctx.bot_data = {"pool": _make_agent_mock("CONDITION_MET:")}
         with (
             patch("kai.cron.log_message"),
             patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock),
@@ -609,7 +645,7 @@ class TestJobCallbackConditionMet:
     @pytest.mark.asyncio()
     async def test_forbidden_still_deactivates(self):
         """Even if the chat is gone (Forbidden), the job is still deactivated."""
-        self.ctx.bot_data = {"pool": _make_claude_mock("CONDITION_MET: done")}
+        self.ctx.bot_data = {"pool": _make_agent_mock("CONDITION_MET: done")}
         self.ctx.bot.send_message.side_effect = Forbidden("blocked")
         with (
             patch("kai.cron.log_message"),
@@ -626,8 +662,8 @@ class TestJobCallbackConditionMet:
 class TestJobCallbackConditionNotMet:
     @pytest.fixture(autouse=True)
     def _setup_auto_remove_context(self, mock_context):
-        """Configure mock_context for auto-remove Claude job tests."""
-        mock_context.job.data["job_type"] = "claude"
+        """Configure mock_context for auto-remove agent job tests."""
+        mock_context.job.data["job_type"] = "agent"
         mock_context.job.data["auto_remove"] = True
         mock_context.job.data["notify_on_check"] = False
         self.ctx = mock_context
@@ -635,7 +671,7 @@ class TestJobCallbackConditionNotMet:
     @pytest.mark.asyncio()
     async def test_detects_condition_not_met(self):
         """CONDITION_NOT_MET is recognized (case-insensitive, no colon required)."""
-        self.ctx.bot_data = {"pool": _make_claude_mock("CONDITION_NOT_MET")}
+        self.ctx.bot_data = {"pool": _make_agent_mock("CONDITION_NOT_MET")}
         with patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock) as mock_deactivate:
             await _job_callback(self.ctx)
         # Job stays active - not deactivated
@@ -645,7 +681,7 @@ class TestJobCallbackConditionNotMet:
     @pytest.mark.asyncio()
     async def test_silent_when_notify_disabled(self):
         """With notify_on_check=False, no message is sent to the user."""
-        self.ctx.bot_data = {"pool": _make_claude_mock("CONDITION_NOT_MET: still waiting")}
+        self.ctx.bot_data = {"pool": _make_agent_mock("CONDITION_NOT_MET: still waiting")}
         await _job_callback(self.ctx)
         self.ctx.bot.send_message.assert_not_called()
 
@@ -653,7 +689,7 @@ class TestJobCallbackConditionNotMet:
     async def test_sends_message_when_notify_enabled(self):
         """With notify_on_check=True, the status message is sent to the user."""
         self.ctx.job.data["notify_on_check"] = True
-        self.ctx.bot_data = {"pool": _make_claude_mock("CONDITION_NOT_MET: Package in transit")}
+        self.ctx.bot_data = {"pool": _make_agent_mock("CONDITION_NOT_MET: Package in transit")}
         with patch("kai.cron.log_message"):
             await _job_callback(self.ctx)
         sent_text = self.ctx.bot.send_message.call_args.kwargs["text"]
@@ -664,7 +700,7 @@ class TestJobCallbackConditionNotMet:
         """Both 'CONDITION_NOT_MET: msg' and 'CONDITION_NOT_MET msg' work."""
         self.ctx.job.data["notify_on_check"] = True
         # Without colon
-        self.ctx.bot_data = {"pool": _make_claude_mock("CONDITION_NOT_MET Still checking")}
+        self.ctx.bot_data = {"pool": _make_agent_mock("CONDITION_NOT_MET Still checking")}
         with patch("kai.cron.log_message"):
             await _job_callback(self.ctx)
         # The lstrip(":") handles the optional colon; without it, the space
@@ -676,7 +712,7 @@ class TestJobCallbackConditionNotMet:
     async def test_no_message_after_marker_with_notify(self):
         """When nothing follows CONDITION_NOT_MET with notify=True, sends default text."""
         self.ctx.job.data["notify_on_check"] = True
-        self.ctx.bot_data = {"pool": _make_claude_mock("CONDITION_NOT_MET")}
+        self.ctx.bot_data = {"pool": _make_agent_mock("CONDITION_NOT_MET")}
         with patch("kai.cron.log_message"):
             await _job_callback(self.ctx)
         sent_text = self.ctx.bot.send_message.call_args.kwargs["text"]
@@ -686,7 +722,7 @@ class TestJobCallbackConditionNotMet:
     async def test_forbidden_with_notify_deactivates(self):
         """Forbidden when sending a notify update deactivates and removes the job."""
         self.ctx.job.data["notify_on_check"] = True
-        self.ctx.bot_data = {"pool": _make_claude_mock("CONDITION_NOT_MET: status")}
+        self.ctx.bot_data = {"pool": _make_agent_mock("CONDITION_NOT_MET: status")}
         self.ctx.bot.send_message.side_effect = Forbidden("blocked")
         with (
             patch("kai.cron.log_message"),
@@ -700,7 +736,7 @@ class TestJobCallbackConditionNotMet:
     async def test_one_shot_condition_not_met_deactivates(self):
         """One-shot auto-remove jobs deactivate even when condition is not met."""
         self.ctx.job.data["schedule_type"] = "once"
-        self.ctx.bot_data = {"pool": _make_claude_mock("CONDITION_NOT_MET")}
+        self.ctx.bot_data = {"pool": _make_agent_mock("CONDITION_NOT_MET")}
         with patch("kai.cron.sessions.deactivate_job", new_callable=AsyncMock) as mock_deactivate:
             await _job_callback(self.ctx)
         mock_deactivate.assert_called_once_with(1)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -247,7 +247,7 @@ class TestJobs:
         job_id = await sessions.create_job(
             chat_id=1,
             name="j1",
-            job_type="claude",
+            job_type="agent",
             prompt="analyze",
             schedule_type="daily",
             schedule_data='{"times": ["09:00"]}',
@@ -255,7 +255,33 @@ class TestJobs:
         job = await sessions.get_job_by_id(job_id)
         assert job is not None
         assert job["name"] == "j1"
-        assert job["job_type"] == "claude"
+        assert job["job_type"] == "agent"
+
+    async def test_legacy_agent_type_is_stored_canonically(self, db):
+        job_id = await sessions.create_job(
+            chat_id=1,
+            name="legacy",
+            job_type="claude",
+            prompt="analyze",
+            schedule_type="daily",
+            schedule_data='{"times": ["09:00"]}',
+        )
+        job = await sessions.get_job_by_id(job_id)
+        assert job is not None
+        assert job["job_type"] == "agent"
+
+    async def test_create_job_rejects_unknown_type(self, db):
+        with pytest.raises(ValueError, match="job_type must be one of: reminder, agent"):
+            await sessions.create_job(
+                chat_id=1,
+                name="invalid",
+                job_type="unknown",
+                prompt="do something",
+                schedule_type="once",
+                schedule_data="{}",
+            )
+
+        assert await sessions.get_jobs(1) == []
 
     async def test_get_job_by_id_unknown(self, db):
         assert await sessions.get_job_by_id(999) is None
@@ -328,7 +354,7 @@ class TestJobs:
         job_id = await sessions.create_job(
             chat_id=1,
             name="j1",
-            job_type="claude",
+            job_type="agent",
             prompt="old prompt",
             schedule_type="interval",
             schedule_data='{"seconds": 3600}',
@@ -380,7 +406,7 @@ class TestJobs:
         job_id = await sessions.create_job(
             chat_id=1,
             name="j1",
-            job_type="claude",
+            job_type="agent",
             prompt="check",
             schedule_type="interval",
             schedule_data='{"seconds": 3600}',
@@ -1448,6 +1474,45 @@ class TestResolveGitHubSettings:
         await sessions.set_setting("issue_triage:111", "FALSE")
         result = await sessions.resolve_github_settings(111, config)
         assert result["issue_triage"] is False
+
+
+# ── Scheduled job type migration ────────────────────────────────────
+
+
+class TestJobTypeMigration:
+    async def test_legacy_agent_jobs_are_migrated_without_data_loss(self, tmp_path):
+        db_path = tmp_path / "legacy_jobs.db"
+        async with aiosqlite.connect(str(db_path)) as conn:
+            await conn.execute("""
+                CREATE TABLE jobs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    chat_id INTEGER NOT NULL,
+                    name TEXT NOT NULL,
+                    job_type TEXT NOT NULL,
+                    prompt TEXT NOT NULL,
+                    schedule_type TEXT NOT NULL,
+                    schedule_data TEXT NOT NULL,
+                    active INTEGER DEFAULT 1,
+                    auto_remove INTEGER DEFAULT 0,
+                    notify_on_check INTEGER DEFAULT 0
+                )
+            """)
+            await conn.execute(
+                "INSERT INTO jobs (chat_id, name, job_type, prompt, schedule_type, schedule_data) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (1, "legacy", "claude", "check status", "interval", '{"seconds": 60}'),
+            )
+            await conn.commit()
+
+        try:
+            await sessions.init_db(db_path)
+            job = await sessions.get_job_by_id(1)
+            assert job is not None
+            assert job["job_type"] == "agent"
+            assert job["name"] == "legacy"
+            assert job["prompt"] == "check status"
+        finally:
+            await sessions.close_db()
 
 
 # ── Workspace history migration ─────────────────────────────────────

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -127,8 +127,8 @@ class TestScheduleJobType:
         assert "error" in body
         assert "job_type" in body["error"]
 
-    async def test_valid_job_type_accepted(self, db, mock_request):
-        """Schedule endpoint accepts valid job_type values without error."""
+    async def test_agent_job_type_accepted(self, db, mock_request):
+        """Schedule endpoint accepts the canonical agent job type."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.app[CHAT_ID_KEY] = 123
         mock_request.app[TELEGRAM_APP_KEY].job_queue = MagicMock()
@@ -140,7 +140,31 @@ class TestScheduleJobType:
 
         mock_request.json = AsyncMock(
             return_value={
-                "name": "test claude job",
+                "name": "test agent job",
+                "prompt": "test",
+                "schedule_type": "once",
+                "schedule_data": {"run_at": "2026-02-20T10:00:00+00:00"},
+                "job_type": "agent",
+            }
+        )
+
+        resp = await _handle_schedule(mock_request)
+
+        assert resp.status == 200
+        body = json.loads(resp.body.decode())
+        assert "job_id" in body
+
+    async def test_legacy_agent_job_type_is_stored_canonically(self, db, mock_request):
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.app[CHAT_ID_KEY] = 123
+        mock_request.app[TELEGRAM_APP_KEY].job_queue = MagicMock()
+
+        import kai.cron as cron_mod
+
+        cron_mod.register_job_by_id = AsyncMock(return_value=True)
+        mock_request.json = AsyncMock(
+            return_value={
+                "name": "legacy agent job",
                 "prompt": "test",
                 "schedule_type": "once",
                 "schedule_data": {"run_at": "2026-02-20T10:00:00+00:00"},
@@ -151,8 +175,9 @@ class TestScheduleJobType:
         resp = await _handle_schedule(mock_request)
 
         assert resp.status == 200
-        body = json.loads(resp.body.decode())
-        assert "job_id" in body
+        job = await sessions.get_job_by_id(json.loads(resp.body.decode())["job_id"])
+        assert job is not None
+        assert job["job_type"] == "agent"
 
 
 # ── DELETE /api/jobs/{id} ────────────────────────────────────────────
@@ -256,7 +281,7 @@ class TestUpdateJob:
         job_id = await sessions.create_job(
             chat_id=123,
             name="old name",
-            job_type="claude",
+            job_type="agent",
             prompt="old prompt",
             schedule_type="interval",
             schedule_data='{"seconds": 3600}',
@@ -1269,7 +1294,7 @@ class TestGetJobs:
         await sessions.create_job(
             chat_id=123,
             name="Job B",
-            job_type="claude",
+            job_type="agent",
             prompt="check",
             schedule_type="interval",
             schedule_data='{"seconds": 3600}',


### PR DESCRIPTION
## Summary

- replace the implementation-named scheduled job type with canonical `agent` semantics
- keep accepting legacy `claude` input and migrate existing database rows in place
- normalize job types at both HTTP ingress and the database write boundary
- make registration and callback dispatch reject unknown job types before any backend invocation
- update injected scheduling instructions to advertise `reminder|agent`

## Compatibility

Existing stored `claude` jobs are changed only in their `job_type` column during the existing atomic database initialization transaction. Their IDs, owners, prompts, schedules, active state, and conditional settings are preserved. Legacy API clients may still submit `job_type: claude`; new rows are stored as `agent`.

Agent jobs continue to call `pool.send(..., chat_id=...)`, so the owning user's configured backend and OS identity remain authoritative. This change does not select or prefer a backend.

## Security impact

Previously the callback handled `reminder` explicitly and routed every other value to the subprocess pool. A corrupt or unexpected stored type could therefore invoke an agent. Dispatch is now explicit: only normalized `agent` jobs reach the pool; unknown values fail registration or are skipped by the callback.

## Verification

- targeted scheduling/session/backend tests: 521 passed
- full suite: 4,842 passed, 1 skipped
- `make check`
- `make typecheck`