### PR TITLE
Remove legacy webhook authentication fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,17 +122,17 @@ Kai has real local authority, so the security model is part of the product rathe
 - **Separated webhook credentials:** GitHub, generic, and Telegram ingress use distinct secrets that are not exposed to persistent agent subprocesses.
 - **Optional OS isolation:** A user's backend subprocess can run under a dedicated OS account through generated sudoers rules.
 
-Upgraded installations may temporarily retain the former shared
-`WEBHOOK_SECRET`. After all GitHub and generic webhook callers have been moved
-to their named secrets, run `make config` and answer `false` to **Retain
-deprecated WEBHOOK_SECRET fallback**. Pressing Enter keeps compatibility. The
-generated `install.conf` can then be reviewed with `make DRY_RUN=1 install`
-before `make install` deploys it.
+The former shared `WEBHOOK_SECRET` is no longer supported and never
+authenticates a runtime route. `make config` omits it from regenerated
+configuration, and `make install` strips it from older artifacts before writing
+the deployed environment. If an older artifact lacks either named replacement,
+installation fails before stopping Kai and asks for a one-time `make config`.
+GitHub and generic callers must use their dedicated named secrets.
 
 Run `make install-status` to inspect the authoritative deployed migration
 state in `/etc/kai/env`. The command uses sudo because that file is root-only;
-it reports only whether the legacy and named variables are configured, never
-their values. It also labels the separate `install.conf` artifact state so
+it reports only whether the unsupported and named variables are configured,
+never their values. It also labels the separate `install.conf` artifact state so
 configuration drift is visible rather than mistaken for deployed truth.
 
 The current remediation status and compatibility exceptions are tracked in

--- a/SECURITY_REMEDIATION_STATUS.md
+++ b/SECURITY_REMEDIATION_STATUS.md
@@ -1,9 +1,7 @@
 # Security Remediation Status
 
 This document records the current implementation status of the static security
-assessment findings. It is intentionally operational: it distinguishes closed
-items from compatibility exceptions so future hardening work does not remove a
-working migration path by accident.
+assessment findings and the operational checks that closed them.
 
 Last reviewed: 2026-08-11
 
@@ -16,15 +14,12 @@ includes one of these:
 - an explicit migration/check command,
 - or an operator-confirmed breaking action.
 
-Do not remove the legacy `WEBHOOK_SECRET` fallback until external GitHub and
-generic webhook callers have been verified or migrated.
-
 ## Finding status
 
 | # | Finding | Status | Notes |
 |---|---|---|---|
 | 1 | Global internal API bearer not bound to a user | Closed | Internal API credentials are principal-bound and scope-limited. Request data cannot select a different principal. |
-| 2 | Agent API secret reused for GitHub and Telegram webhook signing | Closed with compatibility exception | `KAI_WEBHOOK_SECRET`, `GITHUB_WEBHOOK_SECRET`, `GENERIC_WEBHOOK_SECRET`, and `TELEGRAM_WEBHOOK_SECRET` are separate domains. Persistent agents receive only the principal-bound internal API credential. `WEBHOOK_SECRET` remains as a deprecated external-only fallback for upgraded installs. |
+| 2 | Agent API secret reused for GitHub and Telegram webhook signing | Closed | `KAI_WEBHOOK_SECRET`, `GITHUB_WEBHOOK_SECRET`, `GENERIC_WEBHOOK_SECRET`, and `TELEGRAM_WEBHOOK_SECRET` are separate domains. Persistent agents receive only the principal-bound internal API credential. The former `WEBHOOK_SECRET` credential is unsupported and ignored. |
 | 3 | GitHub reads and mutations used shared outer-process identity | Closed | Protected installs require per-user GitHub tokens for user-initiated GitHub operations. Repository access is authorized through admin-controlled per-user configuration. |
 | 4 | Service UID sessions could inherit daemon authority | Closed | Protected installs require distinct target OS users and use a backend registry rather than user-supplied binary paths. Generated sudoers remains exact-command scoped. |
 | 5 | Notification destinations could become inbound Telegram principals | Closed | Inbound authorization principals and outbound notification destinations are separate. GitHub notifications can still target configured Telegram groups. |
@@ -40,40 +35,31 @@ generic webhook callers have been verified or migrated.
 Current secret domains:
 
 - `KAI_WEBHOOK_SECRET`: internal agent API credential, principal-bound and scoped.
-- `GITHUB_WEBHOOK_SECRET`: preferred GitHub webhook HMAC secret.
-- `GENERIC_WEBHOOK_SECRET`: preferred generic webhook header secret.
+- `GITHUB_WEBHOOK_SECRET`: GitHub webhook HMAC secret.
+- `GENERIC_WEBHOOK_SECRET`: generic webhook header secret.
 - `TELEGRAM_WEBHOOK_SECRET`: Telegram update secret token.
-- `WEBHOOK_SECRET`: deprecated compatibility fallback for `/webhook/github` and
-  `/webhook` only.
+- `WEBHOOK_SECRET`: unsupported; ignored by runtime authentication.
 
-`make config` preserves an existing `WEBHOOK_SECRET` by default. The operator
-must explicitly answer `false` to **Retain deprecated WEBHOOK_SECRET fallback**
-to remove it from generated configuration.
+The privileged `make install-status` diagnostic confirmed that the deployed
+environment uses both named external webhook secrets and contains no
+`WEBHOOK_SECRET`. It reports variable presence only, never values.
 
-Before removing fallback support from runtime code:
+Runtime fallback removal is enforced at every configuration boundary:
 
-1. Verify GitHub webhook configuration uses `GITHUB_WEBHOOK_SECRET`.
-2. Verify any generic webhook caller uses `GENERIC_WEBHOOK_SECRET`.
-3. Run `make config` and explicitly retire `WEBHOOK_SECRET`.
-4. Review `make DRY_RUN=1 install`.
-5. Deploy with `make install`.
-6. Confirm GitHub and generic webhook delivery after deployment.
-
-Only after that migration is confirmed should a later PR remove runtime fallback
-acceptance.
+- runtime routes accept only their named credentials;
+- `make config` never carries `WEBHOOK_SECRET` into a regenerated artifact;
+- `make install` strips it from older artifacts before writing `/etc/kai/env`,
+  or fails before stopping Kai if either named replacement is missing;
+- `make install-status` continues to identify stale deployed or artifact state.
 
 ## Next safe work
 
-The original assessment findings are remediated or explicitly documented as a
-compatibility exception. The next security work should be selected from:
-
-- running the privileged `make install-status` diagnostic and confirming the
-  deployed environment no longer contains the legacy `WEBHOOK_SECRET`;
-- verifying external GitHub and generic webhook callers use their named secret
-  domains before removing runtime fallback support; or
-- beginning Kai Workspace architecture validation. Large trust-boundary module
-  decomposition remains normal engineering debt rather than a blocking
-  security fix.
+After deploying runtime fallback removal, confirm that GitHub notifications
+still reach their configured Telegram destination and exercise any active
+generic webhook caller. The original assessment findings are then fully
+remediated, and the next security work is Kai Workspace architecture validation.
+Large trust-boundary module decomposition remains normal engineering debt rather
+than a blocking security fix.
 
 ## Transitional risk: local-process backend executables
 

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1266,9 +1266,6 @@ class Config:
         webhook_port: Port for the local aiohttp server (webhooks + scheduling API)
         github_webhook_secret: HMAC secret for verifying GitHub webhook payloads.
         generic_webhook_secret: Header secret for the generic webhook endpoint.
-        webhook_secret: Deprecated WEBHOOK_SECRET compatibility credential. During
-            the migration window it is accepted only by the GitHub and generic
-            external webhook routes, never by Telegram or internal APIs.
         voice_enabled: Whether to transcribe Telegram voice notes via whisper-cpp
         whisper_model_path: Path to the whisper-cpp GGML model file
         tts_enabled: Whether to enable Piper text-to-speech for voice responses
@@ -1353,9 +1350,6 @@ class Config:
     webhook_port: int = 8080
     github_webhook_secret: str = ""
     generic_webhook_secret: str = ""
-    # Deprecated: temporary external-only fallback for existing GitHub and
-    # generic webhook callers. Never use this for Telegram or internal APIs.
-    webhook_secret: str = ""
     # True when load_config() populated secrets from the protected
     # installation env file (/etc/kai/env). Runtime code uses this to
     # tighten boundaries that would break local single-user installs if
@@ -3510,12 +3504,10 @@ def load_config() -> Config:
 
     github_webhook_secret = os.environ.get("GITHUB_WEBHOOK_SECRET", "").strip()
     generic_webhook_secret = os.environ.get("GENERIC_WEBHOOK_SECRET", "").strip()
-    legacy_webhook_secret = os.environ.get("WEBHOOK_SECRET", "").strip()
-    if legacy_webhook_secret:
+    if os.environ.get("WEBHOOK_SECRET", "").strip():
         log.warning(
-            "WEBHOOK_SECRET is deprecated; temporary compatibility authentication "
-            "is enabled for /webhook/github and /webhook only. It never "
-            "authenticates Telegram or /api/* routes."
+            "WEBHOOK_SECRET is no longer supported and is ignored; configure "
+            "GITHUB_WEBHOOK_SECRET and GENERIC_WEBHOOK_SECRET instead"
         )
 
     configured_ingress_secrets = [
@@ -3547,7 +3539,6 @@ def load_config() -> Config:
         webhook_port=webhook_port,
         github_webhook_secret=github_webhook_secret,
         generic_webhook_secret=generic_webhook_secret,
-        webhook_secret=legacy_webhook_secret,
         protected_install=bool(protected_env),
         voice_enabled=os.environ.get("VOICE_ENABLED", "").lower() in ("1", "true", "yes"),
         tts_enabled=os.environ.get("TTS_ENABLED", "").lower() in ("1", "true", "yes"),

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -298,15 +298,14 @@ def _build_test_configs(memory_enabled_value: bool) -> Config:
     that will read it.
 
     The verify subcommand never spawns subprocesses or hits the
-    network, so the Telegram and webhook fields are placeholder
-    strings. allowed_user_ids contains the fixture chat_id so the
+    network, so the Telegram token is a placeholder string.
+    allowed_user_ids contains the fixture chat_id so the
     user-id scoping in build_session_context resolves the per-user
     MEMORY.md path correctly.
     """
     return Config(
         telegram_bot_token="modeswitch-test",
         allowed_user_ids={_FIXTURE_CHAT_ID},
-        webhook_secret="modeswitch-test",
         memory_enabled=memory_enabled_value,
     )
 

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -990,8 +990,8 @@ def _cmd_config() -> None:
 
     If install.conf already exists, its values are used as defaults so re-running
     only asks about changes. Auto-detects platform, generates distinct named
-    webhook secrets, and offers an explicit safe-default choice to preserve or
-    retire an existing legacy secret. Validates all inputs before writing.
+    webhook secrets, and removes unsupported legacy webhook credentials.
+    Validates all inputs before writing.
 
     No sudo required - this runs as the current user.
     """
@@ -1009,7 +1009,7 @@ def _cmd_config() -> None:
             print(f"Warning: could not read existing {INSTALL_CONF}: {e}\n")
 
     existing_env: dict = existing.get("env", {})
-    legacy_webhook_secret = existing_env.get("WEBHOOK_SECRET", "")
+    had_legacy_webhook_secret = bool(str(existing_env.get("WEBHOOK_SECRET", "")).strip())
 
     # Auto-detect platform
     if sys.platform == "darwin":
@@ -1703,11 +1703,12 @@ def _cmd_config() -> None:
             break
         print("  Must be a valid port number (1-65535).")
 
-    # Named credentials are the long-term configuration. Keep them distinct
-    # from an existing legacy credential so the runtime can identify and log
-    # callers that still depend on compatibility authentication.
+    # Each external ingress has a dedicated credential. A legacy WEBHOOK_SECRET
+    # from an older generated artifact is deliberately not carried forward.
+    if had_legacy_webhook_secret:
+        print("  WEBHOOK_SECRET is no longer supported and will be omitted from the generated configuration.")
     default_github_secret = existing_env.get("GITHUB_WEBHOOK_SECRET", "")
-    reserved_webhook_secrets = {legacy_webhook_secret, tg_webhook_secret}
+    reserved_webhook_secrets = {tg_webhook_secret}
     while not default_github_secret or default_github_secret in reserved_webhook_secrets:
         default_github_secret = secrets.token_hex(32)
     while True:
@@ -1718,34 +1719,13 @@ def _cmd_config() -> None:
         )
         if github_webhook_secret not in reserved_webhook_secrets:
             break
-        print("  GitHub, Telegram, and legacy webhook secrets must use different values.")
+        print("  GitHub and Telegram webhook secrets must use different values.")
         default_github_secret = secrets.token_hex(32)
 
-    if tg_webhook_secret and tg_webhook_secret == legacy_webhook_secret:
-        print("  Telegram and legacy webhook secrets must be different; Telegram will use a generated token.")
-        tg_webhook_secret = ""
-
     generic_webhook_secret = existing_env.get("GENERIC_WEBHOOK_SECRET", "")
-    reserved_webhook_secrets = {github_webhook_secret, legacy_webhook_secret, tg_webhook_secret}
+    reserved_webhook_secrets = {github_webhook_secret, tg_webhook_secret}
     while not generic_webhook_secret or generic_webhook_secret in reserved_webhook_secrets:
         generic_webhook_secret = secrets.token_hex(32)
-
-    # install.conf is generated output from this wizard. An upgraded install
-    # must therefore retire the legacy fallback here rather than by editing or
-    # post-processing that artifact. Preserve compatibility on Enter: callers
-    # have to be migrated and tested before the operator explicitly chooses
-    # false. Fresh installations never carry WEBHOOK_SECRET and skip the prompt.
-    if legacy_webhook_secret:
-        print()
-        print("A deprecated WEBHOOK_SECRET compatibility fallback is present.")
-        print("Retire it only after GitHub and generic webhook callers use their named secrets.")
-        retain_legacy_webhook_secret = _prompt_bool(
-            "Retain deprecated WEBHOOK_SECRET fallback",
-            True,
-        )
-        if not retain_legacy_webhook_secret:
-            legacy_webhook_secret = ""
-            print("  WEBHOOK_SECRET will be omitted from the generated configuration.")
     print()
 
     # -- Workspaces --
@@ -2049,9 +2029,6 @@ def _cmd_config() -> None:
         "VOICE_ENABLED": str(voice_enabled).lower(),
         "TTS_ENABLED": str(tts_enabled).lower(),
     }
-    if legacy_webhook_secret:
-        env["WEBHOOK_SECRET"] = legacy_webhook_secret
-
     # DEFAULT_BACKEND is the global default backend; users.yaml entries
     # can override it per user. The wizard writes the selected backend
     # explicitly; absence is not a backend-selection signal.
@@ -4268,6 +4245,21 @@ def _cmd_apply() -> None:
         env["DEFAULT_PROVIDER"] = env.pop("LLM_PROVIDER")
     elif "LLM_PROVIDER" in env:
         del env["LLM_PROVIDER"]
+    # WEBHOOK_SECRET no longer authenticates any runtime route. Never
+    # redeploy it from an older install.conf. Refuse the upgrade before
+    # stopping Kai when either named replacement is absent; silently
+    # stripping the old credential would otherwise disable an endpoint
+    # that the shared credential previously enabled.
+    if str(env.get("WEBHOOK_SECRET", "")).strip():
+        missing_named_webhook_secrets = [
+            key for key in ("GITHUB_WEBHOOK_SECRET", "GENERIC_WEBHOOK_SECRET") if not str(env.get(key, "")).strip()
+        ]
+        if missing_named_webhook_secrets:
+            raise SystemExit(
+                "install.conf contains unsupported WEBHOOK_SECRET but is missing named replacement(s): "
+                f"{', '.join(missing_named_webhook_secrets)}. Run 'make config' once before 'make install'."
+            )
+    env.pop("WEBHOOK_SECRET", None)
     # Top-level installer metadata: present only when the wizard
     # staged a first-time users.yaml that has not yet been applied.
     # The empty-string -> None coercion treats a hand-edited conf
@@ -6466,11 +6458,11 @@ def _webhook_secret_migration_status(env: dict[str, str], *, source: str = "inst
     """Return a non-secret diagnostic for external webhook migration state."""
     prefix = f"Webhook secret migration ({source}):"
     if env.get("WEBHOOK_SECRET", "").strip():
-        return f"{prefix} legacy WEBHOOK_SECRET fallback configured (GitHub/generic callers may still depend on it)"
+        return f"{prefix} unsupported WEBHOOK_SECRET present (ignored by runtime; remove from configuration)"
     if env.get("GITHUB_WEBHOOK_SECRET", "").strip() and env.get("GENERIC_WEBHOOK_SECRET", "").strip():
-        return f"{prefix} named GitHub/generic secrets configured; no legacy fallback"
+        return f"{prefix} named GitHub/generic secrets configured; unsupported WEBHOOK_SECRET absent"
     missing = [key for key in ("GITHUB_WEBHOOK_SECRET", "GENERIC_WEBHOOK_SECRET") if not env.get(key, "").strip()]
-    return f"{prefix} no legacy fallback; missing named secret(s): {', '.join(missing)}"
+    return f"{prefix} unsupported WEBHOOK_SECRET absent; missing named secret(s): {', '.join(missing)}"
 
 
 def _deployed_webhook_secret_migration_status(env_path: Path) -> str:

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -570,7 +570,7 @@ FORMAT each fact as:
 
   - "User prefers Celsius" -> scope_hint: "global". True in every
     project.
-  - "The webhook secret is read from the WEBHOOK_SECRET env var"
+  - "The GitHub webhook secret is read from GITHUB_WEBHOOK_SECRET"
     -> scope_hint: "project". An implementation detail of the
     project under discussion; in a different project the same
     sentence could be false.

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -33,10 +33,9 @@ Routes are organized into these groups:
 
 Every ingress domain has an independent credential. Telegram uses its configured
 or process-generated secret token, GitHub uses GITHUB_WEBHOOK_SECRET, and the
-generic endpoint uses GENERIC_WEBHOOK_SECRET. During migration only, the
-deprecated WEBHOOK_SECRET is an external-only fallback for the GitHub and generic
-routes; successful fallback use is logged. Internal API routes always use random,
-principal-bound process credentials and do not depend on external webhook secrets.
+generic endpoint uses GENERIC_WEBHOOK_SECRET. Internal API routes always use
+random, principal-bound process credentials and do not depend on external webhook
+secrets.
 
 GitHub events are formatted into human-readable Markdown messages and sent
 to the configured Telegram chat. The formatter pattern (dispatch dict mapping
@@ -91,7 +90,6 @@ CONFIG_KEY: web.AppKey[Config] = web.AppKey("config", Config)
 GENERIC_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("generic_webhook_secret", str)
 GITHUB_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("github_webhook_secret", str)
 INTERNAL_API_AUTH_KEY: web.AppKey[InternalAPIAuth] = web.AppKey("internal_api_auth", InternalAPIAuth)
-LEGACY_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("legacy_webhook_secret", str)
 NOTIFICATION_CHAT_IDS_KEY: web.AppKey[set[int]] = web.AppKey("notification_chat_ids", set)
 POOL_KEY: web.AppKey[object] = web.AppKey("pool", object)
 PR_REVIEW_COOLDOWN_KEY: web.AppKey[int] = web.AppKey("pr_review_cooldown", int)
@@ -424,24 +422,16 @@ def _strip_markdown(text: str) -> str:
 
 
 def _require_generic_webhook_secret(handler):
-    """Validate the generic credential, with observable legacy fallback."""
+    """Validate the dedicated generic webhook credential."""
 
     @functools.wraps(handler)
     async def wrapper(request: web.Request) -> web.Response:
         secret = request.app[GENERIC_WEBHOOK_SECRET_KEY]
-        legacy_secret = request.app.get(LEGACY_WEBHOOK_SECRET_KEY, "")
         provided = request.headers.get("X-Webhook-Secret", "")
         if secret and hmac.compare_digest(provided, secret):
             return await handler(request)
-        if legacy_secret and hmac.compare_digest(provided, legacy_secret):
-            log.warning(
-                "Legacy WEBHOOK_SECRET authenticated /webhook from %s; migrate this caller to GENERIC_WEBHOOK_SECRET",
-                request.remote,
-            )
-            return await handler(request)
-        else:
-            log.warning("Auth failure on %s from %s", request.path, request.remote)
-            return web.Response(status=401, text="Invalid secret")
+        log.warning("Auth failure on %s from %s", request.path, request.remote)
+        return web.Response(status=401, text="Invalid secret")
 
     return wrapper
 
@@ -701,21 +691,12 @@ async def _handle_github(request: web.Request) -> web.Response:
     Unsupported events are silently acknowledged with {"msg": "ignored"}.
     """
     secret = request.app[GITHUB_WEBHOOK_SECRET_KEY]
-    legacy_secret = request.app.get(LEGACY_WEBHOOK_SECRET_KEY, "")
 
     body = await request.read()
 
     # Validate HMAC-SHA256 signature from GitHub
     signature = request.headers.get("X-Hub-Signature-256", "")
-    if secret and _verify_github_signature(secret, body, signature):
-        pass
-    elif legacy_secret and _verify_github_signature(legacy_secret, body, signature):
-        log.warning(
-            "Legacy WEBHOOK_SECRET authenticated /webhook/github from %s; "
-            "migrate the GitHub webhook to GITHUB_WEBHOOK_SECRET",
-            request.remote,
-        )
-    else:
+    if not secret or not _verify_github_signature(secret, body, signature):
         log.warning("GitHub webhook: invalid signature")
         return web.Response(status=401, text="Invalid signature")
 
@@ -2339,22 +2320,19 @@ def _register_routes(app: web.Application, config: Config) -> None:
     """Register independently gated external routes and always-on internal APIs."""
     app.router.add_get("/health", _handle_health)
 
-    if config.webhook_secret:
-        app[LEGACY_WEBHOOK_SECRET_KEY] = config.webhook_secret
-
     if config.telegram_webhook_url:
         if not config.telegram_webhook_secret:
             raise RuntimeError("Telegram webhook mode requires a non-empty secret")
         app[TELEGRAM_WEBHOOK_SECRET_KEY] = config.telegram_webhook_secret
         app.router.add_post("/webhook/telegram", _handle_telegram_update)
 
-    if config.github_webhook_secret or config.webhook_secret:
+    if config.github_webhook_secret:
         app[GITHUB_WEBHOOK_SECRET_KEY] = config.github_webhook_secret
         app.router.add_post("/webhook/github", _handle_github)
     else:
         log.warning("GITHUB_WEBHOOK_SECRET not set - GitHub webhook endpoint disabled")
 
-    if config.generic_webhook_secret or config.webhook_secret:
+    if config.generic_webhook_secret:
         app[GENERIC_WEBHOOK_SECRET_KEY] = config.generic_webhook_secret
         app.router.add_post("/webhook", _handle_generic)
     else:

--- a/templates/.env
+++ b/templates/.env
@@ -93,8 +93,11 @@ CLAUDE_AUTOCOMPACT_PCT=80
 # Port for the local webhook/API server (receives GitHub events, scheduling API)
 WEBHOOK_PORT=8080
 
-# HMAC secret for verifying incoming webhook payloads
-WEBHOOK_SECRET=your-webhook-secret
+# Dedicated secrets for external webhook ingress. GitHub signs request bodies
+# with GITHUB_WEBHOOK_SECRET; generic callers send GENERIC_WEBHOOK_SECRET in
+# the X-Webhook-Secret header. Leave an endpoint's value empty to disable it.
+GITHUB_WEBHOOK_SECRET=
+GENERIC_WEBHOOK_SECRET=
 
 # Global rate limit: minimum seconds between reviews on the same PR.
 # Machine-wide resource limit shared across all users.
@@ -121,7 +124,7 @@ WEBHOOK_SECRET=your-webhook-secret
 #TELEGRAM_WEBHOOK_URL=https://your-host/webhook/telegram
 
 # Separate secret for Telegram webhook auth (only needed in webhook mode).
-# Defaults to WEBHOOK_SECRET if unset.
+# A process-generated secret is used when this is unset.
 #TELEGRAM_WEBHOOK_SECRET=
 
 # ── Voice Messages (optional) ────────────────────────────────────

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -619,7 +619,7 @@ def _make_config(**overrides) -> Config:
 
     Accepts any Config field as a keyword override. Used by both the pure
     function tests (workspace_base, allowed_workspaces) and the handler
-    tests (tts_enabled, voice_enabled, webhook_secret, etc.).
+    tests (tts_enabled, voice_enabled, named webhook secrets, etc.).
 
     `claude_workspace=` is accepted as a back-compat alias for pre-#353
     tests that wanted a specific home directory. Config no longer has
@@ -644,7 +644,6 @@ def _make_config(**overrides) -> Config:
         "allowed_workspaces": [],
         "github_webhook_secret": "github-test-secret",
         "generic_webhook_secret": "generic-test-secret",
-        "webhook_secret": "test-secret",
         "webhook_port": 8080,
         "tts_enabled": False,
         "voice_enabled": False,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -415,7 +415,7 @@ class TestLoadConfigOptional:
         assert config.github_webhook_secret == "github-secret"
         assert config.generic_webhook_secret == "generic-secret"
 
-    def test_legacy_webhook_secret_stays_separate_for_external_fallback(self, monkeypatch, caplog):
+    def test_legacy_webhook_secret_is_ignored(self, monkeypatch, caplog):
         _set_required(monkeypatch)
         monkeypatch.setenv("WEBHOOK_SECRET", "legacy-secret")
 
@@ -424,11 +424,10 @@ class TestLoadConfigOptional:
 
         assert config.github_webhook_secret == ""
         assert config.generic_webhook_secret == ""
-        assert config.webhook_secret == "legacy-secret"
-        assert "deprecated" in caplog.text
-        assert "/webhook/github and /webhook only" in caplog.text
+        assert not hasattr(config, "webhook_secret")
+        assert "no longer supported and is ignored" in caplog.text
 
-    def test_explicit_generic_secret_wins_over_legacy(self, monkeypatch, caplog):
+    def test_explicit_generic_secret_is_unchanged_when_legacy_is_present(self, monkeypatch, caplog):
         _set_required(monkeypatch)
         monkeypatch.setenv("GENERIC_WEBHOOK_SECRET", "generic-secret")
         monkeypatch.setenv("WEBHOOK_SECRET", "legacy-secret")
@@ -438,8 +437,8 @@ class TestLoadConfigOptional:
 
         assert config.generic_webhook_secret == "generic-secret"
         assert config.github_webhook_secret == ""
-        assert config.webhook_secret == "legacy-secret"
-        assert "temporary compatibility authentication" in caplog.text
+        assert not hasattr(config, "webhook_secret")
+        assert "no longer supported and is ignored" in caplog.text
 
     @pytest.mark.parametrize(
         ("left_name", "right_name"),
@@ -537,7 +536,6 @@ class TestTelegramWebhookConfig:
         """Webhook mode gets a process credential without reusing another domain's secret."""
         _set_required(monkeypatch)
         monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.com/webhook/telegram")
-        monkeypatch.setenv("WEBHOOK_SECRET", "legacy-secret")
         monkeypatch.setattr("kai.config.secrets.token_urlsafe", lambda _n: "generated-telegram-secret")
 
         config = load_config()
@@ -547,7 +545,6 @@ class TestTelegramWebhookConfig:
         """TELEGRAM_WEBHOOK_SECRET uses its own value when explicitly set."""
         _set_required(monkeypatch)
         monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.com/webhook/telegram")
-        monkeypatch.setenv("WEBHOOK_SECRET", "legacy-secret")
         monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "tg-only-secret")
         config = load_config()
         assert config.telegram_webhook_secret == "tg-only-secret"

--- a/tests/test_episode_classifier_eval.py
+++ b/tests/test_episode_classifier_eval.py
@@ -42,7 +42,6 @@ _ARTIFACT = Path(__file__).parent / "artifacts" / "episode_classifier_eval.json"
 _BASE_CONFIG = Config(
     telegram_bot_token="test-token",
     allowed_user_ids={12345},
-    webhook_secret="test-secret",
 )
 
 

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -234,7 +234,6 @@ class TestErrorMessageLifecycle:
             "config": Config(
                 telegram_bot_token="t",
                 allowed_user_ids={1},
-                webhook_secret="s",
                 tts_enabled=False,  # voice-mode lookup is skipped
             ),
         }

--- a/tests/test_eval_extraction.py
+++ b/tests/test_eval_extraction.py
@@ -33,7 +33,6 @@ from kai.eval import extraction
 _TEST_CONFIG = Config(
     telegram_bot_token="test-token",
     allowed_user_ids={12345},
-    webhook_secret="test-secret",
 )
 
 # Hash of `_PROMPT_V5_PINNED` captured at #426 landing. If the

--- a/tests/test_eval_memory_backend_gate.py
+++ b/tests/test_eval_memory_backend_gate.py
@@ -26,7 +26,6 @@ from kai.eval import memory_backend_gate as g
 _BASE_CONFIG = Config(
     telegram_bot_token="test-token",
     allowed_user_ids={12345},
-    webhook_secret="test-secret",
     memory_enabled=False,
     memory_extraction_enabled=False,
 )

--- a/tests/test_eval_retrieval_scoped.py
+++ b/tests/test_eval_retrieval_scoped.py
@@ -75,7 +75,6 @@ from kai.eval.retrieval_scoped import (
 _BASE_CONFIG = Config(
     telegram_bot_token="test-token",
     allowed_user_ids={12345},
-    webhook_secret="test-secret",
     memory_enabled=True,
     memory_search_limit=10,
     memory_token_budget=2000,
@@ -718,7 +717,6 @@ class TestProjectRegistryBootstrap:
                 Config(
                     telegram_bot_token="t",
                     allowed_user_ids={1},
-                    webhook_secret="s",
                 )
             )
 
@@ -1227,7 +1225,6 @@ class TestInitMemoryStartupLine:
         cfg = Config(
             telegram_bot_token="t",
             allowed_user_ids={1},
-            webhook_secret="s",
             memory_enabled=True,
         )
         monkeypatch.setattr("kai.config.load_config", lambda: cfg)

--- a/tests/test_eval_unscoped_recall_capture.py
+++ b/tests/test_eval_unscoped_recall_capture.py
@@ -44,7 +44,6 @@ from kai.eval._unscoped_recall_capture import (
 _BASE_CONFIG = Config(
     telegram_bot_token="test-token",
     allowed_user_ids={12345},
-    webhook_secret="test-secret",
     memory_enabled=True,
     memory_search_limit=10,
     memory_token_budget=2000,

--- a/tests/test_github_self_service.py
+++ b/tests/test_github_self_service.py
@@ -597,11 +597,10 @@ class TestEnsureWebhook:
 
     @pytest.mark.asyncio
     async def test_missing_github_secret_raises(self):
-        """GitHub registration cannot borrow a generic or legacy secret."""
+        """GitHub registration cannot borrow the generic secret."""
         config = _make_config(
             github_webhook_secret="",
             generic_webhook_secret="generic-secret",
-            webhook_secret="legacy-secret",
         )
 
         with pytest.raises(GitHubAPIError, match="GITHUB_WEBHOOK_SECRET"):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1924,13 +1924,12 @@ class TestCmdConfig:
         # Should preserve existing values when user accepts defaults
         assert conf["install_dir"] == "/custom/path"
         assert conf["env"]["TELEGRAM_BOT_TOKEN"] == "existing-token"
-        # The legacy value remains available to both external routes during
-        # observation. New named credentials are distinct so fallback use can
-        # be identified and logged endpoint by endpoint.
+        # Named credentials are generated independently and the unsupported
+        # legacy value is not carried forward into the regenerated artifact.
         assert conf["env"]["GITHUB_WEBHOOK_SECRET"] != "existing-secret"
         assert conf["env"]["GENERIC_WEBHOOK_SECRET"] != "existing-secret"
         assert conf["env"]["GITHUB_WEBHOOK_SECRET"] != conf["env"]["GENERIC_WEBHOOK_SECRET"]
-        assert conf["env"]["WEBHOOK_SECRET"] == "existing-secret"
+        assert "WEBHOOK_SECRET" not in conf["env"]
         # With a canonical users.yaml already present the wizard skips the
         # user-creation prompts entirely and never stages a new file, so
         # no admin prompt is shown and no top-level staging key is written.
@@ -1941,13 +1940,11 @@ class TestCmdConfig:
         output = capsys.readouterr().out
         assert "Admin Telegram ID" not in output
         assert "-- User setup --" not in output
-        assert "A deprecated WEBHOOK_SECRET compatibility fallback is present" in output
+        assert "WEBHOOK_SECRET is no longer supported and will be omitted" in output
         assert "users_yaml_staging_path" not in conf
 
-    def test_regeneration_can_retire_legacy_webhook_fallback(self, tmp_path, monkeypatch, capsys):
-        """The operator retires compatibility through make config; the
-        generated artifact omits only the legacy key and keeps named secrets.
-        """
+    def test_regeneration_automatically_removes_legacy_webhook_secret(self, tmp_path, monkeypatch, capsys):
+        """Regeneration omits the unsupported key and keeps named secrets."""
         monkeypatch.chdir(tmp_path)
         conf_path = tmp_path / "install.conf"
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
@@ -1972,12 +1969,7 @@ class TestCmdConfig:
         }
         conf_path.write_text(json.dumps(existing))
 
-        def answer(prompt: str) -> str:
-            if "Retain deprecated WEBHOOK_SECRET fallback" in prompt:
-                return "false"
-            return ""
-
-        monkeypatch.setattr("builtins.input", answer)
+        monkeypatch.setattr("builtins.input", lambda prompt: "")
 
         _cmd_config()
 
@@ -1987,7 +1979,7 @@ class TestCmdConfig:
         assert generated["env"]["GENERIC_WEBHOOK_SECRET"] == "generic-secret"
         assert generated["env"]["TELEGRAM_BOT_TOKEN"] == "existing-token"
         output = capsys.readouterr().out
-        assert "WEBHOOK_SECRET will be omitted from the generated configuration" in output
+        assert "WEBHOOK_SECRET is no longer supported and will be omitted" in output
 
     def test_validates_required_fields(self):
         """Required-field validation rejects empty input."""
@@ -4081,6 +4073,67 @@ class TestCmdApplyDefaultModelGate:
         assert written_env.get("DEFAULT_PROVIDER") == "openai"
         assert "LLM_PROVIDER" not in written_env
 
+    def test_apply_drops_unsupported_WEBHOOK_SECRET(self, tmp_path, monkeypatch):
+        """An old install.conf cannot redeploy the retired credential."""
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {
+                "DEFAULT_MODEL": "sonnet",
+                "DEFAULT_BACKEND": "claude",
+                "WEBHOOK_SECRET": "legacy-secret",
+                "GITHUB_WEBHOOK_SECRET": "github-secret",
+                "GENERIC_WEBHOOK_SECRET": "generic-secret",
+            },
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        self._patch_side_effects(monkeypatch)
+        secrets_mock = MagicMock()
+        monkeypatch.setattr("kai.install._apply_secrets", secrets_mock)
+        monkeypatch.setenv("DRY_RUN", "1")
+
+        _cmd_apply()
+
+        written_env = secrets_mock.call_args.args[0]
+        assert "WEBHOOK_SECRET" not in written_env
+        assert written_env["GITHUB_WEBHOOK_SECRET"] == "github-secret"
+        assert written_env["GENERIC_WEBHOOK_SECRET"] == "generic-secret"
+
+    @pytest.mark.parametrize(
+        "named_secrets",
+        [
+            {},
+            {"GITHUB_WEBHOOK_SECRET": "github-secret"},
+            {"GENERIC_WEBHOOK_SECRET": "generic-secret"},
+        ],
+    )
+    def test_apply_refuses_legacy_secret_without_all_named_replacements(
+        self,
+        tmp_path,
+        monkeypatch,
+        named_secrets,
+    ):
+        """Retirement cannot silently disable a formerly shared route."""
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        conf_path = self._write_install_conf(
+            tmp_path,
+            {
+                "DEFAULT_MODEL": "sonnet",
+                "DEFAULT_BACKEND": "claude",
+                "WEBHOOK_SECRET": "legacy-secret",
+                **named_secrets,
+            },
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        stop_service = self._patch_side_effects(monkeypatch)
+
+        with pytest.raises(SystemExit, match="Run 'make config' once before 'make install'"):
+            _cmd_apply()
+
+        stop_service.assert_not_called()
+
     def test_apply_migrates_legacy_AGENT_TIMEOUT_SECONDS(self, tmp_path, monkeypatch):
         """A legacy install.conf carrying AGENT_TIMEOUT_SECONDS migrates
         to DEFAULT_TIMEOUT in the env dict; /etc/kai/env is written with
@@ -4336,7 +4389,7 @@ class TestCmdStatus:
         output = capsys.readouterr().out
         assert "Installation Status" in output
 
-    def test_reports_legacy_webhook_secret_fallback(self, tmp_path, monkeypatch, capsys):
+    def test_reports_unsupported_webhook_secret(self, tmp_path, monkeypatch, capsys):
         conf_path = tmp_path / "install.conf"
         conf_path.write_text(
             json.dumps(
@@ -4361,7 +4414,8 @@ class TestCmdStatus:
         _cmd_status()
 
         output = capsys.readouterr().out
-        assert "legacy WEBHOOK_SECRET fallback configured" in output
+        assert "unsupported WEBHOOK_SECRET present" in output
+        assert "ignored by runtime" in output
         assert "legacy-secret" not in output
         assert "github-secret" not in output
         assert "generic-secret" not in output
@@ -4391,7 +4445,7 @@ class TestCmdStatus:
 
         output = capsys.readouterr().out
         assert "named GitHub/generic secrets configured" in output
-        assert "no legacy fallback" in output
+        assert "unsupported WEBHOOK_SECRET absent" in output
         assert "github-secret" not in output
         assert "generic-secret" not in output
 
@@ -4423,13 +4477,13 @@ class TestCmdStatus:
 
         output = capsys.readouterr().out
         assert f"Webhook secret migration (deployed {deployed_env}): named GitHub/generic secrets configured" in output
-        assert "Webhook secret migration (install.conf artifact): legacy WEBHOOK_SECRET fallback configured" in output
+        assert "Webhook secret migration (install.conf artifact): unsupported WEBHOOK_SECRET present" in output
         assert "deployed-github-secret" not in output
         assert "deployed-generic-secret" not in output
         assert "artifact-legacy-secret" not in output
 
     def test_webhook_secret_migration_status_is_non_secret(self):
-        assert "legacy WEBHOOK_SECRET fallback configured" in _webhook_secret_migration_status(
+        assert "unsupported WEBHOOK_SECRET present" in _webhook_secret_migration_status(
             {
                 "WEBHOOK_SECRET": "legacy-secret",
                 "GITHUB_WEBHOOK_SECRET": "github-secret",
@@ -4451,18 +4505,19 @@ class TestCmdStatus:
 
         assert f"deployed {env_path}" in status
         assert "named GitHub/generic secrets configured" in status
-        assert "no legacy fallback" in status
+        assert "unsupported WEBHOOK_SECRET absent" in status
         assert "github-deployed-value" not in status
         assert "generic-deployed-value" not in status
 
-    def test_deployed_status_reports_legacy_fallback_without_value(self, tmp_path, monkeypatch):
+    def test_deployed_status_reports_unsupported_secret_without_value(self, tmp_path, monkeypatch):
         env_path = tmp_path / "env"
         env_path.write_text('WEBHOOK_SECRET="legacy-deployed-value"\n')
         monkeypatch.setattr("kai.install.validate_protected_file_metadata", lambda *args, **kwargs: True)
 
         status = _deployed_webhook_secret_migration_status(env_path)
 
-        assert "legacy WEBHOOK_SECRET fallback configured" in status
+        assert "unsupported WEBHOOK_SECRET present" in status
+        assert "ignored by runtime" in status
         assert "legacy-deployed-value" not in status
 
     def test_deployed_status_is_explicit_when_permission_denied(self, tmp_path, monkeypatch):
@@ -8250,7 +8305,8 @@ class TestCmdApplyStagingHandoff:
             "platform": "darwin",
             "env": {
                 "TELEGRAM_BOT_TOKEN": "tok",
-                "WEBHOOK_SECRET": "secret",
+                "GITHUB_WEBHOOK_SECRET": "github-secret",
+                "GENERIC_WEBHOOK_SECRET": "generic-secret",
                 "DEFAULT_MODEL": "sonnet",
                 "DEFAULT_BACKEND": "claude",
             },
@@ -8758,6 +8814,8 @@ class TestCmdApplySingleUserRefuses:
             "env": {
                 "TELEGRAM_BOT_TOKEN": "tok",
                 "WEBHOOK_SECRET": "secret",
+                "GITHUB_WEBHOOK_SECRET": "github-secret",
+                "GENERIC_WEBHOOK_SECRET": "generic-secret",
                 "DEFAULT_MODEL": "sonnet",
                 "DEFAULT_BACKEND": "claude",
             },

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -29,7 +29,6 @@ from kai.config import Config, UserConfig
 _BASE_CONFIG = Config(
     telegram_bot_token="test-token",
     allowed_user_ids={12345},
-    webhook_secret="test-secret",
 )
 
 

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -50,7 +50,6 @@ from kai.memory_extraction import (
 _BASE_CONFIG = Config(
     telegram_bot_token="test-token",
     allowed_user_ids={12345},
-    webhook_secret="test-secret",
     default_backend="claude",
 )
 

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -81,7 +81,6 @@ def _mock_binary_resolver():
 _BASE_CONFIG = Config(
     telegram_bot_token="test-token",
     allowed_user_ids={12345},
-    webhook_secret="test-secret",
     default_backend="claude",
 )
 

--- a/tests/test_memory_provenance_backfill.py
+++ b/tests/test_memory_provenance_backfill.py
@@ -90,7 +90,6 @@ from kai.memory_provenance_backfill import (
 _BASE_CONFIG = Config(
     telegram_bot_token="test-token",
     allowed_user_ids={12345},
-    webhook_secret="test-secret",
     memory_enabled=True,
 )
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -49,7 +49,6 @@ def _make_config(**overrides) -> Config:
         "agent_max_session_hours": 0,
         "agent_idle_timeout": 1800,
         "webhook_port": 8080,
-        "webhook_secret": "secret",
     }
     defaults.update(overrides)
     return Config(**defaults)
@@ -73,14 +72,11 @@ class TestInstanceCreation:
         b = pool.get(222)
         assert a is not b
         assert a._api_context.webhook_secret != b._api_context.webhook_secret
-        assert a._api_context.webhook_secret != "secret"
-        assert b._api_context.webhook_secret != "secret"
 
     def test_internal_api_credential_exists_without_external_webhooks(self):
         """Disabling public ingress must not remove the agent's scoped API."""
         pool = SubprocessPool(
             config=_make_config(
-                webhook_secret="",
                 github_webhook_secret="",
                 generic_webhook_secret="",
             ),

--- a/tests/test_smoke_memory.py
+++ b/tests/test_smoke_memory.py
@@ -26,7 +26,6 @@ from kai.oneshot import OneShotResult
 _BASE_CONFIG = Config(
     telegram_bot_token="test",
     allowed_user_ids={1},
-    webhook_secret="test",
 )
 
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2362,7 +2362,6 @@ class TestNotificationChatIdMutations:
         config.user_configs = {111: admin}
         config.allowed_user_ids = {111}
         config.get_admins.return_value = [admin]
-        config.webhook_secret = None
         config.telegram_webhook_url = None
         config.telegram_webhook_secret = None
         config.github_webhook_secret = None

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -20,7 +20,6 @@ from kai.webhook import (
     GENERIC_WEBHOOK_SECRET_KEY,
     GITHUB_WEBHOOK_SECRET_KEY,
     INTERNAL_API_AUTH_KEY,
-    LEGACY_WEBHOOK_SECRET_KEY,
     POOL_KEY,
     PR_REVIEW_COOLDOWN_KEY,
     TELEGRAM_APP_KEY,
@@ -758,16 +757,6 @@ class TestTelegramUpdate:
         assert resp.status == 401
         telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_not_called()
 
-    async def test_legacy_webhook_secret_is_not_accepted(self, telegram_request):
-        """The external transition credential never crosses into Telegram auth."""
-        telegram_request.app[LEGACY_WEBHOOK_SECRET_KEY] = "legacy-secret"
-        telegram_request.headers = {"X-Telegram-Bot-Api-Secret-Token": "legacy-secret"}
-
-        resp = await _handle_telegram_update(telegram_request)
-
-        assert resp.status == 401
-        telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_not_called()
-
     async def test_missing_secret_returns_401(self, telegram_request):
         """Missing secret header returns 401."""
         telegram_request.headers = {}
@@ -1059,38 +1048,19 @@ class TestGitHubWebhook:
         assert resp.status == 401
         github_request.app[TELEGRAM_BOT_KEY].send_message.assert_not_called()
 
-    async def test_legacy_signature_is_accepted_and_logged(self, github_request, caplog):
-        """An existing GitHub registration stays live and produces migration telemetry."""
+    async def test_legacy_signature_is_rejected(self, github_request):
+        """WEBHOOK_SECRET no longer authenticates the GitHub ingress domain."""
         body = b'{"zen": "migration"}'
-        github_request.app[LEGACY_WEBHOOK_SECRET_KEY] = "legacy-secret"
         github_request.read = AsyncMock(return_value=body)
         github_request.headers = {
             "X-Hub-Signature-256": _sign_body("legacy-secret", body),
             "X-GitHub-Event": "ping",
         }
 
-        with caplog.at_level("WARNING", logger="kai.webhook"):
-            resp = await _handle_github(github_request)
+        resp = await _handle_github(github_request)
 
-        assert resp.status == 200
-        assert "Legacy WEBHOOK_SECRET authenticated /webhook/github" in caplog.text
-        assert "GITHUB_WEBHOOK_SECRET" in caplog.text
-
-    async def test_named_signature_does_not_log_legacy_use(self, github_request, caplog):
-        """The primary named credential wins even while compatibility is configured."""
-        body = b'{"zen": "named"}'
-        github_request.app[LEGACY_WEBHOOK_SECRET_KEY] = "legacy-secret"
-        github_request.read = AsyncMock(return_value=body)
-        github_request.headers = {
-            "X-Hub-Signature-256": _sign_body("test-secret", body),
-            "X-GitHub-Event": "ping",
-        }
-
-        with caplog.at_level("WARNING", logger="kai.webhook"):
-            resp = await _handle_github(github_request)
-
-        assert resp.status == 200
-        assert "Legacy WEBHOOK_SECRET authenticated" not in caplog.text
+        assert resp.status == 401
+        github_request.app[TELEGRAM_BOT_KEY].send_message.assert_not_called()
 
     async def test_ping_event_returns_pong(self, github_request):
         """GitHub ping events are acknowledged without sending to Telegram."""
@@ -1249,29 +1219,15 @@ class TestGenericWebhook:
 
         assert resp.status == 401
 
-    async def test_legacy_secret_is_accepted_and_logged(self, generic_request, caplog):
-        """An unknown external caller gets a compatibility window with telemetry."""
-        generic_request.app[LEGACY_WEBHOOK_SECRET_KEY] = "legacy-secret"
+    async def test_legacy_secret_is_rejected(self, generic_request):
+        """WEBHOOK_SECRET no longer authenticates the generic ingress domain."""
         generic_request.headers = {"X-Webhook-Secret": "legacy-secret"}
         generic_request.json = AsyncMock(return_value={"message": "legacy caller"})
 
-        with caplog.at_level("WARNING", logger="kai.webhook"):
-            resp = await _handle_generic(generic_request)
+        resp = await _handle_generic(generic_request)
 
-        assert resp.status == 200
-        assert "Legacy WEBHOOK_SECRET authenticated /webhook" in caplog.text
-        assert "GENERIC_WEBHOOK_SECRET" in caplog.text
-
-    async def test_named_secret_does_not_log_legacy_use(self, generic_request, caplog):
-        """The generic route checks its named credential before the fallback."""
-        generic_request.app[LEGACY_WEBHOOK_SECRET_KEY] = "legacy-secret"
-        generic_request.json = AsyncMock(return_value={"message": "named caller"})
-
-        with caplog.at_level("WARNING", logger="kai.webhook"):
-            resp = await _handle_generic(generic_request)
-
-        assert resp.status == 200
-        assert "Legacy WEBHOOK_SECRET authenticated" not in caplog.text
+        assert resp.status == 401
+        generic_request.app[TELEGRAM_BOT_KEY].send_message.assert_not_called()
 
 
 # ── GET /api/jobs ──────────────────────────────────────────────────
@@ -1990,18 +1946,6 @@ class TestChatIdAuthorization:
     async def test_external_signing_secret_is_not_an_api_credential(self, mock_request):
         """Possession of the GitHub/generic signing secret does not authorize API calls."""
         mock_request.headers = {"X-Webhook-Secret": "signing-secret"}
-        mock_request.json = AsyncMock(return_value={"text": "hello"})
-
-        resp = await _handle_send_message(mock_request)
-
-        assert resp.status == 401
-        mock_request.app[TELEGRAM_BOT_KEY].send_message.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_legacy_webhook_secret_is_not_an_api_credential(self, mock_request):
-        """The transition fallback remains external-only."""
-        mock_request.app[LEGACY_WEBHOOK_SECRET_KEY] = "legacy-secret"
-        mock_request.headers = {"X-Webhook-Secret": "legacy-secret"}
         mock_request.json = AsyncMock(return_value={"text": "hello"})
 
         resp = await _handle_send_message(mock_request)

--- a/tests/test_webhook_routes.py
+++ b/tests/test_webhook_routes.py
@@ -49,17 +49,6 @@ def test_external_webhook_routes_are_enabled_independently() -> None:
     assert ("POST", "/webhook/github") not in generic_routes
 
 
-def test_legacy_credential_temporarily_enables_both_external_routes() -> None:
-    app = web.Application()
-
-    _register_routes(app, _config(webhook_secret="legacy-secret"))
-
-    routes = _routes(app)
-    assert ("POST", "/webhook/github") in routes
-    assert ("POST", "/webhook") in routes
-    assert ("POST", "/api/schedule") in routes
-
-
 def test_telegram_route_is_independent_of_other_webhooks() -> None:
     app = web.Application()
 


### PR DESCRIPTION
## Summary

- remove `WEBHOOK_SECRET` as an authentication fallback for GitHub and generic webhooks
- remove the retired credential from runtime `Config` and aiohttp application state
- make `make config` automatically omit legacy values from regenerated configuration
- make protected `make install` strip the value from older artifacts before writing `/etc/kai/env`
- fail protected installation before stopping Kai if an older shared-secret artifact lacks either named replacement
- retain the privileged status diagnostic so stale deployed or artifact state remains visible without exposing values

## Deployment evidence and behavior

The authoritative `make install-status` diagnostic was run before this change. The deployed `/etc/kai/env` and the current `install.conf` artifact both report:

```text
named GitHub/generic secrets configured; no legacy fallback
```

Because the current deployed environment contains no `WEBHOOK_SECRET`, the running application does not populate the old fallback key today. Removing that unreachable alternate branch does not change the authentication behavior of this installation: GitHub continues to use `GITHUB_WEBHOOK_SECRET`, generic callers continue to use `GENERIC_WEBHOOK_SECRET`, and Telegram remains independent.

## Deliberate compatibility removal

After this change, `WEBHOOK_SECRET` authenticates no route. This breaking removal was explicitly approved by the operator after reviewing the impact.

Upgrade behavior is fail-safe:

- an old protected artifact containing the shared secret plus both named replacements is accepted; the shared secret is stripped before deployment
- an old protected artifact missing either named replacement is rejected before Kai is stopped, with an instruction to run `make config` once
- regenerated protected and single-user configuration never carries the old value forward
- direct runtime loading warns that a lingering `WEBHOOK_SECRET` is unsupported and ignored

## Preserved behavior

- GitHub HMAC validation still uses `GITHUB_WEBHOOK_SECRET`
- GitHub events still route to configured Telegram notification destinations, including groups
- generic webhooks still validate `X-Webhook-Secret` against `GENERIC_WEBHOOK_SECRET`
- Telegram update authentication and principal-bound internal API credentials are unchanged
- endpoints remain independently enabled by their named secrets

## Tests

- complete suite: 4,853 passed, 1 skipped
- affected configuration, installer, webhook, bot, routing, pool, and GitHub self-service modules exercised
- legacy GitHub signatures and generic headers are explicitly rejected
- protected apply strips the retired value when both replacements exist
- protected apply refuses all three missing-replacement shapes before reaching service shutdown
- `make typecheck`: 0 errors, 0 warnings
- `ruff check .`
- `ruff format --check .`
- `git diff --check`

## Operator validation after merge

No `make config` is required for the current deployment because both named secrets are already present. Run `make install`, then confirm:

1. Kai starts and answers a Telegram message.
2. A GitHub notification still reaches its configured Telegram destination.
3. Any active generic webhook caller still succeeds.
4. `make install-status` reports both named secrets configured and `WEBHOOK_SECRET` absent.
