### PR TITLE
Report authoritative deployed webhook migration state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ install:
 	sudo $(BIN)python -m kai install apply $(if $(strip $(DRY_RUN)),--dry-run,)
 
 install-status:
-	$(BIN)python -m kai install status
+	sudo $(BIN)python -m kai install status
 
 # Refresh helper for PROVIDER_MODELS. Queries each curated provider's
 # /v1/models endpoint and prints a diff against the in-tree list;

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ deprecated WEBHOOK_SECRET fallback**. Pressing Enter keeps compatibility. The
 generated `install.conf` can then be reviewed with `make DRY_RUN=1 install`
 before `make install` deploys it.
 
+Run `make install-status` to inspect the authoritative deployed migration
+state in `/etc/kai/env`. The command uses sudo because that file is root-only;
+it reports only whether the legacy and named variables are configured, never
+their values. It also labels the separate `install.conf` artifact state so
+configuration drift is visible rather than mistaken for deployed truth.
+
 The current remediation status and compatibility exceptions are tracked in
 [Security Remediation Status](SECURITY_REMEDIATION_STATUS.md).
 

--- a/SECURITY_REMEDIATION_STATUS.md
+++ b/SECURITY_REMEDIATION_STATUS.md
@@ -5,7 +5,7 @@ assessment findings. It is intentionally operational: it distinguishes closed
 items from compatibility exceptions so future hardening work does not remove a
 working migration path by accident.
 
-Last reviewed: 2026-08-10
+Last reviewed: 2026-08-11
 
 ## Compatibility rule
 
@@ -67,11 +67,13 @@ acceptance.
 The original assessment findings are remediated or explicitly documented as a
 compatibility exception. The next security work should be selected from:
 
-- adding an operator command or diagnostic that reports whether the legacy
-  `WEBHOOK_SECRET` fallback is still configured,
-- deeper review of the new backend registry and OS-user isolation paths,
-- or normal hardening/refactoring of large trust-boundary modules after the
-  current behavior is pinned by tests.
+- running the privileged `make install-status` diagnostic and confirming the
+  deployed environment no longer contains the legacy `WEBHOOK_SECRET`;
+- verifying external GitHub and generic webhook callers use their named secret
+  domains before removing runtime fallback support; or
+- beginning Kai Workspace architecture validation. Large trust-boundary module
+  decomposition remains normal engineering debt rather than a blocking
+  security fix.
 
 ## Transitional risk: local-process backend executables
 

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -62,6 +62,7 @@ from kai.config import (
     models_for_backend,
     validate_model_for_backend,
 )
+from kai.protected_config import ProtectedConfigError, validate_protected_file_metadata
 from kai.user_isolation import validate_protected_user_isolation
 
 # Config file written by `config`, read by `apply`.
@@ -76,6 +77,7 @@ INSTALL_CONF = PROJECT_ROOT / "install.conf"
 # real runtime config.
 USERS_YAML = Path("/etc/kai/users.yaml")
 BACKENDS_YAML = Path("/etc/kai/backends.yaml")
+_DEPLOYED_ENV_FILE = Path("/etc/kai/env")
 
 # Default installation paths
 _DEFAULT_INSTALL_DIR = "/opt/kai"
@@ -6392,17 +6394,19 @@ def _check_service_status(platform: str) -> str:
 
 def _cmd_status() -> None:
     """
-    Report the current installation state. No sudo required.
+    Report the current installation state.
 
     Checks for the existence of installation directories, config files,
-    and service status. Reports ownership for security verification.
+    and service status. Reports ownership for security verification. The
+    command remains useful without sudo, but authoritative deployed-secret
+    migration state requires permission to read /etc/kai/env.
     """
     # Load install.conf once for platform, install_dir, and data_dir.
     # Falls back to auto-detected platform and default paths if missing.
     platform = "darwin" if sys.platform == "darwin" else "linux"
     install_dir = _DEFAULT_INSTALL_DIR
     data_dir = _DEFAULT_DATA_DIR
-    conf_env: dict[str, str] = {}
+    conf_env: dict[str, str] | None = None
     if INSTALL_CONF.exists():
         try:
             conf = json.loads(INSTALL_CONF.read_text())
@@ -6419,11 +6423,15 @@ def _cmd_status() -> None:
     print("=" * 30)
     print(_check_path(Path(install_dir), "Installation"))
     print(_check_path(Path(data_dir), "Data"))
-    print(_check_path(Path("/etc/kai/env"), "Secrets"))
+    print(_check_path(_DEPLOYED_ENV_FILE, "Secrets"))
     print(_check_path(Path("/etc/kai/services.yaml"), "Services"))
     print(_check_path(Path("/etc/sudoers.d/kai"), "Sudoers"))
     print(_check_service_status(platform))
-    print(_webhook_secret_migration_status(conf_env))
+    print(_deployed_webhook_secret_migration_status(_DEPLOYED_ENV_FILE))
+    if conf_env is None:
+        print("Webhook secret migration (install.conf artifact): unavailable")
+    else:
+        print(_webhook_secret_migration_status(conf_env, source="install.conf artifact"))
 
     # Check workspace path traversal if install.conf has a service user
     if INSTALL_CONF.exists():
@@ -6454,16 +6462,50 @@ def _cmd_status() -> None:
                 break
 
 
-def _webhook_secret_migration_status(env: dict[str, str]) -> str:
+def _webhook_secret_migration_status(env: dict[str, str], *, source: str = "install.conf artifact") -> str:
     """Return a non-secret diagnostic for external webhook migration state."""
+    prefix = f"Webhook secret migration ({source}):"
     if env.get("WEBHOOK_SECRET", "").strip():
-        return (
-            "Webhook secret migration: legacy WEBHOOK_SECRET fallback configured "
-            "(GitHub/generic callers may still depend on it)"
-        )
+        return f"{prefix} legacy WEBHOOK_SECRET fallback configured (GitHub/generic callers may still depend on it)"
     if env.get("GITHUB_WEBHOOK_SECRET", "").strip() and env.get("GENERIC_WEBHOOK_SECRET", "").strip():
-        return "Webhook secret migration: named GitHub/generic secrets configured; no legacy fallback in install.conf"
-    return "Webhook secret migration: no legacy fallback in install.conf"
+        return f"{prefix} named GitHub/generic secrets configured; no legacy fallback"
+    missing = [key for key in ("GITHUB_WEBHOOK_SECRET", "GENERIC_WEBHOOK_SECRET") if not env.get(key, "").strip()]
+    return f"{prefix} no legacy fallback; missing named secret(s): {', '.join(missing)}"
+
+
+def _deployed_webhook_secret_migration_status(env_path: Path) -> str:
+    """Report deployed webhook-secret state without retaining or exposing values."""
+    source = f"deployed {env_path}"
+    try:
+        validate_protected_file_metadata(env_path, max_mode=0o600, require_root_owner=True)
+    except FileNotFoundError:
+        return f"Webhook secret migration ({source}): deployed environment file not found"
+    except ProtectedConfigError as exc:
+        return f"Webhook secret migration ({source}): NOT VERIFIED ({exc})"
+
+    configured: dict[str, str] = {}
+    interesting_keys = {"WEBHOOK_SECRET", "GITHUB_WEBHOOK_SECRET", "GENERIC_WEBHOOK_SECRET"}
+    try:
+        with env_path.open(encoding="utf-8") as env_file:
+            for line in env_file:
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                key, separator, raw_value = stripped.partition("=")
+                key = key.strip()
+                if not separator or key not in interesting_keys:
+                    continue
+                # The installer writes quoted values. Store only a marker,
+                # never the value, so this diagnostic cannot accidentally
+                # expose a credential through output or later formatting.
+                value = raw_value.strip()
+                configured[key] = "configured" if value not in ("", "''", '""') else ""
+    except PermissionError:
+        return f"Webhook secret migration ({source}): NOT VERIFIED (permission denied; run `make install-status`)"
+    except (OSError, UnicodeError) as exc:
+        return f"Webhook secret migration ({source}): NOT VERIFIED (could not read deployed environment: {exc})"
+
+    return _webhook_secret_migration_status(configured, source=source)
 
 
 # ── CLI dispatch ─────────────────────────────────────────────────────

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -40,6 +40,7 @@ from kai.install import (
     _collect_os_users_from_yaml,
     _collect_user_memory_owners,
     _copy_tree,
+    _deployed_webhook_secret_migration_status,
     _file_checksum,
     _generate_env_file,
     _generate_launchd_plist,
@@ -86,6 +87,7 @@ def _isolate_installed_backend_discovery(monkeypatch, tmp_path):
     missing/discovered backend behavior override this fixture locally.
     """
     monkeypatch.setattr("kai.install.BACKENDS_YAML", tmp_path / "absent-backends.yaml")
+    monkeypatch.setattr("kai.install._DEPLOYED_ENV_FILE", tmp_path / "absent-env")
     monkeypatch.setattr(
         "kai.install._discover_backend_commands",
         lambda service_user: {
@@ -4393,6 +4395,39 @@ class TestCmdStatus:
         assert "github-secret" not in output
         assert "generic-secret" not in output
 
+    def test_reports_deployed_state_separately_from_install_conf(self, tmp_path, monkeypatch, capsys):
+        deployed_env = tmp_path / "deployed-env"
+        deployed_env.write_text(
+            'GITHUB_WEBHOOK_SECRET="deployed-github-secret"\nGENERIC_WEBHOOK_SECRET="deployed-generic-secret"\n'
+        )
+        conf_path = tmp_path / "install.conf"
+        conf_path.write_text(
+            json.dumps(
+                {
+                    "platform": "darwin",
+                    "install_dir": str(tmp_path / "opt-kai"),
+                    "data_dir": str(tmp_path / "var-lib-kai"),
+                    "env": {"WEBHOOK_SECRET": "artifact-legacy-secret"},
+                }
+            )
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install._DEPLOYED_ENV_FILE", deployed_env)
+        monkeypatch.setattr("kai.install.validate_protected_file_metadata", lambda *args, **kwargs: True)
+        monkeypatch.setattr(
+            "kai.install.subprocess.run",
+            lambda *a, **kw: subprocess.CompletedProcess(args=[], returncode=1, stdout=""),
+        )
+
+        _cmd_status()
+
+        output = capsys.readouterr().out
+        assert f"Webhook secret migration (deployed {deployed_env}): named GitHub/generic secrets configured" in output
+        assert "Webhook secret migration (install.conf artifact): legacy WEBHOOK_SECRET fallback configured" in output
+        assert "deployed-github-secret" not in output
+        assert "deployed-generic-secret" not in output
+        assert "artifact-legacy-secret" not in output
+
     def test_webhook_secret_migration_status_is_non_secret(self):
         assert "legacy WEBHOOK_SECRET fallback configured" in _webhook_secret_migration_status(
             {
@@ -4402,6 +4437,68 @@ class TestCmdStatus:
             }
         )
         assert "legacy-secret" not in _webhook_secret_migration_status({"WEBHOOK_SECRET": "legacy-secret"})
+
+    def test_deployed_status_reports_named_secrets_without_values(self, tmp_path, monkeypatch):
+        env_path = tmp_path / "env"
+        env_path.write_text(
+            "# protected configuration\n"
+            'GITHUB_WEBHOOK_SECRET="github-deployed-value"\n'
+            'GENERIC_WEBHOOK_SECRET="generic-deployed-value"\n'
+        )
+        monkeypatch.setattr("kai.install.validate_protected_file_metadata", lambda *args, **kwargs: True)
+
+        status = _deployed_webhook_secret_migration_status(env_path)
+
+        assert f"deployed {env_path}" in status
+        assert "named GitHub/generic secrets configured" in status
+        assert "no legacy fallback" in status
+        assert "github-deployed-value" not in status
+        assert "generic-deployed-value" not in status
+
+    def test_deployed_status_reports_legacy_fallback_without_value(self, tmp_path, monkeypatch):
+        env_path = tmp_path / "env"
+        env_path.write_text('WEBHOOK_SECRET="legacy-deployed-value"\n')
+        monkeypatch.setattr("kai.install.validate_protected_file_metadata", lambda *args, **kwargs: True)
+
+        status = _deployed_webhook_secret_migration_status(env_path)
+
+        assert "legacy WEBHOOK_SECRET fallback configured" in status
+        assert "legacy-deployed-value" not in status
+
+    def test_deployed_status_is_explicit_when_permission_denied(self, tmp_path, monkeypatch):
+        env_path = tmp_path / "env"
+        env_path.write_text('WEBHOOK_SECRET="must-not-appear"\n')
+        monkeypatch.setattr("kai.install.validate_protected_file_metadata", lambda *args, **kwargs: True)
+        real_open = Path.open
+
+        def deny_deployed_env(self, *args, **kwargs):
+            if self == env_path:
+                raise PermissionError("denied")
+            return real_open(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "open", deny_deployed_env)
+
+        status = _deployed_webhook_secret_migration_status(env_path)
+
+        assert "NOT VERIFIED" in status
+        assert "permission denied" in status
+        assert "make install-status" in status
+        assert "must-not-appear" not in status
+
+    def test_deployed_status_rejects_untrusted_metadata(self, tmp_path, monkeypatch):
+        env_path = tmp_path / "env"
+        env_path.write_text('WEBHOOK_SECRET="must-not-appear"\n')
+
+        def reject_metadata(*args, **kwargs):
+            raise kai.install.ProtectedConfigError("unsafe permissions")
+
+        monkeypatch.setattr("kai.install.validate_protected_file_metadata", reject_metadata)
+
+        status = _deployed_webhook_secret_migration_status(env_path)
+
+        assert "NOT VERIFIED" in status
+        assert "unsafe permissions" in status
+        assert "must-not-appear" not in status
 
 
 # ── Venv creation ────────────────────────────────────────────────────
@@ -6155,6 +6252,22 @@ class TestMakeInstallDryRun:
         )
 
         assert "install apply --dry-run" not in result.stdout
+
+
+class TestMakeInstallStatus:
+    """The Make status target must have access to deployed protected state."""
+
+    @pytest.mark.skipif(shutil.which("make") is None, reason="make is not installed")
+    def test_status_runs_privileged_installer_command(self):
+        result = subprocess.run(
+            ["make", "-n", "install-status"],
+            cwd=Path(__file__).resolve().parents[1],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        assert "sudo .venv/bin/python -m kai install status" in result.stdout
 
 
 # ── _set_ownership ───────────────────────────────────────────────────

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -6267,7 +6267,9 @@ class TestMakeInstallStatus:
             check=True,
         )
 
-        assert "sudo .venv/bin/python -m kai install status" in result.stdout
+        command_lines = [line for line in result.stdout.splitlines() if line.startswith("sudo ")]
+        assert len(command_lines) == 1
+        assert command_lines[0].endswith("python -m kai install status")
 
 
 # ── _set_ownership ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- make `make install-status` inspect the protected deployed environment with sudo
- report `/etc/kai/env` as the authoritative webhook-secret migration state
- report `install.conf` separately and explicitly as a `make config` artifact
- reject unsafe deployed-environment ownership or permissions before inspection
- report only whether relevant variables are configured; never print their values

## Why

The existing status command inferred webhook migration state from `install.conf`. That file is only the output of `make config`, so it can be absent, stale, or disagree with the live installation. This could falsely suggest that the legacy `WEBHOOK_SECRET` compatibility fallback had been removed when it remained deployed, or vice versa.

The privileged Make target now checks the actual `/etc/kai/env` file. Direct unprivileged invocation remains safe and useful, but reports the deployed secret state as `NOT VERIFIED` when it cannot read the protected file.

## Security behavior

- validates `/etc/kai/env` as root-owned with permissions no broader than `0600`
- recognizes only `WEBHOOK_SECRET`, `GITHUB_WEBHOOK_SECRET`, and `GENERIC_WEBHOOK_SECRET`
- retains only configured/not-configured markers while producing the diagnostic
- never includes credential values in output
- identifies missing named secret domains when no legacy fallback is present
- makes disagreement between deployed state and the configuration artifact visible

This changes diagnostics only. It does not modify runtime webhook handling, deployed secrets, installer configuration, service state, or the legacy compatibility fallback.

## Verification

- `.venv/bin/python -m pytest -q` — 4,854 passed, 1 skipped
- `.venv/bin/python -m pytest tests/test_install.py -q` — 536 passed
- `ruff check .`
- `ruff format --check .`
- `make typecheck` — 0 errors, 0 warnings
- focused authoritative-status and Make target tests — 10 passed

## Operator follow-up after merge

Run `make install-status` and enter the sudo password. No `make config` or `make install` is required for this diagnostic. Confirm the line labeled `deployed /etc/kai/env` reports named GitHub/generic secrets with no legacy fallback before considering removal of runtime compatibility support.
