### PR TITLE
Add shared Pi RPC transport primitives

### DIFF
--- a/src/kai/pi_rpc.py
+++ b/src/kai/pi_rpc.py
@@ -1,0 +1,223 @@
+"""Shared JSONL transport primitives for Pi's RPC mode.
+
+Pi's subprocess protocol is neither JSON-RPC nor ACP.  Commands, command
+responses, and asynchronous agent events all share stdout as strict JSONL.
+This module owns the framing and the small set of event semantics that the
+future conversational backend and one-shot reasoner must agree on.
+
+It intentionally does not launch Pi or make ``pi`` a selectable backend.
+Process lifecycle, user isolation, and Kai ``StreamEvent`` conversion belong
+to those two callers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+# Match the per-line headroom used by Kai's other streaming backends.  Pi
+# emits tool results and final messages as single JSON records, so the default
+# asyncio subprocess reader limit (64 KiB) is too small for real agent turns.
+PI_RPC_STREAM_LIMIT = 16 * 1024 * 1024
+
+PiRpcObject = dict[str, Any]
+PiRpcRequestId = str | int
+
+
+class PiRpcError(RuntimeError):
+    """Base class for Pi RPC transport and protocol failures."""
+
+
+class PiRpcEOFError(PiRpcError):
+    """Raised when Pi closes its RPC stream unexpectedly."""
+
+
+class PiRpcProtocolError(PiRpcError):
+    """Raised when Pi emits a malformed or inconsistent RPC record."""
+
+
+class PiRpcTimeoutError(PiRpcError):
+    """Raised when no complete Pi RPC record arrives before the deadline."""
+
+
+class PiRpcCommandError(PiRpcError):
+    """Raised when Pi returns a correlated ``success: false`` response."""
+
+    def __init__(self, command: str, request_id: PiRpcRequestId, detail: str) -> None:
+        self.command = command
+        self.request_id = request_id
+        self.detail = detail
+        super().__init__(f"Pi RPC command {command!r} ({request_id!r}) failed: {detail}")
+
+
+class _PiRpcWriter(Protocol):
+    """Structural subset of ``asyncio.StreamWriter`` used by subprocesses."""
+
+    def write(self, data: bytes) -> None: ...
+
+    async def drain(self) -> None: ...
+
+
+def encode_pi_rpc_command(command: Mapping[str, Any]) -> bytes:
+    """Encode one Pi command as a UTF-8 JSONL record.
+
+    A non-empty string ``type`` is required because Pi uses that field as the
+    command discriminator.  ``ensure_ascii=False`` preserves Unicode,
+    including U+2028/U+2029; they are valid inside JSON strings and must not
+    be mistaken for record delimiters.
+    """
+
+    command_type = command.get("type")
+    if not isinstance(command_type, str) or not command_type:
+        raise PiRpcProtocolError("Pi RPC command requires a non-empty string 'type'")
+    try:
+        body = json.dumps(dict(command), ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError) as exc:
+        raise PiRpcProtocolError(f"Pi RPC command is not JSON serializable: {exc}") from exc
+    return body.encode("utf-8") + b"\n"
+
+
+def decode_pi_rpc_record(record: bytes) -> PiRpcObject:
+    """Decode one LF-terminated Pi JSONL record.
+
+    Pi specifies LF as the only record delimiter and permits an optional CR
+    immediately before it.  Rejecting an EOF fragment without LF prevents a
+    truncated final JSON value from being mistaken for a complete message.
+    """
+
+    if not record.endswith(b"\n"):
+        raise PiRpcProtocolError("Pi RPC stream ended with an unterminated JSONL record")
+    body = record[:-1]
+    if body.endswith(b"\r"):
+        body = body[:-1]
+    if not body:
+        raise PiRpcProtocolError("Pi RPC emitted an empty JSONL record")
+    try:
+        decoded = body.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise PiRpcProtocolError(f"Pi RPC emitted invalid UTF-8: {exc}") from exc
+    try:
+        message = json.loads(decoded)
+    except json.JSONDecodeError as exc:
+        raise PiRpcProtocolError(f"Pi RPC emitted invalid JSON: {exc.msg}") from exc
+    if not isinstance(message, dict):
+        raise PiRpcProtocolError("Pi RPC record must be a JSON object")
+    message_type = message.get("type")
+    if not isinstance(message_type, str) or not message_type:
+        raise PiRpcProtocolError("Pi RPC record requires a non-empty string 'type'")
+    return message
+
+
+class PiRpcTransport:
+    """Read and write strict Pi RPC records over subprocess streams."""
+
+    def __init__(self, stdin: _PiRpcWriter, stdout: asyncio.StreamReader) -> None:
+        self._stdin = stdin
+        self._stdout = stdout
+
+    async def send(self, command: Mapping[str, Any]) -> None:
+        """Write and flush one command record."""
+
+        encoded = encode_pi_rpc_command(command)
+        try:
+            self._stdin.write(encoded)
+            await self._stdin.drain()
+        except (BrokenPipeError, ConnectionError, RuntimeError) as exc:
+            raise PiRpcEOFError(f"could not write to Pi RPC stdin: {exc}") from exc
+
+    async def receive(self, *, timeout_seconds: float | None = None) -> PiRpcObject:
+        """Read one complete response or event record.
+
+        ``timeout_seconds=None`` waits indefinitely.  Callers normally pass
+        their remaining turn/startup budget so a stalled Pi process cannot
+        hold a Kai request forever.
+        """
+
+        try:
+            if timeout_seconds is None:
+                record = await self._stdout.readline()
+            else:
+                record = await asyncio.wait_for(self._stdout.readline(), timeout=timeout_seconds)
+        except TimeoutError as exc:
+            raise PiRpcTimeoutError("timed out waiting for a Pi RPC record") from exc
+        except (ConnectionError, RuntimeError) as exc:
+            raise PiRpcEOFError(f"could not read Pi RPC stdout: {exc}") from exc
+        if not record:
+            raise PiRpcEOFError("Pi RPC stdout closed")
+        return decode_pi_rpc_record(record)
+
+
+def require_pi_rpc_response(
+    message: Mapping[str, Any],
+    *,
+    request_id: PiRpcRequestId,
+    command: str,
+) -> Any:
+    """Validate and unwrap a response for one correlated command.
+
+    Asynchronous events may appear around command responses; callers decide
+    when to invoke this helper after matching the ``id``.  A response for a
+    different id is a protocol error here rather than being silently accepted.
+    """
+
+    if message.get("type") != "response":
+        raise PiRpcProtocolError(f"expected Pi RPC response for {command!r}, got {message.get('type')!r}")
+    if message.get("id") != request_id:
+        raise PiRpcProtocolError(
+            f"Pi RPC response id mismatch for {command!r}: expected {request_id!r}, got {message.get('id')!r}"
+        )
+    if message.get("command") != command:
+        raise PiRpcProtocolError(
+            f"Pi RPC response command mismatch: expected {command!r}, got {message.get('command')!r}"
+        )
+    success = message.get("success")
+    if not isinstance(success, bool):
+        raise PiRpcProtocolError(f"Pi RPC response for {command!r} requires boolean 'success'")
+    if not success:
+        detail = message.get("error")
+        if not isinstance(detail, str) or not detail:
+            detail = "unknown command error"
+        raise PiRpcCommandError(command, request_id, detail)
+    return message.get("data")
+
+
+def pi_rpc_text_delta(message: Mapping[str, Any]) -> str | None:
+    """Return a visible assistant text delta, ignoring other event kinds."""
+
+    if message.get("type") != "message_update":
+        return None
+    event = message.get("assistantMessageEvent")
+    if not isinstance(event, dict):
+        raise PiRpcProtocolError("Pi message_update requires an assistantMessageEvent object")
+    if event.get("type") != "text_delta":
+        return None
+    delta = event.get("delta")
+    if not isinstance(delta, str):
+        raise PiRpcProtocolError("Pi text_delta requires a string 'delta'")
+    return delta
+
+
+def pi_rpc_is_settled(message: Mapping[str, Any]) -> bool:
+    """Return whether Pi has reached its session-level terminal event.
+
+    ``agent_end`` is deliberately not terminal: current Pi may still retry,
+    compact, or process queued continuation messages before ``agent_settled``.
+    """
+
+    return message.get("type") == "agent_settled"
+
+
+def pi_rpc_extension_error(message: Mapping[str, Any]) -> str | None:
+    """Return a safe diagnostic for an ``extension_error`` event."""
+
+    if message.get("type") != "extension_error":
+        return None
+    error = message.get("error")
+    if not isinstance(error, str) or not error:
+        error = "unknown extension error"
+    extension_path = message.get("extensionPath")
+    if isinstance(extension_path, str) and extension_path:
+        return f"{extension_path}: {error}"
+    return error

--- a/tests/test_pi_rpc.py
+++ b/tests/test_pi_rpc.py
@@ -1,0 +1,241 @@
+"""Tests for the shared Pi JSONL RPC transport."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kai.pi_rpc import (
+    PI_RPC_STREAM_LIMIT,
+    PiRpcCommandError,
+    PiRpcEOFError,
+    PiRpcProtocolError,
+    PiRpcTimeoutError,
+    PiRpcTransport,
+    decode_pi_rpc_record,
+    encode_pi_rpc_command,
+    pi_rpc_extension_error,
+    pi_rpc_is_settled,
+    pi_rpc_text_delta,
+    require_pi_rpc_response,
+)
+
+
+def _reader_with(*records: bytes) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader(limit=PI_RPC_STREAM_LIMIT)
+    for record in records:
+        reader.feed_data(record)
+    reader.feed_eof()
+    return reader
+
+
+class TestPiRpcFraming:
+    def test_command_is_compact_utf8_jsonl(self):
+        encoded = encode_pi_rpc_command({"id": "one", "type": "prompt", "message": "héllo"})
+
+        assert encoded.endswith(b"\n")
+        assert encoded.count(b"\n") == 1
+        assert json.loads(encoded) == {"id": "one", "type": "prompt", "message": "héllo"}
+
+    def test_unicode_line_separators_are_not_record_delimiters(self):
+        encoded = encode_pi_rpc_command({"type": "prompt", "message": "before\u2028middle\u2029after"})
+
+        assert encoded.count(b"\n") == 1
+        assert b"\xe2\x80\xa8" in encoded
+        assert b"\xe2\x80\xa9" in encoded
+        assert decode_pi_rpc_record(encoded)["message"] == "before\u2028middle\u2029after"
+
+    @pytest.mark.parametrize("ending", [b"\n", b"\r\n"])
+    def test_decode_accepts_lf_and_optional_cr(self, ending: bytes):
+        assert decode_pi_rpc_record(b'{"type":"agent_settled"}' + ending) == {"type": "agent_settled"}
+
+    @pytest.mark.parametrize(
+        ("record", "match"),
+        [
+            (b'{"type":"agent_settled"}', "unterminated"),
+            (b"\n", "empty"),
+            (b"\xff\n", "invalid UTF-8"),
+            (b'{"type":\n', "invalid JSON"),
+            (b"[]\n", "JSON object"),
+            (b"{}\n", "non-empty string 'type'"),
+        ],
+    )
+    def test_decode_rejects_malformed_records(self, record: bytes, match: str):
+        with pytest.raises(PiRpcProtocolError, match=match):
+            decode_pi_rpc_record(record)
+
+    def test_encode_requires_command_type(self):
+        with pytest.raises(PiRpcProtocolError, match="command requires"):
+            encode_pi_rpc_command({"id": "missing-type"})
+
+    def test_encode_rejects_non_json_value(self):
+        with pytest.raises(PiRpcProtocolError, match="not JSON serializable"):
+            encode_pi_rpc_command({"type": "prompt", "message": object()})
+
+
+class TestPiRpcTransport:
+    @pytest.mark.asyncio
+    async def test_send_writes_and_drains_one_record(self):
+        writer = MagicMock()
+        writer.drain = AsyncMock()
+        transport = PiRpcTransport(writer, _reader_with())
+
+        await transport.send({"id": "state-1", "type": "get_state"})
+
+        writer.write.assert_called_once_with(b'{"id":"state-1","type":"get_state"}\n')
+        writer.drain.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_maps_broken_pipe_to_eof(self):
+        writer = MagicMock()
+        writer.write.side_effect = BrokenPipeError("closed")
+        writer.drain = AsyncMock()
+        transport = PiRpcTransport(writer, _reader_with())
+
+        with pytest.raises(PiRpcEOFError, match="could not write"):
+            await transport.send({"type": "get_state"})
+
+    @pytest.mark.asyncio
+    async def test_receive_decodes_one_record(self):
+        writer = MagicMock()
+        writer.drain = AsyncMock()
+        transport = PiRpcTransport(writer, _reader_with(b'{"type":"agent_start"}\n'))
+
+        assert await transport.receive() == {"type": "agent_start"}
+
+    @pytest.mark.asyncio
+    async def test_receive_reports_clean_eof(self):
+        writer = MagicMock()
+        writer.drain = AsyncMock()
+        transport = PiRpcTransport(writer, _reader_with())
+
+        with pytest.raises(PiRpcEOFError, match="stdout closed"):
+            await transport.receive()
+
+    @pytest.mark.asyncio
+    async def test_receive_reports_unterminated_eof_fragment(self):
+        writer = MagicMock()
+        writer.drain = AsyncMock()
+        transport = PiRpcTransport(writer, _reader_with(b'{"type":"agent_start"}'))
+
+        with pytest.raises(PiRpcProtocolError, match="unterminated"):
+            await transport.receive()
+
+    @pytest.mark.asyncio
+    async def test_receive_timeout_has_typed_error(self):
+        class SlowReader:
+            async def readline(self) -> bytes:
+                await asyncio.sleep(60)
+                return b""
+
+        writer = MagicMock()
+        writer.drain = AsyncMock()
+        transport = PiRpcTransport(writer, SlowReader())  # type: ignore[arg-type]
+
+        with pytest.raises(PiRpcTimeoutError, match="timed out"):
+            await transport.receive(timeout_seconds=0.001)
+
+
+class TestPiRpcSemantics:
+    def test_success_response_is_correlated_and_unwrapped(self):
+        data = require_pi_rpc_response(
+            {
+                "id": "models-1",
+                "type": "response",
+                "command": "get_available_models",
+                "success": True,
+                "data": {"models": []},
+            },
+            request_id="models-1",
+            command="get_available_models",
+        )
+
+        assert data == {"models": []}
+
+    def test_failed_response_has_typed_error(self):
+        with pytest.raises(PiRpcCommandError, match="model not found") as excinfo:
+            require_pi_rpc_response(
+                {
+                    "id": "model-1",
+                    "type": "response",
+                    "command": "set_model",
+                    "success": False,
+                    "error": "model not found",
+                },
+                request_id="model-1",
+                command="set_model",
+            )
+
+        assert excinfo.value.command == "set_model"
+        assert excinfo.value.request_id == "model-1"
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            {"type": "agent_start"},
+            {"id": "other", "type": "response", "command": "get_state", "success": True},
+            {"id": "state-1", "type": "response", "command": "set_model", "success": True},
+            {"id": "state-1", "type": "response", "command": "get_state", "success": "yes"},
+        ],
+    )
+    def test_response_mismatch_is_protocol_error(self, message):
+        with pytest.raises(PiRpcProtocolError):
+            require_pi_rpc_response(message, request_id="state-1", command="get_state")
+
+    def test_text_delta_is_extracted(self):
+        assert (
+            pi_rpc_text_delta(
+                {
+                    "type": "message_update",
+                    "assistantMessageEvent": {"type": "text_delta", "delta": "hello"},
+                }
+            )
+            == "hello"
+        )
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            {"type": "tool_execution_update"},
+            {
+                "type": "message_update",
+                "assistantMessageEvent": {"type": "thinking_delta", "delta": "private"},
+            },
+            {
+                "type": "message_update",
+                "assistantMessageEvent": {"type": "toolcall_delta", "delta": "arguments"},
+            },
+        ],
+    )
+    def test_non_text_events_do_not_become_assistant_text(self, message):
+        assert pi_rpc_text_delta(message) is None
+
+    def test_malformed_text_delta_is_protocol_error(self):
+        with pytest.raises(PiRpcProtocolError, match="string 'delta'"):
+            pi_rpc_text_delta(
+                {
+                    "type": "message_update",
+                    "assistantMessageEvent": {"type": "text_delta", "delta": 7},
+                }
+            )
+
+    def test_only_agent_settled_is_terminal(self):
+        assert not pi_rpc_is_settled({"type": "turn_end"})
+        assert not pi_rpc_is_settled({"type": "agent_end", "willRetry": False})
+        assert pi_rpc_is_settled({"type": "agent_settled"})
+
+    def test_extension_error_is_safely_formatted(self):
+        assert (
+            pi_rpc_extension_error(
+                {
+                    "type": "extension_error",
+                    "extensionPath": "/tmp/example.ts",
+                    "error": "hook failed",
+                }
+            )
+            == "/tmp/example.ts: hook failed"
+        )
+        assert pi_rpc_extension_error({"type": "agent_start"}) is None


### PR DESCRIPTION
## Summary

Begin the Pi backend work from #696 with the shared protocol layer that both the future conversational backend and `PiOneShotReasoner` will consume.

- add strict byte-oriented JSONL command encoding and record decoding
- accept LF and optional CRLF while preserving valid U+2028/U+2029 characters inside JSON strings
- reject truncated records, invalid UTF-8/JSON, non-object records, and missing type discriminators
- add an async subprocess-stream transport with typed EOF and timeout failures
- correlate and validate command responses with typed command failures
- extract only visible `message_update` text deltas so thinking and tool-call content cannot bleed into assistant text
- treat `agent_settled` as the sole session-level terminal event; `agent_end` is intentionally non-terminal because Pi may still retry, compact, or process queued continuations
- provide safe formatting for extension errors

## Protocol revalidation

Validated against the installed Pi CLI `0.79.9` using a no-model-call RPC probe:

```text
pi --mode rpc --no-session --no-tools --no-extensions \
  --no-skills --no-prompt-templates --no-context-files \
  --no-approve --offline
```

`get_state` and `get_available_models` both returned correlated JSONL responses. The service account correctly reported zero configured models, reinforcing that later model discovery must run under each target OS user's isolated home.

## Deliberate scope boundary

This PR does **not**:

- add `pi` to `VALID_BACKENDS`
- add Pi to `/etc/kai/backends.yaml` generation or sudoers
- alter `make config` or `make install`
- route conversations or one-shot roles through Pi
- change the running Kai service

That keeps an incomplete backend impossible to select. The next integration PR can build on this tested protocol layer and expose Pi only when registry, sudo, configuration, pool dispatch, and runtime lifecycle support land together.

## Tests

- `31 passed` in `tests/test_pi_rpc.py`
- `make check`
- `make typecheck`
- full suite: `4884 passed, 1 skipped`
- `git diff --check`

Refs #696
