### PR TITLE
Prepare v2.0.0 package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kai"
-version = "1.4.0"
-description = "Telegram gateway to Claude Code CLI"
+version = "2.0.0"
+description = "Telegram gateway to AI coding-agent backends"
 license = "Apache-2.0"
 requires-python = ">=3.13"
 dependencies = [

--- a/src/kai/__init__.py
+++ b/src/kai/__init__.py
@@ -1,3 +1,3 @@
-"""Kai — Telegram gateway to Claude Code CLI."""
+"""Kai — Telegram gateway to AI coding-agent backends."""
 
-__version__ = "1.4.0"
+__version__ = "2.0.0"

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,0 +1,15 @@
+"""Tests for release package metadata consistency."""
+
+import tomllib
+from pathlib import Path
+
+import kai
+
+
+def test_package_version_matches_runtime_version():
+    """The build metadata and runtime version must identify the same release."""
+    project_root = Path(__file__).resolve().parents[1]
+    with (project_root / "pyproject.toml").open("rb") as pyproject_file:
+        project = tomllib.load(pyproject_file)
+
+    assert project["project"]["version"] == kai.__version__


### PR DESCRIPTION
## Summary

Prepare Kai’s package metadata for the v2.0.0 release candidate without changing runtime behavior.

- change the project version from `1.4.0` to `2.0.0` in both authoritative sources
- replace the remaining Claude-specific package/module descriptions with backend-neutral wording
- add a regression test requiring the build metadata version and runtime `kai.__version__` to agree

## Scope and safety

This PR changes no runtime logic, configuration, dependency declarations, installation behavior, or backend behavior. The remaining `1.4.0` text is the unrelated lower bound for `piper-tts` and is intentionally unchanged.

## Verification

- `make check`
- `make typecheck` — 0 errors, 0 warnings
- `make check-install-constraints` — resolves Kai as 2.0.0
- `.venv/bin/python -m pytest tests/ -q` — 4933 passed, 1 skipped

Tracks the release-metadata section of #811.