### PR TITLE
docs: refresh backend and install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/github/license/dcellison/kai)](LICENSE)
 [![Version](https://img.shields.io/github/v/tag/dcellison/kai?label=version)](https://github.com/dcellison/kai/releases)
 
-Kai is a local, Telegram-first personal engineering system: a persistent AI collaborator with repo-aware coding, memory, scheduling, PR review, and multi-backend resilience.
+Kai is a local, Telegram-first personal engineering system: a persistent AI collaborator with repo-aware coding, memory, scheduling, PR review, and multi-backend operation.
 
 Run Kai on your own machine, reach it from Telegram, and give it real access to your local workspaces. Kai can inspect repositories, run shell commands, write code, review pull requests, triage issues, remember durable context, handle files, and run scheduled jobs while staying under your control. Your machine, your data, your rules.
 
@@ -20,8 +20,8 @@ Most AI coding tools are either interactive terminals or hosted chat surfaces. K
 - **Persistent agent sessions:** Each user gets a lazily-created subprocess with durable context and idle eviction.
 - **Memory across sessions:** Kai preserves identity, personal memory, and conversation history so useful context survives restarts and workspace switches.
 - **Background engineering workflows:** PR review, issue triage, webhooks, reminders, and condition-monitoring jobs run outside the active chat session.
-- **Backend resilience:** Claude Code is the default backend, with OpenAI Codex CLI, Goose, and OpenCode available as alternatives.
-- **Multi-user direction:** One Kai instance can serve multiple Telegram users with isolated history, files, settings, and optional OS-level process separation.
+- **Multi-backend operation:** Each user can run through any installed supported backend, with an explicit installation default and optional per-user overrides.
+- **Multi-user isolation:** One Kai instance can serve multiple Telegram users with isolated history, files, settings, and optional OS-level process separation.
 
 ## Core Capabilities
 
@@ -55,12 +55,12 @@ In Kai, a backend is more than a model provider. Each backend is a full coding h
 
 | Backend | Runtime | Model Selection Shape | Notes |
 |---|---|---|---|
-| Claude Code | `claude` CLI | Claude aliases and full model IDs | Default backend. |
+| Claude Code | `claude` CLI | Claude aliases and full model IDs | Uses Claude Code's local authentication. |
 | OpenAI Codex CLI | `codex` CLI | Codex CLI model IDs | Uses Codex's own model catalog, separate from OpenAI API model lists. |
 | Goose | `goose acp` | Provider-native model IDs | ACP backend with provider selected through Goose configuration or env. |
 | OpenCode | `opencode acp` | `provider/model` IDs | ACP backend with model resolution owned by OpenCode. |
 
-Only the backend you use needs to be installed and authenticated. Kai does not require every supported backend to exist on every machine.
+Kai does not require every supported backend to exist on every machine. Every backend selected as the installation default or in a user's configuration must be installed and authenticated for the OS account that will run it.
 
 ## Quick Start
 
@@ -80,10 +80,27 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install -e '.[dev]'
 make config
+```
+
+`make config` runs without `sudo`. It discovers the supported backend CLIs installed on the machine, requires an explicit installation default when more than one is available, and writes `install.conf` as the configuration artifact for the selected deployment mode. It does not accept user-supplied backend executable paths. Model defaults come from Kai's backend/provider/role model registry; admin-set per-user model baselines belong in the `models:` map in `users.yaml`, while users can change their active conversational model with `/model`.
+
+For a `single_user` deployment, `make config` also writes the runtime files under the operator's account. Start Kai from the checkout:
+
+```bash
 make run
 ```
 
-`make config` writes the runtime env file and mandatory `users.yaml` for the deployment mode you select. Pick `single_user` for a local repo checkout under your own account. Pick `protected` when you want source, data, and secrets split across protected system directories. Protected mode requires every Telegram user to have a unique `os_user` that differs from the Kai service account; this keeps persistent agents from inheriting the daemon's protected-config capabilities. Single-user mode continues to support running the agent as the operator account.
+For a `protected` deployment, preview and apply the staged configuration:
+
+```bash
+make DRY_RUN=1 install
+make install
+make install-status
+```
+
+`make install` invokes `sudo` internally and installs source, data, and secrets under separate protected system directories. It also generates the admin-owned `/etc/kai/backends.yaml` registry containing the discovered executable paths, allowed model surfaces, and selected default backend. Runtime configuration names backend identifiers; it cannot redirect a protected backend to an arbitrary executable. After a successful protected install, `install.conf` may be deleted because it can contain secrets; re-run `make config` before a later reconfiguration.
+
+Protected mode requires every Telegram user to have a unique `os_user` that differs from the Kai service account; this keeps persistent agents from inheriting the daemon's protected-config capabilities. Single-user mode runs the agent as the operator account.
 
 Protected Linux installations that use Codex image input also require `setfacl` (normally provided by the distribution's `acl` package). Kai uses a read-only named ACL so an image can remain private to the service and its intended `os_user`; if ACL support is unavailable, that image is dropped with a user-visible notice instead of being made world-readable.
 
@@ -97,8 +114,9 @@ Kai has real local authority, so the security model is part of the product rathe
 - **Optional TOTP gate:** Time-based one-time passwords can protect the chat surface after idle timeout.
 - **Local execution:** Kai runs on your machine. Conversations do not pass through a Kai-hosted relay.
 - **Path confinement:** File exchange is constrained to allowed workspace and file-storage paths.
+- **Protected backend registry:** Protected installs resolve backend identifiers through admin-owned `/etc/kai/backends.yaml`; executable paths and allowed model surfaces are installation state, not user input.
 - **Service proxy:** Third-party API keys live in server-side config and are injected only for services explicitly allowed to that user in `users.yaml`; keys are never placed in conversation context.
-- **GitHub operation boundary:** Shared-identity PR review and issue triage run only for repositories explicitly authorized to that user in admin-controlled `users.yaml`; notification subscriptions cannot grant operation access.
+- **GitHub operation boundary:** PR review and issue triage run only for repositories explicitly authorized to that user in admin-controlled `users.yaml`. Protected installs require the user's stored GitHub token, and notification subscriptions cannot grant operation access.
 - **Per-user isolation:** Users have separate history, files, workspaces, jobs, settings, and agent subprocesses.
 - **Principal-bound internal API:** Agent API credentials resolve to a fixed user and explicit scopes in the outer service; request data cannot select another principal.
 - **Separated webhook credentials:** GitHub, generic, and Telegram ingress use distinct secrets that are not exposed to persistent agent subprocesses.

--- a/templates/users.yaml
+++ b/templates/users.yaml
@@ -2,7 +2,7 @@
 # daemon fails closed at startup if it cannot find or parse it.
 #
 # Canonical paths:
-#   protected installs (`sudo make install`): /etc/kai/users.yaml
+#   protected installs (`make install`, which invokes sudo): /etc/kai/users.yaml
 #   single-user installs (`make config` then `make run`):
 #       ${XDG_CONFIG_HOME:-$HOME/.config}/kai/users.yaml
 #
@@ -11,8 +11,8 @@
 #
 # Required fields per user: telegram_id, name.
 # All other fields are optional. Omitted fields inherit installation
-# defaults from .env / /etc/kai/env (model, timeout, workspace_base)
-# or the hardcoded defaults documented in the templates/.env header.
+# defaults from the backend/provider model registry, .env or /etc/kai/env,
+# and the hardcoded defaults documented in the templates/.env header.
 
 users:
   # Example: admin user with full settings
@@ -34,20 +34,25 @@ users:
     # Inherits the global WORKSPACE_BASE installation default if unset.
     # workspace_base: ~/projects
 
-    # Optional per-user defaults. Users can override these at runtime
-    # via /settings. Omitted fields inherit installation defaults
-    # (DEFAULT_MODEL, DEFAULT_TIMEOUT).
-    # model: opus             # haiku/sonnet/opus for claude; provider/model for opencode
-    # timeout: 300            # response timeout in seconds (max 600)
-
-    # Default backend. Overrides the global DEFAULT_BACKEND from .env for
-    # this user only. Default is "claude" (Claude Code CLI). Other
-    # options: "goose" (Goose ACP, requires provider + API key),
-    # "codex" (OpenAI Codex CLI), "opencode" (OpenCode ACP; model is
-    # a full "provider/model" ID, auth managed by `opencode auth login`).
+    # Backend override. When omitted, this user inherits the installation
+    # default selected during `make config`. Protected installs accept only
+    # backend identifiers present in admin-owned /etc/kai/backends.yaml;
+    # users cannot configure executable paths here. Supported identifiers:
+    # "claude", "codex", "goose", and "opencode". Goose and OpenCode
+    # also require a provider; OpenCode models use full "provider/model" IDs
+    # and authentication is managed by `opencode auth login`.
     # backend: goose
     # provider: openai    # required for goose and opencode (selects the model registry)
-    # model: anthropic/claude-sonnet-4-6   # opencode example (full provider/model ID)
+
+    # Optional per-user model and timeout defaults. Users can override the
+    # conversational model and timeout at runtime via /model and /settings.
+    # Omitted model roles inherit the selected backend/provider/role defaults
+    # from the model registry. Model identifiers must match that backend's
+    # surface; OpenCode uses full provider/model IDs.
+    # models:
+    #   agent: gpt-5.5-pro
+    #   pr_review: gpt-5.5
+    # timeout: 300            # response timeout in seconds (max 600)
 
     # GitHub settings. github_repos is the admin-controlled authorization
     # boundary for GitHub review and triage operations, as well as the


### PR DESCRIPTION
## Summary

Refresh the top-level documentation so it describes Kai as the multi-backend system it is today and accurately explains the current configuration and installation workflow.

## What changed

- remove language that assigns priority or fallback status to any supported backend
- describe the installation default as an explicit operator choice among discovered, installed backends
- clarify that every backend referenced globally or per user must be installed and authenticated for the OS account that runs it
- split the Quick Start into the actual `single_user` and `protected` paths
- document that `make config` runs unprivileged, produces `install.conf`, and does not accept backend executable paths
- document that `make install` invokes `sudo` internally, with `make DRY_RUN=1 install` as the protected-install preview
- explain the admin-owned `/etc/kai/backends.yaml` registry and its role in command and model-surface resolution
- document the current backend/provider/role model registry and the per-user `models:` override surface
- update the GitHub security boundary to reflect per-user tokens in protected installs
- replace the legacy `model:` example in `templates/users.yaml` with the canonical per-role `models:` map
- correct the protected-install command shown in the `users.yaml` template

## Why

The README and sample user configuration still reflected older assumptions from before backend registration, per-role model defaults, protected per-user GitHub credentials, and the current install flow. That guidance could lead an operator to use the wrong privilege boundary, expect a backend to exist when it does not, or configure a legacy model field instead of the canonical structure.

This is documentation-only. It does not change runtime behavior or installation state.

## Validation

- `make check`
- focused installer/configuration tests: 933 passed
- full suite: 4,842 passed, 1 skipped

The initial full-suite attempt inside the restricted workspace sandbox could not bind localhost test sockets or start the Qdrant worker threads. The same suite passed in full when rerun with those local test capabilities available.
