### PR TITLE
Add Pi as a first-class backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ In Kai, a backend is more than a model provider. Each backend is a full coding h
 | OpenAI Codex CLI | `codex` CLI | Codex CLI model IDs | Uses Codex's own model catalog, separate from OpenAI API model lists. |
 | Goose | `goose acp` | Provider-native model IDs | ACP backend with provider selected through Goose configuration or env. |
 | OpenCode | `opencode acp` | `provider/model` IDs | ACP backend with model resolution owned by OpenCode. |
+| Pi | `pi --mode rpc` | `provider/model[:thinking]` IDs | JSONL RPC backend using the target OS user's Pi authentication; bounded one-shot tasks disable tools and project resources. |
 
 Kai does not require every supported backend to exist on every machine. Every backend selected as the installation default or in a user's configuration must be installed and authenticated for the OS account that will run it.
 

--- a/src/kai/backend_registry.py
+++ b/src/kai/backend_registry.py
@@ -31,6 +31,7 @@ _BACKEND_ENV_VARS: dict[str, str] = {
     "opencode": "OPENCODE_BIN",
     "goose": "GOOSE_BIN",
 }
+_SUPPORTED_BACKENDS = frozenset((*_BACKEND_ENV_VARS, "pi"))
 _SUPPORTED_RUNTIME = "local_process"
 
 
@@ -118,8 +119,8 @@ def load_backend_registry(path: Path | None = None) -> dict[str, BackendRegistry
         backend = str(backend_id).strip().lower()
         if not backend:
             raise BackendRegistryError(f"backend registry {registry_path}: empty backend id")
-        if backend not in _BACKEND_ENV_VARS:
-            valid = ", ".join(sorted(_BACKEND_ENV_VARS))
+        if backend not in _SUPPORTED_BACKENDS:
+            valid = ", ".join(sorted(_SUPPORTED_BACKENDS))
             raise BackendRegistryError(
                 f"backend registry {registry_path}: unsupported backend {backend!r}; valid backends: {valid}"
             )
@@ -203,8 +204,8 @@ def resolve_default_backend(configured_backend: str = "") -> str:
         registry = load_backend_registry()
 
     if configured:
-        if configured not in _BACKEND_ENV_VARS:
-            valid = ", ".join(sorted(_BACKEND_ENV_VARS))
+        if configured not in _SUPPORTED_BACKENDS:
+            valid = ", ".join(sorted(_SUPPORTED_BACKENDS))
             raise BackendRegistryError(
                 f"configured default backend {configured!r} is not valid; valid backends: {valid}"
             )
@@ -251,10 +252,15 @@ def _validate_absolute_executable(backend: str, command: str, source: str) -> st
 
 def _legacy_env_or_path_command(backend: str, *, allow_bare_fallback: bool) -> str:
     env_var = _BACKEND_ENV_VARS.get(backend)
-    if env_var is None:
+    if backend not in _SUPPORTED_BACKENDS:
         raise ValueError(f"unknown backend for command resolution: {backend!r}")
-    override = os.environ.get(env_var)
+    # Pi landed after executable paths became an admin-registry concern,
+    # so it intentionally has no PI_BIN compatibility surface. Dev mode
+    # resolves it through PATH (or the explicit bare-command fallback)
+    # while protected installs always use /etc/kai/backends.yaml.
+    override = os.environ.get(env_var) if env_var is not None else None
     if override:
+        assert env_var is not None  # override can only be populated from a named legacy variable
         if allow_bare_fallback:
             return override
         return _validate_absolute_executable(backend, override, env_var)
@@ -263,7 +269,8 @@ def _legacy_env_or_path_command(backend: str, *, allow_bare_fallback: bool) -> s
     resolved = shutil.which(backend)
     if resolved is not None:
         return resolved
-    raise BackendRegistryError(f"{env_var} unset, `{backend}` not on PATH")
+    source = f"{env_var} unset" if env_var is not None else "no legacy binary override is supported"
+    raise BackendRegistryError(f"{source}, `{backend}` not on PATH")
 
 
 def resolve_backend_command(backend: str, *, allow_bare_fallback: bool = False) -> str:

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -57,8 +57,9 @@ DATA_DIR = Path(os.environ.get("KAI_DATA_DIR") or str(PROJECT_ROOT))
 # "goose" uses Goose ACP, "codex" uses OpenAI Codex CLI's app-server
 # JSON-RPC protocol, "opencode" uses OpenCode's ACP (model selected
 # via OPENCODE_CONFIG_CONTENT; auth managed by the operator through
-# `opencode auth login`). Shared between load_config() and install.py.
-VALID_BACKENDS = {"claude", "goose", "codex", "opencode"}
+# `opencode auth login`), and "pi" uses Pi's JSONL RPC mode. Shared
+# between load_config() and install.py.
+VALID_BACKENDS = {"claude", "goose", "codex", "opencode", "pi"}
 
 # Backends that ship a `OneShotReasoner` implementation in
 # `src/kai/oneshot.py`. Every site that gates on "does this backend
@@ -85,12 +86,12 @@ VALID_BACKENDS = {"claude", "goose", "codex", "opencode"}
 # validation, wizard prompts, smoke, the /memory retrieval-only
 # note) keys off this set rather than VALID_BACKENDS so that gap
 # stays representable.
-ONESHOT_REASONER_BACKENDS: frozenset[str] = frozenset({"claude", "codex", "goose", "opencode"})
+ONESHOT_REASONER_BACKENDS: frozenset[str] = frozenset({"claude", "codex", "goose", "opencode", "pi"})
 
 # The single authoritative (backend, provider) allowlist. Every site
 # that needs to know "what providers can this backend talk to" reads
 # from this map. Claude and codex are 1:1 with one provider each;
-# opencode and goose are 1:N. load_config validates that every user's
+# opencode, goose, and pi are 1:N. load_config validates that every user's
 # (backend, provider) pair is a member. Adding a new
 # backend is one row here; adding a new provider to an existing
 # backend is one tuple element. Tuple values (not frozensets) so the
@@ -102,6 +103,21 @@ BACKEND_PROVIDERS: dict[str, tuple[str, ...]] = {
     "codex": ("openai",),
     "opencode": ("anthropic", "deepseek", "google", "ollama", "openai", "openrouter"),
     "goose": ("anthropic", "deepseek", "google", "ollama", "openai", "openrouter"),
+    # Pi also exposes subscription-backed identities managed by its
+    # per-user `/login` flow. `anthropic` covers either Anthropic API-key
+    # or Claude Pro/Max OAuth auth; ChatGPT and Copilot have distinct Pi
+    # provider IDs. Models remain open-ended because Pi owns and updates
+    # those catalogs with each release.
+    "pi": (
+        "anthropic",
+        "deepseek",
+        "github-copilot",
+        "google",
+        "ollama",
+        "openai",
+        "openai-codex",
+        "openrouter",
+    ),
 }
 
 # Backends whose runtime configuration requires the operator (or
@@ -423,6 +439,37 @@ _BACKEND_PROVIDER_TIER_MODELS: dict[tuple[str, str], dict[str, str]] = {
     ("goose", "ollama"): {"agent": "llama4:70b", "balanced": "llama4:70b", "cheap": "llama4:8b"},
 }
 
+# Pi and OpenCode both select API-provider registry defaults with the
+# provider-prefixed `provider/model` shape. Pi also accepts a bare runtime
+# model when the effective provider is explicit.
+for _pi_provider in ("anthropic", "deepseek", "google", "ollama", "openai", "openrouter"):
+    _BACKEND_PROVIDER_TIER_MODELS[("pi", _pi_provider)] = dict(
+        _BACKEND_PROVIDER_TIER_MODELS[("opencode", _pi_provider)]
+    )
+
+# OpenRouter's Pi catalog uses dotted Claude generation IDs, unlike the
+# hyphenated model IDs exposed by OpenCode's provider registry.
+_BACKEND_PROVIDER_TIER_MODELS[("pi", "openrouter")] = {
+    "agent": "openrouter/anthropic/claude-sonnet-4.6",
+    "balanced": "openrouter/anthropic/claude-sonnet-4.6",
+    "cheap": "openrouter/anthropic/claude-haiku-4.5",
+}
+
+# Pi's subscription providers are authenticated per target OS user through
+# `pi` -> `/login`. These are curated startup/automation defaults only; Kai's
+# `/model` input remains open-ended so a Pi upgrade can expose new models
+# without requiring a Kai release. IDs below are present in Pi 0.79.9.
+_BACKEND_PROVIDER_TIER_MODELS[("pi", "openai-codex")] = {
+    "agent": "openai-codex/gpt-5.5",
+    "balanced": "openai-codex/gpt-5.5",
+    "cheap": "openai-codex/gpt-5.4-mini",
+}
+_BACKEND_PROVIDER_TIER_MODELS[("pi", "github-copilot")] = {
+    "agent": "github-copilot/gpt-5.5",
+    "balanced": "github-copilot/gpt-5.5",
+    "cheap": "github-copilot/gpt-5-mini",
+}
+
 
 def _build_registry() -> dict[tuple[str, str, ModelRole], str]:
     """Fan out the (backend, provider) tier maps over every ModelRole.
@@ -581,6 +628,19 @@ def _check_model_registry_complete() -> None:
                         f"MODEL_REGISTRY has opencode rows that are not in `provider/model` "
                         f"shape: {details}. Update _BACKEND_PROVIDER_TIER_MODELS in config.py."
                     )
+            if backend == "pi":
+                invalid_pi = [
+                    (role, MODEL_REGISTRY[(backend, provider, role)])
+                    for role in ModelRole
+                    if not is_pi_model_shape(MODEL_REGISTRY[(backend, provider, role)], provider)
+                ]
+                if invalid_pi:
+                    details = ", ".join(f"{role.value}={model}" for role, model in invalid_pi)
+                    raise SystemExit(
+                        "MODEL_REGISTRY has pi rows that are not in matching "
+                        f"`provider/model` shape: {details}. "
+                        "Update _BACKEND_PROVIDER_TIER_MODELS in config.py."
+                    )
 
 
 def get_effective_provider(backend: str, llm_provider: str) -> str:
@@ -690,6 +750,8 @@ def is_opencode_model_shape(model: str) -> bool:
     """
     if not model:
         return False
+    if "/" not in model:
+        return False
     # Split on every "/" and require at least two non-empty segments.
     # The first segment is opencode's provider prefix; remaining
     # segments form the model_id, which itself may contain slashes
@@ -702,6 +764,26 @@ def is_opencode_model_shape(model: str) -> bool:
     if len(parts) < 2:
         return False
     return all(parts)
+
+
+def is_pi_model_shape(model: str, provider: str = "") -> bool:
+    """Validate Pi's `provider/model[:thinking]` selection shape.
+
+    Pi resolves the installed/authenticated model set at runtime, so Kai
+    cannot maintain an accurate static allowlist. The provider prefix is
+    still load-bearing: it must be present and, when Kai has an effective
+    provider, must agree with that provider. Colons remain valid inside
+    model IDs (notably Ollama tags); Pi itself distinguishes an optional
+    recognized thinking suffix from the underlying model ID.
+    """
+    if not model:
+        return False
+    if "/" not in model:
+        return bool(provider and model.strip())
+    parts = model.split("/")
+    if len(parts) < 2 or not all(parts):
+        return False
+    return not provider or parts[0] == provider
 
 
 def _backend_registry_allowed_models(backend: str) -> tuple[str, ...] | None:
@@ -784,14 +866,20 @@ def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> b
     with a clear error on the next message, the same contract
     opencode accepts for its structurally-validated IDs.
 
+    Pi also validates structurally. It accepts the documented
+    `provider/model[:thinking]` form or a bare model only when an
+    explicit effective provider supplies the missing identity.
+
     Canonical model validator: every model-selection site in the
-    codebase routes through this function so codex / goose / opencode
-    share no fallback path.
+    codebase routes through this function so backends share no
+    fallback path.
     """
     if backend == "codex":
         base_allowed = model in CODEX_MODELS
     elif backend == "opencode":
         base_allowed = is_opencode_model_shape(model)
+    elif backend == "pi":
+        base_allowed = is_pi_model_shape(model, eff_provider)
     elif (backend == "claude" or (backend == "goose" and eff_provider == "anthropic")) and model.startswith("claude-"):
         base_allowed = True
     else:
@@ -932,7 +1020,7 @@ def models_for_backend(agent_backend: str, eff_provider: str) -> dict[str, str] 
     """
     if agent_backend == "codex":
         models = CODEX_MODELS
-    elif agent_backend == "opencode" or eff_provider in OPEN_ENDED_PROVIDERS:
+    elif agent_backend in {"opencode", "pi"} or eff_provider in OPEN_ENDED_PROVIDERS:
         return None
     else:
         models = PROVIDER_MODELS.get(eff_provider)
@@ -2544,20 +2632,31 @@ def _load_user_configs(
         # PROVIDER_MODELS[eff_provider] via the provider-only delegate.
         # Cascade: user override -> global config, same as pool.py.
         if model is not None and not validate_model_for_backend(model, eff_backend, eff_provider):
-            if eff_backend == "codex":
-                valid = sorted(CODEX_MODELS.keys())
-                surface_label = "codex"
+            if eff_backend == "pi":
+                log.warning(
+                    "users.yaml: invalid Pi model '%s' for %s (expected "
+                    "provider/model[:thinking] matching provider '%s', or a bare model "
+                    "with that explicit provider); ignoring",
+                    model,
+                    name,
+                    eff_provider,
+                )
+                model = None
             else:
-                valid = sorted(PROVIDER_MODELS.get(eff_provider, {}).keys())
-                surface_label = f"provider '{eff_provider}'"
-            log.warning(
-                "users.yaml: invalid model '%s' for %s (%s, must be one of %s); ignoring",
-                model,
-                name,
-                surface_label,
-                valid,
-            )
-            model = None
+                if eff_backend == "codex":
+                    valid = sorted(CODEX_MODELS.keys())
+                    surface_label = "codex"
+                else:
+                    valid = sorted(PROVIDER_MODELS.get(eff_provider, {}).keys())
+                    surface_label = f"provider '{eff_provider}'"
+                log.warning(
+                    "users.yaml: invalid model '%s' for %s (%s, must be one of %s); ignoring",
+                    model,
+                    name,
+                    surface_label,
+                    valid,
+                )
+                model = None
 
         # Validate optional timeout (positive integer)
         user_timeout = entry.get("timeout")
@@ -3491,6 +3590,12 @@ def load_config() -> Config:
     # letting them propagate to a confusing runtime failure.
     if not validate_model_for_backend(default_model, default_backend, global_provider):
         source_label = "DEFAULT_MODEL" if configured_default_model else "MODEL_REGISTRY agent default"
+        if default_backend == "pi":
+            raise SystemExit(
+                f"{source_label} '{default_model}' is not valid for pi: expected "
+                f"provider/model[:thinking] matching provider '{global_provider}', or a bare model "
+                "with that explicit provider."
+            )
         if default_backend == "codex":
             valid = sorted(CODEX_MODELS.keys())
             raise SystemExit(

--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -116,9 +116,10 @@ from kai.eval._probes import (
     load_probes,
     probe_set_hash,
 )
+from kai.oneshot import OneShotError, PiOneShotReasoner
 from kai.prompt_utils import make_boundary
 
-_SUPPORTED_BEHAVIORAL_BACKENDS = frozenset({"claude", "codex"})
+_SUPPORTED_BEHAVIORAL_BACKENDS = frozenset({"claude", "codex", "pi"})
 
 log = logging.getLogger(__name__)
 
@@ -296,9 +297,13 @@ class BehavioralConfig:
     seed: str
     max_concurrency: int
     # The evaluator currently has protocol-specific implementations for
-    # exactly these two backends. Callers must select one explicitly;
-    # unsupported identities are rejected before any subprocess starts.
+    # these backends. Callers must select one explicitly; unsupported
+    # identities are rejected before any subprocess starts.
     backend: str
+    # Multi-provider reasoners carry the effective provider explicitly.
+    # Empty remains valid for the single-provider backends and for older
+    # programmatic test fixtures.
+    provider: str = ""
     # Eval-only synthetic-pollution count. Defaults to 0 so existing
     # tests and existing CLI invocations stay byte-for-byte identical
     # to today's behavior; a non-zero value opts the run into the
@@ -1188,6 +1193,21 @@ async def _run_one_arm(
     `_parse_codex_gen_stdout` which joins multi-item turns with a
     blank-line separator.
     """
+    if config.backend == "pi":
+        started = time.monotonic()
+        reasoner = PiOneShotReasoner(cwd=cwd, provider=config.provider)
+        try:
+            result = await reasoner.run(
+                prompt=arm_prompt,
+                model=config.gen_model,
+                timeout=config.gen_timeout_s,
+                purpose="behavioral_generation",
+            )
+        except OneShotError:
+            return None, (time.monotonic() - started) * 1000
+        text = result.text.strip()
+        elapsed_ms = (time.monotonic() - started) * 1000
+        return (text or None), elapsed_ms
     if config.backend == "codex":
         cmd = _build_gen_cmd_codex(config)
         stdin_payload = _render_codex_stdin("", arm_prompt)
@@ -1242,6 +1262,22 @@ async def _run_one_judge(
         response_a=response_a,
         response_b=response_b,
     )
+    if config.backend == "pi":
+        started = time.monotonic()
+        reasoner = PiOneShotReasoner(cwd=cwd, provider=config.provider)
+        try:
+            result = await reasoner.run(
+                prompt=payload,
+                system_prompt=_JUDGE_SYSTEM_PROMPT,
+                model=config.judge_model,
+                timeout=config.judge_timeout_s,
+                purpose="behavioral_judge",
+                json_schema=_JUDGE_SCHEMA,
+            )
+        except OneShotError:
+            return None, (time.monotonic() - started) * 1000
+        parsed = _parse_judge_stdout(result.text.encode("utf-8"))
+        return parsed, (time.monotonic() - started) * 1000
     if config.backend == "codex":
         cmd = _build_judge_cmd_codex(config)
         # System prompt is prepended to stdin because codex `exec`
@@ -1729,10 +1765,9 @@ def _pick_qualitative_examples(outcomes: list[ProbeOutcome]) -> dict[str, dict[s
 def _capture_agent_cli_version(backend: str) -> tuple[str, str]:
     """Capture the active agent CLI's version string for the run record.
 
-    Returns `(field_name, value)` where `field_name` is the output
-    JSON key the caller should write under: `"claude_cli_version"` on
-    a claude run, `"codex_cli_version"` on a codex run. The harness
-    writes exactly one of those keys and leaves the other absent.
+    Returns `(field_name, value)` where `field_name` identifies the
+    active backend CLI version in the output JSON. The harness writes
+    exactly one backend-specific key.
     Unsupported backends are rejected rather than being routed through
     a different backend's CLI protocol.
 
@@ -1762,6 +1797,10 @@ def _capture_agent_cli_version(backend: str) -> tuple[str, str]:
         field_name = "claude_cli_version"
         claude_bin = resolve_backend_command("claude", allow_bare_fallback=True)
         argv = [claude_bin, "--version"]
+    elif backend == "pi":
+        field_name = "pi_cli_version"
+        pi_bin = resolve_backend_command("pi", allow_bare_fallback=True)
+        argv = [pi_bin, "--version"]
     else:
         raise ValueError(f"unsupported behavioral-eval backend: {backend!r}")
     try:
@@ -1821,9 +1860,8 @@ def build_output_json(
     machinery. Schema versioned via _OUTPUT_SCHEMA_VERSION; bump it
     when downstream parsers would need to be re-tested.
 
-    `cli_version_field` is the JSON key under which to write the CLI
-    version - "claude_cli_version" on a claude run, "codex_cli_version"
-    on a codex run. The envelope writes EXACTLY ONE of those keys;
+    `cli_version_field` is the backend-specific JSON key under which
+    to write the CLI version. The envelope writes EXACTLY ONE such key;
     the call site computes the pair via _capture_agent_cli_version so
     it is structurally impossible to populate both. This shape was
     chosen over taking two optional Optional[str] arguments because
@@ -1888,14 +1926,16 @@ def _render_summary(output: dict[str, Any]) -> str:
     """
     counts = output["outcomes"]
     # CLI version line dispatches on whichever key is present.
-    # The harness writes exactly one of `claude_cli_version` /
-    # `codex_cli_version` per run; reading the literal claude key
+    # The harness writes exactly one backend-specific CLI version key
+    # per run; reading the literal claude key
     # (the pre-codex shape) would KeyError on a codex run before the
     # JSON file could be written. Fall back to "unknown" if neither
     # key is present so this never raises - a missing version line
     # is a softer failure than a CLI crash mid-render.
     if "codex_cli_version" in output:
         cli_line = f"Codex CLI: {output['codex_cli_version']}"
+    elif "pi_cli_version" in output:
+        cli_line = f"Pi CLI: {output['pi_cli_version']}"
     elif "claude_cli_version" in output:
         cli_line = f"Claude CLI: {output['claude_cli_version']}"
     else:
@@ -2281,6 +2321,7 @@ async def _run_cli(args: argparse.Namespace) -> int:
         pollution_lines=args.pollution_lines,
         data_dir=data_dir,
         backend=eval_backend,
+        provider=eval_provider,
     )
 
     # Capture CLI version for the run record. The helper returns a

--- a/src/kai/eval/gen_collision_probes.py
+++ b/src/kai/eval/gen_collision_probes.py
@@ -84,6 +84,7 @@ from typing import Any
 
 from kai.config import (
     DATA_DIR,
+    ONESHOT_REASONER_BACKENDS,
     Config,
     MemoryProjectConfig,
     ModelRole,
@@ -100,6 +101,7 @@ from kai.oneshot import (
     OneShotError,
     OneShotReasoner,
     OpenCodeOneShotReasoner,
+    PiOneShotReasoner,
 )
 
 log = logging.getLogger(__name__)
@@ -431,7 +433,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # ── Resolver overrides ───────────────────────────────────────
     parser.add_argument(
         "--backend",
-        choices=["claude", "codex", "goose", "opencode"],
+        choices=sorted(ONESHOT_REASONER_BACKENDS),
         help=(
             "Override the target user's effective backend. Default: "
             "resolve from user config via memory_reclassify's "
@@ -663,14 +665,14 @@ def _build_drafting_reasoner(
 
     Mirrors `kai.memory_extraction._build_memory_reasoner` in shape
     but lives here so the generator does not import the extraction-
-    flavored error text from that helper. The four valid backends
+    flavored error text from that helper. The valid backends
     match `ONESHOT_REASONER_BACKENDS`; the RuntimeError branch is a
     defensive net for a future change that widens the set without
     updating this dispatch.
 
-    `provider` is consumed by goose only (goose carries the wire-
-    name on its argv); the other backends derive provider implicitly
-    or embed it in the model string.
+    `provider` is consumed by goose and Pi (both carry it on argv);
+    the other backends derive provider implicitly or embed it in the
+    model string.
     """
     if effective_backend == "claude":
         return ClaudeOneShotReasoner(os_user=os_user)
@@ -680,10 +682,12 @@ def _build_drafting_reasoner(
         return OpenCodeOneShotReasoner(os_user=os_user)
     if effective_backend == "goose":
         return GooseOneShotReasoner(os_user=os_user, provider=provider)
+    if effective_backend == "pi":
+        return PiOneShotReasoner(os_user=os_user, provider=provider)
     raise RuntimeError(
         f"gen_collision_probes: unsupported effective backend "
         f"{effective_backend!r}; expected one of "
-        f"claude/codex/opencode/goose"
+        f"claude/codex/opencode/goose/pi"
     )
 
 

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -617,6 +617,11 @@ def _discover_backend_commands(service_user: str) -> dict[str, str]:
             str(Path(svc_home) / ".local" / "bin" / "opencode"),
             shutil.which("opencode") or "",
         ),
+        "pi": (
+            "/opt/homebrew/bin/pi",
+            "/usr/local/bin/pi",
+            shutil.which("pi") or "",
+        ),
     }
     discovered: dict[str, str] = {}
     for backend, backend_candidates in candidates.items():
@@ -1323,7 +1328,7 @@ def _cmd_config() -> None:
     if not backend_choices:
         raise SystemExit(
             "No installed Kai backends were found. Install at least one supported backend "
-            "(claude, codex, goose, or opencode) globally, then re-run make config."
+            "(claude, codex, goose, opencode, or pi) globally, then re-run make config."
         )
     # Prefill reads DEFAULT_BACKEND, falling back to the deprecated
     # AGENT_BACKEND key so a re-run against a legacy install.conf keeps
@@ -1405,6 +1410,12 @@ def _cmd_config() -> None:
         print("    <service_user> ~$ opencode auth login")
         print("  Kai writes the active model into OPENCODE_CONFIG_CONTENT at process spawn;")
         print("  OpenCode resolves it against the credentials in ~/.local/share/opencode/auth.json.")
+    if agent_backend == "pi":
+        print("  After install, authenticate Pi for at least one provider as each target os_user:")
+        print("    <os_user> ~$ pi")
+        print("    /login")
+        print("  Kai starts Pi with the configured provider/model; Pi resolves credentials")
+        print("  from that user's ~/.pi/agent/auth.json or provider environment.")
 
     # Multi-provider backends (opencode, goose): operator picks the
     # provider that drives the (backend, provider, role) registry
@@ -1441,7 +1452,7 @@ def _cmd_config() -> None:
             sorted(valid_providers),
             provider_prefill,
         )
-        if agent_backend != "opencode":
+        if agent_backend not in {"opencode", "pi"}:
             llm_api_key_var = PROVIDER_KEY_VARS.get(llm_provider, "")
             if llm_api_key_var:
                 llm_api_key = _prompt(
@@ -2974,6 +2985,7 @@ def _generate_sudoers(
     codex_bin: str | None = None,
     opencode_bin: str | None = None,
     goose_bin: str | None = None,
+    pi_bin: str | None = None,
 ) -> str:
     """
     Generate sudoers rules for the service user to read protected config files.
@@ -2987,7 +2999,7 @@ def _generate_sudoers(
     in the current PATH (e.g., when running in a minimal environment).
 
     Per-user `(target_user) SETENV: NOPASSWD:` rules for the claude, codex,
-    opencode, and goose binaries (plus a `NOPASSWD: /bin/kill` rule for the
+    opencode, goose, and pi binaries (plus a `NOPASSWD: /bin/kill` rule for the
     cross-user kill escalation) are emitted for every distinct `os_user`
     value in users.yaml. Users matching `service_user` are skipped (the
     runtime detects self-sudo and spawns the agent directly without
@@ -3054,6 +3066,7 @@ def _generate_sudoers(
         codex_bin_resolved = codex_bin or _resolve_default_codex_bin()
         opencode_bin_resolved = opencode_bin or f"{svc_home}/.local/bin/opencode"
         goose_bin_resolved = goose_bin or "/opt/homebrew/bin/goose"
+        pi_bin_resolved = pi_bin or "/opt/homebrew/bin/pi"
         # kill(1) for the cross-user kill escalation (#456). The bot
         # runs `sudo -n -u <target> /bin/kill -<sig> <pid>` against
         # the inner claude grandchild because POSIX signal permissions
@@ -3092,8 +3105,8 @@ def _generate_sudoers(
         rules += textwrap.dedent("""\
 
             # Per-target sudoers rules for the cross-os-user inner agent spawn.
-            # The claude, codex, opencode, and goose rules grant arbitrary code
-            # execution as <target> (all four agents have shell/file tools); the
+            # The claude, codex, opencode, goose, and pi rules grant arbitrary
+            # code execution as <target> (all five agents have shell/file tools); the
             # kill rule grants signal delivery to any <target>-owned process. The
             # kill rule's scope is broader than a PID-locked rule because sudoers
             # argument matching is not safe per sudo(8). The kill rule is a strict
@@ -3105,6 +3118,7 @@ def _generate_sudoers(
             rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {codex_bin_resolved}\n"
             rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {opencode_bin_resolved}\n"
             rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {goose_bin_resolved}\n"
+            rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {pi_bin_resolved}\n"
             rules += f"{service_user} ALL=({target}) NOPASSWD: {kill_bin}\n"
 
     return rules
@@ -5737,7 +5751,7 @@ def _backend_registry_entries(
     discovered = _discover_backend_commands(service_user)
     if not discovered:
         raise SystemExit(
-            "No supported backend command was found. Install at least one of: claude, codex, goose, opencode."
+            "No supported backend command was found. Install at least one of: claude, codex, goose, opencode, pi."
         )
 
     default_backend = _resolve_install_default_backend(env, discovered)
@@ -5775,6 +5789,12 @@ def _backend_registry_entries(
         elif backend == "opencode":
             entries[backend] = {
                 "driver": "opencode",
+                "runtime": "local_process",
+                "command": command,
+            }
+        elif backend == "pi":
+            entries[backend] = {
+                "driver": "pi",
                 "runtime": "local_process",
                 "command": command,
             }
@@ -6129,6 +6149,7 @@ def _apply_sudoers(
         codex_bin=registry_commands.get("codex"),
         opencode_bin=registry_commands.get("opencode"),
         goose_bin=registry_commands.get("goose"),
+        pi_bin=registry_commands.get("pi"),
     )
 
     # Backstop check: each per-user rule pins a backend binary to a
@@ -6143,7 +6164,7 @@ def _apply_sudoers(
     # in users.yaml): telling an opencode-only operator to install
     # claude would manufacture a requirement that does not exist and
     # train operators to ignore the warning. The rules themselves are
-    # still emitted for all four binaries: a rule pointing at an
+    # still emitted for all five binaries: a rule pointing at an
     # absent path is inert, and unconditional emission means a later
     # backend switch cannot strand a user without a rule.
     if os_users:
@@ -6167,6 +6188,10 @@ def _apply_sudoers(
             "goose": (
                 Path(registry_commands.get("goose", "")),
                 "Install goose globally and rerun make install so /etc/kai/backends.yaml is regenerated.",
+            ),
+            "pi": (
+                Path(registry_commands.get("pi", "")),
+                "Install pi globally and rerun make install so /etc/kai/backends.yaml is regenerated.",
             ),
         }
         for backend in sorted(backends_in_use & expected_bins.keys()):

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -44,6 +44,7 @@ from kai.oneshot import (
     OneShotSubprocessError,
     OneShotTimeout,
     OpenCodeOneShotReasoner,
+    PiOneShotReasoner,
 )
 from kai.oneshot import _ensure_extractor_cwd as _ensure_extractor_cwd
 
@@ -2031,8 +2032,8 @@ def _build_memory_reasoner(
     to inject fake reasoners; the parameters are accepted but not
     inspected on the test side because patches use `return_value=`.
 
-    `provider` is consumed by the goose reasoner only: goose's
-    one-shot argv carries an explicit `--provider` flag, while the
+    `provider` is consumed by the goose and Pi reasoners: both
+    one-shot argv shapes carry an explicit provider flag, while the
     other backends encode the provider implicitly (claude/codex are
     single-provider; opencode embeds it in the model string). The
     other branches accept and ignore it so the call sites stay
@@ -2050,6 +2051,8 @@ def _build_memory_reasoner(
         return OpenCodeOneShotReasoner(os_user=os_user)
     if effective_backend == "goose":
         return GooseOneShotReasoner(os_user=os_user, provider=provider)
+    if effective_backend == "pi":
+        return PiOneShotReasoner(os_user=os_user, provider=provider)
     raise RuntimeError(f"extraction reached _build_memory_reasoner for non-extraction backend: {effective_backend!r}")
 
 

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -12,9 +12,10 @@ persistent state, a hard per-call timeout, stdin-only prompt delivery,
 optional structured-output schema, and an envelope that the CALLER
 parses (the reasoner returns raw text, not parsed memory objects).
 
-Four sibling implementations of the same `OneShotReasoner` protocol
+Five sibling implementations of the same `OneShotReasoner` protocol
 live here: `ClaudeOneShotReasoner`, `CodexOneShotReasoner`,
-`OpenCodeOneShotReasoner`, and `GooseOneShotReasoner`. Memory
+`OpenCodeOneShotReasoner`, `GooseOneShotReasoner`, and
+`PiOneShotReasoner`. Memory
 extraction, episode generation, PR review, and issue triage all
 dispatch onto this family by the user's effective backend.
 
@@ -48,6 +49,17 @@ from kai.opencode import (
     concat_opencode_text,
     extract_opencode_text_delta,
     handle_opencode_permission_request,
+)
+from kai.pi import _assistant_message_error, _assistant_message_text, _pi_provider_env_vars, _split_pi_model
+from kai.pi_rpc import (
+    PI_RPC_STREAM_LIMIT,
+    PiRpcError,
+    PiRpcProtocolError,
+    PiRpcTransport,
+    pi_rpc_extension_error,
+    pi_rpc_is_settled,
+    pi_rpc_text_delta,
+    require_pi_rpc_response,
 )
 from kai.prompt_utils import make_boundary
 
@@ -161,8 +173,8 @@ class OneShotResult:
             parses for the JSON envelope it expects (`is_error`,
             `structured_output`, etc.). The reasoner does not parse
             the envelope; that contract lives in memory_extraction.
-        backend: Provider tag ("claude", "codex", "goose", or
-            "opencode"). Surfaces in structured logs and run-record
+        backend: Provider tag ("claude", "codex", "goose",
+            "opencode", or "pi"). Surfaces in structured logs and run-record
             JSON so cross-backend comparisons are possible.
         model: Model name passed to the provider, or None when the
             caller did not request a specific model. The reasoner
@@ -209,12 +221,13 @@ class OneShotReasoner(Protocol):
     identify which caller spawned the subprocess.
 
     Constructors are not part of this protocol and differ where the
-    underlying CLI demands it: `GooseOneShotReasoner` additionally
-    requires a `provider` argument (goose is multi-provider and its
-    argv carries the provider's wire-level name), while the claude /
-    codex / opencode reasoners derive their provider implicitly.
+    underlying CLI demands it: `GooseOneShotReasoner` and
+    `PiOneShotReasoner` additionally accept a `provider` argument
+    because both CLIs carry provider selection explicitly, while the
+    claude / codex / opencode reasoners derive it implicitly or from
+    the model identifier.
     Callers constructing reasoners by backend name must thread the
-    user's effective provider when the backend is goose.
+    user's effective provider when the backend is goose or Pi.
     """
 
     async def run(
@@ -398,13 +411,21 @@ def _preserved_auth_vars_for(backend: str) -> tuple[str, ...]:
         return _OPENCODE_PRESERVED_AUTH_VARS
     if backend == "goose":
         return _GOOSE_PRESERVED_AUTH_VARS
+    if backend == "pi":
+        raise ValueError("pi preserve-env requires an explicit provider-specific allowlist")
     raise ValueError(f"unknown backend for preserve-env: {backend!r}")
 
 
 # ── Shared wrap / kill helpers ──────────────────────────────────────
 
 
-def _wrap_cmd_for_user(cmd: list[str], target_user: str, backend: str) -> list[str]:
+def _wrap_cmd_for_user(
+    cmd: list[str],
+    target_user: str,
+    backend: str,
+    *,
+    preserve_vars: tuple[str, ...] | None = None,
+) -> list[str]:
     """
     Prefix `cmd` with `sudo -H -u <target> --preserve-env=<csv> --`.
 
@@ -419,16 +440,16 @@ def _wrap_cmd_for_user(cmd: list[str], target_user: str, backend: str) -> list[s
     `claude` / `codex` against that PATH before applying its sudoers
     check (the sudoers rule pins the resolved absolute path).
     """
-    preserve = ",".join(_preserved_auth_vars_for(backend))
-    return [
+    preserve = ",".join(preserve_vars if preserve_vars is not None else _preserved_auth_vars_for(backend))
+    wrapped = [
         "sudo",
         "-H",
         "-u",
         target_user,
-        f"--preserve-env={preserve}",
-        "--",
-        *cmd,
     ]
+    if preserve:
+        wrapped.append(f"--preserve-env={preserve}")
+    return [*wrapped, "--", *cmd]
 
 
 def _os_user_log_field(effective_user: str | None) -> str:
@@ -2535,3 +2556,287 @@ class GooseOneShotReasoner:
             raw_metadata=raw_metadata,
             duration_ms=duration_ms,
         )
+
+
+# ── Pi implementation ───────────────────────────────────────────────
+
+
+# Pi can authenticate either from the target user's ~/.pi/agent/auth.json or
+# through provider keys.  HOME reaches the former (and is rewritten by
+# sudo -H); the remaining entries are the documented provider-key surface.
+# Control-plane credentials and Kai's internal principal never enter this
+# bounded, tool-free subprocess.
+_PI_ENV_BASE_ALLOWLIST = ("PATH", "HOME")
+
+
+class PiOneShotReasoner:
+    """Run one bounded, stateless model call through Pi's JSONL RPC mode.
+
+    The process is started with tools, approval, session persistence, and all
+    project resource discovery disabled.  One prompt is accepted, streamed,
+    and completed only at Pi's ``agent_settled`` event; ``message_end`` is the
+    authoritative final text.  The subprocess is torn down on every exit path.
+    """
+
+    def __init__(self, *, cwd: Path | None = None, os_user: str | None = None, provider: str = "") -> None:
+        self._cwd = cwd if cwd is not None else _EXTRACTOR_CWD
+        self._os_user = os_user
+        self._provider = provider
+
+    async def run(
+        self,
+        *,
+        prompt: str,
+        system_prompt: str | None = None,
+        model: str | None = None,
+        timeout: float | None = None,
+        purpose: str,
+        json_schema: dict[str, Any] | None = None,
+    ) -> OneShotResult:
+        self._cwd.mkdir(parents=True, exist_ok=True)
+        self._cwd.chmod(0o755)
+
+        try:
+            resolved_binary = resolve_oneshot_binary("pi")
+        except BinaryResolutionError as exc:
+            raise OneShotRoutingError(str(exc)) from exc
+
+        cmd: list[str] = [resolved_binary, "--mode", "rpc"]
+        if self._provider:
+            cmd.extend(["--provider", self._provider])
+        if model is not None:
+            cmd.extend(["--model", model])
+        cmd.extend(
+            [
+                "--no-session",
+                "--no-tools",
+                "--no-approve",
+                "--no-extensions",
+                "--no-skills",
+                "--no-prompt-templates",
+                "--no-context-files",
+            ]
+        )
+
+        effective_user = resolve_claude_user(self._os_user)
+        if effective_user is not None:
+            cmd = _wrap_cmd_for_user(
+                cmd,
+                effective_user,
+                "pi",
+                preserve_vars=_pi_provider_env_vars(self._provider),
+            )
+        env_allowlist = (*_PI_ENV_BASE_ALLOWLIST, *_pi_provider_env_vars(self._provider))
+        subprocess_env = {key: os.environ[key] for key in env_allowlist if key in os.environ}
+        rendered_prompt = _render_goose_stdin(system_prompt, prompt)
+        os_user_field = _os_user_log_field(effective_user)
+
+        start = time.monotonic()
+        proc: asyncio.subprocess.Process | None = None
+        stderr_task: asyncio.Task[None] | None = None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(self._cwd),
+                env=subprocess_env,
+                limit=PI_RPC_STREAM_LIMIT,
+                start_new_session=bool(effective_user),
+            )
+            stderr_task = asyncio.create_task(_drain_pi_stderr(proc))
+            try:
+                response_text, completion_error = await asyncio.wait_for(
+                    self._drive_exchange(proc=proc, rendered_prompt=rendered_prompt, model=model),
+                    timeout=timeout,
+                )
+            except TimeoutError:
+                duration_ms = int((time.monotonic() - start) * 1000)
+                log.info(
+                    "oneshot_reasoner purpose=%s backend=pi model=%s duration_ms=%d "
+                    "outcome=timeout error_category=timeout os_user=%s",
+                    purpose,
+                    model,
+                    duration_ms,
+                    os_user_field,
+                )
+                raise OneShotTimeout() from None
+            except PiRpcError as exc:
+                duration_ms = int((time.monotonic() - start) * 1000)
+                if proc.returncode not in (None, 0):
+                    raise OneShotSubprocessError(returncode=proc.returncode, stderr=b"") from exc
+                raise OneShotOutputError(f"pi RPC failed: {exc}") from exc
+
+            duration_ms = int((time.monotonic() - start) * 1000)
+            if completion_error is not None:
+                raise OneShotOutputError(f"pi model request failed: {completion_error}")
+
+            raw_metadata = {
+                "returncode": 0,
+                "stderr": b"",
+                "cwd": str(self._cwd),
+                "cmd": list(cmd),
+                "resolved_binary": resolved_binary,
+            }
+            result_text = self._normalize_output(response_text, json_schema)
+            log.info(
+                "oneshot_reasoner purpose=%s backend=pi model=%s duration_ms=%d "
+                "outcome=success returncode=0 os_user=%s",
+                purpose,
+                model,
+                duration_ms,
+                os_user_field,
+            )
+            return OneShotResult(
+                text=result_text,
+                backend="pi",
+                model=model,
+                raw_metadata=raw_metadata,
+                duration_ms=duration_ms,
+            )
+        finally:
+            if proc is not None:
+                await _shutdown_pi_proc(proc, effective_user=effective_user, purpose=purpose)
+            if stderr_task is not None:
+                stderr_task.cancel()
+                with contextlib.suppress(BaseException):
+                    await stderr_task
+
+    async def _drive_exchange(
+        self,
+        *,
+        proc: asyncio.subprocess.Process,
+        rendered_prompt: str,
+        model: str | None,
+    ) -> tuple[str, str | None]:
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+        transport = PiRpcTransport(proc.stdin, proc.stdout)
+
+        # Validate the active model before spending a one-shot call.  This
+        # catches a CLI/provider silently substituting its own default.
+        state_id = "kai-oneshot-state"
+        await transport.send({"id": state_id, "type": "get_state"})
+        state_message = await transport.receive()
+        state = require_pi_rpc_response(state_message, request_id=state_id, command="get_state")
+        if not isinstance(state, dict):
+            raise PiRpcProtocolError("Pi get_state response requires an object")
+        if model is not None:
+            expected_provider, expected_model, expected_thinking = _split_pi_model(model, self._provider)
+            active_model = state.get("model")
+            if not isinstance(active_model, dict):
+                raise PiRpcProtocolError(f"Pi did not activate configured model {model!r}")
+            if active_model.get("provider") != expected_provider or active_model.get("id") != expected_model:
+                raise PiRpcProtocolError(
+                    "Pi activated a different model than configured: "
+                    f"expected {expected_provider}/{expected_model}, "
+                    f"got {active_model.get('provider')}/{active_model.get('id')}"
+                )
+            if expected_thinking is not None and state.get("thinkingLevel") != expected_thinking:
+                raise PiRpcProtocolError(
+                    f"Pi did not activate configured thinking level {expected_thinking!r}; "
+                    f"got {state.get('thinkingLevel')!r}"
+                )
+
+        prompt_id = "kai-oneshot-prompt"
+        await transport.send({"id": prompt_id, "type": "prompt", "message": rendered_prompt})
+        accepted = False
+        streamed = ""
+        completed: list[str] = []
+        completion_error: str | None = None
+        while True:
+            message = await transport.receive()
+            message_type = message.get("type")
+            if message_type == "response":
+                if accepted:
+                    raise PiRpcProtocolError("Pi emitted more than one response for a one-shot prompt")
+                require_pi_rpc_response(message, request_id=prompt_id, command="prompt")
+                accepted = True
+                continue
+
+            delta = pi_rpc_text_delta(message)
+            if delta is not None:
+                streamed += delta
+                continue
+            if message_type == "message_end":
+                authoritative = _assistant_message_text(message.get("message"))
+                if authoritative:
+                    completed.append(authoritative)
+                completion_error = _assistant_message_error(message.get("message")) or completion_error
+                continue
+            if message_type == "auto_retry_end" and message.get("success") is False:
+                detail = message.get("finalError") or message.get("error")
+                completion_error = detail if isinstance(detail, str) and detail else "Pi exhausted automatic retries"
+                continue
+            extension_error = pi_rpc_extension_error(message)
+            if extension_error is not None:
+                raise PiRpcProtocolError(f"Pi extension failed despite extensions being disabled: {extension_error}")
+            if message_type in {"tool_execution_start", "tool_execution_update", "tool_execution_end"}:
+                raise PiRpcProtocolError(f"Pi emitted {message_type} despite tools being disabled")
+            if message_type == "extension_ui_request":
+                raise PiRpcProtocolError("Pi requested extension UI despite extensions being disabled")
+            if pi_rpc_is_settled(message):
+                if not accepted:
+                    raise PiRpcProtocolError("Pi settled a prompt before acknowledging it")
+                return "\n\n".join(completed) or streamed, completion_error
+
+    @staticmethod
+    def _normalize_output(response_text: str, json_schema: dict[str, Any] | None) -> str:
+        if json_schema is None:
+            return response_text
+        if not response_text:
+            raise OneShotOutputError("pi produced no response text")
+        try:
+            payload = _parse_schema_payload(response_text)
+        except json.JSONDecodeError as exc:
+            raise OneShotOutputError(
+                f"pi response text did not contain a JSON object: {exc}; response begins: {response_text[:200]!r}"
+            ) from None
+        if not isinstance(payload, dict):
+            raise OneShotOutputError("pi response JSON was not an object")
+        required_fields = json_schema.get("required")
+        if isinstance(required_fields, list):
+            missing = [field for field in required_fields if field not in payload]
+            if missing:
+                raise OneShotOutputError(f"pi response JSON missing required fields: {missing}")
+        return json.dumps({"is_error": False, "structured_output": payload})
+
+
+async def _drain_pi_stderr(proc: asyncio.subprocess.Process) -> None:
+    if proc.stderr is None:
+        return
+    while True:
+        try:
+            line = await proc.stderr.readline()
+        except Exception:
+            return
+        if not line:
+            return
+        text = line.decode(errors="replace").strip()
+        if text:
+            log.debug("Pi (one-shot) stderr: %s", text[:200])
+
+
+async def _shutdown_pi_proc(
+    proc: asyncio.subprocess.Process,
+    *,
+    effective_user: str | None,
+    purpose: str,
+) -> None:
+    if proc.returncode is not None:
+        with contextlib.suppress(BaseException):
+            await asyncio.wait_for(proc.wait(), timeout=5)
+        return
+    if effective_user is not None:
+        with contextlib.suppress(BaseException):
+            await _kill_target_user_tree(
+                target_user=effective_user,
+                pgid=proc.pid,
+                purpose=purpose,
+                backend="pi",
+            )
+    with contextlib.suppress(OSError):
+        proc.kill()
+    with contextlib.suppress(BaseException):
+        await asyncio.wait_for(proc.wait(), timeout=5)

--- a/src/kai/oneshot_binary.py
+++ b/src/kai/oneshot_binary.py
@@ -2,7 +2,7 @@
 Shared agent-binary resolver for the one-shot reasoner family.
 
 Single source of truth for "where is the agent binary" across the
-one-shot backends (claude, codex, opencode, goose).
+one-shot backends (claude, codex, opencode, goose, pi).
 `kai.config.load_config()` uses this to fail-fast at startup when the
 memory reasoner backend points at an unreachable binary; the
 `kai.oneshot` reasoner classes use it to build argv with the resolved
@@ -185,6 +185,17 @@ def resolve_oneshot_binary(backend: str) -> str:
         resolved = shutil.which("goose")
         if resolved is None:
             raise BinaryResolutionError("could not resolve goose binary: GOOSE_BIN unset, `goose` not on PATH")
+        return resolved
+
+    if backend == "pi":
+        # Pi joined Kai after protected backend registries became the
+        # deployment contract.  Development installs still get the same PATH
+        # discovery convenience as the other backends, but deliberately do
+        # not introduce a PI_BIN escape hatch that could diverge from the
+        # operator-controlled registry used in production.
+        resolved = shutil.which("pi")
+        if resolved is None:
+            raise BinaryResolutionError("could not resolve pi binary: `pi` not on PATH")
         return resolved
 
     # Unknown backend. Unlike a resolution miss this is a caller bug

--- a/src/kai/pi.py
+++ b/src/kai/pi.py
@@ -1,0 +1,572 @@
+"""Persistent conversational backend for Pi's JSONL RPC mode."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from collections.abc import AsyncIterator, Mapping
+from pathlib import Path
+from typing import Any
+
+from kai.acp import _kill_target_user_tree, _kill_target_user_tree_sync
+from kai.backend import (
+    AgentBackend,
+    AgentResponse,
+    ApiContext,
+    StreamEvent,
+    apply_workspace_model,
+    assemble_turn_context,
+    build_foreign_workspace_reminder,
+    build_session_context,
+    ensure_user_memory,
+    ensure_user_preferences,
+    sanitize_agent_environment,
+)
+from kai.backend_registry import resolve_backend_command
+from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
+from kai.pi_rpc import (
+    PI_RPC_STREAM_LIMIT,
+    PiRpcError,
+    PiRpcProtocolError,
+    PiRpcTransport,
+    pi_rpc_extension_error,
+    pi_rpc_is_settled,
+    pi_rpc_text_delta,
+    require_pi_rpc_response,
+)
+
+log = logging.getLogger(__name__)
+
+_PI_THINKING_LEVELS = frozenset({"off", "minimal", "low", "medium", "high", "xhigh"})
+_PI_PROVIDER_ENV_VARS: dict[str, tuple[str, ...]] = {
+    "anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"),
+    "deepseek": ("DEEPSEEK_API_KEY",),
+    "google": ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+    "ollama": ("OLLAMA_HOST",),
+    "openai": ("OPENAI_API_KEY",),
+    "openrouter": ("OPENROUTER_API_KEY",),
+    # Subscription credentials for these providers live in the target
+    # user's ~/.pi/agent/auth.json and therefore need no environment key.
+    "openai-codex": (),
+    "github-copilot": (),
+}
+_PI_ALL_PROVIDER_ENV_VARS = frozenset(name for names in _PI_PROVIDER_ENV_VARS.values() for name in names)
+
+
+def _pi_provider_env_vars(provider: str) -> tuple[str, ...]:
+    """Return only the environment credentials the selected provider needs."""
+
+    return _PI_PROVIDER_ENV_VARS.get(provider, ())
+
+
+def _split_pi_model(model: str, provider: str = "") -> tuple[str, str, str | None]:
+    """Return provider, model id, and optional thinking suffix.
+
+    Pi accepts either ``provider/model`` or a bare model when ``--provider``
+    is supplied separately.  Kai always has an effective provider at runtime,
+    so both documented forms remain usable from ``/model``.
+    """
+
+    model_provider, separator, model_id = model.partition("/")
+    if separator:
+        if not model_provider or not model_id:
+            raise ValueError("Pi models must use provider/model shape or a bare model with an explicit provider")
+        if provider and model_provider != provider:
+            raise ValueError(f"Pi model provider {model_provider!r} does not match configured provider {provider!r}")
+        provider = model_provider
+    else:
+        model_id = model_provider
+        if not provider or not model_id:
+            raise ValueError("Pi models must use provider/model shape or a bare model with an explicit provider")
+    thinking: str | None = None
+    base, suffix_separator, suffix = model_id.rpartition(":")
+    if suffix_separator and base and suffix in _PI_THINKING_LEVELS:
+        model_id = base
+        thinking = suffix
+    return provider, model_id, thinking
+
+
+def _assistant_message_text(message: Any) -> str | None:
+    """Extract authoritative visible text from a completed Pi message."""
+
+    if not isinstance(message, Mapping) or message.get("role") != "assistant":
+        return None
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return None
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, Mapping) or block.get("type") != "text":
+            continue
+        text = block.get("text")
+        if isinstance(text, str):
+            parts.append(text)
+    return "".join(parts)
+
+
+def _assistant_message_error(message: Any) -> str | None:
+    """Extract a terminal model error from a completed assistant message."""
+
+    if not isinstance(message, Mapping) or message.get("role") != "assistant":
+        return None
+    stop_reason = message.get("stopReason")
+    error_message = message.get("errorMessage")
+    if stop_reason == "error":
+        return error_message if isinstance(error_message, str) and error_message else "Pi model request failed"
+    return None
+
+
+class PiBackend(AgentBackend):
+    """A persistent Pi process using the documented JSONL RPC protocol."""
+
+    backend_name = "pi"
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        workspace: Path,
+        home_workspace: Path | None = None,
+        webhook_port: int = 8080,
+        webhook_secret: str = "",
+        timeout_seconds: int = 300,
+        services_info: list[dict] | None = None,
+        workspace_config: WorkspaceConfig | None = None,
+        provider: str,
+        memory_enabled: bool = False,
+        os_user: str | None = None,
+        max_session_hours: float = 0,
+        defer_user_file_reads: bool = False,
+    ) -> None:
+        self.model = model
+        self.workspace = workspace
+        self.home_workspace = home_workspace or workspace
+        self.timeout_seconds = timeout_seconds
+        self.workspace_config = workspace_config
+        self.provider = provider
+        self.memory_enabled = memory_enabled
+        self.os_user = os_user
+        self.max_session_hours = max_session_hours
+        self.defer_user_file_reads = defer_user_file_reads
+
+        self._api_context = ApiContext(
+            webhook_port=webhook_port,
+            webhook_secret=webhook_secret,
+            services_info=services_info or [],
+        )
+        self._default_model = model
+        self._default_timeout = timeout_seconds
+        if workspace_config:
+            self.model = apply_workspace_model(workspace_config, self.backend_name, self.provider, self.model)
+            if workspace_config.timeout is not None:
+                self.timeout_seconds = workspace_config.timeout
+
+        self._proc: asyncio.subprocess.Process | None = None
+        self._transport: PiRpcTransport | None = None
+        self._session_id: str | None = None
+        self._session_started_at: float | None = None
+        self._effective_os_user: str | None = None
+        self._pgid: int | None = None
+        self._supports_image_input = False
+        self._next_id = 1
+        self._fresh_session = True
+        self._stderr_task: asyncio.Task[None] | None = None
+        self._lock = asyncio.Lock()
+
+    @property
+    def is_alive(self) -> bool:
+        return self._proc is not None and self._proc.returncode is None
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_id
+
+    def _new_request_id(self, command: str) -> str:
+        request_id = f"kai-{command}-{self._next_id}"
+        self._next_id += 1
+        return request_id
+
+    def _build_argv(self) -> list[str]:
+        command = resolve_backend_command("pi", allow_bare_fallback=True)
+        return [
+            command,
+            "--mode",
+            "rpc",
+            "--provider",
+            self.provider,
+            "--model",
+            self.model,
+            "--no-approve",
+            "--no-extensions",
+            "--no-skills",
+            "--no-prompt-templates",
+            "--no-context-files",
+        ]
+
+    def _build_env(self, effective_os_user: str | None) -> dict[str, str]:
+        env = os.environ.copy()
+        if self.workspace_config:
+            if self.workspace_config.env_file:
+                env.update(parse_env_file(self.workspace_config.env_file))
+            if self.workspace_config.env:
+                env.update(self.workspace_config.env)
+        env = sanitize_agent_environment(env)
+        selected_provider_vars = frozenset(_pi_provider_env_vars(self.provider))
+        for name in _PI_ALL_PROVIDER_ENV_VARS - selected_provider_vars:
+            env.pop(name, None)
+        if self._api_context.webhook_secret:
+            env["KAI_WEBHOOK_SECRET"] = self._api_context.webhook_secret
+        if effective_os_user:
+            env["TMPDIR"] = str(DATA_DIR / "tmp" / effective_os_user)
+        return env
+
+    async def _ensure_started(self) -> None:
+        if self.is_alive:
+            return
+
+        effective_os_user = resolve_claude_user(self.os_user)
+        argv = self._build_argv()
+        env = self._build_env(effective_os_user)
+        if effective_os_user:
+            preserve = ",".join(("KAI_WEBHOOK_SECRET", "TMPDIR", *_pi_provider_env_vars(self.provider)))
+            argv = [
+                "sudo",
+                "-H",
+                "-u",
+                effective_os_user,
+                f"--preserve-env={preserve}",
+                "--",
+                *argv,
+            ]
+
+        log.info(
+            "Starting persistent Pi RPC process (model=%s, user=%s)",
+            self.model,
+            effective_os_user or "(same as bot)",
+        )
+        self._proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(self.workspace),
+            env=env,
+            limit=PI_RPC_STREAM_LIMIT,
+            start_new_session=bool(effective_os_user),
+        )
+        self._effective_os_user = effective_os_user
+        self._pgid = self._proc.pid if effective_os_user else None
+        self._session_started_at = time.monotonic()
+        self._stderr_task = asyncio.create_task(self._drain_stderr())
+        assert self._proc.stdin is not None
+        assert self._proc.stdout is not None
+        self._transport = PiRpcTransport(self._proc.stdin, self._proc.stdout)
+        self._next_id = 1
+
+        state = await self._command("get_state")
+        if not isinstance(state, Mapping):
+            raise PiRpcProtocolError("Pi get_state response requires an object")
+        session_id = state.get("sessionId")
+        if not isinstance(session_id, str) or not session_id:
+            raise PiRpcProtocolError("Pi get_state response requires a sessionId")
+        active_model = state.get("model")
+        if not isinstance(active_model, Mapping):
+            raise PiRpcProtocolError(f"Pi did not activate configured model {self.model!r}")
+        expected_provider, expected_model_id, expected_thinking = _split_pi_model(self.model, self.provider)
+        if active_model.get("provider") != expected_provider or active_model.get("id") != expected_model_id:
+            raise PiRpcProtocolError(
+                "Pi activated a different model than configured: "
+                f"expected {expected_provider}/{expected_model_id}, "
+                f"got {active_model.get('provider')}/{active_model.get('id')}"
+            )
+        if expected_thinking is not None and state.get("thinkingLevel") != expected_thinking:
+            raise PiRpcProtocolError(
+                f"Pi did not activate configured thinking level {expected_thinking!r}; "
+                f"got {state.get('thinkingLevel')!r}"
+            )
+        inputs = active_model.get("input")
+        self._supports_image_input = isinstance(inputs, list) and "image" in inputs
+        self._session_id = session_id
+        self._fresh_session = True
+
+    async def _command(self, command: str, **params: Any) -> Any:
+        if self._transport is None:
+            raise PiRpcProtocolError("Pi RPC transport is not started")
+        request_id = self._new_request_id(command)
+        await self._transport.send({"id": request_id, "type": command, **params})
+        while True:
+            message = await self._transport.receive(timeout_seconds=self.timeout_seconds)
+            if message.get("type") != "response":
+                raise PiRpcProtocolError(
+                    f"Pi emitted unexpected {message.get('type')!r} event while waiting for {command!r}"
+                )
+            if message.get("id") != request_id:
+                raise PiRpcProtocolError(f"Pi emitted response for unexpected request id {message.get('id')!r}")
+            return require_pi_rpc_response(message, request_id=request_id, command=command)
+
+    async def _drain_stderr(self) -> None:
+        while self._proc is not None and self._proc.stderr is not None:
+            try:
+                line = await self._proc.stderr.readline()
+            except (ConnectionError, RuntimeError):
+                return
+            if not line:
+                return
+            text = line.decode(errors="replace").strip()
+            if text:
+                log.debug("Pi stderr: %s", text[:500])
+
+    async def send(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
+        async with self._lock:
+            async for event in self._send_locked(prompt, chat_id):
+                yield event
+
+    async def _send_locked(self, prompt: str | list, chat_id: int | None) -> AsyncIterator[StreamEvent]:
+        started_at = time.monotonic()
+        if self._should_recycle():
+            log.info(
+                "Pi session age %.1f hours exceeds limit of %.1f hours; recycling",
+                self._session_age_hours(),
+                self.max_session_hours,
+            )
+            await self._kill()
+
+        try:
+            await self._ensure_started()
+        except (OSError, ValueError, PiRpcError) as exc:
+            await self._kill()
+            yield self._final_event("", started_at, error=f"Pi startup failed: {exc}")
+            return
+
+        session_context = ""
+        if self._fresh_session:
+            self._fresh_session = False
+            ensure_user_memory(chat_id, DATA_DIR)
+            ensure_user_preferences(chat_id, DATA_DIR)
+            session_context = build_session_context(
+                workspace=self.workspace,
+                home_workspace=self.home_workspace,
+                api=self._api_context,
+                workspace_config=self.workspace_config,
+                chat_id=chat_id,
+                data_dir=DATA_DIR,
+                memory_enabled=self.memory_enabled,
+                defer_user_file_reads=self.defer_user_file_reads,
+            )
+        reminder = build_foreign_workspace_reminder(self.workspace, self.home_workspace) or ""
+
+        images: list[dict[str, str]] = []
+        dropped_images = 0
+        had_user_text = isinstance(prompt, str) and bool(prompt.strip())
+        if isinstance(prompt, list):
+            normalized: list[dict[str, str]] = []
+            for block in prompt:
+                if not isinstance(block, Mapping):
+                    continue
+                if block.get("type") == "text" and isinstance(block.get("text"), str):
+                    normalized.append({"type": "text", "text": block["text"]})
+                    if block["text"].strip():
+                        had_user_text = True
+                    continue
+                if block.get("type") == "image":
+                    source = block.get("source")
+                    if self._supports_image_input and isinstance(source, Mapping):
+                        data = source.get("data")
+                        mime_type = source.get("media_type")
+                        if source.get("type") == "base64" and isinstance(data, str) and isinstance(mime_type, str):
+                            images.append({"type": "image", "data": data, "mimeType": mime_type})
+                            continue
+                    dropped_images += 1
+            prompt = normalized or [{"type": "text", "text": "(empty prompt)"}]
+
+        prompt = await assemble_turn_context(
+            prompt,
+            chat_id=chat_id if had_user_text else None,
+            session_context=session_context,
+            workspace_reminder=reminder,
+            workspace=self.workspace,
+            backend_name=self.backend_name,
+            job_type="interactive",
+            session_id=self._session_id,
+        )
+        if isinstance(prompt, str):
+            message_text = prompt
+        else:
+            message_text = "\n\n".join(
+                block["text"]
+                for block in prompt
+                if isinstance(block, Mapping) and block.get("type") == "text" and isinstance(block.get("text"), str)
+            )
+        if not message_text:
+            message_text = "(empty prompt)"
+
+        notice = ""
+        if dropped_images:
+            noun = "image" if dropped_images == 1 else "images"
+            notice = (
+                f"[Note: {dropped_images} attached {noun} could not be passed to Pi; "
+                "this reply is based on the message text only.]\n\n"
+            )
+
+        assert self._transport is not None
+        request_id = self._new_request_id("prompt")
+        command: dict[str, Any] = {"id": request_id, "type": "prompt", "message": message_text}
+        if images:
+            command["images"] = images
+        visible_text = notice
+        try:
+            await self._transport.send(command)
+            async for event in self._read_turn(request_id, notice, started_at):
+                visible_text = event.text_so_far
+                yield event
+        except PiRpcError as exc:
+            await self._kill()
+            yield self._final_event(visible_text, started_at, error=str(exc))
+
+    async def _read_turn(
+        self,
+        request_id: str,
+        notice: str,
+        started_at: float,
+    ) -> AsyncIterator[StreamEvent]:
+        assert self._transport is not None
+        accepted = False
+        streamed = ""
+        completed_messages: list[str] = []
+        terminal_error: str | None = None
+
+        while True:
+            message = await self._transport.receive(timeout_seconds=self.timeout_seconds)
+            message_type = message.get("type")
+
+            if message_type == "response":
+                if accepted:
+                    raise PiRpcProtocolError("Pi emitted more than one response for a prompt")
+                if message.get("id") != request_id:
+                    raise PiRpcProtocolError(f"Pi emitted response for unexpected request id {message.get('id')!r}")
+                require_pi_rpc_response(message, request_id=request_id, command="prompt")
+                accepted = True
+                continue
+
+            delta = pi_rpc_text_delta(message)
+            if delta is not None:
+                streamed += delta
+                yield StreamEvent(text_so_far=notice + streamed)
+                continue
+
+            if message_type == "message_end":
+                authoritative = _assistant_message_text(message.get("message"))
+                if authoritative:
+                    completed_messages.append(authoritative)
+                terminal_error = _assistant_message_error(message.get("message")) or terminal_error
+                continue
+
+            if message_type == "auto_retry_end" and message.get("success") is False:
+                detail = message.get("finalError") or message.get("error")
+                terminal_error = detail if isinstance(detail, str) and detail else "Pi exhausted automatic retries"
+                continue
+
+            extension_error = pi_rpc_extension_error(message)
+            if extension_error is not None:
+                raise PiRpcProtocolError(f"Pi extension failed despite extensions being disabled: {extension_error}")
+
+            if message_type in {"tool_execution_start", "tool_execution_update", "tool_execution_end"}:
+                log.debug(
+                    "Pi tool event type=%s tool=%s call_id=%s",
+                    message_type,
+                    message.get("toolName"),
+                    message.get("toolCallId"),
+                )
+                continue
+
+            if pi_rpc_is_settled(message):
+                if not accepted:
+                    raise PiRpcProtocolError("Pi settled a prompt before acknowledging it")
+                authoritative_text = "\n\n".join(text for text in completed_messages if text)
+                final_text = notice + (authoritative_text or streamed)
+                yield self._final_event(final_text, started_at, error=terminal_error)
+                return
+
+            if message_type == "extension_ui_request":
+                raise PiRpcProtocolError("Pi requested extension UI despite extensions being disabled")
+
+    def _final_event(self, text: str, started_at: float, *, error: str | None) -> StreamEvent:
+        response = AgentResponse(
+            success=error is None,
+            text=text,
+            session_id=self._session_id,
+            duration_ms=int((time.monotonic() - started_at) * 1000),
+            error=error,
+        )
+        return StreamEvent(text_so_far=text, done=True, response=response)
+
+    def force_kill(self) -> None:
+        if self._proc is not None:
+            if self._effective_os_user is not None and self._pgid is not None:
+                _kill_target_user_tree_sync(
+                    target_user=self._effective_os_user,
+                    pgid=self._pgid,
+                    purpose="chat",
+                    backend=self.backend_name,
+                )
+                self._pgid = None
+            try:
+                self._proc.kill()
+            except OSError:
+                pass
+        if self._stderr_task is not None:
+            self._stderr_task.cancel()
+            self._stderr_task = None
+
+    async def _kill(self) -> None:
+        if self._proc is not None:
+            if self._effective_os_user is not None and self._pgid is not None:
+                await _kill_target_user_tree(
+                    target_user=self._effective_os_user,
+                    pgid=self._pgid,
+                    purpose="chat",
+                    backend=self.backend_name,
+                )
+                self._pgid = None
+            self.force_kill()
+            try:
+                await asyncio.wait_for(self._proc.wait(), timeout=5)
+            except TimeoutError:
+                pass
+        self._proc = None
+        self._transport = None
+        self._session_id = None
+        self._effective_os_user = None
+        self._pgid = None
+        self._session_started_at = None
+        self._supports_image_input = False
+
+    async def restart(self) -> None:
+        await self._kill()
+        self._fresh_session = True
+
+    async def change_workspace(
+        self,
+        new_workspace: Path,
+        workspace_config: WorkspaceConfig | None = None,
+    ) -> None:
+        await self._kill()
+        self.workspace = new_workspace
+        self.workspace_config = workspace_config
+        self.model = self._default_model
+        self.timeout_seconds = self._default_timeout
+        if workspace_config:
+            self.model = apply_workspace_model(workspace_config, self.backend_name, self.provider, self.model)
+            if workspace_config.timeout is not None:
+                self.timeout_seconds = workspace_config.timeout
+        self._fresh_session = True
+
+    async def shutdown(self) -> None:
+        # The tracked process may be a sudo wrapper. Killing only that wrapper
+        # can orphan the target user's Pi grandchild, so use the same
+        # cross-user process-group teardown as restart and error recovery.
+        await self._kill()

--- a/src/kai/pi_rpc.py
+++ b/src/kai/pi_rpc.py
@@ -3,11 +3,10 @@
 Pi's subprocess protocol is neither JSON-RPC nor ACP.  Commands, command
 responses, and asynchronous agent events all share stdout as strict JSONL.
 This module owns the framing and the small set of event semantics that the
-future conversational backend and one-shot reasoner must agree on.
+conversational backend and one-shot reasoner agree on.
 
-It intentionally does not launch Pi or make ``pi`` a selectable backend.
-Process lifecycle, user isolation, and Kai ``StreamEvent`` conversion belong
-to those two callers.
+It intentionally does not launch Pi itself. Process lifecycle, user isolation,
+and Kai ``StreamEvent`` conversion belong to those two callers.
 """
 
 from __future__ import annotations

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -237,7 +237,7 @@ class SubprocessPool:
 
         # os_user for sudo -u isolation. None = run as bot user.
         # Resolved here (rather than inside each branch) because all
-        # four backends consume it for per-user subprocess isolation.
+        # conversational backends consume it for per-user subprocess isolation.
         # Each agent's auth state is per-OS-user and operator-
         # provisioned under the target user's home (claude OAuth
         # credentials, codex auth.json, goose keychain or env keys,
@@ -314,6 +314,25 @@ class SubprocessPool:
                 memory_enabled=self._config.memory_enabled,
                 max_session_hours=self._config.agent_max_session_hours,
                 codex_effort_level=self._config.codex_effort_level,
+                defer_user_file_reads=getattr(self._config, "protected_install", False) is True,
+            )
+
+        if backend == "pi":
+            from kai.pi import PiBackend
+
+            return PiBackend(
+                model=model,
+                workspace=workspace,
+                home_workspace=home_ws,
+                webhook_port=self._config.webhook_port,
+                webhook_secret=internal_api_credential,
+                timeout_seconds=timeout,
+                services_info=services_info,
+                workspace_config=ws_config,
+                provider=effective_provider,
+                memory_enabled=self._config.memory_enabled,
+                os_user=os_user,
+                max_session_hours=self._config.agent_max_session_hours,
                 defer_user_file_reads=getattr(self._config, "protected_install", False) is True,
             )
 

--- a/src/kai/review.py
+++ b/src/kai/review.py
@@ -1,5 +1,5 @@
 """
-PR review agent - one-shot subprocess (Claude, Codex, Goose, or OpenCode) for automated code review.
+PR review agent - provider-neutral one-shot subprocess for automated code review.
 
 Provides functionality to:
 1. Fetch PR diffs and metadata via the GitHub CLI
@@ -49,6 +49,7 @@ from kai.oneshot import (
     OneShotError,
     OneShotTimeout,
     OpenCodeOneShotReasoner,
+    PiOneShotReasoner,
 )
 from kai.prompt_utils import make_boundary
 
@@ -3006,17 +3007,17 @@ async def run_review(
     `goose run -i - ... --max-turns 1` argv and the provider
     wire-name translation.
 
+    Pi path: `PiOneShotReasoner`, which owns the strict JSONL RPC
+    exchange and disables tools, persistence, approval, and project
+    resources for the bounded call.
+
     Args:
         prompt: The complete review prompt (from build_review_prompt).
         claude_user: Optional OS user to run the subprocess as (the
             reasoners apply the sudo -H -u wrap).
-        agent_backend: Which LLM backend to use ("claude", "codex",
-            "opencode", or "goose").
+        agent_backend: Which registered LLM backend to use.
         provider: LLM provider name (e.g. "anthropic", "openai").
-            Only used when agent_backend is "goose"; codex always
-            uses openai, claude always uses anthropic, opencode
-            routes through `provider/model` strings on the model
-            itself.
+            Used explicitly by the goose and Pi argv builders.
 
     Returns:
         The review text output from the LLM.
@@ -3119,6 +3120,30 @@ async def run_review(
             raise RuntimeError(f"Review subprocess timed out after {timeout_s}s") from exc
         except OneShotError as exc:
             raise RuntimeError(f"Goose review failed: {exc}") from exc
+        return result.text
+    if agent_backend == "pi":
+        if not provider:
+            raise ValueError(
+                "agent_backend is 'pi' but provider is empty. Set DEFAULT_PROVIDER in .env or per-user config."
+            )
+        review_model = get_model_for(
+            ModelRole.PR_REVIEW,
+            agent_backend,
+            provider,
+            override=model_override,
+        )
+        reasoner = PiOneShotReasoner(os_user=claude_user, provider=provider)
+        try:
+            result = await reasoner.run(
+                prompt=prompt,
+                model=review_model,
+                timeout=timeout_s,
+                purpose="pr_review",
+            )
+        except OneShotTimeout as exc:
+            raise RuntimeError(f"Review subprocess timed out after {timeout_s}s") from exc
+        except OneShotError as exc:
+            raise RuntimeError(f"Pi review failed: {exc}") from exc
         return result.text
     if agent_backend == "claude":
         # Dispatch to the Claude one-shot reasoner in free-form mode

--- a/src/kai/triage.py
+++ b/src/kai/triage.py
@@ -1,5 +1,5 @@
 """
-Issue triage agent - one-shot subprocess (Claude, Codex, Goose, or OpenCode) for automated issue triage.
+Issue triage agent - provider-neutral one-shot subprocess for automated issue triage.
 
 Provides functionality to:
 1. Extract metadata from GitHub issue webhook payloads
@@ -44,6 +44,7 @@ from kai.oneshot import (
     OneShotError,
     OneShotTimeout,
     OpenCodeOneShotReasoner,
+    PiOneShotReasoner,
 )
 from kai.prompt_utils import make_boundary
 
@@ -471,10 +472,9 @@ async def run_triage(
         prompt: The complete triage prompt (from build_triage_prompt).
         claude_user: Optional OS user to run the subprocess as (the
             reasoners apply the sudo -H -u wrap).
-        agent_backend: Which LLM backend to use ("claude", "codex",
-            "opencode", or "goose").
+        agent_backend: Which registered LLM backend to use.
         provider: LLM provider name (e.g. "anthropic", "openai").
-            Only used when agent_backend is "goose".
+            Used explicitly by the goose and Pi argv builders.
 
     Returns:
         The raw triage response text from the LLM (expected to be JSON).
@@ -581,6 +581,30 @@ async def run_triage(
             raise RuntimeError(f"Triage subprocess timed out after {_TRIAGE_TIMEOUT}s") from exc
         except OneShotError as exc:
             raise RuntimeError(f"Goose triage failed: {exc}") from exc
+        return result.text
+    if agent_backend == "pi":
+        if not provider:
+            raise ValueError(
+                "agent_backend is 'pi' but provider is empty. Set DEFAULT_PROVIDER in .env or per-user config."
+            )
+        triage_model = get_model_for(
+            ModelRole.ISSUE_TRIAGE,
+            agent_backend,
+            provider,
+            override=model_override,
+        )
+        reasoner = PiOneShotReasoner(os_user=claude_user, provider=provider)
+        try:
+            result = await reasoner.run(
+                prompt=prompt,
+                model=triage_model,
+                timeout=_TRIAGE_TIMEOUT,
+                purpose="issue_triage",
+            )
+        except OneShotTimeout as exc:
+            raise RuntimeError(f"Triage subprocess timed out after {_TRIAGE_TIMEOUT}s") from exc
+        except OneShotError as exc:
+            raise RuntimeError(f"Pi triage failed: {exc}") from exc
         return result.text
     if agent_backend == "claude":
         # Dispatch to the Claude one-shot reasoner in free-form mode

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -168,6 +168,23 @@ def test_registry_defaults_driver_and_runtime_to_backend_local_process(tmp_path,
     assert entry.runtime == "local_process"
 
 
+def test_registry_accepts_pi_without_model_ceiling(tmp_path, monkeypatch):
+    pi = _exe(tmp_path / "pi")
+    registry = tmp_path / "backends.yaml"
+    registry.write_text(
+        render_backend_registry(
+            {"pi": {"driver": "pi", "runtime": "local_process", "command": str(pi)}},
+            default_backend="pi",
+        )
+    )
+    monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
+
+    entry = load_backend_registry()["pi"]
+    assert entry.command == str(pi)
+    assert entry.allowed_models == ()
+    assert resolve_default_backend("") == "pi"
+
+
 def test_registry_allowed_models_entries_must_be_strings(tmp_path, monkeypatch):
     codex = _exe(tmp_path / "codex")
     registry = tmp_path / "backends.yaml"
@@ -307,6 +324,18 @@ def test_explicit_missing_registry_fails(monkeypatch):
 
     with pytest.raises(BackendRegistryError, match="does not exist"):
         resolve_backend_command("claude")
+
+
+def test_pi_dev_resolution_uses_path_and_has_no_pi_bin_override(tmp_path, monkeypatch):
+    real_pi = _exe(tmp_path / "pi")
+    attacker_pi = _exe(tmp_path / "attacker-pi")
+    monkeypatch.delenv("KAI_BACKENDS_YAML", raising=False)
+    monkeypatch.delenv("KAI_INSTALL_DIR", raising=False)
+    monkeypatch.setenv("PI_BIN", str(attacker_pi))
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    assert resolve_backend_command("pi") == str(real_pi)
+    assert resolve_backend_command("pi", allow_bare_fallback=True) == "pi"
 
 
 def test_render_backend_registry_is_stable():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2590,6 +2590,13 @@ class TestModelRegistry:
                     f"opencode/{provider} {role.value}={value!r} is not provider/model"
                 )
 
+    def test_pi_rows_must_match_their_provider_prefix(self, monkeypatch):
+        monkeypatch.setitem(MODEL_REGISTRY, ("pi", "anthropic", ModelRole.AGENT), "openai/gpt-5.5")
+        with pytest.raises(SystemExit) as excinfo:
+            _check_model_registry_complete()
+        assert "pi" in str(excinfo.value)
+        assert "provider/model" in str(excinfo.value)
+
     def test_completeness_check_raises_on_missing_opencode_row(self, monkeypatch):
         """
         Synthetic missing-row case for opencode: drop a registry
@@ -2973,6 +2980,19 @@ class TestValidateModelForBackend:
         assert validate_model_for_backend("openrouter/anthropic/claude-sonnet-4-5", "opencode", "") is True
         assert validate_model_for_backend("/", "opencode", "") is False
 
+    def test_pi_accepts_prefixed_or_explicit_provider_model_shape(self):
+        from kai.config import validate_model_for_backend
+
+        assert validate_model_for_backend("anthropic/claude-sonnet-4-6", "pi", "anthropic") is True
+        assert validate_model_for_backend("openai/gpt-5.6-sol:xhigh", "pi", "openai") is True
+        assert validate_model_for_backend("ollama/llama4:70b", "pi", "ollama") is True
+        assert validate_model_for_backend("sonnet", "pi", "anthropic") is True
+        assert validate_model_for_backend("sonnet", "pi", "") is False
+        assert validate_model_for_backend("openai/gpt-5.5", "pi", "anthropic") is False
+        assert validate_model_for_backend("anthropic//model", "pi", "anthropic") is False
+        assert validate_model_for_backend("openai-codex/gpt-5.5", "pi", "openai-codex") is True
+        assert validate_model_for_backend("github-copilot/gpt-5.5", "pi", "github-copilot") is True
+
 
 class TestModelsForBackend:
     """Wizard/runtime model-keyboard list helper."""
@@ -3004,15 +3024,21 @@ class TestModelsForBackend:
         assert models_for_backend("opencode", "") is None
         assert models_for_backend("opencode", "anthropic") is None
 
+    def test_pi_returns_none(self):
+        """Pi discovers the target user's authenticated models at runtime."""
+        from kai.config import models_for_backend
+
+        assert models_for_backend("pi", "anthropic") is None
+
 
 class TestValidBackends:
     """Pin the VALID_BACKENDS set membership."""
 
-    def test_all_four_backends_listed(self):
-        """claude, goose, codex, opencode."""
+    def test_all_five_backends_listed(self):
+        """Every supported conversational backend is explicit."""
         from kai.config import VALID_BACKENDS
 
-        assert sorted(VALID_BACKENDS) == ["claude", "codex", "goose", "opencode"]
+        assert sorted(VALID_BACKENDS) == ["claude", "codex", "goose", "opencode", "pi"]
 
     def test_opencode_provider_prompt_gate(self):
         """OpenCode joins BACKENDS_NEEDING_PROVIDER_PROMPT (it talks
@@ -3025,6 +3051,7 @@ class TestValidBackends:
 
         assert "opencode" in BACKEND_PROVIDERS
         assert "opencode" in BACKENDS_NEEDING_PROVIDER_PROMPT
+        assert "pi" in BACKENDS_NEEDING_PROVIDER_PROMPT
         # Single-provider backends are absent from the prompt gate so
         # their provider stays implicit.
         assert "claude" not in BACKENDS_NEEDING_PROVIDER_PROMPT
@@ -3864,17 +3891,17 @@ class TestOneShotReasonerBackendsConstant:
 
     def test_membership(self):
         """Every backend with a OneShotReasoner implementation in
-        `src/kai/oneshot.py` is a member: claude, codex, opencode,
-        and goose all ship one today.
+        `src/kai/oneshot.py` is a member.
         """
         assert "claude" in ONESHOT_REASONER_BACKENDS
         assert "codex" in ONESHOT_REASONER_BACKENDS
         assert "opencode" in ONESHOT_REASONER_BACKENDS
         assert "goose" in ONESHOT_REASONER_BACKENDS
+        assert "pi" in ONESHOT_REASONER_BACKENDS
         # Pin the exact contents so an accidental addition is caught
         # at test time; intentional additions update this assertion
         # in lockstep with the constant's definition.
-        assert frozenset({"claude", "codex", "goose", "opencode"}) == ONESHOT_REASONER_BACKENDS
+        assert frozenset({"claude", "codex", "goose", "opencode", "pi"}) == ONESHOT_REASONER_BACKENDS
 
     def test_is_frozenset(self):
         """The constant must be a `frozenset` so callers only do
@@ -4060,7 +4087,7 @@ class TestBackendProviders:
     def test_membership_contents(self):
         from kai.config import BACKEND_PROVIDERS
 
-        assert set(BACKEND_PROVIDERS.keys()) == {"claude", "codex", "opencode", "goose"}
+        assert set(BACKEND_PROVIDERS.keys()) == {"claude", "codex", "opencode", "goose", "pi"}
         assert BACKEND_PROVIDERS["claude"] == ("anthropic",)
         assert BACKEND_PROVIDERS["codex"] == ("openai",)
         # Multi-provider backends include deepseek (new); openrouter and ollama
@@ -4068,6 +4095,9 @@ class TestBackendProviders:
         assert "deepseek" in BACKEND_PROVIDERS["opencode"]
         assert "deepseek" in BACKEND_PROVIDERS["goose"]
         assert "openrouter" in BACKEND_PROVIDERS["opencode"]
+        assert set(BACKEND_PROVIDERS["opencode"]).issubset(BACKEND_PROVIDERS["pi"])
+        assert "openai-codex" in BACKEND_PROVIDERS["pi"]
+        assert "github-copilot" in BACKEND_PROVIDERS["pi"]
 
     def test_strict_subset_of_valid_backends(self):
         """Every backend listed in BACKEND_PROVIDERS must also be in
@@ -4135,6 +4165,9 @@ class TestModelRegistryTripleKey:
         assert MODEL_REGISTRY[("opencode", "deepseek", ModelRole.PR_REVIEW)] == "deepseek/deepseek-v4-pro"
         assert MODEL_REGISTRY[("opencode", "deepseek", ModelRole.MEMORY_EXTRACTION)] == "deepseek/deepseek-v4-flash"
         assert MODEL_REGISTRY[("goose", "anthropic", ModelRole.PR_REVIEW)] == "claude-sonnet-4-6"
+        assert MODEL_REGISTRY[("pi", "openai-codex", ModelRole.PR_REVIEW)] == "openai-codex/gpt-5.5"
+        assert MODEL_REGISTRY[("pi", "github-copilot", ModelRole.MEMORY_EXTRACTION)] == ("github-copilot/gpt-5-mini")
+        assert MODEL_REGISTRY[("pi", "openrouter", ModelRole.PR_REVIEW)] == ("openrouter/anthropic/claude-sonnet-4.6")
 
     def test_codex_rows_are_in_codex_models(self):
         """The completeness check enforces this at startup; pinning

--- a/tests/test_eval_behavioral.py
+++ b/tests/test_eval_behavioral.py
@@ -1684,6 +1684,61 @@ class TestParseCodexGenStdout:
         assert _parse_codex_gen_stdout(b"") == ""
 
 
+class TestPiBehavioralDispatch:
+    @pytest.mark.asyncio
+    async def test_generation_uses_pi_oneshot_reasoner(self, tmp_path):
+        from kai.oneshot import OneShotResult
+
+        fake = MagicMock()
+        fake.run = AsyncMock(return_value=OneShotResult(text="generated answer", backend="pi", model="anthropic/model"))
+        config = _make_config(backend="pi", provider="anthropic", gen_model="anthropic/model")
+        with patch("kai.eval.behavioral.PiOneShotReasoner", return_value=fake) as ctor:
+            text, _elapsed = await behavioral._run_one_arm(
+                config=config,
+                arm_prompt="question",
+                cwd=tmp_path,
+                env={},
+            )
+
+        assert text == "generated answer"
+        ctor.assert_called_once_with(cwd=tmp_path, provider="anthropic")
+        assert fake.run.call_args.kwargs == {
+            "prompt": "question",
+            "model": "anthropic/model",
+            "timeout": 120,
+            "purpose": "behavioral_generation",
+        }
+
+    @pytest.mark.asyncio
+    async def test_judge_uses_pi_schema_envelope(self, tmp_path):
+        from kai.oneshot import OneShotResult
+
+        envelope = json.dumps(
+            {
+                "is_error": False,
+                "structured_output": {"choice": "tie", "reasoning": "equivalent"},
+            }
+        )
+        fake = MagicMock()
+        fake.run = AsyncMock(return_value=OneShotResult(text=envelope, backend="pi", model="anthropic/model"))
+        config = _make_config(backend="pi", provider="anthropic", judge_model="anthropic/model")
+        with patch("kai.eval.behavioral.PiOneShotReasoner", return_value=fake):
+            parsed, _elapsed = await behavioral._run_one_judge(
+                config=config,
+                question="question",
+                ground_truth_text="fact",
+                response_a="A",
+                response_b="B",
+                cwd=tmp_path,
+                env={},
+            )
+
+        assert parsed == ("tie", "equivalent")
+        assert fake.run.call_args.kwargs["json_schema"] == behavioral._JUDGE_SCHEMA
+        assert fake.run.call_args.kwargs["system_prompt"] == behavioral._JUDGE_SYSTEM_PROMPT
+        assert fake.run.call_args.kwargs["purpose"] == "behavioral_judge"
+
+
 class TestCaptureAgentCliVersionCodex:
     """Backend dispatch for the version-capture helper, plus the
     `CODEX_BIN` override for the codex branch."""
@@ -1730,6 +1785,17 @@ class TestCaptureAgentCliVersionCodex:
             field, _value = _capture_agent_cli_version("codex")
         assert field == "codex_cli_version"
         assert mock_run.call_args[0][0] == ["/tmp/fake-codex", "--version"]
+
+    def test_pi_branch_uses_registry_command(self):
+        fake_result = MagicMock(returncode=0, stdout="0.79.9\n")
+        with (
+            patch("kai.eval.behavioral.resolve_backend_command", return_value="/opt/homebrew/bin/pi") as resolve,
+            patch("kai.eval.behavioral.subprocess.run", return_value=fake_result) as mock_run,
+        ):
+            field, value = _capture_agent_cli_version("pi")
+        assert (field, value) == ("pi_cli_version", "0.79.9")
+        resolve.assert_called_once_with("pi", allow_bare_fallback=True)
+        assert mock_run.call_args[0][0] == ["/opt/homebrew/bin/pi", "--version"]
 
     def test_unknown_backend_fails_closed(self):
         with pytest.raises(ValueError, match="unsupported behavioral-eval backend: 'goose'"):
@@ -1781,6 +1847,20 @@ class TestOutputJsonMutuallyExclusiveVersionFields:
         assert "codex_cli_version" not in output
         assert "backend" not in output
 
+    def test_pi_run_writes_pi_field_only(self):
+        probes, outcomes = self._outcomes_and_probes()
+        output = build_output_json(
+            probes=probes,
+            outcomes=outcomes,
+            drift_count=0,
+            config=_make_config(backend="pi", provider="anthropic"),
+            cli_version_field="pi_cli_version",
+            cli_version_value="0.79.9",
+        )
+        assert output["pi_cli_version"] == "0.79.9"
+        assert "claude_cli_version" not in output
+        assert "codex_cli_version" not in output
+
 
 class TestRenderSummaryVersionDispatch:
     """The summary line picks the right label based on which version key is
@@ -1820,6 +1900,18 @@ class TestRenderSummaryVersionDispatch:
         summary = _render_summary(output)
         assert "Codex CLI: codex 0.130.0" in summary
         assert "Claude CLI:" not in summary
+
+    def test_pi_run_renders_pi_label(self):
+        probes, outcomes = self._outcomes_and_probes()
+        output = build_output_json(
+            probes=probes,
+            outcomes=outcomes,
+            drift_count=0,
+            config=_make_config(backend="pi", provider="anthropic"),
+            cli_version_field="pi_cli_version",
+            cli_version_value="0.79.9",
+        )
+        assert "Pi CLI: 0.79.9" in _render_summary(output)
 
     def test_shared_summary_lines_match_between_backends(self):
         probes, outcomes = self._outcomes_and_probes()

--- a/tests/test_gen_collision_probes.py
+++ b/tests/test_gen_collision_probes.py
@@ -326,6 +326,7 @@ class TestBuildDraftingReasoner:
             CodexOneShotReasoner,
             GooseOneShotReasoner,
             OpenCodeOneShotReasoner,
+            PiOneShotReasoner,
         )
 
         assert isinstance(
@@ -343,6 +344,10 @@ class TestBuildDraftingReasoner:
         assert isinstance(
             gcp._build_drafting_reasoner("goose", os_user=None, provider="anthropic"),
             GooseOneShotReasoner,
+        )
+        assert isinstance(
+            gcp._build_drafting_reasoner("pi", os_user=None, provider="anthropic"),
+            PiOneShotReasoner,
         )
 
     def test_unknown_backend_raises(self):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -80,7 +80,7 @@ from kai.install import (
 def _isolate_installed_backend_discovery(monkeypatch, tmp_path):
     """Keep install tests independent of host-installed backend CLIs.
 
-    CI runners have none of claude/codex/goose/opencode installed,
+    CI runners have none of claude/codex/goose/opencode/pi installed,
     while developer machines may have a real /etc/kai/backends.yaml.
     Most install tests are not about command discovery, so give them a
     deterministic registry-shaped discovery result. Tests that exercise
@@ -95,6 +95,7 @@ def _isolate_installed_backend_discovery(monkeypatch, tmp_path):
             "codex": "/test/bin/codex",
             "goose": "/test/bin/goose",
             "opencode": "/test/bin/opencode",
+            "pi": "/test/bin/pi",
         },
     )
 
@@ -520,6 +521,16 @@ class TestGenerateSudoers:
         bob_lines = [line for line in result.splitlines() if "(bob)" in line and "codex" in line]
         assert len(alice_lines) == 1, alice_lines
         assert len(bob_lines) == 1, bob_lines
+
+    def test_pi_rule_emitted_per_target_from_registry_path(self):
+        result = _generate_sudoers(
+            "kai",
+            os_users=["alice", "bob"],
+            pi_bin="/opt/homebrew/bin/pi",
+        )
+
+        assert "kai ALL=(alice) SETENV: NOPASSWD: /opt/homebrew/bin/pi" in result
+        assert "kai ALL=(bob) SETENV: NOPASSWD: /opt/homebrew/bin/pi" in result
 
     # -- Issue #456: per-target kill rule for cross-user signal escalation ----
 
@@ -7572,6 +7583,7 @@ class TestApplyBackendRegistry:
                 "codex": "/global/codex",
                 "opencode": "/global/opencode",
                 "goose": "/global/goose",
+                "pi": "/global/pi",
             },
         )
         rendered = kai.install._build_backend_registry(
@@ -7590,6 +7602,8 @@ class TestApplyBackendRegistry:
         assert data["backends"]["codex"]["command"] == "/global/codex"
         assert data["backends"]["opencode"]["command"] == "/global/opencode"
         assert data["backends"]["goose"]["command"] == "/global/goose"
+        assert data["backends"]["pi"]["command"] == "/global/pi"
+        assert "allowed_models" not in data["backends"]["pi"]
         assert data["default_backend"] == "codex"
         assert "gpt-5.6-sol" in data["backends"]["codex"]["allowed_models"]
         assert "fable" in data["backends"]["claude"]["allowed_models"]
@@ -7603,6 +7617,7 @@ class TestApplyBackendRegistry:
                 "codex": "/registry/codex",
                 "opencode": "/registry/opencode",
                 "goose": "/registry/goose",
+                "pi": "/registry/pi",
             },
         )
         env = {
@@ -7622,9 +7637,10 @@ class TestApplyBackendRegistry:
             codex_bin=commands["codex"],
             opencode_bin=commands["opencode"],
             goose_bin=commands["goose"],
+            pi_bin=commands["pi"],
         )
 
-        for backend in ("claude", "codex", "opencode", "goose"):
+        for backend in ("claude", "codex", "opencode", "goose", "pi"):
             command = registry["backends"][backend]["command"]
             assert f"kai ALL=(alice) SETENV: NOPASSWD: {command}" in sudoers
 

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -3689,6 +3689,13 @@ class TestMemoryReasonerSelection:
         assert isinstance(reasoner, GooseOneShotReasoner)
         assert reasoner._provider == "deepseek"
 
+    def test_pi_backend_builds_pi_reasoner(self):
+        from kai.oneshot import PiOneShotReasoner
+
+        reasoner = memory_extraction._build_memory_reasoner("pi", os_user=None, provider="anthropic")
+        assert isinstance(reasoner, PiOneShotReasoner)
+        assert reasoner._provider == "anthropic"
+
     def test_unknown_backend_still_raises_defensive_runtime_error(self):
         """The defensive RuntimeError remains the safety net for any
         backend the eligibility gate does not allow through. Every

--- a/tests/test_oneshot_binary.py
+++ b/tests/test_oneshot_binary.py
@@ -335,3 +335,18 @@ class TestUnknownBackend:
         from 'fix the code that asked for the wrong backend'."""
         with pytest.raises(ValueError, match="unknown backend"):
             resolve_oneshot_binary("not-a-real-backend")
+
+
+class TestPiResolution:
+    def test_resolves_via_path_without_pi_bin_override(self, monkeypatch):
+        monkeypatch.setenv("PI_BIN", "/untrusted/operator/path")
+        monkeypatch.setattr(
+            "kai.oneshot_binary.shutil.which",
+            lambda name: "/opt/homebrew/bin/pi" if name == "pi" else None,
+        )
+        assert resolve_oneshot_binary("pi") == "/opt/homebrew/bin/pi"
+
+    def test_unreachable_raises(self, monkeypatch):
+        monkeypatch.setattr("kai.oneshot_binary.shutil.which", lambda name: None)
+        with pytest.raises(BinaryResolutionError, match=r"pi.*PATH"):
+            resolve_oneshot_binary("pi")

--- a/tests/test_pi.py
+++ b/tests/test_pi.py
@@ -1,0 +1,442 @@
+"""Tests for the persistent conversational Pi backend."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kai.pi import PiBackend, _assistant_message_text, _split_pi_model
+from kai.pi_rpc import PiRpcEOFError
+
+
+class FakeTransport:
+    def __init__(self, records=()):
+        self.records = list(records)
+        self.sent: list[dict] = []
+
+    async def send(self, command):
+        self.sent.append(dict(command))
+
+    async def receive(self, *, timeout_seconds=None):
+        if not self.records:
+            raise PiRpcEOFError("test stream exhausted")
+        value = self.records.pop(0)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+class FakeProcess:
+    def __init__(self):
+        self.stdin = MagicMock()
+        self.stdout = MagicMock()
+        self.stderr = MagicMock()
+        self.stderr.readline = AsyncMock(return_value=b"")
+        self.pid = 4321
+        self.returncode = None
+        self.killed = False
+        self.terminated = False
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = 0
+
+    async def wait(self):
+        return self.returncode or 0
+
+
+def make_backend(tmp_path: Path, **overrides) -> PiBackend:
+    values = {
+        "model": "anthropic/claude-sonnet-4-6",
+        "provider": "anthropic",
+        "workspace": tmp_path,
+        "home_workspace": tmp_path,
+        "timeout_seconds": 5,
+    }
+    values.update(overrides)
+    return PiBackend(**values)
+
+
+async def collect(backend: PiBackend, prompt="hello", chat_id=123):
+    return [event async for event in backend.send(prompt, chat_id=chat_id)]
+
+
+class TestPiModelParsing:
+    def test_provider_model_and_thinking_suffix(self):
+        assert _split_pi_model("openai/gpt-5.6-sol:xhigh") == ("openai", "gpt-5.6-sol", "xhigh")
+
+    def test_ollama_tag_is_part_of_model_id(self):
+        assert _split_pi_model("ollama/llama4:70b") == ("ollama", "llama4:70b", None)
+
+    def test_bare_model_is_rejected(self):
+        with pytest.raises(ValueError, match="provider/model"):
+            _split_pi_model("sonnet")
+
+    def test_bare_model_uses_explicit_provider(self):
+        assert _split_pi_model("claude-sonnet-4-6:high", "anthropic") == (
+            "anthropic",
+            "claude-sonnet-4-6",
+            "high",
+        )
+
+    def test_prefixed_model_must_match_explicit_provider(self):
+        with pytest.raises(ValueError, match="does not match"):
+            _split_pi_model("openai/gpt-5.5", "anthropic")
+
+    def test_authoritative_message_text_ignores_thinking_and_tools(self):
+        message = {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "private"},
+                {"type": "text", "text": "hello "},
+                {"type": "toolCall", "name": "bash"},
+                {"type": "text", "text": "world"},
+            ],
+        }
+        assert _assistant_message_text(message) == "hello world"
+
+
+class TestPiStartup:
+    def test_argv_uses_registry_and_disables_ambient_resources(self, tmp_path, monkeypatch):
+        backend = make_backend(tmp_path)
+        monkeypatch.setattr("kai.pi.resolve_backend_command", lambda *a, **kw: "/opt/homebrew/bin/pi")
+
+        argv = backend._build_argv()
+
+        assert argv[:5] == ["/opt/homebrew/bin/pi", "--mode", "rpc", "--provider", "anthropic"]
+        assert argv[5:7] == ["--model", "anthropic/claude-sonnet-4-6"]
+        for flag in (
+            "--no-approve",
+            "--no-extensions",
+            "--no-skills",
+            "--no-prompt-templates",
+            "--no-context-files",
+        ):
+            assert flag in argv
+        assert "--approve" not in argv
+
+    def test_env_removes_control_plane_secrets_and_restores_principal(self, tmp_path, monkeypatch):
+        backend = make_backend(tmp_path, webhook_secret="principal-token")
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "must-not-leak")
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "must-not-leak")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "provider-key")
+        monkeypatch.setenv("OPENAI_API_KEY", "unrelated-provider-key")
+
+        env = backend._build_env("daniel")
+
+        assert "TELEGRAM_BOT_TOKEN" not in env
+        assert "GITHUB_WEBHOOK_SECRET" not in env
+        assert env["KAI_WEBHOOK_SECRET"] == "principal-token"
+        assert env["ANTHROPIC_API_KEY"] == "provider-key"
+        assert "OPENAI_API_KEY" not in env
+        assert env["TMPDIR"].endswith("/tmp/daniel")
+
+    @pytest.mark.asyncio
+    async def test_cross_user_start_uses_sudo_and_validates_state(self, tmp_path, monkeypatch):
+        backend = make_backend(tmp_path, os_user="daniel")
+        proc = FakeProcess()
+        transport = FakeTransport(
+            [
+                {
+                    "id": "kai-get_state-1",
+                    "type": "response",
+                    "command": "get_state",
+                    "success": True,
+                    "data": {
+                        "sessionId": "session-1",
+                        "thinkingLevel": "medium",
+                        "model": {
+                            "provider": "anthropic",
+                            "id": "claude-sonnet-4-6",
+                            "input": ["text", "image"],
+                        },
+                    },
+                }
+            ]
+        )
+        spawn = AsyncMock(return_value=proc)
+        monkeypatch.setattr("kai.pi.resolve_claude_user", lambda value: value)
+        monkeypatch.setattr("kai.pi.resolve_backend_command", lambda *a, **kw: "/opt/homebrew/bin/pi")
+        monkeypatch.setattr("kai.pi.asyncio.create_subprocess_exec", spawn)
+        monkeypatch.setattr("kai.pi.PiRpcTransport", lambda stdin, stdout: transport)
+
+        await backend._ensure_started()
+
+        argv = spawn.await_args.args
+        assert argv[:4] == ("sudo", "-H", "-u", "daniel")
+        assert argv[4].startswith("--preserve-env=")
+        assert "ANTHROPIC_API_KEY" in argv[4]
+        assert argv[5:7] == ("--", "/opt/homebrew/bin/pi")
+        assert backend.session_id == "session-1"
+        assert backend._supports_image_input is True
+        assert transport.sent == [{"id": "kai-get_state-1", "type": "get_state"}]
+
+    @pytest.mark.asyncio
+    async def test_startup_rejects_silent_model_substitution(self, tmp_path, monkeypatch):
+        backend = make_backend(tmp_path)
+        proc = FakeProcess()
+        transport = FakeTransport(
+            [
+                {
+                    "id": "kai-get_state-1",
+                    "type": "response",
+                    "command": "get_state",
+                    "success": True,
+                    "data": {
+                        "sessionId": "session-1",
+                        "model": {"provider": "anthropic", "id": "claude-haiku-4-5", "input": ["text"]},
+                    },
+                }
+            ]
+        )
+        monkeypatch.setattr("kai.pi.resolve_claude_user", lambda value: None)
+        monkeypatch.setattr("kai.pi.asyncio.create_subprocess_exec", AsyncMock(return_value=proc))
+        monkeypatch.setattr("kai.pi.PiRpcTransport", lambda stdin, stdout: transport)
+
+        with pytest.raises(Exception, match="different model"):
+            await backend._ensure_started()
+
+
+class TestPiTurns:
+    @pytest.fixture(autouse=True)
+    def no_context_io(self, monkeypatch):
+        monkeypatch.setattr("kai.pi.ensure_user_memory", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.pi.ensure_user_preferences", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.pi.build_session_context", lambda **kw: "")
+        monkeypatch.setattr("kai.pi.build_foreign_workspace_reminder", lambda *a, **kw: None)
+
+        async def identity(prompt, **kwargs):
+            return prompt
+
+        monkeypatch.setattr("kai.pi.assemble_turn_context", identity)
+
+    @pytest.mark.asyncio
+    async def test_streams_deltas_but_finishes_with_authoritative_message(self, tmp_path, monkeypatch):
+        backend = make_backend(tmp_path)
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._supports_image_input = True
+        backend._fresh_session = False
+        transport = FakeTransport(
+            [
+                {"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True},
+                {"type": "agent_start"},
+                {"type": "message_update", "assistantMessageEvent": {"type": "text_delta", "delta": "hel"}},
+                {"type": "agent_end", "willRetry": False},
+                {
+                    "type": "message_end",
+                    "message": {"role": "assistant", "content": [{"type": "text", "text": "hello"}]},
+                },
+                {"type": "agent_settled"},
+            ]
+        )
+        backend._transport = transport
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+
+        events = await collect(backend)
+
+        assert events[0].text_so_far == "hel"
+        assert events[-1].done is True
+        assert events[-1].response is not None
+        assert events[-1].response.success is True
+        assert events[-1].response.text == "hello"
+        assert events[-1].response.session_id == "session-1"
+        assert transport.sent[0]["type"] == "prompt"
+
+    @pytest.mark.asyncio
+    async def test_image_is_forwarded_in_documented_shape(self, tmp_path, monkeypatch):
+        backend = make_backend(tmp_path)
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._supports_image_input = True
+        backend._fresh_session = False
+        backend._transport = FakeTransport(
+            [
+                {"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True},
+                {"type": "agent_settled"},
+            ]
+        )
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+        prompt = [
+            {"type": "text", "text": "look"},
+            {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "YWJj"}},
+        ]
+
+        await collect(backend, prompt)
+
+        assert backend._transport.sent[0]["images"] == [{"type": "image", "data": "YWJj", "mimeType": "image/png"}]
+
+    @pytest.mark.asyncio
+    async def test_unsupported_image_gets_visible_notice(self, tmp_path, monkeypatch):
+        backend = make_backend(tmp_path)
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._supports_image_input = False
+        backend._fresh_session = False
+        backend._transport = FakeTransport(
+            [
+                {"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True},
+                {"type": "agent_settled"},
+            ]
+        )
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+
+        events = await collect(
+            backend,
+            [{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "YWJj"}}],
+        )
+
+        assert "could not be passed to Pi" in events[-1].text_so_far
+        assert "images" not in backend._transport.sent[0]
+
+    @pytest.mark.asyncio
+    async def test_agent_end_is_not_terminal_and_retry_can_finish(self, tmp_path, monkeypatch):
+        backend = make_backend(tmp_path)
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._fresh_session = False
+        backend._transport = FakeTransport(
+            [
+                {"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True},
+                {"type": "agent_end", "willRetry": True},
+                {"type": "auto_retry_start"},
+                {"type": "message_update", "assistantMessageEvent": {"type": "text_delta", "delta": "recovered"}},
+                {"type": "agent_settled"},
+            ]
+        )
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+
+        events = await collect(backend)
+
+        assert events[-1].response is not None
+        assert events[-1].response.success is True
+        assert events[-1].response.text == "recovered"
+
+    @pytest.mark.asyncio
+    async def test_tool_events_are_not_mixed_into_assistant_text(self, tmp_path, monkeypatch):
+        backend = make_backend(tmp_path)
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._fresh_session = False
+        backend._transport = FakeTransport(
+            [
+                {"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True},
+                {
+                    "type": "tool_execution_start",
+                    "toolCallId": "tool-1",
+                    "toolName": "read",
+                    "args": {"path": "README.md"},
+                },
+                {
+                    "type": "tool_execution_end",
+                    "toolCallId": "tool-1",
+                    "toolName": "read",
+                    "result": {"content": "secret tool output"},
+                    "isError": False,
+                },
+                {"type": "message_update", "assistantMessageEvent": {"type": "text_delta", "delta": "answer"}},
+                {"type": "agent_settled"},
+            ]
+        )
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+
+        events = await collect(backend)
+
+        assert events[-1].response is not None
+        assert events[-1].response.text == "answer"
+        assert "secret tool output" not in events[-1].response.text
+
+    @pytest.mark.asyncio
+    async def test_final_retry_failure_is_reported(self, tmp_path, monkeypatch):
+        backend = make_backend(tmp_path)
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._fresh_session = False
+        backend._transport = FakeTransport(
+            [
+                {"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True},
+                {"type": "auto_retry_end", "success": False, "finalError": "quota exhausted"},
+                {"type": "agent_settled"},
+            ]
+        )
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+
+        events = await collect(backend)
+
+        assert events[-1].response is not None
+        assert events[-1].response.success is False
+        assert events[-1].response.error == "quota exhausted"
+
+    @pytest.mark.asyncio
+    async def test_protocol_failure_preserves_partial_text_and_recycles(self, tmp_path, monkeypatch):
+        backend = make_backend(tmp_path)
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._fresh_session = False
+        backend._transport = FakeTransport(
+            [
+                {"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True},
+                {"type": "message_update", "assistantMessageEvent": {"type": "text_delta", "delta": "partial"}},
+                PiRpcEOFError("Pi exited"),
+            ]
+        )
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+        kill = AsyncMock()
+        monkeypatch.setattr(backend, "_kill", kill)
+
+        events = await collect(backend)
+
+        assert events[-1].text_so_far == "partial"
+        assert events[-1].response is not None
+        assert events[-1].response.success is False
+        assert "Pi exited" in events[-1].response.error
+        kill.assert_awaited_once()
+
+
+class TestPiLifecycle:
+    @pytest.mark.asyncio
+    async def test_change_workspace_resets_overrides_and_session(self, tmp_path, monkeypatch):
+        old = tmp_path / "old"
+        new = tmp_path / "new"
+        old.mkdir()
+        new.mkdir()
+        backend = make_backend(old)
+        backend.model = "anthropic/temporary"
+        backend.timeout_seconds = 99
+        backend._fresh_session = False
+        monkeypatch.setattr(backend, "_kill", AsyncMock())
+
+        await backend.change_workspace(new)
+
+        assert backend.workspace == new
+        assert backend.model == "anthropic/claude-sonnet-4-6"
+        assert backend.timeout_seconds == 5
+        assert backend._fresh_session is True
+
+    @pytest.mark.asyncio
+    async def test_restart_kills_and_marks_session_fresh(self, tmp_path, monkeypatch):
+        backend = make_backend(tmp_path)
+        backend._fresh_session = False
+        kill = AsyncMock()
+        monkeypatch.setattr(backend, "_kill", kill)
+
+        await backend.restart()
+
+        kill.assert_awaited_once()
+        assert backend._fresh_session is True
+
+    @pytest.mark.asyncio
+    async def test_shutdown_uses_cross_user_safe_teardown(self, tmp_path, monkeypatch):
+        backend = make_backend(tmp_path, os_user="daniel")
+        kill = AsyncMock()
+        monkeypatch.setattr(backend, "_kill", kill)
+
+        await backend.shutdown()
+
+        kill.assert_awaited_once()

--- a/tests/test_pi_oneshot.py
+++ b/tests/test_pi_oneshot.py
@@ -1,0 +1,250 @@
+"""Contract tests for Pi's bounded one-shot reasoner."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kai.oneshot import OneShotOutputError, OneShotTimeout, PiOneShotReasoner
+
+
+class FakeWriter:
+    def __init__(self) -> None:
+        self.records: list[dict] = []
+
+    def write(self, data: bytes) -> None:
+        for line in data.splitlines():
+            self.records.append(json.loads(line))
+
+    async def drain(self) -> None:
+        return None
+
+
+class FakeProcess:
+    def __init__(self, records: list[dict] | None = None) -> None:
+        self.stdin = FakeWriter()
+        self.stdout = asyncio.StreamReader()
+        self.stderr = asyncio.StreamReader()
+        for record in records or []:
+            self.stdout.feed_data(json.dumps(record).encode() + b"\n")
+        if records is not None:
+            self.stdout.feed_eof()
+        self.stderr.feed_eof()
+        self.pid = 4321
+        self.returncode: int | None = None
+        self.killed = False
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        return self.returncode or 0
+
+
+def state_response(model: str = "claude-sonnet-4-6") -> dict:
+    return {
+        "id": "kai-oneshot-state",
+        "type": "response",
+        "command": "get_state",
+        "success": True,
+        "data": {
+            "sessionId": "ephemeral",
+            "model": {"provider": "anthropic", "id": model},
+        },
+    }
+
+
+def prompt_response() -> dict:
+    return {
+        "id": "kai-oneshot-prompt",
+        "type": "response",
+        "command": "prompt",
+        "success": True,
+    }
+
+
+def completed_message(text: str) -> dict:
+    return {
+        "type": "message_end",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+    }
+
+
+async def run_with_process(tmp_path: Path, monkeypatch, process: FakeProcess, **kwargs):
+    spawn = AsyncMock(return_value=process)
+    monkeypatch.setattr("kai.oneshot.resolve_oneshot_binary", lambda backend: "/opt/homebrew/bin/pi")
+    monkeypatch.setattr("kai.oneshot.resolve_claude_user", lambda user: user)
+    monkeypatch.setattr("kai.oneshot.asyncio.create_subprocess_exec", spawn)
+    reasoner = PiOneShotReasoner(cwd=tmp_path, os_user=kwargs.pop("os_user", None), provider="anthropic")
+    result = await reasoner.run(
+        prompt=kwargs.pop("prompt", "hello"),
+        system_prompt=kwargs.pop("system_prompt", None),
+        model=kwargs.pop("model", "anthropic/claude-sonnet-4-6"),
+        timeout=kwargs.pop("timeout", 5),
+        purpose=kwargs.pop("purpose", "test"),
+        json_schema=kwargs.pop("json_schema", None),
+    )
+    assert not kwargs
+    return result, spawn
+
+
+@pytest.mark.asyncio
+async def test_pi_oneshot_uses_hardened_rpc_flags_and_authoritative_message(tmp_path, monkeypatch):
+    process = FakeProcess(
+        [
+            state_response(),
+            prompt_response(),
+            {"type": "message_update", "assistantMessageEvent": {"type": "text_delta", "delta": "draft"}},
+            {"type": "agent_end", "willRetry": False},
+            completed_message("final answer"),
+            {"type": "agent_settled"},
+        ]
+    )
+
+    result, spawn = await run_with_process(tmp_path, monkeypatch, process)
+
+    assert result.text == "final answer"
+    assert result.backend == "pi"
+    argv = spawn.await_args_list[0].args
+    assert argv[:3] == ("/opt/homebrew/bin/pi", "--mode", "rpc")
+    for flag in (
+        "--no-session",
+        "--no-tools",
+        "--no-approve",
+        "--no-extensions",
+        "--no-skills",
+        "--no-prompt-templates",
+        "--no-context-files",
+    ):
+        assert flag in argv
+    assert "--approve" not in argv
+    assert process.stdin.records == [
+        {"id": "kai-oneshot-state", "type": "get_state"},
+        {"id": "kai-oneshot-prompt", "type": "prompt", "message": "hello"},
+    ]
+    assert process.killed is True
+
+
+@pytest.mark.asyncio
+async def test_pi_oneshot_schema_normalizes_to_shared_envelope(tmp_path, monkeypatch):
+    process = FakeProcess(
+        [
+            state_response(),
+            prompt_response(),
+            completed_message('```json\n{"facts": []}\n```'),
+            {"type": "agent_settled"},
+        ]
+    )
+    result, _ = await run_with_process(
+        tmp_path,
+        monkeypatch,
+        process,
+        json_schema={"type": "object", "required": ["facts"]},
+    )
+    assert json.loads(result.text) == {"is_error": False, "structured_output": {"facts": []}}
+
+
+@pytest.mark.asyncio
+async def test_pi_oneshot_system_prompt_is_boundary_delimited(tmp_path, monkeypatch):
+    process = FakeProcess([state_response(), prompt_response(), completed_message("ok"), {"type": "agent_settled"}])
+    await run_with_process(tmp_path, monkeypatch, process, system_prompt="system rules", prompt="user input")
+    rendered = process.stdin.records[1]["message"]
+    assert "system rules" in rendered
+    assert rendered.endswith("\n\nuser input")
+    assert "BEGIN SYSTEM" in rendered and "END SYSTEM" in rendered
+
+
+@pytest.mark.asyncio
+async def test_pi_oneshot_rejects_silent_model_substitution(tmp_path, monkeypatch):
+    process = FakeProcess([state_response("claude-haiku-4-5")])
+    with pytest.raises(OneShotOutputError, match="different model"):
+        await run_with_process(tmp_path, monkeypatch, process)
+    assert process.killed is True
+
+
+@pytest.mark.asyncio
+async def test_pi_oneshot_surfaces_terminal_retry_failure(tmp_path, monkeypatch):
+    process = FakeProcess(
+        [
+            state_response(),
+            prompt_response(),
+            {"type": "auto_retry_end", "success": False, "finalError": "quota exhausted"},
+            {"type": "agent_settled"},
+        ]
+    )
+    with pytest.raises(OneShotOutputError, match="quota exhausted"):
+        await run_with_process(tmp_path, monkeypatch, process)
+
+
+@pytest.mark.asyncio
+async def test_pi_oneshot_fails_closed_if_tool_event_appears(tmp_path, monkeypatch):
+    process = FakeProcess(
+        [
+            state_response(),
+            prompt_response(),
+            {"type": "tool_execution_start", "toolCallId": "tool-1", "toolName": "bash", "args": {}},
+        ]
+    )
+    with pytest.raises(OneShotOutputError, match="tools being disabled"):
+        await run_with_process(tmp_path, monkeypatch, process)
+
+
+@pytest.mark.asyncio
+async def test_pi_oneshot_cross_user_wrap_preserves_only_pi_auth(tmp_path, monkeypatch):
+    process = FakeProcess([state_response(), prompt_response(), completed_message("ok"), {"type": "agent_settled"}])
+    _, spawn = await run_with_process(tmp_path, monkeypatch, process, os_user="daniel")
+    argv = spawn.await_args_list[0].args
+    assert argv[:4] == ("sudo", "-H", "-u", "daniel")
+    assert "ANTHROPIC_API_KEY" in argv[4]
+    assert "OPENAI_API_KEY" not in argv[4]
+    assert "GEMINI_API_KEY" not in argv[4]
+    assert "KAI_WEBHOOK_SECRET" not in argv[4]
+    assert spawn.await_args_list[0].kwargs["start_new_session"] is True
+
+
+@pytest.mark.asyncio
+async def test_pi_subscription_wrap_needs_no_environment_credentials(tmp_path, monkeypatch):
+    process = FakeProcess(
+        [
+            {
+                **state_response("gpt-5.5"),
+                "data": {
+                    "sessionId": "ephemeral",
+                    "model": {"provider": "openai-codex", "id": "gpt-5.5"},
+                },
+            },
+            prompt_response(),
+            completed_message("ok"),
+            {"type": "agent_settled"},
+        ]
+    )
+    spawn = AsyncMock(return_value=process)
+    monkeypatch.setattr("kai.oneshot.resolve_oneshot_binary", lambda backend: "/opt/homebrew/bin/pi")
+    monkeypatch.setattr("kai.oneshot.resolve_claude_user", lambda user: user)
+    monkeypatch.setattr("kai.oneshot.asyncio.create_subprocess_exec", spawn)
+    reasoner = PiOneShotReasoner(cwd=tmp_path, os_user="daniel", provider="openai-codex")
+
+    await reasoner.run(
+        prompt="hello",
+        model="openai-codex/gpt-5.5",
+        timeout=5,
+        purpose="test",
+    )
+
+    argv = spawn.await_args_list[0].args
+    assert argv[:4] == ("sudo", "-H", "-u", "daniel")
+    assert argv[4:6] == ("--", "/opt/homebrew/bin/pi")
+    assert not any(str(part).startswith("--preserve-env=") for part in argv)
+
+
+@pytest.mark.asyncio
+async def test_pi_oneshot_timeout_kills_process(tmp_path, monkeypatch):
+    process = FakeProcess(records=None)
+    with pytest.raises(OneShotTimeout):
+        await run_with_process(tmp_path, monkeypatch, process, timeout=0.01)
+    assert process.killed is True

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -233,6 +233,26 @@ class TestPerUserBackendRouting:
         assert instance.provider == "openai"
         assert instance.model == "gpt-5.4"
 
+    def test_user_gets_pi_with_provider_model_and_os_user(self):
+        from kai.pi import PiBackend
+
+        user = UserConfig(
+            telegram_id=111,
+            name="alice",
+            backend="pi",
+            provider="openai",
+            model="openai/gpt-5.6-sol:xhigh",
+            os_user="alice-os",
+        )
+        pool = SubprocessPool(config=_make_config(user_configs={111: user}), services_info=[])
+
+        instance = pool.get(111)
+
+        assert isinstance(instance, PiBackend)
+        assert instance.provider == "openai"
+        assert instance.model == "openai/gpt-5.6-sol:xhigh"
+        assert instance.os_user == "alice-os"
+
     def test_user_without_backend_gets_global(self):
         """User with no backend gets the global backend (claude)."""
         user = UserConfig(telegram_id=111, name="alice")
@@ -428,12 +448,20 @@ class TestPerUserBackendRouting:
         from kai.claude import ClaudeCodeBackend
         from kai.codex import CodexBackend
         from kai.opencode import OpenCodeBackend
+        from kai.pi import PiBackend
 
         users = {
             111: UserConfig(telegram_id=111, name="a", backend="claude", provider="anthropic", model="sonnet"),
             222: UserConfig(telegram_id=222, name="b", backend="codex"),
             333: UserConfig(telegram_id=333, name="c", backend="goose", provider="anthropic", model="sonnet"),
             444: UserConfig(telegram_id=444, name="d", backend="opencode", model="anthropic/claude-sonnet-4-6"),
+            555: UserConfig(
+                telegram_id=555,
+                name="e",
+                backend="pi",
+                provider="anthropic",
+                model="anthropic/claude-sonnet-4-6",
+            ),
         }
         config = _make_config(agent_max_session_hours=6.5, user_configs=users)
         pool = SubprocessPool(config=config, services_info=[])
@@ -442,6 +470,7 @@ class TestPerUserBackendRouting:
             (222, CodexBackend),
             (333, GooseBackend),
             (444, OpenCodeBackend),
+            (555, PiBackend),
         ]:
             instance = pool.get(chat_id)
             assert isinstance(instance, expected_type)
@@ -452,12 +481,20 @@ class TestPerUserBackendRouting:
         from kai.claude import ClaudeCodeBackend
         from kai.codex import CodexBackend
         from kai.opencode import OpenCodeBackend
+        from kai.pi import PiBackend
 
         users = {
             111: UserConfig(telegram_id=111, name="a", backend="claude", provider="anthropic", model="sonnet"),
             222: UserConfig(telegram_id=222, name="b", backend="codex"),
             333: UserConfig(telegram_id=333, name="c", backend="goose", provider="anthropic", model="sonnet"),
             444: UserConfig(telegram_id=444, name="d", backend="opencode", model="anthropic/claude-sonnet-4-6"),
+            555: UserConfig(
+                telegram_id=555,
+                name="e",
+                backend="pi",
+                provider="anthropic",
+                model="anthropic/claude-sonnet-4-6",
+            ),
         }
         config = _make_config(protected_install=True, user_configs=users)
         pool = SubprocessPool(config=config, services_info=[])
@@ -466,6 +503,7 @@ class TestPerUserBackendRouting:
             (222, CodexBackend),
             (333, GooseBackend),
             (444, OpenCodeBackend),
+            (555, PiBackend),
         ]:
             instance = pool.get(chat_id)
             assert isinstance(instance, expected_type)

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -893,6 +893,38 @@ class TestRunReviewGooseDispatch:
             await run_review("prompt", agent_backend="goose", provider="")
 
 
+class TestRunReviewPiDispatch:
+    @pytest.mark.asyncio
+    async def test_pi_routes_provider_model_and_user(self):
+        from kai.oneshot import OneShotResult
+
+        fake = MagicMock()
+        fake.run = AsyncMock(
+            return_value=OneShotResult(
+                text="review from pi",
+                backend="pi",
+                model="anthropic/claude-sonnet-4-6",
+            )
+        )
+        with patch("kai.review.PiOneShotReasoner", return_value=fake) as ctor:
+            result = await run_review(
+                "prompt",
+                agent_backend="pi",
+                provider="anthropic",
+                claude_user="daniel",
+            )
+
+        assert result == "review from pi"
+        ctor.assert_called_once_with(os_user="daniel", provider="anthropic")
+        assert fake.run.call_args.kwargs["model"] == "anthropic/claude-sonnet-4-6"
+        assert fake.run.call_args.kwargs["purpose"] == "pr_review"
+
+    @pytest.mark.asyncio
+    async def test_pi_requires_provider(self):
+        with pytest.raises(ValueError, match="provider is empty"):
+            await run_review("prompt", agent_backend="pi", provider="")
+
+
 class TestRunReviewOpenCodeDispatch:
     """
     `run_review` with `agent_backend="opencode"` dispatches to

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -568,7 +568,7 @@ class TestRunTriageOpenCodeDispatch:
             return_value=OneShotResult(
                 text='{"labels": []}',
                 backend="opencode",
-                model="anthropic/claude-sonnet-4-5",
+                model="anthropic/claude-sonnet-4-6",
             )
         )
 
@@ -713,6 +713,38 @@ class TestRunTriageCodexDispatch:
             pytest.raises(RuntimeError, match=r"Codex triage failed"),
         ):
             await run_triage("prompt", agent_backend="codex")
+
+
+class TestRunTriagePiDispatch:
+    @pytest.mark.asyncio
+    async def test_pi_routes_provider_model_and_user(self):
+        from kai.oneshot import OneShotResult
+
+        fake = MagicMock()
+        fake.run = AsyncMock(
+            return_value=OneShotResult(
+                text='{"labels": []}',
+                backend="pi",
+                model="anthropic/claude-sonnet-4-5",
+            )
+        )
+        with patch("kai.triage.PiOneShotReasoner", return_value=fake) as ctor:
+            result = await run_triage(
+                "prompt",
+                agent_backend="pi",
+                provider="anthropic",
+                claude_user="daniel",
+            )
+
+        assert result == '{"labels": []}'
+        ctor.assert_called_once_with(os_user="daniel", provider="anthropic")
+        assert fake.run.call_args.kwargs["model"] == "anthropic/claude-sonnet-4-6"
+        assert fake.run.call_args.kwargs["purpose"] == "issue_triage"
+
+    @pytest.mark.asyncio
+    async def test_pi_requires_provider(self):
+        with pytest.raises(ValueError, match="provider is empty"):
+            await run_triage("prompt", agent_backend="pi", provider="")
 
 
 class TestGooseTriageModelResolutionViaRegistry:


### PR DESCRIPTION
Closes #696.

## Summary

This completes Pi as Kai's fifth first-class backend. PR #809 established the shared JSONL transport; this PR adds the persistent conversational backend, the bounded one-shot implementation, protected-install integration, provider/model configuration, and every existing one-shot consumer.

Pi is deliberately delivered as conversational and one-shot support together. Exposing only the chat path would silently downgrade memory extraction, PR review, issue triage, collision-probe drafting, and behavioral evaluation for a user routed to Pi.

## Conversational backend

- Adds a persistent `PiBackend` using `pi --mode rpc`.
- Uses the protected `/etc/kai/backends.yaml` command registry in installed mode and PATH discovery only in development mode.
- Runs under each configured target OS user with `sudo -H`, so Pi reads that user's `~/.pi/agent/auth.json`.
- Disables approvals, extensions, skills, prompt templates, and context files supplied by Pi/project configuration while retaining Pi's built-in coding tools.
- Preserves only the selected provider's environment credentials; subscription providers use the target user's auth file.
- Validates `get_state` before use so silent provider/model/thinking substitution fails closed.
- Streams visible text deltas, treats `message_end` as authoritative output, and waits for `agent_settled` because current Pi can retry or compact after `agent_end`.
- Supports Pi's documented image RPC shape and emits a visible fallback notice when the selected model cannot accept images.
- Uses cross-user process-group teardown for restart, failure recovery, workspace changes, and shutdown.

## One-shot parity

- Adds `PiOneShotReasoner` with a fresh no-session RPC process per call.
- Disables tools, approvals, sessions, extensions, skills, prompt templates, and context files.
- Fails closed if Pi nevertheless emits tool or extension UI events.
- Supports free-form and JSON-envelope results with the same `OneShotReasoner` contract as the other backends.
- Wires Pi into memory extraction and episode generation, PR review, issue triage, collision-probe drafting, and behavioral generation/judging.

## Provider and model configuration

- Adds Pi to the unified backend/provider/role registry and per-user pool routing.
- Supports the documented `provider/model[:thinking]` form and bare model IDs when an explicit provider is configured.
- Keeps Pi model selection open-ended so Pi remains the model-catalog authority after upgrades.
- Provides curated role defaults for Kai's existing API-provider surface plus Pi's ChatGPT/Codex and GitHub Copilot subscription providers.
- Correctly uses Pi/OpenRouter's dotted Claude IDs rather than OpenCode's different hyphenated IDs.
- Verified every curated default directly against the installed Pi 0.79.9 catalog without issuing model requests.

Pi's current provider choices include:

- `anthropic` (API-key auth or Claude Pro/Max OAuth managed by Pi)
- `openai-codex` (ChatGPT Plus/Pro)
- `github-copilot`
- `openai`, `google`, `deepseek`, `openrouter`, and operator-defined Ollama models

## Install and security contract

- Discovers globally installed Pi at install time and writes its absolute path to `/etc/kai/backends.yaml`.
- Generates the matching per-target sudoers rule and validates in-use Pi executables during install.
- Does not add `PI_BIN`. That part of the older issue design is intentionally superseded by Kai's protected backend registry: users/configuration select the `pi` identity, while only the admin-owned registry can select an executable path.
- Does not write an `allowed_models` ceiling for Pi because Pi owns an evolving authenticated model catalog; Kai still enforces provider/model structural consistency.
- Adds `make config` authentication guidance for Pi's per-user `/login` flow.

## Verification

- `make check`
- `make typecheck` — 0 errors, 0 warnings
- `.venv/bin/python -m pytest -q` — 4,932 passed, 1 skipped
- Direct `get_state` catalog validation against Pi 0.79.9 for every curated default

No installation was applied from this branch. After merge, the operator should run `make config` if selecting Pi or changing its provider, then `make install`, authenticate Pi as each target `os_user` with `/login`, and test a Telegram turn.
