### PR TITLE
Surface actionable backend authentication failures

### DIFF
--- a/src/kai/agent_failure.py
+++ b/src/kai/agent_failure.py
@@ -1,0 +1,213 @@
+"""Backend-neutral agent failure classification and user-safe rendering.
+
+Backend harnesses expose different protocols and native error strings. This
+module converts the subset Kai understands confidently into a stable contract
+that the Telegram presentation layer consumes today and Workshop workers can
+carry across an isolation boundary later.
+"""
+
+from enum import StrEnum
+
+from kai.config import Config, get_user_backend_and_provider
+
+
+class AgentFailureKind(StrEnum):
+    """Backend-neutral reason an agent interaction failed."""
+
+    AUTHENTICATION_EXPIRED = "authentication_expired"
+    AUTHENTICATION_REQUIRED = "authentication_required"
+    QUOTA_EXHAUSTED = "quota_exhausted"
+    MODEL_UNAVAILABLE = "model_unavailable"
+    PROVIDER_UNAVAILABLE = "provider_unavailable"
+    TRANSIENT = "transient"
+    BACKEND_CRASHED = "backend_crashed"
+    UNKNOWN = "unknown"
+
+
+def classify_agent_failure(error: str | None) -> AgentFailureKind:
+    """Conservatively classify a native backend error string.
+
+    Every supported harness has different error envelopes, but their visible
+    authentication, quota, and model diagnostics use a small set of stable
+    phrases. Matching is deliberately narrow: an unrecognized error retains
+    the legacy user-visible behavior instead of receiving misleading recovery
+    advice. More specific categories run before process/startup wrappers so
+    ``startup failed: OAuth session expired`` remains an authentication error.
+    """
+
+    if not error:
+        return AgentFailureKind.UNKNOWN
+
+    normalized = " ".join(error.casefold().split())
+
+    expired_markers = (
+        "authentication expired",
+        "credentials expired",
+        "oauth session expired",
+        "refresh token expired",
+        "session expired and could not be refreshed",
+        "token expired",
+    )
+    if any(marker in normalized for marker in expired_markers):
+        return AgentFailureKind.AUTHENTICATION_EXPIRED
+
+    authentication_markers = (
+        "auth failed",
+        "authentication failed",
+        "credentials not found",
+        "failed to authenticate",
+        "login required",
+        "missing credentials",
+        "no credentials configured",
+        "not authenticated",
+        "not logged in",
+        "please log in",
+    )
+    if any(marker in normalized for marker in authentication_markers):
+        return AgentFailureKind.AUTHENTICATION_REQUIRED
+
+    quota_markers = (
+        "billing hard limit",
+        "credits exhausted",
+        "insufficient_quota",
+        "no credits remaining",
+        "quota exceeded",
+        "usage limit reached",
+    )
+    if any(marker in normalized for marker in quota_markers):
+        return AgentFailureKind.QUOTA_EXHAUSTED
+
+    model_markers = (
+        "model is not supported",
+        "model not found",
+        "model not supported",
+        "unknown model",
+        "unsupported model",
+    )
+    if any(marker in normalized for marker in model_markers):
+        return AgentFailureKind.MODEL_UNAVAILABLE
+
+    provider_markers = (
+        "failed to connect to provider",
+        "provider is unavailable",
+        "provider unavailable",
+    )
+    if any(marker in normalized for marker in provider_markers):
+        return AgentFailureKind.PROVIDER_UNAVAILABLE
+
+    transient_markers = (
+        "rate limit exceeded",
+        "service temporarily unavailable",
+        "service unavailable",
+        "temporarily unavailable",
+    )
+    if any(marker in normalized for marker in transient_markers):
+        return AgentFailureKind.TRANSIENT
+
+    crashed_markers = (
+        "cli not found",
+        "process died",
+        "process ended unexpectedly",
+        "process exited during handshake",
+        "startup failed",
+    )
+    if any(marker in normalized for marker in crashed_markers):
+        return AgentFailureKind.BACKEND_CRASHED
+
+    return AgentFailureKind.UNKNOWN
+
+
+_BACKEND_DISPLAY_NAMES = {
+    "claude": "Claude Code",
+    "codex": "Codex",
+    "goose": "Goose",
+    "opencode": "OpenCode",
+    "pi": "Pi",
+}
+
+
+def _agent_route_display(backend: str, provider: str) -> str:
+    """Return a concise user-facing name for an active agent route."""
+    backend_label = _BACKEND_DISPLAY_NAMES.get(backend, backend or "Agent backend")
+    provider_label = provider.strip()
+    if not provider_label or (backend, provider_label) in {("claude", "anthropic"), ("codex", "openai")}:
+        return backend_label
+    return f"{backend_label} ({provider_label})"
+
+
+def _authentication_recovery(
+    backend: str,
+    provider: str,
+    os_user: str | None,
+    config: Config,
+    failure_kind: AgentFailureKind,
+) -> str:
+    """Return backend-specific, credential-free sign-in guidance."""
+    account = f"OS user {os_user}" if os_user else "the Kai service account"
+    if backend == "codex":
+        if config.codex_auth_mode == "api_key":
+            return "Ask the Kai operator to refresh the OpenAI API credentials configured for Codex, then retry."
+        return f"Run `codex login` as {account} on the Kai host, then retry."
+    if backend == "opencode":
+        return f"Run `opencode auth login` as {account} on the Kai host, then retry."
+    if backend == "pi":
+        return f"Open `pi` as {account} on the Kai host, use `/login`, then retry."
+    if backend == "claude":
+        if failure_kind is AgentFailureKind.AUTHENTICATION_EXPIRED:
+            return f"Open Claude Code as {account} on the Kai host and sign in again, then retry."
+        return f"Refresh the Claude Code credentials for {account} on the Kai host, then retry."
+    provider_detail = f" for provider {provider}" if provider else ""
+    return f"Ask the Kai operator to refresh the credentials{provider_detail} used by Goose, then retry."
+
+
+def render_agent_failure(
+    failure_kind: AgentFailureKind | None,
+    error: str | None,
+    config: Config,
+    chat_id: int,
+) -> str:
+    """Render a safe, actionable error for a failed backend turn.
+
+    Recognized failures intentionally do not echo the native backend message:
+    provider responses may contain account or endpoint details. Unknown errors
+    preserve the legacy ``Error: <detail>`` behavior until an adapter-specific
+    classifier can identify them confidently.
+    """
+    detail = error or "no error detail provided"
+    kind = failure_kind or AgentFailureKind.UNKNOWN
+    if kind is AgentFailureKind.UNKNOWN:
+        return f"Error: {detail}"
+
+    user_config = config.get_user_config(chat_id)
+    backend, provider = get_user_backend_and_provider(user_config, config)
+    route = _agent_route_display(backend, provider)
+    os_user = user_config.os_user if user_config else None
+
+    if kind in {AgentFailureKind.AUTHENTICATION_EXPIRED, AgentFailureKind.AUTHENTICATION_REQUIRED}:
+        state = "has expired" if kind is AgentFailureKind.AUTHENTICATION_EXPIRED else "is required"
+        recovery = _authentication_recovery(backend, provider, os_user, config, kind)
+        return f"Error: Authentication for {route} {state}. Kai did not complete this request.\n\n{recovery}"
+    if kind is AgentFailureKind.QUOTA_EXHAUSTED:
+        return (
+            f"Error: {route} reported that its credits or usage allowance are exhausted. "
+            "Kai did not complete this request. Try again after the allowance resets, or ask the Kai operator "
+            "to select another configured backend/provider."
+        )
+    if kind is AgentFailureKind.MODEL_UNAVAILABLE:
+        return (
+            f"Error: The configured model is unavailable through {route}. Kai did not complete this request. "
+            "Choose another model with /model, or ask the Kai operator to update the configured route."
+        )
+    if kind is AgentFailureKind.PROVIDER_UNAVAILABLE:
+        return (
+            f"Error: {route} is currently unavailable. Kai did not complete this request. "
+            "Retry later, or ask the Kai operator to select another configured backend/provider."
+        )
+    if kind is AgentFailureKind.TRANSIENT:
+        return f"Error: {route} reported a temporary failure. Kai did not complete this request. Please retry later."
+    if kind is AgentFailureKind.BACKEND_CRASHED:
+        return (
+            f"Error: {route} stopped unexpectedly. Kai did not complete this request. "
+            "Retry once; if it happens again, ask the Kai operator to check the service logs."
+        )
+    return f"Error: {detail}"

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -23,6 +23,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from kai.agent_failure import AgentFailureKind, classify_agent_failure
 from kai.config import (
     DATA_DIR,
     PROJECT_ROOT,
@@ -176,6 +177,8 @@ class AgentResponse:
         session_id: Session identifier (used for session continuity).
         duration_ms: Wall-clock duration of the interaction in milliseconds.
         error: Error message if success is False, None otherwise.
+        failure_kind: Stable backend-neutral failure category. Automatically
+            derived from ``error`` when omitted on an unsuccessful response.
     """
 
     success: bool
@@ -183,6 +186,13 @@ class AgentResponse:
     session_id: str | None = None
     duration_ms: int = 0
     error: str | None = None
+    failure_kind: AgentFailureKind | None = None
+
+    def __post_init__(self) -> None:
+        if self.success:
+            self.failure_kind = None
+        elif self.failure_kind is None:
+            self.failure_kind = classify_agent_failure(self.error)
 
 
 @dataclass

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -58,6 +58,7 @@ from telegram.ext import (
 )
 
 from kai import github_api, memory_command, review, services, sessions, webhook
+from kai.agent_failure import render_agent_failure
 from kai.backend import require_backend_name, resolve_home_workspace
 from kai.config import (
     DATA_DIR,
@@ -4576,9 +4577,9 @@ async def _handle_response(
         # suspenders against a future change that re-introduces None,
         # so the literal "Error: None" string can't reappear via this
         # surface even on a regression.
-        real_error = final_response.error or "no error detail provided"
-        error_text = f"Error: {real_error}"
-        log_message(direction="assistant", chat_id=chat_id, text=f"[error: {real_error}]")
+        error_text = render_agent_failure(final_response.failure_kind, final_response.error, config, chat_id)
+        visible_error = error_text.removeprefix("Error: ")
+        log_message(direction="assistant", chat_id=chat_id, text=f"[error: {visible_error}]")
         # Send the error notice as a NEW message (not an edit of the
         # live streamed message), so any tool-use, partial reasoning,
         # and intermediate output the user was watching stays visible.

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -13,6 +13,7 @@ import stat
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from kai.agent_failure import AgentFailureKind
 from kai.backend import (
     AgentResponse,
     ApiContext,
@@ -1099,6 +1100,27 @@ class TestDataTypes:
         assert resp.session_id is None
         assert resp.duration_ms == 0
         assert resp.error is None
+        assert resp.failure_kind is None
+
+    def test_failed_agent_response_classifies_native_backend_errors(self):
+        """All five harness families feed the same portable failure contract."""
+        cases = {
+            "Failed to authenticate: OAuth session expired and could not be refreshed": (
+                AgentFailureKind.AUTHENTICATION_EXPIRED
+            ),
+            "Codex auth failed": AgentFailureKind.AUTHENTICATION_REQUIRED,
+            "Error: no credentials configured for provider anthropic": AgentFailureKind.AUTHENTICATION_REQUIRED,
+            "Provider unavailable while starting opencode": AgentFailureKind.PROVIDER_UNAVAILABLE,
+            "You have no credits remaining. Add credits to continue using the API": AgentFailureKind.QUOTA_EXHAUSTED,
+        }
+
+        for error, expected in cases.items():
+            response = AgentResponse(success=False, text="", error=error)
+            assert response.failure_kind is expected
+
+    def test_unknown_agent_failure_remains_unknown(self):
+        response = AgentResponse(success=False, text="", error="unrecognized harness failure 8675309")
+        assert response.failure_kind is AgentFailureKind.UNKNOWN
 
     def test_stream_event_defaults(self):
         """StreamEvent has sensible defaults."""

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -226,8 +226,14 @@ class TestErrorMessageLifecycle:
         update.effective_chat.id = 12345
         return update, live_msg
 
-    def _make_context(self):
-        from kai.config import Config
+    def _make_context(
+        self,
+        *,
+        backend: str = "codex",
+        provider: str = "openai",
+        codex_auth_mode: str = "subscription",
+    ):
+        from kai.config import Config, UserConfig
 
         ctx = MagicMock()
         ctx.bot_data = {
@@ -235,6 +241,18 @@ class TestErrorMessageLifecycle:
                 telegram_bot_token="t",
                 allowed_user_ids={1},
                 tts_enabled=False,  # voice-mode lookup is skipped
+                default_backend=backend,
+                default_provider=provider,
+                codex_auth_mode=codex_auth_mode,
+                user_configs={
+                    12345: UserConfig(
+                        telegram_id=12345,
+                        name="Daniel",
+                        os_user="daniel",
+                        backend=backend,
+                        provider=provider,
+                    )
+                },
             ),
         }
         ctx.bot.send_chat_action = AsyncMock()
@@ -320,7 +338,74 @@ class TestErrorMessageLifecycle:
 
         error_calls = self._error_path_calls(mock_reply_safe)
         assert len(error_calls) == 1
-        assert error_calls[0].args[1] == "Error: Authentication failed"
+        assert error_calls[0].args[1] == (
+            "Error: Authentication for Codex is required. Kai did not complete this request.\n\n"
+            "Run `codex login` as OS user daniel on the Kai host, then retry."
+        )
+
+    @pytest.mark.asyncio
+    async def test_expired_auth_error_is_sanitized_and_actionable(self):
+        """Native OAuth detail is classified but not echoed into Telegram."""
+        update, _live_msg = self._make_update_with_live_msg()
+        ctx = self._make_context()
+        native_error = "Failed to authenticate: OAuth session expired and could not be refreshed"
+        pool = self._make_pool_text_then_error(native_error)
+
+        with (
+            patch("kai.bot.log_message"),
+            patch("kai.bot.sessions"),
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock),
+            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply_safe,
+        ):
+            await bot._handle_response(update, ctx, chat_id=12345, prompt="hi", pool=pool, model="gpt-5.6-sol")
+
+        error_calls = self._error_path_calls(mock_reply_safe)
+        assert len(error_calls) == 1
+        rendered = error_calls[0].args[1]
+        assert "Authentication for Codex has expired" in rendered
+        assert "codex login" in rendered
+        assert "daniel" in rendered
+        assert native_error not in rendered
+
+    @pytest.mark.asyncio
+    async def test_expired_claude_subscription_directs_user_to_sign_in(self):
+        update, _live_msg = self._make_update_with_live_msg()
+        ctx = self._make_context(backend="claude", provider="anthropic")
+        pool = self._make_pool_text_then_error(
+            "Failed to authenticate: OAuth session expired and could not be refreshed"
+        )
+
+        with (
+            patch("kai.bot.log_message"),
+            patch("kai.bot.sessions"),
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock),
+            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply_safe,
+        ):
+            await bot._handle_response(update, ctx, chat_id=12345, prompt="hi", pool=pool, model="sonnet")
+
+        rendered = self._error_path_calls(mock_reply_safe)[0].args[1]
+        assert "Authentication for Claude Code has expired" in rendered
+        assert "Open Claude Code as OS user daniel" in rendered
+        assert "sign in again" in rendered
+        assert "codex login" not in rendered
+
+    @pytest.mark.asyncio
+    async def test_codex_api_key_mode_does_not_recommend_subscription_login(self):
+        update, _live_msg = self._make_update_with_live_msg()
+        ctx = self._make_context(codex_auth_mode="api_key")
+        pool = self._make_pool_text_then_error("Codex auth failed")
+
+        with (
+            patch("kai.bot.log_message"),
+            patch("kai.bot.sessions"),
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock),
+            patch("kai.bot._reply_safe", new_callable=AsyncMock) as mock_reply_safe,
+        ):
+            await bot._handle_response(update, ctx, chat_id=12345, prompt="hi", pool=pool, model="gpt-5.6-sol")
+
+        rendered = self._error_path_calls(mock_reply_safe)[0].args[1]
+        assert "OpenAI API credentials" in rendered
+        assert "codex login" not in rendered
 
     @pytest.mark.asyncio
     async def test_no_error_none_literal_in_user_facing_output(self):


### PR DESCRIPTION
## Summary

- add a backend-neutral `AgentFailureKind` contract to unsuccessful `AgentResponse` objects
- conservatively classify authentication expiry, missing credentials, exhausted quota, unavailable models/providers, transient outages, and backend crashes
- replace recognized native backend errors with sanitized, route-aware Telegram recovery guidance
- keep unknown failures on the existing `Error: <detail>` path so Kai does not invent misleading advice

## Authentication recovery

- Claude Code OAuth expiry tells the configured OS user to open Claude Code and sign in again
- Codex subscription installs recommend `codex login`, while `api_key` installs direct the operator to the configured OpenAI credentials
- OpenCode recommends `opencode auth login`
- Pi recommends its interactive `/login` flow
- Goose directs the operator to refresh the configured provider credentials

The native error is not echoed for recognized categories, so account or endpoint detail from a provider response is not copied into Telegram.

## Scope

This PR does **not** add automatic fallback, provider switching, background authentication probes, or persistent route-health state. It establishes the portable failure contract those future Workshop capabilities can consume without coupling it to Telegram or the current local-process runtime.

## Verification

- `make check`
- `make typecheck`
- `.venv/bin/python -m pytest tests/test_backend.py tests/test_error_recovery.py -q` — 101 passed
- `.venv/bin/python -m pytest tests/ -q` — 4,937 passed, 1 skipped
- `make module-sizes`
