### PR TITLE
Add canonical Workshop conversation foundation

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -1,0 +1,459 @@
+# Kai Workshop: Phase 0 Implementation Map
+
+**Status:** Draft for architecture review
+**Date:** 2026-08-11
+**Scope:** Map the current Kai implementation onto the proposed Kai Workshop architecture without changing production behavior.
+
+## 1. Naming and scope
+
+**Kai Workshop** is the product: the server-hosted collaboration environment used through desktop, web, Telegram, and future clients.
+
+A **workspace** keeps its existing Kai meaning: a project or filesystem execution context, usually a repository or directory in which an agent works. The product name no longer competes with this established term.
+
+For the target domain model, this map uses:
+
+- **workshop**: the top-level collaboration and security boundary inside the product;
+- **channel**: an ordered conversation container;
+- **project workspace**: the filesystem/repository context selected for agent work;
+- **principal**: a human, agent, service, or integration identity;
+- **run**: one durable unit of requested agent work;
+- **attempt**: one execution of a run through a harness and runtime.
+
+The first installation may contain exactly one workshop, but identifiers and foreign keys should exist from the first schema so a second workshop does not require redefining identity, authorization, or event ordering.
+
+## 2. Executive assessment
+
+Kai can move toward Kai Workshop incrementally without replacing the working Telegram system or the five backend harnesses.
+
+The strongest existing foundations are:
+
+- a long-running server-authoritative service;
+- a durable SQLite store for configuration state, jobs, and accepted Telegram updates;
+- five functioning backend harness adapters (`claude`, `codex`, `goose`, `opencode`, and `pi`);
+- per-user process isolation and an administrator-owned backend registry;
+- principal-bound internal API credentials with explicit scopes;
+- per-user history, files, preferences, memory, settings, jobs, and project workspace access;
+- working Telegram, GitHub, generic webhook, scheduling, memory, file, and service-proxy paths.
+
+The largest missing foundation is not another harness abstraction. It is a canonical collaboration and execution model independent of Telegram. Today, a Telegram `chat_id` is used as a conversation key, runtime pool key, history partition, settings namespace, job owner, file partition, and often an indirect user key. This works for private Telegram chats, where the human's Telegram user ID and chat ID are normally equal, but it cannot represent Workshop channels, multiple human participants, named agents, threads, or the distinction between an author and a conversation.
+
+The first implementation work should therefore establish durable Workshop, principal, channel, message, and event identities beside the current paths. Telegram should become the first adapter onto that model, not be removed or rewritten in one step.
+
+## 3. Current architecture
+
+```text
+Telegram updates
+    |
+    v
+webhook.py durable Telegram queue (SQLite)
+    |
+    v
+python-telegram-bot handlers in bot.py
+    |                   |                    |
+    |                   |                    +--> JSONL history
+    |                   +--> SQLite settings/jobs/session metadata
+    v
+SubprocessPool keyed by Telegram chat_id
+    |
+    +--> Claude Code backend -----+
+    +--> Codex backend ----------- |
+    +--> Goose/ACP backend ------- +--> local_process runtime embedded in each adapter
+    +--> OpenCode/ACP backend ---- |
+    +--> Pi RPC backend ----------+
+    |
+    +--> project workspace, memory, files, internal API, service proxy
+
+GitHub/generic webhooks and scheduled jobs
+    +--> Telegram delivery and/or the same per-chat backend pool
+```
+
+The outer process is already a control plane in the practical sense: it authenticates callers, owns configuration, routes work, starts agent processes, brokers selected services, and delivers results. It is not yet a distinct control-plane architecture because transport, domain behavior, persistence, scheduling, and execution orchestration remain in one Python service and share Telegram-shaped identifiers.
+
+## 4. Current sources of truth
+
+| Concern | Current authority | Durable key | Important limitation |
+|---|---|---|---|
+| Installed harnesses | Protected `/etc/kai/backends.yaml` through [`backend_registry.py`](src/kai/backend_registry.py) | Backend ID | Describes only `local_process`; it is a machine capability registry, not a durable agent registry. |
+| Human configuration | Protected `users.yaml` loaded into `UserConfig` in [`config.py`](src/kai/config.py) | Telegram user ID | A Telegram identity is the primary human identity. There is no transport-independent principal ID. |
+| Telegram authorization | Sender user ID checked in [`bot.py`](src/kai/bot.py) | Telegram user ID | Authorization correctly uses the sender, but later state routing usually uses the chat ID. |
+| Conversation routing | Telegram effective chat in [`bot.py`](src/kai/bot.py) | Telegram chat ID | Author and conversation are separate Telegram concepts but collapse in private-chat operation. |
+| Accepted inbound Telegram work | `telegram_update_queue` in [`sessions.py`](src/kai/sessions.py) | Telegram update ID | Strong Telegram-specific durability pattern; not yet a general command inbox. |
+| Transcript | Per-user/date JSONL in [`history.py`](src/kai/history.py) | Chat ID + timestamp | No stable message ID, channel ID, thread ID, edit lineage, delivery state, or transactional relation to SQLite. |
+| Harness session metadata | `sessions` table plus live backend instance | Chat ID | The stored session ID is used for statistics and clearing; process/session reconstruction still belongs to the live backend. |
+| Active harness process | `SubprocessPool` in [`pool.py`](src/kai/pool.py) | Chat ID | One implicit agent process per conversation key; no durable agent, run, attempt, lease, or worker identity. |
+| User settings | Generic `settings` rows in [`sessions.py`](src/kai/sessions.py) | Namespaced strings containing chat ID | Flexible but not typed, versioned, or attached to transport-independent principals/channels. |
+| Scheduled jobs | `jobs` table and APScheduler registration | Integer job ID + chat ID | Job definitions survive restart, but executions are not durable runs with attempts and event history. |
+| Project workspace selection | Settings, `allowed_workspaces`, `workspace_history`, static configuration | Chat ID + filesystem path | A project workspace is not a first-class durable object and is coupled to the current chat. |
+| Memory | Qdrant/Mem0 plus per-user files and memory project registry | Stringified chat ID and optional project ID | Useful principal/project scoping exists, but principal IDs are Telegram-derived and no channel/run memory layer exists. |
+| Files | Per-chat paths beneath the Kai data directory | Chat ID + generated filename | No immutable artifact identity, provenance record, channel visibility, or delivery lifecycle. |
+| Internal agent authority | Process-local credentials in [`internal_api_auth.py`](src/kai/internal_api_auth.py) | Credential -> fixed chat ID/scopes | Good capability foundation, but the principal is still represented by chat ID and credentials do not survive control-plane restart. |
+| External services | Static service definitions and per-user grants in [`services.py`](src/kai/services.py) | Service name + chat ID | A useful connector/secret-broker precursor, without attempt-scoped grants or durable access events. |
+| GitHub events | Verified webhook handling and per-user routing in [`webhook.py`](src/kai/webhook.py) | Repository/event payload + configured user | Notifications and automation are not projected into canonical channels/events. |
+| Outbound Telegram delivery | Direct Bot API calls from handlers, jobs, and webhook paths | Telegram chat ID | There is no general durable outbox or delivery-attempt record. JSONL may be written before delivery succeeds. |
+
+## 5. Identity and conversation findings
+
+### 5.1 Sender identity and conversation identity are already distinct at ingress
+
+Telegram exposes an effective user and an effective chat. Kai's authorization wrapper checks the user ID, while message processing, pool selection, history, jobs, settings, and files use the chat ID. In private chats those numbers usually coincide, hiding the distinction.
+
+Kai Workshop must preserve the distinction explicitly:
+
+```text
+Telegram user ID  -> external_identity -> human principal
+Telegram chat ID  -> transport_binding -> Workshop channel
+Telegram message  -> external_message reference -> canonical message
+```
+
+This also preserves the existing security rule that a Telegram group used only as a GitHub notification destination does not become an inbound principal.
+
+### 5.2 The current "agent" is implicit
+
+The selected backend, model, process, identity files, memory, and permissions collectively behave like an agent, but there is no durable named agent object. They are resolved primarily from the owning user's configuration and current chat state.
+
+The first Workshop schema needs a durable default agent definition, even if the UI initially displays only one agent named Kai. Backend and model selection become policy on that agent or its channel attachment, rather than identity itself. Switching from Codex to Pi must not create a different agent identity.
+
+### 5.3 A project workspace is not the collaboration boundary
+
+The current workspace path controls filesystem execution context and workspace-specific model/prompt settings. It should map to a Workshop project workspace or checkout, not to the top-level workshop or channel. A channel may refer to one project workspace, change project workspace, or host discussion with no active project workspace.
+
+## 6. Module-to-target mapping
+
+| Current module or surface | Target concept | Disposition |
+|---|---|---|
+| [`bot.py`](src/kai/bot.py) | Telegram command adapter and Telegram renderer | **Extract gradually.** Keep existing handlers while moving accepted commands and resulting messages through transport-neutral services. |
+| [`webhook.py`](src/kai/webhook.py) | Telegram/GitHub/generic ingress adapters plus current HTTP API | **Split by boundary later.** Authentication and transport parsing remain adapters; domain commands move behind a service layer. |
+| [`sessions.py`](src/kai/sessions.py) | Current SQLite persistence | **Extend first.** Add Workshop event and projection tables behind a narrow store interface; do not migrate databases in the first slice. |
+| [`history.py`](src/kai/history.py) | Legacy transcript store and memory-provenance source | **Preserve during migration.** Shadow-write canonical messages, verify parity, then make JSONL a compatibility export or retained diagnostic source. |
+| [`backend.py`](src/kai/backend.py) | Existing harness-neutral conversational contract and context assembly | **Wrap and evolve.** It is the practical precursor to a Harness Driver, but its event vocabulary is text/session-centric and lacks capabilities, tool events, approvals, usage, and artifacts. |
+| `claude.py`, `codex.py`, `goose.py`, `opencode.py`, `pi.py`, and [`acp.py`](src/kai/acp.py) | Five Harness Drivers | **Preserve equally.** Derive a common capability/normalized-event contract from all five implementations; do not choose one as semantically privileged. |
+| [`backend_registry.py`](src/kai/backend_registry.py) | Installed harness/runtime capability registry | **Preserve.** Later extend descriptors and versions; do not let user or agent configuration supply executable paths. |
+| [`pool.py`](src/kai/pool.py) | Early execution coordinator | **Wrap first, decompose later.** It already resolves identity, configuration, workspace, credentials, lifecycle, and routing. A future orchestrator should use run/attempt IDs rather than chat IDs. |
+| Process creation and teardown inside each backend | Server-process Runtime Backend | **Extract after the event foundation.** The current trusted-host runtime is a migration mode; container work should not block the first Workshop conversation slice. |
+| [`internal_api_auth.py`](src/kai/internal_api_auth.py) | Scoped execution credentials | **Generalize later.** Replace chat-bound principals with durable principal/run/attempt claims and make issuance auditable. |
+| [`cron.py`](src/kai/cron.py) and `jobs` | Schedules and workflow triggers | **Adapt after runs exist.** A firing job should eventually create a durable run rather than directly call a pool and Telegram. |
+| [`services.py`](src/kai/services.py) | Connector registry and early secret broker | **Preserve and wrap.** Later authorize against attempt-scoped grants and emit access audit events. |
+| Memory modules and `memory_projects` | Core, principal, and project memory | **Preserve.** Introduce durable Workshop principal/project/channel/run references without replacing Qdrant in the first phases. |
+| Per-chat file directories | Upload and artifact staging | **Preserve initially.** Add canonical artifact metadata and provenance before changing object storage. |
+| `users.yaml`, `workspaces.yaml`, `memory-projects.yaml` | Operator-managed installation policy/bootstrap | **Retain.** Workshop state may become mutable domain data, but protected files remain the safe bootstrap and installation-policy surface during migration. |
+
+## 7. Harness and runtime assessment
+
+### 7.1 Existing Harness Driver precursor
+
+`AgentBackend` already normalizes:
+
+- asynchronous streaming text;
+- a terminal success/error response;
+- a harness session identifier;
+- model, provider, timeout, and project workspace selection;
+- restart, shutdown, force-kill, and liveness;
+- per-user context, memory, preferences, files, and internal API access.
+
+That contract is sufficient for Telegram conversation but not yet for the Workshop run inspector. It does not expose normalized tool calls, approval requests, usage, artifacts, patches, capability discovery, or distinct lifecycle events.
+
+The next contract must be derived from the behavior of all five harnesses. Capability differences should remain visible. A driver is allowed to report that it cannot resume, branch, expose structured tools, or provide exact usage.
+
+### 7.2 Existing Runtime Backend precursor
+
+Every backend currently owns both harness protocol behavior and local process mechanics:
+
+- command construction;
+- `sudo -H -u` isolation;
+- environment sanitation;
+- subprocess creation;
+- stdout/stderr framing;
+- descendant discovery and termination;
+- temporary-directory and project-workspace setup.
+
+This is the seam for a future `local_process` Runtime Backend, but extracting it now would delay the user-visible Workshop foundation and risk five working integrations. Runtime extraction belongs after canonical runs and normalized run events exist, because those concepts define what the runtime is executing and reporting.
+
+The current server-process mode remains a trusted-host compatibility runtime. Container isolation remains the intended personal-production boundary for Workshop, but it is not a prerequisite for recording and replaying one canonical conversation.
+
+## 8. Durability and ordering findings
+
+### 8.1 Strong reusable pattern: the Telegram update queue
+
+The durable inbound queue persists an update before acknowledging it, deduplicates Telegram retries by `update_id`, atomically claims work, and requeues interrupted processing at startup. This is the best current template for a general command inbox.
+
+It should not simply be renamed into the event log. Commands and events have different meaning:
+
+- the inbox records external intent that may still be rejected;
+- the event log records accepted authoritative facts;
+- projections provide queryable current state;
+- a delivery outbox records effects still owed to external transports.
+
+### 8.2 Transcript writes are durable but not transactional domain events
+
+JSONL history is appended immediately and provides useful recovery and memory provenance. It has no database transaction with Telegram queue completion, session updates, memory extraction, or outbound delivery. An assistant record can be written before the final Telegram delivery attempt succeeds.
+
+The migration must therefore avoid treating existing JSONL ordering as proof of external delivery. Canonical message acceptance and transport delivery need separate states.
+
+### 8.3 Scheduled definitions are durable; executions are not
+
+Job definitions survive restart and are re-registered with APScheduler. A firing job directly invokes Telegram or the backend pool. There is no durable run/attempt record that can distinguish queued, started, waiting, completed, failed, retried, or delivered execution.
+
+Workshop should leave scheduling behavior alone until the run model exists, then make schedule firing create the same run command used by a human message.
+
+## 9. Migration seams
+
+### Seam A: Telegram ingress to canonical commands
+
+After authentication and transport validation, translate an accepted Telegram message into a transport-neutral `messages.create` command carrying:
+
+- authenticated human principal ID;
+- bound channel ID;
+- external update and message references;
+- idempotency key;
+- text/media references;
+- timestamp and transport metadata.
+
+During shadow operation, existing handlers continue to own behavior. The canonical recorder observes the same accepted input but does not alter routing or responses.
+
+### Seam B: Agent output to canonical messages and run events
+
+Wrap `pool.send()` so its existing `StreamEvent` values can produce canonical run/output events while still feeding the Telegram renderer. Initially, only stable facts should be durable: run accepted, run started, visible text snapshot/final result, failure, cancellation, and session reference. Tool-specific normalization follows only after each driver can supply reliable evidence.
+
+### Seam C: Canonical messages to transport delivery
+
+Separate creation of an assistant message from delivery to Telegram. The eventual model is:
+
+```text
+message.created -> delivery.requested -> delivery.succeeded | delivery.failed
+```
+
+The first shadow slice may continue direct Telegram delivery, but authority must not cut over until a durable delivery outbox and idempotent retry policy exist.
+
+### Seam D: Chat-keyed processes to agent/channel sessions
+
+Introduce stable agent and channel IDs before changing pool keys. A compatibility mapping can continue to resolve one `(channel_id, agent_id)` pair to the current Telegram `chat_id` pool entry. Later, the pool/orchestrator can key processes by durable session or attempt ID.
+
+### Seam E: JSONL history to canonical projections
+
+Keep writing JSONL while canonical events are shadowed. Add a parity diagnostic that compares canonical message order/content with the JSONL records for the bound Telegram channel. Only after sustained parity should context assembly and transcript views read from canonical projections.
+
+### Seam F: Current files to artifacts
+
+Retain current per-user file storage. Add artifact metadata containing a stable artifact ID, owning workshop/channel/principal, content hash, media type, provenance, and current local path. Moving bytes to object storage is a later storage decision.
+
+## 10. Recommended architectural decisions
+
+These recommendations narrow the original design's open decisions for the first Workshop slice.
+
+1. **Multi-principal schema from day one.** The first deployment can remain personal, but principals and memberships must not be omitted. Kai's existing multi-user and OS-user isolation makes a single-principal schema a regression.
+2. **One default workshop at migration.** Create one workshop automatically for an existing installation. Do not expose multi-workshop administration in the first UI.
+3. **SQLite first, behind an event-store interface.** Kai already operates a single-server transactional SQLite database in WAL mode. Add the initial event log and projections there. PostgreSQL remains the target when concurrency or deployment topology requires it; adopting it before validating the domain would add operational work without improving the first slice.
+4. **One Telegram chat binding to one channel.** Existing private-chat history maps to a default direct channel. Notification-only Telegram groups remain delivery destinations unless explicitly configured as interactive bindings later.
+5. **One durable default agent named Kai.** Preserve current behavior while separating agent identity from the selected harness and model. All five harnesses remain equal selectable drivers.
+6. **Continue one session per channel/agent by default.** Preserve current conversational continuity. `/new` begins a new harness session without deleting channel history. Explicit branching and cross-channel session policies can follow capability discovery.
+7. **Trusted local process during migration.** Keep the currently working runtime while building the domain/event seam. Container execution begins when durable runs and attempts can describe, observe, and recover it.
+8. **Telegram remains the first write client.** The first web surface is read-only diagnostics/replay. It should not accept commands until server authorization, idempotency, and delivery behavior are proven independently of Telegram.
+9. **No required Redis, object store, or separate queue yet.** SQLite is authoritative for the first personal-server slice. New components require measured need or a later deployment phase.
+
+## 11. First implementation slice after this map
+
+The first code milestone should be **canonical conversation shadowing**. It establishes the model without making it authoritative prematurely.
+
+### 11.1 Minimal domain records
+
+- `workshops`
+- `principals`
+- `external_identities`
+- `workshop_memberships`
+- `channels`
+- `channel_bindings`
+- `agents`
+- `channel_agents`
+- `messages`
+- `event_log`
+- projection checkpoint/version metadata
+
+Identifiers should be opaque, globally unique strings. Telegram numeric identifiers remain external references, never primary domain identifiers.
+
+### 11.2 Minimal event vocabulary
+
+- `workshop.created`
+- `principal.created`
+- `external_identity.bound`
+- `channel.created`
+- `transport.channel_bound`
+- `agent.created`
+- `channel.agent_attached`
+- `message.created`
+
+Run and delivery event families should be designed next, before either becomes authoritative. The first schema should not invent detailed tool or worker events that the current backends cannot yet emit consistently.
+
+### 11.3 Small PR sequence
+
+Every PR that introduces a shadow write, compatibility adapter, fallback, dual-read path, feature flag, or legacy projection must also add or update an entry in the transition retirement ledger in section 17. Transitional work is incomplete until its removal conditions and deletion scope are recorded.
+
+1. **Domain and store contract, unused by production:** typed identifiers, versioned event envelope, SQLite schema/migrations, append/idempotency/projection tests.
+2. **Bootstrap migration:** create the default workshop, human principals, default Kai agent, and Telegram channel bindings deterministically for existing configured users. Dry-run/status diagnostics must disclose actions without exposing secrets.
+3. **Inbound shadow recorder:** append canonical inbound `message.created` events after existing Telegram authentication, using Telegram update/message identity for deduplication. Existing handler behavior remains unchanged.
+4. **Outbound shadow recorder:** append the final assistant message and explicit delivery observations without changing streaming or notification behavior.
+5. **Parity and replay diagnostic:** rebuild the channel projection from events, compare it with current history, and expose a local read-only diagnostic endpoint or page.
+6. **Authority review:** only after parity and restart tests decide whether the canonical store should become the source for transcript reads and outbound delivery.
+
+Every PR should leave Telegram, all five harnesses, memory, schedules, GitHub notifications, and installation behavior working.
+
+### 11.4 Slice exit criteria
+
+- One existing Telegram conversation has a stable Workshop channel identity.
+- The human author and the conversation are represented by different IDs.
+- Replayed events rebuild the same canonical message projection after restart.
+- Duplicate Telegram delivery does not create duplicate canonical messages.
+- Existing Telegram responses and streaming are unchanged.
+- JSONL history remains intact and a parity diagnostic reports divergence.
+- Backend selection remains a policy choice among all five installed harnesses.
+- No new production service is required.
+
+## 12. Compatibility invariants
+
+The migration must preserve all of the following until an explicit replacement is tested and approved:
+
+- `make config`, `make install`, `make install-status`, and protected-install ownership rules;
+- Telegram private-chat interaction and streaming behavior;
+- notification delivery to configured Telegram groups;
+- TOTP behavior, including installations where TOTP is disabled;
+- per-user backend/model selection through protected configuration and runtime settings;
+- all five installed backend harnesses;
+- per-user OS execution and backend authentication;
+- project workspace selection and access controls;
+- semantic memory and transcript provenance;
+- scheduled jobs and condition monitors;
+- GitHub notifications, PR review, and issue triage;
+- generic webhook callers;
+- file, image, voice, and service-proxy behavior;
+- principal-bound internal API scopes and separated external webhook secrets.
+
+## 13. Explicitly deferred work
+
+The following should not be bundled into the canonical conversation foundation:
+
+- React/Tauri production UI;
+- PostgreSQL migration;
+- Redis or a separate message broker;
+- container or Kubernetes runtime extraction;
+- root-owned backend package management;
+- multi-workshop administration;
+- full workflow engine;
+- canvases, reactions, voice huddles, or mobile packaging;
+- generalized tool-call or approval normalization before driver evidence exists;
+- replacing JSONL history, Qdrant, current file storage, or APScheduler.
+
+## 14. Risks and controls
+
+| Risk | Control |
+|---|---|
+| A shadow event log silently diverges from JSONL | Add deterministic parity diagnostics and make divergence visible in tests/status before any read cutover. |
+| Telegram identity leaks into the new schema | Permit Telegram IDs only in external identity/binding records and idempotency metadata. |
+| The first schema overfits private chat | Model author principal, channel, agent, and project workspace separately even when the bootstrap produces one of each. |
+| Event vocabulary overfits one harness | Keep the first vocabulary collaboration-only; derive run/tool capabilities from all five drivers later. |
+| Dual writes create partial state | Treat shadow records as non-authoritative until command/event/outbox transactions and recovery behavior are specified. |
+| Workshop work destabilizes the installed service | Use additive migrations, disabled-by-default wiring where practical, install dry runs/status checks, and a live Telegram smoke test after each deployment-affecting PR. |
+| Infrastructure scope delays the desktop goal | Keep the first store in SQLite and defer runtime/storage distribution until the vertical slice proves the domain. |
+
+## 15. Changes needed in the original design document
+
+The design remains directionally sound, with these updates:
+
+1. Rename the product from **Kai Workspace** to **Kai Workshop**.
+2. Reserve **workspace** for project/filesystem execution contexts.
+3. Rename the original top-level Workspace domain object to **Workshop**.
+4. Replace the "first harness, then Codex and Claude Code" sequence. Kai already has five production-tested harness adapters; the target contract must be validated against all five.
+5. Recognize the current protected backend registry and `local_process` runtime as migration foundations.
+6. Move Harness Driver and Runtime Backend extraction behind the canonical conversation/event foundation unless a specific implementation blocker proves otherwise.
+7. Add the existing durable Telegram queue as the model for command acceptance, while keeping commands, events, projections, and delivery outbox conceptually separate.
+8. Make SQLite the explicit first-slice store and retain PostgreSQL as the scale-out target.
+
+## 16. Phase 0 conclusion
+
+Kai Workshop should begin by giving the conversation durable, transport-independent identity. Kai already runs agents on the server, already supports five harnesses, and already persists enough operational state to migrate safely. Building a desktop shell before defining that shared truth would force the UI to reproduce Telegram assumptions.
+
+The next safe implementation step, after review of this map, is a test-first PR containing only the Workshop domain identifiers, versioned event envelope, SQLite event-store schema, projection contract, and idempotency tests. It should not yet alter a production message path.
+
+## 17. Transition retirement phase
+
+Workshop migration must finish with one authoritative implementation for each responsibility. Shadow stores, dual writes, legacy fallbacks, compatibility flags, and transport-shaped domain paths are temporary migration tools, not acceptable permanent architecture.
+
+Transition retirement is a cross-cutting phase. It begins with the first Workshop PR, because every temporary mechanism needs an exit plan when it is introduced, and ends only after the final obsolete path has been removed. A Workshop capability is not complete merely because the new path works; it is complete when the replaced path is no longer active in production.
+
+### 17.1 Required transition retirement ledger
+
+The ledger is maintained in this document until the project adopts a dedicated architecture-decision or migration-tracking system. Every transitional mechanism must record:
+
+- the mechanism and the reason it exists;
+- the new authoritative component that replaces it;
+- whether it is shadowing, dual-writing, dual-reading, falling back, or adapting;
+- the parity, recovery, and live-operation evidence required for cutover;
+- the exact condition that permits removal;
+- the code, configuration, schema, diagnostics, and tests to delete or convert;
+- the target migration phase or release, once one can be named responsibly.
+
+No entry may use an indefinite condition such as "keep for compatibility." A genuinely supported compatibility surface must instead be documented as a product contract with an owner and tests; it is no longer transitional.
+
+| Transitional mechanism | Replacement authority | Required evidence and removal gate | Retirement work | State |
+|---|---|---|---|---|
+| Canonical conversation shadow writes beside current history | Workshop event store and message projection | Deterministic replay, duplicate-ingress tests, restart tests, and sustained parity with current history | Remove shadow-only mode and make canonical command/event transactions the sole message write path | Planned |
+| JSONL transcript writes and reads | Canonical message projection, with an explicit export facility if still useful | Canonical reads serve complete context and transcript views; migration/parity diagnostics report no unexplained divergence | Stop JSONL writes; remove production reads and dual-write recovery code; retain only a documented importer/exporter if required | Planned |
+| Telegram `chat_id` used as internal identity, namespace, and routing key | Durable principal, channel, agent, and binding IDs | Private chats, notification-only groups, duplicate updates, and restart routing all resolve correctly through bindings | Confine Telegram IDs to external identity, transport binding, and idempotency records; remove chat-shaped domain keys | Planned |
+| `SubprocessPool` keyed by Telegram chat ID | Durable channel/agent session plus run and attempt orchestration | All five harnesses pass continuity, restart, cancellation, and isolation tests through durable identities | Remove chat-key compatibility lookup and move lifecycle ownership behind the orchestrator/runtime contract | Planned |
+| Direct backend invocation from Telegram handlers | Transport-neutral command and run services | Telegram and the first Workshop client produce equivalent authorized runs and visible results | Remove handler-owned orchestration; leave authentication, parsing, and rendering in the Telegram adapter | Planned |
+| Direct Telegram delivery from handlers, schedules, and webhooks | Durable delivery outbox and Telegram delivery adapter | Idempotent retry, crash recovery, ordering, and notification-group delivery tests pass; live delivery is verified | Remove direct Bot API sends from domain paths and delete delivery fallback flags | Planned |
+| Schedule firing directly into the pool or Telegram | Durable Workshop run creation | Scheduled definitions and executions survive restart and expose run/attempt state without duplicate work | Remove schedule-specific execution path; retain schedules only as authenticated run triggers | Planned |
+| GitHub and generic webhook paths that route directly to Telegram or the pool | Canonical integration commands/events plus delivery/run services | Existing GitHub group notifications, generic callers, deduplication, and secret separation pass end-to-end tests | Remove direct routing while retaining verified webhook adapters and supported external contracts | Planned |
+| Per-chat settings, files, memory references, and project selection | Principal/channel/agent/project-workspace records and artifact metadata | Existing per-user isolation, context assembly, memory provenance, file delivery, and workspace access remain equivalent | Migrate namespaces and remove Telegram-derived ownership from domain storage | Planned |
+| `users.yaml` values that represent mutable application state | Workshop administration and durable policy records | Workshop administration can safely inspect and change the relevant state, and bootstrap/recovery behavior is proven | Retain only protected installation/bootstrap policy; remove duplicated mutable state and precedence rules | Planned |
+| Backend-specific execution orchestration embedded in the control plane | Equal Harness Driver contracts and a Runtime Backend boundary | Capability and lifecycle tests cover Claude, Codex, Goose, OpenCode, and Pi without privileging one driver | Delete duplicated process orchestration only after the shared contracts carry the required evidence | Planned |
+| Trusted-host `local_process` execution and its executable-trust warnings | Isolated Workshop workers | Worker identity, filesystem grants, credentials, networking, artifacts, cancellation, upgrade, and recovery are verified for all five harnesses | Retire trusted-host mode or explicitly reclassify it as a supported development mode; remove production mitigations that it alone requires | Planned |
+| Temporary feature flags, legacy fallbacks, and compatibility diagnostics introduced during migration | The corresponding authoritative Workshop path | The owning ledger row has passed its removal gate and rollback no longer depends on the old path | Delete flags, fallback branches, stale status output, environment variables, fixtures, and tests that only preserve the retired path | Ongoing rule |
+| Superseded database tables and columns | Current Workshop schema and projections | Data migration is verified, no supported binary reads the old schema, and rollback/archive policy is explicit | Freeze writes, migrate or archive data, then remove obsolete schema in a dedicated migration | Planned |
+
+This ledger must be refined as implementation exposes concrete file names, table names, feature flags, and measurable thresholds. New rows are required whenever a PR creates another temporary path.
+
+### 17.2 Cutover and deletion sequence
+
+Each ledger entry follows the same controlled sequence:
+
+1. **Introduce:** add the new path without changing production authority.
+2. **Observe:** shadow or project authoritative activity and measure deterministic parity.
+3. **Cut over:** make the new path authoritative, with the old path read-only only when a bounded rollback window requires it.
+4. **Verify:** exercise restart, replay, duplicate delivery, failure recovery, authorization, and live installed-system behavior.
+5. **Retire:** stop old writes and reads, delete fallback behavior, and migrate or archive remaining data.
+6. **Simplify:** remove compatibility configuration, diagnostics, tests, documentation, and dependencies that no longer represent supported behavior.
+
+Cutover and retirement should normally be separate small PRs. The cutover PR proves the new authority; the retirement PR makes the architectural simplification reviewable and prevents unrelated feature work from hiding legacy behavior.
+
+### 17.3 Retirement gates
+
+A transitional path may be removed only when all applicable gates pass:
+
+- deterministic replay produces the expected projection from authoritative events;
+- idempotency tests cover duplicate external delivery and process restart;
+- crash recovery does not require the legacy path;
+- authorization and principal isolation are preserved;
+- all five installed harnesses remain supported where execution is involved;
+- Telegram private interaction and configured notification-group delivery still work;
+- GitHub and generic webhook contracts remain valid where affected;
+- migration and rollback procedures are documented and tested for persistent data;
+- `make config`, `make install`, and `make install-status` accurately represent the new authority;
+- an installed-system smoke test confirms Kai remains usable.
+
+Rollback must not become a reason to keep two authorities indefinitely. During a bounded rollback window, new-schema data must have an explicit backward strategy or the release must declare that rollback requires restoring a backup.
+
+### 17.4 Final architecture after retirement
+
+The retirement phase is complete when:
+
+- the Workshop event store and projections are the canonical collaboration state;
+- Telegram, web, and desktop are transport adapters rather than domain authorities;
+- human principals, channels, agents, project workspaces, runs, attempts, artifacts, and deliveries use durable transport-independent identities;
+- schedules and integrations create the same authenticated commands and runs as interactive clients;
+- external delivery is durable and observable through an outbox;
+- all five harnesses remain equal drivers behind common capability and lifecycle contracts;
+- isolated workers provide the supported production execution boundary;
+- protected files contain secrets and installation/bootstrap policy rather than duplicated mutable application state;
+- Telegram IDs, provider session IDs, executable paths, and filesystem paths appear only at their appropriate adapter or runtime boundaries;
+- no silent legacy fallback, dual authority, or mitigation-only configuration remains.
+
+Any compatibility code remaining at that point must be an intentional, documented, tested product surface. Everything else is transition debt and blocks completion of the Workshop migration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,5 +95,6 @@ include = [
     "src/kai/services.py",
     "src/kai/sessions.py",
     "src/kai/user_isolation.py",
+    "src/kai/workshop",
     "src/kai/workspace_utils.py",
 ]

--- a/src/kai/workshop/__init__.py
+++ b/src/kai/workshop/__init__.py
@@ -1,0 +1,52 @@
+"""Transport-independent Kai Workshop domain and persistence foundations.
+
+This package is intentionally not wired into Kai's production startup or
+message paths yet.  The bootstrap migration will integrate it after the
+domain and event-store contracts have been reviewed independently.
+"""
+
+from kai.workshop.domain import (
+    AgentId,
+    ChannelAgentId,
+    ChannelBindingId,
+    ChannelId,
+    EventEnvelope,
+    EventId,
+    ExternalIdentityId,
+    MessageId,
+    PrincipalId,
+    WorkshopEventType,
+    WorkshopId,
+    WorkshopMembershipId,
+)
+from kai.workshop.store import (
+    AppendResult,
+    EventIntegrityError,
+    IdempotencyConflictError,
+    Projection,
+    ProjectionCheckpoint,
+    StoredEvent,
+    WorkshopEventStore,
+)
+
+__all__ = [
+    "AgentId",
+    "AppendResult",
+    "ChannelAgentId",
+    "ChannelBindingId",
+    "ChannelId",
+    "EventEnvelope",
+    "EventId",
+    "EventIntegrityError",
+    "ExternalIdentityId",
+    "IdempotencyConflictError",
+    "MessageId",
+    "PrincipalId",
+    "Projection",
+    "ProjectionCheckpoint",
+    "StoredEvent",
+    "WorkshopEventStore",
+    "WorkshopEventType",
+    "WorkshopId",
+    "WorkshopMembershipId",
+]

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -1,0 +1,241 @@
+"""Core, transport-independent value objects for Kai Workshop."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any, ClassVar, Self
+
+ENVELOPE_VERSION = 1
+
+_ID_BODY_PATTERN = re.compile(r"^[0-9a-f]{32}$")
+_EVENT_TYPE_PATTERN = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)+$")
+_AGGREGATE_TYPE_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+class WorkshopEventType(StrEnum):
+    """The collaboration-only vocabulary supported by the first schema."""
+
+    WORKSHOP_CREATED = "workshop.created"
+    PRINCIPAL_CREATED = "principal.created"
+    EXTERNAL_IDENTITY_BOUND = "external_identity.bound"
+    CHANNEL_CREATED = "channel.created"
+    TRANSPORT_CHANNEL_BOUND = "transport.channel_bound"
+    AGENT_CREATED = "agent.created"
+    CHANNEL_AGENT_ATTACHED = "channel.agent_attached"
+    MESSAGE_CREATED = "message.created"
+
+
+class OpaqueId(str):
+    """A globally unique identifier whose prefix identifies only its type."""
+
+    prefix: ClassVar[str]
+
+    def __new__(cls, value: str) -> Self:
+        if not isinstance(value, str):
+            raise TypeError(f"{cls.__name__} must be constructed from a string")
+        expected_prefix = f"{cls.prefix}_"
+        body = value.removeprefix(expected_prefix)
+        if not value.startswith(expected_prefix) or not _ID_BODY_PATTERN.fullmatch(body):
+            raise ValueError(f"Invalid {cls.__name__}: expected {expected_prefix}<32 lowercase hex characters>")
+        return str.__new__(cls, value)
+
+    @classmethod
+    def new(cls) -> Self:
+        return cls(f"{cls.prefix}_{uuid.uuid4().hex}")
+
+
+class WorkshopId(OpaqueId):
+    prefix = "wsp"
+
+
+class PrincipalId(OpaqueId):
+    prefix = "prn"
+
+
+class ExternalIdentityId(OpaqueId):
+    prefix = "xid"
+
+
+class WorkshopMembershipId(OpaqueId):
+    prefix = "wmb"
+
+
+class ChannelId(OpaqueId):
+    prefix = "chn"
+
+
+class ChannelBindingId(OpaqueId):
+    prefix = "cbd"
+
+
+class AgentId(OpaqueId):
+    prefix = "agt"
+
+
+class ChannelAgentId(OpaqueId):
+    prefix = "cag"
+
+
+class MessageId(OpaqueId):
+    prefix = "msg"
+
+
+class EventId(OpaqueId):
+    prefix = "evt"
+
+
+_ID_TYPES: dict[str, type[OpaqueId]] = {
+    identifier_type.prefix: identifier_type
+    for identifier_type in (
+        WorkshopId,
+        PrincipalId,
+        ExternalIdentityId,
+        WorkshopMembershipId,
+        ChannelId,
+        ChannelBindingId,
+        AgentId,
+        ChannelAgentId,
+        MessageId,
+        EventId,
+    )
+}
+
+
+def parse_opaque_id(value: str) -> OpaqueId:
+    """Restore the concrete identifier type from a serialized value."""
+    prefix, separator, _ = value.partition("_")
+    identifier_type = _ID_TYPES.get(prefix)
+    if not separator or identifier_type is None:
+        raise ValueError(f"Unknown Workshop identifier: {value!r}")
+    return identifier_type(value)
+
+
+def _canonical_json(value: Any, *, field_name: str) -> tuple[dict[str, Any], str]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be a JSON object")
+    try:
+        encoded = json.dumps(value, allow_nan=False, separators=(",", ":"), sort_keys=True)
+        decoded = json.loads(encoded)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must contain only valid JSON values") from exc
+    return decoded, encoded
+
+
+@dataclass(frozen=True, slots=True)
+class EventEnvelope:
+    """A versioned authoritative-fact envelope independent of any transport."""
+
+    event_id: EventId
+    event_type: str
+    event_version: int
+    workshop_id: WorkshopId
+    aggregate_type: str
+    aggregate_id: OpaqueId
+    occurred_at: datetime
+    payload: dict[str, Any]
+    actor_principal_id: PrincipalId | None = None
+    idempotency_key: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    envelope_version: int = ENVELOPE_VERSION
+    _payload_json: str = field(init=False, repr=False, compare=False)
+    _metadata_json: str = field(init=False, repr=False, compare=False)
+    _content_hash: str = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.event_id, EventId):
+            raise ValueError("event_id must be an EventId")
+        if not _EVENT_TYPE_PATTERN.fullmatch(self.event_type):
+            raise ValueError("event_type must be a lowercase dotted identifier")
+        if not isinstance(self.event_version, int) or isinstance(self.event_version, bool) or self.event_version < 1:
+            raise ValueError("event_version must be a positive integer")
+        if self.envelope_version != ENVELOPE_VERSION:
+            raise ValueError(f"Unsupported envelope_version: {self.envelope_version}")
+        if not isinstance(self.workshop_id, WorkshopId):
+            raise ValueError("workshop_id must be a WorkshopId")
+        if not _AGGREGATE_TYPE_PATTERN.fullmatch(self.aggregate_type):
+            raise ValueError("aggregate_type must be a lowercase identifier")
+        if not isinstance(self.aggregate_id, OpaqueId):
+            raise ValueError("aggregate_id must be a typed Workshop identifier")
+        if self.actor_principal_id is not None and not isinstance(self.actor_principal_id, PrincipalId):
+            raise ValueError("actor_principal_id must be a PrincipalId or None")
+        if self.occurred_at.tzinfo is None or self.occurred_at.utcoffset() is None:
+            raise ValueError("occurred_at must be timezone-aware")
+        if self.idempotency_key is not None:
+            if not self.idempotency_key.strip():
+                raise ValueError("idempotency_key must be non-empty when supplied")
+            if len(self.idempotency_key) > 512:
+                raise ValueError("idempotency_key must be at most 512 characters")
+
+        normalized_payload, payload_json = _canonical_json(self.payload, field_name="payload")
+        normalized_metadata, metadata_json = _canonical_json(self.metadata, field_name="metadata")
+        object.__setattr__(self, "payload", normalized_payload)
+        object.__setattr__(self, "metadata", normalized_metadata)
+        object.__setattr__(self, "occurred_at", self.occurred_at.astimezone(UTC))
+        object.__setattr__(self, "_payload_json", payload_json)
+        object.__setattr__(self, "_metadata_json", metadata_json)
+        object.__setattr__(self, "_content_hash", self._calculate_content_hash())
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        event_type: str,
+        event_version: int,
+        workshop_id: WorkshopId,
+        aggregate_type: str,
+        aggregate_id: OpaqueId,
+        occurred_at: datetime,
+        payload: dict[str, Any],
+        event_id: EventId | None = None,
+        actor_principal_id: PrincipalId | None = None,
+        idempotency_key: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> EventEnvelope:
+        return cls(
+            event_id=event_id or EventId.new(),
+            event_type=event_type,
+            event_version=event_version,
+            workshop_id=workshop_id,
+            aggregate_type=aggregate_type,
+            aggregate_id=aggregate_id,
+            occurred_at=occurred_at,
+            payload=payload,
+            actor_principal_id=actor_principal_id,
+            idempotency_key=idempotency_key,
+            metadata=metadata or {},
+        )
+
+    @property
+    def payload_json(self) -> str:
+        return self._payload_json
+
+    @property
+    def metadata_json(self) -> str:
+        return self._metadata_json
+
+    @property
+    def content_hash(self) -> str:
+        """Hash semantic content while excluding only generated event identity."""
+        return self._content_hash
+
+    def _calculate_content_hash(self) -> str:
+        content = {
+            "actor_principal_id": self.actor_principal_id,
+            "aggregate_id": self.aggregate_id,
+            "aggregate_type": self.aggregate_type,
+            "envelope_version": self.envelope_version,
+            "event_type": self.event_type,
+            "event_version": self.event_version,
+            "metadata": self.metadata,
+            "occurred_at": self.occurred_at.isoformat(),
+            "payload": self.payload,
+            "workshop_id": self.workshop_id,
+        }
+        encoded = json.dumps(content, allow_nan=False, separators=(",", ":"), sort_keys=True)
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -1,0 +1,173 @@
+"""Additive SQLite schema migrations for the Workshop foundation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import aiosqlite
+
+WORKSHOP_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaMigration:
+    version: int
+    name: str
+    statements: tuple[str, ...]
+
+
+_INITIAL_SCHEMA = SchemaMigration(
+    version=1,
+    name="canonical_conversation_foundation",
+    statements=(
+        """
+        CREATE TABLE workshops (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE principals (
+            id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL CHECK (kind IN ('human', 'agent', 'service', 'integration')),
+            display_name TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE external_identities (
+            id TEXT PRIMARY KEY,
+            principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+            provider TEXT NOT NULL,
+            external_subject TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            UNIQUE (provider, external_subject)
+        )
+        """,
+        """
+        CREATE TABLE workshop_memberships (
+            id TEXT PRIMARY KEY,
+            workshop_id TEXT NOT NULL REFERENCES workshops(id) ON DELETE CASCADE,
+            principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+            role TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            UNIQUE (workshop_id, principal_id)
+        )
+        """,
+        """
+        CREATE TABLE channels (
+            id TEXT PRIMARY KEY,
+            workshop_id TEXT NOT NULL REFERENCES workshops(id) ON DELETE CASCADE,
+            kind TEXT NOT NULL,
+            name TEXT,
+            created_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE channel_bindings (
+            id TEXT PRIMARY KEY,
+            channel_id TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+            transport TEXT NOT NULL,
+            external_channel_id TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            UNIQUE (transport, external_channel_id)
+        )
+        """,
+        """
+        CREATE TABLE agents (
+            id TEXT PRIMARY KEY,
+            workshop_id TEXT NOT NULL REFERENCES workshops(id) ON DELETE CASCADE,
+            principal_id TEXT NOT NULL UNIQUE REFERENCES principals(id) ON DELETE RESTRICT,
+            name TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE channel_agents (
+            id TEXT PRIMARY KEY,
+            channel_id TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+            agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+            created_at TEXT NOT NULL,
+            UNIQUE (channel_id, agent_id)
+        )
+        """,
+        """
+        CREATE TABLE event_log (
+            position INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id TEXT NOT NULL UNIQUE,
+            envelope_version INTEGER NOT NULL CHECK (envelope_version > 0),
+            event_type TEXT NOT NULL,
+            event_version INTEGER NOT NULL CHECK (event_version > 0),
+            workshop_id TEXT NOT NULL,
+            aggregate_type TEXT NOT NULL,
+            aggregate_id TEXT NOT NULL,
+            actor_principal_id TEXT,
+            occurred_at TEXT NOT NULL,
+            idempotency_key TEXT UNIQUE,
+            payload_json TEXT NOT NULL,
+            metadata_json TEXT NOT NULL,
+            content_hash TEXT NOT NULL,
+            recorded_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        )
+        """,
+        "CREATE INDEX event_log_workshop_position_idx ON event_log (workshop_id, position)",
+        "CREATE INDEX event_log_aggregate_position_idx ON event_log (aggregate_type, aggregate_id, position)",
+        """
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            channel_id TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+            author_principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE RESTRICT,
+            reply_to_message_id TEXT REFERENCES messages(id) ON DELETE SET NULL,
+            body TEXT NOT NULL,
+            created_event_position INTEGER NOT NULL UNIQUE REFERENCES event_log(position) ON DELETE RESTRICT,
+            created_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE projection_checkpoints (
+            name TEXT PRIMARY KEY,
+            version INTEGER NOT NULL CHECK (version > 0),
+            last_position INTEGER NOT NULL CHECK (last_position >= 0),
+            updated_at TEXT NOT NULL
+        )
+        """,
+    ),
+)
+
+_MIGRATIONS = (_INITIAL_SCHEMA,)
+
+
+async def migrate_workshop_schema(connection: aiosqlite.Connection) -> None:
+    """Apply all pending Workshop migrations in one explicit transaction."""
+    await connection.execute("PRAGMA foreign_keys=ON")
+    try:
+        await connection.execute("BEGIN IMMEDIATE")
+        await connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS workshop_schema_migrations (
+                version INTEGER PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            )
+            """
+        )
+        async with connection.execute("SELECT version FROM workshop_schema_migrations") as cursor:
+            applied = {int(row[0]) for row in await cursor.fetchall()}
+        unknown = {version for version in applied if version > WORKSHOP_SCHEMA_VERSION}
+        if unknown:
+            raise RuntimeError(f"Workshop schema is newer than this Kai build: {sorted(unknown)}")
+
+        for migration in _MIGRATIONS:
+            if migration.version in applied:
+                continue
+            for statement in migration.statements:
+                await connection.execute(statement)
+            await connection.execute(
+                "INSERT INTO workshop_schema_migrations (version, name) VALUES (?, ?)",
+                (migration.version, migration.name),
+            )
+        await connection.commit()
+    except Exception:
+        await connection.rollback()
+        raise

--- a/src/kai/workshop/store.py
+++ b/src/kai/workshop/store.py
@@ -1,0 +1,276 @@
+"""SQLite event-store and projection contracts for Kai Workshop."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+import aiosqlite
+
+from kai.workshop.domain import EventEnvelope, EventId, PrincipalId, WorkshopId, parse_opaque_id
+from kai.workshop.schema import migrate_workshop_schema
+
+_PROJECTION_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,127}$")
+
+
+class IdempotencyConflictError(RuntimeError):
+    """An event identity was reused for different semantic content."""
+
+
+class EventIntegrityError(RuntimeError):
+    """A stored event no longer matches its recorded semantic hash."""
+
+
+@dataclass(frozen=True, slots=True)
+class StoredEvent:
+    position: int
+    envelope: EventEnvelope
+    recorded_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class AppendResult:
+    event: StoredEvent
+    inserted: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionCheckpoint:
+    name: str
+    version: int
+    last_position: int
+
+
+class Projection(Protocol):
+    """A deterministic projection that can be rebuilt from the event log."""
+
+    name: str
+    version: int
+
+    async def reset(self, connection: aiosqlite.Connection) -> None: ...
+
+    async def apply(self, connection: aiosqlite.Connection, event: StoredEvent) -> None: ...
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _format_timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _restrict_database_path(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_CREAT | os.O_RDWR
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+    finally:
+        os.close(descriptor)
+
+
+class WorkshopEventStore:
+    """Append-only Workshop event storage with deterministic replay."""
+
+    def __init__(self, connection: aiosqlite.Connection, *, owns_connection: bool) -> None:
+        self._connection = connection
+        self._owns_connection = owns_connection
+
+    @classmethod
+    async def open(cls, path: Path) -> WorkshopEventStore:
+        _restrict_database_path(path)
+        connection = await aiosqlite.connect(str(path))
+        connection.row_factory = aiosqlite.Row
+        await connection.execute("PRAGMA busy_timeout=5000")
+        try:
+            await migrate_workshop_schema(connection)
+        except Exception:
+            await connection.close()
+            raise
+        return cls(connection, owns_connection=True)
+
+    @classmethod
+    async def attach(cls, connection: aiosqlite.Connection) -> WorkshopEventStore:
+        """Attach to an existing Kai connection without taking ownership."""
+        connection.row_factory = aiosqlite.Row
+        await migrate_workshop_schema(connection)
+        return cls(connection, owns_connection=False)
+
+    @property
+    def connection(self) -> aiosqlite.Connection:
+        return self._connection
+
+    async def close(self) -> None:
+        if self._owns_connection:
+            await self._connection.close()
+
+    async def schema_version(self) -> int:
+        async with self._connection.execute(
+            "SELECT COALESCE(MAX(version), 0) FROM workshop_schema_migrations"
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            raise RuntimeError("Workshop schema version query returned no row")
+        return int(row[0])
+
+    async def schema_tables(self) -> set[str]:
+        async with self._connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+        ) as cursor:
+            return {str(row[0]) for row in await cursor.fetchall()}
+
+    async def append(self, envelope: EventEnvelope) -> AppendResult:
+        """Append once, returning the prior event for a semantic retry."""
+        try:
+            await self._connection.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = await self._connection.execute(
+                    """
+                    INSERT INTO event_log (
+                        event_id, envelope_version, event_type, event_version,
+                        workshop_id, aggregate_type, aggregate_id,
+                        actor_principal_id, occurred_at, idempotency_key,
+                        payload_json, metadata_json, content_hash
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        envelope.event_id,
+                        envelope.envelope_version,
+                        envelope.event_type,
+                        envelope.event_version,
+                        envelope.workshop_id,
+                        envelope.aggregate_type,
+                        envelope.aggregate_id,
+                        envelope.actor_principal_id,
+                        _format_timestamp(envelope.occurred_at),
+                        envelope.idempotency_key,
+                        envelope.payload_json,
+                        envelope.metadata_json,
+                        envelope.content_hash,
+                    ),
+                )
+            except aiosqlite.IntegrityError as exc:
+                existing = await self._find_existing(envelope)
+                if existing is None:
+                    raise
+                if existing.envelope.content_hash != envelope.content_hash:
+                    identity = envelope.idempotency_key or str(envelope.event_id)
+                    raise IdempotencyConflictError(
+                        f"Event identity {identity!r} was reused with different content"
+                    ) from exc
+                await self._connection.rollback()
+                return AppendResult(event=existing, inserted=False)
+
+            position = cursor.lastrowid
+            if position is None:
+                raise RuntimeError("SQLite did not return an event position")
+            stored = await self._event_at_position(int(position))
+            await self._connection.commit()
+            return AppendResult(event=stored, inserted=True)
+        except Exception:
+            await self._connection.rollback()
+            raise
+
+    async def _find_existing(self, envelope: EventEnvelope) -> StoredEvent | None:
+        clauses = ["event_id = ?"]
+        parameters: list[str] = [str(envelope.event_id)]
+        if envelope.idempotency_key is not None:
+            clauses.append("idempotency_key = ?")
+            parameters.append(envelope.idempotency_key)
+        async with self._connection.execute(
+            f"SELECT * FROM event_log WHERE {' OR '.join(clauses)} ORDER BY position",
+            parameters,
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        if len(rows) > 1:
+            raise IdempotencyConflictError("event_id and idempotency_key resolve to different existing events")
+        return self._stored_event_from_row(rows[0]) if rows else None
+
+    async def _event_at_position(self, position: int) -> StoredEvent:
+        async with self._connection.execute("SELECT * FROM event_log WHERE position = ?", (position,)) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            raise RuntimeError(f"Event position {position} disappeared before commit")
+        return self._stored_event_from_row(row)
+
+    def _stored_event_from_row(self, row: aiosqlite.Row) -> StoredEvent:
+        actor = row["actor_principal_id"]
+        envelope = EventEnvelope(
+            event_id=EventId(row["event_id"]),
+            envelope_version=int(row["envelope_version"]),
+            event_type=row["event_type"],
+            event_version=int(row["event_version"]),
+            workshop_id=WorkshopId(row["workshop_id"]),
+            aggregate_type=row["aggregate_type"],
+            aggregate_id=parse_opaque_id(row["aggregate_id"]),
+            actor_principal_id=PrincipalId(actor) if actor is not None else None,
+            occurred_at=_parse_timestamp(row["occurred_at"]),
+            idempotency_key=row["idempotency_key"],
+            payload=json.loads(row["payload_json"]),
+            metadata=json.loads(row["metadata_json"]),
+        )
+        if envelope.content_hash != row["content_hash"]:
+            raise EventIntegrityError(f"Stored event {envelope.event_id} failed its content integrity check")
+        return StoredEvent(
+            position=int(row["position"]),
+            envelope=envelope,
+            recorded_at=_parse_timestamp(row["recorded_at"]),
+        )
+
+    async def read_events(self, *, after_position: int = 0, limit: int | None = None) -> list[StoredEvent]:
+        if after_position < 0:
+            raise ValueError("after_position must be non-negative")
+        if limit is not None and limit < 1:
+            raise ValueError("limit must be positive when supplied")
+        sql = "SELECT * FROM event_log WHERE position > ? ORDER BY position"
+        parameters: list[int] = [after_position]
+        if limit is not None:
+            sql += " LIMIT ?"
+            parameters.append(limit)
+        async with self._connection.execute(sql, parameters) as cursor:
+            rows = await cursor.fetchall()
+        return [self._stored_event_from_row(row) for row in rows]
+
+    async def rebuild_projection(self, projection: Projection) -> ProjectionCheckpoint:
+        """Atomically reset and replay one projection from position zero."""
+        if not _PROJECTION_NAME_PATTERN.fullmatch(projection.name):
+            raise ValueError("Projection name must be a lowercase identifier")
+        if not isinstance(projection.version, int) or isinstance(projection.version, bool) or projection.version < 1:
+            raise ValueError("Projection version must be a positive integer")
+
+        try:
+            await self._connection.execute("BEGIN IMMEDIATE")
+            await projection.reset(self._connection)
+            events = await self.read_events()
+            for event in events:
+                await projection.apply(self._connection, event)
+            last_position = events[-1].position if events else 0
+            updated_at = _format_timestamp(datetime.now(UTC))
+            await self._connection.execute(
+                """
+                INSERT INTO projection_checkpoints (name, version, last_position, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(name) DO UPDATE SET
+                    version = excluded.version,
+                    last_position = excluded.last_position,
+                    updated_at = excluded.updated_at
+                """,
+                (projection.name, projection.version, last_position, updated_at),
+            )
+            await self._connection.commit()
+        except Exception:
+            await self._connection.rollback()
+            raise
+        return ProjectionCheckpoint(
+            name=projection.name,
+            version=projection.version,
+            last_position=last_position,
+        )

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -1,0 +1,401 @@
+"""Contract tests for the production-unused Kai Workshop foundation."""
+
+from __future__ import annotations
+
+import asyncio
+import stat
+from datetime import UTC, datetime
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from kai.workshop.domain import (
+    AgentId,
+    ChannelId,
+    EventEnvelope,
+    EventId,
+    MessageId,
+    PrincipalId,
+    WorkshopEventType,
+    WorkshopId,
+)
+from kai.workshop.store import EventIntegrityError, IdempotencyConflictError, Projection, WorkshopEventStore
+
+
+def _message_event(
+    *,
+    idempotency_key: str | None = "telegram:update:100:message:200",
+    text: str = "hello",
+) -> EventEnvelope:
+    return EventEnvelope.create(
+        event_type="message.created",
+        event_version=1,
+        workshop_id=WorkshopId("wsp_00000000000000000000000000000001"),
+        aggregate_type="message",
+        aggregate_id=MessageId("msg_00000000000000000000000000000001"),
+        actor_principal_id=PrincipalId("prn_00000000000000000000000000000001"),
+        occurred_at=datetime(2026, 8, 11, 12, 0, tzinfo=UTC),
+        idempotency_key=idempotency_key,
+        payload={
+            "channel_id": "chn_00000000000000000000000000000001",
+            "text": text,
+        },
+        metadata={"transport": "telegram"},
+    )
+
+
+class TestWorkshopIdentifiers:
+    def test_generated_identifiers_are_typed_unique_and_opaque(self):
+        first = WorkshopId.new()
+        second = WorkshopId.new()
+
+        assert isinstance(first, WorkshopId)
+        assert first.startswith("wsp_")
+        assert len(first) == 36
+        assert first != second
+
+    @pytest.mark.parametrize(
+        ("identifier_type", "value"),
+        [
+            (WorkshopId, "prn_00000000000000000000000000000001"),
+            (PrincipalId, "principal-1"),
+            (ChannelId, "chn_not-hex"),
+            (AgentId, ""),
+            (MessageId, "msg_0000000000000000000000000000000"),
+            (EventId, "evt_000000000000000000000000000000011"),
+        ],
+    )
+    def test_identifiers_reject_wrong_kind_or_malformed_values(self, identifier_type, value):
+        with pytest.raises(ValueError):
+            identifier_type(value)
+
+
+class TestEventEnvelope:
+    def test_initial_event_vocabulary_is_collaboration_only(self):
+        assert {event_type.value for event_type in WorkshopEventType} == {
+            "workshop.created",
+            "principal.created",
+            "external_identity.bound",
+            "channel.created",
+            "transport.channel_bound",
+            "agent.created",
+            "channel.agent_attached",
+            "message.created",
+        }
+
+    def test_create_builds_a_versioned_transport_independent_envelope(self):
+        event = _message_event()
+
+        assert event.envelope_version == 1
+        assert event.event_type == "message.created"
+        assert event.event_version == 1
+        assert isinstance(event.event_id, EventId)
+        assert isinstance(event.workshop_id, WorkshopId)
+        assert isinstance(event.aggregate_id, MessageId)
+        assert event.payload["text"] == "hello"
+        assert event.metadata == {"transport": "telegram"}
+
+    @pytest.mark.parametrize(
+        ("changes", "match"),
+        [
+            ({"event_type": "Message Created"}, "event_type"),
+            ({"event_version": 0}, "event_version"),
+            ({"aggregate_type": ""}, "aggregate_type"),
+            ({"idempotency_key": ""}, "idempotency_key"),
+            ({"occurred_at": datetime(2026, 8, 11, 12, 0)}, "timezone-aware"),
+            ({"payload": {"bad": object()}}, "JSON"),
+        ],
+    )
+    def test_invalid_envelopes_fail_before_persistence(self, changes, match):
+        values = {
+            "event_type": "message.created",
+            "event_version": 1,
+            "workshop_id": WorkshopId.new(),
+            "aggregate_type": "message",
+            "aggregate_id": MessageId.new(),
+            "occurred_at": datetime.now(UTC),
+            "idempotency_key": "test:event:1",
+            "payload": {"text": "hello"},
+        }
+        values.update(changes)
+
+        with pytest.raises(ValueError, match=match):
+            EventEnvelope.create(**values)
+
+
+@pytest.fixture
+async def workshop_store(tmp_path: Path):
+    store = await WorkshopEventStore.open(tmp_path / "workshop.db")
+    yield store
+    await store.close()
+
+
+class TestWorkshopSchema:
+    async def test_initial_schema_contains_domain_event_and_projection_records(self, workshop_store):
+        expected = {
+            "workshop_schema_migrations",
+            "workshops",
+            "principals",
+            "external_identities",
+            "workshop_memberships",
+            "channels",
+            "channel_bindings",
+            "agents",
+            "channel_agents",
+            "messages",
+            "event_log",
+            "projection_checkpoints",
+        }
+
+        assert expected <= await workshop_store.schema_tables()
+        assert await workshop_store.schema_version() == 1
+
+    async def test_schema_migration_is_idempotent(self, tmp_path: Path):
+        path = tmp_path / "workshop.db"
+        first = await WorkshopEventStore.open(path)
+        await first.close()
+
+        second = await WorkshopEventStore.open(path)
+        assert await second.schema_version() == 1
+        async with second.connection.execute(
+            "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row[0] == 1
+        await second.close()
+
+    async def test_schema_is_additive_to_an_existing_kai_database(self, tmp_path: Path):
+        path = tmp_path / "kai.db"
+        connection = await aiosqlite.connect(path)
+        await connection.execute("CREATE TABLE sessions (chat_id INTEGER PRIMARY KEY, session_id TEXT NOT NULL)")
+        await connection.execute("INSERT INTO sessions (chat_id, session_id) VALUES (42, 'existing-session')")
+        await connection.commit()
+        await connection.close()
+
+        store = await WorkshopEventStore.open(path)
+        async with store.connection.execute("SELECT session_id FROM sessions WHERE chat_id = 42") as cursor:
+            row = await cursor.fetchone()
+        assert row[0] == "existing-session"
+        await store.close()
+
+    async def test_failed_initial_migration_leaves_no_partial_workshop_schema(self, tmp_path: Path):
+        path = tmp_path / "incompatible.db"
+        connection = await aiosqlite.connect(path)
+        await connection.execute("CREATE TABLE principals (incompatible TEXT)")
+        await connection.commit()
+        await connection.close()
+
+        with pytest.raises(aiosqlite.OperationalError):
+            await WorkshopEventStore.open(path)
+
+        connection = await aiosqlite.connect(path)
+        async with connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        ) as cursor:
+            tables = [row[0] for row in await cursor.fetchall()]
+        await connection.close()
+        assert tables == ["principals"]
+
+    async def test_new_database_is_owner_only(self, tmp_path: Path):
+        path = tmp_path / "workshop.db"
+        store = await WorkshopEventStore.open(path)
+        await store.close()
+
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    async def test_domain_foreign_keys_are_enforced(self, workshop_store):
+        with pytest.raises(aiosqlite.IntegrityError):
+            await workshop_store.connection.execute(
+                "INSERT INTO channels (id, workshop_id, kind, created_at) VALUES (?, ?, ?, ?)",
+                (ChannelId.new(), WorkshopId.new(), "direct", "2026-08-11T12:00:00Z"),
+            )
+
+
+class TestWorkshopEventStore:
+    async def test_append_assigns_monotonic_positions_and_replays_in_order(self, workshop_store):
+        first = await workshop_store.append(_message_event(idempotency_key="telegram:message:1", text="one"))
+        second = await workshop_store.append(_message_event(idempotency_key="telegram:message:2", text="two"))
+
+        assert first.inserted is True
+        assert first.event.position == 1
+        assert second.event.position == 2
+        assert [event.envelope.payload["text"] for event in await workshop_store.read_events()] == ["one", "two"]
+
+    async def test_idempotent_retry_returns_original_event_without_duplicate(self, workshop_store):
+        first = await workshop_store.append(_message_event())
+        retry = await workshop_store.append(_message_event())
+
+        assert first.inserted is True
+        assert retry.inserted is False
+        assert retry.event == first.event
+        assert len(await workshop_store.read_events()) == 1
+
+    async def test_idempotency_is_atomic_across_connections(self, tmp_path: Path):
+        path = tmp_path / "shared.db"
+        first_store = await WorkshopEventStore.open(path)
+        second_store = await WorkshopEventStore.open(path)
+
+        first, second = await asyncio.gather(
+            first_store.append(_message_event()),
+            second_store.append(_message_event()),
+        )
+
+        assert sorted((first.inserted, second.inserted)) == [False, True]
+        assert first.event == second.event
+        assert len(await first_store.read_events()) == 1
+        await first_store.close()
+        await second_store.close()
+
+    async def test_idempotency_key_reuse_with_different_content_fails_closed(self, workshop_store):
+        await workshop_store.append(_message_event(text="original"))
+
+        with pytest.raises(IdempotencyConflictError, match="telegram:update:100:message:200"):
+            await workshop_store.append(_message_event(text="changed"))
+
+        assert len(await workshop_store.read_events()) == 1
+
+    async def test_idempotency_key_reuse_with_different_occurrence_time_fails_closed(self, workshop_store):
+        original = _message_event()
+        await workshop_store.append(original)
+        changed = EventEnvelope.create(
+            event_type=original.event_type,
+            event_version=original.event_version,
+            workshop_id=original.workshop_id,
+            aggregate_type=original.aggregate_type,
+            aggregate_id=original.aggregate_id,
+            actor_principal_id=original.actor_principal_id,
+            occurred_at=datetime(2026, 8, 11, 12, 1, tzinfo=UTC),
+            idempotency_key=original.idempotency_key,
+            payload=original.payload,
+            metadata=original.metadata,
+        )
+
+        with pytest.raises(IdempotencyConflictError, match="telegram:update:100:message:200"):
+            await workshop_store.append(changed)
+
+    async def test_duplicate_event_id_with_different_content_fails_closed(self, workshop_store):
+        original = _message_event(idempotency_key=None, text="original")
+        await workshop_store.append(original)
+        changed = EventEnvelope.create(
+            event_id=original.event_id,
+            event_type=original.event_type,
+            event_version=original.event_version,
+            workshop_id=original.workshop_id,
+            aggregate_type=original.aggregate_type,
+            aggregate_id=original.aggregate_id,
+            actor_principal_id=original.actor_principal_id,
+            occurred_at=original.occurred_at,
+            payload={"text": "changed"},
+        )
+
+        with pytest.raises(IdempotencyConflictError, match=str(original.event_id)):
+            await workshop_store.append(changed)
+
+    async def test_event_id_and_idempotency_key_cannot_resolve_to_different_events(self, workshop_store):
+        first = _message_event(idempotency_key="telegram:message:1", text="one")
+        second = _message_event(idempotency_key="telegram:message:2", text="two")
+        await workshop_store.append(first)
+        await workshop_store.append(second)
+        crossed = EventEnvelope.create(
+            event_id=first.event_id,
+            event_type=first.event_type,
+            event_version=first.event_version,
+            workshop_id=first.workshop_id,
+            aggregate_type=first.aggregate_type,
+            aggregate_id=first.aggregate_id,
+            actor_principal_id=first.actor_principal_id,
+            occurred_at=first.occurred_at,
+            idempotency_key=second.idempotency_key,
+            payload=first.payload,
+        )
+
+        with pytest.raises(IdempotencyConflictError, match="different existing events"):
+            await workshop_store.append(crossed)
+
+    async def test_replay_detects_stored_content_tampering(self, workshop_store):
+        result = await workshop_store.append(_message_event())
+        await workshop_store.connection.execute(
+            "UPDATE event_log SET payload_json = ? WHERE position = ?",
+            ('{"text":"tampered"}', result.event.position),
+        )
+        await workshop_store.connection.commit()
+
+        with pytest.raises(EventIntegrityError, match=str(result.event.envelope.event_id)):
+            await workshop_store.read_events()
+
+
+class MessageCountProjection(Projection):
+    name = "test_message_counts"
+    version = 1
+
+    async def reset(self, connection: aiosqlite.Connection) -> None:
+        await connection.execute(
+            "CREATE TABLE IF NOT EXISTS test_message_counts "
+            "(channel_id TEXT PRIMARY KEY, message_count INTEGER NOT NULL)"
+        )
+        await connection.execute("DELETE FROM test_message_counts")
+
+    async def apply(self, connection: aiosqlite.Connection, event) -> None:
+        if event.envelope.event_type != "message.created":
+            return
+        await connection.execute(
+            "INSERT INTO test_message_counts (channel_id, message_count) VALUES (?, 1) "
+            "ON CONFLICT(channel_id) DO UPDATE SET message_count = message_count + 1",
+            (event.envelope.payload["channel_id"],),
+        )
+
+
+class TestProjectionReplay:
+    async def test_rebuild_is_deterministic_and_records_checkpoint(self, workshop_store):
+        await workshop_store.append(_message_event(idempotency_key="telegram:message:1", text="one"))
+        await workshop_store.append(_message_event(idempotency_key="telegram:message:2", text="two"))
+        projection = MessageCountProjection()
+
+        first_checkpoint = await workshop_store.rebuild_projection(projection)
+        second_checkpoint = await workshop_store.rebuild_projection(projection)
+
+        assert first_checkpoint == second_checkpoint
+        assert first_checkpoint.name == projection.name
+        assert first_checkpoint.version == projection.version
+        assert first_checkpoint.last_position == 2
+        async with workshop_store.connection.execute(
+            "SELECT message_count FROM test_message_counts WHERE channel_id = ?",
+            ("chn_00000000000000000000000000000001",),
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row[0] == 2
+
+    async def test_projection_failure_rolls_back_rows_and_checkpoint(self, workshop_store):
+        await workshop_store.append(_message_event())
+        await workshop_store.connection.execute(
+            "CREATE TABLE test_message_counts (channel_id TEXT PRIMARY KEY, message_count INTEGER NOT NULL)"
+        )
+        await workshop_store.connection.execute(
+            "INSERT INTO test_message_counts (channel_id, message_count) VALUES ('preexisting', 7)"
+        )
+        await workshop_store.connection.commit()
+
+        class FailingProjection(MessageCountProjection):
+            name = "test_failing_projection"
+
+            async def apply(self, connection: aiosqlite.Connection, event) -> None:
+                await super().apply(connection, event)
+                raise RuntimeError("projection failed")
+
+        with pytest.raises(RuntimeError, match="projection failed"):
+            await workshop_store.rebuild_projection(FailingProjection())
+
+        async with workshop_store.connection.execute(
+            "SELECT name FROM projection_checkpoints WHERE name = ?",
+            (FailingProjection.name,),
+        ) as cursor:
+            assert await cursor.fetchone() is None
+        async with workshop_store.connection.execute("SELECT COUNT(*) FROM test_message_counts") as cursor:
+            row = await cursor.fetchone()
+        assert row[0] == 1
+        async with workshop_store.connection.execute(
+            "SELECT message_count FROM test_message_counts WHERE channel_id = 'preexisting'"
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row[0] == 7


### PR DESCRIPTION
## Summary

This is the first bounded Kai Workshop implementation slice: a test-first, production-unused foundation for canonical conversations.

It adds:

- typed, opaque identifiers for workshops, principals, external identities, memberships, channels, bindings, agents, channel attachments, messages, and events;
- the initial collaboration-only event vocabulary from the Workshop implementation map;
- a validated, versioned event envelope with canonical JSON and semantic content hashes;
- an additive SQLite schema for the initial domain records, append-only event log, schema migrations, and projection checkpoints;
- an async event-store contract for ordered append, replay, pagination, and idempotent retries;
- fail-closed handling when an event ID or idempotency key is reused for different content;
- atomic deterministic projection rebuilds with rollback and checkpointing;
- the reviewed Workshop implementation map, including the required transition-retirement ledger and final cleanup gates.

## Production impact

None yet by design.

- No existing production module imports `kai.workshop`.
- `main.py`, `bot.py`, `sessions.py`, webhook handling, installation, and runtime configuration are unchanged.
- The Workshop schema migration is not invoked by Kai startup or install.
- No deployed database is modified by this PR.
- Telegram, JSONL history, all five backend harnesses, memory, schedules, GitHub notifications, generic webhooks, files, and streaming retain their current paths.

The next bootstrap PR will explicitly decide how the reviewed schema is attached to the existing Kai database.

## Storage and safety contracts

- Migrations use an explicit transaction and roll back without leaving partial Workshop tables.
- The schema is additive and preserves pre-existing Kai tables and rows.
- SQLite foreign keys are enabled for domain projections.
- Standalone database files are restricted to mode `0600`.
- Event positions are monotonically assigned by SQLite.
- Event and idempotency uniqueness are enforced by the database, including concurrent connections.
- Semantic retries return the original stored event; conflicting reuse fails closed.
- Replay verifies stored content against its recorded hash.
- Projection reset, replay, and checkpoint updates commit atomically.

## Test coverage

The new focused suite covers:

- typed identifier generation and malformed/wrong-kind rejection;
- the initial event vocabulary and envelope validation;
- canonical JSON constraints and timezone requirements;
- schema contents, versioning, idempotent migration, additive coexistence, migration rollback, file mode, and foreign keys;
- ordered append and replay;
- sequential and concurrent idempotent delivery;
- content, occurrence-time, event-ID, and crossed-identity conflicts;
- stored-content tamper detection;
- deterministic projection rebuilds, checkpoints, and transactional rollback.

Local verification:

- `4969 passed, 1 skipped`
- `make check`
- `make typecheck`
- `make module-sizes`

## Explicitly deferred

- Bootstrapping the default workshop, configured humans, Kai agent, or Telegram channel bindings.
- Recording any live inbound or outbound message.
- Making the event store authoritative.
- Changing JSONL history, delivery, process-pool keys, or backend execution.
- Run/attempt and delivery event families.
- Web, desktop, or Tauri surfaces.
- Runtime/container extraction.

Those remain separate small PRs with the cutover and retirement gates documented in the implementation map.
