### PR TITLE
Repair retained users config permissions on install

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -5611,6 +5611,7 @@ def _apply_secrets(
     """
     etc_kai = Path("/etc/kai")
     env_path = etc_kai / "env"
+    users_yaml_dst = USERS_YAML
     env_content = _generate_env_file(env)
 
     # Resolve users.yaml staging once so the dry-run preview and the
@@ -5641,7 +5642,9 @@ def _apply_secrets(
     if dry_run:
         print(f"[DRY RUN] Would write: {env_path} (mode 0600)")
         if users_yaml_src is not None:
-            print(f"[DRY RUN] Would copy: {users_yaml_src} -> {etc_kai / 'users.yaml'} (mode 0600)")
+            print(f"[DRY RUN] Would copy: {users_yaml_src} -> {users_yaml_dst} (mode 0600)")
+        elif users_yaml_dst.is_file():
+            print(f"[DRY RUN] Would secure existing: {users_yaml_dst} (mode 0600, root-owned)")
         for yaml_name, yaml_src in optional_yaml_sources.items():
             print(f"[DRY RUN] Would copy: {yaml_src} -> {etc_kai / yaml_name} (mode 0600)")
         return
@@ -5659,11 +5662,21 @@ def _apply_secrets(
     # happens in `_cmd_apply` after `apply_succeeded = True` so a
     # failed apply preserves both for a clean retry.
     if users_yaml_src is not None:
-        users_yaml_dst = etc_kai / "users.yaml"
         shutil.copy2(users_yaml_src, users_yaml_dst)
-        os.chmod(users_yaml_dst, 0o600)
-        os.chown(users_yaml_dst, 0, 0)
         print(f"  Copied {users_yaml_dst}")
+
+    # Enforce the runtime metadata contract on every protected apply,
+    # including updates that retain the canonical users.yaml instead of
+    # copying a newly staged file.  The runtime refuses a root-owned 0644
+    # users.yaml, so skipping this repair can leave launchd/systemd repeatedly
+    # starting a launcher whose Python child exits before binding /health.
+    # A missing destination with no staged source is left alone here; the
+    # apply preflight rejects that state before the working service is stopped.
+    if users_yaml_src is not None or users_yaml_dst.is_file():
+        os.chmod(users_yaml_dst, _PRIVATE_USER_FILE_MODE)
+        os.chown(users_yaml_dst, 0, 0)
+        if users_yaml_src is None:
+            print(f"  Secured existing {users_yaml_dst} (mode 0600, root-owned)")
 
     # Copy optional YAML config files to /etc/kai/. Staged files
     # recorded by `make config` win; the project-tree fallback remains

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7342,7 +7342,19 @@ class TestApplySecretsDryRun:
         )
         output = capsys.readouterr().out
         assert str(staging) in output
-        assert "/etc/kai/users.yaml" in output
+        assert str(kai.install.USERS_YAML) in output
+
+    def test_dry_run_previews_retained_users_yaml_metadata_repair(self, tmp_path, monkeypatch, capsys):
+        """An update without staging still previews the mandatory mode/owner repair."""
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users: []\n")
+        monkeypatch.setattr("kai.install.USERS_YAML", users_yaml)
+
+        _apply_secrets({"TELEGRAM_BOT_TOKEN": "test"}, dry_run=True)
+
+        output = capsys.readouterr().out
+        assert f"Would secure existing: {users_yaml}" in output
+        assert "mode 0600, root-owned" in output
 
     def test_dry_run_previews_optional_protected_yaml_configs(self, tmp_path, monkeypatch, capsys):
         """Dry run previews every optional YAML file runtime can load from /etc/kai."""
@@ -7519,12 +7531,28 @@ class TestApplySecretsUsersYamlStaging:
             users_yaml_staging_path=str(staging),
         )
 
-        users_copies = [(src, dst) for src, dst in copied if dst == "/etc/kai/users.yaml"]
-        assert users_copies == [(str(staging), "/etc/kai/users.yaml")]
-        users_modes = [m for p, m in chmodded if p == "/etc/kai/users.yaml"]
+        users_yaml_dst = str(kai.install.USERS_YAML)
+        users_copies = [(src, dst) for src, dst in copied if dst == users_yaml_dst]
+        assert users_copies == [(str(staging), users_yaml_dst)]
+        users_modes = [m for p, m in chmodded if p == users_yaml_dst]
         assert 0o600 in users_modes
-        users_owners = [(uid, gid) for p, uid, gid in chowned if p == "/etc/kai/users.yaml"]
+        users_owners = [(uid, gid) for p, uid, gid in chowned if p == users_yaml_dst]
         assert (0, 0) in users_owners
+
+    def test_retained_users_yaml_is_secured_without_copy(self, tmp_path, monkeypatch, capsys):
+        """An existing canonical file is root-owned 0600 even without staging."""
+        self._no_other_yamls(monkeypatch, tmp_path)
+        users_yaml = tmp_path / "installed-users.yaml"
+        users_yaml.write_text("users: []\n")
+        monkeypatch.setattr("kai.install.USERS_YAML", users_yaml)
+        copied, chmodded, chowned = self._intercept_filesystem(monkeypatch)
+
+        _apply_secrets({"TELEGRAM_BOT_TOKEN": "test"}, dry_run=False, users_yaml_staging_path=None)
+
+        assert not any(dst == str(users_yaml) for _src, dst in copied)
+        assert (str(users_yaml), 0o600) in chmodded
+        assert (str(users_yaml), 0, 0) in chowned
+        assert f"Secured existing {users_yaml}" in capsys.readouterr().out
 
     def test_copies_optional_protected_yaml_configs(self, tmp_path, monkeypatch):
         """services/workspaces/memory-projects are installed as root-owned 0600 config."""


### PR DESCRIPTION
## Summary

Make protected installation updates self-heal the ownership and permissions of an existing `/etc/kai/users.yaml`, even when `make config` did not stage a replacement file.

## Production failure

After the protected-config metadata checks were deployed, Kai entered a launchd restart loop:

```text
protected config /etc/kai/users.yaml has unsafe permissions 0o644; expected no more than 0o600
kai launcher: no listener on :8080 after 120s; exiting so launchd restarts the service
```

The file was already root-owned, but had retained its historical `0644` mode. `make config` correctly reused the existing canonical users file rather than staging a replacement. The installer consequently skipped the only branch that applied `0600`, leaving the stricter runtime and installer contracts inconsistent.

## Fix

- Keep the existing copy behavior when a staged users file is present.
- After the optional copy, always enforce root ownership and mode `0600` whenever the canonical protected users file exists.
- Preserve the existing preflight behavior for a missing file: apply rejects that state before stopping a working service, so the secrets step does not invent an empty configuration.
- Report the retained-file repair in normal install output.
- Show the same operation during `DRY_RUN=1` without changing the file.
- Use the canonical `USERS_YAML` path consistently so test and protected-install routing share one contract.

## Safety and compatibility

- No users.yaml content is rewritten when there is no staged replacement.
- No configuration choices or backend selections change.
- The operation is idempotent: every protected install reasserts the metadata required by the runtime.
- Single-user installs do not enter this protected apply path.
- Existing optional protected YAML behavior is unchanged.

## Verification

- Restored the affected deployment manually to root-owned `0600`.
- Confirmed Kai startup completed and localhost `/health` returned HTTP 200 with memory enabled.
- Added regression coverage for both real apply and dry-run behavior when users.yaml is retained.
- Installer tests: 520 passed.
- Full suite: 4,844 passed, 1 skipped.
- Ruff lint and formatting checks passed.
