### PR TITLE
Update GitHub Actions to Node 24 releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           cache: pip

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -16,9 +16,9 @@ jobs:
   pip-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           cache: pip
@@ -37,7 +37,7 @@ jobs:
           exit 0
 
       - name: Upload audit report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pip-audit-report
           path: |


### PR DESCRIPTION
## Summary

- update `actions/checkout` from `v4` to `v7` in CI and dependency audit
- update `actions/setup-python` from `v5` to `v7` in CI and dependency audit
- update `actions/upload-artifact` from `v4` to `v7` in dependency audit

## Why

The v2.0 release-qualification dependency audit completed successfully, but GitHub warned that the pinned action versions target deprecated Node.js 20 and were being forced to run on Node.js 24.

The official v7 manifests for all three actions declare `runs.using: node24`:

- https://github.com/actions/checkout/blob/v7/action.yml
- https://github.com/actions/setup-python/blob/v7/action.yml
- https://github.com/actions/upload-artifact/blob/v7/action.yml

Using their stable v7 major tags removes the compatibility warning and keeps the workflows on the runtime GitHub currently supports.

## Scope and safety

This is CI-only:

- no application code changes
- no workflow trigger changes
- no job permission changes
- no dependency or constraint changes
- no release behavior changes

The existing Python 3.13 setup, pip cache, install commands, validation steps, audit behavior, and artifact paths are unchanged.

## Verification

- `git diff --check`
- `make check`
- official v7 action manifests verified as Node.js 24 actions
- fresh pull-request CI will exercise install constraints, lint/format, Pyright, and the full test suite
- a fresh dependency-audit workflow will be dispatched against this branch and its artifact reviewed

Release tracking: #811