### PR TITLE
Warn when local backend executables are agent-writable

### DIFF
--- a/SECURITY_REMEDIATION_STATUS.md
+++ b/SECURITY_REMEDIATION_STATUS.md
@@ -72,3 +72,36 @@ compatibility exception. The next security work should be selected from:
 - deeper review of the new backend registry and OS-user isolation paths,
 - or normal hardening/refactoring of large trust-boundary modules after the
   current behavior is pinned by tests.
+
+## Transitional risk: local-process backend executables
+
+The backend registry currently prevents operators from supplying arbitrary
+executable paths, but the registered executables may still live in locations
+owned by an agent target OS user. An agent running as that user could replace a
+shared executable and cross an OS-user boundary when Kai later invokes it for a
+different user.
+
+A root-owned managed backend package store was considered, but is deliberately
+deferred. Implementing dependency-closure discovery, provenance verification,
+promotion, health checks, and rollback for host executables would be a large
+transitional subsystem. Kai Workspace instead assigns binary/image preparation
+to its worker Runtime Backend contract and makes isolated container workers the
+personal-production boundary. The current server-process runtime is therefore
+classified as a trusted-host compatibility and migration mode.
+
+As an interim control, install reports a non-blocking warning when ordinary
+ownership/group/mode checks show that a registered command, its resolved
+executable, or either path chain can be modified by the service user or a
+configured agent `os_user`. This makes the limitation visible without breaking
+working Homebrew and other operator-managed installations. The admin-owned
+registry, fixed backend identifiers, exact-command sudoers rules, and existing
+group/other-writable executable rejection remain in force.
+
+Initial inspection of the currently installed macOS executables found no
+non-system dynamic-library dependencies or package-relative runtime search
+paths. That is favorable evidence for relocation, but it is not proof that the
+programs have no runtime dependency on surrounding files. Strict macOS code
+signature verification also does not currently provide a uniform integrity
+mechanism across all four installed backends. These observations are retained
+as context if a protected host-process package store is reconsidered, but that
+store is not part of the current remediation plan.

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -29,6 +29,7 @@ import pwd
 import re
 import secrets
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -4504,7 +4505,7 @@ def _cmd_apply() -> None:
         )
 
         # -- Step 6: Deploy installed backend registry --
-        _apply_backend_registry(service_user, env, dry_run)
+        _apply_backend_registry(service_user, env, dry_run, users_yaml_path=effective_users_yaml)
 
         # -- Step 7: Deploy Goose config (if any goose-backed user) --
         # The function gates itself: global DEFAULT_BACKEND=goose or a
@@ -5796,9 +5797,156 @@ def _build_backend_registry(service_user: str, env: dict[str, str], users_yaml_p
         raise SystemExit(str(exc)) from None
 
 
-def _apply_backend_registry(service_user: str, env: dict[str, str], dry_run: bool) -> None:
+def _identity_can_modify_file(file_stat: os.stat_result, uid: int, gids: set[int]) -> bool:
+    """Return whether an identity can alter a regular file in place.
+
+    File ownership is sufficient even when the current mode is read-only:
+    the owner can normally chmod the file first. Root is included for
+    completeness, although protected user validation rejects root as an
+    agent target.
+    """
+    if uid == 0 or file_stat.st_uid == uid:
+        return True
+    if file_stat.st_gid in gids:
+        return bool(file_stat.st_mode & stat.S_IWGRP)
+    return bool(file_stat.st_mode & stat.S_IWOTH)
+
+
+def _identity_can_replace_entry(
+    parent_stat: os.stat_result,
+    child_stat: os.stat_result,
+    uid: int,
+    gids: set[int],
+) -> bool:
+    """Return whether an identity can replace a child directory entry."""
+    if uid == 0:
+        return True
+    if parent_stat.st_uid == uid:
+        # The owner can chmod the directory to add write/search first.
+        has_write_and_search = True
+    elif parent_stat.st_gid in gids:
+        has_write_and_search = bool(parent_stat.st_mode & stat.S_IWGRP) and bool(parent_stat.st_mode & stat.S_IXGRP)
+    else:
+        has_write_and_search = bool(parent_stat.st_mode & stat.S_IWOTH) and bool(parent_stat.st_mode & stat.S_IXOTH)
+    if not has_write_and_search:
+        return False
+    if parent_stat.st_mode & stat.S_ISVTX:
+        # Sticky directories (notably /tmp) permit removal/rename only
+        # to root, the directory owner, or the child owner.
+        return uid in (parent_stat.st_uid, child_stat.st_uid)
+    return True
+
+
+def _first_agent_replaceable_parent(path: Path, uid: int, gids: set[int]) -> Path | None:
+    """Return the first path parent through which an identity can replace an entry."""
+    child = path
+    for parent in path.parents:
+        try:
+            child_stat = child.lstat()
+            parent_stat = parent.stat()
+        except OSError:
+            return None
+        if _identity_can_replace_entry(parent_stat, child_stat, uid, gids):
+            return parent
+        child = parent
+    return None
+
+
+def _backend_command_trust_issues(command: str, username: str) -> tuple[str, ...]:
+    """Describe basic DAC paths by which an agent OS user can replace a command.
+
+    This is an advisory local-process check, not a complete MAC/ACL audit.
+    It follows the command symlink and separately examines the registered
+    path and resolved target path so a safe target behind a user-replaceable
+    Homebrew-style symlink is still reported.
+    """
+    try:
+        identity = pwd.getpwnam(username)
+    except (KeyError, OSError):
+        return ()
+    try:
+        gids = set(os.getgrouplist(username, identity.pw_gid))
+    except (KeyError, OSError, OverflowError):
+        # macOS uses an unsigned sentinel GID for `nobody` that does
+        # not fit getgrouplist()'s C int argument. The primary group
+        # still gives this advisory check a safe, useful fallback.
+        gids = {identity.pw_gid}
+
+    registered = Path(command)
+    try:
+        target = registered.resolve(strict=True)
+        target_stat = target.stat()
+    except (OSError, RuntimeError):
+        # Existence/executability validation reports unusable commands.
+        return ()
+
+    issues: list[str] = []
+    if _identity_can_modify_file(target_stat, identity.pw_uid, gids):
+        if target_stat.st_uid == identity.pw_uid:
+            issues.append(f"resolved executable {target} is owned by {username}")
+        else:
+            issues.append(f"resolved executable {target} is writable by {username}")
+
+    registered_parent = _first_agent_replaceable_parent(registered, identity.pw_uid, gids)
+    if registered_parent is not None:
+        issues.append(f"registered path can be replaced through {registered_parent}")
+
+    if target != registered:
+        target_parent = _first_agent_replaceable_parent(target, identity.pw_uid, gids)
+        if target_parent is not None and target_parent != registered_parent:
+            issues.append(f"resolved path can be replaced through {target_parent}")
+
+    return tuple(issues)
+
+
+def _backend_command_trust_warnings(
+    commands: dict[str, str], service_user: str, users_yaml_path: str | Path
+) -> tuple[str, ...]:
+    """Return warnings for registered commands modifiable by agent identities."""
+    target_users = [service_user, *_collect_os_users_from_yaml(users_yaml_path)]
+    seen_users: set[str] = set()
+    warnings: list[str] = []
+    for username in target_users:
+        if username in seen_users:
+            continue
+        seen_users.add(username)
+        for backend, command in sorted(commands.items()):
+            issues = _backend_command_trust_issues(command, username)
+            if issues:
+                warnings.append(
+                    f"{backend}: {command} can be modified by agent OS user {username} ({'; '.join(issues)})"
+                )
+    return tuple(warnings)
+
+
+def _apply_backend_registry(
+    service_user: str,
+    env: dict[str, str],
+    dry_run: bool,
+    users_yaml_path: str | Path | None = None,
+) -> None:
     """Write the non-secret installed backend registry."""
-    content = _build_backend_registry(service_user, env)
+    if users_yaml_path is None:
+        users_yaml_path = USERS_YAML
+    content = _build_backend_registry(service_user, env, users_yaml_path)
+    raw_registry = yaml.safe_load(content) or {}
+    raw_backends = raw_registry.get("backends", {}) if isinstance(raw_registry, dict) else {}
+    commands = {
+        str(backend): str(entry["command"])
+        for backend, entry in raw_backends.items()
+        if isinstance(entry, dict) and isinstance(entry.get("command"), str)
+    }
+    trust_warnings = _backend_command_trust_warnings(commands, service_user, users_yaml_path)
+    if trust_warnings:
+        print("Warning: local-process backend executable trust is limited:", file=sys.stderr)
+        for warning in trust_warnings:
+            print(f"  - {warning}", file=sys.stderr)
+        print(
+            "  These commands remain supported for the trusted-host compatibility runtime, "
+            "but they do not provide hostile multi-user isolation. Isolated Kai Workspace "
+            "workers are the planned boundary.",
+            file=sys.stderr,
+        )
     if dry_run:
         print(f"[DRY RUN] Would write: {BACKENDS_YAML} (mode 0644)")
         return

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3,6 +3,7 @@
 import contextlib
 import json
 import os
+import pwd
 import shutil
 import signal
 import stat
@@ -28,6 +29,7 @@ from kai.install import (
     _apply_source,
     _apply_sudoers,
     _apply_venv,
+    _backend_command_trust_issues,
     _check_path,
     _check_service_status,
     _check_traversal,
@@ -7465,6 +7467,71 @@ class TestApplyBackendRegistry:
         output = capsys.readouterr().out
         assert "backends.yaml" in output
         assert "0644" in output
+
+    def test_command_trust_check_reports_agent_owned_executable(self, tmp_path):
+        executable = tmp_path / "codex"
+        executable.write_text("#!/bin/sh\nexit 0\n")
+        executable.chmod(0o555)
+        username = pwd.getpwuid(os.getuid()).pw_name
+
+        issues = _backend_command_trust_issues(str(executable), username)
+
+        assert any(f"resolved executable {executable} is owned by {username}" in issue for issue in issues)
+
+    def test_command_trust_check_reports_replaceable_registered_symlink(self, tmp_path):
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+        executable = target_dir / "codex"
+        executable.write_text("#!/bin/sh\nexit 0\n")
+        executable.chmod(0o555)
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        registered = bin_dir / "codex"
+        registered.symlink_to(executable)
+        username = pwd.getpwuid(os.getuid()).pw_name
+
+        issues = _backend_command_trust_issues(str(registered), username)
+
+        assert f"registered path can be replaced through {bin_dir}" in issues
+
+    def test_command_trust_check_accepts_path_unwritable_to_identity(self, tmp_path, monkeypatch):
+        import types
+
+        executable = tmp_path / "codex"
+        executable.write_text("#!/bin/sh\nexit 0\n")
+        executable.chmod(0o555)
+        fake_uid = os.getuid() + 100_000
+        fake_gid = os.getgid() + 100_000
+        monkeypatch.setattr(
+            "kai.install.pwd.getpwnam",
+            lambda username: types.SimpleNamespace(pw_uid=fake_uid, pw_gid=fake_gid),
+        )
+        monkeypatch.setattr("kai.install.os.getgrouplist", lambda username, gid: [gid])
+
+        assert _backend_command_trust_issues(str(executable), "isolated-agent") == ()
+
+    def test_dry_run_warns_for_agent_writable_backend_command(self, tmp_path, capsys, monkeypatch):
+        executable = tmp_path / "codex"
+        executable.write_text("#!/bin/sh\nexit 0\n")
+        executable.chmod(0o755)
+        username = pwd.getpwuid(os.getuid()).pw_name
+        monkeypatch.setattr(
+            "kai.install._discover_backend_commands",
+            lambda service_user: {"codex": str(executable)},
+        )
+
+        _apply_backend_registry(
+            username,
+            {"DEFAULT_BACKEND": "codex"},
+            dry_run=True,
+            users_yaml_path=tmp_path / "absent-users.yaml",
+        )
+
+        captured = capsys.readouterr()
+        assert "Would write" in captured.out
+        assert "local-process backend executable trust is limited" in captured.err
+        assert f"codex: {executable} can be modified by agent OS user {username}" in captured.err
+        assert "trusted-host compatibility runtime" in captured.err
 
     def test_configured_backend_must_be_discovered(self, monkeypatch):
         monkeypatch.setattr("kai.install._discover_backend_commands", lambda service_user: {"codex": "/global/codex"})


### PR DESCRIPTION
## Summary

- add a non-blocking installer warning when a registered local-process backend can be modified by the Kai service user or a configured agent `os_user`
- inspect both the registered command path and its resolved executable so replaceable Homebrew-style symlinks and user-owned targets are visible
- account for file ownership, supplementary groups, writable/searchable path components, and sticky-directory semantics
- use the effective `users.yaml` during first-install dry runs as well as established installations
- document local-process execution as a trusted-host compatibility mode and defer backend packaging to the Kai Workspace worker/runtime architecture

## Security boundary

The root-owned backend registry, fixed backend identifiers, exact-command sudoers rules, and the existing rejection of group/world-writable executable targets remain unchanged.

This PR deliberately does **not** copy, repackage, relocate, or update backend binaries. It does not claim hostile multi-user isolation for the current local-process runtime. It makes the remaining limitation explicit while preserving working operator-managed installations.

The check is advisory and cannot block installation. Even supplementary-group lookup failures such as macOS's sentinel `nobody` GID fall back safely to the primary group.

## Compatibility

- no configuration format changes
- no executable path changes
- no sudoers changes
- no service/runtime behavior changes
- warnings appear in both dry-run and real installation output only when a relevant identity can modify a registered backend path

## Verification

- `ruff check src/kai/install.py tests/test_install.py`
- `ruff format --check src/kai/install.py tests/test_install.py`
- `pytest tests/test_backend_registry.py tests/test_install.py -q` — 548 passed
- `pytest -q` — 4,848 passed, 1 skipped

Direct file-scoped Pyright still reports the two pre-existing diagnostics at `src/kai/install.py:853`; this change adds no new Pyright diagnostics.
