### PR TITLE
feat: bootstrap canonical Workshop state

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -273,6 +273,7 @@ Identifiers should be opaque, globally unique strings. Telegram numeric identifi
 ### 11.2 Minimal event vocabulary
 
 - `workshop.created`
+- `workshop.member_added`
 - `principal.created`
 - `external_identity.bound`
 - `channel.created`

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -64,6 +64,7 @@ from kai.config import (
 )
 from kai.protected_config import ProtectedConfigError, validate_protected_file_metadata
 from kai.user_isolation import validate_protected_user_isolation
+from kai.workshop.diagnostics import workshop_bootstrap_status
 
 # Config file written by `config`, read by `apply`.
 # Anchored to PROJECT_ROOT so it resolves correctly regardless of CWD.
@@ -4418,6 +4419,16 @@ def _cmd_apply() -> None:
         print(f"Creating new installation at {install_dir}")
     print()
 
+    if dry_run:
+        expected_humans = len(_protected_user_assignments(effective_users_yaml))
+        print(
+            "[DRY RUN] "
+            + workshop_bootstrap_status(
+                data_path / "kai.db",
+                expected_humans=expected_humans,
+            )
+        )
+
     # -- Stop service before making changes --
     _stop_service(platform, dry_run)
 
@@ -6449,6 +6460,19 @@ def _cmd_status() -> None:
         print("Webhook secret migration (install.conf artifact): unavailable")
     else:
         print(_webhook_secret_migration_status(conf_env, source="install.conf artifact"))
+
+    expected_humans: int | None = None
+    if os.geteuid() == 0:
+        try:
+            expected_humans = len(_protected_user_assignments(USERS_YAML))
+        except ValueError:
+            pass
+    print(
+        workshop_bootstrap_status(
+            Path(data_dir) / "kai.db",
+            expected_humans=expected_humans,
+        )
+    )
 
     # Check workspace path traversal if install.conf has a service user
     if INSTALL_CONF.exists():

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -45,6 +45,21 @@ from telegram.error import NetworkError
 from kai import cron, services, sessions, webhook
 from kai.bot import create_bot
 from kai.config import DATA_DIR, PROJECT_ROOT, _read_protected_file, load_config
+from kai.workshop.bootstrap import BootstrapHuman
+
+
+def _workshop_bootstrap_humans(config) -> tuple[BootstrapHuman, ...]:
+    """Map authorized humans to transport bindings without notification groups."""
+    return tuple(
+        BootstrapHuman(
+            display_name=user.name,
+            role="admin" if user.role == "admin" else "member",
+            transport="telegram",
+            external_subject=str(user.telegram_id),
+            external_channel_id=str(user.telegram_id),
+        )
+        for user in sorted(config.user_configs.values(), key=lambda user: user.telegram_id)
+    )
 
 
 def setup_logging() -> None:
@@ -245,6 +260,19 @@ def _start() -> None:
         use_webhook = config.telegram_webhook_url is not None
 
         await sessions.init_db(config.session_db_path)
+
+        # Seed the non-authoritative Workshop identity/channel projection.
+        # Only configured interactive users participate; GitHub notification
+        # destinations are delivery targets and never become principals or
+        # inbound channel bindings through this migration.
+        workshop_bootstrap = await sessions.bootstrap_workshop_foundation(_workshop_bootstrap_humans(config))
+        logging.info(
+            "Workshop bootstrap ready (humans=%d, channels=%d, new_events=%d, existing_events=%d)",
+            workshop_bootstrap.human_count,
+            workshop_bootstrap.channel_count,
+            workshop_bootstrap.created_events,
+            workshop_bootstrap.existing_events,
+        )
 
         # Load user-registered memory projects into the detection
         # cache. Must follow init_db (the rows live in the session

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -42,6 +42,9 @@ from typing import TYPE_CHECKING, TypedDict
 import aiosqlite
 
 from kai.job_types import JOB_TYPE_AGENT, LEGACY_JOB_TYPE_AGENT, normalize_job_type
+from kai.workshop.bootstrap import BootstrapHuman, BootstrapResult, bootstrap_default_workshop
+from kai.workshop.schema import migrate_workshop_schema
+from kai.workshop.store import WorkshopEventStore
 
 if TYPE_CHECKING:
     from kai.config import Config, WorkspaceConfig
@@ -128,6 +131,7 @@ async def init_db(db_path: Path) -> None:
         if row and row[0] != "wal":
             log.warning("Failed to enable WAL mode; journal_mode is %s", row[0])
     await _get_db().execute("PRAGMA busy_timeout=5000")
+    await _get_db().execute("PRAGMA foreign_keys=ON")
     _restrict_sqlite_files(db_path)
 
     try:
@@ -266,6 +270,10 @@ async def init_db(db_path: Path) -> None:
             await _get_db().execute("DROP TABLE workspace_history")
             await _get_db().execute("ALTER TABLE workspace_history_new RENAME TO workspace_history")
 
+        # Additive Workshop schema only. Canonical bootstrap records are
+        # created separately after the protected user configuration has
+        # loaded; no message path reads these tables yet.
+        await migrate_workshop_schema(_get_db(), manage_transaction=False)
         await _get_db().commit()
         _restrict_sqlite_files(db_path)
     except Exception:
@@ -287,6 +295,12 @@ async def init_db(db_path: Path) -> None:
 
 
 # ── Session management ───────────────────────────────────────────────
+
+
+async def bootstrap_workshop_foundation(humans: tuple[BootstrapHuman, ...]) -> BootstrapResult:
+    """Seed non-authoritative Workshop records on Kai's initialized DB."""
+    store = WorkshopEventStore.from_initialized_connection(_get_db())
+    return await bootstrap_default_workshop(store, humans)
 
 
 async def get_session(chat_id: int) -> str | None:

--- a/src/kai/workshop/bootstrap.py
+++ b/src/kai/workshop/bootstrap.py
@@ -1,0 +1,249 @@
+"""Deterministic bootstrap of the first Workshop collaboration records."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from kai.workshop.domain import (
+    AgentId,
+    ChannelAgentId,
+    ChannelBindingId,
+    ChannelId,
+    EventEnvelope,
+    ExternalIdentityId,
+    OpaqueId,
+    PrincipalId,
+    WorkshopEventType,
+    WorkshopId,
+    WorkshopMembershipId,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.store import StoredEvent, WorkshopEventStore
+
+_BOOTSTRAP_PREFIX = "workshop-bootstrap:v1"
+_TRANSPORT_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+@dataclass(frozen=True, slots=True)
+class BootstrapHuman:
+    display_name: str
+    role: str
+    transport: str
+    external_subject: str
+    external_channel_id: str
+
+    def __post_init__(self) -> None:
+        if not self.display_name.strip():
+            raise ValueError("display_name must be non-empty")
+        if self.role not in {"admin", "member"}:
+            raise ValueError("role must be 'admin' or 'member'")
+        if not _TRANSPORT_PATTERN.fullmatch(self.transport):
+            raise ValueError("transport must be a lowercase identifier")
+        if not self.external_subject.strip():
+            raise ValueError("external_subject must be non-empty")
+        if not self.external_channel_id.strip():
+            raise ValueError("external_channel_id must be non-empty")
+
+
+@dataclass(frozen=True, slots=True)
+class BootstrapResult:
+    workshop_id: WorkshopId
+    agent_id: AgentId
+    created_events: int
+    existing_events: int
+    human_count: int
+    channel_count: int
+
+
+def _stable_token(*parts: str) -> str:
+    encoded = "\0".join(parts).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _idempotency_key(kind: str, stable_token: str) -> str:
+    return f"{_BOOTSTRAP_PREFIX}:{kind}:{stable_token}"
+
+
+async def _ensure_event(
+    store: WorkshopEventStore,
+    *,
+    idempotency_key: str,
+    event_type: WorkshopEventType,
+    workshop_id: WorkshopId,
+    aggregate_type: str,
+    aggregate_id: OpaqueId,
+    occurred_at: datetime,
+    payload: dict[str, Any],
+) -> tuple[StoredEvent, bool]:
+    existing = await store.event_by_idempotency_key(idempotency_key)
+    if existing is not None:
+        return existing, False
+    result = await store.append(
+        EventEnvelope.create(
+            event_type=event_type,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type=aggregate_type,
+            aggregate_id=aggregate_id,
+            occurred_at=occurred_at,
+            idempotency_key=idempotency_key,
+            payload=payload,
+            metadata={"source": "bootstrap"},
+        )
+    )
+    return result.event, result.inserted
+
+
+async def bootstrap_default_workshop(
+    store: WorkshopEventStore,
+    humans: Iterable[BootstrapHuman],
+) -> BootstrapResult:
+    """Seed one Workshop and its configured humans without changing routing."""
+    ordered_humans = sorted(humans, key=lambda human: (human.transport, human.external_subject))
+    seen_identities: set[tuple[str, str]] = set()
+    seen_channels: set[tuple[str, str]] = set()
+    for human in ordered_humans:
+        identity = (human.transport, human.external_subject)
+        channel = (human.transport, human.external_channel_id)
+        if identity in seen_identities:
+            raise ValueError(f"Duplicate bootstrap external identity for transport {human.transport!r}")
+        if channel in seen_channels:
+            raise ValueError(f"Duplicate bootstrap external channel for transport {human.transport!r}")
+        seen_identities.add(identity)
+        seen_channels.add(channel)
+
+    created_events = 0
+    existing_events = 0
+    now = datetime.now(UTC)
+    workshop_key = _idempotency_key("workshop", "default")
+    workshop_event = await store.event_by_idempotency_key(workshop_key)
+    if workshop_event is None:
+        workshop_id = WorkshopId.new()
+        result = await store.append(
+            EventEnvelope.create(
+                event_type=WorkshopEventType.WORKSHOP_CREATED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="workshop",
+                aggregate_id=workshop_id,
+                occurred_at=now,
+                idempotency_key=workshop_key,
+                payload={"name": "Kai Workshop"},
+                metadata={"source": "bootstrap"},
+            )
+        )
+        workshop_event = result.event
+        created_events += int(result.inserted)
+        existing_events += int(not result.inserted)
+    else:
+        existing_events += 1
+    if not isinstance(workshop_event.envelope.aggregate_id, WorkshopId):
+        raise RuntimeError("Default Workshop bootstrap event has the wrong aggregate type")
+    workshop_id = workshop_event.envelope.aggregate_id
+
+    async def ensure(**kwargs) -> StoredEvent:
+        nonlocal created_events, existing_events
+        event, inserted = await _ensure_event(store, occurred_at=now, workshop_id=workshop_id, **kwargs)
+        created_events += int(inserted)
+        existing_events += int(not inserted)
+        return event
+
+    agent_principal_id = PrincipalId.derived(workshop_id, "agent-principal:kai")
+    agent_membership_id = WorkshopMembershipId.derived(workshop_id, "membership:agent:kai")
+    agent_id = AgentId.derived(workshop_id, "agent:kai")
+    await ensure(
+        idempotency_key=_idempotency_key("principal", "agent-kai"),
+        event_type=WorkshopEventType.PRINCIPAL_CREATED,
+        aggregate_type="principal",
+        aggregate_id=agent_principal_id,
+        payload={"kind": "agent", "display_name": "Kai"},
+    )
+    await ensure(
+        idempotency_key=_idempotency_key("membership", "agent-kai"),
+        event_type=WorkshopEventType.WORKSHOP_MEMBER_ADDED,
+        aggregate_type="workshop_membership",
+        aggregate_id=agent_membership_id,
+        payload={"principal_id": agent_principal_id, "role": "agent"},
+    )
+    await ensure(
+        idempotency_key=_idempotency_key("agent", "kai"),
+        event_type=WorkshopEventType.AGENT_CREATED,
+        aggregate_type="agent",
+        aggregate_id=agent_id,
+        payload={"principal_id": agent_principal_id, "name": "Kai"},
+    )
+
+    for human in ordered_humans:
+        token = _stable_token(human.transport, human.external_subject)
+        channel_token = _stable_token(human.transport, human.external_channel_id)
+        principal_id = PrincipalId.derived(workshop_id, f"human:{token}")
+        external_identity_id = ExternalIdentityId.derived(workshop_id, f"external-identity:{token}")
+        membership_id = WorkshopMembershipId.derived(workshop_id, f"membership:human:{token}")
+        channel_id = ChannelId.derived(workshop_id, f"direct-channel:{channel_token}")
+        binding_id = ChannelBindingId.derived(workshop_id, f"channel-binding:{channel_token}")
+        channel_agent_id = ChannelAgentId.derived(workshop_id, f"channel-agent:{channel_token}:kai")
+        await ensure(
+            idempotency_key=_idempotency_key("principal", token),
+            event_type=WorkshopEventType.PRINCIPAL_CREATED,
+            aggregate_type="principal",
+            aggregate_id=principal_id,
+            payload={"kind": "human", "display_name": human.display_name.strip()},
+        )
+        await ensure(
+            idempotency_key=_idempotency_key("external-identity", token),
+            event_type=WorkshopEventType.EXTERNAL_IDENTITY_BOUND,
+            aggregate_type="external_identity",
+            aggregate_id=external_identity_id,
+            payload={
+                "principal_id": principal_id,
+                "provider": human.transport,
+                "external_subject": human.external_subject,
+            },
+        )
+        await ensure(
+            idempotency_key=_idempotency_key("membership", token),
+            event_type=WorkshopEventType.WORKSHOP_MEMBER_ADDED,
+            aggregate_type="workshop_membership",
+            aggregate_id=membership_id,
+            payload={"principal_id": principal_id, "role": human.role},
+        )
+        await ensure(
+            idempotency_key=_idempotency_key("channel", channel_token),
+            event_type=WorkshopEventType.CHANNEL_CREATED,
+            aggregate_type="channel",
+            aggregate_id=channel_id,
+            payload={"kind": "direct", "name": "Direct"},
+        )
+        await ensure(
+            idempotency_key=_idempotency_key("channel-binding", channel_token),
+            event_type=WorkshopEventType.TRANSPORT_CHANNEL_BOUND,
+            aggregate_type="channel_binding",
+            aggregate_id=binding_id,
+            payload={
+                "channel_id": channel_id,
+                "transport": human.transport,
+                "external_channel_id": human.external_channel_id,
+            },
+        )
+        await ensure(
+            idempotency_key=_idempotency_key("channel-agent", channel_token),
+            event_type=WorkshopEventType.CHANNEL_AGENT_ATTACHED,
+            aggregate_type="channel_agent",
+            aggregate_id=channel_agent_id,
+            payload={"channel_id": channel_id, "agent_id": agent_id},
+        )
+
+    await store.rebuild_projection(CanonicalConversationProjection())
+    return BootstrapResult(
+        workshop_id=workshop_id,
+        agent_id=agent_id,
+        created_events=created_events,
+        existing_events=existing_events,
+        human_count=len(ordered_humans),
+        channel_count=len(ordered_humans),
+    )

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -1,0 +1,76 @@
+"""Non-secret operator diagnostics for Workshop bootstrap state."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+_REQUIRED_TABLES = {
+    "workshops",
+    "principals",
+    "agents",
+    "channel_bindings",
+    "projection_checkpoints",
+}
+
+
+def _pending_status(expected_humans: int | None) -> str:
+    if expected_humans is None:
+        return "Workshop bootstrap: pending; configured-human count unavailable"
+    return (
+        "Workshop bootstrap: pending; service startup will seed "
+        f"1 workshop, {expected_humans} human principal(s), "
+        f"{expected_humans} Telegram direct channel binding(s), and 1 Kai agent"
+    )
+
+
+def _scalar(connection: sqlite3.Connection, query: str, parameters: tuple[object, ...] = ()) -> int:
+    row = connection.execute(query, parameters).fetchone()
+    if row is None:
+        return 0
+    return int(row[0])
+
+
+def workshop_bootstrap_status(db_path: Path, *, expected_humans: int | None) -> str:
+    """Describe canonical bootstrap state without exposing identity data."""
+    if not db_path.is_file():
+        return _pending_status(expected_humans)
+
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        try:
+            rows = connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+            tables = {str(row[0]) for row in rows}
+            if not tables >= _REQUIRED_TABLES:
+                return _pending_status(expected_humans)
+
+            workshop_count = _scalar(connection, "SELECT COUNT(*) FROM workshops")
+            human_count = _scalar(connection, "SELECT COUNT(*) FROM principals WHERE kind = 'human'")
+            agent_count = _scalar(connection, "SELECT COUNT(*) FROM agents")
+            telegram_binding_count = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM channel_bindings WHERE transport = ?",
+                ("telegram",),
+            )
+            projection_count = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM projection_checkpoints WHERE name = ?",
+                ("canonical_conversations",),
+            )
+        finally:
+            connection.close()
+    except (OSError, sqlite3.Error) as exc:
+        return f"Workshop bootstrap: NOT VERIFIED ({type(exc).__name__})"
+
+    expected_state_present = expected_humans is None or (
+        human_count >= expected_humans and telegram_binding_count >= expected_humans
+    )
+    initialized = workshop_count >= 1 and agent_count >= 1 and projection_count == 1 and expected_state_present
+    state = "initialized" if initialized else "pending"
+    expectation = (
+        "configured-human count unavailable" if expected_humans is None else f"expected humans={expected_humans}"
+    )
+    return (
+        f"Workshop bootstrap: {state}; workshops={workshop_count}, humans={human_count}, "
+        f"Telegram bindings={telegram_binding_count}, agents={agent_count}; {expectation}"
+    )

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -22,6 +22,7 @@ class WorkshopEventType(StrEnum):
     """The collaboration-only vocabulary supported by the first schema."""
 
     WORKSHOP_CREATED = "workshop.created"
+    WORKSHOP_MEMBER_ADDED = "workshop.member_added"
     PRINCIPAL_CREATED = "principal.created"
     EXTERNAL_IDENTITY_BOUND = "external_identity.bound"
     CHANNEL_CREATED = "channel.created"
@@ -48,6 +49,14 @@ class OpaqueId(str):
     @classmethod
     def new(cls) -> Self:
         return cls(f"{cls.prefix}_{uuid.uuid4().hex}")
+
+    @classmethod
+    def derived(cls, namespace: OpaqueId, stable_name: str) -> Self:
+        """Derive a stable typed ID within an already-random Workshop namespace."""
+        if not stable_name:
+            raise ValueError("stable_name must be non-empty")
+        namespace_uuid = uuid.UUID(hex=namespace.partition("_")[2])
+        return cls(f"{cls.prefix}_{uuid.uuid5(namespace_uuid, f'{cls.prefix}:{stable_name}').hex}")
 
 
 class WorkshopId(OpaqueId):

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -1,0 +1,148 @@
+"""Canonical collaboration projection for Workshop events."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiosqlite
+
+from kai.workshop.domain import WorkshopEventType
+from kai.workshop.store import StoredEvent
+
+
+def _required_text(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"Workshop event payload requires non-empty {key!r}")
+    return value
+
+
+class CanonicalConversationProjection:
+    """Rebuild the initial Workshop collaboration records from events."""
+
+    name = "canonical_conversations"
+    version = 1
+
+    async def reset(self, connection: aiosqlite.Connection) -> None:
+        for table in (
+            "messages",
+            "channel_agents",
+            "channel_bindings",
+            "channels",
+            "agents",
+            "workshop_memberships",
+            "external_identities",
+            "principals",
+            "workshops",
+        ):
+            await connection.execute(f"DELETE FROM {table}")
+
+    async def apply(self, connection: aiosqlite.Connection, event: StoredEvent) -> None:
+        envelope = event.envelope
+        payload = envelope.payload
+        occurred_at = envelope.occurred_at.isoformat()
+
+        if envelope.event_type == WorkshopEventType.WORKSHOP_CREATED:
+            await connection.execute(
+                "INSERT INTO workshops (id, name, created_at) VALUES (?, ?, ?)",
+                (envelope.aggregate_id, _required_text(payload, "name"), occurred_at),
+            )
+        elif envelope.event_type == WorkshopEventType.PRINCIPAL_CREATED:
+            await connection.execute(
+                "INSERT INTO principals (id, kind, display_name, created_at) VALUES (?, ?, ?, ?)",
+                (
+                    envelope.aggregate_id,
+                    _required_text(payload, "kind"),
+                    _required_text(payload, "display_name"),
+                    occurred_at,
+                ),
+            )
+        elif envelope.event_type == WorkshopEventType.EXTERNAL_IDENTITY_BOUND:
+            await connection.execute(
+                "INSERT INTO external_identities "
+                "(id, principal_id, provider, external_subject, created_at) VALUES (?, ?, ?, ?, ?)",
+                (
+                    envelope.aggregate_id,
+                    _required_text(payload, "principal_id"),
+                    _required_text(payload, "provider"),
+                    _required_text(payload, "external_subject"),
+                    occurred_at,
+                ),
+            )
+        elif envelope.event_type == WorkshopEventType.WORKSHOP_MEMBER_ADDED:
+            await connection.execute(
+                "INSERT INTO workshop_memberships "
+                "(id, workshop_id, principal_id, role, created_at) VALUES (?, ?, ?, ?, ?)",
+                (
+                    envelope.aggregate_id,
+                    envelope.workshop_id,
+                    _required_text(payload, "principal_id"),
+                    _required_text(payload, "role"),
+                    occurred_at,
+                ),
+            )
+        elif envelope.event_type == WorkshopEventType.CHANNEL_CREATED:
+            name = payload.get("name")
+            if name is not None and not isinstance(name, str):
+                raise ValueError("Workshop channel name must be a string or null")
+            await connection.execute(
+                "INSERT INTO channels (id, workshop_id, kind, name, created_at) VALUES (?, ?, ?, ?, ?)",
+                (
+                    envelope.aggregate_id,
+                    envelope.workshop_id,
+                    _required_text(payload, "kind"),
+                    name,
+                    occurred_at,
+                ),
+            )
+        elif envelope.event_type == WorkshopEventType.TRANSPORT_CHANNEL_BOUND:
+            await connection.execute(
+                "INSERT INTO channel_bindings "
+                "(id, channel_id, transport, external_channel_id, created_at) VALUES (?, ?, ?, ?, ?)",
+                (
+                    envelope.aggregate_id,
+                    _required_text(payload, "channel_id"),
+                    _required_text(payload, "transport"),
+                    _required_text(payload, "external_channel_id"),
+                    occurred_at,
+                ),
+            )
+        elif envelope.event_type == WorkshopEventType.AGENT_CREATED:
+            await connection.execute(
+                "INSERT INTO agents (id, workshop_id, principal_id, name, created_at) VALUES (?, ?, ?, ?, ?)",
+                (
+                    envelope.aggregate_id,
+                    envelope.workshop_id,
+                    _required_text(payload, "principal_id"),
+                    _required_text(payload, "name"),
+                    occurred_at,
+                ),
+            )
+        elif envelope.event_type == WorkshopEventType.CHANNEL_AGENT_ATTACHED:
+            await connection.execute(
+                "INSERT INTO channel_agents (id, channel_id, agent_id, created_at) VALUES (?, ?, ?, ?)",
+                (
+                    envelope.aggregate_id,
+                    _required_text(payload, "channel_id"),
+                    _required_text(payload, "agent_id"),
+                    occurred_at,
+                ),
+            )
+        elif envelope.event_type == WorkshopEventType.MESSAGE_CREATED:
+            reply_to = payload.get("reply_to_message_id")
+            if reply_to is not None and not isinstance(reply_to, str):
+                raise ValueError("Workshop reply_to_message_id must be a string or null")
+            await connection.execute(
+                "INSERT INTO messages "
+                "(id, channel_id, author_principal_id, reply_to_message_id, body, "
+                "created_event_position, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    envelope.aggregate_id,
+                    _required_text(payload, "channel_id"),
+                    _required_text(payload, "author_principal_id"),
+                    reply_to,
+                    _required_text(payload, "body"),
+                    event.position,
+                    occurred_at,
+                ),
+            )

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -138,11 +138,17 @@ _INITIAL_SCHEMA = SchemaMigration(
 _MIGRATIONS = (_INITIAL_SCHEMA,)
 
 
-async def migrate_workshop_schema(connection: aiosqlite.Connection) -> None:
-    """Apply all pending Workshop migrations in one explicit transaction."""
-    await connection.execute("PRAGMA foreign_keys=ON")
+async def migrate_workshop_schema(
+    connection: aiosqlite.Connection,
+    *,
+    manage_transaction: bool = True,
+) -> None:
+    """Apply pending migrations, optionally inside the caller's transaction."""
+    if manage_transaction:
+        await connection.execute("PRAGMA foreign_keys=ON")
     try:
-        await connection.execute("BEGIN IMMEDIATE")
+        if manage_transaction:
+            await connection.execute("BEGIN IMMEDIATE")
         await connection.execute(
             """
             CREATE TABLE IF NOT EXISTS workshop_schema_migrations (
@@ -167,7 +173,9 @@ async def migrate_workshop_schema(connection: aiosqlite.Connection) -> None:
                 "INSERT INTO workshop_schema_migrations (version, name) VALUES (?, ?)",
                 (migration.version, migration.name),
             )
-        await connection.commit()
+        if manage_transaction:
+            await connection.commit()
     except Exception:
-        await connection.rollback()
+        if manage_transaction:
+            await connection.rollback()
         raise

--- a/src/kai/workshop/store.py
+++ b/src/kai/workshop/store.py
@@ -104,6 +104,11 @@ class WorkshopEventStore:
         await migrate_workshop_schema(connection)
         return cls(connection, owns_connection=False)
 
+    @classmethod
+    def from_initialized_connection(cls, connection: aiosqlite.Connection) -> WorkshopEventStore:
+        """Use a connection whose Workshop schema was initialized by Kai startup."""
+        return cls(connection, owns_connection=False)
+
     @property
     def connection(self) -> aiosqlite.Connection:
         return self._connection
@@ -238,6 +243,16 @@ class WorkshopEventStore:
         async with self._connection.execute(sql, parameters) as cursor:
             rows = await cursor.fetchall()
         return [self._stored_event_from_row(row) for row in rows]
+
+    async def event_by_idempotency_key(self, idempotency_key: str) -> StoredEvent | None:
+        if not idempotency_key.strip():
+            raise ValueError("idempotency_key must be non-empty")
+        async with self._connection.execute(
+            "SELECT * FROM event_log WHERE idempotency_key = ?",
+            (idempotency_key,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return self._stored_event_from_row(row) if row is not None else None
 
     async def rebuild_projection(self, projection: Projection) -> ProjectionCheckpoint:
         """Atomically reset and replay one projection from position zero."""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3013,6 +3013,8 @@ class TestCmdApply:
 
         output = capsys.readouterr().out
         assert "[DRY RUN]" in output
+        assert "[DRY RUN] Workshop bootstrap: pending" in output
+        assert "1 human principal(s)" in output
         # Verify nothing was actually created
         assert not (tmp_path / "opt" / "kai").exists()
         # Secrets reminder should NOT appear during dry run
@@ -4399,6 +4401,7 @@ class TestCmdStatus:
         _cmd_status()
         output = capsys.readouterr().out
         assert "Installation Status" in output
+        assert "Workshop bootstrap:" in output
 
     def test_reports_unsupported_webhook_secret(self, tmp_path, monkeypatch, capsys):
         conf_path = tmp_path / "install.conf"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,7 +19,31 @@ from unittest.mock import patch
 
 import pytest
 
-from kai.main import _file_age, _file_cleanup_loop, setup_logging
+from kai.config import UserConfig
+from kai.main import _file_age, _file_cleanup_loop, _workshop_bootstrap_humans, setup_logging
+
+
+class TestWorkshopBootstrapMapping:
+    def test_only_interactive_user_identity_becomes_a_channel_binding(self):
+        config = SimpleNamespace(
+            user_configs={
+                101: UserConfig(
+                    telegram_id=101,
+                    name="Admin",
+                    role="admin",
+                    github_notify_chat_id=-999,
+                )
+            }
+        )
+
+        humans = _workshop_bootstrap_humans(config)
+
+        assert len(humans) == 1
+        assert humans[0].external_subject == "101"
+        assert humans[0].external_channel_id == "101"
+        assert humans[0].role == "admin"
+        assert "-999" not in repr(humans)
+
 
 # ── setup_logging() ──────────────────────────────────────────────────
 

--- a/tests/test_workshop_bootstrap.py
+++ b/tests/test_workshop_bootstrap.py
@@ -1,0 +1,263 @@
+"""Tests for deterministic, non-authoritative Workshop bootstrap records."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kai import sessions
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.diagnostics import workshop_bootstrap_status
+from kai.workshop.store import WorkshopEventStore
+
+
+@pytest.fixture
+async def store(tmp_path: Path):
+    event_store = await WorkshopEventStore.open(tmp_path / "kai.db")
+    yield event_store
+    await event_store.close()
+
+
+def _human(
+    telegram_id: int,
+    name: str,
+    *,
+    role: str = "member",
+) -> BootstrapHuman:
+    return BootstrapHuman(
+        display_name=name,
+        role=role,
+        transport="telegram",
+        external_subject=str(telegram_id),
+        external_channel_id=str(telegram_id),
+    )
+
+
+class TestBootstrapInput:
+    @pytest.mark.parametrize(
+        ("changes", "match"),
+        [
+            ({"display_name": ""}, "display_name"),
+            ({"role": "owner"}, "role"),
+            ({"transport": "Telegram"}, "transport"),
+            ({"external_subject": ""}, "external_subject"),
+            ({"external_channel_id": ""}, "external_channel_id"),
+        ],
+    )
+    def test_invalid_human_fails_before_database_changes(self, changes, match):
+        values = {
+            "display_name": "Daniel",
+            "role": "admin",
+            "transport": "telegram",
+            "external_subject": "123",
+            "external_channel_id": "123",
+        }
+        values.update(changes)
+
+        with pytest.raises(ValueError, match=match):
+            BootstrapHuman(**values)
+
+
+class TestDefaultWorkshopBootstrap:
+    async def test_creates_default_workshop_agent_humans_and_direct_channels(self, store):
+        result = await bootstrap_default_workshop(
+            store,
+            [_human(202, "Second"), _human(101, "Admin", role="admin")],
+        )
+
+        assert result.created_events == 16
+        assert result.existing_events == 0
+        assert result.human_count == 2
+        assert result.channel_count == 2
+
+        connection = store.connection
+        async with connection.execute("SELECT id, name FROM workshops") as cursor:
+            workshops = await cursor.fetchall()
+        async with connection.execute(
+            "SELECT id, kind, display_name FROM principals ORDER BY kind, display_name"
+        ) as cursor:
+            principals = await cursor.fetchall()
+        async with connection.execute("SELECT role FROM workshop_memberships ORDER BY role") as cursor:
+            roles = [row[0] for row in await cursor.fetchall()]
+        async with connection.execute("SELECT name FROM agents") as cursor:
+            agents = await cursor.fetchall()
+        async with connection.execute("SELECT id, kind FROM channels ORDER BY id") as cursor:
+            channels = await cursor.fetchall()
+        async with connection.execute(
+            "SELECT transport, external_channel_id FROM channel_bindings ORDER BY external_channel_id"
+        ) as cursor:
+            bindings = await cursor.fetchall()
+        async with connection.execute("SELECT COUNT(*) FROM channel_agents") as cursor:
+            channel_agent_count = (await cursor.fetchone())[0]
+
+        assert len(workshops) == 1
+        assert workshops[0][1] == "Kai Workshop"
+        assert [(row[1], row[2]) for row in principals] == [
+            ("agent", "Kai"),
+            ("human", "Admin"),
+            ("human", "Second"),
+        ]
+        assert roles == ["admin", "agent", "member"]
+        assert [row[0] for row in agents] == ["Kai"]
+        assert len(channels) == 2
+        assert all(row[1] == "direct" for row in channels)
+        assert [(row[0], row[1]) for row in bindings] == [("telegram", "101"), ("telegram", "202")]
+        assert channel_agent_count == 2
+
+    async def test_human_principal_and_conversation_have_distinct_ids(self, store):
+        await bootstrap_default_workshop(store, [_human(101, "Admin", role="admin")])
+
+        async with store.connection.execute(
+            "SELECT p.id, c.id FROM principals p "
+            "JOIN external_identities e ON e.principal_id = p.id "
+            "JOIN channel_bindings b ON b.external_channel_id = e.external_subject "
+            "JOIN channels c ON c.id = b.channel_id "
+            "WHERE p.kind = 'human'"
+        ) as cursor:
+            row = await cursor.fetchone()
+
+        assert row[0].startswith("prn_")
+        assert row[1].startswith("chn_")
+        assert row[0] != row[1]
+
+    async def test_rerun_is_idempotent_and_preserves_stable_ids(self, store):
+        first = await bootstrap_default_workshop(store, [_human(101, "Admin", role="admin")])
+        first_events = await store.read_events()
+
+        second = await bootstrap_default_workshop(store, [_human(101, "Admin", role="admin")])
+        second_events = await store.read_events()
+
+        assert first.created_events == 10
+        assert second.created_events == 0
+        assert second.existing_events == 10
+        assert second.workshop_id == first.workshop_id
+        assert second.agent_id == first.agent_id
+        assert second_events == first_events
+
+    async def test_input_order_does_not_change_event_or_projection_order(self, tmp_path: Path):
+        first_store = await WorkshopEventStore.open(tmp_path / "first.db")
+        second_store = await WorkshopEventStore.open(tmp_path / "second.db")
+        users = [_human(202, "Second"), _human(101, "Admin", role="admin")]
+
+        await bootstrap_default_workshop(first_store, users)
+        await bootstrap_default_workshop(second_store, list(reversed(users)))
+
+        first_types = [event.envelope.event_type for event in await first_store.read_events()]
+        second_types = [event.envelope.event_type for event in await second_store.read_events()]
+        async with first_store.connection.execute(
+            "SELECT external_channel_id FROM channel_bindings ORDER BY rowid"
+        ) as cursor:
+            first_channels = [row[0] for row in await cursor.fetchall()]
+        async with second_store.connection.execute(
+            "SELECT external_channel_id FROM channel_bindings ORDER BY rowid"
+        ) as cursor:
+            second_channels = [row[0] for row in await cursor.fetchall()]
+
+        assert first_types == second_types
+        assert first_channels == second_channels == ["101", "202"]
+        await first_store.close()
+        await second_store.close()
+
+    async def test_new_configured_human_can_be_added_after_initial_bootstrap(self, store):
+        await bootstrap_default_workshop(store, [_human(101, "Admin", role="admin")])
+
+        result = await bootstrap_default_workshop(
+            store,
+            [_human(101, "Admin", role="admin"), _human(202, "Second")],
+        )
+
+        assert result.created_events == 6
+        assert result.existing_events == 10
+        assert result.human_count == 2
+        assert result.channel_count == 2
+        assert len(await store.read_events()) == 16
+
+    async def test_duplicate_external_identity_or_channel_is_rejected(self, store):
+        with pytest.raises(ValueError, match="Duplicate bootstrap external identity"):
+            await bootstrap_default_workshop(
+                store,
+                [_human(101, "First"), _human(101, "Duplicate")],
+            )
+
+        assert await store.read_events() == []
+
+    async def test_existing_bootstrap_metadata_is_not_silently_rewritten(self, store):
+        await bootstrap_default_workshop(store, [_human(101, "Original", role="member")])
+
+        result = await bootstrap_default_workshop(store, [_human(101, "Changed", role="admin")])
+
+        assert result.created_events == 0
+        async with store.connection.execute(
+            "SELECT p.display_name, m.role FROM principals p "
+            "JOIN external_identities e ON e.principal_id = p.id "
+            "JOIN workshop_memberships m ON m.principal_id = p.id "
+            "WHERE e.provider = 'telegram' AND e.external_subject = '101'"
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert tuple(row) == ("Original", "member")
+
+
+class TestKaiDatabaseIntegration:
+    async def test_sessions_initialization_applies_workshop_schema_atomically(self, tmp_path: Path):
+        await sessions.init_db(tmp_path / "kai.db")
+        try:
+            tables = await WorkshopEventStore.from_initialized_connection(sessions._get_db()).schema_tables()
+            assert {"sessions", "event_log", "workshops", "projection_checkpoints"} <= tables
+        finally:
+            await sessions.close_db()
+
+    async def test_sessions_bootstrap_wrapper_uses_the_shared_database(self, tmp_path: Path):
+        await sessions.init_db(tmp_path / "kai.db")
+        try:
+            result = await sessions.bootstrap_workshop_foundation((_human(101, "Admin", role="admin"),))
+            assert result.human_count == 1
+            async with sessions._get_db().execute("SELECT COUNT(*) FROM workshops") as cursor:
+                assert (await cursor.fetchone())[0] == 1
+        finally:
+            await sessions.close_db()
+
+
+class TestWorkshopBootstrapStatus:
+    def test_missing_database_reports_pending_without_identity_data(self, tmp_path: Path):
+        status = workshop_bootstrap_status(tmp_path / "kai.db", expected_humans=2)
+
+        assert status.startswith("Workshop bootstrap: pending")
+        assert "2 human principal(s)" in status
+
+    async def test_initialized_database_reports_counts_only(self, tmp_path: Path):
+        db_path = tmp_path / "kai.db"
+        event_store = await WorkshopEventStore.open(db_path)
+        try:
+            await bootstrap_default_workshop(
+                event_store,
+                [_human(101, "Secret Name", role="admin")],
+            )
+        finally:
+            await event_store.close()
+
+        status = workshop_bootstrap_status(db_path, expected_humans=1)
+
+        assert status == (
+            "Workshop bootstrap: initialized; workshops=1, humans=1, Telegram bindings=1, agents=1; expected humans=1"
+        )
+        assert "Secret Name" not in status
+        assert "101" not in status
+
+    async def test_schema_without_bootstrap_reports_pending(self, tmp_path: Path):
+        db_path = tmp_path / "kai.db"
+        event_store = await WorkshopEventStore.open(db_path)
+        await event_store.close()
+
+        status = workshop_bootstrap_status(db_path, expected_humans=1)
+
+        assert status.startswith("Workshop bootstrap: pending;")
+        assert "humans=0" in status
+
+    def test_invalid_database_reports_not_verified(self, tmp_path: Path):
+        db_path = tmp_path / "kai.db"
+        db_path.write_text("not a SQLite database")
+
+        status = workshop_bootstrap_status(db_path, expected_humans=1)
+
+        assert status.startswith("Workshop bootstrap: NOT VERIFIED (DatabaseError)")

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -75,6 +75,7 @@ class TestEventEnvelope:
     def test_initial_event_vocabulary_is_collaboration_only(self):
         assert {event_type.value for event_type in WorkshopEventType} == {
             "workshop.created",
+            "workshop.member_added",
             "principal.created",
             "external_identity.bound",
             "channel.created",


### PR DESCRIPTION
## Summary

This is the second bounded Kai Workshop implementation slice after #816. It bootstraps the first canonical collaboration records into the existing Kai database while leaving all production message routing and response behavior on the current paths.

The migration creates one default Workshop, one Kai agent principal and agent, one human principal per configured interactive user, Workshop memberships, Telegram external identities, one direct channel per human, Telegram channel bindings, and Kai channel attachments.

## Safety boundary

- Current Telegram handlers remain authoritative.
- Current sessions, JSONL history, jobs, files, backends, GitHub notifications, and generic webhook behavior are unchanged.
- GitHub notification-only Telegram groups do not become principals or inbound channel bindings.
- The new canonical tables are populated and replayable but are not read by the production message path.
- Re-running startup is idempotent and does not duplicate events or records.
- Adding a configured user later adds only that user and direct-channel event set.
- Existing bootstrap metadata is not silently rewritten when display names or roles change; future explicit domain events will own those changes.

## Implementation

- Add deterministic opaque IDs scoped to the randomly generated default Workshop.
- Add the missing neutral `workshop.member_added` event needed to project Workshop membership.
- Add a canonical conversation projection covering the initial Workshop event vocabulary.
- Apply the additive Workshop schema inside the existing atomic Kai database initialization transaction.
- Seed canonical state after configuration has loaded and before Telegram begins accepting work.
- Rebuild the canonical projection deterministically from the append-only event log.
- Add idempotency-key lookup and a safe adapter for the already-initialized shared Kai database connection.

## Operator diagnostics

- `make DRY_RUN=1 install` reports whether startup would seed the Workshop foundation.
- `make install-status` reports initialized, pending, or unverifiable state using aggregate counts only.
- Diagnostics never emit Telegram IDs, names, channel identifiers, event payloads, or other identity data.

## Tests

Coverage includes:

- input validation and duplicate identity rejection;
- deterministic event and projection order;
- stable, distinct typed identifiers;
- idempotent restart behavior;
- incremental addition of a later configured user;
- preservation of existing bootstrap metadata;
- shared Kai database initialization and bootstrap integration;
- exclusion of notification-only Telegram group IDs;
- pending, initialized, and corrupt-database diagnostics;
- dry-run diagnostic output and no-mutation behavior.

Verification:

- `make check`
- `make typecheck`
- `make module-sizes`
- `pytest -q` — 4,988 passed, 1 skipped

## Follow-up

The next map milestone remains inbound canonical shadow recording after existing Telegram authentication. That cutover is intentionally not part of this PR.
